### PR TITLE
feat(composer): drag-and-drop and paste file upload with size/count limits

### DIFF
--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
+import { MAX_UPLOAD_FILE_BYTES, PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
 import { UploadRepository } from './repository'
 
 let storageRoot: string | undefined
@@ -49,6 +49,18 @@ describe('upload repository', () => {
       join(root, 'uploads', 'default-project', PENDING_UPLOAD_SESSION_ID, 'paste.png')
     )
     await expect(readFile(attachment.path, 'utf8')).resolves.toBe('png-bytes')
+  })
+
+  it('rejects staging a file whose content exceeds the size limit', async () => {
+    const root = await createStorageRoot()
+    const repository = new UploadRepository(root)
+    const oversized = Buffer.alloc(MAX_UPLOAD_FILE_BYTES + 1)
+
+    await expect(
+      repository.stageFiles({
+        files: [{ name: 'huge.bin', content: oversized.toString('base64') }]
+      })
+    ).rejects.toThrow(/maximum allowed size/)
   })
 
   it('finalizes pending uploads into the real session directory without changing ids', async () => {

--- a/src/main/uploads/repository.ts
+++ b/src/main/uploads/repository.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'node:crypto'
 import type { ArtifactPreviewResult, ReadArtifactPreviewRequest } from '../../shared/artifacts'
 import {
   DEFAULT_UPLOAD_PROJECT_NAME,
+  MAX_UPLOAD_FILE_BYTES,
   PENDING_UPLOAD_SESSION_ID,
   type DeleteUploadRequest,
   type ReadUploadBytesRequest,
@@ -107,10 +108,17 @@ class UploadRepository {
       request.files.map(async (file) => {
         // Preserve the original display name separately from the sanitized filesystem name.
         const originalName = file.name.trim() || 'upload'
+        const content = Buffer.from(file.content, 'base64')
+
+        // Authoritative per-file size guard so no entry point can persist an oversized upload.
+        if (content.byteLength > MAX_UPLOAD_FILE_BYTES) {
+          throw new Error(`Upload exceeds the maximum allowed size: ${originalName}`)
+        }
+
         const { filename, filePath } = await this.writeUniqueFile(
           directory,
           toSafeUploadFilename(originalName),
-          Buffer.from(file.content, 'base64')
+          content
         )
 
         return this.createAttachment({

--- a/src/renderer/src/pages/workspace/ComposerDropOverlay.tsx
+++ b/src/renderer/src/pages/workspace/ComposerDropOverlay.tsx
@@ -1,10 +1,10 @@
 import { Upload } from 'lucide-react'
 
-// Fills the conversation panel while a file drag is active to signal the drop target.
+// Fills the composer input card while a file drag is active to signal the drop target.
 const ComposerDropOverlay = (): React.JSX.Element => (
   <div
     aria-hidden="true"
-    className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-lg border-2 border-action-primary bg-bg-000/70"
+    className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-2xl border-2 border-action-primary bg-bg-000/70"
   >
     <div className="flex flex-col items-center gap-2 text-text-000">
       <Upload className="size-8 text-action-primary" strokeWidth={2} aria-hidden="true" />

--- a/src/renderer/src/pages/workspace/ComposerDropOverlay.tsx
+++ b/src/renderer/src/pages/workspace/ComposerDropOverlay.tsx
@@ -1,0 +1,16 @@
+import { Upload } from 'lucide-react'
+
+// Fills the conversation panel while a file drag is active to signal the drop target.
+const ComposerDropOverlay = (): React.JSX.Element => (
+  <div
+    aria-hidden="true"
+    className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-lg border-2 border-action-primary bg-bg-000/70"
+  >
+    <div className="flex flex-col items-center gap-2 text-text-000">
+      <Upload className="size-8 text-action-primary" strokeWidth={2} aria-hidden="true" />
+      <span className="text-sm font-medium">Drop files to attach</span>
+    </div>
+  </div>
+)
+
+export { ComposerDropOverlay }

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -63,10 +63,10 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
   })
 }
 
-const getSection = (): HTMLElement => {
-  const section = container.querySelector('section[data-session-id]')
-  if (!section) throw new Error('conversation section not found')
-  return section as HTMLElement
+const getComposerForm = (): HTMLElement => {
+  const form = container.querySelector('form')
+  if (!form) throw new Error('composer form not found')
+  return form as HTMLElement
 }
 
 const dispatchPaste = (files: File[]): boolean => {
@@ -85,7 +85,7 @@ const dispatchDrag = (type: string, dataTransferTypes: string[], files: File[] =
     value: { types: dataTransferTypes, files, dropEffect: 'none' }
   })
   act(() => {
-    getSection().dispatchEvent(event)
+    getComposerForm().dispatchEvent(event)
   })
 }
 

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { PropsWithChildren } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ConversationPanel } from './ConversationPanel'
+
+// React's act() refuses to run unless the environment opts in to act-aware scheduling.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Child regions pull in stores/UI unrelated to composer intake, so stub them to plain markers.
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanel: ({ children }: PropsWithChildren): React.JSX.Element => <div>{children}</div>
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...values: Array<string | false | undefined>) => values.filter(Boolean).join(' ')
+}))
+
+vi.mock('./ComposerModelPicker', () => ({
+  ComposerModelPicker: (): null => null
+}))
+
+vi.mock('./WorkspaceMessageScroller', () => ({
+  WorkspaceMessageScroller: (): null => null
+}))
+
+vi.mock('./PermissionApprovalControls', () => ({
+  PermissionApprovalControls: (): null => null
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+const onStageAttachmentFiles = vi.fn()
+
+const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {}): void => {
+  act(() => {
+    root.render(
+      <ConversationPanel
+        activeSession={undefined}
+        messageDraft=""
+        canSendMessage={false}
+        canEditDraft
+        actionError={null}
+        isPreviewPanelCollapsed={false}
+        attachments={[]}
+        isUploadingAttachments={false}
+        notebookReference={undefined}
+        pendingPermissions={[]}
+        onMessageDraftChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onStageAttachmentFiles={onStageAttachmentFiles}
+        onRemoveAttachment={vi.fn()}
+        onCancelRun={vi.fn()}
+        onOpenNotebook={vi.fn()}
+        onTogglePreviewPanel={vi.fn()}
+        onRespondToPermission={vi.fn()}
+        {...props}
+      />
+    )
+  })
+}
+
+const getSection = (): HTMLElement => {
+  const section = container.querySelector('section[data-session-id]')
+  if (!section) throw new Error('conversation section not found')
+  return section as HTMLElement
+}
+
+const dispatchPaste = (files: File[]): boolean => {
+  const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', { value: { files } })
+  act(() => {
+    textarea.dispatchEvent(event)
+  })
+  return event.defaultPrevented
+}
+
+const dispatchDrag = (type: string, dataTransferTypes: string[], files: File[] = []): void => {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'dataTransfer', {
+    value: { types: dataTransferTypes, files, dropEffect: 'none' }
+  })
+  act(() => {
+    getSection().dispatchEvent(event)
+  })
+}
+
+const hasDropOverlay = (): boolean =>
+  container.textContent?.includes('Drop files to attach') ?? false
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  onStageAttachmentFiles.mockClear()
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('ConversationPanel composer intake', () => {
+  it('stages a pasted non-image file', () => {
+    renderPanel()
+    const pdf = new File(['%PDF'], 'report.pdf', { type: 'application/pdf' })
+
+    const prevented = dispatchPaste([pdf])
+
+    expect(onStageAttachmentFiles).toHaveBeenCalledWith([pdf])
+    expect(prevented).toBe(true)
+  })
+
+  it('leaves plain-text paste untouched when no files are present', () => {
+    renderPanel()
+
+    const prevented = dispatchPaste([])
+
+    expect(onStageAttachmentFiles).not.toHaveBeenCalled()
+    expect(prevented).toBe(false)
+  })
+
+  it('shows the overlay during a file drag and stages the dropped files', () => {
+    renderPanel()
+    const file = new File(['data'], 'data.csv', { type: 'text/csv' })
+
+    dispatchDrag('dragenter', ['Files'])
+    expect(hasDropOverlay()).toBe(true)
+
+    dispatchDrag('drop', ['Files'], [file])
+    expect(onStageAttachmentFiles).toHaveBeenCalledWith([file])
+    expect(hasDropOverlay()).toBe(false)
+  })
+
+  it('ignores plain-text drags with no overlay and no upload', () => {
+    renderPanel()
+
+    dispatchDrag('dragenter', ['text/plain'])
+    expect(hasDropOverlay()).toBe(false)
+
+    dispatchDrag('drop', ['text/plain'])
+    expect(onStageAttachmentFiles).not.toHaveBeenCalled()
+  })
+
+  it('never activates the drop overlay when editing is disabled', () => {
+    renderPanel({ canEditDraft: false })
+
+    dispatchDrag('dragenter', ['Files'])
+    expect(hasDropOverlay()).toBe(false)
+  })
+})

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -17,9 +17,11 @@ import { ResizablePanel } from '@/components/ui/resizable'
 import { cn } from '@/lib/utils'
 import type { ChatSession } from '@/stores/session-store'
 
+import { ComposerDropOverlay } from './ComposerDropOverlay'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { submitMessageDraftFromKeyDown } from './message-draft-keyboard'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
+import { useFileDropZone } from './useFileDropZone'
 import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'
 
 const composerInteractiveTransitionClassName = 'transition-colors duration-200 ease-out'
@@ -104,6 +106,12 @@ const ConversationPanel = ({
 }: ConversationPanelProps): React.JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
+  // Drag-and-drop shares the same staging callback as the picker and paste paths.
+  const { isDragging, dropZoneProps } = useFileDropZone({
+    enabled: canEditDraft,
+    onFiles: onStageAttachmentFiles
+  })
+
   // Keeps keyboard submission behavior colocated with the composer while the helper owns rules.
   const handleMessageDraftKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>): void => {
     submitMessageDraftFromKeyDown(event, canSendMessage)
@@ -121,27 +129,27 @@ const ConversationPanel = ({
     }
   }
 
-  // Treats pasted clipboard images exactly like selected files, then keeps text paste behavior intact.
+  // Treats pasted clipboard files exactly like selected files, then keeps text paste behavior intact.
   const handleMessageDraftPaste = (event: React.ClipboardEvent<HTMLTextAreaElement>): void => {
     if (!canEditDraft) return
 
-    const imageFiles = Array.from(event.clipboardData.files).filter((file) =>
-      file.type.startsWith('image/')
-    )
+    const files = Array.from(event.clipboardData.files)
 
-    if (imageFiles.length === 0) return
+    if (files.length === 0) return
 
     event.preventDefault()
-    onStageAttachmentFiles(imageFiles)
+    onStageAttachmentFiles(files)
   }
 
   return (
     <ResizablePanel id="main-content" defaultSize="60%" minSize="30%">
       <section
-        className="flex h-full min-w-0 flex-col overflow-hidden bg-bg-10 p-2 pl-4"
+        className="relative flex h-full min-w-0 flex-col overflow-hidden bg-bg-10 p-2 pl-4"
         data-session-id={activeSession?.id ?? ''}
         data-agent-running={activeSession?.status === 'running' ? 'true' : 'false'}
+        {...dropZoneProps}
       >
+        {isDragging ? <ComposerDropOverlay /> : null}
         <header className="flex shrink-0 items-center gap-2 px-4 pb-3 pt-1">
           <h1 className="min-w-0 flex-1 truncate text-[13px] font-semibold text-text-000">
             {activeSession?.title ?? 'New conversation'}

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -144,12 +144,10 @@ const ConversationPanel = ({
   return (
     <ResizablePanel id="main-content" defaultSize="60%" minSize="30%">
       <section
-        className="relative flex h-full min-w-0 flex-col overflow-hidden bg-bg-10 p-2 pl-4"
+        className="flex h-full min-w-0 flex-col overflow-hidden bg-bg-10 p-2 pl-4"
         data-session-id={activeSession?.id ?? ''}
         data-agent-running={activeSession?.status === 'running' ? 'true' : 'false'}
-        {...dropZoneProps}
       >
-        {isDragging ? <ComposerDropOverlay /> : null}
         <header className="flex shrink-0 items-center gap-2 px-4 pb-3 pt-1">
           <h1 className="min-w-0 flex-1 truncate text-[13px] font-semibold text-text-000">
             {activeSession?.title ?? 'New conversation'}
@@ -218,7 +216,10 @@ const ConversationPanel = ({
                   <form
                     className="relative z-10 flex flex-col gap-2 rounded-2xl bg-bg-000 px-3 py-2 shadow-card-opaque transition-shadow duration-[180ms] ease-out"
                     onSubmit={onSendMessage}
+                    {...dropZoneProps}
                   >
+                    {/* File-drag overlay is scoped to the composer input card only. */}
+                    {isDragging ? <ComposerDropOverlay /> : null}
                     <div className="flex flex-col gap-2">
                       {attachments.length > 0 ? (
                         <div className="flex max-h-[92px] flex-wrap gap-2 overflow-y-auto border-b border-border-200 pb-2">

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -19,6 +19,7 @@ import type { ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
 import type { StageUploadFile, UploadedAttachment } from '../../../../shared/uploads'
 
+import { planComposerAttachmentIntake } from './composer-attachment-intake'
 import { ConversationPanel } from './ConversationPanel'
 import { DeleteSessionDialog } from './DeleteSessionDialog'
 import { PreviewPanel } from './PreviewPanel'
@@ -365,14 +366,20 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const stageAttachmentFiles = (files: File[]): void => {
     if (!canEditDraft || files.length === 0) return
 
-    setAttachmentError(null)
+    // Enforce the size and count limits up front so rejected files are never read or uploaded.
+    const { accepted, error } = planComposerAttachmentIntake(files, attachments.length)
+
+    setAttachmentError(error)
+
+    if (accepted.length === 0) return
+
     setIsUploadingAttachments(true)
 
     void (async () => {
       try {
         // Browser File objects cannot cross IPC directly, so send base64 content plus metadata.
         const stagedFiles: StageUploadFile[] = await Promise.all(
-          files.map(async (file, index) => ({
+          accepted.map(async (file, index) => ({
             name: getUploadFilename(file, index),
             mimeType: file.type || undefined,
             content: await readFileAsBase64(file)

--- a/src/renderer/src/pages/workspace/composer-attachment-intake.test.ts
+++ b/src/renderer/src/pages/workspace/composer-attachment-intake.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import { MAX_COMPOSER_ATTACHMENTS, MAX_UPLOAD_FILE_BYTES } from '../../../../shared/uploads'
+import { planComposerAttachmentIntake } from './composer-attachment-intake'
+
+// Builds a File-like object with a controlled size without allocating large buffers.
+const makeFile = (name: string, size: number): File => {
+  const file = new File([], name)
+  Object.defineProperty(file, 'size', { value: size })
+  return file
+}
+
+describe('planComposerAttachmentIntake', () => {
+  it('accepts files within the size limit and reports no error', () => {
+    const small = makeFile('a.txt', 10)
+
+    const result = planComposerAttachmentIntake([small], 0)
+
+    expect(result.accepted).toEqual([small])
+    expect(result.error).toBeNull()
+  })
+
+  it('skips oversized files while still accepting valid ones', () => {
+    const valid = makeFile('ok.txt', 1024)
+    const huge = makeFile('big.zip', MAX_UPLOAD_FILE_BYTES + 1)
+
+    const result = planComposerAttachmentIntake([valid, huge], 0)
+
+    expect(result.accepted).toEqual([valid])
+    expect(result.error).toBe('big.zip exceeds the 50 MB limit')
+  })
+
+  it('combines multiple oversized file names in the error', () => {
+    const first = makeFile('one.bin', MAX_UPLOAD_FILE_BYTES + 1)
+    const second = makeFile('two.bin', MAX_UPLOAD_FILE_BYTES + 2)
+
+    const result = planComposerAttachmentIntake([first, second], 0)
+
+    expect(result.accepted).toEqual([])
+    expect(result.error).toBe('one.bin, two.bin exceeds the 50 MB limit')
+  })
+
+  it('rejects the whole batch when it would exceed the attachment count', () => {
+    const files = Array.from({ length: 3 }, (_, index) => makeFile(`f${index}.txt`, 10))
+
+    const result = planComposerAttachmentIntake(files, MAX_COMPOSER_ATTACHMENTS - 2)
+
+    expect(result.accepted).toEqual([])
+    expect(result.error).toBe('You can attach up to 10 files')
+  })
+
+  it('accepts a batch that exactly fills the remaining slots', () => {
+    const files = Array.from({ length: 2 }, (_, index) => makeFile(`f${index}.txt`, 10))
+
+    const result = planComposerAttachmentIntake(files, MAX_COMPOSER_ATTACHMENTS - 2)
+
+    expect(result.accepted).toEqual(files)
+    expect(result.error).toBeNull()
+  })
+})

--- a/src/renderer/src/pages/workspace/composer-attachment-intake.ts
+++ b/src/renderer/src/pages/workspace/composer-attachment-intake.ts
@@ -1,0 +1,32 @@
+import { MAX_COMPOSER_ATTACHMENTS, MAX_UPLOAD_FILE_BYTES } from '../../../../shared/uploads'
+
+// Result of applying the composer size/count limits to an incoming batch of files.
+export type ComposerAttachmentIntake = {
+  accepted: File[]
+  error: string | null
+}
+
+const MB_LIMIT = MAX_UPLOAD_FILE_BYTES / (1024 * 1024)
+
+// Applies per-file size and total count limits before any file is read or uploaded.
+export const planComposerAttachmentIntake = (
+  files: File[],
+  currentAttachmentCount: number
+): ComposerAttachmentIntake => {
+  // Oversized files are dropped and reported by name; they are never read or staged.
+  const oversized = files.filter((file) => file.size > MAX_UPLOAD_FILE_BYTES)
+  const withinSize = files.filter((file) => file.size <= MAX_UPLOAD_FILE_BYTES)
+
+  // The count check rejects the whole batch so the composer never partially accepts files.
+  const remaining = MAX_COMPOSER_ATTACHMENTS - currentAttachmentCount
+  if (withinSize.length > remaining) {
+    return { accepted: [], error: `You can attach up to ${MAX_COMPOSER_ATTACHMENTS} files` }
+  }
+
+  const oversizedError =
+    oversized.length > 0
+      ? `${oversized.map((file) => file.name).join(', ')} exceeds the ${MB_LIMIT} MB limit`
+      : null
+
+  return { accepted: withinSize, error: oversizedError }
+}

--- a/src/renderer/src/pages/workspace/useFileDropZone.test.ts
+++ b/src/renderer/src/pages/workspace/useFileDropZone.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useFileDropZone } from './useFileDropZone'
+
+// React's act() refuses to run unless the environment opts in to act-aware scheduling.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Minimal renderHook mirroring the repo's other hook tests (no @testing-library/react dependency).
+const renderHook = <Value>(hook: () => Value): { result: { current: Value } } => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const result = { current: undefined as unknown as Value }
+
+  const HookHarness = (): null => {
+    result.current = hook()
+    return null
+  }
+
+  act(() => {
+    root.render(createElement(HookHarness))
+  })
+
+  return { result }
+}
+
+// Builds a drag event stub whose dataTransfer exposes the requested types and files.
+const createDragEvent = (types: string[], files: File[] = []): React.DragEvent<HTMLElement> => {
+  const dataTransfer = {
+    types,
+    files,
+    dropEffect: 'none' as DataTransfer['dropEffect']
+  }
+
+  return {
+    preventDefault: vi.fn(),
+    dataTransfer
+  } as unknown as React.DragEvent<HTMLElement>
+}
+
+describe('useFileDropZone', () => {
+  it('sets isDragging on file dragenter and clears it on dragleave at zero depth', () => {
+    const onFiles = vi.fn()
+    const { result } = renderHook(() => useFileDropZone({ enabled: true, onFiles }))
+
+    act(() => {
+      result.current.dropZoneProps.onDragEnter(createDragEvent(['Files']))
+    })
+    expect(result.current.isDragging).toBe(true)
+
+    act(() => {
+      result.current.dropZoneProps.onDragLeave(createDragEvent(['Files']))
+    })
+    expect(result.current.isDragging).toBe(false)
+  })
+
+  it('keeps the overlay stable across nested enter/leave pairs (no flicker)', () => {
+    const onFiles = vi.fn()
+    const { result } = renderHook(() => useFileDropZone({ enabled: true, onFiles }))
+
+    act(() => {
+      result.current.dropZoneProps.onDragEnter(createDragEvent(['Files']))
+      result.current.dropZoneProps.onDragEnter(createDragEvent(['Files']))
+    })
+    expect(result.current.isDragging).toBe(true)
+
+    // Leaving the child still leaves one outstanding enter, so the overlay stays visible.
+    act(() => {
+      result.current.dropZoneProps.onDragLeave(createDragEvent(['Files']))
+    })
+    expect(result.current.isDragging).toBe(true)
+
+    act(() => {
+      result.current.dropZoneProps.onDragLeave(createDragEvent(['Files']))
+    })
+    expect(result.current.isDragging).toBe(false)
+  })
+
+  it('ignores non-file drags such as selected text or elements', () => {
+    const onFiles = vi.fn()
+    const { result } = renderHook(() => useFileDropZone({ enabled: true, onFiles }))
+
+    act(() => {
+      result.current.dropZoneProps.onDragEnter(createDragEvent(['text/plain']))
+    })
+    expect(result.current.isDragging).toBe(false)
+  })
+
+  it('forwards dropped files and resets dragging state', () => {
+    const onFiles = vi.fn()
+    const { result } = renderHook(() => useFileDropZone({ enabled: true, onFiles }))
+    const file = new File(['content'], 'note.txt', { type: 'text/plain' })
+
+    act(() => {
+      result.current.dropZoneProps.onDragEnter(createDragEvent(['Files']))
+      result.current.dropZoneProps.onDrop(createDragEvent(['Files'], [file]))
+    })
+
+    expect(onFiles).toHaveBeenCalledWith([file])
+    expect(result.current.isDragging).toBe(false)
+  })
+
+  it('never activates or reports dragging when disabled', () => {
+    const onFiles = vi.fn()
+    const { result } = renderHook(() => useFileDropZone({ enabled: false, onFiles }))
+
+    act(() => {
+      result.current.dropZoneProps.onDragEnter(createDragEvent(['Files']))
+    })
+    expect(result.current.isDragging).toBe(false)
+
+    const file = new File(['x'], 'x.txt')
+    act(() => {
+      result.current.dropZoneProps.onDrop(createDragEvent(['Files'], [file]))
+    })
+    expect(onFiles).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/pages/workspace/useFileDropZone.ts
+++ b/src/renderer/src/pages/workspace/useFileDropZone.ts
@@ -1,0 +1,92 @@
+import { useCallback, useRef, useState } from 'react'
+
+type FileDropZoneProps = {
+  onDragEnter: (event: React.DragEvent<HTMLElement>) => void
+  onDragOver: (event: React.DragEvent<HTMLElement>) => void
+  onDragLeave: (event: React.DragEvent<HTMLElement>) => void
+  onDrop: (event: React.DragEvent<HTMLElement>) => void
+}
+
+type UseFileDropZoneOptions = {
+  enabled: boolean
+  onFiles: (files: File[]) => void
+}
+
+type UseFileDropZoneResult = {
+  isDragging: boolean
+  dropZoneProps: FileDropZoneProps
+}
+
+// Only file drags should activate the composer overlay; text or element drags are ignored.
+const isFileDrag = (event: React.DragEvent<HTMLElement>): boolean =>
+  Array.from(event.dataTransfer.types).includes('Files')
+
+// Adds drag-and-drop file intake to a container while ignoring non-file drags and flicker.
+const useFileDropZone = ({ enabled, onFiles }: UseFileDropZoneOptions): UseFileDropZoneResult => {
+  const [isDragging, setIsDragging] = useState(false)
+  // Counter offsets dragenter/dragleave pairs from child elements so the overlay never flickers.
+  const dragDepthRef = useRef(0)
+
+  const handleDragEnter = useCallback(
+    (event: React.DragEvent<HTMLElement>): void => {
+      if (!enabled || !isFileDrag(event)) return
+
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'copy'
+      dragDepthRef.current += 1
+      setIsDragging(true)
+    },
+    [enabled]
+  )
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLElement>): void => {
+      if (!enabled || !isFileDrag(event)) return
+
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'copy'
+      setIsDragging(true)
+    },
+    [enabled]
+  )
+
+  const handleDragLeave = useCallback(
+    (event: React.DragEvent<HTMLElement>): void => {
+      if (!enabled || !isFileDrag(event)) return
+
+      dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
+      if (dragDepthRef.current === 0) {
+        setIsDragging(false)
+      }
+    },
+    [enabled]
+  )
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLElement>): void => {
+      if (!enabled || !isFileDrag(event)) return
+
+      event.preventDefault()
+      dragDepthRef.current = 0
+      setIsDragging(false)
+
+      const files = Array.from(event.dataTransfer.files)
+      if (files.length > 0) {
+        onFiles(files)
+      }
+    },
+    [enabled, onFiles]
+  )
+
+  return {
+    isDragging: enabled && isDragging,
+    dropZoneProps: {
+      onDragEnter: handleDragEnter,
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      onDrop: handleDrop
+    }
+  }
+}
+
+export { useFileDropZone }

--- a/src/shared/uploads.ts
+++ b/src/shared/uploads.ts
@@ -5,6 +5,11 @@ export const DEFAULT_UPLOAD_PROJECT_NAME = DEFAULT_ARTIFACT_PROJECT_NAME
 // New-conversation uploads are staged here until the runtime returns a durable session id.
 export const PENDING_UPLOAD_SESSION_ID = '.pending'
 
+// Per-file 50 MB cap enforced in both the composer and the main-process staging entry.
+export const MAX_UPLOAD_FILE_BYTES = 50 * 1024 * 1024
+// Composer total attachment cap; enforced renderer-side since main is stateless about composer state.
+export const MAX_COMPOSER_ATTACHMENTS = 10
+
 export type StageUploadFile = {
   name: string
   content: string


### PR DESCRIPTION
## Summary

Adds file upload to the composer via **drag-and-drop** and broadens **paste** to all file types, reusing the existing `stageAttachmentFiles` pipeline. Also introduces per-file size and total count limits.

## Changes

- **Drag & drop**: new `useFileDropZone` hook (ref-based depth counter to avoid flicker, `Files`-only guard, `dropEffect = 'copy'`). Drop zone and overlay are scoped to the composer input card only.
- **Paste**: `handleMessageDraftPaste` now accepts all clipboard files (not just images); plain-text paste behavior is unchanged.
- **Overlay**: new `ComposerDropOverlay` — semi-transparent scrim + themed `border-action-primary` border, `Upload` icon, and "Drop files to attach" copy, filling the input card while dragging.
- **Limits**: 50 MB per file and a total of 10 attachments. Renderer pre-checks via a pure `planComposerAttachmentIntake` helper; the main process enforces an authoritative per-file size guard in `stageFiles` (defense in depth for all entry points).

## New shared constants

- `MAX_UPLOAD_FILE_BYTES = 50 MB`
- `MAX_COMPOSER_ATTACHMENTS = 10`

## Error messages

- Oversized: `{name} exceeds the 50 MB limit`
- Too many: `You can attach up to 10 files`

## Testing

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — 723 passed (97 files), including new unit tests for `useFileDropZone`, `planComposerAttachmentIntake`, the composer paste/drop interaction, and the main-process oversized-upload guard.
- Manually verified in `npm run dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
