### PR TITLE
fix(skills): read-only materialized skill dirs; keep generated files out of skills

### DIFF
--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -126,6 +126,7 @@ const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   'Do not save generated user-facing files directly into the workspace or current directory unless the user explicitly asks to modify project files.',
   'Pass only the filename, MIME type, and either inline content or a local source path to `write_artifact_file`; the app assigns the project, session, run, and final message location.',
   'After using the tool, mention the generated filename rather than an absolute filesystem path. The app will display the generated file list below your message.',
+  'Never write files inside a skill directory — loaded skills are read-only; route any file a skill generates through `write_artifact_file`.',
   '</open_science_artifact_instructions>'
 ].join('\n')
 

--- a/src/main/skills/materializer.test.ts
+++ b/src/main/skills/materializer.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, readdir, stat, writeFile, chmod } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -84,5 +84,61 @@ describe('ClaudeCodeSkillMaterializer', () => {
     expect(await readFile(join(configDir, 'skills', 'os-gamma', 'SKILL.md'), 'utf8')).toBe(
       '# gamma edited'
     )
+  })
+
+  it('materializes skill files with no write bits', async () => {
+    const configDir = await skillsDir()
+    const skill = await makeSkill('delta')
+    await new ClaudeCodeSkillMaterializer().sync(configDir, [skill])
+
+    const file = join(configDir, 'skills', 'os-delta', 'scripts', 'main.py')
+    expect((await stat(file)).mode & 0o222).toBe(0)
+  })
+
+  it('re-materializes despite a prior read-only state, leaving the new content read-only', async () => {
+    const configDir = await skillsDir()
+    const skill = { ...(await makeSkill('epsilon')), updatedAt: 'v1' }
+    const materializer = new ClaudeCodeSkillMaterializer()
+
+    await materializer.sync(configDir, [skill])
+    const file = join(configDir, 'skills', 'os-epsilon', 'SKILL.md')
+    expect((await stat(file)).mode & 0o222).toBe(0)
+
+    // Change source content and bump the version: chmod-writable → rm → cp must succeed despite the
+    // prior read-only dir, and the fresh copy is read-only again.
+    await writeFile(join(skill.sourceDir, 'SKILL.md'), '# epsilon v2', 'utf8')
+    await materializer.sync(configDir, [{ ...skill, updatedAt: 'v2' }])
+
+    expect(await readFile(file, 'utf8')).toBe('# epsilon v2')
+    expect((await stat(file)).mode & 0o222).toBe(0)
+  })
+
+  it('re-applies read-only to a skill skipped as unchanged, fixing an earlier writable materialize', async () => {
+    const configDir = await skillsDir()
+    const skill = { ...(await makeSkill('theta')), updatedAt: 'v1' }
+    const materializer = new ClaudeCodeSkillMaterializer()
+
+    await materializer.sync(configDir, [skill])
+    const file = join(configDir, 'skills', 'os-theta', 'SKILL.md')
+
+    // Simulate a dir left writable by an earlier version of the materializer.
+    await chmod(file, 0o644)
+    expect((await stat(file)).mode & 0o222).not.toBe(0)
+
+    // Same version means the copy is skipped, but the final read-only pass still fixes the mode.
+    await materializer.sync(configDir, [skill])
+    expect((await stat(file)).mode & 0o222).toBe(0)
+  })
+
+  it('removes a read-only os- dir once the skill is disabled', async () => {
+    const configDir = await skillsDir()
+    const skill = await makeSkill('zeta')
+    const materializer = new ClaudeCodeSkillMaterializer()
+
+    await materializer.sync(configDir, [skill])
+    // The materialized dir is read-only; a following empty sync must still remove it.
+    await materializer.sync(configDir, [])
+
+    expect(await listSkillDirs(configDir)).toEqual([])
   })
 })

