### PR TITLE
feat(skills): editable Skill ID on create and editable References on edit

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -635,6 +635,37 @@ describe('SettingsService: skills', () => {
     expect(skills.map((skill) => skill.id)).toEqual(['demo'])
   })
 
+  it('creates with a custom slug and reconciles references reported by the detail view', async () => {
+    const service = await createSkillService()
+    const b64 = (text: string): string => Buffer.from(text).toString('base64')
+
+    await service.createSkill({
+      name: 'Ref Skill',
+      description: 'd',
+      body: '# body',
+      slug: 'ref-skill-id',
+      references: [
+        { path: 'keep.py', dataBase64: b64('keep') },
+        { path: 'drop.py', dataBase64: b64('drop') }
+      ]
+    })
+
+    let detail = await service.getSkillDetail('personal-ref-skill-id')
+    expect(detail.references.map((ref) => ref.path)).toEqual(['drop.py', 'keep.py'])
+
+    // Editing keeps one file, drops one, and adds one.
+    await service.updateSkill({
+      id: 'personal-ref-skill-id',
+      name: 'Ref Skill',
+      description: 'd',
+      body: '# body',
+      references: [{ path: 'keep.py' }, { path: 'new.py', dataBase64: b64('new') }]
+    })
+
+    detail = await service.getSkillDetail('personal-ref-skill-id')
+    expect(detail.references.map((ref) => ref.path)).toEqual(['keep.py', 'new.py'])
+  })
+
   it('force-loads a disabled picked skill for the turn without mutating stored settings', async () => {
     const service = await createSkillService()
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process'
-import { access } from 'node:fs/promises'
+import { access, readdir } from 'node:fs/promises'
 import { constants } from 'node:fs'
+import { join } from 'node:path'
 import { promisify } from 'node:util'
 
 import type {
@@ -203,8 +204,23 @@ class SettingsService {
 
     const disabled = new Set(settings.disabledSkillIds ?? [])
     const { body } = await readSkillFile(skill.sourceDir)
+    const references = await this.listSkillReferences(skill.sourceDir)
 
-    return { ...this.toSkillView(skill, disabled), body }
+    return { ...this.toSkillView(skill, disabled), body, references }
+  }
+
+  // Lists the file names directly under a skill's `references/` directory (empty when absent).
+  private async listSkillReferences(sourceDir: string): Promise<{ path: string }[]> {
+    try {
+      const entries = await readdir(join(sourceDir, 'references'), { withFileTypes: true })
+
+      return entries
+        .filter((entry) => entry.isFile())
+        .map((entry) => ({ path: entry.name }))
+        .sort((a, b) => a.path.localeCompare(b.path))
+    } catch {
+      return []
+    }
   }
 
   // Toggles a skill and returns the refreshed list. The agent picks up the change on its next reconnect
@@ -217,7 +233,7 @@ class SettingsService {
 
   // Creates a personal skill from the in-app editor, returning the refreshed list.
   async createSkill(request: CreateSkillRequest): Promise<SkillView[]> {
-    await this.userSkills.createPersonal(request)
+    await this.userSkills.createPersonal(request, request.slug)
 
     return this.listSkills()
   }

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -163,6 +163,62 @@ describe('UserSkillRepository', () => {
     expect(written).toBe('print(1)')
   })
 
+  it('honors an explicit slug and rejects collisions, reserved prefixes, and invalid ids', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+
+    const id = await repo.createPersonal({ name: 'Anything', description: 'd', body: 'x' }, 'my-id')
+    expect(id).toBe('personal-my-id')
+
+    // Colliding with the just-created slug is rejected (no silent suffix).
+    await expect(
+      repo.createPersonal({ name: 'Other', description: 'd', body: 'y' }, 'my-id')
+    ).rejects.toThrow(/already exists/)
+
+    // Reserved built-in / MCP prefixes are rejected.
+    await expect(
+      repo.createPersonal({ name: 'x', description: 'd', body: 'x' }, 'os-thing')
+    ).rejects.toThrow(/os- or mcp-/)
+    await expect(
+      repo.createPersonal({ name: 'x', description: 'd', body: 'x' }, 'mcp-thing')
+    ).rejects.toThrow(/os- or mcp-/)
+
+    // Unsafe characters are rejected.
+    await expect(
+      repo.createPersonal({ name: 'x', description: 'd', body: 'x' }, 'Bad ID')
+    ).rejects.toThrow(/lowercase/)
+  })
+
+  it('reconciles references on update: keeps untouched, adds new, deletes removed', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const b64 = (text: string): string => Buffer.from(text).toString('base64')
+
+    const id = await repo.createPersonal({
+      name: 'Refs',
+      description: 'd',
+      body: 'x',
+      references: [
+        { path: 'keep.py', dataBase64: b64('keep') },
+        { path: 'drop.py', dataBase64: b64('drop') }
+      ]
+    })
+
+    await repo.updatePersonal(id, {
+      name: 'Refs',
+      description: 'd',
+      body: 'x',
+      references: [
+        { path: 'keep.py' }, // no base64 -> keep the existing file
+        { path: 'new.py', dataBase64: b64('new') } // new file
+      ]
+    })
+
+    const dir = join(storage, 'skills', 'personal', 'refs', 'references')
+    expect(await readFile(join(dir, 'keep.py'), 'utf8')).toBe('keep')
+    expect(await readFile(join(dir, 'new.py'), 'utf8')).toBe('new')
+    await expect(readFile(join(dir, 'drop.py'), 'utf8')).rejects.toThrow()
+  })
+
   it('lists imported skills with their frontmatter metadata', async () => {
     const storage = await makeStorage()
     const dir = join(storage, 'skills', 'imported', 'foo')

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -30,6 +30,21 @@ const USER_SOURCES: ReadonlyArray<Extract<SkillSource, 'imported' | 'personal'>>
 // Only lowercase slugs so a skill id maps 1:1 to a safe directory name.
 const SAFE_SLUG = /^[a-z0-9-]+$/
 
+// Reserved id namespaces a user-authored skill may not claim: `os-` is the app's own materialized
+// prefix and `mcp-` is reserved for MCP-provided skills.
+const RESERVED_SLUG_PREFIXES = ['os-', 'mcp-'] as const
+
+// Validates a user-chosen slug, throwing a user-facing error for empty, unsafe, or reserved values.
+const assertUsableSlug = (slug: string): void => {
+  if (!slug) throw new Error('Skill ID is required.')
+  if (!SAFE_SLUG.test(slug)) {
+    throw new Error('Skill ID may only contain lowercase letters, numbers, and hyphens.')
+  }
+  if (RESERVED_SLUG_PREFIXES.some((prefix) => slug.startsWith(prefix))) {
+    throw new Error(`Skill ID may not start with ${RESERVED_SLUG_PREFIXES.join(' or ')}.`)
+  }
+}
+
 // Builds a filesystem-safe slug from a display name (e.g. "My Skill!" -> "my-skill").
 const toSlug = (name: string): string =>
   name
@@ -165,8 +180,21 @@ class UserSkillRepository {
     return (await readSkillFile(this.skillDir(parsed.source, parsed.slug))).body
   }
 
-  // Creates a personal skill, returning its new id. Slug collisions get a numeric suffix.
-  async createPersonal(input: WriteSkillInput): Promise<string> {
+  // Creates a personal skill, returning its new id. With an explicit `requestedSlug`, that slug is
+  // used verbatim (validated, and rejected if already taken); otherwise a slug is derived from the
+  // name and collisions get a numeric suffix.
+  async createPersonal(input: WriteSkillInput, requestedSlug?: string): Promise<string> {
+    if (requestedSlug !== undefined) {
+      const slug = requestedSlug.trim()
+      assertUsableSlug(slug)
+      if (await this.slugTaken('personal', slug)) {
+        throw new Error(`A skill with ID "${slug}" already exists.`)
+      }
+      await this.writeSkill('personal', slug, input)
+
+      return `personal-${slug}`
+    }
+
     const base = toSlug(input.name) || 'skill'
     const slug = await this.uniqueSlug('personal', base)
     await this.writeSkill('personal', slug, input)
@@ -387,6 +415,16 @@ class UserSkillRepository {
     }
   }
 
+  // Whether a slug's directory already exists under the source.
+  private async slugTaken(source: (typeof USER_SOURCES)[number], slug: string): Promise<boolean> {
+    try {
+      const slugs = await readdir(this.sourceDir(source))
+      return slugs.includes(slug)
+    } catch {
+      return false
+    }
+  }
+
   // Writes a SKILL.md with a minimal frontmatter block (name/description) followed by the body.
   private async writeSkill(
     source: (typeof USER_SOURCES)[number],
@@ -406,13 +444,35 @@ class UserSkillRepository {
 
     await writeFile(join(dir, 'SKILL.md'), contents, 'utf8')
 
-    // Write any supporting files under references/, using each file's basename as a safe path.
-    for (const reference of input.references ?? []) {
-      const name = reference.path.split(/[\\/]/).pop() ?? ''
-      if (!name || !/^[A-Za-z0-9._-]+$/.test(name)) continue
-      const target = join(dir, 'references', name)
-      await mkdir(dirname(target), { recursive: true })
-      await writeFile(target, Buffer.from(reference.dataBase64, 'base64'))
+    // Reconcile the references/ dir to the desired set when references are provided (an array — even
+    // empty — reconciles; `undefined` leaves the dir untouched). A reference with `dataBase64` is
+    // written (created or replaced); one without it is an existing file to keep as-is. Any file not in
+    // the desired set is removed, so the editor's removals delete the file on disk.
+    if (input.references !== undefined) {
+      const refsDir = join(dir, 'references')
+      const desired = new Map<string, SkillReference>()
+      for (const reference of input.references) {
+        const name = reference.path.split(/[\\/]/).pop() ?? ''
+        if (!name || !/^[A-Za-z0-9._-]+$/.test(name)) continue
+        desired.set(name, reference)
+      }
+
+      let existing: string[] = []
+      try {
+        existing = await readdir(refsDir)
+      } catch {
+        existing = []
+      }
+      for (const name of existing) {
+        if (!desired.has(name)) await rm(join(refsDir, name), { recursive: true, force: true })
+      }
+
+      for (const [name, reference] of desired) {
+        if (reference.dataBase64 === undefined) continue
+        const target = join(refsDir, name)
+        await mkdir(dirname(target), { recursive: true })
+        await writeFile(target, Buffer.from(reference.dataBase64, 'base64'))
+      }
     }
   }
 }

--- a/src/renderer/src/pages/settings/SkillEditor.tsx
+++ b/src/renderer/src/pages/settings/SkillEditor.tsx
@@ -1,5 +1,5 @@
 import { FileUp, Upload, X } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import type { SkillReference } from '../../../../shared/settings'
 import { Input } from '@/components/ui/input'
@@ -10,8 +10,13 @@ export type SkillDraft = {
   name: string
   description: string
   body: string
+  slug?: string
   references?: SkillReference[]
 }
+
+// Reserved id namespaces a user-authored skill may not claim (mirrors the main-process rule):
+// `os-` is the app's own materialized prefix, `mcp-` is reserved for MCP-provided skills.
+const RESERVED_SLUG_PREFIXES = ['os-', 'mcp-']
 
 // Reads a File as base64 (for binary-safe reference transport to the main process).
 const fileToBase64 = (file: File): Promise<string> =>
@@ -58,14 +63,40 @@ type SkillEditorProps = {
 // Create/edit form for a personal skill: Identity (name/id/description) + Content (SKILL.md body).
 // Pasting a full SKILL.md with a frontmatter block auto-fills name/description.
 const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX.Element => {
+  const isCreate = !initial.id
+  const skills = useSettingsStore((state) => state.skills)
   const [name, setName] = useState(initial.name)
   const [description, setDescription] = useState(initial.description)
   const [body, setBody] = useState(initial.body)
   const [contentMode, setContentMode] = useState<'write' | 'upload'>('write')
-  const [references, setReferences] = useState<{ name: string; dataBase64: string }[]>([])
+  const [references, setReferences] = useState<{ path: string; dataBase64?: string }[]>(() =>
+    (initial.references ?? []).map((ref) => ({ path: ref.path, dataBase64: ref.dataBase64 }))
+  )
+  const [slug, setSlug] = useState('')
+  const [slugTouched, setSlugTouched] = useState(false)
   const [saving, setSaving] = useState(false)
 
-  const canSave = name.trim().length > 0 && body.trim().length > 0 && !saving
+  // The effective id: the user's typed value once they edit it, otherwise derived from the name.
+  const currentSlug = isCreate && !slugTouched ? toSlug(name) : slug
+
+  // Validates the chosen id against the same rules the main process enforces, plus a live
+  // collision check against already-loaded personal skills. Only meaningful when creating.
+  const slugError = useMemo((): string | null => {
+    if (!isCreate) return null
+    if (!currentSlug) return 'Skill ID is required.'
+    if (!/^[a-z0-9-]+$/.test(currentSlug)) {
+      return 'Only lowercase letters, numbers, and hyphens.'
+    }
+    if (RESERVED_SLUG_PREFIXES.some((prefix) => currentSlug.startsWith(prefix))) {
+      return `Can't start with ${RESERVED_SLUG_PREFIXES.join(' or ')}.`
+    }
+    if (skills.some((entry) => entry.id === `personal-${currentSlug}`)) {
+      return 'A skill with this ID already exists.'
+    }
+    return null
+  }, [isCreate, currentSlug, skills])
+
+  const canSave = name.trim().length > 0 && body.trim().length > 0 && !slugError && !saving
 
   const handleBodyChange = (value: string): void => {
     const parsed = consumeFrontmatter(value)
@@ -92,17 +123,18 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
     input.click()
   }
 
-  // Adds one or more supporting files to the references list (base64-encoded).
+  // Adds one or more supporting files to the references list (base64-encoded), replacing any
+  // existing entry with the same name.
   const addReferences = async (files: FileList | null): Promise<void> => {
     if (!files) return
     const added = await Promise.all(
       Array.from(files).map(async (file) => ({
-        name: file.name,
+        path: file.name,
         dataBase64: await fileToBase64(file)
       }))
     )
     setReferences((prev) => [
-      ...prev.filter((ref) => !added.some((a) => a.name === ref.name)),
+      ...prev.filter((ref) => !added.some((a) => a.path === ref.path)),
       ...added
     ])
   }
@@ -116,7 +148,8 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
         name: name.trim(),
         description: description.trim(),
         body,
-        references: references.map((ref) => ({ path: ref.name, dataBase64: ref.dataBase64 }))
+        slug: isCreate ? currentSlug : undefined,
+        references: references.map((ref) => ({ path: ref.path, dataBase64: ref.dataBase64 }))
       })
     } finally {
       setSaving(false)
@@ -146,13 +179,34 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
                 <span className="text-sm font-medium text-foreground">Skill ID</span>
                 <Input
                   aria-label="Skill ID"
-                  value={initial.id ? initial.id.replace(/^personal-/, '') : toSlug(name)}
-                  readOnly
-                  className="font-mono text-muted-foreground"
+                  value={isCreate ? currentSlug : (initial.id ?? '').replace(/^personal-/, '')}
+                  onChange={
+                    isCreate
+                      ? (event) => {
+                          setSlugTouched(true)
+                          setSlug(event.target.value.toLowerCase())
+                        }
+                      : undefined
+                  }
+                  readOnly={!isCreate}
+                  aria-invalid={slugError ? true : undefined}
+                  className={`font-mono ${
+                    isCreate
+                      ? slugError
+                        ? 'border-danger-000 text-foreground'
+                        : 'text-foreground'
+                      : 'text-muted-foreground'
+                  }`}
                 />
-                <span className="text-xs text-muted-foreground">
-                  Derived from the name — lowercase a–z, 0–9, hyphens.
-                </span>
+                {slugError ? (
+                  <span className="text-xs text-danger-000">{slugError}</span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    {isCreate
+                      ? 'Used as the folder name — lowercase a–z, 0–9, hyphens. Locked after creation.'
+                      : 'The skill ID is fixed after creation.'}
+                  </span>
+                )}
               </label>
               <label className="flex flex-col gap-1.5">
                 <span className="text-sm font-medium text-foreground">Description</span>
@@ -275,15 +329,15 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
             {references.length > 0 ? (
               <ul className="mt-3 flex flex-col divide-y divide-border">
                 {references.map((ref) => (
-                  <li key={ref.name} className="flex items-center gap-2 py-2 text-sm">
+                  <li key={ref.path} className="flex items-center gap-2 py-2 text-sm">
                     <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
-                      references/{ref.name}
+                      references/{ref.path}
                     </span>
                     <button
                       type="button"
-                      aria-label={`Remove ${ref.name}`}
+                      aria-label={`Remove ${ref.path}`}
                       onClick={() =>
-                        setReferences((prev) => prev.filter((item) => item.name !== ref.name))
+                        setReferences((prev) => prev.filter((item) => item.path !== ref.path))
                       }
                       className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
                     >
@@ -336,7 +390,8 @@ const SkillEditLoader = ({ skillId, onDone }: SkillEditLoaderProps): React.JSX.E
           id: detail.id,
           name: detail.name,
           description: detail.description,
-          body: detail.body
+          body: detail.body,
+          references: detail.references.map((ref) => ({ path: ref.path }))
         })
       }
     })

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -162,6 +162,7 @@ describe('SkillsPanel (sub-views)', () => {
       name: 'My New Skill',
       description: '',
       body: '# Body',
+      slug: 'my-new-skill',
       references: []
     })
   })

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -115,6 +115,7 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
             name: draft.name,
             description: draft.description,
             body: draft.body,
+            slug: draft.slug,
             references: draft.references
           })
           onNavigate({ kind: 'list' })

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -257,9 +257,16 @@ export type SkillView = {
   thirdParty?: string
 }
 
-// A skill view plus its SKILL.md body (frontmatter stripped), for the detail view.
+// A skill view plus its SKILL.md body (frontmatter stripped) and the names of any files under its
+// `references/` directory, for the detail/edit view.
 export type SkillDetailView = SkillView & {
   body: string
+  references: SkillReferenceInfo[]
+}
+
+// A reference file's name (basename under `references/`), without its content.
+export type SkillReferenceInfo = {
+  path: string
 }
 
 export type SetSkillEnabledRequest = {
@@ -267,17 +274,20 @@ export type SetSkillEnabledRequest = {
   enabled: boolean
 }
 
-// A supporting file bundled under the skill's `references/` directory (base64-encoded for transport).
+// A supporting file bundled under the skill's `references/` directory. `dataBase64` carries new file
+// content; when omitted (on edit), it means "keep the existing file with this path unchanged".
 export type SkillReference = {
   path: string
-  dataBase64: string
+  dataBase64?: string
 }
 
-// Create a personal (user-authored) skill from the in-app editor.
+// Create a personal (user-authored) skill from the in-app editor. `slug` is the user-chosen Skill ID
+// (without the `personal-` prefix); when omitted, it is derived from the name.
 export type CreateSkillRequest = {
   name: string
   description: string
   body: string
+  slug?: string
   references?: SkillReference[]
 }
 


### PR DESCRIPTION
## Summary

Two authoring-polish improvements for personal skills in Settings → Skills:

- **Editable Skill ID (create-only).** When creating a personal skill, the Skill ID is now editable. It defaults to the name-derived slug and decouples once the user edits it. It is validated against unsafe characters, the reserved `os-`/`mcp-` prefixes (built-in / MCP namespaces), and collisions with existing personal IDs — invalid values block Publish with an inline message. On **edit** the ID stays read-only, since renaming the directory would break references that force-load by id.
- **Editable References (edit).** Editing a skill now loads its existing `references/` files so they can be viewed and removed, alongside adding new ones. Saving reconciles the directory: removed files are deleted, new files written, untouched files kept.

## Changes

- **shared** (`settings.ts`): add `CreateSkillRequest.slug`; make `SkillReference.dataBase64` optional (absent = keep the existing file); add `SkillDetailView.references`.
- **main / repository** (`user-skill-repository.ts`): `createPersonal` honors an explicit slug, rejecting collisions, reserved prefixes, and unsafe ids; `writeSkill` reconciles the `references/` dir.
- **main / service** (`service.ts`): pass the slug through; `getSkillDetail` returns the reference file names.
- **renderer** (`SkillEditor.tsx`, `SkillsPanel.tsx`): editable/validated ID field on create; load + add/remove references on edit.

## Testing

- `npm run typecheck` ✓ · `npm run lint` ✓ · `npm run test` ✓ (862 passed; +3 new)
- New coverage: explicit-slug honored / collision / reserved-prefix / unsafe-id rejection; references reconcile (keep + add + delete); `getSkillDetail` references.
- Manual `npm run dev` pass: custom ID with reserved/collision errors, and edit-time reference add/remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)