### PR TITLE
feat(ci): mirror releases to website S3 + version.json manifest

### DIFF
--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -1,0 +1,108 @@
+# Mirror a published GitHub Release to the website's S3-compatible storage + CDN. Decoupled downstream
+# consumer of release.yml: GitHub Release stays the single source of truth, this job re-publishes its
+# installers to a fast, in-country endpoint and writes version.json (website + in-app update prompt).
+name: Mirror to website
+
+on:
+  # Auto-run once a Release is published; also runnable by hand to backfill or re-mirror a past tag.
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to mirror (e.g. v0.1.2)'
+        required: true
+
+# Only needs to read Release assets; it never writes back to the repo.
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (for the manifest script)
+        uses: actions/checkout@v4
+
+      # Tag from the Release event, or the manual input; version is the tag without a leading 'v'.
+      - name: Resolve tag and version
+        id: ref
+        run: |
+          tag="${{ github.event.release.tag_name || inputs.tag }}"
+          if [ -z "$tag" ]; then
+            echo "No tag resolved from event or input" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      # Pull every installer + SHA256SUMS.txt for the tag. GH_TOKEN authenticates gh with the repo.
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "${{ steps.ref.outputs.tag }}" --repo "${{ github.repository }}" --dir dist-assets
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Build version.json from the downloaded files. Missing platforms warn (not fail) inside the
+      # script, so a partial release still yields a usable manifest.
+      - name: Generate version.json
+        env:
+          DIST_DIR: dist-assets
+          OUTPUT: version.json
+          VERSION: ${{ steps.ref.outputs.version }}
+          CDN_BASE_URL: ${{ vars.CDN_BASE_URL }}
+          S3_PREFIX: ${{ vars.S3_PREFIX }}
+          NOTES: ${{ github.event.release.body }}
+          RELEASE_DATE: ${{ github.event.release.published_at }}
+        run: node scripts/generate-version-manifest.mjs
+
+      # aws-cli talks to any S3-compatible endpoint via --endpoint-url. Credentials/region come from
+      # secrets/vars — nothing about the storage backend is hardcoded here.
+      - name: Configure AWS credentials
+        env:
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          S3_REGION: ${{ vars.S3_REGION }}
+        run: |
+          aws configure set aws_access_key_id "$S3_ACCESS_KEY_ID"
+          aws configure set aws_secret_access_key "$S3_SECRET_ACCESS_KEY"
+          aws configure set default.region "$S3_REGION"
+
+      # Installers go to an immutable, per-version path: re-running the same tag overwrites identical
+      # bytes (idempotent backfill), and the versioned path never needs CDN invalidation. version.json
+      # is excluded here and published separately as the one mutable object.
+      - name: Sync installers to versioned path
+        env:
+          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          S3_PREFIX: ${{ vars.S3_PREFIX }}
+          VERSION: ${{ steps.ref.outputs.version }}
+        run: |
+          aws --endpoint-url "$S3_ENDPOINT" s3 sync dist-assets/ \
+            "s3://$S3_BUCKET/$S3_PREFIX/releases/$VERSION/" --exclude "version.json"
+
+      # The single mutable manifest, overwritten on every release; website + app read this path.
+      - name: Upload version.json
+        env:
+          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          S3_PREFIX: ${{ vars.S3_PREFIX }}
+        run: |
+          aws --endpoint-url "$S3_ENDPOINT" s3 cp version.json \
+            "s3://$S3_BUCKET/$S3_PREFIX/version.json"
+
+      # Pluggable CDN invalidation: only version.json can change, so only it is invalidated. Skipped
+      # entirely when no CDN credential is configured (e.g. MinIO-only setups), keeping the CDN vendor
+      # out of the hard dependency path. Swap the command body for your CDN's API when enabling.
+      - name: Invalidate CDN cache for version.json
+        if: ${{ secrets.CDN_API_TOKEN != '' }}
+        env:
+          CDN_API_TOKEN: ${{ secrets.CDN_API_TOKEN }}
+          S3_PREFIX: ${{ vars.S3_PREFIX }}
+        run: |
+          echo "Invalidating $S3_PREFIX/version.json via CDN API"
+          # TODO(sub-project): call the configured CDN's purge API for /$S3_PREFIX/version.json.

