### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug report
+description: Report something that isn't working as expected
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill out the
+        sections below so we can reproduce and fix the issue.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues and this has not been reported yet.
+          required: true
+        - label: I'm running a recent version of Open Science.
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen.
+      placeholder: I expected X, but Y happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: The exact steps needed to trigger the bug.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Found in the app's About screen or the release you installed.
+      placeholder: e.g. 0.1.1
+    validations:
+      required: true
+  - type: input
+    id: provider-model
+    attributes:
+      label: Provider / model
+      description: Which AI provider and model were configured when the bug occurred?
+      placeholder: e.g. OpenAI gpt-4o, Anthropic claude-opus-4, local model, ...
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Paste any relevant log output or attach screenshots. Logs will be automatically formatted, so no need for backticks.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discussions
+    url: https://github.com/aipoch/open-science/discussions
+    about: Ask questions, share ideas, and talk through open-ended topics here.
+  - name: Discord community
+    url: https://discord.gg/85dKfuGM9
+    about: Chat with the community and the maintainers in real time.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest an idea or improvement for Open Science
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? We'd love to hear it. For open-ended ideas or questions,
+        consider starting a [Discussion](https://github.com/aipoch/open-science/discussions)
+        instead — it's a better fit for conversation.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues and discussions and this hasn't been proposed yet.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the problem or limitation you're running into. Focus on the "why".
+      placeholder: I'm always frustrated when ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've thought about.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that would help — mockups, links, use cases.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds GitHub issue form templates under `.github/ISSUE_TEMPLATE/`:

- **`bug_report.yml`** — description, repro steps, OS, app version, provider/model, and logs (mirrors the "Reporting Issues" checklist in CONTRIBUTING.md).
- **`feature_request.yml`** — problem / proposal / alternatives, with a nudge toward Discussions for open-ended ideas.
- **`config.yml`** — disables blank issues and links out to Discussions and Discord.

All in English, matching the project's language convention.

## Testing

Templates are YAML config only — no build/test impact. Rendering will be verified by GitHub's issue form parser on merge.