### PR TITLE
feat: model provider settings and first-run onboarding

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -20,10 +20,13 @@ files:
   # "Cannot find module '.prisma/client/default'" (window never opens; dock icon bounces and quits).
   - '!node_modules/@prisma/client{,/**/*}'
   - '!node_modules/.prisma{,/**/*}'
+  # The bundled Claude native binary (~220MB) is never executed: the app spawns the ACP agent with
+  # CLAUDE_CODE_EXECUTABLE pointing at the user's system-installed claude, and claude-agent-acp only
+  # resolves this optional platform package when that env var is unset. Excluding it drops ~220MB.
+  - '!node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64{,/**/*}'
 asarUnpack:
   - resources/**
-  # Native Claude CLI and ACP agent must live outside asar so the child process can execute them.
-  - node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/**
+  # The ACP agent runs as a spawned child process, so its entry must live outside the asar.
   - node_modules/@agentclientprotocol/claude-agent-acp/**
 # The Prisma generated client (`node_modules/.prisma`) is produced by `prisma generate` and is NOT a
 # declared dependency, so electron-builder's node_modules collector never bundles it into the asar.

--- a/src/main/acp/agent-process.ts
+++ b/src/main/acp/agent-process.ts
@@ -4,7 +4,8 @@ import { createRequire } from 'node:module'
 
 const nodeRequire = createRequire(import.meta.url)
 
-// Resolves the packaged Claude ACP agent entry through Node's module resolver.
+// Resolves the packaged Claude ACP agent entry through Node's module resolver. This is a JS entry
+// executed by Electron-as-Node, not the native claude binary, so it stays bundled with the app.
 const resolveClaudeAgentAcpEntry = (): string =>
   nodeRequire.resolve('@agentclientprotocol/claude-agent-acp/dist/index.js')
 
@@ -12,17 +13,32 @@ const resolveClaudeAgentAcpEntry = (): string =>
 const toUnpackedAsarPath = (filePath: string): string =>
   filePath.replace(/([/\\])app\.asar([/\\])/, '$1app.asar.unpacked$2')
 
-// Resolves the native Claude executable that the ACP agent spawns during session creation.
-const resolveClaudeCodeExecutable = (): string =>
-  toUnpackedAsarPath(nodeRequire.resolve('@anthropic-ai/claude-agent-sdk-darwin-arm64/claude'))
+// Spawn configuration for the ACP agent. `executablePath` is the system-installed claude resolved by
+// detection; `envOverrides` carries the active provider's credentials/model. The app no longer ships
+// a bundled claude binary, so a missing executablePath is a hard, actionable error.
+export type SpawnClaudeAgentAcpOptions = {
+  envOverrides?: Record<string, string>
+  executablePath?: string
+}
 
-// Starts the bundled Claude ACP agent as a child process with pipe-based IO.
-const spawnClaudeAgentAcp = (): ChildProcessWithoutNullStreams => {
+// Starts the Claude ACP agent as a child process with pipe-based IO, injecting the active provider's
+// environment and pointing CLAUDE_CODE_EXECUTABLE at the detected system claude.
+const spawnClaudeAgentAcp = ({
+  envOverrides = {},
+  executablePath
+}: SpawnClaudeAgentAcpOptions = {}): ChildProcessWithoutNullStreams => {
+  if (!executablePath) {
+    throw new Error(
+      'Claude executable path is not configured. Complete Claude detection in settings first.'
+    )
+  }
+
   // Electron is the Node runtime available after packaging; this keeps dev and packaged paths aligned.
   return spawn(process.execPath, [resolveClaudeAgentAcpEntry()], {
     env: {
       ...process.env,
-      CLAUDE_CODE_EXECUTABLE: process.env.CLAUDE_CODE_EXECUTABLE ?? resolveClaudeCodeExecutable(),
+      ...envOverrides,
+      CLAUDE_CODE_EXECUTABLE: executablePath,
       ELECTRON_RUN_AS_NODE: '1'
     },
     stdio: 'pipe',
@@ -30,9 +46,4 @@ const spawnClaudeAgentAcp = (): ChildProcessWithoutNullStreams => {
   })
 }
 
-export {
-  resolveClaudeAgentAcpEntry,
-  resolveClaudeCodeExecutable,
-  spawnClaudeAgentAcp,
-  toUnpackedAsarPath
-}
+export { resolveClaudeAgentAcpEntry, spawnClaudeAgentAcp, toUnpackedAsarPath }

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -22,6 +22,7 @@ import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
 import { NotebookRunRepository } from '../notebook/repository'
 import { NotebookRuntimeService } from '../notebook/runtime-service'
 import { resolveStorageRoot } from '../storage-root'
+import type { SettingsService } from '../settings/service'
 import type { UploadRepository } from '../uploads/repository'
 
 type AcpIpcArtifacts = {
@@ -33,6 +34,8 @@ type AcpIpcOptions = AcpIpcArtifacts & {
   mcpEntryPath: string
   uploadRepository: UploadRepository
   notebookRpcServer: NotebookLocalRpcServer
+  // Drives the agent spawn env from the active provider so switching takes effect on reconnect.
+  settingsService: SettingsService
 }
 
 // Sends one runtime payload to every currently open renderer window.
@@ -50,7 +53,8 @@ const createRuntime = ({
   repository,
   runRegistry,
   uploadRepository,
-  notebookRpcServer
+  notebookRpcServer,
+  settingsService
 }: AcpIpcOptions): AcpRuntime => {
   const storageRoot = resolveStorageRoot()
 
@@ -58,6 +62,8 @@ const createRuntime = ({
     appVersion: app.getVersion(),
     // Packaged macOS apps often start with cwd at "/" or the app bundle; use home instead.
     defaultCwd: homedir(),
+    // Read the active provider's credentials/model on every connect so provider switches apply.
+    resolveSpawnConfig: () => settingsService.resolveActiveSpawnConfig(),
     artifacts: {
       // Reuse the session persistence root so chat state and generated files move together.
       storageRoot,
@@ -86,8 +92,9 @@ const createRuntime = ({
   })
 }
 
-// Registers renderer-callable runtime commands on Electron IPC.
-const registerAcpIpcHandlers = (options: AcpIpcOptions): void => {
+// Registers renderer-callable runtime commands on Electron IPC and returns the shared runtime so the
+// settings layer can drop the connection when the active provider changes.
+const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntime => {
   const runtime = createRuntime(options)
 
   ipcMain.handle('acp:get-state', () => runtime.getSnapshot())
@@ -115,6 +122,8 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): void => {
   ipcMain.handle('acp:respond-permission', (_event, response: AcpPermissionResponse) =>
     runtime.respondToPermission(response)
   )
+
+  return runtime
 }
 
 // Creates the shared notebook runtime used by both renderer IPC and agent MCP calls.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -28,7 +28,7 @@ import type {
   AcpResumeSessionRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
-import { spawnClaudeAgentAcp } from './agent-process'
+import { spawnClaudeAgentAcp, type SpawnClaudeAgentAcpOptions } from './agent-process'
 import { toAcpRuntimeEvent } from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { AcpPermissionBroker } from './permission-broker'
@@ -55,6 +55,9 @@ type AcpRuntimeOptions = {
   defaultCwd: string
   callbacks?: AcpRuntimeCallbacks
   spawnAgent?: () => ChildProcessWithoutNullStreams
+  // Resolves the current active-provider spawn config at connect time so switching providers takes
+  // effect on reconnect. Ignored when an explicit spawnAgent is provided (tests inject that directly).
+  resolveSpawnConfig?: () => Promise<SpawnClaudeAgentAcpOptions> | SpawnClaudeAgentAcpOptions
   artifacts?: AcpRuntimeArtifactOptions
   uploads?: AcpRuntimeUploadOptions
   notebook?: AcpRuntimeNotebookOptions
@@ -144,7 +147,7 @@ class AcpRuntime {
   private expectedProcessExits = new WeakSet<ChildProcessWithoutNullStreams>()
   private readonly permissionBroker: AcpPermissionBroker
   private readonly callbacks: AcpRuntimeCallbacks
-  private readonly spawnAgent: () => ChildProcessWithoutNullStreams
+  private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
   private readonly artifactOptions: AcpRuntimeArtifactOptions | undefined
   private readonly notebookOptions: AcpRuntimeNotebookOptions | undefined
   private readonly artifactRepository: ArtifactRepository | undefined
@@ -159,7 +162,7 @@ class AcpRuntime {
   constructor(private readonly options: AcpRuntimeOptions) {
     this.cwd = resolve(options.defaultCwd)
     this.callbacks = options.callbacks ?? {}
-    this.spawnAgent = options.spawnAgent ?? spawnClaudeAgentAcp
+    this.spawnAgent = options.spawnAgent
     this.artifactOptions = options.artifacts
     this.notebookOptions = options.notebook
     this.artifactRepository = options.artifacts
@@ -233,7 +236,7 @@ class AcpRuntime {
     this.setStatus('connecting')
 
     try {
-      this.agentProcess = this.spawnAgent()
+      this.agentProcess = await this.spawnAgentProcess()
       this.attachAgentProcessEvents(this.agentProcess)
 
       const stream = acp.ndJsonStream(
@@ -456,6 +459,24 @@ class AcpRuntime {
     if (generation !== this.connectionGeneration) {
       throw new Error('ACP connection was superseded.')
     }
+  }
+
+  // Creates the agent process, preferring an injected spawner (tests) and otherwise resolving the
+  // current active-provider spawn config so each reconnect uses up-to-date credentials.
+  private async spawnAgentProcess(): Promise<ChildProcessWithoutNullStreams> {
+    if (this.spawnAgent) {
+      return this.spawnAgent()
+    }
+
+    const config = this.options.resolveSpawnConfig
+      ? await this.options.resolveSpawnConfig()
+      : undefined
+
+    if (!config) {
+      throw new Error('ACP agent spawn configuration is not available.')
+    }
+
+    return spawnClaudeAgentAcp(config)
   }
 
   // Sends one prompt turn to the targeted session and streams updates until stop.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -6,6 +6,8 @@ import { registerNotebookIpcHandlers } from './notebook/ipc'
 import { NotebookLocalRpcServer } from './notebook/local-rpc-server'
 import { registerProjectIpcHandlers } from './projects/ipc'
 import { registerSessionPersistenceIpcHandlers } from './session-persistence/ipc'
+import { registerSettingsIpcHandlers } from './settings/ipc'
+import { createDefaultSettingsService } from './settings/service'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './uploads/ipc'
 
 type IpcRegistrationOptions = {
@@ -21,14 +23,23 @@ const registerIpcHandlers = ({ mainEntryPath }: IpcRegistrationOptions): void =>
   const uploadRepository = createDefaultUploadRepository()
   const notebookService = createDefaultNotebookRuntimeService()
   const notebookRpcServer = new NotebookLocalRpcServer(notebookService)
+  // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
+  const settingsService = createDefaultSettingsService()
 
   registerFileSaveHandlers()
-  registerAcpIpcHandlers({
+  const runtime = registerAcpIpcHandlers({
     mcpEntryPath: mainEntryPath,
     repository: artifactRepository,
     runRegistry: artifactRunRegistry,
     uploadRepository,
-    notebookRpcServer
+    notebookRpcServer,
+    settingsService
+  })
+  // Switching the active provider drops the agent connection so the next prompt reconnects with the
+  // new credentials (and resumes the active session through the existing resume path).
+  registerSettingsIpcHandlers({
+    service: settingsService,
+    onActiveProviderChanged: () => void runtime.disconnect()
   })
   registerNotebookIpcHandlers(notebookService)
   registerArtifactIpcHandlers(artifactRepository, artifactRunRegistry)

--- a/src/main/settings/claude-detect.test.ts
+++ b/src/main/settings/claude-detect.test.ts
@@ -1,0 +1,85 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  collectCandidateDirs,
+  detectClaude,
+  parseVersion,
+  type ClaudeDetectDeps
+} from './claude-detect'
+
+// Builds detect deps around a set of "installed" executables keyed by absolute path.
+const createDeps = (
+  installed: Record<string, string>,
+  overrides: Partial<ClaudeDetectDeps> = {}
+): ClaudeDetectDeps => ({
+  env: { PATH: '/usr/bin:/usr/local/bin' },
+  homePath: '/home/user',
+  isExecutable: (path) => Promise.resolve(path in installed),
+  getVersion: (path) => Promise.resolve(installed[path]),
+  resolveNpmBinDirs: () => Promise.resolve([]),
+  ...overrides
+})
+
+describe('claude-detect', () => {
+  it('parses a version string out of --version output', () => {
+    expect(parseVersion('2.1.3 (Claude Code)')).toBe('2.1.3')
+    expect(parseVersion('claude 1.0.0-beta.2')).toBe('1.0.0-beta.2')
+  })
+
+  it('returns not found when no candidate is executable', async () => {
+    const result = await detectClaude(createDeps({}))
+
+    expect(result).toEqual({ found: false })
+  })
+
+  it('finds claude on PATH and records its absolute path and version', async () => {
+    const result = await detectClaude(createDeps({ '/usr/local/bin/claude': '2.1.0' }))
+
+    expect(result).toEqual({ found: true, path: '/usr/local/bin/claude', version: '2.1.0' })
+  })
+
+  it('falls back to ~/.local/bin and npm bin dirs when PATH misses', async () => {
+    const npmBin = '/home/user/.nvm/bin'
+    const result = await detectClaude(
+      createDeps(
+        { [join(npmBin, 'claude')]: '2.2.0' },
+        { resolveNpmBinDirs: () => Promise.resolve([npmBin]) }
+      )
+    )
+
+    expect(result).toEqual({ found: true, path: join(npmBin, 'claude'), version: '2.2.0' })
+  })
+
+  it('skips a path that exists but cannot report a version', async () => {
+    const deps = createDeps(
+      { '/usr/local/bin/claude': undefined as unknown as string },
+      { isExecutable: () => Promise.resolve(true), getVersion: () => Promise.resolve(undefined) }
+    )
+    const result = await detectClaude(deps)
+
+    expect(result.found).toBe(false)
+  })
+
+  it('probes PATH, ~/.local/bin, homebrew, then npm dirs without duplicates', async () => {
+    const dirs = await collectCandidateDirs(
+      createDeps({}, { resolveNpmBinDirs: () => Promise.resolve(['/usr/local/bin']) })
+    )
+
+    expect(dirs).toContain('/usr/bin')
+    expect(dirs).toContain('/home/user/.local/bin')
+    expect(dirs).toContain('/opt/homebrew/bin')
+    // /usr/local/bin appears in PATH and the npm dir list but is only probed once.
+    expect(dirs.filter((dir) => dir === '/usr/local/bin')).toHaveLength(1)
+  })
+
+  it('tolerates a failing npm bin resolution', async () => {
+    const deps = createDeps(
+      { '/usr/local/bin/claude': '2.0.0' },
+      { resolveNpmBinDirs: () => Promise.reject(new Error('npm missing')) }
+    )
+    const result = await detectClaude(deps)
+
+    expect(result.found).toBe(true)
+  })
+})

--- a/src/main/settings/claude-detect.ts
+++ b/src/main/settings/claude-detect.ts
@@ -1,0 +1,115 @@
+import { access } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { homedir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import type { ClaudeDetectResult } from '../../shared/settings'
+
+const execFileAsync = promisify(execFile)
+
+// Detects a runnable claude executable across the locations a GUI app might miss because its PATH
+// differs from the user's login shell. Injectable deps keep the probe order unit-testable.
+
+export type ClaudeDetectDeps = {
+  // Environment used to read PATH; injected so tests can drive candidate discovery.
+  env: NodeJS.ProcessEnv
+  // Home directory for the ~/.local/bin fallback.
+  homePath: string
+  // Resolves whether a candidate file exists and is executable.
+  isExecutable: (path: string) => Promise<boolean>
+  // Runs `<path> --version` and returns the trimmed version string, or undefined on failure.
+  getVersion: (path: string) => Promise<string | undefined>
+  // Extra bin directories to probe (e.g. `npm prefix -g`); resolved lazily and tolerant of failure.
+  resolveNpmBinDirs: () => Promise<string[]>
+}
+
+const CLAUDE_BINARY = 'claude'
+
+// Common non-PATH install locations, in the order the design specifies.
+const WELL_KNOWN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin']
+
+// Builds the ordered list of directories to search for the claude binary.
+const collectCandidateDirs = async (deps: ClaudeDetectDeps): Promise<string[]> => {
+  const pathDirs = (deps.env.PATH ?? '').split(delimiter).filter((dir) => dir.length > 0)
+  const npmBinDirs = await deps.resolveNpmBinDirs().catch(() => [])
+  const localBin = join(deps.homePath, '.local', 'bin')
+
+  // De-duplicate while preserving first-seen order so the first real hit wins.
+  return Array.from(new Set([...pathDirs, localBin, ...WELL_KNOWN_DIRS, ...npmBinDirs]))
+}
+
+// Probes each candidate directory, returning the first executable whose `--version` succeeds.
+const detectClaude = async (
+  deps: ClaudeDetectDeps = createDefaultDetectDeps()
+): Promise<ClaudeDetectResult> => {
+  const candidateDirs = await collectCandidateDirs(deps)
+
+  for (const dir of candidateDirs) {
+    const candidate = join(dir, CLAUDE_BINARY)
+
+    if (!(await deps.isExecutable(candidate))) continue
+
+    const version = await deps.getVersion(candidate)
+
+    // A path that exists but cannot report a version is not a usable claude; keep searching.
+    if (version === undefined) continue
+
+    return { found: true, path: candidate, version }
+  }
+
+  return { found: false }
+}
+
+// Real filesystem executable check used in production.
+const isExecutableFile = async (path: string): Promise<boolean> => {
+  try {
+    await access(path, constants.X_OK)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Parses the first version-looking token out of `claude --version` output.
+const parseVersion = (output: string): string | undefined => {
+  const match = output.match(/\d+\.\d+\.[\w.-]+/)
+
+  return match ? match[0] : output.trim() || undefined
+}
+
+// Real `<path> --version` runner used in production.
+const runClaudeVersion = async (path: string): Promise<string | undefined> => {
+  try {
+    const { stdout } = await execFileAsync(path, ['--version'], { timeout: 10_000 })
+
+    return parseVersion(stdout)
+  } catch {
+    return undefined
+  }
+}
+
+// Resolves the npm global bin directory (`npm prefix -g` -> `<prefix>/bin`) if npm is present.
+const resolveNpmBinDirs = async (): Promise<string[]> => {
+  try {
+    const { stdout } = await execFileAsync('npm', ['prefix', '-g'], { timeout: 10_000 })
+    const prefix = stdout.trim()
+
+    return prefix ? [join(prefix, 'bin')] : []
+  } catch {
+    return []
+  }
+}
+
+// Production dependency bundle wired to real fs/child_process.
+const createDefaultDetectDeps = (): ClaudeDetectDeps => ({
+  env: process.env,
+  homePath: homedir(),
+  isExecutable: isExecutableFile,
+  getVersion: runClaudeVersion,
+  resolveNpmBinDirs
+})
+
+export { collectCandidateDirs, createDefaultDetectDeps, detectClaude, parseVersion }

--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ClaudeInstallLogEvent } from '../../shared/settings'
+import { detectNpmAvailable, getInstallSpawnSpec, runInstall } from './claude-install'
+
+// Minimal fake child process exposing the stdout/stderr/exit surface runInstall consumes.
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  kill = vi.fn()
+}
+
+describe('claude-install: command construction', () => {
+  it('runs npm against the China mirror registry', () => {
+    const spec = getInstallSpawnSpec('npm-mirror')
+
+    expect(spec.command).toBe('npm')
+    expect(spec.args).toEqual([
+      'i',
+      '-g',
+      '@anthropic-ai/claude-code',
+      '--registry=https://registry.npmmirror.com'
+    ])
+  })
+
+  it('pipes the official installer through a shell', () => {
+    const spec = getInstallSpawnSpec('official-script')
+
+    expect(spec.command).toBe('bash')
+    expect(spec.args.at(-1)).toContain('curl -fsSL https://claude.ai/install.sh | bash')
+  })
+})
+
+describe('claude-install: run', () => {
+  it('streams stdout/stderr and resolves ok on exit code 0', async () => {
+    const child = new FakeChild()
+    const logs: ClaudeInstallLogEvent[] = []
+    const promise = runInstall({
+      source: 'npm-mirror',
+      installId: 'install-1',
+      onLog: (event) => logs.push(event),
+      spawnImpl: () => child as never
+    })
+
+    child.stdout.emit('data', Buffer.from('adding package\n'))
+    child.stderr.emit('data', Buffer.from('warn\n'))
+    child.emit('exit', 0)
+
+    const result = await promise
+
+    expect(result).toMatchObject({ installId: 'install-1', ok: true, exitCode: 0 })
+    expect(
+      logs.some((log) => log.stream === 'stdout' && log.chunk.includes('adding package'))
+    ).toBe(true)
+    expect(logs.some((log) => log.stream === 'stderr')).toBe(true)
+  })
+
+  it('resolves not ok on a non-zero exit', async () => {
+    const child = new FakeChild()
+    const promise = runInstall({
+      source: 'npm-mirror',
+      installId: 'install-2',
+      onLog: () => undefined,
+      spawnImpl: () => child as never
+    })
+
+    child.emit('exit', 1)
+
+    await expect(promise).resolves.toMatchObject({ ok: false, exitCode: 1 })
+  })
+
+  it('reports a spawn failure without throwing', async () => {
+    const result = await runInstall({
+      source: 'npm-mirror',
+      installId: 'install-3',
+      onLog: () => undefined,
+      spawnImpl: () => {
+        throw new Error('spawn npm ENOENT')
+      }
+    })
+
+    expect(result).toMatchObject({ ok: false })
+    expect(result.error).toContain('ENOENT')
+  })
+})
+
+describe('claude-install: npm availability', () => {
+  it('reports available when the npm probe resolves', async () => {
+    await expect(detectNpmAvailable(() => Promise.resolve())).resolves.toEqual({ available: true })
+  })
+
+  it('reports unavailable when the npm probe rejects', async () => {
+    await expect(detectNpmAvailable(() => Promise.reject(new Error('not found')))).resolves.toEqual(
+      { available: false }
+    )
+  })
+})

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -1,0 +1,145 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import type {
+  ClaudeInstallLogEvent,
+  ClaudeInstallResult,
+  ClaudeInstallSource,
+  NpmAvailability
+} from '../../shared/settings'
+import { CLAUDE_INSTALL_SOURCES } from '../../shared/settings'
+
+const execFileAsync = promisify(execFile)
+
+// Constructs and runs the one-click claude installer for a chosen source, streaming output back so
+// the UI can show live progress and never spin silently. Command construction is pure and testable;
+// the spawn is injectable for the same reason.
+
+// How a source is actually executed. The official script is piped through a shell; the npm mirror
+// install runs npm directly with the registry flag.
+type InstallSpawnSpec = {
+  command: string
+  args: string[]
+}
+
+const INSTALL_SPAWN_SPECS: Record<ClaudeInstallSource, InstallSpawnSpec> = {
+  'npm-mirror': {
+    command: 'npm',
+    args: ['i', '-g', '@anthropic-ai/claude-code', '--registry=https://registry.npmmirror.com']
+  },
+  'official-script': {
+    command: 'bash',
+    args: ['-lc', 'curl -fsSL https://claude.ai/install.sh | bash']
+  }
+}
+
+// Default guard so a hung network install cannot block the wizard forever.
+const DEFAULT_INSTALL_TIMEOUT_MS = 5 * 60 * 1000
+
+export type RunInstallOptions = {
+  source: ClaudeInstallSource
+  installId: string
+  onLog: (event: ClaudeInstallLogEvent) => void
+  timeoutMs?: number
+  // Injectable spawn so tests can drive stdout/stderr/exit without a real process.
+  spawnImpl?: (command: string, args: string[]) => ChildProcessWithoutNullStreams
+}
+
+// Returns the exact spawn command/args for a source (also the source of the copyable display text).
+const getInstallSpawnSpec = (source: ClaudeInstallSource): InstallSpawnSpec =>
+  INSTALL_SPAWN_SPECS[source]
+
+// Real installer spawn with piped stdio.
+const defaultInstallSpawn = (command: string, args: string[]): ChildProcessWithoutNullStreams =>
+  spawn(command, args, { stdio: 'pipe', windowsHide: true }) as ChildProcessWithoutNullStreams
+
+// Runs an install source to completion, forwarding every stdout/stderr chunk through onLog and
+// enforcing a timeout. Resolves (never rejects) with a structured result the service can act on.
+const runInstall = ({
+  source,
+  installId,
+  onLog,
+  timeoutMs = DEFAULT_INSTALL_TIMEOUT_MS,
+  spawnImpl = defaultInstallSpawn
+}: RunInstallOptions): Promise<ClaudeInstallResult> => {
+  const spec = getInstallSpawnSpec(source)
+
+  onLog({ installId, stream: 'system', chunk: `$ ${spec.command} ${spec.args.join(' ')}` })
+
+  return new Promise<ClaudeInstallResult>((resolve) => {
+    let child: ChildProcessWithoutNullStreams
+
+    try {
+      child = spawnImpl(spec.command, spec.args)
+    } catch (error) {
+      resolve({
+        installId,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      })
+
+      return
+    }
+
+    let settled = false
+    let timedOut = false
+
+    // Ensures we resolve exactly once across exit/error/timeout races.
+    const settle = (result: ClaudeInstallResult): void => {
+      if (settled) return
+
+      settled = true
+      clearTimeout(timer)
+      resolve(result)
+    }
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      onLog({ installId, stream: 'system', chunk: 'Install timed out; terminating.' })
+      child.kill()
+    }, timeoutMs)
+
+    child.stdout.on('data', (data: Buffer) => {
+      onLog({ installId, stream: 'stdout', chunk: data.toString('utf8') })
+    })
+
+    child.stderr.on('data', (data: Buffer) => {
+      onLog({ installId, stream: 'stderr', chunk: data.toString('utf8') })
+    })
+
+    child.on('error', (error) => {
+      settle({ installId, ok: false, error: error.message })
+    })
+
+    child.on('exit', (code) => {
+      settle({
+        installId,
+        ok: !timedOut && code === 0,
+        exitCode: code ?? undefined,
+        timedOut: timedOut || undefined
+      })
+    })
+  })
+}
+
+// Reports whether npm is on PATH so the UI can default to/enable the npm-mirror source.
+const detectNpmAvailable = async (
+  runNpm: () => Promise<unknown> = () => execFileAsync('npm', ['--version'], { timeout: 10_000 })
+): Promise<NpmAvailability> => {
+  try {
+    await runNpm()
+
+    return { available: true }
+  } catch {
+    return { available: false }
+  }
+}
+
+export {
+  CLAUDE_INSTALL_SOURCES,
+  DEFAULT_INSTALL_TIMEOUT_MS,
+  detectNpmAvailable,
+  getInstallSpawnSpec,
+  runInstall
+}

--- a/src/main/settings/crypto.test.ts
+++ b/src/main/settings/crypto.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Fake safeStorage: a reversible "encryption" so the crypto wrapper's base64/prefix handling and
+// round-trip contract can be tested without a real OS keychain.
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`cipher:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => {
+      const decoded = buffer.toString('utf8')
+
+      if (!decoded.startsWith('cipher:')) {
+        throw new Error('bad ciphertext')
+      }
+
+      return decoded.slice('cipher:'.length)
+    }
+  }
+}))
+
+const { decryptKey, encryptKey, maskKey, tryDecryptKey } = await import('./crypto')
+
+describe('crypto', () => {
+  it('round-trips a key through encrypt/decrypt with the enc: prefix', () => {
+    const keyRef = encryptKey('sk-secret-value')
+
+    expect(keyRef.startsWith('enc:')).toBe(true)
+    expect(decryptKey(keyRef)).toBe('sk-secret-value')
+  })
+
+  it('throws on a malformed key reference', () => {
+    expect(() => decryptKey('plain-nonsense')).toThrow(/malformed/i)
+  })
+
+  it('tryDecryptKey returns undefined instead of throwing on bad input', () => {
+    expect(tryDecryptKey(undefined)).toBeUndefined()
+    expect(tryDecryptKey('enc:' + Buffer.from('garbage').toString('base64'))).toBeUndefined()
+  })
+
+  it('masks long keys as prefix…suffix and short keys as bullets', () => {
+    expect(maskKey('sk-abcdef1234')).toBe('sk-a…1234')
+    expect(maskKey('short')).toBe('•••••')
+    expect(maskKey('')).toBe('')
+  })
+})

--- a/src/main/settings/crypto.ts
+++ b/src/main/settings/crypto.ts
@@ -1,0 +1,54 @@
+import { safeStorage } from 'electron'
+
+// Wraps Electron safeStorage for API-key material. Plaintext keys exist only transiently in main
+// memory (during validation and env assembly); at rest they are OS-encrypted ciphertext, and the
+// renderer only ever sees the masked hint produced by maskKey().
+
+// Stored ciphertext is base64 with this prefix so the on-disk shape is self-describing.
+const KEY_REF_PREFIX = 'enc:'
+
+// Reports whether the OS keychain backing safeStorage is usable on this machine.
+const isEncryptionAvailable = (): boolean => safeStorage.isEncryptionAvailable()
+
+// Encrypts a plaintext key into a prefixed base64 keyRef for storage.
+const encryptKey = (plaintext: string): string => {
+  const ciphertext = safeStorage.encryptString(plaintext)
+
+  return `${KEY_REF_PREFIX}${ciphertext.toString('base64')}`
+}
+
+// Decrypts a stored keyRef back to plaintext. Throws when the ref is malformed or undecryptable
+// (e.g. the keychain changed), which the service maps to a "needs re-entry" provider state.
+const decryptKey = (keyRef: string): string => {
+  if (!keyRef.startsWith(KEY_REF_PREFIX)) {
+    throw new Error('Malformed key reference.')
+  }
+
+  const ciphertext = Buffer.from(keyRef.slice(KEY_REF_PREFIX.length), 'base64')
+
+  return safeStorage.decryptString(ciphertext)
+}
+
+// Best-effort decrypt used where a missing key should degrade gracefully instead of throwing.
+const tryDecryptKey = (keyRef: string | undefined): string | undefined => {
+  if (!keyRef) return undefined
+
+  try {
+    return decryptKey(keyRef)
+  } catch {
+    return undefined
+  }
+}
+
+// Builds a non-secret display hint like "sk-a…wxyz". Short keys are collapsed to bullets so the
+// full value can never be reconstructed from the mask.
+const maskKey = (plaintext: string): string => {
+  const trimmed = plaintext.trim()
+
+  if (trimmed.length === 0) return ''
+  if (trimmed.length <= 8) return '•'.repeat(trimmed.length)
+
+  return `${trimmed.slice(0, 4)}…${trimmed.slice(-4)}`
+}
+
+export { KEY_REF_PREFIX, decryptKey, encryptKey, isEncryptionAvailable, maskKey, tryDecryptKey }

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SettingsService } from './service'
+
+// Capture every ipcMain.handle registration so handlers can be invoked directly in the test.
+const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown, payload: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }
+  },
+  BrowserWindow: { getAllWindows: () => [] }
+}))
+
+const { registerSettingsIpcHandlers } = await import('./ipc')
+
+// A fake service whose methods are all spies; cast to SettingsService only when registering handlers.
+type FakeSettingsService = Record<
+  | 'getPreflight'
+  | 'getSettingsView'
+  | 'isEncryptionAvailable'
+  | 'isNpmAvailable'
+  | 'detectClaude'
+  | 'installClaude'
+  | 'upsertProvider'
+  | 'deleteProvider'
+  | 'setActiveProvider'
+  | 'validateProvider',
+  ReturnType<typeof vi.fn>
+>
+
+const createFakeService = (): FakeSettingsService => ({
+  getPreflight: vi.fn().mockResolvedValue({ claudeReady: true, activeProviderReady: true }),
+  getSettingsView: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
+  isEncryptionAvailable: vi.fn().mockReturnValue(true),
+  isNpmAvailable: vi.fn().mockResolvedValue(true),
+  detectClaude: vi.fn().mockResolvedValue({ found: false }),
+  installClaude: vi.fn().mockResolvedValue({ installId: 'i', ok: true }),
+  upsertProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
+  deleteProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
+  setActiveProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
+  validateProvider: vi.fn().mockResolvedValue({ ok: true, category: 'ok' })
+})
+
+// Adapts the spy bag into the SettingsService shape the registration function expects.
+const asService = (fake: FakeSettingsService): SettingsService => fake as unknown as SettingsService
+
+const invoke = (channel: string, payload?: unknown): unknown =>
+  handlers.get(channel)!(undefined, payload)
+
+describe('settings IPC handlers', () => {
+  it('registers every settings channel', () => {
+    handlers.clear()
+    registerSettingsIpcHandlers({ service: asService(createFakeService()) })
+
+    for (const channel of [
+      'settings:get-preflight',
+      'settings:get-settings',
+      'settings:encryption-available',
+      'settings:npm-available',
+      'settings:detect-claude',
+      'settings:install-claude',
+      'settings:upsert-provider',
+      'settings:delete-provider',
+      'settings:set-active-provider',
+      'settings:validate-provider'
+    ]) {
+      expect(handlers.has(channel)).toBe(true)
+    }
+  })
+
+  it('routes provider commands to the service', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    registerSettingsIpcHandlers({ service: asService(service) })
+
+    await invoke('settings:upsert-provider', { type: 'custom', name: 'G' })
+    expect(service.upsertProvider).toHaveBeenCalledWith({ type: 'custom', name: 'G' })
+
+    await invoke('settings:delete-provider', { id: 'p1' })
+    expect(service.deleteProvider).toHaveBeenCalledWith('p1')
+
+    await invoke('settings:validate-provider', { providerId: 'p1' })
+    expect(service.validateProvider).toHaveBeenCalledWith({ providerId: 'p1' })
+  })
+
+  it('drops the agent connection when the active provider changes', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const onActiveProviderChanged = vi.fn()
+    registerSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+
+    await invoke('settings:set-active-provider', { id: 'p1' })
+
+    expect(service.setActiveProvider).toHaveBeenCalledWith('p1')
+    expect(onActiveProviderChanged).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -1,0 +1,68 @@
+import { BrowserWindow, ipcMain } from 'electron'
+
+import type {
+  DeleteProviderRequest,
+  InstallClaudeRequest,
+  SetActiveProviderRequest,
+  UpsertProviderRequest,
+  ValidateProviderRequest
+} from '../../shared/settings'
+import { createDefaultSettingsService, SettingsService } from './service'
+
+// IPC channel names for the settings/onboarding surface. Kept together so preload and main agree.
+const SETTINGS_INSTALL_LOG_CHANNEL = 'settings:install-log'
+
+export type SettingsIpcOptions = {
+  service?: SettingsService
+  // Called after the active provider changes so the ACP runtime can drop its stale connection.
+  onActiveProviderChanged?: () => void
+}
+
+// Streams one install log line to every open renderer window.
+const broadcastInstallLog = (payload: unknown): void => {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(SETTINGS_INSTALL_LOG_CHANNEL, payload)
+    }
+  }
+}
+
+// Registers renderer-callable settings commands. Secret handling stays entirely in the service; the
+// handlers only marshal typed requests and forward install log streaming.
+const registerSettingsIpcHandlers = ({
+  service = createDefaultSettingsService(),
+  onActiveProviderChanged
+}: SettingsIpcOptions = {}): void => {
+  ipcMain.handle('settings:get-preflight', () => service.getPreflight())
+  ipcMain.handle('settings:get-settings', () => service.getSettingsView())
+  ipcMain.handle('settings:encryption-available', () => service.isEncryptionAvailable())
+  ipcMain.handle('settings:npm-available', () => service.isNpmAvailable())
+  ipcMain.handle('settings:detect-claude', () => service.detectClaude())
+
+  ipcMain.handle('settings:install-claude', (_event, request: InstallClaudeRequest) =>
+    service.installClaude(request, broadcastInstallLog)
+  )
+
+  ipcMain.handle('settings:upsert-provider', (_event, request: UpsertProviderRequest) =>
+    service.upsertProvider(request)
+  )
+  ipcMain.handle('settings:delete-provider', (_event, request: DeleteProviderRequest) =>
+    service.deleteProvider(request.id)
+  )
+  ipcMain.handle(
+    'settings:set-active-provider',
+    async (_event, request: SetActiveProviderRequest) => {
+      const snapshot = await service.setActiveProvider(request.id)
+
+      // Switching providers requires a fresh agent process so the new credentials take effect.
+      onActiveProviderChanged?.()
+
+      return snapshot
+    }
+  )
+  ipcMain.handle('settings:validate-provider', (_event, request: ValidateProviderRequest) =>
+    service.validateProvider(request)
+  )
+}
+
+export { SETTINGS_INSTALL_LOG_CHANNEL, registerSettingsIpcHandlers }

--- a/src/main/settings/preflight.test.ts
+++ b/src/main/settings/preflight.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { computePreflight } from './preflight'
+import type { StoredProvider, StoredSettings } from './types'
+
+const customProvider: StoredProvider = {
+  id: 'p1',
+  type: 'custom',
+  name: 'Gateway',
+  keyRef: 'enc:abc',
+  lastValidatedAt: 100
+}
+
+const baseSettings = (overrides: Partial<StoredSettings> = {}): StoredSettings => ({
+  version: 1,
+  claude: { resolvedPath: '/bin/claude' },
+  providers: [customProvider],
+  activeProviderId: 'p1',
+  ...overrides
+})
+
+const alwaysUsable = (): boolean => true
+
+describe('computePreflight', () => {
+  it('is fully ready when claude exists and the active provider validated with a usable key', () => {
+    expect(
+      computePreflight({
+        settings: baseSettings(),
+        claudePathExists: true,
+        isProviderKeyUsable: alwaysUsable
+      })
+    ).toEqual({ claudeReady: true, activeProviderReady: true })
+  })
+
+  it('is not claude-ready when the recorded path no longer exists', () => {
+    const result = computePreflight({
+      settings: baseSettings(),
+      claudePathExists: false,
+      isProviderKeyUsable: alwaysUsable
+    })
+
+    expect(result.claudeReady).toBe(false)
+  })
+
+  it('is not claude-ready when no path was ever recorded', () => {
+    const result = computePreflight({
+      settings: baseSettings({ claude: {} }),
+      claudePathExists: false,
+      isProviderKeyUsable: alwaysUsable
+    })
+
+    expect(result.claudeReady).toBe(false)
+  })
+
+  it('is not provider-ready without an active provider', () => {
+    const result = computePreflight({
+      settings: baseSettings({ activeProviderId: undefined }),
+      claudePathExists: true,
+      isProviderKeyUsable: alwaysUsable
+    })
+
+    expect(result.activeProviderReady).toBe(false)
+  })
+
+  it('is not provider-ready when the active provider never validated', () => {
+    const result = computePreflight({
+      settings: baseSettings({ providers: [{ ...customProvider, lastValidatedAt: undefined }] }),
+      claudePathExists: true,
+      isProviderKeyUsable: alwaysUsable
+    })
+
+    expect(result.activeProviderReady).toBe(false)
+  })
+
+  it('is not provider-ready when the active provider key is unusable', () => {
+    const result = computePreflight({
+      settings: baseSettings(),
+      claudePathExists: true,
+      isProviderKeyUsable: () => false
+    })
+
+    expect(result.activeProviderReady).toBe(false)
+  })
+})

--- a/src/main/settings/preflight.ts
+++ b/src/main/settings/preflight.ts
@@ -1,0 +1,37 @@
+import type { Preflight } from '../../shared/settings'
+import type { StoredProvider, StoredSettings } from './types'
+
+// Pure computation of the two startup gates from stored settings plus a couple of injected checks.
+// Kept free of Electron so the gating matrix is unit-testable in isolation.
+
+export type PreflightInput = {
+  settings: StoredSettings
+  // Whether the recorded claude executable still exists/executes (light re-check each launch).
+  claudePathExists: boolean
+  // Whether a provider's credentials are usable (claude-default is always true; custom must decrypt).
+  isProviderKeyUsable: (provider: StoredProvider) => boolean
+}
+
+// Applies the design's gating rules: claude must be present, and an active provider must exist,
+// have validated at least once, and have usable credentials.
+const computePreflight = ({
+  settings,
+  claudePathExists,
+  isProviderKeyUsable
+}: PreflightInput): Preflight => {
+  const claudeReady = Boolean(settings.claude?.resolvedPath) && claudePathExists
+
+  const activeProvider = settings.activeProviderId
+    ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
+    : undefined
+
+  const activeProviderReady = Boolean(
+    activeProvider &&
+    activeProvider.lastValidatedAt !== undefined &&
+    isProviderKeyUsable(activeProvider)
+  )
+
+  return { claudeReady, activeProviderReady }
+}
+
+export { computePreflight }

--- a/src/main/settings/provider-env.test.ts
+++ b/src/main/settings/provider-env.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildProviderEnv, getIsolatedClaudeConfigDir } from './provider-env'
+
+const options = { storageRoot: '/root', claudeExecutablePath: '/bin/claude' }
+
+describe('provider-env', () => {
+  it('builds isolated env for a custom provider (always bearer)', () => {
+    const env = buildProviderEnv(
+      {
+        type: 'custom',
+        baseUrl: 'https://gateway.example/v1',
+        model: 'claude-sonnet-4-5',
+        key: 'secret-token'
+      },
+      options
+    )
+
+    expect(env).toEqual({
+      CLAUDE_CODE_EXECUTABLE: '/bin/claude',
+      ANTHROPIC_BASE_URL: 'https://gateway.example/v1',
+      ANTHROPIC_AUTH_TOKEN: 'secret-token',
+      ANTHROPIC_MODEL: 'claude-sonnet-4-5',
+      CLAUDE_CONFIG_DIR: getIsolatedClaudeConfigDir('/root')
+    })
+    // Custom providers never use x-api-key; the key is always sent as a bearer token.
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined()
+  })
+
+  it('omits base URL and isolated config dir for claude-default with a model override', () => {
+    const env = buildProviderEnv({ type: 'claude-default', model: 'claude-opus' }, options)
+
+    expect(env).toEqual({
+      CLAUDE_CODE_EXECUTABLE: '/bin/claude',
+      ANTHROPIC_MODEL: 'claude-opus'
+    })
+    expect(env.ANTHROPIC_BASE_URL).toBeUndefined()
+    expect(env.CLAUDE_CONFIG_DIR).toBeUndefined()
+  })
+
+  it('omits the model for claude-default when none is set', () => {
+    const env = buildProviderEnv({ type: 'claude-default' }, options)
+
+    expect(env).toEqual({ CLAUDE_CODE_EXECUTABLE: '/bin/claude' })
+    expect(env.ANTHROPIC_MODEL).toBeUndefined()
+  })
+})

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -1,0 +1,57 @@
+import { join } from 'node:path'
+
+import type { ProviderType } from '../../shared/settings'
+
+// Resolves an active provider into the environment overrides that the ACP agent (and the claude
+// binary it spawns) read. Pure and free of Electron so the branch matrix stays unit-testable.
+
+// A provider resolved for spawning: the plaintext key is already decrypted by the caller.
+export type ResolvedProvider = {
+  type: ProviderType
+  baseUrl?: string
+  model?: string
+  key?: string
+}
+
+export type ProviderEnvOptions = {
+  // App storage root; custom providers get an isolated CLAUDE_CONFIG_DIR beneath it.
+  storageRoot: string
+  // Absolute path to the detected claude executable.
+  claudeExecutablePath: string
+}
+
+// The private config directory a custom provider uses so app runs never touch (or inherit) the
+// user's own ~/.claude auth. claude-default deliberately omits this to reuse the user's config.
+const getIsolatedClaudeConfigDir = (storageRoot: string): string => join(storageRoot, 'claude')
+
+// Builds spawn env overrides for one provider. Empty/omitted fields are simply not set so callers
+// can merge this over process.env without erasing unrelated variables.
+const buildProviderEnv = (
+  provider: ResolvedProvider,
+  { storageRoot, claudeExecutablePath }: ProviderEnvOptions
+): Record<string, string> => {
+  const env: Record<string, string> = {
+    CLAUDE_CODE_EXECUTABLE: claudeExecutablePath
+  }
+
+  // claude-default reuses the user's own ~/.claude auth: only an optional model override applies.
+  if (provider.type === 'claude-default') {
+    if (provider.model) env.ANTHROPIC_MODEL = provider.model
+
+    return env
+  }
+
+  // custom providers are fully isolated: gateway URL, key, model, and a private config directory.
+  if (provider.baseUrl) env.ANTHROPIC_BASE_URL = provider.baseUrl
+
+  // Custom gateways authenticate with a bearer token (ANTHROPIC_AUTH_TOKEN).
+  if (provider.key) env.ANTHROPIC_AUTH_TOKEN = provider.key
+
+  if (provider.model) env.ANTHROPIC_MODEL = provider.model
+
+  env.CLAUDE_CONFIG_DIR = getIsolatedClaudeConfigDir(storageRoot)
+
+  return env
+}
+
+export { buildProviderEnv, getIsolatedClaudeConfigDir }

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -1,0 +1,129 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { SettingsRepository } from './repository'
+import type { StoredProvider } from './types'
+
+let storageRoot: string | undefined
+
+const createStorageRoot = async (): Promise<string> => {
+  storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-'))
+  return storageRoot
+}
+
+const provider = (overrides: Partial<StoredProvider> = {}): StoredProvider => ({
+  id: 'p1',
+  type: 'custom',
+  name: 'Gateway',
+  baseUrl: 'https://g/v1',
+  model: 'm',
+  keyRef: 'enc:abc',
+  keyMask: 'sk-…abcd',
+  ...overrides
+})
+
+afterEach(async () => {
+  if (storageRoot) {
+    await rm(storageRoot, { recursive: true, force: true })
+    storageRoot = undefined
+  }
+})
+
+describe('settings repository', () => {
+  it('returns empty settings when nothing is stored yet', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+
+    await expect(repository.getSettings()).resolves.toEqual({ version: 1, providers: [] })
+  })
+
+  it('writes settings.json atomically and reads it back', async () => {
+    const root = await createStorageRoot()
+    const repository = new SettingsRepository(root)
+
+    await repository.setClaudeInfo({ resolvedPath: '/bin/claude', version: '2.1.0' })
+    await repository.upsertProvider(provider())
+
+    const raw = JSON.parse(await readFile(join(root, 'settings.json'), 'utf8')) as {
+      version: number
+    }
+    expect(raw.version).toBe(1)
+
+    const settings = await repository.getSettings()
+    expect(settings.claude).toEqual({ resolvedPath: '/bin/claude', version: '2.1.0' })
+    expect(settings.providers).toHaveLength(1)
+    expect(settings.providers[0]).toMatchObject({ id: 'p1', keyRef: 'enc:abc' })
+  })
+
+  it('replaces a provider in place on upsert by id', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+
+    await repository.upsertProvider(provider({ name: 'First' }))
+    await repository.upsertProvider(provider({ name: 'Renamed' }))
+
+    const settings = await repository.getSettings()
+    expect(settings.providers).toHaveLength(1)
+    expect(settings.providers[0].name).toBe('Renamed')
+  })
+
+  it('clears the active pointer when the active provider is deleted', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+
+    await repository.upsertProvider(provider())
+    await repository.setActiveProvider('p1')
+    expect((await repository.getSettings()).activeProviderId).toBe('p1')
+
+    await repository.deleteProvider('p1')
+    const settings = await repository.getSettings()
+    expect(settings.providers).toEqual([])
+    expect(settings.activeProviderId).toBeUndefined()
+  })
+
+  it('ignores an active pointer that references an unknown provider', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+
+    await repository.upsertProvider(provider())
+    await repository.setActiveProvider('does-not-exist')
+
+    expect((await repository.getSettings()).activeProviderId).toBeUndefined()
+  })
+
+  it('drops unknown fields and invalid providers on load', async () => {
+    const root = await createStorageRoot()
+    const repository = new SettingsRepository(root)
+
+    await writeFile(
+      join(root, 'settings.json'),
+      JSON.stringify({
+        version: 1,
+        activeProviderId: 'p1',
+        claude: { resolvedPath: '/bin/claude', junk: 'drop' },
+        providers: [
+          { id: 'p1', type: 'custom', name: 'Ok', secretPlaintext: 'should not persist' },
+          { id: 'p2', type: 'not-a-type', name: 'Bad' },
+          { type: 'custom', name: 'No id' }
+        ]
+      }),
+      'utf8'
+    )
+
+    const settings = await repository.getSettings()
+    expect(settings.providers.map((item) => item.id)).toEqual(['p1'])
+    expect(settings.providers[0]).not.toHaveProperty('secretPlaintext')
+    expect(settings.claude).toEqual({ resolvedPath: '/bin/claude' })
+  })
+
+  it('serializes concurrent mutations without losing writes', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+
+    await Promise.all([
+      repository.upsertProvider(provider({ id: 'p1', name: 'One' })),
+      repository.upsertProvider(provider({ id: 'p2', name: 'Two' })),
+      repository.upsertProvider(provider({ id: 'p3', name: 'Three' }))
+    ])
+
+    const settings = await repository.getSettings()
+    expect(settings.providers.map((item) => item.id).sort()).toEqual(['p1', 'p2', 'p3'])
+  })
+})

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -1,0 +1,181 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { ClaudeInfo, ProviderType } from '../../shared/settings'
+import { SETTINGS_FILE_VERSION } from '../../shared/settings'
+import { createEmptySettings, type StoredProvider, type StoredSettings } from './types'
+
+const SETTINGS_FILE = 'settings.json'
+
+const PROVIDER_TYPES = new Set<ProviderType>(['custom', 'claude-default'])
+
+// Checks for plain JSON objects so untrusted settings payloads can be sanitized safely.
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined
+
+// Rebuilds claude metadata from allowed fields only.
+const sanitizeClaudeInfo = (value: unknown): ClaudeInfo | undefined => {
+  if (!isRecord(value)) return undefined
+
+  const info: ClaudeInfo = {}
+  const resolvedPath = asString(value.resolvedPath)
+  const version = asString(value.version)
+
+  if (resolvedPath) info.resolvedPath = resolvedPath
+  if (version) info.version = version
+
+  return Object.keys(info).length > 0 ? info : undefined
+}
+
+// Rebuilds one provider record, dropping unknown fields and records missing required identity.
+const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
+  if (!isRecord(value)) return undefined
+
+  const id = asString(value.id)
+  const type = asString(value.type) as ProviderType | undefined
+  const name = asString(value.name)
+
+  if (!id || !type || !PROVIDER_TYPES.has(type) || name === undefined) return undefined
+
+  const provider: StoredProvider = { id, type, name }
+  const baseUrl = asString(value.baseUrl)
+  const model = asString(value.model)
+  const keyRef = asString(value.keyRef)
+  const keyMask = asString(value.keyMask)
+  const lastValidatedAt = asNumber(value.lastValidatedAt)
+
+  if (baseUrl) provider.baseUrl = baseUrl
+  if (model) provider.model = model
+  if (keyRef) provider.keyRef = keyRef
+  if (keyMask) provider.keyMask = keyMask
+  if (lastValidatedAt !== undefined) provider.lastValidatedAt = lastValidatedAt
+
+  return provider
+}
+
+// Rebuilds the whole settings document, keeping activeProviderId only when it points at a provider.
+const sanitizeSettings = (value: unknown): StoredSettings => {
+  if (!isRecord(value)) return createEmptySettings()
+
+  const providers = Array.isArray(value.providers)
+    ? value.providers
+        .map(sanitizeProvider)
+        .filter((provider): provider is StoredProvider => !!provider)
+    : []
+  const settings: StoredSettings = {
+    version: SETTINGS_FILE_VERSION,
+    providers
+  }
+  const claude = sanitizeClaudeInfo(value.claude)
+  const activeProviderId = asString(value.activeProviderId)
+
+  if (claude) settings.claude = claude
+  if (activeProviderId && providers.some((provider) => provider.id === activeProviderId)) {
+    settings.activeProviderId = activeProviderId
+  }
+
+  return settings
+}
+
+// Owns durable reads/writes of the single settings.json document. Writes are serialized through a
+// queue and made atomic (temp + rename); an unreadable file falls back to empty settings so the app
+// still boots into onboarding. All secret handling lives above this layer (crypto.ts / service.ts);
+// the repository only persists whatever records it is given.
+class SettingsRepository {
+  private saveQueue: Promise<void> = Promise.resolve()
+  private writeSequence = 0
+
+  constructor(private readonly storageDir: string) {}
+
+  private get settingsPath(): string {
+    return join(this.storageDir, SETTINGS_FILE)
+  }
+
+  // Reads and sanitizes the settings document, returning empty settings when nothing is stored yet.
+  async getSettings(): Promise<StoredSettings> {
+    try {
+      const raw = await readFile(this.settingsPath, 'utf8')
+
+      return sanitizeSettings(JSON.parse(raw) as unknown)
+    } catch {
+      return createEmptySettings()
+    }
+  }
+
+  // Inserts or replaces a provider by id, then returns the persisted document.
+  async upsertProvider(provider: StoredProvider): Promise<StoredSettings> {
+    return this.mutate((settings) => {
+      const providers = settings.providers.filter((existing) => existing.id !== provider.id)
+
+      providers.push(provider)
+
+      return { ...settings, providers }
+    })
+  }
+
+  // Removes a provider and clears the active pointer when it referenced the removed provider.
+  async deleteProvider(id: string): Promise<StoredSettings> {
+    return this.mutate((settings) => {
+      const providers = settings.providers.filter((provider) => provider.id !== id)
+      const activeProviderId =
+        settings.activeProviderId === id ? undefined : settings.activeProviderId
+
+      return { ...settings, providers, activeProviderId }
+    })
+  }
+
+  // Sets (or clears) the single active provider pointer, ignoring ids that do not exist.
+  async setActiveProvider(id: string | undefined): Promise<StoredSettings> {
+    return this.mutate((settings) => {
+      if (id !== undefined && !settings.providers.some((provider) => provider.id === id)) {
+        return settings
+      }
+
+      return { ...settings, activeProviderId: id }
+    })
+  }
+
+  // Records the detected claude executable metadata for later spawns.
+  async setClaudeInfo(claude: ClaudeInfo): Promise<StoredSettings> {
+    return this.mutate((settings) => ({ ...settings, claude }))
+  }
+
+  // Serializes a read-modify-write cycle so concurrent callers cannot clobber each other.
+  private mutate(update: (settings: StoredSettings) => StoredSettings): Promise<StoredSettings> {
+    const run = this.saveQueue.then(async () => {
+      const current = await this.getSettings()
+      const next = update(current)
+
+      await this.writeSettings(next)
+
+      return next
+    })
+
+    // Keep the queue chained even when a write rejects so later mutations still run.
+    this.saveQueue = run.then(
+      () => undefined,
+      () => undefined
+    )
+
+    return run
+  }
+
+  // Writes through a unique temp file, then atomically replaces settings.json.
+  private async writeSettings(settings: StoredSettings): Promise<void> {
+    await mkdir(this.storageDir, { recursive: true })
+
+    this.writeSequence += 1
+    const temporaryPath = `${this.settingsPath}.${Date.now()}-${this.writeSequence}.tmp`
+
+    await writeFile(temporaryPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
+    await rename(temporaryPath, this.settingsPath)
+  }
+}
+
+export { SettingsRepository, sanitizeSettings }

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1,0 +1,241 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { execPath } from 'node:process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Reversible fake safeStorage so provider keys can be encrypted/decrypted without an OS keychain.
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`cipher:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => {
+      const decoded = buffer.toString('utf8')
+
+      if (!decoded.startsWith('cipher:')) throw new Error('bad ciphertext')
+
+      return decoded.slice('cipher:'.length)
+    }
+  },
+  app: { getPath: () => '/home', isPackaged: false }
+}))
+
+const { SettingsService } = await import('./service')
+const { SettingsRepository } = await import('./repository')
+const { getIsolatedClaudeConfigDir } = await import('./provider-env')
+
+let storageRoot: string
+let repository: InstanceType<typeof SettingsRepository>
+
+const createService = (
+  detectResult = { found: true, path: '/bin/claude', version: '2.1.0' }
+): InstanceType<typeof SettingsService> =>
+  new SettingsService({
+    repository,
+    storageRoot,
+    detectDeps: {
+      env: {},
+      homePath: '/home',
+      isExecutable: () => Promise.resolve(true),
+      getVersion: () => Promise.resolve(detectResult.version),
+      resolveNpmBinDirs: () => Promise.resolve([])
+    }
+  })
+
+beforeEach(async () => {
+  storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-service-'))
+  repository = new SettingsRepository(storageRoot)
+})
+
+afterEach(async () => {
+  vi.unstubAllGlobals()
+  await rm(storageRoot, { recursive: true, force: true })
+})
+
+describe('SettingsService: providers', () => {
+  it('encrypts the key on upsert and never exposes plaintext in the view', async () => {
+    const service = createService()
+
+    const snapshot = await service.upsertProvider({
+      type: 'custom',
+      name: 'Gateway',
+      baseUrl: 'https://g/v1',
+      model: 'm',
+      key: 'sk-super-secret'
+    })
+
+    const view = snapshot.providers[0]
+    expect(view.hasKey).toBe(true)
+    expect(view.maskedKey).toBe('sk-s…cret')
+    expect(JSON.stringify(view)).not.toContain('sk-super-secret')
+
+    // The stored record holds ciphertext, not the plaintext key.
+    const stored = (await repository.getSettings()).providers[0]
+    expect(stored.keyRef?.startsWith('enc:')).toBe(true)
+    expect(JSON.stringify(stored)).not.toContain('sk-super-secret')
+  })
+
+  it('keeps the stored key when an edit omits a new key', async () => {
+    const service = createService()
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k1'
+      })
+    ).providers[0]
+
+    await service.upsertProvider({ id: created.id, type: 'custom', name: 'Renamed' })
+
+    const stored = (await repository.getSettings()).providers[0]
+    expect(stored.name).toBe('Renamed')
+    expect(stored.keyRef).toBeDefined()
+  })
+
+  it('rejects an incomplete custom provider and never persists it', async () => {
+    const service = createService()
+
+    // Missing base URL / model / key each block the save with a clear error.
+    await expect(
+      service.upsertProvider({ type: 'custom', name: 'No base URL', model: 'm', key: 'k' })
+    ).rejects.toThrow(/base url is required/i)
+    await expect(
+      service.upsertProvider({
+        type: 'custom',
+        name: 'No model',
+        baseUrl: 'https://g/v1',
+        key: 'k'
+      })
+    ).rejects.toThrow(/model is required/i)
+    await expect(
+      service.upsertProvider({
+        type: 'custom',
+        name: 'No key',
+        baseUrl: 'https://g/v1',
+        model: 'm'
+      })
+    ).rejects.toThrow(/api key is required/i)
+
+    // None of the rejected drafts reached disk.
+    expect((await repository.getSettings()).providers).toEqual([])
+  })
+
+  it('allows a claude-default provider with no key or base URL', async () => {
+    const service = createService()
+
+    const snapshot = await service.upsertProvider({ type: 'claude-default', name: 'Local Claude' })
+
+    expect(snapshot.providers).toHaveLength(1)
+    expect(snapshot.providers[0]).toMatchObject({ type: 'claude-default', hasKey: false })
+    expect(snapshot.providers[0].baseUrl).toBeUndefined()
+  })
+})
+
+describe('SettingsService: validation', () => {
+  it('records lastValidatedAt for a saved provider on success', async () => {
+    const service = createService()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200 }))
+
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+
+    const result = await service.validateProvider({ providerId: created.id })
+
+    expect(result.ok).toBe(true)
+    expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeGreaterThan(0)
+  })
+
+  it('does not record validation on failure', async () => {
+    const service = createService()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 401 }))
+
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+
+    const result = await service.validateProvider({ providerId: created.id })
+
+    expect(result).toMatchObject({ ok: false, category: 'auth' })
+    expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeUndefined()
+  })
+})
+
+describe('SettingsService: preflight & spawn config', () => {
+  it('gates on a detected claude and a validated active provider', async () => {
+    const service = createService()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200 }))
+
+    // Seed an existing executable path so the launch re-check passes.
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+
+    // Before validation/activation the provider gate is closed.
+    expect(await service.getPreflight()).toMatchObject({
+      claudeReady: true,
+      activeProviderReady: false
+    })
+
+    await service.validateProvider({ providerId: created.id })
+    await service.setActiveProvider(created.id)
+
+    expect(await service.getPreflight()).toEqual({ claudeReady: true, activeProviderReady: true })
+  })
+
+  it('builds spawn env from the active provider with the decrypted key', async () => {
+    const service = createService()
+
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'sk-key'
+      })
+    ).providers[0]
+    await service.setActiveProvider(created.id)
+
+    const config = await service.resolveActiveSpawnConfig()
+
+    expect(config.executablePath).toBe(execPath)
+    expect(config.envOverrides).toMatchObject({
+      ANTHROPIC_BASE_URL: 'https://g/v1',
+      ANTHROPIC_AUTH_TOKEN: 'sk-key',
+      ANTHROPIC_MODEL: 'm',
+      CLAUDE_CONFIG_DIR: getIsolatedClaudeConfigDir(storageRoot)
+    })
+    // Custom providers always use the bearer token variable, never x-api-key.
+    expect(config.envOverrides.ANTHROPIC_API_KEY).toBeUndefined()
+  })
+
+  it('throws a clear error when no active provider is configured', async () => {
+    const service = createService()
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+
+    await expect(service.resolveActiveSpawnConfig()).rejects.toThrow(/active model provider/i)
+  })
+})

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1,0 +1,368 @@
+import { execFile } from 'node:child_process'
+import { access } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { promisify } from 'node:util'
+
+import type {
+  ClaudeDetectResult,
+  ClaudeInstallLogEvent,
+  ClaudeInstallResult,
+  InstallClaudeRequest,
+  Preflight,
+  ProviderView,
+  SettingsSnapshot,
+  UpsertProviderRequest,
+  ValidateProviderRequest,
+  ValidateProviderResult
+} from '../../shared/settings'
+import { resolveStorageRoot } from '../storage-root'
+import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
+import { detectNpmAvailable, runInstall } from './claude-install'
+import { encryptKey, isEncryptionAvailable, maskKey, tryDecryptKey } from './crypto'
+import { computePreflight } from './preflight'
+import { buildProviderEnv, type ResolvedProvider } from './provider-env'
+import { SettingsRepository } from './repository'
+import type { StoredProvider, StoredSettings } from './types'
+import { validateProvider, type ClaudeProbeResult } from './validate'
+
+const execFileAsync = promisify(execFile)
+
+// Hard ceiling for the claude-default probe so a stuck local claude can never hang the wizard.
+const CLAUDE_PROBE_TIMEOUT_MS = 20_000
+
+// Detects a child-process timeout (SIGTERM kill or ETIMEDOUT) so the probe can report it distinctly.
+const isTimeoutError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) return false
+
+  const candidate = error as { killed?: boolean; signal?: string; code?: string }
+
+  return (
+    candidate.killed === true || candidate.signal === 'SIGTERM' || candidate.code === 'ETIMEDOUT'
+  )
+}
+
+// A spawn configuration the ACP runtime reads at connect time so the active provider's credentials
+// are always current.
+export type AgentSpawnConfig = {
+  envOverrides: Record<string, string>
+  executablePath: string
+}
+
+export type SettingsServiceOptions = {
+  repository?: SettingsRepository
+  storageRoot?: string
+  detectDeps?: ClaudeDetectDeps
+}
+
+// Orchestrates the settings units (repository + crypto + detect/install + validate) behind one
+// object shared by the settings IPC handlers and the ACP runtime. Secrets are decrypted here only
+// transiently; nothing that leaves this object (views, spawn config aside) carries plaintext.
+class SettingsService {
+  private readonly repository: SettingsRepository
+  private readonly storageRoot: string
+  private readonly detectDeps: ClaudeDetectDeps
+  private providerSequence = 0
+
+  constructor(options: SettingsServiceOptions = {}) {
+    this.storageRoot = options.storageRoot ?? resolveStorageRoot()
+    this.repository = options.repository ?? new SettingsRepository(this.storageRoot)
+    this.detectDeps = options.detectDeps ?? createDefaultDetectDeps()
+  }
+
+  // Returns the renderer-safe (masked) snapshot of settings.
+  async getSettingsView(): Promise<SettingsSnapshot> {
+    const settings = await this.repository.getSettings()
+
+    return {
+      claude: settings.claude ?? {},
+      activeProviderId: settings.activeProviderId,
+      providers: settings.providers.map((provider) => this.toProviderView(provider))
+    }
+  }
+
+  // Computes the two startup gates, re-checking the claude path each call as the design requires.
+  async getPreflight(): Promise<Preflight> {
+    const settings = await this.repository.getSettings()
+    const claudePathExists = settings.claude?.resolvedPath
+      ? await this.pathExists(settings.claude.resolvedPath)
+      : false
+
+    return computePreflight({
+      settings,
+      claudePathExists,
+      isProviderKeyUsable: (provider) => this.isProviderKeyUsable(provider)
+    })
+  }
+
+  // Detects claude and persists the resolved path/version for later spawns.
+  async detectClaude(): Promise<ClaudeDetectResult> {
+    const result = await detectClaude(this.detectDeps)
+
+    if (result.found && result.path) {
+      await this.repository.setClaudeInfo({ resolvedPath: result.path, version: result.version })
+    }
+
+    return result
+  }
+
+  // Runs the one-click installer, then re-detects claude so a success immediately unblocks the gate.
+  async installClaude(
+    request: InstallClaudeRequest,
+    onLog: (event: ClaudeInstallLogEvent) => void
+  ): Promise<ClaudeInstallResult> {
+    this.providerSequence += 1
+    const installId = `install-${Date.now()}-${this.providerSequence}`
+    const result = await runInstall({ source: request.source, installId, onLog })
+
+    if (result.ok) {
+      await this.detectClaude()
+    }
+
+    return result
+  }
+
+  // Encrypts any new key, recomputes its mask, and inserts/updates the provider record.
+  async upsertProvider(request: UpsertProviderRequest): Promise<SettingsSnapshot> {
+    const settings = await this.repository.getSettings()
+    const existing = request.id
+      ? settings.providers.find((provider) => provider.id === request.id)
+      : undefined
+
+    const provider: StoredProvider = {
+      id: existing?.id ?? this.createProviderId(),
+      type: request.type,
+      name: request.name?.trim() || existing?.name || 'Untitled provider'
+    }
+
+    // Model applies to both types (required for custom, optional override for claude-default).
+    const model = request.model?.trim() || existing?.model
+
+    if (request.type === 'custom') {
+      const baseUrl = request.baseUrl?.trim() || existing?.baseUrl
+      // A key is present if one is provided now or a ciphertext was stored earlier (edit case).
+      const hasKey = Boolean(request.key) || Boolean(existing?.keyRef)
+
+      // Required-field guard: never persist an incomplete custom provider, even if the UI is bypassed.
+      if (!baseUrl) throw new Error('Base URL is required for a custom provider.')
+      if (!model) throw new Error('Model is required for a custom provider.')
+      if (!hasKey) throw new Error('API key is required for a custom provider.')
+
+      provider.baseUrl = baseUrl
+
+      // A provided key is (re-)encrypted; an omitted key keeps the previously stored ciphertext.
+      if (request.key) {
+        provider.keyRef = encryptKey(request.key)
+        provider.keyMask = maskKey(request.key)
+      } else if (existing?.keyRef) {
+        provider.keyRef = existing.keyRef
+        provider.keyMask = existing.keyMask
+      }
+    }
+
+    if (model) provider.model = model
+
+    // Editing credentials invalidates a prior validation; a re-test is required before it re-gates.
+    const keyChanged = request.type === 'custom' && Boolean(request.key)
+
+    if (existing?.lastValidatedAt !== undefined && !keyChanged) {
+      provider.lastValidatedAt = existing.lastValidatedAt
+    }
+
+    await this.repository.upsertProvider(provider)
+
+    return this.getSettingsView()
+  }
+
+  async deleteProvider(id: string): Promise<SettingsSnapshot> {
+    await this.repository.deleteProvider(id)
+
+    return this.getSettingsView()
+  }
+
+  async setActiveProvider(id: string): Promise<SettingsSnapshot> {
+    await this.repository.setActiveProvider(id)
+
+    return this.getSettingsView()
+  }
+
+  // Validates a saved provider or an unsaved draft; on success for a saved provider records the time.
+  async validateProvider(request: ValidateProviderRequest): Promise<ValidateProviderResult> {
+    const settings = await this.repository.getSettings()
+    const resolved = this.resolveValidationTarget(request, settings)
+
+    if (!resolved) {
+      return { ok: false, category: 'unknown', message: 'No provider to validate.' }
+    }
+
+    const result = await validateProvider(resolved.provider, {
+      runClaudeProbe:
+        resolved.provider.type === 'claude-default'
+          ? () => this.runClaudeProbe(resolved.provider, settings)
+          : undefined
+    })
+
+    if (result.ok && resolved.storedId) {
+      await this.repository.upsertProvider({
+        ...settings.providers.find((provider) => provider.id === resolved.storedId)!,
+        lastValidatedAt: Date.now()
+      })
+    }
+
+    return result
+  }
+
+  // Reports whether the OS keychain is usable so the UI can warn before a save is attempted.
+  isEncryptionAvailable(): boolean {
+    return isEncryptionAvailable()
+  }
+
+  // Reports whether npm is on PATH so the installer UI can default to/enable the npm-mirror source.
+  async isNpmAvailable(): Promise<boolean> {
+    const { available } = await detectNpmAvailable()
+
+    return available
+  }
+
+  // Builds the spawn env for the active provider, read fresh so switching takes effect on reconnect.
+  async resolveActiveSpawnConfig(): Promise<AgentSpawnConfig> {
+    const settings = await this.repository.getSettings()
+    const executablePath = settings.claude?.resolvedPath
+
+    if (!executablePath) {
+      throw new Error('Claude executable is not configured. Complete onboarding in settings.')
+    }
+
+    const activeProvider = settings.activeProviderId
+      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
+      : undefined
+
+    if (!activeProvider) {
+      throw new Error('No active model provider is configured. Configure one in settings.')
+    }
+
+    const envOverrides = buildProviderEnv(this.resolveProvider(activeProvider), {
+      storageRoot: this.storageRoot,
+      claudeExecutablePath: executablePath
+    })
+
+    return { envOverrides, executablePath }
+  }
+
+  // Maps a stored provider to its masked renderer view, flagging custom keys that no longer decrypt.
+  private toProviderView(provider: StoredProvider): ProviderView {
+    const hasKey = Boolean(provider.keyRef)
+    const needsKey =
+      provider.type === 'custom' && hasKey && tryDecryptKey(provider.keyRef) === undefined
+
+    return {
+      id: provider.id,
+      type: provider.type,
+      name: provider.name,
+      baseUrl: provider.baseUrl,
+      model: provider.model,
+      maskedKey: provider.keyMask,
+      hasKey,
+      needsKey,
+      lastValidatedAt: provider.lastValidatedAt
+    }
+  }
+
+  // Credentials usable: claude-default always; custom needs a key that still decrypts.
+  private isProviderKeyUsable(provider: StoredProvider): boolean {
+    if (provider.type === 'claude-default') return true
+
+    return Boolean(provider.keyRef) && tryDecryptKey(provider.keyRef) !== undefined
+  }
+
+  // Decrypts a stored provider into the spawn/validation shape (plaintext key held only transiently).
+  private resolveProvider(provider: StoredProvider): ResolvedProvider {
+    return {
+      type: provider.type,
+      baseUrl: provider.baseUrl,
+      model: provider.model,
+      key: provider.keyRef ? tryDecryptKey(provider.keyRef) : undefined
+    }
+  }
+
+  // Resolves what validateProvider should probe: a stored provider (by id) or an inline draft.
+  private resolveValidationTarget(
+    request: ValidateProviderRequest,
+    settings: StoredSettings
+  ): { provider: ResolvedProvider; storedId?: string } | undefined {
+    if (request.providerId) {
+      const stored = settings.providers.find((provider) => provider.id === request.providerId)
+
+      return stored ? { provider: this.resolveProvider(stored), storedId: stored.id } : undefined
+    }
+
+    if (request.draft) {
+      return {
+        provider: {
+          type: request.draft.type,
+          baseUrl: request.draft.baseUrl,
+          model: request.draft.model,
+          key: request.draft.key
+        }
+      }
+    }
+
+    return undefined
+  }
+
+  // One-shot `claude -p "ok"` probe for claude-default validation, using the isolated/default env.
+  // One-shot `claude -p "ok"` probe for claude-default validation, using the isolated/default env. A
+  // hard timeout guarantees the wizard never hangs on a claude that never returns; a timeout is
+  // reported distinctly so the UI can say "timed out" rather than "auth failed".
+  private async runClaudeProbe(
+    provider: ResolvedProvider,
+    settings: StoredSettings
+  ): Promise<ClaudeProbeResult> {
+    const executablePath = settings.claude?.resolvedPath
+
+    if (!executablePath) {
+      return { ok: false, message: 'Claude executable is not configured.' }
+    }
+
+    const env = {
+      ...process.env,
+      ...buildProviderEnv(provider, {
+        storageRoot: this.storageRoot,
+        claudeExecutablePath: executablePath
+      })
+    }
+
+    try {
+      await execFileAsync(executablePath, ['-p', 'ok'], {
+        env,
+        timeout: CLAUDE_PROBE_TIMEOUT_MS
+      })
+
+      return { ok: true }
+    } catch (error) {
+      return isTimeoutError(error)
+        ? { ok: false, timedOut: true, message: 'Local claude did not respond in time.' }
+        : { ok: false, message: 'Local claude could not complete a request.' }
+    }
+  }
+
+  private createProviderId(): string {
+    this.providerSequence += 1
+
+    return `p_${Date.now()}_${this.providerSequence}`
+  }
+
+  private async pathExists(path: string): Promise<boolean> {
+    try {
+      await access(path, constants.X_OK)
+
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+
+// Production service rooted at the shared storage root with real detection dependencies.
+const createDefaultSettingsService = (): SettingsService => new SettingsService()
+
+export { SettingsService, createDefaultSettingsService }

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -1,0 +1,32 @@
+import type { ClaudeInfo, ProviderType } from '../../shared/settings'
+import { SETTINGS_FILE_VERSION } from '../../shared/settings'
+
+// Main-process-only stored shapes for settings.json. These carry the encrypted key reference and a
+// non-secret masked hint; the plaintext key never lives here (only transiently in service memory).
+
+// A single stored provider record. `keyRef` is a safeStorage ciphertext (see crypto.ts); `keyMask`
+// is a non-secret display hint recomputed whenever the key changes.
+export type StoredProvider = {
+  id: string
+  type: ProviderType
+  name: string
+  baseUrl?: string
+  model?: string
+  keyRef?: string
+  keyMask?: string
+  lastValidatedAt?: number
+}
+
+// The whole settings.json document.
+export type StoredSettings = {
+  version: typeof SETTINGS_FILE_VERSION
+  claude?: ClaudeInfo
+  activeProviderId?: string
+  providers: StoredProvider[]
+}
+
+// Canonical empty settings used for a first run or an unreadable file.
+export const createEmptySettings = (): StoredSettings => ({
+  version: SETTINGS_FILE_VERSION,
+  providers: []
+})

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  buildValidationRequest,
+  classifyFetchError,
+  classifyStatus,
+  validateProvider
+} from './validate'
+
+describe('validate: request construction', () => {
+  it('builds a bearer /v1/messages probe with anthropic-version and a 1-token body', () => {
+    const request = buildValidationRequest({
+      type: 'custom',
+      baseUrl: 'https://gateway.example/v1',
+      model: 'claude-sonnet-4-5',
+      key: 'tok'
+    })
+
+    expect(request.url).toBe('https://gateway.example/v1/v1/messages')
+    expect(request.headers.authorization).toBe('Bearer tok')
+    expect(request.headers['anthropic-version']).toBe('2023-06-01')
+    expect(JSON.parse(request.body)).toMatchObject({ model: 'claude-sonnet-4-5', max_tokens: 1 })
+  })
+
+  it('always authenticates with a bearer token and normalizes a trailing-slash base URL', () => {
+    const request = buildValidationRequest({
+      type: 'custom',
+      baseUrl: 'https://g/v1/',
+      key: 'k'
+    })
+
+    expect(request.headers.authorization).toBe('Bearer k')
+    // Custom providers never send an x-api-key header.
+    expect(request.headers['x-api-key']).toBeUndefined()
+    // A trailing slash on the base URL must not double up the slash before /v1/messages.
+    expect(request.url).toBe('https://g/v1/v1/messages')
+  })
+
+  it('throws for a missing or unparseable base URL', () => {
+    expect(() => buildValidationRequest({ type: 'custom' })).toThrow(/missing base url/i)
+    expect(() => buildValidationRequest({ type: 'custom', baseUrl: 'not a url' })).toThrow(
+      /invalid base url/i
+    )
+  })
+})
+
+describe('validate: classification', () => {
+  it('maps status codes to categories', () => {
+    expect(classifyStatus(200)).toBe('ok')
+    expect(classifyStatus(401)).toBe('auth')
+    expect(classifyStatus(403)).toBe('auth')
+    expect(classifyStatus(404)).toBe('model-not-found')
+    expect(classifyStatus(400)).toBe('model-not-found')
+    expect(classifyStatus(500)).toBe('unknown')
+  })
+
+  it('maps thrown errors to categories', () => {
+    const abort = new Error('aborted')
+    abort.name = 'AbortError'
+
+    expect(classifyFetchError(abort)).toBe('timeout')
+    expect(classifyFetchError(new Error('Invalid base URL.'))).toBe('bad-url')
+    expect(classifyFetchError(new Error('fetch failed'))).toBe('network')
+  })
+})
+
+describe('validate: provider dispatch', () => {
+  it('returns ok for a 200 custom response', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 200 } as Response)
+
+    const result = await validateProvider(
+      { type: 'custom', baseUrl: 'https://g/v1', key: 'k', model: 'm' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    )
+
+    expect(result).toMatchObject({ ok: true, category: 'ok', status: 200 })
+  })
+
+  it('classifies a 401 custom response as auth', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 401 } as Response)
+
+    const result = await validateProvider(
+      { type: 'custom', baseUrl: 'https://g/v1', key: 'k' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    )
+
+    expect(result).toMatchObject({ ok: false, category: 'auth', status: 401 })
+  })
+
+  it('classifies a thrown fetch as network', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('fetch failed'))
+
+    const result = await validateProvider(
+      { type: 'custom', baseUrl: 'https://g/v1', key: 'k' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    )
+
+    expect(result.category).toBe('network')
+  })
+
+  it('reports bad-url before any fetch is attempted', async () => {
+    const fetchImpl = vi.fn()
+
+    const result = await validateProvider(
+      { type: 'custom', baseUrl: 'nonsense' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    )
+
+    expect(result.category).toBe('bad-url')
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('runs the claude probe for claude-default providers', async () => {
+    const okResult = await validateProvider(
+      { type: 'claude-default' },
+      { runClaudeProbe: () => Promise.resolve({ ok: true }) }
+    )
+    const failResult = await validateProvider(
+      { type: 'claude-default' },
+      { runClaudeProbe: () => Promise.resolve({ ok: false }) }
+    )
+
+    expect(okResult).toMatchObject({ ok: true, category: 'ok' })
+    expect(failResult).toMatchObject({ ok: false, category: 'auth' })
+  })
+
+  it('classifies a claude-default probe timeout as timeout, not auth', async () => {
+    const result = await validateProvider(
+      { type: 'claude-default' },
+      { runClaudeProbe: () => Promise.resolve({ ok: false, timedOut: true }) }
+    )
+
+    expect(result).toMatchObject({ ok: false, category: 'timeout' })
+  })
+})

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -1,0 +1,180 @@
+import type { ValidateProviderResult, ValidationCategory } from '../../shared/settings'
+import type { ResolvedProvider } from './provider-env'
+
+// Runs a real connectivity/auth probe for a provider and classifies the outcome into an actionable
+// category. Request construction and classification are pure so the branch matrix is unit-testable;
+// the network/subprocess calls are injected.
+
+// Default probe timeout; a stuck gateway should fail fast rather than hang the wizard.
+const DEFAULT_VALIDATE_TIMEOUT_MS = 20_000
+const ANTHROPIC_VERSION = '2023-06-01'
+
+// A minimal, cheap Messages request used only to confirm the endpoint + credentials + model work.
+type ValidationHttpRequest = {
+  url: string
+  headers: Record<string, string>
+  body: string
+}
+
+// Builds the /v1/messages probe request for a custom provider. Throws on an unusable base URL so the
+// caller can classify it as bad-url instead of firing a doomed fetch.
+const buildValidationRequest = (provider: ResolvedProvider): ValidationHttpRequest => {
+  if (!provider.baseUrl) {
+    throw new Error('Missing base URL.')
+  }
+
+  let url: string
+
+  try {
+    // Mirror how the claude client builds requests: ANTHROPIC_BASE_URL + "/v1/messages". Validate it
+    // parses as a URL so an unusable base can be classified as bad-url instead of firing a bad fetch.
+    url = new URL(`${provider.baseUrl.replace(/\/+$/, '')}/v1/messages`).toString()
+  } catch {
+    throw new Error('Invalid base URL.')
+  }
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'anthropic-version': ANTHROPIC_VERSION
+  }
+
+  // Custom gateways authenticate with a bearer token.
+  if (provider.key) {
+    headers.authorization = `Bearer ${provider.key}`
+  }
+
+  const body = JSON.stringify({
+    model: provider.model ?? '',
+    max_tokens: 1,
+    messages: [{ role: 'user', content: 'ping' }]
+  })
+
+  return { url, headers, body }
+}
+
+// Maps an HTTP status to a validation category. 2xx is success; auth/model errors are distinguished
+// so the UI can point the user at the credential vs. the model field.
+const classifyStatus = (status: number): ValidationCategory => {
+  if (status >= 200 && status < 300) return 'ok'
+  if (status === 401 || status === 403) return 'auth'
+  if (status === 404 || status === 400) return 'model-not-found'
+
+  return 'unknown'
+}
+
+// Maps a thrown fetch error (or URL failure) to a category.
+const classifyFetchError = (error: unknown): ValidationCategory => {
+  const message = error instanceof Error ? error.message : String(error)
+
+  if (/invalid base url|missing base url/i.test(message)) return 'bad-url'
+  if (error instanceof Error && error.name === 'AbortError') return 'timeout'
+  if (/timed out|timeout/i.test(message)) return 'timeout'
+
+  return 'network'
+}
+
+const toResult = (
+  category: ValidationCategory,
+  extra: { status?: number; message?: string } = {}
+): ValidateProviderResult => ({
+  ok: category === 'ok',
+  category,
+  ...extra
+})
+
+// Outcome of the one-shot claude-default probe. `timedOut` lets the UI show a timeout message instead
+// of a misleading auth failure when the local claude never responds.
+export type ClaudeProbeResult = {
+  ok: boolean
+  timedOut?: boolean
+  message?: string
+}
+
+export type ValidateProviderDeps = {
+  fetchImpl?: typeof fetch
+  timeoutMs?: number
+  // Runs a one-shot `claude -p "ok"` probe for claude-default providers.
+  runClaudeProbe?: () => Promise<ClaudeProbeResult>
+}
+
+// Validates a custom provider by hitting its Messages endpoint with a 1-token request.
+const validateCustomProvider = async (
+  provider: ResolvedProvider,
+  { fetchImpl = fetch, timeoutMs = DEFAULT_VALIDATE_TIMEOUT_MS }: ValidateProviderDeps
+): Promise<ValidateProviderResult> => {
+  let request: ValidationHttpRequest
+
+  try {
+    request = buildValidationRequest(provider)
+  } catch (error) {
+    return toResult(classifyFetchError(error), {
+      message: error instanceof Error ? error.message : String(error)
+    })
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const response = await fetchImpl(request.url, {
+      method: 'POST',
+      headers: request.headers,
+      body: request.body,
+      signal: controller.signal
+    })
+    const category = classifyStatus(response.status)
+
+    return toResult(category, { status: response.status })
+  } catch (error) {
+    return toResult(classifyFetchError(error), {
+      message: error instanceof Error ? error.message : String(error)
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// Validates a claude-default provider by running a one-shot claude probe against the user's auth.
+const validateClaudeDefaultProvider = async (
+  deps: ValidateProviderDeps
+): Promise<ValidateProviderResult> => {
+  if (!deps.runClaudeProbe) {
+    return toResult('unknown', { message: 'Claude probe is not configured.' })
+  }
+
+  try {
+    const probe = await deps.runClaudeProbe()
+
+    if (probe.ok) return toResult('ok')
+
+    return toResult(probe.timedOut ? 'timeout' : 'auth', {
+      message:
+        probe.message ??
+        (probe.timedOut
+          ? 'Local claude did not respond in time.'
+          : 'Local claude could not complete a request.')
+    })
+  } catch (error) {
+    return toResult('unknown', {
+      message: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+// Dispatches validation by provider type.
+const validateProvider = (
+  provider: ResolvedProvider,
+  deps: ValidateProviderDeps = {}
+): Promise<ValidateProviderResult> =>
+  provider.type === 'claude-default'
+    ? validateClaudeDefaultProvider(deps)
+    : validateCustomProvider(provider, deps)
+
+export {
+  ANTHROPIC_VERSION,
+  DEFAULT_VALIDATE_TIMEOUT_MS,
+  buildValidationRequest,
+  classifyFetchError,
+  classifyStatus,
+  validateProvider
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -51,6 +51,19 @@ import type {
   SaveSessionManifestRequest
 } from '../shared/session-persistence'
 import type {
+  ClaudeDetectResult,
+  ClaudeInstallLogEvent,
+  ClaudeInstallResult,
+  DeleteProviderRequest,
+  InstallClaudeRequest,
+  Preflight,
+  SetActiveProviderRequest,
+  SettingsSnapshot,
+  UpsertProviderRequest,
+  ValidateProviderRequest,
+  ValidateProviderResult
+} from '../shared/settings'
+import type {
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
   StageUploadFilesRequest,
@@ -87,6 +100,19 @@ interface OpenScienceAPI {
     deleteSession(request: DeleteSessionRequest): Promise<void>
     deleteProjectSessions(request: DeleteProjectSessionsRequest): Promise<void>
     saveManifest(request: SaveSessionManifestRequest): Promise<void>
+  }
+  settings: {
+    getPreflight(): Promise<Preflight>
+    getSettings(): Promise<SettingsSnapshot>
+    isEncryptionAvailable(): Promise<boolean>
+    isNpmAvailable(): Promise<boolean>
+    detectClaude(): Promise<ClaudeDetectResult>
+    installClaude(request: InstallClaudeRequest): Promise<ClaudeInstallResult>
+    upsertProvider(request: UpsertProviderRequest): Promise<SettingsSnapshot>
+    deleteProvider(request: DeleteProviderRequest): Promise<SettingsSnapshot>
+    setActiveProvider(request: SetActiveProviderRequest): Promise<SettingsSnapshot>
+    validateProvider(request: ValidateProviderRequest): Promise<ValidateProviderResult>
+    onInstallLog(listener: AcpListener<ClaudeInstallLogEvent>): RemoveListener
   }
   projects: {
     list(): Promise<Project[]>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -53,6 +53,19 @@ import type {
   SaveSessionManifestRequest
 } from '../shared/session-persistence'
 import type {
+  ClaudeDetectResult,
+  ClaudeInstallLogEvent,
+  ClaudeInstallResult,
+  DeleteProviderRequest,
+  InstallClaudeRequest,
+  Preflight,
+  SetActiveProviderRequest,
+  SettingsSnapshot,
+  UpsertProviderRequest,
+  ValidateProviderRequest,
+  ValidateProviderResult
+} from '../shared/settings'
+import type {
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
   StageUploadFilesRequest,
@@ -101,6 +114,19 @@ type OpenScienceAPI = {
     deleteSession: (request: DeleteSessionRequest) => Promise<void>
     deleteProjectSessions: (request: DeleteProjectSessionsRequest) => Promise<void>
     saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
+  }
+  settings: {
+    getPreflight: () => Promise<Preflight>
+    getSettings: () => Promise<SettingsSnapshot>
+    isEncryptionAvailable: () => Promise<boolean>
+    isNpmAvailable: () => Promise<boolean>
+    detectClaude: () => Promise<ClaudeDetectResult>
+    installClaude: (request: InstallClaudeRequest) => Promise<ClaudeInstallResult>
+    upsertProvider: (request: UpsertProviderRequest) => Promise<SettingsSnapshot>
+    deleteProvider: (request: DeleteProviderRequest) => Promise<SettingsSnapshot>
+    setActiveProvider: (request: SetActiveProviderRequest) => Promise<SettingsSnapshot>
+    validateProvider: (request: ValidateProviderRequest) => Promise<ValidateProviderResult>
+    onInstallLog: (listener: AcpListener<ClaudeInstallLogEvent>) => RemoveListener
   }
   projects: {
     list: () => Promise<Project[]>
@@ -206,6 +232,27 @@ const api: OpenScienceAPI = {
     // Persists the last-open project/session pointer.
     saveManifest: (request) =>
       ipcRenderer.invoke('sessions:save-manifest', request) as Promise<void>
+  },
+  settings: {
+    // Model-settings/onboarding surface: secrets stay in main, the renderer only sees masked views.
+    getPreflight: () => ipcRenderer.invoke('settings:get-preflight') as Promise<Preflight>,
+    getSettings: () => ipcRenderer.invoke('settings:get-settings') as Promise<SettingsSnapshot>,
+    isEncryptionAvailable: () =>
+      ipcRenderer.invoke('settings:encryption-available') as Promise<boolean>,
+    isNpmAvailable: () => ipcRenderer.invoke('settings:npm-available') as Promise<boolean>,
+    detectClaude: () => ipcRenderer.invoke('settings:detect-claude') as Promise<ClaudeDetectResult>,
+    installClaude: (request) =>
+      ipcRenderer.invoke('settings:install-claude', request) as Promise<ClaudeInstallResult>,
+    upsertProvider: (request) =>
+      ipcRenderer.invoke('settings:upsert-provider', request) as Promise<SettingsSnapshot>,
+    deleteProvider: (request) =>
+      ipcRenderer.invoke('settings:delete-provider', request) as Promise<SettingsSnapshot>,
+    setActiveProvider: (request) =>
+      ipcRenderer.invoke('settings:set-active-provider', request) as Promise<SettingsSnapshot>,
+    validateProvider: (request) =>
+      ipcRenderer.invoke('settings:validate-provider', request) as Promise<ValidateProviderResult>,
+    // Streams live installer output while a one-click install runs.
+    onInstallLog: (listener) => onIpcMessage('settings:install-log', listener)
   },
   projects: {
     // Project CRUD backed by the SQLite/Prisma layer (scope: projects only).

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,26 +2,54 @@ import { useEffect } from 'react'
 
 import { useSessionPersistence } from '@/lib/session-persistence/session-persistence'
 import { HomePage } from '@/pages/home/HomePage'
+import { OnboardingWizard } from '@/pages/onboarding/OnboardingWizard'
+import { SettingsPage } from '@/pages/settings/SettingsPage'
 import { WorkspacePage } from '@/pages/workspace/WorkspacePage'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useProjectStore } from '@/stores/project-store'
+import { useSettingsStore } from '@/stores/settings-store'
 
-const App = (): React.JSX.Element => {
+const App = (): React.JSX.Element | null => {
   // Persistence is started once at the top so sessions stay loaded for both Home and Workspace.
   const isSessionPersistenceReady = useSessionPersistence()
   const view = useNavigationStore((state) => state.view)
   const loadProjects = useProjectStore((state) => state.loadProjects)
+  const isSettingsLoaded = useSettingsStore((state) => state.isLoaded)
+  const preflight = useSettingsStore((state) => state.preflight)
+  const loadSettings = useSettingsStore((state) => state.load)
+  const isSettingsOpen = useSettingsStore((state) => state.isSettingsOpen)
+  const closeSettings = useSettingsStore((state) => state.closeSettings)
 
   // Load the project list once on startup so Home can render immediately after hydration.
   useEffect(() => {
     void loadProjects()
   }, [loadProjects])
 
-  if (view === 'home') {
-    return <HomePage />
+  // Load settings/preflight once so the startup gate can decide between onboarding and the app.
+  useEffect(() => {
+    void loadSettings()
+  }, [loadSettings])
+
+  // Hold rendering until the preflight gate is known so the wizard does not flash for ready users.
+  if (!isSettingsLoaded) {
+    return null
   }
 
-  return <WorkspacePage isSessionPersistenceReady={isSessionPersistenceReady} />
+  // Hard startup gate: a runnable claude plus a validated active provider are both required.
+  if (!preflight.claudeReady || !preflight.activeProviderReady) {
+    return <OnboardingWizard onComplete={() => undefined} />
+  }
+
+  return (
+    <>
+      {view === 'home' ? (
+        <HomePage />
+      ) : (
+        <WorkspacePage isSessionPersistenceReady={isSessionPersistenceReady} />
+      )}
+      <SettingsPage open={isSettingsOpen} onClose={closeSettings} />
+    </>
+  )
 }
 
 export default App

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -196,11 +196,18 @@ const startPendingSessionPrompt = (
       return
     }
 
-    void runtime.sendPrompt(runtimeSessionId, content, promptAttachments).then((snapshot) => {
-      if (!snapshot) {
-        useSessionStore.getState().failRun(runtimeSessionId, 'Agent run failed')
-      }
-    })
+    void runtime
+      .sendPrompt(runtimeSessionId, content, promptAttachments)
+      .then((snapshot) => {
+        if (!snapshot) {
+          useSessionStore.getState().failRun(runtimeSessionId, 'Agent run failed')
+        }
+      })
+      .catch((error) => {
+        // A rejected prompt (e.g. an upstream gateway 5xx) must surface as a visible session error
+        // instead of being swallowed as an unhandled rejection.
+        useSessionStore.getState().failRun(runtimeSessionId, getErrorMessage(error))
+      })
   })()
 }
 
@@ -304,11 +311,18 @@ const sendWorkspaceMessage = async (
     }
 
     // The hook returns after local state is updated; event listeners handle the streamed result.
-    void runtime.sendPrompt(targetSessionId, content, promptAttachments).then((snapshot) => {
-      if (!snapshot) {
-        useSessionStore.getState().failRun(targetSessionId, 'Agent run failed')
-      }
-    })
+    void runtime
+      .sendPrompt(targetSessionId, content, promptAttachments)
+      .then((snapshot) => {
+        if (!snapshot) {
+          useSessionStore.getState().failRun(targetSessionId, 'Agent run failed')
+        }
+      })
+      .catch((error) => {
+        // A rejected prompt (e.g. an upstream gateway 5xx) must surface as a visible session error
+        // instead of being swallowed as an unhandled rejection.
+        useSessionStore.getState().failRun(targetSessionId, getErrorMessage(error))
+      })
 
     return appended
   }

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -1,4 +1,13 @@
-import { Archive, Building2, Clock, MoreVertical, Pencil, Plus, Trash2 } from 'lucide-react'
+import {
+  Archive,
+  Building2,
+  Clock,
+  MoreVertical,
+  Pencil,
+  Plus,
+  Settings,
+  Trash2
+} from 'lucide-react'
 import { DropdownMenu } from 'radix-ui'
 import { useMemo, useState } from 'react'
 
@@ -9,6 +18,7 @@ import { useNavigationStore } from '@/stores/navigation-store'
 import type { ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
 import { useProjectStore } from '@/stores/project-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import type { Project } from '../../../../shared/projects'
 
 import { DeleteProjectDialog } from './DeleteProjectDialog'
@@ -61,6 +71,7 @@ const HomePage = (): React.JSX.Element => {
   const sessions = useSessionStore((state) => state.sessions)
   const openProject = useNavigationStore((state) => state.openProject)
   const openSession = useNavigationStore((state) => state.openSession)
+  const openSettings = useSettingsStore((state) => state.openSettings)
 
   const [formState, setFormState] = useState<ProjectFormState | null>(null)
   const [nameDraft, setNameDraft] = useState('')
@@ -201,6 +212,14 @@ const HomePage = (): React.JSX.Element => {
             <div className="mt-1 text-[11px] text-text-100">Beta</div>
           </div>
           <div className="flex items-center gap-2">
+            <button
+              type="button"
+              aria-label="Model settings"
+              onClick={openSettings}
+              className="inline-flex size-9 items-center justify-center rounded-lg text-text-300 transition-colors duration-150 ease-out hover:bg-bg-300 hover:text-text-000"
+            >
+              <Settings className="size-4" strokeWidth={2} aria-hidden="true" />
+            </button>
             <button
               type="button"
               aria-label="Account"

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import type { UpsertProviderRequest } from '../../../../shared/settings'
+import { useSettingsStore } from '@/stores/settings-store'
+import { ClaudeInstallCard } from '../settings/ClaudeInstallCard'
+import { ClaudeStatusCard } from '../settings/ClaudeStatusCard'
+import { ProviderForm } from '../settings/ProviderForm'
+import {
+  createEmptyProviderFormValue,
+  getProviderFormErrors,
+  hasProviderFormErrors,
+  type ProviderFormValue
+} from '../settings/provider-form-value'
+import { describeValidation } from '../settings/validation-message'
+
+type OnboardingWizardProps = {
+  // Called once both startup gates are satisfied so the app can enter the main UI.
+  onComplete: () => void
+}
+
+// Converts a form value into the upsert request the main process expects.
+const toUpsertRequest = (value: ProviderFormValue): UpsertProviderRequest => ({
+  type: value.type,
+  name: value.name,
+  baseUrl: value.baseUrl,
+  model: value.model,
+  key: value.key || undefined
+})
+
+// First-run gate: install/detect claude, then configure and validate a model provider. Reuses the
+// same cards/form as the settings page so both surfaces stay in sync.
+const OnboardingWizard = ({ onComplete }: OnboardingWizardProps): React.JSX.Element => {
+  const claude = useSettingsStore((state) => state.claude)
+  const preflight = useSettingsStore((state) => state.preflight)
+  const isDetectingClaude = useSettingsStore((state) => state.isDetectingClaude)
+  const isInstalling = useSettingsStore((state) => state.isInstalling)
+  const installLogs = useSettingsStore((state) => state.installLogs)
+  const npmAvailable = useSettingsStore((state) => state.npmAvailable)
+  const encryptionAvailable = useSettingsStore((state) => state.encryptionAvailable)
+  const load = useSettingsStore((state) => state.load)
+  const detectClaude = useSettingsStore((state) => state.detectClaude)
+  const installClaude = useSettingsStore((state) => state.installClaude)
+  const saveAndActivateProvider = useSettingsStore((state) => state.saveAndActivateProvider)
+
+  const [formValue, setFormValue] = useState<ProviderFormValue>(() =>
+    createEmptyProviderFormValue()
+  )
+  const [isSaving, setIsSaving] = useState(false)
+  const [validationMessage, setValidationMessage] = useState<string | undefined>(undefined)
+  const [validationOk, setValidationOk] = useState(false)
+  const didAutoDetect = useRef(false)
+
+  // Load settings once, then auto-detect claude so a machine that already has it skips straight ahead.
+  useEffect(() => {
+    void (async () => {
+      await load()
+
+      if (!didAutoDetect.current) {
+        didAutoDetect.current = true
+        await detectClaude()
+      }
+    })()
+  }, [load, detectClaude])
+
+  // Enter the app as soon as both gates are satisfied.
+  useEffect(() => {
+    if (preflight.claudeReady && preflight.activeProviderReady) {
+      onComplete()
+    }
+  }, [preflight.claudeReady, preflight.activeProviderReady, onComplete])
+
+  const step = useMemo<'claude' | 'provider'>(
+    () => (preflight.claudeReady ? 'provider' : 'claude'),
+    [preflight.claudeReady]
+  )
+
+  // Onboarding always creates a provider, so required fields must be filled before it can continue.
+  const formErrors = getProviderFormErrors(formValue)
+  const canContinue = !isSaving && !hasProviderFormErrors(formErrors)
+
+  const handleSaveProvider = async (): Promise<void> => {
+    setIsSaving(true)
+    setValidationMessage(undefined)
+
+    try {
+      const { validation } = await saveAndActivateProvider(toUpsertRequest(formValue))
+
+      setValidationOk(validation.ok)
+      setValidationMessage(describeValidation(validation))
+    } catch (error) {
+      setValidationOk(false)
+      setValidationMessage(error instanceof Error ? error.message : 'Could not save provider.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <main className="min-h-svh bg-background text-foreground">
+      <div className="mx-auto max-w-xl px-6 py-12">
+        <h1 className="font-serif text-2xl font-medium">Welcome to Open Science</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Two quick steps and you are ready: install Claude, then connect a model.
+        </p>
+
+        <ol className="mt-6 flex items-center gap-3 text-xs text-muted-foreground">
+          <li className={step === 'claude' ? 'font-medium text-foreground' : ''}>1. Claude</li>
+          <li aria-hidden="true">→</li>
+          <li className={step === 'provider' ? 'font-medium text-foreground' : ''}>2. Model</li>
+        </ol>
+
+        {step === 'claude' ? (
+          <section aria-label="Install Claude" className="mt-6 space-y-4">
+            <ClaudeStatusCard
+              claude={claude}
+              claudeReady={preflight.claudeReady}
+              isDetecting={isDetectingClaude}
+              onDetect={() => void detectClaude()}
+            />
+            <ClaudeInstallCard
+              isInstalling={isInstalling}
+              installLogs={installLogs}
+              npmAvailable={npmAvailable}
+              onInstall={(source) => void installClaude(source)}
+            />
+          </section>
+        ) : (
+          <section aria-label="Configure model" className="mt-6 space-y-4">
+            {!encryptionAvailable ? (
+              <p className="rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                Secure key storage is unavailable on this machine. Your key will be stored with
+                reduced protection.
+              </p>
+            ) : null}
+            <ProviderForm
+              value={formValue}
+              onChange={(patch) => setFormValue((current) => ({ ...current, ...patch }))}
+              errors={formErrors}
+              disabled={isSaving}
+            />
+            {validationMessage ? (
+              <p
+                className={`text-sm ${validationOk ? 'text-primary' : 'text-destructive'}`}
+                role="alert"
+              >
+                {validationMessage}
+              </p>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => void handleSaveProvider()}
+              disabled={!canContinue}
+              className="rounded-lg border border-primary bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+            >
+              {isSaving ? 'Testing connection…' : 'Test connection & continue'}
+            </button>
+          </section>
+        )}
+      </div>
+    </main>
+  )
+}
+
+export { OnboardingWizard }

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+
+import type { ClaudeInstallSource } from '../../../../shared/settings'
+import { CLAUDE_INSTALL_SOURCES } from '../../../../shared/settings'
+
+type ClaudeInstallCardProps = {
+  isInstalling: boolean
+  installLogs: string[]
+  // Whether npm is available on the host; disables/deprioritizes the npm-mirror source when false.
+  npmAvailable: boolean
+  onInstall: (source: ClaudeInstallSource) => void
+}
+
+// Source picker + one-click installer with a live log pane and an always-visible, copyable command so
+// manual installers are never blocked. Shared by the onboarding wizard and the settings page.
+const ClaudeInstallCard = ({
+  isInstalling,
+  installLogs,
+  npmAvailable,
+  onInstall
+}: ClaudeInstallCardProps): React.JSX.Element => {
+  const [source, setSource] = useState<ClaudeInstallSource>(
+    npmAvailable ? 'npm-mirror' : 'official-script'
+  )
+  const selectedSource = CLAUDE_INSTALL_SOURCES.find((item) => item.id === source)
+  const npmMissing = source === 'npm-mirror' && !npmAvailable
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-muted-foreground" htmlFor="install-source">
+          Install source
+        </label>
+        <select
+          id="install-source"
+          aria-label="Install source"
+          value={source}
+          disabled={isInstalling}
+          onChange={(event) => setSource(event.target.value as ClaudeInstallSource)}
+          className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring"
+        >
+          {CLAUDE_INSTALL_SOURCES.map((item) => (
+            <option key={item.id} value={item.id}>
+              {item.label}
+              {item.requiresNpm && !npmAvailable ? ' (npm not found)' : ''}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {selectedSource ? (
+        <div className="mt-3">
+          <span className="text-xs font-medium text-muted-foreground">Command</span>
+          <pre
+            className="mt-1 overflow-x-auto rounded-lg bg-muted px-3 py-2 font-mono text-xs text-foreground"
+            aria-label="Install command"
+          >
+            {selectedSource.displayCommand}
+          </pre>
+        </div>
+      ) : null}
+
+      {npmMissing ? (
+        <p className="mt-2 text-xs text-destructive" role="alert">
+          npm was not found on this machine. Use the official script or install npm first.
+        </p>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={() => onInstall(source)}
+        disabled={isInstalling || npmMissing}
+        className="mt-3 rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+      >
+        {isInstalling ? 'Installing…' : 'Install with one click'}
+      </button>
+
+      {installLogs.length > 0 ? (
+        <pre
+          className="mt-3 max-h-48 overflow-auto rounded-lg bg-foreground/5 px-3 py-2 font-mono text-[11px] leading-relaxed whitespace-pre-wrap text-foreground/80"
+          aria-label="Install log"
+        >
+          {installLogs.join('')}
+        </pre>
+      ) : null}
+    </div>
+  )
+}
+
+export { ClaudeInstallCard }

--- a/src/renderer/src/pages/settings/ClaudeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeStatusCard.tsx
@@ -1,0 +1,64 @@
+import { CheckCircle2, XCircle } from 'lucide-react'
+
+import type { ClaudeInfo } from '../../../../shared/settings'
+
+type ClaudeStatusCardProps = {
+  claude: ClaudeInfo
+  claudeReady: boolean
+  isDetecting: boolean
+  onDetect: () => void
+}
+
+// Shows whether a runnable claude executable was found, with its resolved path/version, plus a
+// re-detect action. Shared by the onboarding wizard and the settings page.
+const ClaudeStatusCard = ({
+  claude,
+  claudeReady,
+  isDetecting,
+  onDetect
+}: ClaudeStatusCardProps): React.JSX.Element => (
+  <div className="rounded-xl border border-border p-4">
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex items-center gap-2">
+        {claudeReady ? (
+          <CheckCircle2 className="size-4 text-primary" aria-hidden="true" />
+        ) : (
+          <XCircle className="size-4 text-muted-foreground" aria-hidden="true" />
+        )}
+        <span className="text-sm font-medium text-foreground">
+          {claudeReady ? 'Claude is installed' : 'Claude not detected'}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onDetect}
+        disabled={isDetecting}
+        className="rounded-lg border border-border px-2.5 py-1 text-xs text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+      >
+        {isDetecting ? 'Detecting…' : 'Re-detect'}
+      </button>
+    </div>
+    {claude.resolvedPath ? (
+      <dl className="mt-3 space-y-1 text-xs text-muted-foreground">
+        <div className="flex gap-2">
+          <dt className="shrink-0">Path</dt>
+          <dd className="truncate font-mono text-foreground/80" title={claude.resolvedPath}>
+            {claude.resolvedPath}
+          </dd>
+        </div>
+        {claude.version ? (
+          <div className="flex gap-2">
+            <dt className="shrink-0">Version</dt>
+            <dd className="font-mono text-foreground/80">{claude.version}</dd>
+          </div>
+        ) : null}
+      </dl>
+    ) : (
+      <p className="mt-3 text-xs text-muted-foreground">
+        Install Claude below, or run the command manually, then re-detect.
+      </p>
+    )}
+  </div>
+)
+
+export { ClaudeStatusCard }

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ProviderForm } from './ProviderForm'
+import {
+  createEmptyProviderFormValue,
+  type ProviderFormErrors,
+  type ProviderFormValue
+} from './provider-form-value'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const render = (
+  value: ProviderFormValue,
+  { onChange = vi.fn(), errors }: { onChange?: () => void; errors?: ProviderFormErrors } = {}
+): void => {
+  act(() => {
+    root.render(<ProviderForm value={value} onChange={onChange} errors={errors} />)
+  })
+}
+
+describe('ProviderForm field switching', () => {
+  it('shows gateway/key/model fields for a custom provider and no auth-style control', () => {
+    render(createEmptyProviderFormValue({ type: 'custom' }))
+
+    expect(container.querySelector('[aria-label="Base URL"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="API key"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="Model"]')).not.toBeNull()
+    // The auth style selector was removed; custom always uses a bearer token.
+    expect(container.querySelector('[aria-label="Auth style"]')).toBeNull()
+  })
+
+  it('hides gateway/key fields for a local-claude provider', () => {
+    render(createEmptyProviderFormValue({ type: 'claude-default' }))
+
+    expect(container.querySelector('[aria-label="Base URL"]')).toBeNull()
+    expect(container.querySelector('[aria-label="API key"]')).toBeNull()
+    // Only the optional model override remains.
+    expect(container.querySelector('[aria-label="Model"]')).not.toBeNull()
+  })
+
+  it('reports a type change through onChange', () => {
+    const onChange = vi.fn()
+    render(createEmptyProviderFormValue({ type: 'custom' }), { onChange })
+
+    const localButton = container.querySelector<HTMLButtonElement>('button[aria-pressed="false"]')
+    act(() => localButton?.click())
+
+    expect(onChange).toHaveBeenCalledWith({ type: 'claude-default' })
+  })
+
+  it('never renders a stored plaintext key: the key input stays empty and masked-only', () => {
+    // The form is given no plaintext key (the renderer never receives one); only a mask is shown.
+    render(createEmptyProviderFormValue({ type: 'custom', key: '' }))
+    const keyInput = container.querySelector<HTMLInputElement>('[aria-label="API key"]')
+
+    expect(keyInput?.getAttribute('type')).toBe('password')
+    expect(keyInput?.value).toBe('')
+  })
+
+  it('renders inline required-field errors for a custom provider', () => {
+    render(createEmptyProviderFormValue({ type: 'custom' }), {
+      errors: {
+        baseUrl: 'Base URL is required.',
+        key: 'API key is required.',
+        model: 'Model is required.'
+      }
+    })
+
+    expect(container.textContent).toContain('Base URL is required.')
+    expect(container.textContent).toContain('API key is required.')
+    expect(container.textContent).toContain('Model is required.')
+  })
+})

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -1,0 +1,171 @@
+import { Input } from '@/components/ui/input'
+import type { ProviderFormErrors, ProviderFormValue } from './provider-form-value'
+
+type ProviderFormProps = {
+  value: ProviderFormValue
+  onChange: (patch: Partial<ProviderFormValue>) => void
+  // Whether a stored key already exists (drives the "leave blank to keep" affordance).
+  hasStoredKey?: boolean
+  // Masked hint for the stored key; never the plaintext value.
+  maskedKey?: string
+  // True when the stored key could not be decrypted and must be re-entered.
+  needsKey?: boolean
+  // Per-field required-field errors to display inline (custom only).
+  errors?: ProviderFormErrors
+  disabled?: boolean
+}
+
+const fieldLabelClassName = 'text-xs font-medium text-muted-foreground'
+const fieldErrorClassName = 'text-xs text-destructive'
+const typeButtonBaseClassName =
+  'flex-1 rounded-lg border px-3 py-2 text-left text-sm transition-colors'
+
+// Provider fields that switch by type: custom exposes gateway/key/model, claude-default only a model
+// override. No plaintext key is ever rendered — the stored key surfaces only as a masked placeholder.
+const ProviderForm = ({
+  value,
+  onChange,
+  hasStoredKey = false,
+  maskedKey,
+  needsKey = false,
+  errors = {},
+  disabled = false
+}: ProviderFormProps): React.JSX.Element => {
+  const isCustom = value.type === 'custom'
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <span className={fieldLabelClassName}>Provider type</span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            aria-pressed={isCustom}
+            disabled={disabled}
+            onClick={() => onChange({ type: 'custom' })}
+            className={`${typeButtonBaseClassName} ${
+              isCustom ? 'border-primary bg-primary/5' : 'border-border'
+            }`}
+          >
+            <span className="font-medium text-foreground">Custom gateway</span>
+            <span className="mt-0.5 block text-xs text-muted-foreground">
+              Base URL, API key, and model
+            </span>
+          </button>
+          <button
+            type="button"
+            aria-pressed={!isCustom}
+            disabled={disabled}
+            onClick={() => onChange({ type: 'claude-default' })}
+            className={`${typeButtonBaseClassName} ${
+              !isCustom ? 'border-primary bg-primary/5' : 'border-border'
+            }`}
+          >
+            <span className="font-medium text-foreground">Local Claude</span>
+            <span className="mt-0.5 block text-xs text-muted-foreground">
+              Reuse this machine&apos;s Claude login
+            </span>
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <label className={fieldLabelClassName} htmlFor="provider-name">
+          Name
+        </label>
+        <Input
+          id="provider-name"
+          aria-label="Provider name"
+          value={value.name}
+          disabled={disabled}
+          placeholder={isCustom ? 'e.g. My gateway' : 'e.g. Local Claude'}
+          onChange={(event) => onChange({ name: event.target.value })}
+        />
+      </div>
+
+      {isCustom ? (
+        <>
+          <div className="space-y-1.5">
+            <label className={fieldLabelClassName} htmlFor="provider-base-url">
+              Base URL
+            </label>
+            <Input
+              id="provider-base-url"
+              aria-label="Base URL"
+              value={value.baseUrl}
+              disabled={disabled}
+              placeholder="https://gateway.example/v1"
+              onChange={(event) => onChange({ baseUrl: event.target.value })}
+            />
+            {errors.baseUrl ? (
+              <p className={fieldErrorClassName} role="alert">
+                {errors.baseUrl}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-1.5">
+            <label className={fieldLabelClassName} htmlFor="provider-key">
+              API key
+            </label>
+            <Input
+              id="provider-key"
+              aria-label="API key"
+              type="password"
+              value={value.key}
+              disabled={disabled}
+              placeholder={
+                hasStoredKey ? `${maskedKey ?? 'stored key'} — leave blank to keep` : 'sk-...'
+              }
+              onChange={(event) => onChange({ key: event.target.value })}
+            />
+            {needsKey ? (
+              <p className={fieldErrorClassName} role="alert">
+                The stored key could not be decrypted. Enter it again to continue.
+              </p>
+            ) : errors.key ? (
+              <p className={fieldErrorClassName} role="alert">
+                {errors.key}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-1.5">
+            <label className={fieldLabelClassName} htmlFor="provider-model">
+              Model
+            </label>
+            <Input
+              id="provider-model"
+              aria-label="Model"
+              value={value.model}
+              disabled={disabled}
+              placeholder="claude-sonnet-4-5"
+              onChange={(event) => onChange({ model: event.target.value })}
+            />
+            {errors.model ? (
+              <p className={fieldErrorClassName} role="alert">
+                {errors.model}
+              </p>
+            ) : null}
+          </div>
+        </>
+      ) : (
+        <div className="space-y-1.5">
+          <label className={fieldLabelClassName} htmlFor="provider-model">
+            Model <span className="text-muted-foreground">(optional override)</span>
+          </label>
+          <Input
+            id="provider-model"
+            aria-label="Model"
+            value={value.model}
+            disabled={disabled}
+            placeholder="Leave blank to use Claude's default"
+            onChange={(event) => onChange({ model: event.target.value })}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export { ProviderForm }

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProviderView } from '../../../../shared/settings'
+import { ProviderList } from './ProviderList'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const provider = (overrides: Partial<ProviderView> = {}): ProviderView => ({
+  id: 'p1',
+  type: 'custom',
+  name: 'Gateway',
+  baseUrl: 'https://g/v1',
+  model: 'claude-sonnet-4-5',
+  maskedKey: 'sk-a…wxyz',
+  hasKey: true,
+  needsKey: false,
+  lastValidatedAt: 1,
+  ...overrides
+})
+
+const noop = vi.fn()
+
+const renderList = (providers: ProviderView[], activeId?: string): void => {
+  act(() => {
+    root.render(
+      <ProviderList
+        providers={providers}
+        activeProviderId={activeId}
+        onEdit={noop}
+        onDelete={noop}
+        onSetActive={noop}
+        onTest={noop}
+      />
+    )
+  })
+}
+
+// Finds an icon action button by its accessible name.
+const buttonByLabel = (label: string): HTMLButtonElement | undefined =>
+  Array.from(container.querySelectorAll('button')).find(
+    (button) => button.getAttribute('aria-label') === label
+  )
+
+describe('ProviderList', () => {
+  it('shows the masked key and model but never a plaintext key', () => {
+    renderList([provider()])
+
+    expect(container.textContent).toContain('sk-a…wxyz')
+    expect(container.textContent).toContain('claude-sonnet-4-5')
+    // A masked hint is displayed, but there is no way to render a real secret here.
+    expect(container.textContent).not.toContain('sk-abcdefwxyz')
+  })
+
+  it('leads an unselected row with a Select button, never Test connection', () => {
+    renderList([provider()])
+
+    const buttons = Array.from(container.querySelectorAll('button'))
+    // The first action must be Select; Test connection must never be first.
+    expect(buttons[0]?.textContent?.trim()).toBe('Select')
+    expect(buttons[0]?.getAttribute('aria-label')).not.toBe('Test connection')
+
+    const selectIndex = buttons.findIndex((button) => button.textContent?.trim() === 'Select')
+    const testIndex = buttons.findIndex(
+      (button) => button.getAttribute('aria-label') === 'Test connection'
+    )
+    expect(selectIndex).toBe(0)
+    expect(testIndex).toBeGreaterThan(selectIndex)
+  })
+
+  it('marks the selected provider with a Selected badge and no Select button (no "Active" wording)', () => {
+    renderList([provider()], 'p1')
+
+    expect(container.textContent).toContain('Selected')
+    // "Active" is intentionally avoided because it implies availability, not selection.
+    expect(container.textContent).not.toContain('Active')
+    const selectButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Select'
+    )
+    expect(selectButton).toBeUndefined()
+  })
+
+  it('renders edit/delete/test as icon-only buttons with accessible labels', () => {
+    renderList([provider()])
+
+    const test = buttonByLabel('Test connection')
+    const edit = buttonByLabel('Edit')
+    const del = buttonByLabel('Delete')
+
+    expect(test).toBeDefined()
+    expect(edit).toBeDefined()
+    expect(del).toBeDefined()
+    // Icon-only: the button shows an SVG, not a visible text name.
+    expect(edit?.querySelector('svg')).not.toBeNull()
+    expect(del?.querySelector('svg')).not.toBeNull()
+    expect(edit?.textContent?.trim()).toBe('')
+    expect(del?.textContent?.trim()).toBe('')
+  })
+
+  it('disables delete for the selected provider so it cannot drop back to onboarding', () => {
+    renderList([provider({ id: 'p1' }), provider({ id: 'p2', name: 'Other' })], 'p1')
+
+    const deletes = Array.from(container.querySelectorAll('button')).filter(
+      (button) => button.getAttribute('aria-label') === 'Delete'
+    )
+    // p1 is selected -> its delete is disabled; p2 is unselected with siblings -> enabled.
+    expect((deletes[0] as HTMLButtonElement).disabled).toBe(true)
+    expect((deletes[1] as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('disables delete when only one provider remains', () => {
+    renderList([provider()])
+
+    expect((buttonByLabel('Delete') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('exposes an icon action name as a hover tooltip on focus', async () => {
+    renderList([provider()])
+
+    const edit = buttonByLabel('Edit')
+
+    await act(async () => {
+      edit?.focus()
+    })
+
+    // Radix opens the tooltip on focus and portals its content to the document body.
+    expect(document.body.textContent).toContain('Edit')
+  })
+
+  it('flags a provider whose key needs re-entry', () => {
+    renderList([provider({ needsKey: true })])
+
+    expect(container.textContent).toContain('Key needs re-entry')
+  })
+
+  it('shows only the model for a local Claude provider and never a key row', () => {
+    renderList([
+      provider({
+        type: 'claude-default',
+        name: 'Local Claude',
+        baseUrl: undefined,
+        model: 'claude-opus',
+        maskedKey: undefined,
+        hasKey: false
+      })
+    ])
+
+    expect(container.textContent).toContain('Model: claude-opus')
+    expect(container.textContent).not.toContain('Key:')
+  })
+
+  it('labels an empty local-Claude model as the default', () => {
+    renderList([
+      provider({
+        type: 'claude-default',
+        name: 'Local Claude',
+        baseUrl: undefined,
+        model: undefined,
+        maskedKey: undefined,
+        hasKey: false
+      })
+    ])
+
+    expect(container.textContent).toContain('Model: default')
+    expect(container.textContent).not.toContain('Key:')
+  })
+
+  it('renders an empty state with no providers', () => {
+    renderList([])
+
+    expect(container.textContent).toContain('No providers yet')
+  })
+})

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -1,0 +1,164 @@
+import { CheckCircle2, Pencil, PlugZap, Trash2 } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+import type { ProviderView } from '../../../../shared/settings'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+type ProviderListProps = {
+  providers: ProviderView[]
+  // Id of the currently selected provider (the one requests are routed through).
+  activeProviderId: string | undefined
+  busyProviderId?: string
+  onEdit: (provider: ProviderView) => void
+  onDelete: (provider: ProviderView) => void
+  onSetActive: (provider: ProviderView) => void
+  onTest: (provider: ProviderView) => void
+}
+
+type IconActionButtonProps = {
+  // Accessible name and hover tooltip text (kept identical so the hover label is also the a11y name).
+  label: string
+  icon: LucideIcon
+  onClick: () => void
+  disabled?: boolean
+  danger?: boolean
+}
+
+// Human label for a provider type badge.
+const describeType = (type: ProviderView['type']): string =>
+  type === 'custom' ? 'Custom' : 'Local Claude'
+
+// An icon-only row action with a hover tooltip. The label is exposed via aria-label for accessibility
+// and shown on hover via the shared tooltip so the actions row stays compact.
+const IconActionButton = ({
+  label,
+  icon: Icon,
+  onClick,
+  disabled = false,
+  danger = false
+}: IconActionButtonProps): React.JSX.Element => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <button
+        type="button"
+        aria-label={label}
+        disabled={disabled}
+        onClick={onClick}
+        className={cn(
+          'inline-flex size-7 items-center justify-center rounded-lg border border-border text-foreground transition-colors hover:bg-muted',
+          danger && 'text-destructive hover:bg-destructive/10 hover:text-destructive',
+          // Disabled actions read as inert gray with no hover affordance (e.g. delete on the selected provider).
+          'disabled:pointer-events-none disabled:border-border disabled:text-muted-foreground disabled:opacity-50'
+        )}
+      >
+        <Icon className="size-3.5" strokeWidth={2} aria-hidden="true" />
+      </button>
+    </TooltipTrigger>
+    <TooltipContent>{label}</TooltipContent>
+  </Tooltip>
+)
+
+// Lists configured providers with their type, masked key, and model. Each row leads with the
+// select/selected control, followed by compact icon actions (test / edit / delete) with hover
+// tooltips. Shared by the settings page (the onboarding wizard uses the form directly).
+const ProviderList = ({
+  providers,
+  activeProviderId,
+  busyProviderId,
+  onEdit,
+  onDelete,
+  onSetActive,
+  onTest
+}: ProviderListProps): React.JSX.Element => {
+  if (providers.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+        No providers yet. Add one to choose your model source.
+      </div>
+    )
+  }
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <ul className="space-y-2">
+        {providers.map((provider) => {
+          const isSelected = provider.id === activeProviderId
+          const isBusy = provider.id === busyProviderId
+          // The selected provider (and the last remaining one) can't be deleted: removing the active
+          // provider would drop the app back to onboarding, so its delete action stays disabled.
+          const canDelete = !isSelected && providers.length > 1
+
+          return (
+            <li key={provider.id} className="rounded-xl border border-border p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium text-foreground">
+                      {provider.name}
+                    </span>
+                    <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                      {describeType(provider.type)}
+                    </span>
+                  </div>
+                  <div className="mt-1 space-y-0.5 text-xs text-muted-foreground">
+                    {provider.type === 'custom' ? (
+                      <>
+                        {provider.model ? (
+                          <div className="truncate">Model: {provider.model}</div>
+                        ) : null}
+                        {provider.maskedKey ? (
+                          <div className="font-mono">Key: {provider.maskedKey}</div>
+                        ) : null}
+                        {provider.needsKey ? (
+                          <div className="text-destructive">Key needs re-entry</div>
+                        ) : null}
+                      </>
+                    ) : (
+                      // Local Claude reuses the machine's own auth: show only the model (never a key).
+                      <div className="truncate">Model: {provider.model || 'default'}</div>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {/* First action is always the select control: a marker when selected, a button otherwise. */}
+                {isSelected ? (
+                  <span className="inline-flex items-center gap-1 rounded-lg bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+                    <CheckCircle2 className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                    Selected
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    disabled={isBusy}
+                    onClick={() => onSetActive(provider)}
+                    className="rounded-lg border border-primary px-2.5 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
+                  >
+                    Select
+                  </button>
+                )}
+                <IconActionButton
+                  label="Test connection"
+                  icon={PlugZap}
+                  onClick={() => onTest(provider)}
+                  disabled={isBusy}
+                />
+                <IconActionButton label="Edit" icon={Pencil} onClick={() => onEdit(provider)} />
+                <IconActionButton
+                  label="Delete"
+                  icon={Trash2}
+                  onClick={() => onDelete(provider)}
+                  disabled={!canDelete}
+                  danger
+                />
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </TooltipProvider>
+  )
+}
+
+export { ProviderList }

