### PR TITLE
fix(settings): flag providers that fail their test instead of deleting them

### DIFF
--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -114,6 +114,56 @@ describe('settings repository', () => {
     expect(settings.claude).toEqual({ resolvedPath: '/bin/claude' })
   })
 
+  it('round-trips a recorded validation failure across a reload', async () => {
+    const root = await createStorageRoot()
+    const repository = new SettingsRepository(root)
+
+    await repository.upsertProvider(
+      provider({
+        lastValidationFailure: {
+          at: 1717000000000,
+          category: 'auth',
+          status: 401,
+          message: 'nope'
+        }
+      })
+    )
+
+    const reloaded = await new SettingsRepository(root).getSettings()
+    expect(reloaded.providers[0].lastValidationFailure).toEqual({
+      at: 1717000000000,
+      category: 'auth',
+      status: 401,
+      message: 'nope'
+    })
+  })
+
+  it('drops a malformed validation failure (bad category or missing timestamp) on load', async () => {
+    const root = await createStorageRoot()
+
+    await writeFile(
+      join(root, 'settings.json'),
+      JSON.stringify({
+        version: 2,
+        providers: [
+          {
+            id: 'a',
+            type: 'custom',
+            name: 'A',
+            lastValidationFailure: { at: 1, category: 'bogus' }
+          },
+          { id: 'b', type: 'custom', name: 'B', lastValidationFailure: { category: 'auth' } }
+        ]
+      }),
+      'utf8'
+    )
+
+    const settings = await new SettingsRepository(root).getSettings()
+    expect(settings.providers.map((item) => item.id)).toEqual(['a', 'b'])
+    expect(settings.providers[0].lastValidationFailure).toBeUndefined()
+    expect(settings.providers[1].lastValidationFailure).toBeUndefined()
+  })
+
   it('serializes concurrent mutations without losing writes', async () => {
     const repository = new SettingsRepository(await createStorageRoot())
 

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -67,6 +67,21 @@ describe('settings repository', () => {
     expect(settings.providers[0].name).toBe('Renamed')
   })
 
+  it('keeps provider order stable when an existing provider is updated in place', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+
+    await repository.upsertProvider(provider({ id: 'p1', name: 'One' }))
+    await repository.upsertProvider(provider({ id: 'p2', name: 'Two' }))
+    await repository.upsertProvider(provider({ id: 'p3', name: 'Three' }))
+
+    // Editing p1 (or recording a test result on it) must not move it to the end of the list.
+    await repository.upsertProvider(provider({ id: 'p1', name: 'One (edited)' }))
+
+    const settings = await repository.getSettings()
+    expect(settings.providers.map((item) => item.id)).toEqual(['p1', 'p2', 'p3'])
+    expect(settings.providers[0].name).toBe('One (edited)')
+  })
+
   it('clears the active pointer when the active provider is deleted', async () => {
     const repository = new SettingsRepository(await createStorageRoot())
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -175,12 +175,16 @@ class SettingsRepository {
     }
   }
 
-  // Inserts or replaces a provider by id, then returns the persisted document.
+  // Inserts or replaces a provider by id, then returns the persisted document. An existing provider is
+  // replaced in place so the list keeps its creation order (editing or re-testing must not reorder it);
+  // a new provider is appended.
   async upsertProvider(provider: StoredProvider): Promise<StoredSettings> {
     return this.mutate((settings) => {
-      const providers = settings.providers.filter((existing) => existing.id !== provider.id)
+      const index = settings.providers.findIndex((existing) => existing.id === provider.id)
+      const providers = [...settings.providers]
 
-      providers.push(provider)
+      if (index >= 0) providers[index] = provider
+      else providers.push(provider)
 
       return { ...settings, providers }
     })

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -1,7 +1,12 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
-import type { ClaudeInfo, ProviderType } from '../../shared/settings'
+import type {
+  ClaudeInfo,
+  ProviderType,
+  ProviderValidationFailure,
+  ValidationCategory
+} from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import { isOfficialVendorId } from '../../shared/provider-registry'
 import { createEmptySettings, type StoredProvider, type StoredSettings } from './types'
@@ -9,6 +14,16 @@ import { createEmptySettings, type StoredProvider, type StoredSettings } from '.
 const SETTINGS_FILE = 'settings.json'
 
 const PROVIDER_TYPES = new Set<ProviderType>(['custom', 'claude-default', 'official'])
+
+const VALIDATION_CATEGORIES = new Set<ValidationCategory>([
+  'ok',
+  'network',
+  'auth',
+  'model-not-found',
+  'bad-url',
+  'timeout',
+  'unknown'
+])
 
 // Checks for plain JSON objects so untrusted settings payloads can be sanitized safely.
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -34,6 +49,26 @@ const sanitizeClaudeInfo = (value: unknown): ClaudeInfo | undefined => {
   return Object.keys(info).length > 0 ? info : undefined
 }
 
+// Rebuilds a recorded validation failure, dropping it unless it has a numeric timestamp and a known
+// category (status/message are optional). Without this the field would be stripped on every read.
+const sanitizeValidationFailure = (value: unknown): ProviderValidationFailure | undefined => {
+  if (!isRecord(value)) return undefined
+
+  const at = asNumber(value.at)
+  const category = asString(value.category) as ValidationCategory | undefined
+
+  if (at === undefined || !category || !VALIDATION_CATEGORIES.has(category)) return undefined
+
+  const failure: ProviderValidationFailure = { at, category }
+  const status = asNumber(value.status)
+  const message = asString(value.message)
+
+  if (status !== undefined) failure.status = status
+  if (message) failure.message = message
+
+  return failure
+}
+
 // Rebuilds one provider record, dropping unknown fields and records missing required identity.
 const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   if (!isRecord(value)) return undefined
@@ -57,6 +92,7 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   const keyRef = asString(value.keyRef)
   const keyMask = asString(value.keyMask)
   const lastValidatedAt = asNumber(value.lastValidatedAt)
+  const lastValidationFailure = sanitizeValidationFailure(value.lastValidationFailure)
   // Keep only a clean list of non-empty string model ids.
   const fetchedModels = Array.isArray(value.fetchedModels)
     ? value.fetchedModels.filter(
@@ -72,6 +108,7 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   if (keyRef) provider.keyRef = keyRef
   if (keyMask) provider.keyMask = keyMask
   if (lastValidatedAt !== undefined) provider.lastValidatedAt = lastValidatedAt
+  if (lastValidationFailure) provider.lastValidationFailure = lastValidationFailure
 
   return provider
 }

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -157,7 +157,7 @@ describe('SettingsService: validation', () => {
     expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeGreaterThan(0)
   })
 
-  it('does not record validation on failure', async () => {
+  it('records the failure (not lastValidatedAt) for a saved provider on failure', async () => {
     const service = createService()
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 401 }))
 
@@ -174,7 +174,62 @@ describe('SettingsService: validation', () => {
     const result = await service.validateProvider({ providerId: created.id })
 
     expect(result).toMatchObject({ ok: false, category: 'auth' })
-    expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeUndefined()
+
+    const stored = (await repository.getSettings()).providers[0]
+
+    expect(stored.lastValidatedAt).toBeUndefined()
+    expect(stored.lastValidationFailure).toMatchObject({ category: 'auth' })
+    expect(stored.lastValidationFailure?.at).toBeGreaterThan(0)
+  })
+
+  it('clears a recorded failure once a later validation succeeds', async () => {
+    const service = createService()
+    const fetchMock = vi.fn().mockResolvedValue({ status: 401 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+
+    await service.validateProvider({ providerId: created.id })
+    expect((await repository.getSettings()).providers[0].lastValidationFailure).toBeDefined()
+
+    fetchMock.mockResolvedValue({ status: 200 })
+    await service.validateProvider({ providerId: created.id })
+
+    const stored = (await repository.getSettings()).providers[0]
+
+    expect(stored.lastValidationFailure).toBeUndefined()
+    expect(stored.lastValidatedAt).toBeGreaterThan(0)
+  })
+
+  it('drops a recorded failure when credentials change on edit', async () => {
+    const service = createService()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 401 }))
+
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+
+    await service.validateProvider({ providerId: created.id })
+    expect((await repository.getSettings()).providers[0].lastValidationFailure).toBeDefined()
+
+    // Editing with a new key changes credentials, so the stale failure is dropped (re-test needed).
+    await service.upsertProvider({ id: created.id, type: 'custom', name: 'G', key: 'k2' })
+
+    expect((await repository.getSettings()).providers[0].lastValidationFailure).toBeUndefined()
   })
 })
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -229,6 +229,12 @@ class SettingsService {
       provider.lastValidatedAt = existing.lastValidatedAt
     }
 
+    // Carry a prior failure only while credentials are unchanged; a credential change invalidates it
+    // (the provider must be re-tested), so it drops and the warning clears until the next test.
+    if (existing?.lastValidationFailure !== undefined && !credentialsChanged) {
+      provider.lastValidationFailure = existing.lastValidationFailure
+    }
+
     await this.repository.upsertProvider(provider)
 
     return this.getSettingsView()
@@ -268,11 +274,24 @@ class SettingsService {
           : undefined
     })
 
