### PR TITLE
fix(composer): preserve unsent composer state per session when switching

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -5,6 +5,7 @@ import type { PropsWithChildren } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ConversationPanel } from './ConversationPanel'
+import { emptyDoc } from './composer/composer-doc'
 
 // React's act() refuses to run unless the environment opts in to act-aware scheduling.
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -40,7 +41,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
     root.render(
       <ConversationPanel
         activeSession={undefined}
-        messageDraft=""
+        draftDoc={emptyDoc}
         canSendMessage={false}
         canEditDraft
         actionError={null}
@@ -49,7 +50,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         isUploadingAttachments={false}
         notebookReference={undefined}
         pendingPermissions={[]}
-        onMessageDraftChange={vi.fn()}
+        onDraftDocChange={vi.fn()}
         onSendMessage={vi.fn()}
         onStageAttachmentFiles={onStageAttachmentFiles}
         onRemoveAttachment={vi.fn()}
@@ -174,9 +175,9 @@ describe('ConversationPanel composer intake', () => {
     expect(onSendMessage).toHaveBeenCalledWith([])
   })
 
-  it('persists typed text as a plain-string draft via onMessageDraftChange', () => {
-    const onMessageDraftChange = vi.fn()
-    renderPanel({ onMessageDraftChange })
+  it('persists typed text as a doc via onDraftDocChange', () => {
+    const onDraftDocChange = vi.fn()
+    renderPanel({ onDraftDocChange })
 
     const editor = getComposerEditor()
     editor.textContent = 'hello'
@@ -184,6 +185,6 @@ describe('ConversationPanel composer intake', () => {
       editor.dispatchEvent(new Event('input', { bubbles: true }))
     })
 
-    expect(onMessageDraftChange).toHaveBeenCalledWith('hello')
+    expect(onDraftDocChange).toHaveBeenCalledWith({ nodes: [{ type: 'text', text: 'hello' }] })
   })
 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -11,7 +11,7 @@ import {
   Square,
   X
 } from 'lucide-react'
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 
 import { ResizablePanel } from '@/components/ui/resizable'
 import { cn } from '@/lib/utils'
@@ -19,7 +19,7 @@ import type { ChatSession } from '@/stores/session-store'
 
 import { ComposerDropOverlay } from './ComposerDropOverlay'
 import { ComposerEditor } from './composer/ComposerEditor'
-import { docFromText, docToSkillIds, docToText, type ComposerDoc } from './composer/composer-doc'
+import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
 import { useFileDropZone } from './useFileDropZone'
@@ -62,7 +62,7 @@ const formatAttachmentSize = (size: number): string => {
 
 type ConversationPanelProps = {
   activeSession: ChatSession | undefined
-  messageDraft: string
+  draftDoc: ComposerDoc
   canSendMessage: boolean
   canEditDraft: boolean
   actionError: string | null
@@ -71,7 +71,7 @@ type ConversationPanelProps = {
   isUploadingAttachments: boolean
   notebookReference: NotebookSessionReference | undefined
   pendingPermissions: AcpPermissionRequest[]
-  onMessageDraftChange: (value: string) => void
+  onDraftDocChange: (doc: ComposerDoc) => void
   onSendMessage: (forcedSkillIds: string[]) => void
   onStageAttachmentFiles: (files: File[]) => void
   onRemoveAttachment: (attachment: UploadedAttachment) => void
@@ -84,7 +84,7 @@ type ConversationPanelProps = {
 // Middle chat surface owns the visible conversation and local message composer UI.
 const ConversationPanel = ({
   activeSession,
-  messageDraft,
+  draftDoc,
   canSendMessage,
   canEditDraft,
   actionError,
@@ -93,7 +93,7 @@ const ConversationPanel = ({
   isUploadingAttachments,
   notebookReference,
   pendingPermissions,
-  onMessageDraftChange,
+  onDraftDocChange,
   onSendMessage,
   onStageAttachmentFiles,
   onRemoveAttachment,
@@ -104,19 +104,6 @@ const ConversationPanel = ({
 }: ConversationPanelProps): React.JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
-  // Local doc mirrors the composer's rich content (text runs + skill chips). The persisted draft
-  // stays a plain string, so we derive it via docToText on every edit and hydrate from it on reset.
-  const [doc, setDoc] = useState<ComposerDoc>(() => docFromText(messageDraft))
-
-  // Keep the doc in sync when the draft string changes externally (send reset to '', restore on
-  // failure, session switch). Using the setState-during-render pattern instead of an effect keeps
-  // us within the repo's react-hooks/set-state-in-effect rule.
-  const [lastDraft, setLastDraft] = useState(messageDraft)
-  if (lastDraft !== messageDraft) {
-    setLastDraft(messageDraft)
-    if (messageDraft !== docToText(doc)) setDoc(docFromText(messageDraft))
-  }
-
   // Drag-and-drop shares the same staging callback as the picker and paste paths.
   const { isDragging, dropZoneProps } = useFileDropZone({
     enabled: canEditDraft,
@@ -126,7 +113,7 @@ const ConversationPanel = ({
   // Submits the current doc, passing the ids of any skills picked as inline chips.
   const handleSubmit = (): void => {
     if (!canEditDraft) return
-    onSendMessage(docToSkillIds(doc))
+    onSendMessage(docToSkillIds(draftDoc))
   }
 
   // Converts the hidden file input selection into the shared staging callback.
@@ -276,11 +263,8 @@ const ConversationPanel = ({
                       <div className="relative min-w-0 flex-1">
                         {/* Draft editing waits for persistence hydration to avoid targeting the wrong session. */}
                         <ComposerEditor
-                          doc={doc}
-                          onDocChange={(next) => {
-                            setDoc(next)
-                            onMessageDraftChange(docToText(next))
-                          }}
+                          doc={draftDoc}
+                          onDocChange={onDraftDocChange}
                           onSubmit={handleSubmit}
                           onPaste={handleMessageDraftPaste}
                           disabled={!canEditDraft}

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -1,0 +1,354 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as React from 'react'
+
+import { useNavigationStore } from '@/stores/navigation-store'
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore
+} from '@/stores/preview-workbench-store'
+import { useProjectStore } from '@/stores/project-store'
+import {
+  createInitialSessionState,
+  useSessionStore,
+  type ChatSession
+} from '@/stores/session-store'
+import type { UploadedAttachment } from '../../../../shared/uploads'
+
+import { emptyDoc, type ComposerDoc } from './composer/composer-doc'
+
+// Capture the props passed to the heavy child components so the test can drive selection and drafts.
+let conversationProps: {
+  draftDoc: ComposerDoc
+  attachments: UploadedAttachment[]
+  onDraftDocChange: (doc: ComposerDoc) => void
+  onSendMessage: (forcedSkillIds: string[]) => void
+  onStageAttachmentFiles: (files: File[]) => void
+}
+let sidebarProps: {
+  onOpenSession: (id: string) => void
+  onNewConversation: () => void
+  onDeleteSession: (session: ChatSession) => void
+}
+let deleteDialogProps: { session: ChatSession | undefined; onConfirmDelete: () => void }
+
+// The runtime bridge is stubbed; sendMessage resolves truthy so the success path clears the composer.
+const runtime = vi.hoisted(() => ({
+  sendMessage: vi.fn(),
+  cancelRun: vi.fn(),
+  deleteRuntimeSession: vi.fn(),
+  respondToPermission: vi.fn()
+}))
+
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: (): React.JSX.Element => <div data-testid="resize-handle" />
+}))
+
+vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
+  useWorkspaceAgentRuntime: () => ({
+    actionError: null,
+    pendingPermissions: [],
+    sendMessage: runtime.sendMessage,
+    cancelRun: runtime.cancelRun,
+    deleteRuntimeSession: runtime.deleteRuntimeSession,
+    respondToPermission: runtime.respondToPermission
+  })
+}))
+
+vi.mock('./WorkspaceSidebar', () => ({
+  WorkspaceSidebar: (props: typeof sidebarProps): React.JSX.Element => {
+    sidebarProps = props
+    return <aside />
+  }
+}))
+
+vi.mock('./ConversationPanel', () => ({
+  ConversationPanel: (props: typeof conversationProps): React.JSX.Element => {
+    conversationProps = props
+    return <section data-testid="conversation" />
+  }
+}))
+
+vi.mock('./PreviewPanel', () => ({
+  PreviewPanel: (): React.JSX.Element => <div data-testid="preview-panel" />
+}))
+
+vi.mock('./RenameSessionDialog', () => ({
+  RenameSessionDialog: (): React.JSX.Element => <div />
+}))
+
+vi.mock('./DeleteSessionDialog', () => ({
+  DeleteSessionDialog: (props: typeof deleteDialogProps): React.JSX.Element => {
+    deleteDialogProps = props
+    return <div />
+  }
+}))
+
+const { WorkspacePage } = await import('./WorkspacePage')
+
+// Builds a minimal persisted-shape session that belongs to a given project.
+const createSession = (id: string, projectId: string): ChatSession => {
+  const now = Date.now()
+
+  return {
+    id,
+    projectId,
+    title: id,
+    cwd: `/workspace/${projectId}`,
+    status: 'idle',
+    messages: [],
+    createdAt: now,
+    updatedAt: now
+  }
+}
+
+// Builds a staged-attachment record with a known path so file deletion can be asserted.
+const createAttachment = (id: string): UploadedAttachment => ({
+  id,
+  sessionId: '.pending',
+  name: `${id}.txt`,
+  originalName: `${id}.txt`,
+  path: `/uploads/.pending/${id}.txt`,
+  size: 4
+})
+
+// Deterministic doc containing a single text run.
+const textDoc = (text: string): ComposerDoc => ({ nodes: [{ type: 'text', text }] })
+
+const deleteUpload = vi.fn(() => Promise.resolve())
+const stageFiles = vi.fn()
+
+describe('WorkspacePage draft preservation', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let originalFileReader: typeof FileReader
+
+  beforeEach(() => {
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    useProjectStore.setState({ projects: [] })
+    useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession('sess-a', 'proj-1'), createSession('sess-b', 'proj-1')],
+      selectedSessionId: 'sess-a'
+    })
+    vi.clearAllMocks()
+    runtime.sendMessage.mockResolvedValue({ sessionId: 'sess-a', messageId: 'm1' })
+    runtime.deleteRuntimeSession.mockImplementation((id: string) => {
+      useSessionStore.getState().deleteSession(id)
+      return Promise.resolve()
+    })
+    deleteUpload.mockResolvedValue(undefined)
+
+    // A deterministic FileReader keeps the async staging pipeline within the microtask queue.
+    originalFileReader = globalThis.FileReader
+    class MockFileReader {
+      result = ''
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      readAsDataURL(): void {
+        this.result = 'data:text/plain;base64,ZmFrZQ=='
+        queueMicrotask(() => this.onload?.())
+      }
+    }
+    globalThis.FileReader = MockFileReader as never
+
+    window.api = {
+      notebook: {
+        onAvailable: vi.fn(() => vi.fn()),
+        getReference: vi.fn(() => Promise.resolve(null))
+      },
+      preview: {
+        load: vi.fn(() => Promise.resolve(undefined)),
+        save: vi.fn(() => Promise.resolve())
+      },
+      uploads: {
+        deleteUpload,
+        stageFiles
+      }
+    } as never
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount()
+    })
+    globalThis.FileReader = originalFileReader
+    vi.restoreAllMocks()
+    container.remove()
+  })
+
+  const renderPage = async (): Promise<void> => {
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+    })
+  }
+
+  // Drives the composer's real staging pipeline so a per-session attachment lands in page state.
+  const stageAttachment = async (attachment: UploadedAttachment): Promise<void> => {
+    stageFiles.mockResolvedValueOnce([attachment])
+    await act(async () => {
+      conversationProps.onStageAttachmentFiles([
+        new File(['data'], `${attachment.id}.txt`, { type: 'text/plain' })
+      ])
+    })
+  }
+
+  const openSession = async (id: string): Promise<void> => {
+    await act(async () => {
+      sidebarProps.onOpenSession(id)
+    })
+  }
+
+  it('preserves each session doc independently when switching away and back', async () => {
+    await renderPage()
+
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('draft for A'))
+    })
+    expect(conversationProps.draftDoc).toEqual(textDoc('draft for A'))
+
+    // Switching to session B clears the composer to B's own (empty) doc.
+    await openSession('sess-b')
+    expect(conversationProps.draftDoc).toEqual(emptyDoc)
+
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('draft for B'))
+    })
+
+    // Switching back to session A restores A's doc, and B keeps its own.
+    await openSession('sess-a')
+    expect(conversationProps.draftDoc).toEqual(textDoc('draft for A'))
+
+    await openSession('sess-b')
+    expect(conversationProps.draftDoc).toEqual(textDoc('draft for B'))
+  })
+
+  it('preserves the new-conversation draft across session switches', async () => {
+    await renderPage()
+
+    await act(async () => {
+      sidebarProps.onNewConversation()
+    })
+    expect(conversationProps.draftDoc).toEqual(emptyDoc)
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('draft for new conversation'))
+    })
+
+    await openSession('sess-a')
+    expect(conversationProps.draftDoc).toEqual(emptyDoc)
+
+    await act(async () => {
+      sidebarProps.onNewConversation()
+    })
+    expect(conversationProps.draftDoc).toEqual(textDoc('draft for new conversation'))
+  })
+
+  it('preserves a skill chip as a structured node when switching away and back', async () => {
+    await renderPage()
+
+    const skillDoc: ComposerDoc = {
+      nodes: [
+        { type: 'skill', id: 'lit', name: 'Literature' },
+        { type: 'text', text: ' review please' }
+      ]
+    }
+    await act(async () => {
+      conversationProps.onDraftDocChange(skillDoc)
+    })
+
+    await openSession('sess-b')
+    expect(conversationProps.draftDoc).toEqual(emptyDoc)
+
+    // On return the chip must survive as a skill node with its id, not be flattened to `/Literature`.
+    await openSession('sess-a')
+    expect(conversationProps.draftDoc).toEqual(skillDoc)
+    expect(conversationProps.draftDoc.nodes[0]).toEqual({
+      type: 'skill',
+      id: 'lit',
+      name: 'Literature'
+    })
+  })
+
+  it('preserves staged attachments per session without deleting files on switch', async () => {
+    await renderPage()
+
+    const attachmentA = createAttachment('att-a')
+    await stageAttachment(attachmentA)
+    expect(conversationProps.attachments).toEqual([attachmentA])
+
+    // Switching away must not delete the staged file and must clear the composer for B.
+    await openSession('sess-b')
+    expect(conversationProps.attachments).toEqual([])
+    expect(deleteUpload).not.toHaveBeenCalled()
+
+    const attachmentB = createAttachment('att-b')
+    await stageAttachment(attachmentB)
+    expect(conversationProps.attachments).toEqual([attachmentB])
+
+    // Returning to A restores A's own attachment; B keeps its independent attachment.
+    await openSession('sess-a')
+    expect(conversationProps.attachments).toEqual([attachmentA])
+
+    await openSession('sess-b')
+    expect(conversationProps.attachments).toEqual([attachmentB])
+
+    expect(deleteUpload).not.toHaveBeenCalled()
+  })
+
+  it('clears the doc and attachments on a successful send without deleting staged files', async () => {
+    await renderPage()
+
+    const attachment = createAttachment('att-send')
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('send me'))
+    })
+    await stageAttachment(attachment)
+
+    await act(async () => {
+      conversationProps.onSendMessage([])
+    })
+
+    expect(runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'send me', attachments: [attachment] })
+    )
+    expect(conversationProps.draftDoc).toEqual(emptyDoc)
+    expect(conversationProps.attachments).toEqual([])
+    // The runtime consumes (moves) the staged files, so the page must not delete them itself.
+    expect(deleteUpload).not.toHaveBeenCalled()
+  })
+
+  it('drops a stored draft and deletes its staged files when the session is deleted', async () => {
+    await renderPage()
+
+    // Give session B an unsent draft with a staged attachment, then leave it for session A.
+    await openSession('sess-b')
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('draft for B'))
+    })
+    const attachmentB = createAttachment('att-del')
+    await stageAttachment(attachmentB)
+    await openSession('sess-a')
+
+    const sessionB = useSessionStore.getState().sessions.find((session) => session.id === 'sess-b')!
+    await act(async () => {
+      sidebarProps.onDeleteSession(sessionB)
+    })
+    await act(async () => {
+      deleteDialogProps.onConfirmDelete()
+    })
+
+    // B's abandoned staged file is deleted and its draft entry is dropped; A stays untouched.
+    expect(deleteUpload).toHaveBeenCalledWith({ path: attachmentB.path })
+    expect(runtime.deleteRuntimeSession).toHaveBeenCalledWith('sess-b')
+    expect(conversationProps.draftDoc).toEqual(emptyDoc)
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -20,6 +20,7 @@ import { useSessionStore } from '@/stores/session-store'
 import type { StageUploadFile, UploadedAttachment } from '../../../../shared/uploads'
 
 import { planComposerAttachmentIntake } from './composer-attachment-intake'