--- a/src/renderer/src/pages/settings/ProviderSwitchDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderSwitchDialog.render.test.tsx
@@ -1,0 +1,89 @@
+import { Children, isValidElement, type ReactElement, type ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...values: Array<string | false | undefined>) => values.filter(Boolean).join(' ')
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: Record<string, unknown> & { children?: ReactNode }) => (
+    <button {...props}>{children}</button>
+  )
+}))
+
+type ElementWithProps = ReactElement<Record<string, unknown>>
+
+const collectElements = (node: ReactNode): ElementWithProps[] => {
+  const elements: ElementWithProps[] = []
+
+  const visit = (value: ReactNode): void => {
+    Children.forEach(value, (child) => {
+      if (!isValidElement(child)) return
+
+      const element = child as ElementWithProps
+      elements.push(element)
+      visit(element.props.children as ReactNode)
+    })
+  }
+
+  visit(node)
+  return elements
+}
+
+const getTextContent = (node: ReactNode): string => {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (!isValidElement(node)) return ''
+
+  return Children.toArray((node as ElementWithProps).props.children as ReactNode)
+    .map(getTextContent)
+    .join('')
+}
+
+describe('ProviderSwitchDialog wiring', () => {
+  it('routes cancel via the overlay close and confirm via the action button', async () => {
+    const { ProviderSwitchDialog } = await import('./ProviderSwitchDialog')
+    const onCancel = vi.fn()
+    const onConfirm = vi.fn()
+    const tree = ProviderSwitchDialog({ open: true, runningCount: 1, onCancel, onConfirm })
+    const elements = collectElements(tree)
+    const root = elements[0]
+    const confirmButton = elements.find(
+      (element) =>
+        getTextContent(element).trim() === 'Interrupt and switch' && element.props.onClick
+    )
+
+    // Dismissing the dialog (Esc / overlay) reports a cancel and changes nothing.
+    expect(root.props.onOpenChange).toBeTypeOf('function')
+    ;(root.props.onOpenChange as (open: boolean) => void)(false)
+    expect(onCancel).toHaveBeenCalledOnce()
+
+    expect(confirmButton?.props.onClick).toBeTypeOf('function')
+    ;(confirmButton?.props.onClick as () => void)()
+    expect(onConfirm).toHaveBeenCalledOnce()
+  })
+
+  it('describes a single running session in the interrupt warning', async () => {
+    const { ProviderSwitchDialog } = await import('./ProviderSwitchDialog')
+    const tree = ProviderSwitchDialog({
+      open: true,
+      runningCount: 1,
+      onCancel: vi.fn(),
+      onConfirm: vi.fn()
+    })
+
+    expect(getTextContent(tree)).toContain('A session is currently running')
+    expect(getTextContent(tree)).toContain('interrupt the in-progress turn')
+  })
+
+  it('pluralizes the warning for multiple running sessions', async () => {
+    const { ProviderSwitchDialog } = await import('./ProviderSwitchDialog')
+    const tree = ProviderSwitchDialog({
+      open: true,
+      runningCount: 3,
+      onCancel: vi.fn(),
+      onConfirm: vi.fn()
+    })
+
+    expect(getTextContent(tree)).toContain('3 sessions are currently running')
+  })
+})

