### PR TITLE
feat(skills): sort Featured skills alphabetically by name

### DIFF
--- a/src/main/skills/registry.test.ts
+++ b/src/main/skills/registry.test.ts
@@ -79,4 +79,36 @@ describe('SkillRegistry', () => {
     const root = await mkdtemp(join(tmpdir(), 'skills-empty-'))
     expect(await new SkillRegistry(root).list()).toEqual([])
   })
+
+  it('sorts featured skills alphabetically by name regardless of manifest order', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-sort-'))
+    const seed = [
+      { id: 'charlie', name: 'Charlie' },
+      { id: 'alpha', name: 'Alpha' },
+      { id: 'bravo', name: 'Bravo' }
+    ]
+    for (const { id, name } of seed) {
+      await mkdir(join(root, id), { recursive: true })
+      await writeFile(
+        join(root, id, 'SKILL.md'),
+        ['---', `name: ${name}`, `description: ${name} skill.`, '---', '', `# ${name}`].join('\n'),
+        'utf8'
+      )
+    }
+    await writeFile(
+      join(root, 'manifest.json'),
+      JSON.stringify({
+        version: 1,
+        skills: seed.map(({ id, name }) => ({
+          id,
+          name,
+          source: 'featured',
+          updatedAt: '2026-01-01T00:00:00.000Z'
+        }))
+      }),
+      'utf8'
+    )
+    const skills = await new SkillRegistry(root).list()
+    expect(skills.map((skill) => skill.name)).toEqual(['Alpha', 'Bravo', 'Charlie'])
+  })
 })

--- a/src/main/skills/registry.ts
+++ b/src/main/skills/registry.ts
@@ -97,7 +97,8 @@ class SkillRegistry {
       }
     }
 
-    return skills
+    // Featured skills always display alphabetically by name; the manifest order is not significant.
+    return skills.sort((a, b) => a.name.localeCompare(b.name))
   }
 
   async body(id: string): Promise<string> {


### PR DESCRIPTION
## Summary

The **Featured** group in Settings → Skills previously rendered in raw `manifest.json` order (a curated, non-alphabetical order). This sorts bundled skills alphabetically by name so the catalog always displays A→Z, independent of manifest ordering.

- Sort applied once in `SkillRegistry.list()` (`skills.sort((a, b) => a.name.localeCompare(b.name))`), the single source of truth for featured skills.
- **Featured only** — Imported and Personal skills come from a separate repository and keep their existing order.
- The `manifest.json` file is left untouched; ordering is derived at read time.
- Cross-platform: pure main-process JS, no OS-specific APIs (Windows / macOS / Linux behave identically; current skill names are ASCII English so `localeCompare` is deterministic everywhere).

## Test plan

- [x] `SkillRegistry` unit test: seeds a non-alphabetical manifest (Charlie/Alpha/Bravo) and asserts output is `Alpha, Bravo, Charlie`.
- [x] Full suite passes (registry + settings service + config provision): 34 tests, 0 failures.
- [x] `npm run lint` and `npm run typecheck` clean.
- [x] Verified in the running dev app (Settings → Skills): live IPC and rendered DOM both return the Featured group A→Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)