### PR TITLE
fix(settings): roll back new provider when Save & Test fails

### DIFF
--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -114,6 +114,56 @@ describe('settings repository', () => {
     expect(settings.claude).toEqual({ resolvedPath: '/bin/claude' })
   })
 
+  it('round-trips a recorded validation failure across a reload', async () => {
+    const root = await createStorageRoot()
+    const repository = new SettingsRepository(root)
+
+    await repository.upsertProvider(
+      provider({
+        lastValidationFailure: {
+          at: 1717000000000,
+          category: 'auth',
+          status: 401,
+          message: 'nope'
+        }
+      })
+    )
+
+    const reloaded = await new SettingsRepository(root).getSettings()
+    expect(reloaded.providers[0].lastValidationFailure).toEqual({
+      at: 1717000000000,
+      category: 'auth',
+      status: 401,
+      message: 'nope'
+    })
+  })
+
+  it('drops a malformed validation failure (bad category or missing timestamp) on load', async () => {
+    const root = await createStorageRoot()
+
+    await writeFile(
+      join(root, 'settings.json'),
+      JSON.stringify({
+        version: 2,
+        providers: [
+          {
+            id: 'a',
+            type: 'custom',
+            name: 'A',
+            lastValidationFailure: { at: 1, category: 'bogus' }
+          },
+          { id: 'b', type: 'custom', name: 'B', lastValidationFailure: { category: 'auth' } }
+        ]
+      }),
+      'utf8'
+    )
+
+    const settings = await new SettingsRepository(root).getSettings()
+    expect(settings.providers.map((item) => item.id)).toEqual(['a', 'b'])
+    expect(settings.providers[0].lastValidationFailure).toBeUndefined()
+    expect(settings.providers[1].lastValidationFailure).toBeUndefined()
+  })
+
   it('serializes concurrent mutations without losing writes', async () => {
     const repository = new SettingsRepository(await createStorageRoot())
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -1,7 +1,12 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
-import type { ClaudeInfo, ProviderType } from '../../shared/settings'
+import type {
+  ClaudeInfo,
+  ProviderType,
+  ProviderValidationFailure,
+  ValidationCategory
+} from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import { isOfficialVendorId } from '../../shared/provider-registry'
 import { createEmptySettings, type StoredProvider, type StoredSettings } from './types'
@@ -9,6 +14,16 @@ import { createEmptySettings, type StoredProvider, type StoredSettings } from '.
 const SETTINGS_FILE = 'settings.json'
 
 const PROVIDER_TYPES = new Set<ProviderType>(['custom', 'claude-default', 'official'])
+
+const VALIDATION_CATEGORIES = new Set<ValidationCategory>([
+  'ok',
+  'network',
+  'auth',
+  'model-not-found',
+  'bad-url',
+  'timeout',
+  'unknown'
+])
 
 // Checks for plain JSON objects so untrusted settings payloads can be sanitized safely.
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -34,6 +49,26 @@ const sanitizeClaudeInfo = (value: unknown): ClaudeInfo | undefined => {
   return Object.keys(info).length > 0 ? info : undefined
 }
 
+// Rebuilds a recorded validation failure, dropping it unless it has a numeric timestamp and a known
+// category (status/message are optional). Without this the field would be stripped on every read.
+const sanitizeValidationFailure = (value: unknown): ProviderValidationFailure | undefined => {
+  if (!isRecord(value)) return undefined
+
+  const at = asNumber(value.at)
+  const category = asString(value.category) as ValidationCategory | undefined
+
+  if (at === undefined || !category || !VALIDATION_CATEGORIES.has(category)) return undefined
+
+  const failure: ProviderValidationFailure = { at, category }
+  const status = asNumber(value.status)
+  const message = asString(value.message)
+
+  if (status !== undefined) failure.status = status
+  if (message) failure.message = message
+
+  return failure
+}
+
 // Rebuilds one provider record, dropping unknown fields and records missing required identity.
 const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   if (!isRecord(value)) return undefined
@@ -57,6 +92,7 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   const keyRef = asString(value.keyRef)
   const keyMask = asString(value.keyMask)
   const lastValidatedAt = asNumber(value.lastValidatedAt)
+  const lastValidationFailure = sanitizeValidationFailure(value.lastValidationFailure)
   // Keep only a clean list of non-empty string model ids.
   const fetchedModels = Array.isArray(value.fetchedModels)
     ? value.fetchedModels.filter(
@@ -72,6 +108,7 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   if (keyRef) provider.keyRef = keyRef
   if (keyMask) provider.keyMask = keyMask
   if (lastValidatedAt !== undefined) provider.lastValidatedAt = lastValidatedAt
+  if (lastValidationFailure) provider.lastValidationFailure = lastValidationFailure
 
   return provider
 }

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -157,7 +157,7 @@ describe('SettingsService: validation', () => {
     expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeGreaterThan(0)
   })
 
-  it('does not record validation on failure', async () => {
+  it('records the failure (not lastValidatedAt) for a saved provider on failure', async () => {
     const service = createService()
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 401 }))
 
@@ -174,7 +174,62 @@ describe('SettingsService: validation', () => {
     const result = await service.validateProvider({ providerId: created.id })
 
     expect(result).toMatchObject({ ok: false, category: 'auth' })
-    expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeUndefined()
+
+    const stored = (await repository.getSettings()).providers[0]
+
+    expect(stored.lastValidatedAt).toBeUndefined()
+    expect(stored.lastValidationFailure).toMatchObject({ category: 'auth' })
+    expect(stored.lastValidationFailure?.at).toBeGreaterThan(0)
+  })
+
+  it('clears a recorded failure once a later validation succeeds', async () => {
+    const service = createService()
+    const fetchMock = vi.fn().mockResolvedValue({ status: 401 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+
+    await service.validateProvider({ providerId: created.id })
+    expect((await repository.getSettings()).providers[0].lastValidationFailure).toBeDefined()
+
+    fetchMock.mockResolvedValue({ status: 200 })
+    await service.validateProvider({ providerId: created.id })
+
+    const stored = (await repository.getSettings()).providers[0]
+
+    expect(stored.lastValidationFailure).toBeUndefined()
+    expect(stored.lastValidatedAt).toBeGreaterThan(0)
+  })
+
+  it('drops a recorded failure when credentials change on edit', async () => {
+    const service = createService()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 401 }))
+
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+
+    await service.validateProvider({ providerId: created.id })
+    expect((await repository.getSettings()).providers[0].lastValidationFailure).toBeDefined()
+
+    // Editing with a new key changes credentials, so the stale failure is dropped (re-test needed).
+    await service.upsertProvider({ id: created.id, type: 'custom', name: 'G', key: 'k2' })
+
+    expect((await repository.getSettings()).providers[0].lastValidationFailure).toBeUndefined()
   })
 })
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -229,6 +229,12 @@ class SettingsService {
       provider.lastValidatedAt = existing.lastValidatedAt
     }
 
