### PR TITLE
feat(ui): add ExternalTextLink with ArrowUpRight for external links

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -365,6 +365,12 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Compact button: `h-8 px-3 rounded-md text-xs font-medium`; the top create button is `32px` tall.
 - Icon button: usually `size-8 rounded-md`; top bars and viewer toolbar buttons may use `size-7`.
 
+### External Link
+
+- Links that leave the app use the shared `ExternalTextLink` component: an underlined `text-primary` label trailed by a lucide `ArrowUpRight` icon. Do not use a bare `<a>` or a Unicode `↗`.
+- Navigation: it renders `<a target="_blank" rel="noreferrer">`; the main process (`setWindowOpenHandler` → `shell.openExternal`) opens these in the system browser, never in an app window.
+- In-app / agent-markdown prose links keep the inline Activity Stream style and do not get the arrow.
+
 ### Card / Panel
 
 - Home list rows do not need a heavy outer card; the row itself uses `rounded-lg hover:bg-accent`.

--- a/src/renderer/src/components/ExternalTextLink.tsx
+++ b/src/renderer/src/components/ExternalTextLink.tsx
@@ -1,0 +1,34 @@
+import { ArrowUpRight } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+// Inline external link: an underlined label trailed by an up-right arrow, signaling that it opens
+// outside the app in the system browser. Shared so every "leaves the app" link reads the same.
+// Font size is inherited from the surrounding text; pass className to tune color or size per context.
+const ExternalTextLink = ({
+  href,
+  children,
+  className,
+  'aria-label': ariaLabel
+}: {
+  href: string
+  children: React.ReactNode
+  className?: string
+  'aria-label'?: string
+}): React.JSX.Element => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noreferrer"
+    aria-label={ariaLabel}
+    className={cn(
+      'inline-flex items-center gap-0.5 font-medium text-primary underline underline-offset-2 transition-colors hover:text-primary/80',
+      className
+    )}
+  >
+    {children}
+    <ArrowUpRight className="size-3.5 shrink-0" aria-hidden="true" />
+  </a>
+)
+
+export { ExternalTextLink }

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 
+import { ExternalTextLink } from '@/components/ExternalTextLink'
 import type { ClaudeInstallSource } from '../../../../shared/settings'
 import { getClaudeInstallSources, getNodeInstallHint } from '../../../../shared/settings'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
@@ -86,10 +87,8 @@ const ClaudeInstallCard = ({
           ) : null}
           <p className="text-muted-foreground">
             Or download it from{' '}
-            <a href={nodeHint.url} target="_blank" rel="noreferrer" className="underline">
-              {nodeHint.url}
-            </a>
-            , then re-detect above so npm is picked up.
+            <ExternalTextLink href={nodeHint.url}>{nodeHint.url}</ExternalTextLink>, then re-detect
+            above so npm is picked up.
           </p>
         </div>
       ) : null}

--- a/src/renderer/src/pages/settings/GeneralPanel.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink, Globe } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
+import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { GitHubStarBadge } from '@/components/GitHubStarBadge'
 import { APP } from '../../../../shared/app-config'
 
@@ -88,14 +89,7 @@ const GeneralPanel = (): React.JSX.Element => {
 
         <p className="mt-3 text-xs text-muted-foreground">
           Something not working as expected?{' '}
-          <a
-            href={APP.links.githubIssues}
-            target="_blank"
-            rel="noreferrer"
-            className="font-medium text-foreground underline underline-offset-2 transition-colors hover:text-text-000"
-          >
-            Open an issue on GitHub
-          </a>{' '}
+          <ExternalTextLink href={APP.links.githubIssues}>Open an issue on GitHub</ExternalTextLink>{' '}
           and attach the log above.
         </p>
 

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -1,3 +1,4 @@
+import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { Input } from '@/components/ui/input'
 import {
   Select,
@@ -88,14 +89,9 @@ const ProviderForm = ({
           <RequiredMark />
         </label>
         {apiKeyUrl ? (
-          <a
-            href={apiKeyUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="text-xs font-medium text-primary underline underline-offset-2 hover:text-primary/80"
-          >
-            Get an API key ↗
-          </a>
+          <ExternalTextLink href={apiKeyUrl} className="text-xs">
+            Get an API key
+          </ExternalTextLink>
         ) : null}
       </div>
       <Input


### PR DESCRIPTION
## Summary
Adds a shared **`ExternalTextLink`** component that renders links leaving the app as an underlined `text-primary` label trailed by a lucide **`ArrowUpRight`** icon — the standard "opens outside the app" affordance.

Replaces three ad-hoc external text links with the component:
- **ProviderForm** — "Get an API key" (previously a Unicode `↗` glyph)
- **ClaudeInstallCard** — the Node.js download URL
- **GeneralPanel** — "Open an issue on GitHub"

These are the external links surfaced on the **Onboarding wizard** (which reuses `ProviderForm` + `ClaudeInstallCard`) and the **Settings** page.

## Design doc
`docs/design.md` gains an **External Link** guideline, including the navigation method: these render `<a target="_blank" rel="noreferrer">` and are opened in the system browser via the main-process `setWindowOpenHandler` → `shell.openExternal`, never in an in-app window.

## Verification
- `npm run lint`, `npm run typecheck`, full `vitest` suite — all pass
- Drove the built app and confirmed both links render correctly in Settings → Model (Get an API key ↗) and Settings → General (Open an issue on GitHub ↗)

🤖 Generated with [Claude Code](https://claude.com/claude-code)