--- a/src/main/skills/materializer.ts
+++ b/src/main/skills/materializer.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { chmod, cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { createLogger } from '../logger'
@@ -13,6 +13,40 @@ const OS_SKILL_PREFIX = 'os-'
 // Tracks the version (updatedAt) last materialized per managed dir so unchanged skills are skipped
 // instead of recopied on every spawn. Not a skill dir, so the claude skill loader ignores it.
 const VERSION_MANIFEST = '.os-versions.json'
+
+// Recursively chmods a materialized skill tree. Read-only keeps the agent from writing generated files
+// into a loaded skill dir; writable is applied before removal since a read-only dir cannot have its
+// children unlinked. Best-effort: logs and continues on error, and no-ops when the dir is absent.
+// POSIX-enforced only — on Windows a read-only directory does not enforce write-containment.
+async function chmodTree(dir: string, mode: 'readonly' | 'writable'): Promise<void> {
+  const dirMode = mode === 'readonly' ? 0o555 : 0o755
+  const fileMode = mode === 'readonly' ? 0o444 : 0o644
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    log.warn('failed to read skill dir for chmod', { dir, error })
+    return
+  }
+  for (const entry of entries) {
+    const child = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      await chmodTree(child, mode)
+    } else {
+      try {
+        await chmod(child, fileMode)
+      } catch (error) {
+        log.warn('failed to chmod skill file', { child, error })
+      }
+    }
+  }
+  try {
+    await chmod(dir, dirMode)
+  } catch (error) {
+    log.warn('failed to chmod skill dir', { dir, error })
+  }
+}
 
 // Writes an enabled skill set into a framework's config dir. One implementation per agent framework.
 interface SkillMaterializer {
@@ -41,8 +75,11 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
     // Remove managed dirs that should no longer exist (disabled or removed skills).
     for (const name of existing) {
       if (name.startsWith(OS_SKILL_PREFIX) && !wanted.has(name)) {
+        const stale = join(skillsDir, name)
         try {
-          await rm(join(skillsDir, name), { recursive: true, force: true })
+          // Restore write bits first: a read-only dir cannot have its children unlinked.
+          await chmodTree(stale, 'writable')
+          await rm(stale, { recursive: true, force: true })
         } catch (error) {
           log.warn('failed to remove stale skill dir', { name, error })
         }
@@ -59,13 +96,24 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
 
       const target = join(skillsDir, name)
       try {
+        // Restore write bits before removal in case a prior sync left the dir read-only.
+        await chmodTree(target, 'writable')
         await rm(target, { recursive: true, force: true })
         await cp(skill.sourceDir, target, { recursive: true, force: true })
+        // Loaded skills are read-only so the agent cannot write generated files into them.
+        await chmodTree(target, 'readonly')
         versions[name] = version
       } catch (error) {
         log.warn('failed to materialize skill', { id: skill.id, error })
         delete versions[name]
       }
+    }
+
+    // Ensure every managed dir is read-only, including ones skipped as unchanged above — otherwise a
+    // skill materialized as writable by an earlier version would stay writable until its version bumps.
+    // chmod is idempotent and cheap, so re-applying it to unchanged dirs is safe.
+    for (const name of wanted.keys()) {
+      await chmodTree(join(skillsDir, name), 'readonly')
     }
 
     await this.writeVersions(skillsDir, versions)


### PR DESCRIPTION
## Summary

Stops generated files from leaking into materialized skill directories (the `mindmap` skill wrote its output into `.../claude/skills/os-mindmap/assets/…`). Materialized skill dirs are now read-only, and the agent is told to route any generated file through the artifact system.

## Changes

**Read-only materialized skill dirs** (`materializer.ts`)
- After copying each `os-<id>` skill into the config dir, `chmod` the tree read-only (`0o555` dirs / `0o444` files) so the agent physically cannot write generated files inside a loaded skill.
- The tree is chmod'd writable again before any removal or re-materialize (a read-only dir cannot have its children unlinked).
- Read-only is re-applied as a final idempotent pass over **all** managed dirs each sync — not just freshly-copied ones — so skills materialized as writable by an earlier build are fixed on the next spawn even though the version manifest skips re-copying them.
- POSIX-enforced; Windows is best-effort (a read-only directory does not enforce write-containment there).

**Guidance** (`runtime.ts`)
- Adds one line to the artifact system-prompt block: never write inside a skill directory (loaded skills are read-only); route any generated file through `write_artifact_file`.

## Investigated, no code change
- **Catalog warning** (`skills.importBundle: … cannot reach claude.ai …`) is emitted by the external `claude` binary, not this app. The only env flag that might silence it (`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`) also disables the security auto-updater, so it is not set. It is a benign "cannot verify" warning when claude.ai is unreachable (e.g. a custom provider offline).
- **Packaging**: `resources/**` is included and `asarUnpack`'d, and `resolveBundledSkillsRoot` rewrites `app.asar → app.asar.unpacked`, so bundled skills ship and load in a packaged build. No gap.

## Testing
- `npm run lint`, `npm run typecheck`, and the full `vitest` suite (853) all pass, rebased on latest `main`.
- New materializer tests cover: read-only after materialize; re-materialize succeeds past a prior read-only state; a skill skipped as unchanged is still re-applied read-only; a disabled read-only dir is still removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
