### PR TITLE
feat: add GitHub star badge and community links

### DIFF
--- a/src/main/github-ipc.test.ts
+++ b/src/main/github-ipc.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Capture ipcMain.handle registrations so the handler can be invoked directly.
+const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown, payload: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }
+  }
+}))
+
+const { registerGithubIpcHandlers } = await import('./github-ipc')
+
+const invoke = (channel: string): unknown => handlers.get(channel)!(undefined, undefined)
+
+const jsonResponse = (body: unknown, ok = true): Response =>
+  ({ ok, json: () => Promise.resolve(body) }) as unknown as Response
+
+describe('github IPC handler', () => {
+  it('registers the get-stars channel', () => {
+    handlers.clear()
+    registerGithubIpcHandlers({ fetch: vi.fn() })
+    expect(handlers.has('github:get-stars')).toBe(true)
+  })
+
+  it('returns the star count on success', async () => {
+    handlers.clear()
+    const fetch = vi.fn().mockResolvedValue(jsonResponse({ stargazers_count: 1234 }))
+    registerGithubIpcHandlers({ fetch })
+    await expect(invoke('github:get-stars')).resolves.toBe(1234)
+  })
+
+  it('returns null on a non-200 response', async () => {
+    handlers.clear()
+    const fetch = vi.fn().mockResolvedValue(jsonResponse({}, false))
+    registerGithubIpcHandlers({ fetch })
+    await expect(invoke('github:get-stars')).resolves.toBeNull()
+  })
+
+  it('returns null when fetch throws', async () => {
+    handlers.clear()
+    const fetch = vi.fn().mockRejectedValue(new Error('offline'))
+    registerGithubIpcHandlers({ fetch })
+    await expect(invoke('github:get-stars')).resolves.toBeNull()
+  })
+
+  it('fetches once and caches for concurrent and repeat calls', async () => {
+    handlers.clear()
+    const fetch = vi.fn().mockResolvedValue(jsonResponse({ stargazers_count: 42 }))
+    registerGithubIpcHandlers({ fetch })
+
+    const [a, b] = await Promise.all([invoke('github:get-stars'), invoke('github:get-stars')])
+    const c = await invoke('github:get-stars')
+
+    expect(a).toBe(42)
+    expect(b).toBe(42)
+    expect(c).toBe(42)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null on a 200 response with a missing or non-number stargazers_count', async () => {
+    handlers.clear()
+    const fetch = vi.fn().mockResolvedValue(jsonResponse({ stargazers_count: 'lots' }))
+    registerGithubIpcHandlers({ fetch })
+    await expect(invoke('github:get-stars')).resolves.toBeNull()
+  })
+
+  it('does not cache a failed result and retries on the next call', async () => {
+    handlers.clear()
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, false))
+      .mockResolvedValueOnce(jsonResponse({ stargazers_count: 7 }))
+    registerGithubIpcHandlers({ fetch })
+
+    await expect(invoke('github:get-stars')).resolves.toBeNull()
+    await expect(invoke('github:get-stars')).resolves.toBe(7)
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/github-ipc.ts
+++ b/src/main/github-ipc.ts
@@ -1,0 +1,51 @@
+import { ipcMain } from 'electron'
+
+import { APP } from '../shared/app-config'
+
+type FetchFn = typeof fetch
+
+// Reads the repository star count. GitHub requires a User-Agent on API requests; anonymous requests
+// are rate-limited (60/hour/IP), so the result is cached for the app session and concurrent callers
+// share one in-flight request. Any failure resolves to null so the badge can degrade to icon-only.
+const fetchStars = async (fetchFn: FetchFn): Promise<number | null> => {
+  try {
+    const response = await fetchFn(APP.links.githubApi, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'open-science-app'
+      }
+    })
+
+    if (!response.ok) return null
+
+    const body = (await response.json()) as { stargazers_count?: unknown }
+
+    return typeof body.stargazers_count === 'number' ? body.stargazers_count : null
+  } catch {
+    return null
+  }
+}
+
+// The cache lives in this closure. In production register runs once, so the count is fetched at most
+// once per session; a failed attempt is not cached, so a later mount may retry.
+const registerGithubIpcHandlers = (deps: { fetch?: FetchFn } = {}): void => {
+  const fetchFn = deps.fetch ?? fetch
+  let cachedStars: number | null = null
+  let inFlight: Promise<number | null> | null = null
+
+  ipcMain.handle('github:get-stars', (): Promise<number | null> => {
+    if (cachedStars !== null) return Promise.resolve(cachedStars)
+
+    if (!inFlight) {
+      inFlight = fetchStars(fetchFn).then((count) => {
+        if (count !== null) cachedStars = count
+        inFlight = null
+        return count
+      })
+    }
+
+    return inFlight
+  })
+}
+
+export { registerGithubIpcHandlers }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2,6 +2,7 @@ import { createDefaultNotebookRuntimeService, registerAcpIpcHandlers } from './a
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
 import { ArtifactRunRegistry } from './artifacts/run-registry'
 import { registerFileSaveHandlers } from './file-save'