--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -1,6 +1,8 @@
 # Mirror a published GitHub Release to the website's S3-compatible storage + CDN. Decoupled downstream
 # consumer of release.yml: GitHub Release stays the single source of truth, this job re-publishes its
 # installers to a fast, in-country endpoint and writes version.json (website + in-app update prompt).
+# Cache correctness is handled purely via Cache-Control headers at upload time (immutable installers,
+# no-cache manifest) — no CDN purge API is needed.
 name: Mirror to website
 
 on:
@@ -73,36 +75,29 @@ jobs:
           aws configure set default.region "$S3_REGION"
 
       # Installers go to an immutable, per-version path: re-running the same tag overwrites identical
-      # bytes (idempotent backfill), and the versioned path never needs CDN invalidation. version.json
-      # is excluded here and published separately as the one mutable object.
+      # bytes (idempotent backfill). The immutable Cache-Control lets the CDN/browsers cache these
+      # large files forever without any purge. version.json is excluded here and published separately
+      # as the one mutable object. Bucket is a secret so it stays masked in the public Actions log, and
+      # --only-show-errors suppresses the per-file `upload: ... to s3://...` lines that would leak it.
       - name: Sync installers to versioned path
         env:
           S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_PREFIX: ${{ vars.S3_PREFIX }}
           VERSION: ${{ steps.ref.outputs.version }}
         run: |
           aws --endpoint-url "$S3_ENDPOINT" s3 sync dist-assets/ \
-            "s3://$S3_BUCKET/$S3_PREFIX/releases/$VERSION/" --exclude "version.json"
+            "s3://$S3_BUCKET/$S3_PREFIX/releases/$VERSION/" --exclude "version.json" \
+            --cache-control "public, max-age=31536000, immutable" --only-show-errors
 
-      # The single mutable manifest, overwritten on every release; website + app read this path.
+      # The single mutable manifest, overwritten on every release; website + app read this path. no-cache
+      # keeps the CDN/browsers revalidating so a new version is picked up immediately without a purge.
       - name: Upload version.json
         env:
           S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_PREFIX: ${{ vars.S3_PREFIX }}
         run: |
           aws --endpoint-url "$S3_ENDPOINT" s3 cp version.json \
-            "s3://$S3_BUCKET/$S3_PREFIX/version.json"
-
-      # Pluggable CDN invalidation: only version.json can change, so only it is invalidated. Skipped
-      # entirely when no CDN credential is configured (e.g. MinIO-only setups), keeping the CDN vendor
-      # out of the hard dependency path. Swap the command body for your CDN's API when enabling.
-      - name: Invalidate CDN cache for version.json
-        if: ${{ secrets.CDN_API_TOKEN != '' }}
-        env:
-          CDN_API_TOKEN: ${{ secrets.CDN_API_TOKEN }}
-          S3_PREFIX: ${{ vars.S3_PREFIX }}
-        run: |
-          echo "Invalidating $S3_PREFIX/version.json via CDN API"
-          # TODO(sub-project): call the configured CDN's purge API for /$S3_PREFIX/version.json.
+            "s3://$S3_BUCKET/$S3_PREFIX/version.json" \
+            --cache-control "no-cache" --content-type "application/json" --only-show-errors

