### PR TITLE
fix(onboarding): re-detect npm on Re-detect and right-align step buttons

### DIFF
--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -133,14 +133,16 @@ const OnboardingWizard = (): React.JSX.Element => {
                 onInstall={(source) => void installClaude(source)}
               />
             ) : null}
-            <button
-              type="button"
-              onClick={() => setStep('provider')}
-              disabled={!preflight.claudeReady}
-              className="rounded-lg border border-primary bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
-            >
-              Continue
-            </button>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={() => setStep('provider')}
+                disabled={!preflight.claudeReady}
+                className="rounded-lg border border-primary bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+              >
+                Continue
+              </button>
+            </div>
           </section>
         ) : (
           <section aria-label="Configure model" className="mt-6 space-y-4">
@@ -164,7 +166,7 @@ const OnboardingWizard = (): React.JSX.Element => {
                 {validationMessage}
               </p>
             ) : null}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center justify-end gap-3">
               <button
                 type="button"
                 onClick={() => setStep('claude')}

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -89,7 +89,7 @@ const ClaudeInstallCard = ({
             <a href={nodeHint.url} target="_blank" rel="noreferrer" className="underline">
               {nodeHint.url}
             </a>
-            , then restart the app so npm is detected.
+            , then re-detect above so npm is picked up.
           </p>
         </div>
       ) : null}

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -13,6 +13,7 @@ type SettingsApi = {
   getPreflight: ReturnType<typeof vi.fn>
   isEncryptionAvailable: ReturnType<typeof vi.fn>
   isNpmAvailable: ReturnType<typeof vi.fn>
+  detectClaude: ReturnType<typeof vi.fn>
   upsertProvider: ReturnType<typeof vi.fn>
   validateProvider: ReturnType<typeof vi.fn>
   refreshProviderModels: ReturnType<typeof vi.fn>
@@ -55,6 +56,7 @@ beforeEach(() => {
     getPreflight: vi.fn().mockResolvedValue({ claudeReady: true, activeProviderReady: true }),
     isEncryptionAvailable: vi.fn().mockResolvedValue(true),
     isNpmAvailable: vi.fn().mockResolvedValue(true),
+    detectClaude: vi.fn().mockResolvedValue({ found: false }),
     upsertProvider: vi.fn(),
     validateProvider: vi.fn(),
     refreshProviderModels: vi.fn(),
@@ -238,6 +240,19 @@ describe('settings store: hasEnteredApp latch (onboarding is first-run only)', (
     await useSettingsStore.getState().load()
 
     expect(useSettingsStore.getState().hasEnteredApp).toBe(true)
+  })
+})
+
+describe('settings store: detectClaude refreshes npm', () => {
+  it('re-checks npm availability so a mid-onboarding Node.js install is picked up', async () => {
+    // Start from the "npm missing" state a genuine first run without Node.js would have.
+    useSettingsStore.setState({ npmAvailable: false })
+    api.isNpmAvailable.mockResolvedValue(true)
+
+    await useSettingsStore.getState().detectClaude()
+
+    expect(api.isNpmAvailable).toHaveBeenCalledTimes(1)
+    expect(useSettingsStore.getState().npmAvailable).toBe(true)
   })
 })
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -194,11 +194,19 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     set({ isDetectingClaude: true })
 
     try {
-      const result = await window.api.settings.detectClaude()
+      // Re-detect claude and npm together so a mid-onboarding Node.js install is picked up by the same
+      // Re-detect action. npm has no separate refresh; it was previously latched at load() only, so
+      // users who installed Node.js after opening onboarding were stuck until an app restart.
+      const [result, npmAvailable] = await Promise.all([
+        window.api.settings.detectClaude(),
+        window.api.settings.isNpmAvailable()
+      ])
 
-      if (result.found && result.path) {
-        set({ claude: { resolvedPath: result.path, version: result.version } })
-      }
+      set(() =>
+        result.found && result.path
+          ? { npmAvailable, claude: { resolvedPath: result.path, version: result.version } }
+          : { npmAvailable }
+      )
 
       await get().refreshPreflight()
 


### PR DESCRIPTION
## Summary

- **Fix npm detection stuck after a mid-onboarding Node.js install.** `npmAvailable` was fetched only once in `load()`, so if a user opened onboarding without Node.js, installed it manually, then came back, the npm install source stayed disabled with no in-app way to refresh — the hint even told them to restart the app. `detectClaude()` now re-checks npm alongside Claude, so the existing **Re-detect** button refreshes both. The npm-not-found hint now points at Re-detect instead of a restart.
- **Right-align the wizard buttons.** `Continue` (Claude step) and `Back` / `Test connection & continue` (Model step) are now right-aligned within the onboarding column.

## Testing

- `npm run typecheck` — passes
- `npm run lint` — passes
- `npx vitest run` — 706 passed (94 files), including a new regression test asserting `detectClaude` refreshes `npmAvailable` from false to true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)