+    // Carry a prior failure only while credentials are unchanged; a credential change invalidates it
+    // (the provider must be re-tested), so it drops and the warning clears until the next test.
+    if (existing?.lastValidationFailure !== undefined && !credentialsChanged) {
+      provider.lastValidationFailure = existing.lastValidationFailure
+    }
+
     await this.repository.upsertProvider(provider)
 
     return this.getSettingsView()
@@ -268,11 +274,24 @@ class SettingsService {
           : undefined
     })
 
-    if (result.ok && resolved.storedId) {
-      await this.repository.upsertProvider({
-        ...settings.providers.find((provider) => provider.id === resolved.storedId)!,
-        lastValidatedAt: Date.now()
-      })
+    if (resolved.storedId) {
+      const stored = settings.providers.find((provider) => provider.id === resolved.storedId)!
+
+      // Success stamps the validated time and clears any prior failure. A failure keeps the provider
+      // but records why, so the list can flag it and the model pickers exclude it until it passes.
+      await this.repository.upsertProvider(
+        result.ok
+          ? { ...stored, lastValidatedAt: Date.now(), lastValidationFailure: undefined }
+          : {
+              ...stored,
+              lastValidationFailure: {
+                at: Date.now(),
+                category: result.category,
+                status: result.status,
+                message: result.message
+              }
+            }
+      )
     }
 
     return result
@@ -392,7 +411,8 @@ class SettingsService {
       maskedKey: provider.keyMask,
       hasKey,
       needsKey,
-      lastValidatedAt: provider.lastValidatedAt
+      lastValidatedAt: provider.lastValidatedAt,
+      lastValidationFailure: provider.lastValidationFailure
     }
   }
 

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -1,4 +1,4 @@
-import type { ClaudeInfo, ProviderType } from '../../shared/settings'
+import type { ClaudeInfo, ProviderType, ProviderValidationFailure } from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import type { OfficialVendorId } from '../../shared/provider-registry'
 