+import { docIsEmpty, docToText, emptyDoc, type ComposerDoc } from './composer/composer-doc'
 import { ConversationPanel } from './ConversationPanel'
 import { DeleteSessionDialog } from './DeleteSessionDialog'
 import { PreviewPanel } from './PreviewPanel'
@@ -34,6 +35,9 @@ type WorkspacePageProps = {
 // Converts unknown async failures into composer-visible text.
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
+
+// Stable draft-map key for the "new conversation" composer, which has no selected session id.
+const NEW_CONVERSATION_DRAFT_KEY = '__new_conversation__'
 
 const PREVIEW_PANEL_DEFAULT_SIZE = 40
 const PREVIEW_PANEL_DEFAULT_SIZE_CSS = `${PREVIEW_PANEL_DEFAULT_SIZE}%`
@@ -129,7 +133,13 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     deleteRuntimeSession,
     respondToPermission
   } = useWorkspaceAgentRuntime()
-  const [messageDraft, setMessageDraft] = useState('')
+  const [draftDoc, setDraftDoc] = useState<ComposerDoc>(emptyDoc)
+  // Unsent composer state (rich doc + staged attachments) is kept per session (and per new conversation)
+  // so switching away and back restores it. The active key's state is live; this map holds inactive keys.
+  const composerDraftsRef = useRef<
+    Record<string, { doc: ComposerDoc; attachments: UploadedAttachment[] }>
+  >({})
+  const previousDraftKeyRef = useRef<string>(selectedSessionId ?? NEW_CONVERSATION_DRAFT_KEY)
   const [attachments, setAttachments] = useState<UploadedAttachment[]>([])
   const [isUploadingAttachments, setIsUploadingAttachments] = useState(false)
   const [attachmentError, setAttachmentError] = useState<string | null>(null)
