### PR TITLE
fix(settings): keep the Settings panel open when dismissing a dropdown

### DIFF
--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -126,7 +126,7 @@ describe('OnboardingWizard', () => {
     })
 
     // Nothing to install when claude is already runnable — the install source picker is gone.
-    expect(container.querySelector('select[aria-label="Install source"]')).toBeNull()
+    expect(container.querySelector('[role="combobox"][aria-label="Install source"]')).toBeNull()
   })
 
   it('shows the install source UI when Claude is missing', async () => {
@@ -138,7 +138,7 @@ describe('OnboardingWizard', () => {
       root.render(<OnboardingWizard />)
     })
 
-    expect(container.querySelector('select[aria-label="Install source"]')).not.toBeNull()
+    expect(container.querySelector('[role="combobox"][aria-label="Install source"]')).not.toBeNull()
   })
 
   it('defers required-field errors until the first submit attempt', async () => {

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.render.test.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.render.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ClaudeInstallCard } from './ClaudeInstallCard'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const render = (
+  props: Partial<React.ComponentProps<typeof ClaudeInstallCard>> = {}
+): (() => void) => {
+  const onInstall = props.onInstall ?? vi.fn()
+
+  act(() => {
+    root.render(
+      <ClaudeInstallCard
+        isInstalling={false}
+        installLogs={[]}
+        npmAvailable
+        onInstall={onInstall}
+        {...props}
+      />
+    )
+  })
+
+  return onInstall as () => void
+}
+
+describe('ClaudeInstallCard install-source picker', () => {
+  it('renders the install source as a styled combobox, never a native <select>', () => {
+    // Regression guard: the picker used to be a native <select>, whose OS-level option popup lives
+    // outside the React tree. Dismissing it inside the settings Radix Dialog registered as an
+    // "interact outside" and closed the whole dialog. The Radix Select renders in a dismissable-layer
+    // portal instead, so the trigger must be a styled button (role=combobox), not a native select.
+    render()
+
+    expect(container.querySelector('select[aria-label="Install source"]')).toBeNull()
+
+    const trigger = container.querySelector('[aria-label="Install source"]')
+
+    expect(trigger?.tagName).toBe('BUTTON')
+    expect(trigger?.getAttribute('role')).toBe('combobox')
+  })
+
+  it('defaults to npm and shows its copyable command when npm is available', () => {
+    render({ npmAvailable: true })
+
+    const trigger = container.querySelector('[aria-label="Install source"]')
+
+    expect(trigger?.textContent).toContain('npm (global install)')
+    expect(container.querySelector('[aria-label="Install command"]')?.textContent).toContain(
+      'npm i -g @anthropic-ai/claude-code'
+    )
+  })
+
+  it('defaults to the official installer when npm is unavailable', () => {
+    render({ npmAvailable: false })
+
+    const trigger = container.querySelector('[aria-label="Install source"]')
+
+    // Falls back to the script installer (no npm needed) and shows its command; the npm-missing note
+    // only appears when npm itself is the selected source, so it stays hidden here.
+    expect(trigger?.textContent).toContain('Official install.sh')
+    expect(container.querySelector('[aria-label="Install command"]')?.textContent).toContain(
+      'curl -fsSL https://claude.ai/install.sh'
+    )
+  })
+
+  it('installs the currently selected source when the button is clicked', () => {
+    const onInstall = render({ npmAvailable: true })
+
+    const button = Array.from(container.querySelectorAll('button')).find((element) =>
+      element.textContent?.includes('Install with one click')
+    )
+
+    act(() => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onInstall).toHaveBeenCalledWith('npm')
+  })
+})

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 
 import type { ClaudeInstallSource } from '../../../../shared/settings'
 import { getClaudeInstallSources, getNodeInstallHint } from '../../../../shared/settings'
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 
 type ClaudeInstallCardProps = {
   isInstalling: boolean
@@ -29,27 +30,32 @@ const ClaudeInstallCard = ({
   const selectedSource = installSources.find((item) => item.id === source)
   const npmMissing = source === 'npm' && !npmAvailable
 
+  // Option label with an inline "(npm not found)" hint for sources that need npm when it's missing.
+  const sourceLabel = (item: (typeof installSources)[number]): string =>
+    `${item.label}${item.requiresNpm && !npmAvailable ? ' (npm not found)' : ''}`
+
   return (
     <div className="rounded-xl border border-border p-4">
       <div className="space-y-1.5">
         <label className="text-xs font-medium text-muted-foreground" htmlFor="install-source">
           Install source
         </label>
-        <select
-          id="install-source"
-          aria-label="Install source"
+        <Select
           value={source}
           disabled={isInstalling}
-          onChange={(event) => setSource(event.target.value as ClaudeInstallSource)}
-          className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring"
+          onValueChange={(next) => setSource(next as ClaudeInstallSource)}
         >
-          {installSources.map((item) => (
-            <option key={item.id} value={item.id}>
-              {item.label}
-              {item.requiresNpm && !npmAvailable ? ' (npm not found)' : ''}
-            </option>
-          ))}
-        </select>
+          <SelectTrigger id="install-source" aria-label="Install source">
+            <span className="truncate">{selectedSource ? sourceLabel(selectedSource) : ''}</span>
+          </SelectTrigger>
+          <SelectContent>
+            {installSources.map((item) => (
+              <SelectItem key={item.id} value={item.id}>
+                {sourceLabel(item)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {selectedSource ? (

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -184,7 +184,15 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
     <Dialog.Root open={open} onOpenChange={(next) => (next ? undefined : onClose())}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex h-[min(640px,calc(100vh-2rem))] w-[min(920px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-border bg-card text-foreground shadow-dialog data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+        <Dialog.Content
+          // Don't let a click/focus outside the dialog dismiss it. A Radix Select inside the panel
+          // (provider type, active model, install source) portals its listbox outside the dialog's
+          // DOM, so an outside-click meant only to close the open dropdown would otherwise also close
+          // the whole panel. The dropdown's own dismiss still closes just the dropdown; the panel is
+          // closed intentionally via the ✕ button or Escape.
+          onInteractOutside={(event) => event.preventDefault()}
+          className="fixed left-1/2 top-1/2 z-50 flex h-[min(640px,calc(100vh-2rem))] w-[min(920px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-border bg-card text-foreground shadow-dialog data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+        >
           {/* Radix requires a Title/Description for a11y; the visible panel title lives in the header. */}
           <Dialog.Title className="sr-only">Settings</Dialog.Title>
           <Dialog.Description className="sr-only">


### PR DESCRIPTION
## Problem

Opening a dropdown inside the Settings dialog and then clicking anywhere outside the dropdown's options — **even inside the panel itself** — closed the entire Settings dialog instead of just the dropdown.

## Root cause

The Settings dialog is a Radix `Dialog`, which dismisses on any interaction outside its content. A Radix `Select` (provider type, active model, install source) portals its listbox **outside** the dialog's DOM subtree. So an outside-click meant only to close the open dropdown was also treated as an interaction outside the dialog and closed the whole panel.

This is not specific to any one dropdown — it affected every Radix `Select` in the dialog. An earlier attempt to "fix" it by only changing the install-source control did not help, which is what pointed at the dialog-level cause.

## Fix

Suppress the dialog's outside-interaction dismissal:

```tsx
<Dialog.Content onInteractOutside={(event) => event.preventDefault()} … >
```

- The dropdown's own dismiss still closes just the dropdown (return to the panel).
- The panel is closed intentionally via the close button or Escape (both still work).
- An accidental backdrop click no longer discards an in-progress settings edit — desirable for a settings panel with forms.

Also convert the install-source picker from a native `<select>` to the shared Radix `Select` used by the other settings pickers, so every dropdown in the dialog is consistent.

## Tests

- **New** `ClaudeInstallCard.render.test.tsx`: the install-source picker is a styled combobox (never a native `<select>`), shows the default source and its command, falls back to the official installer when npm is absent, and calls `onInstall` with the selected source.
- Updated the onboarding render assertions to query the combobox trigger.

The `onInteractOutside` behavior itself is verified manually (jsdom can't drive Radix's dismissable-layer pointer sequence — pointerdown + follow-up click + timers — reliably, so an automated test there would be a false guard).

## Verification

- `npm run lint` — 0 errors / 0 warnings
- `npm run typecheck` — passes
- `npm run test:coverage` — 692 tests pass, coverage gate green
- `npm run build` — passes
- Manual: open Settings → open a dropdown → click inside the panel outside the options → only the dropdown closes, panel stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
