### PR TITLE
fix: handle large PDFs and images instead of overflowing the 32MB request limit

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -33,6 +33,15 @@ files:
   # Wildcard every platform variant (darwin-arm64/-x64, linux-*, win32-*) so the exclusion holds no
   # matter which OS the release job builds on — npm only installs the one matching the build host.
   - '!node_modules/@anthropic-ai/claude-agent-sdk-*{,/**/*}'
+  # pdfjs-dist ships several redundant copies. The main process only loads `legacy/build` (text
+  # extraction) and needs `cmaps`/`standard_fonts` for CJK/CID PDFs; the renderer bundles its own
+  # copy via Vite. Drop the modern build, viewer, image decoders, TS types, and source maps
+  # (~16MB) so the packaged app carries only what runs.
+  - '!node_modules/pdfjs-dist/build{,/**/*}'
+  - '!node_modules/pdfjs-dist/web{,/**/*}'
+  - '!node_modules/pdfjs-dist/image_decoders{,/**/*}'
+  - '!node_modules/pdfjs-dist/types{,/**/*}'
+  - '!node_modules/pdfjs-dist/**/*.map'
 asarUnpack:
   - resources/**
   # The ACP agent runs as a spawned child process, so its entry must live outside the asar.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@prisma/client": "^6.19.3",
         "electron-updater": "^6.3.9",
+        "pdfjs-dist": "^4.10.38",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -2418,6 +2419,256 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@noble/hashes": {
@@ -13568,6 +13819,18 @@
       "version": "2.0.3",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
     },
     "node_modules/pe-library": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@prisma/client": "^6.19.3",
     "electron-updater": "^6.3.9",
+    "pdfjs-dist": "^4.10.38",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -289,6 +289,57 @@ describe('ACP runtime session management', () => {
     ).resolves.toBe('hello from upload')
   })
 
+  it('sends PDFs as extracted text, never as an inlined base64 file', async () => {
+    const root = await createTemporaryRoot()
+    const uploadRepository = new UploadRepository(root)
+    // Non-PDF bytes make extraction fail deterministically; the block must still be text, not the file.
+    const stagedAttachments = await uploadRepository.stageFiles({
+      files: [
+        {
+          name: 'doc.pdf',
+          mimeType: 'application/pdf',
+          content: Buffer.from('not a real pdf payload').toString('base64')
+        }
+      ]
+    })
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploadRepository }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'summarize this pdf',
+      attachments: stagedAttachments
+    })
+
+    expect(receivedPrompts).toHaveLength(1)
+    const pdfBlock = receivedPrompts[0][1]
+    expect(pdfBlock.type).toBe('resource')
+    expect(pdfBlock).toMatchObject({
+      type: 'resource',
+      resource: {
+        mimeType: 'text/plain',
+        uri: expect.stringContaining('/uploads/default-project/remote-session-1/doc.pdf')
+      }
+    })
+    // The raw file bytes must never be inlined as base64 anywhere in the prompt.
+    const rawBase64 = Buffer.from('not a real pdf payload').toString('base64')
+    const serialized = JSON.stringify(receivedPrompts[0])
+    expect(serialized).not.toContain(rawBase64)
+    expect(receivedPrompts[0].some((block) => block.type === 'image')).toBe(false)
+  })
+
   it('allows prompts from different sessions to run concurrently', async () => {
     const process = new FakeAgentProcess()
     const promptCanStopBySession = new Map<string, ReturnType<typeof createDeferred>>()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -44,6 +44,7 @@ import {
 import { getNotebookSessionRoot } from '../notebook/repository'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
+import { buildImageContentData, extractPdfText } from '../uploads/attachment-media'
 
 type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -790,13 +791,21 @@ class AcpRuntime {
     const uri = pathToFileURL(filePath).href
 
     // Images are embedded as base64 so vision-capable agents receive the actual pixels.
+    // Large images are downscaled/re-encoded first so one upload cannot overflow the request.
     if (attachment.mimeType?.startsWith('image/')) {
-      return {
-        type: 'image',
-        data: (await readFile(filePath)).toString('base64'),
-        mimeType: attachment.mimeType ?? 'application/octet-stream',
-        uri
-      }
+      const { data, mimeType } = await buildImageContentData(
+        filePath,
+        attachment.mimeType,
+        attachment.size
+      )
+
+      return { type: 'image', data, mimeType, uri }
+    }
+
+    // PDFs are never inlined as base64 (a 20MB file overflows the 32MB request limit); instead we
+    // extract selectable text so the model reads readable content. Page images are a future option.
+    if (this.isPdfAttachment(attachment)) {
+      return this.createPdfContentBlock(attachment, filePath, uri)
     }
 
     // Small text-like files are embedded for direct reading; oversized text falls through to a link.
@@ -822,6 +831,49 @@ class AcpRuntime {
       title: attachment.originalName || attachment.name,
       mimeType: attachment.mimeType,
       size: attachment.size
+    }
+  }
+
+  // Recognizes PDFs by MIME type or extension since the renderer does not always send a MIME type.
+  private isPdfAttachment(attachment: UploadedAttachment): boolean {
+    if (attachment.mimeType === 'application/pdf') return true
+
+    const name = attachment.originalName || attachment.name
+    return name.toLowerCase().endsWith('.pdf')
+  }
+
+  // Turns a PDF into a text resource block, degrading to an explanatory note when extraction fails
+  // or yields nothing (e.g. scanned/image-only PDFs) rather than ever inlining the raw file.
+  private async createPdfContentBlock(
+    attachment: UploadedAttachment,
+    filePath: string,
+    uri: string
+  ): Promise<ContentBlock> {
+    const name = attachment.originalName || attachment.name
+
+    const toResource = (text: string): ContentBlock => ({
+      type: 'resource',
+      resource: { uri, mimeType: 'text/plain', text }
+    })
+
+    try {
+      const { text, pageCount, truncated } = await extractPdfText(filePath)
+
+      if (!text) {
+        return toResource(
+          `[No selectable text could be extracted from "${name}" (${pageCount} page(s)). It may be a scanned or image-only PDF.]`
+        )
+      }
+
+      const header = `[PDF text extracted from "${name}" — ${pageCount} page(s)${
+        truncated ? ', truncated' : ''
+      }]`
+
+      return toResource(`${header}\n\n${text}`)
+    } catch (error) {
+      return toResource(
+        `[Failed to extract text from "${name}": ${errorMessage(error)}. The PDF was not sent to avoid exceeding the request size limit.]`
+      )
     }
   }
 

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -3,7 +3,9 @@ import { ipcMain, shell } from 'electron'
 import type { ArtifactFile, ArtifactPreviewResult } from '../../shared/artifacts'
 import type {
   FinalizeRunArtifactsRequest,
+  ManagedFileBytesResult,
   OpenArtifactFileRequest,
+  ReadArtifactBytesRequest,
   ReadArtifactPreviewRequest
 } from '../../shared/artifacts'
 import { resolveStorageRoot } from '../storage-root'
@@ -14,6 +16,7 @@ type ArtifactHandlers = {
   finalizeRunArtifacts: (request: FinalizeRunArtifactsRequest) => Promise<ArtifactFile[]>
   openFile: (request: OpenArtifactFileRequest) => Promise<void>
   readPreview: (request: ReadArtifactPreviewRequest) => Promise<ArtifactPreviewResult>
+  readBytes: (request: ReadArtifactBytesRequest) => Promise<ManagedFileBytesResult>
 }
 
 type ArtifactHandlerDependencies = {
@@ -73,7 +76,8 @@ const createArtifactHandlers = (
         throw new Error(openError)
       }
     },
-    readPreview: (request) => repository.readManagedFilePreview(request)
+    readPreview: (request) => repository.readManagedFilePreview(request),
+    readBytes: (request) => repository.readManagedFileBytes(request)
   }
 }
 
@@ -132,6 +136,9 @@ const registerArtifactIpcHandlers = (
   )
   ipcMain.handle('artifacts:read-preview', (_event, request: ReadArtifactPreviewRequest) =>
     handlers.readPreview(request)
+  )
+  ipcMain.handle('artifacts:read-bytes', (_event, request: ReadArtifactBytesRequest) =>
+    handlers.readBytes(request)
   )
 }
 

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -59,6 +59,27 @@ describe('artifact repository', () => {
     await expect(readFile(artifact.path, 'utf8')).resolves.toBe('<report />')
   })
 
+  it('reads full artifact bytes as base64 for viewers, only within the managed tree', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+    const bytes = Buffer.from('%PDF-1.4 artifact bytes')
+    const artifact = await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      filename: 'report.pdf',
+      mimeType: 'application/pdf',
+      source: createInlineSource(bytes.toString('base64'), 'base64')
+    })
+
+    const result = await repository.readManagedFileBytes({ path: artifact.path })
+
+    expect(result).toEqual({ data: bytes.toString('base64'), size: bytes.byteLength })
+    await expect(
+      repository.readManagedFileBytes({ path: join(root, 'outside.pdf') })
+    ).rejects.toThrow()
+  })
+
   it('writes large inline base64 artifacts without repository size limits', async () => {
     const root = await createStorageRoot()
     const repository = new ArtifactRepository(root)

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -18,8 +18,10 @@ import type {
   ArtifactPreviewResult,
   ListPendingRunArtifactsRequest,
   ListProjectMessageArtifactsRequest,
+  ManagedFileBytesResult,
   MovePendingRunArtifactsRequest,
   OpenArtifactFileRequest,
+  ReadArtifactBytesRequest,
   ReadArtifactPreviewRequest,
   WritePendingArtifactFileRequest
 } from '../../shared/artifacts'
@@ -29,6 +31,8 @@ const ARTIFACTS_DIR = 'artifacts'
 const PENDING_DIR = '.pending'
 const METADATA_DIR = '.metadata'
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+// Hard ceiling for reading a whole artifact into memory (e.g. for PDF thumbnails) to avoid OOM.
+const MAX_ARTIFACT_BYTES_READ = 100 * 1024 * 1024
 
 type ArtifactMetadata = {
   mimeType?: string
@@ -330,6 +334,20 @@ class ArtifactRepository {
   ): Promise<ArtifactPreviewResult> {
     const filePath = await this.resolveManagedFilePath(request)
     return readBoundedManagedFilePreview(filePath, request, 'Invalid artifact preview encoding.')
+  }
+
+  // Reads a whole managed artifact as base64 bytes for viewers (e.g. PDF thumbnails) that need the
+  // full file rather than a bounded text/image preview. Path safety is enforced before any read.
+  async readManagedFileBytes(request: ReadArtifactBytesRequest): Promise<ManagedFileBytesResult> {
+    const filePath = await this.resolveManagedFilePath(request)
+    const fileStat = await stat(filePath)
+
+    if (fileStat.size > MAX_ARTIFACT_BYTES_READ) {
+      throw new Error('Artifact is too large to read into memory.')
+    }
+
+    const buffer = await readFile(filePath)
+    return { data: buffer.toString('base64'), size: buffer.byteLength }
   }
 
   // Builds the temporary directory for files generated during one active assistant turn.

--- a/src/main/uploads/attachment-media.test.ts
+++ b/src/main/uploads/attachment-media.test.ts
@@ -1,0 +1,143 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { buildImageContentData, extractPdfText } from './attachment-media'
+
+// A configurable fake nativeImage so the >2MB compression path is exercised without an Electron runtime.
+type FakeImage = {
+  isEmpty: () => boolean
+  getSize: () => { width: number; height: number }
+  resize: ReturnType<typeof vi.fn>
+  toJPEG: (quality: number) => Buffer
+  toPNG: () => Buffer
+}
+
+let fakeImage: FakeImage
+// The wrapper ignores the path arg at runtime; the spy just records that a decode was attempted.
+const createFromPath = vi.fn(() => fakeImage)
+
+vi.mock('electron', () => ({
+  nativeImage: {
+    createFromPath: () => createFromPath()
+  }
+}))
+
+// A fake pdfjs document so text extraction is deterministic and does not parse a real PDF.
+let fakePdf: { numPages: number; pages: string[][] }
+const getDocument = vi.fn(() => ({
+  promise: Promise.resolve({
+    numPages: fakePdf.numPages,
+    getPage: async (pageNumber: number) => ({
+      getTextContent: async () => ({
+        items: (fakePdf.pages[pageNumber - 1] ?? []).map((str) => ({ str }))
+      }),
+      cleanup: () => {}
+    }),
+    destroy: async () => {}
+  })
+}))
+
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({ getDocument: () => getDocument() }))
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'attachment-media-'))
+  createFromPath.mockClear()
+  getDocument.mockClear()
+  fakeImage = {
+    isEmpty: () => false,
+    getSize: () => ({ width: 4000, height: 2000 }),
+    resize: vi.fn(function (this: FakeImage) {
+      return this
+    }),
+    toJPEG: (quality: number) => Buffer.from(`jpeg-${quality}`),
+    toPNG: () => Buffer.from('png-bytes')
+  }
+  fakePdf = {
+    numPages: 2,
+    pages: [
+      ['Hello', ' world'],
+      ['Second', ' page']
+    ]
+  }
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('buildImageContentData', () => {
+  it('passes small images through untouched as raw base64', async () => {
+    const filePath = join(root, 'small.png')
+    const bytes = Buffer.from('tiny-image-bytes')
+    await writeFile(filePath, bytes)
+
+    const result = await buildImageContentData(filePath, 'image/png', bytes.byteLength)
+
+    expect(result).toEqual({ data: bytes.toString('base64'), mimeType: 'image/png' })
+    expect(createFromPath).not.toHaveBeenCalled()
+  })
+
+  it('downscales large images to the long-edge cap and re-encodes to JPEG', async () => {
+    const filePath = join(root, 'large.jpg')
+    await writeFile(filePath, Buffer.from('ignored-because-nativeimage-is-mocked'))
+
+    const result = await buildImageContentData(filePath, 'image/jpeg', 3 * 1024 * 1024)
+
+    // 4000px long edge is scaled to the 1568 cap while preserving aspect ratio.
+    expect(fakeImage.resize).toHaveBeenCalledWith(
+      expect.objectContaining({ width: 1568, height: 784 })
+    )
+    expect(result.mimeType).toBe('image/jpeg')
+    expect(result.data).toBe(Buffer.from('jpeg-80').toString('base64'))
+  })
+
+  it('keeps PNG encoding for large PNGs to preserve transparency', async () => {
+    const filePath = join(root, 'large.png')
+    await writeFile(filePath, Buffer.from('ignored'))
+
+    const result = await buildImageContentData(filePath, 'image/png', 3 * 1024 * 1024)
+
+    expect(result.mimeType).toBe('image/png')
+    expect(result.data).toBe(Buffer.from('png-bytes').toString('base64'))
+  })
+
+  it('falls back to raw bytes when the image cannot be decoded', async () => {
+    fakeImage.isEmpty = () => true
+    const filePath = join(root, 'broken.jpg')
+    const bytes = Buffer.from('not-a-real-image-but-larger-than-threshold')
+    await writeFile(filePath, bytes)
+
+    const result = await buildImageContentData(filePath, 'image/jpeg', 3 * 1024 * 1024)
+
+    expect(result).toEqual({ data: bytes.toString('base64'), mimeType: 'image/jpeg' })
+  })
+})
+
+describe('extractPdfText', () => {
+  it('joins per-page text with page markers', async () => {
+    const filePath = join(root, 'doc.pdf')
+    await writeFile(filePath, Buffer.from('%PDF-1.4 fake'))
+
+    const result = await extractPdfText(filePath)
+
+    expect(result.pageCount).toBe(2)
+    expect(result.truncated).toBe(false)
+    expect(result.text).toBe('--- Page 1 ---\nHello world\n\n--- Page 2 ---\nSecond page')
+  })
+
+  it('returns empty text for a PDF with no extractable content', async () => {
+    fakePdf = { numPages: 1, pages: [[]] }
+    const filePath = join(root, 'scanned.pdf')
+    await writeFile(filePath, Buffer.from('%PDF-1.4 fake'))
+
+    const result = await extractPdfText(filePath)
+
+    expect(result.pageCount).toBe(1)
+    expect(result.text).toBe('')
+  })
+})

--- a/src/main/uploads/attachment-media.ts
+++ b/src/main/uploads/attachment-media.ts
@@ -1,0 +1,154 @@
+import { createRequire } from 'node:module'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+// Images larger than this are downscaled/re-encoded before inlining so a single upload never
+// blows past the model's per-image (~5MB) and total-request (~32MB) limits after base64 growth.
+export const MAX_INLINE_IMAGE_BYTES = 2 * 1024 * 1024
+
+// Anthropic rejects a single image whose payload exceeds 5MB; stay comfortably under it.
+const MAX_IMAGE_PAYLOAD_BYTES = 4.5 * 1024 * 1024
+
+// Anthropic downscales images past 1568px on the long edge anyway, so this is a lossless-of-info cap.
+const MAX_IMAGE_LONG_EDGE = 1568
+
+// Extracted PDF text is bounded so a huge document can never recreate the oversized-request problem.
+export const MAX_PDF_TEXT_CHARS = 1024 * 1024
+
+export type ImageContentData = {
+  data: string
+  mimeType: string
+}
+
+export type PdfTextResult = {
+  text: string
+  pageCount: number
+  truncated: boolean
+}
+
+// Builds the base64 payload for an image content block, downscaling oversized images first.
+// Small images and anything we cannot decode fall back to the raw bytes so behavior is unchanged.
+export const buildImageContentData = async (
+  filePath: string,
+  mimeType: string | undefined,
+  size: number
+): Promise<ImageContentData> => {
+  const fallbackMimeType = mimeType ?? 'application/octet-stream'
+
+  if (size <= MAX_INLINE_IMAGE_BYTES) {
+    return { data: (await readFile(filePath)).toString('base64'), mimeType: fallbackMimeType }
+  }
+
+  try {
+    const { nativeImage } = await import('electron')
+    const image = nativeImage.createFromPath(filePath)
+
+    // A non-decodable or empty image cannot be compressed; send the original and let the API judge it.
+    if (image.isEmpty()) {
+      return { data: (await readFile(filePath)).toString('base64'), mimeType: fallbackMimeType }
+    }
+
+    const { width, height } = image.getSize()
+    const longEdge = Math.max(width, height)
+    const scale = longEdge > MAX_IMAGE_LONG_EDGE ? MAX_IMAGE_LONG_EDGE / longEdge : 1
+    const resized =
+      scale < 1
+        ? image.resize({
+            width: Math.max(1, Math.round(width * scale)),
+            height: Math.max(1, Math.round(height * scale)),
+            quality: 'better'
+          })
+        : image
+
+    // PNGs keep transparency on the first pass; everything else re-encodes to JPEG for size.
+    const preferPng = mimeType === 'image/png'
+    let outMimeType = preferPng ? 'image/png' : 'image/jpeg'
+    let buffer = preferPng ? resized.toPNG() : resized.toJPEG(80)
+
+    // Progressive fallbacks keep the payload under the per-image limit for stubborn inputs.
+    if (buffer.byteLength > MAX_IMAGE_PAYLOAD_BYTES) {
+      outMimeType = 'image/jpeg'
+      buffer = resized.toJPEG(70)
+    }
+    if (buffer.byteLength > MAX_IMAGE_PAYLOAD_BYTES) {
+      const smaller = resized.resize({ width: 1024, quality: 'better' })
+      buffer = smaller.toJPEG(65)
+    }
+
+    return { data: buffer.toString('base64'), mimeType: outMimeType }
+  } catch {
+    // If image processing is unavailable (e.g. no Electron runtime), fall back to the raw bytes.
+    return { data: (await readFile(filePath)).toString('base64'), mimeType: fallbackMimeType }
+  }
+}
+
+// Resolves the on-disk pdfjs asset directories so CID/CJK fonts map to Unicode during extraction.
+const resolvePdfjsAssetUrls = (): { cMapUrl: string; standardFontDataUrl: string } => {
+  const require = createRequire(import.meta.url)
+  const packageDir = dirname(require.resolve('pdfjs-dist/package.json'))
+
+  return {
+    cMapUrl: `${pathToFileURL(join(packageDir, 'cmaps')).href}/`,
+    standardFontDataUrl: `${pathToFileURL(join(packageDir, 'standard_fonts')).href}/`
+  }
+}
+
+// Extracts selectable text from a PDF so the model receives readable content instead of the raw
+// (base64) file, which would otherwise overflow the request size limit.
+export const extractPdfText = async (filePath: string): Promise<PdfTextResult> => {
+  const pdfjs = (await import('pdfjs-dist/legacy/build/pdf.mjs')) as typeof import('pdfjs-dist')
+  const { cMapUrl, standardFontDataUrl } = resolvePdfjsAssetUrls()
+  const fileData = await readFile(filePath)
+
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(fileData),
+    cMapUrl,
+    cMapPacked: true,
+    standardFontDataUrl,
+    isEvalSupported: false,
+    useSystemFonts: false,
+    verbosity: 0
+  })
+
+  const document = await loadingTask.promise
+
+  try {
+    const pageTexts: string[] = []
+    let totalChars = 0
+    let truncated = false
+
+    for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+      const page = await document.getPage(pageNumber)
+      const content = await page.getTextContent()
+      page.cleanup()
+
+      const pageText = content.items
+        .map((item) => ('str' in item ? item.str : ''))
+        .join('')
+        .trim()
+
+      // Skip empty pages so a scanned/image-only PDF yields no text and hits the caller's fallback.
+      if (!pageText) continue
+
+      const block = `--- Page ${pageNumber} ---\n${pageText}`
+      pageTexts.push(block)
+      totalChars += block.length
+
+      if (totalChars >= MAX_PDF_TEXT_CHARS) {
+        truncated = true
+        break
+      }
+    }
+
+    let text = pageTexts.join('\n\n')
+    if (text.length > MAX_PDF_TEXT_CHARS) {
+      text = text.slice(0, MAX_PDF_TEXT_CHARS)
+      truncated = true
+    }
+
+    return { text: text.trim(), pageCount: document.numPages, truncated }
+  } finally {
+    await document.destroy()
+  }
+}

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -4,6 +4,7 @@ import type { ReadArtifactPreviewRequest } from '../../shared/artifacts'
 import type {
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
+  ReadUploadBytesRequest,
   StageUploadFilesRequest
 } from '../../shared/uploads'
 import { getSessionPersistenceDir } from '../session-persistence/repository'
@@ -26,6 +27,9 @@ const registerUploadIpcHandlers = (repository = createDefaultUploadRepository())
   )
   ipcMain.handle('uploads:read-preview', (_event, request: ReadArtifactPreviewRequest) =>
     repository.readManagedUploadPreview(request)
+  )
+  ipcMain.handle('uploads:read-bytes', (_event, request: ReadUploadBytesRequest) =>
+    repository.readManagedUploadBytes(request)
   )
 }
 

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -153,4 +153,20 @@ describe('upload repository', () => {
       /outside upload storage/
     )
   })
+
+  it('reads full upload bytes as base64 for viewers, only within the managed tree', async () => {
+    const root = await createStorageRoot()
+    const repository = new UploadRepository(root)
+    const bytes = Buffer.from('%PDF-1.4 upload bytes')
+    const [attachment] = await repository.stageFiles({
+      files: [{ name: 'doc.pdf', content: bytes.toString('base64'), mimeType: 'application/pdf' }]
+    })
+
+    const result = await repository.readManagedUploadBytes({ path: attachment.path })
+
+    expect(result).toEqual({ data: bytes.toString('base64'), size: bytes.byteLength })
+    await expect(
+      repository.readManagedUploadBytes({ path: join(root, 'outside.pdf') })
+    ).rejects.toThrow(/outside upload storage/)
+  })
 })

--- a/src/main/uploads/repository.ts
+++ b/src/main/uploads/repository.ts
@@ -1,5 +1,5 @@
 import { constants } from 'node:fs'
-import { copyFile, mkdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { copyFile, mkdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { randomUUID } from 'node:crypto'
 
@@ -8,13 +8,17 @@ import {
   DEFAULT_UPLOAD_PROJECT_NAME,
   PENDING_UPLOAD_SESSION_ID,
   type DeleteUploadRequest,
+  type ReadUploadBytesRequest,
   type StageUploadFilesRequest,
+  type UploadBytesResult,
   type UploadedAttachment
 } from '../../shared/uploads'
 import { readBoundedManagedFilePreview } from '../managed-file-preview'
 
 const UPLOADS_DIR = 'uploads'
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+// Hard ceiling for reading a whole upload into memory (e.g. for PDF preview) to avoid OOM.
+const MAX_UPLOAD_BYTES_READ = 100 * 1024 * 1024
 
 type CreateAttachmentInput = {
   id: string
@@ -178,6 +182,20 @@ class UploadRepository {
   ): Promise<ArtifactPreviewResult> {
     const filePath = await this.resolveManagedUploadPath(request)
     return readBoundedManagedFilePreview(filePath, request, 'Invalid upload preview encoding.')
+  }
+
+  // Reads a whole managed upload as base64 bytes for viewers (e.g. PDF preview) that need the full
+  // file rather than a bounded text/image preview. Path safety is enforced before any read.
+  async readManagedUploadBytes(request: ReadUploadBytesRequest): Promise<UploadBytesResult> {
+    const filePath = await this.resolveManagedUploadPath(request)
+    const fileStat = await stat(filePath)
+
+    if (fileStat.size > MAX_UPLOAD_BYTES_READ) {
+      throw new Error('Upload is too large to read into memory.')
+    }
+
+    const buffer = await readFile(filePath)
+    return { data: buffer.toString('base64'), size: buffer.byteLength }
   }
 
   // Converts one pending attachment record into a durable session-owned upload record.

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -15,7 +15,9 @@ import type {
   ArtifactFile,
   ArtifactPreviewResult,
   FinalizeRunArtifactsRequest,
+  ManagedFileBytesResult,
   OpenArtifactFileRequest,
+  ReadArtifactBytesRequest,
   ReadArtifactPreviewRequest
 } from '../shared/artifacts'
 import type { SaveBlobFileRequest, SaveBlobFileResult } from '../shared/file-save'
@@ -67,7 +69,9 @@ import type {
 import type {
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
+  ReadUploadBytesRequest,
   StageUploadFilesRequest,
+  UploadBytesResult,
   UploadedAttachment
 } from '../shared/uploads'
 
@@ -138,6 +142,7 @@ interface OpenScienceAPI {
     finalizeRunArtifacts(request: FinalizeRunArtifactsRequest): Promise<ArtifactFile[]>
     openFile(request: OpenArtifactFileRequest): Promise<void>
     readPreview(request: ReadArtifactPreviewRequest): Promise<ArtifactPreviewResult>
+    readBytes(request: ReadArtifactBytesRequest): Promise<ManagedFileBytesResult>
   }
   uploads: {
     // Stages files selected or pasted in the renderer into app-managed upload storage.
@@ -148,6 +153,8 @@ interface OpenScienceAPI {
     finalizeSession(request: FinalizeUploadSessionRequest): Promise<UploadedAttachment[]>
     // Reads a bounded preview from upload storage using the same preview result shape as artifacts.
     readPreview(request: ReadArtifactPreviewRequest): Promise<ArtifactPreviewResult>
+    // Reads a whole upload as base64 bytes for viewers that need the full file (e.g. PDF preview).
+    readBytes(request: ReadUploadBytesRequest): Promise<UploadBytesResult>
   }
   notebook: {
     state(request: NotebookSessionRequest): Promise<NotebookSessionState>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,7 +17,9 @@ import type {
   ArtifactFile,
   ArtifactPreviewResult,
   FinalizeRunArtifactsRequest,
+  ManagedFileBytesResult,
   OpenArtifactFileRequest,
+  ReadArtifactBytesRequest,
   ReadArtifactPreviewRequest
 } from '../shared/artifacts'
 import type { SaveBlobFileRequest, SaveBlobFileResult } from '../shared/file-save'
@@ -69,7 +71,9 @@ import type {
 import type {
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
+  ReadUploadBytesRequest,
   StageUploadFilesRequest,
+  UploadBytesResult,
   UploadedAttachment
 } from '../shared/uploads'
 
@@ -156,6 +160,8 @@ type OpenScienceAPI = {
     openFile: (request: OpenArtifactFileRequest) => Promise<void>
     // Reads a bounded text preview from managed generated files.
     readPreview: (request: ReadArtifactPreviewRequest) => Promise<ArtifactPreviewResult>
+    // Reads a whole managed artifact as base64 bytes for viewers that need the full file.
+    readBytes: (request: ReadArtifactBytesRequest) => Promise<ManagedFileBytesResult>
   }
   uploads: {
     // Stages files selected or pasted in the renderer into app-managed upload storage.
@@ -166,6 +172,8 @@ type OpenScienceAPI = {
     finalizeSession: (request: FinalizeUploadSessionRequest) => Promise<UploadedAttachment[]>
     // Reads a bounded preview from upload storage using the same preview result shape as artifacts.
     readPreview: (request: ReadArtifactPreviewRequest) => Promise<ArtifactPreviewResult>
+    // Reads a whole upload as base64 bytes for viewers that need the full file (e.g. PDF preview).
+    readBytes: (request: ReadUploadBytesRequest) => Promise<UploadBytesResult>
   }
   notebook: {
     state: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
@@ -292,7 +300,9 @@ const api: OpenScienceAPI = {
     openFile: (request) => ipcRenderer.invoke('artifacts:open-file', request) as Promise<void>,
     // Keep preview reads on the same managed-file trust path as opening files.
     readPreview: (request) =>
-      ipcRenderer.invoke('artifacts:read-preview', request) as Promise<ArtifactPreviewResult>
+      ipcRenderer.invoke('artifacts:read-preview', request) as Promise<ArtifactPreviewResult>,
+    readBytes: (request) =>
+      ipcRenderer.invoke('artifacts:read-bytes', request) as Promise<ManagedFileBytesResult>
   },
   uploads: {
     // Upload IPC remains behind the preload bridge so renderer code never receives raw fs access.
@@ -302,7 +312,9 @@ const api: OpenScienceAPI = {
     finalizeSession: (request) =>
       ipcRenderer.invoke('uploads:finalize-session', request) as Promise<UploadedAttachment[]>,
     readPreview: (request) =>
-      ipcRenderer.invoke('uploads:read-preview', request) as Promise<ArtifactPreviewResult>
+      ipcRenderer.invoke('uploads:read-preview', request) as Promise<ArtifactPreviewResult>,
+    readBytes: (request) =>
+      ipcRenderer.invoke('uploads:read-bytes', request) as Promise<UploadBytesResult>
   },
   notebook: {
     // Notebook commands stay behind typed IPC so renderer code never talks to local RPC directly.

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -129,6 +129,7 @@ const FileTile = ({
   name,
   previewArtifact,
   preview,
+  source,
   size,
   timestamp,
   previewLabel,
@@ -137,6 +138,7 @@ const FileTile = ({
   name: string
   previewArtifact: MessageArtifact
   preview?: ArtifactPreviewResult
+  source: 'artifact' | 'upload'
   size?: number
   timestamp?: number
   previewLabel: string
@@ -158,7 +160,7 @@ const FileTile = ({
         data-testid="project-file-preview"
         className="h-[82px] w-full overflow-hidden bg-bg-200"
       >
-        <ArtifactPreview artifact={previewArtifact} preview={preview} />
+        <ArtifactPreview artifact={previewArtifact} preview={preview} source={source} />
       </span>
       <span
         data-testid="project-file-meta"
@@ -460,6 +462,7 @@ const ProjectFilesView = (): React.JSX.Element => {
                     name={file.name}
                     previewArtifact={createUploadPreviewArtifact(file)}
                     preview={filePreviews[file.id]}
+                    source="upload"
                     size={file.size}
                     timestamp={file.timestamp}
                     previewLabel={`Preview uploaded file ${file.name}`}
@@ -499,6 +502,7 @@ const ProjectFilesView = (): React.JSX.Element => {
                           name={file.name}
                           previewArtifact={file.artifact}
                           preview={filePreviews[file.id]}
+                          source="artifact"
                           size={file.size}
                           timestamp={file.artifact.mtimeMs}
                           previewLabel={`Preview generated file ${file.name}`}

--- a/src/renderer/src/pages/workspace/artifact-preview-utils.ts
+++ b/src/renderer/src/pages/workspace/artifact-preview-utils.ts
@@ -19,6 +19,12 @@ export const isImageArtifact = (artifact: MessageArtifact): boolean => {
   return /\.(avif|gif|jpe?g|png|svg|webp)$/i.test(getArtifactName(artifact))
 }
 
+export const isPdfArtifact = (artifact: MessageArtifact): boolean => {
+  if (artifact.mimeType === 'application/pdf') return true
+
+  return /\.pdf$/i.test(getArtifactName(artifact))
+}
+
 export const shouldReadArtifactPreview = (artifact: MessageArtifact): boolean => {
   const extension = getArtifactExtension(artifact)
   const mimeType = artifact.mimeType ?? ''

--- a/src/renderer/src/pages/workspace/artifact-preview.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.tsx
@@ -2,9 +2,17 @@ import type { ChatSession } from '@/stores/session-store'
 import { File, FileArchive, FileCode2, FileImage, FileSpreadsheet, FileText } from 'lucide-react'
 import { parse } from 'papaparse'
 
+import type { PreviewFileSource } from '@/stores/preview-workbench-store'
+
 import type { ArtifactPreviewResult } from '../../../../shared/artifacts'
-import { getArtifactExtension, getArtifactName, isImageArtifact } from './artifact-preview-utils'
+import {
+  getArtifactExtension,
+  getArtifactName,
+  isImageArtifact,
+  isPdfArtifact
+} from './artifact-preview-utils'
 import { getImageMimeTypeForExtension } from './preview-support'
+import { PdfThumbnail } from './previews/renderers/PdfThumbnail'
 
 type MessageArtifact = NonNullable<ChatSession['artifacts']>[number]
 type ArtifactIconKind = 'archive' | 'code' | 'file' | 'image' | 'spreadsheet' | 'text'
@@ -270,12 +278,19 @@ const FileTypePreview = ({ artifact }: { artifact: MessageArtifact }): React.JSX
 
 export const ArtifactPreview = ({
   artifact,
-  preview
+  preview,
+  source = 'artifact'
 }: {
   artifact: MessageArtifact
   preview?: ArtifactPreviewResult
+  source?: PreviewFileSource
 }): React.JSX.Element => {
   const artifactName = getArtifactName(artifact)
+
+  // PDFs render their first page as a thumbnail; the component fetches its own full bytes.
+  if (isPdfArtifact(artifact)) {
+    return <PdfThumbnail path={artifact.path} name={artifactName} source={source} />
+  }
 
   if (isImageArtifact(artifact)) {
     const mimeType = getImageMimeType(artifact)

--- a/src/renderer/src/pages/workspace/preview-support.ts
+++ b/src/renderer/src/pages/workspace/preview-support.ts
@@ -24,6 +24,7 @@ const PREVIEW_SUPPORTED_EXTENSIONS: Record<string, PreviewFileFormat> = {
   markdown: 'markdown',
   md: 'markdown',
   pdb: 'pdb',
+  pdf: 'pdf',
   bash: 'text',
   conf: 'text',
   config: 'text',
@@ -64,6 +65,7 @@ const getPreviewFormatForMimeType = (mimeType: string): PreviewFileFormat => {
   ) {
     return 'pdb'
   }
+  if (normalizedMimeType === 'application/pdf') return 'pdf'
   if (normalizedMimeType.startsWith('text/')) return 'text'
 
   return 'unknown'

--- a/src/renderer/src/pages/workspace/previews/pdf-bytes.ts
+++ b/src/renderer/src/pages/workspace/previews/pdf-bytes.ts
@@ -1,0 +1,17 @@
+import type { PreviewFileSource } from '@/stores/preview-workbench-store'
+
+import { base64ToUint8Array } from './pdfjs'
+
+// Reads a whole managed PDF (uploads or artifacts) as bytes for pdfjs. Both sources expose a
+// full-bytes IPC so a large PDF is never truncated the way the bounded preview reader would.
+export const readPdfBytes = async (
+  path: string,
+  source: PreviewFileSource
+): Promise<Uint8Array> => {
+  const { data } =
+    source === 'upload'
+      ? await window.api.uploads.readBytes({ path })
+      : await window.api.artifacts.readBytes({ path })
+
+  return base64ToUint8Array(data)
+}

--- a/src/renderer/src/pages/workspace/previews/pdfjs.ts
+++ b/src/renderer/src/pages/workspace/previews/pdfjs.ts
@@ -1,0 +1,20 @@
+import * as pdfjsLib from 'pdfjs-dist'
+
+// Vite rewrites this to the bundled worker URL, so pdfjs runs off the main thread in dev and prod.
+// Configured once here and shared by the full preview and the thumbnail renderer.
+pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url
+).toString()
+
+// Decodes a base64 payload (from the read-bytes IPC) into the byte array pdfjs expects.
+export const base64ToUint8Array = (base64: string): Uint8Array => {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return bytes
+}
+
+export { pdfjsLib }

--- a/src/renderer/src/pages/workspace/previews/preview-registry.tsx
+++ b/src/renderer/src/pages/workspace/previews/preview-registry.tsx
@@ -6,6 +6,7 @@ import { ImagePreviewRenderer } from './renderers/ImagePreview'
 import { JsonPreviewRenderer } from './renderers/JsonPreview'
 import { MarkdownPreviewRenderer } from './renderers/MarkdownPreview'
 import { PdbPreviewRenderer } from './renderers/PdbPreview'
+import { PdfPreviewRenderer } from './renderers/PdfPreview'
 import { TextPreviewRenderer } from './renderers/TextPreview'
 
 // Keeps the registry as the single routing point while avoiding dynamic component creation in render.
@@ -30,6 +31,7 @@ export const renderPreviewFile = ({
     case 'text':
       return <TextPreviewRenderer item={item} />
     case 'pdf':
+      return <PdfPreviewRenderer item={item} />
     case 'unknown':
       return undefined
   }

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from 'react'
+import { FileWarning } from 'lucide-react'
+
+import type { PreviewFileSource } from '@/stores/preview-workbench-store'
+
+import { PreviewFallbackCard, PreviewLoadingContent } from '../PreviewFallback'
+import { pdfjsLib } from '../pdfjs'
+import { readPdfBytes } from '../pdf-bytes'
+import type { PreviewFileRendererProps } from '../preview-types'
+
+// Rendering every page of a huge PDF would freeze the panel; cap the preview at a sensible depth.
+const MAX_PREVIEW_PAGES = 30
+
+type LoadState = 'loading' | 'ready' | 'error'
+
+export const PdfPreviewContent = ({
+  path,
+  name,
+  source = 'artifact'
+}: {
+  path: string
+  name: string
+  source?: PreviewFileSource
+}): React.JSX.Element => {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  // Track the outcome per path so the status is derived, not reset synchronously inside the effect.
+  const [rendered, setRendered] = useState<{ path: string; status: 'ready' | 'error' } | null>(null)
+
+  useEffect(() => {
+    let canceled = false
+    const container = containerRef.current
+
+    const render = async (): Promise<void> => {
+      const bytes = await readPdfBytes(path, source)
+      // getDocument transfers the buffer, so hand it a copy it can consume freely.
+      const document = await pdfjsLib.getDocument({ data: bytes }).promise
+
+      try {
+        if (canceled || !container) return
+        container.replaceChildren()
+
+        const scale = Math.min(2, Math.max(1, window.devicePixelRatio || 1))
+        const pageCount = Math.min(document.numPages, MAX_PREVIEW_PAGES)
+
+        for (let pageNumber = 1; pageNumber <= pageCount; pageNumber += 1) {
+          const page = await document.getPage(pageNumber)
+          if (canceled) return
+
+          const viewport = page.getViewport({ scale })
+          const canvas = window.document.createElement('canvas')
+          const context = canvas.getContext('2d')
+          if (!context) continue
+
+          canvas.width = viewport.width
+          canvas.height = viewport.height
+          canvas.className = 'mx-auto mb-3 h-auto w-full max-w-3xl rounded-sm shadow-sm'
+          container.appendChild(canvas)
+
+          await page.render({ canvasContext: context, viewport }).promise
+          page.cleanup()
+        }
+
+        if (!canceled) setRendered({ path, status: 'ready' })
+      } finally {
+        await document.destroy()
+      }
+    }
+
+    render().catch((error) => {
+      console.error('Failed to render PDF preview', error)
+      if (!canceled) setRendered({ path, status: 'error' })
+    })
+
+    return () => {
+      canceled = true
+    }
+  }, [path, source])
+
+  // Until the effect resolves for the current path, the file is still loading.
+  const status: LoadState = rendered?.path === path ? rendered.status : 'loading'
+
+  if (status === 'error') {
+    return (
+      <PreviewFallbackCard
+        icon={FileWarning}
+        path={path}
+        name={name}
+        source={source}
+        message="This PDF couldn't be rendered for preview"
+      />
+    )
+  }
+
+  return (
+    <div className="relative size-full overflow-auto bg-bg-20 p-4">
+      {status === 'loading' && (
+        <div className="absolute inset-0">
+          <PreviewLoadingContent />
+        </div>
+      )}
+      <div ref={containerRef} />
+    </div>
+  )
+}
+
+export const PdfPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JSX.Element => (
+  <PdfPreviewContent path={item.path} name={item.name} source={item.source} />
+)

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfThumbnail.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfThumbnail.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react'
+import { FileText } from 'lucide-react'
+
+import type { PreviewFileSource } from '@/stores/preview-workbench-store'
+
+import { pdfjsLib } from '../pdfjs'
+import { readPdfBytes } from '../pdf-bytes'
+
+// Roughly the card width; rendering the first page near this size keeps the data URL small.
+const THUMBNAIL_WIDTH = 220
+
+// Rendered first-page data URLs are cached by path so scrolling the file list never re-renders a PDF.
+const thumbnailCache = new Map<string, string>()
+
+const renderFirstPage = async (path: string, source: PreviewFileSource): Promise<string> => {
+  const cached = thumbnailCache.get(path)
+  if (cached) return cached
+
+  const bytes = await readPdfBytes(path, source)
+  const document = await pdfjsLib.getDocument({ data: bytes }).promise
+
+  try {
+    const page = await document.getPage(1)
+    const baseViewport = page.getViewport({ scale: 1 })
+    const scale = THUMBNAIL_WIDTH / baseViewport.width
+    const viewport = page.getViewport({ scale })
+
+    const canvas = window.document.createElement('canvas')
+    const context = canvas.getContext('2d')
+    if (!context) throw new Error('Canvas 2D context unavailable.')
+
+    canvas.width = viewport.width
+    canvas.height = viewport.height
+    await page.render({ canvasContext: context, viewport }).promise
+    page.cleanup()
+
+    const dataUrl = canvas.toDataURL('image/png')
+    thumbnailCache.set(path, dataUrl)
+    return dataUrl
+  } finally {
+    await document.destroy()
+  }
+}
+
+// A generic PDF icon shown while the first page renders or if rendering fails.
+const PdfIconFallback = (): React.JSX.Element => (
+  <div className="flex size-full items-center justify-center bg-bg-000">
+    <FileText className="size-7 text-text-300" aria-hidden />
+  </div>
+)
+
+export const PdfThumbnail = ({
+  path,
+  name,
+  source = 'artifact'
+}: {
+  path: string
+  name: string
+  source?: PreviewFileSource
+}): React.JSX.Element => {
+  const [dataUrl, setDataUrl] = useState<string | undefined>(() => thumbnailCache.get(path))
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    if (dataUrl) return
+    let canceled = false
+
+    renderFirstPage(path, source)
+      .then((url) => {
+        if (!canceled) setDataUrl(url)
+      })
+      .catch((error) => {
+        console.error('Failed to render PDF thumbnail', error)
+        if (!canceled) setFailed(true)
+      })
+
+    return () => {
+      canceled = true
+    }
+  }, [dataUrl, path, source])
+
+  if (failed) return <PdfIconFallback />
+  if (!dataUrl) return <PdfIconFallback />
+
+  return (
+    <img
+      src={dataUrl}
+      alt={`Preview of ${name}`}
+      className="size-full object-cover object-top"
+      loading="lazy"
+      decoding="async"
+      draggable={false}
+    />
+  )
+}

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -64,6 +64,17 @@ export type ArtifactPreviewResult = {
   truncated: boolean
 }
 
+// Renderer request for the full bytes of one managed artifact (e.g. to render a PDF thumbnail).
+export type ReadArtifactBytesRequest = {
+  path: string
+}
+
+// Full-file bytes for a managed artifact, base64-encoded so it survives IPC structured cloning.
+export type ManagedFileBytesResult = {
+  data: string
+  size: number
+}
+
 // Repository request that moves pending run files into a durable message directory.
 export type MovePendingRunArtifactsRequest = {
   projectName: string

--- a/src/shared/uploads.ts
+++ b/src/shared/uploads.ts
@@ -29,6 +29,16 @@ export type DeleteUploadRequest = {
   path: string
 }
 
+export type ReadUploadBytesRequest = {
+  path: string
+}
+
+// Full-file bytes for a managed upload, base64-encoded so it survives IPC structured cloning.
+export type UploadBytesResult = {
+  data: string
+  size: number
+}
+
 export type FinalizeUploadSessionRequest = {
   sessionId: string
   attachments: UploadedAttachment[]


### PR DESCRIPTION
## Summary

Fixes the `Request too large (max 32MB)` failure when uploading large files (e.g. a ~20MB PDF). The 32MB ceiling is the provider's **total request-body size measured after base64 encoding**, not the raw file size. Two paths hit it:

- Images were inlined at full resolution as base64 (no size cap).
- PDFs were sent as a file reference, and the agent's Read tool embedded the **whole PDF as base64** — which is why it only failed *after* the read + compaction step.

base64 inflates payloads by ~33%, so a 20MB file becomes ~27MB and, with prompt/history overhead, crosses 32MB.

## Changes

**Prompt content (main process)**
- Images >2MB are downscaled (long edge 1568px) and re-encoded via `nativeImage` before inlining; small images keep the existing passthrough behavior.
- PDFs are sent as **extracted text** (pdfjs), never the raw base64 file. Scanned/image-only PDFs with no extractable text get a clear note instead of silently overflowing.

**Preview**
- New PDF preview renderer in the Artifact panel (pdfjs page rendering).
- First-page **thumbnail** for PDF cards instead of a generic file icon.
- New `uploads:read-bytes` and `artifacts:read-bytes` IPC so viewers can read the full file (the bounded preview reader truncates large PDFs).

**Packaging**
- Trim unused `pdfjs-dist` parts (modern build, viewer, decoders, types, source maps) from the packaged app; keep `legacy/build` plus `cmaps`/`standard_fonts` for CJK support. Net installer impact ~2-4MB.

## Testing

- `npm run typecheck` — passes
- `npm run test` — 571 tests / 81 suites pass, including new coverage for image compression, PDF text extraction, PDF routing (never inlined), and the read-bytes methods
- `npm run build` (electron-vite) — passes; renderer emits the pdfjs worker, main externalizes the pdfjs dynamic import
- Manual dev smoke test of upload + preview

## Notes

- Attaching page screenshots for scanned/image-only PDFs is planned as a follow-up.
- An app-level `@` mention picker for reusing uploads is out of scope (tracked on the roadmap).

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)