### PR TITLE
fix(artifacts): emit pending files when a prompt fails mid-turn

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1204,6 +1204,83 @@ describe('ACP runtime session management', () => {
     ])
   })
 
+  it('emits an artifact event for pending files even when the prompt fails', async () => {
+    const storageRoot = await createTemporaryRoot()
+    const repository = new ArtifactRepository(storageRoot)
+    const process = new FakeAgentProcess()
+    const events: Array<{
+      kind: string
+      sessionId?: string
+      runId?: string
+      artifactClaimId?: string
+      artifactCount?: number
+    }> = []
+    let currentRunFile = ''
+    const fakeAgent = startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: async () => {
+        const context = JSON.parse(await readFile(currentRunFile, 'utf8')) as { runId: string }
+
+        await repository.writePendingFile({
+          projectName: 'default-project',
+          sessionId: getEnvValue(
+            fakeAgent.newSessions[0].mcpServers[0],
+            'OPEN_SCIENCE_ARTIFACT_SESSION_ID'
+          ),
+          runId: context.runId,
+          filename: 'result.txt',
+          source: { kind: 'inline', content: 'artifact content', encoding: 'utf8' }
+        })
+
+        // Fail the turn after the file was written so it never reaches a clean stop.
+        throw new Error('agent exploded mid-turn')
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        storageRoot,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        mcpCommand: '/usr/bin/electron',
+        repository
+      },
+      callbacks: {
+        onEvent: (event) => {
+          if (event.kind === 'artifact') {
+            events.push({
+              kind: event.kind,
+              sessionId: event.sessionId,
+              runId: event.runId,
+              artifactClaimId: event.artifactClaimId,
+              artifactCount: event.artifacts?.length
+            })
+          }
+        }
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    currentRunFile = getEnvValue(
+      fakeAgent.newSessions[0].mcpServers[0],
+      'OPEN_SCIENCE_ARTIFACT_CURRENT_RUN_FILE'
+    )
+    await expect(
+      runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'make a file' })
+    ).rejects.toThrow()
+
+    expect(events).toEqual([
+      {
+        kind: 'artifact',
+        sessionId: 'remote-session-1',
+        runId: expect.stringMatching(/^artifact-run-/),
+        artifactClaimId: expect.stringMatching(/^artifact-claim-/),
+        artifactCount: 1
+      }
+    ])
+  })
+
   it('cleans up prompt in-flight state when artifact run activation fails', async () => {
     const storageRoot = await createTemporaryRoot()
     const blockedStorageRoot = join(storageRoot, 'storage-file')

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -606,6 +606,7 @@ class AcpRuntime {
       textLength: request.text?.length ?? 0
     })
     let artifactRun: ActiveArtifactRun | undefined
+    let artifactEmitted = false
 
     try {
       // Create a fresh run context before prompting so MCP writes can be attributed to this turn.
@@ -631,6 +632,7 @@ class AcpRuntime {
         if (message.kind === 'stop') {
           // Emit artifact metadata before stop so the renderer can attach files to the finished message.
           await this.emitArtifactRunEvent(request.sessionId, artifactRun)
+          artifactEmitted = true
           log.info('prompt stopped', {
             sessionId: request.sessionId,
             stopReason: message.stopReason
@@ -662,6 +664,18 @@ class AcpRuntime {
       })
       throw error
     } finally {
+      // A turn that fails or is aborted never reaches the stop branch; still surface any files it
+      // wrote so they are attached to a message instead of being orphaned in the pending directory.
+      if (!artifactEmitted) {
+        try {
+          await this.emitArtifactRunEvent(request.sessionId, artifactRun)
+        } catch (error) {
+          log.error('artifact emit after prompt failure failed', {
+            sessionId: request.sessionId,
+            error
+          })
+        }
+      }
       try {
         await this.clearArtifactRun(artifactRun)
       } catch (error) {


### PR DESCRIPTION
## Summary

Generated artifact files were being orphaned in `.pending/<runId>/` when an assistant turn failed, so the **GENERATED** block never rendered even though the file was written to disk.

`write_artifact_file` writes the file into the run's pending directory, and the only path that surfaces those files to the renderer is `emitArtifactRunEvent` — which the prompt loop invoked **exclusively** on a clean `stop` (`runtime.ts`). When `prompt()` rejects (agent / tool / connection error), the loop takes the `catch` path, pushes an error event, and the `finally` clears the run file **without ever emitting the artifacts**. The files stay in `.pending/`, never get attached to a message or finalized, and the GENERATED list (which only renders artifacts attached to a message) never appears. Cancellation still resolves to a `stop`, so only the failure path was affected.

## Fix

- Emit pending run artifacts in the `finally` block as well, so a failed/aborted turn still surfaces the files it wrote.
- Guard with an `artifactEmitted` flag so the clean-stop path remains single-emit.
- Change is pure control flow (no path handling), so it is unaffected by platform / Windows path differences.

## Tested

- New test `emits an artifact event for pending files even when the prompt fails` — verified red before the fix, green after.
- `runtime` + `artifacts` + `renderer/lib/acp` suites: 80 passed.
- `npm run typecheck` clean; `npm run lint` clean.
- Verified via `npm run dev`: the dev app builds and launches without errors.

## Known limitation (follow-up)

An app crash / quit **mid-turn** can still orphan pending files, because the run claim registry is in-memory and lost on restart. Covering that needs a startup reconciliation pass over `.pending/`, which is a larger change left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)