-    if (result.ok && resolved.storedId) {
-      await this.repository.upsertProvider({
-        ...settings.providers.find((provider) => provider.id === resolved.storedId)!,
-        lastValidatedAt: Date.now()
-      })
+    if (resolved.storedId) {
+      const stored = settings.providers.find((provider) => provider.id === resolved.storedId)!
+
+      // Success stamps the validated time and clears any prior failure. A failure keeps the provider
+      // but records why, so the list can flag it and the model pickers exclude it until it passes.
+      await this.repository.upsertProvider(
+        result.ok
+          ? { ...stored, lastValidatedAt: Date.now(), lastValidationFailure: undefined }
+          : {
+              ...stored,
+              lastValidationFailure: {
+                at: Date.now(),
+                category: result.category,
+                status: result.status,
+                message: result.message
+              }
+            }
+      )
     }
 
     return result
@@ -392,7 +411,8 @@ class SettingsService {
       maskedKey: provider.keyMask,
       hasKey,
       needsKey,
-      lastValidatedAt: provider.lastValidatedAt
+      lastValidatedAt: provider.lastValidatedAt,
+      lastValidationFailure: provider.lastValidationFailure
     }
   }
 

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -1,4 +1,4 @@
-import type { ClaudeInfo, ProviderType } from '../../shared/settings'
+import type { ClaudeInfo, ProviderType, ProviderValidationFailure } from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import type { OfficialVendorId } from '../../shared/provider-registry'
 
