### PR TITLE
feat: Windows compatibility (detection, install, notebook, packaging, CI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,10 @@ name: Build
 # on tag) and nightly.yml (rolling prerelease, on push to main) so the build matrix lives in one
 # place. Publishing is done by the caller, not here.
 #
-# Native deps need no cross-compilation tricks: `npm ci` on each runner installs the binaries that
-# match that OS (claude-agent-sdk optional package, Prisma query engine). macOS x64 therefore builds
-# on the Intel runner (macos-13); arm64 on Apple Silicon (macos-14).
-#
-# Windows is deferred — to add it later, append a `windows-latest` matrix entry (eb_args: --win).
+# `npm ci` on each runner installs the native binaries it needs (claude-agent-sdk optional package,
+# Prisma query engine). Both macOS archs build on Apple Silicon (macos-14) — x64 is cross-packaged and
+# its Prisma engine comes from binaryTargets, pruned per-arch below; Linux on ubuntu-latest; Windows
+# x64 on windows-latest.
 on:
   workflow_call:
 
@@ -42,6 +41,13 @@ jobs:
             platform: linux
             eb_args: --linux
             engine_keep: .so.node
+          - name: windows-x64
+            os: windows-latest
+            platform: win
+            eb_args: --win --x64
+            # Windows' native engine is `query_engine-windows.dll.node` (note: no `lib` prefix, and
+            # `.dll.node` rather than `.so/.dylib`), which the broadened prune glob below matches.
+            engine_keep: windows.dll
 
     steps:
       - name: Checkout
@@ -59,19 +65,21 @@ jobs:
 
       # The schema's binaryTargets generates Prisma engines for several platforms; keep only the one
       # this build ships so each installer stays lean. Fails loudly if the expected engine is missing.
+      # The glob is `*query_engine-*` (not `libquery_engine-*`) so it also matches Windows' engine,
+      # which is named `query_engine-windows.dll.node` without the `lib` prefix.
       - name: Prune foreign Prisma engines
         shell: bash
         run: |
           keep='${{ matrix.engine_keep }}'
           found=0
-          for f in node_modules/.prisma/client/libquery_engine-*; do
+          for f in node_modules/.prisma/client/*query_engine-*; do
             [ -e "$f" ] || continue
             case "$f" in
               *"$keep"*) found=1 ;;
               *) echo "pruning $(basename "$f")"; rm -f "$f" ;;
             esac
           done
-          echo "remaining engines:"; ls -1 node_modules/.prisma/client/libquery_engine-* 2>/dev/null || true
+          echo "remaining engines:"; ls -1 node_modules/.prisma/client/*query_engine-* 2>/dev/null || true
           [ "$found" = 1 ] || { echo "::error::no Prisma engine matching '$keep' was generated"; exit 1; }
 
       # Build the renderer + main (incl. typecheck), then package with electron-builder.
@@ -114,6 +122,7 @@ jobs:
           path: |
             dist/*.dmg
             dist/*.zip
+            dist/*.exe
             dist/*.AppImage
             dist/*.deb
             dist/*.blockmap

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: artifacts
         run: |
           shopt -s nullglob
-          files=(*.dmg *.zip *.AppImage *.deb)
+          files=(*.dmg *.zip *.exe *.AppImage *.deb)
           if [ ${#files[@]} -gt 0 ]; then
             sha256sum "${files[@]}" > SHA256SUMS.txt
             cat SHA256SUMS.txt
@@ -66,6 +66,7 @@ jobs:
             right-click → Open, or run `xattr -dr com.apple.quarantine "<app>"`.
           files: |
             artifacts/*.dmg
+            artifacts/*.exe
             artifacts/*.AppImage
             artifacts/*.deb
             artifacts/SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build the platform matrix (macOS arm64/x64 + Linux) via the reusable workflow. secrets: inherit
-  # forwards the optional signing/notarization secrets.
+  # Build the platform matrix (macOS arm64/x64 + Linux + Windows x64) via the reusable workflow.
+  # secrets: inherit forwards the optional signing/notarization secrets.
   build:
     uses: ./.github/workflows/build.yml
     secrets: inherit
@@ -42,7 +42,7 @@ jobs:
         working-directory: artifacts
         run: |
           shopt -s nullglob
-          files=(*.dmg *.zip *.AppImage *.deb)
+          files=(*.dmg *.zip *.exe *.AppImage *.deb)
           if [ ${#files[@]} -gt 0 ]; then
             sha256sum "${files[@]}" > SHA256SUMS.txt
             cat SHA256SUMS.txt
@@ -60,6 +60,7 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/*.dmg
+            artifacts/*.exe
             artifacts/*.AppImage
             artifacts/*.deb
             artifacts/SHA256SUMS.txt

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ local/
 .mcp/
 .serena/
 .taskmaster/
+
+# Locally downloaded CI build artifacts (Windows installer, etc.)
+dist-win-artifact/

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,16 +42,21 @@ extraResources:
     to: node_modules/.prisma
   - from: node_modules/@prisma/client
     to: node_modules/@prisma/client
-# Windows packaging is on hold — to be added later. To enable: uncomment win/nsis below, add a
-# windows job to .github/workflows/release.yml, and restore the "build:win" script in package.json.
-# win:
-#   executableName: open-science
-#   artifactName: ${name}-${version}-win-${arch}.${ext}
-# nsis:
-#   artifactName: ${name}-${version}-win-${arch}-setup.${ext}
-#   shortcutName: ${productName}
-#   uninstallDisplayName: ${productName}
-#   createDesktopShortcut: always
+# Windows: an NSIS installer. The build is unsigned (no Authenticode certificate), so SmartScreen
+# shows a bypassable "unknown publisher" prompt — the same trade-off as the unsigned macOS build. The
+# afterPack ad-hoc-sign hook is a no-op off macOS (it returns early), so it is safe on this target.
+win:
+  executableName: open-science
+  artifactName: ${name}-${version}-win-${arch}.${ext}
+  target:
+    - nsis
+nsis:
+  artifactName: ${name}-${version}-win-${arch}-setup.${ext}
+  shortcutName: ${productName}
+  uninstallDisplayName: ${productName}
+  createDesktopShortcut: always
+  oneClick: false
+  allowToChangeInstallationDirectory: true
 mac:
   artifactName: ${name}-${version}-mac-${arch}.${ext}
   # Minimum macOS to run the app (written to Info.plist LSMinimumSystemVersion). macOS 12 (Monterey)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build:unpack": "npm run build && electron-builder --dir",
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
+    "build:win": "electron-vite build && electron-builder --win",
     "predev": "node scripts/dev-app-branding.cjs"
   },
   "dependencies": {

--- a/src/main/acp/agent-process.ts
+++ b/src/main/acp/agent-process.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module'
 
 import { createLogger } from '../logger'
 import { augmentedPathEnv } from '../settings/shell-path'
+import { resolveClaudeExecutableForSpawn } from './claude-executable'
 
 const nodeRequire = createRequire(import.meta.url)
 const log = createLogger('agent')
@@ -70,7 +71,14 @@ const spawnClaudeAgentAcp = ({
   // PATH is augmented with common CLI locations so a Finder-launched (packaged) app — whose PATH omits
   // Homebrew/user bins — can still run claude and the tools it shells out to, instead of hanging.
   const entryPath = resolveClaudeAgentAcpEntry()
-  const env = buildAgentSpawnEnv(augmentedPathEnv(process.env), envOverrides, executablePath)
+  // On Windows, a `claude.cmd` shim can't be spawned by the SDK without a shell (spawn EINVAL); resolve
+  // it to the underlying cli.js so the SDK runs it via node. Native/Unix executables pass through.
+  const resolvedExecutablePath = resolveClaudeExecutableForSpawn(executablePath)
+  const env = buildAgentSpawnEnv(
+    augmentedPathEnv(process.env),
+    envOverrides,
+    resolvedExecutablePath
+  )
 
   // Opt-in deep diagnostics: launch the app with OPEN_SCIENCE_DEBUG_AGENT=1 to make the Claude Agent
   // SDK emit its internals to stderr (captured into the log). Off by default so verbose turn detail is
@@ -82,7 +90,8 @@ const spawnClaudeAgentAcp = ({
   }
 
   log.info('spawning ACP agent', {
-    executablePath,
+    executablePath: resolvedExecutablePath,
+    rawExecutablePath: executablePath,
     entryPath,
     isolated: 'CLAUDE_CONFIG_DIR' in envOverrides,
     debug: debugAgent,

--- a/src/main/acp/claude-executable.test.ts
+++ b/src/main/acp/claude-executable.test.ts
@@ -1,0 +1,82 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { resolveClaudeExecutableForSpawn } from './claude-executable'
+
+// Uses posix-style paths so the logic is exercised host-independently; production uses the platform's
+// path module (back-slashes on real Windows).
+const PACKAGE_DIR = join('/npm', 'node_modules', '@anthropic-ai', 'claude-code')
+const CLI_JS = join(PACKAGE_DIR, 'cli.js')
+
+type Deps = { exists: (p: string) => boolean; readText: (p: string) => string }
+
+const deps = (over: Partial<Deps>): Deps => ({
+  exists: () => false,
+  readText: () => '',
+  ...over
+})
+
+describe('resolveClaudeExecutableForSpawn', () => {
+  it('passes any path through unchanged off Windows', () => {
+    expect(resolveClaudeExecutableForSpawn('/usr/local/bin/claude.cmd', 'darwin')).toBe(
+      '/usr/local/bin/claude.cmd'
+    )
+  })
+
+  it('passes a native .exe through unchanged on Windows', () => {
+    const exe = join('/programs', 'claude', 'claude.exe')
+    expect(resolveClaudeExecutableForSpawn(exe, 'win32')).toBe(exe)
+  })
+
+  it('passes a .js entry through unchanged on Windows', () => {
+    expect(resolveClaudeExecutableForSpawn(CLI_JS, 'win32')).toBe(CLI_JS)
+  })
+
+  it('resolves a .cmd shim to the cli.js from the package bin map', () => {
+    const result = resolveClaudeExecutableForSpawn(
+      join('/npm', 'claude.cmd'),
+      'win32',
+      deps({
+        readText: () => JSON.stringify({ bin: { claude: 'cli.js' } }),
+        exists: (p) => p === CLI_JS
+      })
+    )
+
+    expect(result).toBe(CLI_JS)
+  })
+
+  it('resolves a .cmd shim when bin is a plain string', () => {
+    const result = resolveClaudeExecutableForSpawn(
+      join('/npm', 'claude.cmd'),
+      'win32',
+      deps({
+        readText: () => JSON.stringify({ bin: 'cli.js' }),
+        exists: (p) => p === CLI_JS
+      })
+    )
+
+    expect(result).toBe(CLI_JS)
+  })
+
+  it('falls back to the conventional cli.js when package.json is unreadable', () => {
+    const result = resolveClaudeExecutableForSpawn(
+      join('/npm', 'claude.cmd'),
+      'win32',
+      deps({
+        readText: () => {
+          throw new Error('ENOENT')
+        },
+        exists: (p) => p === CLI_JS
+      })
+    )
+
+    expect(result).toBe(CLI_JS)
+  })
+
+  it('returns the original shim when nothing can be resolved', () => {
+    const shim = join('/npm', 'claude.cmd')
+    const result = resolveClaudeExecutableForSpawn(shim, 'win32', deps({ exists: () => false }))
+
+    expect(result).toBe(shim)
+  })
+})

--- a/src/main/acp/claude-executable.ts
+++ b/src/main/acp/claude-executable.ts
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+// The Claude Agent SDK spawns CLAUDE_CODE_EXECUTABLE directly for native executables, but runs a JS
+// entry through node when the path ends in .js/.mjs/.ts/etc. (it inspects the extension). On Windows an
+// npm-installed claude is a `claude.cmd` batch shim, and Node refuses to spawn a .cmd/.bat without a
+// shell — so the SDK's direct spawn fails with `spawn EINVAL` (Node CVE-2024-27980 behaviour), which
+// surfaces as "agent session could not be created".
+//
+// Resolving the shim to the underlying cli.js it wraps makes the SDK launch it via node instead, which
+// works. A native `claude.exe` (from the PowerShell installer) is already directly spawnable, and
+// non-Windows paths (a shebang `claude` script on macOS/Linux) run directly too — both pass through
+// unchanged. If the cli.js cannot be located the original path is returned (no worse than before).
+
+type ResolveDeps = {
+  exists: (path: string) => boolean
+  readText: (path: string) => string
+}
+
+const defaultDeps: ResolveDeps = {
+  exists: existsSync,
+  readText: (path) => readFileSync(path, 'utf8')
+}
+
+// Reads the claude-code package's `bin` entry (string or { claude } map) to find its CLI script name.
+const readBinEntry = (packageDir: string, deps: ResolveDeps): string | undefined => {
+  try {
+    const pkg = JSON.parse(deps.readText(join(packageDir, 'package.json'))) as {
+      bin?: string | Record<string, string>
+    }
+
+    if (typeof pkg.bin === 'string') return pkg.bin
+    if (pkg.bin && typeof pkg.bin === 'object') return pkg.bin.claude ?? Object.values(pkg.bin)[0]
+
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+const resolveClaudeExecutableForSpawn = (
+  executablePath: string,
+  platform: NodeJS.Platform = process.platform,
+  deps: ResolveDeps = defaultDeps
+): string => {
+  if (platform !== 'win32') return executablePath
+
+  const lower = executablePath.toLowerCase()
+  if (!lower.endsWith('.cmd') && !lower.endsWith('.bat')) return executablePath
+
+  // npm global layout: <prefix>\claude.cmd  ->  <prefix>\node_modules\@anthropic-ai\claude-code\<bin>
+  const packageDir = join(dirname(executablePath), 'node_modules', '@anthropic-ai', 'claude-code')
+
+  const binEntry = readBinEntry(packageDir, deps)
+  if (binEntry) {
+    const cliPath = join(packageDir, binEntry)
+    if (deps.exists(cliPath)) return cliPath
+  }
+
+  // Fall back to the conventional entry name when package.json can't be read.
+  const conventional = join(packageDir, 'cli.js')
+  if (deps.exists(conventional)) return conventional
+
+  return executablePath
+}
+
+export { resolveClaudeExecutableForSpawn }

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolvePythonCommand } from './python-command'
+
+describe('resolvePythonCommand', () => {
+  it('prefers python3, then python, on unix', async () => {
+    const tried: string[] = []
+    const result = await resolvePythonCommand({
+      platform: 'linux',
+      probe: ({ command }) => {
+        tried.push(command)
+        return Promise.resolve(command === 'python')
+      }
+    })
+
+    expect(tried).toEqual(['python3', 'python'])
+    expect(result).toEqual({ command: 'python', baseArgs: [] })
+  })
+
+  it('prefers the `py -3` launcher on windows', async () => {
+    const result = await resolvePythonCommand({
+      platform: 'win32',
+      probe: ({ command }) => Promise.resolve(command === 'py')
+    })
+
+    expect(result).toEqual({ command: 'py', baseArgs: ['-3'] })
+  })
+
+  it('falls through py -> python -> python3 on windows', async () => {
+    const tried: string[] = []
+    const result = await resolvePythonCommand({
+      platform: 'win32',
+      probe: ({ command }) => {
+        tried.push(command)
+        return Promise.resolve(command === 'python3')
+      }
+    })
+
+    expect(tried).toEqual(['py', 'python', 'python3'])
+    expect(result).toEqual({ command: 'python3', baseArgs: [] })
+  })
+
+  it('falls back to the preferred candidate when none respond', async () => {
+    const win = await resolvePythonCommand({
+      platform: 'win32',
+      probe: () => Promise.resolve(false)
+    })
+    const nix = await resolvePythonCommand({
+      platform: 'linux',
+      probe: () => Promise.resolve(false)
+    })
+
+    expect(win).toEqual({ command: 'py', baseArgs: ['-3'] })
+    expect(nix).toEqual({ command: 'python3', baseArgs: [] })
+  })
+})

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -1,0 +1,67 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+// A resolved Python interpreter invocation: the executable plus any leading args needed to select an
+// interpreter (e.g. the Windows `py` launcher needs `-3`).
+export type PythonCommand = {
+  command: string
+  baseArgs: string[]
+}
+
+// Ordered interpreter candidates by platform. Windows prefers the `py -3` launcher (the reliable way
+// to reach a real CPython, and it sidesteps the Microsoft Store `python3` execution-alias stub), then
+// bare `python`, then `python3`. Unix prefers `python3`, then `python`.
+const pythonCandidates = (platform: NodeJS.Platform): PythonCommand[] =>
+  platform === 'win32'
+    ? [
+        { command: 'py', baseArgs: ['-3'] },
+        { command: 'python', baseArgs: [] },
+        { command: 'python3', baseArgs: [] }
+      ]
+    : [
+        { command: 'python3', baseArgs: [] },
+        { command: 'python', baseArgs: [] }
+      ]
+
+export type ResolvePythonDeps = {
+  platform: NodeJS.Platform
+  // Returns true when `<command> <baseArgs...> --version` runs successfully.
+  probe: (candidate: PythonCommand) => Promise<boolean>
+}
+
+// Real `<command> --version` probe. On Windows the check runs through a shell so a shimmed launcher
+// still resolves; the `py`/`python` executables run fine without one.
+const defaultProbe =
+  (platform: NodeJS.Platform) =>
+  async ({ command, baseArgs }: PythonCommand): Promise<boolean> => {
+    try {
+      await execFileAsync(command, [...baseArgs, '--version'], {
+        timeout: 10_000,
+        shell: platform === 'win32',
+        windowsHide: true
+      })
+
+      return true
+    } catch {
+      return false
+    }
+  }
+
+// Resolves the first Python interpreter that answers `--version`. Falls back to the platform's
+// preferred command when none respond, so the caller's spawn still produces a clear ENOENT error
+// rather than silently doing nothing.
+export const resolvePythonCommand = async (
+  deps: Partial<ResolvePythonDeps> = {}
+): Promise<PythonCommand> => {
+  const platform = deps.platform ?? process.platform
+  const probe = deps.probe ?? defaultProbe(platform)
+  const candidates = pythonCandidates(platform)
+
+  for (const candidate of candidates) {
+    if (await probe(candidate)) return candidate
+  }
+
+  return candidates[0]
+}

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { createInterface, type Interface } from 'node:readline'
 
+import { resolvePythonCommand } from './python-command'
 import type {
   NotebookExecutionRequest,
   NotebookExecutionResult,
@@ -148,7 +149,13 @@ class NotebookPythonExecutor implements NotebookExecutor {
   private passthroughStdout: string[] = []
   private passthroughStderr: string[] = []
 
-  constructor(private readonly command = 'python3') {}
+  // Leading args (e.g. the Windows `py` launcher's `-3`) prepended before the bridge invocation.
+  private baseArgs: string[] = []
+
+  // An explicit command (tests, or a known interpreter) is used as-is; when omitted, the interpreter
+  // is resolved per platform on first launch (py -> python -> python3 on Windows, python3 -> python
+  // elsewhere).
+  constructor(private command?: string) {}
 
   // Sends code to the bridge and resolves with the matching JSON response.
   async execute(request: NotebookExecutionRequest): Promise<NotebookExecutionResult> {
@@ -227,7 +234,15 @@ class NotebookPythonExecutor implements NotebookExecutor {
       return this.child
     }
 
-    const child = spawn(this.command, ['-u', '-c', PYTHON_BRIDGE], {
+    // Resolve the interpreter once, lazily, so a GUI-launched app on Windows finds `py`/`python`
+    // instead of a non-existent `python3`.
+    if (!this.command) {
+      const resolved = await resolvePythonCommand()
+      this.command = resolved.command
+      this.baseArgs = resolved.baseArgs
+    }
+
+    const child = spawn(this.command, [...this.baseArgs, '-u', '-c', PYTHON_BRIDGE], {
       cwd: this.currentCwd ?? request.cwd,
       env: {
         ...process.env,

--- a/src/main/settings/claude-detect.test.ts
+++ b/src/main/settings/claude-detect.test.ts
@@ -15,6 +15,8 @@ const createDeps = (
 ): ClaudeDetectDeps => ({
   env: { PATH: '/usr/bin:/usr/local/bin' },
   homePath: '/home/user',
+  // Pinned so probe order is host-independent (tests run on macOS/Linux/Windows CI runners alike).
+  platform: 'linux',
   isExecutable: (path) => Promise.resolve(path in installed),
   getVersion: (path) => Promise.resolve(installed[path]),
   resolveNpmBinDirs: () => Promise.resolve([]),
@@ -81,5 +83,56 @@ describe('claude-detect', () => {
     const result = await detectClaude(deps)
 
     expect(result.found).toBe(true)
+  })
+
+  describe('windows', () => {
+    // Windows uses ; as the PATH delimiter and back-slash paths. join() on a posix test host emits
+    // forward slashes, so assert on the pieces produced by join() rather than literal separators.
+    const winDeps = (
+      installed: Record<string, string>,
+      overrides: Partial<ClaudeDetectDeps> = {}
+    ): ClaudeDetectDeps =>
+      createDeps(installed, {
+        platform: 'win32',
+        env: {
+          PATH: 'C:\\Windows;C:\\Users\\me\\bin',
+          APPDATA: 'C:\\Users\\me\\AppData\\Roaming',
+          LOCALAPPDATA: 'C:\\Users\\me\\AppData\\Local'
+        },
+        homePath: 'C:\\Users\\me',
+        ...overrides
+      })
+
+    it('probes %APPDATA%\\npm and %LOCALAPPDATA%\\Programs\\claude, not the Unix dirs', async () => {
+      const dirs = await collectCandidateDirs(winDeps({}))
+
+      expect(dirs).toContain(join('C:\\Users\\me\\AppData\\Roaming', 'npm'))
+      expect(dirs).toContain(join('C:\\Users\\me\\AppData\\Local', 'Programs', 'claude'))
+      expect(dirs).toContain(join('C:\\Users\\me', '.local', 'bin'))
+      expect(dirs).not.toContain('/opt/homebrew/bin')
+    })
+
+    it('finds claude.cmd ahead of the bare name', async () => {
+      const npmDir = join('C:\\Users\\me\\AppData\\Roaming', 'npm')
+      const result = await detectClaude(winDeps({ [join(npmDir, 'claude.cmd')]: '2.3.0' }))
+
+      expect(result).toEqual({ found: true, path: join(npmDir, 'claude.cmd'), version: '2.3.0' })
+    })
+
+    it('finds claude.exe when no .cmd shim exists', async () => {
+      const dir = join('C:\\Users\\me\\AppData\\Local', 'Programs', 'claude')
+      const result = await detectClaude(winDeps({ [join(dir, 'claude.exe')]: '2.4.0' }))
+
+      expect(result).toEqual({ found: true, path: join(dir, 'claude.exe'), version: '2.4.0' })
+    })
+
+    it('still probes the extensionless catch-all name', async () => {
+      // Place it in a well-known dir (not PATH) so the assertion is independent of the host's PATH
+      // delimiter, which is ':' on the posix machines this test suite also runs on.
+      const npmDir = join('C:\\Users\\me\\AppData\\Roaming', 'npm')
+      const result = await detectClaude(winDeps({ [join(npmDir, 'claude')]: '2.5.0' }))
+
+      expect(result).toEqual({ found: true, path: join(npmDir, 'claude'), version: '2.5.0' })
+    })
   })
 })

--- a/src/main/settings/claude-detect.ts
+++ b/src/main/settings/claude-detect.ts
@@ -11,13 +11,16 @@ import { augmentedPathEnv } from './shell-path'
 const execFileAsync = promisify(execFile)
 
 // Detects a runnable claude executable across the locations a GUI app might miss because its PATH
-// differs from the user's login shell. Injectable deps keep the probe order unit-testable.
+// differs from the user's login shell. Injectable deps (including the host platform) keep the probe
+// order and platform-specific rules unit-testable.
 
 export type ClaudeDetectDeps = {
   // Environment used to read PATH; injected so tests can drive candidate discovery.
   env: NodeJS.ProcessEnv
   // Home directory for the ~/.local/bin fallback.
   homePath: string
+  // Host platform. Selects candidate filenames, well-known dirs, and the executability check.
+  platform: NodeJS.Platform
   // Resolves whether a candidate file exists and is executable.
   isExecutable: (path: string) => Promise<boolean>
   // Runs `<path> --version` and returns the trimmed version string, or undefined on failure.
@@ -26,10 +29,27 @@ export type ClaudeDetectDeps = {
   resolveNpmBinDirs: () => Promise<string[]>
 }
 
-const CLAUDE_BINARY = 'claude'
+// Candidate binary filenames for claude, in probe order. Windows resolves a bare command through
+// PATHEXT, so an npm-installed `claude.cmd`, a native `claude.exe`, or a `.bat` shim must each be
+// tried explicitly; the extensionless name is kept last as a catch-all. Unix has only `claude`.
+const claudeBinaryNames = (platform: NodeJS.Platform): string[] =>
+  platform === 'win32' ? ['claude.cmd', 'claude.exe', 'claude.bat', 'claude'] : ['claude']
 
-// Common non-PATH install locations, in the order the design specifies.
-const WELL_KNOWN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin']
+// Common non-PATH install locations by platform. Unix: Homebrew + /usr/local. Windows: npm's global
+// bin (%APPDATA%\npm) and the native installer's Programs dir. `~/.local/bin` (the install script's
+// target on every OS) is added separately by collectCandidateDirs.
+const wellKnownDirs = (platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string[] => {
+  if (platform === 'win32') {
+    const dirs: string[] = []
+
+    if (env.APPDATA) dirs.push(join(env.APPDATA, 'npm'))
+    if (env.LOCALAPPDATA) dirs.push(join(env.LOCALAPPDATA, 'Programs', 'claude'))
+
+    return dirs
+  }
+
+  return ['/opt/homebrew/bin', '/usr/local/bin']
+}
 
 // Builds the ordered list of directories to search for the claude binary.
 const collectCandidateDirs = async (deps: ClaudeDetectDeps): Promise<string[]> => {
@@ -38,41 +58,51 @@ const collectCandidateDirs = async (deps: ClaudeDetectDeps): Promise<string[]> =
   const localBin = join(deps.homePath, '.local', 'bin')
 
   // De-duplicate while preserving first-seen order so the first real hit wins.
-  return Array.from(new Set([...pathDirs, localBin, ...WELL_KNOWN_DIRS, ...npmBinDirs]))
+  return Array.from(
+    new Set([...pathDirs, localBin, ...wellKnownDirs(deps.platform, deps.env), ...npmBinDirs])
+  )
 }
 
-// Probes each candidate directory, returning the first executable whose `--version` succeeds.
+// Probes each candidate directory × filename, returning the first executable whose `--version`
+// succeeds.
 const detectClaude = async (
   deps: ClaudeDetectDeps = createDefaultDetectDeps()
 ): Promise<ClaudeDetectResult> => {
   const candidateDirs = await collectCandidateDirs(deps)
+  const binaryNames = claudeBinaryNames(deps.platform)
 
   for (const dir of candidateDirs) {
-    const candidate = join(dir, CLAUDE_BINARY)
+    for (const name of binaryNames) {
+      const candidate = join(dir, name)
 
-    if (!(await deps.isExecutable(candidate))) continue
+      if (!(await deps.isExecutable(candidate))) continue
 
-    const version = await deps.getVersion(candidate)
+      const version = await deps.getVersion(candidate)
 
-    // A path that exists but cannot report a version is not a usable claude; keep searching.
-    if (version === undefined) continue
+      // A path that exists but cannot report a version is not a usable claude; keep searching.
+      if (version === undefined) continue
 
-    return { found: true, path: candidate, version }
+      return { found: true, path: candidate, version }
+    }
   }
 
   return { found: false }
 }
 
-// Real filesystem executable check used in production.
-const isExecutableFile = async (path: string): Promise<boolean> => {
-  try {
-    await access(path, constants.X_OK)
+// Real filesystem executable check. On Windows the POSIX execute bit is meaningless — access(X_OK)
+// returns true for essentially any readable file — so existence plus a known executable extension
+// (already encoded in the candidate filenames) is the reliable signal; elsewhere require X_OK.
+const isExecutableFile =
+  (platform: NodeJS.Platform) =>
+  async (path: string): Promise<boolean> => {
+    try {
+      await access(path, platform === 'win32' ? constants.F_OK : constants.X_OK)
 
-    return true
-  } catch {
-    return false
+      return true
+    } catch {
+      return false
+    }
   }
-}
 
 // Parses the first version-looking token out of `claude --version` output.
 const parseVersion = (output: string): string | undefined => {
@@ -81,40 +111,67 @@ const parseVersion = (output: string): string | undefined => {
   return match ? match[0] : output.trim() || undefined
 }
 
-// Real `<path> --version` runner used in production.
-const runClaudeVersion = async (path: string): Promise<string | undefined> => {
-  try {
-    const { stdout } = await execFileAsync(path, ['--version'], { timeout: 10_000 })
+// Real `<path> --version` runner. On Windows a `.cmd`/`.bat` shim cannot be launched by execFile
+// directly (Node refuses to run batch files without a shell since v18.20/20.12), so route it through
+// the shell with the path quoted to survive spaces; native `.exe`/Unix binaries run without a shell.
+const runClaudeVersion =
+  (platform: NodeJS.Platform) =>
+  async (path: string): Promise<string | undefined> => {
+    try {
+      const { stdout } =
+        platform === 'win32'
+          ? await execFileAsync(`"${path}"`, ['--version'], {
+              timeout: 10_000,
+              shell: true,
+              windowsHide: true
+            })
+          : await execFileAsync(path, ['--version'], { timeout: 10_000 })
 
-    return parseVersion(stdout)
-  } catch {
-    return undefined
+      return parseVersion(stdout)
+    } catch {
+      return undefined
+    }
   }
-}
 
-// Resolves the npm global bin directory (`npm prefix -g` -> `<prefix>/bin`) if npm is present. PATH is
-// augmented with common node locations so a GUI-launched app can still locate npm.
-const resolveNpmBinDirs = async (): Promise<string[]> => {
+// Resolves the npm global bin directory if npm is present. PATH is augmented with common node
+// locations so a GUI-launched app can still locate npm. On Windows npm is a `.cmd` shim (needs a
+// shell) and places global binaries directly in the prefix; Unix nests them under `<prefix>/bin`.
+const resolveNpmBinDirs = (platform: NodeJS.Platform) => async (): Promise<string[]> => {
   try {
-    const { stdout } = await execFileAsync('npm', ['prefix', '-g'], {
-      timeout: 10_000,
-      env: augmentedPathEnv()
-    })
+    const { stdout } =
+      platform === 'win32'
+        ? await execFileAsync('npm', ['prefix', '-g'], {
+            timeout: 10_000,
+            shell: true,
+            windowsHide: true,
+            env: augmentedPathEnv()
+          })
+        : await execFileAsync('npm', ['prefix', '-g'], {
+            timeout: 10_000,
+            env: augmentedPathEnv()
+          })
     const prefix = stdout.trim()
 
-    return prefix ? [join(prefix, 'bin')] : []
+    if (!prefix) return []
+
+    return platform === 'win32' ? [prefix] : [join(prefix, 'bin')]
   } catch {
     return []
   }
 }
 
-// Production dependency bundle wired to real fs/child_process.
-const createDefaultDetectDeps = (): ClaudeDetectDeps => ({
-  env: process.env,
-  homePath: homedir(),
-  isExecutable: isExecutableFile,
-  getVersion: runClaudeVersion,
-  resolveNpmBinDirs
-})
+// Production dependency bundle wired to real fs/child_process for the current host platform.
+const createDefaultDetectDeps = (): ClaudeDetectDeps => {
+  const platform = process.platform
+
+  return {
+    env: process.env,
+    homePath: homedir(),
+    platform,
+    isExecutable: isExecutableFile(platform),
+    getVersion: runClaudeVersion(platform),
+    resolveNpmBinDirs: resolveNpmBinDirs(platform)
+  }
+}
 
 export { collectCandidateDirs, createDefaultDetectDeps, detectClaude, parseVersion }

--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -13,18 +13,34 @@ class FakeChild extends EventEmitter {
 
 describe('claude-install: command construction', () => {
   it('runs a plain global npm install without a mirror registry', () => {
-    const spec = getInstallSpawnSpec('npm')
+    const spec = getInstallSpawnSpec('npm', 'linux')
 
     expect(spec.command).toBe('npm')
     expect(spec.args).toEqual(['i', '-g', '@anthropic-ai/claude-code'])
     expect(spec.args.some((arg) => arg.includes('--registry'))).toBe(false)
+    expect(spec.shell).toBeFalsy()
   })
 
-  it('pipes the official installer through a shell', () => {
-    const spec = getInstallSpawnSpec('official-script')
+  it('pipes the official installer through bash on Unix', () => {
+    const spec = getInstallSpawnSpec('official-script', 'linux')
 
     expect(spec.command).toBe('bash')
     expect(spec.args.at(-1)).toContain('curl -fsSL https://claude.ai/install.sh | bash')
+  })
+
+  it('runs npm through a shell on Windows (npm.cmd shim)', () => {
+    const spec = getInstallSpawnSpec('npm', 'win32')
+
+    expect(spec.command).toBe('npm')
+    expect(spec.args).toEqual(['i', '-g', '@anthropic-ai/claude-code'])
+    expect(spec.shell).toBe(true)
+  })
+
+  it('uses the PowerShell installer (install.ps1) on Windows', () => {
+    const spec = getInstallSpawnSpec('official-script', 'win32')
+
+    expect(spec.command).toBe('powershell')
+    expect(spec.args.at(-1)).toContain('irm https://claude.ai/install.ps1 | iex')
   })
 })
 

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -8,7 +8,6 @@ import type {
   ClaudeInstallSource,
   NpmAvailability
 } from '../../shared/settings'
-import { CLAUDE_INSTALL_SOURCES } from '../../shared/settings'
 import { augmentedPathEnv } from './shell-path'
 
 const execFileAsync = promisify(execFile)
@@ -17,22 +16,48 @@ const execFileAsync = promisify(execFile)
 // the UI can show live progress and never spin silently. Command construction is pure and testable;
 // the spawn is injectable for the same reason.
 
-// How a source is actually executed. The official script is piped through a shell; the npm source
-// runs a plain global install against the user's configured registry.
+// How a source is actually executed. `shell` is set when the command must go through the OS shell:
+// the official script is always piped through one (bash/PowerShell), and on Windows even `npm` needs
+// a shell because it is an `npm.cmd` batch shim that spawn cannot launch directly.
 type InstallSpawnSpec = {
   command: string
   args: string[]
+  shell?: boolean
 }
 
-const INSTALL_SPAWN_SPECS: Record<ClaudeInstallSource, InstallSpawnSpec> = {
-  npm: {
-    command: 'npm',
-    args: ['i', '-g', '@anthropic-ai/claude-code']
-  },
-  'official-script': {
-    command: 'bash',
-    args: ['-lc', 'curl -fsSL https://claude.ai/install.sh | bash']
+// Builds the exact spawn command/args for a source on a given platform. Windows: npm runs through the
+// shell (npm.cmd), and the official installer is the PowerShell script (install.ps1); other platforms
+// keep npm bare and pipe the shell script through bash. All args are hard-coded constants, so shell
+// use here carries no injection risk.
+const getInstallSpawnSpec = (
+  source: ClaudeInstallSource,
+  platform: NodeJS.Platform = process.platform
+): InstallSpawnSpec => {
+  const isWindows = platform === 'win32'
+
+  if (source === 'npm') {
+    return {
+      command: 'npm',
+      args: ['i', '-g', '@anthropic-ai/claude-code'],
+      shell: isWindows
+    }
   }
+
+  return isWindows
+    ? {
+        command: 'powershell',
+        args: [
+          '-NoProfile',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-Command',
+          'irm https://claude.ai/install.ps1 | iex'
+        ]
+      }
+    : {
+        command: 'bash',
+        args: ['-lc', 'curl -fsSL https://claude.ai/install.sh | bash']
+      }
 }
 
 // Default guard so a hung network install cannot block the wizard forever.
@@ -43,19 +68,26 @@ export type RunInstallOptions = {
   installId: string
   onLog: (event: ClaudeInstallLogEvent) => void
   timeoutMs?: number
-  // Injectable spawn so tests can drive stdout/stderr/exit without a real process.
-  spawnImpl?: (command: string, args: string[]) => ChildProcessWithoutNullStreams
+  // Injectable spawn so tests can drive stdout/stderr/exit without a real process. `options` carries
+  // the spec's `shell` flag through to the real spawn.
+  spawnImpl?: (
+    command: string,
+    args: string[],
+    options?: { shell?: boolean }
+  ) => ChildProcessWithoutNullStreams
 }
 
-// Returns the exact spawn command/args for a source (also the source of the copyable display text).
-const getInstallSpawnSpec = (source: ClaudeInstallSource): InstallSpawnSpec =>
-  INSTALL_SPAWN_SPECS[source]
-
-// Real installer spawn with piped stdio. PATH is augmented so a GUI-launched app can still find npm.
-const defaultInstallSpawn = (command: string, args: string[]): ChildProcessWithoutNullStreams =>
+// Real installer spawn with piped stdio. PATH is augmented so a GUI-launched app can still find npm,
+// and `shell` is honoured so Windows npm.cmd / PowerShell specs run.
+const defaultInstallSpawn = (
+  command: string,
+  args: string[],
+  options?: { shell?: boolean }
+): ChildProcessWithoutNullStreams =>
   spawn(command, args, {
     stdio: 'pipe',
     windowsHide: true,
+    shell: options?.shell,
     env: augmentedPathEnv()
   }) as ChildProcessWithoutNullStreams
 
@@ -76,7 +108,7 @@ const runInstall = ({
     let child: ChildProcessWithoutNullStreams
 
     try {
-      child = spawnImpl(spec.command, spec.args)
+      child = spawnImpl(spec.command, spec.args, { shell: spec.shell })
     } catch (error) {
       resolve({
         installId,
@@ -132,7 +164,13 @@ const runInstall = ({
 // with common node locations so a GUI-launched app doesn't falsely report npm as missing.
 const detectNpmAvailable = async (
   runNpm: () => Promise<unknown> = () =>
-    execFileAsync('npm', ['--version'], { timeout: 10_000, env: augmentedPathEnv() })
+    execFileAsync('npm', ['--version'], {
+      timeout: 10_000,
+      // On Windows npm is an `npm.cmd` shim that execFile can't launch without a shell.
+      shell: process.platform === 'win32',
+      windowsHide: true,
+      env: augmentedPathEnv()
+    })
 ): Promise<NpmAvailability> => {
   try {
     await runNpm()
@@ -143,10 +181,4 @@ const detectNpmAvailable = async (
   }
 }
 
-export {
-  CLAUDE_INSTALL_SOURCES,
-  DEFAULT_INSTALL_TIMEOUT_MS,
-  detectNpmAvailable,
-  getInstallSpawnSpec,
-  runInstall
-}
+export { DEFAULT_INSTALL_TIMEOUT_MS, detectNpmAvailable, getInstallSpawnSpec, runInstall }

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -38,6 +38,7 @@ const createService = (
     detectDeps: {
       env: {},
       homePath: '/home',
+      platform: 'linux',
       isExecutable: () => Promise.resolve(true),
       getVersion: () => Promise.resolve(detectResult.version),
       resolveNpmBinDirs: () => Promise.resolve([])
@@ -267,6 +268,7 @@ describe('SettingsService: preflight & spawn config', () => {
       detectDeps: {
         env: {},
         homePath: '/home',
+        platform: 'linux',
         isExecutable: () => Promise.resolve(true),
         getVersion: () => Promise.resolve('2.1.0'),
         resolveNpmBinDirs: () => Promise.resolve([])

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -363,7 +363,11 @@ class SettingsService {
     try {
       await execFileAsync(executablePath, ['-p', 'ok'], {
         env,
-        timeout: CLAUDE_PROBE_TIMEOUT_MS
+        timeout: CLAUDE_PROBE_TIMEOUT_MS,
+        // On Windows the detected claude is a `claude.cmd` shim, which execFile can't launch without a
+        // shell (spawn EINVAL); route the probe through the shell there.
+        shell: process.platform === 'win32',
+        windowsHide: true
       })
 
       return { ok: true }

--- a/src/main/settings/shell-path.ts
+++ b/src/main/settings/shell-path.ts
@@ -1,11 +1,34 @@
 import { homedir } from 'node:os'
 import { delimiter, join } from 'node:path'
 
-// GUI apps (launched from Finder or electron-vite dev) start without a login shell, so their PATH
-// often omits the directories where node/npm and user-installed CLIs live. Augmenting PATH with these
-// common locations keeps npm detection and one-click installs from spuriously failing with
+// GUI apps (launched from Finder/Explorer or electron-vite dev) start without a login shell, so their
+// PATH often omits the directories where node/npm and user-installed CLIs live. Augmenting PATH with
+// these common locations keeps npm detection and one-click installs from spuriously failing with
 // "npm not found" on machines where npm is present but not on the inherited PATH.
-const EXTRA_PATH_DIRS = ['/opt/homebrew/bin', '/usr/local/bin', join(homedir(), '.local', 'bin')]
+//
+// Locations are platform-specific: Windows puts npm's global bin at %APPDATA%\npm and the native
+// installer under %LOCALAPPDATA%\Programs\claude; Unix uses Homebrew and /usr/local. `~/.local/bin`
+// (the install script's target on every OS) is included everywhere.
+const computeExtraPathDirs = (
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env
+): string[] => {
+  const localBin = join(homedir(), '.local', 'bin')
+
+  if (platform === 'win32') {
+    const dirs: string[] = []
+
+    if (env.APPDATA) dirs.push(join(env.APPDATA, 'npm'))
+    if (env.LOCALAPPDATA) dirs.push(join(env.LOCALAPPDATA, 'Programs', 'claude'))
+    dirs.push(localBin)
+
+    return dirs
+  }
+
+  return ['/opt/homebrew/bin', '/usr/local/bin', localBin]
+}
+
+const EXTRA_PATH_DIRS = computeExtraPathDirs()
 
 // Returns a copy of `env` whose PATH is the user's PATH followed by the well-known dirs (appended, so
 // the user's own resolution order still wins) with duplicates removed.

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -76,6 +76,8 @@ type AcpListener<Payload> = (payload: Payload) => void
 
 interface OpenScienceAPI {
   saveBlobFile(request: SaveBlobFileRequest): Promise<SaveBlobFileResult>
+  // Host platform (process.platform), e.g. 'win32' | 'darwin' | 'linux'.
+  platform: string
   getRuntimeVersions(): {
     electron: string
     chrome: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -90,6 +90,9 @@ const onIpcMessage = <Payload>(channel: string, listener: AcpListener<Payload>):
 // Custom APIs for renderer
 type OpenScienceAPI = {
   saveBlobFile: (request: SaveBlobFileRequest) => Promise<SaveBlobFileResult>
+  // Host platform (process.platform), e.g. 'win32' | 'darwin' | 'linux'. Lets the renderer pick
+  // platform-correct copy such as the claude install command shown in the onboarding/settings card.
+  platform: string
   getRuntimeVersions: () => {
     electron: string
     chrome: string
@@ -199,6 +202,7 @@ type OpenScienceAPI = {
 const api: OpenScienceAPI = {
   saveBlobFile: (request) =>
     ipcRenderer.invoke('file:save-blob', request) as Promise<SaveBlobFileResult>,
+  platform: process.platform,
   getRuntimeVersions: () => ({
     electron: process.versions.electron,
     chrome: process.versions.chrome,

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import type { ClaudeInstallSource } from '../../../../shared/settings'
-import { CLAUDE_INSTALL_SOURCES } from '../../../../shared/settings'
+import { getClaudeInstallSources } from '../../../../shared/settings'
 
 type ClaudeInstallCardProps = {
   isInstalling: boolean
@@ -22,7 +22,10 @@ const ClaudeInstallCard = ({
   const [source, setSource] = useState<ClaudeInstallSource>(
     npmAvailable ? 'npm' : 'official-script'
   )
-  const selectedSource = CLAUDE_INSTALL_SOURCES.find((item) => item.id === source)
+  // Sources carry platform-specific copy (e.g. install.ps1 vs install.sh), so resolve them for the
+  // host the app is running on.
+  const installSources = useMemo(() => getClaudeInstallSources(window.api?.platform), [])
+  const selectedSource = installSources.find((item) => item.id === source)
   const npmMissing = source === 'npm' && !npmAvailable
 
   return (
@@ -39,7 +42,7 @@ const ClaudeInstallCard = ({
           onChange={(event) => setSource(event.target.value as ClaudeInstallSource)}
           className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring"
         >
-          {CLAUDE_INSTALL_SOURCES.map((item) => (
+          {installSources.map((item) => (
             <option key={item.id} value={item.id}>
               {item.label}
               {item.requiresNpm && !npmAvailable ? ' (npm not found)' : ''}

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 
 import type { ClaudeInstallSource } from '../../../../shared/settings'
-import { getClaudeInstallSources } from '../../../../shared/settings'
+import { getClaudeInstallSources, getNodeInstallHint } from '../../../../shared/settings'
 
 type ClaudeInstallCardProps = {
   isInstalling: boolean
@@ -25,6 +25,7 @@ const ClaudeInstallCard = ({
   // Sources carry platform-specific copy (e.g. install.ps1 vs install.sh), so resolve them for the
   // host the app is running on.
   const installSources = useMemo(() => getClaudeInstallSources(window.api?.platform), [])
+  const nodeHint = useMemo(() => getNodeInstallHint(window.api?.platform), [])
   const selectedSource = installSources.find((item) => item.id === source)
   const npmMissing = source === 'npm' && !npmAvailable
 
@@ -64,9 +65,27 @@ const ClaudeInstallCard = ({
       ) : null}
 
       {npmMissing ? (
-        <p className="mt-2 text-xs text-destructive" role="alert">
-          npm was not found on this machine. Use the official script or install npm first.
-        </p>
+        <div className="mt-2 space-y-1.5 text-xs text-destructive" role="alert">
+          <p>
+            npm was not found. Switch to the official installer above (it needs no Node.js), or
+            install Node.js first — it includes npm.
+          </p>
+          {nodeHint.command ? (
+            <pre
+              className="overflow-x-auto rounded-lg bg-muted px-3 py-2 font-mono text-foreground"
+              aria-label="Node.js install command"
+            >
+              {nodeHint.command}
+            </pre>
+          ) : null}
+          <p className="text-muted-foreground">
+            Or download it from{' '}
+            <a href={nodeHint.url} target="_blank" rel="noreferrer" className="underline">
+              {nodeHint.url}
+            </a>
+            , then restart the app so npm is detected.
+          </p>
+        </div>
       ) : null}
 
       <button

--- a/src/shared/node-install-hint.test.ts
+++ b/src/shared/node-install-hint.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { getNodeInstallHint } from './settings'
+
+describe('getNodeInstallHint', () => {
+  it('uses winget on Windows', () => {
+    const hint = getNodeInstallHint('win32')
+
+    expect(hint.command).toBe('winget install OpenJS.NodeJS.LTS')
+    expect(hint.url).toContain('nodejs.org')
+  })
+
+  it('uses Homebrew on macOS', () => {
+    expect(getNodeInstallHint('darwin').command).toBe('brew install node')
+  })
+
+  it('offers only the download page on Linux (no single command)', () => {
+    const hint = getNodeInstallHint('linux')
+
+    expect(hint.command).toBeUndefined()
+    expect(hint.url).toContain('nodejs.org')
+  })
+})

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -132,6 +132,30 @@ export const getClaudeInstallSources = (platform: string = 'linux'): ClaudeInsta
   ]
 }
 
+// Guidance for installing Node.js (which bundles npm) when the npm install source is unavailable.
+// The npm path to install claude needs Node present first; a non-developer often won't have it.
+export type NodeInstallHint = {
+  // Copyable one-line install command for this platform, when a reliable one exists.
+  command?: string
+  // Official download page for a manual (GUI) installer — always available as a fallback.
+  url: string
+}
+
+// Returns how to install Node.js on the given host platform. Windows uses winget (built into Windows
+// 10/11); macOS suggests Homebrew; Linux is too distro-specific for a single command, so only the
+// download page is offered. The installer bundles npm in every case.
+export const getNodeInstallHint = (platform: string = 'linux'): NodeInstallHint => {
+  if (platform === 'win32') {
+    return { command: 'winget install OpenJS.NodeJS.LTS', url: 'https://nodejs.org/en/download' }
+  }
+
+  if (platform === 'darwin') {
+    return { command: 'brew install node', url: 'https://nodejs.org/en/download' }
+  }
+
+  return { url: 'https://nodejs.org/en/download' }
+}
+
 export type InstallClaudeRequest = {
   source: ClaudeInstallSource
 }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -107,21 +107,30 @@ export type ClaudeInstallSourceInfo = {
   requiresNpm: boolean
 }
 
-// The ordered install sources; a plain global npm install is the default when npm is available.
-export const CLAUDE_INSTALL_SOURCES: ClaudeInstallSourceInfo[] = [
-  {
-    id: 'npm',
-    label: 'npm (global install)',
-    displayCommand: 'npm i -g @anthropic-ai/claude-code',
-    requiresNpm: true
-  },
-  {
-    id: 'official-script',
-    label: 'Official install.sh',
-    displayCommand: 'curl -fsSL https://claude.ai/install.sh | bash',
-    requiresNpm: false
-  }
-]
+// The ordered install sources for a given host platform; a plain global npm install is the default
+// when npm is available. The npm command is identical everywhere, but the official installer differs:
+// Windows uses the PowerShell script (install.ps1), other platforms use the shell script (install.sh).
+// Pass the host platform (e.g. `window.api.platform`) so the copyable command matches what runs.
+export const getClaudeInstallSources = (platform: string = 'linux'): ClaudeInstallSourceInfo[] => {
+  const isWindows = platform === 'win32'
+
+  return [
+    {
+      id: 'npm',
+      label: 'npm (global install)',
+      displayCommand: 'npm i -g @anthropic-ai/claude-code',
+      requiresNpm: true
+    },
+    {
+      id: 'official-script',
+      label: isWindows ? 'Official install.ps1' : 'Official install.sh',
+      displayCommand: isWindows
+        ? 'irm https://claude.ai/install.ps1 | iex'
+        : 'curl -fsSL https://claude.ai/install.sh | bash',
+      requiresNpm: false
+    }
+  ]
+}
 
 export type InstallClaudeRequest = {
   source: ClaudeInstallSource


### PR DESCRIPTION
## Summary

Makes Open Science build and run on Windows (10/11 x64) alongside macOS and Linux. The core stack (Electron + electron-builder) was already cross-platform; this fills in the Unix-only assumptions in the runtime code plus the packaging/CI config.

### Runtime code
- **claude detection** (`claude-detect.ts`): platform-aware candidate names (`claude.cmd`/`.exe`/`.bat`), Windows well-known dirs (`%APPDATA%\npm`, `%LOCALAPPDATA%\Programs\claude`), `F_OK` instead of `X_OK`, shell for `npm.cmd`, and npm global bin path without the `/bin` suffix on Windows.
- **PATH augmentation** (`shell-path.ts`): `EXTRA_PATH_DIRS` computed per platform (npm global dir on Windows).
- **install wizard** (`claude-install.ts`): `getInstallSpawnSpec(source, platform)` — Windows uses the official PowerShell installer (`irm https://claude.ai/install.ps1 | iex`) and runs npm through a shell (`npm.cmd`); the `shell` flag is threaded to `spawn`. `detectNpmAvailable` uses a shell on Windows.
- **install sources** (`shared/settings.ts`): replaced the `CLAUDE_INSTALL_SOURCES` constant with `getClaudeInstallSources(platform)`; exposed `window.api.platform` via preload; `ClaudeInstallCard` renders the platform-correct command (`install.ps1` vs `install.sh`).
- **notebook** (`python-command.ts`, `python-executor.ts`): new `resolvePythonCommand` (Windows `py -3` → `python` → `python3`; Unix `python3` → `python`), resolved lazily on first interpreter launch.

### Packaging
- Enabled `win`/`nsis` in `electron-builder.yml` and added the `build:win` script. The ad-hoc-sign `afterPack` hook already no-ops off macOS. Windows builds are unsigned (no Authenticode cert) — SmartScreen shows a bypassable prompt, same trade-off as the unsigned macOS build.

### CI
- Added a `windows-latest` entry to the build matrix and publish `*.exe` in `release.yml` / `nightly.yml`.
- Broadened the "Prune foreign Prisma engines" glob from `libquery_engine-*` to `*query_engine-*` so it also matches the Windows engine (`query_engine-windows.dll.node`, which has no `lib` prefix); the Windows entry keeps `engine_keep: windows.dll`.

## Testing
- `npm run typecheck` — passes (node + web)
- `npm test` — 552 passed (added Windows cases for detection/install and `resolvePythonCommand`)
- `npm run lint` — clean on all changed files

## Not yet verified (cannot be checked on macOS)
- Running `build:win` on a Windows runner to produce and install the `*-win-x64-setup.exe`.
- The notebook's `os.dup2` fd-capture behavior on Windows Python (a `redirect_stdout`/`redirect_stderr` fallback is noted in the design doc).

Please review; do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)