### PR TITLE
feat(composer): / skill selector with an inline chip

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -519,6 +519,13 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Composer area uses a top fade `bg-gradient-to-t from-bg-10 to-bg-10/0`.
 - Message scroller and preview panel both use `bg-bg-10`.
 
+#### Composer skill selector
+
+- The composer input is a `contenteditable` editor (`role="textbox" aria-multiline`), not a textarea, so it can hold inline non-editable mention chips. Placeholder via `empty:before:content-[attr(data-placeholder)]` in a muted `text-text-300`: `Ask anything — / for skills`. Only `/` skills is wired; `@`/`#`/`⌘K` are reserved for later and are not advertised in the placeholder.
+- Typing `/` at a word boundary opens a **skill popup** above the input: `absolute bottom-full mb-1 z-50 bg-bg-000 border-0.5 border-border-200 rounded-xl shadow p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)]`. It is a `role="listbox"` of `role="option"` rows — name (`font-medium text-sm truncate`) + source badge (`text-[10px] px-1.5 py-0.5 rounded bg-accent text-accent-foreground`) + 2-line description (`text-xs text-text-300 line-clamp-2`); active row `bg-bg-200 !text-text-000`. A footer hint bar shows `↑↓ navigate · Enter select · Esc close`.
+- Selecting inserts an inline **skill chip**: `inline-flex items-center px-1.5 py-0.5 mx-0.5 bg-accent text-accent-foreground rounded text-sm font-medium select-all`, `contenteditable="false"`, label `/<Name>`, carrying `data-mention-type="skill" data-skill-id`. Backspace deletes the whole chip; chips are atomic to caret motion.
+- On send, chips serialize to `/<Name>` inline in the visible message, and their skill ids are carried as `forcedSkillIds`: the agent prompt is prefixed with a steering nudge naming the skills, and any picked skill toggled off in Settings is force-loaded for that turn only (the message text the user sees is unchanged).
+
 ### Settings
 
 - Use a large `Dialog`; the default panel is bordered `rounded-xl border border-border bg-card shadow-dialog`. A maximize control enlarges it to `h-[80vh] w-[80vw]`; the restored size follows content density.

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -64,6 +64,14 @@ const createRuntime = ({
     defaultCwd: homedir(),
     // Read the active provider's credentials/model on every connect so provider switches apply.
     resolveSpawnConfig: () => settingsService.resolveActiveSpawnConfig(),
+    // Turn-scoped skill force-load: the runtime uses these to respawn with a picked-but-disabled skill
+    // for one prompt and to build the steering nudge naming the picked skills.
+    skills: {
+      needForceLoad: (ids) => settingsService.skillsNeedingForceLoad(ids),
+      setTurnForced: (ids) => settingsService.setTurnForcedSkillIds(ids),
+      clearTurnForced: () => settingsService.clearTurnForcedSkillIds(),
+      namesForIds: (ids) => settingsService.skillNamesForIds(ids)
+    },
     artifacts: {
       // Reuse the session persistence root so chat state and generated files move together.
       storageRoot,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -6,7 +6,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from './runtime'
 import { ArtifactRepository } from '../artifacts/repository'
@@ -1445,5 +1445,146 @@ describe('ACP runtime session management', () => {
 
     expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([])
     expect(prompts).toEqual(['first prompt'])
+  })
+})
+
+describe('ACP runtime skill force-load + nudge', () => {
+  // Builds a spawner that returns a fresh fake agent per connect, so a force-load reconnect can spawn a
+  // second working agent. All agent handles are collected so tests can assert prompts across reconnects.
+  const createFreshAgentSpawner = (): {
+    spawn: () => ChildProcessWithoutNullStreams
+    agents: Array<ReturnType<typeof startFakeAgent>>
+    spawnCount: () => number
+  } => {
+    const agents: Array<ReturnType<typeof startFakeAgent>> = []
+    let count = 0
+
+    return {
+      spawn: () => {
+        count += 1
+        const process = new FakeAgentProcess()
+        agents.push(startFakeAgent(process, ['remote-session-1']))
+        return asAgentProcess(process)
+      },
+      agents,
+      spawnCount: () => count
+    }
+  }
+
+  // A stub of the settings-service skill hooks with per-call spies for assertions.
+  const createSkillsHooks = (options: {
+    needForceLoad: string[]
+    names: Record<string, string>
+  }): {
+    needForceLoad: ReturnType<typeof vi.fn<(ids: string[]) => Promise<string[]>>>
+    setTurnForced: ReturnType<typeof vi.fn<(ids: string[]) => void>>
+    clearTurnForced: ReturnType<typeof vi.fn<() => void>>
+    namesForIds: ReturnType<typeof vi.fn<(ids: string[]) => Promise<string[]>>>
+  } => ({
+    needForceLoad: vi.fn<(ids: string[]) => Promise<string[]>>(async () => options.needForceLoad),
+    setTurnForced: vi.fn<(ids: string[]) => void>(),
+    clearTurnForced: vi.fn<() => void>(),
+    namesForIds: vi.fn<(ids: string[]) => Promise<string[]>>(async (ids: string[]) =>
+      ids.map((id) => options.names[id]).filter((name): name is string => name !== undefined)
+    )
+  })
+
+  it('respawns and nudges when a picked skill is disabled, then restores after the turn', async () => {
+    const spawner = createFreshAgentSpawner()
+    const hooks = createSkillsHooks({
+      needForceLoad: ['research'],
+      names: { research: 'Deep Research' }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: spawner.spawn,
+      skills: hooks
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    expect(spawner.spawnCount()).toBe(1)
+
+    await runtime.sendPrompt({
+      sessionId: 'remote-session-1',
+      text: 'summarize the paper',
+      forcedSkillIds: ['research']
+    })
+
+    // The picked skill was marked forced and the agent respawned before the prompt (resume path).
+    expect(hooks.setTurnForced).toHaveBeenCalledWith(['research'])
+    expect(spawner.spawnCount()).toBe(2)
+    expect(spawner.agents[1].resumedSessions).toHaveLength(1)
+
+    // The nudge is prepended to the text the agent receives (on the respawned agent).
+    expect(spawner.agents[1].prompts).toEqual([
+      {
+        sessionId: 'remote-session-1',
+        text: 'Use the following skill(s) for this task: Deep Research.\n\nsummarize the paper'
+      }
+    ])
+
+    // After the turn the force set is cleared and a restore reconnect is scheduled (agent torn down).
+    expect(hooks.clearTurnForced).toHaveBeenCalledTimes(1)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(runtime.getSnapshot().status).toBe('closed')
+  })
+
+  it('nudges without any reconnect when every picked skill is already enabled', async () => {
+    const spawner = createFreshAgentSpawner()
+    const hooks = createSkillsHooks({
+      needForceLoad: [],
+      names: { research: 'Deep Research' }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: spawner.spawn,
+      skills: hooks
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: 'remote-session-1',
+      text: 'summarize the paper',
+      forcedSkillIds: ['research']
+    })
+
+    // No disabled picks → no respawn and no force set toggling, but the nudge is still prepended.
+    expect(hooks.setTurnForced).not.toHaveBeenCalled()
+    expect(hooks.clearTurnForced).not.toHaveBeenCalled()
+    expect(spawner.spawnCount()).toBe(1)
+    expect(spawner.agents[0].prompts).toEqual([
+      {
+        sessionId: 'remote-session-1',
+        text: 'Use the following skill(s) for this task: Deep Research.\n\nsummarize the paper'
+      }
+    ])
+  })
+
+  it('leaves the prompt untouched when no skills are picked', async () => {
+    const spawner = createFreshAgentSpawner()
+    const hooks = createSkillsHooks({
+      needForceLoad: ['research'],
+      names: { research: 'Deep Research' }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: spawner.spawn,
+      skills: hooks
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'plain prompt' })
+
+    // With no forcedSkillIds, none of the skill hooks run and the text is unchanged.
+    expect(hooks.needForceLoad).not.toHaveBeenCalled()
+    expect(hooks.namesForIds).not.toHaveBeenCalled()
+    expect(hooks.setTurnForced).not.toHaveBeenCalled()
+    expect(spawner.spawnCount()).toBe(1)
+    expect(spawner.agents[0].prompts).toEqual([
+      { sessionId: 'remote-session-1', text: 'plain prompt' }
+    ])
   })
 })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -63,6 +63,20 @@ type AcpRuntimeOptions = {
   artifacts?: AcpRuntimeArtifactOptions
   uploads?: AcpRuntimeUploadOptions
   notebook?: AcpRuntimeNotebookOptions
+  skills?: AcpRuntimeSkillsOptions
+}
+
+// Turn-scoped skill force-load hooks, wired from the settings service. Optional so tests that construct
+// the runtime without them are unaffected; every usage guards on presence.
+type AcpRuntimeSkillsOptions = {
+  // Returns the subset of forced ids that are currently disabled (i.e. need a respawn to materialize).
+  needForceLoad: (ids: string[]) => Promise<string[]>
+  // Marks these ids force-loaded for the next spawn's provisioning.
+  setTurnForced: (ids: string[]) => void
+  // Clears the turn-scoped force-load set so later spawns use the normal enabled set.
+  clearTurnForced: () => void
+  // Resolves picked ids to display names for the steering nudge.
+  namesForIds: (ids: string[]) => Promise<string[]>
 }
 
 type AcpRuntimeArtifactOptions = {
@@ -168,6 +182,7 @@ class AcpRuntime {
   private readonly permissionBroker: AcpPermissionBroker
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
+  private readonly skillsHooks: AcpRuntimeSkillsOptions | undefined
   private readonly artifactOptions: AcpRuntimeArtifactOptions | undefined
   private readonly notebookOptions: AcpRuntimeNotebookOptions | undefined
   private readonly artifactRepository: ArtifactRepository | undefined
@@ -183,6 +198,7 @@ class AcpRuntime {
     this.cwd = resolve(options.defaultCwd)
     this.callbacks = options.callbacks ?? {}
     this.spawnAgent = options.spawnAgent
+    this.skillsHooks = options.skills
     this.artifactOptions = options.artifacts
     this.notebookOptions = options.notebook
     this.artifactRepository = options.artifacts
@@ -611,7 +627,7 @@ class AcpRuntime {
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
   async sendPrompt(request: AcpPromptRequest): Promise<PromptResponse> {
-    const activeSession = this.sessions.get(request.sessionId)
+    let activeSession = this.sessions.get(request.sessionId)
 
     if (!activeSession) {
       throw new Error(`ACP session not found: ${request.sessionId}`)
@@ -619,6 +635,33 @@ class AcpRuntime {
 
     if (this.promptInFlightSessionIds.has(request.sessionId)) {
       throw new Error('An ACP prompt is already running for this session')
+    }
+
+    // Turn-scoped skill force-load: a skill the user picked but has toggled off must run this turn only.
+    // If any pick is currently disabled, mark the picks forced and respawn the agent (drop the connection,
+    // then resume the same session) so the fresh spawn's provisioning materializes them with full context
+    // restored. Picks that are already enabled need no respawn. Restored to the normal set after the turn.
+    const forced = request.forcedSkillIds ?? []
+    let didForceReload = false
+
+    if (this.skillsHooks && forced.length > 0) {
+      const toForce = await this.skillsHooks.needForceLoad(forced)
+
+      if (toForce.length > 0) {
+        // Capture routing before the disconnect clears it, so the resume lands on the same conversation.
+        const sessionCwd = this.sessionCwds.get(request.sessionId) ?? this.cwd
+        const projectName = this.resolveSessionProjectName(request.sessionId)
+        this.skillsHooks.setTurnForced(forced)
+        didForceReload = true
+        await this.disconnect(false)
+        await this.resumeSession({ sessionId: request.sessionId, cwd: sessionCwd, projectName })
+
+        const reloaded = this.sessions.get(request.sessionId)
+        if (!reloaded) {
+          throw new Error(`ACP session not found after force-load: ${request.sessionId}`)
+        }
+        activeSession = reloaded
+      }
     }
 
     this.currentSessionId = request.sessionId
@@ -634,7 +677,13 @@ class AcpRuntime {
     try {
       // Create a fresh run context before prompting so MCP writes can be attributed to this turn.
       artifactRun = await this.activateArtifactRun(request.sessionId)
-      const promptContent = await this.createPromptContent(request.sessionId, request)
+      // Prepend a short steering nudge naming the picked skills. It goes only into the content sent to
+      // the agent; the user-facing message event keeps the original text (which already shows /Name).
+      const promptText = await this.applySkillNudge(request.text, forced)
+      const promptContent = await this.createPromptContent(request.sessionId, {
+        ...request,
+        text: promptText
+      })
 
       this.pushEvent({
         kind: 'message',
@@ -712,6 +761,13 @@ class AcpRuntime {
       }
       this.promptInFlightSessionIds.delete(request.sessionId)
       this.emitState()
+      // A disabled skill forced for this turn is restored now: clear the force set, then schedule a
+      // reconnect so the NEXT prompt respawns with the normal enabled set. Ordering matters — the clear
+      // must happen before the reconnect is applied so the fresh spawn no longer sees the forced ids.
+      if (didForceReload && this.skillsHooks) {
+        this.skillsHooks.clearTurnForced()
+        this.pendingSkillsReload = true
+      }
       // A provider switch requested mid-turn is applied now that the session is idle.
       this.maybeApplyPendingProviderReconnect()
     }
@@ -789,6 +845,17 @@ class AcpRuntime {
     this.emitState()
 
     return this.getSnapshot()
+  }
+
+  // Prepends a one-line steering nudge naming the picked skills to the prompt text. No-op when no skills
+  // were picked or no hooks are wired. It is prompt text, not a system directive, per the design.
+  private async applySkillNudge(text: string, forcedSkillIds: string[]): Promise<string> {
+    if (!this.skillsHooks || forcedSkillIds.length === 0) return text
+
+    const names = await this.skillsHooks.namesForIds(forcedSkillIds)
+    if (names.length === 0) return text
+
+    return `Use the following skill(s) for this task: ${names.join(', ')}.\n\n${text}`
   }
 
   // Turns the renderer prompt plus upload references into the ACP prompt payload.

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { execPath } from 'node:process'
@@ -633,5 +633,57 @@ describe('SettingsService: skills', () => {
 
     skills = await service.deleteSkill({ id: 'personal-my-skill' })
     expect(skills.map((skill) => skill.id)).toEqual(['demo'])
+  })
+
+  it('force-loads a disabled picked skill for the turn without mutating stored settings', async () => {
+    const service = await createSkillService()
+
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+    const created = (await service.upsertProvider({ type: 'claude-default', name: 'Local' }))
+      .providers[0]
+    await service.setActiveProvider(created.id)
+    await service.setSkillEnabled({ id: 'demo', enabled: false })
+
+    const skillDir = join(getAppClaudeConfigDir(storageRoot), 'skills', 'os-demo')
+    const exists = async (path: string): Promise<boolean> =>
+      readFile(join(path, 'SKILL.md'), 'utf8').then(
+        () => true,
+        () => false
+      )
+
+    // Disabled: the skill is not materialized on a normal spawn.
+    await service.resolveActiveSpawnConfig()
+    expect(await exists(skillDir)).toBe(false)
+
+    // Turn-forced: the disabled skill is materialized for this spawn only.
+    service.setTurnForcedSkillIds(['demo'])
+    await service.resolveActiveSpawnConfig()
+    expect(await exists(skillDir)).toBe(true)
+
+    // The stored disabled set is untouched, so the skill still lists as disabled.
+    const skills = await service.listSkills()
+    expect(skills.find((skill) => skill.id === 'demo')?.enabled).toBe(false)
+
+    // Clearing the force set removes it again on the next spawn.
+    service.clearTurnForcedSkillIds()
+    await service.resolveActiveSpawnConfig()
+    expect(await exists(skillDir)).toBe(false)
+  })
+
+  it('reports only disabled picks as needing force-load and maps ids to names', async () => {
+    const service = await createSkillService()
+
+    await service.createSkill({ name: 'My Skill', description: 'Mine.', body: '# Mine' })
+    await service.setSkillEnabled({ id: 'demo', enabled: false })
+
+    // Only the disabled pick (demo) needs a respawn; the enabled personal skill does not.
+    expect(await service.skillsNeedingForceLoad(['demo', 'personal-my-skill'])).toEqual(['demo'])
+    expect(await service.skillsNeedingForceLoad(['personal-my-skill'])).toEqual([])
+
+    // Names resolve in the given id order, skipping unknown ids.
+    expect(await service.skillNamesForIds(['personal-my-skill', 'demo', 'nope'])).toEqual([
+      'My Skill',
+      'Demo'
+    ])
   })
 })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -117,6 +117,9 @@ class SettingsService {
   private readonly userSkills: UserSkillRepository
   private readonly executeClaudeProbe: ExecuteClaudeProbe
   private providerSequence = 0
+  // Skills force-loaded for the current turn: subtracted from the stored disabled set at spawn time so
+  // a picked-but-disabled skill materializes for this prompt only, without mutating stored settings.
+  private turnForcedSkillIds = new Set<string>()
 
   constructor(options: SettingsServiceOptions = {}) {
     this.storageRoot = options.storageRoot ?? resolveStorageRoot()
@@ -157,6 +160,33 @@ class SettingsService {
     const disabled = new Set(settings.disabledSkillIds ?? [])
 
     return skills.map((skill) => this.toSkillView(skill, disabled))
+  }
+
+  // Sets the skills to force-load for the current turn (picked in the composer). Cleared after the turn.
+  setTurnForcedSkillIds(ids: string[]): void {
+    this.turnForcedSkillIds = new Set(ids)
+  }
+
+  // Clears the turn-scoped force-load set so later spawns use the normal enabled set.
+  clearTurnForcedSkillIds(): void {
+    this.turnForcedSkillIds.clear()
+  }
+
+  // Returns the subset of forced ids that are currently disabled in settings — i.e. the picks that need
+  // a respawn to materialize. Enabled picks are already present and need no reconnect.
+  async skillsNeedingForceLoad(forcedIds: string[]): Promise<string[]> {
+    const settings = await this.repository.getSettings()
+    const disabled = new Set(settings.disabledSkillIds ?? [])
+
+    return forcedIds.filter((id) => disabled.has(id))
+  }
+
+  // Maps skill ids to their display names in the given order, skipping unknown ids. Used for the nudge.
+  async skillNamesForIds(ids: string[]): Promise<string[]> {
+    const skills = await this.skillCatalog()
+    const nameById = new Map(skills.map((skill) => [skill.id, skill.name]))
+
+    return ids.map((id) => nameById.get(id)).filter((name): name is string => name !== undefined)
   }
 
   // Returns one skill's view plus its SKILL.md body for the detail view (any source).
@@ -521,11 +551,15 @@ class SettingsService {
 
     // Ensure the app-owned config dir exists (and app assets are injected) before the agent spawns. The
     // enabled skill set (featured + imported + personal) is materialized here, so a toggle/create/import
-    // takes effect on the next spawn.
+    // takes effect on the next spawn. Any skill force-loaded for the current turn is subtracted from the
+    // disabled set so a picked-but-disabled skill materializes for this prompt without mutating settings.
     const appConfigDir = getAppClaudeConfigDir(this.storageRoot)
+    const disabledSkillIds = (settings.disabledSkillIds ?? []).filter(
+      (id) => !this.turnForcedSkillIds.has(id)
+    )
     await provisionAppClaudeConfigDir(appConfigDir, {
       skills: await this.skillCatalog(),
-      disabledSkillIds: settings.disabledSkillIds
+      disabledSkillIds
     })
 
     let envOverrides = buildProviderEnv(

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -47,7 +47,8 @@ const useAcpRuntime = (): {
   sendPrompt: (
     sessionId: string,
     text: string,
-    attachments?: AcpPromptRequest['attachments']
+    attachments?: AcpPromptRequest['attachments'],
+    forcedSkillIds?: string[]
   ) => Promise<AcpStateSnapshot | undefined>
   respondToPermission: (
     requestId: string,
@@ -189,10 +190,17 @@ const useAcpRuntime = (): {
     (
       sessionId: AcpPromptRequest['sessionId'],
       text: AcpPromptRequest['text'],
-      attachments?: AcpPromptRequest['attachments']
+      attachments?: AcpPromptRequest['attachments'],
+      forcedSkillIds?: string[]
     ) =>
       runSnapshotAction(undefined, () =>
-        window.api.acp.sendPrompt({ sessionId, text, attachments })
+        window.api.acp.sendPrompt({
+          sessionId,
+          text,
+          attachments,
+          // Omit the field entirely when no skills were picked so the request stays minimal.
+          ...(forcedSkillIds && forcedSkillIds.length > 0 ? { forcedSkillIds } : {})
+        })
       ),
     [runSnapshotAction]
   )

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -252,7 +252,8 @@ describe('workspace agent message sending', () => {
     expect(runtime.sendPrompt).toHaveBeenCalledWith(
       'transport-session-1',
       'Help me inspect this notebook',
-      []
+      [],
+      undefined
     )
   })
 
@@ -311,9 +312,12 @@ describe('workspace agent message sending', () => {
         })
       ]
     })
-    expect(runtime.sendPrompt).toHaveBeenCalledWith('transport-session-1', '', [
-      finalizedAttachment
-    ])
+    expect(runtime.sendPrompt).toHaveBeenCalledWith(
+      'transport-session-1',
+      '',
+      [finalizedAttachment],
+      undefined
+    )
   })
 
   it('retries ACP session creation for an unbound pending conversation', async () => {
@@ -354,7 +358,12 @@ describe('workspace agent message sending', () => {
 
     expect(runtime.resumeSession).not.toHaveBeenCalled()
     expect(runtime.createSession).toHaveBeenCalledTimes(2)
-    expect(runtime.sendPrompt).toHaveBeenCalledWith('transport-session-1', 'Try again', [])
+    expect(runtime.sendPrompt).toHaveBeenCalledWith(
+      'transport-session-1',
+      'Try again',
+      [],
+      undefined
+    )
     expect(useSessionStore.getState().selectedSessionId).toBe('transport-session-1')
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       id: 'transport-session-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -15,6 +15,8 @@ type SendWorkspaceMessageInput = {
   projectId?: string
   // Storage project the artifact/notebook MCP servers write under (usually the same value).
   projectName?: string
+  // Skills the user picked in the composer; force-loaded and nudged for this turn only.
+  forcedSkillIds?: string[]
 }
 
 type SendWorkspaceMessageResult = {
@@ -161,7 +163,8 @@ const startPendingSessionPrompt = (
   content: string,
   attachments: UploadedAttachment[],
   cwd: string | undefined,
-  projectName: string | undefined
+  projectName: string | undefined,
+  forcedSkillIds: string[] | undefined
 ): void => {
   void (async () => {
     const createdSession = await runtime.createSession(cwd, projectName).catch(() => undefined)
@@ -197,7 +200,7 @@ const startPendingSessionPrompt = (
     }
 
     void runtime
-      .sendPrompt(runtimeSessionId, content, promptAttachments)
+      .sendPrompt(runtimeSessionId, content, promptAttachments, forcedSkillIds)
       .then((snapshot) => {
         if (!snapshot) {
           useSessionStore.getState().failRun(runtimeSessionId, 'Agent run failed')
@@ -214,7 +217,15 @@ const startPendingSessionPrompt = (
 // Records the user's prompt before slow runtime work continues.
 const sendWorkspaceMessage = async (
   runtime: WorkspaceMessageRuntime,
-  { sessionId, text, attachments = [], cwd, projectId, projectName }: SendWorkspaceMessageInput
+  {
+    sessionId,
+    text,
+    attachments = [],
+    cwd,
+    projectId,
+    projectName,
+    forcedSkillIds
+  }: SendWorkspaceMessageInput
 ): Promise<SendWorkspaceMessageResult | undefined> => {
   const content = text.trim()
 
@@ -254,7 +265,8 @@ const sendWorkspaceMessage = async (
         content,
         attachments,
         retryCwd,
-        sessionProjectName
+        sessionProjectName,
+        forcedSkillIds
       )
       return appended
     }
@@ -312,7 +324,7 @@ const sendWorkspaceMessage = async (
 
     // The hook returns after local state is updated; event listeners handle the streamed result.
     void runtime
-      .sendPrompt(targetSessionId, content, promptAttachments)
+      .sendPrompt(targetSessionId, content, promptAttachments, forcedSkillIds)
       .then((snapshot) => {
         if (!snapshot) {
           useSessionStore.getState().failRun(targetSessionId, 'Agent run failed')
@@ -343,7 +355,8 @@ const sendWorkspaceMessage = async (
     content,
     attachments,
     targetCwd ?? runtime.state.cwd,
-    projectName
+    projectName,
+    forcedSkillIds
   )
 
   return pending

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -69,12 +69,19 @@ const getComposerForm = (): HTMLElement => {
   return form as HTMLElement
 }
 
+const getComposerEditor = (): HTMLElement => {
+  const editor = container.querySelector('[role="textbox"]')
+  if (!editor) throw new Error('composer editor not found')
+  return editor as HTMLElement
+}
+
 const dispatchPaste = (files: File[]): boolean => {
-  const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+  const editor = getComposerEditor()
   const event = new Event('paste', { bubbles: true, cancelable: true })
-  Object.defineProperty(event, 'clipboardData', { value: { files } })
+  // The editor also reads text/plain, so the mock clipboard exposes both files and getData.
+  Object.defineProperty(event, 'clipboardData', { value: { files, getData: () => '' } })
   act(() => {
-    textarea.dispatchEvent(event)
+    editor.dispatchEvent(event)
   })
   return event.defaultPrevented
 }
@@ -151,5 +158,32 @@ describe('ConversationPanel composer intake', () => {
 
     dispatchDrag('dragenter', ['Files'])
     expect(hasDropOverlay()).toBe(false)
+  })
+
+  it('submits on Enter through the editor with the picked skill ids', () => {
+    const onSendMessage = vi.fn()
+    renderPanel({ onSendMessage })
+
+    const editor = getComposerEditor()
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    act(() => {
+      editor.dispatchEvent(event)
+    })
+
+    // A plain-text draft carries no chips, so the send handler receives an empty id list.
+    expect(onSendMessage).toHaveBeenCalledWith([])
+  })
+
+  it('persists typed text as a plain-string draft via onMessageDraftChange', () => {
+    const onMessageDraftChange = vi.fn()
+    renderPanel({ onMessageDraftChange })
+
+    const editor = getComposerEditor()
+    editor.textContent = 'hello'
+    act(() => {
+      editor.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(onMessageDraftChange).toHaveBeenCalledWith('hello')
   })
 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -11,23 +11,21 @@ import {
   Square,
   X
 } from 'lucide-react'
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 
 import { ResizablePanel } from '@/components/ui/resizable'
 import { cn } from '@/lib/utils'
 import type { ChatSession } from '@/stores/session-store'
 
 import { ComposerDropOverlay } from './ComposerDropOverlay'
+import { ComposerEditor } from './composer/ComposerEditor'
+import { docFromText, docToSkillIds, docToText, type ComposerDoc } from './composer/composer-doc'
 import { ComposerModelPicker } from './ComposerModelPicker'
-import { submitMessageDraftFromKeyDown } from './message-draft-keyboard'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
 import { useFileDropZone } from './useFileDropZone'
 import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'
 
 const composerInteractiveTransitionClassName = 'transition-colors duration-200 ease-out'
-
-const composerTextareaClassName =
-  'min-h-[36px] max-h-[200px] w-full resize-none overflow-y-auto bg-transparent py-1.5 text-[15px] leading-relaxed text-text-000 outline-none placeholder:text-text-100'
 
 const composerIconButtonClassName = cn(
   'flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-text-300 hover:bg-bg-200 hover:text-text-100 disabled:cursor-not-allowed disabled:opacity-50',
@@ -74,7 +72,7 @@ type ConversationPanelProps = {
   notebookReference: NotebookSessionReference | undefined
   pendingPermissions: AcpPermissionRequest[]
   onMessageDraftChange: (value: string) => void
-  onSendMessage: (event: React.FormEvent<HTMLFormElement>) => void
+  onSendMessage: (forcedSkillIds: string[]) => void
   onStageAttachmentFiles: (files: File[]) => void
   onRemoveAttachment: (attachment: UploadedAttachment) => void
   onCancelRun: () => void
@@ -106,15 +104,29 @@ const ConversationPanel = ({
 }: ConversationPanelProps): React.JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
+  // Local doc mirrors the composer's rich content (text runs + skill chips). The persisted draft
+  // stays a plain string, so we derive it via docToText on every edit and hydrate from it on reset.
+  const [doc, setDoc] = useState<ComposerDoc>(() => docFromText(messageDraft))
+
+  // Keep the doc in sync when the draft string changes externally (send reset to '', restore on
+  // failure, session switch). Using the setState-during-render pattern instead of an effect keeps
+  // us within the repo's react-hooks/set-state-in-effect rule.
+  const [lastDraft, setLastDraft] = useState(messageDraft)
+  if (lastDraft !== messageDraft) {
+    setLastDraft(messageDraft)
+    if (messageDraft !== docToText(doc)) setDoc(docFromText(messageDraft))
+  }
+
   // Drag-and-drop shares the same staging callback as the picker and paste paths.
   const { isDragging, dropZoneProps } = useFileDropZone({
     enabled: canEditDraft,
     onFiles: onStageAttachmentFiles
   })
 
-  // Keeps keyboard submission behavior colocated with the composer while the helper owns rules.
-  const handleMessageDraftKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>): void => {
-    submitMessageDraftFromKeyDown(event, canSendMessage)
+  // Submits the current doc, passing the ids of any skills picked as inline chips.
+  const handleSubmit = (): void => {
+    if (!canEditDraft) return
+    onSendMessage(docToSkillIds(doc))
   }
 
   // Converts the hidden file input selection into the shared staging callback.
@@ -130,7 +142,7 @@ const ConversationPanel = ({
   }
 
   // Treats pasted clipboard files exactly like selected files, then keeps text paste behavior intact.
-  const handleMessageDraftPaste = (event: React.ClipboardEvent<HTMLTextAreaElement>): void => {
+  const handleMessageDraftPaste = (event: React.ClipboardEvent<HTMLDivElement>): void => {
     if (!canEditDraft) return
 
     const files = Array.from(event.clipboardData.files)
@@ -212,10 +224,11 @@ const ConversationPanel = ({
                     className="relative -mb-8 rounded-2xl bg-bg-200 pb-8 shadow-card"
                   />
 
-                  {/* Composer keeps draft input local until submit delegates to the session store. */}
+                  {/* Composer keeps draft input local until submit delegates to the session store.
+                      Enter-to-send is owned by ComposerEditor; the form only guards native submit. */}
                   <form
                     className="relative z-10 flex flex-col gap-2 rounded-2xl bg-bg-000 px-3 py-2 shadow-card-opaque transition-shadow duration-[180ms] ease-out"
-                    onSubmit={onSendMessage}
+                    onSubmit={(event) => event.preventDefault()}
                     {...dropZoneProps}
                   >
                     {/* File-drag overlay is scoped to the composer input card only. */}
@@ -262,15 +275,17 @@ const ConversationPanel = ({
 
                       <div className="relative min-w-0 flex-1">
                         {/* Draft editing waits for persistence hydration to avoid targeting the wrong session. */}
-                        <textarea
-                          value={messageDraft}
-                          onChange={(event) => onMessageDraftChange(event.target.value)}
-                          onKeyDown={handleMessageDraftKeyDown}
+                        <ComposerEditor
+                          doc={doc}
+                          onDocChange={(next) => {
+                            setDoc(next)
+                            onMessageDraftChange(docToText(next))
+                          }}
+                          onSubmit={handleSubmit}
                           onPaste={handleMessageDraftPaste}
                           disabled={!canEditDraft}
-                          className={composerTextareaClassName}
-                          placeholder="Ask anything"
-                          aria-label="Ask anything"
+                          placeholder="Ask anything — / for skills"
+                          ariaLabel="Ask anything"
                         />
                       </div>
 
@@ -313,7 +328,8 @@ const ConversationPanel = ({
                           </button>
                         ) : (
                           <button
-                            type="submit"
+                            type="button"
+                            onClick={handleSubmit}
                             disabled={!canSendMessage}
                             className={composerSendButtonClassName}
                             aria-label="Send message"

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -407,9 +407,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   }
 
   // Sends the current draft only after hydration so restored selection cannot overwrite intent.
-  const sendCurrentMessage = (event: React.FormEvent<HTMLFormElement>): void => {
-    event.preventDefault()
-
+  // ConversationPanel owns preventDefault and passes the skills picked as inline chips.
+  const sendCurrentMessage = (forcedSkillIds: string[]): void => {
     if (!canSendMessage) return
 
     const draft = messageDraft
@@ -428,7 +427,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
       attachments: attachmentsForSend,
       cwd: activeSession?.cwd,
       projectId: activeSession?.projectId ?? scopedProjectId,
-      projectName: activeSession?.projectId ?? scopedProjectId
+      projectName: activeSession?.projectId ?? scopedProjectId,
+      forcedSkillIds
     }).then((result) => {
       if (!result) {
         setMessageDraft(draft)

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ComposerEditor } from './ComposerEditor'
+import { emptyDoc, type ComposerDoc } from './composer-doc'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+
+let container: HTMLDivElement
+let root: Root
+
+// jsdom omits Range.getBoundingClientRect, which the mention hook uses to anchor the popup.
+Range.prototype.getBoundingClientRect = () =>
+  ({
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  }) as DOMRect
+
+const seedSkills = [
+  {
+    id: 'lit',
+    name: 'Literature',
+    description: 'Find, verify, and synthesize scientific papers',
+    source: 'featured' as const,
+    updatedAt: '2026-07-08T00:00:00.000Z',
+    enabled: true
+  },
+  {
+    id: 'mpnn',
+    name: 'ProteinMPNN',
+    description: 'Inverse-fold a protein backbone into sequence',
+    source: 'personal' as const,
+    updatedAt: '2026-07-08T00:00:00.000Z',
+    enabled: true
+  }
+]
+
+beforeEach(() => {
+  useSettingsStore.setState({ ...createInitialSettingsState(), skills: seedSkills })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+// Default no-op props; individual tests override the ones they assert on.
+const noop = (): void => {}
+
+type Overrides = Partial<{
+  doc: ComposerDoc
+  onDocChange: (doc: ComposerDoc) => void
+  onSubmit: () => void
+  onPaste: (event: React.ClipboardEvent<HTMLDivElement>) => void
+  disabled: boolean
+}>
+
+const renderEditor = (overrides: Overrides = {}): void => {
+  act(() => {
+    root.render(
+      <ComposerEditor
+        doc={overrides.doc ?? emptyDoc}
+        onDocChange={overrides.onDocChange ?? noop}
+        onSubmit={overrides.onSubmit ?? noop}
+        onPaste={overrides.onPaste ?? noop}
+        disabled={overrides.disabled}
+        placeholder="Ask anything"
+        ariaLabel="Ask anything"
+      />
+    )
+  })
+}
+
+const editor = (): HTMLElement =>
+  document.body.querySelector<HTMLElement>('[role="textbox"]') as HTMLElement
+
+// Set a collapsed caret at the given offset inside a node.
+const setCaret = (node: Node, offset: number): void => {
+  const range = document.createRange()
+  range.setStart(node, offset)
+  range.collapse(true)
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+}
+
+const dispatchKey = (target: EventTarget, key: string, init: KeyboardEventInit = {}): void => {
+  act(() => {
+    target.dispatchEvent(
+      new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...init })
+    )
+  })
+}
+
+describe('ComposerEditor', () => {
+  it('emits the typed text as a doc on input', () => {
+    const onDocChange = vi.fn()
+    renderEditor({ onDocChange })
+
+    act(() => {
+      editor().appendChild(document.createTextNode('hello'))
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(onDocChange).toHaveBeenCalledWith({ nodes: [{ type: 'text', text: 'hello' }] })
+  })
+
+  it('submits on Enter without shift and not on Shift+Enter', () => {
+    const onSubmit = vi.fn()
+    renderEditor({ onSubmit })
+
+    dispatchKey(editor(), 'Enter', { shiftKey: true })
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    dispatchKey(editor(), 'Enter')
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not submit while an IME composition is active', () => {
+    const onSubmit = vi.fn()
+    renderEditor({ onSubmit })
+
+    act(() => {
+      editor().dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+    })
+    dispatchKey(editor(), 'Enter')
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    // Ending composition restores Enter-to-submit.
+    act(() => {
+      editor().dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }))
+    })
+    dispatchKey(editor(), 'Enter')
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards paste to onPaste and inserts clipboard text as plain text', () => {
+    const onPaste = vi.fn()
+    const onDocChange = vi.fn()
+    renderEditor({ onPaste, onDocChange })
+
+    // Place the caret inside the editor so the plain-text insertion has a target range.
+    editor().appendChild(document.createTextNode(''))
+    setCaret(editor().firstChild as Node, 0)
+
+    const clipboardData = { getData: (type: string) => (type === 'text/plain' ? 'pasted' : '') }
+    act(() => {
+      const event = new Event('paste', { bubbles: true, cancelable: true }) as Event & {
+        clipboardData: unknown
+      }
+      event.clipboardData = clipboardData
+      editor().dispatchEvent(event)
+    })
+
+    expect(onPaste).toHaveBeenCalledTimes(1)
+    expect(editor().textContent).toContain('pasted')
+    expect(onDocChange).toHaveBeenCalledWith({ nodes: [{ type: 'text', text: 'pasted' }] })
+  })
+
+  it('keeps pasted "/name" text as plain text, never a functional skill chip', () => {
+    const onDocChange = vi.fn()
+    renderEditor({ onDocChange })
+    editor().appendChild(document.createTextNode(''))
+    setCaret(editor().firstChild as Node, 0)
+
+    const clipboardData = {
+      getData: (type: string) => (type === 'text/plain' ? '/Literature' : '')
+    }
+    act(() => {
+      const event = new Event('paste', { bubbles: true, cancelable: true }) as Event & {
+        clipboardData: unknown
+      }
+      event.clipboardData = clipboardData
+      editor().dispatchEvent(event)
+    })
+
+    // No chip is created; the doc holds only a text node, so it carries no skill id.
+    expect(editor().querySelector('[data-skill-id]')).toBeNull()
+    expect(onDocChange).toHaveBeenLastCalledWith({ nodes: [{ type: 'text', text: '/Literature' }] })
+  })
+
+  it('inserts a skill chip when a suggestion is chosen from the popup', () => {
+    const onDocChange = vi.fn()
+    renderEditor({ onDocChange })
+
+    // Simulate typing "/lit": place the token in the DOM and the caret at its end, then let the
+    // mention hook read the live selection via an input event.
+    const textNode = document.createTextNode('/lit')
+    editor().appendChild(textNode)
+    setCaret(textNode, 4)
+    act(() => {
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    // The popup opens for the query.
+    const listbox = document.body.querySelector('[role="listbox"]')
+    expect(listbox).not.toBeNull()
+
+    // Enter selects the first match; the editor swaps the token for a chip and re-emits the doc.
+    dispatchKey(document, 'Enter')
+
+    const chip = editor().querySelector('[data-skill-id]')
+    expect(chip).not.toBeNull()
+    expect(chip?.getAttribute('data-skill-id')).toBe('lit')
+
+    const lastCall = onDocChange.mock.calls.at(-1)?.[0] as ComposerDoc
+    expect(lastCall.nodes.some((node) => node.type === 'skill' && node.id === 'lit')).toBe(true)
+  })
+
+  it('deletes the whole chip on Backspace when the caret is right after it', () => {
+    const onDocChange = vi.fn()
+    renderEditor({
+      doc: { nodes: [{ type: 'skill', id: 'lit', name: 'Literature' }] },
+      onDocChange
+    })
+
+    // Caret at editor offset 1 sits right after the chip (the editor's only child).
+    setCaret(editor(), 1)
+    dispatchKey(editor(), 'Backspace')
+
+    expect(editor().querySelector('[data-skill-id]')).toBeNull()
+    expect(onDocChange).toHaveBeenLastCalledWith(emptyDoc)
+  })
+
+  it('suppresses the popup once a skill chip exists (one skill per message)', () => {
+    renderEditor({ doc: { nodes: [{ type: 'skill', id: 'lit', name: 'Literature' }] } })
+
+    // Type "/" after the existing chip — the trigger is suppressed, so no popup opens.
+    const slash = document.createTextNode('/')
+    editor().appendChild(slash)
+    setCaret(slash, 1)
+    act(() => {
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(document.body.querySelector('[role="listbox"]')).toBeNull()
+  })
+
+  it('is not editable and never submits when disabled', () => {
+    const onSubmit = vi.fn()
+    renderEditor({ onSubmit, disabled: true })
+
+    expect(editor().getAttribute('contenteditable')).toBe('false')
+    expect(editor().getAttribute('aria-disabled')).toBe('true')
+
+    dispatchKey(editor(), 'Enter')
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useLayoutEffect, useRef } from 'react'
+
+import type { SkillView } from '../../../../../shared/settings'
+import { cn } from '@/lib/utils'
+
+import { applyDocToDom, domToDoc, type ComposerDoc, type ComposerNode } from './composer-doc'
+import { SkillMentionPopup } from './SkillMentionPopup'
+import { useMentionTrigger } from './useMentionTrigger'
+
+// Base editor styling: mirrors the sizing/leading of the legacy composer textarea and adds the
+// mockup's empty:before placeholder technique so the hint shows only while the doc is empty.
+const composerEditorClassName =
+  'min-h-[36px] max-h-[200px] w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent py-1.5 text-[15px] leading-relaxed text-text-000 outline-none empty:before:content-[attr(data-placeholder)] empty:before:text-text-300 empty:before:pointer-events-none empty:before:whitespace-nowrap empty:before:overflow-hidden empty:before:text-ellipsis empty:before:max-w-full'
+
+type ComposerEditorProps = {
+  doc: ComposerDoc
+  onDocChange: (doc: ComposerDoc) => void
+  onSubmit: () => void
+  onPaste: (event: React.ClipboardEvent<HTMLDivElement>) => void
+  disabled?: boolean
+  placeholder: string
+  className?: string
+  ariaLabel: string
+}
+
+// Structural equality over doc nodes; used to decide whether the incoming prop diverges from what
+// the contenteditable already shows, so we only re-render the DOM when an external change requires it.
+const nodesEqual = (a: ComposerNode[], b: ComposerNode[]): boolean => {
+  if (a.length !== b.length) return false
+  return a.every((node, index) => {
+    const other = b[index]
+    if (node.type !== other.type) return false
+    if (node.type === 'text' && other.type === 'text') return node.text === other.text
+    if (node.type === 'skill' && other.type === 'skill') {
+      return node.id === other.id && node.name === other.name
+    }
+    return false
+  })
+}
+
+// Insert plain text at the current caret and collapse the caret after it. Used for paste so the
+// contenteditable never absorbs rich HTML from the clipboard.
+const insertPlainTextAtCaret = (text: string): void => {
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0) return
+  const range = selection.getRangeAt(0)
+  range.deleteContents()
+  const inserted = document.createTextNode(text)
+  range.insertNode(inserted)
+  range.setStartAfter(inserted)
+  range.collapse(true)
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
+// A rendered skill chip element (atomic, non-editable token).
+const asSkillChip = (node: Node | null): HTMLElement | null =>
+  node?.nodeType === Node.ELEMENT_NODE &&
+  (node as HTMLElement).getAttribute('data-mention-type') === 'skill'
+    ? (node as HTMLElement)
+    : null
+
+// Find the skill chip immediately on one side of a collapsed caret, so Backspace/Delete can remove the
+// whole chip instead of letting the browser edit into it character by character.
+const chipBesideCaret = (root: HTMLElement, side: 'before' | 'after'): HTMLElement | null => {
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0) return null
+  const range = selection.getRangeAt(0)
+  if (!range.collapsed || !root.contains(range.startContainer)) return null
+  const node = range.startContainer
+  const offset = range.startOffset
+
+  if (node.nodeType === Node.TEXT_NODE) {
+    if (side === 'before') return offset === 0 ? asSkillChip(node.previousSibling) : null
+    return offset === (node.textContent ?? '').length ? asSkillChip(node.nextSibling) : null
+  }
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const index = side === 'before' ? offset - 1 : offset
+    return asSkillChip(node.childNodes[index] ?? null)
+  }
+  return null
+}
+
+// A contenteditable composer driven by a pure ComposerDoc model. External doc changes flow into the
+// DOM via applyDocToDom; user edits flow out via domToDoc. A `/` mention trigger mounts a skill popup.
+export const ComposerEditor = ({
+  doc,
+  onDocChange,
+  onSubmit,
+  onPaste,
+  disabled = false,
+  placeholder,
+  className,
+  ariaLabel
+}: ComposerEditorProps): React.JSX.Element => {
+  const editorRef = useRef<HTMLDivElement>(null)
+  // Tracks IME composition so Enter never submits mid-composition.
+  const composingRef = useRef(false)
+
+  // At most one skill per message: once a chip exists, suppress the trigger so a further `/` does nothing.
+  const hasSkill = doc.nodes.some((node) => node.type === 'skill')
+
+  // The hook guards a null current internally; widen the element type for its generic ref option.
+  const mention = useMentionTrigger({
+    editorRef: editorRef as React.RefObject<HTMLElement>,
+    trigger: '/',
+    disabled: disabled || hasSkill
+  })
+
+  // Read the live DOM back into a doc and notify the parent.
+  const emitDocFromDom = useCallback((): void => {
+    const root = editorRef.current
+    if (root) onDocChange(domToDoc(root))
+  }, [onDocChange])
+
+  // Apply the incoming doc to the DOM only when it diverges from what the editor already shows.
+  // Comparing against domToDoc(root) avoids clobbering the caret on the keystroke the user just made.
+  useLayoutEffect(() => {
+    const root = editorRef.current
+    if (!root) return
+    if (!nodesEqual(domToDoc(root).nodes, doc.nodes)) applyDocToDom(root, doc)
+  }, [doc])
+
+  const handleInput = useCallback((): void => emitDocFromDom(), [emitDocFromDom])
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (disabled) return
+    // While the mention popup is open it owns Enter/arrow keys; leave them to its document listener.
+    if (mention.active) return
+    // Backspace/Delete next to a chip removes the whole chip atomically (never edits its label).
+    if (event.key === 'Backspace' || event.key === 'Delete') {
+      const root = editorRef.current
+      const chip = root && chipBesideCaret(root, event.key === 'Backspace' ? 'before' : 'after')
+      if (chip) {
+        event.preventDefault()
+        chip.remove()
+        emitDocFromDom()
+        return
+      }
+    }
+    // Enter submits; Shift+Enter inserts a newline; IME composition never submits.
+    if (event.key === 'Enter' && !event.shiftKey && !composingRef.current) {
+      event.preventDefault()
+      onSubmit()
+    }
+  }
+
+  const handlePaste = (event: React.ClipboardEvent<HTMLDivElement>): void => {
+    // Forward first so the panel can route file attachments to its intake.
+    onPaste(event)
+    if (disabled || event.isDefaultPrevented()) return
+    // For text, insert it as plain text ourselves to keep the contenteditable free of rich HTML.
+    const text = event.clipboardData?.getData('text/plain') ?? ''
+    if (text) {
+      event.preventDefault()
+      insertPlainTextAtCaret(text)
+      emitDocFromDom()
+    }
+  }
+
+  // Replace the active `/query` token with a skill chip, then close the popup.
+  const handleSelectSkill = (skill: SkillView): void => {
+    mention.replaceTokenWith({ type: 'skill', id: skill.id, name: skill.name })
+    mention.cancel()
+  }
+
+  return (
+    <div className="relative min-w-0">
+      <div
+        ref={editorRef}
+        role="textbox"
+        aria-multiline="true"
+        aria-label={ariaLabel}
+        aria-disabled={disabled || undefined}
+        aria-haspopup="listbox"
+        contentEditable={!disabled}
+        suppressContentEditableWarning
+        data-placeholder={placeholder}
+        className={cn(composerEditorClassName, className)}
+        onInput={handleInput}
+        onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
+        onCompositionStart={() => {
+          composingRef.current = true
+        }}
+        onCompositionEnd={() => {
+          composingRef.current = false
+        }}
+      />
+      {mention.active ? (
+        <SkillMentionPopup
+          query={mention.query}
+          onSelect={handleSelectSkill}
+          onClose={mention.cancel}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SkillMentionPopup } from './SkillMentionPopup'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+
+let container: HTMLDivElement
+let root: Root
+
+const seedSkills = [
+  {
+    id: 'lit',
+    name: 'Literature Review',
+    description: 'Find, verify, and synthesize scientific papers',
+    source: 'featured' as const,
+    updatedAt: '2026-07-08T00:00:00.000Z',
+    enabled: true
+  },
+  {
+    id: 'mpnn',
+    name: 'ProteinMPNN',
+    description: 'Inverse-fold a protein backbone into sequence',
+    source: 'personal' as const,
+    updatedAt: '2026-07-08T00:00:00.000Z',
+    enabled: true
+  },
+  {
+    id: 'imp',
+    name: 'Imported Helper',
+    description: 'A literature-adjacent skill from GitHub',
+    source: 'imported' as const,
+    updatedAt: '2026-07-08T00:00:00.000Z',
+    enabled: false
+  }
+]
+
+beforeEach(() => {
+  useSettingsStore.setState({
+    ...createInitialSettingsState(),
+    skills: seedSkills
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+const options = (): HTMLElement[] =>
+  Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]'))
+
+const pressKey = (key: string): void => {
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }))
+  })
+}
+
+describe('SkillMentionPopup', () => {
+  it('filters by name or description and renders name, badge, and description', () => {
+    act(() => {
+      root.render(<SkillMentionPopup query="lit" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    // "lit" matches "Literature Review" by name and "Imported Helper" by description, not ProteinMPNN.
+    const rendered = options()
+    expect(rendered).toHaveLength(2)
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('Literature Review')
+    expect(text).toContain('Imported Helper')
+    expect(text).not.toContain('ProteinMPNN')
+
+    // Badge label + description are present for the matches.
+    expect(text).toContain('Featured')
+    expect(text).toContain('Imported')
+    expect(text).toContain('Find, verify, and synthesize scientific papers')
+  })
+
+  it('shows every source when the query is empty', () => {
+    act(() => {
+      root.render(<SkillMentionPopup query="" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    expect(options()).toHaveLength(3)
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('Featured')
+    expect(text).toContain('Personal')
+    expect(text).toContain('Imported')
+  })
+
+  it('moves aria-selected with ArrowDown/ArrowUp and wraps', () => {
+    act(() => {
+      root.render(<SkillMentionPopup query="" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    const selectedIndex = (): number =>
+      options().findIndex((option) => option.getAttribute('aria-selected') === 'true')
+
+    // Starts on the first option.
+    expect(selectedIndex()).toBe(0)
+
+    pressKey('ArrowDown')
+    expect(selectedIndex()).toBe(1)
+
+    pressKey('ArrowDown')
+    expect(selectedIndex()).toBe(2)
+
+    // Wraps forward past the end.
+    pressKey('ArrowDown')
+    expect(selectedIndex()).toBe(0)
+
+    // Wraps backward before the start.
+    pressKey('ArrowUp')
+    expect(selectedIndex()).toBe(2)
+  })
+
+  it('selects the active skill on Enter', () => {
+    const onSelect = vi.fn()
+    act(() => {
+      root.render(<SkillMentionPopup query="" onSelect={onSelect} onClose={vi.fn()} />)
+    })
+
+    pressKey('ArrowDown')
+    pressKey('Enter')
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'mpnn' }))
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    act(() => {
+      root.render(<SkillMentionPopup query="" onSelect={vi.fn()} onClose={onClose} />)
+    })
+
+    pressKey('Escape')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('selects a skill on click and sets it active on hover', () => {
+    const onSelect = vi.fn()
+    act(() => {
+      root.render(<SkillMentionPopup query="" onSelect={onSelect} onClose={vi.fn()} />)
+    })
+
+    const third = options()[2]
+    act(() => {
+      // React synthesizes onMouseEnter from mouseover events at the root.
+      third.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    })
+    expect(third.getAttribute('aria-selected')).toBe('true')
+
+    act(() => third.click())
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'imp' }))
+  })
+})

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useId, useMemo, useState } from 'react'
+
+import type { SkillSource, SkillView } from '../../../../../shared/settings'
+import { useSettingsStore } from '@/stores/settings-store'
+
+// Popup that suggests skills for the composer's `/` mention trigger. The composer keeps focus in its
+// editor, so this listens for navigation keys on document while mounted rather than owning focus.
+type SkillMentionPopupProps = {
+  query: string
+  onSelect: (skill: SkillView) => void
+  onClose: () => void
+}
+
+// Human-readable badge label per skill source.
+const SOURCE_LABELS: Record<SkillSource, string> = {
+  featured: 'Featured',
+  imported: 'Imported',
+  personal: 'Personal'
+}
+
+export const SkillMentionPopup = ({
+  query,
+  onSelect,
+  onClose
+}: SkillMentionPopupProps): React.JSX.Element | null => {
+  const skills = useSettingsStore((state) => state.skills)
+  const loadSkills = useSettingsStore((state) => state.loadSkills)
+  const listboxId = useId()
+
+  // The skill list is loaded lazily by the Settings panel; the composer may open before that ever ran,
+  // so hydrate it here when empty. Cheap and idempotent — the store keeps the result after the first load.
+  useEffect(() => {
+    if (skills.length === 0) void loadSkills()
+  }, [skills.length, loadSkills])
+
+  // Case-insensitive match of the query against name or description; empty query shows every skill.
+  const matches = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    if (needle.length === 0) return skills
+
+    return skills.filter(
+      (skill) =>
+        skill.name.toLowerCase().includes(needle) ||
+        skill.description.toLowerCase().includes(needle)
+    )
+  }, [skills, query])
+
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  // Reset the highlight to the top when the query changes. This is the setState-during-render pattern
+  // React recommends over a synchronizing effect for deriving state from a changing prop.
+  const [lastQuery, setLastQuery] = useState(query)
+  if (lastQuery !== query) {
+    setLastQuery(query)
+    setActiveIndex(0)
+  }
+
+  // Keep the highlight within the current match set even after filtering shrinks it.
+  const safeIndex = matches.length === 0 ? 0 : Math.min(activeIndex, matches.length - 1)
+
+  // Handle navigation keys at the document level while mounted, since focus stays in the editor.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        if (matches.length > 0) setActiveIndex((safeIndex + 1) % matches.length)
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        if (matches.length > 0) setActiveIndex((safeIndex - 1 + matches.length) % matches.length)
+      } else if (event.key === 'Enter') {
+        const active = matches[safeIndex]
+        if (active) {
+          event.preventDefault()
+          onSelect(active)
+        }
+      } else if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [matches, safeIndex, onSelect, onClose])
+
+  return (
+    <div className="absolute bottom-full left-0 mb-1 z-50 bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)] overflow-hidden">
+      <ul
+        id={`${listboxId}-listbox`}
+        role="listbox"
+        aria-label="Skill suggestions"
+        className="overflow-y-auto max-h-[min(45vh,18rem)]"
+      >
+        {matches.map((skill, index) => {
+          const isActive = index === safeIndex
+          return (
+            <li
+              key={skill.id}
+              id={`${listboxId}-option-${index}`}
+              role="option"
+              aria-selected={isActive}
+              onMouseEnter={() => setActiveIndex(index)}
+              // Keep the editor focused/caret intact so the mention stays open long enough for the click.
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => onSelect(skill)}
+              className={`w-full flex items-start gap-2 px-2 py-1.5 rounded-lg text-sm text-text-100 hover:bg-bg-200 hover:text-text-000 transition-colors cursor-pointer${
+                isActive ? ' bg-bg-200 !text-text-000' : ''
+              }`}
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="truncate font-medium text-sm">{skill.name}</span>
+                  <div className="flex-1" />
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent text-accent-foreground">
+                    {SOURCE_LABELS[skill.source]}
+                  </span>
+                </div>
+                <div className="text-xs text-text-300 line-clamp-2 mt-0.5">{skill.description}</div>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+      <div className="mt-1 -mx-1.5 -mb-1.5 px-3.5 pt-1.5 pb-2 border-t border-border-300 flex items-center gap-3 text-[11px] text-text-400 select-none">
+        <span>
+          <span className="text-text-300">↑↓</span> navigate
+        </span>
+        <span>
+          <span className="text-text-300">Enter</span> select
+        </span>
+        <span>
+          <span className="text-text-300">Esc</span> close
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyDocToDom,
+  docFromText,
+  docIsEmpty,
+  docToSkillIds,
+  docToText,
+  domToDoc,
+  emptyDoc,
+  type ComposerDoc
+} from './composer-doc'
+
+describe('docToText', () => {
+  it('concatenates text nodes and renders skill nodes as /<name>', () => {
+    const doc: ComposerDoc = {
+      nodes: [
+        { type: 'text', text: 'run ' },
+        { type: 'skill', id: 'tdd', name: 'TDD' },
+        { type: 'text', text: ' now' }
+      ]
+    }
+    expect(docToText(doc)).toBe('run /TDD now')
+  })
+
+  it('returns an empty string for the empty doc', () => {
+    expect(docToText(emptyDoc)).toBe('')
+  })
+})
+
+describe('docToSkillIds', () => {
+  it('collects skill ids in order and de-duplicates them', () => {
+    const doc: ComposerDoc = {
+      nodes: [
+        { type: 'skill', id: 'a', name: 'A' },
+        { type: 'text', text: ' and ' },
+        { type: 'skill', id: 'b', name: 'B' },
+        { type: 'skill', id: 'a', name: 'A' }
+      ]
+    }
+    expect(docToSkillIds(doc)).toEqual(['a', 'b'])
+  })
+
+  it('returns an empty array when there are no skill nodes', () => {
+    expect(docToSkillIds(docFromText('plain text'))).toEqual([])
+  })
+})
+
+describe('docFromText', () => {
+  it('wraps plain text in a single text node', () => {
+    expect(docFromText('hello world')).toEqual({
+      nodes: [{ type: 'text', text: 'hello world' }]
+    })
+  })
+
+  it('maps an empty string to the empty doc', () => {
+    expect(docFromText('')).toEqual(emptyDoc)
+  })
+
+  it('round-trips through docToText', () => {
+    expect(docToText(docFromText('some draft'))).toBe('some draft')
+  })
+})
+
+describe('docIsEmpty', () => {
+  it('is true for the empty doc', () => {
+    expect(docIsEmpty(emptyDoc)).toBe(true)
+  })
+
+  it('is true for whitespace-only text and no skill nodes', () => {
+    expect(docIsEmpty({ nodes: [{ type: 'text', text: '   \n\t' }] })).toBe(true)
+  })
+
+  it('is false when a skill node exists even with only whitespace text', () => {
+    expect(
+      docIsEmpty({
+        nodes: [
+          { type: 'text', text: '  ' },
+          { type: 'skill', id: 'a', name: 'A' }
+        ]
+      })
+    ).toBe(false)
+  })
+
+  it('is false when text has non-whitespace content', () => {
+    expect(docIsEmpty(docFromText('x'))).toBe(false)
+  })
+})
+
+describe('domToDoc', () => {
+  it('reads a text node followed by a skill chip', () => {
+    const root = document.createElement('div')
+    root.appendChild(document.createTextNode('do '))
+    const chip = document.createElement('span')
+    chip.setAttribute('contenteditable', 'false')
+    chip.setAttribute('data-mention-type', 'skill')
+    chip.setAttribute('data-skill-id', 'tdd')
+    chip.textContent = '/TDD'
+    root.appendChild(chip)
+
+    expect(domToDoc(root)).toEqual({
+      nodes: [
+        { type: 'text', text: 'do ' },
+        { type: 'skill', id: 'tdd', name: 'TDD' }
+      ]
+    })
+  })
+
+  it('collapses adjacent text nodes', () => {
+    const root = document.createElement('div')
+    root.appendChild(document.createTextNode('a'))
+    root.appendChild(document.createTextNode('b'))
+    expect(domToDoc(root)).toEqual({ nodes: [{ type: 'text', text: 'ab' }] })
+  })
+
+  it('returns the empty doc for an empty root', () => {
+    const root = document.createElement('div')
+    expect(domToDoc(root)).toEqual(emptyDoc)
+  })
+})
+
+describe('applyDocToDom + domToDoc round-trip', () => {
+  it('renders a doc into the root and reads it back unchanged', () => {
+    const doc: ComposerDoc = {
+      nodes: [
+        { type: 'text', text: 'run ' },
+        { type: 'skill', id: 'tdd', name: 'TDD' },
+        { type: 'text', text: ' then ' },
+        { type: 'skill', id: 'review', name: 'Review' }
+      ]
+    }
+    const root = document.createElement('div')
+    applyDocToDom(root, doc)
+    expect(domToDoc(root)).toEqual(doc)
+  })
+
+  it('clears prior content before rendering', () => {
+    const root = document.createElement('div')
+    root.textContent = 'stale'
+    applyDocToDom(root, emptyDoc)
+    expect(root.childNodes.length).toBe(0)
+  })
+
+  it('renders the chip with the expected attributes and label', () => {
+    const root = document.createElement('div')
+    applyDocToDom(root, { nodes: [{ type: 'skill', id: 'tdd', name: 'TDD' }] })
+    const chip = root.querySelector('span[data-mention-type="skill"]')
+    expect(chip?.getAttribute('data-skill-id')).toBe('tdd')
+    expect(chip?.getAttribute('contenteditable')).toBe('false')
+    expect(chip?.textContent).toBe('/TDD')
+  })
+})

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -1,0 +1,83 @@
+// Pure serialization model for the composer: a document is an ordered list of text runs and
+// skill chips. Task 1 functions are DOM-free; domToDoc/applyDocToDom bridge to contenteditable.
+
+export type ComposerNode =
+  { type: 'text'; text: string } | { type: 'skill'; id: string; name: string }
+
+export type ComposerDoc = { nodes: ComposerNode[] }
+
+// Shared canonical empty document.
+export const emptyDoc: ComposerDoc = { nodes: [] }
+
+// Render the document as plain text; a skill chip serializes to its `/<name>` label.
+export const docToText = (doc: ComposerDoc): string =>
+  doc.nodes.map((node) => (node.type === 'text' ? node.text : `/${node.name}`)).join('')
+
+// Collect picked skill ids in document order, dropping duplicates.
+export const docToSkillIds = (doc: ComposerDoc): string[] => {
+  const ids: string[] = []
+  for (const node of doc.nodes) {
+    if (node.type === 'skill' && !ids.includes(node.id)) ids.push(node.id)
+  }
+  return ids
+}
+
+// Hydrate a plain-text draft into a single text node; empty text yields the empty doc.
+export const docFromText = (text: string): ComposerDoc =>
+  text === '' ? emptyDoc : { nodes: [{ type: 'text', text }] }
+
+// A doc is empty when it has no skill chips and no non-whitespace text.
+export const docIsEmpty = (doc: ComposerDoc): boolean =>
+  doc.nodes.every((node) => node.type === 'text' && node.text.trim() === '')
+
+// Chip markers on the contenteditable span.
+const SKILL_MENTION_TYPE = 'skill'
+
+// Read a contenteditable root into a doc, mapping chip spans to skill nodes and collapsing
+// runs of adjacent text into a single text node.
+export const domToDoc = (root: HTMLElement): ComposerDoc => {
+  const nodes: ComposerNode[] = []
+  for (const child of Array.from(root.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      const text = child.textContent ?? ''
+      const last = nodes[nodes.length - 1]
+      // Merge into a preceding text node so adjacent text collapses.
+      if (last && last.type === 'text') last.text += text
+      else nodes.push({ type: 'text', text })
+      continue
+    }
+    if (child.nodeType === Node.ELEMENT_NODE) {
+      const el = child as HTMLElement
+      const id = el.getAttribute('data-skill-id')
+      if (id !== null && el.getAttribute('data-mention-type') === SKILL_MENTION_TYPE) {
+        // Chip label is `/<name>`; strip the leading slash to recover the display name.
+        const label = el.textContent ?? ''
+        nodes.push({ type: 'skill', id, name: label.replace(/^\//, '') })
+      }
+    }
+  }
+  return nodes.length === 0 ? emptyDoc : { nodes }
+}
+
+// Render a skill chip span: an atomic, non-editable blue mention token. Exported so the mention hook
+// inserts the exact same markup it re-renders here, and the styling can never drift between the two.
+export const createSkillChip = (node: { id: string; name: string }): HTMLSpanElement => {
+  const span = document.createElement('span')
+  span.setAttribute('contenteditable', 'false')
+  span.setAttribute('data-mention-type', SKILL_MENTION_TYPE)
+  span.setAttribute('data-skill-id', node.id)
+  // Blue mention pill using the interactive `primary` token; select-all keeps it atomic to selection.
+  span.className =
+    'inline-flex items-center rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium bg-primary/15 text-primary select-all'
+  span.textContent = `/${node.name}`
+  return span
+}
+
+// Replace the root's content with the doc rendered as text nodes and chip spans.
+export const applyDocToDom = (root: HTMLElement, doc: ComposerDoc): void => {
+  root.textContent = ''
+  for (const node of doc.nodes) {
+    if (node.type === 'text') root.appendChild(document.createTextNode(node.text))
+    else root.appendChild(createSkillChip(node))
+  }
+}

--- a/src/renderer/src/pages/workspace/composer/useMentionTrigger.test.ts
+++ b/src/renderer/src/pages/workspace/composer/useMentionTrigger.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectTrigger } from './useMentionTrigger'
+
+describe('detectTrigger', () => {
+  it('is active with the query when the trigger opens the string', () => {
+    expect(detectTrigger('/lit', '/')).toEqual({ active: true, query: 'lit' })
+  })
+
+  it('is active when the trigger is preceded by whitespace', () => {
+    expect(detectTrigger('hi /a', '/')).toEqual({ active: true, query: 'a' })
+  })
+
+  it('is inactive when the trigger has no whitespace boundary', () => {
+    expect(detectTrigger('hi/a', '/')).toEqual({ active: false, query: '' })
+  })
+
+  it('is inactive once whitespace follows the trigger', () => {
+    expect(detectTrigger('/a b', '/')).toEqual({ active: false, query: '' })
+  })
+
+  it('is inactive for an empty string', () => {
+    expect(detectTrigger('', '/')).toEqual({ active: false, query: '' })
+  })
+
+  it('is active with an empty query when the trigger is the last char', () => {
+    expect(detectTrigger('type /', '/')).toEqual({ active: true, query: '' })
+  })
+
+  it('is active with an empty query when the trigger alone opens the string', () => {
+    expect(detectTrigger('/', '/')).toEqual({ active: true, query: '' })
+  })
+
+  it('ignores leading whitespace before the trigger', () => {
+    expect(detectTrigger('   /foo', '/')).toEqual({ active: true, query: 'foo' })
+  })
+
+  it('treats a tab after the trigger as a boundary that closes it', () => {
+    expect(detectTrigger('/foo\tbar', '/')).toEqual({ active: false, query: '' })
+  })
+
+  it('treats a newline before the trigger as whitespace', () => {
+    expect(detectTrigger('line one\n/cmd', '/')).toEqual({ active: true, query: 'cmd' })
+  })
+
+  it('is inactive when the trigger sits inside a word', () => {
+    expect(detectTrigger('a/b', '/')).toEqual({ active: false, query: '' })
+  })
+
+  it('keeps a trailing trigger char inside the query', () => {
+    expect(detectTrigger('//x', '/')).toEqual({ active: true, query: '/x' })
+  })
+
+  it('supports a multi-character trigger', () => {
+    expect(detectTrigger('see ::note', '::')).toEqual({ active: true, query: 'note' })
+    expect(detectTrigger('see :note', '::')).toEqual({ active: false, query: '' })
+  })
+
+  it('is inactive for an empty trigger', () => {
+    expect(detectTrigger('anything', '')).toEqual({ active: false, query: '' })
+  })
+})

--- a/src/renderer/src/pages/workspace/composer/useMentionTrigger.ts
+++ b/src/renderer/src/pages/workspace/composer/useMentionTrigger.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { createSkillChip, type ComposerNode } from './composer-doc'
+
+// A trigger match derived purely from the text before the caret.
+export type TriggerMatch = { active: boolean; query: string }
+
+// Detect an active mention trigger at the end of `textBeforeCaret`. The trigger is only valid
+// at the very start of the text or immediately after whitespace, and its query runs to the caret
+// without containing whitespace. The trailing run of non-whitespace chars is exactly that token:
+// it always begins at string start or right after whitespace, so it is our only candidate.
+export const detectTrigger = (textBeforeCaret: string, trigger: string): TriggerMatch => {
+  if (trigger === '') return { active: false, query: '' }
+  const token = textBeforeCaret.match(/\S*$/)?.[0] ?? ''
+  if (!token.startsWith(trigger)) return { active: false, query: '' }
+  return { active: true, query: token.slice(trigger.length) }
+}
+
+// Live trigger state plus the on-screen rect of the trigger position for popup placement.
+export type MentionState = { active: boolean; query: string; anchorRect: DOMRect | null }
+
+type UseMentionTriggerOptions = {
+  editorRef: React.RefObject<HTMLElement>
+  trigger: string
+  disabled?: boolean
+  onStateChange?: (state: MentionState) => void
+}
+
+type UseMentionTriggerResult = MentionState & {
+  cancel: () => void
+  replaceTokenWith: (node: ComposerNode) => void
+}
+
+const INACTIVE: MentionState = { active: false, query: '', anchorRect: null }
+
+// Read the text preceding the caret within its text node. A preceding chip (or any element) acts as a
+// clean word boundary, so a trigger at the start of a post-chip text node opens a fresh mention — this
+// is what lets a second skill be picked right after an existing chip.
+const textBeforeCaretIn = (node: Node, offset: number): string => {
+  if (node.nodeType !== Node.TEXT_NODE) return ''
+  return (node.textContent ?? '').slice(0, offset)
+}
+
+// Build a collapsed range at the trigger's start position to anchor the popup.
+const computeAnchorRect = (
+  node: Node,
+  caretOffset: number,
+  tokenLength: number
+): DOMRect | null => {
+  if (node.nodeType !== Node.TEXT_NODE) return null
+  const start = Math.max(0, caretOffset - tokenLength)
+  const range = document.createRange()
+  range.setStart(node, start)
+  range.collapse(true)
+  return range.getBoundingClientRect()
+}
+
+// A generic mention-trigger hook: watches the live selection inside a contenteditable editor,
+// exposes the current trigger state, and can swap the active token for a chip or text node.
+export const useMentionTrigger = ({
+  editorRef,
+  trigger,
+  disabled = false,
+  onStateChange
+}: UseMentionTriggerOptions): UseMentionTriggerResult => {
+  const [state, setState] = useState<MentionState>(INACTIVE)
+
+  // Refs keep the latest state and callback available to event handlers without re-subscribing.
+  const stateRef = useRef(state)
+  const onStateChangeRef = useRef(onStateChange)
+  useEffect(() => {
+    onStateChangeRef.current = onStateChange
+  }, [onStateChange])
+
+  const emit = useCallback((next: MentionState): void => {
+    const prev = stateRef.current
+    if (
+      prev.active === next.active &&
+      prev.query === next.query &&
+      prev.anchorRect === next.anchorRect
+    ) {
+      return
+    }
+    stateRef.current = next
+    setState(next)
+    onStateChangeRef.current?.(next)
+  }, [])
+
+  const cancel = useCallback((): void => emit(INACTIVE), [emit])
+
+  // Compute the trigger state from the current selection, guarding disabled and out-of-editor cases.
+  const sync = useCallback((): void => {
+    const editor = editorRef.current
+    if (!editor || disabled) return emit(INACTIVE)
+    const selection = window.getSelection()
+    if (!selection || selection.rangeCount === 0) return emit(INACTIVE)
+    const { anchorNode, anchorOffset } = selection
+    if (!anchorNode || !editor.contains(anchorNode)) return emit(INACTIVE)
+
+    const match = detectTrigger(textBeforeCaretIn(anchorNode, anchorOffset), trigger)
+    if (!match.active) return emit(INACTIVE)
+
+    const rect = computeAnchorRect(anchorNode, anchorOffset, trigger.length + match.query.length)
+    emit({ active: true, query: match.query, anchorRect: rect })
+  }, [editorRef, trigger, disabled, emit])
+
+  // Subscribe to selection and input changes while enabled; reset on teardown or disable.
+  useEffect(() => {
+    const editor = editorRef.current
+    if (!editor || disabled) {
+      emit(INACTIVE)
+      return
+    }
+    document.addEventListener('selectionchange', sync)
+    editor.addEventListener('input', sync)
+    return () => {
+      document.removeEventListener('selectionchange', sync)
+      editor.removeEventListener('input', sync)
+    }
+  }, [editorRef, disabled, sync, emit])
+
+  // Replace the active trigger token with a chip or text node and place the caret after it.
+  const replaceTokenWith = useCallback(
+    (node: ComposerNode): void => {
+      const editor = editorRef.current
+      const selection = window.getSelection()
+      if (!editor || !selection || selection.rangeCount === 0) return
+      const { anchorNode, anchorOffset } = selection
+      if (!anchorNode || anchorNode.nodeType !== Node.TEXT_NODE || !editor.contains(anchorNode)) {
+        return
+      }
+
+      const match = detectTrigger(textBeforeCaretIn(anchorNode, anchorOffset), trigger)
+      if (!match.active) return
+
+      // Delete the `<trigger><query>` run ending at the caret.
+      const tokenLength = trigger.length + match.query.length
+      const range = document.createRange()
+      range.setStart(anchorNode, Math.max(0, anchorOffset - tokenLength))
+      range.setEnd(anchorNode, anchorOffset)
+      range.deleteContents()
+
+      // Insert the replacement, then collapse the caret immediately after it.
+      const inserted =
+        node.type === 'skill' ? createSkillChip(node) : document.createTextNode(node.text)
+      range.insertNode(inserted)
+      const after = document.createRange()
+      after.setStartAfter(inserted)
+      after.collapse(true)
+      selection.removeAllRanges()
+      selection.addRange(after)
+
+      emit(INACTIVE)
+      // Let the editor re-read its DOM into the doc model.
+      editor.dispatchEvent(new Event('input', { bubbles: true }))
+    },
+    [editorRef, trigger, emit]
+  )
+
+  return { ...state, cancel, replaceTokenWith }
+}

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -453,21 +453,17 @@ describe('conversation message scroller integration', () => {
   })
 })
 
-describe('conversation composer keyboard integration', () => {
-  // The textarea delegates keyboard submit behavior to the tested composer helper.
-  it('wires the draft textarea to the Enter submit keyboard handler', () => {
+describe('conversation composer editor integration', () => {
+  // The composer is a contenteditable ComposerEditor that owns Enter-to-send and skill chips.
+  it('wires the ComposerEditor submit path to the skill-id send handler', () => {
     const conversationPanelSource = readFileSync(conversationPanelPath, 'utf8')
 
     expect(conversationPanelSource).toContain(
-      "import { submitMessageDraftFromKeyDown } from './message-draft-keyboard'"
+      "import { ComposerEditor } from './composer/ComposerEditor'"
     )
-    expect(conversationPanelSource).toContain(
-      'const handleMessageDraftKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>): void => {'
-    )
-    expect(conversationPanelSource).toContain(
-      'submitMessageDraftFromKeyDown(event, canSendMessage)'
-    )
-    expect(conversationPanelSource).toContain('onKeyDown={handleMessageDraftKeyDown}')
+    expect(conversationPanelSource).toContain('onSendMessage(docToSkillIds(doc))')
+    expect(conversationPanelSource).toContain('onSubmit={handleSubmit}')
+    expect(conversationPanelSource).toContain('onDocChange={(next) => {')
   })
 })
 

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -101,6 +101,8 @@ export type AcpPromptRequest = {
   sessionId: string
   text: string
   attachments?: UploadedAttachment[]
+  // Skills the user explicitly picked in the composer; the runtime force-loads and nudges them.
+  forcedSkillIds?: string[]
 }
 
 export type AcpCancelPromptRequest = {


### PR DESCRIPTION
## Summary

Adds a `/`-triggered **skill selector** to the composer. Typing `/` opens a filtered popup of the available skills; picking one inserts a single inline, atomic **mention chip**. On send, the message shows `/Name` inline and the picked skill is steered (and force-loaded if needed) for that turn.

## What's included

**Editor foundation**
- Replaces the composer `<textarea>` with a `contenteditable` **ComposerEditor** driven by a pure `ComposerDoc` model (text runs + a skill chip). Preserves every prior behavior: Enter-to-send, Shift+Enter newline, IME composition, paste → attachment intake, disabled state, placeholder, and draft persistence.
- A generic **useMentionTrigger** hook (pure `detectTrigger` core) watches the caret and drives the popup — reusable for `@`/`#` later, which are intentionally out of scope here.

**Popup + chip**
- **SkillMentionPopup**: a `role="listbox"` of skills (name + source badge + 2-line description), aligned above the input, with keyboard (↑↓/Enter/Esc) and mouse selection.
- The **chip** is a blue mention pill (`primary` token), `contenteditable="false"` and atomic: the caret treats it as one unit and Backspace/Delete removes the whole chip.

**Behavior**
- **One skill per message**: once a chip exists the trigger is suppressed, so a further `/` does nothing. Pasted `/name` text stays plain and never auto-converts to a functional skill.
- **On send** (`AcpPromptRequest.forcedSkillIds`): the agent prompt is prefixed with a steering nudge naming the skill (the user-facing message keeps the original `/Name`), and a picked-but-**disabled** skill is force-loaded for that turn only — respawn before, restore after; an already-enabled pick needs no reconnect.

## Out of scope (deferred)
- `@` artifacts, `#` sessions, `⌘K` search (same foundation makes them small follow-ups; not advertised in the placeholder).
- Chips do not survive a draft reload (drafts persist as plain text).

## Docs
- `docs/design.md` gains a Composer skill-selector section. The spec/plan live in gitignored `docs/internal/` and are not part of this PR.

## Testing
- `npm run lint`, `npm run typecheck`, and the full `vitest` suite all green (rebased on latest `main`). New unit tests cover the doc model, mention trigger, popup, chip insert/delete, the one-skill limit, paste-stays-plain, and the runtime force-load + nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
