### PR TITLE
docs: prebuilt downloads, star chart fix, and a security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **An open-source, model-agnostic AI workbench for scientific discovery.**
 
+[![Download](https://img.shields.io/badge/⬇%20Download%20the%20App-Latest%20Release-2f9e44?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![License](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](LICENSE)
 ![Status](https://img.shields.io/badge/Status-Early%20Alpha-ff9f43?style=for-the-badge)
 [![Discussions](https://img.shields.io/badge/Discussions-Welcome-9775fa?style=for-the-badge)](https://github.com/aipoch/open-science/discussions)
@@ -27,7 +28,7 @@
 - [Design Principles](#design-principles)
 - [What We're Building](#what-were-building)
 - [Current Status](#current-status)
-- [Getting Started](#getting-started)
+- [Development & Packaging](#development--packaging)
 - [Building From Source (macOS Gatekeeper Note)](#building-from-source-macos-gatekeeper-note)
 - [Roadmap](#roadmap)
 - [Relationship to the aipoch Ecosystem](#relationship-to-the-aipoch-ecosystem)
@@ -44,14 +45,21 @@ Three ways to get the app running — pick whichever matches how you work.
 
 ### Option 1 — Download a prebuilt app (no toolchain required)
 
-The fastest path if you just want to use it: grab the latest installer from the [**Releases**](https://github.com/aipoch/open-science/releases/latest) page.
+The fastest path if you just want to use it — no Node, no Git, nothing to build. Three steps:
 
-| Platform | Download |
-| --- | --- |
-| macOS (Apple Silicon) | `open-science-<version>-mac-arm64.dmg` |
-| macOS (Intel) | `open-science-<version>-mac-x64.dmg` |
-| Windows (x64) | `open-science-<version>-win-x64-setup.exe` |
-| Linux | `open-science-<version>-linux-x86_64.AppImage` or `open-science_<version>_amd64.deb` |
+1. Open the **[Releases page](https://github.com/aipoch/open-science/releases/latest)** (or click the green **Download the App** button at the top of this page).
+2. Under the latest release, expand **▸ Assets** and download the file that matches your computer:
+
+   | Your computer | File to download |
+   | --- | --- |
+   | Mac with Apple Silicon (M1–M4) | `open-science-<version>-mac-arm64.dmg` |
+   | Mac with Intel chip | `open-science-<version>-mac-x64.dmg` |
+   | Windows | `open-science-<version>-win-x64-setup.exe` |
+   | Linux | `open-science-<version>-linux-x86_64.AppImage` or `open-science_<version>_amd64.deb` |
+
+   > Not sure which Mac you have? Open the Apple menu (top-left) → **About This Mac**. A "Chip" line reading "Apple M1/M2/M3/M4…" means Apple Silicon; "Intel" means Intel.
+
+3. Open the downloaded file and install it like any other app.
 
 Builds aren't signed with a paid Apple/Microsoft certificate yet, so on first launch your OS shows an "unverified developer" (macOS) or "unknown publisher" (Windows) prompt — this is expected, not a corrupted download. See the [macOS Gatekeeper note](#building-from-source-macos-gatekeeper-note) for the one-time steps to open it. Want the bleeding edge instead? The **Nightly (latest main)** pre-release tracks the newest commits.
 
@@ -86,7 +94,7 @@ npm run dev
 
 > **Tip:** on a cold first launch the window occasionally fails to appear even though the process is running — just `Ctrl+C` and run `npm run dev` again.
 
-To run agent sessions inside the app, sign in with your Claude Code login (reused automatically if you already have one) or configure a custom model gateway in the app's settings; the app keeps this auth in its own config dir rather than reading `ANTHROPIC_*` variables from your shell. To package an installable app instead of running from source, see [Getting Started](#getting-started).
+To run agent sessions inside the app, sign in with your Claude Code login (reused automatically if you already have one) or configure a custom model gateway in the app's settings; the app keeps this auth in its own config dir rather than reading `ANTHROPIC_*` variables from your shell. To package an installable app instead of running from source, see [Development & Packaging](#development--packaging).
 
 
 ## Why
@@ -253,7 +261,9 @@ The authoritative, kept-up-to-date breakdown of what's shipping versus still ahe
 - **[Capability Map](ROADMAP.md#capability-map)** — layer-by-layer status (✅ shipping / 🟡 partial / ⬜ not started)
 - **[`docs/PRD.md`](docs/PRD.md)** — the full product spec and current architecture, mapped to the actual code
 
-## Getting Started
+## Development & Packaging
+
+For contributors. Cloning, `npm install`, and `npm run dev` are covered in [Quick Start → Run from source](#option-3--run-from-source); this section is the rest of the developer toolchain.
 
 Open Science is an Electron application built with React and TypeScript.
 
@@ -261,23 +271,7 @@ Open Science is an Electron application built with React and TypeScript.
 
 - [VS Code](https://code.visualstudio.com/) + [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) + [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 
-### Install
-
-```bash
-npm install
-```
-
-`postinstall` runs `prisma generate` (for the local project database) and `electron-builder install-app-deps` automatically.
-
-### Development
-
-```bash
-npm run dev
-```
-
-This starts the app in development mode via `electron-vite`. Development builds isolate their local data under `~/.open-science-project` so parallel development doesn't touch a production install's data (which lives under `~/.open-science`).
-
-### Other useful scripts
+### Useful scripts
 
 ```bash
 npm run lint          # ESLint

--- a/README.md
+++ b/README.md
@@ -40,9 +40,24 @@
 
 ## Quick Start
 
-Two ways to get the app running — pick whichever matches how you work.
+Three ways to get the app running — pick whichever matches how you work.
 
-### Option 1 — Hand it to an AI agent
+### Option 1 — Download a prebuilt app (no toolchain required)
+
+The fastest path if you just want to use it: grab the latest installer from the [**Releases**](https://github.com/aipoch/open-science/releases/latest) page.
+
+| Platform | Download |
+| --- | --- |
+| macOS (Apple Silicon) | `open-science-<version>-mac-arm64.dmg` |
+| macOS (Intel) | `open-science-<version>-mac-x64.dmg` |
+| Windows (x64) | `open-science-<version>-win-x64-setup.exe` |
+| Linux | `open-science-<version>-linux-x86_64.AppImage` or `open-science_<version>_amd64.deb` |
+
+Builds aren't signed with a paid Apple/Microsoft certificate yet, so on first launch your OS shows an "unverified developer" (macOS) or "unknown publisher" (Windows) prompt — this is expected, not a corrupted download. See the [macOS Gatekeeper note](#building-from-source-macos-gatekeeper-note) for the one-time steps to open it. Want the bleeding edge instead? The **Nightly (latest main)** pre-release tracks the newest commits.
+
+> To run agent sessions, the app uses your existing Claude Code login (reused automatically if you have one) or a custom model gateway you set up in-app — it manages this auth in its own config dir and ignores `ANTHROPIC_*` variables from your shell.
+
+### Option 2 — Hand it to an AI agent
 
 If you use a coding agent (Claude Code, Codex, WorkBuddy, Cursor, …), one sentence is enough — the agent will clone, install, and launch it on its own:
 
@@ -50,7 +65,7 @@ If you use a coding agent (Claude Code, Codex, WorkBuddy, Cursor, …), one sent
 
 That's genuinely all the context an agent needs today: it's a standard Electron + npm project, `npm install` handles every setup step (Prisma client generation, native Electron dependencies) automatically via `postinstall`, and `npm run dev` opens the desktop window.
 
-### Option 2 — Manual setup
+### Option 3 — Run from source
 
 Prerequisites: [Node.js](https://nodejs.org/) (LTS or newer) with npm, and Git. Optional: `python3` on your `PATH` if you want the built-in notebook kernel to execute code.
 
@@ -71,7 +86,7 @@ npm run dev
 
 > **Tip:** on a cold first launch the window occasionally fails to appear even though the process is running — just `Ctrl+C` and run `npm run dev` again.
 
-To run agent sessions inside the app, the bundled Claude ACP agent picks up your existing Claude Code login (or `ANTHROPIC_API_KEY`) from your environment. To package an installable app instead of running from source, see [Getting Started](#getting-started).
+To run agent sessions inside the app, sign in with your Claude Code login (reused automatically if you already have one) or configure a custom model gateway in the app's settings; the app keeps this auth in its own config dir rather than reading `ANTHROPIC_*` variables from your shell. To package an installable app instead of running from source, see [Getting Started](#getting-started).
 
 
 ## Why
@@ -120,7 +135,7 @@ So let's be direct about where each project actually stands, instead of hand-wav
 | **Compute**                       | SSH/HPC access plus Modal for on-demand GPUs                              | Pluggable compute fabric — any HPC scheduler, any cloud GPU provider (planned)                                                                                          |
 | **Reviewer / verification agent** | Yes, shipping today                                                       | Yes, planned as an open, inspectable layer ([Phase 4](#roadmap))                                                                                                        |
 | **Customization**                 | Configure agents inside Anthropic's product surface                       | Every layer — gateway, skill runtime, compute broker, reviewer — is inspectable and replaceable                                                                         |
-| **Maturity**                      | A shipping, polished product, in use today                                | Pre-alpha: architecture and vision stage (see [Roadmap](#roadmap))                                                                                                      |
+| **Maturity**                      | A shipping, polished product, in use today                                | Early alpha: working core loop with downloadable desktop builds; the differentiating layers are still ahead (see [Roadmap](#roadmap))                                                                                                      |
 
 The Maturity row matters most, so we won't bury it: if you need a working AI research assistant today, Claude Science is the more capable choice. Open Science's advantage isn't feature parity yet — it's the structural ceiling underneath.
 
@@ -364,10 +379,10 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=aipoch%2Fopen-science&type=date&legend=top-left">
+<a href="https://star-history.com/#aipoch/open-science&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=aipoch/open-science&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=aipoch/open-science&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=aipoch/open-science&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=aipoch/open-science&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=aipoch/open-science&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=aipoch/open-science&type=Date" />
  </picture>
 </a>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,7 @@ The current codebase is an early, working implementation of the first stretch of
 - ✅ Artifact file storage organized by session / message / run
 - ✅ Rich in-app file previews (CSV, FASTA, HTML, image, JSON, Markdown, plain text, notebook cells)
 - ✅ Attachment uploads and a permission-approval UI for tool calls
+- ✅ Packaged desktop installers for macOS (Apple Silicon + Intel), Windows, and Linux, plus a nightly build channel off `main`
 
 **Not yet built — the hardest, most differentiating work is still ahead:**
 - ⬜ A model-agnostic gateway; the runtime today is Claude-specific via ACP, not yet multi-LLM
@@ -97,7 +98,7 @@ flowchart LR
 ```
 
 - **Phase 0 — Vision & Architecture (done).** This roadmap, the [PRD](docs/PRD.md), the design system, and initial community formation.
-- **Phase 1 — Core Loop (in progress).** Desktop shell, single-agent runtime, project/session persistence, a single execution kernel, artifact storage, and rich in-app previews — all shipping today. Still open in this phase: a model-agnostic gateway, a CLI/SDK entry point, and a file-based skill runtime.
+- **Phase 1 — Core Loop (in progress).** Desktop shell, single-agent runtime, project/session persistence, a single execution kernel, artifact storage, rich in-app previews, and packaged installers for macOS/Windows/Linux — all shipping today. Still open in this phase: a model-agnostic gateway, a CLI/SDK entry point, and a file-based skill runtime.
 - **Phase 2 — Reproducibility & Multi-Agent.** Artifact versioning with a full provenance chain; additional kernels (R, a REPL control plane) and environment management; specialist sub-agents alongside the generalist coordinator. This is the project's core differentiation from a generic coding agent, and the highest-priority phase for contributors who want to make the biggest structural dent.
 - **Phase 3 — Knowledge & Connectors.** A skills commons with versioned, forkable skills and lexical discovery; pre-built connectors to open scientific databases and literature; savable "specialist" roles (instructions + skills + connectors + permissions bundled together).
 - **Phase 4 — Compute & Trust.** Remote compute as a first-class primitive (SSH/Slurm/cloud GPU) with async job notifications and sub-agent fan-out; a reviewer/verifier agent; the full security stack (scoped permissions, network allowlisting, directory-level file sandboxing, a credential vault); a pluggable multi-agent-framework backend so the runtime isn't locked to one agent implementation.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,113 @@
+# Security Policy
+
+Open Science is a desktop research workbench that runs an AI agent, executes code
+locally, and handles your credentials and data on your own machine. We take the
+security of that surface seriously and appreciate reports that help us keep it safe.
+
+## Supported versions
+
+This project is pre-1.0 and moving fast. Only the latest `0.x` release (and the
+`main` branch) receives security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| latest `0.x` / `main` | ✅ |
+| older releases | ❌ |
+
+The **Nightly (latest main)** pre-release tracks unreviewed commits and is provided
+as-is for testing — treat it as less hardened than tagged releases.
+
+## Reporting a vulnerability
+
+**Do not open a public issue, discussion, or pull request for security problems.**
+A public report exposes the details to everyone before a fix ships.
+
+Report privately via GitHub's **"Report a vulnerability"** button under this
+repository's **Security** tab (Private Vulnerability Reporting). If that is
+unavailable to you, contact a maintainer directly through the channels listed in
+the [README](README.md#get-involved) rather than filing anything public.
+
+Please include:
+
+- affected component (desktop shell, agent runtime, notebook kernel, file
+  upload/preview, packaging/updater, or a specific config)
+- version or commit, and your OS/platform
+- reproduction steps and the impact you observed
+
+We aim to acknowledge reports within a few days. Please give us reasonable time to
+ship a fix before any public disclosure.
+
+## Verifying your download
+
+Official builds are distributed **only** through this repository's
+[GitHub Releases](https://github.com/aipoch/open-science/releases) page. Do not run
+`.dmg` / `.exe` / `.AppImage` / `.deb` files obtained from anywhere else.
+
+Every release ships a `SHA256SUMS.txt`. Verify your download before opening it:
+
+```bash
+# macOS / Linux
+shasum -a 256 open-science-<version>-mac-arm64.dmg
+# compare the output against the matching line in SHA256SUMS.txt
+```
+
+Builds are **not** signed with a paid Apple/Microsoft certificate yet, so your OS
+will show an "unverified developer" (macOS) or "unknown publisher" (Windows) prompt
+on first launch. That prompt is expected and is **not** evidence of tampering — but
+a checksum mismatch is. See the
+[macOS Gatekeeper note](README.md#building-from-source-macos-gatekeeper-note) for the
+one-time steps to open an unsigned build.
+
+## Credentials and local data — do not leak them
+
+Open Science is local-first. Credentials and project data stay on your machine, and
+the agent is deliberately isolated from your ambient shell environment:
+
+- The agent runs under an app-owned config directory (`~/.open-science/claude`).
+  Inherited `ANTHROPIC_*` shell variables (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
+  `ANTHROPIC_BASE_URL`) are **dropped** before it launches, so a stray key in your
+  shell never leaks into a run.
+- The default (local) provider uses the Claude auth stored in that app config
+  directory — imported from your `~/.claude` Claude Code login, or created by an
+  in-app login.
+- API tokens for a custom gateway that you enter in the app are **encrypted at rest**
+  with the OS keychain (Electron `safeStorage`); the UI only ever shows a masked hint.
+- Project data, sessions, notebooks, and artifacts live under `~/.open-science`
+  (production) or `~/.open-science-project` (development builds).
+
+**Never paste an API key, access token, or other credential — or the contents of
+those directories — into an issue, PR, log excerpt, or screenshot.** Redact secrets
+before sharing anything for a bug report.
+
+## Scope and trust boundaries
+
+Some behavior is intentional by design and is **not** a vulnerability on its own:
+
+- **The notebook kernel and the agent's tool calls execute code and shell commands
+  by design.** Running local code is the product's purpose. A tool-call approval gate
+  is the current control in front of higher-risk actions.
+- **Sandboxing is still on the roadmap.** Network allowlisting, a credential vault,
+  directory-scoped file access, and per-scope permission tiers are **not implemented
+  yet** (tracked as 🟡 *Security & Permissions* in the [Roadmap](ROADMAP.md#capability-map)).
+  The absence of these is a known limitation, not a defect to report — though ideas on
+  how to build them are very welcome as Issues/Discussions.
+
+Reports we especially want to hear about:
+
+- ways an untrusted project file, attachment, or preview can execute code or read
+  files **outside** the intended tool-call flow (e.g. a malicious file that runs code
+  when merely opened or previewed);
+- credential or local-data exposure beyond what you explicitly provide;
+- issues in packaging, the auto-updater, or the release/download path;
+- vulnerable or compromised dependencies (including anything pulled in by
+  `postinstall`'s `prisma generate` / `electron-builder install-app-deps` step).
+
+## Dependencies and supply chain
+
+Open Science is an Electron + npm application. If you find a vulnerability rooted in a
+third-party dependency, please report it to the upstream project as well; we will help
+triage and will bump the affected dependency.
+
+---
+
+_This policy will evolve as the project's sandboxing and permission model matures._


### PR DESCRIPTION
## Summary
- **README — Quick Start:** add a *Download a prebuilt app* option now that ad-hoc-signed installers ship on GitHub Releases (macOS arm64/x64 `.dmg`, Windows `-setup.exe`, Linux `.AppImage`/`.deb`), with checksum + first-launch guidance; the AI-agent and run-from-source paths become options 2 and 3.
- **README — Star History:** switch the embed from the flaky `/image?...&type=date&legend=top-left` endpoint to the canonical `/svg?...&type=Date` form so the chart renders on GitHub.
- **README — accuracy fixes:** the app runs under its own `CLAUDE_CONFIG_DIR` and drops inherited `ANTHROPIC_*` shell vars, so the old "reads `ANTHROPIC_API_KEY` from your environment" note was wrong — corrected in both spots. Refreshed the vs-Claude maturity cell from "pre-alpha" to "early alpha".
- **ROADMAP:** record packaged installers (mac/win/linux + nightly channel) as shipping in *Where We Are Today* and Phase 1.
- **SECURITY.md (new):** private vulnerability reporting, supported versions, download verification (`SHA256SUMS.txt`), credential/local-data handling, and the intentional code-execution trust boundaries — all tailored to the desktop app rather than copied from the MCP repo.

## Verification
Docs-only change (no source touched). All cross-references were checked against the code: anchor links resolve, data dirs match `src/main/storage-root.ts`, and the credential description matches `src/main/acp/agent-process.ts` + `src/main/settings/crypto.ts`.

## Follow-ups (maintainer action, not in this PR)
- Enable GitHub **Private Vulnerability Reporting** (Settings → Security) so the "Report a vulnerability" button SECURITY.md points to actually appears.
- Decide whether to add a dedicated security contact email (currently falls back to the community channels in the README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)