### PR TITLE
ci: fix macOS build failure on the no-cert (unsigned) path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,9 +69,15 @@ jobs:
         run: |
           npm run build
           if [ "${{ matrix.platform }}" = "mac" ] && [ -n "$CSC_LINK" ]; then
-            # Override the config's notarize:false once a real cert is configured.
+            # Real Developer ID cert present -> sign + notarize (override the config's notarize:false).
             npx electron-builder ${{ matrix.eb_args }} --publish never -c.mac.notarize=true
           else
+            # No cert: GitHub injects unset secrets as EMPTY strings, and electron-builder mis-reads an
+            # empty CSC_LINK as a certificate path — it resolves to the cwd and dies with
+            # "<repo path> not a file". Drop the empty vars and disable auto-discovery so electron-builder
+            # skips its own signing entirely; the afterPack hook (build/adhoc-sign.cjs) ad-hoc signs instead.
+            unset CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
             npx electron-builder ${{ matrix.eb_args }} --publish never
           fi
 


### PR DESCRIPTION
## Problem

The macOS jobs in the new release pipeline (#5) fail when no signing certificate is configured:

```
• empty password will be used for code signing  reason=CSC_KEY_PASSWORD is not defined
⨯ /Users/runner/work/open-science/open-science not a file
```

GitHub Actions injects **unset** secrets as **empty strings**. electron-builder then reads the empty `CSC_LINK` as a certificate path, resolves it to the repo root, and dies with `<path> not a file` — and it also enters its signing flow instead of skipping it.

## Fix

On the no-cert path (`build.yml`): `unset` the empty signing vars and set `CSC_IDENTITY_AUTO_DISCOVERY=false`, so electron-builder skips its own code signing entirely. The `afterPack` hook (`build/adhoc-sign.cjs`) still applies the valid ad-hoc signature. The Developer-ID path (secrets present) is unchanged.

## Testing

YAML validated locally. Definitive check is the next macOS run on GitHub (nightly on push to main, or a manual `workflow_dispatch`).