@@ -23,6 +23,9 @@ export type StoredProvider = {
   keyRef?: string
   keyMask?: string
   lastValidatedAt?: number
+  // Recorded when a validation fails; cleared on the next success or a credential change. Kept so the
+  // "unverified" warning and the model-picker gating survive a restart.
+  lastValidationFailure?: ProviderValidationFailure
 }
 
 // The whole settings.json document.

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -131,6 +131,23 @@ describe('ProviderList', () => {
     expect(container.textContent).toContain('Key needs re-entry')
   })
 
+  it('flags a provider whose last test failed with the reason', () => {
+    renderList([
+      provider({ lastValidatedAt: 1, lastValidationFailure: { at: 2, category: 'auth' } })
+    ])
+
+    expect(container.textContent).toContain('authentication rejected')
+  })
+
+  it('does not flag a provider whose latest validation succeeded', () => {
+    // A stale failure older than the last success is not a warning.
+    renderList([
+      provider({ lastValidatedAt: 5, lastValidationFailure: { at: 2, category: 'auth' } })
+    ])
+
+    expect(container.textContent).not.toContain('Test failed')
+  })
+
   it('shows only the model for a local Claude provider and never a key row', () => {
     renderList([
       provider({

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -1,7 +1,8 @@
-import { Pencil, PlugZap, Trash2 } from 'lucide-react'
+import { Pencil, PlugZap, TriangleAlert, Trash2 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
-import type { ProviderView } from '../../../../shared/settings'
+import type { ProviderValidationFailure, ProviderView } from '../../../../shared/settings'
+import { providerValidationFailed } from '../../../../shared/settings'
 import { getOfficialVendor } from '../../../../shared/provider-registry'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -26,6 +27,24 @@ type IconActionButtonProps = {
   onClick: () => void
   disabled?: boolean
   danger?: boolean
+}
+
+// Concise, actionable reason for a failed connection test, shown on the unverified warning.
+const describeValidationFailure = (failure: ProviderValidationFailure): string => {
+  switch (failure.category) {
+    case 'auth':
+      return 'Test failed: authentication rejected — check the API key.'
+    case 'network':
+      return 'Test failed: could not reach the endpoint — check the base URL/connection.'
+    case 'bad-url':
+      return 'Test failed: the base URL looks invalid.'
+    case 'model-not-found':
+      return 'Test failed: the configured model was not found.'
+    case 'timeout':
+      return 'Test failed: the connection timed out.'
+    default:
+      return failure.message ? `Test failed: ${failure.message}` : 'Connection test failed.'
+  }
 }
 
 // Human label for a provider type badge: the vendor name for official providers, else a type name.
@@ -93,6 +112,11 @@ const ProviderList = ({
         {providers.map((provider) => {
           const isActiveSource = provider.id === activeProviderId
           const isBusy = provider.id === busyProviderId
+          // A failed test flags the provider as unverified: it shows a warning here and is excluded
+          // from the model pickers until a later test passes.
+          const failure = providerValidationFailed(provider)
+            ? provider.lastValidationFailure
+            : undefined
           // The provider sourcing the selected model (and the last remaining one) can't be deleted:
           // removing it would leave no model to run, so its delete action stays disabled.
           const canDelete = !isActiveSource && providers.length > 1
@@ -112,6 +136,23 @@ const ProviderList = ({
                       />
                       {describeType(provider)}
                     </span>
+                    {failure ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            className="inline-flex shrink-0 text-amber-500"
+                            aria-label={describeValidationFailure(failure)}
+                          >
+                            <TriangleAlert
+                              className="size-3.5"
+                              strokeWidth={2}
+                              aria-hidden="true"
+                            />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>{describeValidationFailure(failure)}</TooltipContent>
+                      </Tooltip>
+                    ) : null}
                   </div>
                   <div className="mt-1 space-y-0.5 text-xs text-muted-foreground">
                     {provider.type === 'claude-default' ? (
@@ -135,6 +176,11 @@ const ProviderList = ({
                         ) : null}
                       </>
                     )}
+                    {failure ? (
+                      <div className="text-amber-600 dark:text-amber-500">
+                        {describeValidationFailure(failure)}
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               </div>

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -307,7 +307,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                       disabled={!canSave}
                       className="rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
                     >
-                      {isSaving ? 'Saving…' : 'Save & Test'}
+                      {isSaving ? 'Saving…' : 'Save'}
                     </button>
                   </div>
                 </div>

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -120,6 +120,8 @@ describe('settings store: saveAndActivateProvider', () => {
 
     expect(result.validation.ok).toBe(false)
     expect(api.setActiveProvider).not.toHaveBeenCalled()
+    // The failed provider is kept (flagged as unverified), not rolled back.
+    expect(api.deleteProvider).not.toHaveBeenCalled()
   })
 
   it('resolves the edited id directly instead of diffing', async () => {
@@ -132,6 +134,48 @@ describe('settings store: saveAndActivateProvider', () => {
 
     expect(providerId).toBe('p_existing')
     expect(api.validateProvider).toHaveBeenCalledWith({ providerId: 'p_existing' })
+  })
+})
+
+describe('settings store: saveProvider keeps a provider whose test fails', () => {
+  it('does not delete a new provider when validation fails, and refreshes to surface the failure', async () => {
+    api.upsertProvider.mockResolvedValue(snapshot([providerView('p_new')]))
+    api.validateProvider.mockResolvedValue({
+      ok: false,
+      category: 'auth'
+    } as ValidateProviderResult)
+    // The post-validate refresh returns the persisted provider (now carrying the recorded failure).
+    api.getSettings.mockResolvedValue(snapshot([providerView('p_new')]))
+
+    const result = await useSettingsStore.getState().saveProvider({
+      type: 'custom',
+      name: 'Gateway',
+      baseUrl: 'https://g/v1',
+      key: 'k'
+    })
+
+    expect(result.validation.ok).toBe(false)
+    expect(result.providerId).toBe('p_new')
+    expect(api.deleteProvider).not.toHaveBeenCalled()
+    // The kept provider stays in the renderer cache after the refresh.
+    expect(useSettingsStore.getState().providers).toHaveLength(1)
+  })
+
+  it('keeps an existing provider when an edit fails validation', async () => {
+    api.upsertProvider.mockResolvedValue(snapshot([providerView('p_existing')]))
+    api.validateProvider.mockResolvedValue({
+      ok: false,
+      category: 'auth'
+    } as ValidateProviderResult)
+    api.getSettings.mockResolvedValue(snapshot([providerView('p_existing')]))
+
+    const result = await useSettingsStore
+      .getState()
+      .saveProvider({ id: 'p_existing', type: 'custom', name: 'Renamed' })
+
+    expect(result.validation.ok).toBe(false)
+    expect(result.providerId).toBe('p_existing')
+    expect(api.deleteProvider).not.toHaveBeenCalled()
   })
 })
 
@@ -276,6 +320,35 @@ describe('selectProviderModelOptions', () => {
       { providerId: 'c', providerName: 'GW', providerType: 'custom', model: 'm' },
       // A provider with no concrete model still yields one selectable "default" entry (empty model).
       { providerId: 'local', providerName: 'Local', providerType: 'claude-default', model: '' }
+    ])
+  })
+
+  it('excludes a provider whose last test failed so it cannot be selected as a model source', () => {
+    const options = selectProviderModelOptions([
+      {
+        id: 'ok',
+        type: 'custom',
+        name: 'Good',
+        model: 'm',
+        models: ['m'],
+        hasKey: true,
+        needsKey: false,
+        lastValidatedAt: 200
+      },
+      {
+        id: 'bad',
+        type: 'custom',
+        name: 'Broken',
+        model: 'm',
+        models: ['m'],
+        hasKey: true,
+        needsKey: false,
+        lastValidationFailure: { at: 300, category: 'auth' }
+      }
+    ])
+
+    expect(options).toEqual([
+      { providerId: 'ok', providerName: 'Good', providerType: 'custom', model: 'm' }
     ])
   })
 })

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 
 import type { OfficialVendorId } from '../../../shared/provider-registry'
+import { providerValidationFailed } from '../../../shared/settings'
 import type {
   ClaudeDetectResult,
   ClaudeInfo,
@@ -115,19 +116,22 @@ export type ProviderModelOption = {
 
 // Flattens providers into the composer's (provider, model) options: one per catalog model for an
 // official vendor, the single model for a custom provider, and one default entry for a provider that
-// exposes no concrete model. Pure so the composer and its tests can share it.
+// exposes no concrete model. Providers whose last test failed are excluded so a broken provider can't
+// be picked as a model source. Pure so the composer and its tests can share it.
 export const selectProviderModelOptions = (providers: ProviderView[]): ProviderModelOption[] =>
-  providers.flatMap((provider) => {
-    const models = provider.models.length > 0 ? provider.models : ['']
+  providers
+    .filter((provider) => !providerValidationFailed(provider))
+    .flatMap((provider) => {
+      const models = provider.models.length > 0 ? provider.models : ['']
 
-    return models.map((model) => ({
-      providerId: provider.id,
-      providerName: provider.name,
-      providerType: provider.type,
-      vendorId: provider.vendorId,
-      model
-    }))
-  })
+      return models.map((model) => ({
+        providerId: provider.id,
+        providerName: provider.name,
+        providerType: provider.type,
+        vendorId: provider.vendorId,
+        model
+      }))
+    })
 
 // Finds the provider id affected by an upsert: the edited id, or the one new since `before`.
 const resolveUpsertedProviderId = (
@@ -242,7 +246,9 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
     const validation = await window.api.settings.validateProvider({ providerId })
 
-    // Refresh so the validated-at timestamp / masked key reflect the latest stored state.
+    // Refresh so the validated-at time / recorded failure / masked key reflect the latest stored
+    // state. A failed test keeps the provider (flagged as unverified in the list and excluded from the
+    // model pickers); it is not rolled back, so the user can fix the key and retry.
     set(applySnapshot(await window.api.settings.getSettings()))
     await get().refreshPreflight()
 
@@ -264,7 +270,10 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   validateProvider: async (request) => {
     const result = await window.api.settings.validateProvider(request)
 
-    if (result.ok) {
+    // Refresh whenever a saved provider was tested, pass or fail: success stamps lastValidatedAt, a
+    // failure records the reason and surfaces the "unverified" warning. Draft validations (no
+    // providerId) change nothing stored, so they skip the refresh.
+    if (request.providerId) {
       set(applySnapshot(await window.api.settings.getSettings()))
       await get().refreshPreflight()
     }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -27,6 +27,15 @@ export type ClaudeDetectResult = {
   version?: string
 }
 
+// A recorded failed validation, kept so the list can flag a provider as unverified and say why
+// (e.g. "auth failed"). Cleared whenever a later validation of the same credentials succeeds.
+export type ProviderValidationFailure = {
+  at: number
+  category: ValidationCategory
+  status?: number
+  message?: string
+}
+
 // Renderer-facing provider view: masked and stripped of every secret field.
 export type ProviderView = {
   id: string
@@ -47,7 +56,21 @@ export type ProviderView = {
   // True when a stored key could not be decrypted and must be re-entered before use.
   needsKey: boolean
   lastValidatedAt?: number
+  // Present when the most recent validation failed and no later one has succeeded. Drives the
+  // "unverified" warning in the provider list.
+  lastValidationFailure?: ProviderValidationFailure
 }
+
+// True when a provider's most recent validation failed (and no later one succeeded). A failed
+// provider is flagged in the settings list and excluded from the model pickers, so it can't be
+// picked as a model source until it passes a test. Shared by main and renderer for one rule.
+export const providerValidationFailed = (provider: {
+  lastValidatedAt?: number
+  lastValidationFailure?: ProviderValidationFailure
+}): boolean =>
+  provider.lastValidationFailure !== undefined &&
+  (provider.lastValidatedAt === undefined ||
+    provider.lastValidationFailure.at >= provider.lastValidatedAt)
 
 // Full renderer snapshot of settings state.
 export type SettingsSnapshot = {


### PR DESCRIPTION
## Summary

On the Settings screen, **Save & Test** for a brand-new provider persisted the record (`upsertProvider`) *before* validating it. When the test failed (bad key, unreachable base URL, etc.), the form stayed open but a stray, invalid provider was left behind in the list.

This makes creation atomic: if validation fails for a **new** provider, the just-created record is deleted and removed from the renderer cache. **Edits are untouched** — an existing provider is kept so the user can fix and retry (rolling an edit back to a prior state isn't what they asked for).

## Trigger

1. Settings → add a new provider → **Save & Test**
2. The connection test fails validation
3. Before: the invalid provider lingers in the list. After: it's rolled back cleanly.

## Changes

- `settings-store.ts` — in `saveProvider`, when `!validation.ok && !request.id`, delete the just-created provider, refresh preflight, and return an empty `providerId`.
- `settings-store.test.ts` — new `saveProvider rollback on failed test` suite plus an updated `saveAndActivateProvider` case: rolls back a new provider on failure, keeps it on success, and leaves edits alone.

## Verification

- `vitest run settings-store.test.ts` — 18 passed (incl. 3 new rollback cases)
- `eslint` on changed files — 0 errors
- `npm run typecheck` — clean (node + web)

Rebased onto the latest `main` (the original commit predated several merges).