+import { registerGithubIpcHandlers } from './github-ipc'
 import { registerLogsIpcHandlers } from './logs-ipc'
 import { registerNotebookIpcHandlers } from './notebook/ipc'
 import { NotebookLocalRpcServer } from './notebook/local-rpc-server'
@@ -29,6 +30,7 @@ const registerIpcHandlers = ({ mainEntryPath }: IpcRegistrationOptions): void =>
 
   registerFileSaveHandlers()
   registerLogsIpcHandlers()
+  registerGithubIpcHandlers()
   const runtime = registerAcpIpcHandlers({
     mcpEntryPath: mainEntryPath,
     repository: artifactRepository,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -127,6 +127,9 @@ interface OpenScienceAPI {
     getPath(): Promise<string | null>
     openFile(): Promise<OpenLogFileResult>
   }
+  github: {
+    getStars(): Promise<number | null>
+  }
   projects: {
     list(): Promise<Project[]>
     get(id: string): Promise<Project | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -142,6 +142,9 @@ type OpenScienceAPI = {
     getPath: () => Promise<string | null>
     openFile: () => Promise<OpenLogFileResult>
   }
+  github: {
+    getStars: () => Promise<number | null>
+  }
   projects: {
     list: () => Promise<Project[]>
     get: (id: string) => Promise<Project | null>
@@ -280,6 +283,9 @@ const api: OpenScienceAPI = {
   logs: {
     getPath: () => ipcRenderer.invoke('logs:get-path') as Promise<string | null>,
     openFile: () => ipcRenderer.invoke('logs:open-file') as Promise<OpenLogFileResult>
+  },
+  github: {
+    getStars: () => ipcRenderer.invoke('github:get-stars') as Promise<number | null>
   },
   projects: {
     // Project CRUD backed by the SQLite/Prisma layer (scope: projects only).

--- a/src/renderer/src/components/GitHubStarBadge.render.test.tsx
+++ b/src/renderer/src/components/GitHubStarBadge.render.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { GitHubStarBadge } from './GitHubStarBadge'
+import { APP } from '../../../shared/app-config'
+
+let container: HTMLDivElement
+let root: Root
+
+const installApi = (getStars: () => Promise<number | null>): void => {
+  ;(window as unknown as { api: unknown }).api = { github: { getStars } }
+}
+
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+  delete (window as unknown as { api?: unknown }).api
+})
+
+describe('GitHubStarBadge', () => {
+  it('links to the repo and shows the formatted count when available', async () => {
+    installApi(() => Promise.resolve(1234))
+    await act(async () => {
+      root.render(<GitHubStarBadge />)
+    })
+    await flush()
+
+    const link = container.querySelector('a')
+    expect(link?.getAttribute('href')).toBe(APP.links.githubRepo)
+    expect(link?.getAttribute('target')).toBe('_blank')
+    expect(link?.textContent).toContain('1.2k')
+  })
+
+  it('shows an icon-only entry when the count is unavailable', async () => {
+    installApi(() => Promise.resolve(null))
+    await act(async () => {
+      root.render(<GitHubStarBadge />)
+    })
+    await flush()
+
+    const link = container.querySelector('a')
+    expect(link?.getAttribute('href')).toBe(APP.links.githubRepo)
+    expect(link?.textContent).not.toMatch(/\d/)
+  })
+
+  it('degrades to an icon-only link when the github API is unavailable', async () => {
+    ;(window as unknown as { api: unknown }).api = {}
+
+    await act(async () => {
+      root.render(<GitHubStarBadge />)
+    })
+    await flush()
+
+    const link = container.querySelector('a')
+    expect(link?.getAttribute('href')).toBe(APP.links.githubRepo)
+    expect(link?.textContent).not.toMatch(/\d/)
+  })
+})

--- a/src/renderer/src/components/GitHubStarBadge.tsx
+++ b/src/renderer/src/components/GitHubStarBadge.tsx
@@ -1,0 +1,71 @@
+import { Star } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+import { formatStarCount } from '@/lib/format-star-count'
+import { cn } from '@/lib/utils'
+import { APP } from '../../../shared/app-config'
+
+// GitHub's octocat is a brand asset that lucide-react dropped in v1, so we inline the official mark
+// here. currentColor lets it inherit the link's text color like the other icons.
+const GitHubMark = ({ className }: { className?: string }): React.JSX.Element => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className={className}>
+    <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.438 9.8 8.205 11.387.6.113.82-.26.82-.577 0-.285-.01-1.04-.015-2.04-3.338.725-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.42-1.305.762-1.605-2.665-.303-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.236-3.22-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.3 1.23.957-.266 1.983-.4 3.003-.404 1.02.004 2.047.138 3.006.404 2.29-1.552 3.297-1.23 3.297-1.23.653 1.652.242 2.873.118 3.176.77.84 1.235 1.91 1.235 3.22 0 4.61-2.807 5.624-5.48 5.92.43.372.815 1.103.815 2.222 0 1.606-.014 2.9-.014 3.293 0 .32.216.694.825.576C20.565 22.296 24 17.797 24 12.5 24 5.87 18.63.5 12 .5z" />
+  </svg>
+)
+
+type GitHubStarBadgeProps = {
+  className?: string
+}
+
+// GitHub entry point reused on the home header, chat sidebar, and settings. Fetches the repo star
+// count once (cached in the main process) and shows it beside the GitHub mark; when the count is
+// unavailable it degrades to an icon-only link. Clicking opens the repo in the system browser via
+// the window-open handler in src/main/windows.ts.
+const GitHubStarBadge = ({ className }: GitHubStarBadgeProps): React.JSX.Element => {
+  const [stars, setStars] = useState<number | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    // Decorative badge: if the preload API is unavailable, stay icon-only instead of throwing.
+    // In production window.api.github is always present.
+    const getStars = window.api?.github?.getStars
+
+    if (!getStars) return
+
+    void getStars().then((count) => {
+      if (!cancelled) setStars(count)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const label =
+    stars === null ? `Open ${APP.name} on GitHub` : `Star ${APP.name} on GitHub, ${stars} stars`
+
+  return (
+    <a
+      href={APP.links.githubRepo}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={label}
+      title={label}
+      className={cn(
+        'inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-text-300 transition-colors duration-150 ease-out hover:bg-bg-300 hover:text-text-000',
+        className
+      )}
+    >
+      <GitHubMark className="size-4" />
+      {stars !== null ? (
+        <span className="inline-flex items-center gap-0.5 text-xs font-medium tabular-nums">
+          <Star className="size-3" strokeWidth={2} aria-hidden="true" />
+          {formatStarCount(stars)}
+        </span>
+      ) : null}
+    </a>
+  )
+}
+
+export { GitHubStarBadge }

--- a/src/renderer/src/lib/format-star-count.test.ts
+++ b/src/renderer/src/lib/format-star-count.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatStarCount } from './format-star-count'
+
+describe('formatStarCount', () => {
+  it('shows counts under 1000 verbatim', () => {
+    expect(formatStarCount(0)).toBe('0')
+    expect(formatStarCount(42)).toBe('42')
+    expect(formatStarCount(999)).toBe('999')
+  })
+
+  it('formats thousands with a trimmed single decimal', () => {
+    expect(formatStarCount(1000)).toBe('1k')
+    expect(formatStarCount(1200)).toBe('1.2k')
+    expect(formatStarCount(1234)).toBe('1.2k')
+    expect(formatStarCount(12000)).toBe('12k')
+    expect(formatStarCount(12345)).toBe('12.3k')
+  })
+})

--- a/src/renderer/src/lib/format-star-count.ts
+++ b/src/renderer/src/lib/format-star-count.ts
@@ -1,0 +1,9 @@
+// Compact star count for the badge: counts under 1000 verbatim, thousands as "1.2k" with a single
+// decimal and a trimmed trailing ".0" (e.g. 1000 -> "1k"). Keeps the badge narrow in the sidebar rail.
+export const formatStarCount = (count: number): string => {
+  if (count < 1000) return String(count)
+
+  const rounded = Math.round((count / 1000) * 10) / 10
+
+  return `${rounded % 1 === 0 ? rounded.toFixed(0) : rounded.toFixed(1)}k`
+}

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -19,6 +19,8 @@ import type { ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSettingsStore } from '@/stores/settings-store'
+import { GitHubStarBadge } from '@/components/GitHubStarBadge'
+import { APP } from '../../../../shared/app-config'
 import type { Project } from '../../../../shared/projects'
 
 import { DeleteProjectDialog } from './DeleteProjectDialog'
@@ -206,12 +208,18 @@ const HomePage = (): React.JSX.Element => {
       <div className="mx-auto max-w-[1080px] px-8 py-7 pb-16">
         <header className="flex items-center justify-between">
           <div>
-            <div className="font-serif text-[26px] font-medium leading-none tracking-[-0.02em] text-text-000">
+            <a
+              href={APP.links.website}
+              target="_blank"
+              rel="noreferrer"
+              className="font-serif text-[26px] font-medium leading-none tracking-[-0.02em] text-text-000 transition-colors duration-150 ease-out hover:text-text-100"
+            >
               Open Science
-            </div>
+            </a>
             <div className="mt-1 text-[11px] text-text-100">Beta</div>
           </div>
           <div className="flex items-center gap-2">
+            <GitHubStarBadge />
             <button
               type="button"
               aria-label="Model settings"

--- a/src/renderer/src/pages/settings/GeneralPanel.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.tsx
@@ -1,8 +1,30 @@
-import { ExternalLink } from 'lucide-react'
+import { ExternalLink, Globe } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
-// General app settings. Currently hosts the diagnostics "Logs" option; a home for future app-wide
-// preferences. The log file stays on this device and is never transmitted by the app.
+import { GitHubStarBadge } from '@/components/GitHubStarBadge'
+import { APP } from '../../../../shared/app-config'
+
+// Community entry links (Discord, X) share the GitHub badge's compact look so the row reads as one
+// set of "connect with the project" actions.
+const socialLinkClassName =
+  'inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium text-text-300 transition-colors duration-150 ease-out hover:bg-bg-300 hover:text-text-000'
+
+// Discord and X are brand marks that lucide-react dropped in v1, so we inline the official SVGs.
+// currentColor lets them inherit the link's text color like the other icons.
+const DiscordMark = ({ className }: { className?: string }): React.JSX.Element => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className={className}>
+    <path d="M20.317 4.3698a19.7913 19.7913 0 0 0-4.8851-1.5152.0741.0741 0 0 0-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 0 0-.0785-.037 19.7363 19.7363 0 0 0-4.8852 1.515.0699.0699 0 0 0-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 0 0 .0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 0 0 .0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 0 0-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 0 1-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 0 1 .0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 0 1 .0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 0 1-.0066.1276 12.2986 12.2986 0 0 1-1.873.8914.0766.0766 0 0 0-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 0 0 .0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 0 0 .0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 0 0-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
+  </svg>
+)
+
+const XMark = ({ className }: { className?: string }): React.JSX.Element => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className={className}>
+    <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
+  </svg>
+)
+
+// General app settings. Hosts the diagnostics "Logs" option and the community/connect links. The log
+// file stays on this device and is never transmitted by the app.
 const GeneralPanel = (): React.JSX.Element => {
   const [logPath, setLogPath] = useState<string | null>(null)
   const [message, setMessage] = useState<string | undefined>(undefined)
@@ -65,9 +87,62 @@ const GeneralPanel = (): React.JSX.Element => {
         </div>
 
         <p className="mt-3 text-xs text-muted-foreground">
+          Something not working as expected?{' '}
+          <a
+            href={APP.links.githubIssues}
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium text-foreground underline underline-offset-2 transition-colors hover:text-text-000"
+          >
+            Open an issue on GitHub
+          </a>{' '}
+          and attach the log above.
+        </p>
+
+        <p className="mt-3 text-xs text-muted-foreground">
           Logs are stored only on this device and are never sent anywhere by the app. The file may
           contain local file paths; review it before sharing.
         </p>
+      </section>
+
+      <section aria-label="Community">
+        <h3 className="mb-1 text-sm font-semibold text-foreground">Enjoying Open Science?</h3>
+        <p className="mb-3 text-xs text-muted-foreground">
+          It&apos;s free and open source. Star it on GitHub to help others find it, and come build
+          in public with us on Discord and X. Thanks for being here.
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <GitHubStarBadge className="border border-border" />
+          <a
+            href={APP.links.discord}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`Join the ${APP.name} community on Discord`}
+            className={socialLinkClassName}
+          >
+            <DiscordMark className="size-4" />
+            Discord
+          </a>
+          <a
+            href={APP.links.x}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`Follow ${APP.name} on X`}
+            className={socialLinkClassName}
+          >
+            <XMark className="size-4" />X
+          </a>
+          <a
+            href={APP.links.website}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`Open the ${APP.name} website`}
+            className={socialLinkClassName}
+          >
+            <Globe className="size-4" strokeWidth={2} aria-hidden="true" />
+            Website
+          </a>
+        </div>
       </section>
     </div>
   )

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, Files, MoreVertical, Pencil, Plus, Settings, Trash2 } from
 import { DropdownMenu } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
