### PR TITLE
ci: shorten artifact retention and move actions off deprecated Node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
 
       # Upload only the distributables + electron-updater metadata for the caller's publish job.
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }}
           retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,7 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.name }}
+          retention-days: 1
           path: |
             dist/*.dmg
             dist/*.zip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -53,7 +53,7 @@ jobs:
         run: gh release delete nightly --cleanup-tag --yes || true
 
       - name: Publish nightly pre-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: nightly
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true # flatten every platform's files into one directory
@@ -54,7 +54,7 @@ jobs:
       # each emits its own latest-mac.yml (they'd collide), and Squirrel.Mac can't auto-update an
       # unsigned build anyway. Revisit latest*.yml once a Developer ID cert is configured.
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: false
           prerelease: false


### PR DESCRIPTION
Two CI maintenance changes to the release/nightly/manual pipelines.

## 1. Shorten build-artifact retention

Set `retention-days: 1` on the build-artifact upload in `build.yml`.

Build artifacts are a build→publish handoff within a single workflow run (`publish` needs `build`), so the 90-day default is unnecessary and inflates Actions storage — the main source of storage on our public repo. Final distributables live in the GitHub Release, which doesn't count against Actions storage.

Applies to all three pipelines (release / nightly / manual) since they share the reusable `build.yml`.

## 2. Move actions off the deprecated Node.js 20 runtime

GitHub is removing the Node.js 20 runtime from Actions runners; these actions still declared `node20` and were being forced onto `node24` with a deprecation warning. Bumped to the current node24 majors:

- `actions/upload-artifact` v5 → v7
- `actions/download-artifact` v5 → v8
- `softprops/action-gh-release` v2 → v3

Runtime-only bump: every input the workflows use (`name`/`retention-days`/`path`, `path`/`merge-multiple`, `draft`/`prerelease`/`generate_release_notes`/`files`/`tag_name`/`target_commitish`/`name`) still exists in the new majors. `actions/checkout@v5` and `actions/setup-node@v5` were already on node24 and are unchanged.

## Notes
- Config-only; the retention change is verifiable on the next run (artifact expiry should show 1 day), and the Node 20 warnings disappear once build/nightly/release actually run (they don't execute on PR checks).
- Retention only affects new uploads; already-uploaded artifacts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)