### PR TITLE
fix(ci): drop --endpoint-url so aws-cli resolves the S3 endpoint from region

### DIFF
--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -62,8 +62,9 @@ jobs:
           RELEASE_DATE: ${{ github.event.release.published_at }}
         run: node scripts/generate-version-manifest.mjs
 
-      # aws-cli talks to any S3-compatible endpoint via --endpoint-url. Credentials/region come from
-      # secrets/vars — nothing about the storage backend is hardcoded here.
+      # Credentials + region for aws-cli. The region alone lets aws-cli resolve the correct AWS S3
+      # endpoint on its own — do NOT pass --endpoint-url: a bucket/website-style endpoint there makes
+      # ListObjectsV2 return NoSuchKey and breaks the sync.
       - name: Configure AWS credentials
         env:
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
@@ -81,12 +82,11 @@ jobs:
       # --only-show-errors suppresses the per-file `upload: ... to s3://...` lines that would leak it.
       - name: Sync installers to versioned path
         env:
-          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_PREFIX: ${{ vars.S3_PREFIX }}
           VERSION: ${{ steps.ref.outputs.version }}
         run: |
-          aws --endpoint-url "$S3_ENDPOINT" s3 sync dist-assets/ \
+          aws s3 sync dist-assets/ \
             "s3://$S3_BUCKET/$S3_PREFIX/releases/$VERSION/" --exclude "version.json" \
             --cache-control "public, max-age=31536000, immutable" --only-show-errors
 
@@ -94,10 +94,9 @@ jobs:
       # keeps the CDN/browsers revalidating so a new version is picked up immediately without a purge.
       - name: Upload version.json
         env:
-          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_PREFIX: ${{ vars.S3_PREFIX }}
         run: |
-          aws --endpoint-url "$S3_ENDPOINT" s3 cp version.json \
+          aws s3 cp version.json \
             "s3://$S3_BUCKET/$S3_PREFIX/version.json" \
             --cache-control "no-cache" --content-type "application/json" --only-show-errors


### PR DESCRIPTION
## Problem

The mirror workflow passed `--endpoint-url "$S3_ENDPOINT"` to `aws s3 sync`/`cp`. With a bucket/website-style endpoint value this made `ListObjectsV2` fail with:

```
fatal error: An error occurred (NoSuchKey) when calling the ListObjectsV2 operation: The specified key does not exist.
```

(seen in run [29227576781](https://github.com/aipoch/open-science/actions/runs/29227576781); auth already passed, the endpoint was the culprit). Confirmed locally that removing `--endpoint-url` fixes it.

## Fix

For real AWS S3, the region alone (already set via `aws configure set default.region`) lets aws-cli resolve the correct endpoint. This PR:

- Removes `--endpoint-url "$S3_ENDPOINT"` from both the installer sync and the `version.json` upload commands.
- Removes the now-unused `S3_ENDPOINT` env from both steps.
- Updates the step comment to warn against re-adding an endpoint override.

## Follow-up (ops)

- The `S3_ENDPOINT` **secret can be deleted** — it is no longer referenced.
- `S3_REGION` must be the bucket's actual region (it drives endpoint resolution now).

No script/app changes; YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)