### PR TITLE
ci: bump GitHub Actions to Node 24 (v4 -> v5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -83,7 +83,7 @@ jobs:
 
       # Upload only the distributables + electron-updater metadata for the caller's publish job.
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.name }}
           path: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ jobs:
     if: ${{ vars.ENABLE_CLAUDE_REVIEW != 'false' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
           merge-multiple: true # flatten every platform's files into one directory


### PR DESCRIPTION
## Why

GitHub Actions runners now warn that Node 20 is deprecated and force these actions onto Node 24:

> actions/checkout@v4, actions/setup-node@v4, actions/upload-artifact@v4 ... being forced to run on Node.js 24

See the [deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## Change

Bump the affected actions to their Node 24 major versions (drop-in):

- `actions/checkout@v4 → v5`
- `actions/setup-node@v4 → v5`
- `actions/upload-artifact@v4 → v5`
- `actions/download-artifact@v4 → v5`

Across `build.yml`, `release.yml`, `nightly.yml`, `pr-check.yml`, `claude-review.yml`.

Not changed:
- `softprops/action-gh-release@v2` — third-party, not in the deprecation list.
- `node-version: 22` in setup-node — that's the Node used to *build* the app, independent of the action runtime.