--- a/src/renderer/src/pages/settings/ProviderSwitchDialog.tsx
+++ b/src/renderer/src/pages/settings/ProviderSwitchDialog.tsx
@@ -1,0 +1,65 @@
+import { AlertDialog } from 'radix-ui'
+
+import { Button } from '@/components/ui/button'
+
+type ProviderSwitchDialogProps = {
+  open: boolean
+  // Number of sessions with an in-flight turn that would be interrupted by the switch.
+  runningCount: number
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+const switchDialogCancelButtonClassName =
+  'border-border-200 bg-bg-000 text-text-000 hover:bg-bg-200 hover:text-text-000'
+
+const switchDialogConfirmButtonClassName =
+  'border-transparent bg-text-000 text-bg-000 hover:bg-text-100 hover:text-bg-000'
+
+// Confirms interrupting in-flight turns before switching the active provider. The interrupted turn is
+// not resumed automatically; the user continues by sending a new message afterward.
+const ProviderSwitchDialog = ({
+  open,
+  runningCount,
+  onCancel,
+  onConfirm
+}: ProviderSwitchDialogProps): React.JSX.Element => (
+  <AlertDialog.Root
+    open={open}
+    onOpenChange={(next) => {
+      if (!next) onCancel()
+    }}
+  >
+    <AlertDialog.Portal>
+      <AlertDialog.Overlay className="fixed inset-0 z-50 bg-black/25 backdrop-blur-[2px]" />
+      <AlertDialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(440px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-bg-000 p-6 text-text-000 shadow-dialog">
+        <AlertDialog.Title className="text-base font-semibold text-text-000">
+          Switch active provider?
+        </AlertDialog.Title>
+        <AlertDialog.Description className="mt-2 text-sm leading-relaxed text-text-100">
+          {runningCount === 1
+            ? 'A session is currently running. Switching will interrupt the in-progress turn. You can continue that conversation afterward by sending a new message.'
+            : `${runningCount} sessions are currently running. Switching will interrupt their in-progress turns. You can continue those conversations afterward by sending a new message.`}
+        </AlertDialog.Description>
+        <div className="mt-6 flex justify-end gap-2">
+          <AlertDialog.Cancel asChild>
+            <Button type="button" variant="outline" className={switchDialogCancelButtonClassName}>
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action asChild>
+            <Button
+              type="button"
+              className={switchDialogConfirmButtonClassName}
+              onClick={onConfirm}
+            >
+              Interrupt and switch
+            </Button>
+          </AlertDialog.Action>
+        </div>
+      </AlertDialog.Content>
+    </AlertDialog.Portal>
+  </AlertDialog.Root>
+)
+
+export { ProviderSwitchDialog }

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SettingsPage } from './SettingsPage'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+
+let container: HTMLDivElement
+let root: Root
+
+// Minimal window.api surface the settings store touches when the dialog opens. Attached onto the
+// real jsdom window so DOM globals radix relies on (getComputedStyle, etc.) stay intact.
+const installApi = (): void => {
+  ;(window as unknown as { api: unknown }).api = {
+    settings: {
+      getSettings: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
+      getPreflight: vi.fn().mockResolvedValue({ claudeReady: true, activeProviderReady: true }),
+      isEncryptionAvailable: vi.fn().mockResolvedValue(true),
+      isNpmAvailable: vi.fn().mockResolvedValue(true)
+    },
+    acp: {
+      getState: vi.fn().mockResolvedValue({ promptInFlightSessionIds: [] }),
+      cancel: vi.fn()
+    }
+  }
+}
+
+beforeEach(() => {
+  installApi()
+  useSettingsStore.setState(createInitialSettingsState())
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+  delete (window as unknown as { api?: unknown }).api
+})
+
+describe('SettingsPage layout', () => {
+  it('mounts the sidebar + content layout with a single Model nav item and a close control', () => {
+    act(() => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+
+    // Dialog content is portaled to the document body.
+    const dialog = document.body.querySelector('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+
+    // Left navigation labelled "Settings" with exactly one nav item: Model.
+    const nav = document.body.querySelector('nav[aria-label="Settings"]')
+    expect(nav).not.toBeNull()
+    const navItems = nav?.querySelectorAll('li') ?? []
+    expect(navItems).toHaveLength(1)
+    expect(navItems[0]?.textContent).toContain('Model')
+    expect(nav?.querySelector('[aria-current="page"]')).not.toBeNull()
+
+    // The header shows the panel title and a close control.
+    expect(document.body.querySelector('[aria-label="Close settings"]')).not.toBeNull()
+
+    // The Model panel content is present (Claude + Providers sections).
+    expect(document.body.textContent).toContain('Claude')
+    expect(document.body.textContent).toContain('Providers')
+  })
+
+  it('does not render when closed', () => {
+    act(() => {
+      root.render(<SettingsPage open={false} onClose={vi.fn()} />)
+    })
+
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+  })
+})

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -1,0 +1,338 @@
+import { SlidersHorizontal, X } from 'lucide-react'
+import { Dialog } from 'radix-ui'
+import { useEffect, useState } from 'react'
+
+import type { ProviderView, UpsertProviderRequest } from '../../../../shared/settings'
+import { useSettingsStore, type ProviderSwitchPlan } from '@/stores/settings-store'
+import { ClaudeInstallCard } from './ClaudeInstallCard'
+import { ClaudeStatusCard } from './ClaudeStatusCard'
+import { ProviderForm } from './ProviderForm'
+import {
+  createEmptyProviderFormValue,
+  getProviderFormErrors,
+  hasProviderFormErrors,
+  type ProviderFormValue
+} from './provider-form-value'
+import { ProviderList } from './ProviderList'
+import { ProviderSwitchDialog } from './ProviderSwitchDialog'
+import { describeValidation } from './validation-message'
+
+type SettingsPageProps = {
+  open: boolean
+  onClose: () => void
+}
+
+// Form target: a brand-new provider or an existing one being edited.
+type FormTarget = { mode: 'create' } | { mode: 'edit'; provider: ProviderView }
+
+// Builds a form value from an existing provider (never carrying the plaintext key).
+const toFormValue = (provider: ProviderView): ProviderFormValue =>
+  createEmptyProviderFormValue({
+    type: provider.type,
+    name: provider.name,
+    baseUrl: provider.baseUrl ?? '',
+    model: provider.model ?? ''
+  })
+
+const toUpsertRequest = (
+  value: ProviderFormValue,
+  id: string | undefined
+): UpsertProviderRequest => ({
+  id,
+  type: value.type,
+  name: value.name,
+  baseUrl: value.baseUrl,
+  model: value.model,
+  key: value.key || undefined
+})
+
+// App-level model settings surface. Reuses the onboarding cards/form; manages providers (CRUD +
+// activate + test). Opened from the Home/Workspace gear entry.
+const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element => {
+  const claude = useSettingsStore((state) => state.claude)
+  const preflight = useSettingsStore((state) => state.preflight)
+  const providers = useSettingsStore((state) => state.providers)
+  const activeProviderId = useSettingsStore((state) => state.activeProviderId)
+  const isDetectingClaude = useSettingsStore((state) => state.isDetectingClaude)
+  const isInstalling = useSettingsStore((state) => state.isInstalling)
+  const installLogs = useSettingsStore((state) => state.installLogs)
+  const npmAvailable = useSettingsStore((state) => state.npmAvailable)
+  const load = useSettingsStore((state) => state.load)
+  const detectClaude = useSettingsStore((state) => state.detectClaude)
+  const installClaude = useSettingsStore((state) => state.installClaude)
+  const saveProvider = useSettingsStore((state) => state.saveProvider)
+  const setActiveProvider = useSettingsStore((state) => state.setActiveProvider)
+  const prepareProviderSwitch = useSettingsStore((state) => state.prepareProviderSwitch)
+  const interruptAndSetActiveProvider = useSettingsStore(
+    (state) => state.interruptAndSetActiveProvider
+  )
+  const deleteProvider = useSettingsStore((state) => state.deleteProvider)
+  const validateProvider = useSettingsStore((state) => state.validateProvider)
+
+  const [formTarget, setFormTarget] = useState<FormTarget | null>(null)
+  const [formValue, setFormValue] = useState<ProviderFormValue>(() =>
+    createEmptyProviderFormValue()
+  )
+  const [isSaving, setIsSaving] = useState(false)
+  const [statusMessage, setStatusMessage] = useState<string | undefined>(undefined)
+  const [statusOk, setStatusOk] = useState(false)
+  const [busyProviderId, setBusyProviderId] = useState<string | undefined>(undefined)
+  // A switch awaiting confirmation because one or more sessions are mid-turn.
+  const [pendingSwitch, setPendingSwitch] = useState<ProviderSwitchPlan | null>(null)
+
+  // Refresh settings whenever the dialog opens so external changes are reflected.
+  useEffect(() => {
+    if (open) void load()
+  }, [open, load])
+
+  const editingProvider = formTarget?.mode === 'edit' ? formTarget.provider : undefined
+  // Required-field errors for the open draft; a custom provider must be complete before it can save.
+  const formErrors = getProviderFormErrors(formValue, { hasStoredKey: editingProvider?.hasKey })
+  const canSave = !isSaving && !hasProviderFormErrors(formErrors)
+
+  const openCreate = (): void => {
+    setFormTarget({ mode: 'create' })
+    setFormValue(createEmptyProviderFormValue())
+    setStatusMessage(undefined)
+  }
+
+  const openEdit = (provider: ProviderView): void => {
+    setFormTarget({ mode: 'edit', provider })
+    setFormValue(toFormValue(provider))
+    setStatusMessage(undefined)
+  }
+
+  const closeForm = (): void => {
+    setFormTarget(null)
+    setStatusMessage(undefined)
+  }
+
+  const handleSave = async (): Promise<void> => {
+    setIsSaving(true)
+    setStatusMessage(undefined)
+
+    try {
+      const { validation } = await saveProvider(toUpsertRequest(formValue, editingProvider?.id))
+
+      setStatusOk(validation.ok)
+      setStatusMessage(describeValidation(validation))
+
+      if (validation.ok) setFormTarget(null)
+    } catch (error) {
+      setStatusOk(false)
+      setStatusMessage(error instanceof Error ? error.message : 'Could not save provider.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleTest = async (provider: ProviderView): Promise<void> => {
+    setBusyProviderId(provider.id)
+    setStatusMessage(undefined)
+
+    try {
+      const validation = await validateProvider({ providerId: provider.id })
+
+      setStatusOk(validation.ok)
+      setStatusMessage(`${provider.name}: ${describeValidation(validation)}`)
+    } finally {
+      setBusyProviderId(undefined)
+    }
+  }
+
+  // Begins a provider switch. With no in-flight turns it switches immediately; otherwise it opens the
+  // interrupt confirmation and defers the switch until the user confirms.
+  const handleSetActive = async (provider: ProviderView): Promise<void> => {
+    setBusyProviderId(provider.id)
+
+    try {
+      const plan = await prepareProviderSwitch(provider.id)
+
+      if (plan.needsConfirm) {
+        setPendingSwitch(plan)
+        return
+      }
+
+      await setActiveProvider(provider.id)
+    } finally {
+      setBusyProviderId(undefined)
+    }
+  }
+
+  // Confirmed the interrupt: cancel the in-flight turns, then switch the active provider.
+  const confirmPendingSwitch = async (): Promise<void> => {
+    const plan = pendingSwitch
+
+    if (!plan) return
+
+    setPendingSwitch(null)
+    setBusyProviderId(plan.providerId)
+
+    try {
+      await interruptAndSetActiveProvider(plan.providerId, plan.runningSessionIds)
+    } finally {
+      setBusyProviderId(undefined)
+    }
+  }
+
+  // Cancelled the confirmation: leave the active provider and running sessions untouched.
+  const cancelPendingSwitch = (): void => {
+    setPendingSwitch(null)
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(next) => (next ? undefined : onClose())}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex h-[min(640px,calc(100vh-2rem))] w-[min(920px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-border bg-card text-foreground shadow-dialog data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+          {/* Radix requires a Title/Description for a11y; the visible panel title lives in the header. */}
+          <Dialog.Title className="sr-only">Settings</Dialog.Title>
+          <Dialog.Description className="sr-only">
+            Manage your Claude installation and model providers.
+          </Dialog.Description>
+
+          {/* Left navigation: a single Model panel for now. */}
+          <nav
+            aria-label="Settings"
+            className="flex w-52 shrink-0 flex-col gap-1 border-r border-border bg-muted/40 p-3"
+          >
+            <div className="px-2 pb-1 pt-1 text-xs font-medium text-muted-foreground">Settings</div>
+            <ul className="flex flex-col gap-0.5">
+              <li>
+                <button
+                  type="button"
+                  aria-current="page"
+                  className="flex h-8 w-full items-center gap-2 rounded-lg bg-muted px-2 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted"
+                >
+                  <SlidersHorizontal className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  <span className="min-w-0 flex-1 truncate">Model</span>
+                </button>
+              </li>
+            </ul>
+          </nav>
+
+          {/* Right column: header bar + scrollable panel content. */}
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-card">
+            <div className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-border px-5">
+              <h2 className="truncate text-sm font-semibold text-foreground">Model</h2>
+              <Dialog.Close
+                aria-label="Close settings"
+                className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <X className="size-4" aria-hidden="true" />
+              </Dialog.Close>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="space-y-6 p-5">
+                <section aria-label="Claude">
+                  <h3 className="mb-3 text-sm font-semibold text-foreground">Claude</h3>
+                  <div className="space-y-3">
+                    <ClaudeStatusCard
+                      claude={claude}
+                      claudeReady={preflight.claudeReady}
+                      isDetecting={isDetectingClaude}
+                      onDetect={() => void detectClaude()}
+                    />
+                    {!preflight.claudeReady ? (
+                      <ClaudeInstallCard
+                        isInstalling={isInstalling}
+                        installLogs={installLogs}
+                        npmAvailable={npmAvailable}
+                        onInstall={(source) => void installClaude(source)}
+                      />
+                    ) : null}
+                  </div>
+                </section>
+
+                <section aria-label="Providers" className="border-t border-border pt-6">
+                  <div className="mb-3 flex items-center justify-between">
+                    <h3 className="text-sm font-semibold text-foreground">Providers</h3>
+                    {!formTarget ? (
+                      <button
+                        type="button"
+                        onClick={openCreate}
+                        className="rounded-lg border border-border px-2.5 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+                      >
+                        Add provider
+                      </button>
+                    ) : null}
+                  </div>
+
+                  {formTarget ? (
+                    <div className="rounded-xl border border-border p-4">
+                      <ProviderForm
+                        value={formValue}
+                        onChange={(patch) => setFormValue((current) => ({ ...current, ...patch }))}
+                        hasStoredKey={editingProvider?.hasKey}
+                        maskedKey={editingProvider?.maskedKey}
+                        needsKey={editingProvider?.needsKey}
+                        errors={formErrors}
+                        disabled={isSaving}
+                      />
+                      {statusMessage ? (
+                        <p
+                          className={`mt-3 text-sm ${statusOk ? 'text-primary' : 'text-destructive'}`}
+                          role="alert"
+                        >
+                          {statusMessage}
+                        </p>
+                      ) : null}
+                      <div className="mt-4 flex justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={closeForm}
+                          disabled={isSaving}
+                          className="rounded-lg border border-border px-3 py-1.5 text-sm transition-colors hover:bg-muted disabled:opacity-50"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void handleSave()}
+                          disabled={!canSave}
+                          className="rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+                        >
+                          {isSaving ? 'Saving…' : 'Save & test'}
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      {statusMessage ? (
+                        <p
+                          className={`mb-3 text-sm ${statusOk ? 'text-primary' : 'text-destructive'}`}
+                          role="alert"
+                        >
+                          {statusMessage}
+                        </p>
+                      ) : null}
+                      <ProviderList
+                        providers={providers}
+                        activeProviderId={activeProviderId}
+                        busyProviderId={busyProviderId}
+                        onEdit={openEdit}
+                        onDelete={(provider) => void deleteProvider(provider.id)}
+                        onSetActive={(provider) => void handleSetActive(provider)}
+                        onTest={(provider) => void handleTest(provider)}
+                      />
+                    </>
+                  )}
+                </section>
+              </div>
+            </div>
+          </div>
+
+          <ProviderSwitchDialog
+            open={pendingSwitch !== null}
+            runningCount={pendingSwitch?.runningSessionIds.length ?? 0}
+            onCancel={cancelPendingSwitch}
+            onConfirm={() => void confirmPendingSwitch()}
+          />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+export { SettingsPage }

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createEmptyProviderFormValue,
+  getProviderFormErrors,
+  hasProviderFormErrors
+} from './provider-form-value'
+
+describe('getProviderFormErrors', () => {
+  it('flags every missing required field for a new custom provider', () => {
+    const errors = getProviderFormErrors(createEmptyProviderFormValue({ type: 'custom' }))
+
+    expect(errors).toEqual({
+      baseUrl: 'Base URL is required.',
+      key: 'API key is required.',
+      model: 'Model is required.'
+    })
+    expect(hasProviderFormErrors(errors)).toBe(true)
+  })
+
+  it('has no errors once a custom provider is fully filled', () => {
+    const errors = getProviderFormErrors(
+      createEmptyProviderFormValue({
+        type: 'custom',
+        baseUrl: 'https://g/v1',
+        key: 'sk-key',
+        model: 'claude-sonnet-4-5'
+      })
+    )
+
+    expect(errors).toEqual({})
+    expect(hasProviderFormErrors(errors)).toBe(false)
+  })
+
+  it('lets an edit keep a stored key by leaving the key blank', () => {
+    const errors = getProviderFormErrors(
+      createEmptyProviderFormValue({ type: 'custom', baseUrl: 'https://g/v1', model: 'm' }),
+      { hasStoredKey: true }
+    )
+
+    expect(errors.key).toBeUndefined()
+    expect(hasProviderFormErrors(errors)).toBe(false)
+  })
+
+  it('never requires fields for a local-claude provider', () => {
+    const errors = getProviderFormErrors(createEmptyProviderFormValue({ type: 'claude-default' }))
+
+    expect(errors).toEqual({})
+    expect(hasProviderFormErrors(errors)).toBe(false)
+  })
+})

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -1,0 +1,52 @@
+import type { ProviderType } from '../../../../shared/settings'
+
+// Editable value for the provider form, kept in its own module so the component file only exports a
+// component (satisfying react-refresh) while the wizard and settings page share this shape/factory.
+export type ProviderFormValue = {
+  type: ProviderType
+  name: string
+  baseUrl: string
+  model: string
+  // Plaintext only while the user is typing a new key; empty means "keep the stored key".
+  key: string
+}
+
+// Builds an empty form value, defaulting to a custom provider (the common first-run case).
+export const createEmptyProviderFormValue = (
+  overrides: Partial<ProviderFormValue> = {}
+): ProviderFormValue => ({
+  type: 'custom',
+  name: '',
+  baseUrl: '',
+  model: '',
+  key: '',
+  ...overrides
+})
+
+// Per-field validation errors for a custom provider draft. claude-default has no required fields.
+export type ProviderFormErrors = {
+  baseUrl?: string
+  key?: string
+  model?: string
+}
+
+// Computes required-field errors for a custom draft. On edit, an already-stored key satisfies the key
+// requirement, so the user can leave the key blank to keep it.
+export const getProviderFormErrors = (
+  value: ProviderFormValue,
+  options: { hasStoredKey?: boolean } = {}
+): ProviderFormErrors => {
+  if (value.type !== 'custom') return {}
+
+  const errors: ProviderFormErrors = {}
+
+  if (!value.baseUrl.trim()) errors.baseUrl = 'Base URL is required.'
+  if (!value.model.trim()) errors.model = 'Model is required.'
+  if (!value.key.trim() && !options.hasStoredKey) errors.key = 'API key is required.'
+
+  return errors
+}
+
+// True when a draft has at least one required-field error (blocks save/test).
+export const hasProviderFormErrors = (errors: ProviderFormErrors): boolean =>
+  Object.keys(errors).length > 0

--- a/src/renderer/src/pages/settings/validation-message.ts
+++ b/src/renderer/src/pages/settings/validation-message.ts
@@ -1,0 +1,36 @@
+import type { ValidateProviderResult, ValidationCategory } from '../../../../shared/settings'
+
+// Maps a validation category to an actionable, user-facing message. Centralized so the wizard and the
+// settings page phrase failures identically.
+const CATEGORY_MESSAGES: Record<ValidationCategory, string> = {
+  ok: 'Connection succeeded.',
+  network: 'Could not reach the endpoint. Check your network and base URL.',
+  auth: 'Authentication failed. Check the API key.',
+  'model-not-found': 'The model was rejected. Check the model name for this gateway.',
+  'bad-url': 'The base URL is invalid. Enter a full URL like https://gateway.example/v1.',
+  timeout: 'The request timed out and was stopped.',
+  unknown: 'Validation failed for an unknown reason.'
+}
+
+// Categories whose generic text benefits from the specific error/probe message (e.g. a local-Claude
+// timeout or network failure). Auth/model/bad-url already carry actionable text.
+const MESSAGE_CATEGORIES = new Set<ValidationCategory>(['network', 'timeout', 'unknown'])
+
+// Produces the message to show for a validation result, appending a specific server/probe message when
+// the category is generic and an HTTP status when one is available.
+const describeValidation = (result: ValidateProviderResult): string => {
+  const base = CATEGORY_MESSAGES[result.category]
+
+  if (result.message && MESSAGE_CATEGORIES.has(result.category)) {
+    return `${base} (${result.message})`
+  }
+
+  if (result.status) {
+    return `${base} (HTTP ${result.status})`
+  }
+
+  return base
+}
+
+export { CATEGORY_MESSAGES, describeValidation }
+

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -8,6 +8,7 @@ import { useWorkspaceAgentRuntime } from '@/lib/acp/useWorkspaceAgentRuntime'
 import { usePreviewPersistence } from '@/lib/preview-persistence/preview-persistence'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useProjectStore } from '@/stores/project-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import {
   createNotebookPreviewItem,
   createProjectFilesPreviewItem,
@@ -88,6 +89,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   // matches no session and triggers the redirect below.
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
   const goHome = useNavigationStore((state) => state.goHome)
+  const openSettings = useSettingsStore((state) => state.openSettings)
   const scopedProjectId = activeProjectId ?? ''
   const activeProject = useProjectStore((state) =>
     state.projects.find((project) => project.id === scopedProjectId)
@@ -466,6 +468,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
           onOpenSession={openSession}
           onRenameSession={openRenameDialog}
           onDeleteSession={setSessionToDelete}
+          onOpenSettings={openSettings}
         />
 
         {/* Resizable panels follow the existing workspace layout; main content owns chat state. */}

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -35,6 +35,7 @@ const renderSidebar = async (sessions: ChatSession[]): Promise<string> => {
       onOpenSession={vi.fn()}
       onRenameSession={vi.fn()}
       onDeleteSession={vi.fn()}
+      onOpenSettings={vi.fn()}
     />
   )
 }
@@ -112,7 +113,8 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles: vi.fn(),
       onOpenSession,
       onRenameSession,
-      onDeleteSession
+      onDeleteSession,
+      onOpenSettings: vi.fn()
     })
     const elements = collectElements(tree)
     const notebookButton = elements.find(
@@ -151,7 +153,8 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles,
       onOpenSession: vi.fn(),
       onRenameSession: vi.fn(),
-      onDeleteSession: vi.fn()
+      onDeleteSession: vi.fn(),
+      onOpenSettings: vi.fn()
     })
     const buttons = collectElements(tree).filter((element) => element.type === 'button')
     const newButtonIndex = buttons.findIndex((button) => getTextContent(button).trim() === 'New')

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -16,6 +16,7 @@ type WorkspaceSidebarProps = {
   onOpenSession: (sessionId: string) => void
   onRenameSession: (session: ChatSession) => void
   onDeleteSession: (session: ChatSession) => void
+  onOpenSettings: () => void
 }
 
 // Maps each session status to the left-side indicator dot using emitted theme colors.
@@ -66,7 +67,8 @@ const WorkspaceSidebar = ({
   onOpenFiles,
   onOpenSession,
   onRenameSession,
-  onDeleteSession
+  onDeleteSession,
+  onOpenSettings
 }: WorkspaceSidebarProps): React.JSX.Element => (
   <aside className="z-10 flex h-full w-[220px] min-w-0 shrink-0 flex-col">
     <div className="m-2 mr-0 flex min-h-0 flex-1 flex-col rounded-lg bg-rail-card-bg shadow-card">
@@ -225,6 +227,7 @@ const WorkspaceSidebar = ({
           />
           <button
             type="button"
+            onClick={onOpenSettings}
             className={cn(
               'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-text-300 hover:bg-bg-300 hover:text-text-000',
               sidebarInteractiveTransitionClassName

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SettingsSnapshot, ValidateProviderResult } from '../../../shared/settings'
+import { createInitialSettingsState, useSettingsStore } from './settings-store'
+
+// Minimal window.api.settings surface the store calls.
+type SettingsApi = {
+  getSettings: ReturnType<typeof vi.fn>
+  getPreflight: ReturnType<typeof vi.fn>
+  isEncryptionAvailable: ReturnType<typeof vi.fn>
+  isNpmAvailable: ReturnType<typeof vi.fn>
+  upsertProvider: ReturnType<typeof vi.fn>
+  validateProvider: ReturnType<typeof vi.fn>
+  setActiveProvider: ReturnType<typeof vi.fn>
+  deleteProvider: ReturnType<typeof vi.fn>
+}
+
+// Minimal window.api.acp surface the provider-switch flow reads/uses.
+type AcpApi = {
+  getState: ReturnType<typeof vi.fn>
+  cancel: ReturnType<typeof vi.fn>
+}
+
+const snapshot = (providers: SettingsSnapshot['providers']): SettingsSnapshot => ({
+  claude: {},
+  activeProviderId: undefined,
+  providers
+})
+
+const providerView = (id: string): SettingsSnapshot['providers'][number] => ({
+  id,
+  type: 'custom',
+  name: 'Gateway',
+  hasKey: true,
+  needsKey: false
+})
+
+let api: SettingsApi
+let acp: AcpApi
+// Ordered log of significant calls, used to assert cancel-before-switch ordering.
+let callLog: string[]
+
+beforeEach(() => {
+  callLog = []
+  api = {
+    getSettings: vi.fn().mockResolvedValue(snapshot([])),
+    getPreflight: vi.fn().mockResolvedValue({ claudeReady: true, activeProviderReady: true }),
+    isEncryptionAvailable: vi.fn().mockResolvedValue(true),
+    isNpmAvailable: vi.fn().mockResolvedValue(true),
+    upsertProvider: vi.fn(),
+    validateProvider: vi.fn(),
+    setActiveProvider: vi.fn().mockImplementation((request: { id: string }) => {
+      callLog.push(`setActive:${request.id}`)
+      return Promise.resolve({ ...snapshot([]), activeProviderId: request.id })
+    }),
+    deleteProvider: vi.fn()
+  }
+  acp = {
+    getState: vi.fn().mockResolvedValue({ promptInFlightSessionIds: [] }),
+    cancel: vi.fn().mockImplementation((request: { sessionId: string }) => {
+      callLog.push(`cancel:${request.sessionId}`)
+      return Promise.resolve({})
+    })
+  }
+  ;(globalThis as { window?: unknown }).window = { api: { settings: api, acp } }
+  useSettingsStore.setState(createInitialSettingsState())
+})
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window
+})
+
+describe('settings store: saveAndActivateProvider', () => {
+  it('creates, validates, then activates a new provider on success', async () => {
+    api.upsertProvider.mockResolvedValue(snapshot([providerView('p_new')]))
+    api.validateProvider.mockResolvedValue({ ok: true, category: 'ok' } as ValidateProviderResult)
+    api.setActiveProvider.mockResolvedValue({
+      ...snapshot([providerView('p_new')]),
+      activeProviderId: 'p_new'
+    })
+
+    const result = await useSettingsStore.getState().saveAndActivateProvider({
+      type: 'custom',
+      name: 'Gateway',
+      baseUrl: 'https://g/v1',
+      key: 'k'
+    })
+
+    expect(result).toEqual({ providerId: 'p_new', validation: { ok: true, category: 'ok' } })
+    expect(api.validateProvider).toHaveBeenCalledWith({ providerId: 'p_new' })
+    expect(api.setActiveProvider).toHaveBeenCalledWith({ id: 'p_new' })
+    expect(useSettingsStore.getState().activeProviderId).toBe('p_new')
+  })
+
+  it('does not activate when validation fails', async () => {
+    api.upsertProvider.mockResolvedValue(snapshot([providerView('p_new')]))
+    api.validateProvider.mockResolvedValue({
+      ok: false,
+      category: 'auth'
+    } as ValidateProviderResult)
+
+    const result = await useSettingsStore.getState().saveAndActivateProvider({
+      type: 'custom',
+      name: 'Gateway',
+      baseUrl: 'https://g/v1',
+      key: 'k'
+    })
+
+    expect(result.validation.ok).toBe(false)
+    expect(api.setActiveProvider).not.toHaveBeenCalled()
+  })
+
+  it('resolves the edited id directly instead of diffing', async () => {
+    api.upsertProvider.mockResolvedValue(snapshot([providerView('p_existing')]))
+    api.validateProvider.mockResolvedValue({ ok: true, category: 'ok' } as ValidateProviderResult)
+
+    const { providerId } = await useSettingsStore
+      .getState()
+      .saveProvider({ id: 'p_existing', type: 'custom', name: 'Renamed' })
+
+    expect(providerId).toBe('p_existing')
+    expect(api.validateProvider).toHaveBeenCalledWith({ providerId: 'p_existing' })
+  })
+})
+
+describe('settings store: provider switch flow', () => {
+  it('does not need confirmation when no session is running', async () => {
+    acp.getState.mockResolvedValue({ promptInFlightSessionIds: [] })
+
+    const plan = await useSettingsStore.getState().prepareProviderSwitch('p2')
+
+    expect(plan).toEqual({ providerId: 'p2', runningSessionIds: [], needsConfirm: false })
+  })
+
+  it('needs confirmation and reports the running sessions when a turn is in flight', async () => {
+    acp.getState.mockResolvedValue({ promptInFlightSessionIds: ['s1', 's2'] })
+
+    const plan = await useSettingsStore.getState().prepareProviderSwitch('p2')
+
+    expect(plan).toEqual({
+      providerId: 'p2',
+      runningSessionIds: ['s1', 's2'],
+      needsConfirm: true
+    })
+  })
+
+  it('interrupts every running session before switching the active provider', async () => {
+    await useSettingsStore.getState().interruptAndSetActiveProvider('p2', ['s1', 's2'])
+
+    // Both cancels must precede the switch so the in-flight turns are interrupted first.
+    expect(callLog).toEqual(['cancel:s1', 'cancel:s2', 'setActive:p2'])
+    expect(acp.cancel).toHaveBeenCalledWith({ sessionId: 's1' })
+    expect(acp.cancel).toHaveBeenCalledWith({ sessionId: 's2' })
+    expect(api.setActiveProvider).toHaveBeenCalledWith({ id: 'p2' })
+    expect(useSettingsStore.getState().activeProviderId).toBe('p2')
+  })
+
+  it('switches directly with no cancels when there are no running sessions', async () => {
+    await useSettingsStore.getState().interruptAndSetActiveProvider('p2', [])
+
+    expect(acp.cancel).not.toHaveBeenCalled()
+    expect(callLog).toEqual(['setActive:p2'])
+  })
+})

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -1,0 +1,269 @@
+import { create } from 'zustand'
+
+import type {
+  ClaudeDetectResult,
+  ClaudeInfo,
+  ClaudeInstallResult,
+  ClaudeInstallSource,
+  Preflight,
+  ProviderView,
+  SettingsSnapshot,
+  UpsertProviderRequest,
+  ValidateProviderRequest,
+  ValidateProviderResult
+} from '../../../shared/settings'
+
+// Result of the combined onboarding save flow (create/edit -> validate -> activate).
+type SaveProviderResult = {
+  providerId: string
+  validation: ValidateProviderResult
+}
+
+// A planned provider switch: which provider to activate, which sessions are mid-turn, and whether the
+// caller must confirm the interruption first.
+type ProviderSwitchPlan = {
+  providerId: string
+  runningSessionIds: string[]
+  needsConfirm: boolean
+}
+
+type SettingsStoreData = {
+  isLoaded: boolean
+  claude: ClaudeInfo
+  activeProviderId: string | undefined
+  providers: ProviderView[]
+  preflight: Preflight
+  encryptionAvailable: boolean
+  npmAvailable: boolean
+  // Transient UI state for the wizard/settings page.
+  isDetectingClaude: boolean
+  isInstalling: boolean
+  installLogs: string[]
+  // Whether the settings dialog is open (rendered at the app root, over Home/Workspace).
+  isSettingsOpen: boolean
+}
+
+type SettingsStore = SettingsStoreData & {
+  load: () => Promise<void>
+  refreshPreflight: () => Promise<Preflight>
+  detectClaude: () => Promise<ClaudeDetectResult>
+  installClaude: (source: ClaudeInstallSource) => Promise<ClaudeInstallResult>
+  clearInstallLogs: () => void
+  // Persists the draft and validates it, without changing the active provider.
+  saveProvider: (request: UpsertProviderRequest) => Promise<SaveProviderResult>
+  // Combined onboarding flow: persist + validate + activate only on success.
+  saveAndActivateProvider: (request: UpsertProviderRequest) => Promise<SaveProviderResult>
+  validateProvider: (request: ValidateProviderRequest) => Promise<ValidateProviderResult>
+  setActiveProvider: (providerId: string) => Promise<void>
+  // Reads the ACP runtime snapshot to decide whether switching needs an interrupt confirmation.
+  prepareProviderSwitch: (providerId: string) => Promise<ProviderSwitchPlan>
+  // Interrupts the given in-flight turns (existing cancel path), then switches the active provider.
+  interruptAndSetActiveProvider: (providerId: string, runningSessionIds: string[]) => Promise<void>
+  deleteProvider: (providerId: string) => Promise<void>
+  openSettings: () => void
+  closeSettings: () => void
+}
+
+const createInitialPreflight = (): Preflight => ({
+  claudeReady: false,
+  activeProviderReady: false
+})
+
+export const createInitialSettingsState = (): SettingsStoreData => ({
+  isLoaded: false,
+  claude: {},
+  activeProviderId: undefined,
+  providers: [],
+  preflight: createInitialPreflight(),
+  encryptionAvailable: true,
+  npmAvailable: true,
+  isDetectingClaude: false,
+  isInstalling: false,
+  installLogs: [],
+  isSettingsOpen: false
+})
+
+// Applies a fresh main-process snapshot to the renderer cache.
+const applySnapshot = (snapshot: SettingsSnapshot): Partial<SettingsStoreData> => ({
+  claude: snapshot.claude,
+  activeProviderId: snapshot.activeProviderId,
+  providers: snapshot.providers
+})
+
+// Finds the provider id affected by an upsert: the edited id, or the one new since `before`.
+const resolveUpsertedProviderId = (
+  request: UpsertProviderRequest,
+  before: ProviderView[],
+  after: ProviderView[]
+): string | undefined => {
+  if (request.id) return request.id
+
+  const beforeIds = new Set(before.map((provider) => provider.id))
+
+  return after.find((provider) => !beforeIds.has(provider.id))?.id
+}
+
+// Renderer cache of the main-process settings service. The main process stays the source of truth
+// for secrets; this store only ever holds masked provider views.
+export const useSettingsStore = create<SettingsStore>((set, get) => ({
+  ...createInitialSettingsState(),
+
+  // Loads settings, preflight, and encryption availability in one startup pass.
+  load: async () => {
+    const [snapshot, preflight, encryptionAvailable, npmAvailable] = await Promise.all([
+      window.api.settings.getSettings(),
+      window.api.settings.getPreflight(),
+      window.api.settings.isEncryptionAvailable(),
+      window.api.settings.isNpmAvailable()
+    ])
+
+    set({
+      ...applySnapshot(snapshot),
+      preflight,
+      encryptionAvailable,
+      npmAvailable,
+      isLoaded: true
+    })
+  },
+
+  // Re-checks the two startup gates without reloading the whole snapshot.
+  refreshPreflight: async () => {
+    const preflight = await window.api.settings.getPreflight()
+
+    set({ preflight })
+
+    return preflight
+  },
+
+  // Detects claude and folds the resolved path/version back into the cache.
+  detectClaude: async () => {
+    set({ isDetectingClaude: true })
+
+    try {
+      const result = await window.api.settings.detectClaude()
+
+      if (result.found && result.path) {
+        set({ claude: { resolvedPath: result.path, version: result.version } })
+      }
+
+      await get().refreshPreflight()
+
+      return result
+    } finally {
+      set({ isDetectingClaude: false })
+    }
+  },
+
+  // Runs a one-click install, streaming output into installLogs, then refreshes settings/preflight.
+  installClaude: async (source) => {
+    set({ isInstalling: true, installLogs: [] })
+
+    const unsubscribe = window.api.settings.onInstallLog((event) => {
+      set((state) => ({ installLogs: [...state.installLogs, event.chunk] }))
+    })
+
+    try {
+      const result = await window.api.settings.installClaude({ source })
+
+      // A successful install re-detects claude in main; reload so the cache reflects it.
+      const snapshot = await window.api.settings.getSettings()
+
+      set(applySnapshot(snapshot))
+      await get().refreshPreflight()
+
+      return result
+    } finally {
+      unsubscribe()
+      set({ isInstalling: false })
+    }
+  },
+
+  clearInstallLogs: () => set({ installLogs: [] }),
+
+  // Persists a provider draft and validates it (without activating), refreshing derived state.
+  saveProvider: async (request) => {
+    const before = get().providers
+    const afterUpsert = await window.api.settings.upsertProvider(request)
+
+    set(applySnapshot(afterUpsert))
+
+    const providerId = resolveUpsertedProviderId(request, before, afterUpsert.providers)
+
+    if (!providerId) {
+      return { providerId: '', validation: { ok: false, category: 'unknown' } }
+    }
+
+    const validation = await window.api.settings.validateProvider({ providerId })
+
+    // Refresh so the validated-at timestamp / masked key reflect the latest stored state.
+    set(applySnapshot(await window.api.settings.getSettings()))
+    await get().refreshPreflight()
+
+    return { providerId, validation }
+  },
+
+  // Persists a provider draft, validates it, and activates it only when validation passes.
+  saveAndActivateProvider: async (request) => {
+    const result = await get().saveProvider(request)
+
+    if (result.validation.ok && result.providerId) {
+      await get().setActiveProvider(result.providerId)
+    }
+
+    return result
+  },
+
+  // Validates a saved provider or draft without changing the active selection.
+  validateProvider: async (request) => {
+    const result = await window.api.settings.validateProvider(request)
+
+    if (result.ok) {
+      set(applySnapshot(await window.api.settings.getSettings()))
+      await get().refreshPreflight()
+    }
+
+    return result
+  },
+
+  // Switches the active provider (main drops the agent connection so the next prompt reconnects).
+  setActiveProvider: async (providerId) => {
+    const snapshot = await window.api.settings.setActiveProvider({ id: providerId })
+
+    set(applySnapshot(snapshot))
+    await get().refreshPreflight()
+  },
+
+  // Inspects the ACP runtime for in-flight turns so the caller can confirm before interrupting them.
+  prepareProviderSwitch: async (providerId) => {
+    const { promptInFlightSessionIds } = await window.api.acp.getState()
+
+    return {
+      providerId,
+      runningSessionIds: promptInFlightSessionIds,
+      needsConfirm: promptInFlightSessionIds.length > 0
+    }
+  },
+
+  // Interrupts each in-flight turn (reusing the existing acp cancel path), then switches the active
+  // provider. Interrupted turns are not auto-resumed; the user continues by sending a new message.
+  interruptAndSetActiveProvider: async (providerId, runningSessionIds) => {
+    for (const sessionId of runningSessionIds) {
+      await window.api.acp.cancel({ sessionId })
+    }
+
+    await get().setActiveProvider(providerId)
+  },
+
+  deleteProvider: async (providerId) => {
+    const snapshot = await window.api.settings.deleteProvider({ id: providerId })
+
+    set(applySnapshot(snapshot))
+    await get().refreshPreflight()
+  },
+
+  openSettings: () => set({ isSettingsOpen: true }),
+
+  closeSettings: () => set({ isSettingsOpen: false })
+}))
+
+export type { ProviderSwitchPlan, SaveProviderResult }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,0 +1,147 @@
+// Shared model-settings & onboarding types crossing the main <-> renderer IPC boundary.
+//
+// The main process owns settings.json and all secret material. The renderer only ever receives the
+// masked provider view (never keyRef or plaintext keys) and sends drafts that carry a plaintext key
+// only while the user is actively typing one in.
+
+// Settings file schema version; bumped when the on-disk shape changes.
+export const SETTINGS_FILE_VERSION = 1
+
+// A provider either targets a custom Anthropic-compatible gateway or reuses the local claude auth.
+export type ProviderType = 'custom' | 'claude-default'
+
+// Detected claude executable metadata, persisted so later spawns skip re-detection.
+export type ClaudeInfo = {
+  resolvedPath?: string
+  version?: string
+}
+
+// Result of probing the machine for a runnable claude executable.
+export type ClaudeDetectResult = {
+  found: boolean
+  path?: string
+  version?: string
+}
+
+// Renderer-facing provider view: masked and stripped of every secret field.
+export type ProviderView = {
+  id: string
+  type: ProviderType
+  name: string
+  baseUrl?: string
+  model?: string
+  // A short, non-secret hint like "sk-…abcd" for display only.
+  maskedKey?: string
+  // True when a key is stored (custom providers). Lets the form show "leave blank to keep".
+  hasKey: boolean
+  // True when a stored key could not be decrypted and must be re-entered before use.
+  needsKey: boolean
+  lastValidatedAt?: number
+}
+
+// Full renderer snapshot of settings state.
+export type SettingsSnapshot = {
+  claude: ClaudeInfo
+  activeProviderId?: string
+  providers: ProviderView[]
+}
+
+// The two hard startup gates. Kept as plain booleans so the wizard can target the first unmet step.
+export type Preflight = {
+  claudeReady: boolean
+  activeProviderReady: boolean
+}
+
+// A provider draft as entered in the renderer form. The plaintext `key` is present only when the user
+// typed a new one; leaving it undefined on edit keeps the previously stored key.
+export type ProviderDraft = {
+  type: ProviderType
+  name?: string
+  baseUrl?: string
+  model?: string
+  key?: string
+}
+
+// Create/update request: an existing `id` edits in place, otherwise a new provider is created.
+export type UpsertProviderRequest = ProviderDraft & {
+  id?: string
+}
+
+export type DeleteProviderRequest = {
+  id: string
+}
+
+export type SetActiveProviderRequest = {
+  id: string
+}
+
+// Validation may target a saved provider (key resolved from storage) or an unsaved draft.
+export type ValidateProviderRequest = {
+  providerId?: string
+  draft?: ProviderDraft
+}
+
+// Structured validation outcome so the renderer can render an actionable message per category.
+export type ValidationCategory =
+  'ok' | 'network' | 'auth' | 'model-not-found' | 'bad-url' | 'timeout' | 'unknown'
+
+export type ValidateProviderResult = {
+  ok: boolean
+  category: ValidationCategory
+  status?: number
+  message?: string
+}
+
+// Selectable install sources for the one-click claude installer.
+export type ClaudeInstallSource = 'npm-mirror' | 'official-script'
+
+// Static, non-secret description of an install source shown in the UI (command is copyable).
+export type ClaudeInstallSourceInfo = {
+  id: ClaudeInstallSource
+  label: string
+  // Human-readable command shown in the UI and safe to copy/paste.
+  displayCommand: string
+  // Whether this source needs npm on PATH (drives default selection + disabled state).
+  requiresNpm: boolean
+}
+
+// The ordered install sources; npm mirror is the mainland-friendly default.
+export const CLAUDE_INSTALL_SOURCES: ClaudeInstallSourceInfo[] = [
+  {
+    id: 'npm-mirror',
+    label: 'npm + China mirror',
+    displayCommand: 'npm i -g @anthropic-ai/claude-code --registry=https://registry.npmmirror.com',
+    requiresNpm: true
+  },
+  {
+    id: 'official-script',
+    label: 'Official install.sh',
+    displayCommand: 'curl -fsSL https://claude.ai/install.sh | bash',
+    requiresNpm: false
+  }
+]
+
+export type InstallClaudeRequest = {
+  source: ClaudeInstallSource
+}
+
+// One streamed line of installer output. `installId` groups a single install run.
+export type ClaudeInstallLogEvent = {
+  installId: string
+  stream: 'stdout' | 'stderr' | 'system'
+  chunk: string
+}
+
+// Final result of an install run; on success the caller re-detects claude.
+export type ClaudeInstallResult = {
+  installId: string
+  ok: boolean
+  exitCode?: number
+  timedOut?: boolean
+  error?: string
+}
+
+// Availability of npm on the host, used to gate the npm-mirror source.
+export type NpmAvailability = {
+  available: boolean
+}


### PR DESCRIPTION
Add a settings and onboarding system so the app no longer depends on the launching shell already having Claude credentials configured.

- Onboarding gate: block entry until a runnable system `claude` is detected and one provider validates. Detect claude across PATH, ~/.local/bin, Homebrew, and the npm global bin; offer one-click install (npm mirror or the official script) with a copyable manual command as fallback.
- Providers: manage multiple providers with a single selected one. Two types — custom (base_url + key + model, isolated CLAUDE_CONFIG_DIR) and local Claude (reuses the machine's own auth). API keys are encrypted via Electron safeStorage; the renderer only ever receives masked hints. A required-field guard (front-end and main) prevents persisting incomplete custom providers, and the selected/last provider cannot be deleted.
- Runtime: inject the selected provider as spawn env for the ACP agent and point CLAUDE_CODE_EXECUTABLE at the detected system claude. Switching providers reconnects; switching mid-run first prompts to interrupt the in-flight turn.
- Settings UI: a sidebar + content modal with a Model panel (Claude status and install plus provider list/form), icon row actions with hover labels, and a close button reachable from the Home and Workspace gear entries.
- Surface rejected prompts (e.g. an upstream gateway 5xx) as visible session errors instead of silently swallowing them.