@@ -23,6 +23,9 @@ export type StoredProvider = {
   keyRef?: string
   keyMask?: string
   lastValidatedAt?: number
+  // Recorded when a validation fails; cleared on the next success or a credential change. Kept so the
+  // "unverified" warning and the model-picker gating survive a restart.
+  lastValidationFailure?: ProviderValidationFailure
 }
 
 // The whole settings.json document.

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -131,6 +131,23 @@ describe('ProviderList', () => {
     expect(container.textContent).toContain('Key needs re-entry')
   })
 
+  it('flags a provider whose last test failed with the reason', () => {
+    renderList([
+      provider({ lastValidatedAt: 1, lastValidationFailure: { at: 2, category: 'auth' } })
+    ])
+
+    expect(container.textContent).toContain('authentication rejected')
+  })
+
+  it('does not flag a provider whose latest validation succeeded', () => {
+    // A stale failure older than the last success is not a warning.
+    renderList([
+      provider({ lastValidatedAt: 5, lastValidationFailure: { at: 2, category: 'auth' } })
+    ])
+
+    expect(container.textContent).not.toContain('Test failed')
+  })
+
   it('shows only the model for a local Claude provider and never a key row', () => {
     renderList([
       provider({

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -36,12 +36,13 @@ const provider = (overrides: Partial<ProviderView> = {}): ProviderView => ({
 
 const noop = vi.fn()
 
-const renderList = (providers: ProviderView[], activeId?: string): void => {
+const renderList = (providers: ProviderView[], activeId?: string, busyId?: string): void => {
   act(() => {
     root.render(
       <ProviderList
         providers={providers}
         activeProviderId={activeId}
+        busyProviderId={busyId}
         onEdit={noop}
         onDelete={noop}
         onTest={noop}
@@ -146,6 +147,20 @@ describe('ProviderList', () => {
     ])
 
     expect(container.textContent).not.toContain('Test failed')
+  })
+
+  it('marks a provider whose test passed with a verified check', () => {
+    renderList([provider({ lastValidatedAt: 5 })])
+
+    expect(container.querySelector('[aria-label="Connection verified"]')).not.toBeNull()
+    expect(container.textContent).not.toContain('Test failed')
+  })
+
+  it('shows a testing state (and no check/warning) while a provider is being validated', () => {
+    renderList([provider({ id: 'p1', lastValidatedAt: 5 })], undefined, 'p1')
+
+    expect(container.textContent).toContain('Testing…')
+    expect(container.querySelector('[aria-label="Connection verified"]')).toBeNull()
   })
 
   it('shows only the model for a local Claude provider and never a key row', () => {

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -1,4 +1,4 @@
-import { Pencil, PlugZap, TriangleAlert, Trash2 } from 'lucide-react'
+import { CircleCheck, Pencil, PlugZap, TriangleAlert, Trash2 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 import type { ProviderValidationFailure, ProviderView } from '../../../../shared/settings'
@@ -117,6 +117,8 @@ const ProviderList = ({
           const failure = providerValidationFailed(provider)
             ? provider.lastValidationFailure
             : undefined
+          // A passing test shows a green check. Suppressed while a test is in flight.
+          const isVerified = !failure && !isBusy && provider.lastValidatedAt !== undefined
           // The provider sourcing the selected model (and the last remaining one) can't be deleted:
           // removing it would leave no model to run, so its delete action stays disabled.
           const canDelete = !isActiveSource && providers.length > 1
@@ -136,7 +138,9 @@ const ProviderList = ({
                       />
                       {describeType(provider)}
                     </span>
-                    {failure ? (
+                    {isBusy ? (
+                      <span className="shrink-0 text-[10px] text-muted-foreground">Testing…</span>
+                    ) : failure ? (
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span
@@ -151,6 +155,18 @@ const ProviderList = ({
                           </span>
                         </TooltipTrigger>
                         <TooltipContent>{describeValidationFailure(failure)}</TooltipContent>
+                      </Tooltip>
+                    ) : isVerified ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            className="inline-flex shrink-0 text-emerald-500"
+                            aria-label="Connection verified"
+                          >
+                            <CircleCheck className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>Connection verified</TooltipContent>
                       </Tooltip>
                     ) : null}
                   </div>

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -1,7 +1,8 @@
-import { Pencil, PlugZap, Trash2 } from 'lucide-react'
+import { Pencil, PlugZap, TriangleAlert, Trash2 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
-import type { ProviderView } from '../../../../shared/settings'
+import type { ProviderValidationFailure, ProviderView } from '../../../../shared/settings'
+import { providerValidationFailed } from '../../../../shared/settings'
 import { getOfficialVendor } from '../../../../shared/provider-registry'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -26,6 +27,24 @@ type IconActionButtonProps = {
   onClick: () => void
   disabled?: boolean
   danger?: boolean
+}
+
+// Concise, actionable reason for a failed connection test, shown on the unverified warning.
+const describeValidationFailure = (failure: ProviderValidationFailure): string => {
+  switch (failure.category) {
+    case 'auth':
+      return 'Test failed: authentication rejected — check the API key.'
+    case 'network':
+      return 'Test failed: could not reach the endpoint — check the base URL/connection.'
+    case 'bad-url':
+      return 'Test failed: the base URL looks invalid.'
+    case 'model-not-found':
+      return 'Test failed: the configured model was not found.'
+    case 'timeout':
+      return 'Test failed: the connection timed out.'
+    default:
+      return failure.message ? `Test failed: ${failure.message}` : 'Connection test failed.'
+  }
 }
 
 // Human label for a provider type badge: the vendor name for official providers, else a type name.
@@ -93,6 +112,11 @@ const ProviderList = ({
         {providers.map((provider) => {
           const isActiveSource = provider.id === activeProviderId
           const isBusy = provider.id === busyProviderId
+          // A failed test flags the provider as unverified: it shows a warning here and is excluded
+          // from the model pickers until a later test passes.
+          const failure = providerValidationFailed(provider)
+            ? provider.lastValidationFailure
+            : undefined
           // The provider sourcing the selected model (and the last remaining one) can't be deleted:
           // removing it would leave no model to run, so its delete action stays disabled.
           const canDelete = !isActiveSource && providers.length > 1
@@ -112,6 +136,23 @@ const ProviderList = ({
                       />
                       {describeType(provider)}
                     </span>
+                    {failure ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            className="inline-flex shrink-0 text-amber-500"
+                            aria-label={describeValidationFailure(failure)}
+                          >
+                            <TriangleAlert
+                              className="size-3.5"
+                              strokeWidth={2}
+                              aria-hidden="true"
+                            />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>{describeValidationFailure(failure)}</TooltipContent>
+                      </Tooltip>
+                    ) : null}
                   </div>
                   <div className="mt-1 space-y-0.5 text-xs text-muted-foreground">
                     {provider.type === 'claude-default' ? (
@@ -135,6 +176,11 @@ const ProviderList = ({
                         ) : null}
                       </>
                     )}
+                    {failure ? (
+                      <div className="text-amber-600 dark:text-amber-500">
+                        {describeValidationFailure(failure)}
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               </div>

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -307,7 +307,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                       disabled={!canSave}
                       className="rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
                     >
-                      {isSaving ? 'Saving…' : 'Save & Test'}
+                      {isSaving ? 'Saving…' : 'Save'}
                     </button>
                   </div>
                 </div>

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -17,7 +17,6 @@ import {
   type ProviderFormValue
 } from './provider-form-value'
 import { ProviderList } from './ProviderList'
-import { describeValidation } from './validation-message'
 
 type SettingsPageProps = {
   open: boolean
@@ -78,7 +77,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const load = useSettingsStore((state) => state.load)
   const detectClaude = useSettingsStore((state) => state.detectClaude)
   const installClaude = useSettingsStore((state) => state.installClaude)
-  const saveProvider = useSettingsStore((state) => state.saveProvider)
+  const persistProvider = useSettingsStore((state) => state.persistProvider)
   const deleteProvider = useSettingsStore((state) => state.deleteProvider)
   const validateProvider = useSettingsStore((state) => state.validateProvider)
   const refreshProviderModels = useSettingsStore((state) => state.refreshProviderModels)
@@ -132,12 +131,17 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
     setStatusMessage(undefined)
 
     try {
-      const { validation } = await saveProvider(toUpsertRequest(formValue, editingProvider?.id))
+      // Persist first and return to the provider list immediately — don't hold the form open waiting
+      // for the connection test. The test then runs in the background and its result (green check or
+      // warning) lands on the provider's card.
+      const providerId = await persistProvider(toUpsertRequest(formValue, editingProvider?.id))
 
-      setStatusOk(validation.ok)
-      setStatusMessage(describeValidation(validation))
+      setFormTarget(null)
 
-      if (validation.ok) setFormTarget(null)
+      if (providerId) {
+        setBusyProviderId(providerId)
+        void validateProvider({ providerId }).finally(() => setBusyProviderId(undefined))
+      }
     } catch (error) {
       setStatusOk(false)
       setStatusMessage(error instanceof Error ? error.message : 'Could not save provider.')
@@ -168,13 +172,11 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
 
   const handleTest = async (provider: ProviderView): Promise<void> => {
     setBusyProviderId(provider.id)
-    setStatusMessage(undefined)
 
     try {
-      const validation = await validateProvider({ providerId: provider.id })
-
-      setStatusOk(validation.ok)
-      setStatusMessage(`${provider.name}: ${describeValidation(validation)}`)
+      // The pass/fail result is reflected on the provider's card (green check or warning), not as a
+      // separate status line.
+      await validateProvider({ providerId: provider.id })
     } finally {
       setBusyProviderId(undefined)
     }
@@ -354,14 +356,6 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                       </div>
                     ) : null}
 
-                    {statusMessage ? (
-                      <p
-                        className={`mb-3 text-sm ${statusOk ? 'text-primary' : 'text-destructive'}`}
-                        role="alert"
-                      >
-                        {statusMessage}
-                      </p>
-                    ) : null}
                     <ProviderList
                       providers={providers}
                       activeProviderId={activeProviderId}

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -137,6 +137,24 @@ describe('settings store: saveAndActivateProvider', () => {
   })
 })
 
+describe('settings store: persistProvider', () => {
+  it('persists a new provider and returns its id without testing it', async () => {
+    api.upsertProvider.mockResolvedValue(snapshot([providerView('p_new')]))
+
+    const providerId = await useSettingsStore.getState().persistProvider({
+      type: 'custom',
+      name: 'Gateway',
+      baseUrl: 'https://g/v1',
+      key: 'k'
+    })
+
+    expect(providerId).toBe('p_new')
+    // Persisting does not run the connection test — the Settings page tests in the background.
+    expect(api.validateProvider).not.toHaveBeenCalled()
+    expect(useSettingsStore.getState().providers).toHaveLength(1)
+  })
+})
+
 describe('settings store: saveProvider keeps a provider whose test fails', () => {
   it('does not delete a new provider when validation fails, and refreshes to surface the failure', async () => {
     api.upsertProvider.mockResolvedValue(snapshot([providerView('p_new')]))

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -120,6 +120,8 @@ describe('settings store: saveAndActivateProvider', () => {
 
     expect(result.validation.ok).toBe(false)
     expect(api.setActiveProvider).not.toHaveBeenCalled()
+    // The failed provider is kept (flagged as unverified), not rolled back.
+    expect(api.deleteProvider).not.toHaveBeenCalled()
   })
 
   it('resolves the edited id directly instead of diffing', async () => {
@@ -132,6 +134,48 @@ describe('settings store: saveAndActivateProvider', () => {
 
     expect(providerId).toBe('p_existing')
     expect(api.validateProvider).toHaveBeenCalledWith({ providerId: 'p_existing' })
+  })
+})
+
+describe('settings store: saveProvider keeps a provider whose test fails', () => {
+  it('does not delete a new provider when validation fails, and refreshes to surface the failure', async () => {
+    api.upsertProvider.mockResolvedValue(snapshot([providerView('p_new')]))
+    api.validateProvider.mockResolvedValue({
+      ok: false,
+      category: 'auth'
+    } as ValidateProviderResult)
+    // The post-validate refresh returns the persisted provider (now carrying the recorded failure).
+    api.getSettings.mockResolvedValue(snapshot([providerView('p_new')]))
+
+    const result = await useSettingsStore.getState().saveProvider({
+      type: 'custom',
+      name: 'Gateway',
+      baseUrl: 'https://g/v1',
+      key: 'k'
+    })
+
+    expect(result.validation.ok).toBe(false)
+    expect(result.providerId).toBe('p_new')
+    expect(api.deleteProvider).not.toHaveBeenCalled()
+    // The kept provider stays in the renderer cache after the refresh.
+    expect(useSettingsStore.getState().providers).toHaveLength(1)
+  })
+
+  it('keeps an existing provider when an edit fails validation', async () => {
+    api.upsertProvider.mockResolvedValue(snapshot([providerView('p_existing')]))
+    api.validateProvider.mockResolvedValue({
+      ok: false,
+      category: 'auth'
+    } as ValidateProviderResult)
+    api.getSettings.mockResolvedValue(snapshot([providerView('p_existing')]))
+
+    const result = await useSettingsStore
+      .getState()
+      .saveProvider({ id: 'p_existing', type: 'custom', name: 'Renamed' })
+
+    expect(result.validation.ok).toBe(false)
+    expect(result.providerId).toBe('p_existing')
+    expect(api.deleteProvider).not.toHaveBeenCalled()
   })
 })
 
@@ -276,6 +320,35 @@ describe('selectProviderModelOptions', () => {
       { providerId: 'c', providerName: 'GW', providerType: 'custom', model: 'm' },
       // A provider with no concrete model still yields one selectable "default" entry (empty model).
       { providerId: 'local', providerName: 'Local', providerType: 'claude-default', model: '' }
+    ])
+  })
+
+  it('excludes a provider whose last test failed so it cannot be selected as a model source', () => {
+    const options = selectProviderModelOptions([
+      {
+        id: 'ok',
+        type: 'custom',
+        name: 'Good',
+        model: 'm',
+        models: ['m'],
+        hasKey: true,
+        needsKey: false,
+        lastValidatedAt: 200
+      },
+      {
+        id: 'bad',
+        type: 'custom',
+        name: 'Broken',
+        model: 'm',
+        models: ['m'],
+        hasKey: true,
+        needsKey: false,
+        lastValidationFailure: { at: 300, category: 'auth' }
+      }
+    ])
+
+    expect(options).toEqual([
+      { providerId: 'ok', providerName: 'Good', providerType: 'custom', model: 'm' }
     ])
   })
 })

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 
 import type { OfficialVendorId } from '../../../shared/provider-registry'
+import { providerValidationFailed } from '../../../shared/settings'
 import type {
   ClaudeDetectResult,
   ClaudeInfo,
@@ -115,19 +116,22 @@ export type ProviderModelOption = {
 
 // Flattens providers into the composer's (provider, model) options: one per catalog model for an
 // official vendor, the single model for a custom provider, and one default entry for a provider that
-// exposes no concrete model. Pure so the composer and its tests can share it.
+// exposes no concrete model. Providers whose last test failed are excluded so a broken provider can't
+// be picked as a model source. Pure so the composer and its tests can share it.
 export const selectProviderModelOptions = (providers: ProviderView[]): ProviderModelOption[] =>
-  providers.flatMap((provider) => {
-    const models = provider.models.length > 0 ? provider.models : ['']
+  providers
+    .filter((provider) => !providerValidationFailed(provider))
+    .flatMap((provider) => {
+      const models = provider.models.length > 0 ? provider.models : ['']
 
-    return models.map((model) => ({
-      providerId: provider.id,
-      providerName: provider.name,
-      providerType: provider.type,
-      vendorId: provider.vendorId,
-      model
-    }))
-  })
+      return models.map((model) => ({
+        providerId: provider.id,
+        providerName: provider.name,
+        providerType: provider.type,
+        vendorId: provider.vendorId,
+        model
+      }))
+    })
 
 // Finds the provider id affected by an upsert: the edited id, or the one new since `before`.
 const resolveUpsertedProviderId = (
@@ -242,7 +246,9 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
     const validation = await window.api.settings.validateProvider({ providerId })
 
-    // Refresh so the validated-at timestamp / masked key reflect the latest stored state.
+    // Refresh so the validated-at time / recorded failure / masked key reflect the latest stored
+    // state. A failed test keeps the provider (flagged as unverified in the list and excluded from the
+    // model pickers); it is not rolled back, so the user can fix the key and retry.
     set(applySnapshot(await window.api.settings.getSettings()))
     await get().refreshPreflight()
 
@@ -264,7 +270,10 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   validateProvider: async (request) => {
     const result = await window.api.settings.validateProvider(request)
 
-    if (result.ok) {
+    // Refresh whenever a saved provider was tested, pass or fail: success stamps lastValidatedAt, a
+    // failure records the reason and surfaces the "unverified" warning. Draft validations (no
+    // providerId) change nothing stored, so they skip the refresh.
+    if (request.providerId) {
       set(applySnapshot(await window.api.settings.getSettings()))
       await get().refreshPreflight()
     }

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -52,6 +52,9 @@ type SettingsStore = SettingsStoreData & {
   detectClaude: () => Promise<ClaudeDetectResult>
   installClaude: (source: ClaudeInstallSource) => Promise<ClaudeInstallResult>
   clearInstallLogs: () => void
+  // Persists the draft (create/update) without testing it, returning the affected provider id. The
+  // Settings page uses this to return to the list immediately, then tests in the background.
+  persistProvider: (request: UpsertProviderRequest) => Promise<string>
   // Persists the draft and validates it, without changing the active provider.
   saveProvider: (request: UpsertProviderRequest) => Promise<SaveProviderResult>
   // Combined onboarding flow: persist + validate + activate only on success.
@@ -230,6 +233,17 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   },
 
   clearInstallLogs: () => set({ installLogs: [] }),
+
+  // Persists a provider draft (create/update) and refreshes derived state, without testing it.
+  persistProvider: async (request) => {
+    const before = get().providers
+    const afterUpsert = await window.api.settings.upsertProvider(request)
+
+    set(applySnapshot(afterUpsert))
+    await get().refreshPreflight()
+
+    return resolveUpsertedProviderId(request, before, afterUpsert.providers) ?? ''
+  },
 
   // Persists a provider draft and validates it (without activating), refreshing derived state.
   saveProvider: async (request) => {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -27,6 +27,15 @@ export type ClaudeDetectResult = {
   version?: string
 }
 
+// A recorded failed validation, kept so the list can flag a provider as unverified and say why
+// (e.g. "auth failed"). Cleared whenever a later validation of the same credentials succeeds.
+export type ProviderValidationFailure = {
+  at: number
+  category: ValidationCategory
+  status?: number
+  message?: string
+}
+
 // Renderer-facing provider view: masked and stripped of every secret field.
 export type ProviderView = {
   id: string
@@ -47,7 +56,21 @@ export type ProviderView = {
   // True when a stored key could not be decrypted and must be re-entered before use.
   needsKey: boolean
   lastValidatedAt?: number
+  // Present when the most recent validation failed and no later one has succeeded. Drives the
+  // "unverified" warning in the provider list.
+  lastValidationFailure?: ProviderValidationFailure
 }
+
+// True when a provider's most recent validation failed (and no later one succeeded). A failed
+// provider is flagged in the settings list and excluded from the model pickers, so it can't be
+// picked as a model source until it passes a test. Shared by main and renderer for one rule.
+export const providerValidationFailed = (provider: {
+  lastValidatedAt?: number
+  lastValidationFailure?: ProviderValidationFailure
+}): boolean =>
+  provider.lastValidationFailure !== undefined &&
+  (provider.lastValidatedAt === undefined ||
+    provider.lastValidationFailure.at >= provider.lastValidatedAt)
 
 // Full renderer snapshot of settings state.
 export type SettingsSnapshot = {


### PR DESCRIPTION
## Summary

A brand-new provider whose Save test fails is now **kept and marked unverified**, rather than being rolled back and lost. The failure reason is persisted and surfaced, so the user can see what went wrong and fix it. This replaces the earlier delete-on-failure approach (the closed PR #33).

Testing surfaced two problems with delete-on-failure: the user silently loses their input, and "Save & Test" is a misleading label since the record is saved regardless of the test result.

## Behavior

1. Settings → add a new provider → **Save** (renamed from "Save & Test").
2. The connection test runs. On failure the provider is **kept**, flagged with a warning icon + reason ("Test failed: authentication rejected — check the API key", etc.).
3. A failed provider is **excluded from the model pickers** (composer + settings), so it can't be selected as a model source until it passes a test.
4. Fixing the key and testing again clears the warning. Editing that changes credentials also clears the stale failure (a re-test is required).

## Changes

- **shared**: `ProviderValidationFailure` type + `lastValidationFailure` on `ProviderView`; a `providerValidationFailed()` predicate shared by the list warning and the picker gate.
- **main**: record the failure on a failed validate and clear it on success; carry it across an edit only when credentials are unchanged; sanitize/round-trip the field in the repository; expose it in the provider view.
- **renderer**: drop the delete-on-failure rollback in `saveProvider`; refresh after a failed test so the warning shows; warning icon + reason in `ProviderList`; exclude failed providers from `selectProviderModelOptions`; rename the button to "Save".

## Verification

- `vitest` (settings-store, service, repository, ProviderList, ComposerModelPicker) — 72 passed
- `eslint` changed files — 0 problems
- `npm run typecheck` — clean (node + web)

Rebased onto the latest `main`.