--- a/scripts/generate-version-manifest.mjs
+++ b/scripts/generate-version-manifest.mjs
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+// Generate version.json: the single manifest that powers the website's download page and the
+// in-app update prompt (sub-project 2). Pure Node ESM, zero network — input is a local directory of
+// release installers plus SHA256SUMS.txt, output is the manifest object / a version.json file.
+//
+// CLI (executed directly), inputs from argv + env:
+//   node scripts/generate-version-manifest.mjs [dir] [outputPath]
+//     dir         positional or env DIST_DIR   directory holding installers + SHA256SUMS.txt
+//                 (default: dist-assets)
+//     outputPath  positional or env OUTPUT      where to write version.json (default: <dir>/version.json)
+//     VERSION       required  release version without a leading 'v' (e.g. 0.1.2)
+//     CDN_BASE_URL  required  public base URL used to build each download url
+//     S3_PREFIX     required  path prefix inside the bucket (e.g. open-science)
+//     NOTES         optional  release notes (GitHub Release body)
+//     RELEASE_DATE  optional  ISO timestamp (GitHub Release published_at)
+
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+// Filename -> downloads key. Explicit regex table so an unexpected artifact name fails loudly (as a
+// warning) rather than being silently misfiled. deb uses the dpkg convention (underscores + amd64).
+const KEY_RULES = [
+  { key: 'mac-arm64', pattern: /-mac-arm64\.dmg$/ },
+  { key: 'mac-x64', pattern: /-mac-x64\.dmg$/ },
+  { key: 'win-x64', pattern: /-win-x64-setup\.exe$/ },
+  { key: 'linux-x64-appimage', pattern: /-linux-x64\.AppImage$/ },
+  { key: 'linux-x64-deb', pattern: /_amd64\.deb$/ }
+]
+
+// Non-installer files that legitimately live in the release dir; skipped without a warning.
+const IGNORED = [/\.zip$/, /^SHA256SUMS\.txt$/, /^version\.json$/, /\.ya?ml$/, /\.blockmap$/]
+
+// Parse a `<hex>  <filename>` per-line SHA256SUMS.txt into { filename: hex }. Tolerates 1+ spaces
+// and an optional leading '*' binary marker that some sha256sum variants emit.
+export function parseSha256Sums(content) {
+  const map = {}
+  for (const line of content.split('\n')) {
+    const match = line.trim().match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/)
+    if (match) map[match[2]] = match[1].toLowerCase()
+  }
+  return map
+}
+
+// Match a filename to its downloads key, or null when no rule applies.
+function keyForFile(filename) {
+  return KEY_RULES.find((rule) => rule.pattern.test(filename))?.key ?? null
+}
+
+// Build the version.json manifest object from a directory of installers + SHA256SUMS.txt.
+// Pure: reads the filesystem but performs no network I/O. Only keys whose installer actually exists
+// (and has a checksum) are emitted; unrecognized files and files missing from SHA256SUMS warn.
+export function buildManifest({ dir, version, notes, releaseDate, cdnBase, prefix }) {
+  const sums = parseSha256Sums(readFileSync(join(dir, 'SHA256SUMS.txt'), 'utf8'))
+  const base = `${cdnBase}/${prefix}/releases/${version}`
+
+  const downloads = {}
+  for (const filename of readdirSync(dir)) {
+    const key = keyForFile(filename)
+    if (!key) {
+      // Warn only for genuinely unexpected files, not known non-manifest artifacts (zips, sums, ...).
+      if (!IGNORED.some((pattern) => pattern.test(filename))) {
+        console.warn(`[version-manifest] unrecognized file, ignoring: ${filename}`)
+      }
+      continue
+    }
+    const sha256 = sums[filename]
+    if (!sha256) {
+      // No verifiable hash -> useless to the in-app integrity check, so drop it rather than emit it.
+      console.warn(`[version-manifest] no sha256 in SHA256SUMS.txt, skipping: ${filename}`)
+      continue
+    }
+    downloads[key] = {
+      url: `${base}/${filename}`,
+      size: statSync(join(dir, filename)).size,
+      sha256
+    }
+  }
+
+  return { version, releaseDate, notes, downloads }
+}
+
+// CLI entry: only runs when the file is executed directly, not when imported by the test.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const dir = process.argv[2] || process.env.DIST_DIR || 'dist-assets'
+  const outputPath = process.argv[3] || process.env.OUTPUT || join(dir, 'version.json')
+
+  const version = process.env.VERSION
+  const cdnBase = process.env.CDN_BASE_URL
+  const prefix = process.env.S3_PREFIX
+  if (!version || !cdnBase || !prefix) {
+    console.error('[version-manifest] VERSION, CDN_BASE_URL and S3_PREFIX are required')
+    process.exit(1)
+  }
+
+  const manifest = buildManifest({
+    dir,
+    version,
+    notes: process.env.NOTES ?? '',
+    releaseDate: process.env.RELEASE_DATE ?? '',
+    cdnBase,
+    prefix
+  })
+
+  writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  console.log(outputPath)
+}

