### PR TITLE
test(ci): coverage gate, build-time + cross-platform test runs, and HIGH-risk unit tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # Track npm lockfile drift and open grouped update PRs weekly. Keeps transitive advisories moving
+  # (the app ships native modules + spawns child processes, so a stale vulnerable dep reaches users).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Batch low-risk dev/tooling bumps into one PR to cut review noise.
+      dev-dependencies:
+        dependency-type: development
+
+  # Keep the GitHub Actions used by the workflows current (checkout, setup-node, upload-artifact, ...).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,37 @@ on:
   workflow_call:
 
 jobs:
+  # Gate every packaged build on the quality suite so nightly (push to main) and release (tag) can
+  # never publish installers that were never tested. Runs once on Apple Silicon to match the
+  # release/verification environment (see pr-check.yml for why macOS). The build matrix `needs` this.
+  verify:
+    name: Verify (lint + typecheck + test)
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test (with coverage)
+        run: npm run test:coverage
+
   build:
     name: Build ${{ matrix.name }}
+    needs: verify
     runs-on: ${{ matrix.os }}
     strategy:
       # Don't let one platform's failure cancel the others.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,11 +1,11 @@
 name: Claude PR Review
 
-# PR 提交/更新时用 Claude 自动做代码审查，并在 PR 下留下审查评论。
-# 需要在仓库 Secrets 配置 ANTHROPIC_API_KEY。未配置时该 job 会跳过，不阻塞 PR。
+# Auto-review PRs with Claude and post the review as a PR comment. Requires ANTHROPIC_API_KEY in
+# repo Secrets; skips (does not block) when disabled via the ENABLE_CLAUDE_REVIEW variable.
 on:
   pull_request:
     branches:
-      - master
+      - main
     types: [opened, synchronize, reopened]
 
 concurrency:
@@ -20,7 +20,7 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    # 没配 ANTHROPIC_API_KEY 就不跑，避免报错阻塞（人工/CI 门禁仍然生效）。
+    # Toggle off by setting repo variable ENABLE_CLAUDE_REVIEW=false; manual/CI gates still apply.
     if: ${{ vars.ENABLE_CLAUDE_REVIEW != 'false' }}
     steps:
       - name: Checkout
@@ -30,19 +30,21 @@ jobs:
 
       - name: Claude review
         uses: anthropics/claude-code-action@v1
+        # Optional custom endpoint; when set it overrides the default and is used with the API key below.
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # 让 Claude 读取本次 PR 的 diff 并写审查评论。
           prompt: |
