### PR TITLE
feat(composer): align model picker to reference composer layout

### DIFF
--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from 'lucide-react'
+import { Check, ChevronDown } from 'lucide-react'
 
 import {
   DropdownMenu,
@@ -18,7 +18,7 @@ import {
 } from '@/stores/settings-store'
 
 const triggerClassName =
-  'flex h-8 max-w-[220px] items-center gap-1 rounded-md border border-border-200 px-2 text-xs text-text-100 hover:bg-bg-200 disabled:cursor-not-allowed disabled:opacity-50 transition-colors'
+  'flex h-8 max-w-[220px] items-center gap-1 rounded-md px-2.5 text-sm text-text-300 hover:bg-bg-200 hover:text-text-100 disabled:cursor-not-allowed disabled:opacity-50 transition-colors'
 
 // Label for an option: the model name, or the provider name when the option carries no concrete model
 // (a claude-default without an override).
@@ -65,7 +65,7 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
         <span className="truncate">
           {current ? (
             <>
-              {optionLabel(current)}
+              <span className="font-medium text-text-100">{optionLabel(current)}</span>
               {current.model ? (
                 <span className="ml-1.5 text-text-300">· {current.providerName}</span>
               ) : null}
@@ -76,7 +76,7 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
         </span>
         <ChevronDown className="size-3.5 shrink-0" aria-hidden="true" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="max-h-[320px] overflow-y-auto">
+      <DropdownMenuContent align="end" className="max-h-[320px] min-w-[15rem] overflow-y-auto">
         {groups.map((group) => (
           <DropdownMenuGroup key={group.provider.id}>
             <DropdownMenuLabel>{group.provider.name}</DropdownMenuLabel>
@@ -87,14 +87,23 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
               return (
                 <DropdownMenuItem
                   key={`${option.providerId}:${option.model}`}
+                  role="menuitemradio"
+                  aria-checked={isActive}
                   onSelect={() => void setActiveProvider(option.providerId, option.model)}
-                  className={cn('gap-2', isActive && 'bg-bg-200 font-medium')}
+                  className={cn('gap-2', isActive && 'font-medium')}
                 >
                   <ProviderKindIcon
                     kindKey={providerKindKey(option.providerType, option.vendorId)}
-                    className="size-4"
+                    className="size-4 shrink-0"
                   />
-                  {optionLabel(option)}
+                  <span className="min-w-0 flex-1 truncate">{optionLabel(option)}</span>
+                  {isActive ? (
+                    <Check
+                      className="size-4 shrink-0 text-action-primary"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    />
+                  ) : null}
                 </DropdownMenuItem>
               )
             })}

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -285,10 +285,11 @@ const ConversationPanel = ({
                           onChange={handleAttachmentInputChange}
                         />
 
-                        {/* Model/provider switcher; hides itself unless more than one is configured. */}
-                        <ComposerModelPicker />
-
                         <div className="flex-1" />
+
+                        {/* Model/provider switcher; hides itself unless more than one is configured.
+                            Grouped on the right with Send, mirroring the reference composer layout. */}
+                        <ComposerModelPicker />
 
                         {activeSession?.status === 'running' ||
                         activeSession?.status === 'waiting-permission' ? (


### PR DESCRIPTION
## Summary

Aligns the composer model picker with the reference composer design, covering both position and style.

- **Position**: move the model picker to the right of the composer toolbar so it groups with the send button (`[+] — spacer — [Model] [Send]`).
- **Menu**: open the dropdown right-aligned under the trigger (`align="end"`) with a minimum width so items have room to breathe.
- **Trigger style**: borderless ghost button, `text-sm`, bolder model name; keeps the provider icon and `· provider` suffix since this app is multi-provider.
- **Item internals**: active model is marked with a trailing accent check (with `menuitemradio` / `aria-checked` semantics) and a `flex-1 truncate` label, replacing the persistent background highlight.

## Testing

- `npm run typecheck:web`
- `npx vitest run` on `ComposerModelPicker.render.test.tsx` (3/3 passing)
- `eslint` clean on both changed files
- Verified in `npm run dev`