### PR TITLE
fix: make custom model providers work end-to-end

### DIFF
--- a/src/main/acp/agent-process.test.ts
+++ b/src/main/acp/agent-process.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { toUnpackedAsarPath } from './agent-process'
+import { buildAgentSpawnEnv, toUnpackedAsarPath } from './agent-process'
 
 describe('ACP agent process packaging paths', () => {
   it('uses the real unpacked path for executables resolved inside app.asar', () => {
@@ -19,5 +19,52 @@ describe('ACP agent process packaging paths', () => {
         '/Users/lj/Desktop/cs/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude'
       )
     ).toBe('/Users/lj/Desktop/cs/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude')
+  })
+})
+
+describe('buildAgentSpawnEnv', () => {
+  // A custom provider is isolated (its overrides include CLAUDE_CONFIG_DIR).
+  const isolatedOverrides = {
+    ANTHROPIC_BASE_URL: 'https://gateway.example',
+    ANTHROPIC_AUTH_TOKEN: 'provider-token',
+    ANTHROPIC_MODEL: 'gateway-model',
+    CLAUDE_CONFIG_DIR: '/root/claude'
+  }
+
+  it('drops inherited ANTHROPIC_* for an isolated provider so parent creds cannot leak', () => {
+    const env = buildAgentSpawnEnv(
+      {
+        ANTHROPIC_BASE_URL: 'https://proxy.example', // inherited proxy — must not survive
+        ANTHROPIC_API_KEY: 'inherited-token', // not overridden — must be dropped, not leaked
+        ANTHROPIC_CUSTOM_HEADERS: 'x: y',
+        PATH: '/usr/bin'
+      },
+      isolatedOverrides,
+      '/bin/claude'
+    )
+
+    // Only the provider's own endpoint/token/model remain.
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://gateway.example')
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('provider-token')
+    // Inherited ANTHROPIC_* that the provider does not set are removed entirely.
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined()
+    expect(env.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined()
+    // Non-Anthropic inherited vars are preserved.
+    expect(env.PATH).toBe('/usr/bin')
+    expect(env.CLAUDE_CODE_EXECUTABLE).toBe('/bin/claude')
+  })
+
+  it('keeps inherited ANTHROPIC_* for a non-isolated (claude-default) provider', () => {
+    const env = buildAgentSpawnEnv(
+      { ANTHROPIC_BASE_URL: 'https://proxy.example', PATH: '/usr/bin' },
+      // claude-default overrides carry no CLAUDE_CONFIG_DIR → not isolated.
+      { ANTHROPIC_MODEL: 'claude-opus' },
+      '/bin/claude'
+    )
+
+    // Reuses the user's global environment (proxy, login, etc.).
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://proxy.example')
+    expect(env.ANTHROPIC_MODEL).toBe('claude-opus')
+    expect(env.CLAUDE_CODE_EXECUTABLE).toBe('/bin/claude')
   })
 })

--- a/src/main/acp/agent-process.ts
+++ b/src/main/acp/agent-process.ts
@@ -13,12 +13,47 @@ const resolveClaudeAgentAcpEntry = (): string =>
 const toUnpackedAsarPath = (filePath: string): string =>
   filePath.replace(/([/\\])app\.asar([/\\])/, '$1app.asar.unpacked$2')
 
+// Env vars carrying an Anthropic endpoint/credentials/model that an isolated provider must not inherit.
+const ANTHROPIC_ENV_PREFIX = 'ANTHROPIC_'
+
+// Builds the environment for the ACP agent child process. For an isolated (custom) provider —
+// signalled by an isolated CLAUDE_CONFIG_DIR among the overrides — inherited ANTHROPIC_* variables are
+// dropped before the provider's own overrides are applied. This keeps the parent's global endpoint or
+// credentials (e.g. a shell `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, or a proxy `ANTHROPIC_AUTH_TOKEN`)
+// from leaking into a provider that is meant to be fully self-contained; only what the provider sets
+// remains. claude-default (no isolated config dir) keeps the inherited env so it reuses the user's setup.
+const buildAgentSpawnEnv = (
+  sourceEnv: NodeJS.ProcessEnv,
+  envOverrides: Record<string, string>,
+  executablePath: string
+): NodeJS.ProcessEnv => {
+  const isolated = 'CLAUDE_CONFIG_DIR' in envOverrides
+  const base: NodeJS.ProcessEnv = {}
+
+  for (const [key, value] of Object.entries(sourceEnv)) {
+    if (isolated && key.startsWith(ANTHROPIC_ENV_PREFIX)) continue
+    base[key] = value
+  }
+
+  return {
+    ...base,
+    ...envOverrides,
+    CLAUDE_CODE_EXECUTABLE: executablePath,
+    ELECTRON_RUN_AS_NODE: '1'
+  }
+}
+
 // Spawn configuration for the ACP agent. `executablePath` is the system-installed claude resolved by
 // detection; `envOverrides` carries the active provider's credentials/model. The app no longer ships
 // a bundled claude binary, so a missing executablePath is a hard, actionable error.
 export type SpawnClaudeAgentAcpOptions = {
   envOverrides?: Record<string, string>
   executablePath?: string
+  // For an isolated (custom) provider, the Claude Code settings scopes the session should load. When
+  // set to ["user"], the user's global ~/.claude project/local settings (which may carry a proxy
+  // ANTHROPIC_BASE_URL env block) are excluded so they can't override the injected provider endpoint.
+  // Consumed by the runtime when building session `_meta`, not by the spawn itself.
+  settingSources?: readonly string[]
 }
 
 // Starts the Claude ACP agent as a child process with pipe-based IO, injecting the active provider's
@@ -35,15 +70,15 @@ const spawnClaudeAgentAcp = ({
 
   // Electron is the Node runtime available after packaging; this keeps dev and packaged paths aligned.
   return spawn(process.execPath, [resolveClaudeAgentAcpEntry()], {
-    env: {
-      ...process.env,
-      ...envOverrides,
-      CLAUDE_CODE_EXECUTABLE: executablePath,
-      ELECTRON_RUN_AS_NODE: '1'
-    },
+    env: buildAgentSpawnEnv(process.env, envOverrides, executablePath),
     stdio: 'pipe',
     windowsHide: true
   })
 }
 
-export { resolveClaudeAgentAcpEntry, spawnClaudeAgentAcp, toUnpackedAsarPath }
+export {
+  buildAgentSpawnEnv,
+  resolveClaudeAgentAcpEntry,
+  spawnClaudeAgentAcp,
+  toUnpackedAsarPath
+}

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -138,6 +138,9 @@ class AcpRuntime {
   private connectionGeneration = 0
   private currentSessionId: string | undefined
   private supportsSessionClose = false
+  // Settings scopes to load for sessions on the current connection (from the active provider's spawn
+  // config). Undefined means unrestricted (agent default). Set for isolated custom providers.
+  private activeSettingSources: readonly string[] | undefined
   private supportsSessionResume = false
   private readonly sessions = new Map<string, ActiveSession>()
   private readonly sessionCwds = new Map<string, string>()
@@ -475,6 +478,11 @@ class AcpRuntime {
     if (!config) {
       throw new Error('ACP agent spawn configuration is not available.')
     }
+
+    // Remember the active provider's settings-scope restriction so sessions created on this connection
+    // load only the intended scopes (see createSessionMeta). Cleared to undefined for unrestricted
+    // providers so a later claude-default reconnect doesn't inherit a stale restriction.
+    this.activeSettingSources = config.settingSources
 
     return spawnClaudeAgentAcp(config)
   }
@@ -867,34 +875,36 @@ class AcpRuntime {
     ]
   }
 
-  // Builds Claude-specific session metadata for system-prompt guidance without modifying user text.
-  private createSessionMeta():
-    | {
-        _meta: {
-          systemPrompt: {
-            type: 'preset'
-            preset: 'claude_code'
-            append: string
-          }
-        }
-      }
-    | Record<string, never> {
+  // Builds Claude-specific session metadata: system-prompt guidance for artifact/notebook tooling, and
+  // (for isolated custom providers) a settingSources restriction so the user's global ~/.claude
+  // project/local settings can't override the injected provider endpoint. Returns `{}` when neither
+  // applies so the session is created with no extra `_meta`.
+  private createSessionMeta(): { _meta: Record<string, unknown> } | Record<string, never> {
     const appendSections = [
       ...(this.artifactOptions ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
       ...(this.notebookOptions ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : [])
     ]
 
-    if (appendSections.length === 0) return {}
+    const meta: Record<string, unknown> = {}
 
-    return {
-      _meta: {
-        systemPrompt: {
-          type: 'preset',
-          preset: 'claude_code',
-          append: appendSections.join('\n\n')
-        }
+    if (appendSections.length > 0) {
+      meta.systemPrompt = {
+        type: 'preset',
+        preset: 'claude_code',
+        append: appendSections.join('\n\n')
       }
     }
+
+    // `_meta.claudeCode.options` is forwarded by the ACP agent into the SDK query options, where it
+    // overrides the agent's default settingSources of ["user","project","local"]. Restricting to
+    // ["user"] keeps only the isolated CLAUDE_CONFIG_DIR scope for custom providers.
+    if (this.activeSettingSources) {
+      meta.claudeCode = { options: { settingSources: [...this.activeSettingSources] } }
+    }
+
+    if (Object.keys(meta).length === 0) return {}
+
+    return { _meta: meta }
   }
 
   // Resolves the artifact/notebook storage project for a session, defaulting to the runtime constant.

--- a/src/main/settings/base-url.test.ts
+++ b/src/main/settings/base-url.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeAnthropicBaseUrl } from './base-url'
+
+describe('normalizeAnthropicBaseUrl', () => {
+  it('leaves a bare gateway root untouched', () => {
+    expect(normalizeAnthropicBaseUrl('https://api.anthropic.com')).toBe('https://api.anthropic.com')
+  })
+
+  it('strips a redundant trailing /v1 the client would double up', () => {
+    // The claude client (and the validation probe) always append `/v1/messages`, so a base URL that
+    // already carries `/v1` would resolve to `.../v1/v1/messages` → 404 without this normalization.
+    expect(normalizeAnthropicBaseUrl('https://api.anthropic.com/v1')).toBe(
+      'https://api.anthropic.com'
+    )
+  })
+
+  it('strips a pasted full /v1/messages endpoint back to the base', () => {
+    expect(normalizeAnthropicBaseUrl('https://api.anthropic.com/v1/messages')).toBe(
+      'https://api.anthropic.com'
+    )
+  })
+
+  it('trims whitespace and trailing slashes before and after stripping /v1', () => {
+    expect(normalizeAnthropicBaseUrl('  https://api.anthropic.com/v1/  ')).toBe(
+      'https://api.anthropic.com'
+    )
+  })
+
+  it('is case-insensitive about the version segment', () => {
+    expect(normalizeAnthropicBaseUrl('https://api.anthropic.com/V1')).toBe(
+      'https://api.anthropic.com'
+    )
+  })
+
+  it('only strips a whole trailing /v1 segment, not a substring', () => {
+    // A path segment that merely ends in "v1" (e.g. an api version folder named "apiv1") must survive.
+    expect(normalizeAnthropicBaseUrl('https://api.anthropic.com/apiv1')).toBe(
+      'https://api.anthropic.com/apiv1'
+    )
+  })
+
+  it('returns an empty string unchanged', () => {
+    expect(normalizeAnthropicBaseUrl('')).toBe('')
+  })
+})

--- a/src/main/settings/base-url.ts
+++ b/src/main/settings/base-url.ts
@@ -1,0 +1,16 @@
+// Normalizes a user-entered Anthropic-compatible gateway base URL into the value the claude client
+// expects for ANTHROPIC_BASE_URL. Both the runtime client and the validation probe append
+// `/v1/messages`, so a base URL that already carries a trailing `/v1` (or the full `/v1/messages`
+// endpoint) would resolve to `.../v1/v1/messages` → 404. Stripping it here keeps whatever the user
+// pastes — the bare root, the `.../v1` base, or the full endpoint — resolving to the same correct URL.
+
+// Matches a trailing `/v1` or `/v1/messages` segment (case-insensitive), with optional trailing slash.
+const REDUNDANT_SUFFIX = /\/v1(\/messages)?\/*$/i
+
+const normalizeAnthropicBaseUrl = (baseUrl: string): string => {
+  const trimmed = baseUrl.trim().replace(/\/+$/, '')
+
+  return trimmed.replace(REDUNDANT_SUFFIX, '')
+}
+
+export { normalizeAnthropicBaseUrl }

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -97,4 +97,42 @@ describe('settings IPC handlers', () => {
     expect(service.setActiveProvider).toHaveBeenCalledWith('p1')
     expect(onActiveProviderChanged).toHaveBeenCalledOnce()
   })
+
+  it('drops the agent connection when the edited provider is the active one', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    service.upsertProvider.mockResolvedValue({ claude: {}, activeProviderId: 'p1', providers: [] })
+    const onActiveProviderChanged = vi.fn()
+    registerSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+
+    await invoke('settings:upsert-provider', { id: 'p1', type: 'custom', name: 'G' })
+
+    // Editing the live provider must respawn the agent so the new base URL / key / model take effect.
+    expect(onActiveProviderChanged).toHaveBeenCalledOnce()
+  })
+
+  it('does not drop the connection when editing a non-active provider', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    service.upsertProvider.mockResolvedValue({ claude: {}, activeProviderId: 'p1', providers: [] })
+    const onActiveProviderChanged = vi.fn()
+    registerSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+
+    await invoke('settings:upsert-provider', { id: 'p2', type: 'custom', name: 'Other' })
+
+    expect(onActiveProviderChanged).not.toHaveBeenCalled()
+  })
+
+  it('does not drop the connection when creating a new provider', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    service.upsertProvider.mockResolvedValue({ claude: {}, activeProviderId: 'p1', providers: [] })
+    const onActiveProviderChanged = vi.fn()
+    registerSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+
+    // A create has no id, so it can't be the active provider yet — no respawn.
+    await invoke('settings:upsert-provider', { type: 'custom', name: 'New' })
+
+    expect(onActiveProviderChanged).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -43,9 +43,18 @@ const registerSettingsIpcHandlers = ({
     service.installClaude(request, broadcastInstallLog)
   )
 
-  ipcMain.handle('settings:upsert-provider', (_event, request: UpsertProviderRequest) =>
-    service.upsertProvider(request)
-  )
+  ipcMain.handle('settings:upsert-provider', async (_event, request: UpsertProviderRequest) => {
+    const snapshot = await service.upsertProvider(request)
+
+    // Editing the currently-active provider in place must also refresh the agent. The live process
+    // baked its base URL / key / model in at spawn time, so without this a credential or model edit
+    // would silently keep hitting the pre-edit gateway until the next manual provider switch.
+    if (request.id && request.id === snapshot.activeProviderId) {
+      onActiveProviderChanged?.()
+    }
+
+    return snapshot
+  })
   ipcMain.handle('settings:delete-provider', (_event, request: DeleteProviderRequest) =>
     service.deleteProvider(request.id)
   )

--- a/src/main/settings/provider-env.test.ts
+++ b/src/main/settings/provider-env.test.ts
@@ -9,22 +9,37 @@ describe('provider-env', () => {
     const env = buildProviderEnv(
       {
         type: 'custom',
-        baseUrl: 'https://gateway.example/v1',
+        baseUrl: 'https://api.anthropic.com',
         model: 'claude-sonnet-4-5',
-        key: 'secret-token'
+        key: 'test-token'
       },
       options
     )
 
     expect(env).toEqual({
       CLAUDE_CODE_EXECUTABLE: '/bin/claude',
-      ANTHROPIC_BASE_URL: 'https://gateway.example/v1',
-      ANTHROPIC_AUTH_TOKEN: 'secret-token',
+      ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+      ANTHROPIC_AUTH_TOKEN: 'test-token',
       ANTHROPIC_MODEL: 'claude-sonnet-4-5',
       CLAUDE_CONFIG_DIR: getIsolatedClaudeConfigDir('/root')
     })
     // Custom providers never use x-api-key; the key is always sent as a bearer token.
     expect(env.ANTHROPIC_API_KEY).toBeUndefined()
+  })
+
+  it('normalizes a base URL that already carries /v1 so the client does not double it', () => {
+    const env = buildProviderEnv(
+      {
+        type: 'custom',
+        baseUrl: 'https://api.anthropic.com/v1',
+        model: 'claude-sonnet-4-5',
+        key: 'test-token'
+      },
+      options
+    )
+
+    // The client appends /v1/messages itself; ANTHROPIC_BASE_URL must not carry a redundant /v1.
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://api.anthropic.com')
   })
 
   it('omits base URL and isolated config dir for claude-default with a model override', () => {

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path'
 
 import type { ProviderType } from '../../shared/settings'
+import { normalizeAnthropicBaseUrl } from './base-url'
 
 // Resolves an active provider into the environment overrides that the ACP agent (and the claude
 // binary it spawns) read. Pure and free of Electron so the branch matrix stays unit-testable.
@@ -42,7 +43,13 @@ const buildProviderEnv = (
   }
 
   // custom providers are fully isolated: gateway URL, key, model, and a private config directory.
-  if (provider.baseUrl) env.ANTHROPIC_BASE_URL = provider.baseUrl
+  // The base URL is normalized so a user-supplied trailing `/v1` isn't doubled by the client's own
+  // `/v1/messages` suffix (which would 404).
+  if (provider.baseUrl) {
+    const baseUrl = normalizeAnthropicBaseUrl(provider.baseUrl)
+
+    if (baseUrl) env.ANTHROPIC_BASE_URL = baseUrl
+  }
 
   // Custom gateways authenticate with a bearer token (ANTHROPIC_AUTH_TOKEN).
   if (provider.key) env.ANTHROPIC_AUTH_TOKEN = provider.key

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -212,9 +212,9 @@ describe('SettingsService: preflight & spawn config', () => {
       await service.upsertProvider({
         type: 'custom',
         name: 'G',
-        baseUrl: 'https://g/v1',
+        baseUrl: 'https://api.anthropic.com/v1',
         model: 'm',
-        key: 'sk-key'
+        key: 'test-key'
       })
     ).providers[0]
     await service.setActiveProvider(created.id)
@@ -223,13 +223,31 @@ describe('SettingsService: preflight & spawn config', () => {
 
     expect(config.executablePath).toBe(execPath)
     expect(config.envOverrides).toMatchObject({
-      ANTHROPIC_BASE_URL: 'https://g/v1',
-      ANTHROPIC_AUTH_TOKEN: 'sk-key',
+      // A user-supplied trailing /v1 is normalized away; the client appends /v1/messages itself.
+      ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+      ANTHROPIC_AUTH_TOKEN: 'test-key',
       ANTHROPIC_MODEL: 'm',
       CLAUDE_CONFIG_DIR: getIsolatedClaudeConfigDir(storageRoot)
     })
     // Custom providers always use the bearer token variable, never x-api-key.
     expect(config.envOverrides.ANTHROPIC_API_KEY).toBeUndefined()
+    // Custom providers restrict the session to the isolated "user" settings scope so the user's global
+    // ~/.claude project/local settings can't override the injected endpoint.
+    expect(config.settingSources).toEqual(['user'])
+  })
+
+  it('leaves settingSources unset for a claude-default provider (reuses user settings)', async () => {
+    const service = createService()
+
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+    const created = (
+      await service.upsertProvider({ type: 'claude-default', name: 'Local' })
+    ).providers[0]
+    await service.setActiveProvider(created.id)
+
+    const config = await service.resolveActiveSpawnConfig()
+
+    expect(config.settingSources).toBeUndefined()
   })
 
   it('throws a clear error when no active provider is configured', async () => {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -46,6 +46,10 @@ const isTimeoutError = (error: unknown): boolean => {
 export type AgentSpawnConfig = {
   envOverrides: Record<string, string>
   executablePath: string
+  // Settings scopes the ACP session should load. Custom (isolated) providers restrict this to
+  // ["user"] so the user's global ~/.claude project/local settings can't override the injected
+  // endpoint; claude-default leaves it undefined to reuse the user's full settings.
+  settingSources?: readonly string[]
 }
 
 export type SettingsServiceOptions = {
@@ -245,7 +249,13 @@ class SettingsService {
       claudeExecutablePath: executablePath
     })
 
-    return { envOverrides, executablePath }
+    // Custom providers are fully isolated: restrict the agent to the "user" settings scope (the
+    // isolated CLAUDE_CONFIG_DIR) so the user's global ~/.claude project/local settings — which may
+    // carry a proxy ANTHROPIC_BASE_URL env block — can't override the injected endpoint. claude-default
+    // reuses the user's full settings, so it leaves this unset.
+    const settingSources = activeProvider.type === 'custom' ? (['user'] as const) : undefined
+
+    return { envOverrides, executablePath, settingSources }
   }
 
   // Maps a stored provider to its masked renderer view, flagging custom keys that no longer decrypt.

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -11,29 +11,29 @@ describe('validate: request construction', () => {
   it('builds a bearer /v1/messages probe with anthropic-version and a 1-token body', () => {
     const request = buildValidationRequest({
       type: 'custom',
-      baseUrl: 'https://gateway.example/v1',
+      baseUrl: 'https://api.anthropic.com',
       model: 'claude-sonnet-4-5',
-      key: 'tok'
+      key: 'test-token'
     })
 
-    expect(request.url).toBe('https://gateway.example/v1/v1/messages')
-    expect(request.headers.authorization).toBe('Bearer tok')
+    expect(request.url).toBe('https://api.anthropic.com/v1/messages')
+    expect(request.headers.authorization).toBe('Bearer test-token')
     expect(request.headers['anthropic-version']).toBe('2023-06-01')
     expect(JSON.parse(request.body)).toMatchObject({ model: 'claude-sonnet-4-5', max_tokens: 1 })
   })
 
-  it('always authenticates with a bearer token and normalizes a trailing-slash base URL', () => {
+  it('normalizes a base URL that already carries /v1 so the probe never doubles it', () => {
     const request = buildValidationRequest({
       type: 'custom',
-      baseUrl: 'https://g/v1/',
-      key: 'k'
+      baseUrl: 'https://api.anthropic.com/v1',
+      key: 'test-token'
     })
 
-    expect(request.headers.authorization).toBe('Bearer k')
+    expect(request.headers.authorization).toBe('Bearer test-token')
     // Custom providers never send an x-api-key header.
     expect(request.headers['x-api-key']).toBeUndefined()
-    // A trailing slash on the base URL must not double up the slash before /v1/messages.
-    expect(request.url).toBe('https://g/v1/v1/messages')
+    // A user-supplied trailing /v1 (and/or slash) must resolve to a single /v1/messages, not two.
+    expect(request.url).toBe('https://api.anthropic.com/v1/messages')
   })
 
   it('throws for a missing or unparseable base URL', () => {

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -1,4 +1,5 @@
 import type { ValidateProviderResult, ValidationCategory } from '../../shared/settings'
+import { normalizeAnthropicBaseUrl } from './base-url'
 import type { ResolvedProvider } from './provider-env'
 
 // Runs a real connectivity/auth probe for a provider and classifies the outcome into an actionable
@@ -26,9 +27,11 @@ const buildValidationRequest = (provider: ResolvedProvider): ValidationHttpReque
   let url: string
 
   try {
-    // Mirror how the claude client builds requests: ANTHROPIC_BASE_URL + "/v1/messages". Validate it
-    // parses as a URL so an unusable base can be classified as bad-url instead of firing a bad fetch.
-    url = new URL(`${provider.baseUrl.replace(/\/+$/, '')}/v1/messages`).toString()
+    // Mirror how the claude client builds requests: ANTHROPIC_BASE_URL + "/v1/messages". The base URL
+    // is normalized first so a user-supplied trailing `/v1` isn't doubled into `.../v1/v1/messages`
+    // (a 404). Validate it parses as a URL so an unusable base is classified as bad-url instead of
+    // firing a doomed fetch.
+    url = new URL(`${normalizeAnthropicBaseUrl(provider.baseUrl)}/v1/messages`).toString()
   } catch {
     throw new Error('Invalid base URL.')
   }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -16,6 +16,8 @@ const App = (): React.JSX.Element | null => {
   const loadProjects = useProjectStore((state) => state.loadProjects)
   const isSettingsLoaded = useSettingsStore((state) => state.isLoaded)
   const preflight = useSettingsStore((state) => state.preflight)
+  // Latched once both gates first pass; keeps onboarding a first-run gate (see settings-store).
+  const hasEnteredApp = useSettingsStore((state) => state.hasEnteredApp)
   const loadSettings = useSettingsStore((state) => state.load)
   const isSettingsOpen = useSettingsStore((state) => state.isSettingsOpen)
   const closeSettings = useSettingsStore((state) => state.closeSettings)
@@ -35,8 +37,12 @@ const App = (): React.JSX.Element | null => {
     return null
   }
 
-  // Hard startup gate: a runnable claude plus a validated active provider are both required.
-  if (!preflight.claudeReady || !preflight.activeProviderReady) {
+  const gatesReady = preflight.claudeReady && preflight.activeProviderReady
+
+  // Hard first-run gate: a runnable claude plus a validated active provider are both required before
+  // the app is ever shown. After that (hasEnteredApp), changing providers in settings stays in the app
+  // instead of yanking the user back to the wizard.
+  if (!gatesReady && !hasEnteredApp) {
     return <OnboardingWizard onComplete={() => undefined} />
   }
 

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -94,9 +94,13 @@ const ProviderForm = ({
               aria-label="Base URL"
               value={value.baseUrl}
               disabled={disabled}
-              placeholder="https://gateway.example/v1"
+              placeholder="https://gateway.example"
               onChange={(event) => onChange({ baseUrl: event.target.value })}
             />
+            <p className="text-xs text-muted-foreground">
+              The gateway root — don&apos;t include a trailing <code>/v1</code>; it&apos;s added
+              automatically.
+            </p>
             {errors.baseUrl ? (
               <p className={fieldErrorClassName} role="alert">
                 {errors.baseUrl}

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -293,7 +293,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                           disabled={!canSave}
                           className="rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
                         >
-                          {isSaving ? 'Saving…' : 'Save & test'}
+                          {isSaving ? 'Saving…' : 'Save & Test'}
                         </button>
                       </div>
                     </div>

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -123,6 +123,50 @@ describe('settings store: saveAndActivateProvider', () => {
   })
 })
 
+describe('settings store: hasEnteredApp latch (onboarding is first-run only)', () => {
+  it('latches on when load finds both gates ready', async () => {
+    api.getPreflight.mockResolvedValue({ claudeReady: true, activeProviderReady: true })
+
+    await useSettingsStore.getState().load()
+
+    expect(useSettingsStore.getState().hasEnteredApp).toBe(true)
+  })
+
+  it('stays off when load finds a gate unmet on a genuine first run', async () => {
+    api.getPreflight.mockResolvedValue({ claudeReady: true, activeProviderReady: false })
+
+    await useSettingsStore.getState().load()
+
+    expect(useSettingsStore.getState().hasEnteredApp).toBe(false)
+  })
+
+  it('does not turn back off when a later preflight flips a gate (provider select)', async () => {
+    // Entered the app: both gates ready.
+    api.getPreflight.mockResolvedValue({ claudeReady: true, activeProviderReady: true })
+    await useSettingsStore.getState().load()
+    expect(useSettingsStore.getState().hasEnteredApp).toBe(true)
+
+    // Selecting a not-yet-validated provider makes the active provider not-ready again...
+    api.getPreflight.mockResolvedValue({ claudeReady: true, activeProviderReady: false })
+    await useSettingsStore.getState().refreshPreflight()
+
+    // ...but the app must stay entered so it doesn't jump back to onboarding.
+    expect(useSettingsStore.getState().preflight.activeProviderReady).toBe(false)
+    expect(useSettingsStore.getState().hasEnteredApp).toBe(true)
+  })
+
+  it('does not turn back off when settings is reopened (load) on an unready provider', async () => {
+    api.getPreflight.mockResolvedValue({ claudeReady: true, activeProviderReady: true })
+    await useSettingsStore.getState().load()
+
+    // Reopening settings triggers another load while the active provider is temporarily not-ready.
+    api.getPreflight.mockResolvedValue({ claudeReady: true, activeProviderReady: false })
+    await useSettingsStore.getState().load()
+
+    expect(useSettingsStore.getState().hasEnteredApp).toBe(true)
+  })
+})
+
 describe('settings store: provider switch flow', () => {
   it('does not need confirmation when no session is running', async () => {
     acp.getState.mockResolvedValue({ promptInFlightSessionIds: [] })

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -33,6 +33,10 @@ type SettingsStoreData = {
   activeProviderId: string | undefined
   providers: ProviderView[]
   preflight: Preflight
+  // Latched true the first time both startup gates pass. Onboarding is a first-run gate, so once the
+  // user has entered the app, later provider changes (which may momentarily flip a gate) must not send
+  // them back to the wizard — the app reads this instead of preflight alone to decide onboarding.
+  hasEnteredApp: boolean
   encryptionAvailable: boolean
   npmAvailable: boolean
   // Transient UI state for the wizard/settings page.
@@ -69,12 +73,17 @@ const createInitialPreflight = (): Preflight => ({
   activeProviderReady: false
 })
 
+// Both hard startup gates satisfied — the condition that latches hasEnteredApp and clears onboarding.
+const isPreflightReady = (preflight: Preflight): boolean =>
+  preflight.claudeReady && preflight.activeProviderReady
+
 export const createInitialSettingsState = (): SettingsStoreData => ({
   isLoaded: false,
   claude: {},
   activeProviderId: undefined,
   providers: [],
   preflight: createInitialPreflight(),
+  hasEnteredApp: false,
   encryptionAvailable: true,
   npmAvailable: true,
   isDetectingClaude: false,
@@ -117,20 +126,28 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       window.api.settings.isNpmAvailable()
     ])
 
-    set({
+    set((state) => ({
       ...applySnapshot(snapshot),
       preflight,
+      // Latch on only; a later load (e.g. reopening settings on a not-yet-validated provider) must
+      // never turn this back off and resurrect onboarding.
+      hasEnteredApp: state.hasEnteredApp || isPreflightReady(preflight),
       encryptionAvailable,
       npmAvailable,
       isLoaded: true
-    })
+    }))
   },
 
   // Re-checks the two startup gates without reloading the whole snapshot.
   refreshPreflight: async () => {
     const preflight = await window.api.settings.getPreflight()
 
-    set({ preflight })
+    // Latch hasEnteredApp on (never off): once the app is entered, a later gate flip in settings must
+    // not resurrect the onboarding wizard.
+    set((state) => ({
+      preflight,
+      hasEnteredApp: state.hasEnteredApp || isPreflightReady(preflight)
+    }))
 
     return preflight
   },


### PR DESCRIPTION
## Summary

Custom (Anthropic-compatible gateway) model providers were configured but never actually used at runtime. This PR makes them work end-to-end and hardens their isolation from the user's global Claude configuration.

## Fixes

- **Isolate custom providers from global Claude settings.** The ACP session now restricts settings to the `user` scope for custom providers, so a `~/.claude/settings.json` `env` block (e.g. a proxy `ANTHROPIC_BASE_URL`) can no longer override the configured provider endpoint. `claude-default` continues to reuse the user's full settings.
- **Don't leak inherited credentials.** When spawning the agent for an isolated custom provider, inherited `ANTHROPIC_*` environment variables are dropped before the provider's own overrides are applied, so a parent process's endpoint/credentials can't leak in.
- **Normalize the base URL.** A redundant trailing `/v1` (or `/v1/messages`) is stripped; the client appends `/v1/messages` itself, so a base URL carrying `/v1` would resolve to `.../v1/v1/messages` (404). Applied to both connection validation and the runtime environment.
- **Apply edits to the running agent.** Editing the active provider in place now re-spawns the agent, so base URL / key / model changes take effect on the next message instead of requiring a restart.
- **Onboarding is first-run only.** Selecting a provider in Settings updates the selection instead of bouncing the user back to the onboarding wizard.
- **UI polish.** Generic Base URL placeholder with helper text; the settings action is renamed to "Save & Test".

## Testing

- `npm run typecheck`, `npm run lint`, and `npm run test` (508 tests) all pass.
- Verified end-to-end against a local probe server: the agent's real request now reaches the configured provider endpoint with the provider's own credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)