-            请审查当前这个 Pull Request（仓库 ${{ github.repository }}，PR #${{ github.event.pull_request.number }}）。
-            这是一个 Electron + React + TypeScript 的桌面客户端项目。请重点关注：
-            - 逻辑正确性与潜在 bug、边界条件、错误处理
-            - 主进程/渲染进程边界、IPC、原生依赖（prisma、claude-agent-sdk）相关的安全与稳定性
-            - 类型安全、明显的性能问题、资源泄漏
-            - 是否可能破坏打包/签名/自动更新流程
-            用中文审查。先给一句总体结论（可否合并 / 需修改），再按文件列出具体问题（附行号与修改建议）。
-            没有问题就明确说明通过。请通过 `gh pr comment` 把审查意见发布为 PR 评论。
-          # 允许 Claude 使用 gh CLI 读取 diff 和发表评论。
+            Review this Pull Request (repo ${{ github.repository }}, PR #${{ github.event.pull_request.number }}).
+            This is an Electron + React + TypeScript desktop client. Focus on:
+            - Logic correctness, potential bugs, edge cases, error handling
+            - Main/renderer boundary, IPC, and native deps (prisma, claude-agent-sdk) — safety and stability
+            - Type safety, obvious performance issues, resource leaks
+            - Whether it could break the packaging/signing/auto-update flow
+            Review in English. Start with a one-line verdict (mergeable / needs changes), then list concrete
+            issues per file (with line numbers and suggested fixes). If nothing is wrong, say so explicitly.
+            Post the review as a PR comment via `gh pr comment`.
           claude_args: |
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Read,Grep,Glob"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,10 +18,19 @@ permissions:
 
 jobs:
   verify:
-    # Matches the release environment: the project has an arm64-only native dependency, so
-    # verification runs on Apple Silicon to avoid a mismatch between what's tested on Linux
-    # (missing the darwin native package) and what's actually released.
-    runs-on: macos-14
+    name: Verify (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Don't let one platform's failure hide another's.
+      fail-fast: false
+      matrix:
+        # macOS is the release/verification target and the only platform with the project's
+        # arm64-only darwin native dependency present, so it runs the FULL gate (test + coverage +
+        # build). Linux/Windows validate the platform-independent code paths (lint + typecheck are
+        # hard-gated everywhere); their test leg is advisory (continue-on-error) because the missing
+        # darwin native package can trip suites that reach the ACP/native layer — see the test steps.
+        os: [macos-14, ubuntu-latest, windows-latest]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -36,15 +45,45 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Lint + typecheck are platform-independent and hard-gated on all three OSes: they catch
+      # cross-platform compile/type/style regressions that the macOS-only test run would miss.
       - name: Lint
         run: npm run lint
 
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Test
+      # Full test suite + coverage gate on macOS (thresholds live in vitest.config.ts).
+      - name: Test (with coverage)
+        if: matrix.os == 'macos-14'
+        run: npm run test:coverage
+
+      # Cross-platform test signal, advisory only: a failure here is surfaced in the PR but does not
+      # block merge, because the darwin-only native dependency is absent on Linux/Windows and can fail
+      # suites that touch it. Promote to a hard gate once those suites are made platform-independent.
+      - name: Test (advisory)
+        if: matrix.os != 'macos-14'
+        continue-on-error: true
         run: npm run test
 
-      # Build only, no packaging (electron-vite build), to surface compile errors early.
+      - name: Upload coverage report
+        if: matrix.os == 'macos-14'
+        uses: actions/upload-artifact@v7
+        with:
+          # Whole report dir: browsable HTML (open index.html) plus lcov.info for tooling.
+          name: coverage-report
+          path: coverage/
+          retention-days: 5
+          if-no-files-found: warn
+
+      # Build only, no packaging (electron-vite build), to surface compile errors early. Full
+      # packaging is validated in build.yml. Runs on macOS only (the release target).
       - name: Build
+        if: matrix.os == 'macos-14'
         run: npm run build
+
+      # Non-blocking dependency audit: surfaces known-vulnerable deps in the PR log without gating
+      # merge. Dependabot (see dependabot.yml) tracks lockfile drift and opens update PRs.
+      - name: Audit dependencies (advisory)
+        if: matrix.os == 'macos-14'
+        run: npm audit --audit-level=high || true

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 dist/
 out/
 release/
+
+# Test coverage reports
+coverage/
 *.asar
 *.blockmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "@vitest/coverage-v8": "^4.1.10",
         "3dmol": "^2.5.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -313,7 +314,6 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -669,6 +669,7 @@
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -713,6 +714,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -816,7 +827,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -861,7 +871,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1430,6 +1439,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1449,6 +1459,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1463,6 +1474,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1475,6 +1487,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2385,7 +2398,6 @@
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -4731,7 +4743,8 @@
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -5013,6 +5026,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
@@ -5142,6 +5221,8 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5381,6 +5462,8 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5443,7 +5526,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -5456,7 +5538,6 @@
     "node_modules/@types/node": {
       "version": "22.20.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5473,7 +5554,6 @@
       "version": "19.2.17",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5482,7 +5562,6 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5557,7 +5636,6 @@
       "version": "8.62.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -5782,15 +5860,60 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.9",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -5799,11 +5922,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.9",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.9",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -5824,7 +5949,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.9",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5835,11 +5962,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.9",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -5847,12 +5976,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.9",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -5861,7 +5992,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.9",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5869,11 +6002,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.9",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -5948,7 +6083,6 @@
       "version": "8.17.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6338,6 +6472,8 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6354,6 +6490,25 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -6554,7 +6709,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -6815,6 +6969,8 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7212,7 +7368,8 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7275,7 +7432,6 @@
       "version": "3.34.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7661,7 +7817,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8110,7 +8265,6 @@
       "version": "26.15.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -8259,7 +8413,6 @@
       "version": "39.8.10",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -8478,6 +8631,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -8496,6 +8650,7 @@
       "version": "7.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -8851,7 +9006,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8910,7 +9064,6 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9172,6 +9325,8 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9448,7 +9603,8 @@
     },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
@@ -10366,7 +10522,6 @@
     "node_modules/hono": {
       "version": "4.12.27",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10408,6 +10563,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
@@ -11165,6 +11327,45 @@
         "node": ">=18"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "dev": true,
@@ -11337,6 +11538,7 @@
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -11845,6 +12047,49 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "dev": true,
@@ -12298,7 +12543,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -12904,8 +13148,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -13031,6 +13274,7 @@
       "version": "0.5.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -14060,6 +14304,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -14075,6 +14320,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -14102,7 +14348,6 @@
       "version": "3.9.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14143,7 +14388,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -14458,7 +14702,6 @@
       "version": "19.2.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14467,7 +14710,6 @@
       "version": "19.2.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14994,6 +15236,7 @@
       "version": "2.6.3",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -15633,6 +15876,7 @@
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
@@ -16008,8 +16252,7 @@
     "node_modules/tailwindcss": {
       "version": "4.3.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -16050,6 +16293,7 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -16260,7 +16504,8 @@
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -16460,7 +16705,6 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16535,7 +16779,6 @@
       "version": "11.0.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -16868,7 +17111,6 @@
       "version": "7.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -17419,17 +17661,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.9",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/runner": "4.1.9",
-        "@vitest/snapshot": "4.1.9",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -17457,12 +17701,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.9",
-        "@vitest/browser-preview": "4.1.9",
-        "@vitest/browser-webdriverio": "4.1.9",
-        "@vitest/coverage-istanbul": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9",
-        "@vitest/ui": "4.1.9",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -17826,7 +18070,6 @@
     "node_modules/zod": {
       "version": "4.4.3",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write .",
     "lint": "eslint --cache .",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
@@ -36,7 +37,6 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "3dmol": "^2.5.5",
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
     "@electron-toolkit/eslint-config-ts": "^3.1.0",
     "@electron-toolkit/tsconfig": "^2.0.0",
@@ -52,6 +52,8 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^4.1.10",
+    "3dmol": "^2.5.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "electron": "^39.2.6",

--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+import type { AcpPermissionResponse, AcpStateSnapshot } from '../../../../shared/acp'
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useAcpRuntime } from './useAcpRuntime'
+
+// React's act() refuses to run unless the environment opts in to act-aware scheduling.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+type AcpRuntimeApi = ReturnType<typeof useAcpRuntime>
+type OnStateListener = (snapshot: AcpStateSnapshot) => void
+
+// Minimal renderHook so we can exercise the real hook without pulling in @testing-library/react,
+// which the repo does not depend on. A null-rendering harness captures each render's return value.
+const renderHook = <Value>(
+  hook: () => Value
+): { result: { current: Value }; unmount: () => void } => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const result = { current: undefined as unknown as Value }
+
+  const HookHarness = (): null => {
+    result.current = hook()
+    return null
+  }
+
+  act(() => {
+    root.render(createElement(HookHarness))
+  })
+
+  return {
+    result,
+    unmount: () =>
+      act(() => {
+        root.unmount()
+      })
+  }
+}
+
+const createSnapshot = (overrides: Partial<AcpStateSnapshot> = {}): AcpStateSnapshot => ({
+  status: 'connected',
+  cwd: '/workspace/project',
+  sessionIds: [],
+  events: [],
+  pendingPermissions: [],
+  promptInFlight: false,
+  promptInFlightSessionIds: [],
+  ...overrides
+})
+
+const createDeferred = <Value>(): {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+  reject: (reason: unknown) => void
+} => {
+  let resolve!: (value: Value) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<Value>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, resolve, reject }
+}
+
+// Captures the applySnapshot listener the hook registers so tests can push broadcasts through it.
+let capturedStateListener: OnStateListener | undefined
+let removeStateListener: ReturnType<typeof vi.fn>
+let acpApi: {
+  getState: ReturnType<typeof vi.fn>
+  onState: ReturnType<typeof vi.fn>
+  connect: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+  createSession: ReturnType<typeof vi.fn>
+  resumeSession: ReturnType<typeof vi.fn>
+  deleteSession: ReturnType<typeof vi.fn>
+  cancel: ReturnType<typeof vi.fn>
+  sendPrompt: ReturnType<typeof vi.fn>
+  respondToPermission: ReturnType<typeof vi.fn>
+}
+
+// Lets the initial effect (getState + onState subscription) settle before assertions.
+const mountRuntime = async (): Promise<{
+  result: { current: AcpRuntimeApi }
+  unmount: () => void
+}> => {
+  const rendered = renderHook(() => useAcpRuntime())
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  return rendered
+}
+
+beforeEach(() => {
+  capturedStateListener = undefined
+  removeStateListener = vi.fn()
+  acpApi = {
+    getState: vi.fn().mockResolvedValue(createSnapshot({ status: 'idle' })),
+    onState: vi.fn((listener: OnStateListener) => {
+      capturedStateListener = listener
+      return removeStateListener
+    }),
+    connect: vi.fn().mockResolvedValue(createSnapshot()),
+    disconnect: vi.fn().mockResolvedValue(createSnapshot({ status: 'idle' })),
+    createSession: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+    resumeSession: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+    deleteSession: vi.fn().mockResolvedValue(createSnapshot()),
+    cancel: vi.fn().mockResolvedValue(createSnapshot()),
+    sendPrompt: vi.fn().mockResolvedValue(createSnapshot()),
+    respondToPermission: vi.fn().mockResolvedValue(createSnapshot())
+  }
+
+  vi.stubGlobal('window', { api: { acp: acpApi } })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('useAcpRuntime respondToPermission', () => {
+  it('builds a cancelled response with an undefined optionId when none is chosen', async () => {
+    const { result } = await mountRuntime()
+
+    await act(async () => {
+      await result.current.respondToPermission('request-1')
+    })
+
+    expect(acpApi.respondToPermission).toHaveBeenCalledTimes(1)
+    const [payload] = acpApi.respondToPermission.mock.calls[0] as [AcpPermissionResponse]
+    expect(payload).toEqual({
+      requestId: 'request-1',
+      optionId: undefined,
+      cancelled: true
+    })
+    // The undefined optionId key must be present, not merely absent.
+    expect('optionId' in payload).toBe(true)
+  })
+
+  it('forwards the chosen option and marks the response as not cancelled', async () => {
+    const { result } = await mountRuntime()
+
+    await act(async () => {
+      await result.current.respondToPermission('request-1', 'allow-once')
+    })
+
+    expect(acpApi.respondToPermission).toHaveBeenCalledWith({
+      requestId: 'request-1',
+      optionId: 'allow-once',
+      cancelled: false
+    })
+  })
+})
+
+describe('useAcpRuntime snapshot action failures', () => {
+  it('swallows a rejecting snapshot action, records the error, and clears the pending flag', async () => {
+    acpApi.connect.mockRejectedValueOnce(new Error('connect failed'))
+    const { result } = await mountRuntime()
+
+    let returned: AcpStateSnapshot | undefined = createSnapshot()
+    await act(async () => {
+      returned = await result.current.connect('/workspace/project')
+    })
+
+    // runSnapshotAction returns undefined on failure instead of rethrowing.
+    expect(returned).toBeUndefined()
+    expect(result.current.actionError).toBe('connect failed')
+    expect(result.current.isConnecting).toBe(false)
+  })
+
+  it('normalizes non-Error rejections into UI-safe text', async () => {
+    acpApi.cancel.mockRejectedValueOnce('raw failure string')
+    const { result } = await mountRuntime()
+
+    await act(async () => {
+      await result.current.cancel('session-1')
+    })
+
+    expect(result.current.actionError).toBe('raw failure string')
+  })
+})
+
+describe('useAcpRuntime value action failures', () => {
+  it('rethrows a rejecting value action while still recording the error and clearing pending', async () => {
+    const failure = new Error('createSession failed')
+    acpApi.createSession.mockRejectedValueOnce(failure)
+    const { result } = await mountRuntime()
+
+    let thrown: unknown
+    await act(async () => {
+      await result.current.createSession('/workspace/project').catch((error: unknown) => {
+        thrown = error
+      })
+    })
+
+    expect(thrown).toBe(failure)
+    expect(result.current.actionError).toBe('createSession failed')
+    expect(result.current.isConnecting).toBe(false)
+  })
+})
+
+describe('useAcpRuntime state subscription', () => {
+  it('subscribes on mount, applies pushed snapshots, and unsubscribes on unmount', async () => {
+    const { result, unmount } = await mountRuntime()
+
+    expect(acpApi.onState).toHaveBeenCalledTimes(1)
+    expect(capturedStateListener).toBeTypeOf('function')
+
+    const pushed = createSnapshot({
+      status: 'connected',
+      cwd: '/pushed/cwd',
+      sessionIds: ['session-9']
+    })
+
+    act(() => {
+      capturedStateListener?.(pushed)
+    })
+
+    expect(result.current.state).toEqual(pushed)
+    expect(removeStateListener).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(removeStateListener).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useAcpRuntime pending lifecycle', () => {
+  it('raises the connecting flag while an action is in flight and lowers it once it resolves', async () => {
+    const deferred = createDeferred<AcpStateSnapshot>()
+    acpApi.connect.mockReturnValueOnce(deferred.promise)
+    const { result } = await mountRuntime()
+
+    expect(result.current.isConnecting).toBe(false)
+
+    let inFlight: Promise<AcpStateSnapshot | undefined> | undefined
+    await act(async () => {
+      inFlight = result.current.connect('/workspace/project')
+    })
+
+    // Pending flag is raised synchronously before the IPC promise settles.
+    expect(result.current.isConnecting).toBe(true)
+
+    await act(async () => {
+      deferred.resolve(createSnapshot({ cwd: '/connected' }))
+      await inFlight
+    })
+
+    expect(result.current.isConnecting).toBe(false)
+    expect(result.current.state.cwd).toBe('/connected')
+  })
+})

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PREVIEW_STATE_VERSION, type PersistedPreviewState } from '../../../../shared/preview-state'
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore
+} from '../../stores/preview-workbench-store'
+import {
+  toPersistedPreviewState,
+  toRestoredSlice,
+  usePreviewPersistence
+} from './preview-persistence'
+
+type StoreState = ReturnType<typeof usePreviewWorkbenchStore.getState>
+
+type Deferred<Value> = {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+}
+
+const createDeferred = <Value,>(): Deferred<Value> => {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((innerResolve) => {
+    resolve = innerResolve
+  })
+
+  return { promise, resolve }
+}
+
+// A stored file item as it lives in the workbench store (timestamps + type included).
+const createStoredFileItem = (
+  overrides: Partial<StoreState['items'][number]> = {}
+): StoreState['items'][number] =>
+  ({
+    id: 'file:session-1:/workspace/project/report.md',
+    sessionId: 'session-1',
+    type: 'file',
+    title: 'report.md',
+    source: 'artifact',
+    path: '/workspace/project/report.md',
+    format: 'markdown',
+    name: 'report.md',
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides
+  }) as StoreState['items'][number]
+
+// A runtime-only tool tab that must be dropped from the durable subset.
+const createStoredToolItem = (): StoreState['items'][number] =>
+  ({
+    id: 'tool:session-1:notebook',
+    sessionId: 'session-1',
+    type: 'tool',
+    toolKind: 'notebook',
+    title: 'Notebook',
+    createdAt: 1,
+    updatedAt: 2
+  }) as StoreState['items'][number]
+
+describe('preview persistence projections', () => {
+  beforeEach(() => {
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  })
+
+  it('keeps only file items and stamps the current preview state version', () => {
+    usePreviewWorkbenchStore.setState({
+      panelState: 'open',
+      activeItemId: 'file:session-1:/workspace/project/report.md',
+      items: [createStoredFileItem(), createStoredToolItem()]
+    })
+
+    const persisted = toPersistedPreviewState(usePreviewWorkbenchStore.getState())
+
+    expect(persisted).toEqual({
+      version: PREVIEW_STATE_VERSION,
+      panelState: 'open',
+      activeItemId: 'file:session-1:/workspace/project/report.md',
+      items: [
+        {
+          id: 'file:session-1:/workspace/project/report.md',
+          sessionId: 'session-1',
+          title: 'report.md',
+          source: 'artifact',
+          path: '/workspace/project/report.md',
+          format: 'markdown',
+          name: 'report.md'
+        }
+      ]
+    })
+    // Runtime-only timestamps and tab type are dropped from the durable projection.
+    expect(persisted.items[0]).not.toHaveProperty('createdAt')
+    expect(persisted.items[0]).not.toHaveProperty('type')
+  })
+
+  it('round-trips durable file fields through persist then restore', () => {
+    usePreviewWorkbenchStore.setState({
+      panelState: 'open',
+      activeItemId: 'file:session-1:/workspace/project/report.md',
+      items: [createStoredFileItem({ source: 'upload', format: 'csv', name: 'data.csv' })]
+    })
+
+    const restored = toRestoredSlice(toPersistedPreviewState(usePreviewWorkbenchStore.getState()))
+
+    expect(restored).toEqual({
+      panelState: 'open',
+      activeItemId: 'file:session-1:/workspace/project/report.md',
+      items: [
+        {
+          id: 'file:session-1:/workspace/project/report.md',
+          sessionId: 'session-1',
+          title: 'report.md',
+          type: 'file',
+          source: 'upload',
+          path: '/workspace/project/report.md',
+          format: 'csv',
+          name: 'data.csv'
+        }
+      ]
+    })
+  })
+})
+
+// Minimal wrapper so the effect-only hook can be mounted/rerendered/unmounted.
+const PersistenceHarness = ({ projectId }: { projectId: string | undefined }): null => {
+  usePreviewPersistence(projectId)
+  return null
+}
+
+describe('usePreviewPersistence per-project save/restore', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let load: ReturnType<typeof vi.fn>
+  let save: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    load = vi.fn(() => Promise.resolve(undefined))
+    save = vi.fn(() => Promise.resolve())
+    window.api = { preview: { load, save } } as never
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    vi.restoreAllMocks()
+  })
+
+  it('loads the incoming project and activates it from restored persistence', async () => {
+    const persisted: PersistedPreviewState = {
+      version: PREVIEW_STATE_VERSION,
+      panelState: 'open',
+      activeItemId: 'file:session-1:/workspace/project/report.md',
+      items: [
+        {
+          id: 'file:session-1:/workspace/project/report.md',
+          sessionId: 'session-1',
+          title: 'report.md',
+          source: 'artifact',
+          path: '/workspace/project/report.md',
+          format: 'markdown',
+          name: 'report.md'
+        }
+      ]
+    }
+    load.mockResolvedValueOnce(persisted)
+
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+
+    expect(load).toHaveBeenCalledWith({ projectId: 'project-a' })
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeProjectId: 'project-a',
+      panelState: 'open',
+      activeItemId: 'file:session-1:/workspace/project/report.md',
+      items: [{ id: 'file:session-1:/workspace/project/report.md', type: 'file' }]
+    })
+  })
+
+  it('saves the outgoing project before switching when the live slice still belongs to it', async () => {
+    // Mount on project-a and let its (empty) restore apply so the live slice belongs to project-a.
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+    expect(usePreviewWorkbenchStore.getState().activeProjectId).toBe('project-a')
+
+    // A file preview opened for project-a; this is what must be flushed on switch.
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        panelState: 'open',
+        activeItemId: 'file:session-1:/workspace/project/report.md',
+        items: [createStoredFileItem()]
+      })
+    })
+
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-b" />)
+    })
+
+    expect(save).toHaveBeenCalledWith({
+      projectId: 'project-a',
+      state: {
+        version: PREVIEW_STATE_VERSION,
+        panelState: 'open',
+        activeItemId: 'file:session-1:/workspace/project/report.md',
+        items: [
+          {
+            id: 'file:session-1:/workspace/project/report.md',
+            sessionId: 'session-1',
+            title: 'report.md',
+            source: 'artifact',
+            path: '/workspace/project/report.md',
+            format: 'markdown',
+            name: 'report.md'
+          }
+        ]
+      }
+    })
+    // The incoming project is still loaded after the outgoing save.
+    expect(load).toHaveBeenCalledWith({ projectId: 'project-b' })
+  })
+
+  it('skips the outgoing save when a pending load left the live slice on another project', async () => {
+    // project-a's load never resolves, so activateProject never runs: the top-level slice does not
+    // belong to project-a when the rapid switch to project-b happens.
+    const pendingLoad = createDeferred<PersistedPreviewState | undefined>()
+    load.mockReturnValueOnce(pendingLoad.promise)
+
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+    expect(usePreviewWorkbenchStore.getState().activeProjectId).toBeUndefined()
+
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-b" />)
+    })
+
+    // Nothing was saved for project-a: its last persisted state must stand, not be overwritten.
+    expect(save).not.toHaveBeenCalledWith(expect.objectContaining({ projectId: 'project-a' }))
+    // The switch still loads the incoming project.
+    expect(load).toHaveBeenCalledWith({ projectId: 'project-b' })
+  })
+
+  it('flushes the active project on unmount', async () => {
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        panelState: 'open',
+        activeItemId: 'file:session-1:/workspace/project/report.md',
+        items: [createStoredFileItem()]
+      })
+    })
+
+    save.mockClear()
+
+    await act(async () => {
+      root.unmount()
+    })
+
+    expect(save).toHaveBeenCalledTimes(1)
+    expect(save).toHaveBeenCalledWith({
+      projectId: 'project-a',
+      state: {
+        version: PREVIEW_STATE_VERSION,
+        panelState: 'open',
+        activeItemId: 'file:session-1:/workspace/project/report.md',
+        items: [
+          {
+            id: 'file:session-1:/workspace/project/report.md',
+            sessionId: 'session-1',
+            title: 'report.md',
+            source: 'artifact',
+            path: '/workspace/project/report.md',
+            format: 'markdown',
+            name: 'report.md'
+          }
+        ]
+      }
+    })
+  })
+})

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChatMessage, ToolActivity } from '@/stores/session-store'
+import type { ConversationItem } from './workspace-conversation-items'
+import {
+  formatActivityGroupTitle,
+  formatStepCount,
+  getRenderableActivityEntries,
+  groupConversationItems,
+  isSearchActivity
+} from './workspace-tool-activity-groups'
+
+const createActivity = (overrides: Partial<ToolActivity>): ToolActivity => ({
+  id: 'tool-1',
+  kind: 'tool',
+  title: '',
+  status: 'completed',
+  eventIds: [],
+  sortIndex: 1,
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000,
+  ...overrides
+})
+
+const createMessage = (overrides: Partial<ChatMessage>): ChatMessage => ({
+  id: 'message-1',
+  role: 'user',
+  content: 'Hello',
+  status: 'complete',
+  eventIds: [],
+  sortIndex: 1,
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000,
+  ...overrides
+})
+
+const messageItem = (message: ChatMessage): ConversationItem => ({
+  id: message.id,
+  type: 'message',
+  createdAt: message.createdAt,
+  sortIndex: message.sortIndex ?? 0,
+  message
+})
+
+const activityItem = (activity: ToolActivity): ConversationItem => ({
+  id: `activity-${activity.id}`,
+  type: 'activity',
+  createdAt: activity.createdAt,
+  sortIndex: activity.sortIndex,
+  activity
+})
+
+// The ToolSearch wrapper row that can precede concrete search entries.
+const toolSearchWrapper = (overrides: Partial<ToolActivity> = {}): ToolActivity =>
+  createActivity({ id: 'tool-search-wrapper', title: 'ToolSearch', ...overrides })
+
+// A quoted, provider-less fetch row that ToolSearch emits as a concrete search query.
+const inferredSearchRow = (overrides: Partial<ToolActivity> = {}): ToolActivity =>
+  createActivity({
+    id: 'tool-search-query',
+    title: '"open science repositories"',
+    toolKind: 'fetch',
+    status: 'in_progress',
+    ...overrides
+  })
+
+describe('groupConversationItems', () => {
+  it('collapses consecutive activities into a single group', () => {
+    const grouped = groupConversationItems([
+      activityItem(createActivity({ id: 'a1', sortIndex: 1 })),
+      activityItem(createActivity({ id: 'a2', sortIndex: 2 })),
+      activityItem(createActivity({ id: 'a3', sortIndex: 3 }))
+    ])
+
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0].type).toBe('activity-group')
+    if (grouped[0].type === 'activity-group') {
+      expect(grouped[0].id).toBe('activity-group-a1')
+      expect(grouped[0].activities.map((activity) => activity.id)).toEqual(['a1', 'a2', 'a3'])
+    }
+  })
+
+  it('splits activity groups at message boundaries', () => {
+    const grouped = groupConversationItems([
+      activityItem(createActivity({ id: 'a1', sortIndex: 1 })),
+      messageItem(createMessage({ id: 'm1', sortIndex: 2 })),
+      activityItem(createActivity({ id: 'a2', sortIndex: 3 })),
+      activityItem(createActivity({ id: 'a3', sortIndex: 4 }))
+    ])
+
+    expect(grouped.map((item) => item.type)).toEqual([
+      'activity-group',
+      'message',
+      'activity-group'
+    ])
+    const [firstGroup, , secondGroup] = grouped
+    if (firstGroup.type === 'activity-group') {
+      expect(firstGroup.activities.map((activity) => activity.id)).toEqual(['a1'])
+    }
+    if (secondGroup.type === 'activity-group') {
+      expect(secondGroup.activities.map((activity) => activity.id)).toEqual(['a2', 'a3'])
+    }
+  })
+})
+
+describe('formatActivityGroupTitle', () => {
+  it('emits ordered, pluralized clauses for a mixed group', () => {
+    const activities = [
+      createActivity({ id: 'edit-1', toolKind: 'edit' }),
+      createActivity({ id: 'cmd-1', toolKind: 'execute' }),
+      createActivity({ id: 'cmd-2', toolKind: 'execute' }),
+      createActivity({ id: 'read-1', toolKind: 'read' })
+    ]
+
+    // command precedes read precedes edit in ACTIVITY_CATEGORY_ORDER regardless of input order.
+    expect(formatActivityGroupTitle(activities)).toBe('Ran 2 commands, read a file, edited a file')
+  })
+
+  it('falls back to a generic title when no activities match', () => {
+    expect(formatActivityGroupTitle([])).toBe('Ran a tool')
+  })
+
+  it('drops the synthetic ToolSearch wrapper once concrete searches exist', () => {
+    const title = formatActivityGroupTitle([toolSearchWrapper(), inferredSearchRow()])
+
+    expect(title).toBe('Ran a search')
+  })
+
+  it('keeps the tool-search wrapper category when no concrete searches exist', () => {
+    expect(formatActivityGroupTitle([toolSearchWrapper()])).toBe('Ran a tool search')
+  })
+
+  // categorizeActivity is not exported; exercise its branches through the single-clause title.
+  it('categorizes representative tools through the header clause', () => {
+    const cases: Array<[Partial<ToolActivity>, string]> = [
+      [{ providerToolName: 'websearch' }, 'Ran a search'],
+      [{ providerToolName: 'mcp__open-science-notebook__notebook_execute' }, 'Ran a notebook cell'],
+      [{ providerToolName: 'skill' }, 'Loaded a skill'],
+      [{ providerToolName: 'save_artifacts' }, 'Saved a file'],
+      [{ providerToolName: 'manage_packages' }, 'Managed an environment'],
+      [{ providerToolName: 'request_network_access' }, 'Made a call'],
+      [{ providerToolName: 'bash' }, 'Ran a command'],
+      [{ toolKind: 'execute' }, 'Ran a command'],
+      [{ toolKind: 'edit' }, 'Edited a file'],
+      [{ toolKind: 'read' }, 'Read a file'],
+      [{ toolKind: 'fetch' }, 'Fetched a page'],
+      [{}, 'Ran a tool']
+    ]
+
+    for (const [overrides, expected] of cases) {
+      expect(formatActivityGroupTitle([createActivity(overrides)])).toBe(expected)
+    }
+  })
+})
+
+describe('isSearchActivity and search counting', () => {
+  it('detects the concrete WebSearch provider tool', () => {
+    const activity = createActivity({ providerToolName: 'websearch' })
+
+    expect(isSearchActivity(activity, [activity], 0)).toBe(true)
+  })
+
+  it('does not treat a quoted row as a search without an earlier wrapper', () => {
+    const activity = inferredSearchRow()
+
+    expect(isSearchActivity(activity, [activity], 0)).toBe(false)
+  })
+
+  it('infers a quoted search row that follows a ToolSearch wrapper', () => {
+    const activities = [toolSearchWrapper(), inferredSearchRow()]
+
+    expect(isSearchActivity(activities[1], activities, 1)).toBe(true)
+  })
+})
+
+describe('getRenderableActivityEntries', () => {
+  it('drops the ToolSearch wrapper once concrete searches exist', () => {
+    const activities = [toolSearchWrapper(), inferredSearchRow()]
+
+    const rendered = getRenderableActivityEntries(activities)
+
+    expect(rendered.map((entry) => entry.activity.id)).toEqual(['tool-search-query'])
+    expect(rendered[0].activityIndex).toBe(1)
+  })
+
+  it('keeps every entry when there are no concrete searches', () => {
+    const activities = [toolSearchWrapper(), createActivity({ id: 'read-1', toolKind: 'read' })]
+
+    const rendered = getRenderableActivityEntries(activities)
+
+    expect(rendered.map((entry) => entry.activity.id)).toEqual(['tool-search-wrapper', 'read-1'])
+  })
+})
+
+describe('formatStepCount', () => {
+  it('summarizes step totals and flags failures', () => {
+    expect(
+      formatStepCount([
+        createActivity({ id: 's1' }),
+        createActivity({ id: 's2', status: 'failed' }),
+        createActivity({ id: 's3' })
+      ])
+    ).toBe('3 steps · 1 failed')
+  })
+
+  it('uses the singular label for a single step', () => {
+    expect(formatStepCount([createActivity({ id: 's1' })])).toBe('1 step')
+  })
+
+  it('omits the failed clause when nothing failed', () => {
+    expect(formatStepCount([createActivity({ id: 's1' }), createActivity({ id: 's2' })])).toBe(
+      '2 steps'
+    )
+  })
+})

