### PR TITLE
ci: cross-build macOS x64 on Apple Silicon; set min macOS 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Both mac archs build on Apple Silicon (macos-14). x64 is cross-packaged here — electron
+          # downloads the x64 runtime, and the only per-arch native artifact we ship (the Prisma
+          # query engine) is provided by the schema's binaryTargets, then pruned below. This avoids
+          # the scarce Intel `macos-13` runner (long queues). engine_keep = substring of the Prisma
+          # engine filename to keep for this build.
           - name: macos-arm64
-            os: macos-14 # Apple Silicon
+            os: macos-14
             platform: mac
             eb_args: --mac --arm64
+            engine_keep: darwin-arm64
           - name: macos-x64
-            os: macos-13 # last Intel runner: gets darwin-x64 native deps natively
+            os: macos-14
             platform: mac
             eb_args: --mac --x64
+            engine_keep: darwin.dylib
           - name: linux-x64
             os: ubuntu-latest
             platform: linux
             eb_args: --linux
+            engine_keep: .so.node
 
     steps:
       - name: Checkout
@@ -48,6 +56,23 @@ jobs:
       # npm ci runs postinstall: prisma generate + electron-builder install-app-deps.
       - name: Install dependencies
         run: npm ci
+
+      # The schema's binaryTargets generates Prisma engines for several platforms; keep only the one
+      # this build ships so each installer stays lean. Fails loudly if the expected engine is missing.
+      - name: Prune foreign Prisma engines
+        shell: bash
+        run: |
+          keep='${{ matrix.engine_keep }}'
+          found=0
+          for f in node_modules/.prisma/client/libquery_engine-*; do
+            [ -e "$f" ] || continue
+            case "$f" in
+              *"$keep"*) found=1 ;;
+              *) echo "pruning $(basename "$f")"; rm -f "$f" ;;
+            esac
+          done
+          echo "remaining engines:"; ls -1 node_modules/.prisma/client/libquery_engine-* 2>/dev/null || true
+          [ "$found" = 1 ] || { echo "::error::no Prisma engine matching '$keep' was generated"; exit 1; }
 
       # Build the renderer + main (incl. typecheck), then package with electron-builder.
       #

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -54,6 +54,9 @@ extraResources:
 #   createDesktopShortcut: always
 mac:
   artifactName: ${name}-${version}-mac-${arch}.${ext}
+  # Minimum macOS to run the app (written to Info.plist LSMinimumSystemVersion). macOS 12 (Monterey)
+  # and up; below this the OS refuses to launch. Independent of the CI build runner's macOS version.
+  minimumSystemVersion: '12.0.0'
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     CFBundleName: Open Science

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,11 @@
 
 generator client {
   provider = "prisma-client-js"
+  // Generate query engines for both macOS architectures so the x64 build can be cross-packaged on an
+  // Apple Silicon CI runner (the scarce Intel `macos-13` runner is no longer needed). "native" is the
+  // build host's engine (darwin-arm64 on mac CI, the distro engine on Linux); "darwin" adds x64 mac.
+  // The release build prunes engines it doesn't need per platform (see .github/workflows/build.yml).
+  binaryTargets = ["native", "darwin"]
 }
 
 datasource db {


### PR DESCRIPTION
## Why

The Intel `macos-13` runner is scarce — nightly jobs were observed queuing 8+ minutes waiting for a runner.

## Change

- **Build both mac archs on `macos-14`** (Apple Silicon). electron-builder downloads the x64 Electron runtime, so x64 is cross-packaged. The only per-arch native artifact shipped is the Prisma query engine, now generated for x64 too via `binaryTargets = ["native", "darwin"]` in `prisma/schema.prisma`. A prune step in `build.yml` keeps only the engine each platform ships (keyed by `engine_keep`), so installers stay lean.
- **`mac.minimumSystemVersion: '12.0.0'`** — declares macOS 12 (Monterey) as the runtime floor in `Info.plist` (`LSMinimumSystemVersion`). Independent of the build runner's macOS version.

Result: no dependency on the scarce Intel runner; mac arm64 + x64 both build on plentiful Apple Silicon.