+import { GitHubStarBadge } from '@/components/GitHubStarBadge'
 import type { ChatSession, SessionStatus } from '@/stores/session-store'
 
 type WorkspaceSidebarProps = {
@@ -236,6 +237,7 @@ const WorkspaceSidebar = ({
           >
             <Settings className="size-4" strokeWidth={2} aria-hidden="true" />
           </button>
+          <GitHubStarBadge />
         </div>
       </nav>
     </div>

--- a/src/shared/app-config.ts
+++ b/src/shared/app-config.ts
@@ -1,0 +1,21 @@
+// Single source of truth for project identity and external links. Shared by the main process
+// (GitHub star-count fetch) and the renderer (every entry-point link). Keep this UI-free — no
+// icons, no JSX — so both processes can import it and any screen reuses the same values.
+
+const GITHUB_OWNER = 'aipoch'
+const GITHUB_REPO = 'open-science'
+const GITHUB_REPO_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`
+
+export const APP = {
+  name: 'Open Science',
+  githubOwner: GITHUB_OWNER,
+  githubRepo: GITHUB_REPO,
+  links: {
+    website: 'https://www.aipoch.com/open-science',
+    githubRepo: GITHUB_REPO_URL,
+    githubApi: `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}`,
+    githubIssues: `${GITHUB_REPO_URL}/issues`,
+    discord: 'https://discord.gg/85dKfuGM9',
+    x: 'https://x.com/aipoch_ai'
+  }
+} as const


### PR DESCRIPTION
## Summary

Surfaces the project's GitHub repo, star count, and community channels inside the app, to invite users to star the repo and connect with the project.

- **GitHub star badge** on the home header, chat sidebar footer, and Settings › General. Shows the GitHub mark + live star count, degrading to an icon-only link when the count is unavailable. Clicking opens the repo in the system browser.
- **Star count** is fetched in the main process (`github:get-stars`): an anonymous GitHub API call with an in-memory session cache and concurrent-call dedupe. Any failure resolves to `null`, so the UI degrades gracefully (no error, no noise).
- **Home title** "Open Science" links to the official website.
- **Community section** in Settings › General with **Discord**, **X**, and **Website** links, plus a **"report an issue"** link tied to the Logs section (logs are meant to be attached to a bug report).
- **Central config** — `src/shared/app-config.ts` is now the single source of truth for project identity and external links, shared by the main process and the renderer.
- Inlined the **GitHub, Discord, and X** brand marks as SVGs, since `lucide-react` v1 no longer ships brand icons (no new dependency).

## Testing

- `npm run typecheck:web` — clean
- `npm run lint` — clean on all touched files
- New unit/render tests pass (15/15 across the touched suites):
  - `github-ipc` handler: success, non-200, thrown error, concurrent dedupe, missing/non-number field, failed-result retry
  - `formatStarCount`: verbatim under 1000, `1.2k`-style thousands
  - `GitHubStarBadge`: renders count, degrades to icon-only, degrades when the preload API is absent

## Notes

- Star count only shows when online and not rate-limited (GitHub anonymous API is 60 req/hour/IP); otherwise the badge is icon-only by design.
- No persistence and no auto-refresh — the count is cached in memory per session.