### PR TITLE
ci: skip non-release workflows for docs-only changes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,13 @@ on:
   push:
     branches:
       - main
+    # Docs-only pushes don't change the app, so skip the 4-platform build+publish for them.
+    # workflow_dispatch below still forces a nightly regardless of what changed.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,6 +7,13 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened]
+    # Docs-only PRs don't affect lint/typecheck/test/build, so don't spend runners on them.
+    # `main` isn't branch-protected, so a skipped check can't block the merge.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 # Cancel a still-running check from the same PR when a new push arrives, to save CI minutes.
 concurrency:


### PR DESCRIPTION
## Summary

Non-release CI currently runs on every change regardless of what was touched. Recent history shows several docs-only commits (README/ROADMAP/SECURITY, spec files) that each triggered a full 4-platform nightly build and the PR quality gate — pure waste for changes that can't affect the app.

This adds a `paths-ignore` filter to the two **non-release** workflows so documentation-only changes no longer consume CI.

## Changes

- **`nightly.yml`** — docs-only pushes to `main` no longer trigger the 4-platform build + nightly publish. `workflow_dispatch` still forces a nightly manually when wanted.
- **`pr-check.yml`** — docs-only PRs no longer spend runners on lint/typecheck/test/build. `main` isn't branch-protected, so a skipped required check can't deadlock the merge.

Ignored paths: `**/*.md`, `docs/**`, `LICENSE`, `.gitignore`.

## Not changed

`release.yml` and `build.yml` are untouched — a `v*` tag always builds and packages every platform.

## Notes

- Uses `paths-ignore` (ignore docs) rather than `paths` (allowlist code) on purpose: any file not in the ignore list still triggers CI, so it fails safe. `.github/workflows/**` isn't ignored, so workflow edits still re-run.
- YAML validated by inspection; the trigger-filtering behavior is only observable on GitHub after merge.