### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-science",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-science",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-science",
   "productName": "Open Science",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Open Science — an open-source, model-agnostic AI workbench for scientific discovery.",
   "main": "./out/main/index.js",
   "author": "aipoch",


### PR DESCRIPTION
## Summary
Bump version from 0.1.0 to 0.1.1 to prepare the v0.1.1 release.

Changes since v0.1.0 (already on `main`):
- feat: Windows compatibility — detection, install, notebook, packaging, CI (#10)
- ci: cross-build macOS x64 on Apple Silicon; set min macOS 12 (#9)
- ci: bump GitHub Actions to Node 24 versions (v4 -> v5) (#8)
- feat: first-run onboarding, diagnostics, and unified provider config (#6)
- ci: build unsigned macOS on the no-cert path (#7)

## Changes
- `package.json`: version 0.1.0 → 0.1.1
- `package-lock.json`: version 0.1.0 → 0.1.1

## Release flow
Merge this PR, then tag `v0.1.1` on `main` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)