### PR TITLE
fix: show full command in permission approval dialog

### DIFF
--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -47,13 +47,14 @@ const renderControls = (): string =>
   )
 
 describe('PermissionApprovalControls', () => {
-  it('clips the permission command and keeps details off action labels', () => {
+  it('shows the full command with copy and keeps details off action labels', () => {
     const html = renderControls()
 
-    expect(html).toContain(`title="${longRequestTitle}"`)
+    expect(html).toContain(longRequestTitle)
+    expect(html).toContain('whitespace-pre-wrap break-words')
+    expect(html).toContain('aria-label="Copy command"')
     expect(html).not.toContain(`title="${longAlwaysOptionName}"`)
     expect(html).toContain('flex min-w-0 flex-col items-stretch gap-2 overflow-hidden')
-    expect(html).toContain('w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap')
     expect(html).toContain('Always</span>')
     expect(html).not.toContain(`>${longAlwaysOptionName}</span>`)
   })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -1,3 +1,6 @@
+import { Check, Copy } from 'lucide-react'
+import { useCallback, useState } from 'react'
+
 import type { AcpPermissionRequest } from '../../../../shared/acp'
 
 type PermissionApprovalControlsProps = {
@@ -47,6 +50,45 @@ const getOrderedPermissionOptions = (options: PermissionOption[]): PermissionOpt
       permissionActionOrder[getPermissionActionKind(rightOption)]
   )
 
+// Shows the full command being approved. Permission is security-sensitive, so the command must be
+// fully readable: newlines are preserved and long lines wrap, with a scroll cap for very long
+// commands and a copy button so users can review it verbatim before allowing.
+const PermissionCommandBlock = ({ command }: { command: string }): React.JSX.Element => {
+  const [copied, setCopied] = useState(false)
+
+  const copyCommand = useCallback(async (): Promise<void> => {
+    if (!navigator.clipboard?.writeText) return
+
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard may be unavailable in sandboxed contexts.
+    }
+  }, [command])
+
+  return (
+    <div className="flex min-w-0 items-start gap-2">
+      <pre className="max-h-48 min-w-0 flex-1 overflow-auto whitespace-pre-wrap break-words rounded-md border border-amber-200 bg-white/70 px-2 py-1 font-mono text-[11px] leading-5 text-amber-900">
+        {command}
+      </pre>
+      <button
+        type="button"
+        className="inline-flex shrink-0 items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-1 text-[12px] hover:bg-amber-100"
+        aria-label={copied ? 'Copied command' : 'Copy command'}
+        onClick={() => void copyCommand()}
+      >
+        {copied ? (
+          <Check className="size-3.5" aria-hidden />
+        ) : (
+          <Copy className="size-3.5" aria-hidden />
+        )}
+      </button>
+    </div>
+  )
+}
+
 const PermissionApprovalControls = ({
   requests,
   onRespond
@@ -60,12 +102,7 @@ const PermissionApprovalControls = ({
           key={request.requestId}
           className="flex min-w-0 flex-col items-stretch gap-2 overflow-hidden"
         >
-          <span
-            className="w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap"
-            title={request.title}
-          >
-            {request.title}
-          </span>
+          <PermissionCommandBlock command={request.title} />
           <span className="flex flex-wrap items-center justify-end gap-1 w-full overflow-hidden">
             {getOrderedPermissionOptions(request.options).map((option) => {
               const actionKind = getPermissionActionKind(option)

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -274,7 +274,7 @@ describe('conversation message scroller integration', () => {
       'className="flex min-w-0 flex-col items-stretch gap-2 overflow-hidden"'
     )
     expect(permissionApprovalControlsSource).toContain(
-      'className="w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap"'
+      'max-h-48 min-w-0 flex-1 overflow-auto whitespace-pre-wrap break-words'
     )
     expect(permissionApprovalControlsSource).toContain(
       'className="flex flex-wrap items-center justify-end gap-1 w-full overflow-hidden"'


### PR DESCRIPTION
## Summary

The permission approval dialog rendered the command on a single truncated line (`text-ellipsis whitespace-nowrap`), so long or multi-line commands (e.g. heredocs) were clipped to `...`. Approving a command is security-sensitive, so users need to see exactly what they are allowing.

The full command already existed in the request data — this was purely a display limitation. The command is now shown in full via a new `PermissionCommandBlock`:

- Monospace block with `whitespace-pre-wrap break-words` — preserves newlines and wraps long lines
- `max-h` + scroll — very long commands scroll instead of pushing the action buttons off-screen
- Copy button (reusing the existing `LinkSafetyModal` clipboard pattern) for verbatim review

## Testing

- `PermissionApprovalControls.render.test.tsx` updated and passing (dropped the old truncation-class assertions; added full-command, wrap, and copy-button assertions)
- `npm run lint`, `npm run typecheck:web`, and Prettier all clean

Closes #17