--- a/src/shared/preview-state.test.ts
+++ b/src/shared/preview-state.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createEmptyPersistedPreviewState,
+  normalizePersistedPreviewState,
+  PREVIEW_STATE_VERSION
+} from './preview-state'
+
+// A complete, valid persisted item used as a base for building test inputs.
+const validItem = {
+  id: 'item-1',
+  sessionId: 'session-1',
+  title: 'Report',
+  source: 'artifact',
+  path: '/project/report.md',
+  format: 'markdown',
+  name: 'report.md'
+}
+
+// Builds a copy of validItem without the given key, for exercising the optional/default branches.
+const validItemWithout = (key: keyof typeof validItem): Record<string, unknown> => {
+  const copy: Record<string, unknown> = { ...validItem }
+  delete copy[key]
+  return copy
+}
+
+describe('createEmptyPersistedPreviewState', () => {
+  it('produces a collapsed, empty, versioned state', () => {
+    const state = createEmptyPersistedPreviewState()
+
+    expect(state).toEqual({
+      version: PREVIEW_STATE_VERSION,
+      panelState: 'collapsed',
+      items: []
+    })
+    // The canonical empty state never carries an active item.
+    expect(state.activeItemId).toBeUndefined()
+  })
+})
+
+// sanitizePreviewFileItem is not exported, so its behavior is exercised through the items array
+// of normalizePersistedPreviewState.
+describe('normalizePersistedPreviewState item sanitization', () => {
+  it('keeps a fully valid item and preserves its source', () => {
+    const state = normalizePersistedPreviewState({ items: [validItem] })
+
+    expect(state.items).toEqual([validItem])
+  })
+
+  it('drops items missing any of id, sessionId, path, or name', () => {
+    const state = normalizePersistedPreviewState({
+      items: [
+        { ...validItem, id: undefined },
+        { ...validItem, sessionId: undefined },
+        { ...validItem, path: undefined },
+        { ...validItem, name: undefined }
+      ]
+    })
+
+    expect(state.items).toEqual([])
+  })
+
+  it('drops items whose required fields are empty strings', () => {
+    // Empty strings are falsy, so they fail the id/sessionId/path/name guard.
+    const state = normalizePersistedPreviewState({ items: [{ ...validItem, id: '' }] })
+
+    expect(state.items).toEqual([])
+  })
+
+  it('drops non-record items', () => {
+    const state = normalizePersistedPreviewState({ items: [null, 'string', 42, [], validItem] })
+
+    expect(state.items).toEqual([validItem])
+  })
+
+  it('defaults title to name when title is missing', () => {
+    const state = normalizePersistedPreviewState({ items: [validItemWithout('title')] })
+
+    expect(state.items[0]?.title).toBe(validItem.name)
+  })
+
+  it('defaults format to "unknown" when format is missing', () => {
+    const state = normalizePersistedPreviewState({ items: [validItemWithout('format')] })
+
+    expect(state.items[0]?.format).toBe('unknown')
+  })
+
+  it('omits source when it is absent', () => {
+    const state = normalizePersistedPreviewState({ items: [validItemWithout('source')] })
+
+    expect(state.items[0]).not.toHaveProperty('source')
+  })
+
+  it('keeps source when it is present', () => {
+    const state = normalizePersistedPreviewState({ items: [{ ...validItem, source: 'upload' }] })
+
+    expect(state.items[0]?.source).toBe('upload')
+  })
+
+  it('ignores non-string field values, falling back to defaults or dropping the item', () => {
+    // A non-string title falls back to name; a non-string path fails the guard and drops the item.
+    const stringTitle = normalizePersistedPreviewState({ items: [{ ...validItem, title: 123 }] })
+    const badPath = normalizePersistedPreviewState({ items: [{ ...validItem, path: 123 }] })
+
+    expect(stringTitle.items[0]?.title).toBe(validItem.name)
+    expect(badPath.items).toEqual([])
+  })
+})
+
+describe('normalizePersistedPreviewState top-level normalization', () => {
+  it('returns the empty state for non-object input', () => {
+    const empty = createEmptyPersistedPreviewState()
+
+    expect(normalizePersistedPreviewState(null)).toEqual(empty)
+    expect(normalizePersistedPreviewState(undefined)).toEqual(empty)
+    expect(normalizePersistedPreviewState('string')).toEqual(empty)
+    expect(normalizePersistedPreviewState(42)).toEqual(empty)
+    // Arrays are records to typeof but are explicitly rejected by isRecord.
+    expect(normalizePersistedPreviewState([validItem])).toEqual(empty)
+  })
+
+  it('treats a missing or non-array items field as no items', () => {
+    expect(normalizePersistedPreviewState({}).items).toEqual([])
+    expect(normalizePersistedPreviewState({ items: 'nope' }).items).toEqual([])
+  })
+
+  it('always stamps the current version', () => {
+    expect(normalizePersistedPreviewState({ items: [validItem] }).version).toBe(
+      PREVIEW_STATE_VERSION
+    )
+  })
+
+  it('coerces panelState to "collapsed" unless it is exactly "open"', () => {
+    expect(normalizePersistedPreviewState({ panelState: 'open' }).panelState).toBe('open')
+    expect(normalizePersistedPreviewState({ panelState: 'collapsed' }).panelState).toBe('collapsed')
+    expect(normalizePersistedPreviewState({ panelState: 'anything' }).panelState).toBe('collapsed')
+    expect(normalizePersistedPreviewState({ panelState: 42 }).panelState).toBe('collapsed')
+    expect(normalizePersistedPreviewState({}).panelState).toBe('collapsed')
+  })
+
+  it('keeps activeItemId when it points at a surviving item', () => {
+    const state = normalizePersistedPreviewState({
+      items: [validItem],
+      activeItemId: validItem.id
+    })
+
+    expect(state.activeItemId).toBe(validItem.id)
+  })
+
+  it('drops activeItemId when its item was filtered out', () => {
+    // The active item is invalid (missing path) and gets dropped, so the id must not survive.
+    const state = normalizePersistedPreviewState({
+      items: [{ ...validItem, path: undefined }],
+      activeItemId: validItem.id
+    })
+
+    expect(state.items).toEqual([])
+    expect(state.activeItemId).toBeUndefined()
+  })
+
+  it('drops activeItemId that matches no item', () => {
+    const state = normalizePersistedPreviewState({
+      items: [validItem],
+      activeItemId: 'nonexistent'
+    })
+
+    expect(state.activeItemId).toBeUndefined()
+  })
+
+  it('ignores a non-string activeItemId', () => {
+    const state = normalizePersistedPreviewState({ items: [validItem], activeItemId: 123 })
+
+    expect(state.activeItemId).toBeUndefined()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'path'
-import { defineConfig } from 'vitest/config'
+import { defineConfig, configDefaults } from 'vitest/config'
 
 // Mirrors the renderer alias from electron.vite.config.ts so tests that mount real component
 // trees (instead of mocking every aliased import) can resolve '@/...' without a build step.
@@ -8,6 +8,37 @@ export default defineConfig({
     alias: {
       '@': resolve('src/renderer/src'),
       '@renderer': resolve('src/renderer/src')
+    }
+  },
+  test: {
+    // Keep vitest's defaults (node_modules, dist, .git, ...) and also ignore git worktrees created
+    // under .claude/worktrees — those hold full source + node_modules copies that would otherwise be
+    // discovered and run as duplicate (and often stale) suites during local runs.
+    exclude: [...configDefaults.exclude, '**/.claude/**'],
+    coverage: {
+      provider: 'v8',
+      // text for the CI log, lcov for upload/tooling, html for local inspection.
+      reporter: ['text', 'lcov', 'html'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      // Exclude non-logic files so coverage reflects testable code, not wiring/types.
+      exclude: [
+        '**/*.test.{ts,tsx}',
+        '**/*.d.ts',
+        'src/**/index.ts', // process entry / IPC composition wiring
+        'src/preload/**', // declarative ipcRenderer bridge
+        'src/**/*types.ts',
+        'src/renderer/src/main.tsx'
+      ],
+      // Baseline thresholds: fail CI when global coverage drops below these. Set ~5pts under the
+      // current measured baseline (lines 71 / statements 70 / functions 68 / branches 62) so the gate
+      // catches regressions while absorbing minor cross-environment variance. Raise over time.
+      thresholds: {
+        lines: 66,
+        functions: 62,
+        branches: 57,
+        statements: 64
+      }
     }
   }
 })


### PR DESCRIPTION
## Summary

Closes gaps that let CI pass while shipping under-tested code. Adds a coverage gate, runs the test suite where it previously didn't (packaged builds, non-macOS platforms), fixes a dead workflow, and backfills unit tests for the highest-risk previously-uncovered modules.

## CI completeness

- **`claude-review.yml`**: fix trigger branch `master` → `main`. The default branch is `main`, so this AI-review workflow never ran.
- **`build.yml`**: add a `verify` job (lint + typecheck + test) that the build matrix `needs`, so **nightly and release can no longer publish installers that were never tested**.
- **`pr-check.yml`**: run on a `macos-14 / ubuntu-latest / windows-latest` matrix. `lint` + `typecheck` are hard-gated on all three; the test suite is hard-gated on macOS (with coverage), and **advisory** (`continue-on-error`) on Linux/Windows because of the documented darwin-only native dependency. Also uploads the coverage report and runs a non-blocking `npm audit`.
- **Coverage gate**: add `@vitest/coverage-v8` + v8 coverage config with regression thresholds (`test:coverage` script). Thresholds sit ~5pts under the current baseline.
- **`vitest.config.ts`**: exclude `.claude/worktrees` so nested worktree copies aren't discovered and run as duplicate/stale suites.
- **`dependabot.yml`**: weekly npm + github-actions updates.

## HIGH-risk unit tests (previously 0% covered)

- `src/shared/preview-state.ts` — sanitizers for untrusted, SQLite-loaded preview state (46 → +18 assertions)
- `workspace-tool-activity-groups.ts` — activity grouping / search-detection / categorization / title heuristics
- `lib/acp/useAcpRuntime.ts` — permission + action error semantics (swallow vs rethrow) and `onState` subscription lifecycle
- `lib/preview-persistence` — per-project save/restore and the cross-project overwrite guard

## Verification

- Full suite: **630 tests pass** (87 files).
- Typecheck passes for both `tsconfig.node.json` and `tsconfig.web.json`.
- Coverage gate passes. Baseline: lines 71% / statements 70% / functions 68% / branches 62%.

## Notes / follow-ups

- The Linux/Windows test legs are **advisory only** for now; promote to a hard gate once the suites that touch the ACP/native layer are made platform-independent.
- Out of scope here, recommended next: an e2e/smoke test that launches the packaged app, and a Prisma schema/DB round-trip test — these cover the integration risks unit tests can't see.