--- a/scripts/generate-version-manifest.test.ts
+++ b/scripts/generate-version-manifest.test.ts
@@ -1,0 +1,160 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { buildManifest, parseSha256Sums } from './generate-version-manifest.mjs'
+
+const VERSION = '0.1.2'
+const CDN = 'https://cdn.example.com'
+const PREFIX = 'open-science'
+
+// The full set of installer filenames a complete release produces (matches release.yml output).
+const INSTALLERS = {
+  'mac-arm64': `open-science-${VERSION}-mac-arm64.dmg`,
+  'mac-x64': `open-science-${VERSION}-mac-x64.dmg`,
+  'win-x64': `open-science-${VERSION}-win-x64-setup.exe`,
+  'linux-x64-appimage': `open-science-${VERSION}-linux-x64.AppImage`,
+  'linux-x64-deb': `open-science_${VERSION}_amd64.deb`
+}
+
+// One line of SHA256SUMS.txt worth of file: content is hashed by `sha` (or omitted when sha is null).
+type FileSpec = { name: string; content: string; sha: string | null }
+
+// Builds a hermetic release directory: writes each given file with deterministic contents and a
+// matching SHA256SUMS.txt. Contents/hashes are arbitrary but fixed, so assertions stay stable.
+function makeReleaseDir(files: FileSpec[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'version-manifest-'))
+  const sumsLines: string[] = []
+  for (const { name, content, sha } of files) {
+    writeFileSync(join(dir, name), content)
+    if (sha !== null) sumsLines.push(`${sha}  ${name}`)
+  }
+  writeFileSync(join(dir, 'SHA256SUMS.txt'), `${sumsLines.join('\n')}\n`)
+  return dir
+}
+
+// A canonical entry: 64-hex sha keyed off the platform so each file gets a distinct, checkable hash.
+const HEX = (n: string): string => n.repeat(64)
+function entry(key: keyof typeof INSTALLERS, extra = 0): FileSpec {
+  return { name: INSTALLERS[key], content: 'x'.repeat(10 + extra), sha: HEX(String(extra % 10)) }
+}
+
+describe('parseSha256Sums', () => {
+  it('parses `<hex>  <filename>` lines and lowercases the hash', () => {
+    const map = parseSha256Sums(
+      `${'A'.repeat(64)}  file-one.dmg\n${'b'.repeat(64)}  file two.exe\n`
+    )
+    expect(map['file-one.dmg']).toBe('a'.repeat(64))
+    expect(map['file two.exe']).toBe('b'.repeat(64))
+  })
+
+  it('tolerates the optional binary-mode `*` marker and ignores junk lines', () => {
+    const map = parseSha256Sums(`${'c'.repeat(64)} *app.AppImage\nnot a checksum line\n`)
+    expect(map['app.AppImage']).toBe('c'.repeat(64))
+    expect(Object.keys(map)).toHaveLength(1)
+  })
+})
+
+describe('buildManifest', () => {
+  let dir: string | undefined
+  afterEach(() => dir && rmSync(dir, { recursive: true, force: true }))
+
+  it('maps every installer to its key with url, size and sha256', () => {
+    const files = Object.keys(INSTALLERS).map((key, i) => entry(key, i + 1))
+    dir = makeReleaseDir(files)
+
+    const manifest = buildManifest({
+      dir,
+      version: VERSION,
+      notes: 'Release notes here',
+      releaseDate: '2026-07-12T00:00:00Z',
+      cdnBase: CDN,
+      prefix: PREFIX
+    })
+
+    // version / notes / releaseDate pass through untouched.
+    expect(manifest.version).toBe(VERSION)
+    expect(manifest.notes).toBe('Release notes here')
+    expect(manifest.releaseDate).toBe('2026-07-12T00:00:00Z')
+
+    // All five platform keys present.
+    expect(Object.keys(manifest.downloads).sort()).toEqual(Object.keys(INSTALLERS).sort())
+
+    // url construction: <cdn>/<prefix>/releases/<version>/<filename>.
+    expect(manifest.downloads['win-x64'].url).toBe(
+      `${CDN}/${PREFIX}/releases/${VERSION}/${INSTALLERS['win-x64']}`
+    )
+    // deb keeps the underscore/amd64 convention in its url.
+    expect(manifest.downloads['linux-x64-deb'].url).toBe(
+      `${CDN}/${PREFIX}/releases/${VERSION}/open-science_${VERSION}_amd64.deb`
+    )
+
+    // sha256 comes from SHA256SUMS.txt (entry #2 -> content length 12, sha of '2').
+    const deb = files.find((f) => f.name === INSTALLERS['linux-x64-deb'])
+    expect(manifest.downloads['linux-x64-deb'].sha256).toBe(deb.sha)
+    expect(manifest.downloads['linux-x64-deb'].size).toBe(deb.content.length)
+  })
+
+  it('omits a platform whose installer is missing', () => {
+    dir = makeReleaseDir([entry('mac-arm64', 1), entry('win-x64', 2)])
+
+    const manifest = buildManifest({
+      dir,
+      version: VERSION,
+      notes: '',
+      releaseDate: '',
+      cdnBase: CDN,
+      prefix: PREFIX
+    })
+
+    expect(Object.keys(manifest.downloads).sort()).toEqual(['mac-arm64', 'win-x64'])
+    expect(manifest.downloads['mac-x64']).toBeUndefined()
+    expect(manifest.downloads['linux-x64-deb']).toBeUndefined()
+  })
+
+  it('warns and skips an installer missing from SHA256SUMS', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    dir = makeReleaseDir([entry('mac-arm64', 1), { ...entry('mac-x64', 2), sha: null }])
+
+    const manifest = buildManifest({
+      dir,
+      version: VERSION,
+      notes: '',
+      releaseDate: '',
+      cdnBase: CDN,
+      prefix: PREFIX
+    })
+
+    expect(manifest.downloads['mac-arm64']).toBeDefined()
+    expect(manifest.downloads['mac-x64']).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no sha256'))
+    warn.mockRestore()
+  })
+
+  it('warns on an unrecognized file but stays silent for zips and checksums', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    dir = makeReleaseDir([
+      entry('mac-arm64', 1),
+      { name: 'open-science-0.1.2-mac-arm64.zip', content: 'zip', sha: HEX('9') },
+      { name: 'mystery-artifact.bin', content: 'bin', sha: HEX('8') }
+    ])
+
+    const manifest = buildManifest({
+      dir,
+      version: VERSION,
+      notes: '',
+      releaseDate: '',
+      cdnBase: CDN,
+      prefix: PREFIX
+    })
+
+    // zip is mirrored to S3 but is not a manifest key.
+    expect(manifest.downloads['mac-arm64']).toBeDefined()
+    expect(Object.keys(manifest.downloads)).toEqual(['mac-arm64'])
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('mystery-artifact.bin'))
+    warn.mockRestore()
+  })
+})