@@ -155,7 +165,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const canSendMessage =
     isSessionPersistenceReady &&
     !isUploadingAttachments &&
-    (messageDraft.trim().length > 0 || attachments.length > 0) &&
+    (!docIsEmpty(draftDoc) || attachments.length > 0) &&
     activeSession?.status !== 'running' &&
     activeSession?.status !== 'waiting-permission'
   const visibleActionError = attachmentError ?? (activeSession ? null : actionError)
@@ -254,6 +264,24 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     []
   )
 
+  // Save the outgoing draft and load the incoming one whenever the selected session changes, covering
+  // every selection path (session list, new conversation, project switch, deletes) in one place.
+  useEffect(() => {
+    const currentDraftKey = selectedSessionId ?? NEW_CONVERSATION_DRAFT_KEY
+    const previousDraftKey = previousDraftKeyRef.current
+
+    if (currentDraftKey === previousDraftKey) return
+
+    composerDraftsRef.current[previousDraftKey] = { doc: draftDoc, attachments }
+    const nextDraft = composerDraftsRef.current[currentDraftKey] ?? {
+      doc: emptyDoc,
+      attachments: []
+    }
+    setDraftDoc(nextDraft.doc)
+    setAttachments(nextDraft.attachments)
+    previousDraftKeyRef.current = currentDraftKey
+  }, [selectedSessionId, draftDoc, attachments])
+
   // The first agent-side notebook call promotes a notebook entry into the composer status bar.
   useEffect(() => {
     const removeNotebookAvailableListener = window.api.notebook.onAvailable((notebook) => {
@@ -344,22 +372,16 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const openNewConversation = (): void => {
     if (!isSessionPersistenceReady) return
 
-    // Staged files belong to the current draft, not the next new conversation.
-    deleteAttachmentFiles(attachments)
-    setAttachments([])
+    // The draft effect saves the outgoing doc/attachments and restores the new-conversation state.
     setAttachmentError(null)
     clearSelection()
-    setMessageDraft('')
   }
 
   // Synchronizes the hidden chat session id with the selected session list item.
   const openSession = (sessionId: string): void => {
-    // Switching sessions abandons unsent attachments so they cannot leak into another chat.
-    deleteAttachmentFiles(attachments)
-    setAttachments([])
+    // The draft effect saves the outgoing doc/attachments and restores the target session's state.
     setAttachmentError(null)
     selectSession(sessionId)
-    setMessageDraft('')
   }
 
   // Converts selected or pasted files into app-managed uploads before they appear in the composer.
@@ -411,11 +433,14 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const sendCurrentMessage = (forcedSkillIds: string[]): void => {
     if (!canSendMessage) return
 
-    const draft = messageDraft
+    const doc = draftDoc
     const attachmentsForSend = attachments
 
-    // Optimistically clear composer state; failed sends restore both text and attachments below.
-    setMessageDraft('')
+    // Optimistically clear composer state; failed sends restore both doc and attachments below. Staged
+    // files are consumed (moved into the session dir) by the runtime, so they are not deleted here.
+    setDraftDoc(emptyDoc)
+    // Drop the stored draft for this key so a sent message never lingers as a restorable draft.
+    delete composerDraftsRef.current[selectedSessionId ?? NEW_CONVERSATION_DRAFT_KEY]
     setAttachments([])
     setAttachmentError(null)
 
@@ -423,7 +448,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     // with the active project (both as the durable projectId and the MCP storage projectName).
     void sendMessage({
       sessionId: activeSession?.id,
-      text: draft,
+      text: docToText(doc),
       attachments: attachmentsForSend,
       cwd: activeSession?.cwd,
       projectId: activeSession?.projectId ?? scopedProjectId,
@@ -431,7 +456,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
       forcedSkillIds
     }).then((result) => {
       if (!result) {
-        setMessageDraft(draft)
+        setDraftDoc(doc)
         setAttachments(attachmentsForSend)
       }
     })
@@ -466,6 +491,16 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     const deletedSessionId = sessionToDelete.id
 
     setSessionToDelete(undefined)
+    // The session's unsent draft is abandoned, so drop it and delete its now-orphaned staged files.
+    const storedDraft = composerDraftsRef.current[deletedSessionId]
+    if (storedDraft) deleteAttachmentFiles(storedDraft.attachments)
+    delete composerDraftsRef.current[deletedSessionId]
+    // The active session's live draft is not in the map yet, so clear and delete its files directly.
+    if (deletedSessionId === selectedSessionId) {
+      deleteAttachmentFiles(attachments)
+      setAttachments([])
+      setDraftDoc(emptyDoc)
+    }
     void deleteRuntimeSession(deletedSessionId)
   }
 
@@ -521,7 +556,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
         >
           <ConversationPanel
             activeSession={activeSession}
-            messageDraft={messageDraft}
+            draftDoc={draftDoc}
             canSendMessage={canSendMessage}
             canEditDraft={canEditDraft}
             actionError={visibleActionError}
@@ -530,7 +565,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             isUploadingAttachments={isUploadingAttachments}
             notebookReference={activeNotebookReference}
             pendingPermissions={visiblePermissionRequests}
-            onMessageDraftChange={setMessageDraft}
+            onDraftDocChange={setDraftDoc}
             onSendMessage={sendCurrentMessage}
             onStageAttachmentFiles={stageAttachmentFiles}
             onRemoveAttachment={removeComposerAttachment}

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -461,9 +461,9 @@ describe('conversation composer editor integration', () => {
     expect(conversationPanelSource).toContain(
       "import { ComposerEditor } from './composer/ComposerEditor'"
     )
-    expect(conversationPanelSource).toContain('onSendMessage(docToSkillIds(doc))')
+    expect(conversationPanelSource).toContain('onSendMessage(docToSkillIds(draftDoc))')
     expect(conversationPanelSource).toContain('onSubmit={handleSubmit}')
-    expect(conversationPanelSource).toContain('onDocChange={(next) => {')
+    expect(conversationPanelSource).toContain('onDocChange={onDraftDocChange}')
   })
 })
 


### PR DESCRIPTION
## Problem
Switching sessions discarded the current session's unsent composer state and never restored it on return:
- typed **draft text** was lost;
- **skill chips** (`/skill` inline chips from #50) collapsed to literal `/name` text — losing their styling and skill id;
- **staged attachments** were deleted on switch.

## Fix
Preserve the full composer state **per session**.
- Lift the rich `ComposerDoc` up to `WorkspacePage` and keep a per-key snapshot of `{ doc, attachments }` (keyed by session id, plus a sentinel for the new conversation). The existing `selectedSessionId` effect saves the outgoing session's snapshot and restores the incoming one, covering every selection path (session list, new conversation, project switch, deletes).
- `ConversationPanel` is now fully controlled by the lifted doc, so skill chips round-trip as structured `{type:'skill', id, name}` nodes and keep their styling.
- Staged files are no longer deleted on switch; they are cleaned up only when genuinely abandoned (session delete) and are consumed (moved into the session dir) by the runtime on a successful send — so nothing is deleted around send that would break attachment sends.

## Tests
- Extended `WorkspacePage.draft-preservation.test.tsx`: independent per-session drafts, new-conversation draft, skill chip preserved as a structured node (not flattened), staged attachments preserved across a switch with `deleteUpload` **not** called, successful send clears doc + attachments without deleting files, session delete drops the stored draft and deletes its staged files.
- Updated `ConversationPanel.interaction.test.tsx` / `workspace-components.test.tsx` for the new `draftDoc` / `onDraftDocChange` contract.
- `npm run lint`, `npm run typecheck`, and the full vitest suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)