### PR TITLE
fix(settings): reuse native authentication for Local Claude

### DIFF
--- a/src/main/acp/agent-process.test.ts
+++ b/src/main/acp/agent-process.test.ts
@@ -56,7 +56,11 @@ describe('buildAgentSpawnEnv', () => {
 
   it('keeps inherited ANTHROPIC_* for a non-isolated (claude-default) provider', () => {
     const env = buildAgentSpawnEnv(
-      { ANTHROPIC_BASE_URL: 'https://proxy.example', PATH: '/usr/bin' },
+      {
+        ANTHROPIC_BASE_URL: 'https://proxy.example',
+        CLAUDE_CONFIG_DIR: '/inherited/isolated-config',
+        PATH: '/usr/bin'
+      },
       // claude-default overrides carry no CLAUDE_CONFIG_DIR → not isolated.
       { ANTHROPIC_MODEL: 'claude-opus' },
       '/bin/claude'
@@ -65,6 +69,8 @@ describe('buildAgentSpawnEnv', () => {
     // Reuses the user's global environment (proxy, login, etc.).
     expect(env.ANTHROPIC_BASE_URL).toBe('https://proxy.example')
     expect(env.ANTHROPIC_MODEL).toBe('claude-opus')
+    // Native credential stores are keyed to Claude's implicit config context.
+    expect(env.CLAUDE_CONFIG_DIR).toBeUndefined()
     expect(env.CLAUDE_CODE_EXECUTABLE).toBe('/bin/claude')
   })
 })

--- a/src/main/acp/agent-process.ts
+++ b/src/main/acp/agent-process.ts
@@ -21,11 +21,9 @@ const toUnpackedAsarPath = (filePath: string): string =>
 // Env vars carrying an Anthropic endpoint/credentials/model that an isolated provider must not inherit.
 const ANTHROPIC_ENV_PREFIX = 'ANTHROPIC_'
 
-// Builds the environment for the ACP agent child process. Every provider now runs under an app-owned
-// CLAUDE_CONFIG_DIR (present in envOverrides), so inherited ANTHROPIC_* variables are dropped before the
-// provider's own overrides are applied. This keeps a stray shell `ANTHROPIC_BASE_URL`/`ANTHROPIC_API_KEY`
-// /`ANTHROPIC_AUTH_TOKEN` from leaking into the run; only what the provider sets (custom gateways) or the
-// app dir's stored auth (local) is used.
+// Builds the environment for the ACP agent child process. Isolated providers carry CLAUDE_CONFIG_DIR,
+// so inherited ANTHROPIC_* variables are dropped before their own overrides are applied. A local provider
+// with OS-store-only OAuth deliberately omits CLAUDE_CONFIG_DIR and reuses Claude's default auth context.
 const buildAgentSpawnEnv = (
   sourceEnv: NodeJS.ProcessEnv,
   envOverrides: Record<string, string>,
@@ -36,6 +34,9 @@ const buildAgentSpawnEnv = (
 
   for (const [key, value] of Object.entries(sourceEnv)) {
     if (isolated && key.startsWith(ANTHROPIC_ENV_PREFIX)) continue
+    // A non-isolated local provider must use Claude's implicit default context. Inheriting an explicit
+    // CLAUDE_CONFIG_DIR would recreate the same native-credential lookup failure we are avoiding.
+    if (!isolated && key === 'CLAUDE_CONFIG_DIR') continue
     base[key] = value
   }
 

--- a/src/main/settings/local-claude-auth.test.ts
+++ b/src/main/settings/local-claude-auth.test.ts
@@ -33,8 +33,11 @@ describe('resolveLocalClaudeAuth', () => {
     )
 
     await expect(resolveLocalClaudeAuth({ userClaudeDir, appConfigDir })).resolves.toEqual({
-      ANTHROPIC_AUTH_TOKEN: 'sk-user',
-      ANTHROPIC_BASE_URL: 'https://gw'
+      envOverrides: {
+        ANTHROPIC_AUTH_TOKEN: 'sk-user',
+        ANTHROPIC_BASE_URL: 'https://gw'
+      },
+      useDefaultConfigDir: false
     })
   })
 
@@ -43,18 +46,21 @@ describe('resolveLocalClaudeAuth', () => {
     await writeFile(join(userClaudeDir, 'settings.json'), JSON.stringify({ env: {} }))
     await writeFile(join(userClaudeDir, '.credentials.json'), '{"oauth":"secret"}')
 
-    const env = await resolveLocalClaudeAuth({ userClaudeDir, appConfigDir })
+    const resolution = await resolveLocalClaudeAuth({ userClaudeDir, appConfigDir })
 
-    expect(env).toEqual({})
+    expect(resolution).toEqual({ envOverrides: {}, useDefaultConfigDir: false })
     // The OAuth credentials were copied into the app config dir for claude to use.
     await expect(readFile(join(appConfigDir, '.credentials.json'), 'utf8')).resolves.toContain(
       'oauth'
     )
   })
 
-  it('returns no overrides and does not throw when ~/.claude has neither', async () => {
+  it('falls back to the implicit default config when portable auth is unavailable', async () => {
     const { userClaudeDir, appConfigDir } = await setup()
 
-    await expect(resolveLocalClaudeAuth({ userClaudeDir, appConfigDir })).resolves.toEqual({})
+    await expect(resolveLocalClaudeAuth({ userClaudeDir, appConfigDir })).resolves.toEqual({
+      envOverrides: {},
+      useDefaultConfigDir: true
+    })
   })
 })

--- a/src/main/settings/local-claude-auth.ts
+++ b/src/main/settings/local-claude-auth.ts
@@ -17,6 +17,14 @@ export type LocalClaudeAuthEnv = {
   ANTHROPIC_AUTH_TOKEN?: string
 }
 
+export type LocalClaudeAuthResolution = {
+  envOverrides: LocalClaudeAuthEnv
+  // Recent Claude Code builds can keep OAuth only in the OS credential store. That login is scoped to
+  // Claude's implicit default config context and becomes invisible as soon as CLAUDE_CONFIG_DIR is set,
+  // even when it points at ~/.claude. In that case the caller must omit CLAUDE_CONFIG_DIR entirely.
+  useDefaultConfigDir: boolean
+}
+
 const fileExists = async (path: string): Promise<boolean> => {
   try {
     await access(path, constants.F_OK)
@@ -54,18 +62,18 @@ export type ResolveLocalClaudeAuthOptions = {
   appConfigDir: string
 }
 
-// Returns spawn-env overrides for the local provider, copying OAuth credentials into the app dir when
-// there is no token to inject. Best-effort: any failure yields no overrides rather than throwing.
+// Resolves how the local provider should reuse the machine login. Portable auth stays in the app-owned
+// config context; OS-credential-store auth falls back to Claude's implicit default config context.
 const resolveLocalClaudeAuth = async ({
   userClaudeDir,
   appConfigDir
-}: ResolveLocalClaudeAuthOptions): Promise<LocalClaudeAuthEnv> => {
+}: ResolveLocalClaudeAuthOptions): Promise<LocalClaudeAuthResolution> => {
   const { token, baseUrl } = await readUserClaudeEnv(userClaudeDir)
 
   if (token) {
     const env: LocalClaudeAuthEnv = { ANTHROPIC_AUTH_TOKEN: token }
     if (baseUrl) env.ANTHROPIC_BASE_URL = baseUrl
-    return env
+    return { envOverrides: env, useDefaultConfigDir: false }
   }
 
   // No token → reuse the OAuth login by copying its credentials into the app config dir. claude only
@@ -75,15 +83,34 @@ const resolveLocalClaudeAuth = async ({
   if (await fileExists(credentialsSource)) {
     try {
       await copyFile(credentialsSource, join(appConfigDir, '.credentials.json'))
+      return { envOverrides: {}, useDefaultConfigDir: false }
     } catch {
-      // A failed copy just means local login isn't available; surface nothing here.
+      // Fall through to the default config context, where Claude can still read its native auth store.
     }
   }
 
-  return {}
+  // No portable token/file usually means OAuth lives in Keychain/Credential Manager/libsecret. Do not
+  // copy or expose that secret; let Claude access it through its normal, implicit config context.
+  return { envOverrides: {}, useDefaultConfigDir: true }
+}
+
+// Applies the resolution to a provider env. Deleting (rather than rewriting) CLAUDE_CONFIG_DIR is
+// intentional: current Claude Code treats any explicit value as a separate auth context.
+const applyLocalClaudeAuth = async (
+  providerEnv: Record<string, string>,
+  options: ResolveLocalClaudeAuthOptions
+): Promise<Record<string, string>> => {
+  const resolution = await resolveLocalClaudeAuth(options)
+  const env: Record<string, string> = { ...providerEnv, ...resolution.envOverrides }
+
+  if (resolution.useDefaultConfigDir) {
+    delete env.CLAUDE_CONFIG_DIR
+  }
+
+  return env
 }
 
 // The machine's own Claude config dir.
 const defaultUserClaudeDir = (): string => join(homedir(), '.claude')
 
-export { defaultUserClaudeDir, resolveLocalClaudeAuth }
+export { applyLocalClaudeAuth, defaultUserClaudeDir, resolveLocalClaudeAuth }

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -29,13 +29,18 @@ let storageRoot: string
 let repository: InstanceType<typeof SettingsRepository>
 
 const createService = (
-  detectResult = { found: true, path: '/bin/claude', version: '2.1.0' }
+  detectResult = { found: true, path: '/bin/claude', version: '2.1.0' },
+  options: {
+    userClaudeDir?: string
+    executeClaudeProbe?: (executablePath: string, env: NodeJS.ProcessEnv) => Promise<void>
+  } = {}
 ): InstanceType<typeof SettingsService> =>
   new SettingsService({
     repository,
     storageRoot,
     // Point at a non-existent user Claude dir so tests never read the real ~/.claude for local auth.
-    userClaudeDir: join(storageRoot, 'no-user-claude'),
+    userClaudeDir: options.userClaudeDir ?? join(storageRoot, 'no-user-claude'),
+    executeClaudeProbe: options.executeClaudeProbe,
     detectDeps: {
       env: {},
       homePath: '/home',
@@ -138,6 +143,21 @@ describe('SettingsService: providers', () => {
 })
 
 describe('SettingsService: validation', () => {
+  it('tests Local Claude in the implicit default config when auth is OS-store-only', async () => {
+    const probe = vi.fn<(executablePath: string, env: NodeJS.ProcessEnv) => Promise<void>>()
+    probe.mockResolvedValue(undefined)
+    const service = createService(undefined, { executeClaudeProbe: probe })
+    await repository.setClaudeInfo({ resolvedPath: '/bin/claude', version: '2.1.0' })
+
+    const result = await service.validateProvider({ draft: { type: 'claude-default' } })
+
+    expect(result).toMatchObject({ ok: true, category: 'ok' })
+    expect(probe).toHaveBeenCalledOnce()
+    const probeEnv = probe.mock.calls[0][1]
+    // No portable token/credentials fixture exists, so Claude must be allowed to use its native login.
+    expect(Object.hasOwn(probeEnv, 'CLAUDE_CONFIG_DIR')).toBe(false)
+  })
+
   it('records lastValidatedAt for a saved provider on success', async () => {
     const service = createService()
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200 }))
@@ -292,7 +312,7 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(config.envOverrides.ANTHROPIC_API_KEY).toBeUndefined()
   })
 
-  it('runs a local (claude-default) provider under the shared app config dir, no endpoint/token', async () => {
+  it("uses Claude's implicit default config for a local provider with OS-store-only auth", async () => {
     const service = createService()
 
     await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
@@ -302,9 +322,9 @@ describe('SettingsService: preflight & spawn config', () => {
 
     const config = await service.resolveActiveSpawnConfig()
 
-    // Same app config dir as custom providers (stable across switches); no injected endpoint/token —
-    // local uses the auth stored in the app dir.
-    expect(config.envOverrides.CLAUDE_CONFIG_DIR).toBe(getAppClaudeConfigDir(storageRoot))
+    // No portable auth fixture exists, so the explicit app config is removed. This lets Claude Code
+    // reuse native credential stores that are available only in its implicit default context.
+    expect(config.envOverrides.CLAUDE_CONFIG_DIR).toBeUndefined()
     expect(config.envOverrides.ANTHROPIC_BASE_URL).toBeUndefined()
     expect(config.envOverrides.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
   })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -43,7 +43,7 @@ import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import { detectNpmAvailable, runInstall } from './claude-install'
 import { encryptKey, isEncryptionAvailable, maskKey, tryDecryptKey } from './crypto'
-import { defaultUserClaudeDir, resolveLocalClaudeAuth } from './local-claude-auth'
+import { applyLocalClaudeAuth, defaultUserClaudeDir } from './local-claude-auth'
 import { computePreflight } from './preflight'
 import { listProviderModels } from './list-models'
 import { buildProviderEnv, getAppClaudeConfigDir, type ResolvedProvider } from './provider-env'
@@ -58,6 +58,19 @@ const execFileAsync = promisify(execFile)
 
 // Hard ceiling for the claude-default probe so a stuck local claude can never hang the wizard.
 const CLAUDE_PROBE_TIMEOUT_MS = 20_000
+
+type ExecuteClaudeProbe = (executablePath: string, env: NodeJS.ProcessEnv) => Promise<void>
+
+const executeClaudeProbe: ExecuteClaudeProbe = async (executablePath, env) => {
+  await execFileAsync(executablePath, ['-p', 'ok'], {
+    env,
+    timeout: CLAUDE_PROBE_TIMEOUT_MS,
+    // On Windows the detected claude is a `claude.cmd` shim, which execFile can't launch without a
+    // shell (spawn EINVAL); route the probe through the shell there.
+    shell: process.platform === 'win32',
+    windowsHide: true
+  })
+}
 
 // Detects a child-process timeout (SIGTERM kill or ETIMEDOUT) so the probe can report it distinctly.
 const isTimeoutError = (error: unknown): boolean => {
@@ -88,6 +101,8 @@ export type SettingsServiceOptions = {
   skillRegistry?: SkillRegistry
   // Writable personal/imported skill store, injectable so tests can use a temp storage root.
   userSkills?: UserSkillRepository
+  // One-shot Claude command runner, injectable so validation tests can inspect the exact auth env.
+  executeClaudeProbe?: ExecuteClaudeProbe
 }
 
 // Orchestrates the settings units (repository + crypto + detect/install + validate) behind one
@@ -100,6 +115,7 @@ class SettingsService {
   private readonly userClaudeDir: string
   private readonly skillRegistry: SkillRegistry
   private readonly userSkills: UserSkillRepository
+  private readonly executeClaudeProbe: ExecuteClaudeProbe
   private providerSequence = 0
 
   constructor(options: SettingsServiceOptions = {}) {
@@ -109,6 +125,7 @@ class SettingsService {
     this.userClaudeDir = options.userClaudeDir ?? defaultUserClaudeDir()
     this.skillRegistry = options.skillRegistry ?? new SkillRegistry()
     this.userSkills = options.userSkills ?? new UserSkillRepository(this.storageRoot)
+    this.executeClaudeProbe = options.executeClaudeProbe ?? executeClaudeProbe
   }
 
   // Returns the renderer-safe (masked) snapshot of settings.
@@ -511,7 +528,7 @@ class SettingsService {
       disabledSkillIds: settings.disabledSkillIds
     })
 
-    const envOverrides = buildProviderEnv(
+    let envOverrides = buildProviderEnv(
       this.resolveProvider(activeProvider, settings.activeModel),
       {
         storageRoot: this.storageRoot,
@@ -520,13 +537,13 @@ class SettingsService {
     )
 
     // The "local" provider reuses the machine's own Claude login: inject its token/base URL (or copy
-    // OAuth credentials) at spawn time. Custom providers already carry their own credentials.
+    // OAuth credentials) at spawn time. OS-store-only OAuth falls back to Claude's implicit default
+    // config context, because setting CLAUDE_CONFIG_DIR makes that native login invisible.
     if (activeProvider.type === 'claude-default') {
-      const localAuth = await resolveLocalClaudeAuth({
+      envOverrides = await applyLocalClaudeAuth(envOverrides, {
         userClaudeDir: this.userClaudeDir,
         appConfigDir
       })
-      Object.assign(envOverrides, localAuth)
     }
 
     return { envOverrides, executablePath }
@@ -654,7 +671,6 @@ class SettingsService {
     return undefined
   }
 
-  // One-shot `claude -p "ok"` probe for claude-default validation, using the isolated/default env.
   // One-shot `claude -p "ok"` probe for claude-default validation, using the isolated/default env. A
   // hard timeout guarantees the wizard never hangs on a claude that never returns; a timeout is
   // reported distinctly so the UI can say "timed out" rather than "auth failed".
@@ -668,29 +684,39 @@ class SettingsService {
       return { ok: false, message: 'Claude executable is not configured.' }
     }
 
-    const env = {
-      ...process.env,
-      ...buildProviderEnv(provider, {
+    const appConfigDir = getAppClaudeConfigDir(this.storageRoot)
+    await provisionAppClaudeConfigDir(appConfigDir, {
+      skills: await this.skillCatalog(),
+      disabledSkillIds: settings.disabledSkillIds
+    })
+
+    const envOverrides = await applyLocalClaudeAuth(
+      buildProviderEnv(provider, {
         storageRoot: this.storageRoot,
         claudeExecutablePath: executablePath
-      })
+      }),
+      { userClaudeDir: this.userClaudeDir, appConfigDir }
+    )
+    const env = {
+      ...process.env,
+      ...envOverrides
     }
 
+    // The native-auth fallback requires the variable to be absent, including from the parent process.
+    if (!('CLAUDE_CONFIG_DIR' in envOverrides)) delete env.CLAUDE_CONFIG_DIR
+
     try {
-      await execFileAsync(executablePath, ['-p', 'ok'], {
-        env,
-        timeout: CLAUDE_PROBE_TIMEOUT_MS,
-        // On Windows the detected claude is a `claude.cmd` shim, which execFile can't launch without a
-        // shell (spawn EINVAL); route the probe through the shell there.
-        shell: process.platform === 'win32',
-        windowsHide: true
-      })
+      await this.executeClaudeProbe(executablePath, env)
 
       return { ok: true }
     } catch (error) {
       return isTimeoutError(error)
         ? { ok: false, timedOut: true, message: 'Local claude did not respond in time.' }
-        : { ok: false, message: 'Local claude could not complete a request.' }
+        : {
+            ok: false,
+            message:
+              'Local Claude could not authenticate. Run `claude` in a terminal and log in, then try again.'
+          }
     }
   }
 

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -140,6 +140,23 @@ describe('ProviderList', () => {
     expect(container.textContent).toContain('authentication rejected')
   })
 
+  it('shows the Local Claude probe message instead of referring to an API key', () => {
+    renderList([
+      provider({
+        type: 'claude-default',
+        name: 'Local Claude',
+        lastValidationFailure: {
+          at: 2,
+          category: 'auth',
+          message: 'Local Claude could not authenticate. Run `claude` in a terminal and log in.'
+        }
+      })
+    ])
+
+    expect(container.textContent).toContain('Run `claude` in a terminal')
+    expect(container.textContent).not.toContain('check the API key')
+  })
+
   it('does not flag a provider whose latest validation succeeded', () => {
     // A stale failure older than the last success is not a warning.
     renderList([

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -33,7 +33,9 @@ type IconActionButtonProps = {
 const describeValidationFailure = (failure: ProviderValidationFailure): string => {
   switch (failure.category) {
     case 'auth':
-      return 'Test failed: authentication rejected — check the API key.'
+      return failure.message
+        ? `Test failed: ${failure.message}`
+        : 'Test failed: authentication rejected — check the API key.'
     case 'network':
       return 'Test failed: could not reach the endpoint — check the base URL/connection.'
     case 'bad-url':

--- a/src/renderer/src/pages/settings/validation-message.test.ts
+++ b/src/renderer/src/pages/settings/validation-message.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { describeValidation } from './validation-message'
+
+describe('describeValidation', () => {
+  it('uses the controlled Local Claude auth message when the subprocess probe supplies one', () => {
+    expect(
+      describeValidation({
+        ok: false,
+        category: 'auth',
+        message: 'Local Claude could not authenticate. Run `claude` in a terminal and log in.'
+      })
+    ).toBe('Local Claude could not authenticate. Run `claude` in a terminal and log in.')
+  })
+
+  it('keeps the generic API-key guidance for HTTP auth failures', () => {
+    expect(describeValidation({ ok: false, category: 'auth', status: 401 })).toBe(
+      'Authentication failed. Check the API key. (HTTP 401)'
+    )
+  })
+})

--- a/src/renderer/src/pages/settings/validation-message.ts
+++ b/src/renderer/src/pages/settings/validation-message.ts
@@ -21,6 +21,12 @@ const MESSAGE_CATEGORIES = new Set<ValidationCategory>(['network', 'timeout', 'u
 const describeValidation = (result: ValidateProviderResult): string => {
   const base = CATEGORY_MESSAGES[result.category]
 
+  // Local Claude has no API-key field. Its subprocess probe supplies a controlled, actionable auth
+  // message, so prefer that over the generic gateway wording used for HTTP 401/403 responses.
+  if (result.category === 'auth' && result.message) {
+    return result.message
+  }
+
   if (result.message && MESSAGE_CATEGORIES.has(result.category)) {
     return `${base} (${result.message})`
   }


### PR DESCRIPTION
## Summary

- reuse the local Claude installation's native authentication when credentials are stored in the operating system credential store
- make the Local Claude connection probe use the same authentication setup as the actual agent process
- preserve the isolated app configuration for token- and credentials-file-based authentication
- show Local Claude-specific authentication guidance instead of the misleading API-key error

## Root cause

The connection probe always set the app-owned `CLAUDE_CONFIG_DIR`. Recent Claude Code installations can store login credentials only in the macOS Keychain, Windows Credential Manager, or Linux secret service. Setting `CLAUDE_CONFIG_DIR` prevents Claude Code from resolving those native credentials, so a valid local login was reported as an authentication failure.

The agent spawn path also only handled settings tokens and a portable `.credentials.json` file, leaving native credential-store users affected there as well.

## Fix

When no portable token or credentials file is available, omit `CLAUDE_CONFIG_DIR` entirely so Claude Code can use its normal native credential resolution. Apply the same logic to both the connection probe and the agent process environment, and prevent an inherited `CLAUDE_CONFIG_DIR` from reintroducing the failure.

## User impact

Users who are already logged in through the local `claude` CLI can select Local Claude and connect without supplying an API key, including installations whose credentials live only in the operating system credential store.

## Validation

- `npm test` — 106 test files, 789 tests passed
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Added coverage for native credential-store fallback, probe environment handling, agent spawn environment handling, and Local Claude-specific validation messages.
