### PR TITLE
ci(release): attest SLSA build provenance for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,13 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # Job-level permissions fully override the workflow-level block, so contents:write is restated
+    # alongside the two scopes the SLSA attestation needs: id-token to sign via Sigstore OIDC, and
+    # attestations to write the provenance record.
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Download all build artifacts
         uses: actions/download-artifact@v8
@@ -47,6 +54,21 @@ jobs:
             sha256sum "${files[@]}" > SHA256SUMS.txt
             cat SHA256SUMS.txt
           fi
+
+      # Sign a SLSA build-provenance attestation for the exact installer bytes about to be published,
+      # so users can prove each download was built by this workflow from this commit (verify with
+      # `gh attestation verify <file> --repo <owner>/<repo>`). SHA256SUMS.txt is excluded — it's a
+      # digest list, not a build product. The attestation lives in the repo's Attestations, not as a
+      # Release asset, so it doesn't clutter the download list.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            artifacts/*.dmg
+            artifacts/*.zip
+            artifacts/*.exe
+            artifacts/*.AppImage
+            artifacts/*.deb
 
       # Attach user-facing artifacts + checksums: installers (dmg/exe/AppImage/deb) and portable
       # zips (mac + win). Auto-update metadata (latest*.yml / blockmap) is intentionally NOT published:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The fastest path if you just want to use it — no Node, no Git, nothing to buil
 
 3. Open the downloaded file and install it like any other app.
 
+> Security-conscious? Each release ships a `SHA256SUMS.txt` and a signed build-provenance attestation, so you can confirm a download is intact **and** was built by this repo's CI. See [Verifying your download](SECURITY.md#verifying-your-download).
+
 Builds aren't signed with a paid Apple/Microsoft certificate yet, so on first launch your OS shows an "unverified developer" (macOS) or "unknown publisher" (Windows) prompt — this is expected, not a corrupted download. See the [macOS Gatekeeper note](#building-from-source-macos-gatekeeper-note) for the one-time steps to open it. Want the bleeding edge instead? The **Nightly (latest main)** pre-release tracks the newest commits.
 
 > To run agent sessions, the app uses your existing Claude Code login (reused automatically if you have one) or a custom model gateway you set up in-app — it manages this auth in its own config dir and ignores `ANTHROPIC_*` variables from your shell.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,6 +51,20 @@ shasum -a 256 open-science-<version>-mac-arm64.dmg
 # compare the output against the matching line in SHA256SUMS.txt
 ```
 
+The checksum proves the file is intact; **build provenance** proves where it came
+from. Every tagged release attaches a signed [SLSA provenance][slsa] attestation
+tying each installer to the exact commit and CI run that produced it. Verify it with
+the [GitHub CLI](https://cli.github.com/):
+
+```bash
+gh attestation verify open-science-<version>-mac-arm64.dmg --repo aipoch/open-science
+```
+
+A passing check means the binary was built by this repository's Release workflow from
+a specific commit — not repackaged by a third party. (Nightly builds are not attested.)
+
+[slsa]: https://slsa.dev/spec/v1.0/provenance
+
 Builds are **not** signed with a paid Apple/Microsoft certificate yet, so your OS
 will show an "unverified developer" (macOS) or "unknown publisher" (Windows) prompt
 on first launch. That prompt is expected and is **not** evidence of tampering — but


### PR DESCRIPTION
## Summary

Adds a signed **build-provenance attestation** to the release publish job so users can verify each installer was actually built by this repository's CI from a specific commit — not just that the bytes are intact (checksums already cover integrity).

This closes the last gap in "verifiable release artifacts": checksums prove **integrity**, provenance proves **origin**.

## Changes

- **`.github/workflows/release.yml`** — grant the `publish` job `id-token: write` + `attestations: write` (restated alongside the existing `contents: write`, since job-level permissions fully override the workflow-level block), and run `actions/attest-build-provenance@v4` over the `dmg`/`zip`/`exe`/`AppImage`/`deb` artifacts, between checksum generation and the GitHub Release step. `SHA256SUMS.txt` is excluded — it's a digest list, not a build product.
- **`SECURITY.md`** — document `gh attestation verify` alongside the existing checksum steps under *Verifying your download*.
- **`README.md`** — point the download section at the verification steps.

Nightly builds are intentionally **not** attested (rolling, unstable pre-release).

## Notes

- Uses `actions/attest-build-provenance@v4` (current latest major).
- The attestation is stored in the repo's Attestations, **not** as a Release asset, so it doesn't clutter the download list.
- No auto-update metadata (`latest*.yml`) behavior changes.

## Tested

- Validated `release.yml` parses (js-yaml): `publish` permissions and step order confirmed (`Generate checksums` → `Attest build provenance` → `Publish GitHub Release`).
- Verified `actions/attest-build-provenance@v4` is a real, current major tag.
- End-to-end attestation only exercisable on a real tag push, which this PR does not trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)