### PR DESCRIPTION
## What

Sub-project 1 of website distribution: a **decoupled** workflow that mirrors each published GitHub Release to the website's S3-compatible storage + CDN, and writes a `version.json` manifest for the site + future in-app update prompt. `release.yml` is untouched — GitHub Release stays the single source of truth.

## How it works

- Triggers on `release: published` (auto) and `workflow_dispatch` with a `tag` input (manual backfill).
- `gh release download` → generate `version.json` → `aws s3 sync` installers to an immutable `releases/<version>/` path → upload `version.json`.
- Bucket layout: `<prefix>/releases/<version>/…` (immutable) + `<prefix>/version.json` (mutable). Intended `S3_PREFIX = open-science/app/stable` (product / category / channel), reserving room for `nightly`, `sdk`, etc.

## Distribution model

All platforms use **notify + manual** (no silent auto-update): the app will read `version.json`, and on a newer version prompt the user, download the platform installer in-app, verify sha256, and launch the installer. No `electron-updater`, no signing dependency, no `latest*.yml` — those are out of scope here (see sub-projects 2/3).

## Security / caching (public repo)

- `S3_BUCKET` + `S3_ENDPOINT` are **Secrets** (masked in the public Actions log); `--only-show-errors` suppresses per-file `s3://…` output as defense-in-depth.
- Cache handled at upload time — no CDN purge API: installers `Cache-Control: immutable`, `version.json` `Cache-Control: no-cache`. `CDN_API_TOKEN` removed.

## Config required before this runs

- Secrets: `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`
- Variables: `S3_REGION`, `S3_PREFIX`, `CDN_BASE_URL`

## Files

- `.github/workflows/mirror-to-website.yml`
- `scripts/generate-version-manifest.mjs` (pure ESM; exported `buildManifest`)
- `scripts/generate-version-manifest.test.ts` (6 vitest cases, hermetic)

## Verification

- `eslint` clean on both scripts.
- `vitest` — 6/6 pass (key mapping, sha256 parse, url/size, missing-platform omission, warn-and-skip).
- Workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)