### PR TITLE
feat(connectors): life-sciences data connectors + custom MCP servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ local/
 
 # Locally downloaded CI build artifacts (Windows installer, etc.)
 dist-win-artifact/
+
+# SDD scratch (progress ledger, task briefs, reports) — worktree-local, not tracked
+.superpowers/

--- a/src/main/connectors/approval-broker.test.ts
+++ b/src/main/connectors/approval-broker.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ApprovalBroker } from './approval-broker'
+import type { ConnectorApprovalRequest } from '../../shared/settings'
+
+// A synchronous fake timer so timeout behavior is deterministic without real time passing.
+const makeTimer = (): {
+  set: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  fire: () => void
+  clear: (h: ReturnType<typeof setTimeout>) => void
+} => {
+  let pending: (() => void) | undefined
+  return {
+    set: (fn) => {
+      pending = fn
+      return 1 as unknown as ReturnType<typeof setTimeout>
+    },
+    fire: () => pending?.(),
+    clear: () => {
+      pending = undefined
+    }
+  }
+}
+
+describe('ApprovalBroker', () => {
+  it('broadcasts a request and resolves with the renderer decision', async () => {
+    const timer = makeTimer()
+    let broadcast: ConnectorApprovalRequest | undefined
+    let n = 0
+    const broker = new ApprovalBroker({
+      generateId: () => `id-${++n}`,
+      broadcast: (r) => {
+        broadcast = r
+      },
+      setTimer: timer.set,
+      clearTimer: timer.clear
+    })
+
+    const decision = broker.request({ connector: 'biomart', method: 'get_data', argsPreview: '{}' })
+    expect(broadcast).toEqual({
+      id: 'id-1',
+      connector: 'biomart',
+      method: 'get_data',
+      argsPreview: '{}'
+    })
+
+    broker.respond('id-1', 'allow')
+    await expect(decision).resolves.toBe('allow')
+  })
+
+  it('auto-denies when the request times out', async () => {
+    const timer = makeTimer()
+    const broker = new ApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast: () => undefined,
+      setTimer: timer.set,
+      clearTimer: timer.clear
+    })
+
+    const decision = broker.request({ connector: 'biomart', method: 'get_data', argsPreview: '{}' })
+    timer.fire()
+    await expect(decision).resolves.toBe('deny')
+  })
+
+  it('ignores a response for an unknown or already-settled id', async () => {
+    const timer = makeTimer()
+    const broker = new ApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast: () => undefined,
+      setTimer: timer.set,
+      clearTimer: timer.clear
+    })
+
+    const decision = broker.request({ connector: 'biomart', method: 'get_data', argsPreview: '{}' })
+    broker.respond('id-1', 'deny')
+    broker.respond('id-1', 'allow') // no-op: already settled
+    await expect(decision).resolves.toBe('deny')
+    expect(() => broker.respond('nope', 'allow')).not.toThrow()
+  })
+
+  it('runs concurrent requests independently', async () => {
+    const timers: Array<() => void> = []
+    let n = 0
+    const broker = new ApprovalBroker({
+      generateId: () => `id-${++n}`,
+      broadcast: () => undefined,
+      setTimer: (fn) => {
+        timers.push(fn)
+        return timers.length as unknown as ReturnType<typeof setTimeout>
+      },
+      clearTimer: () => undefined
+    })
+
+    const a = broker.request({ connector: 'x', method: 'm', argsPreview: '{}' })
+    const b = broker.request({ connector: 'y', method: 'm', argsPreview: '{}' })
+    broker.respond('id-2', 'allow')
+    broker.respond('id-1', 'deny')
+    await expect(a).resolves.toBe('deny')
+    await expect(b).resolves.toBe('allow')
+    expect(vi.isMockFunction(broker.request)).toBe(false)
+  })
+})

--- a/src/main/connectors/approval-broker.ts
+++ b/src/main/connectors/approval-broker.ts
@@ -1,0 +1,58 @@
+import type { ApprovalDecision, ConnectorApprovalRequest } from '../../shared/settings'
+
+export type ApprovalInfo = { connector: string; method: string; argsPreview: string }
+
+type ApprovalBrokerDeps = {
+  // Pushes a pending request to the renderer(s) that show the approval card.
+  broadcast: (request: ConnectorApprovalRequest) => void
+  // Injectable so tests are deterministic; defaults to crypto.randomUUID in the factory below.
+  generateId: () => string
+  // How long a request waits before it is auto-denied (a connector call must never block forever).
+  timeoutMs?: number
+  // Injectable timer for tests.
+  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void
+}
+
+// Bridges the main-process connector gate to the renderer approval card: it holds a connector call
+// open (a promise) while the user decides, and resolves it when the renderer responds. Unanswered
+// requests are auto-denied after `timeoutMs` so a call can never hang the kernel indefinitely.
+export class ApprovalBroker {
+  private readonly pending = new Map<
+    string,
+    { resolve: (decision: ApprovalDecision) => void; timer: ReturnType<typeof setTimeout> }
+  >()
+  private readonly timeoutMs: number
+  private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
+
+  constructor(private readonly deps: ApprovalBrokerDeps) {
+    this.timeoutMs = deps.timeoutMs ?? 5 * 60_000
+    this.setTimer = deps.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
+    this.clearTimer = deps.clearTimer ?? ((h) => clearTimeout(h))
+  }
+
+  // Broadcasts an approval request and resolves once the renderer responds (or the timeout denies it).
+  request(info: ApprovalInfo): Promise<ApprovalDecision> {
+    const id = this.deps.generateId()
+
+    return new Promise<ApprovalDecision>((resolve) => {
+      const timer = this.setTimer(() => this.settle(id, 'deny'), this.timeoutMs)
+      this.pending.set(id, { resolve, timer })
+      this.deps.broadcast({ id, ...info })
+    })
+  }
+
+  // Called from the IPC handler when the renderer responds. Unknown ids are ignored (already settled).
+  respond(id: string, decision: ApprovalDecision): void {
+    this.settle(id, decision)
+  }
+
+  private settle(id: string, decision: ApprovalDecision): void {
+    const entry = this.pending.get(id)
+    if (!entry) return
+    this.clearTimer(entry.timer)
+    this.pending.delete(id)
+    entry.resolve(decision)
+  }
+}

--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -1,0 +1,284 @@
+import type { ConnectorGroup } from '../../shared/settings'
+
+export type ConnectorMeta = {
+  id: string
+  displayName: string
+  description: string
+  // Trigger-style summary ("Use when …") that drives automatic skill discovery — the agent matches a
+  // plain user question against this without the user naming the connector. Keep it query-oriented.
+  useWhen: string
+  sources: string[]
+  termsUrl?: string
+  requiresNcbi: boolean
+  // Settings-list section. Absent = "featured" (Anthropic research connectors); "directory" connectors
+  // mirror entries in the Claude Connectors Directory.
+  group?: ConnectorGroup
+}
+
+// Static connector metadata for the settings UI (tool lists come from the registry).
+export const CONNECTOR_CATALOG: ConnectorMeta[] = [
+  {
+    id: 'chemistry',
+    displayName: 'Chemistry',
+    description: 'Small-molecule chemistry via PubChem.',
+    useWhen:
+      'Use when a question needs authoritative data about a chemical compound or drug — molecular formula, molecular weight, SMILES/InChI, IUPAC name, or PubChem identifiers (e.g. aspirin, caffeine, ibuprofen). Sourced from PubChem.',
+    sources: ['PubChem'],
+    termsUrl: 'https://www.ncbi.nlm.nih.gov/home/about/policies/',
+    requiresNcbi: false
+  },
+  {
+    id: 'literature',
+    displayName: 'Literature',
+    description: 'Scientific literature via arXiv.',
+    useWhen:
+      'Use when searching the scientific or preprint literature for papers, titles, or abstracts on a topic, method, or field. Sourced from arXiv.',
+    sources: ['arXiv'],
+    termsUrl: 'https://info.arxiv.org/help/license/index.html',
+    requiresNcbi: false
+  },
+  {
+    id: 'pubmed',
+    displayName: 'PubMed',
+    description: 'Biomedical literature via NCBI E-utilities.',
+    useWhen:
+      'Use when searching the biomedical literature for articles, publication counts, or titles about a disease, gene, drug, or clinical topic. Sourced from PubMed (NCBI).',
+    sources: ['PubMed'],
+    termsUrl: 'https://www.ncbi.nlm.nih.gov/home/about/policies/',
+    requiresNcbi: true,
+    group: 'directory'
+  },
+  {
+    id: 'genes',
+    displayName: 'Genes & Proteins',
+    description: 'Protein and gene annotation via UniProt and MyGene.',
+    useWhen:
+      'Use when you need protein or gene annotation — a UniProt entry (protein name, gene, function) for an accession, or resolving a gene symbol to identifiers (Entrez/Ensembl).',
+    sources: ['UniProt', 'MyGene'],
+    termsUrl: 'https://www.uniprot.org/help/license',
+    requiresNcbi: false
+  },
+  {
+    id: 'genomes',
+    displayName: 'Genomes',
+    description: 'Gene genomic location and identifiers via Ensembl.',
+    useWhen:
+      "Use when you need a gene's Ensembl ID, genomic location (chromosome/coordinates), or biotype — from a species + gene symbol, or an Ensembl ID.",
+    sources: ['Ensembl'],
+    termsUrl: 'https://www.ensembl.org/info/about/legal/disclaimer.html',
+    requiresNcbi: false
+  },
+  {
+    id: 'variants',
+    displayName: 'Variants',
+    description: 'Genetic variant clinical significance via ClinVar.',
+    useWhen:
+      'Use when you need ClinVar records for a gene or genetic variant — clinical significance and summaries.',
+    sources: ['ClinVar'],
+    termsUrl: 'https://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use/',
+    requiresNcbi: true
+  },
+  {
+    id: 'clinical_trials',
+    displayName: 'Clinical Trials',
+    description: 'Clinical trial records via ClinicalTrials.gov.',
+    useWhen:
+      'Use when searching or fetching clinical trials from ClinicalTrials.gov — by NCT id, or by a condition, intervention, or free-text query.',
+    sources: ['ClinicalTrials.gov'],
+    termsUrl: 'https://clinicaltrials.gov/about-site/terms-conditions',
+    requiresNcbi: false,
+    group: 'directory'
+  },
+  {
+    id: 'clinical_genomics',
+    displayName: 'Clinical Genomics',
+    description: 'Target-disease associations and drug mechanisms via Open Targets.',
+    useWhen:
+      "Use when you need target-disease association scores for a gene (which diseases are most linked to a target), or a drug's mechanism of action and clinical indications by ChEMBL id. Sourced from the Open Targets Platform.",
+    sources: ['Open Targets'],
+    termsUrl: 'https://platform-docs.opentargets.org/licence',
+    requiresNcbi: false
+  },
+  {
+    id: 'structures',
+    displayName: 'Structures',
+    description: 'Protein 3D structures via PDB and AlphaFold.',
+    useWhen:
+      'Use when you need a protein 3D structure — an experimental PDB entry by PDB id, or an AlphaFold predicted model by UniProt accession.',
+    sources: ['PDB', 'AlphaFold'],
+    termsUrl: 'https://www.rcsb.org/pages/usage-policy',
+    requiresNcbi: false
+  },
+  {
+    id: 'gnomad',
+    displayName: 'gnomAD',
+    description: 'Population variant frequencies via the gnomAD GraphQL API.',
+    useWhen:
+      'Use when you need population allele frequencies or variant data for a gene or genetic variant from gnomAD.',
+    sources: ['gnomAD'],
+    termsUrl: 'https://gnomad.broadinstitute.org/policies',
+    requiresNcbi: false
+  },
+  {
+    id: 'geo',
+    displayName: 'GEO',
+    description: 'Gene-expression / functional-genomics datasets via NCBI GEO DataSets.',
+    useWhen:
+      'Use when searching gene-expression / functional-genomics datasets (NCBI GEO) — series and datasets by disease, tissue, organism, or assay.',
+    sources: ['GEO'],
+    termsUrl: 'https://www.ncbi.nlm.nih.gov/home/about/policies/',
+    requiresNcbi: true
+  },
+  {
+    id: 'openalex',
+    displayName: 'OpenAlex',
+    description: 'Scholarly works across all disciplines via OpenAlex.',
+    useWhen:
+      'Use when searching scholarly works across all disciplines — papers by topic/keyword with citation counts, authors, year, and DOI. Sourced from OpenAlex.',
+    sources: ['OpenAlex'],
+    termsUrl: 'https://docs.openalex.org/additional-help/terms',
+    requiresNcbi: false
+  },
+  {
+    id: 'chembl',
+    displayName: 'ChEMBL',
+    description: 'Bioactive drug-like small molecules via the ChEMBL REST API.',
+    useWhen:
+      'Use when searching for a bioactive small molecule or drug by name, or looking up a known ChEMBL compound record (preferred name, clinical phase, molecule type) by ChEMBL ID.',
+    sources: ['ChEMBL'],
+    termsUrl: 'https://chembl.gitbook.io/chembl-interface-documentation/about',
+    requiresNcbi: false,
+    group: 'directory'
+  },
+  {
+    id: 'biorxiv',
+    displayName: 'bioRxiv',
+    description: 'Preprint metadata via the bioRxiv/medRxiv REST API.',
+    useWhen:
+      'Use when looking up a bioRxiv or medRxiv preprint by DOI, or listing preprints posted in a date range (optionally filtered by category) — title, authors, date, category, and journal-publication link.',
+    sources: ['bioRxiv'],
+    termsUrl: 'https://www.biorxiv.org/about/FAQ',
+    requiresNcbi: false,
+    group: 'directory'
+  },
+  {
+    id: 'drug_regulatory',
+    displayName: 'Drug Regulatory',
+    description: 'FDA drug labels and adverse event reports via openFDA.',
+    useWhen:
+      'Use when you need FDA regulatory data for a drug — product label sections (indications, brand/generic name, manufacturer) or adverse event reports (FAERS) by drug name or openFDA query.',
+    sources: ['openFDA'],
+    termsUrl: 'https://open.fda.gov/terms/',
+    requiresNcbi: false
+  },
+  {
+    id: 'human_genetics',
+    displayName: 'Human Genetics',
+    description: 'Genome-wide association study results via the GWAS Catalog.',
+    useWhen:
+      'Use when you need genome-wide association study (GWAS) evidence — variant-trait associations mapped to a gene symbol, or associations reported for a specific dbSNP variant (rsID), including p-value, risk allele, and mapped trait.',
+    sources: ['GWAS Catalog'],
+    termsUrl: 'https://www.ebi.ac.uk/gwas/docs/about',
+    requiresNcbi: false
+  },
+  {
+    id: 'expression',
+    displayName: 'Expression',
+    description: 'Gene expression across human tissues via the GTEx Portal.',
+    useWhen:
+      'Use when you need gene expression levels across human tissues — resolving a gene symbol to its GTEx gencodeId, or median expression (TPM) by tissue for a gene. Sourced from GTEx.',
+    sources: ['GTEx'],
+    termsUrl: 'https://gtexportal.org/home/license',
+    requiresNcbi: false
+  },
+  {
+    id: 'protein_annotation',
+    displayName: 'Protein Annotation',
+    description: 'Protein-protein interaction data via STRING-DB.',
+    useWhen:
+      'Use when you need protein-protein interaction data — interaction partners for a gene/protein ranked by confidence score, or the interaction network among a set of genes/proteins. Sourced from STRING-DB.',
+    sources: ['STRING'],
+    termsUrl: 'https://string-db.org/cgi/access?footer_active_subpage=licensing',
+    requiresNcbi: false
+  },
+  {
+    id: 'cancer_models',
+    displayName: 'Cancer Models',
+    description: 'Cancer genomics study records via the cBioPortal REST API.',
+    useWhen:
+      'Use when you need cancer genomics study data — searching cBioPortal cancer studies by keyword (cancer type, cohort name), or looking up a known study by its cBioPortal study id (cancer type, sample counts, citation).',
+    sources: ['cBioPortal'],
+    termsUrl: 'https://www.cbioportal.org/faq',
+    requiresNcbi: false
+  },
+  {
+    id: 'rna',
+    displayName: 'RNA',
+    description: 'Non-coding RNA family metadata via Rfam.',
+    useWhen:
+      'Use when you need RNA family metadata — Rfam accession, family id, description, or RNA type (e.g. tRNA, rRNA, riboswitch) for an Rfam accession or family id.',
+    sources: ['Rfam'],
+    termsUrl: 'https://docs.rfam.org/en/latest/',
+    requiresNcbi: false
+  },
+  {
+    id: 'omics_archives',
+    displayName: 'Omics Archives',
+    description: 'Functional-genomics experiments in ArrayExpress (BioStudies).',
+    useWhen:
+      'Use when finding or looking up functional-genomics experiments and omics datasets in ArrayExpress / BioStudies — by keyword or by accession (title, type, organism, release date).',
+    sources: ['ArrayExpress'],
+    termsUrl: 'https://www.ebi.ac.uk/about/terms-of-use',
+    requiresNcbi: false
+  },
+  {
+    id: 'cellguide',
+    displayName: 'CellGuide',
+    description: 'Cell-type identity and canonical marker genes via CELLxGENE CellGuide.',
+    useWhen:
+      'Use when you need cell-type identity, description, or canonical marker genes for a Cell Ontology (CL) id. Sourced from CELLxGENE CellGuide.',
+    sources: ['CELLxGENE'],
+    termsUrl: 'https://cellxgene.cziscience.com/',
+    requiresNcbi: false
+  },
+  {
+    id: 'regulation',
+    displayName: 'Regulation',
+    description: 'Gene-regulation functional-genomics experiments via the ENCODE portal.',
+    useWhen:
+      'Use when you need gene-regulation / functional-genomics experiment data — searching ENCODE experiments (ChIP-seq, ATAC-seq, ...) by free text, or looking up a known ENCODE experiment by accession (assay, target, biosample, status).',
+    sources: ['ENCODE'],
+    termsUrl: 'https://www.encodeproject.org/about/data-use-policy/',
+    requiresNcbi: false
+  },
+  {
+    id: 'research_resources',
+    displayName: 'Research Resources',
+    description: 'Antibody catalog lookups via the Antibody Registry.',
+    useWhen:
+      'Use when you need a research antibody by target, name, or catalog text — RRID, vendor, target, and clonality. Sourced from the Antibody Registry.',
+    sources: ['Antibody Registry'],
+    termsUrl: 'https://www.antibodyregistry.org/',
+    requiresNcbi: false
+  },
+  {
+    id: 'biomart',
+    displayName: 'BioMart',
+    description: 'Ensembl BioMart identifier translation and attribute queries.',
+    useWhen:
+      'Use when you need Ensembl BioMart data — listing available marts, or querying gene attributes / cross-references (identifier translation) for a dataset with filters.',
+    sources: ['Ensembl BioMart'],
+    termsUrl: 'https://www.ensembl.org/info/about/legal/disclaimer.html',
+    requiresNcbi: false
+  },
+  {
+    id: 'zinc',
+    displayName: 'ZINC',
+    description: 'Purchasable compound lookups via ZINC22.',
+    useWhen:
+      'Use when you need to look up a purchasable compound by ZINC identifier — structure (SMILES), tranche properties, and which suppliers sell it. Sourced from ZINC22.',
+    sources: ['ZINC'],
+    termsUrl: 'https://zinc.docking.org/',
+    requiresNcbi: false
+  }
+]

--- a/src/main/connectors/custom-mcp-bootstrap.test.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { selectEnabledCustomServers, toCustomMcpConfig } from './custom-mcp-bootstrap'
+import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
+
+describe('toCustomMcpConfig', () => {
+  it('maps a stored stdio server to a McpClientManager config', () => {
+    const server: StoredCustomMcpServer = {
+      id: 'srv-1',
+      name: 'My Server',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', 'some-mcp-server'],
+      env: { FOO: 'bar' },
+      enabled: true
+    }
+
+    expect(toCustomMcpConfig(server)).toEqual({
+      id: 'srv-1',
+      name: 'My Server',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', 'some-mcp-server'],
+      env: { FOO: 'bar' },
+      url: undefined,
+      headers: undefined
+    })
+  })
+
+  it('falls back to an empty command when the stored server has none', () => {
+    const server: StoredCustomMcpServer = {
+      id: 'srv-1',
+      name: 'My Server',
+      transport: 'stdio',
+      enabled: true
+    }
+
+    expect(toCustomMcpConfig(server).command).toBe('')
+  })
+
+  it('maps a remote server url/headers/transport', () => {
+    const server: StoredCustomMcpServer = {
+      id: 'srv-remote',
+      name: 'Remote Server',
+      transport: 'streamable_http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer token' },
+      enabled: true
+    }
+
+    expect(toCustomMcpConfig(server)).toEqual({
+      id: 'srv-remote',
+      name: 'Remote Server',
+      transport: 'streamable_http',
+      command: '',
+      args: undefined,
+      env: undefined,
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer token' }
+    })
+  })
+})
+
+describe('selectEnabledCustomServers', () => {
+  const stdioServer: StoredCustomMcpServer = {
+    id: 'srv-stdio',
+    name: 'Stdio Server',
+    transport: 'stdio',
+    command: 'npx',
+    enabled: true
+  }
+  const disabledServer: StoredCustomMcpServer = { ...stdioServer, id: 'srv-off', enabled: false }
+  const remoteServer: StoredCustomMcpServer = {
+    id: 'srv-remote',
+    name: 'Remote Server',
+    transport: 'streamable_http',
+    url: 'https://example.com/mcp',
+    enabled: true
+  }
+  const sseServer: StoredCustomMcpServer = {
+    id: 'srv-sse',
+    name: 'SSE Server',
+    transport: 'sse',
+    url: 'https://example.com/sse',
+    enabled: true
+  }
+
+  it('returns enabled servers across all supported transports', () => {
+    const connectors: StoredConnectors = {
+      enabledIds: [],
+      autoAllowIds: [],
+      customMcpServers: [stdioServer, disabledServer, remoteServer, sseServer]
+    }
+
+    expect(selectEnabledCustomServers(connectors)).toEqual([stdioServer, remoteServer, sseServer])
+  })
+
+  it('returns an empty array when connectors is undefined', () => {
+    expect(selectEnabledCustomServers(undefined)).toEqual([])
+  })
+
+  it('returns an empty array when there are no custom servers', () => {
+    expect(selectEnabledCustomServers({ enabledIds: [], autoAllowIds: [] })).toEqual([])
+  })
+})

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -1,0 +1,43 @@
+import type { CustomMcpServerConfig } from './mcp-client-manager'
+import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
+
+// Pure mapping/filtering helpers used to wire custom MCP servers into app bootstrap (ipc.ts).
+// Split out from ipc.ts so they can be unit-tested without pulling in ipc.ts's Electron-touching
+// transitive imports (acp/ipc, artifacts/ipc, settings/crypto, ...).
+// See docs/internal/2026-07-12-custom-mcp-connectors-plan4.md §3.2/§3.4.
+
+// Maps a stored custom MCP server to the config McpClientManager needs, for any supported
+// transport. A stdio server with a missing command becomes an empty string so a misconfigured
+// entry fails the connect attempt (caught by the caller) rather than throwing here.
+export function toCustomMcpConfig(server: StoredCustomMcpServer): CustomMcpServerConfig {
+  return {
+    id: server.id,
+    name: server.name,
+    transport: server.transport,
+    command: server.command ?? '',
+    args: server.args,
+    env: server.env,
+    url: server.url,
+    headers: server.headers
+  }
+}
+
+// Supported custom MCP server transports (Phase 2: stdio + remote streamable_http/sse). OAuth is
+// a later task, so an `oauth`-configured remote entry (once that field exists) would still land
+// here once it has a reachable url — auth is handled by the transport, not this selector.
+const SUPPORTED_CUSTOM_MCP_TRANSPORTS = new Set<StoredCustomMcpServer['transport']>([
+  'stdio',
+  'streamable_http',
+  'sse'
+])
+
+// Selects enabled custom servers across all supported transports, for dispatch and skill-doc sync.
+export function selectEnabledCustomServers(
+  connectors: StoredConnectors | undefined
+): StoredCustomMcpServer[] {
+  return (
+    connectors?.customMcpServers?.filter(
+      (s) => s.enabled && SUPPORTED_CUSTOM_MCP_TRANSPORTS.has(s.transport)
+    ) ?? []
+  )
+}

--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtemp, readdir, readFile, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { renderCustomSkillDoc } from './skill-doc'
+import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './provision'
+import type { StoredCustomMcpServer } from '../settings/types'
+
+const FAKE_TOOLS = [
+  { name: 'search', description: 'Search the corpus', inputSchema: { type: 'object' } },
+  { name: 'fetch', description: 'Fetch one record' }
+]
+
+function makeServer(overrides: Partial<StoredCustomMcpServer> = {}): StoredCustomMcpServer {
+  return {
+    id: 'srv-1',
+    name: 'myserver',
+    transport: 'stdio',
+    command: 'npx',
+    enabled: true,
+    ...overrides
+  }
+}
+
+describe('renderCustomSkillDoc', () => {
+  it('renders frontmatter, a composed "Use when" description, and each tool', () => {
+    const md = renderCustomSkillDoc({ name: 'myserver' }, FAKE_TOOLS)
+    expect(md).toContain('name: mcp-myserver')
+    expect(md).toContain('source: connector')
+    expect(md).toMatch(/description: ".*Use when.*"/)
+    expect(md).toContain('## When to Use')
+    expect(md).toContain('search')
+    expect(md).toContain('fetch')
+    expect(md).toContain('"type": "object"')
+    expect(md).toContain('host.mcp("myserver", "search", ...)')
+    expect(md).toContain('host.mcp("myserver", "fetch", ...)')
+  })
+
+  it('uses the server-provided description verbatim when present', () => {
+    const md = renderCustomSkillDoc(
+      { name: 'myserver', description: 'Use when the user asks about widgets.' },
+      FAKE_TOOLS
+    )
+    const frontmatter = md.slice(0, md.indexOf('---', 3))
+    expect(frontmatter).toContain('Use when the user asks about widgets.')
+  })
+})
+
+describe('syncCustomServerSkillDocs', () => {
+  it('writes mcp-<name>/SKILL.md for an enabled server and removes it once disabled', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'custom-skills-'))
+    const server = makeServer()
+    const listTools = async (): Promise<typeof FAKE_TOOLS> => FAKE_TOOLS
+
+    await syncCustomServerSkillDocs(dir, [server], listTools)
+
+    let entries = (await readdir(dir)).sort()
+    expect(entries).toEqual(['mcp-myserver'])
+    expect((await stat(join(dir, 'mcp-myserver'))).isDirectory()).toBe(true)
+    const doc = await readFile(join(dir, 'mcp-myserver', 'SKILL.md'), 'utf8')
+    expect(doc).toContain('name: mcp-myserver')
+
+    // Server no longer enabled -> its skill dir is removed.
+    await syncCustomServerSkillDocs(dir, [], listTools)
+    entries = (await readdir(dir)).sort()
+    expect(entries).toEqual([])
+  })
+})
+
+describe('bundled and custom skill-doc sync coexist', () => {
+  it("do not delete each other's directories when run against the same skills dir", async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'coexist-skills-'))
+    const server = makeServer({ name: 'myserver' })
+    const listTools = async (): Promise<typeof FAKE_TOOLS> => FAKE_TOOLS
+
+    await syncConnectorSkillDocs(dir, ['chemistry'])
+    await syncCustomServerSkillDocs(dir, [server], listTools)
+
+    let entries = (await readdir(dir)).sort()
+    expect(entries).toEqual(['mcp-chemistry', 'mcp-myserver'])
+
+    // Re-running the bundled sync must not remove the custom server's directory...
+    await syncConnectorSkillDocs(dir, ['chemistry'])
+    entries = (await readdir(dir)).sort()
+    expect(entries).toEqual(['mcp-chemistry', 'mcp-myserver'])
+
+    // ...and re-running the custom sync must not remove the bundled connector's directory.
+    await syncCustomServerSkillDocs(dir, [server], listTools)
+    entries = (await readdir(dir)).sort()
+    expect(entries).toEqual(['mcp-chemistry', 'mcp-myserver'])
+
+    // Disabling the bundled connector only removes the bundled dir, leaving the custom one intact.
+    await syncConnectorSkillDocs(dir, [])
+    entries = (await readdir(dir)).sort()
+    expect(entries).toEqual(['mcp-myserver'])
+
+    // And disabling the custom server only removes the custom dir.
+    await syncConnectorSkillDocs(dir, ['chemistry'])
+    await syncCustomServerSkillDocs(dir, [], listTools)
+    entries = (await readdir(dir)).sort()
+    expect(entries).toEqual(['mcp-chemistry'])
+  })
+})

--- a/src/main/connectors/descriptors/biomart.test.ts
+++ b/src/main/connectors/descriptors/biomart.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { BIOMART_TOOLS } from './biomart'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => BIOMART_TOOLS.find((t) => t.id === id)!
+const textRes = (body: string): Response =>
+  ({ ok: true, status: 200, text: async () => body }) as Response
+
+const REGISTRY_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<MartRegistry>
+  <MartURLLocation database="ensembl_mart_115" default="1" displayName="Ensembl Genes 115" host="www.ensembl.org" name="ENSEMBL_MART_ENSEMBL" path="/biomart/martservice" port="443" serverVirtualSchema="default" visible="1" />
+  <MartURLLocation database="ensembl_mart_snp_115" default="0" displayName="Ensembl Variation 115" host="www.ensembl.org" name="ENSEMBL_MART_SNP" path="/biomart/martservice" port="443" serverVirtualSchema="default" visible="1" />
+</MartRegistry>`
+
+describe('biomart / list_marts', () => {
+  it('parses the registry XML into name/displayName records', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(textRes(REGISTRY_XML))
+    const out = await new ParserEngine({ fetchImpl }).call(tool('biomart_list_marts'), {}, {})
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.ensembl.org/biomart/martservice?type=registry'
+    )
+    expect(out).toEqual([
+      { name: 'ENSEMBL_MART_ENSEMBL', displayName: 'Ensembl Genes 115' },
+      { name: 'ENSEMBL_MART_SNP', displayName: 'Ensembl Variation 115' }
+    ])
+  })
+
+  it('returns an empty array when the registry has no marts', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(textRes('<?xml version="1.0"?><MartRegistry></MartRegistry>'))
+    const out = await new ParserEngine({ fetchImpl }).call(tool('biomart_list_marts'), {}, {})
+    expect(out).toEqual([])
+  })
+})
+
+describe('biomart / query', () => {
+  it('builds a GET query URL and parses sorted TSV rows', async () => {
+    const raw = 'ENSG00000141510\tTP53\nENSG00000012048\tBRCA1\n[success]\n'
+    const fetchImpl = vi.fn().mockResolvedValue(textRes(raw))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('biomart_query'),
+      { dataset: 'hsapiens_gene_ensembl', attributes: ['ensembl_gene_id', 'external_gene_name'] },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url.startsWith('https://www.ensembl.org/biomart/martservice?query=')).toBe(true)
+    const xml = decodeURIComponent(url.split('query=')[1])
+    expect(xml).toContain('<Dataset name="hsapiens_gene_ensembl" interface="default">')
+    expect(xml).toContain('<Attribute name="ensembl_gene_id" />')
+    expect(xml).toContain('<Attribute name="external_gene_name" />')
+    expect(xml).toContain('formatter="TSV"')
+    expect(xml).toContain('completionStamp="1"')
+    expect(out).toEqual({
+      dataset: 'hsapiens_gene_ensembl',
+      columns: ['ensembl_gene_id', 'external_gene_name'],
+      rows: [
+        ['ENSG00000012048', 'BRCA1'],
+        ['ENSG00000141510', 'TP53']
+      ]
+    })
+  })
+
+  it('includes filters in the query XML', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(textRes('[success]\n'))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('biomart_query'),
+      {
+        dataset: 'hsapiens_gene_ensembl',
+        attributes: ['ensembl_gene_id'],
+        filters: { chromosome_name: '17', biotype: true }
+      },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    const xml = decodeURIComponent(url.split('query=')[1])
+    expect(xml).toContain('<Filter name="chromosome_name" value="17" />')
+    expect(xml).toContain('<Filter name="biotype" value="only" />')
+  })
+
+  it('throws on a rejected query (Query ERROR body)', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(textRes('Query ERROR: caught BioMart::Exception::Usage: bad attribute'))
+    await expect(
+      new ParserEngine({ fetchImpl }).call(
+        tool('biomart_query'),
+        { dataset: 'hsapiens_gene_ensembl', attributes: ['ensembl_gene_id'] },
+        {}
+      )
+    ).rejects.toThrow(/BioMart query rejected/)
+  })
+
+  it('throws on a truncated response missing the completion stamp', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(textRes('ENSG00000141510'))
+    await expect(
+      new ParserEngine({ fetchImpl }).call(
+        tool('biomart_query'),
+        { dataset: 'hsapiens_gene_ensembl', attributes: ['ensembl_gene_id'] },
+        {}
+      )
+    ).rejects.toThrow(/completion stamp/)
+  })
+})

--- a/src/main/connectors/descriptors/biomart.ts
+++ b/src/main/connectors/descriptors/biomart.ts
@@ -1,0 +1,142 @@
+import { DOMParser } from '@xmldom/xmldom'
+import type { ToolDescriptor } from '../types'
+
+const MARTSERVICE = 'https://www.ensembl.org/biomart/martservice'
+const COMPLETION_STAMP = '[success]'
+
+// Escapes a value for use inside a double-quoted XML attribute (mirrors the upstream Python
+// build_query_xml, which relies on ElementTree's own attribute escaping).
+function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+// Filter values may be a string, a number, a bool (BioMart's own only/excluded convention), or an
+// array (joined with commas) — mirrors upstream biomart_query.client.build_query_xml.
+function filterValue(value: unknown): string {
+  if (typeof value === 'boolean') return value ? 'only' : 'excluded'
+  if (Array.isArray(value)) return value.map(String).join(',')
+  return String(value)
+}
+
+// Builds a martservice <Query> XML document (transcribed from upstream biomart_query.client's
+// build_query_xml: header=0/uniqueRows=0 defaults, completionStamp always requested).
+function buildQueryXml(
+  dataset: string,
+  attributes: string[],
+  filters: Record<string, unknown>,
+  virtualSchema: string
+): string {
+  const filterXml = Object.entries(filters)
+    .map(
+      ([name, value]) =>
+        `<Filter name="${escapeXmlAttr(name)}" value="${escapeXmlAttr(filterValue(value))}" />`
+    )
+    .join('')
+  const attrXml = attributes.map((a) => `<Attribute name="${escapeXmlAttr(a)}" />`).join('')
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Query>' +
+    `<Query virtualSchemaName="${escapeXmlAttr(virtualSchema)}" formatter="TSV" header="0" uniqueRows="0" datasetConfigVersion="0.6" completionStamp="1">` +
+    `<Dataset name="${escapeXmlAttr(dataset)}" interface="default">${filterXml}${attrXml}</Dataset>` +
+    '</Query>'
+  )
+}
+
+// Parses a completed martservice TSV body into rows, validating the completion stamp and column
+// count (mirrors upstream biomart_query.client._post + _parse_tsv). Throws on a rejected query
+// (BioMart returns 200 with a "Query ERROR" / exception body for bad attribute/filter combos) or
+// a truncated response (missing the trailing [success] marker).
+function parseTsvBody(text: string, nCols: number): string[][] {
+  const head = text.slice(0, 2000)
+  if (
+    head.trimStart().toLowerCase().startsWith('<html') ||
+    head.trimStart().toLowerCase().startsWith('<!doctype html')
+  ) {
+    throw new Error('martservice returned an HTML page (Ensembl outage/maintenance notice)')
+  }
+  if (text.trimStart().startsWith('Query ERROR') || head.includes('BioMart::Exception')) {
+    throw new Error(`BioMart query rejected: ${text.slice(0, 500).trim()}`)
+  }
+  const stripped = text.replace(/[\r\n ]+$/, '')
+  if (!stripped.endsWith(COMPLETION_STAMP)) {
+    throw new Error(
+      'martservice response missing the [success] completion stamp (truncated download)'
+    )
+  }
+  const body = stripped.slice(0, -COMPLETION_STAMP.length).replace(/[\r\n]+$/, '')
+  const rows: string[][] = []
+  if (!body) return rows
+  for (const line of body.replace(/\r\n/g, '\n').split('\n')) {
+    if (line === '') continue
+    const fields = line.split('\t')
+    if (fields.length !== nCols) {
+      throw new Error(
+        `malformed TSV line: expected ${nCols} columns, got ${fields.length}: ${line.slice(0, 200)}`
+      )
+    }
+    rows.push(fields)
+  }
+  return rows
+}
+
+type Mart = { name: string; displayName: string }
+
+// Ensembl BioMart martservice: XML query registry + TSV attribute queries (read-only).
+export const BIOMART_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'biomart_list_marts',
+    connector: 'biomart',
+    description:
+      'List available Ensembl BioMart marts (name and display name) from the martservice registry.',
+    input: { type: 'object', properties: {} },
+    format: 'text',
+    url: () => `${MARTSERVICE}?type=registry`,
+    parse: (raw) => {
+      const doc = new DOMParser().parseFromString(String(raw), 'text/xml')
+      const marts: Mart[] = []
+      const locs = doc.getElementsByTagName('MartURLLocation')
+      for (let i = 0; i < locs.length; i++) {
+        const el = locs[i]
+        marts.push({
+          name: el.getAttribute('name') ?? '',
+          displayName: el.getAttribute('displayName') ?? ''
+        })
+      }
+      return marts
+    }
+  },
+  {
+    id: 'biomart_query',
+    connector: 'biomart',
+    description:
+      'Run a BioMart attribute query against a dataset (e.g. hsapiens_gene_ensembl) with optional filters; returns parsed TSV rows in request column order.',
+    input: {
+      type: 'object',
+      properties: {
+        dataset: { type: 'string' },
+        attributes: { type: 'array', items: { type: 'string' } },
+        filters: { type: 'object' },
+        virtual_schema: { type: 'string', default: 'default' }
+      },
+      required: ['dataset', 'attributes']
+    },
+    required: ['dataset', 'attributes'],
+    run: async (ctx, a) => {
+      const dataset = String(a.dataset)
+      const attributes = (a.attributes as unknown[]).map(String)
+      const filters = (a.filters ?? {}) as Record<string, unknown>
+      const virtualSchema = String(a.virtual_schema ?? 'default')
+      const xml = buildQueryXml(dataset, attributes, filters, virtualSchema)
+      // martservice's documented GET form: the XML query as a `query` URL parameter (equivalent
+      // to upstream's POST body={"query": xml}; avoids needing a raw form-POST context method).
+      const url = `${MARTSERVICE}?query=${encodeURIComponent(xml)}`
+      const text = await ctx.fetchText(url)
+      const rows = parseTsvBody(text, attributes.length)
+      rows.sort((x, y) => (x.join('\t') < y.join('\t') ? -1 : x.join('\t') > y.join('\t') ? 1 : 0))
+      return { dataset, columns: attributes, rows }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/biorxiv.test.ts
+++ b/src/main/connectors/descriptors/biorxiv.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { BIORXIV_TOOLS } from './biorxiv'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => BIORXIV_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+const RECORD = {
+  title: 'Oxygen restriction induces a viable but non-culturable population in bacteria',
+  authors: 'Kvich, L. A.; Fritz, B. G.; Bjarnsholt, T.',
+  author_corresponding: 'Thomas  Bjarnsholt',
+  author_corresponding_institution: 'University of Copenhagen',
+  doi: '10.1101/339747',
+  date: '2018-06-05',
+  version: '1',
+  type: 'new results',
+  license: 'cc_no',
+  category: 'microbiology',
+  jatsxml: 'https://www.biorxiv.org/content/early/2018/06/05/339747.source.xml',
+  abstract: 'Induction of a non-culturable state...',
+  funder: 'NA',
+  published: 'NA',
+  server: 'bioRxiv'
+}
+
+const COMPACT_RECORD = {
+  doi: '10.1101/339747',
+  title: 'Oxygen restriction induces a viable but non-culturable population in bacteria',
+  authors: 'Kvich, L. A.; Fritz, B. G.; Bjarnsholt, T.',
+  date: '2018-06-05',
+  category: 'microbiology',
+  published: 'NA'
+}
+
+describe('biorxiv / get_details', () => {
+  it('builds the DOI details URL and parses a compact list', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ messages: [{ status: 'ok' }], collection: [RECORD] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('biorxiv_get_details'),
+      { doi: '10.1101/339747' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://api.biorxiv.org/details/biorxiv/10.1101/339747'
+    )
+    expect(out).toEqual([COMPACT_RECORD])
+  })
+
+  it('defaults to biorxiv and keeps the DOI slash unencoded, strips a doi.org prefix', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ collection: [] }))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('biorxiv_get_details'),
+      { doi: 'https://doi.org/10.1101/339747' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://api.biorxiv.org/details/biorxiv/10.1101/339747'
+    )
+  })
+
+  it('honors server=medrxiv', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ collection: [] }))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('biorxiv_get_details'),
+      { doi: '10.1101/2020.09.09.20191205', server: 'medrxiv' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://api.biorxiv.org/details/medrxiv/10.1101/2020.09.09.20191205'
+    )
+  })
+
+  it('returns an empty array when there is no matching preprint', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ messages: [{ status: 'no posts found' }], collection: [] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('biorxiv_get_details'),
+      { doi: '10.1101/nonexistent' },
+      {}
+    )
+    expect(out).toEqual([])
+  })
+})
+
+describe('biorxiv / list_interval', () => {
+  it('builds the interval URL with default cursor and no category', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        jsonRes({ messages: [{ status: 'ok', total: '220' }], collection: [RECORD] })
+      )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('biorxiv_list_interval'),
+      { from: '2024-01-01', to: '2024-01-02' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://api.biorxiv.org/details/biorxiv/2024-01-01/2024-01-02/0'
+    )
+    expect(out).toEqual({ total: '220', results: [COMPACT_RECORD] })
+  })
+
+  it('includes a normalized category filter and a custom cursor', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ messages: [{ status: 'ok', total: 5 }], collection: [] }))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('biorxiv_list_interval'),
+      { from: '2024-01-01', to: '2024-01-02', category: 'Cell Biology', cursor: 30 },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe(
+      'https://api.biorxiv.org/details/biorxiv/2024-01-01/2024-01-02/30?category=cell_biology'
+    )
+  })
+})

--- a/src/main/connectors/descriptors/biorxiv.ts
+++ b/src/main/connectors/descriptors/biorxiv.ts
@@ -1,0 +1,85 @@
+import type { ToolDescriptor } from '../types'
+
+const BASE = 'https://api.biorxiv.org'
+
+type BiorxivRecord = {
+  doi?: string
+  title?: string
+  authors?: string
+  date?: string
+  category?: string
+  published?: string
+}
+
+type BiorxivMessage = { status?: string; total?: string | number }
+type BiorxivResponse = { messages?: BiorxivMessage[]; collection?: BiorxivRecord[] }
+
+const summarize = (records: BiorxivRecord[]): BiorxivRecord[] =>
+  records.map((r) => ({
+    doi: r.doi,
+    title: r.title,
+    authors: r.authors,
+    date: r.date,
+    category: r.category,
+    // "NA" until the preprint is later linked to a published journal article.
+    published: r.published
+  }))
+
+const normalizeServer = (server: unknown): 'biorxiv' | 'medrxiv' =>
+  server === 'medrxiv' ? 'medrxiv' : 'biorxiv'
+
+// Strips a doi.org URL prefix; the API path takes the bare "10.xxxx/yyyy" DOI, slash included
+// (NOT URL-encoded — it is two literal path segments, e.g. /details/biorxiv/10.1101/339747).
+const normalizeDoi = (doi: string): string =>
+  doi.trim().replace(/^https?:\/\/(dx\.)?doi\.org\//i, '')
+
+// bioRxiv/medRxiv REST API (api.biorxiv.org): read-only preprint metadata lookups.
+export const BIORXIV_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'biorxiv_get_details',
+    connector: 'biorxiv',
+    description:
+      'Get bioRxiv/medRxiv preprint details (title, authors, date, category, published link) for a DOI.',
+    input: {
+      type: 'object',
+      properties: {
+        doi: { type: 'string' },
+        server: { type: 'string', enum: ['biorxiv', 'medrxiv'], default: 'biorxiv' }
+      },
+      required: ['doi']
+    },
+    required: ['doi'],
+    url: (a) => `${BASE}/details/${normalizeServer(a.server)}/${normalizeDoi(String(a.doi))}`,
+    parse: (raw) => summarize((raw as BiorxivResponse).collection ?? [])
+  },
+  {
+    id: 'biorxiv_list_interval',
+    connector: 'biorxiv',
+    description:
+      'List bioRxiv/medRxiv preprints posted in a closed date interval (YYYY-MM-DD), optionally filtered by category; one page of up to 30.',
+    input: {
+      type: 'object',
+      properties: {
+        from: { type: 'string', description: 'YYYY-MM-DD' },
+        to: { type: 'string', description: 'YYYY-MM-DD' },
+        server: { type: 'string', enum: ['biorxiv', 'medrxiv'], default: 'biorxiv' },
+        category: { type: 'string' },
+        cursor: { type: 'integer', default: 0 }
+      },
+      required: ['from', 'to']
+    },
+    required: ['from', 'to'],
+    url: (a) => {
+      const cursor = Number.isFinite(Number(a.cursor)) ? Math.max(0, Number(a.cursor)) : 0
+      const path = `${BASE}/details/${normalizeServer(a.server)}/${encodeURIComponent(String(a.from))}/${encodeURIComponent(String(a.to))}/${cursor}`
+      const category = a.category
+        ? `?category=${encodeURIComponent(String(a.category).trim().toLowerCase().replace(/ /g, '_'))}`
+        : ''
+      return `${path}${category}`
+    },
+    parse: (raw) => {
+      const r = raw as BiorxivResponse
+      return { total: r.messages?.[0]?.total, results: summarize(r.collection ?? []) }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/cancer-models.test.ts
+++ b/src/main/connectors/descriptors/cancer-models.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { CANCER_MODELS_TOOLS } from './cancer-models'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => CANCER_MODELS_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('cancer_models / search studies', () => {
+  it('cbioportal_search_studies builds the search URL and parses compact rows', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes([
+        {
+          studyId: 'brca_pareja_msk_2020',
+          name: 'Breast Cancer (MSK, Clinical Cancer Res 2020)',
+          description: 'Whole-exome and MSK-IMPACT sequencing of 60 tumor/normal matched samples.',
+          cancerTypeId: 'brca',
+          cancerType: { name: 'Invasive Breast Carcinoma' },
+          allSampleCount: 60,
+          sequencedSampleCount: 60
+        },
+        {
+          studyId: 'brca_hta9_htan_2022',
+          name: 'Breast Cancer (HTAN, 2022)',
+          cancerTypeId: 'brca',
+          cancerType: { name: 'Invasive Breast Carcinoma' },
+          allSampleCount: 5,
+          sequencedSampleCount: 5
+        }
+      ])
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('cbioportal_search_studies'),
+      { query: 'breast' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.cbioportal.org/api/studies?keyword=breast&projection=DETAILED&pageSize=10&pageNumber=0'
+    )
+    expect(out).toEqual([
+      {
+        studyId: 'brca_pareja_msk_2020',
+        name: 'Breast Cancer (MSK, Clinical Cancer Res 2020)',
+        cancerType: 'Invasive Breast Carcinoma',
+        allSampleCount: 60
+      },
+      {
+        studyId: 'brca_hta9_htan_2022',
+        name: 'Breast Cancer (HTAN, 2022)',
+        cancerType: 'Invasive Breast Carcinoma',
+        allSampleCount: 5
+      }
+    ])
+  })
+
+  it('respects a custom page_size and returns an empty array for no matches', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('cbioportal_search_studies'),
+      { query: 'nonexistent-cancer-xyz', page_size: 5 },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toContain('pageSize=5')
+    expect(out).toEqual([])
+  })
+
+  it('encodes special characters in the query', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('cbioportal_search_studies'),
+      { query: 'a b&c' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.cbioportal.org/api/studies?keyword=a%20b%26c&projection=DETAILED&pageSize=10&pageNumber=0'
+    )
+  })
+})
+
+describe('cancer_models / get study', () => {
+  it('cbioportal_get_study builds the record URL and parses a compact summary', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        studyId: 'msk_impact_2017',
+        name: 'MSK-IMPACT Clinical Sequencing Cohort (MSK, Nat Med 2017)',
+        description: 'Targeted sequencing of tumor/normal pairs.',
+        cancerTypeId: 'mixed',
+        cancerType: { name: 'Mixed Cancer Types' },
+        pmid: '28481359',
+        citation: 'Zehir et al. Nat Med 2017',
+        referenceGenome: 'hg19',
+        allSampleCount: 10945,
+        sequencedSampleCount: 10945,
+        cnaSampleCount: 10336,
+        structuralVariantCount: 0
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('cbioportal_get_study'),
+      { study_id: 'msk_impact_2017' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.cbioportal.org/api/studies/msk_impact_2017?projection=DETAILED'
+    )
+    expect(out).toEqual({
+      studyId: 'msk_impact_2017',
+      name: 'MSK-IMPACT Clinical Sequencing Cohort (MSK, Nat Med 2017)',
+      description: 'Targeted sequencing of tumor/normal pairs.',
+      cancerType: 'Mixed Cancer Types',
+      cancerTypeId: 'mixed',
+      pmid: '28481359',
+      citation: 'Zehir et al. Nat Med 2017',
+      referenceGenome: 'hg19',
+      allSampleCount: 10945,
+      sequencedSampleCount: 10945,
+      cnaSampleCount: 10336,
+      structuralVariantCount: 0
+    })
+  })
+
+  it('encodes special characters in the study id', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ studyId: 'a/b' }))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('cbioportal_get_study'),
+      { study_id: 'a b' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.cbioportal.org/api/studies/a%20b?projection=DETAILED'
+    )
+  })
+})

--- a/src/main/connectors/descriptors/cancer-models.ts
+++ b/src/main/connectors/descriptors/cancer-models.ts
@@ -1,0 +1,77 @@
+import type { ToolDescriptor } from '../types'
+
+const CBIOPORTAL = 'https://www.cbioportal.org/api'
+const DEFAULT_PAGE_SIZE = 10
+
+type CBioCancerType = { name?: string }
+
+type CBioStudy = {
+  studyId?: string
+  name?: string
+  description?: string
+  cancerTypeId?: string
+  cancerType?: CBioCancerType
+  pmid?: string
+  citation?: string
+  referenceGenome?: string
+  allSampleCount?: number
+  sequencedSampleCount?: number
+  cnaSampleCount?: number
+  structuralVariantCount?: number
+}
+
+const compactStudyRow = (s: CBioStudy): Record<string, unknown> => ({
+  studyId: s.studyId,
+  name: s.name,
+  cancerType: s.cancerType?.name,
+  allSampleCount: s.allSampleCount
+})
+
+const compactStudyDetail = (s: CBioStudy): Record<string, unknown> => ({
+  studyId: s.studyId,
+  name: s.name,
+  description: s.description,
+  cancerType: s.cancerType?.name,
+  cancerTypeId: s.cancerTypeId,
+  pmid: s.pmid,
+  citation: s.citation,
+  referenceGenome: s.referenceGenome,
+  allSampleCount: s.allSampleCount,
+  sequencedSampleCount: s.sequencedSampleCount,
+  cnaSampleCount: s.cnaSampleCount,
+  structuralVariantCount: s.structuralVariantCount
+})
+
+// cBioPortal public REST API (keyless): read-only cancer study search/lookup.
+export const CANCER_MODELS_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'cbioportal_search_studies',
+    connector: 'cancer_models',
+    description:
+      'Search cBioPortal cancer studies by keyword (name/description/cancer type); returns study id, name, cancer type, and sample count per hit.',
+    input: {
+      type: 'object',
+      properties: { query: { type: 'string' }, page_size: { type: 'integer', default: 10 } },
+      required: ['query']
+    },
+    required: ['query'],
+    url: (a) =>
+      `${CBIOPORTAL}/studies?keyword=${encodeURIComponent(String(a.query))}&projection=DETAILED&pageSize=${Number(a.page_size ?? DEFAULT_PAGE_SIZE)}&pageNumber=0`,
+    parse: (raw) => ((raw as CBioStudy[] | null) ?? []).map(compactStudyRow)
+  },
+  {
+    id: 'cbioportal_get_study',
+    connector: 'cancer_models',
+    description:
+      'Get a cBioPortal cancer study by study id; returns name, description, cancer type, citation, and sample counts.',
+    input: {
+      type: 'object',
+      properties: { study_id: { type: 'string' } },
+      required: ['study_id']
+    },
+    required: ['study_id'],
+    url: (a) =>
+      `${CBIOPORTAL}/studies/${encodeURIComponent(String(a.study_id))}?projection=DETAILED`,
+    parse: (raw) => compactStudyDetail(raw as CBioStudy)
+  }
+]

--- a/src/main/connectors/descriptors/cellguide.test.ts
+++ b/src/main/connectors/descriptors/cellguide.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { CELLGUIDE_TOOLS } from './cellguide'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => CELLGUIDE_TOOLS.find((t) => t.id === id)!
+
+const SNAPSHOT = '1763135102'
+const ACINAR_METADATA = {
+  'CL:0000622': {
+    name: 'acinar cell',
+    id: 'CL:0000622',
+    clDescription: 'A secretory cell that ... releases zymogen granules.',
+    synonyms: ['acinic cell', 'acinous cell']
+  }
+}
+// Live shape confirmed against the CDN (2026-07-12): {tissue, symbol, name, publication,
+// publication_titles} — no marker_score/groupby_dims (those only exist on
+// computational_marker_genes; client.py's shared formatter assumes them incorrectly).
+const CANONICAL_MARKERS = [
+  {
+    tissue: 'pancreas',
+    symbol: 'PRSS1',
+    name: 'trypsinogen',
+    publication: '',
+    publication_titles: ''
+  },
+  {
+    tissue: 'pancreas',
+    symbol: 'CPA1',
+    name: 'carboxypeptidase A1',
+    publication: 'PMID:12345',
+    publication_titles: 'Some paper title'
+  }
+]
+
+// Maps a URL substring to a canned response; throws for anything unexpected so tests can assert
+// exactly which calls were made (e.g. "not found" must short-circuit before description/markers).
+function mockFetch(
+  responses: Record<string, { text?: string; json?: unknown; status?: number }>
+): typeof fetch {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    const key = Object.keys(responses).find((k) => url.includes(k))
+    if (!key) throw new Error(`unexpected fetch: ${url}`)
+    const r = responses[key]
+    const status = r.status ?? 200
+    return {
+      ok: status < 400,
+      status,
+      // Mirror real fetch: .json() on an empty body throws (no 'json' provided means "parse the
+      // text field"), matching the CDN's 200-with-empty-body response for uncurated cell types.
+      json: async () => {
+        if ('json' in r) return r.json
+        if (!r.text) throw new SyntaxError('Unexpected end of JSON input')
+        return JSON.parse(r.text)
+      },
+      text: async () => r.text ?? ''
+    } as Response
+  }) as unknown as typeof fetch
+}
+
+describe('cellguide / cellguide_cell_type', () => {
+  it('fetches snapshot, metadata, description, and canonical markers for a CL id', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: ACINAR_METADATA },
+      '/validated_descriptions/CL_0000622.json': {
+        json: { description: 'Acinar cells secrete digestive enzymes.', references: ['PMID:123'] }
+      },
+      '/canonical_marker_genes/CL_0000622.json': { json: CANONICAL_MARKERS }
+    })
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('cellguide_cell_type'),
+      { cellType: 'CL:0000622' },
+      {}
+    )
+    expect(out).toEqual({
+      id: 'CL:0000622',
+      name: 'acinar cell',
+      synonyms: ['acinic cell', 'acinous cell'],
+      ontologyDescription: 'A secretory cell that ... releases zymogen granules.',
+      description: 'Acinar cells secrete digestive enzymes.',
+      descriptionSource: 'validated',
+      references: ['PMID:123'],
+      canonicalMarkerGenes: [
+        {
+          symbol: 'PRSS1',
+          name: 'trypsinogen',
+          tissue: 'pancreas',
+          publication: undefined,
+          publicationTitle: undefined
+        },
+        {
+          symbol: 'CPA1',
+          name: 'carboxypeptidase A1',
+          tissue: 'pancreas',
+          publication: 'PMID:12345',
+          publicationTitle: 'Some paper title'
+        }
+      ]
+    })
+  })
+
+  it('builds the CDN urls with snapshot id and URL-format (underscore) cell id', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: ACINAR_METADATA },
+      '/validated_descriptions/CL_0000622.json': { json: { description: 'x', references: [] } },
+      '/canonical_marker_genes/CL_0000622.json': { json: [] }
+    })
+    await new ParserEngine({ fetchImpl }).call(
+      tool('cellguide_cell_type'),
+      { cellType: 'CL:0000622' },
+      {}
+    )
+    const calls = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]))
+    expect(calls[0]).toBe('https://cellguide.cellxgene.cziscience.com/latest_snapshot_identifier')
+    expect(calls[1]).toBe(
+      `https://cellguide.cellxgene.cziscience.com/${SNAPSHOT}/celltype_metadata.json`
+    )
+    expect(calls[2]).toBe(
+      'https://cellguide.cellxgene.cziscience.com/validated_descriptions/CL_0000622.json'
+    )
+    expect(calls[3]).toBe(
+      `https://cellguide.cellxgene.cziscience.com/${SNAPSHOT}/canonical_marker_genes/CL_0000622.json`
+    )
+  })
+
+  it('returns an error and skips further fetches when the cell type is not in metadata', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: ACINAR_METADATA }
+    })
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('cellguide_cell_type'),
+      { cellType: 'CL:9999999' },
+      {}
+    )
+    expect(out).toEqual({ error: "Cell type 'CL:9999999' not found" })
+    expect((fetchImpl as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2)
+  })
+
+  it('falls back to the GPT description when no validated description exists', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: ACINAR_METADATA },
+      '/validated_descriptions/CL_0000622.json': { status: 404 },
+      '/gpt_descriptions/CL_0000622.json': { json: 'A GPT-generated description.' },
+      '/canonical_marker_genes/CL_0000622.json': { json: [] }
+    })
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('cellguide_cell_type'),
+      { cellType: 'CL:0000622' },
+      {}
+    )) as { description: string; descriptionSource: string; references: unknown[] }
+    expect(out.description).toBe('A GPT-generated description.')
+    expect(out.descriptionSource).toBe('gpt')
+    expect(out.references).toEqual([])
+  })
+
+  it('returns an empty marker list when the canonical markers file is missing (404)', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: ACINAR_METADATA },
+      '/validated_descriptions/CL_0000622.json': { json: { description: 'x', references: [] } },
+      '/canonical_marker_genes/CL_0000622.json': { status: 404 }
+    })
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('cellguide_cell_type'),
+      { cellType: 'CL:0000622' },
+      {}
+    )) as { canonicalMarkerGenes: unknown[] }
+    expect(out.canonicalMarkerGenes).toEqual([])
+  })
+
+  it('returns an empty marker list on a 200 with an empty body (live CDN behavior for cell types with no curated canonical markers)', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: ACINAR_METADATA },
+      '/validated_descriptions/CL_0000622.json': { json: { description: 'x', references: [] } },
+      // json: undefined -> JSON.stringify(undefined) is not valid JSON; simulate the real CDN's
+      // empty-string body, whose .json() parse throws and is swallowed by tryFetchJson.
+      '/canonical_marker_genes/CL_0000622.json': { text: '' }
+    })
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('cellguide_cell_type'),
+      { cellType: 'CL:0000622' },
+      {}
+    )) as { canonicalMarkerGenes: unknown[] }
+    expect(out.canonicalMarkerGenes).toEqual([])
+  })
+
+  it('normalizes CL_ and bare-digit id formats to CL: for lookup', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: ACINAR_METADATA },
+      '/validated_descriptions/CL_0000622.json': { json: { description: 'x', references: [] } },
+      '/canonical_marker_genes/CL_0000622.json': { json: [] }
+    })
+    const out1 = (await new ParserEngine({ fetchImpl }).call(
+      tool('cellguide_cell_type'),
+      { cellType: 'CL_0000622' },
+      {}
+    )) as { id: string }
+    expect(out1.id).toBe('CL:0000622')
+
+    const out2 = (await new ParserEngine({ fetchImpl }).call(
+      tool('cellguide_cell_type'),
+      { cellType: '0000622' },
+      {}
+    )) as { id: string }
+    expect(out2.id).toBe('CL:0000622')
+  })
+})

--- a/src/main/connectors/descriptors/cellguide.ts
+++ b/src/main/connectors/descriptors/cellguide.ts
@@ -1,0 +1,142 @@
+import type { ToolContext, ToolDescriptor } from '../types'
+
+// CellGuide (CELLxGENE) serves static, snapshot-versioned JSON blobs from this CDN — no live
+// query API (endpoints/snapshot-id indirection mirror upstream mcp_cellguide/client.py; the
+// canonical_marker_genes record shape below was corrected against a live fetch — client.py
+// applies the *computational* marker shape {marker_score, specificity, me, pc, groupby_dims} to
+// canonical markers too, but the live canonical_marker_genes/<CL_id>.json blobs are actually
+// literature-curated {tissue, symbol, name, publication, publication_titles} records with no
+// score field, so client.py's marker_score-descending sort on canonical is a no-op there).
+const BASE_URL = 'https://cellguide.cellxgene.cziscience.com'
+
+type CellTypeMetadataEntry = {
+  name?: string
+  id?: string
+  clDescription?: string
+  synonyms?: string[]
+}
+type CellTypeMetadata = Record<string, CellTypeMetadataEntry>
+
+type CanonicalMarkerGene = {
+  tissue?: string
+  symbol?: string
+  name?: string
+  publication?: string
+  publication_titles?: string
+}
+
+type ValidatedDescription = { description?: string; references?: unknown[] }
+
+// CL:0000622 <-> CL_0000622 <-> 0000622 (mirrors client.py's to_url_format/to_json_format).
+function toUrlFormat(cellId: string): string {
+  if (cellId.includes('_') && cellId.startsWith('CL_')) return cellId
+  if (cellId.includes(':')) return cellId.replace(':', '_')
+  if (/^\d+$/.test(cellId)) return `CL_${cellId}`
+  return cellId
+}
+
+function toJsonFormat(cellId: string): string {
+  if (cellId.includes(':') && cellId.startsWith('CL:')) return cellId
+  if (cellId.includes('_')) return cellId.replace('_', ':')
+  if (/^\d+$/.test(cellId)) return `CL:${cellId}`
+  return cellId
+}
+
+async function fetchSnapshotId(ctx: ToolContext): Promise<string> {
+  return (await ctx.fetchText(`${BASE_URL}/latest_snapshot_identifier`)).trim()
+}
+
+// client.py swallows fetch failures for the optional blobs (description/markers may not exist
+// for every cell type) and falls back to empty results; mirror that instead of failing the call.
+async function tryFetchJson(ctx: ToolContext, url: string): Promise<unknown | undefined> {
+  try {
+    return await ctx.fetchJson(url)
+  } catch {
+    return undefined
+  }
+}
+
+async function fetchDescription(
+  ctx: ToolContext,
+  urlId: string
+): Promise<{ description: string; references: unknown[]; source: string }> {
+  const validated = await tryFetchJson(
+    ctx,
+    `${BASE_URL}/validated_descriptions/${encodeURIComponent(urlId)}.json`
+  )
+  if (validated && typeof validated === 'object') {
+    const v = validated as ValidatedDescription
+    return { description: v.description ?? '', references: v.references ?? [], source: 'validated' }
+  }
+  // GPT-generated descriptions are stored as a bare JSON string, not an object.
+  const gpt = await tryFetchJson(
+    ctx,
+    `${BASE_URL}/gpt_descriptions/${encodeURIComponent(urlId)}.json`
+  )
+  if (typeof gpt === 'string') return { description: gpt, references: [], source: 'gpt' }
+  return { description: '', references: [], source: 'none' }
+}
+
+function formatMarkerGene(g: CanonicalMarkerGene): Record<string, unknown> {
+  return {
+    symbol: g.symbol,
+    name: g.name,
+    tissue: g.tissue,
+    publication: g.publication || undefined,
+    publicationTitle: g.publication_titles || undefined
+  }
+}
+
+// CellGuide CDN: cell-type metadata + validated/GPT description + canonical marker genes,
+// keyed by Cell Ontology (CL) id. No search endpoint on the CDN — pass a CL id directly.
+export const CELLGUIDE_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'cellguide_cell_type',
+    connector: 'cellguide',
+    description:
+      'Get CellGuide (CELLxGENE) info for a Cell Ontology id: name, synonyms, description, and canonical marker genes.',
+    input: {
+      type: 'object',
+      properties: {
+        cellType: {
+          type: 'string',
+          description: 'Cell Ontology id, e.g. CL:0000622 (CL:x, CL_x, or bare digits all accepted)'
+        }
+      },
+      required: ['cellType']
+    },
+    required: ['cellType'],
+    run: async (ctx, a) => {
+      const cellType = String(a.cellType)
+      const jsonId = toJsonFormat(cellType)
+      const urlId = toUrlFormat(cellType)
+
+      const snapshot = await fetchSnapshotId(ctx)
+      const metadata = (await ctx.fetchJson(
+        `${BASE_URL}/${snapshot}/celltype_metadata.json`
+      )) as CellTypeMetadata
+      const info = metadata[jsonId]
+      if (!info) return { error: `Cell type '${cellType}' not found` }
+
+      const description = await fetchDescription(ctx, urlId)
+      const markersRaw = await tryFetchJson(
+        ctx,
+        `${BASE_URL}/${snapshot}/canonical_marker_genes/${encodeURIComponent(urlId)}.json`
+      )
+      // Empty body (no curated canonical markers for this cell type) fails .json() parsing;
+      // tryFetchJson already folds that into undefined, same as a 404.
+      const markers = Array.isArray(markersRaw) ? (markersRaw as CanonicalMarkerGene[]) : []
+
+      return {
+        id: jsonId,
+        name: info.name,
+        synonyms: info.synonyms ?? [],
+        ontologyDescription: info.clDescription,
+        description: description.description,
+        descriptionSource: description.source,
+        references: description.references,
+        canonicalMarkerGenes: markers.slice(0, 30).map(formatMarkerGene)
+      }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/chembl.test.ts
+++ b/src/main/connectors/descriptors/chembl.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { CHEMBL_TOOLS } from './chembl'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => CHEMBL_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('chembl / search', () => {
+  it('chembl_search_molecule builds the search URL and parses compact summaries', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        molecules: [
+          {
+            molecule_chembl_id: 'CHEMBL25',
+            pref_name: 'ASPIRIN',
+            max_phase: '4.0',
+            molecule_type: 'Small molecule',
+            molecule_structures: { canonical_smiles: 'CC(=O)Oc1ccccc1C(=O)O' }
+          },
+          {
+            molecule_chembl_id: 'CHEMBL5282669',
+            pref_name: null,
+            max_phase: null,
+            molecule_type: null
+          }
+        ],
+        page_meta: { limit: 20, offset: 0, total_count: 52 }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('chembl_search_molecule'),
+      { query: 'aspirin' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.ebi.ac.uk/chembl/api/data/molecule/search?q=aspirin&format=json'
+    )
+    expect(out).toEqual([
+      {
+        chembl_id: 'CHEMBL25',
+        pref_name: 'ASPIRIN',
+        max_phase: '4.0',
+        molecule_type: 'Small molecule'
+      },
+      { chembl_id: 'CHEMBL5282669', pref_name: null, max_phase: null, molecule_type: null }
+    ])
+  })
+
+  it('chembl_search_molecule returns an empty array when there are no matches', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ molecules: [] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('chembl_search_molecule'),
+      { query: 'nonexistent-compound-xyz' },
+      {}
+    )
+    expect(out).toEqual([])
+  })
+
+  it('encodes special characters in the query', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ molecules: [] }))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('chembl_search_molecule'),
+      { query: 'a b&c' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.ebi.ac.uk/chembl/api/data/molecule/search?q=a%20b%26c&format=json'
+    )
+  })
+})
+
+describe('chembl / get molecule', () => {
+  it('chembl_get_molecule builds the record URL and parses a compact summary', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        molecule_chembl_id: 'CHEMBL25',
+        pref_name: 'ASPIRIN',
+        max_phase: '4.0',
+        molecule_type: 'Small molecule',
+        withdrawn_flag: false
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('chembl_get_molecule'),
+      { chembl_id: 'CHEMBL25' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.ebi.ac.uk/chembl/api/data/molecule/CHEMBL25?format=json'
+    )
+    expect(out).toEqual({
+      chembl_id: 'CHEMBL25',
+      pref_name: 'ASPIRIN',
+      max_phase: '4.0',
+      molecule_type: 'Small molecule'
+    })
+  })
+})

--- a/src/main/connectors/descriptors/chembl.ts
+++ b/src/main/connectors/descriptors/chembl.ts
@@ -1,0 +1,50 @@
+import type { ToolDescriptor } from '../types'
+
+const CHEMBL = 'https://www.ebi.ac.uk/chembl/api/data'
+
+type ChemblMolecule = {
+  molecule_chembl_id?: string
+  pref_name?: string | null
+  max_phase?: string | number | null
+  molecule_type?: string | null
+}
+
+type ChemblSearchResponse = { molecules?: ChemblMolecule[] }
+
+const summarize = (m: ChemblMolecule): unknown => ({
+  chembl_id: m.molecule_chembl_id,
+  pref_name: m.pref_name,
+  max_phase: m.max_phase,
+  molecule_type: m.molecule_type
+})
+
+// ChEMBL REST (EBI): read-only compound/drug lookups.
+export const CHEMBL_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'chembl_search_molecule',
+    connector: 'chembl',
+    description:
+      'Full-text search for ChEMBL molecules by name; returns compact molecule summaries.',
+    input: {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query']
+    },
+    required: ['query'],
+    url: (a) => `${CHEMBL}/molecule/search?q=${encodeURIComponent(String(a.query))}&format=json`,
+    parse: (raw) => ((raw as ChemblSearchResponse).molecules ?? []).map(summarize)
+  },
+  {
+    id: 'chembl_get_molecule',
+    connector: 'chembl',
+    description: 'Get a ChEMBL molecule record (name, phase, type) by ChEMBL ID.',
+    input: {
+      type: 'object',
+      properties: { chembl_id: { type: 'string' } },
+      required: ['chembl_id']
+    },
+    required: ['chembl_id'],
+    url: (a) => `${CHEMBL}/molecule/${encodeURIComponent(String(a.chembl_id))}?format=json`,
+    parse: (raw) => summarize(raw as ChemblMolecule)
+  }
+]

--- a/src/main/connectors/descriptors/chemistry.test.ts
+++ b/src/main/connectors/descriptors/chemistry.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { CHEMISTRY_TOOLS } from './chemistry'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => CHEMISTRY_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('chemistry / pubchem', () => {
+  it('pubchem_get_properties parses PropertyTable', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        jsonRes({ PropertyTable: { Properties: [{ CID: 2244, MolecularFormula: 'C9H8O4' }] } })
+      )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('pubchem_get_properties'),
+      { cids: [2244] },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toContain('/compound/cid/2244/property/')
+    expect(out).toEqual([{ CID: 2244, MolecularFormula: 'C9H8O4' }])
+  })
+
+  it('pubchem_search_compounds resolves name -> cids -> properties', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ IdentifierList: { CID: [2519, 999] } }))
+      .mockResolvedValueOnce(jsonRes({ PropertyTable: { Properties: [{ CID: 2519 }] } }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('pubchem_search_compounds'),
+      { query: 'caffeine', max_cids: 1 },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toContain('/compound/name/caffeine/cids/JSON')
+    expect(fetchImpl.mock.calls[1][0]).toContain('/compound/cid/2519/property/')
+    expect(out).toEqual({ query: 'caffeine', compounds: [{ CID: 2519 }] })
+  })
+})
+
+describe('chemistry / chebi', () => {
+  it('chebi_get_entity normalizes the compound record', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        chebi_accession: 'CHEBI:27732',
+        name: 'caffeine',
+        definition: 'A trimethylxanthine.',
+        chemical_data: { formula: 'C8H10N4O2', charge: '0', mass: '194.19' },
+        default_structure: {
+          smiles: 'CN1C=NC2=C1C(=O)N(C(=O)N2C)C',
+          standard_inchi: 'InChI=1S/C8H10N4O2',
+          standard_inchi_key: 'RYYVLZVUVIJVGH-UHFFFAOYSA-N'
+        }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('chebi_get_entity'),
+      { chebi_id: 'CHEBI:27732' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.ebi.ac.uk/chebi/backend/api/public/compound/27732/'
+    )
+    expect(out).toEqual({
+      chebi_accession: 'CHEBI:27732',
+      name: 'caffeine',
+      definition: 'A trimethylxanthine.',
+      formula: 'C8H10N4O2',
+      charge: '0',
+      mass: '194.19',
+      smiles: 'CN1C=NC2=C1C(=O)N(C(=O)N2C)C',
+      inchi: 'InChI=1S/C8H10N4O2',
+      inchikey: 'RYYVLZVUVIJVGH-UHFFFAOYSA-N'
+    })
+  })
+
+  it('chebi_get_entity accepts a bare numeric id and rejects a malformed one', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ chebi_accession: 'CHEBI:27732' }))
+    await new ParserEngine({ fetchImpl }).call(tool('chebi_get_entity'), { chebi_id: '27732' }, {})
+    expect(fetchImpl.mock.calls[0][0]).toContain('/compound/27732/')
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('chebi_get_entity'), { chebi_id: 'nope' }, {})
+    ).rejects.toThrow(/not a ChEBI ID/)
+  })
+})
+
+describe('chemistry / rhea', () => {
+  it('rhea_get_reaction parses SPARQL bindings into equation + sides', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        results: {
+          bindings: [
+            {
+              side: { value: 'http://rdf.rhea-db.org/10280_L' },
+              status: { value: 'http://rdf.rhea-db.org/Approved' },
+              equation: { value: 'A + B = C + D' },
+              cacc: { value: 'CHEBI:1' },
+              cname: { value: 'A' }
+            },
+            {
+              side: { value: 'http://rdf.rhea-db.org/10280_R' },
+              status: { value: 'http://rdf.rhea-db.org/Approved' },
+              equation: { value: 'A + B = C + D' },
+              cacc: { value: 'CHEBI:2' },
+              cname: { value: 'C' }
+            }
+          ]
+        }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('rhea_get_reaction'),
+      { rhea_id: '10280' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toContain('https://sparql.rhea-db.org/sparql?query=')
+    expect(out).toEqual({
+      rhea_id: 'RHEA:10280',
+      equation: 'A + B = C + D',
+      status: 'Approved',
+      left_side: [{ compound_accession: 'CHEBI:1', name: 'A' }],
+      right_side: [{ compound_accession: 'CHEBI:2', name: 'C' }]
+    })
+  })
+
+  it('rhea_get_reaction throws when no bindings come back', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ results: { bindings: [] } }))
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('rhea_get_reaction'), { rhea_id: '999999' }, {})
+    ).rejects.toThrow(/no Rhea reaction/)
+  })
+})
+
+describe('chemistry / bindingdb', () => {
+  it('bindingdb_affinities unwraps the misspelled root key and normalizes rows', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        getLindsByUniprotsResponse: {
+          affinities: [
+            {
+              query: 'Epidermal growth factor receptor',
+              monomerid: 3032,
+              smile: 'COc1cc2ncnc(Nc3cccc(Br)c3)c2cc1OC',
+              affinity_type: 'Ki',
+              affinity: '0.006',
+              pmid: 18077363,
+              doi: '10.1073/pnas.0708800104'
+            }
+          ]
+        }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('bindingdb_affinities'),
+      { uniprot: 'p00533', cutoff_nm: 100 },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toContain('uniprot=P00533')
+    expect(fetchImpl.mock.calls[0][0]).toContain('cutoff=100')
+    expect(out).toEqual({
+      uniprot: 'P00533',
+      cutoff_nm: 100,
+      n_rows: 1,
+      affinities: [
+        {
+          target_name: 'Epidermal growth factor receptor',
+          monomer_id: '3032',
+          smiles: 'COc1cc2ncnc(Nc3cccc(Br)c3)c2cc1OC',
+          affinity_type: 'Ki',
+          affinity: '0.006',
+          pmid: '18077363',
+          doi: '10.1073/pnas.0708800104'
+        }
+      ]
+    })
+  })
+
+  it('bindingdb_affinities rejects a malformed UniProt accession', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('bindingdb_affinities'), { uniprot: 'nope' }, {})
+    ).rejects.toThrow(/not a UniProt accession/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/connectors/descriptors/chemistry.ts
+++ b/src/main/connectors/descriptors/chemistry.ts
@@ -1,0 +1,206 @@
+import type { ToolDescriptor } from '../types'
+
+const PUBCHEM = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug'
+const PROPS = 'MolecularFormula,MolecularWeight,CanonicalSMILES,IUPACName'
+
+// ChEBI's 2024+ website backend: keyless JSON REST (the legacy SOAP service is being retired).
+const CHEBI_API = 'https://www.ebi.ac.uk/chebi/backend/api/public'
+
+// Rhea has no plain REST lookup; the DB is served via SPARQL. GET with an `Accept: application/
+// json` header returns `application/sparql-results+json` bindings, so a single SELECT works
+// through the same fetchJson path as every other tool here.
+const RHEA_SPARQL = 'https://sparql.rhea-db.org/sparql'
+const RHEA_PREFIXES =
+  'PREFIX rh: <http://rdf.rhea-db.org/>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n'
+
+const BINDINGDB_API = 'https://bindingdb.org/rest'
+const UNIPROT_RE = /^[OPQ][0-9][A-Z0-9]{3}[0-9]$|^[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$/i
+const CHEBI_ID_RE = /^(?:CHEBI:)?(\d+)$/i
+const RHEA_ID_RE = /^(?:RHEA:)?(\d+)$/i
+
+type Props = { PropertyTable: { Properties: unknown[] } }
+
+type ChebiCompound = {
+  chebi_accession?: string
+  name?: string
+  definition?: string
+  chemical_data?: { formula?: string; charge?: string; mass?: string }
+  default_structure?: { smiles?: string; standard_inchi?: string; standard_inchi_key?: string }
+}
+
+type SparqlBinding = Record<string, { value?: string }>
+type SparqlResponse = { results?: { bindings?: SparqlBinding[] } }
+
+type BindingDbAffinity = {
+  query?: string
+  monomerid?: string | number
+  smile?: string
+  affinity_type?: string
+  affinity?: string | number
+  pmid?: string | number
+  doi?: string
+}
+
+// Accept `CHEBI:27732` / `27732` / 27732; return the bare numeric id string.
+function normalizeChebiId(id: unknown): string {
+  const m = CHEBI_ID_RE.exec(String(id).trim())
+  if (!m) throw new Error(`not a ChEBI ID: ${String(id)}`)
+  return m[1]
+}
+
+// Accept `RHEA:10280` / `10280` / 10280; return `RHEA:10280`.
+function normalizeRheaId(id: unknown): string {
+  const m = RHEA_ID_RE.exec(String(id).trim())
+  if (!m) throw new Error(`not a Rhea ID: ${String(id)}`)
+  return `RHEA:${m[1]}`
+}
+
+// http://rdf.rhea-db.org/10280_L -> "10280_L"; http://.../Approved -> "Approved".
+function localName(uri?: string): string | undefined {
+  if (!uri) return undefined
+  return uri.replace(/\/$/, '').split(/[/#]/).pop()
+}
+
+// PubChem PUG REST: read-only compound lookups.
+export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'pubchem_get_properties',
+    connector: 'chemistry',
+    description: 'Get molecular properties for one or more PubChem CIDs.',
+    input: {
+      type: 'object',
+      properties: { cids: { type: 'array', items: { type: 'integer' } } },
+      required: ['cids']
+    },
+    required: ['cids'],
+    url: (a) =>
+      `${PUBCHEM}/compound/cid/${([] as unknown[]).concat(a.cids as never).join(',')}/property/${PROPS}/JSON`,
+    parse: (raw) => (raw as Props).PropertyTable.Properties
+  },
+  {
+    id: 'pubchem_search_compounds',
+    connector: 'chemistry',
+    description: 'Search PubChem compounds by name; returns matched CIDs with properties.',
+    input: {
+      type: 'object',
+      properties: { query: { type: 'string' }, max_cids: { type: 'integer', default: 5 } },
+      required: ['query']
+    },
+    required: ['query'],
+    run: async (ctx, a) => {
+      const cidRes = (await ctx.fetchJson(
+        `${PUBCHEM}/compound/name/${encodeURIComponent(String(a.query))}/cids/JSON`
+      )) as {
+        IdentifierList?: { CID?: number[] }
+      }
+      const cids = (cidRes.IdentifierList?.CID ?? []).slice(0, Number(a.max_cids ?? 5))
+      if (!cids.length) return { query: a.query, compounds: [] }
+      const propRes = (await ctx.fetchJson(
+        `${PUBCHEM}/compound/cid/${cids.join(',')}/property/${PROPS}/JSON`
+      )) as Props
+      return { query: a.query, compounds: propRes.PropertyTable.Properties }
+    }
+  },
+  {
+    id: 'chebi_get_entity',
+    connector: 'chemistry',
+    description: 'Look up a ChEBI ontology entity by ID: name, formula, structure, definition.',
+    input: {
+      type: 'object',
+      properties: { chebi_id: { type: 'string' } },
+      required: ['chebi_id']
+    },
+    required: ['chebi_id'],
+    url: (a) => `${CHEBI_API}/compound/${normalizeChebiId(a.chebi_id)}/`,
+    parse: (raw) => {
+      const c = raw as ChebiCompound
+      return {
+        chebi_accession: c.chebi_accession,
+        name: c.name,
+        definition: c.definition,
+        formula: c.chemical_data?.formula,
+        charge: c.chemical_data?.charge,
+        mass: c.chemical_data?.mass,
+        smiles: c.default_structure?.smiles,
+        inchi: c.default_structure?.standard_inchi,
+        inchikey: c.default_structure?.standard_inchi_key
+      }
+    }
+  },
+  {
+    id: 'rhea_get_reaction',
+    connector: 'chemistry',
+    description: 'Look up a Rhea reaction by ID: chemical equation and left/right participants.',
+    input: {
+      type: 'object',
+      properties: { rhea_id: { type: 'string' } },
+      required: ['rhea_id']
+    },
+    required: ['rhea_id'],
+    run: async (ctx, a) => {
+      const acc = normalizeRheaId(a.rhea_id)
+      const query = `${RHEA_PREFIXES}SELECT ?equation ?status ?side ?cacc ?cname WHERE {
+  ?r rh:accession "${acc}" ; rh:equation ?equation ; rh:status ?status ; rh:side ?side .
+  ?side ?coefProp ?part . ?coefProp rdfs:subPropertyOf rh:contains .
+  ?part rh:compound ?c . ?c rh:accession ?cacc .
+  OPTIONAL { ?c rh:name ?cname }
+}`
+      const res = (await ctx.fetchJson(
+        `${RHEA_SPARQL}?query=${encodeURIComponent(query)}`
+      )) as SparqlResponse
+      const rows = res.results?.bindings ?? []
+      if (!rows.length) throw new Error(`no Rhea reaction ${acc}`)
+
+      const left: Array<{ compound_accession?: string; name?: string }> = []
+      const right: Array<{ compound_accession?: string; name?: string }> = []
+      for (const row of rows) {
+        const entry = { compound_accession: row.cacc?.value, name: row.cname?.value }
+        if (row.side?.value?.endsWith('_L')) left.push(entry)
+        else if (row.side?.value?.endsWith('_R')) right.push(entry)
+      }
+      return {
+        rhea_id: acc,
+        equation: rows[0].equation?.value,
+        status: localName(rows[0].status?.value),
+        left_side: left,
+        right_side: right
+      }
+    }
+  },
+  {
+    id: 'bindingdb_affinities',
+    connector: 'chemistry',
+    description:
+      'Get BindingDB ligand binding affinities for a UniProt target, filtered to a max affinity (nM).',
+    input: {
+      type: 'object',
+      properties: {
+        uniprot: { type: 'string' },
+        cutoff_nm: { type: 'integer', default: 1000 }
+      },
+      required: ['uniprot']
+    },
+    required: ['uniprot'],
+    run: async (ctx, a) => {
+      const uniprot = String(a.uniprot).trim().toUpperCase()
+      if (!UNIPROT_RE.test(uniprot)) throw new Error(`not a UniProt accession: ${uniprot}`)
+      const cutoff = Number(a.cutoff_nm ?? 1000)
+      const raw = (await ctx.fetchJson(
+        `${BINDINGDB_API}/getLigandsByUniprots?uniprot=${encodeURIComponent(uniprot)}&cutoff=${cutoff}&code=0&response=application/json`
+      )) as Record<string, { affinities?: BindingDbAffinity[] }>
+      // Response root key is misspelled upstream (getLindsByUniprotsResponse) and varies by
+      // route; unwrap by taking the single value rather than depending on the exact spelling.
+      const root = Object.values(raw)[0] ?? {}
+      const rows = (root.affinities ?? []).map((r) => ({
+        target_name: r.query,
+        monomer_id: r.monomerid != null ? String(r.monomerid) : undefined,
+        smiles: r.smile,
+        affinity_type: r.affinity_type,
+        affinity: r.affinity != null ? String(r.affinity) : undefined,
+        pmid: r.pmid != null ? String(r.pmid) : undefined,
+        doi: r.doi
+      }))
+      return { uniprot, cutoff_nm: cutoff, n_rows: rows.length, affinities: rows }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/clinical-genomics.test.ts
+++ b/src/main/connectors/descriptors/clinical-genomics.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { CLINICAL_GENOMICS_TOOLS } from './clinical-genomics'
+
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+const OT_API = 'https://api.platform.opentargets.org/api/v4/graphql'
+
+describe('clinical-genomics (Open Targets)', () => {
+  describe('opentargets_target_diseases', () => {
+    const tool = CLINICAL_GENOMICS_TOOLS.find((t) => t.id === 'opentargets_target_diseases')!
+
+    it('resolves a gene symbol via search, then POSTs the target diseases query', async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonRes({
+            data: {
+              search: {
+                hits: [
+                  { id: 'ENSG00000224057', entity: 'target', name: 'EGFR-AS1' },
+                  { id: 'ENSG00000146648', entity: 'target', name: 'EGFR' }
+                ]
+              }
+            }
+          })
+        )
+        .mockResolvedValueOnce(
+          jsonRes({
+            data: {
+              target: {
+                id: 'ENSG00000146648',
+                approvedSymbol: 'EGFR',
+                approvedName: 'epidermal growth factor receptor',
+                associatedDiseases: {
+                  count: 6459,
+                  rows: [
+                    {
+                      score: 0.8525670184292347,
+                      disease: { id: 'MONDO_0005233', name: 'non-small cell lung carcinoma' }
+                    },
+                    {
+                      score: 0.7744435748658476,
+                      disease: { id: 'MONDO_0005061', name: 'lung adenocarcinoma' }
+                    }
+                  ]
+                }
+              }
+            }
+          })
+        )
+
+      const out = (await new ParserEngine({ fetchImpl }).call(tool, { gene: 'EGFR' }, {})) as {
+        gene_id: string
+        symbol: string
+        approved_name: string
+        n_diseases_total: number
+        returned: number
+        diseases: Array<{ disease_id: string; disease_name: string; score: number }>
+      }
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2)
+      const [searchUrl, searchInit] = fetchImpl.mock.calls[0] as [string, RequestInit]
+      expect(searchUrl).toBe(OT_API)
+      const searchBody = JSON.parse(searchInit.body as string) as {
+        query: string
+        variables: unknown
+      }
+      expect(searchBody.query).toContain('search(queryString: $q')
+      expect(searchBody.variables).toEqual({ q: 'EGFR' })
+
+      const [diseasesUrl, diseasesInit] = fetchImpl.mock.calls[1] as [string, RequestInit]
+      expect(diseasesUrl).toBe(OT_API)
+      const diseasesBody = JSON.parse(diseasesInit.body as string) as {
+        query: string
+        variables: unknown
+      }
+      expect(diseasesBody.query).toContain('target(ensemblId: $ensemblId)')
+      expect(diseasesBody.query).toContain('associatedDiseases(page: { size: $size, index: 0 })')
+      // Picks the exact-name hit ("EGFR"), not the first hit ("EGFR-AS1").
+      expect(diseasesBody.variables).toEqual({ ensemblId: 'ENSG00000146648', size: 10 })
+
+      expect(out.gene_id).toBe('ENSG00000146648')
+      expect(out.symbol).toBe('EGFR')
+      expect(out.approved_name).toBe('epidermal growth factor receptor')
+      expect(out.n_diseases_total).toBe(6459)
+      expect(out.returned).toBe(2)
+      expect(out.diseases).toEqual([
+        {
+          disease_id: 'MONDO_0005233',
+          disease_name: 'non-small cell lung carcinoma',
+          score: 0.8525670184292347
+        },
+        {
+          disease_id: 'MONDO_0005061',
+          disease_name: 'lung adenocarcinoma',
+          score: 0.7744435748658476
+        }
+      ])
+    })
+
+    it('skips the search round-trip when given an Ensembl gene id directly', async () => {
+      const fetchImpl = vi.fn().mockResolvedValueOnce(
+        jsonRes({
+          data: {
+            target: {
+              id: 'ENSG00000146648',
+              approvedSymbol: 'EGFR',
+              associatedDiseases: {
+                count: 1,
+                rows: [{ score: 0.5, disease: { id: 'D1', name: 'disease one' } }]
+              }
+            }
+          }
+        })
+      )
+      await new ParserEngine({ fetchImpl }).call(tool, { gene: 'ENSG00000146648' }, {})
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1)
+      const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+      const body = JSON.parse(init.body as string) as { variables: { ensemblId: string } }
+      expect(body.variables.ensemblId).toBe('ENSG00000146648')
+    })
+
+    it('honors an explicit limit as the GraphQL page size', async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonRes({ data: { target: { id: 'ENSG1', associatedDiseases: { count: 0, rows: [] } } } })
+        )
+      await new ParserEngine({ fetchImpl }).call(tool, { gene: 'ENSG00000146648', limit: 3 }, {})
+      const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+      const body = JSON.parse(init.body as string) as { variables: { size: number } }
+      expect(body.variables.size).toBe(3)
+    })
+
+    it('returns an empty compact result when the search finds no target hits', async () => {
+      const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ data: { search: { hits: [] } } }))
+      const out = (await new ParserEngine({ fetchImpl }).call(tool, { gene: 'NOPEGENE' }, {})) as {
+        gene: string
+        gene_id: null
+        n_diseases_total: number
+        diseases: unknown[]
+      }
+      expect(fetchImpl).toHaveBeenCalledTimes(1)
+      expect(out.gene).toBe('NOPEGENE')
+      expect(out.gene_id).toBeNull()
+      expect(out.n_diseases_total).toBe(0)
+      expect(out.diseases).toEqual([])
+    })
+
+    it('returns an empty compact result when the target itself is absent (data null)', async () => {
+      const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ data: { target: null } }))
+      const out = (await new ParserEngine({ fetchImpl }).call(
+        tool,
+        { gene: 'ENSG00000000000' },
+        {}
+      )) as { gene_id: string; n_diseases_total: number; diseases: unknown[] }
+      expect(out.gene_id).toBe('ENSG00000000000')
+      expect(out.n_diseases_total).toBe(0)
+      expect(out.diseases).toEqual([])
+    })
+
+    it('throws on a GraphQL error from the target diseases query', async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(jsonRes({ errors: [{ message: "Cannot query field 'nope'" }] }))
+      await expect(
+        new ParserEngine({ fetchImpl }).call(tool, { gene: 'ENSG00000146648' }, {})
+      ).rejects.toThrow(/Cannot query field/)
+    })
+  })
+
+  describe('opentargets_drug', () => {
+    const tool = CLINICAL_GENOMICS_TOOLS.find((t) => t.id === 'opentargets_drug')!
+
+    it('POSTs the chembl id and parses mechanism of action + indications, capped to limit', async () => {
+      const fetchImpl = vi.fn().mockResolvedValueOnce(
+        jsonRes({
+          data: {
+            drug: {
+              id: 'CHEMBL1201583',
+              name: 'BEVACIZUMAB',
+              drugType: 'Antibody',
+              maximumClinicalStage: 'APPROVAL',
+              mechanismsOfAction: {
+                rows: [
+                  {
+                    mechanismOfAction: 'Vascular endothelial growth factor A inhibitor',
+                    actionType: 'INHIBITOR',
+                    targets: [{ id: 'ENSG00000112715', approvedSymbol: 'VEGFA' }]
+                  }
+                ]
+              },
+              indications: {
+                count: 275,
+                rows: [
+                  {
+                    disease: { id: 'MONDO_0005401', name: 'colonic neoplasm' },
+                    maxClinicalStage: 'APPROVAL'
+                  },
+                  {
+                    disease: { id: 'MONDO_0007254', name: 'breast cancer' },
+                    maxClinicalStage: 'APPROVAL'
+                  },
+                  {
+                    disease: { id: 'MONDO_0021211', name: 'brain neoplasm' },
+                    maxClinicalStage: 'PHASE_2'
+                  }
+                ]
+              }
+            }
+          }
+        })
+      )
+
+      const out = (await new ParserEngine({ fetchImpl }).call(
+        tool,
+        { chembl_id: 'CHEMBL1201583', limit: 2 },
+        {}
+      )) as {
+        chembl_id: string
+        name: string
+        drug_type: string
+        max_clinical_stage: string
+        mechanisms_of_action: Array<{
+          mechanism_of_action: string
+          action_type: string
+          targets: Array<{ id: string; approved_symbol: string }>
+        }>
+        n_indications_total: number
+        returned_indications: number
+        indications: Array<{ disease_id: string; disease_name: string; max_clinical_stage: string }>
+      }
+
+      const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(OT_API)
+      const body = JSON.parse(init.body as string) as { query: string; variables: unknown }
+      expect(body.query).toContain('drug(chemblId: $chemblId)')
+      expect(body.query).toContain('maxClinicalStage')
+      expect(body.variables).toEqual({ chemblId: 'CHEMBL1201583' })
+
+      expect(out.chembl_id).toBe('CHEMBL1201583')
+      expect(out.name).toBe('BEVACIZUMAB')
+      expect(out.drug_type).toBe('Antibody')
+      expect(out.max_clinical_stage).toBe('APPROVAL')
+      expect(out.mechanisms_of_action).toEqual([
+        {
+          mechanism_of_action: 'Vascular endothelial growth factor A inhibitor',
+          action_type: 'INHIBITOR',
+          targets: [{ id: 'ENSG00000112715', approved_symbol: 'VEGFA' }]
+        }
+      ])
+      expect(out.n_indications_total).toBe(275)
+      expect(out.returned_indications).toBe(2)
+      expect(out.indications).toEqual([
+        {
+          disease_id: 'MONDO_0005401',
+          disease_name: 'colonic neoplasm',
+          max_clinical_stage: 'APPROVAL'
+        },
+        {
+          disease_id: 'MONDO_0007254',
+          disease_name: 'breast cancer',
+          max_clinical_stage: 'APPROVAL'
+        }
+      ])
+    })
+
+    it('returns found=false when the drug is absent (data null)', async () => {
+      const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ data: { drug: null } }))
+      const out = (await new ParserEngine({ fetchImpl }).call(
+        tool,
+        { chembl_id: 'CHEMBL_NOPE' },
+        {}
+      )) as { chembl_id: string; found: boolean }
+      expect(out.chembl_id).toBe('CHEMBL_NOPE')
+      expect(out.found).toBe(false)
+    })
+
+    it('throws on a GraphQL error from the drug query', async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(jsonRes({ errors: [{ message: 'Internal server error' }] }))
+      await expect(
+        new ParserEngine({ fetchImpl }).call(tool, { chembl_id: 'CHEMBL1201583' }, {})
+      ).rejects.toThrow(/Internal server error/)
+    })
+  })
+})

--- a/src/main/connectors/descriptors/clinical-genomics.ts
+++ b/src/main/connectors/descriptors/clinical-genomics.ts
@@ -1,0 +1,238 @@
+import type { ToolDescriptor } from '../types'
+
+const OPEN_TARGETS_API = 'https://api.platform.opentargets.org/api/v4/graphql'
+// Top disease/indication rows can run into the hundreds — bound the response like gnomad's
+// variant limit, rather than returning every row unbounded.
+const DEFAULT_LIMIT = 10
+
+// Resolves a free-text gene symbol to an Ensembl target id via the platform's cross-entity
+// search (transcribed from the upstream open_targets_graphql docstring example query shape).
+const SEARCH_TARGET_QUERY = `
+query SearchTarget($q: String!) {
+  search(queryString: $q, entityNames: ["target"]) {
+    hits { id entity name }
+  }
+}
+`
+
+// Transcribed from the upstream mcp_clinical_genomics open_targets_graphql docstring example
+// (target(ensemblId:$id){approvedSymbol associatedDiseases{count}}), extended with the disease
+// rows/score fields symmetric to the upstream open_targets_disease_targets query.
+const TARGET_DISEASES_QUERY = `
+query TargetDiseases($ensemblId: String!, $size: Int!) {
+  target(ensemblId: $ensemblId) {
+    id
+    approvedSymbol
+    approvedName
+    associatedDiseases(page: { size: $size, index: 0 }) {
+      count
+      rows { score disease { id name } }
+    }
+  }
+}
+`
+
+// Transcribed from the upstream _OT_DRUG_Q document (mcp_clinical_genomics/server.py), extended
+// with indications (live-introspected field name is maxClinicalStage, not maxPhaseForIndication).
+const DRUG_QUERY = `
+query DrugDetail($chemblId: String!) {
+  drug(chemblId: $chemblId) {
+    id
+    name
+    drugType
+    maximumClinicalStage
+    mechanismsOfAction {
+      rows { mechanismOfAction actionType targets { id approvedSymbol } }
+    }
+    indications {
+      count
+      rows { disease { id name } maxClinicalStage }
+    }
+  }
+}
+`
+
+type SearchHit = { id: string; entity: string; name?: string }
+type SearchResponse = {
+  data?: { search?: { hits?: SearchHit[] | null } | null }
+  errors?: Array<{ message?: string }>
+}
+
+type DiseaseRow = { score?: number; disease?: { id?: string; name?: string } | null }
+type TargetDiseasesResponse = {
+  data?: {
+    target?: {
+      id: string
+      approvedSymbol?: string
+      approvedName?: string
+      associatedDiseases?: { count?: number; rows?: DiseaseRow[] | null } | null
+    } | null
+  }
+  errors?: Array<{ message?: string }>
+}
+
+type MoaRow = {
+  mechanismOfAction?: string
+  actionType?: string
+  targets?: Array<{ id?: string; approvedSymbol?: string }> | null
+}
+type IndicationRow = {
+  disease?: { id?: string; name?: string } | null
+  maxClinicalStage?: string
+}
+type DrugResponse = {
+  data?: {
+    drug?: {
+      id: string
+      name?: string
+      drugType?: string
+      maximumClinicalStage?: string
+      mechanismsOfAction?: { rows?: MoaRow[] | null } | null
+      indications?: { count?: number; rows?: IndicationRow[] | null } | null
+    } | null
+  }
+  errors?: Array<{ message?: string }>
+}
+
+function throwOnErrors(errors: Array<{ message?: string }> | undefined, label: string): void {
+  if (errors?.length) {
+    throw new Error(
+      `Open Targets GraphQL error (${label}): ${errors.map((e) => e.message).join('; ')}`
+    )
+  }
+}
+
+// Ensembl human gene ids look like ENSG00000146648 — skip the search round-trip when already given one.
+const ENSEMBL_GENE_ID = /^ensg\d+$/i
+
+async function resolveEnsemblId(
+  postJson: (url: string, body: unknown) => Promise<unknown>,
+  gene: string
+): Promise<string | null> {
+  if (ENSEMBL_GENE_ID.test(gene)) return gene.toUpperCase()
+  const result = (await postJson(OPEN_TARGETS_API, {
+    query: SEARCH_TARGET_QUERY,
+    variables: { q: gene }
+  })) as SearchResponse
+  throwOnErrors(result.errors, 'search')
+  const hits = (result.data?.search?.hits ?? []).filter((h) => h.entity === 'target')
+  if (!hits.length) return null
+  const exact = hits.find((h) => (h.name ?? '').toLowerCase() === gene.toLowerCase())
+  return (exact ?? hits[0]).id
+}
+
+// Open Targets Platform GraphQL API: every call is a POST of {query, variables} to a single
+// endpoint. Unlike gnomAD, an absent entity comes back as `data: { target: null }` / `{ drug:
+// null }` with no accompanying "not found" error — so there's no error-message allowlist to check.
+export const CLINICAL_GENOMICS_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'opentargets_target_diseases',
+    connector: 'clinical_genomics',
+    description:
+      'Open Targets: top diseases associated with a gene/target (by symbol or Ensembl gene id), ranked by overall association score.',
+    input: {
+      type: 'object',
+      properties: {
+        gene: { type: 'string' },
+        limit: { type: 'integer', default: DEFAULT_LIMIT }
+      },
+      required: ['gene']
+    },
+    required: ['gene'],
+    run: async (ctx, a) => {
+      const gene = String(a.gene)
+      const limit = Number(a.limit ?? DEFAULT_LIMIT)
+
+      const ensemblId = await resolveEnsemblId(ctx.postJson, gene)
+      if (!ensemblId) {
+        // Free-text symbol had no matching target hit — compact empty result, no error thrown.
+        return { gene, gene_id: null, symbol: null, n_diseases_total: 0, returned: 0, diseases: [] }
+      }
+
+      const result = (await ctx.postJson(OPEN_TARGETS_API, {
+        query: TARGET_DISEASES_QUERY,
+        variables: { ensemblId, size: limit }
+      })) as TargetDiseasesResponse
+      throwOnErrors(result.errors, 'target_diseases')
+
+      const target = result.data?.target
+      if (!target) {
+        return {
+          gene,
+          gene_id: ensemblId,
+          symbol: null,
+          n_diseases_total: 0,
+          returned: 0,
+          diseases: []
+        }
+      }
+
+      const rows = target.associatedDiseases?.rows ?? []
+      return {
+        gene_id: target.id,
+        symbol: target.approvedSymbol ?? gene,
+        approved_name: target.approvedName,
+        n_diseases_total: target.associatedDiseases?.count ?? rows.length,
+        returned: rows.length,
+        diseases: rows.map((r) => ({
+          disease_id: r.disease?.id,
+          disease_name: r.disease?.name,
+          score: r.score
+        }))
+      }
+    }
+  },
+  {
+    id: 'opentargets_drug',
+    connector: 'clinical_genomics',
+    description:
+      "Open Targets: a drug's mechanism of action (target, action type) and clinical indications, by ChEMBL id.",
+    input: {
+      type: 'object',
+      properties: {
+        chembl_id: { type: 'string' },
+        limit: { type: 'integer', default: DEFAULT_LIMIT }
+      },
+      required: ['chembl_id']
+    },
+    required: ['chembl_id'],
+    run: async (ctx, a) => {
+      const chemblId = String(a.chembl_id)
+      const limit = Number(a.limit ?? DEFAULT_LIMIT)
+
+      const result = (await ctx.postJson(OPEN_TARGETS_API, {
+        query: DRUG_QUERY,
+        variables: { chemblId }
+      })) as DrugResponse
+      throwOnErrors(result.errors, 'drug')
+
+      const drug = result.data?.drug
+      if (!drug) {
+        return { chembl_id: chemblId, found: false }
+      }
+
+      const moaRows = drug.mechanismsOfAction?.rows ?? []
+      const allIndications = drug.indications?.rows ?? []
+      const indications = allIndications.slice(0, limit)
+
+      return {
+        chembl_id: drug.id,
+        name: drug.name,
+        drug_type: drug.drugType,
+        max_clinical_stage: drug.maximumClinicalStage,
+        mechanisms_of_action: moaRows.map((r) => ({
+          mechanism_of_action: r.mechanismOfAction,
+          action_type: r.actionType,
+          targets: (r.targets ?? []).map((t) => ({ id: t.id, approved_symbol: t.approvedSymbol }))
+        })),
+        n_indications_total: drug.indications?.count ?? allIndications.length,
+        returned_indications: indications.length,
+        indications: indications.map((i) => ({
+          disease_id: i.disease?.id,
+          disease_name: i.disease?.name,
+          max_clinical_stage: i.maxClinicalStage
+        }))
+      }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/clinical-trials.test.ts
+++ b/src/main/connectors/descriptors/clinical-trials.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { CLINICAL_TRIALS_TOOLS } from './clinical-trials'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => CLINICAL_TRIALS_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('clinical_trials / get_study', () => {
+  it('parses nct_id, title, status, phase, conditions', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        protocolSection: {
+          identificationModule: { nctId: 'NCT00000419', briefTitle: 'A Study of Aspirin' },
+          statusModule: { overallStatus: 'COMPLETED' },
+          designModule: { phases: ['PHASE3'] },
+          conditionsModule: { conditions: ['Heart Disease'] }
+        }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('clinicaltrials_get_study'),
+      { nct_id: 'NCT00000419' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://clinicaltrials.gov/api/v2/studies/NCT00000419')
+    expect(out).toEqual({
+      nct_id: 'NCT00000419',
+      title: 'A Study of Aspirin',
+      status: 'COMPLETED',
+      phase: ['PHASE3'],
+      conditions: ['Heart Disease']
+    })
+  })
+
+  it('tolerates missing modules', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ protocolSection: {} }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('clinicaltrials_get_study'),
+      { nct_id: 'NCT00000419' },
+      {}
+    )
+    expect(out).toEqual({
+      nct_id: undefined,
+      title: undefined,
+      status: undefined,
+      phase: undefined,
+      conditions: undefined
+    })
+  })
+})
+
+describe('clinical_trials / search', () => {
+  it('builds the query URL and parses a compact study list', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        studies: [
+          {
+            protocolSection: {
+              identificationModule: { nctId: 'NCT00000001', briefTitle: 'Aspirin Trial' },
+              statusModule: { overallStatus: 'RECRUITING' }
+            }
+          },
+          {
+            protocolSection: {
+              identificationModule: { nctId: 'NCT00000002', briefTitle: 'Aspirin Follow-up' },
+              statusModule: { overallStatus: 'COMPLETED' }
+            }
+          }
+        ],
+        nextPageToken: 'abc123'
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('clinicaltrials_search'),
+      { query: 'aspirin', page_size: 2 },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe('https://clinicaltrials.gov/api/v2/studies?query.term=aspirin&pageSize=2')
+    expect(out).toEqual({
+      studies: [
+        { nct_id: 'NCT00000001', title: 'Aspirin Trial', status: 'RECRUITING' },
+        { nct_id: 'NCT00000002', title: 'Aspirin Follow-up', status: 'COMPLETED' }
+      ],
+      nextPageToken: 'abc123'
+    })
+  })
+
+  it('omits nextPageToken when absent, defaults page_size to 10', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ studies: [] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('clinicaltrials_search'),
+      { query: 'rare disease' },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe(
+      'https://clinicaltrials.gov/api/v2/studies?query.term=rare%20disease&pageSize=10'
+    )
+    expect(out).toEqual({ studies: [] })
+  })
+})

--- a/src/main/connectors/descriptors/clinical-trials.ts
+++ b/src/main/connectors/descriptors/clinical-trials.ts
@@ -1,0 +1,64 @@
+import type { ToolDescriptor } from '../types'
+
+const STUDIES = 'https://clinicaltrials.gov/api/v2/studies'
+
+type ProtocolSection = {
+  identificationModule?: { nctId?: string; briefTitle?: string }
+  statusModule?: { overallStatus?: string }
+  designModule?: { phases?: string[] }
+  conditionsModule?: { conditions?: string[] }
+}
+
+type Study = { protocolSection?: ProtocolSection }
+type SearchResponse = { studies?: Study[]; nextPageToken?: string }
+
+// ClinicalTrials.gov API v2: read-only study lookup + free-text search.
+export const CLINICAL_TRIALS_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'clinicaltrials_get_study',
+    connector: 'clinical_trials',
+    description: 'Get a ClinicalTrials.gov study by NCT id (title, status, phase, conditions).',
+    input: {
+      type: 'object',
+      properties: { nct_id: { type: 'string' } },
+      required: ['nct_id']
+    },
+    required: ['nct_id'],
+    url: (a) => `${STUDIES}/${encodeURIComponent(String(a.nct_id))}`,
+    parse: (raw) => {
+      const proto = (raw as Study).protocolSection ?? {}
+      return {
+        nct_id: proto.identificationModule?.nctId,
+        title: proto.identificationModule?.briefTitle,
+        status: proto.statusModule?.overallStatus,
+        phase: proto.designModule?.phases,
+        conditions: proto.conditionsModule?.conditions
+      }
+    }
+  },
+  {
+    id: 'clinicaltrials_search',
+    connector: 'clinical_trials',
+    description:
+      'Search ClinicalTrials.gov studies by condition, intervention, or free-text query.',
+    input: {
+      type: 'object',
+      properties: { query: { type: 'string' }, page_size: { type: 'integer', default: 10 } },
+      required: ['query']
+    },
+    required: ['query'],
+    run: async (ctx, a) => {
+      const url = `${STUDIES}?query.term=${encodeURIComponent(String(a.query))}&pageSize=${Number(a.page_size ?? 10)}`
+      const res = (await ctx.fetchJson(url)) as SearchResponse
+      const studies = (res.studies ?? []).map((s) => {
+        const proto = s.protocolSection ?? {}
+        return {
+          nct_id: proto.identificationModule?.nctId,
+          title: proto.identificationModule?.briefTitle,
+          status: proto.statusModule?.overallStatus
+        }
+      })
+      return res.nextPageToken ? { studies, nextPageToken: res.nextPageToken } : { studies }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/drug-regulatory.test.ts
+++ b/src/main/connectors/descriptors/drug-regulatory.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { DRUG_REGULATORY_TOOLS } from './drug-regulatory'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => DRUG_REGULATORY_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('drug_regulatory / openfda label', () => {
+  it('openfda_search_drug_label builds the search URL and parses compact fields', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        results: [
+          {
+            id: '22d94fd9-9488-a812-e063-6394a90a7ffc',
+            set_id: '015a6179-bacb-452d-b594-4de628ddc11d',
+            openfda: {
+              brand_name: ['TYLENOL Extra Strength'],
+              generic_name: ['ACETAMINOPHEN'],
+              manufacturer_name: ['Kenvue Brands LLC']
+            },
+            indications_and_usage: ['Uses temporarily relieves minor aches and pains.']
+          }
+        ]
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('openfda_search_drug_label'),
+      { query: 'openfda.brand_name:"Tylenol"', limit: 5 },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe(
+      'https://api.fda.gov/drug/label.json?search=openfda.brand_name%3A%22Tylenol%22&limit=5'
+    )
+    expect(out).toEqual([
+      {
+        id: '22d94fd9-9488-a812-e063-6394a90a7ffc',
+        brand_name: 'TYLENOL Extra Strength',
+        generic_name: 'ACETAMINOPHEN',
+        manufacturer: 'Kenvue Brands LLC',
+        indications: 'Uses temporarily relieves minor aches and pains.'
+      }
+    ])
+  })
+
+  it('openfda_search_drug_label defaults limit to 10 and tolerates missing results', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({}))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('openfda_search_drug_label'),
+      { query: 'aspirin' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://api.fda.gov/drug/label.json?search=aspirin&limit=10'
+    )
+    expect(out).toEqual([])
+  })
+
+  it('openfda_search_drug_label tolerates a result with no openfda block', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        results: [{ id: 'abc', indications_and_usage: undefined }]
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('openfda_search_drug_label'),
+      { query: 'abc' },
+      {}
+    )
+    expect(out).toEqual([
+      {
+        id: 'abc',
+        brand_name: undefined,
+        generic_name: undefined,
+        manufacturer: undefined,
+        indications: undefined
+      }
+    ])
+  })
+})
+
+describe('drug_regulatory / openfda adverse events', () => {
+  it('openfda_search_adverse_events builds the search URL and parses compact fields', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        results: [
+          {
+            safetyreportid: '10003304',
+            receivedate: '20140312',
+            serious: '1',
+            patient: {
+              reaction: [
+                { reactionmeddrapt: 'Drug hypersensitivity' },
+                { reactionmeddrapt: 'Nausea' }
+              ]
+            }
+          }
+        ]
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('openfda_search_adverse_events'),
+      { query: 'patient.drug.medicinalproduct:"ASPIRIN"', limit: 3 },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe(
+      'https://api.fda.gov/drug/event.json?search=patient.drug.medicinalproduct%3A%22ASPIRIN%22&limit=3'
+    )
+    expect(out).toEqual([
+      {
+        safety_report_id: '10003304',
+        receive_date: '20140312',
+        serious: true,
+        reactions: ['Drug hypersensitivity', 'Nausea']
+      }
+    ])
+  })
+
+  it('openfda_search_adverse_events returns an empty array when there are no results', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ results: [] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('openfda_search_adverse_events'),
+      { query: 'NOPE' },
+      {}
+    )
+    expect(out).toEqual([])
+  })
+})

--- a/src/main/connectors/descriptors/drug-regulatory.ts
+++ b/src/main/connectors/descriptors/drug-regulatory.ts
@@ -1,0 +1,82 @@
+import type { ToolDescriptor } from '../types'
+
+const LABEL = 'https://api.fda.gov/drug/label.json'
+const EVENT = 'https://api.fda.gov/drug/event.json'
+
+type OpenFdaBlock = {
+  brand_name?: string[]
+  generic_name?: string[]
+  manufacturer_name?: string[]
+}
+
+type LabelResult = {
+  id?: string
+  openfda?: OpenFdaBlock
+  indications_and_usage?: string[]
+}
+
+type LabelSearchResponse = { results?: LabelResult[] }
+
+type Reaction = { reactionmeddrapt?: string }
+
+type EventResult = {
+  safetyreportid?: string
+  receivedate?: string
+  serious?: string
+  patient?: { reaction?: Reaction[] }
+}
+
+type EventSearchResponse = { results?: EventResult[] }
+
+// openFDA (drug/label + drug/event): read-only regulatory search, anonymous rate limits apply.
+export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'openfda_search_drug_label',
+    connector: 'drug_regulatory',
+    description:
+      'Search FDA drug product labels (SPL) by an openFDA query, e.g. openfda.brand_name:"Tylenol".',
+    input: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        limit: { type: 'integer', default: 10 }
+      },
+      required: ['query']
+    },
+    required: ['query'],
+    url: (a) =>
+      `${LABEL}?search=${encodeURIComponent(String(a.query))}&limit=${Number(a.limit ?? 10)}`,
+    parse: (raw) =>
+      ((raw as LabelSearchResponse).results ?? []).map((r) => ({
+        id: r.id,
+        brand_name: r.openfda?.brand_name?.[0],
+        generic_name: r.openfda?.generic_name?.[0],
+        manufacturer: r.openfda?.manufacturer_name?.[0],
+        indications: r.indications_and_usage?.[0]
+      }))
+  },
+  {
+    id: 'openfda_search_adverse_events',
+    connector: 'drug_regulatory',
+    description:
+      'Search FDA adverse event reports (FAERS) by an openFDA query, e.g. patient.drug.medicinalproduct:"ASPIRIN".',
+    input: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        limit: { type: 'integer', default: 10 }
+      },
+      required: ['query']
+    },
+    required: ['query'],
+    url: (a) =>
+      `${EVENT}?search=${encodeURIComponent(String(a.query))}&limit=${Number(a.limit ?? 10)}`,
+    parse: (raw) =>
+      ((raw as EventSearchResponse).results ?? []).map((r) => ({
+        safety_report_id: r.safetyreportid,
+        receive_date: r.receivedate,
+        serious: r.serious === '1',
+        reactions: (r.patient?.reaction ?? []).map((rx) => rx.reactionmeddrapt).filter(Boolean)
+      }))
+  }
+]

--- a/src/main/connectors/descriptors/expression.test.ts
+++ b/src/main/connectors/descriptors/expression.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { EXPRESSION_TOOLS } from './expression'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => EXPRESSION_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('expression / gtex_resolve_gene', () => {
+  it('builds the reference/gene URL and parses gene rows', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        data: [
+          {
+            geneSymbol: 'BRCA2',
+            gencodeId: 'ENSG00000139618.14',
+            gencodeVersion: 'v26',
+            genomeBuild: 'GRCh38/hg38'
+          }
+        ],
+        paging_info: { numberOfPages: 1, page: 0, maxItemsPerPage: 250, totalNumberOfItems: 1 }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('gtex_resolve_gene'),
+      { geneId: 'BRCA2' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://gtexportal.org/api/v2/reference/gene?geneId=BRCA2'
+    )
+    expect(out).toEqual([
+      {
+        gene_symbol: 'BRCA2',
+        gencode_id: 'ENSG00000139618.14',
+        gencode_version: 'v26',
+        genome_build: 'GRCh38/hg38'
+      }
+    ])
+  })
+
+  it('returns an empty array when there is no data', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ data: [] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('gtex_resolve_gene'),
+      { geneId: 'NOPE' },
+      {}
+    )
+    expect(out).toEqual([])
+  })
+})
+
+describe('expression / gtex_gene_expression', () => {
+  it('builds the medianGeneExpression URL (with default dataset) and parses tissue medians', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        data: [
+          {
+            median: 0.578425,
+            tissueSiteDetailId: 'Adipose_Subcutaneous',
+            datasetId: 'gtex_v8',
+            gencodeId: 'ENSG00000139618.14',
+            geneSymbol: 'BRCA2',
+            unit: 'TPM'
+          },
+          {
+            median: 0.372348,
+            tissueSiteDetailId: 'Adipose_Visceral_Omentum',
+            datasetId: 'gtex_v8',
+            gencodeId: 'ENSG00000139618.14',
+            geneSymbol: 'BRCA2',
+            unit: 'TPM'
+          }
+        ]
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('gtex_gene_expression'),
+      { gencodeId: 'ENSG00000139618.14' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://gtexportal.org/api/v2/expression/medianGeneExpression?gencodeId=ENSG00000139618.14&datasetId=gtex_v8'
+    )
+    expect(out).toEqual([
+      { tissue: 'Adipose_Subcutaneous', median_tpm: 0.578425, unit: 'TPM' },
+      { tissue: 'Adipose_Visceral_Omentum', median_tpm: 0.372348, unit: 'TPM' }
+    ])
+  })
+
+  it('honors an explicit datasetId override', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ data: [] }))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('gtex_gene_expression'),
+      { gencodeId: 'ENSG00000139618.14', datasetId: 'gtex_v10' },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toContain('datasetId=gtex_v10')
+  })
+
+  it('returns an empty array when there is no data', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ data: [] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('gtex_gene_expression'),
+      { gencodeId: 'ENSG00000000000.0' },
+      {}
+    )
+    expect(out).toEqual([])
+  })
+})

--- a/src/main/connectors/descriptors/expression.ts
+++ b/src/main/connectors/descriptors/expression.ts
@@ -1,0 +1,71 @@
+import type { ToolDescriptor } from '../types'
+
+const GTEX = 'https://gtexportal.org/api/v2'
+const DEFAULT_DATASET = 'gtex_v8'
+
+type GtexGeneRef = {
+  geneSymbol?: string
+  gencodeId?: string
+  gencodeVersion?: string
+  genomeBuild?: string
+}
+
+type GtexGeneRefResponse = { data?: GtexGeneRef[] }
+
+type GtexMedianExpressionRow = {
+  tissueSiteDetailId?: string
+  median?: number
+  unit?: string
+}
+
+type GtexMedianExpressionResponse = { data?: GtexMedianExpressionRow[] }
+
+// GTEx Portal API v2: read-only gene reference resolution + median tissue expression (bulk RNA-seq).
+// Both routes wrap their rows in a top-level `data` array (confirmed live against v2).
+export const EXPRESSION_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'gtex_resolve_gene',
+    connector: 'expression',
+    description:
+      'Resolve a gene symbol (or unversioned Ensembl id) to its versioned GTEx gencodeId, e.g. BRCA2 -> ENSG00000139618.14.',
+    input: {
+      type: 'object',
+      properties: { geneId: { type: 'string' } },
+      required: ['geneId']
+    },
+    required: ['geneId'],
+    url: (a) => `${GTEX}/reference/gene?geneId=${encodeURIComponent(String(a.geneId))}`,
+    parse: (raw) =>
+      ((raw as GtexGeneRefResponse).data ?? []).map((g) => ({
+        gene_symbol: g.geneSymbol,
+        gencode_id: g.gencodeId,
+        gencode_version: g.gencodeVersion,
+        genome_build: g.genomeBuild
+      }))
+  },
+  {
+    id: 'gtex_gene_expression',
+    connector: 'expression',
+    description:
+      'Median gene expression (TPM) across GTEx tissues for a versioned GENCODE id (use gtex_resolve_gene first to get one from a gene symbol).',
+    input: {
+      type: 'object',
+      properties: {
+        gencodeId: { type: 'string' },
+        datasetId: { type: 'string', default: DEFAULT_DATASET }
+      },
+      required: ['gencodeId']
+    },
+    required: ['gencodeId'],
+    url: (a) => {
+      const dataset = String(a.datasetId ?? DEFAULT_DATASET)
+      return `${GTEX}/expression/medianGeneExpression?gencodeId=${encodeURIComponent(String(a.gencodeId))}&datasetId=${encodeURIComponent(dataset)}`
+    },
+    parse: (raw) =>
+      ((raw as GtexMedianExpressionResponse).data ?? []).map((r) => ({
+        tissue: r.tissueSiteDetailId,
+        median_tpm: r.median,
+        unit: r.unit
+      }))
+  }
+]

--- a/src/main/connectors/descriptors/genes.test.ts
+++ b/src/main/connectors/descriptors/genes.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { GENES_TOOLS } from './genes'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => GENES_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('genes / uniprot', () => {
+  it('uniprot_get_entry parses accession, name, gene, function', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        primaryAccession: 'P04637',
+        proteinDescription: {
+          recommendedName: { fullName: { value: 'Cellular tumor antigen p53' } }
+        },
+        genes: [{ geneName: { value: 'TP53' } }],
+        comments: [
+          { commentType: 'FUNCTION', texts: [{ value: 'Acts as a tumor suppressor.' }] },
+          { commentType: 'SUBUNIT', texts: [{ value: 'Binds DNA as a homotetramer.' }] }
+        ]
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('uniprot_get_entry'),
+      { accession: 'P04637' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://rest.uniprot.org/uniprotkb/P04637.json')
+    expect(out).toEqual({
+      accession: 'P04637',
+      name: 'Cellular tumor antigen p53',
+      gene: 'TP53',
+      function: 'Acts as a tumor suppressor.'
+    })
+  })
+
+  it('uniprot_get_entry tolerates missing function comment', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        primaryAccession: 'P04637',
+        proteinDescription: { recommendedName: { fullName: { value: 'p53' } } },
+        genes: [{ geneName: { value: 'TP53' } }],
+        comments: []
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('uniprot_get_entry'),
+      { accession: 'P04637' },
+      {}
+    )
+    expect(out).toEqual({
+      accession: 'P04637',
+      name: 'p53',
+      gene: 'TP53',
+      function: undefined
+    })
+  })
+})
+
+describe('genes / mygene', () => {
+  it('mygene_query builds the query URL and parses hits', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        hits: [
+          {
+            _id: '7157',
+            symbol: 'TP53',
+            name: 'tumor protein p53',
+            entrezgene: '7157',
+            ensembl: { gene: 'ENSG00000141510' }
+          }
+        ]
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('mygene_query'),
+      { symbol: 'TP53' },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toContain('https://mygene.info/v3/query?q=TP53')
+    expect(url).toContain('species=human')
+    expect(url).toContain('fields=symbol,name,entrezgene,ensembl.gene')
+    expect(out).toEqual([
+      {
+        symbol: 'TP53',
+        name: 'tumor protein p53',
+        entrezgene: '7157',
+        ensembl: { gene: 'ENSG00000141510' }
+      }
+    ])
+  })
+
+  it('mygene_query returns an empty array when there are no hits', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ hits: [] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('mygene_query'),
+      { symbol: 'NOPE' },
+      {}
+    )
+    expect(out).toEqual([])
+  })
+})
+
+describe('genes / go', () => {
+  it('go_get_term builds the obo_id lookup URL and parses the embedded term', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        _embedded: {
+          terms: [
+            {
+              obo_id: 'GO:0006281',
+              label: 'DNA repair',
+              description: ['The process of restoring DNA after damage.'],
+              ontology_name: 'go'
+            }
+          ]
+        }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('go_get_term'),
+      { id: 'GO:0006281' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.ebi.ac.uk/ols4/api/ontologies/go/terms?obo_id=GO%3A0006281'
+    )
+    expect(out).toEqual({
+      id: 'GO:0006281',
+      label: 'DNA repair',
+      definition: 'The process of restoring DNA after damage.',
+      ontology: 'go'
+    })
+  })
+
+  it('go_get_term tolerates an empty terms list', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ _embedded: { terms: [] } }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('go_get_term'),
+      { id: 'GO:9999999' },
+      {}
+    )
+    expect(out).toEqual({
+      id: undefined,
+      label: undefined,
+      definition: undefined,
+      ontology: undefined
+    })
+  })
+})
+
+describe('genes / reactome', () => {
+  it('reactome_pathways_for_gene defaults to the UniProt resource and human species', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes([
+        {
+          stId: 'R-HSA-111448',
+          displayName: 'Activation of NOXA and translocation to mitochondria'
+        },
+        {
+          stId: 'R-HSA-139915',
+          displayName: 'Activation of PUMA and translocation to mitochondria'
+        }
+      ])
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('reactome_pathways_for_gene'),
+      { identifier: 'P04637' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://reactome.org/ContentService/data/mapping/UniProt/P04637/pathways?species=9606'
+    )
+    expect(out).toEqual([
+      { pathway_id: 'R-HSA-111448', name: 'Activation of NOXA and translocation to mitochondria' },
+      { pathway_id: 'R-HSA-139915', name: 'Activation of PUMA and translocation to mitochondria' }
+    ])
+  })
+
+  it('reactome_pathways_for_gene honors an explicit resource and species', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('reactome_pathways_for_gene'),
+      { identifier: 'TP53', resource: 'HGNC', species: '10090' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://reactome.org/ContentService/data/mapping/HGNC/TP53/pathways?species=10090'
+    )
+    expect(out).toEqual([])
+  })
+})

--- a/src/main/connectors/descriptors/genes.ts
+++ b/src/main/connectors/descriptors/genes.ts
@@ -1,0 +1,136 @@
+import type { ToolDescriptor } from '../types'
+
+const UNIPROT = 'https://rest.uniprot.org/uniprotkb'
+const MYGENE = 'https://mygene.info/v3/query'
+// Explicit fields (mirrors upstream mygene client's "no implicit defaults" convention).
+const MYGENE_FIELDS = 'symbol,name,entrezgene,ensembl.gene'
+const OLS = 'https://www.ebi.ac.uk/ols4/api'
+const REACTOME_CONTENT = 'https://reactome.org/ContentService'
+
+type UniProtEntry = {
+  primaryAccession?: string
+  proteinDescription?: { recommendedName?: { fullName?: { value?: string } } }
+  genes?: Array<{ geneName?: { value?: string } }>
+  comments?: Array<{ commentType?: string; texts?: Array<{ value?: string }> }>
+}
+
+type MyGeneHit = {
+  symbol?: string
+  name?: string
+  entrezgene?: string
+  ensembl?: { gene?: string } | Array<{ gene?: string }>
+}
+
+type MyGeneResponse = { hits?: MyGeneHit[] }
+
+// EBI OLS4 v1 term JSON (see `ontologies/{ontology}/terms?obo_id=...`).
+type OlsTerm = {
+  obo_id?: string
+  label?: string
+  description?: string[]
+  ontology_name?: string
+}
+
+type OlsTermsResponse = { _embedded?: { terms?: OlsTerm[] } }
+
+// Reactome ContentService pathway-mapping entry (`data/mapping/{resource}/{id}/pathways`).
+type ReactomePathway = {
+  stId?: string
+  displayName?: string
+}
+
+// UniProtKB REST + MyGene.info + EBI OLS4 (GO) + Reactome ContentService: read-only lookups.
+export const GENES_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'uniprot_get_entry',
+    connector: 'genes',
+    description: 'Get a UniProtKB entry (protein name, gene, function) for an accession.',
+    input: {
+      type: 'object',
+      properties: { accession: { type: 'string' } },
+      required: ['accession']
+    },
+    required: ['accession'],
+    url: (a) => `${UNIPROT}/${encodeURIComponent(String(a.accession))}.json`,
+    parse: (raw) => {
+      const entry = raw as UniProtEntry
+      const fn = entry.comments?.find((c) => c.commentType === 'FUNCTION')
+      return {
+        accession: entry.primaryAccession,
+        name: entry.proteinDescription?.recommendedName?.fullName?.value,
+        gene: entry.genes?.[0]?.geneName?.value,
+        function: fn?.texts?.[0]?.value
+      }
+    }
+  },
+  {
+    id: 'mygene_query',
+    connector: 'genes',
+    description: 'Resolve a gene symbol to identifiers (Entrez, Ensembl) via MyGene.info.',
+    input: {
+      type: 'object',
+      properties: { symbol: { type: 'string' } },
+      required: ['symbol']
+    },
+    required: ['symbol'],
+    url: (a) =>
+      `${MYGENE}?q=${encodeURIComponent(String(a.symbol))}&species=human&fields=${MYGENE_FIELDS}`,
+    parse: (raw) =>
+      ((raw as MyGeneResponse).hits ?? []).map((h) => ({
+        symbol: h.symbol,
+        name: h.name,
+        entrezgene: h.entrezgene,
+        ensembl: h.ensembl
+      }))
+  },
+  {
+    id: 'go_get_term',
+    connector: 'genes',
+    description: 'Look up a Gene Ontology term (label, definition) by GO id via EBI OLS4.',
+    input: {
+      type: 'object',
+      properties: { id: { type: 'string', description: 'GO term id, e.g. GO:0006281' } },
+      required: ['id']
+    },
+    required: ['id'],
+    // OLS4 `obo_id` lookup avoids double-encoding a full term IRI (see upstream ols_terms client).
+    url: (a) => `${OLS}/ontologies/go/terms?obo_id=${encodeURIComponent(String(a.id))}`,
+    parse: (raw) => {
+      const term = (raw as OlsTermsResponse)._embedded?.terms?.[0]
+      return {
+        id: term?.obo_id,
+        label: term?.label,
+        definition: term?.description?.[0],
+        ontology: term?.ontology_name
+      }
+    }
+  },
+  {
+    id: 'reactome_pathways_for_gene',
+    connector: 'genes',
+    description: 'Map a gene symbol or UniProt accession to Reactome pathways via ContentService.',
+    input: {
+      type: 'object',
+      properties: {
+        identifier: { type: 'string', description: 'Gene symbol or UniProt accession' },
+        resource: {
+          type: 'string',
+          description: "Reactome identifier resource (default 'UniProt')"
+        },
+        species: { type: 'string', description: "NCBI taxon id (default '9606', human)" }
+      },
+      required: ['identifier']
+    },
+    required: ['identifier'],
+    url: (a) => {
+      const resource = a.resource ? String(a.resource) : 'UniProt'
+      const species = a.species ? String(a.species) : '9606'
+      return `${REACTOME_CONTENT}/data/mapping/${encodeURIComponent(resource)}/${encodeURIComponent(String(a.identifier))}/pathways?species=${encodeURIComponent(species)}`
+    },
+    parse: (raw) =>
+      ((raw as ReactomePathway[]) ?? []).map((p) => ({
+        pathway_id: p.stId,
+        name: p.displayName
+      }))
+  }
+]

--- a/src/main/connectors/descriptors/genomes.test.ts
+++ b/src/main/connectors/descriptors/genomes.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { GENOMES_TOOLS } from './genomes'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => GENOMES_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+const BRCA2_FEATURE = {
+  id: 'ENSG00000139618',
+  display_name: 'BRCA2',
+  biotype: 'protein_coding',
+  seq_region_name: '13',
+  start: 32315086,
+  end: 32400268,
+  strand: 1,
+  version: 19,
+  assembly_name: 'GRCh38',
+  description: 'BRCA2 DNA repair associated'
+}
+
+describe('genomes / ensembl_lookup_symbol', () => {
+  it('builds the lookup URL with a default species and parses the feature', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(BRCA2_FEATURE))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('ensembl_lookup_symbol'),
+      { symbol: 'BRCA2' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rest.ensembl.org/lookup/symbol/homo_sapiens/BRCA2?content-type=application/json'
+    )
+    expect(out).toEqual({
+      id: 'ENSG00000139618',
+      display_name: 'BRCA2',
+      biotype: 'protein_coding',
+      seq_region_name: '13',
+      start: 32315086,
+      end: 32400268,
+      strand: 1
+    })
+  })
+
+  it('honors an explicit species', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(BRCA2_FEATURE))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('ensembl_lookup_symbol'),
+      { symbol: 'Brca2', species: 'mus_musculus' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rest.ensembl.org/lookup/symbol/mus_musculus/Brca2?content-type=application/json'
+    )
+  })
+})
+
+describe('genomes / ensembl_lookup_id', () => {
+  it('builds the lookup URL and parses the feature', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(BRCA2_FEATURE))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('ensembl_lookup_id'),
+      { id: 'ENSG00000139618' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rest.ensembl.org/lookup/id/ENSG00000139618?content-type=application/json'
+    )
+    expect(out).toEqual({
+      id: 'ENSG00000139618',
+      display_name: 'BRCA2',
+      biotype: 'protein_coding',
+      seq_region_name: '13',
+      start: 32315086,
+      end: 32400268,
+      strand: 1
+    })
+  })
+})

--- a/src/main/connectors/descriptors/genomes.ts
+++ b/src/main/connectors/descriptors/genomes.ts
@@ -1,0 +1,77 @@
+import type { ToolDescriptor } from '../types'
+
+const ENSEMBL = 'https://rest.ensembl.org'
+const DEFAULT_SPECIES = 'homo_sapiens'
+
+type EnsemblFeature = {
+  id?: string
+  display_name?: string
+  biotype?: string
+  seq_region_name?: string
+  start?: number
+  end?: number
+  strand?: number
+}
+
+type ParsedFeature = {
+  id?: string
+  display_name?: string
+  biotype?: string
+  seq_region_name?: string
+  start?: number
+  end?: number
+  strand?: number
+}
+
+function parseFeature(raw: unknown): ParsedFeature {
+  const f = raw as EnsemblFeature
+  return {
+    id: f.id,
+    display_name: f.display_name,
+    biotype: f.biotype,
+    seq_region_name: f.seq_region_name,
+    start: f.start,
+    end: f.end,
+    strand: f.strand
+  }
+}
+
+// Ensembl REST: read-only gene lookups by symbol or stable ID (keyless GETs, no rate-limit key).
+export const GENOMES_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'ensembl_lookup_symbol',
+    connector: 'genomes',
+    description:
+      'Look up a gene by symbol (e.g. BRCA2) and species; returns its Ensembl ID, biotype, and genomic location.',
+    input: {
+      type: 'object',
+      properties: {
+        symbol: { type: 'string' },
+        species: { type: 'string', default: DEFAULT_SPECIES }
+      },
+      required: ['symbol']
+    },
+    required: ['symbol'],
+    url: (a) => {
+      const species = String(a.species ?? DEFAULT_SPECIES)
+      const symbol = String(a.symbol)
+      return `${ENSEMBL}/lookup/symbol/${encodeURIComponent(species)}/${encodeURIComponent(symbol)}?content-type=application/json`
+    },
+    parse: parseFeature
+  },
+  {
+    id: 'ensembl_lookup_id',
+    connector: 'genomes',
+    description:
+      'Look up a gene, transcript, or exon by Ensembl stable ID; returns its biotype and genomic location.',
+    input: {
+      type: 'object',
+      properties: { id: { type: 'string' } },
+      required: ['id']
+    },
+    required: ['id'],
+    url: (a) =>
+      `${ENSEMBL}/lookup/id/${encodeURIComponent(String(a.id))}?content-type=application/json`,
+    parse: parseFeature
+  }
+]

--- a/src/main/connectors/descriptors/geo.test.ts
+++ b/src/main/connectors/descriptors/geo.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { GEO_TOOLS } from './geo'
+
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('geo', () => {
+  it('esearch + esummary, includes etiquette', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonRes({ esearchresult: { count: '20657', idlist: ['200272072', '200327658'] } })
+      )
+      .mockResolvedValueOnce(
+        jsonRes({
+          result: {
+            '200272072': {
+              accession: 'GSE272072',
+              title: 'Effects of dexamethasone and desisobutyryl ciclesonide on gene expression',
+              summary: 'Infants born before 30 weeks gestation are at risk of developing BPD.',
+              taxon: 'Rattus norvegicus',
+              n_samples: 24,
+              gdstype: 'Expression profiling by high throughput sequencing'
+            },
+            '200327658': {
+              accession: 'GSE327658',
+              title: 'Persistent transcriptomic changes following repeated exposure to wood smoke',
+              summary: 'Exposure to wildfire smoke is a significant public health concern.',
+              taxon: 'Macaca mulatta',
+              n_samples: 8,
+              gdstype: 'Methylation profiling by high throughput sequencing'
+            }
+          }
+        })
+      )
+    const tool = GEO_TOOLS.find((t) => t.id === 'geo_search')!
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool,
+      { term: 'asthma', retmax: 2 },
+      { ncbiEmail: 'x@y.org' }
+    )) as {
+      count: number
+      records: unknown[]
+    }
+    expect(fetchImpl.mock.calls[0][0]).toContain('email=x%40y.org')
+    expect(fetchImpl.mock.calls[0][0]).toContain('db=gds')
+    expect(out.count).toBe(20657)
+    expect(out.records).toEqual([
+      {
+        accession: 'GSE272072',
+        title: 'Effects of dexamethasone and desisobutyryl ciclesonide on gene expression',
+        summary: 'Infants born before 30 weeks gestation are at risk of developing BPD.',
+        taxon: 'Rattus norvegicus',
+        n_samples: 24,
+        gdstype: 'Expression profiling by high throughput sequencing'
+      },
+      {
+        accession: 'GSE327658',
+        title: 'Persistent transcriptomic changes following repeated exposure to wood smoke',
+        summary: 'Exposure to wildfire smoke is a significant public health concern.',
+        taxon: 'Macaca mulatta',
+        n_samples: 8,
+        gdstype: 'Methylation profiling by high throughput sequencing'
+      }
+    ])
+  })
+})

--- a/src/main/connectors/descriptors/geo.ts
+++ b/src/main/connectors/descriptors/geo.ts
@@ -1,0 +1,54 @@
+import { ncbiEtiquette } from '../engine'
+import type { ToolDescriptor } from '../types'
+
+const EUTILS = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils'
+
+// esummary db=gds document shape (confirmed live against real records — field names are lowercase
+// and unprefixed: `accession`, `title`, `summary`, `taxon`, `n_samples`, `gdstype`).
+type GdsSummaryDoc = {
+  accession?: string
+  title?: string
+  summary?: string
+  taxon?: string
+  n_samples?: number | string
+  gdstype?: string
+}
+
+// NCBI E-utilities in JSON mode against db=gds (GEO DataSets): esearch -> esummary (mirrors pubmed.ts).
+export const GEO_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'geo_search',
+    connector: 'geo',
+    description:
+      'Search NCBI GEO DataSets; returns total count and series/dataset summary records.',
+    input: {
+      type: 'object',
+      properties: { term: { type: 'string' }, retmax: { type: 'integer', default: 5 } },
+      required: ['term']
+    },
+    required: ['term'],
+    run: async (ctx, a) => {
+      const q = ncbiEtiquette(ctx.credentials)
+      const es = (await ctx.fetchJson(
+        `${EUTILS}/esearch.fcgi?db=gds&retmode=json&retmax=${Number(a.retmax ?? 5)}&term=${encodeURIComponent(String(a.term))}${q}`
+      )) as { esearchresult?: { count?: string; idlist?: string[] } }
+      const ids = es.esearchresult?.idlist ?? []
+      if (!ids.length) return { term: a.term, count: 0, records: [] }
+      const sum = (await ctx.fetchJson(
+        `${EUTILS}/esummary.fcgi?db=gds&retmode=json&id=${ids.join(',')}${q}`
+      )) as { result: Record<string, GdsSummaryDoc> }
+      return {
+        term: a.term,
+        count: Number(es.esearchresult?.count ?? 0),
+        records: ids.map((id) => ({
+          accession: sum.result[id]?.accession,
+          title: sum.result[id]?.title,
+          summary: sum.result[id]?.summary,
+          taxon: sum.result[id]?.taxon,
+          n_samples: Number(sum.result[id]?.n_samples ?? 0),
+          gdstype: sum.result[id]?.gdstype
+        }))
+      }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/gnomad.test.ts
+++ b/src/main/connectors/descriptors/gnomad.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { GNOMAD_TOOLS } from './gnomad'
+
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('gnomad', () => {
+  it('POSTs a GraphQL query + variables and parses gene variants', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        data: {
+          gene: {
+            gene_id: 'ENSG00000169174',
+            symbol: 'PCSK9',
+            chrom: '1',
+            start: 55039475,
+            stop: 55064852,
+            variants: [
+              {
+                variant_id: '1-55039774-C-T',
+                pos: 55039774,
+                ref: 'C',
+                alt: 'T',
+                rsids: ['rs28362263'],
+                exome: { ac: 5, an: 251312, af: 0.0000199 },
+                genome: { ac: 1, an: 152180, af: 0.0000066 }
+              }
+            ]
+          }
+        }
+      })
+    )
+    const tool = GNOMAD_TOOLS.find((t) => t.id === 'gnomad_gene_variants')!
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool,
+      { gene_symbol: 'PCSK9' },
+      {}
+    )) as {
+      gene_id: string
+      symbol: string
+      dataset: string
+      n_variants_total: number
+      returned: number
+      variants: Array<{ variant_id: string; exome: unknown; genome: unknown }>
+    }
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://gnomad.broadinstitute.org/api')
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as { query: string; variables: unknown }
+    expect(body.query).toContain('query GeneVariants')
+    expect(body.query).toContain('variants(dataset: $dataset)')
+    expect(body.variables).toEqual({ symbol: 'PCSK9', geneId: null, dataset: 'gnomad_r4' })
+
+    expect(out.gene_id).toBe('ENSG00000169174')
+    expect(out.symbol).toBe('PCSK9')
+    expect(out.dataset).toBe('gnomad_r4')
+    expect(out.n_variants_total).toBe(1)
+    expect(out.returned).toBe(1)
+    expect(out.variants).toEqual([
+      {
+        variant_id: '1-55039774-C-T',
+        pos: 55039774,
+        ref: 'C',
+        alt: 'T',
+        rsids: ['rs28362263'],
+        exome: { ac: 5, an: 251312, af: 0.0000199 },
+        genome: { ac: 1, an: 152180, af: 0.0000066 }
+      }
+    ])
+  })
+
+  it('bounds the variant payload to the limit while reporting the true total', async () => {
+    const makeVariant = (i: number): unknown => ({
+      variant_id: `1-${55039774 + i}-C-T`,
+      pos: 55039774 + i,
+      ref: 'C',
+      alt: 'T',
+      rsids: [],
+      exome: null,
+      genome: null
+    })
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        data: {
+          gene: {
+            gene_id: 'ENSG00000169174',
+            symbol: 'PCSK9',
+            chrom: '1',
+            start: 55039475,
+            stop: 55064852,
+            variants: Array.from({ length: 30 }, (_, i) => makeVariant(i))
+          }
+        }
+      })
+    )
+    const tool = GNOMAD_TOOLS.find((t) => t.id === 'gnomad_gene_variants')!
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool,
+      { gene_symbol: 'PCSK9', limit: 10 },
+      {}
+    )) as { n_variants_total: number; returned: number; variants: unknown[] }
+
+    expect(out.n_variants_total).toBe(30)
+    expect(out.returned).toBe(10)
+    expect(out.variants).toHaveLength(10)
+  })
+
+  it('defaults the limit to 25 when unspecified', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        data: {
+          gene: {
+            gene_id: 'ENSG00000169174',
+            symbol: 'PCSK9',
+            variants: Array.from({ length: 40 }, (_, i) => ({
+              variant_id: `1-${55039774 + i}-C-T`,
+              pos: 55039774 + i,
+              ref: 'C',
+              alt: 'T',
+              rsids: [],
+              exome: null,
+              genome: null
+            }))
+          }
+        }
+      })
+    )
+    const tool = GNOMAD_TOOLS.find((t) => t.id === 'gnomad_gene_variants')!
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool,
+      { gene_symbol: 'PCSK9' },
+      {}
+    )) as {
+      n_variants_total: number
+      returned: number
+    }
+
+    expect(out.n_variants_total).toBe(40)
+    expect(out.returned).toBe(25)
+  })
+
+  it('honors an explicit dataset arg', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ data: { gene: { gene_id: 'g1', variants: [] } } }))
+    const tool = GNOMAD_TOOLS.find((t) => t.id === 'gnomad_gene_variants')!
+    await new ParserEngine({ fetchImpl }).call(
+      tool,
+      { gene_symbol: 'BRCA1', dataset: 'gnomad_r2_1' },
+      {}
+    )
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string) as { variables: { dataset: string } }
+    expect(body.variables.dataset).toBe('gnomad_r2_1')
+  })
+
+  it('returns an empty compact result when the gene is absent (data null), keyed by symbol', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ data: { gene: null } }))
+    const tool = GNOMAD_TOOLS.find((t) => t.id === 'gnomad_gene_variants')!
+    const out = (await new ParserEngine({ fetchImpl }).call(tool, { gene_symbol: 'NOPE' }, {})) as {
+      symbol: string
+      gene_id: null
+      n_variants: number
+      variants: unknown[]
+    }
+    expect(out.symbol).toBe('NOPE')
+    expect(out.gene_id).toBeNull()
+    expect(out.n_variants).toBe(0)
+    expect(out.variants).toEqual([])
+  })
+
+  it('returns an empty compact result on a "gene not found" GraphQL error, keyed by symbol', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonRes({ data: { gene: null }, errors: [{ message: 'Gene not found' }] })
+      )
+    const tool = GNOMAD_TOOLS.find((t) => t.id === 'gnomad_gene_variants')!
+    const out = (await new ParserEngine({ fetchImpl }).call(tool, { gene_symbol: 'NOPE' }, {})) as {
+      symbol: string
+      n_variants: number
+    }
+    expect(out.symbol).toBe('NOPE')
+    expect(out.n_variants).toBe(0)
+  })
+
+  it('throws on a non-not-found GraphQL error', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ errors: [{ message: 'query complexity too high' }] }))
+    const tool = GNOMAD_TOOLS.find((t) => t.id === 'gnomad_gene_variants')!
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool, { gene_symbol: 'PCSK9' }, {})
+    ).rejects.toThrow(/query complexity too high/)
+  })
+})

--- a/src/main/connectors/descriptors/gnomad.ts
+++ b/src/main/connectors/descriptors/gnomad.ts
@@ -1,0 +1,131 @@
+import type { ToolDescriptor } from '../types'
+
+const GNOMAD_API = 'https://gnomad.broadinstitute.org/api'
+// gnomAD defaults its own UI/API to gnomad_r4 (current release); pin it explicitly rather than
+// relying on the server-side default so callers get a stable, documented dataset.
+const DEFAULT_DATASET = 'gnomad_r4'
+// A gene like TTN/BRCA2 can carry tens of thousands of variants — bound the response like geo
+// (retmax) and openalex (per_page) do, rather than returning every row unbounded.
+const DEFAULT_LIMIT = 25
+
+// Lean gene-scoped variant listing (transcribed from the upstream gnomad_variants GraphQL
+// document): gene id/span plus a compact per-variant row. Field selection matches gnomAD's
+// complexity-limited API — only scientifically load-bearing fields are requested.
+const GENE_VARIANTS_QUERY = `
+query GeneVariants($symbol: String, $geneId: String, $dataset: DatasetId!) {
+  gene(gene_symbol: $symbol, gene_id: $geneId, reference_genome: GRCh38) {
+    gene_id symbol start stop chrom
+    variants(dataset: $dataset) {
+      variant_id pos ref alt rsids
+      exome { ac an af } genome { ac an af }
+    }
+  }
+}
+`
+
+type FreqBlock = { ac?: number; an?: number; af?: number } | null
+
+type GeneVariantRow = {
+  variant_id: string
+  pos?: number
+  ref?: string
+  alt?: string
+  rsids?: string[] | null
+  exome?: FreqBlock
+  genome?: FreqBlock
+}
+
+type GeneVariantsResponse = {
+  data?: {
+    gene?: {
+      gene_id: string
+      symbol?: string
+      chrom?: string
+      start?: number
+      stop?: number
+      variants?: GeneVariantRow[] | null
+    } | null
+  }
+  errors?: Array<{ message?: string }>
+}
+
+// GraphQL error messages that mean "entity absent", not "request failed" — mirrors the upstream
+// gnomad_variants client's NOT_FOUND_MESSAGES handling for the gene lookup.
+const NOT_FOUND_MESSAGES = new Set(['gene not found'])
+
+function freqBlock(block: FreqBlock): FreqBlock {
+  if (!block) return null
+  return { ac: block.ac, an: block.an, af: block.af }
+}
+
+// gnomAD is GraphQL-only: every call is a POST of {query, variables} to a single endpoint.
+export const GNOMAD_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'gnomad_gene_variants',
+    connector: 'gnomad',
+    description:
+      'gnomAD population variants for a gene by symbol: variant ids, positions, alleles, rsids, and exome/genome allele counts and frequencies.',
+    input: {
+      type: 'object',
+      properties: {
+        gene_symbol: { type: 'string' },
+        dataset: { type: 'string', default: DEFAULT_DATASET },
+        limit: { type: 'integer', default: DEFAULT_LIMIT }
+      },
+      required: ['gene_symbol']
+    },
+    required: ['gene_symbol'],
+    run: async (ctx, a) => {
+      const symbol = String(a.gene_symbol)
+      const dataset = String(a.dataset ?? DEFAULT_DATASET)
+      const limit = Number(a.limit ?? DEFAULT_LIMIT)
+      const result = (await ctx.postJson(GNOMAD_API, {
+        query: GENE_VARIANTS_QUERY,
+        variables: { symbol, geneId: null, dataset }
+      })) as GeneVariantsResponse
+
+      const errors = result.errors ?? []
+      if (
+        errors.length &&
+        !errors.every((e) =>
+          NOT_FOUND_MESSAGES.has(
+            String(e.message ?? '')
+              .trim()
+              .toLowerCase()
+          )
+        )
+      ) {
+        throw new Error(`gnomAD GraphQL error: ${errors.map((e) => e.message).join('; ')}`)
+      }
+
+      const gene = result.data?.gene
+      if (!gene) {
+        // Absent entity (data null, or only "gene not found" errors) — compact empty result.
+        return { symbol, dataset, gene_id: null, n_variants: 0, variants: [] }
+      }
+
+      const allVariants = (gene.variants ?? []).map((v) => ({
+        variant_id: v.variant_id,
+        pos: v.pos,
+        ref: v.ref,
+        alt: v.alt,
+        rsids: v.rsids ?? [],
+        exome: freqBlock(v.exome ?? null),
+        genome: freqBlock(v.genome ?? null)
+      }))
+      const variants = allVariants.slice(0, limit)
+
+      return {
+        gene_id: gene.gene_id,
+        symbol: gene.symbol ?? symbol,
+        chrom: gene.chrom,
+        start: gene.start,
+        stop: gene.stop,
+        dataset,
+        n_variants_total: allVariants.length,
+        returned: variants.length,
+        variants
+      }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/human-genetics.test.ts
+++ b/src/main/connectors/descriptors/human-genetics.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { HUMAN_GENETICS_TOOLS } from './human-genetics'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => HUMAN_GENETICS_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+// GWAS Catalog REST API v2 shape: flat snake_case association records wrapped in a HAL-style
+// `_embedded` collection (confirmed against the upstream fleet client's gwas_catalog/tool.py).
+const HAL_ASSOCIATIONS = {
+  page: { size: 50, totalElements: 2, totalPages: 1, number: 0 },
+  _embedded: {
+    associations: [
+      {
+        association_id: '12345',
+        p_value: 1.2e-15,
+        snp_effect_allele: ['rs7412-T'],
+        snp_allele: [{ rs_id: 'rs7412' }],
+        mapped_genes: ['APOE'],
+        efo_traits: [{ efo_id: 'EFO_0004611', efo_trait: 'LDL cholesterol measurement' }],
+        reported_trait: ['LDL cholesterol']
+      },
+      {
+        association_id: '67890',
+        p_value: 3.4e-8,
+        snp_effect_allele: ['rs429358-C'],
+        snp_allele: [{ rs_id: 'rs429358' }],
+        mapped_genes: ['APOE', 'TOMM40'],
+        efo_traits: [],
+        reported_trait: ['Alzheimer disease']
+      }
+    ]
+  }
+}
+
+describe('human_genetics / gwas_search_associations', () => {
+  it('builds the mapped_gene URL and parses the HAL _embedded collection', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(HAL_ASSOCIATIONS))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('gwas_search_associations'),
+      { gene: 'APOE' },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe(
+      'https://www.ebi.ac.uk/gwas/rest/api/v2/associations?mapped_gene=APOE&size=50&sort=p_value&direction=asc'
+    )
+    expect(out).toEqual([
+      {
+        rsId: 'rs7412',
+        pValue: 1.2e-15,
+        riskAllele: 'rs7412-T',
+        mappedGenes: ['APOE'],
+        trait: 'LDL cholesterol measurement'
+      },
+      {
+        rsId: 'rs429358',
+        pValue: 3.4e-8,
+        riskAllele: 'rs429358-C',
+        mappedGenes: ['APOE', 'TOMM40'],
+        trait: 'Alzheimer disease'
+      }
+    ])
+  })
+
+  it('returns an empty array when there are no embedded associations', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ page: { totalElements: 0 }, _embedded: { associations: [] } }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('gwas_search_associations'),
+      { gene: 'NOPE' },
+      {}
+    )
+    expect(out).toEqual([])
+  })
+})
+
+describe('human_genetics / gwas_variant_associations', () => {
+  it('builds the rs_id URL and parses associations', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(HAL_ASSOCIATIONS))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('gwas_variant_associations'),
+      { rsId: 'rs7412' },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe(
+      'https://www.ebi.ac.uk/gwas/rest/api/v2/associations?rs_id=rs7412&size=50&sort=p_value&direction=asc'
+    )
+    expect((out as unknown[])[0]).toEqual({
+      rsId: 'rs7412',
+      pValue: 1.2e-15,
+      riskAllele: 'rs7412-T',
+      mappedGenes: ['APOE'],
+      trait: 'LDL cholesterol measurement'
+    })
+  })
+
+  it('tolerates missing embedded/trait fields', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        page: { totalElements: 1 },
+        _embedded: {
+          associations: [{ p_value: 0.001, snp_allele: [{ rs_id: 'rs1' }], mapped_genes: [] }]
+        }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('gwas_variant_associations'),
+      { rsId: 'rs1' },
+      {}
+    )
+    expect(out).toEqual([
+      { rsId: 'rs1', pValue: 0.001, riskAllele: undefined, mappedGenes: [], trait: undefined }
+    ])
+  })
+})

--- a/src/main/connectors/descriptors/human-genetics.ts
+++ b/src/main/connectors/descriptors/human-genetics.ts
@@ -1,0 +1,78 @@
+import type { ToolDescriptor } from '../types'
+
+const GWAS_ASSOCIATIONS = 'https://www.ebi.ac.uk/gwas/rest/api/v2/associations'
+const PAGE_SIZE = 50
+
+// v2 API response shapes (confirmed against the upstream fleet client's gwas_catalog/tool.py:
+// flat snake_case records wrapped in a HAL-style `_embedded` collection, NOT link-follow HATEOAS).
+type GwasEfoTrait = { efo_id?: string; efo_trait?: string }
+type GwasSnpAllele = { rs_id?: string }
+type GwasAssociationRecord = {
+  p_value?: number
+  snp_effect_allele?: string[]
+  snp_allele?: GwasSnpAllele[]
+  mapped_genes?: string[]
+  efo_traits?: GwasEfoTrait[]
+  reported_trait?: string[]
+}
+type GwasAssociationsResponse = { _embedded?: { associations?: GwasAssociationRecord[] } }
+
+type CompactAssociation = {
+  rsId?: string
+  pValue?: number
+  riskAllele?: string
+  mappedGenes: string[]
+  trait?: string
+}
+
+function flattenAssociations(raw: unknown): CompactAssociation[] {
+  const records = (raw as GwasAssociationsResponse)._embedded?.associations ?? []
+  return records.map((rec) => ({
+    rsId: rec.snp_allele?.[0]?.rs_id,
+    pValue: rec.p_value,
+    riskAllele: rec.snp_effect_allele?.[0],
+    mappedGenes: rec.mapped_genes ?? [],
+    trait: rec.efo_traits?.[0]?.efo_trait ?? rec.reported_trait?.[0]
+  }))
+}
+
+// NHGRI-EBI GWAS Catalog REST API v2: read-only genome-wide-association lookups by gene or rsID.
+export const HUMAN_GENETICS_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'gwas_search_associations',
+    connector: 'human_genetics',
+    description:
+      'Search GWAS Catalog associations mapped to a gene symbol, most significant (lowest p-value) first.',
+    input: {
+      type: 'object',
+      properties: {
+        gene: {
+          type: 'string',
+          description: 'HGNC gene symbol, exact match, e.g. PCSK9, APOE'
+        }
+      },
+      required: ['gene']
+    },
+    required: ['gene'],
+    url: (a) =>
+      `${GWAS_ASSOCIATIONS}?mapped_gene=${encodeURIComponent(String(a.gene))}&size=${PAGE_SIZE}&sort=p_value&direction=asc`,
+    parse: (raw) => flattenAssociations(raw)
+  },
+  {
+    id: 'gwas_variant_associations',
+    connector: 'human_genetics',
+    description:
+      'GWAS Catalog associations reported for one dbSNP variant (rsID), most significant first.',
+    input: {
+      type: 'object',
+      properties: {
+        rsId: { type: 'string', description: 'dbSNP rsID, e.g. rs7412' }
+      },
+      required: ['rsId']
+    },
+    required: ['rsId'],
+    url: (a) =>
+      `${GWAS_ASSOCIATIONS}?rs_id=${encodeURIComponent(String(a.rsId))}&size=${PAGE_SIZE}&sort=p_value&direction=asc`,
+    parse: (raw) => flattenAssociations(raw)
+  }
+]

--- a/src/main/connectors/descriptors/literature.test.ts
+++ b/src/main/connectors/descriptors/literature.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { LITERATURE_TOOLS } from './literature'
+
+const ATOM = `<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom">
+<entry><id>http://arxiv.org/abs/1234</id><title>Test Title</title><summary>A summary.</summary></entry>
+</feed>`
+
+describe('literature / arxiv', () => {
+  it('parses Atom XML entries', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 200, text: async () => ATOM } as Response)
+    const tool = LITERATURE_TOOLS.find((t) => t.id === 'arxiv_search')!
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool,
+      { query: 'diffusion' },
+      {}
+    )) as unknown[]
+    expect(out).toEqual([
+      { id: 'http://arxiv.org/abs/1234', title: 'Test Title', summary: 'A summary.' }
+    ])
+  })
+})

--- a/src/main/connectors/descriptors/literature.ts
+++ b/src/main/connectors/descriptors/literature.ts
@@ -1,0 +1,30 @@
+import { DOMParser } from '@xmldom/xmldom'
+import type { ToolDescriptor } from '../types'
+
+const text = (el: Element | undefined): string | undefined => el?.textContent?.trim() ?? undefined
+
+// arXiv Atom API: read-only literature search (XML response).
+export const LITERATURE_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'arxiv_search',
+    connector: 'literature',
+    description: 'Search arXiv papers; returns id, title, and summary per hit.',
+    input: {
+      type: 'object',
+      properties: { query: { type: 'string' }, max_results: { type: 'integer', default: 5 } },
+      required: ['query']
+    },
+    required: ['query'],
+    format: 'text',
+    url: (a) =>
+      `https://export.arxiv.org/api/query?search_query=all:${encodeURIComponent(String(a.query))}&max_results=${Number(a.max_results ?? 5)}`,
+    parse: (raw) => {
+      const doc = new DOMParser().parseFromString(String(raw), 'text/xml')
+      return Array.from(doc.getElementsByTagName('entry')).map((e) => ({
+        id: text(e.getElementsByTagName('id')[0]),
+        title: text(e.getElementsByTagName('title')[0]),
+        summary: text(e.getElementsByTagName('summary')[0])
+      }))
+    }
+  }
+]

--- a/src/main/connectors/descriptors/omics-archives.test.ts
+++ b/src/main/connectors/descriptors/omics-archives.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { OMICS_ARCHIVES_TOOLS } from './omics-archives'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => OMICS_ARCHIVES_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('omics_archives / arrayexpress_search', () => {
+  it('builds the search URL and parses hits to a compact shape', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        page: 1,
+        pageSize: 2,
+        totalHits: 15546,
+        isTotalHitsExact: true,
+        hits: [
+          {
+            accession: 'E-MTAB-17244',
+            type: 'study',
+            title: 'Single-nucleus RNA sequencing of human fetal lung from 4 anatomic regions',
+            author: 'Xiangning Dong',
+            links: 1,
+            files: 42,
+            release_date: '2026-07-12',
+            views: 0,
+            isPublic: true
+          }
+        ]
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('arrayexpress_search'),
+      { query: 'cancer', pageSize: 2 },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe(
+      'https://www.ebi.ac.uk/biostudies/api/v1/arrayexpress/search?query=cancer&pageSize=2&sortBy=release_date&sortOrder=descending'
+    )
+    expect(out).toEqual([
+      {
+        accession: 'E-MTAB-17244',
+        title: 'Single-nucleus RNA sequencing of human fetal lung from 4 anatomic regions',
+        type: 'study',
+        release_date: '2026-07-12'
+      }
+    ])
+  })
+
+  it('defaults pageSize when not provided', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ hits: [] }))
+    await new ParserEngine({ fetchImpl }).call(tool('arrayexpress_search'), { query: 'liver' }, {})
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toContain('pageSize=20')
+  })
+
+  it('returns an empty array when there are no hits', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ hits: [] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('arrayexpress_search'),
+      { query: 'nope-nothing-here' },
+      {}
+    )
+    expect(out).toEqual([])
+  })
+})
+
+describe('omics_archives / arrayexpress_get_study', () => {
+  it('builds the study URL and parses attributes from top-level + section', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        accno: 'E-MTAB-17244',
+        attributes: [
+          {
+            name: 'Title',
+            value: 'Single-nucleus RNA sequencing of human fetal lung from 4 anatomic regions'
+          },
+          { name: 'ReleaseDate', value: '2026-07-12' },
+          { name: 'RootPath', value: 'E-MTAB-17244' }
+        ],
+        section: {
+          accno: 's-E-MTAB-17244',
+          type: 'Study',
+          attributes: [
+            {
+              name: 'Title',
+              value: 'Single-nucleus RNA sequencing of human fetal lung from 4 anatomic regions'
+            },
+            { name: 'Study type', value: 'single nucleus RNA sequencing' },
+            { name: 'Organism', value: 'Homo sapiens' },
+            { name: 'Description', value: 'We performed micro-dissections of developing lungs.' }
+          ]
+        }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('arrayexpress_get_study'),
+      { accession: 'E-MTAB-17244' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-17244'
+    )
+    expect(out).toEqual({
+      accession: 'E-MTAB-17244',
+      title: 'Single-nucleus RNA sequencing of human fetal lung from 4 anatomic regions',
+      release_date: '2026-07-12',
+      organism: 'Homo sapiens',
+      study_type: 'single nucleus RNA sequencing',
+      description: 'We performed micro-dissections of developing lungs.'
+    })
+  })
+
+  it('tolerates a missing section', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        accno: 'E-MTAB-1',
+        attributes: [{ name: 'Title', value: 'Old study' }]
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('arrayexpress_get_study'),
+      { accession: 'E-MTAB-1' },
+      {}
+    )
+    expect(out).toEqual({
+      accession: 'E-MTAB-1',
+      title: 'Old study',
+      release_date: undefined,
+      organism: undefined,
+      study_type: undefined,
+      description: undefined
+    })
+  })
+})

--- a/src/main/connectors/descriptors/omics-archives.ts
+++ b/src/main/connectors/descriptors/omics-archives.ts
@@ -1,0 +1,86 @@
+import type { ToolDescriptor } from '../types'
+
+const BIOSTUDIES = 'https://www.ebi.ac.uk/biostudies/api/v1'
+const DEFAULT_PAGE_SIZE = 20
+
+type BioStudiesSearchHit = {
+  accession?: string
+  title?: string
+  type?: string
+  release_date?: string
+}
+
+type BioStudiesSearchResponse = { hits?: BioStudiesSearchHit[] }
+
+type BioStudiesAttribute = { name?: string; value?: string }
+
+type BioStudiesSection = { attributes?: BioStudiesAttribute[] }
+
+type BioStudiesStudy = {
+  accno?: string
+  attributes?: BioStudiesAttribute[]
+  section?: BioStudiesSection
+}
+
+const attr = (attributes: BioStudiesAttribute[] | undefined, name: string): string | undefined =>
+  attributes?.find((a) => a.name === name)?.value
+
+// BioStudies REST API (EBI): read-only search + lookup over the ArrayExpress
+// collection of functional-genomics experiments. Endpoints and field shapes
+// confirmed live against https://www.ebi.ac.uk/biostudies/api/v1.
+export const OMICS_ARCHIVES_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'arrayexpress_search',
+    connector: 'omics_archives',
+    description:
+      'Search the ArrayExpress collection of functional-genomics experiments (BioStudies) by free-text query.',
+    input: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        pageSize: { type: 'number', default: DEFAULT_PAGE_SIZE }
+      },
+      required: ['query']
+    },
+    required: ['query'],
+    url: (a) => {
+      const pageSize = Number(a.pageSize ?? DEFAULT_PAGE_SIZE)
+      return (
+        `${BIOSTUDIES}/arrayexpress/search?query=${encodeURIComponent(String(a.query))}` +
+        `&pageSize=${pageSize}&sortBy=release_date&sortOrder=descending`
+      )
+    },
+    parse: (raw) =>
+      ((raw as BioStudiesSearchResponse).hits ?? []).map((h) => ({
+        accession: h.accession,
+        title: h.title,
+        type: h.type,
+        release_date: h.release_date
+      }))
+  },
+  {
+    id: 'arrayexpress_get_study',
+    connector: 'omics_archives',
+    description:
+      'Get an ArrayExpress/BioStudies study by accession (title, release date, organism, study type, description).',
+    input: {
+      type: 'object',
+      properties: { accession: { type: 'string' } },
+      required: ['accession']
+    },
+    required: ['accession'],
+    url: (a) => `${BIOSTUDIES}/studies/${encodeURIComponent(String(a.accession))}`,
+    parse: (raw) => {
+      const study = raw as BioStudiesStudy
+      const sectionAttrs = study.section?.attributes
+      return {
+        accession: study.accno,
+        title: attr(study.attributes, 'Title'),
+        release_date: attr(study.attributes, 'ReleaseDate'),
+        organism: attr(sectionAttrs, 'Organism'),
+        study_type: attr(sectionAttrs, 'Study type'),
+        description: attr(sectionAttrs, 'Description')
+      }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/openalex.test.ts
+++ b/src/main/connectors/descriptors/openalex.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { OPENALEX_TOOLS } from './openalex'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => OPENALEX_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+const WORK = {
+  id: 'https://openalex.org/W2741809807',
+  title: 'The state of OA: a large-scale analysis',
+  publication_year: 2018,
+  doi: 'https://doi.org/10.7717/peerj.4375',
+  cited_by_count: 421,
+  authorships: [
+    { author: { display_name: 'Heather Piwowar' } },
+    { author: { display_name: 'Jason Priem' } },
+    { author: { display_name: 'Vincent Larivière' } },
+    { author: { display_name: 'Juan Pablo Alperin' } },
+    { author: { display_name: 'Lisa Matthias' } },
+    { author: { display_name: 'Bree Norlander' } }
+  ]
+}
+
+const COMPACT_WORK = {
+  id: 'W2741809807',
+  title: 'The state of OA: a large-scale analysis',
+  publication_year: 2018,
+  doi: 'https://doi.org/10.7717/peerj.4375',
+  cited_by_count: 421,
+  authors: [
+    'Heather Piwowar',
+    'Jason Priem',
+    'Vincent Larivière',
+    'Juan Pablo Alperin',
+    'Lisa Matthias'
+  ]
+}
+
+describe('openalex / search_works', () => {
+  it('builds the search URL and parses a compact list', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ results: [WORK] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('openalex_search_works'),
+      { query: 'open access' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://api.openalex.org/works?search=open%20access&per_page=5'
+    )
+    expect(out).toEqual([COMPACT_WORK])
+  })
+
+  it('respects a custom per_page and sends no mailto/api key', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ results: [] }))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('openalex_search_works'),
+      { query: 'CRISPR', per_page: 2 },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe('https://api.openalex.org/works?search=CRISPR&per_page=2')
+    expect(url).not.toContain('mailto')
+    expect(url).not.toContain('api_key')
+  })
+
+  it('returns an empty array when there are no results', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ results: [] }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('openalex_search_works'),
+      { query: 'nonexistent-topic-xyz' },
+      {}
+    )
+    expect(out).toEqual([])
+  })
+})
+
+describe('openalex / get_work', () => {
+  it('fetches by bare W-id and parses the compact shape', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(WORK))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('openalex_get_work'),
+      { id: 'W2741809807' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://api.openalex.org/works/W2741809807')
+    expect(out).toEqual(COMPACT_WORK)
+  })
+
+  it('normalizes a DOI URL to the doi: alias form', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(WORK))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('openalex_get_work'),
+      { id: 'https://doi.org/10.7717/peerj.4375' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://api.openalex.org/works/doi%3A10.7717%2Fpeerj.4375'
+    )
+  })
+})

--- a/src/main/connectors/descriptors/openalex.ts
+++ b/src/main/connectors/descriptors/openalex.ts
@@ -1,0 +1,81 @@
+import type { ToolDescriptor } from '../types'
+
+const WORKS = 'https://api.openalex.org/works'
+
+type OpenAlexAuthor = { display_name?: string }
+type OpenAlexAuthorship = { author?: OpenAlexAuthor }
+type OpenAlexWork = {
+  id?: string
+  title?: string
+  display_name?: string
+  publication_year?: number
+  doi?: string
+  cited_by_count?: number
+  authorships?: OpenAlexAuthorship[]
+}
+type OpenAlexWorksResponse = { results?: OpenAlexWork[] }
+
+const MAX_AUTHORS = 5
+
+// https://openalex.org/W... -> W...; DOI URLs pass through as https://doi.org/10...., which the
+// /works/{id} endpoint also accepts directly as a work identifier.
+const shortId = (id: string | undefined): string | undefined =>
+  id?.startsWith('https://openalex.org/') ? id.slice('https://openalex.org/'.length) : id
+
+const compactWork = (w: OpenAlexWork): Record<string, unknown> => ({
+  id: shortId(w.id),
+  title: w.title ?? w.display_name,
+  publication_year: w.publication_year,
+  doi: w.doi,
+  cited_by_count: w.cited_by_count,
+  authors: (w.authorships ?? [])
+    .slice(0, MAX_AUTHORS)
+    .map((a) => a.author?.display_name)
+    .filter((name): name is string => Boolean(name))
+})
+
+// Normalizes a work id/DOI into the /works/{id} path segment. OpenAlex accepts a bare W-id, an
+// openalex.org URL, or a DOI (bare or as a doi.org URL) via the "doi:..." alias form.
+function normalizeWorkId(input: string): string {
+  const id = input.trim()
+  if (/^https?:\/\/(dx\.)?doi\.org\//i.test(id)) {
+    return `doi:${id.replace(/^https?:\/\/(dx\.)?doi\.org\//i, '')}`
+  }
+  if (id.toLowerCase().startsWith('doi:')) return id
+  if (id.startsWith('10.') && id.includes('/')) return `doi:${id}`
+  return shortId(id) ?? id
+}
+
+// OpenAlex REST API: read-only scholarly work search/lookup. Per upstream policy sends no
+// mailto/api key on any request.
+export const OPENALEX_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'openalex_search_works',
+    connector: 'openalex',
+    description:
+      'Search OpenAlex scholarly works by keyword; returns id, title, year, DOI, citation count, and authors per hit.',
+    input: {
+      type: 'object',
+      properties: { query: { type: 'string' }, per_page: { type: 'integer', default: 5 } },
+      required: ['query']
+    },
+    required: ['query'],
+    url: (a) =>
+      `${WORKS}?search=${encodeURIComponent(String(a.query))}&per_page=${Number(a.per_page ?? 5)}`,
+    parse: (raw) => ((raw as OpenAlexWorksResponse).results ?? []).map(compactWork)
+  },
+  {
+    id: 'openalex_get_work',
+    connector: 'openalex',
+    description:
+      'Get an OpenAlex work by OpenAlex id or DOI; returns id, title, year, DOI, citation count, and authors.',
+    input: {
+      type: 'object',
+      properties: { id: { type: 'string' } },
+      required: ['id']
+    },
+    required: ['id'],
+    url: (a) => `${WORKS}/${encodeURIComponent(normalizeWorkId(String(a.id)))}`,
+    parse: (raw) => compactWork(raw as OpenAlexWork)
+  }
+]

--- a/src/main/connectors/descriptors/protein-annotation.test.ts
+++ b/src/main/connectors/descriptors/protein-annotation.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { PROTEIN_ANNOTATION_TOOLS } from './protein-annotation'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => PROTEIN_ANNOTATION_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('protein_annotation / string-db', () => {
+  it('string_interaction_partners builds the URL and parses partners + scores', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes([
+        {
+          stringId_A: '9606.ENSP00000269305',
+          stringId_B: '9606.ENSP00000340989',
+          preferredName_A: 'TP53',
+          preferredName_B: 'SFN',
+          ncbiTaxonId: 9606,
+          score: 0.999
+        },
+        {
+          stringId_A: '9606.ENSP00000269305',
+          stringId_B: '9606.ENSP00000263253',
+          preferredName_A: 'TP53',
+          preferredName_B: 'EP300',
+          ncbiTaxonId: 9606,
+          score: 0.999
+        }
+      ])
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('string_interaction_partners'),
+      { gene: 'TP53', limit: 2 },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://string-db.org/api/json/interaction_partners?identifiers=TP53&species=9606&limit=2'
+    )
+    expect(out).toEqual([
+      { partner: 'SFN', score: 0.999 },
+      { partner: 'EP300', score: 0.999 }
+    ])
+  })
+
+  it('string_interaction_partners defaults limit to 10 when omitted', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('string_interaction_partners'),
+      { gene: 'TP53' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://string-db.org/api/json/interaction_partners?identifiers=TP53&species=9606&limit=10'
+    )
+  })
+
+  it('string_network builds the URL and parses edges', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes([
+        {
+          stringId_A: '9606.ENSP00000258149',
+          stringId_B: '9606.ENSP00000269305',
+          preferredName_A: 'MDM2',
+          preferredName_B: 'TP53',
+          ncbiTaxonId: '9606',
+          score: 0.999
+        }
+      ])
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('string_network'),
+      { genes: ['TP53', 'MDM2'] },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://string-db.org/api/json/network?identifiers=TP53%2CMDM2&species=9606'
+    )
+    expect(out).toEqual([{ a: 'MDM2', b: 'TP53', score: 0.999 }])
+  })
+})

--- a/src/main/connectors/descriptors/protein-annotation.ts
+++ b/src/main/connectors/descriptors/protein-annotation.ts
@@ -1,0 +1,60 @@
+import type { ToolDescriptor } from '../types'
+
+const STRING_BASE = 'https://string-db.org/api/json'
+const HUMAN_TAXON_ID = 9606
+
+type StringEdge = {
+  preferredName_A?: string
+  preferredName_B?: string
+  score?: number
+}
+
+// STRING-DB REST (JSON output): protein-protein interaction lookups for human (taxon 9606).
+export const PROTEIN_ANNOTATION_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'string_interaction_partners',
+    connector: 'protein_annotation',
+    description: 'List STRING-DB interaction partners for a gene/protein, ranked by score.',
+    input: {
+      type: 'object',
+      properties: {
+        gene: { type: 'string' },
+        limit: { type: 'number', description: 'Max partners to return (default 10).' }
+      },
+      required: ['gene']
+    },
+    required: ['gene'],
+    url: (a) => {
+      const limit = typeof a.limit === 'number' ? a.limit : 10
+      return `${STRING_BASE}/interaction_partners?identifiers=${encodeURIComponent(String(a.gene))}&species=${HUMAN_TAXON_ID}&limit=${limit}`
+    },
+    parse: (raw) =>
+      (raw as StringEdge[]).map((e) => ({
+        partner: e.preferredName_B,
+        score: e.score
+      }))
+  },
+  {
+    id: 'string_network',
+    connector: 'protein_annotation',
+    description: 'Get the STRING-DB interaction network among a set of genes/proteins.',
+    input: {
+      type: 'object',
+      properties: {
+        genes: { type: 'array', items: { type: 'string' } }
+      },
+      required: ['genes']
+    },
+    required: ['genes'],
+    url: (a) => {
+      const genes = a.genes as string[]
+      return `${STRING_BASE}/network?identifiers=${encodeURIComponent(genes.join(','))}&species=${HUMAN_TAXON_ID}`
+    },
+    parse: (raw) =>
+      (raw as StringEdge[]).map((e) => ({
+        a: e.preferredName_A,
+        b: e.preferredName_B,
+        score: e.score
+      }))
+  }
+]

--- a/src/main/connectors/descriptors/pubmed.test.ts
+++ b/src/main/connectors/descriptors/pubmed.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { PUBMED_TOOLS } from './pubmed'
+
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('pubmed', () => {
+  it('esearch + esummary, includes etiquette', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ esearchresult: { count: '2', idlist: ['1', '2'] } }))
+      .mockResolvedValueOnce(
+        jsonRes({
+          result: { '1': { title: 'A', pubdate: '2020' }, '2': { title: 'B', pubdate: '2021' } }
+        })
+      )
+    const tool = PUBMED_TOOLS.find((t) => t.id === 'pubmed_search')!
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool,
+      { term: 'crispr', retmax: 2 },
+      { ncbiEmail: 'x@y.org' }
+    )) as {
+      count: number
+      articles: unknown[]
+    }
+    expect(fetchImpl.mock.calls[0][0]).toContain('email=x%40y.org')
+    expect(out.count).toBe(2)
+    expect(out.articles).toEqual([
+      { pmid: '1', title: 'A', date: '2020' },
+      { pmid: '2', title: 'B', date: '2021' }
+    ])
+  })
+})

--- a/src/main/connectors/descriptors/pubmed.ts
+++ b/src/main/connectors/descriptors/pubmed.ts
@@ -1,0 +1,41 @@
+import { ncbiEtiquette } from '../engine'
+import type { ToolDescriptor } from '../types'
+
+const EUTILS = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils'
+
+// NCBI E-utilities in JSON mode (no biopython/XML needed): esearch -> esummary.
+export const PUBMED_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'pubmed_search',
+    connector: 'pubmed',
+    description: 'Search PubMed; returns total count and article titles/dates.',
+    input: {
+      type: 'object',
+      properties: { term: { type: 'string' }, retmax: { type: 'integer', default: 5 } },
+      required: ['term']
+    },
+    required: ['term'],
+    run: async (ctx, a) => {
+      const q = ncbiEtiquette(ctx.credentials)
+      const es = (await ctx.fetchJson(
+        `${EUTILS}/esearch.fcgi?db=pubmed&retmode=json&retmax=${Number(a.retmax ?? 5)}&term=${encodeURIComponent(String(a.term))}${q}`
+      )) as { esearchresult?: { count?: string; idlist?: string[] } }
+      const ids = es.esearchresult?.idlist ?? []
+      if (!ids.length) return { term: a.term, count: 0, articles: [] }
+      const sum = (await ctx.fetchJson(
+        `${EUTILS}/esummary.fcgi?db=pubmed&retmode=json&id=${ids.join(',')}${q}`
+      )) as {
+        result: Record<string, { title?: string; pubdate?: string }>
+      }
+      return {
+        term: a.term,
+        count: Number(es.esearchresult?.count ?? 0),
+        articles: ids.map((id) => ({
+          pmid: id,
+          title: sum.result[id]?.title,
+          date: sum.result[id]?.pubdate
+        }))
+      }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/regulation.test.ts
+++ b/src/main/connectors/descriptors/regulation.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { REGULATION_TOOLS } from './regulation'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => REGULATION_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('regulation / encode', () => {
+  it('encode_search builds the search URL and parses @graph rows', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        '@graph': [
+          {
+            accession: 'ENCSR613LSQ',
+            assay_title: 'CRISPR RNA-seq',
+            biosample_ontology: { term_name: 'K562' },
+            target: { label: 'CTCF' },
+            status: 'released'
+          },
+          {
+            accession: 'ENCSR356GHP',
+            assay_title: 'ChIA-PET',
+            biosample_ontology: { term_name: 'HCT116' },
+            target: { label: 'CTCF' },
+            status: 'released'
+          }
+        ]
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('encode_search'),
+      { query: 'CTCF' },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe(
+      'https://www.encodeproject.org/search/?searchTerm=CTCF&type=Experiment&format=json&limit=25'
+    )
+    expect(out).toEqual([
+      {
+        accession: 'ENCSR613LSQ',
+        assay_title: 'CRISPR RNA-seq',
+        biosample: 'K562',
+        target: 'CTCF',
+        status: 'released'
+      },
+      {
+        accession: 'ENCSR356GHP',
+        assay_title: 'ChIA-PET',
+        biosample: 'HCT116',
+        target: 'CTCF',
+        status: 'released'
+      }
+    ])
+  })
+
+  it('encode_search honors a custom limit and encodes the query', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ '@graph': [] }))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('encode_search'),
+      { query: 'H3K27ac ChIP', limit: 5 },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe(
+      'https://www.encodeproject.org/search/?searchTerm=H3K27ac%20ChIP&type=Experiment&format=json&limit=5'
+    )
+  })
+
+  it('encode_search returns an empty array when @graph is missing', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({}))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('encode_search'),
+      { query: 'nothing' },
+      {}
+    )
+    expect(out).toEqual([])
+  })
+
+  it('encode_get_experiment builds the accession URL and parses a compact record', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        accession: 'ENCSR613LSQ',
+        status: 'released',
+        assay_title: 'CRISPR RNA-seq',
+        assay_term_name: 'CRISPR genome editing followed by RNA-seq',
+        biosample_ontology: { term_name: 'K562' },
+        target: { label: 'CTCF' },
+        description: 'RNA-seq on K562 cells treated with a CRISPR gRNA against CTCF.',
+        lab: { title: 'Brenton Graveley, UConn' },
+        date_released: '2020-11-30'
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('encode_get_experiment'),
+      { accession: 'ENCSR613LSQ' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.encodeproject.org/experiments/ENCSR613LSQ/?format=json'
+    )
+    expect(out).toEqual({
+      accession: 'ENCSR613LSQ',
+      status: 'released',
+      assay_title: 'CRISPR RNA-seq',
+      assay_term_name: 'CRISPR genome editing followed by RNA-seq',
+      biosample: 'K562',
+      target: 'CTCF',
+      description: 'RNA-seq on K562 cells treated with a CRISPR gRNA against CTCF.',
+      lab: 'Brenton Graveley, UConn',
+      date_released: '2020-11-30'
+    })
+  })
+
+  it('encode_get_experiment tolerates a bare @id string for target/lab', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        accession: 'ENCSR000AKP',
+        status: 'released',
+        target: '/targets/no-target/',
+        lab: '/labs/some-lab/'
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('encode_get_experiment'),
+      { accession: 'ENCSR000AKP' },
+      {}
+    )
+    expect(out).toMatchObject({
+      target: '/targets/no-target/',
+      lab: '/labs/some-lab/'
+    })
+  })
+})

--- a/src/main/connectors/descriptors/regulation.ts
+++ b/src/main/connectors/descriptors/regulation.ts
@@ -1,0 +1,84 @@
+import type { ToolDescriptor } from '../types'
+
+const ENCODE = 'https://www.encodeproject.org'
+const DEFAULT_SEARCH_LIMIT = 25
+
+// target/lab arrive as embedded objects in most frames, but can degrade to a bare @id string.
+type EncodeEmbedded = { label?: string; title?: string } | string | undefined
+
+type EncodeExperiment = {
+  accession?: string
+  status?: string
+  assay_title?: string
+  assay_term_name?: string
+  biosample_ontology?: { term_name?: string }
+  target?: EncodeEmbedded
+  description?: string
+  lab?: EncodeEmbedded
+  date_released?: string
+}
+
+type EncodeSearchResponse = { '@graph'?: EncodeExperiment[] }
+
+function embeddedLabel(v: EncodeEmbedded): string | undefined {
+  return typeof v === 'string' ? v : (v?.label ?? v?.title)
+}
+
+// ENCODE portal REST API (encodeproject.org): every route accepts format=json; the client
+// also sends Accept: application/json via ParserEngine's default fetchJson header.
+export const REGULATION_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'encode_search',
+    connector: 'regulation',
+    description:
+      'Search ENCODE functional-genomics experiments (ChIP-seq, ATAC-seq, ...) by free text.',
+    input: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        limit: { type: 'number' }
+      },
+      required: ['query']
+    },
+    required: ['query'],
+    url: (a) => {
+      const limit = typeof a.limit === 'number' && a.limit > 0 ? a.limit : DEFAULT_SEARCH_LIMIT
+      return `${ENCODE}/search/?searchTerm=${encodeURIComponent(String(a.query))}&type=Experiment&format=json&limit=${limit}`
+    },
+    parse: (raw) =>
+      ((raw as EncodeSearchResponse)['@graph'] ?? []).map((e) => ({
+        accession: e.accession,
+        assay_title: e.assay_title,
+        biosample: e.biosample_ontology?.term_name,
+        target: embeddedLabel(e.target),
+        status: e.status
+      }))
+  },
+  {
+    id: 'encode_get_experiment',
+    connector: 'regulation',
+    description:
+      'Get one ENCODE experiment by accession (assay, target, biosample, status, dates).',
+    input: {
+      type: 'object',
+      properties: { accession: { type: 'string' } },
+      required: ['accession']
+    },
+    required: ['accession'],
+    url: (a) => `${ENCODE}/experiments/${encodeURIComponent(String(a.accession))}/?format=json`,
+    parse: (raw) => {
+      const e = raw as EncodeExperiment
+      return {
+        accession: e.accession,
+        status: e.status,
+        assay_title: e.assay_title,
+        assay_term_name: e.assay_term_name,
+        biosample: e.biosample_ontology?.term_name,
+        target: embeddedLabel(e.target),
+        description: e.description,
+        lab: embeddedLabel(e.lab),
+        date_released: e.date_released
+      }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/research-resources.test.ts
+++ b/src/main/connectors/descriptors/research-resources.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { RESEARCH_RESOURCES_TOOLS } from './research-resources'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => RESEARCH_RESOURCES_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('research_resources / antibody registry', () => {
+  it('antibody_search builds the fts-antibodies URL and parses compact hits', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        totalElements: 2,
+        items: [
+          {
+            abId: 3717446,
+            abName: 'Tumor Protein P53 Peptide 2',
+            abTarget: 'TP53',
+            vendorName: 'DSHB',
+            clonality: 'recombinant monoclonal'
+          },
+          {
+            abId: 2877664,
+            abName: 'Rabbit monoclonal anti-TP53',
+            abTarget: 'TP53',
+            vendorName: 'DSHB',
+            clonality: 'monoclonal'
+          }
+        ]
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('antibody_search'),
+      { query: 'TP53' },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe('https://www.antibodyregistry.org/api/fts-antibodies?q=TP53&page=1&size=10')
+    expect(out).toEqual({
+      total_elements: 2,
+      items: [
+        {
+          ab_id: 'AB_3717446',
+          name: 'Tumor Protein P53 Peptide 2',
+          vendor: 'DSHB',
+          target: 'TP53',
+          clonality: 'recombinant monoclonal'
+        },
+        {
+          ab_id: 'AB_2877664',
+          name: 'Rabbit monoclonal anti-TP53',
+          vendor: 'DSHB',
+          target: 'TP53',
+          clonality: 'monoclonal'
+        }
+      ]
+    })
+  })
+
+  it('antibody_search honors page/size overrides', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ totalElements: 0, items: [] }))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('antibody_search'),
+      { query: 'p53', page: 2, size: 25 },
+      {}
+    )
+    const url = fetchImpl.mock.calls[0][0] as string
+    expect(url).toBe('https://www.antibodyregistry.org/api/fts-antibodies?q=p53&page=2&size=25')
+  })
+
+  it('antibody_search returns an empty list when there are no items', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ totalElements: 0 }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('antibody_search'),
+      { query: 'nonexistent' },
+      {}
+    )
+    expect(out).toEqual({ total_elements: 0, items: [] })
+  })
+
+  it('antibody_get accepts a plain numeric id and parses the list response', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes([
+        {
+          abId: 3717446,
+          abName: 'Tumor Protein P53 Peptide 2',
+          abTarget: 'TP53',
+          vendorName: 'DSHB',
+          clonality: 'recombinant monoclonal'
+        }
+      ])
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('antibody_get'),
+      { ab_id: '3717446' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.antibodyregistry.org/api/antibodies/3717446'
+    )
+    expect(out).toEqual([
+      {
+        ab_id: 'AB_3717446',
+        name: 'Tumor Protein P53 Peptide 2',
+        vendor: 'DSHB',
+        target: 'TP53',
+        clonality: 'recombinant monoclonal'
+      }
+    ])
+  })
+
+  it('antibody_get accepts "AB_<id>" and "RRID:AB_<id>" forms', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
+    await new ParserEngine({ fetchImpl }).call(tool('antibody_get'), { ab_id: 'AB_3717446' }, {})
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.antibodyregistry.org/api/antibodies/3717446'
+    )
+    await new ParserEngine({ fetchImpl }).call(
+      tool('antibody_get'),
+      { ab_id: 'RRID:AB_3717446' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[1][0]).toBe(
+      'https://www.antibodyregistry.org/api/antibodies/3717446'
+    )
+  })
+
+  it('antibody_get returns an empty array for a nonexistent id (upstream 200 + [])', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
+    const out = await new ParserEngine({ fetchImpl }).call(tool('antibody_get'), { ab_id: '1' }, {})
+    expect(out).toEqual([])
+  })
+
+  it('antibody_get rejects a malformed id', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('antibody_get'), { ab_id: 'not-an-id' }, {})
+    ).rejects.toThrow(/not a valid antibody id/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/connectors/descriptors/research-resources.ts
+++ b/src/main/connectors/descriptors/research-resources.ts
@@ -1,0 +1,81 @@
+import type { ToolDescriptor } from '../types'
+
+const BASE = 'https://www.antibodyregistry.org/api'
+
+type AntibodyRecord = {
+  abId?: number
+  abName?: string
+  abTarget?: string
+  vendorName?: string
+  clonality?: string
+}
+
+type FtsAntibodiesResponse = { totalElements?: number; items?: AntibodyRecord[] }
+
+const toRrid = (abId: number | undefined): string | undefined =>
+  abId === undefined ? undefined : `AB_${abId}`
+
+const compactAntibody = (r: AntibodyRecord): Record<string, unknown> => ({
+  ab_id: toRrid(r.abId),
+  name: r.abName,
+  vendor: r.vendorName,
+  target: r.abTarget,
+  clonality: r.clonality
+})
+
+// Accepts a plain integer, "AB_<id>" or "RRID:AB_<id>" and returns the bare numeric id
+// (mirrors the upstream Python client's parse_ab_id).
+const parseAbId = (value: unknown): string => {
+  const s = String(value).trim()
+  const m = /^(?:RRID:)?AB_(\d+)$/i.exec(s)
+  if (m) return m[1]
+  if (/^\d+$/.test(s)) return s
+  throw new Error(`not a valid antibody id / RRID: ${s}`)
+}
+
+// Antibody Registry (antibodyregistry.org) REST API: read-only antibody catalog lookups.
+// Anonymous depth cap upstream: fts-antibodies returns HTTP 401 once page*size > 500.
+export const RESEARCH_RESOURCES_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'antibody_search',
+    connector: 'research_resources',
+    description:
+      'Full-text search the Antibody Registry by target/name/catalog text; returns RRID, name, vendor, target, and clonality per hit.',
+    input: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        page: { type: 'integer', default: 1 },
+        size: { type: 'integer', default: 10 }
+      },
+      required: ['query']
+    },
+    required: ['query'],
+    url: (a) => {
+      const page = Number.isFinite(Number(a.page)) ? Math.max(1, Number(a.page)) : 1
+      const size = Number.isFinite(Number(a.size)) ? Math.max(1, Number(a.size)) : 10
+      return `${BASE}/fts-antibodies?q=${encodeURIComponent(String(a.query))}&page=${page}&size=${size}`
+    },
+    parse: (raw) => {
+      const r = raw as FtsAntibodiesResponse
+      return {
+        total_elements: r.totalElements,
+        items: (r.items ?? []).map(compactAntibody)
+      }
+    }
+  },
+  {
+    id: 'antibody_get',
+    connector: 'research_resources',
+    description:
+      'Get Antibody Registry record(s) for an accession/RRID (plain id, "AB_<id>", or "RRID:AB_<id>"); an accession can map to several curated records.',
+    input: {
+      type: 'object',
+      properties: { ab_id: { type: 'string' } },
+      required: ['ab_id']
+    },
+    required: ['ab_id'],
+    url: (a) => `${BASE}/antibodies/${parseAbId(a.ab_id)}`,
+    parse: (raw) => (raw as AntibodyRecord[]).map(compactAntibody)
+  }
+]

--- a/src/main/connectors/descriptors/rna.test.ts
+++ b/src/main/connectors/descriptors/rna.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { RNA_TOOLS } from './rna'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => RNA_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+const textRes = (body: string): Response =>
+  ({ ok: true, status: 200, text: async () => body }) as Response
+
+describe('rna / rfam', () => {
+  it('rfam_get_family builds the URL and flattens the rfam envelope', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        rfam: {
+          acc: 'RF00005',
+          id: 'tRNA',
+          description: 'tRNA',
+          curation: { type: 'Gene; tRNA;' }
+        }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('rfam_get_family'),
+      { family: 'RF00005' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rfam.org/family/RF00005?content-type=application/json'
+    )
+    expect(out).toEqual({
+      rfam_acc: 'RF00005',
+      id: 'tRNA',
+      description: 'tRNA',
+      type: 'Gene; tRNA;'
+    })
+  })
+
+  it('rfam_get_family accepts a family id and tolerates missing curation', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        rfam: { acc: 'RF00005', id: 'tRNA', description: 'tRNA' }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('rfam_get_family'),
+      { family: 'tRNA' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rfam.org/family/tRNA?content-type=application/json'
+    )
+    expect(out).toEqual({
+      rfam_acc: 'RF00005',
+      id: 'tRNA',
+      description: 'tRNA',
+      type: undefined
+    })
+  })
+
+  it('rfam_acc_to_id builds the URL and trims the text response', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(textRes('tRNA\n'))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('rfam_acc_to_id'),
+      { accession: 'RF00005' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rfam.org/family/RF00005/id?content-type=text/plain'
+    )
+    expect(out).toEqual({ accession: 'RF00005', id: 'tRNA' })
+  })
+})

--- a/src/main/connectors/descriptors/rna.ts
+++ b/src/main/connectors/descriptors/rna.ts
@@ -1,0 +1,57 @@
+import type { ToolDescriptor } from '../types'
+
+const RFAM = 'https://rfam.org'
+
+// Rfam /family JSON wraps everything under a top-level "rfam" key
+// (rfam.acc, rfam.id, rfam.description, rfam.curation.type, ...).
+type RfamFamilyPayload = {
+  rfam?: {
+    acc?: string
+    id?: string
+    description?: string
+    curation?: { type?: string }
+  }
+}
+
+// Rfam REST API: read-only RNA family lookups. Accepts either an Rfam
+// accession (RF00005) or a family id (tRNA) — the upstream routes resolve both.
+export const RNA_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'rfam_get_family',
+    connector: 'rna',
+    description:
+      'Get Rfam family metadata (accession, id, description, RNA type) for an Rfam accession or family id.',
+    input: {
+      type: 'object',
+      properties: { family: { type: 'string' } },
+      required: ['family']
+    },
+    required: ['family'],
+    url: (a) =>
+      `${RFAM}/family/${encodeURIComponent(String(a.family))}?content-type=application/json`,
+    parse: (raw) => {
+      const rfam = (raw as RfamFamilyPayload).rfam ?? {}
+      return {
+        rfam_acc: rfam.acc,
+        id: rfam.id,
+        description: rfam.description,
+        type: rfam.curation?.type
+      }
+    }
+  },
+  {
+    id: 'rfam_acc_to_id',
+    connector: 'rna',
+    description: 'Resolve an Rfam accession (RF00005) to its family id (e.g. tRNA).',
+    input: {
+      type: 'object',
+      properties: { accession: { type: 'string' } },
+      required: ['accession']
+    },
+    required: ['accession'],
+    format: 'text',
+    url: (a) =>
+      `${RFAM}/family/${encodeURIComponent(String(a.accession))}/id?content-type=text/plain`,
+    parse: (raw, a) => ({ accession: String(a.accession), id: String(raw).trim() })
+  }
+]

--- a/src/main/connectors/descriptors/structures.test.ts
+++ b/src/main/connectors/descriptors/structures.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { STRUCTURES_TOOLS } from './structures'
+import type { ToolDescriptor } from '../types'
+
+const tool = (id: string): ToolDescriptor => STRUCTURES_TOOLS.find((t) => t.id === id)!
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('structures / pdb', () => {
+  it('pdb_get_entry builds the URL (uppercased id) and parses title/method/resolution', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        rcsb_id: '1TUP',
+        struct: { title: 'TUMOR SUPPRESSOR P53 COMPLEXED WITH DNA' },
+        exptl: [{ method: 'X-RAY DIFFRACTION' }],
+        rcsb_entry_info: { resolution_combined: [2.2] }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('pdb_get_entry'),
+      { pdb_id: '1tup' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://data.rcsb.org/rest/v1/core/entry/1TUP')
+    expect(out).toEqual({
+      pdb_id: '1TUP',
+      title: 'TUMOR SUPPRESSOR P53 COMPLEXED WITH DNA',
+      method: 'X-RAY DIFFRACTION',
+      resolution: 2.2
+    })
+  })
+
+  it('pdb_get_entry tolerates a missing resolution', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        rcsb_id: '1ABC',
+        struct: { title: 'Some entry' },
+        exptl: [{ method: 'SOLUTION NMR' }],
+        rcsb_entry_info: { resolution_combined: [] }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('pdb_get_entry'),
+      { pdb_id: '1ABC' },
+      {}
+    )
+    expect(out).toEqual({
+      pdb_id: '1ABC',
+      title: 'Some entry',
+      method: 'SOLUTION NMR',
+      resolution: undefined
+    })
+  })
+})
+
+describe('structures / alphafold', () => {
+  it('alphafold_get builds the URL and parses the first model', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes([
+        {
+          uniprotAccession: 'P04637',
+          pdbUrl: 'https://alphafold.ebi.ac.uk/files/AF-P04637-F1-model_v6.pdb',
+          cifUrl: 'https://alphafold.ebi.ac.uk/files/AF-P04637-F1-model_v6.cif',
+          globalMetricValue: 75.06
+        }
+      ])
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('alphafold_get'),
+      { uniprot_accession: 'P04637' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://alphafold.ebi.ac.uk/api/prediction/P04637')
+    expect(out).toEqual({
+      uniprot: 'P04637',
+      model_url: 'https://alphafold.ebi.ac.uk/files/AF-P04637-F1-model_v6.pdb',
+      cif_url: 'https://alphafold.ebi.ac.uk/files/AF-P04637-F1-model_v6.cif',
+      mean_plddt: 75.06
+    })
+  })
+
+  it('alphafold_get tolerates an empty prediction list', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('alphafold_get'),
+      { uniprot_accession: 'Q99999' },
+      {}
+    )
+    expect(out).toEqual({
+      uniprot: undefined,
+      model_url: undefined,
+      cif_url: undefined,
+      mean_plddt: undefined
+    })
+  })
+})
+
+describe('structures / intact', () => {
+  it('intact_interactions POSTs query params on the URL (no body) and parses interactions', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        data: {
+          totalElements: 4424,
+          content: [
+            {
+              ac: 'EBI-6974073',
+              binaryInteractionId: 14904189,
+              idA: 'Q00987 (uniprotkb)',
+              idB: 'P04637 (uniprotkb)',
+              moleculeA: 'MDM2',
+              moleculeB: 'TP53',
+              type: 'physical association',
+              typeMIIdentifier: 'MI:0915',
+              detectionMethod: 'anti bait coip',
+              detectionMethodMIIdentifier: 'MI:0006',
+              intactMiscore: 0.56,
+              publicationPubmedIdentifier: '12915590'
+            }
+          ]
+        }
+      })
+    )
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('intact_interactions'),
+      { query: 'TP53' },
+      {}
+    )
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(
+      'https://www.ebi.ac.uk/intact/ws/interaction/findInteractionWithFacet?query=TP53&minMIScore=0&maxMIScore=1&pageSize=25&page=0'
+    )
+    expect(init.method).toBe('POST')
+    expect(init.body).toBeUndefined()
+    expect(out).toEqual({
+      query: 'TP53',
+      total_elements: 4424,
+      returned: 1,
+      interactions: [
+        {
+          interactor_a: 'Q00987',
+          interactor_b: 'P04637',
+          molecule_a: 'MDM2',
+          molecule_b: 'TP53',
+          interaction_type: 'physical association',
+          interaction_type_mi: 'MI:0915',
+          detection_method: 'anti bait coip',
+          detection_method_mi: 'MI:0006',
+          mi_score: 0.56,
+          pubmed_id: '12915590'
+        }
+      ]
+    })
+  })
+
+  it('intact_interactions respects min_mi_score/limit and tolerates an empty result', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ data: { totalElements: 0, content: [] } }))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('intact_interactions'),
+      { query: 'BRCA2', min_mi_score: 0.5, limit: 10 },
+      {}
+    )
+    const [url] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(
+      'https://www.ebi.ac.uk/intact/ws/interaction/findInteractionWithFacet?query=BRCA2&minMIScore=0.5&maxMIScore=1&pageSize=10&page=0'
+    )
+    expect(out).toEqual({ query: 'BRCA2', total_elements: 0, returned: 0, interactions: [] })
+  })
+})

--- a/src/main/connectors/descriptors/structures.ts
+++ b/src/main/connectors/descriptors/structures.ts
@@ -1,0 +1,160 @@
+import type { ToolDescriptor } from '../types'
+
+const PDB_DATA = 'https://data.rcsb.org/rest/v1/core'
+const ALPHAFOLD = 'https://alphafold.ebi.ac.uk/api/prediction'
+const INTACT_WS = 'https://www.ebi.ac.uk/intact/ws'
+// A gene/protein query can hit thousands of interactions (e.g. TP53 ~4400) — bound the response
+// like gnomad's variant listing does, rather than returning every row unbounded.
+const INTACT_DEFAULT_LIMIT = 25
+
+// RCSB data API core/entry shape (confirmed live against 1TUP — resolution_combined is an
+// array, e.g. [2.2]; exptl is an array of methods, one entry per experiment).
+type PdbEntry = {
+  rcsb_id?: string
+  struct?: { title?: string }
+  exptl?: Array<{ method?: string }>
+  rcsb_entry_info?: { resolution_combined?: number[] }
+}
+
+// AlphaFold DB prediction API response: an array of model records (confirmed live against
+// P04637); field names are camelCase, not the "meanPlddt" guess — the confidence score is
+// globalMetricValue.
+type AlphaFoldModel = {
+  uniprotAccession?: string
+  pdbUrl?: string
+  cifUrl?: string
+  globalMetricValue?: number
+}
+
+// IntAct search endpoint (interaction/findInteractionWithFacet) response shape — transcribed from
+// the upstream intact_interactions client (core.py: SEARCH_PATH + slim_record). The service
+// accepts the query params on the URL even though the HTTP method is POST (no request body).
+type IntActRawRecord = {
+  ac?: string
+  binaryInteractionId?: number
+  idA?: string
+  idB?: string
+  moleculeA?: string
+  moleculeB?: string
+  type?: string
+  typeMIIdentifier?: string
+  detectionMethod?: string
+  detectionMethodMIIdentifier?: string
+  intactMiscore?: number
+  publicationPubmedIdentifier?: string
+}
+
+type IntActSearchResponse = {
+  data?: { totalElements?: number; content?: IntActRawRecord[] }
+}
+
+// Strips the ' (databasename)' suffix IntAct appends to participant identifiers, e.g.
+// 'P04637 (uniprotkb)' -> 'P04637' (mirrors the upstream _strip_db_suffix).
+function stripIntactDbSuffix(identifier: string | undefined): string | undefined {
+  if (!identifier) return identifier
+  const idx = identifier.indexOf(' (')
+  return idx === -1 ? identifier : identifier.slice(0, idx)
+}
+
+// RCSB PDB data API + AlphaFold DB prediction API + EBI IntAct molecular-interactions API:
+// read-only 3D structure and interaction lookups.
+export const STRUCTURES_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'pdb_get_entry',
+    connector: 'structures',
+    description: 'Get an experimental PDB entry (title, method, resolution) by PDB id.',
+    input: {
+      type: 'object',
+      properties: { pdb_id: { type: 'string' } },
+      required: ['pdb_id']
+    },
+    required: ['pdb_id'],
+    url: (a) => `${PDB_DATA}/entry/${encodeURIComponent(String(a.pdb_id).trim().toUpperCase())}`,
+    parse: (raw) => {
+      const entry = raw as PdbEntry
+      return {
+        pdb_id: entry.rcsb_id,
+        title: entry.struct?.title,
+        method: entry.exptl?.[0]?.method,
+        resolution: entry.rcsb_entry_info?.resolution_combined?.[0]
+      }
+    }
+  },
+  {
+    id: 'alphafold_get',
+    connector: 'structures',
+    description:
+      'Get the AlphaFold predicted model (model/CIF URLs, mean pLDDT) for a UniProt accession.',
+    input: {
+      type: 'object',
+      properties: { uniprot_accession: { type: 'string' } },
+      required: ['uniprot_accession']
+    },
+    required: ['uniprot_accession'],
+    url: (a) => `${ALPHAFOLD}/${encodeURIComponent(String(a.uniprot_accession).trim())}`,
+    parse: (raw) => {
+      const model = ((raw as AlphaFoldModel[]) ?? [])[0] ?? {}
+      return {
+        uniprot: model.uniprotAccession,
+        model_url: model.pdbUrl,
+        cif_url: model.cifUrl,
+        mean_plddt: model.globalMetricValue
+      }
+    }
+  },
+  {
+    id: 'intact_interactions',
+    connector: 'structures',
+    description:
+      'Molecular interactions for a protein/gene from EBI IntAct (interactor pair, interaction type, detection method, MI score), MI-score filtered.',
+    input: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        min_mi_score: { type: 'number', default: 0 },
+        limit: { type: 'integer', default: INTACT_DEFAULT_LIMIT }
+      },
+      required: ['query']
+    },
+    required: ['query'],
+    run: async (ctx, a) => {
+      const query = String(a.query)
+      const minMiScore = Number(a.min_mi_score ?? 0)
+      const limit = Number(a.limit ?? INTACT_DEFAULT_LIMIT)
+      // IntAct's search endpoint takes its params as a URL query string even on POST (matches
+      // the upstream client, which passes them via httpx's `params=` on a POST request).
+      const params = new URLSearchParams({
+        query,
+        minMIScore: String(minMiScore),
+        maxMIScore: '1',
+        pageSize: String(limit),
+        page: '0'
+      })
+      const result = (await ctx.postJson(
+        `${INTACT_WS}/interaction/findInteractionWithFacet?${params.toString()}`,
+        undefined
+      )) as IntActSearchResponse
+
+      const content = result.data?.content ?? []
+      const interactions = content.map((r) => ({
+        interactor_a: stripIntactDbSuffix(r.idA),
+        interactor_b: stripIntactDbSuffix(r.idB),
+        molecule_a: r.moleculeA,
+        molecule_b: r.moleculeB,
+        interaction_type: r.type,
+        interaction_type_mi: r.typeMIIdentifier,
+        detection_method: r.detectionMethod,
+        detection_method_mi: r.detectionMethodMIIdentifier,
+        mi_score: r.intactMiscore,
+        pubmed_id: r.publicationPubmedIdentifier
+      }))
+
+      return {
+        query,
+        total_elements: result.data?.totalElements ?? interactions.length,
+        returned: interactions.length,
+        interactions
+      }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/variants.test.ts
+++ b/src/main/connectors/descriptors/variants.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from '../engine'
+import { VARIANTS_TOOLS } from './variants'
+
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('variants', () => {
+  it('esearch + esummary, includes etiquette', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ esearchresult: { count: '2', idlist: ['1', '2'] } }))
+      .mockResolvedValueOnce(
+        jsonRes({
+          result: {
+            '1': {
+              title: 'NM_007294.3:c.5075_5277dup',
+              germline_classification: { description: 'Likely pathogenic' },
+              genes: [{ symbol: 'BRCA1' }]
+            },
+            '2': {
+              title: 'NM_007294.4(BRCA1):c.5467+200G>A',
+              germline_classification: { description: 'Uncertain significance' },
+              genes: [{ symbol: 'BRCA1' }]
+            }
+          }
+        })
+      )
+    const tool = VARIANTS_TOOLS.find((t) => t.id === 'clinvar_search')!
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool,
+      { term: 'BRCA1', retmax: 2 },
+      { ncbiEmail: 'x@y.org' }
+    )) as {
+      count: number
+      records: unknown[]
+    }
+    expect(fetchImpl.mock.calls[0][0]).toContain('email=x%40y.org')
+    expect(fetchImpl.mock.calls[0][0]).toContain('db=clinvar')
+    expect(out.count).toBe(2)
+    expect(out.records).toEqual([
+      {
+        uid: '1',
+        title: 'NM_007294.3:c.5075_5277dup',
+        clinical_significance: 'Likely pathogenic',
+        gene: 'BRCA1'
+      },
+      {
+        uid: '2',
+        title: 'NM_007294.4(BRCA1):c.5467+200G>A',
+        clinical_significance: 'Uncertain significance',
+        gene: 'BRCA1'
+      }
+    ])
+  })
+
+  it('dbsnp_get_variant: esummary db=snp, includes etiquette, strips rs prefix', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        result: {
+          '7412': {
+            snp_id: 7412,
+            chr: '19',
+            chrpos: '19:44908822',
+            spdi: 'NC_000019.10:44908821:C:T',
+            genes: [{ name: 'APOE' }],
+            clinical_significance:
+              'drug-response,risk-factor,benign,likely-benign,uncertain-significance,pathogenic,other'
+          }
+        }
+      })
+    )
+    const tool = VARIANTS_TOOLS.find((t) => t.id === 'dbsnp_get_variant')!
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool,
+      { rsid: 'rs7412' },
+      { ncbiEmail: 'x@y.org' }
+    )) as {
+      rsid: string
+      chr: string
+      pos: number
+      alleles: string
+      gene: string
+      clinical_significance: string
+    }
+    expect(fetchImpl.mock.calls[0][0]).toContain('email=x%40y.org')
+    expect(fetchImpl.mock.calls[0][0]).toContain('db=snp')
+    expect(fetchImpl.mock.calls[0][0]).toContain('id=7412')
+    expect(out).toEqual({
+      rsid: 'rs7412',
+      chr: '19',
+      pos: 44908822,
+      alleles: 'C>T',
+      gene: 'APOE',
+      clinical_significance:
+        'drug-response,risk-factor,benign,likely-benign,uncertain-significance,pathogenic,other'
+    })
+  })
+
+  it('dbsnp_get_variant: accepts a bare rs number (no rs prefix)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        result: {
+          '7412': {
+            snp_id: 7412,
+            chr: '19',
+            chrpos: '19:44908822',
+            spdi: 'NC_000019.10:44908821:C:T'
+          }
+        }
+      })
+    )
+    const tool = VARIANTS_TOOLS.find((t) => t.id === 'dbsnp_get_variant')!
+    const out = (await new ParserEngine({ fetchImpl }).call(tool, { rsid: '7412' }, {})) as {
+      rsid: string
+    }
+    expect(fetchImpl.mock.calls[0][0]).toContain('id=7412')
+    expect(out.rsid).toBe('rs7412')
+  })
+})

--- a/src/main/connectors/descriptors/variants.ts
+++ b/src/main/connectors/descriptors/variants.ts
@@ -1,0 +1,92 @@
+import { ncbiEtiquette } from '../engine'
+import type { ToolDescriptor } from '../types'
+
+const EUTILS = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils'
+
+// esummary db=clinvar document shape (confirmed live against real records — the top-level
+// field is `germline_classification` with a `.description`, not a flat `clinical_significance`).
+type ClinVarSummaryDoc = {
+  title?: string
+  germline_classification?: { description?: string }
+  genes?: Array<{ symbol?: string }>
+}
+
+// esummary db=snp document shape (confirmed live against rs7412 — flat `clinical_significance`
+// string, `chr`/`chrpos` for location, `spdi` (ref:alt trail) for alleles, `genes[].name`).
+type DbSnpSummaryDoc = {
+  snp_id?: number
+  chr?: string
+  chrpos?: string
+  spdi?: string
+  genes?: Array<{ name?: string }>
+  clinical_significance?: string
+}
+
+// NCBI E-utilities in JSON mode against db=clinvar: esearch -> esummary (mirrors pubmed.ts).
+export const VARIANTS_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'clinvar_search',
+    connector: 'variants',
+    description: 'Search ClinVar; returns total count and variant clinical-significance records.',
+    input: {
+      type: 'object',
+      properties: { term: { type: 'string' }, retmax: { type: 'integer', default: 5 } },
+      required: ['term']
+    },
+    required: ['term'],
+    run: async (ctx, a) => {
+      const q = ncbiEtiquette(ctx.credentials)
+      const es = (await ctx.fetchJson(
+        `${EUTILS}/esearch.fcgi?db=clinvar&retmode=json&retmax=${Number(a.retmax ?? 5)}&term=${encodeURIComponent(String(a.term))}${q}`
+      )) as { esearchresult?: { count?: string; idlist?: string[] } }
+      const ids = es.esearchresult?.idlist ?? []
+      if (!ids.length) return { term: a.term, count: 0, records: [] }
+      const sum = (await ctx.fetchJson(
+        `${EUTILS}/esummary.fcgi?db=clinvar&retmode=json&id=${ids.join(',')}${q}`
+      )) as { result: Record<string, ClinVarSummaryDoc> }
+      return {
+        term: a.term,
+        count: Number(es.esearchresult?.count ?? 0),
+        records: ids.map((id) => ({
+          uid: id,
+          title: sum.result[id]?.title,
+          clinical_significance: sum.result[id]?.germline_classification?.description,
+          gene: sum.result[id]?.genes?.[0]?.symbol
+        }))
+      }
+    }
+  },
+  {
+    id: 'dbsnp_get_variant',
+    connector: 'variants',
+    description:
+      'Look up a dbSNP variant by rsID; returns chromosome, position, alleles, gene, and clinical significance.',
+    input: {
+      type: 'object',
+      properties: { rsid: { type: 'string', description: 'rsID, with or without the rs prefix' } },
+      required: ['rsid']
+    },
+    required: ['rsid'],
+    run: async (ctx, a) => {
+      const q = ncbiEtiquette(ctx.credentials)
+      const id = String(a.rsid).trim().replace(/^rs/i, '')
+      const sum = (await ctx.fetchJson(
+        `${EUTILS}/esummary.fcgi?db=snp&retmode=json&id=${encodeURIComponent(id)}${q}`
+      )) as { result?: Record<string, DbSnpSummaryDoc> }
+      const doc = sum.result?.[id]
+      // spdi trail is `seqId:position:deletedSequence:insertedSequence` (ref:alt for the row).
+      const spdiParts = (doc?.spdi ?? '').split(':')
+      const ref = spdiParts[2]
+      const alt = spdiParts[3]
+      const pos = doc?.chrpos?.split(':')[1]
+      return {
+        rsid: `rs${id}`,
+        chr: doc?.chr,
+        pos: pos ? Number(pos) : undefined,
+        alleles: ref && alt ? `${ref}>${alt}` : undefined,
+        gene: doc?.genes?.[0]?.name,
+        clinical_significance: doc?.clinical_significance
+      }
+    }
+  }
+]

--- a/src/main/connectors/descriptors/zinc.test.ts
+++ b/src/main/connectors/descriptors/zinc.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ZINC_TOOLS } from './zinc'
+import type { ToolContext } from '../types'
+
+const tool = ZINC_TOOLS.find((t) => t.id === 'zinc_search_by_id')!
+
+const ctx: ToolContext = {
+  credentials: {},
+  fetchJson: async () => {
+    throw new Error('zinc_search_by_id must not use ctx.fetchJson (form-encoded POST needed)')
+  },
+  fetchText: async () => {
+    throw new Error('zinc_search_by_id must not use ctx.fetchText')
+  },
+  postJson: async () => {
+    throw new Error('zinc_search_by_id must not use ctx.postJson (JSON body, not form-encoded)')
+  }
+}
+
+const textRes = (status: number, body: unknown): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body)
+  }) as Response
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('zinc / zinc_search_by_id', () => {
+  it('POSTs form-encoded fields to substances.txt, polls to SUCCESS, and returns a compact shape', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(textRes(200, { task: 'ZTASK-1' })) // submit
+      .mockResolvedValueOnce(textRes(200, { status: 'PENDING' })) // poll #1
+      .mockResolvedValueOnce(
+        textRes(200, {
+          status: 'SUCCESS',
+          result: {
+            zinc22: [
+              {
+                zinc_id: 'ZINC000000000012',
+                smiles: 'CC(=O)Oc1ccccc1C(=O)O',
+                tranche_name: 'H13P130',
+                catalogs: ['vendorA', 'vendorB']
+              }
+            ]
+          }
+        })
+      ) // poll #2
+    vi.stubGlobal('fetch', fetchImpl)
+
+    const promise = tool.run!(ctx, { zinc_ids: ['ZINC000000000012'] })
+    await vi.runAllTimersAsync()
+    const out = (await promise) as {
+      query: unknown
+      total_available: number
+      returned_count: number
+      truncated: boolean
+      records: Array<Record<string, unknown>>
+    }
+
+    expect(fetchImpl.mock.calls).toHaveLength(3)
+    const [submitUrl, submitInit] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    expect(submitUrl).toBe('https://cartblanche22.docking.org/substances.txt')
+    expect(submitInit.method).toBe('POST')
+    expect((submitInit.headers as Record<string, string>)['content-type']).toBe(
+      'application/x-www-form-urlencoded'
+    )
+    const submitBody = new URLSearchParams(submitInit.body as string)
+    expect(submitBody.get('zinc_ids')).toBe('ZINC000000000012')
+    expect(submitBody.get('output_fields')).toBe('zinc_id,smiles,tranche_name,catalogs')
+
+    const [pollUrl] = fetchImpl.mock.calls[1] as [string, RequestInit]
+    expect(pollUrl).toBe('https://cartblanche22.docking.org/search/result/ZTASK-1')
+    const [pollUrl2] = fetchImpl.mock.calls[2] as [string, RequestInit]
+    expect(pollUrl2).toBe('https://cartblanche22.docking.org/search/result/ZTASK-1')
+
+    expect(out.query).toEqual({ zinc_ids: ['ZINC000000000012'] })
+    expect(out.total_available).toBe(1)
+    expect(out.returned_count).toBe(1)
+    expect(out.truncated).toBe(false)
+    expect(out.records).toEqual([
+      {
+        zinc_id: 'ZINC000000000012',
+        smiles: 'CC(=O)Oc1ccccc1C(=O)O',
+        tranche_name: 'H13P130',
+        catalogs: ['vendorA', 'vendorB'],
+        source: 'zinc22'
+      }
+    ])
+  })
+
+  it('joins multiple ids with commas in one submission', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(textRes(200, { task: 'ZTASK-2' }))
+      .mockResolvedValueOnce(textRes(200, { status: 'SUCCESS', result: { zinc22: [] } }))
+    vi.stubGlobal('fetch', fetchImpl)
+
+    const promise = tool.run!(ctx, { zinc_ids: ['ZINC000000000012', 'ZINC000000000013'] })
+    await vi.runAllTimersAsync()
+    await promise
+
+    const [, submitInit] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    const submitBody = new URLSearchParams(submitInit.body as string)
+    expect(submitBody.get('zinc_ids')).toBe('ZINC000000000012,ZINC000000000013')
+  })
+
+  it('rejects a malformed ZINC id without making a network call', async () => {
+    const fetchImpl = vi.fn()
+    vi.stubGlobal('fetch', fetchImpl)
+    await expect(tool.run!(ctx, { zinc_ids: ['not-a-zinc-id'] })).rejects.toThrow(
+      /not a valid ZINC id/
+    )
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('rejects an id list entry containing a delimiter (comma-join injection guard)', async () => {
+    const fetchImpl = vi.fn()
+    vi.stubGlobal('fetch', fetchImpl)
+    await expect(
+      tool.run!(ctx, { zinc_ids: ['ZINC000000000012,ZINC000000000013'] })
+    ).rejects.toThrow(/comma or whitespace/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('rejects a batch over the 100-id bound', async () => {
+    const fetchImpl = vi.fn()
+    vi.stubGlobal('fetch', fetchImpl)
+    const ids = Array.from({ length: 101 }, (_, i) => `ZINC${String(i).padStart(12, '0')}`)
+    await expect(tool.run!(ctx, { zinc_ids: ids })).rejects.toThrow(
+      /exceeds the per-call bound of 100/
+    )
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('requires at least one id', async () => {
+    const fetchImpl = vi.fn()
+    vi.stubGlobal('fetch', fetchImpl)
+    await expect(tool.run!(ctx, { zinc_ids: [] })).rejects.toThrow(/at least one ZINC id/)
+  })
+
+  it('surfaces an HTTP 400 submit rejection with the server detail', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(textRes(400, { error: 'bad zinc_ids' }))
+    vi.stubGlobal('fetch', fetchImpl)
+    await expect(tool.run!(ctx, { zinc_ids: ['ZINC000000000012'] })).rejects.toThrow(/HTTP 400/)
+  })
+
+  it('surfaces the HTML SPA shell as an actionable error', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => '<!doctype html><html><body>app</body></html>'
+    } as Response)
+    vi.stubGlobal('fetch', fetchImpl)
+    await expect(tool.run!(ctx, { zinc_ids: ['ZINC000000000012'] })).rejects.toThrow(
+      /HTML app shell/
+    )
+  })
+
+  it('surfaces a server-side FAILURE status', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(textRes(200, { task: 'ZTASK-3' }))
+      .mockResolvedValueOnce(textRes(200, { status: 'FAILURE' }))
+    vi.stubGlobal('fetch', fetchImpl)
+    const promise = tool.run!(ctx, { zinc_ids: ['ZINC000000000012'] })
+    const assertion = expect(promise).rejects.toThrow(/failed server-side/)
+    await vi.runAllTimersAsync()
+    await assertion
+  })
+
+  it('reports a task timeout naming the task uuid once the deadline passes', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(textRes(200, { task: 'ZTASK-STUCK' }))
+      .mockResolvedValue(textRes(200, { status: 'PENDING' }))
+    vi.stubGlobal('fetch', fetchImpl)
+
+    const promise = tool.run!(ctx, { zinc_ids: ['ZINC000000000012'], timeout_s: 5 })
+    const assertion = expect(promise).rejects.toThrow(/ZTASK-STUCK/)
+    await vi.runAllTimersAsync()
+    await assertion
+  })
+
+  it('bounds returned_count to max_results while reporting the true total', async () => {
+    vi.useFakeTimers()
+    const records = Array.from({ length: 5 }, (_, i) => ({
+      zinc_id: `ZINC${String(i).padStart(12, '0')}`,
+      smiles: 'C',
+      tranche_name: 'H10P100',
+      catalogs: []
+    }))
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(textRes(200, { task: 'ZTASK-4' }))
+      .mockResolvedValueOnce(textRes(200, { status: 'SUCCESS', result: { zinc22: records } }))
+    vi.stubGlobal('fetch', fetchImpl)
+
+    const promise = tool.run!(ctx, { zinc_ids: ['ZINC000000000000'], max_results: 2 })
+    await vi.runAllTimersAsync()
+    const out = (await promise) as {
+      total_available: number
+      returned_count: number
+      truncated: boolean
+    }
+    expect(out.total_available).toBe(5)
+    expect(out.returned_count).toBe(2)
+    expect(out.truncated).toBe(true)
+  })
+})

--- a/src/main/connectors/descriptors/zinc.ts
+++ b/src/main/connectors/descriptors/zinc.ts
@@ -1,0 +1,303 @@
+import type { ToolDescriptor } from '../types'
+
+// CartBlanche22 (ZINC22 purchasable-compound search) — every search endpoint is ASYNC and
+// POST-only (form-encoded): submit returns a task receipt {"task": "<uuid>"}, and the result is
+// fetched by polling GET /search/result/<uuid> until `status` is SUCCESS (or a status-less body
+// carries a `result` key). A naive GET ?param=value returns HTTP 400 or the HTML SPA shell.
+// ToolContext's fetchJson/fetchText/postJson can't express a form-encoded POST or a manual poll
+// loop, so this tool talks to the API directly via the global fetch (mirrors upstream
+// mcp_zinc/client.py's ZincClient, simplified to the one endpoint this tool needs).
+const BASE_URL = 'https://cartblanche22.docking.org'
+const OUTPUT_FIELDS = 'zinc_id,smiles,tranche_name,catalogs'
+const USER_AGENT = 'OpenScience/1.0 (+https://github.com/aipoch/open-science)'
+
+// Overall submit->result budget (default/clamp mirrors upstream DEFAULT/MIN/MAX_TIMEOUT_S, pulled
+// in a bit under the MCP-style 60s transport ceiling that upstream targets).
+const DEFAULT_TIMEOUT_S = 25
+const MIN_TIMEOUT_S = 5
+const MAX_TIMEOUT_S = 45
+const POLL_INTERVAL_MS = 1500
+const HTTP_TIMEOUT_MS = 10_000
+
+const DEFAULT_MAX_RESULTS = 50
+const MAX_RESULTS_CAP = 500
+const MAX_IDS_PER_CALL = 100
+
+const ZINC_ID_RE = /^ZINC[a-zA-Z]?\d+$/i
+const ID_DELIM_RE = /[,\s]/
+// Result sources, presentation order (current release first) — mirrors upstream SOURCE_ORDER.
+const SOURCE_ORDER = ['zinc22', 'zinc20']
+
+type ZincRecord = {
+  zinc_id?: string
+  smiles?: string
+  tranche_name?: string
+  catalogs?: unknown
+  source?: string
+}
+
+type SubmitResponse = { task?: string }
+type PollResponse = { status?: string; result?: unknown }
+
+function clampTimeoutS(raw: unknown): number {
+  const n = Number(raw ?? DEFAULT_TIMEOUT_S)
+  return Math.max(
+    MIN_TIMEOUT_S,
+    Math.min(MAX_TIMEOUT_S, Number.isFinite(n) ? n : DEFAULT_TIMEOUT_S)
+  )
+}
+
+function clampMaxResults(raw: unknown): number {
+  const n = Number(raw ?? DEFAULT_MAX_RESULTS)
+  return Math.max(
+    1,
+    Math.min(MAX_RESULTS_CAP, Number.isFinite(n) ? Math.trunc(n) : DEFAULT_MAX_RESULTS)
+  )
+}
+
+// Normalizes + bounds a ZINC id list. Entries are joined with commas into the upstream form
+// field, so a single entry containing a delimiter would let one list element submit many ids and
+// defeat MAX_IDS_PER_CALL — reject those explicitly (mirrors upstream _require_ids).
+function normalizeZincIds(raw: unknown): string[] {
+  const list = Array.isArray(raw) ? raw : [raw]
+  const cleaned = list.map((v) => String(v).trim()).filter((v) => v.length > 0)
+  if (!cleaned.length) throw new Error('provide at least one ZINC id')
+  if (cleaned.length > MAX_IDS_PER_CALL) {
+    throw new Error(
+      `${cleaned.length} ZINC ids exceeds the per-call bound of ${MAX_IDS_PER_CALL} — split the lookup into smaller batches`
+    )
+  }
+  for (const id of cleaned) {
+    if (ID_DELIM_RE.test(id)) {
+      throw new Error(
+        `ZINC id ${idRepr(id)} contains a comma or whitespace — pass each id as its own list element`
+      )
+    }
+    if (!ZINC_ID_RE.test(id)) {
+      throw new Error(
+        `ZINC id ${idRepr(id)} is not a valid ZINC id (expected pattern ${ZINC_ID_RE})`
+      )
+    }
+  }
+  return cleaned
+}
+
+// Quotes the offending value unambiguously in error messages (mirrors Python's !r used in the
+// upstream error messages this tool's wording is transcribed from).
+function idRepr(id: string): string {
+  return `'${id}'`
+}
+
+function looksLikeHtml(text: string): boolean {
+  const head = text.trimStart().slice(0, 300).toLowerCase()
+  return head.startsWith('<!doctype') || head.startsWith('<html')
+}
+
+function bodyExcerpt(text: string, n = 200): string {
+  const excerpt = text.split(/\s+/).filter(Boolean).join(' ').slice(0, n)
+  return excerpt || '<empty body>'
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), Math.max(1, timeoutMs))
+  try {
+    return await fetch(url, {
+      ...init,
+      headers: { 'user-agent': USER_AGENT, ...init.headers },
+      signal: controller.signal
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// POST form fields to a CartBlanche22 search endpoint; return the task uuid.
+async function submit(
+  endpoint: string,
+  data: Record<string, string>,
+  deadline: number
+): Promise<string> {
+  const url = `${BASE_URL}/${endpoint}`
+  const budgetMs = Math.min(HTTP_TIMEOUT_MS, Math.max(1000, deadline - Date.now()))
+  const res = await fetchWithTimeout(
+    url,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded', accept: 'application/json' },
+      body: new URLSearchParams(data).toString()
+    },
+    budgetMs
+  )
+  const text = await res.text()
+  if (res.status === 400) {
+    throw new Error(
+      `CartBlanche22 rejected the ${endpoint} submission (HTTP 400). Server detail: ${bodyExcerpt(text)}`
+    )
+  }
+  if (!res.ok) {
+    throw new Error(`CartBlanche22 ${endpoint} returned HTTP ${res.status}: ${bodyExcerpt(text)}`)
+  }
+  if (looksLikeHtml(text)) {
+    throw new Error(
+      `CartBlanche22 returned its HTML app shell instead of a JSON task receipt for ${endpoint} — the request was not understood as an API call.`
+    )
+  }
+  let payload: SubmitResponse
+  try {
+    payload = JSON.parse(text) as SubmitResponse
+  } catch {
+    throw new Error(
+      `CartBlanche22 ${endpoint} returned a non-JSON body where a task receipt was expected: ${bodyExcerpt(text)}`
+    )
+  }
+  if (!payload.task) {
+    throw new Error(
+      `CartBlanche22 ${endpoint} response carried no task id — the async submit contract may have changed.`
+    )
+  }
+  return String(payload.task)
+}
+
+const PENDING_STATUSES = new Set(['PENDING', 'STARTED', 'PROGRESS', 'RETRY'])
+
+// Poll /search/result/<task> until completion (SUCCESS, or a status-less body whose `result` key
+// is present); throws a ZINC-task-timeout error naming the task uuid for manual re-poll once the
+// deadline passes, mirroring upstream ZincTaskTimeout.
+async function poll(task: string, deadline: number): Promise<PollResponse> {
+  const url = `${BASE_URL}/search/result/${encodeURIComponent(task)}`
+  for (;;) {
+    const budgetMs = Math.min(HTTP_TIMEOUT_MS, Math.max(1000, deadline - Date.now()))
+    const res = await fetchWithTimeout(url, { headers: { accept: 'application/json' } }, budgetMs)
+    const text = await res.text()
+    if (!res.ok) {
+      throw new Error(`polling ZINC task ${task} returned HTTP ${res.status}: ${bodyExcerpt(text)}`)
+    }
+    if (looksLikeHtml(text)) {
+      throw new Error(
+        `polling ZINC task ${task} returned the HTML app shell instead of JSON — the task id was not recognized.`
+      )
+    }
+    let payload: PollResponse
+    try {
+      payload = JSON.parse(text) as PollResponse
+    } catch {
+      throw new Error(`polling ZINC task ${task} returned a non-JSON body: ${bodyExcerpt(text)}`)
+    }
+    if (payload.status === 'FAILURE') {
+      throw new Error(
+        `ZINC task ${task} failed server-side (status FAILURE). Check the query parameters and retry.`
+      )
+    }
+    const ready =
+      payload.status === 'SUCCESS' ||
+      (payload.status == null && Object.prototype.hasOwnProperty.call(payload, 'result'))
+    if (ready) return payload
+    const stillPending = payload.status == null || PENDING_STATUSES.has(payload.status)
+    if (!stillPending) {
+      throw new Error(`ZINC task ${task} reported unexpected status '${String(payload.status)}'.`)
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `ZINC task ${task} did not complete in time — the server is likely still computing. Re-poll ${BASE_URL}/search/result/${task} later, or retry with fewer ids or a larger timeout_s.`
+      )
+    }
+    const wait = Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now()))
+    await new Promise((resolve) => setTimeout(resolve, wait))
+  }
+}
+
+// Flattens a per-source result ({zinc22: [...], zinc20: [...]}, or a bare list for a
+// single-source deployment) into one record list tagged with `source`, zinc22 first.
+function flattenResult(result: unknown): ZincRecord[] {
+  if (result == null) return []
+  if (Array.isArray(result)) {
+    return result
+      .filter((r): r is ZincRecord => typeof r === 'object' && r !== null)
+      .map((r) => ({ ...r, source: 'zinc22' }))
+  }
+  if (typeof result !== 'object') return []
+  const bySource = result as Record<string, unknown>
+  const sources = [
+    ...SOURCE_ORDER.filter((s) => s in bySource),
+    ...Object.keys(bySource).filter((s) => !SOURCE_ORDER.includes(s))
+  ]
+  const records: ZincRecord[] = []
+  for (const source of sources) {
+    const rows = bySource[source]
+    if (!Array.isArray(rows)) continue
+    for (const row of rows) {
+      if (row && typeof row === 'object') records.push({ ...(row as ZincRecord), source })
+    }
+  }
+  return records
+}
+
+// ZINC22 purchasable-compound search (CartBlanche22): direct ZINC-id lookup only.
+// zinc_search_by_smiles / zinc_search_by_supplier / zinc_random_sample / zinc_get_3d are upstream
+// tools on the same async submit-poll transport, deliberately left as follow-up (the SMILES/
+// docking-analog search in particular is the slow path this tool intentionally avoids).
+export const ZINC_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'zinc_search_by_id',
+    connector: 'zinc',
+    description:
+      'Look up purchasable compounds in ZINC22/ZINC20 by ZINC identifier — answers "what is this compound and who sells it". Async upstream (submit + poll); can take up to timeout_s seconds.',
+    input: {
+      type: 'object',
+      properties: {
+        zinc_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'One or more ZINC ids, e.g. ZINC000000000012 (max 100 per call).'
+        },
+        max_results: {
+          type: 'integer',
+          default: DEFAULT_MAX_RESULTS,
+          description: 'Response bound (hard cap 500).'
+        },
+        timeout_s: {
+          type: 'number',
+          default: DEFAULT_TIMEOUT_S,
+          description: 'Overall submit->result budget in seconds (clamped 5-45).'
+        }
+      },
+      required: ['zinc_ids']
+    },
+    required: ['zinc_ids'],
+    run: async (_ctx, a) => {
+      const ids = normalizeZincIds(a.zinc_ids)
+      const cap = clampMaxResults(a.max_results)
+      const timeoutS = clampTimeoutS(a.timeout_s)
+      const deadline = Date.now() + timeoutS * 1000
+
+      const task = await submit(
+        'substances.txt',
+        { zinc_ids: ids.join(','), output_fields: OUTPUT_FIELDS },
+        deadline
+      )
+      const payload = await poll(task, deadline)
+      const records = flattenResult(payload.result)
+      const total = records.length
+      const page = records.slice(0, cap)
+
+      return {
+        query: { zinc_ids: ids },
+        total_available: total,
+        returned_count: page.length,
+        truncated: total > page.length,
+        records: page.map((r) => ({
+          zinc_id: r.zinc_id,
+          smiles: r.smiles,
+          tranche_name: r.tranche_name,
+          catalogs: r.catalogs,
+          source: r.source
+        }))
+      }
+    }
+  }
+]

--- a/src/main/connectors/engine.test.ts
+++ b/src/main/connectors/engine.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ParserEngine } from './engine'
+import type { ToolDescriptor } from './types'
+
+const jsonResponse = (body: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body)
+  }) as Response
+
+describe('ParserEngine declarative path', () => {
+  it('builds the url, fetches json, and runs parse', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ value: 42 }))
+    const engine = new ParserEngine({ fetchImpl })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: (a) => `https://example.test/${a.id}`,
+      parse: (raw) => (raw as { value: number }).value
+    }
+    const out = await engine.call(desc, { id: 7 }, {})
+    expect(fetchImpl).toHaveBeenCalledWith('https://example.test/7', expect.any(Object))
+    expect(out).toBe(42)
+  })
+
+  it('throws on missing required args', async () => {
+    const engine = new ParserEngine({ fetchImpl: vi.fn() })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      required: ['q'],
+      url: () => 'x',
+      parse: (r) => r
+    }
+    await expect(engine.call(desc, {}, {})).rejects.toThrow(/required arg: q/)
+  })
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 503 } as Response)
+    const engine = new ParserEngine({ fetchImpl })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://x.test',
+      parse: (r) => r
+    }
+    await expect(engine.call(desc, {}, {})).rejects.toThrow(/HTTP 503/)
+  })
+
+  it('postJson sends a POST with a JSON body and parses the response', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: { ok: true } }))
+    const engine = new ParserEngine({ fetchImpl })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      run: async (ctx) => ctx.postJson('https://gql.test/api', { query: 'q', variables: { a: 1 } })
+    }
+    const out = await engine.call(desc, {}, {})
+    const init = fetchImpl.mock.calls[0][1] as RequestInit & { headers: Record<string, string> }
+    expect(init.method).toBe('POST')
+    expect(init.headers['content-type']).toBe('application/json')
+    expect(JSON.parse(init.body as string)).toEqual({ query: 'q', variables: { a: 1 } })
+    expect(out).toEqual({ data: { ok: true } })
+  })
+
+  it('sends a User-Agent header (some APIs 403 without one)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ ok: 1 }))
+    const engine = new ParserEngine({ fetchImpl })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://example.test',
+      parse: (r) => r
+    }
+    await engine.call(desc, {}, {})
+    const headers = (fetchImpl.mock.calls[0][1] as { headers: Record<string, string> }).headers
+    expect(headers['user-agent']).toMatch(/OpenScience/)
+  })
+
+  it('redacts credentials from the URL in error messages', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 401 } as Response)
+    const engine = new ParserEngine({ fetchImpl })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://eutils.ncbi.nlm.nih.gov/entrez?email=a@b.com&api_key=SECRET',
+      parse: (r) => r
+    }
+    let message = ''
+    try {
+      await engine.call(desc, {}, {})
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+    expect(message).not.toContain('SECRET')
+    expect(message).toContain('HTTP 401')
+  })
+})

--- a/src/main/connectors/engine.ts
+++ b/src/main/connectors/engine.ts
@@ -1,0 +1,87 @@
+import type { ConnectorCredentials, ToolContext, ToolDescriptor } from './types'
+
+const DEFAULT_TIMEOUT_MS = 30_000
+
+// Some public APIs (e.g. AlphaFold EBI) reject requests without a User-Agent; send a stable one.
+const USER_AGENT = 'OpenScience/1.0 (+https://github.com/aipoch/open-science)'
+
+// Builds the NCBI E-utilities etiquette query suffix; empty when unset (calls still work).
+export function ncbiEtiquette(credentials: ConnectorCredentials): string {
+  const parts: string[] = []
+  if (credentials.ncbiEmail) parts.push(`email=${encodeURIComponent(credentials.ncbiEmail)}`)
+  if (credentials.ncbiApiKey) parts.push(`api_key=${encodeURIComponent(credentials.ncbiApiKey)}`)
+  return parts.length ? `&${parts.join('&')}` : ''
+}
+
+// Strips credential query params (NCBI email/api_key) from a URL before it can land in an error
+// message or log. Falls back to the raw string if it doesn't parse as a URL.
+function redactUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    parsed.searchParams.delete('email')
+    parsed.searchParams.delete('api_key')
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+// Generic executor shared by every connector: declarative { url, parse } or a run() escape hatch.
+export class ParserEngine {
+  private readonly fetchImpl: typeof fetch
+  private readonly timeoutMs: number
+
+  constructor(opts?: { fetchImpl?: typeof fetch; timeoutMs?: number }) {
+    this.fetchImpl = opts?.fetchImpl ?? fetch
+    this.timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  }
+
+  async call(
+    descriptor: ToolDescriptor,
+    args: Record<string, unknown>,
+    credentials: ConnectorCredentials
+  ): Promise<unknown> {
+    for (const key of descriptor.required ?? []) {
+      if (args[key] == null) throw new Error(`missing required arg: ${key}`)
+    }
+    const ctx = this.makeContext(credentials)
+    if (descriptor.run) return descriptor.run(ctx, args)
+    if (!descriptor.url || !descriptor.parse) {
+      throw new Error(`descriptor ${descriptor.id} needs either run() or url()+parse()`)
+    }
+    const url = descriptor.url(args)
+    const raw = descriptor.format === 'text' ? await ctx.fetchText(url) : await ctx.fetchJson(url)
+    return descriptor.parse(raw, args)
+  }
+
+  private makeContext(credentials: ConnectorCredentials): ToolContext {
+    const doFetch = async (url: string, accept: string, init?: RequestInit): Promise<Response> => {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+      try {
+        const res = await this.fetchImpl(url, {
+          ...init,
+          headers: { accept, 'user-agent': USER_AGENT, ...init?.headers },
+          signal: controller.signal
+        })
+        if (!res.ok) throw new Error(`HTTP ${res.status} for ${redactUrl(url)}`)
+        return res
+      } finally {
+        clearTimeout(timer)
+      }
+    }
+    return {
+      credentials,
+      fetchJson: async (url) => (await doFetch(url, 'application/json')).json(),
+      fetchText: async (url) => (await doFetch(url, 'text/plain, application/xml, */*')).text(),
+      postJson: async (url, body) =>
+        (
+          await doFetch(url, 'application/json', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(body)
+          })
+        ).json()
+    }
+  }
+}

--- a/src/main/connectors/etiquette.test.ts
+++ b/src/main/connectors/etiquette.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { ncbiEtiquette } from './engine'
+
+describe('ncbiEtiquette', () => {
+  it('returns empty string when no credentials', () => {
+    expect(ncbiEtiquette({})).toBe('')
+  })
+  it('url-encodes email and appends api key', () => {
+    expect(ncbiEtiquette({ ncbiEmail: 'a b@x.org', ncbiApiKey: 'KEY' })).toBe(
+      '&email=a%20b%40x.org&api_key=KEY'
+    )
+  })
+})

--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { z } from 'zod'
+import { McpClientManager, buildTransport } from './mcp-client-manager'
+import type { CustomMcpServerConfig } from './mcp-client-manager'
+
+// Builds an in-memory MCP server with one echo tool and one always-erroring tool, and an
+// injectable createClient that links a fresh Client to it via InMemoryTransport — no process
+// spawn, no network.
+function makeTestServer(): { createClient: () => Promise<Client> } {
+  const server = new McpServer({ name: 'test-server', version: '0.0.0' })
+
+  server.registerTool(
+    'echo',
+    { description: 'Echoes back its args as JSON.', inputSchema: { value: z.string() } },
+    async (args) => ({ content: [{ type: 'text', text: JSON.stringify(args) }] })
+  )
+
+  server.registerTool('boom', { description: 'Always fails.' }, async () => ({
+    content: [{ type: 'text', text: 'kaboom' }],
+    isError: true
+  }))
+
+  const createClient = async (): Promise<Client> => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    const client = new Client({ name: 'test-client', version: '0.0.0' })
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+    return client
+  }
+
+  return { createClient }
+}
+
+const config: CustomMcpServerConfig = {
+  id: 'srv-1',
+  name: 'test-server',
+  transport: 'stdio',
+  command: 'unused'
+}
+
+describe('McpClientManager', () => {
+  it('lists tools registered on the server', async () => {
+    const { createClient } = makeTestServer()
+    const manager = new McpClientManager({ createClient: () => createClient() })
+
+    const tools = await manager.listTools(config)
+
+    const names = tools.map((t) => t.name).sort()
+    expect(names).toEqual(['boom', 'echo'])
+    expect(tools.find((t) => t.name === 'echo')?.description).toMatch(/Echoes/)
+  })
+
+  it('calls a tool and returns the parsed JSON dict', async () => {
+    const { createClient } = makeTestServer()
+    const manager = new McpClientManager({ createClient: () => createClient() })
+
+    const out = await manager.call(config, 'echo', { value: 'hello' })
+
+    expect(out).toEqual({ value: 'hello' })
+  })
+
+  it('throws when the tool result has isError set', async () => {
+    const { createClient } = makeTestServer()
+    const manager = new McpClientManager({ createClient: () => createClient() })
+
+    await expect(manager.call(config, 'boom', {})).rejects.toThrow(/kaboom/)
+  })
+
+  it('dedupes concurrent connects for the same server id', async () => {
+    let connectCount = 0
+    const { createClient } = makeTestServer()
+    const manager = new McpClientManager({
+      createClient: async () => {
+        connectCount += 1
+        return createClient()
+      }
+    })
+
+    await Promise.all([manager.listTools(config), manager.call(config, 'echo', { value: 'x' })])
+
+    expect(connectCount).toBe(1)
+  })
+
+  it('closeAll drops cached clients so a later call reconnects', async () => {
+    let connectCount = 0
+    const { createClient } = makeTestServer()
+    const manager = new McpClientManager({
+      createClient: async () => {
+        connectCount += 1
+        return createClient()
+      }
+    })
+
+    await manager.listTools(config)
+    await manager.closeAll()
+    await manager.listTools(config)
+
+    expect(connectCount).toBe(2)
+  })
+})
+
+describe('buildTransport', () => {
+  it('builds a StdioClientTransport for a stdio config', () => {
+    const transport = buildTransport({
+      id: 'srv-stdio',
+      name: 'stdio-server',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', 'some-mcp-server']
+    })
+
+    expect(transport).toBeInstanceOf(StdioClientTransport)
+  })
+
+  it('throws when a stdio config is missing a command', () => {
+    expect(() =>
+      buildTransport({ id: 'srv-stdio', name: 'stdio-server', transport: 'stdio' })
+    ).toThrow()
+  })
+
+  it('builds a StreamableHTTPClientTransport for a streamable_http config', () => {
+    const transport = buildTransport({
+      id: 'srv-http',
+      name: 'http-server',
+      transport: 'streamable_http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer token' }
+    })
+
+    expect(transport).toBeInstanceOf(StreamableHTTPClientTransport)
+  })
+
+  it('throws when a streamable_http config is missing a url', () => {
+    expect(() =>
+      buildTransport({ id: 'srv-http', name: 'http-server', transport: 'streamable_http' })
+    ).toThrow()
+  })
+
+  it('builds an SSEClientTransport for an sse config', () => {
+    const transport = buildTransport({
+      id: 'srv-sse',
+      name: 'sse-server',
+      transport: 'sse',
+      url: 'https://example.com/sse'
+    })
+
+    expect(transport).toBeInstanceOf(SSEClientTransport)
+  })
+
+  it('throws when an sse config is missing a url', () => {
+    expect(() => buildTransport({ id: 'srv-sse', name: 'sse-server', transport: 'sse' })).toThrow()
+  })
+})

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -1,0 +1,159 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+
+// Config for a user-added custom MCP server. Phase 1 (stdio/local command) + Phase 2
+// (streamable_http/sse remote, with static auth headers). OAuth and a dynamic headers-helper
+// command are a later task — not modeled here.
+// See docs/internal/2026-07-12-custom-mcp-connectors-plan4.md §3.1.
+export type CustomMcpServerConfig = {
+  id: string
+  name: string
+  transport: 'stdio' | 'streamable_http' | 'sse'
+  // stdio (local command):
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  // remote (streamable_http / sse):
+  url?: string
+  headers?: Record<string, string>
+}
+
+export type McpClientManagerTool = {
+  name: string
+  description?: string
+  inputSchema?: unknown
+}
+
+type McpClientManagerDeps = {
+  createClient?: (config: CustomMcpServerConfig) => Promise<Client>
+}
+
+// Pure factory: picks the transport for a custom server config. Exported so callers/tests can
+// build a transport without a full connect, and so defaultCreateClient below stays a thin wrapper.
+export function buildTransport(config: CustomMcpServerConfig): Transport {
+  switch (config.transport) {
+    case 'stdio': {
+      if (!config.command) {
+        throw new Error(`custom MCP server "${config.name}" is missing a command for stdio`)
+      }
+      return new StdioClientTransport({
+        command: config.command,
+        args: config.args,
+        env: config.env
+      })
+    }
+    case 'streamable_http': {
+      if (!config.url) {
+        throw new Error(`custom MCP server "${config.name}" is missing a url for streamable_http`)
+      }
+      return new StreamableHTTPClientTransport(
+        new URL(config.url),
+        config.headers ? { requestInit: { headers: config.headers } } : undefined
+      )
+    }
+    case 'sse': {
+      if (!config.url) {
+        throw new Error(`custom MCP server "${config.name}" is missing a url for sse`)
+      }
+      return new SSEClientTransport(
+        new URL(config.url),
+        config.headers ? { requestInit: { headers: config.headers } } : undefined
+      )
+    }
+  }
+}
+
+// Default factory: build the transport for the server's configured type and connect an MCP client.
+async function defaultCreateClient(config: CustomMcpServerConfig): Promise<Client> {
+  const transport = buildTransport(config)
+  const client = new Client({ name: 'open-science', version: '0.0.0' })
+  await client.connect(transport)
+  return client
+}
+
+// MCP client for user-added custom servers (Phase 1: local/stdio). Mirrors the bundled
+// ParserEngine's structured-dict + isError-throws call contract so ConnectorService can
+// dispatch to either uniformly. Lazily connects and caches one client per server id.
+export class McpClientManager {
+  private readonly createClient: (config: CustomMcpServerConfig) => Promise<Client>
+  private readonly clients = new Map<string, Client>()
+  private readonly connecting = new Map<string, Promise<Client>>()
+
+  constructor(deps?: McpClientManagerDeps) {
+    this.createClient = deps?.createClient ?? defaultCreateClient
+  }
+
+  async listTools(config: CustomMcpServerConfig): Promise<McpClientManagerTool[]> {
+    const client = await this.connect(config)
+    const { tools } = await client.listTools()
+    return tools
+  }
+
+  async call(
+    config: CustomMcpServerConfig,
+    method: string,
+    args: Record<string, unknown>
+  ): Promise<unknown> {
+    const client = await this.connect(config)
+    const result = await client.callTool({ name: method, arguments: args })
+    return unwrapToolResult(result)
+  }
+
+  async close(id: string): Promise<void> {
+    const client = this.clients.get(id)
+    this.clients.delete(id)
+    this.connecting.delete(id)
+    if (client) await client.close()
+  }
+
+  async closeAll(): Promise<void> {
+    await Promise.all([...this.clients.keys()].map((id) => this.close(id)))
+  }
+
+  // Lazily connects, caching the client by server id and deduping concurrent connect calls.
+  private async connect(config: CustomMcpServerConfig): Promise<Client> {
+    const cached = this.clients.get(config.id)
+    if (cached) return cached
+
+    const inFlight = this.connecting.get(config.id)
+    if (inFlight) return inFlight
+
+    const connectPromise = this.createClient(config)
+      .then((client) => {
+        this.clients.set(config.id, client)
+        return client
+      })
+      .finally(() => {
+        this.connecting.delete(config.id)
+      })
+    this.connecting.set(config.id, connectPromise)
+    return connectPromise
+  }
+}
+
+// Unwraps a callTool() result the same way the bundled engine's descriptors return data:
+// isError -> throw; a single text content block -> JSON.parse (fallback to { text }); else raw.
+function unwrapToolResult(result: unknown): unknown {
+  if (typeof result !== 'object' || result === null) return result
+  const { content, isError } = result as { content?: unknown; isError?: boolean }
+  const first = Array.isArray(content) ? content[0] : undefined
+  const text =
+    typeof first === 'object' && first !== null && (first as { type?: unknown }).type === 'text'
+      ? (first as { text?: unknown }).text
+      : undefined
+
+  if (isError) {
+    throw new Error(typeof text === 'string' ? text : 'MCP tool call failed')
+  }
+  if (typeof text === 'string') {
+    try {
+      return JSON.parse(text)
+    } catch {
+      return { text }
+    }
+  }
+  return result
+}

--- a/src/main/connectors/provision.test.ts
+++ b/src/main/connectors/provision.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtemp, mkdir, readdir, readFile, writeFile, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { syncConnectorSkillDocs } from './provision'
+
+describe('syncConnectorSkillDocs', () => {
+  it('writes enabled connectors as mcp-<id>/SKILL.md and removes disabled ones', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'skills-'))
+    // A stale disabled connector directory that should be removed.
+    await mkdir(join(dir, 'mcp-pubmed'), { recursive: true })
+    await writeFile(join(dir, 'mcp-pubmed', 'SKILL.md'), 'stale')
+
+    await syncConnectorSkillDocs(dir, ['chemistry'])
+
+    const entries = (await readdir(dir)).sort()
+    expect(entries).toEqual(['mcp-chemistry'])
+    // Claude Code discovers skills as a directory containing SKILL.md.
+    expect((await stat(join(dir, 'mcp-chemistry'))).isDirectory()).toBe(true)
+    const doc = await readFile(join(dir, 'mcp-chemistry', 'SKILL.md'), 'utf8')
+    expect(doc).toContain('name: mcp-chemistry')
+    expect(doc).toContain('source: connector')
+  })
+})

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -1,0 +1,61 @@
+import { mkdir, readdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { ALL_CONNECTOR_IDS } from './registry'
+import { renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
+import type { CustomSkillDocTool } from './skill-doc'
+import type { StoredCustomMcpServer } from '../settings/types'
+
+// Writes skills/mcp-<connector>/SKILL.md for enabled connectors; removes the directory for
+// disabled ones. Claude Code discovers skills as `<name>/SKILL.md` directories, not flat files.
+// Custom-server directories (see syncCustomServerSkillDocs below) live in the same skills dir;
+// cleanup here only ever touches names that are known bundled connector ids, so the two sync
+// passes can never delete each other's output.
+export async function syncConnectorSkillDocs(
+  skillsDir: string,
+  enabledIds: string[]
+): Promise<void> {
+  // A first-run pre-enabled connector may sync before the skills dir has ever been created.
+  await mkdir(skillsDir, { recursive: true })
+  const enabled = new Set(enabledIds.filter((id) => ALL_CONNECTOR_IDS.includes(id)))
+  for (const id of enabled) {
+    const dir = join(skillsDir, `mcp-${id}`)
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'SKILL.md'), renderSkillDoc(id), 'utf8')
+  }
+  const existing = await readdir(skillsDir).catch(() => [] as string[])
+  for (const entry of existing) {
+    const m = /^mcp-(.+)$/.exec(entry)
+    if (m && ALL_CONNECTOR_IDS.includes(m[1]) && !enabled.has(m[1])) {
+      await rm(join(skillsDir, entry), { recursive: true, force: true })
+    }
+  }
+}
+
+export type CustomServerListTools = (server: StoredCustomMcpServer) => Promise<CustomSkillDocTool[]>
+
+// Writes skills/mcp-<name>/SKILL.md for enabled custom MCP servers, sourced from the server's
+// live listTools() schema rather than a bundled descriptor table (§3.4). Cleanup mirrors
+// syncConnectorSkillDocs: it only removes names that are NOT known bundled connector ids, so
+// the two sync passes never delete each other's directories even when run against the same dir.
+export async function syncCustomServerSkillDocs(
+  skillsDir: string,
+  servers: StoredCustomMcpServer[],
+  listTools: CustomServerListTools
+): Promise<void> {
+  await mkdir(skillsDir, { recursive: true })
+  const enabledNames = new Set(servers.map((s) => s.name))
+  for (const server of servers) {
+    const tools = await listTools(server)
+    const dir = join(skillsDir, `mcp-${server.name}`)
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'SKILL.md'), renderCustomSkillDoc(server, tools), 'utf8')
+  }
+  const existing = await readdir(skillsDir).catch(() => [] as string[])
+  for (const entry of existing) {
+    const m = /^mcp-(.+)$/.exec(entry)
+    if (!m || ALL_CONNECTOR_IDS.includes(m[1])) continue // owned by syncConnectorSkillDocs
+    if (!enabledNames.has(m[1])) {
+      await rm(join(skillsDir, entry), { recursive: true, force: true })
+    }
+  }
+}

--- a/src/main/connectors/registry.test.ts
+++ b/src/main/connectors/registry.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { getConnectorTools, getDescriptor, ALL_CONNECTOR_IDS } from './registry'
+import { CONNECTOR_CATALOG } from './catalog'
+
+describe('registry + catalog', () => {
+  it('resolves a tool by connector+method', () => {
+    expect(getDescriptor('chemistry', 'pubchem_get_properties')?.id).toBe('pubchem_get_properties')
+    expect(getDescriptor('chemistry', 'nope')).toBeUndefined()
+  })
+  it('lists tools for a connector', () => {
+    expect(getConnectorTools('pubmed').map((t) => t.id)).toContain('pubmed_search')
+  })
+  it('catalog ids and registry ids are consistent', () => {
+    for (const meta of CONNECTOR_CATALOG) expect(ALL_CONNECTOR_IDS).toContain(meta.id)
+    for (const id of ALL_CONNECTOR_IDS) expect(CONNECTOR_CATALOG.map((c) => c.id)).toContain(id)
+  })
+})

--- a/src/main/connectors/registry.ts
+++ b/src/main/connectors/registry.ts
@@ -1,0 +1,66 @@
+import { BIOMART_TOOLS } from './descriptors/biomart'
+import { BIORXIV_TOOLS } from './descriptors/biorxiv'
+import { CANCER_MODELS_TOOLS } from './descriptors/cancer-models'
+import { CELLGUIDE_TOOLS } from './descriptors/cellguide'
+import { CHEMBL_TOOLS } from './descriptors/chembl'
+import { CHEMISTRY_TOOLS } from './descriptors/chemistry'
+import { CLINICAL_GENOMICS_TOOLS } from './descriptors/clinical-genomics'
+import { CLINICAL_TRIALS_TOOLS } from './descriptors/clinical-trials'
+import { DRUG_REGULATORY_TOOLS } from './descriptors/drug-regulatory'
+import { EXPRESSION_TOOLS } from './descriptors/expression'
+import { GENES_TOOLS } from './descriptors/genes'
+import { GENOMES_TOOLS } from './descriptors/genomes'
+import { GEO_TOOLS } from './descriptors/geo'
+import { GNOMAD_TOOLS } from './descriptors/gnomad'
+import { HUMAN_GENETICS_TOOLS } from './descriptors/human-genetics'
+import { LITERATURE_TOOLS } from './descriptors/literature'
+import { OMICS_ARCHIVES_TOOLS } from './descriptors/omics-archives'
+import { OPENALEX_TOOLS } from './descriptors/openalex'
+import { PROTEIN_ANNOTATION_TOOLS } from './descriptors/protein-annotation'
+import { PUBMED_TOOLS } from './descriptors/pubmed'
+import { REGULATION_TOOLS } from './descriptors/regulation'
+import { RESEARCH_RESOURCES_TOOLS } from './descriptors/research-resources'
+import { RNA_TOOLS } from './descriptors/rna'
+import { STRUCTURES_TOOLS } from './descriptors/structures'
+import { VARIANTS_TOOLS } from './descriptors/variants'
+import { ZINC_TOOLS } from './descriptors/zinc'
+import type { ToolDescriptor } from './types'
+
+const ALL_TOOLS: ToolDescriptor[] = [
+  ...BIOMART_TOOLS,
+  ...BIORXIV_TOOLS,
+  ...CANCER_MODELS_TOOLS,
+  ...CELLGUIDE_TOOLS,
+  ...CHEMBL_TOOLS,
+  ...CHEMISTRY_TOOLS,
+  ...CLINICAL_GENOMICS_TOOLS,
+  ...CLINICAL_TRIALS_TOOLS,
+  ...DRUG_REGULATORY_TOOLS,
+  ...EXPRESSION_TOOLS,
+  ...GENES_TOOLS,
+  ...GENOMES_TOOLS,
+  ...GEO_TOOLS,
+  ...GNOMAD_TOOLS,
+  ...HUMAN_GENETICS_TOOLS,
+  ...LITERATURE_TOOLS,
+  ...OMICS_ARCHIVES_TOOLS,
+  ...OPENALEX_TOOLS,
+  ...PROTEIN_ANNOTATION_TOOLS,
+  ...PUBMED_TOOLS,
+  ...REGULATION_TOOLS,
+  ...RESEARCH_RESOURCES_TOOLS,
+  ...RNA_TOOLS,
+  ...STRUCTURES_TOOLS,
+  ...VARIANTS_TOOLS,
+  ...ZINC_TOOLS
+]
+
+export const ALL_CONNECTOR_IDS = [...new Set(ALL_TOOLS.map((t) => t.connector))]
+
+export function getConnectorTools(connector: string): ToolDescriptor[] {
+  return ALL_TOOLS.filter((t) => t.connector === connector)
+}
+
+export function getDescriptor(connector: string, method: string): ToolDescriptor | undefined {
+  return ALL_TOOLS.find((t) => t.connector === connector && t.id === method)
+}

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ConnectorService } from './service'
+import { ParserEngine } from './engine'
+
+const jsonRes = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as Response
+
+describe('ConnectorService', () => {
+  it('rejects calls to a disabled connector', async () => {
+    const svc = new ConnectorService({
+      getConnectors: () => ({
+        enabledIds: [],
+        autoAllowIds: [],
+        disabledConnectorIds: ['chemistry']
+      }),
+      resolveApiKey: () => undefined
+    })
+    await expect(svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })).rejects.toThrow(
+      /not enabled/
+    )
+  })
+  it('treats a bundled connector as enabled by default (opt-out model)', async () => {
+    const svc = new ConnectorService({
+      getConnectors: () => ({ enabledIds: [], autoAllowIds: [] }),
+      resolveApiKey: () => undefined
+    })
+    // No disabledConnectorIds ⇒ chemistry is enabled, so an unknown method (not enablement) is what fails.
+    await expect(svc.call('chemistry', 'nope', {})).rejects.toThrow(/unknown tool/)
+  })
+  it('rejects an unknown method', async () => {
+    const svc = new ConnectorService({
+      getConnectors: () => ({ enabledIds: ['chemistry'], autoAllowIds: [] }),
+      resolveApiKey: () => undefined
+    })
+    await expect(svc.call('chemistry', 'nope', {})).rejects.toThrow(/unknown tool/)
+  })
+  it('routes an enabled call through the engine with resolved credentials', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ PropertyTable: { Properties: [{ CID: 1 }] } }))
+    const svc = new ConnectorService({
+      engine: new ParserEngine({ fetchImpl }),
+      getConnectors: () => ({
+        enabledIds: ['chemistry'],
+        autoAllowIds: [],
+        contactEmail: 'x@y.org',
+        ncbiApiKeyRef: 'ref'
+      }),
+      resolveApiKey: (ref) => (ref === 'ref' ? 'SECRET' : undefined)
+    })
+    const out = await svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })
+    expect(out).toEqual([{ CID: 1 }])
+  })
+  it('rejects a blocked tool', async () => {
+    const svc = new ConnectorService({
+      getConnectors: () => ({
+        enabledIds: ['chemistry'],
+        autoAllowIds: [],
+        blockedToolIds: ['chemistry/pubchem_get_properties']
+      }),
+      resolveApiKey: () => undefined
+    })
+    await expect(svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })).rejects.toThrow(
+      /blocked by policy/
+    )
+  })
+
+  it('requests approval for an ask-flagged tool and runs it when allowed', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ PropertyTable: { Properties: [{ CID: 1 }] } }))
+    const requestApproval = vi.fn().mockResolvedValue('allow')
+    const svc = new ConnectorService({
+      engine: new ParserEngine({ fetchImpl }),
+      getConnectors: () => ({
+        enabledIds: [],
+        autoAllowIds: [],
+        askToolIds: ['chemistry/pubchem_get_properties']
+      }),
+      resolveApiKey: () => undefined,
+      requestApproval
+    })
+    const out = await svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })
+    expect(out).toEqual([{ CID: 1 }])
+    expect(requestApproval).toHaveBeenCalledWith({
+      connector: 'chemistry',
+      method: 'pubchem_get_properties',
+      args: { cids: [1] }
+    })
+  })
+
+  it('rejects an ask-flagged tool when the user denies approval', async () => {
+    const fetchImpl = vi.fn()
+    const requestApproval = vi.fn().mockResolvedValue('deny')
+    const svc = new ConnectorService({
+      engine: new ParserEngine({ fetchImpl }),
+      getConnectors: () => ({
+        enabledIds: [],
+        autoAllowIds: [],
+        askToolIds: ['chemistry/pubchem_get_properties']
+      }),
+      resolveApiKey: () => undefined,
+      requestApproval
+    })
+    await expect(svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })).rejects.toThrow(
+      /denied by user/
+    )
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('does not prompt for a tool at the default (allow)', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ PropertyTable: { Properties: [{ CID: 1 }] } }))
+    const requestApproval = vi.fn()
+    const svc = new ConnectorService({
+      engine: new ParserEngine({ fetchImpl }),
+      getConnectors: () => ({ enabledIds: [], autoAllowIds: [] }),
+      resolveApiKey: () => undefined,
+      requestApproval
+    })
+    await svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })
+    expect(requestApproval).not.toHaveBeenCalled()
+  })
+
+  it('skips approval for an ask tool when the connector has skip-approvals', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ PropertyTable: { Properties: [{ CID: 1 }] } }))
+    const requestApproval = vi.fn()
+    const svc = new ConnectorService({
+      engine: new ParserEngine({ fetchImpl }),
+      getConnectors: () => ({
+        enabledIds: [],
+        autoAllowIds: ['chemistry'],
+        askToolIds: ['chemistry/pubchem_get_properties']
+      }),
+      resolveApiKey: () => undefined,
+      requestApproval
+    })
+    await svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })
+    expect(requestApproval).not.toHaveBeenCalled()
+  })
+
+  describe('custom MCP servers', () => {
+    it('routes a call to a custom server through mcpClientManager.call', async () => {
+      const call = vi.fn().mockResolvedValue({ ok: true })
+      const svc = new ConnectorService({
+        mcpClientManager: { call },
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'srv-1',
+              name: 'myserver',
+              transport: 'stdio',
+              command: 'npx',
+              args: ['-y', '@example/server'],
+              env: { FOO: 'bar' },
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined
+      })
+      const out = await svc.call('myserver', 'do_thing', { x: 1 })
+      expect(out).toEqual({ ok: true })
+      expect(call).toHaveBeenCalledWith(
+        {
+          id: 'srv-1',
+          name: 'myserver',
+          transport: 'stdio',
+          command: 'npx',
+          args: ['-y', '@example/server'],
+          env: { FOO: 'bar' },
+          url: undefined,
+          headers: undefined
+        },
+        'do_thing',
+        { x: 1 }
+      )
+    })
+
+    it('routes a call to a remote (streamable_http) custom server with its url/headers', async () => {
+      const call = vi.fn().mockResolvedValue({ ok: true })
+      const svc = new ConnectorService({
+        mcpClientManager: { call },
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'srv-remote',
+              name: 'remoteserver',
+              transport: 'streamable_http',
+              url: 'https://example.com/mcp',
+              headers: { Authorization: 'Bearer token' },
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined
+      })
+      const out = await svc.call('remoteserver', 'do_thing', { x: 1 })
+      expect(out).toEqual({ ok: true })
+      expect(call).toHaveBeenCalledWith(
+        {
+          id: 'srv-remote',
+          name: 'remoteserver',
+          transport: 'streamable_http',
+          command: '',
+          args: undefined,
+          env: undefined,
+          url: 'https://example.com/mcp',
+          headers: { Authorization: 'Bearer token' }
+        },
+        'do_thing',
+        { x: 1 }
+      )
+    })
+
+    it('rejects a disabled custom server', async () => {
+      const call = vi.fn()
+      const svc = new ConnectorService({
+        mcpClientManager: { call },
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            { id: 'srv-1', name: 'myserver', transport: 'stdio', command: 'npx', enabled: false }
+          ]
+        }),
+        resolveApiKey: () => undefined
+      })
+      await expect(svc.call('myserver', 'do_thing', {})).rejects.toThrow(/not enabled/)
+      expect(call).not.toHaveBeenCalled()
+    })
+
+    it('rejects a blocked tool on a custom server', async () => {
+      const call = vi.fn()
+      const svc = new ConnectorService({
+        mcpClientManager: { call },
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          blockedToolIds: ['myserver/dangerous'],
+          customMcpServers: [
+            { id: 'srv-1', name: 'myserver', transport: 'stdio', command: 'npx', enabled: true }
+          ]
+        }),
+        resolveApiKey: () => undefined
+      })
+      await expect(svc.call('myserver', 'dangerous', {})).rejects.toThrow(/blocked by policy/)
+      expect(call).not.toHaveBeenCalled()
+    })
+
+    it('rejects a call to an unknown server name (neither bundled nor custom)', async () => {
+      const svc = new ConnectorService({
+        getConnectors: () => ({ enabledIds: [], autoAllowIds: [], customMcpServers: [] }),
+        resolveApiKey: () => undefined
+      })
+      await expect(svc.call('nope', 'do_thing', {})).rejects.toThrow(/not enabled/)
+    })
+  })
+})

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -1,0 +1,118 @@
+import { ParserEngine } from './engine'
+import { ALL_CONNECTOR_IDS, getDescriptor } from './registry'
+import { toCustomMcpConfig } from './custom-mcp-bootstrap'
+import type { CustomMcpServerConfig } from './mcp-client-manager'
+import type { ConnectorCredentials, ToolDescriptor } from './types'
+import type { StoredConnectors } from '../settings/types'
+import type { ApprovalDecision } from '../../shared/settings'
+
+type McpClientManagerLike = {
+  call(
+    config: CustomMcpServerConfig,
+    method: string,
+    args: Record<string, unknown>
+  ): Promise<unknown>
+}
+
+type ConnectorServiceDeps = {
+  engine?: ParserEngine
+  mcpClientManager?: McpClientManagerLike
+  getConnectors: () => StoredConnectors | undefined
+  resolveApiKey: (ref?: string) => string | undefined
+  // Human approval gate for a tool call that isn't pre-approved. Absent (e.g. in tests) means the
+  // call runs without prompting. A connector call sends data to an external service, so a call that
+  // is neither pre-allowed nor skip-approved must be confirmed before it runs.
+  requestApproval?: (info: {
+    connector: string
+    method: string
+    args: Record<string, unknown>
+  }) => Promise<ApprovalDecision>
+}
+
+// Agent-agnostic gate: enforces enabled state + per-tool policy, prompts for approval on un-trusted
+// calls, injects credentials, and dispatches each call to either the bundled ParserEngine or a
+// user-added custom MCP server's McpClientManager. See docs/internal/2026-07-12-custom-mcp-connectors-plan4.md §3.2.
+export class ConnectorService {
+  private readonly engine: ParserEngine
+  constructor(private readonly deps: ConnectorServiceDeps) {
+    this.engine = deps.engine ?? new ParserEngine()
+  }
+
+  isEnabled(connector: string): boolean {
+    // Bundled connectors are enabled by default; only an explicit opt-out disables one.
+    return !(this.deps.getConnectors()?.disabledConnectorIds ?? []).includes(connector)
+  }
+
+  async call(connector: string, method: string, args: Record<string, unknown>): Promise<unknown> {
+    const descriptor = getDescriptor(connector, method)
+    const isBundled = descriptor !== undefined || ALL_CONNECTOR_IDS.includes(connector)
+    if (isBundled) return this.callBundled(connector, method, args, descriptor)
+
+    const custom = (this.deps.getConnectors()?.customMcpServers ?? []).find(
+      (s) => s.name === connector
+    )
+    if (!custom) throw new Error(`connector not enabled: ${connector}`)
+    return this.callCustom(custom, method, args)
+  }
+
+  private async callBundled(
+    connector: string,
+    method: string,
+    args: Record<string, unknown>,
+    descriptor: ToolDescriptor | undefined
+  ): Promise<unknown> {
+    if (!this.isEnabled(connector)) throw new Error(`connector not enabled: ${connector}`)
+    if (!descriptor) throw new Error(`unknown tool: ${connector}/${method}`)
+
+    if (this.isBlocked(connector, method)) {
+      throw new Error(`tool blocked by policy: ${connector}/${method}`)
+    }
+    await this.ensureApproved(connector, method, args)
+
+    return this.engine.call(descriptor, args, this.credentials())
+  }
+
+  private async callCustom(
+    custom: NonNullable<StoredConnectors['customMcpServers']>[number],
+    method: string,
+    args: Record<string, unknown>
+  ): Promise<unknown> {
+    if (!custom.enabled) throw new Error(`connector not enabled: ${custom.name}`)
+    if (this.isBlocked(custom.name, method)) {
+      throw new Error(`tool blocked by policy: ${custom.name}/${method}`)
+    }
+    if (!this.deps.mcpClientManager) throw new Error('connector runtime not configured')
+    await this.ensureApproved(custom.name, method, args)
+
+    return this.deps.mcpClientManager.call(toCustomMcpConfig(custom), method, args)
+  }
+
+  private isBlocked(connector: string, method: string): boolean {
+    const blocked = this.deps.getConnectors()?.blockedToolIds ?? []
+    return blocked.includes(`${connector}/${method}`)
+  }
+
+  // Tools run without a prompt by default. A call is confirmed by a human only when the tool is
+  // explicitly set to "Ask each time" AND the connector does not skip approvals.
+  private async ensureApproved(
+    connector: string,
+    method: string,
+    args: Record<string, unknown>
+  ): Promise<void> {
+    const c = this.deps.getConnectors()
+    const requiresAsk = (c?.askToolIds ?? []).includes(`${connector}/${method}`)
+    const skipApprovals = (c?.autoAllowIds ?? []).includes(connector)
+    if (!requiresAsk || skipApprovals) return
+    if (!this.deps.requestApproval) return // no approver wired (tests) — do not block
+
+    const decision = await this.deps.requestApproval({ connector, method, args })
+    if (decision !== 'allow') {
+      throw new Error(`tool call denied by user: ${connector}/${method}`)
+    }
+  }
+
+  private credentials(): ConnectorCredentials {
+    const c = this.deps.getConnectors()
+    return { ncbiEmail: c?.contactEmail, ncbiApiKey: this.deps.resolveApiKey(c?.ncbiApiKeyRef) }
+  }
+}

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { renderSkillDoc } from './skill-doc'
+
+describe('renderSkillDoc', () => {
+  it('renders frontmatter, conventions, and each tool', () => {
+    const md = renderSkillDoc('chemistry')
+    expect(md).toContain('name: mcp-chemistry')
+    expect(md).toContain('source: connector')
+    expect(md).toContain('host.mcp(')
+    expect(md).toContain('pubchem_get_properties')
+    expect(md).toContain('rate-limited') // rate warning present
+  })
+  it('uses the trigger-style useWhen as the frontmatter description for auto-discovery', () => {
+    const md = renderSkillDoc('chemistry')
+    // The frontmatter description is what Claude Code matches a plain user question against.
+    const frontmatter = md.slice(0, md.indexOf('---', 3))
+    expect(frontmatter).toMatch(/description: ".*Use when.*"/)
+    expect(md).toContain('## When to Use')
+  })
+  it('throws for an unknown connector', () => {
+    expect(() => renderSkillDoc('nope')).toThrow()
+  })
+})

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -1,0 +1,57 @@
+import { CONNECTOR_CATALOG } from './catalog'
+import { getConnectorTools } from './registry'
+
+const CONVENTIONS = [
+  'Reach this service ONLY via `host.mcp(server, method, **kwargs)` from the notebook kernel.',
+  'Do NOT reimplement these calls with raw HTTP (urllib / requests / httpx / fetch) or hit the upstream endpoints directly — that bypasses the approval gate, per-tool policy, credentials, and rate limits, and can leak project data.',
+  'Prefer bulk/list tools over per-item loops — the upstream API is rate-limited and shared across subagents.',
+  'Pass large results between cells via `./handoff/*.json`, not the model context.'
+].join('\n')
+
+// Renders one connector's tools as a searchable skill document (frontmatter + conventions + methods).
+// The frontmatter description is the trigger-style `useWhen` so Claude Code auto-discovers the skill
+// from a plain user question, without the user naming the connector.
+export function renderSkillDoc(connectorId: string): string {
+  const meta = CONNECTOR_CATALOG.find((c) => c.id === connectorId)
+  if (!meta) throw new Error(`unknown connector: ${connectorId}`)
+  const tools = getConnectorTools(connectorId)
+  const header = `---\nname: mcp-${connectorId}\ndescription: ${JSON.stringify(meta.useWhen)}\nsource: connector\n---\n`
+  const methods = tools
+    .map(
+      (t) =>
+        `### ${t.id}\n\n${t.description}\n\n\`\`\`json\n${JSON.stringify(t.input, null, 2)}\n\`\`\`\n\n` +
+        `Example: \`host.mcp("${connectorId}", "${t.id}", ...)\`\n`
+    )
+    .join('\n')
+  return (
+    `${header}\n## When to Use\n\n${meta.useWhen}\n\n` +
+    `> This connector is rate-limited at the upstream API.\n\n${CONVENTIONS}\n\n## Tools\n\n${methods}`
+  )
+}
+
+export type CustomSkillDocServer = { name: string; description?: string }
+export type CustomSkillDocTool = { name: string; description?: string; inputSchema?: unknown }
+
+// Same shape as renderSkillDoc, but for a user-added custom MCP server: schema comes from
+// McpClientManager.listTools() at runtime rather than a bundled descriptor table, and the
+// trigger-style description falls back to a composed one when the server has no useWhen text.
+export function renderCustomSkillDoc(
+  server: CustomSkillDocServer,
+  tools: CustomSkillDocTool[]
+): string {
+  const useWhen =
+    server.description ??
+    `Use when you need tools from the ${server.name} MCP server — ${tools.map((t) => t.name).join(', ')}.`
+  const header = `---\nname: mcp-${server.name}\ndescription: ${JSON.stringify(useWhen)}\nsource: connector\n---\n`
+  const methods = tools
+    .map(
+      (t) =>
+        `### ${t.name}\n\n${t.description ?? ''}\n\n\`\`\`json\n${JSON.stringify(t.inputSchema ?? {}, null, 2)}\n\`\`\`\n\n` +
+        `Example: \`host.mcp("${server.name}", "${t.name}", ...)\`\n`
+    )
+    .join('\n')
+  return (
+    `${header}\n## When to Use\n\n${useWhen}\n\n` +
+    `> This connector is rate-limited at the upstream API.\n\n${CONVENTIONS}\n\n## Tools\n\n${methods}`
+  )
+}

--- a/src/main/connectors/types.ts
+++ b/src/main/connectors/types.ts
@@ -1,0 +1,22 @@
+export type ConnectorCredentials = { ncbiEmail?: string; ncbiApiKey?: string }
+
+export type ToolContext = {
+  fetchJson(url: string): Promise<unknown>
+  fetchText(url: string): Promise<string>
+  // POST a JSON body and parse the JSON response — for GraphQL / POST-only APIs (e.g. gnomAD).
+  postJson(url: string, body: unknown): Promise<unknown>
+  credentials: ConnectorCredentials
+}
+
+// One connector tool = a request-mapper (url) + response-parser (parse), or a run() escape hatch.
+export type ToolDescriptor = {
+  id: string
+  connector: string
+  description: string
+  input: Record<string, unknown> // JSON Schema for the tool args (also used by docs)
+  required?: string[]
+  format?: 'json' | 'text'
+  url?: (args: Record<string, unknown>) => string
+  parse?: (raw: unknown, args: Record<string, unknown>) => unknown
+  run?: (ctx: ToolContext, args: Record<string, unknown>) => Promise<unknown>
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,6 +1,17 @@
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+import { BrowserWindow, ipcMain } from 'electron'
+
 import { createDefaultNotebookRuntimeService, registerAcpIpcHandlers } from './acp/ipc'
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
 import { ArtifactRunRegistry } from './artifacts/run-registry'
+import { ApprovalBroker } from './connectors/approval-broker'
+import { toCustomMcpConfig, selectEnabledCustomServers } from './connectors/custom-mcp-bootstrap'
+import { McpClientManager } from './connectors/mcp-client-manager'
+import { ALL_CONNECTOR_IDS } from './connectors/registry'
+import { ConnectorService } from './connectors/service'
+import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './connectors/provision'
 import { registerFileSaveHandlers } from './file-save'
 import { registerGithubIpcHandlers } from './github-ipc'
 import { registerLogsIpcHandlers } from './logs-ipc'
@@ -8,12 +19,59 @@ import { registerNotebookIpcHandlers } from './notebook/ipc'
 import { NotebookLocalRpcServer } from './notebook/local-rpc-server'
 import { registerProjectIpcHandlers } from './projects/ipc'
 import { registerSessionPersistenceIpcHandlers } from './session-persistence/ipc'
+import { tryDecryptKey } from './settings/crypto'
 import { registerSettingsIpcHandlers } from './settings/ipc'
-import { createDefaultSettingsService } from './settings/service'
+import { getAppClaudeConfigDir } from './settings/provider-env'
+import { createDefaultSettingsService, type SettingsService } from './settings/service'
+import type { StoredConnectors } from './settings/types'
+import { resolveStorageRoot } from './storage-root'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './uploads/ipc'
 
 type IpcRegistrationOptions = {
   mainEntryPath: string
+}
+
+// Builds a short, human-readable preview of a connector call's arguments for the approval card.
+const previewArgs = (args: Record<string, unknown>): string => {
+  let json: string
+  try {
+    json = JSON.stringify(args)
+  } catch {
+    json = '{…}'
+  }
+  return json.length > 300 ? `${json.slice(0, 300)}…` : json
+}
+
+// Reads the connectors settings block and refreshes the mcp-<connector>/mcp-<server> skill docs to
+// match — both the bundled catalog and any enabled custom MCP servers (stdio + remote). Called at
+// startup;
+// a future connectors-settings mutation (Plan 2/5 UI) should call this again so enable/disable
+// (bundled or custom) takes effect without an app restart. Never throws — a bad read or a
+// misconfigured/unreachable custom server (e.g. bad command) is logged and leaves the previous
+// snapshot and on-disk docs in place rather than breaking bootstrap.
+const refreshConnectorSkillDocs = async (
+  settingsService: SettingsService,
+  storageRoot: string,
+  mcpClientManager: McpClientManager,
+  onSnapshot: (connectors: StoredConnectors | undefined) => void
+): Promise<void> => {
+  try {
+    const connectors = await settingsService.getConnectors()
+
+    onSnapshot(connectors)
+    const skillsDir = join(getAppClaudeConfigDir(storageRoot), 'skills')
+
+    // Opt-out model: every bundled connector is enabled unless explicitly disabled.
+    const disabled = new Set(connectors?.disabledConnectorIds ?? [])
+    const enabledIds = ALL_CONNECTOR_IDS.filter((id) => !disabled.has(id))
+
+    await syncConnectorSkillDocs(skillsDir, enabledIds)
+    await syncCustomServerSkillDocs(skillsDir, selectEnabledCustomServers(connectors), (server) =>
+      mcpClientManager.listTools(toCustomMcpConfig(server))
+    )
+  } catch (error) {
+    console.error('Failed to sync connector skill docs:', error)
+  }
 }
 
 // Registers every main-process IPC surface used by the renderer.
@@ -24,9 +82,55 @@ const registerIpcHandlers = ({ mainEntryPath }: IpcRegistrationOptions): void =>
   // Share one upload repository so composer staging, prompt finalization, and previews agree.
   const uploadRepository = createDefaultUploadRepository()
   const notebookService = createDefaultNotebookRuntimeService()
-  const notebookRpcServer = new NotebookLocalRpcServer(notebookService)
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
   const settingsService = createDefaultSettingsService()
+
+  // Read fresh on every call so a future connectors-settings mutation (Plan 2 UI) only needs to call
+  // refreshConnectorSkillDocs again to take effect, without reconstructing the connector service.
+  let connectorsSnapshot: StoredConnectors | undefined
+  // One MCP client manager backs both dispatch (ConnectorService.call → custom server) and skill-doc
+  // generation (listTools) for user-added custom MCP servers (stdio + remote). It lazily connects per
+  // server, so constructing it here does not spawn anything until a custom server is actually used.
+  const mcpClientManager = new McpClientManager()
+  // Bridges un-trusted connector calls to the renderer approval card. A tool call that isn't
+  // pre-allowed or skip-approved is held here until the user decides (or it auto-denies on timeout).
+  const approvalBroker = new ApprovalBroker({
+    generateId: () => randomUUID(),
+    broadcast: (request) => {
+      for (const window of BrowserWindow.getAllWindows()) {
+        if (!window.isDestroyed()) window.webContents.send('connectors:approval-request', request)
+      }
+    }
+  })
+  const connectorService = new ConnectorService({
+    getConnectors: () => connectorsSnapshot,
+    resolveApiKey: (ref) => tryDecryptKey(ref),
+    mcpClientManager,
+    requestApproval: ({ connector, method, args }) =>
+      approvalBroker.request({ connector, method, argsPreview: previewArgs(args) })
+  })
+  const notebookRpcServer = new NotebookLocalRpcServer(notebookService, { connectorService })
+  // The RPC server needs the runtime service to dispatch to, and the runtime service needs the RPC
+  // server's (lazily-started) connection for host.mcp() env injection — wire the second half here to
+  // avoid a construction cycle.
+  notebookService.setMcpRpcConnectionResolver(() => notebookRpcServer.ensureStarted())
+
+  // The renderer's approval card responds here; the broker resolves the held connector call.
+  ipcMain.handle(
+    'connectors:approval-respond',
+    (_event, request: { id: string; decision: 'allow' | 'deny' }) => {
+      approvalBroker.respond(request.id, request.decision)
+    }
+  )
+
+  void refreshConnectorSkillDocs(
+    settingsService,
+    resolveStorageRoot(),
+    mcpClientManager,
+    (connectors) => {
+      connectorsSnapshot = connectors
+    }
+  )
 
   registerFileSaveHandlers()
   registerLogsIpcHandlers()
@@ -45,7 +149,18 @@ const registerIpcHandlers = ({ mainEntryPath }: IpcRegistrationOptions): void =>
   registerSettingsIpcHandlers({
     service: settingsService,
     onActiveProviderChanged: () => void runtime.requestProviderReconnect(),
-    onSkillsChanged: () => void runtime.requestSkillsReload()
+    onSkillsChanged: () => void runtime.requestSkillsReload(),
+    // Re-sync bundled + custom skill docs and refresh the in-memory snapshot the connector
+    // service reads, so a connector/tool/credential change takes effect without an app restart.
+    onConnectorsChanged: () =>
+      void refreshConnectorSkillDocs(
+        settingsService,
+        resolveStorageRoot(),
+        mcpClientManager,
+        (connectors) => {
+          connectorsSnapshot = connectors
+        }
+      )
   })
   registerNotebookIpcHandlers(notebookService)
   registerArtifactIpcHandlers(artifactRepository, artifactRunRegistry)

--- a/src/main/notebook/host-mcp.integration.test.ts
+++ b/src/main/notebook/host-mcp.integration.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { NotebookPythonExecutor } from './python-executor'
+
+// Requires python3 on PATH. Run with: RUN_KERNEL=1 npx vitest run <file>
+describe.skipIf(!process.env.RUN_KERNEL)('kernel host.mcp', () => {
+  it('host.mcp posts to the RPC endpoint and returns the parsed dict', async () => {
+    // Minimal stub RPC endpoint returning a fixed dict for any mcpCall.
+    const { createServer } = await import('node:http')
+    const server = createServer((req, res) => {
+      let body = ''
+      req.on('data', (c) => (body += c))
+      req.on('end', () =>
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ result: { ok: true } }))
+      )
+    })
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
+    const addr = server.address() as { port: number }
+    const exec = new NotebookPythonExecutor()
+    const result = await exec.execute({
+      code: 'r = host.mcp("chemistry","pubchem_get_properties", cids=[1]); print(r["ok"])',
+      cwd: process.cwd(),
+      notebookSessionRoot: '',
+      dataRoot: '',
+      runtimeRoot: '',
+      // test-only fields consumed by the executor env wiring:
+      mcpRpcEndpoint: `http://127.0.0.1:${addr.port}`,
+      mcpRpcToken: 'tok'
+    } as never)
+    await exec.shutdown()
+    server.close()
+    expect(result.stdout).toContain('True')
+  })
+
+  it('surfaces the RPC server error message when host.mcp gets a non-2xx response', async () => {
+    // Stub RPC endpoint mirroring NotebookLocalRpcServer's failure shape: HTTP 500 + {"error": ...}.
+    const { createServer } = await import('node:http')
+    const server = createServer((req, res) => {
+      let body = ''
+      req.on('data', (c) => (body += c))
+      req.on('end', () =>
+        res
+          .writeHead(500, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ error: 'connector not enabled: chemistry' }))
+      )
+    })
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
+    const addr = server.address() as { port: number }
+    const exec = new NotebookPythonExecutor()
+    const result = await exec.execute({
+      code: 'host.mcp("chemistry","pubchem_get_properties", cids=[1])',
+      cwd: process.cwd(),
+      notebookSessionRoot: '',
+      dataRoot: '',
+      runtimeRoot: '',
+      mcpRpcEndpoint: `http://127.0.0.1:${addr.port}`,
+      mcpRpcToken: 'tok'
+    } as never)
+    await exec.shutdown()
+    server.close()
+    expect(result.status).toBe('failed')
+    expect(result.traceback).toContain('connector not enabled: chemistry')
+  })
+})

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { NotebookLocalRpcServer } from './local-rpc-server'
+
+const fakeConnector = {
+  call: async (s: string, m: string, a: Record<string, unknown>) => ({ s, m, a })
+}
+let server: NotebookLocalRpcServer | undefined
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+describe('mcpCall RPC', () => {
+  it('routes mcpCall to the connector service', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      connectorService: fakeConnector as never
+    })
+    const { endpoint, token } = await server.ensureStarted()
+    const res = await fetch(`${endpoint}`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        method: 'mcpCall',
+        params: { server: 'chemistry', method: 'pubchem_get_properties', args: { cids: [1] } }
+      })
+    })
+    expect(await res.json()).toEqual({
+      result: { s: 'chemistry', m: 'pubchem_get_properties', a: { cids: [1] } }
+    })
+  })
+})

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -14,6 +14,9 @@ import type { NotebookRuntimeService } from './runtime-service'
 type NotebookLocalRpcServerOptions = {
   token?: string
   host?: string
+  connectorService?: {
+    call(server: string, method: string, args: Record<string, unknown>): Promise<unknown>
+  }
 }
 
 type NotebookRpcPayload = {
@@ -53,6 +56,7 @@ const assertSessionParams = (params: Record<string, unknown>): void => {
 class NotebookLocalRpcServer {
   private readonly token: string
   private readonly host: string
+  private readonly connectorService: NotebookLocalRpcServerOptions['connectorService']
   private server: Server | undefined
   private startPromise: Promise<NotebookRpcConnection> | undefined
   private readonly sessionAliases = new Map<string, string>()
@@ -63,6 +67,7 @@ class NotebookLocalRpcServer {
   ) {
     this.token = options.token ?? randomUUID()
     this.host = options.host ?? '127.0.0.1'
+    this.connectorService = options.connectorService
   }
 
   // Starts the server once on an ephemeral port and returns the connection details for MCP env.
@@ -146,6 +151,15 @@ class NotebookLocalRpcServer {
 
   // Maps the narrow RPC method names to strongly-typed runtime service calls.
   private async dispatch(method: string, params: Record<string, unknown>): Promise<unknown> {
+    // mcpCall is not session-scoped, so it bypasses assertSessionParams below.
+    if (method === 'mcpCall') {
+      if (!this.connectorService) throw new Error('Connector service is not configured.')
+      const server = typeof params.server === 'string' ? params.server : ''
+      const toolMethod = typeof params.method === 'string' ? params.method : ''
+      const args = isRecord(params.args) ? params.args : {}
+      return this.connectorService.call(server, toolMethod, args)
+    }
+
     assertSessionParams(params)
 
     const handlers: Record<string, (request: Record<string, unknown>) => Promise<unknown>> = {

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -26,9 +26,37 @@ import os
 import sys
 import tempfile
 import traceback
+import urllib.error
+import urllib.request
+
+class _Host:
+    # Control-plane bridge to the main process connector service.
+    def mcp(self, server, method, **kwargs):
+        endpoint = os.environ.get("OPEN_SCIENCE_MCP_RPC_ENDPOINT")
+        token = os.environ.get("OPEN_SCIENCE_MCP_RPC_TOKEN")
+        if not endpoint:
+            raise RuntimeError("host.mcp is unavailable: connector RPC endpoint not set")
+        payload = json.dumps({"method": "mcpCall", "params": {"server": server, "method": method, "args": kwargs}}).encode("utf-8")
+        req = urllib.request.Request(endpoint, data=payload, method="POST",
+            headers={"content-type": "application/json", "authorization": "Bearer " + (token or "")})
+        try:
+            with urllib.request.urlopen(req) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            # urlopen raises on non-2xx before the body is read as a normal response, so the error
+            # detail from the RPC server's JSON body must be pulled out of the exception instead.
+            try:
+                parsed = json.loads(e.read().decode("utf-8"))
+            except Exception:
+                parsed = {}
+            raise RuntimeError(parsed.get("error") or ("host.mcp HTTP " + str(e.code)))
+        if body.get("error"):
+            raise RuntimeError("host.mcp error: " + str(body["error"]))
+        return body["result"]
 
 # Reuse a single global namespace so variables survive across notebook runs.
 globals_ns = {"__name__": "__main__"}
+globals_ns["host"] = _Host()
 # Keep protocol responses on the original stdout even if executed code changes file descriptor 1.
 protocol_stdout = os.fdopen(os.dup(1), "w", buffering=1)
 
@@ -273,7 +301,11 @@ class NotebookPythonExecutor implements NotebookExecutor {
         MPLBACKEND: process.env.MPLBACKEND || 'Agg',
         OPEN_SCIENCE_NOTEBOOK_DIR: request.notebookSessionRoot,
         OPEN_SCIENCE_NOTEBOOK_DATA_DIR: request.dataRoot,
-        OPEN_SCIENCE_RUNTIME_DIR: request.runtimeRoot
+        OPEN_SCIENCE_RUNTIME_DIR: request.runtimeRoot,
+        ...(request.mcpRpcEndpoint
+          ? { OPEN_SCIENCE_MCP_RPC_ENDPOINT: request.mcpRpcEndpoint }
+          : {}),
+        ...(request.mcpRpcToken ? { OPEN_SCIENCE_MCP_RPC_TOKEN: request.mcpRpcToken } : {})
       }
     })
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -298,6 +298,47 @@ describe('notebook runtime service', () => {
     expect(changedSessions.filter((sessionId) => sessionId === 'agent-session').length).toBe(5)
   })
 
+  it('threads the resolved mcp RPC connection into the execute request env', async () => {
+    const root = await createStorageRoot()
+    const executions: NotebookExecutionRequest[] = []
+    const service = new NotebookRuntimeService({
+      storageRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => {
+          executions.push(request)
+          return {
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }
+        },
+        shutdown: async () => undefined
+      })
+    })
+
+    service.setMcpRpcConnectionResolver(async () => ({
+      endpoint: 'http://127.0.0.1:1/x',
+      token: 'tok'
+    }))
+
+    await service.execute({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      code: "print('hi')"
+    })
+
+    expect(executions[0]).toMatchObject({
+      mcpRpcEndpoint: 'http://127.0.0.1:1/x',
+      mcpRpcToken: 'tok'
+    })
+  })
+
   it('returns null when a session has no persisted notebook run history', async () => {
     const root = await createStorageRoot()
     const service = new NotebookRuntimeService({

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -28,6 +28,9 @@ type NotebookExecutionRequest = {
   dataRoot: string
   runtimeRoot: string
   timeoutMs?: number
+  // Connector RPC connection injected into the kernel spawn env for host.mcp().
+  mcpRpcEndpoint?: string
+  mcpRpcToken?: string
 }
 
 type NotebookExecutionResult = {
@@ -50,12 +53,21 @@ type NotebookRuntimeServiceCallbacks = {
   onNotebookChanged?: (event: NotebookSessionReference) => void
 }
 
+// The connector RPC endpoint/token injected into a kernel's spawn env for host.mcp(). The token is
+// stable for the lifetime of the local RPC server that issues it, so resolving it again on every run
+// is cheap and always yields the same value the already-spawned kernel captured at its own spawn time.
+type McpRpcConnection = { endpoint: string; token: string }
+
 type NotebookRuntimeServiceOptions = {
   storageRoot: string
   projectName: string
   repository?: NotebookRunRepository
   executorFactory?: (sessionId: string) => NotebookExecutor
   callbacks?: NotebookRuntimeServiceCallbacks
+  // Resolves the connector RPC connection to inject into the kernel spawn env. Usually set after
+  // construction via setMcpRpcConnectionResolver, since the RPC server is constructed with this
+  // service as a dependency (constructing them in the other order would cycle).
+  getMcpRpcConnection?: () => Promise<McpRpcConnection>
 }
 
 type RuntimeSession = {
@@ -115,9 +127,17 @@ class NotebookRuntimeService {
   private readonly sessions = new Map<string, RuntimeSession>()
   private readonly announcedAgentSessionIds = new Set<string>()
   private runSequence = 0
+  private mcpRpcConnectionResolver: (() => Promise<McpRpcConnection>) | undefined
 
   constructor(private readonly options: NotebookRuntimeServiceOptions) {
     this.repository = options.repository ?? new NotebookRunRepository(options.storageRoot)
+    this.mcpRpcConnectionResolver = options.getMcpRpcConnection
+  }
+
+  // Wires the connector RPC connection lookup after construction (the local RPC server that provides
+  // it is itself constructed with this service as a dependency, so it cannot be passed in up front).
+  setMcpRpcConnectionResolver(resolver: () => Promise<McpRpcConnection>): void {
+    this.mcpRpcConnectionResolver = resolver
   }
 
   // Starts an exclusive agent/user write stream into a cell and locks notebook editing.
@@ -256,6 +276,9 @@ class NotebookRuntimeService {
       run: runningRun
     })
     this.notifyNotebookChanged(session)
+    // Resolved fresh per run, but backed by the RPC server's cached start promise so it settles to the
+    // same stable {endpoint, token} an already-spawned kernel captured at its own spawn time.
+    const mcpRpc = await this.resolveMcpRpcConnection()
     // Every execution result, including errors, is normalized into data for agent analysis.
     const result = await session.executor
       .execute({
@@ -264,7 +287,9 @@ class NotebookRuntimeService {
         notebookSessionRoot: session.notebookSessionRoot,
         dataRoot: session.dataRoot,
         runtimeRoot: session.runtimeRoot,
-        timeoutMs: request.timeoutMs
+        timeoutMs: request.timeoutMs,
+        mcpRpcEndpoint: mcpRpc?.endpoint,
+        mcpRpcToken: mcpRpc?.token
       })
       .catch((error: unknown) => errorToExecutionResult(error, cwdBefore))
     // Replace the running record instead of appending so each run id has one durable entry.
@@ -462,6 +487,18 @@ class NotebookRuntimeService {
   // Builds the interpreter backend, allowing tests to inject a fake executor.
   private createExecutor(sessionId: string): NotebookExecutor {
     return this.options.executorFactory?.(sessionId) ?? new NotebookPythonExecutor()
+  }
+
+  // Best-effort lookup of the connector RPC connection: host.mcp() is unavailable (rather than the
+  // whole cell failing) when no resolver is wired or the RPC server fails to start.
+  private async resolveMcpRpcConnection(): Promise<McpRpcConnection | undefined> {
+    if (!this.mcpRpcConnectionResolver) return undefined
+
+    try {
+      return await this.mcpRpcConnectionResolver()
+    } catch {
+      return undefined
+    }
   }
 
   // Verifies that streamed writes are still targeting the currently locked cell.

--- a/src/main/settings/connectors-settings.test.ts
+++ b/src/main/settings/connectors-settings.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { sanitizeConnectors, SettingsRepository } from './repository'
+import type { StoredConnectors } from './types'
+
+describe('sanitizeConnectors', () => {
+  it('keeps arrays of strings and optional fields', () => {
+    expect(
+      sanitizeConnectors({
+        enabledIds: ['chemistry', 1, 'pubmed'],
+        autoAllowIds: ['chemistry'],
+        contactEmail: 'a@b.org',
+        ncbiApiKeyRef: 'ref1',
+        blockedToolIds: ['chemistry/pubchem_get_properties'],
+        disabledConnectorIds: ['zinc', 'zinc', 'rna']
+      })
+    ).toEqual({
+      enabledIds: ['chemistry', 'pubmed'],
+      autoAllowIds: ['chemistry'],
+      contactEmail: 'a@b.org',
+      ncbiApiKeyRef: 'ref1',
+      blockedToolIds: ['chemistry/pubchem_get_properties'],
+      disabledConnectorIds: ['zinc', 'rna']
+    })
+  })
+  it('returns undefined for non-objects', () => {
+    expect(sanitizeConnectors(null)).toBeUndefined()
+  })
+})
+
+describe('SettingsRepository connector mutators', () => {
+  const withRepo = async (fn: (repo: SettingsRepository) => Promise<void>): Promise<void> => {
+    const dir = await mkdtemp(join(tmpdir(), 'osci-connectors-'))
+    try {
+      await fn(new SettingsRepository(dir))
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  }
+  const readConnectors = async (repo: SettingsRepository): Promise<StoredConnectors | undefined> =>
+    (await repo.getSettings()).connectors
+
+  it('adds and removes a disabled connector id (default-on)', async () => {
+    await withRepo(async (repo) => {
+      expect((await readConnectors(repo))?.disabledConnectorIds).toBeUndefined()
+      await repo.setConnectorDisabled('zinc', true)
+      expect((await readConnectors(repo))?.disabledConnectorIds).toEqual(['zinc'])
+      await repo.setConnectorDisabled('zinc', false)
+      expect((await readConnectors(repo))?.disabledConnectorIds).toBeUndefined()
+    })
+  })
+
+  it('toggles connector auto-allow (skip approvals)', async () => {
+    await withRepo(async (repo) => {
+      await repo.setConnectorAutoAllow('biomart', true)
+      expect((await readConnectors(repo))?.autoAllowIds).toEqual(['biomart'])
+      await repo.setConnectorAutoAllow('biomart', false)
+      expect((await readConnectors(repo))?.autoAllowIds).toEqual([])
+    })
+  })
+
+  it('blocks and unblocks a tool id', async () => {
+    await withRepo(async (repo) => {
+      await repo.setToolBlocked('biomart/get_data', true)
+      expect((await readConnectors(repo))?.blockedToolIds).toEqual(['biomart/get_data'])
+      await repo.setToolBlocked('biomart/get_data', false)
+      expect((await readConnectors(repo))?.blockedToolIds).toBeUndefined()
+    })
+  })
+
+  it('sets and clears NCBI credentials', async () => {
+    await withRepo(async (repo) => {
+      await repo.setNcbiCredentials('me@lab.org', 'cipher-ref')
+      let c = await readConnectors(repo)
+      expect(c?.contactEmail).toBe('me@lab.org')
+      expect(c?.ncbiApiKeyRef).toBe('cipher-ref')
+      await repo.setNcbiCredentials(undefined, undefined)
+      c = await readConnectors(repo)
+      expect(c?.contactEmail).toBeUndefined()
+      expect(c?.ncbiApiKeyRef).toBeUndefined()
+    })
+  })
+
+  it('persists mutations to disk', async () => {
+    await withRepo(async (repo) => {
+      await repo.setConnectorDisabled('rna', true)
+      const raw = await readFile(
+        join((repo as unknown as { storageDir: string }).storageDir, 'settings.json'),
+        'utf8'
+      )
+      expect(JSON.parse(raw).connectors.disabledConnectorIds).toEqual(['rna'])
+    })
+  })
+})

--- a/src/main/settings/custom-mcp-settings.test.ts
+++ b/src/main/settings/custom-mcp-settings.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeConnectors, sanitizeCustomMcpServer } from './repository'
+
+describe('sanitizeCustomMcpServer', () => {
+  it('round-trips a valid stdio server with args/env/trustedAt', () => {
+    expect(
+      sanitizeCustomMcpServer({
+        id: 'srv-1',
+        name: 'My Server',
+        transport: 'stdio',
+        command: 'npx',
+        args: ['-y', 'some-mcp-server'],
+        env: { FOO: 'bar' },
+        enabled: true,
+        trustedAt: 1700000000000,
+        description: 'A test server'
+      })
+    ).toEqual({
+      id: 'srv-1',
+      name: 'My Server',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', 'some-mcp-server'],
+      env: { FOO: 'bar' },
+      enabled: true,
+      trustedAt: 1700000000000,
+      description: 'A test server'
+    })
+  })
+
+  it('drops a stdio server missing command', () => {
+    expect(
+      sanitizeCustomMcpServer({
+        id: 'srv-1',
+        name: 'My Server',
+        transport: 'stdio',
+        enabled: true
+      })
+    ).toBeUndefined()
+  })
+
+  it('drops an entry with an invalid transport', () => {
+    expect(
+      sanitizeCustomMcpServer({
+        id: 'srv-1',
+        name: 'My Server',
+        transport: 'websocket',
+        command: 'npx',
+        enabled: true
+      })
+    ).toBeUndefined()
+  })
+
+  it('strips non-string env values', () => {
+    expect(
+      sanitizeCustomMcpServer({
+        id: 'srv-1',
+        name: 'My Server',
+        transport: 'stdio',
+        command: 'npx',
+        env: { FOO: 'bar', BAD: 42, ALSO_BAD: { nested: true } },
+        enabled: true
+      })
+    ).toEqual({
+      id: 'srv-1',
+      name: 'My Server',
+      transport: 'stdio',
+      command: 'npx',
+      env: { FOO: 'bar' },
+      enabled: true
+    })
+  })
+
+  it('round-trips a valid remote (streamable_http) server with url and headers', () => {
+    expect(
+      sanitizeCustomMcpServer({
+        id: 'srv-remote',
+        name: 'Remote Server',
+        transport: 'streamable_http',
+        url: 'https://example.com/mcp',
+        headers: { Authorization: 'Bearer token' },
+        enabled: true
+      })
+    ).toEqual({
+      id: 'srv-remote',
+      name: 'Remote Server',
+      transport: 'streamable_http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer token' },
+      enabled: true
+    })
+  })
+
+  it('round-trips a valid sse server with url', () => {
+    expect(
+      sanitizeCustomMcpServer({
+        id: 'srv-sse',
+        name: 'SSE Server',
+        transport: 'sse',
+        url: 'https://example.com/sse',
+        enabled: true
+      })
+    ).toEqual({
+      id: 'srv-sse',
+      name: 'SSE Server',
+      transport: 'sse',
+      url: 'https://example.com/sse',
+      enabled: true
+    })
+  })
+
+  it('drops a remote server missing a url', () => {
+    expect(
+      sanitizeCustomMcpServer({
+        id: 'srv-remote',
+        name: 'Remote Server',
+        transport: 'streamable_http',
+        enabled: true
+      })
+    ).toBeUndefined()
+    expect(
+      sanitizeCustomMcpServer({
+        id: 'srv-sse',
+        name: 'SSE Server',
+        transport: 'sse',
+        enabled: true
+      })
+    ).toBeUndefined()
+  })
+
+  it('strips non-string header values', () => {
+    expect(
+      sanitizeCustomMcpServer({
+        id: 'srv-remote',
+        name: 'Remote Server',
+        transport: 'streamable_http',
+        url: 'https://example.com/mcp',
+        headers: { Authorization: 'Bearer token', BAD: 42 },
+        enabled: true
+      })
+    ).toEqual({
+      id: 'srv-remote',
+      name: 'Remote Server',
+      transport: 'streamable_http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer token' },
+      enabled: true
+    })
+  })
+})
+
+describe('sanitizeConnectors customMcpServers', () => {
+  it('collects valid custom servers and filters out invalid ones', () => {
+    const result = sanitizeConnectors({
+      enabledIds: [],
+      autoAllowIds: [],
+      customMcpServers: [
+        { id: 'srv-1', name: 'Valid', transport: 'stdio', command: 'npx', enabled: true },
+        { id: 'srv-2', name: 'Missing command', transport: 'stdio', enabled: true },
+        { id: '', name: 'No id', transport: 'stdio', command: 'npx', enabled: true }
+      ]
+    })
+
+    expect(result?.customMcpServers).toEqual([
+      { id: 'srv-1', name: 'Valid', transport: 'stdio', command: 'npx', enabled: true }
+    ])
+  })
+
+  it('omits customMcpServers when the resulting list is empty', () => {
+    const result = sanitizeConnectors({
+      enabledIds: [],
+      autoAllowIds: [],
+      customMcpServers: []
+    })
+
+    expect(result?.customMcpServers).toBeUndefined()
+  })
+})

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -11,7 +11,15 @@ import type {
   InstallClaudeRequest,
   RefreshProviderModelsRequest,
   SetActiveProviderRequest,
+  AddCustomServerRequest,
+  RemoveCustomServerRequest,
+  SetCustomServerEnabledRequest,
+  UpdateCustomServerRequest,
+  SetConnectorAutoAllowRequest,
+  SetConnectorEnabledRequest,
+  SetNcbiCredentialsRequest,
   SetSkillEnabledRequest,
+  SetToolPermissionRequest,
   UpdateSkillRequest,
   UpsertProviderRequest,
   ValidateProviderRequest
@@ -27,6 +35,8 @@ export type SettingsIpcOptions = {
   onActiveProviderChanged?: () => void
   // Called after a skill is toggled so the ACP runtime reloads skills on its next reconnect.
   onSkillsChanged?: () => void
+  // Called after a connector/tool/credential change so bundled + custom skill docs re-sync.
+  onConnectorsChanged?: () => void
 }
 
 // Streams one install log line to every open renderer window.
@@ -43,7 +53,8 @@ const broadcastInstallLog = (payload: unknown): void => {
 const registerSettingsIpcHandlers = ({
   service = createDefaultSettingsService(),
   onActiveProviderChanged,
-  onSkillsChanged
+  onSkillsChanged,
+  onConnectorsChanged
 }: SettingsIpcOptions = {}): void => {
   ipcMain.handle('settings:get-preflight', () => service.getPreflight())
   ipcMain.handle('settings:get-settings', () => service.getSettingsView())
@@ -131,6 +142,72 @@ const registerSettingsIpcHandlers = ({
   )
   ipcMain.handle('settings:scan-repo-skills', (_event, request: ScanRepoRequest) =>
     service.scanRepoSkills(request)
+  )
+
+  ipcMain.handle('settings:list-connectors', () => service.listConnectors())
+  ipcMain.handle('settings:get-connector-detail', (_event, id: string) =>
+    service.getConnectorDetail(id)
+  )
+  ipcMain.handle(
+    'settings:set-connector-enabled',
+    async (_event, request: SetConnectorEnabledRequest) => {
+      const snapshot = await service.setConnectorEnabled(request)
+      onConnectorsChanged?.()
+      return snapshot
+    }
+  )
+  ipcMain.handle(
+    'settings:set-connector-auto-allow',
+    async (_event, request: SetConnectorAutoAllowRequest) => {
+      const snapshot = await service.setConnectorAutoAllow(request)
+      onConnectorsChanged?.()
+      return snapshot
+    }
+  )
+  ipcMain.handle(
+    'settings:set-tool-permission',
+    async (_event, request: SetToolPermissionRequest) => {
+      const detail = await service.setToolPermission(request)
+      onConnectorsChanged?.()
+      return detail
+    }
+  )
+  ipcMain.handle(
+    'settings:set-ncbi-credentials',
+    async (_event, request: SetNcbiCredentialsRequest) => {
+      const snapshot = await service.setNcbiCredentials(request)
+      onConnectorsChanged?.()
+      return snapshot
+    }
+  )
+  ipcMain.handle('settings:add-custom-server', async (_event, request: AddCustomServerRequest) => {
+    const snapshot = await service.addCustomServer(request)
+    onConnectorsChanged?.()
+    return snapshot
+  })
+  ipcMain.handle(
+    'settings:set-custom-server-enabled',
+    async (_event, request: SetCustomServerEnabledRequest) => {
+      const snapshot = await service.setCustomServerEnabled(request)
+      onConnectorsChanged?.()
+      return snapshot
+    }
+  )
+  ipcMain.handle(
+    'settings:remove-custom-server',
+    async (_event, request: RemoveCustomServerRequest) => {
+      const snapshot = await service.removeCustomServer(request)
+      onConnectorsChanged?.()
+      return snapshot
+    }
+  )
+  ipcMain.handle(
+    'settings:update-custom-server',
+    async (_event, request: UpdateCustomServerRequest) => {
+      const snapshot = await service.updateCustomServer(request)
+      onConnectorsChanged?.()
+      return snapshot
+    }
   )
 }
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -9,7 +9,13 @@ import type {
 } from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import { isOfficialVendorId } from '../../shared/provider-registry'
-import { createEmptySettings, type StoredProvider, type StoredSettings } from './types'
+import {
+  createEmptySettings,
+  type StoredConnectors,
+  type StoredCustomMcpServer,
+  type StoredProvider,
+  type StoredSettings
+} from './types'
 
 const SETTINGS_FILE = 'settings.json'
 
@@ -34,6 +40,30 @@ const asString = (value: unknown): string | undefined =>
 
 const asNumber = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isFinite(value) ? value : undefined
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : []
+
+const asBoolean = (value: unknown): boolean | undefined =>
+  typeof value === 'boolean' ? value : undefined
+
+// Rebuilds a record<string,string>, dropping any key whose value isn't a string. Returns undefined
+// for a non-record input or when nothing survives.
+const asStringRecord = (value: unknown): Record<string, string> | undefined => {
+  if (!isRecord(value)) return undefined
+
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string'
+  )
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined
+}
+
+const CUSTOM_MCP_TRANSPORTS = new Set<StoredCustomMcpServer['transport']>([
+  'stdio',
+  'streamable_http',
+  'sse'
+])
 
 // Rebuilds claude metadata from allowed fields only.
 const sanitizeClaudeInfo = (value: unknown): ClaudeInfo | undefined => {
@@ -113,6 +143,78 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   return provider
 }
 
+// Rebuilds one custom MCP server, dropping unknown fields and records missing required identity.
+// Phase 1 only wires up the stdio transport end-to-end, so stdio additionally requires a non-empty
+// `command`; `url` is accepted (for the remote transports) but not yet validated further.
+export const sanitizeCustomMcpServer = (value: unknown): StoredCustomMcpServer | undefined => {
+  if (!isRecord(value)) return undefined
+
+  const id = asString(value.id)
+  const name = asString(value.name)
+  const transport = asString(value.transport) as StoredCustomMcpServer['transport'] | undefined
+  const enabled = asBoolean(value.enabled)
+
+  if (
+    !id ||
+    !name ||
+    !transport ||
+    !CUSTOM_MCP_TRANSPORTS.has(transport) ||
+    enabled === undefined
+  ) {
+    return undefined
+  }
+
+  const command = asString(value.command)
+  const url = asString(value.url)
+
+  if (transport === 'stdio' && !command) return undefined
+  if ((transport === 'streamable_http' || transport === 'sse') && !url) return undefined
+
+  const server: StoredCustomMcpServer = { id, name, transport, enabled }
+
+  if (command) server.command = command
+  const args = asStringArray(value.args)
+  if (args.length) server.args = args
+  const env = asStringRecord(value.env)
+  if (env) server.env = env
+  if (url) server.url = url
+  const headers = asStringRecord(value.headers)
+  if (headers) server.headers = headers
+  const trustedAt = asNumber(value.trustedAt)
+  if (trustedAt !== undefined) server.trustedAt = trustedAt
+  const description = asString(value.description)
+  if (description) server.description = description
+
+  return server
+}
+
+// Rebuilds the connectors block from allowed fields only.
+export const sanitizeConnectors = (value: unknown): StoredConnectors | undefined => {
+  if (!isRecord(value)) return undefined
+  const connectors: StoredConnectors = {
+    enabledIds: asStringArray(value.enabledIds),
+    autoAllowIds: asStringArray(value.autoAllowIds)
+  }
+  const contactEmail = asString(value.contactEmail)
+  const ncbiApiKeyRef = asString(value.ncbiApiKeyRef)
+  if (contactEmail) connectors.contactEmail = contactEmail
+  if (ncbiApiKeyRef) connectors.ncbiApiKeyRef = ncbiApiKeyRef
+  const blockedToolIds = asStringArray(value.blockedToolIds)
+  if (blockedToolIds.length) connectors.blockedToolIds = blockedToolIds
+  const askToolIds = asStringArray(value.askToolIds)
+  if (askToolIds.length) connectors.askToolIds = askToolIds
+  const disabledConnectorIds = asStringArray(value.disabledConnectorIds)
+  if (disabledConnectorIds.length)
+    connectors.disabledConnectorIds = [...new Set(disabledConnectorIds)]
+  const customMcpServers = Array.isArray(value.customMcpServers)
+    ? value.customMcpServers
+        .map(sanitizeCustomMcpServer)
+        .filter((server): server is StoredCustomMcpServer => !!server)
+    : []
+  if (customMcpServers.length) connectors.customMcpServers = customMcpServers
+  return connectors
+}
+
 // Rebuilds the whole settings document, keeping activeProviderId only when it points at a provider.
 const sanitizeSettings = (value: unknown): StoredSettings => {
   if (!isRecord(value)) return createEmptySettings()
@@ -160,6 +262,10 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
   if (disabledSkillIds.length > 0) {
     settings.disabledSkillIds = disabledSkillIds
   }
+
+  const connectors = sanitizeConnectors(value.connectors)
+
+  if (connectors) settings.connectors = connectors
 
   return settings
 }
@@ -259,6 +365,113 @@ class SettingsRepository {
       return disabledSkillIds.length > 0
         ? { ...settings, disabledSkillIds }
         : { ...settings, disabledSkillIds: undefined }
+    })
+  }
+
+  // Adds or removes a bundled connector id from the disabled set (default-on model).
+  async setConnectorDisabled(id: string, disabled: boolean): Promise<StoredSettings> {
+    return this.mutateConnectors((connectors) => {
+      const set = new Set(connectors.disabledConnectorIds ?? [])
+      if (disabled) set.add(id)
+      else set.delete(id)
+      connectors.disabledConnectorIds = set.size > 0 ? [...set] : undefined
+    })
+  }
+
+  // Adds or removes a connector id from the "skip approvals" auto-allow set.
+  async setConnectorAutoAllow(id: string, autoAllow: boolean): Promise<StoredSettings> {
+    return this.mutateConnectors((connectors) => {
+      const set = new Set(connectors.autoAllowIds ?? [])
+      if (autoAllow) set.add(id)
+      else set.delete(id)
+      connectors.autoAllowIds = [...set]
+    })
+  }
+
+  // Adds or removes a "<connector>/<method>" id from the per-tool blocklist.
+  async setToolBlocked(toolId: string, blocked: boolean): Promise<StoredSettings> {
+    return this.mutateConnectors((connectors) => {
+      const set = new Set(connectors.blockedToolIds ?? [])
+      if (blocked) set.add(toolId)
+      else set.delete(toolId)
+      connectors.blockedToolIds = set.size > 0 ? [...set] : undefined
+    })
+  }
+
+  // Sets a tool's full policy (ask / blocked) in one write. A tool is never in both sets; a tool in
+  // neither is at the default (allow, no prompt).
+  async setToolPolicy(toolId: string, ask: boolean, blocked: boolean): Promise<StoredSettings> {
+    return this.mutateConnectors((connectors) => {
+      const askSet = new Set(connectors.askToolIds ?? [])
+      const block = new Set(connectors.blockedToolIds ?? [])
+      if (ask) askSet.add(toolId)
+      else askSet.delete(toolId)
+      if (blocked) block.add(toolId)
+      else block.delete(toolId)
+      connectors.askToolIds = askSet.size > 0 ? [...askSet] : undefined
+      connectors.blockedToolIds = block.size > 0 ? [...block] : undefined
+    })
+  }
+
+  // Sets or clears the shared research-service contact email and the NCBI API key reference.
+  async setNcbiCredentials(
+    contactEmail: string | undefined,
+    apiKeyRef: string | undefined
+  ): Promise<StoredSettings> {
+    return this.mutateConnectors((connectors) => {
+      connectors.contactEmail = contactEmail || undefined
+      connectors.ncbiApiKeyRef = apiKeyRef || undefined
+    })
+  }
+
+  // Appends a fully-formed custom MCP server record.
+  async addCustomServer(server: StoredCustomMcpServer): Promise<StoredSettings> {
+    return this.mutateConnectors((connectors) => {
+      connectors.customMcpServers = [...(connectors.customMcpServers ?? []), server]
+    })
+  }
+
+  // Removes a custom MCP server by id (and any stale per-tool blocks under its name).
+  async removeCustomServer(id: string): Promise<StoredSettings> {
+    return this.mutateConnectors((connectors) => {
+      const removed = (connectors.customMcpServers ?? []).find((s) => s.id === id)
+      connectors.customMcpServers = (connectors.customMcpServers ?? []).filter((s) => s.id !== id)
+      if (removed && connectors.blockedToolIds) {
+        const prefix = `${removed.name}/`
+        const kept = connectors.blockedToolIds.filter((t) => !t.startsWith(prefix))
+        connectors.blockedToolIds = kept.length > 0 ? kept : undefined
+      }
+    })
+  }
+
+  // Enables or disables one custom MCP server by id.
+  async setCustomServerEnabled(id: string, enabled: boolean): Promise<StoredSettings> {
+    return this.mutateConnectors((connectors) => {
+      connectors.customMcpServers = (connectors.customMcpServers ?? []).map((s) =>
+        s.id === id ? { ...s, enabled } : s
+      )
+    })
+  }
+
+  // Replaces one custom MCP server record (identity fields must be preserved by the caller).
+  async updateCustomServer(id: string, server: StoredCustomMcpServer): Promise<StoredSettings> {
+    return this.mutateConnectors((connectors) => {
+      connectors.customMcpServers = (connectors.customMcpServers ?? []).map((s) =>
+        s.id === id ? server : s
+      )
+    })
+  }
+
+  // Read-modify-write over the connectors block, seeding an empty block on first mutation.
+  private mutateConnectors(fn: (connectors: StoredConnectors) => void): Promise<StoredSettings> {
+    return this.mutate((settings) => {
+      const connectors: StoredConnectors = {
+        enabledIds: [],
+        autoAllowIds: [],
+        ...settings.connectors
+      }
+      fn(connectors)
+      return { ...settings, connectors }
     })
   }
 

--- a/src/main/settings/service.connectors.test.ts
+++ b/src/main/settings/service.connectors.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Reversible fake safeStorage so the NCBI key can be encrypted without an OS keychain.
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`cipher:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => buffer.toString('utf8').slice('cipher:'.length)
+  },
+  app: { getPath: () => '/home', getAppPath: () => '/home/no-such-app-root', isPackaged: false }
+}))
+
+const { SettingsService } = await import('./service')
+const { SettingsRepository } = await import('./repository')
+const { ALL_CONNECTOR_IDS } = await import('../connectors/registry')
+
+// Exercises the connector surface of SettingsService against a real on-disk repository.
+describe('SettingsService connectors', () => {
+  let dir: string
+  let service: InstanceType<typeof SettingsService>
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'osci-svc-connectors-'))
+    service = new SettingsService({ repository: new SettingsRepository(dir) })
+    return async () => {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('lists every bundled connector, all enabled and not auto-allowed by default', async () => {
+    const snapshot = await service.listConnectors()
+
+    expect(snapshot.connectors).toHaveLength(ALL_CONNECTOR_IDS.length)
+    expect(snapshot.connectors.every((c) => c.enabled)).toBe(true)
+    expect(snapshot.connectors.every((c) => !c.autoAllow)).toBe(true)
+    expect(snapshot.customServers).toEqual([])
+    expect(snapshot.ncbi).toEqual({ contactEmail: undefined, hasApiKey: false })
+  })
+
+  it('disables and re-enables one connector', async () => {
+    let snapshot = await service.setConnectorEnabled({ id: 'chemistry', enabled: false })
+    expect(snapshot.connectors.find((c) => c.id === 'chemistry')?.enabled).toBe(false)
+    // Others stay enabled.
+    expect(snapshot.connectors.find((c) => c.id === 'pubmed')?.enabled).toBe(true)
+
+    snapshot = await service.setConnectorEnabled({ id: 'chemistry', enabled: true })
+    expect(snapshot.connectors.find((c) => c.id === 'chemistry')?.enabled).toBe(true)
+  })
+
+  it('toggles connector auto-allow (skip approvals)', async () => {
+    const snapshot = await service.setConnectorAutoAllow({ id: 'biomart', autoAllow: true })
+    expect(snapshot.connectors.find((c) => c.id === 'biomart')?.autoAllow).toBe(true)
+  })
+
+  it('returns connector detail with tools defaulting to allow', async () => {
+    const detail = await service.getConnectorDetail('chemistry')
+
+    expect(detail.id).toBe('chemistry')
+    expect(detail.tools.length).toBeGreaterThan(0)
+    expect(detail.tools.every((t) => t.permission === 'allow')).toBe(true)
+    expect(detail.tools[0].id).toBe(`chemistry/${detail.tools[0].method}`)
+  })
+
+  it('cycles a tool through block, ask, and back to allow', async () => {
+    const first = await service.getConnectorDetail('chemistry')
+    const toolId = first.tools[0].id
+
+    const blocked = await service.setToolPermission({ toolId, permission: 'block' })
+    expect(blocked.tools.find((t) => t.id === toolId)?.permission).toBe('block')
+
+    const asked = await service.setToolPermission({ toolId, permission: 'ask' })
+    expect(asked.tools.find((t) => t.id === toolId)?.permission).toBe('ask')
+
+    const allowed = await service.setToolPermission({ toolId, permission: 'allow' })
+    expect(allowed.tools.find((t) => t.id === toolId)?.permission).toBe('allow')
+  })
+
+  it('never keeps a tool in both ask and blocked sets', async () => {
+    const first = await service.getConnectorDetail('chemistry')
+    const toolId = first.tools[0].id
+
+    await service.setToolPermission({ toolId, permission: 'ask' })
+    await service.setToolPermission({ toolId, permission: 'block' })
+    const c = await service.getConnectors()
+    expect(c?.askToolIds ?? []).not.toContain(toolId)
+    expect(c?.blockedToolIds ?? []).toContain(toolId)
+  })
+
+  it('stores contact email and reports hasApiKey without exposing the key', async () => {
+    const snapshot = await service.setNcbiCredentials({
+      contactEmail: 'me@lab.org',
+      apiKey: 'secret-key'
+    })
+
+    expect(snapshot.ncbi.contactEmail).toBe('me@lab.org')
+    expect(snapshot.ncbi.hasApiKey).toBe(true)
+    // The raw key never appears in the renderer snapshot.
+    expect(JSON.stringify(snapshot)).not.toContain('secret-key')
+  })
+
+  it('throws for an unknown connector id', async () => {
+    await expect(service.getConnectorDetail('nope')).rejects.toThrow(/Unknown connector/)
+  })
+
+  it('adds, toggles, and removes a local (stdio) custom server', async () => {
+    let snapshot = await service.addCustomServer({
+      name: 'my-mem',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-memory'],
+      description: 'Memory server'
+    })
+    expect(snapshot.customServers).toHaveLength(1)
+    const added = snapshot.customServers[0]
+    expect(added).toMatchObject({
+      name: 'my-mem',
+      transport: 'stdio',
+      command: 'npx',
+      enabled: true,
+      description: 'Memory server'
+    })
+    expect(added.id).toBeTruthy()
+
+    snapshot = await service.setCustomServerEnabled({ id: added.id, enabled: false })
+    expect(snapshot.customServers[0].enabled).toBe(false)
+
+    snapshot = await service.removeCustomServer({ id: added.id })
+    expect(snapshot.customServers).toEqual([])
+  })
+
+  it('adds a remote (streamable_http) custom server with a url', async () => {
+    const snapshot = await service.addCustomServer({
+      name: 'remote-x',
+      transport: 'streamable_http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer t' }
+    })
+    expect(snapshot.customServers[0]).toMatchObject({
+      name: 'remote-x',
+      transport: 'streamable_http',
+      url: 'https://example.com/mcp'
+    })
+  })
+
+  it('rejects an invalid custom server (stdio without a command)', async () => {
+    await expect(service.addCustomServer({ name: 'bad', transport: 'stdio' })).rejects.toThrow(
+      /Invalid custom connector/
+    )
+  })
+
+  it('does not expose custom-server env or header secrets in the view', async () => {
+    const snapshot = await service.addCustomServer({
+      name: 'secretful',
+      transport: 'stdio',
+      command: 'run',
+      env: { TOKEN: 'super-secret' }
+    })
+    expect(JSON.stringify(snapshot)).not.toContain('super-secret')
+  })
+
+  it('edits a custom server, keeping its name and preserving omitted env', async () => {
+    const added = await service.addCustomServer({
+      name: 'my-mem',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', 'old'],
+      env: { TOKEN: 'keep-me' }
+    })
+    const id = added.customServers[0].id
+
+    // Change command/args but omit env — the stored secret env must be preserved.
+    const updated = await service.updateCustomServer({
+      id,
+      transport: 'stdio',
+      command: 'node',
+      args: ['server.js']
+    })
+    const view = updated.customServers.find((s) => s.id === id)
+    expect(view?.name).toBe('my-mem') // name is immutable
+    expect(view?.command).toBe('node')
+    expect(view?.args).toEqual(['server.js'])
+
+    const stored = (await service.getConnectors())?.customMcpServers?.find((s) => s.id === id)
+    expect(stored?.env).toEqual({ TOKEN: 'keep-me' })
+  })
+
+  it('rejects editing an unknown custom server', async () => {
+    await expect(
+      service.updateCustomServer({ id: 'nope', transport: 'stdio', command: 'x' })
+    ).rejects.toThrow(/Unknown custom connector/)
+  })
+})

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2,24 +2,39 @@ import { execFile } from 'node:child_process'
 import { access, readdir } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
 import { promisify } from 'node:util'
 
 import type {
   ClaudeDetectResult,
   ClaudeInstallLogEvent,
   ClaudeInstallResult,
+  ConnectorDetailView,
+  ConnectorsSnapshot,
+  ConnectorView,
+  CustomServerView,
+  AddCustomServerRequest,
+  RemoveCustomServerRequest,
+  SetCustomServerEnabledRequest,
+  UpdateCustomServerRequest,
   CreateSkillRequest,
   DeleteSkillRequest,
   InstallClaudeRequest,
+  NcbiCredentialsView,
   Preflight,
   ProviderDraft,
   ProviderView,
   RefreshProviderModelsRequest,
   RefreshProviderModelsResult,
+  SetConnectorAutoAllowRequest,
+  SetConnectorEnabledRequest,
+  SetNcbiCredentialsRequest,
   SetSkillEnabledRequest,
+  SetToolPermissionRequest,
   SettingsSnapshot,
   SkillDetailView,
   SkillView,
+  ToolPermission,
   ImportSkillRequest,
   ImportSkillResult,
   ImportSkillZipRequest,
@@ -49,10 +64,18 @@ import { computePreflight } from './preflight'
 import { listProviderModels } from './list-models'
 import { buildProviderEnv, getAppClaudeConfigDir, type ResolvedProvider } from './provider-env'
 import { SettingsRepository } from './repository'
+import { sanitizeCustomMcpServer } from './repository'
+import { CONNECTOR_CATALOG } from '../connectors/catalog'
+import { getConnectorTools } from '../connectors/registry'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { UserSkillRepository } from '../skills/user-skill-repository'
 import { readSkillFile } from '../skills/skill-files'
-import type { StoredProvider, StoredSettings } from './types'
+import type {
+  StoredConnectors,
+  StoredCustomMcpServer,
+  StoredProvider,
+  StoredSettings
+} from './types'
 import { classifyStatus, validateProvider, type ClaudeProbeResult } from './validate'
 
 const execFileAsync = promisify(execFile)
@@ -541,6 +564,210 @@ class SettingsService {
   // Reports whether the OS keychain is usable so the UI can warn before a save is attempted.
   isEncryptionAvailable(): boolean {
     return isEncryptionAvailable()
+  }
+
+  // Reads the connector enablement/config block, read fresh so callers see the latest saved state.
+  // Undefined when no connector has ever been configured.
+  async getConnectors(): Promise<StoredConnectors | undefined> {
+    const settings = await this.repository.getSettings()
+
+    return settings.connectors
+  }
+
+  // Projects the bundled catalog into renderer views, applying the stored opt-out / auto-allow sets.
+  private toConnectorViews(connectors: StoredConnectors | undefined): ConnectorView[] {
+    const disabled = new Set(connectors?.disabledConnectorIds ?? [])
+    const autoAllow = new Set(connectors?.autoAllowIds ?? [])
+
+    return CONNECTOR_CATALOG.map((meta) => ({
+      id: meta.id,
+      displayName: meta.displayName,
+      description: meta.description,
+      sources: meta.sources,
+      requiresNcbi: meta.requiresNcbi,
+      enabled: !disabled.has(meta.id),
+      autoAllow: autoAllow.has(meta.id),
+      group: meta.group ?? 'featured'
+    })).sort((a, b) => a.displayName.localeCompare(b.displayName))
+  }
+
+  private ncbiView(connectors: StoredConnectors | undefined): NcbiCredentialsView {
+    return { contactEmail: connectors?.contactEmail, hasApiKey: !!connectors?.ncbiApiKeyRef }
+  }
+
+  // Projects stored custom MCP servers into renderer views (no secret env/header values).
+  private toCustomServerViews(connectors: StoredConnectors | undefined): CustomServerView[] {
+    return (connectors?.customMcpServers ?? [])
+      .map((s) => ({
+        id: s.id,
+        name: s.name,
+        description: s.description,
+        transport: s.transport,
+        enabled: s.enabled,
+        command: s.command,
+        args: s.args,
+        url: s.url
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  private async connectorsSnapshot(): Promise<ConnectorsSnapshot> {
+    const connectors = await this.getConnectors()
+
+    return {
+      connectors: this.toConnectorViews(connectors),
+      customServers: this.toCustomServerViews(connectors),
+      ncbi: this.ncbiView(connectors)
+    }
+  }
+
+  // Lists every bundled connector with enabled / auto-allow state, plus shared NCBI credential state.
+  async listConnectors(): Promise<ConnectorsSnapshot> {
+    return this.connectorsSnapshot()
+  }
+
+  // Returns one connector's view plus its tools (with per-tool permission) and metadata.
+  async getConnectorDetail(id: string): Promise<ConnectorDetailView> {
+    const meta = CONNECTOR_CATALOG.find((entry) => entry.id === id)
+
+    if (!meta) throw new Error(`Unknown connector: ${id}`)
+
+    const connectors = await this.getConnectors()
+    const view = this.toConnectorViews(connectors).find((entry) => entry.id === id)
+    const blocked = new Set(connectors?.blockedToolIds ?? [])
+    const ask = new Set(connectors?.askToolIds ?? [])
+    const tools = getConnectorTools(id).map((tool) => {
+      const toolId = `${id}/${tool.id}`
+      // Precedence: block > ask > allow (the default; tools run without a prompt unless opted in).
+      const permission: ToolPermission = blocked.has(toolId)
+        ? 'block'
+        : ask.has(toolId)
+          ? 'ask'
+          : 'allow'
+
+      return { id: toolId, method: tool.id, description: tool.description, permission }
+    })
+
+    return { ...view!, useWhen: meta.useWhen, termsUrl: meta.termsUrl, tools }
+  }
+
+  // Enables/disables one bundled connector and returns the refreshed snapshot.
+  async setConnectorEnabled(request: SetConnectorEnabledRequest): Promise<ConnectorsSnapshot> {
+    await this.repository.setConnectorDisabled(request.id, !request.enabled)
+
+    return this.connectorsSnapshot()
+  }
+
+  // Toggles "skip approvals" for one connector (autoAllowIds) and returns the refreshed snapshot.
+  async setConnectorAutoAllow(request: SetConnectorAutoAllowRequest): Promise<ConnectorsSnapshot> {
+    await this.repository.setConnectorAutoAllow(request.id, request.autoAllow)
+
+    return this.connectorsSnapshot()
+  }
+
+  // Sets one tool's permission (allow = run without a prompt [default], ask = prompt each call,
+  // block = denied) and returns the connector's refreshed detail.
+  async setToolPermission(request: SetToolPermissionRequest): Promise<ConnectorDetailView> {
+    await this.repository.setToolPolicy(
+      request.toolId,
+      request.permission === 'ask',
+      request.permission === 'block'
+    )
+    const connectorId = request.toolId.split('/')[0]
+
+    return this.getConnectorDetail(connectorId)
+  }
+
+  // Sets or clears the shared contact email and NCBI API key (encrypted at rest), returning state.
+  async setNcbiCredentials(request: SetNcbiCredentialsRequest): Promise<ConnectorsSnapshot> {
+    const existing = await this.getConnectors()
+    // An omitted apiKey leaves the stored key unchanged; an empty string clears it.
+    const apiKeyRef =
+      request.apiKey === undefined
+        ? existing?.ncbiApiKeyRef
+        : request.apiKey === ''
+          ? undefined
+          : encryptKey(request.apiKey)
+
+    await this.repository.setNcbiCredentials(request.contactEmail?.trim() || undefined, apiKeyRef)
+
+    return this.connectorsSnapshot()
+  }
+
+  // Adds a user-provided custom MCP server (add-time trust is the caller's responsibility). The
+  // config is sanitized to enforce per-transport requirements before it is persisted.
+  async addCustomServer(request: AddCustomServerRequest): Promise<ConnectorsSnapshot> {
+    const candidate: StoredCustomMcpServer = {
+      id: randomUUID(),
+      name: request.name.trim(),
+      transport: request.transport,
+      enabled: true,
+      trustedAt: Date.now(),
+      ...(request.description?.trim() ? { description: request.description.trim() } : {}),
+      ...(request.command?.trim() ? { command: request.command.trim() } : {}),
+      ...(request.args && request.args.length > 0 ? { args: request.args } : {}),
+      ...(request.env && Object.keys(request.env).length > 0 ? { env: request.env } : {}),
+      ...(request.url?.trim() ? { url: request.url.trim() } : {}),
+      ...(request.headers && Object.keys(request.headers).length > 0
+        ? { headers: request.headers }
+        : {})
+    }
+    const server = sanitizeCustomMcpServer(candidate)
+
+    if (!server) throw new Error('Invalid custom connector configuration')
+
+    await this.repository.addCustomServer(server)
+
+    return this.connectorsSnapshot()
+  }
+
+  // Enables/disables one custom MCP server and returns the refreshed snapshot.
+  async setCustomServerEnabled(
+    request: SetCustomServerEnabledRequest
+  ): Promise<ConnectorsSnapshot> {
+    await this.repository.setCustomServerEnabled(request.id, request.enabled)
+
+    return this.connectorsSnapshot()
+  }
+
+  // Removes one custom MCP server and returns the refreshed snapshot.
+  async removeCustomServer(request: RemoveCustomServerRequest): Promise<ConnectorsSnapshot> {
+    await this.repository.removeCustomServer(request.id)
+
+    return this.connectorsSnapshot()
+  }
+
+  // Edits an existing custom MCP server, keeping its immutable identity (id, name, enabled, trust).
+  // Omitted env/headers keep the stored secret values; providing them replaces the set.
+  async updateCustomServer(request: UpdateCustomServerRequest): Promise<ConnectorsSnapshot> {
+    const existing = (await this.getConnectors())?.customMcpServers?.find(
+      (s) => s.id === request.id
+    )
+
+    if (!existing) throw new Error(`Unknown custom connector: ${request.id}`)
+
+    const env = request.env ?? existing.env
+    const headers = request.headers ?? existing.headers
+    const merged: StoredCustomMcpServer = {
+      id: existing.id,
+      name: existing.name,
+      transport: request.transport,
+      enabled: existing.enabled,
+      ...(existing.trustedAt !== undefined ? { trustedAt: existing.trustedAt } : {}),
+      ...(request.description?.trim() ? { description: request.description.trim() } : {}),
+      ...(request.command?.trim() ? { command: request.command.trim() } : {}),
+      ...(request.args && request.args.length > 0 ? { args: request.args } : {}),
+      ...(env && Object.keys(env).length > 0 ? { env } : {}),
+      ...(request.url?.trim() ? { url: request.url.trim() } : {}),
+      ...(headers && Object.keys(headers).length > 0 ? { headers } : {})
+    }
+    const server = sanitizeCustomMcpServer(merged)
+
+    if (!server) throw new Error('Invalid custom connector configuration')
+
+    await this.repository.updateCustomServer(request.id, server)
+
+    return this.connectorsSnapshot()
   }
 
   // Reports whether npm is on PATH so the installer UI can default to/enable the npm source.

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -28,6 +28,44 @@ export type StoredProvider = {
   lastValidationFailure?: ProviderValidationFailure
 }
 
+// A user-added custom MCP server. Phase 1 = stdio (local command). Phase 2 adds the remote
+// transports (streamable_http / sse) with static auth `headers` (e.g. Authorization). OAuth and a
+// dynamic headers-helper command are a later task. Env/header values are stored as-is for now —
+// sensitive values are the caller's responsibility.
+export type StoredCustomMcpServer = {
+  id: string
+  name: string
+  transport: 'stdio' | 'streamable_http' | 'sse'
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  // Static auth headers (e.g. Authorization) sent with every request on remote transports.
+  headers?: Record<string, string>
+  enabled: boolean
+  // Timestamp of the user's explicit add-time trust confirmation (see plan §3.5).
+  trustedAt?: number
+  description?: string
+}
+
+// Connector enablement and non-secret settings. `ncbiApiKeyRef` is a safeStorage ciphertext
+// reference, like `StoredProvider.keyRef`; the plaintext key never lives here.
+export type StoredConnectors = {
+  enabledIds: string[]
+  autoAllowIds: string[]
+  contactEmail?: string
+  ncbiApiKeyRef?: string
+  // Fully-qualified "<connector>/<method>" ids denied by policy; allow by default otherwise.
+  blockedToolIds?: string[]
+  // Fully-qualified "<connector>/<method>" ids that require per-call approval (opt-in). Tools default
+  // to allow (no prompt); this is the set the user switched to "Ask each time".
+  askToolIds?: string[]
+  // Ids of bundled connectors the user turned OFF. Absent/empty means every bundled connector is
+  // enabled (default-on), mirroring disabledSkillIds. This is the authoritative bundled gate.
+  disabledConnectorIds?: string[]
+  customMcpServers?: StoredCustomMcpServer[]
+}
+
 // The whole settings.json document.
 export type StoredSettings = {
   version: typeof SETTINGS_FILE_VERSION
@@ -43,6 +81,7 @@ export type StoredSettings = {
   // Ids of bundled skills the user turned OFF. Absent/empty means every bundled skill is enabled
   // (default-on), so new bundled skills are enabled automatically.
   disabledSkillIds?: string[]
+  connectors?: StoredConnectors
 }
 
 // Canonical empty settings used for a first run or an unreadable file.

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -78,6 +78,18 @@ import type {
   SkillBundlePreview,
   ScanRepoRequest,
   ScanRepoResult,
+  ConnectorsSnapshot,
+  ConnectorDetailView,
+  SetConnectorEnabledRequest,
+  SetConnectorAutoAllowRequest,
+  SetToolPermissionRequest,
+  SetNcbiCredentialsRequest,
+  AddCustomServerRequest,
+  SetCustomServerEnabledRequest,
+  RemoveCustomServerRequest,
+  UpdateCustomServerRequest,
+  ConnectorApprovalRequest,
+  RespondApprovalRequest,
   UpsertProviderRequest,
   ValidateProviderRequest,
   ValidateProviderResult
@@ -149,6 +161,18 @@ interface OpenScienceAPI {
     importSkillZip(request: ImportSkillZipRequest): Promise<ImportSkillResult>
     previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreview>
     scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult>
+    listConnectors(): Promise<ConnectorsSnapshot>
+    getConnectorDetail(id: string): Promise<ConnectorDetailView>
+    setConnectorEnabled(request: SetConnectorEnabledRequest): Promise<ConnectorsSnapshot>
+    setConnectorAutoAllow(request: SetConnectorAutoAllowRequest): Promise<ConnectorsSnapshot>
+    setToolPermission(request: SetToolPermissionRequest): Promise<ConnectorDetailView>
+    setNcbiCredentials(request: SetNcbiCredentialsRequest): Promise<ConnectorsSnapshot>
+    addCustomServer(request: AddCustomServerRequest): Promise<ConnectorsSnapshot>
+    setCustomServerEnabled(request: SetCustomServerEnabledRequest): Promise<ConnectorsSnapshot>
+    removeCustomServer(request: RemoveCustomServerRequest): Promise<ConnectorsSnapshot>
+    updateCustomServer(request: UpdateCustomServerRequest): Promise<ConnectorsSnapshot>
+    onConnectorApprovalRequest(listener: AcpListener<ConnectorApprovalRequest>): RemoveListener
+    respondConnectorApproval(request: RespondApprovalRequest): Promise<void>
     onInstallLog(listener: AcpListener<ClaudeInstallLogEvent>): RemoveListener
   }
   logs: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -80,6 +80,18 @@ import type {
   SkillBundlePreview,
   ScanRepoRequest,
   ScanRepoResult,
+  ConnectorsSnapshot,
+  ConnectorDetailView,
+  SetConnectorEnabledRequest,
+  SetConnectorAutoAllowRequest,
+  SetToolPermissionRequest,
+  SetNcbiCredentialsRequest,
+  AddCustomServerRequest,
+  SetCustomServerEnabledRequest,
+  RemoveCustomServerRequest,
+  UpdateCustomServerRequest,
+  ConnectorApprovalRequest,
+  RespondApprovalRequest,
   UpsertProviderRequest,
   ValidateProviderRequest,
   ValidateProviderResult
@@ -164,6 +176,18 @@ type OpenScienceAPI = {
     importSkillZip: (request: ImportSkillZipRequest) => Promise<ImportSkillResult>
     previewSkillZip: (request: PreviewSkillZipRequest) => Promise<SkillBundlePreview>
     scanRepoSkills: (request: ScanRepoRequest) => Promise<ScanRepoResult>
+    listConnectors: () => Promise<ConnectorsSnapshot>
+    getConnectorDetail: (id: string) => Promise<ConnectorDetailView>
+    setConnectorEnabled: (request: SetConnectorEnabledRequest) => Promise<ConnectorsSnapshot>
+    setConnectorAutoAllow: (request: SetConnectorAutoAllowRequest) => Promise<ConnectorsSnapshot>
+    setToolPermission: (request: SetToolPermissionRequest) => Promise<ConnectorDetailView>
+    setNcbiCredentials: (request: SetNcbiCredentialsRequest) => Promise<ConnectorsSnapshot>
+    addCustomServer: (request: AddCustomServerRequest) => Promise<ConnectorsSnapshot>
+    setCustomServerEnabled: (request: SetCustomServerEnabledRequest) => Promise<ConnectorsSnapshot>
+    removeCustomServer: (request: RemoveCustomServerRequest) => Promise<ConnectorsSnapshot>
+    updateCustomServer: (request: UpdateCustomServerRequest) => Promise<ConnectorsSnapshot>
+    onConnectorApprovalRequest: (listener: AcpListener<ConnectorApprovalRequest>) => RemoveListener
+    respondConnectorApproval: (request: RespondApprovalRequest) => Promise<void>
     onInstallLog: (listener: AcpListener<ClaudeInstallLogEvent>) => RemoveListener
   }
   logs: {
@@ -329,6 +353,36 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('settings:preview-skill-zip', request) as Promise<SkillBundlePreview>,
     scanRepoSkills: (request: ScanRepoRequest) =>
       ipcRenderer.invoke('settings:scan-repo-skills', request) as Promise<ScanRepoResult>,
+    listConnectors: () =>
+      ipcRenderer.invoke('settings:list-connectors') as Promise<ConnectorsSnapshot>,
+    getConnectorDetail: (id: string) =>
+      ipcRenderer.invoke('settings:get-connector-detail', id) as Promise<ConnectorDetailView>,
+    setConnectorEnabled: (request: SetConnectorEnabledRequest) =>
+      ipcRenderer.invoke('settings:set-connector-enabled', request) as Promise<ConnectorsSnapshot>,
+    setConnectorAutoAllow: (request: SetConnectorAutoAllowRequest) =>
+      ipcRenderer.invoke(
+        'settings:set-connector-auto-allow',
+        request
+      ) as Promise<ConnectorsSnapshot>,
+    setToolPermission: (request: SetToolPermissionRequest) =>
+      ipcRenderer.invoke('settings:set-tool-permission', request) as Promise<ConnectorDetailView>,
+    setNcbiCredentials: (request: SetNcbiCredentialsRequest) =>
+      ipcRenderer.invoke('settings:set-ncbi-credentials', request) as Promise<ConnectorsSnapshot>,
+    addCustomServer: (request: AddCustomServerRequest) =>
+      ipcRenderer.invoke('settings:add-custom-server', request) as Promise<ConnectorsSnapshot>,
+    setCustomServerEnabled: (request: SetCustomServerEnabledRequest) =>
+      ipcRenderer.invoke(
+        'settings:set-custom-server-enabled',
+        request
+      ) as Promise<ConnectorsSnapshot>,
+    removeCustomServer: (request: RemoveCustomServerRequest) =>
+      ipcRenderer.invoke('settings:remove-custom-server', request) as Promise<ConnectorsSnapshot>,
+    updateCustomServer: (request: UpdateCustomServerRequest) =>
+      ipcRenderer.invoke('settings:update-custom-server', request) as Promise<ConnectorsSnapshot>,
+    // Fires when a connector call needs the user's approval (external data-egress gate).
+    onConnectorApprovalRequest: (listener) => onIpcMessage('connectors:approval-request', listener),
+    respondConnectorApproval: (request: RespondApprovalRequest) =>
+      ipcRenderer.invoke('connectors:approval-respond', request) as Promise<void>,
     // Streams live installer output while a one-click install runs.
     onInstallLog: (listener) => onIpcMessage('settings:install-log', listener)
   },

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { useSessionPersistence } from '@/lib/session-persistence/session-persist
 import { HomePage } from '@/pages/home/HomePage'
 import { OnboardingWizard } from '@/pages/onboarding/OnboardingWizard'
 import { resolveStartupView, shouldMarkOnboardingComplete } from '@/pages/onboarding/startup-gate'
+import { ConnectorApprovalDialog } from '@/pages/settings/ConnectorApprovalDialog'
 import { SettingsPage } from '@/pages/settings/SettingsPage'
 import { WorkspacePage } from '@/pages/workspace/WorkspacePage'
 import { useNavigationStore } from '@/stores/navigation-store'
@@ -24,6 +25,14 @@ const App = (): React.JSX.Element | null => {
   const completeOnboarding = useSettingsStore((state) => state.completeOnboarding)
   const isSettingsOpen = useSettingsStore((state) => state.isSettingsOpen)
   const closeSettings = useSettingsStore((state) => state.closeSettings)
+  const enqueueApproval = useSettingsStore((state) => state.enqueueApproval)
+
+  // Subscribe once to connector approval requests from the main-process gate; they surface as a
+  // modal the user must answer before the held connector call proceeds.
+  useEffect(
+    () => window.api.settings.onConnectorApprovalRequest(enqueueApproval),
+    [enqueueApproval]
+  )
 
   // Load the project list once on startup so Home can render immediately after hydration.
   useEffect(() => {
@@ -70,6 +79,7 @@ const App = (): React.JSX.Element | null => {
         <WorkspacePage isSessionPersistenceReady={isSessionPersistenceReady} />
       )}
       <SettingsPage open={isSettingsOpen} onClose={closeSettings} />
+      <ConnectorApprovalDialog />
     </>
   )
 }

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ConnectorAddForm } from './ConnectorAddForm'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  useSettingsStore.setState({
+    ...createInitialSettingsState(),
+    addCustomServer: vi.fn().mockResolvedValue(undefined)
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+// Sets a controlled input/textarea value the way React expects (native setter + input event).
+const setValue = (label: string, value: string): void => {
+  const field = document.body.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+    `[aria-label="${label}"]`
+  )
+  const proto =
+    field instanceof HTMLTextAreaElement
+      ? window.HTMLTextAreaElement.prototype
+      : window.HTMLInputElement.prototype
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set
+  act(() => {
+    setter?.call(field, value)
+    field?.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+const checkTrust = (): void => {
+  const checkbox = document.body.querySelector<HTMLInputElement>(
+    '[aria-label="I trust this connector"]'
+  )
+  act(() => checkbox?.click())
+}
+
+const addButton = (): HTMLButtonElement | undefined =>
+  Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+    (button) => button.textContent?.trim() === 'Add connector'
+  )
+
+describe('ConnectorAddForm (local command)', () => {
+  it('adds a stdio server with the default npx command, then calls onDone', async () => {
+    const onDone = vi.fn()
+    act(() => {
+      root.render(<ConnectorAddForm initialTransport="local" onDone={onDone} onCancel={vi.fn()} />)
+    })
+
+    setValue('Name', 'Memory')
+    checkTrust()
+
+    await act(async () => {
+      addButton()?.click()
+    })
+
+    expect(useSettingsStore.getState().addCustomServer).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Memory', transport: 'stdio', command: 'npx' })
+    )
+    expect(onDone).toHaveBeenCalled()
+  })
+
+  it('keeps Add connector disabled until the trust checkbox is checked', () => {
+    act(() => {
+      root.render(<ConnectorAddForm initialTransport="local" onDone={vi.fn()} onCancel={vi.fn()} />)
+    })
+
+    setValue('Name', 'Memory')
+    expect(addButton()?.disabled).toBe(true)
+
+    checkTrust()
+    expect(addButton()?.disabled).toBe(false)
+  })
+})
+
+describe('ConnectorAddForm (remote server)', () => {
+  it('renders a Server URL field in remote mode', () => {
+    act(() => {
+      root.render(
+        <ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />
+      )
+    })
+
+    expect(document.body.querySelector('[aria-label="Server URL"]')).not.toBeNull()
+  })
+})
+
+describe('ConnectorAddForm (edit)', () => {
+  const editServer = {
+    id: 'srv-1',
+    name: 'my-mem',
+    description: 'Memory server',
+    transport: 'stdio' as const,
+    enabled: true,
+    command: 'npx',
+    args: ['-y', 'old-pkg']
+  }
+
+  it('pre-fills fields, locks the name, and updates on save', async () => {
+    useSettingsStore.setState({
+      ...createInitialSettingsState(),
+      updateCustomServer: vi.fn().mockResolvedValue(undefined)
+    })
+    const onDone = vi.fn()
+    act(() => {
+      root.render(<ConnectorAddForm editServer={editServer} onDone={onDone} onCancel={vi.fn()} />)
+    })
+
+    const nameInput = document.body.querySelector<HTMLInputElement>('[aria-label="Name"]')
+    expect(nameInput?.value).toBe('my-mem')
+    expect(nameInput?.disabled).toBe(true) // name is immutable
+    // The command Select shows the pre-filled runtime.
+    expect(document.body.querySelector('[aria-label="Command"]')?.textContent).toContain('npx')
+
+    // Edit a non-secret field.
+    setValue('Description', 'Updated memory')
+    const save = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (b) => b.textContent?.trim() === 'Save changes'
+    )
+    expect(save).not.toBeUndefined()
+
+    await act(async () => {
+      save?.click()
+    })
+
+    expect(useSettingsStore.getState().updateCustomServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'srv-1',
+        transport: 'stdio',
+        command: 'npx',
+        description: 'Updated memory'
+      })
+    )
+    // No `name` is sent on edit — the name is immutable.
+    const call = (useSettingsStore.getState().updateCustomServer as ReturnType<typeof vi.fn>).mock
+      .calls[0][0]
+    expect(call).not.toHaveProperty('name')
+    expect(onDone).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/pages/settings/ConnectorAddForm.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.tsx
@@ -1,0 +1,439 @@
+import { useState } from 'react'
+
+import type {
+  AddCustomServerRequest,
+  CustomServerTransport,
+  CustomServerView,
+  UpdateCustomServerRequest
+} from '../../../../shared/settings'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
+import { useSettingsStore } from '@/stores/settings-store'
+
+// Which kind of custom connector is being added: a local stdio command or a remote HTTP/SSE server.
+type ConnectorMode = 'local' | 'remote'
+
+// The two remote transports, kept out of the local (stdio) mode.
+type RemoteTransport = Extract<CustomServerTransport, 'streamable_http' | 'sse'>
+
+const fieldLabelClassName = 'text-xs font-medium text-muted-foreground'
+const textareaClassName =
+  'w-full resize-none rounded-lg border border-input bg-transparent px-2.5 py-2 font-mono text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50'
+
+// Splits an arguments textarea on any whitespace/newlines into a positional arg list, dropping empties.
+const parseArgs = (raw: string): string[] =>
+  raw
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+
+// Parses one KEY=VALUE per line into a record; blank lines and lines without '=' are ignored.
+const parseEnv = (raw: string): Record<string, string> => {
+  const env: Record<string, string> = {}
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const eq = trimmed.indexOf('=')
+    if (eq <= 0) continue
+    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim()
+  }
+  return env
+}
+
+// Parses one "Name: Value" per line into a headers record; blank/invalid lines are ignored.
+const parseHeaders = (raw: string): Record<string, string> => {
+  const headers: Record<string, string> = {}
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const colon = trimmed.indexOf(':')
+    if (colon <= 0) continue
+    headers[trimmed.slice(0, colon).trim()] = trimmed.slice(colon + 1).trim()
+  }
+  return headers
+}
+
+// A required-field marker next to a label. Purely visual; the real guard is the disabled Add button.
+const RequiredMark = (): React.JSX.Element => (
+  <span aria-hidden="true" className="ml-0.5 text-destructive">
+    *
+  </span>
+)
+
+const REMOTE_TRANSPORTS: { id: RemoteTransport; label: string }[] = [
+  { id: 'streamable_http', label: 'Streamable HTTP' },
+  { id: 'sse', label: 'SSE' }
+]
+
+// Common runtimes used to launch a local stdio MCP server, plus an "other" escape hatch for an
+// absolute path or an uncommon binary.
+const COMMAND_OPTIONS: { value: string; label: string }[] = [
+  { value: 'npx', label: 'npx — Node package' },
+  { value: 'uvx', label: 'uvx — Python (uv)' },
+  { value: 'node', label: 'node — script file' },
+  { value: 'python3', label: 'python3 — script file' },
+  { value: 'docker', label: 'docker — container' },
+  { value: 'other', label: 'Other…' }
+]
+
+type ConnectorAddFormProps = {
+  initialTransport?: ConnectorMode
+  // When set, the form edits this custom server instead of adding a new one. The name is immutable.
+  editServer?: CustomServerView
+  // Called after the custom server has been added/updated successfully.
+  onDone: () => void
+  onCancel: () => void
+}
+
+// Maps a stored transport to the form's local/remote mode.
+const modeForTransport = (transport: CustomServerTransport): ConnectorMode =>
+  transport === 'stdio' ? 'local' : 'remote'
+
+// Add or edit a custom MCP server ("custom connector"): a local stdio command or a remote HTTP/SSE
+// server, gated behind an explicit trust confirmation the way Claude Science's "Add connector" flow is.
+export function ConnectorAddForm({
+  initialTransport,
+  editServer,
+  onDone,
+  onCancel
+}: ConnectorAddFormProps): React.JSX.Element {
+  const addCustomServer = useSettingsStore((s) => s.addCustomServer)
+  const updateCustomServer = useSettingsStore((s) => s.updateCustomServer)
+  const isEdit = editServer !== undefined
+
+  const [mode, setMode] = useState<ConnectorMode>(
+    editServer ? modeForTransport(editServer.transport) : (initialTransport ?? 'local')
+  )
+  const [name, setName] = useState(editServer?.name ?? '')
+  const [description, setDescription] = useState(editServer?.description ?? '')
+  // Local (stdio) fields. The command is chosen from common runtimes, with an "other" escape hatch
+  // for an absolute path or an uncommon binary.
+  const initialCommandIsPreset = editServer?.command
+    ? COMMAND_OPTIONS.some((o) => o.value === editServer.command)
+    : true
+  const [commandChoice, setCommandChoice] = useState<string>(
+    editServer?.command ? (initialCommandIsPreset ? editServer.command : 'other') : 'npx'
+  )
+  const [customCommand, setCustomCommand] = useState(
+    editServer?.command && !initialCommandIsPreset ? editServer.command : ''
+  )
+  const command = commandChoice === 'other' ? customCommand : commandChoice
+  const [argsText, setArgsText] = useState((editServer?.args ?? []).join(' '))
+  const [envText, setEnvText] = useState('')
+  // Remote fields.
+  const [url, setUrl] = useState(editServer?.url ?? '')
+  const [remoteTransport, setRemoteTransport] = useState<RemoteTransport>(
+    editServer && editServer.transport !== 'stdio' ? editServer.transport : 'streamable_http'
+  )
+  const [headersText, setHeadersText] = useState('')
+  // Add-time trust confirmation and submission state. An existing (already-trusted) server starts trusted.
+  const [trusted, setTrusted] = useState(isEdit)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const parsedArgs = parseArgs(argsText)
+  const commandPreview = [command.trim(), ...parsedArgs].filter((part) => part.length > 0).join(' ')
+
+  const requiredFilled =
+    name.trim().length > 0 && (mode === 'local' ? command.trim().length > 0 : url.trim().length > 0)
+  const canSubmit = requiredFilled && trusted && !submitting
+
+  const switchMode = (next: ConnectorMode): void => {
+    setMode(next)
+    setError(null)
+  }
+
+  const handleSubmit = async (): Promise<void> => {
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const env = parseEnv(envText)
+      const headers = parseHeaders(headersText)
+      // Omitted env/headers keep the stored (secret) values on edit; on add they are simply unset.
+      const hasEnv = envText.trim().length > 0
+      const hasHeaders = headersText.trim().length > 0
+      const transport: CustomServerTransport = mode === 'local' ? 'stdio' : remoteTransport
+      const shared = {
+        description: description.trim() || undefined,
+        transport,
+        ...(mode === 'local'
+          ? {
+              command: command.trim(),
+              ...(parsedArgs.length > 0 ? { args: parsedArgs } : {})
+            }
+          : { url: url.trim() })
+      }
+
+      if (isEdit && editServer) {
+        const request: UpdateCustomServerRequest = {
+          id: editServer.id,
+          ...shared,
+          ...(mode === 'local' && hasEnv ? { env } : {}),
+          ...(mode === 'remote' && hasHeaders ? { headers } : {})
+        }
+        await updateCustomServer(request)
+      } else {
+        const request: AddCustomServerRequest = {
+          name: name.trim(),
+          ...shared,
+          ...(mode === 'local' && Object.keys(env).length > 0 ? { env } : {}),
+          ...(mode === 'remote' && Object.keys(headers).length > 0 ? { headers } : {})
+        }
+        await addCustomServer(request)
+      }
+      onDone()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save connector.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const segmentButtonClassName = (active: boolean): string =>
+    `inline-flex h-7 items-center rounded-md px-3 text-sm transition-colors ${
+      active
+        ? 'bg-card font-medium text-foreground shadow-sm'
+        : 'text-muted-foreground hover:text-foreground'
+    }`
+
+  return (
+    <div className="p-5">
+      <div className="flex max-w-xl flex-col gap-4">
+        <div
+          role="radiogroup"
+          aria-label="Connector type"
+          className="inline-flex w-fit items-center rounded-lg bg-muted p-0.5"
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={mode === 'local'}
+            onClick={() => switchMode('local')}
+            className={segmentButtonClassName(mode === 'local')}
+          >
+            Local command
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={mode === 'remote'}
+            onClick={() => switchMode('remote')}
+            className={segmentButtonClassName(mode === 'remote')}
+          >
+            Remote server
+          </button>
+        </div>
+
+        <div className="space-y-1.5">
+          <label className={fieldLabelClassName} htmlFor="connector-name">
+            Name
+            {isEdit ? null : <RequiredMark />}
+          </label>
+          <Input
+            id="connector-name"
+            aria-label="Name"
+            value={name}
+            disabled={isEdit}
+            placeholder="e.g. Memory server"
+            onChange={(event) => setName(event.target.value)}
+          />
+          {isEdit ? (
+            <p className="text-xs text-muted-foreground">
+              The name is the connector&apos;s identity and can&apos;t be changed.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="space-y-1.5">
+          <label className={fieldLabelClassName} htmlFor="connector-description">
+            Description <span className="text-muted-foreground">(optional)</span>
+          </label>
+          <Input
+            id="connector-description"
+            aria-label="Description"
+            value={description}
+            placeholder="What this connector provides"
+            onChange={(event) => setDescription(event.target.value)}
+          />
+        </div>
+
+        {mode === 'local' ? (
+          <>
+            <div className="space-y-1.5">
+              <label className={fieldLabelClassName} htmlFor="connector-command">
+                Command
+                <RequiredMark />
+              </label>
+              <Select value={commandChoice} onValueChange={setCommandChoice}>
+                <SelectTrigger aria-label="Command">
+                  <span>
+                    {COMMAND_OPTIONS.find((o) => o.value === commandChoice)?.label ?? commandChoice}
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  {COMMAND_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {commandChoice === 'other' ? (
+                <Input
+                  aria-label="Custom command"
+                  value={customCommand}
+                  placeholder="/absolute/path/to/executable"
+                  className="font-mono"
+                  onChange={(event) => setCustomCommand(event.target.value)}
+                />
+              ) : null}
+            </div>
+
+            <div className="space-y-1.5">
+              <label className={fieldLabelClassName} htmlFor="connector-args">
+                Arguments <span className="text-muted-foreground">(optional)</span>
+              </label>
+              <textarea
+                id="connector-args"
+                aria-label="Arguments"
+                value={argsText}
+                rows={2}
+                placeholder="-y @modelcontextprotocol/server-memory"
+                className={textareaClassName}
+                onChange={(event) => setArgsText(event.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">Separated by spaces or newlines.</p>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className={fieldLabelClassName} htmlFor="connector-env">
+                Environment variables <span className="text-muted-foreground">(optional)</span>
+              </label>
+              <textarea
+                id="connector-env"
+                aria-label="Environment variables"
+                value={envText}
+                rows={3}
+                placeholder={'KEY=value\nANOTHER_KEY=value'}
+                className={textareaClassName}
+                onChange={(event) => setEnvText(event.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                One KEY=VALUE per line.
+                {isEdit ? ' Leave blank to keep the current values.' : ''}
+              </p>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="space-y-1.5">
+              <label className={fieldLabelClassName} htmlFor="connector-url">
+                Server URL
+                <RequiredMark />
+              </label>
+              <Input
+                id="connector-url"
+                aria-label="Server URL"
+                value={url}
+                placeholder="https://example.com/mcp"
+                className="font-mono"
+                onChange={(event) => setUrl(event.target.value)}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <span className={fieldLabelClassName}>Transport</span>
+              <Select
+                value={remoteTransport}
+                onValueChange={(value) => setRemoteTransport(value as RemoteTransport)}
+              >
+                <SelectTrigger aria-label="Transport">
+                  <span>
+                    {REMOTE_TRANSPORTS.find((entry) => entry.id === remoteTransport)?.label}
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  {REMOTE_TRANSPORTS.map((entry) => (
+                    <SelectItem key={entry.id} value={entry.id}>
+                      {entry.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className={fieldLabelClassName} htmlFor="connector-headers">
+                Headers <span className="text-muted-foreground">(optional)</span>
+              </label>
+              <textarea
+                id="connector-headers"
+                aria-label="Headers"
+                value={headersText}
+                rows={3}
+                placeholder={'Authorization: Bearer <token>\nX-Api-Key: <key>'}
+                className={textareaClassName}
+                onChange={(event) => setHeadersText(event.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                One <span className="font-mono">Name: Value</span> per line (not JSON).
+                {isEdit ? ' Leave blank to keep the current values.' : ''}
+              </p>
+            </div>
+          </>
+        )}
+
+        <div className="rounded-lg border border-border bg-muted/30 p-3">
+          {mode === 'local' && commandPreview ? (
+            <p className="mb-2 break-all font-mono text-xs text-muted-foreground">
+              {commandPreview}
+            </p>
+          ) : null}
+          <label className="flex items-start gap-2.5">
+            <input
+              type="checkbox"
+              aria-label="I trust this connector"
+              checked={trusted}
+              className="mt-0.5 size-4 shrink-0"
+              onChange={(event) => setTrusted(event.target.checked)}
+            />
+            <span className="text-sm text-foreground">
+              I trust this connector. Only add connectors from developers you trust.
+            </span>
+          </label>
+        </div>
+
+        {error ? (
+          <p className="text-xs text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="inline-flex h-8 items-center rounded-lg px-3 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit}
+            className="inline-flex h-8 items-center rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+          >
+            {submitting
+              ? isEdit
+                ? 'Saving…'
+                : 'Adding…'
+              : isEdit
+                ? 'Save changes'
+                : 'Add connector'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ConnectorApprovalDialog } from './ConnectorApprovalDialog'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  useSettingsStore.setState({
+    ...createInitialSettingsState(),
+    connectors: [
+      {
+        id: 'biomart',
+        displayName: 'BioMart',
+        description: '',
+        sources: [],
+        requiresNcbi: false,
+        enabled: true,
+        autoAllow: false,
+        group: 'featured'
+      }
+    ],
+    respondApproval: vi.fn().mockResolvedValue(undefined),
+    setConnectorAutoAllow: vi.fn().mockResolvedValue(undefined)
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+const button = (text: string): HTMLButtonElement | undefined =>
+  Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+    (b) => b.textContent?.trim() === text
+  )
+
+describe('ConnectorApprovalDialog', () => {
+  it('renders nothing when there are no pending approvals', () => {
+    act(() => root.render(<ConnectorApprovalDialog />))
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('shows the oldest request with the resolved connector name and tool', () => {
+    useSettingsStore.setState({
+      pendingApprovals: [
+        { id: 'r1', connector: 'biomart', method: 'get_data', argsPreview: '{"x":1}' }
+      ]
+    })
+    act(() => root.render(<ConnectorApprovalDialog />))
+
+    expect(document.body.textContent).toContain('BioMart')
+    expect(document.body.textContent).toContain('get_data')
+    expect(document.body.textContent).toContain('{"x":1}')
+  })
+
+  it('Allow once responds allow without pre-trusting the connector', () => {
+    useSettingsStore.setState({
+      pendingApprovals: [{ id: 'r1', connector: 'biomart', method: 'get_data', argsPreview: '{}' }]
+    })
+    act(() => root.render(<ConnectorApprovalDialog />))
+
+    act(() => button('Allow once')?.click())
+    expect(useSettingsStore.getState().respondApproval).toHaveBeenCalledWith('r1', 'allow')
+    expect(useSettingsStore.getState().setConnectorAutoAllow).not.toHaveBeenCalled()
+  })
+
+  it('Always allow pre-trusts the connector then allows', () => {
+    useSettingsStore.setState({
+      pendingApprovals: [{ id: 'r1', connector: 'biomart', method: 'get_data', argsPreview: '{}' }]
+    })
+    act(() => root.render(<ConnectorApprovalDialog />))
+
+    act(() => button('Always allow')?.click())
+    expect(useSettingsStore.getState().setConnectorAutoAllow).toHaveBeenCalledWith('biomart', true)
+  })
+
+  it('Deny responds deny', () => {
+    useSettingsStore.setState({
+      pendingApprovals: [{ id: 'r1', connector: 'biomart', method: 'get_data', argsPreview: '{}' }]
+    })
+    act(() => root.render(<ConnectorApprovalDialog />))
+
+    act(() => button('Deny')?.click())
+    expect(useSettingsStore.getState().respondApproval).toHaveBeenCalledWith('r1', 'deny')
+  })
+})

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
@@ -1,0 +1,98 @@
+import { ShieldAlert } from 'lucide-react'
+import { Dialog } from 'radix-ui'
+
+import { useSettingsStore } from '@/stores/settings-store'
+
+// A modal approval card for an un-trusted connector call. A connector tool sends data to an external
+// service, so a call that isn't pre-allowed or skip-approved is held until the user decides here.
+// Requests are answered one at a time (oldest first); the card can't be dismissed without a decision.
+export function ConnectorApprovalDialog(): React.JSX.Element | null {
+  const request = useSettingsStore((state) => state.pendingApprovals[0])
+  const connectors = useSettingsStore((state) => state.connectors)
+  const customServers = useSettingsStore((state) => state.customServers)
+  const respondApproval = useSettingsStore((state) => state.respondApproval)
+  const setConnectorAutoAllow = useSettingsStore((state) => state.setConnectorAutoAllow)
+
+  if (!request) return null
+
+  const displayName =
+    connectors.find((c) => c.id === request.connector)?.displayName ??
+    customServers.find((s) => s.name === request.connector)?.name ??
+    request.connector
+
+  const allowOnce = (): void => void respondApproval(request.id, 'allow')
+  const deny = (): void => void respondApproval(request.id, 'deny')
+  // Pre-trust the whole connector ("Skip approvals"), then allow this call.
+  const allowAlways = (): void => {
+    void setConnectorAutoAllow(request.connector, true).finally(
+      () => void respondApproval(request.id, 'allow')
+    )
+  }
+
+  return (
+    <Dialog.Root open>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/50" />
+        <Dialog.Content
+          onInteractOutside={(event) => event.preventDefault()}
+          onEscapeKeyDown={(event) => event.preventDefault()}
+          className="fixed left-1/2 top-1/2 z-[60] w-[min(440px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-card p-5 text-foreground shadow-dialog"
+        >
+          <div className="flex items-start gap-3">
+            <ShieldAlert className="mt-0.5 size-5 shrink-0 text-amber-500" aria-hidden="true" />
+            <div className="min-w-0">
+              <Dialog.Title className="text-sm font-semibold text-foreground">
+                Allow external request?
+              </Dialog.Title>
+              <Dialog.Description className="mt-1 text-xs text-muted-foreground [text-wrap:pretty]">
+                Claude wants to call a connector tool that sends data to an external service.
+                Approve only if you trust this connector with the current request.
+              </Dialog.Description>
+            </div>
+          </div>
+
+          <div className="mt-3 space-y-1.5 rounded-lg border border-border bg-muted/40 p-3 text-xs">
+            <div className="flex gap-2">
+              <span className="w-16 shrink-0 text-muted-foreground">Connector</span>
+              <span className="min-w-0 truncate font-medium text-foreground">{displayName}</span>
+            </div>
+            <div className="flex gap-2">
+              <span className="w-16 shrink-0 text-muted-foreground">Tool</span>
+              <span className="min-w-0 truncate font-mono text-foreground">{request.method}</span>
+            </div>
+            <div className="flex gap-2">
+              <span className="w-16 shrink-0 text-muted-foreground">Args</span>
+              <span className="min-w-0 break-all font-mono text-muted-foreground">
+                {request.argsPreview}
+              </span>
+            </div>
+          </div>
+
+          <div className="mt-4 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={deny}
+              className="rounded-lg border border-border px-3 py-1.5 text-sm text-destructive transition-colors hover:bg-muted"
+            >
+              Deny
+            </button>
+            <button
+              type="button"
+              onClick={allowAlways}
+              className="rounded-lg border border-border px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-muted"
+            >
+              Always allow
+            </button>
+            <button
+              type="button"
+              onClick={allowOnce}
+              className="rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              Allow once
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/renderer/src/pages/settings/ConnectorDetailView.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorDetailView.render.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ConnectorDetailView as ConnectorDetail } from '../../../../shared/settings'
+import { ConnectorDetailView } from './ConnectorDetailView'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+
+let container: HTMLDivElement
+let root: Root
+
+const detail: ConnectorDetail = {
+  id: 'ensembl',
+  displayName: 'Ensembl',
+  description: 'Query the Ensembl genome database.',
+  sources: ['Ensembl'],
+  requiresNcbi: false,
+  enabled: true,
+  autoAllow: false,
+  group: 'featured',
+  useWhen: 'Use when exploring genes.',
+  termsUrl: 'https://example.com/terms',
+  tools: [
+    {
+      id: 'ensembl/lookup_gene',
+      method: 'lookup_gene',
+      description: 'Look up a gene.',
+      permission: 'allow'
+    },
+    {
+      id: 'ensembl/list_species',
+      method: 'list_species',
+      description: 'List species.',
+      permission: 'block'
+    }
+  ]
+}
+
+// The refreshed detail returned by setToolPermission after flipping lookup_gene to block.
+const updatedDetail: ConnectorDetail = {
+  ...detail,
+  tools: [{ ...detail.tools[0], permission: 'block' }, detail.tools[1]]
+}
+
+beforeEach(() => {
+  ;(window as unknown as { api: unknown }).api = {
+    settings: { getConnectorDetail: vi.fn().mockResolvedValue(detail) }
+  }
+  useSettingsStore.setState({
+    ...createInitialSettingsState(),
+    setConnectorEnabled: vi.fn().mockResolvedValue(undefined),
+    setConnectorAutoAllow: vi.fn().mockResolvedValue(undefined),
+    setToolPermission: vi.fn().mockResolvedValue(updatedDetail)
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+  delete (window as unknown as { api?: unknown }).api
+})
+
+const render = async (): Promise<void> => {
+  await act(async () => {
+    root.render(<ConnectorDetailView id="ensembl" />)
+  })
+  // Let the getConnectorDetail promise resolve and re-render with the tools.
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+// Finds the Block segment button within a specific tool's permission control.
+const blockSegment = (method: string): HTMLButtonElement | null => {
+  const group = document.body.querySelector<HTMLElement>(
+    `[role="radiogroup"][aria-label="Permission for ${method}"]`
+  )
+  return group?.querySelector<HTMLButtonElement>('[role="radio"][aria-label="Block"]') ?? null
+}
+
+describe('ConnectorDetailView', () => {
+  it('renders the connector name and a permission control per tool', async () => {
+    await render()
+
+    expect(document.body.textContent).toContain('Ensembl')
+    expect(document.body.textContent).toContain('lookup_gene')
+    expect(document.body.textContent).toContain('list_species')
+
+    // One radiogroup (ToolPermissionControl) per tool.
+    expect(document.body.querySelectorAll('[role="radiogroup"]')).toHaveLength(2)
+  })
+
+  it('expands a tool row to reveal its description', async () => {
+    await render()
+
+    // Collapsed by default: the tool's description is not shown.
+    expect(document.body.textContent).not.toContain('Look up a gene.')
+
+    const toolButton = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button[aria-expanded]')
+    ).find((button) => button.textContent?.includes('lookup_gene'))
+    expect(toolButton).not.toBeUndefined()
+
+    await act(async () => {
+      toolButton?.click()
+    })
+
+    expect(document.body.textContent).toContain('Look up a gene.')
+  })
+
+  it('persists a tool permission change when Block is clicked on the allow-tool', async () => {
+    await render()
+
+    await act(async () => {
+      blockSegment('lookup_gene')?.click()
+    })
+
+    expect(useSettingsStore.getState().setToolPermission).toHaveBeenCalledWith(
+      'ensembl/lookup_gene',
+      'block'
+    )
+  })
+
+  it('toggles the connector from the header switch and skip-approvals row', async () => {
+    await render()
+
+    const switches = document.body.querySelectorAll<HTMLButtonElement>('[role="switch"]')
+    // First switch is the header enable toggle; second is the skip-approvals toggle.
+    act(() => switches[0]?.click())
+    expect(useSettingsStore.getState().setConnectorEnabled).toHaveBeenCalledWith('ensembl', false)
+
+    act(() => switches[1]?.click())
+    expect(useSettingsStore.getState().setConnectorAutoAllow).toHaveBeenCalledWith('ensembl', true)
+  })
+
+  it('tracks live store state so the header toggle flips both directions', async () => {
+    // Seed the connectors list as ConnectorsPanel.loadConnectors would; the header switch must read
+    // this reconciled state, not the one-time detail fetch, or it sticks and only fires one way.
+    useSettingsStore.setState({
+      connectors: [
+        {
+          id: 'ensembl',
+          displayName: 'Ensembl',
+          description: 'Query the Ensembl genome database.',
+          sources: ['Ensembl'],
+          requiresNcbi: false,
+          enabled: true,
+          autoAllow: false,
+          group: 'featured'
+        }
+      ]
+    })
+    await render()
+
+    const header = (): HTMLButtonElement =>
+      document.body.querySelectorAll<HTMLButtonElement>('[role="switch"]')[0]
+
+    expect(header().getAttribute('aria-checked')).toBe('true')
+    act(() => header().click())
+    expect(useSettingsStore.getState().setConnectorEnabled).toHaveBeenLastCalledWith(
+      'ensembl',
+      false
+    )
+
+    // Simulate the store reconciling to disabled after the mutation.
+    act(() =>
+      useSettingsStore.setState((state) => ({
+        connectors: state.connectors.map((c) => ({ ...c, enabled: false }))
+      }))
+    )
+
+    // The header now reflects OFF, and clicking re-enables (would still send `false` if it read the
+    // stale detail).
+    expect(header().getAttribute('aria-checked')).toBe('false')
+    act(() => header().click())
+    expect(useSettingsStore.getState().setConnectorEnabled).toHaveBeenLastCalledWith(
+      'ensembl',
+      true
+    )
+  })
+})

--- a/src/renderer/src/pages/settings/ConnectorDetailView.tsx
+++ b/src/renderer/src/pages/settings/ConnectorDetailView.tsx
@@ -1,0 +1,195 @@
+import { ArrowUpRight, ChevronRight } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+import type {
+  ConnectorDetailView as ConnectorDetail,
+  ToolPermission
+} from '../../../../shared/settings'
+import { useSettingsStore } from '@/stores/settings-store'
+import { ConnectorGlyph } from './connector-icons'
+import { SkillToggle } from './SkillsPanel'
+import { ToolPermissionControl } from './ToolPermissionControl'
+
+type ConnectorDetailViewProps = {
+  id: string
+}
+
+// One label/value row in the Details section.
+const DetailRow = ({
+  label,
+  children
+}: {
+  label: string
+  children: React.ReactNode
+}): React.JSX.Element => (
+  <div className="flex flex-col gap-0.5 py-1.5">
+    <span className="text-xs font-medium text-muted-foreground">{label}</span>
+    <span className="text-sm text-foreground">{children}</span>
+  </div>
+)
+
+// Detail view for one bundled connector: header (name + Featured badge + enable toggle + description),
+// a "Skip approvals" row, the per-tool permission list, and connector metadata under "Details". The
+// breadcrumb and back control live in the settings header, not here.
+const ConnectorDetailView = ({ id }: ConnectorDetailViewProps): React.JSX.Element => {
+  const setConnectorEnabled = useSettingsStore((state) => state.setConnectorEnabled)
+  const setConnectorAutoAllow = useSettingsStore((state) => state.setConnectorAutoAllow)
+  const setToolPermission = useSettingsStore((state) => state.setToolPermission)
+  // The connector-level enabled/auto-allow state lives in the store's connectors list, which the
+  // toggle actions reconcile authoritatively; the detail fetch only seeds tools + metadata. Reading
+  // enabled/autoAllow from the store (falling back to the initial detail) keeps the two header
+  // switches live after a toggle, mirroring how SkillDetailView derives enabled from the store.
+  const storeConnector = useSettingsStore((state) => state.connectors.find((c) => c.id === id))
+  const [detail, setDetail] = useState<ConnectorDetail | null>(null)
+  // Ids of tools whose description is expanded.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  const toggleExpanded = (toolId: string): void =>
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(toolId)) next.delete(toolId)
+      else next.add(toolId)
+      return next
+    })
+
+  useEffect(() => {
+    let active = true
+    void window.api.settings.getConnectorDetail(id).then((result) => {
+      if (active) setDetail(result)
+    })
+    return () => {
+      active = false
+    }
+  }, [id])
+
+  // Persist one tool's permission, folding the refreshed detail back into local state.
+  const handleToolChange = async (toolId: string, permission: ToolPermission): Promise<void> => {
+    await setToolPermission(toolId, permission).then(setDetail)
+  }
+
+  if (!detail) return <div className="p-5" />
+
+  const enabled = storeConnector?.enabled ?? detail.enabled
+  const autoAllow = storeConnector?.autoAllow ?? detail.autoAllow
+
+  return (
+    <div className="p-5">
+      {/* Header: icon + name + Featured badge + enable toggle, then description below. */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <ConnectorGlyph size={28} />
+          <div className="flex min-w-0 items-center gap-2">
+            <h1 className="truncate text-heading font-semibold text-foreground">
+              {detail.displayName}
+            </h1>
+            <span className="inline-flex shrink-0 items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+              Featured
+            </span>
+          </div>
+        </div>
+        <SkillToggle
+          enabled={enabled}
+          label={`Toggle ${detail.displayName}`}
+          onToggle={() => void setConnectorEnabled(id, !enabled)}
+        />
+      </div>
+
+      {detail.description ? (
+        <p className="mt-2 text-sm text-muted-foreground [text-wrap:pretty]">
+          {detail.description}
+        </p>
+      ) : null}
+
+      {/* Skip approvals: allow every tool without a per-call approval card. */}
+      <div className="mt-4 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm text-foreground">Skip approvals</p>
+          <p className="text-xs text-muted-foreground [text-wrap:pretty]">
+            Allow Claude to use every tool from this connector without showing an approval card each
+            time.
+          </p>
+        </div>
+        <SkillToggle
+          enabled={autoAllow}
+          label={`Skip approvals for ${id}`}
+          onToggle={() => void setConnectorAutoAllow(id, !autoAllow)}
+        />
+      </div>
+
+      {/* Tools: per-tool permission controls. */}
+      <section className="mt-6 border-t border-border pt-4">
+        <h2 className="text-sm font-semibold text-foreground">Tools</h2>
+        <p className="text-xs text-muted-foreground">What Claude can do with this connector</p>
+        {detail.tools.length === 0 ? (
+          <p className="mt-3 text-sm text-muted-foreground">This connector has no tools.</p>
+        ) : (
+          <div className="mt-2 flex flex-col">
+            {detail.tools.map((tool) => {
+              const isExpanded = expanded.has(tool.id)
+
+              return (
+                <div key={tool.id}>
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      aria-expanded={isExpanded}
+                      onClick={() => toggleExpanded(tool.id)}
+                      className="flex min-w-0 flex-1 items-center gap-2 py-2.5 text-left"
+                    >
+                      <ChevronRight
+                        className={`size-4 shrink-0 text-muted-foreground transition-transform ${
+                          isExpanded ? 'rotate-90' : ''
+                        }`}
+                        aria-hidden="true"
+                      />
+                      <span className="truncate text-sm text-foreground">{tool.method}</span>
+                    </button>
+                    <ToolPermissionControl
+                      value={tool.permission}
+                      label={`Permission for ${tool.method}`}
+                      onChange={(permission) => void handleToolChange(tool.id, permission)}
+                    />
+                  </div>
+                  {isExpanded ? (
+                    <p className="whitespace-pre-wrap pb-3 pl-6 pr-2 text-xs text-muted-foreground [text-wrap:pretty]">
+                      {tool.description || 'No description provided for this tool.'}
+                    </p>
+                  ) : null}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </section>
+
+      {/* Details: third-party source(s) and terms. */}
+      {detail.sources.length > 0 ? (
+        <section className="mt-6 border-t border-border pt-4">
+          <h2 className="mb-1 text-sm font-semibold text-foreground">Details</h2>
+          <DetailRow label="Third-party software, content, terms, and information">
+            <span className="text-foreground">{detail.sources.join(', ')}</span>
+            {detail.termsUrl ? (
+              <>
+                {' '}
+                <span aria-hidden="true" className="text-muted-foreground">
+                  —
+                </span>{' '}
+                <a
+                  href={detail.termsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-0.5 align-baseline text-primary"
+                >
+                  <span className="underline">Terms</span>
+                  <ArrowUpRight className="size-3.5" aria-hidden="true" />
+                </a>
+              </>
+            ) : null}
+          </DetailRow>
+        </section>
+      ) : null}
+    </div>
+  )
+}
+
+export { ConnectorDetailView }

--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ConnectorsPanel } from './ConnectorsPanel'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+
+// Radix Select/DropdownMenu call pointer-capture and scroll APIs jsdom does not implement.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = (): void => undefined
+}
+
+let container: HTMLDivElement
+let root: Root
+
+const seedConnectors = [
+  {
+    id: 'pubmed',
+    displayName: 'PubMed',
+    description: 'Biomedical literature',
+    sources: ['NCBI'],
+    requiresNcbi: true,
+    enabled: true,
+    autoAllow: false,
+    group: 'directory' as const
+  },
+  {
+    id: 'europepmc',
+    displayName: 'Europe PMC',
+    description: 'Open-access life-science papers',
+    sources: ['EBI'],
+    requiresNcbi: false,
+    enabled: false,
+    autoAllow: false,
+    group: 'featured' as const
+  },
+  {
+    id: 'openalex',
+    displayName: 'OpenAlex',
+    description: 'Scholarly works catalog',
+    sources: ['OurResearch'],
+    requiresNcbi: false,
+    enabled: true,
+    autoAllow: true,
+    group: 'featured' as const
+  }
+]
+
+const seedCustomServers = [
+  {
+    id: 'my-mcp',
+    name: 'My MCP',
+    description: 'A local tool server',
+    transport: 'stdio' as const,
+    enabled: true,
+    command: 'node server.js'
+  }
+]
+
+beforeEach(() => {
+  useSettingsStore.setState({
+    ...createInitialSettingsState(),
+    connectors: seedConnectors,
+    customServers: seedCustomServers,
+    ncbi: { contactEmail: undefined, hasApiKey: false },
+    loadConnectors: vi.fn().mockResolvedValue(undefined),
+    setConnectorEnabled: vi.fn().mockResolvedValue(undefined),
+    setConnectorAutoAllow: vi.fn().mockResolvedValue(undefined),
+    setToolPermission: vi.fn().mockResolvedValue(undefined),
+    setNcbiCredentials: vi.fn().mockResolvedValue(undefined),
+    addCustomServer: vi.fn().mockResolvedValue(undefined),
+    setCustomServerEnabled: vi.fn().mockResolvedValue(undefined),
+    removeCustomServer: vi.fn().mockResolvedValue(undefined)
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+const setValue = (label: string, value: string): void => {
+  const field = document.body.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+    `[aria-label="${label}"]`
+  )
+  const proto =
+    field instanceof HTMLTextAreaElement
+      ? window.HTMLTextAreaElement.prototype
+      : window.HTMLInputElement.prototype
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set
+  act(() => {
+    setter?.call(field, value)
+    field?.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+const clickButtonByText = (text: string): void => {
+  const button = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+    (candidate) => candidate.textContent?.trim() === text
+  )
+  act(() => button?.click())
+}
+
+const openMenu = (label: string): void => {
+  const trigger = document.body.querySelector<HTMLButtonElement>(`[aria-label="${label}"]`)
+  act(() => {
+    trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+    trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+const openDropdownByText = (text: string): void => {
+  const trigger = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+    (candidate) => candidate.textContent?.includes(text)
+  )
+  act(() => {
+    trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+    trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+// Select an item (radix option/menuitem) by its visible text.
+const clickItemByText = (role: string, text: string): void => {
+  const item = Array.from(document.body.querySelectorAll<HTMLElement>(`[role="${role}"]`)).find(
+    (candidate) => candidate.textContent?.includes(text)
+  )
+  act(() => {
+    item?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, button: 0 }))
+    item?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+describe('ConnectorsPanel (groups)', () => {
+  it('renders Featured connector rows with a toggle each and the Custom group', () => {
+    act(() => {
+      root.render(<ConnectorsPanel onNavigate={vi.fn()} />)
+    })
+
+    expect(document.body.textContent).toContain('Featured')
+    expect(document.body.textContent).toContain('Custom')
+    expect(document.body.textContent).toContain('PubMed')
+    expect(document.body.textContent).toContain('Europe PMC')
+    expect(document.body.textContent).toContain('OpenAlex')
+    expect(document.body.textContent).toContain('My MCP')
+    // Three featured toggles + one custom toggle.
+    expect(document.body.querySelectorAll('[role="switch"]')).toHaveLength(4)
+  })
+
+  it('toggles a featured connector and navigates to its detail on row click', () => {
+    const onNavigate = vi.fn()
+    act(() => {
+      root.render(<ConnectorsPanel onNavigate={onNavigate} />)
+    })
+
+    act(() => document.body.querySelector<HTMLButtonElement>('[aria-label="PubMed"]')?.click())
+    expect(useSettingsStore.getState().setConnectorEnabled).toHaveBeenCalledWith('pubmed', false)
+
+    const row = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('PubMed')
+    )
+    act(() => row?.click())
+    expect(onNavigate).toHaveBeenCalledWith({ kind: 'detail', id: 'pubmed' })
+  })
+
+  it('renders a custom server that can be toggled and removed', () => {
+    act(() => {
+      root.render(<ConnectorsPanel onNavigate={vi.fn()} />)
+    })
+
+    act(() => document.body.querySelector<HTMLButtonElement>('[aria-label="My MCP"]')?.click())
+    expect(useSettingsStore.getState().setCustomServerEnabled).toHaveBeenCalledWith('my-mcp', false)
+
+    act(() =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Remove My MCP"]')?.click()
+    )
+    expect(useSettingsStore.getState().removeCustomServer).toHaveBeenCalledWith('my-mcp')
+  })
+
+  it('shows an empty-state line when there are no custom servers', () => {
+    useSettingsStore.setState({ customServers: [] })
+    act(() => {
+      root.render(<ConnectorsPanel onNavigate={vi.fn()} />)
+    })
+
+    expect(document.body.textContent).toContain(
+      'Add a custom connector to connect your own server.'
+    )
+  })
+
+  it('filters groups with the source Select', () => {
+    act(() => {
+      root.render(<ConnectorsPanel onNavigate={vi.fn()} />)
+    })
+
+    openMenu('Filter connectors by group')
+    clickItemByText('option', 'Custom')
+
+    expect(document.body.textContent).toContain('My MCP')
+    expect(document.body.textContent).not.toContain('PubMed')
+    expect(document.body.textContent).not.toContain('OpenAlex')
+
+    // Featured shows featured-group connectors but not the directory one (PubMed) or custom.
+    openMenu('Filter connectors by group')
+    clickItemByText('option', 'Featured')
+
+    expect(document.body.textContent).toContain('OpenAlex')
+    expect(document.body.textContent).not.toContain('PubMed')
+    expect(document.body.textContent).not.toContain('My MCP')
+
+    // Directory shows only the directory-group connector (PubMed).
+    openMenu('Filter connectors by group')
+    clickItemByText('option', 'Directory')
+
+    expect(document.body.textContent).toContain('PubMed')
+    expect(document.body.textContent).not.toContain('OpenAlex')
+  })
+
+  it('filters rows by the search query', () => {
+    act(() => {
+      root.render(<ConnectorsPanel onNavigate={vi.fn()} />)
+    })
+
+    setValue('Search connectors', 'europe')
+    expect(document.body.textContent).toContain('Europe PMC')
+    expect(document.body.textContent).not.toContain('PubMed')
+  })
+
+  it('navigates to the add-local flow from the Add connector dropdown', () => {
+    const onNavigate = vi.fn()
+    act(() => {
+      root.render(<ConnectorsPanel onNavigate={onNavigate} />)
+    })
+
+    openDropdownByText('Add connector')
+    clickItemByText('menuitem', 'Local command')
+    expect(onNavigate).toHaveBeenCalledWith({ kind: 'add', transport: 'local' })
+  })
+})
+
+describe('ConnectorsPanel (contact email)', () => {
+  it('saves the entered contact email on Edit then Save', () => {
+    act(() => {
+      root.render(<ConnectorsPanel onNavigate={vi.fn()} />)
+    })
+
+    clickButtonByText('Edit')
+    setValue('Contact email', 'me@example.com')
+    clickButtonByText('Save')
+
+    expect(useSettingsStore.getState().setNcbiCredentials).toHaveBeenCalledWith({
+      contactEmail: 'me@example.com',
+      apiKey: undefined
+    })
+  })
+})

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -1,0 +1,395 @@
+import { ChevronDown, Globe, Pencil, Plus, Search, Terminal, Trash2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+
+import type { ConnectorView, CustomServerView } from '../../../../shared/settings'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
+import { useSettingsStore } from '@/stores/settings-store'
+import { ConnectorGlyph } from './connector-icons'
+import { SkillToggle } from './SkillsPanel'
+
+// The connectors panel sub-view, driven by the settings navigation history. The detail and add pages
+// are separate components owned by SettingsPage; this panel only renders the list + contact-email section.
+export type ConnectorsView =
+  | { kind: 'list' }
+  | { kind: 'detail'; id: string }
+  | { kind: 'add'; transport: 'local' | 'remote' }
+  | { kind: 'edit'; id: string }
+
+type GroupFilter = 'all' | 'featured' | 'directory' | 'custom'
+
+const FILTER_LABELS: Record<GroupFilter, string> = {
+  all: 'All',
+  featured: 'Featured',
+  directory: 'Directory',
+  custom: 'Custom'
+}
+
+type ConnectorsPanelProps = {
+  onNavigate: (view: ConnectorsView) => void
+}
+
+export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX.Element {
+  const connectors = useSettingsStore((state) => state.connectors)
+  const customServers = useSettingsStore((state) => state.customServers)
+  const ncbi = useSettingsStore((state) => state.ncbi)
+  const loadConnectors = useSettingsStore((state) => state.loadConnectors)
+  const setConnectorEnabled = useSettingsStore((state) => state.setConnectorEnabled)
+  const setCustomServerEnabled = useSettingsStore((state) => state.setCustomServerEnabled)
+  const removeCustomServer = useSettingsStore((state) => state.removeCustomServer)
+  const setNcbiCredentials = useSettingsStore((state) => state.setNcbiCredentials)
+
+  const [filter, setFilter] = useState<GroupFilter>('all')
+  const [query, setQuery] = useState('')
+  const [collapsed, setCollapsed] = useState<
+    Partial<Record<'featured' | 'directory' | 'custom', boolean>>
+  >({})
+  const [editing, setEditing] = useState(false)
+  const [emailField, setEmailField] = useState('')
+  const [keyField, setKeyField] = useState('')
+
+  useEffect(() => {
+    void loadConnectors()
+  }, [loadConnectors])
+
+  const visibleConnectors = useMemo<ConnectorView[]>(() => {
+    const term = query.trim().toLowerCase()
+    if (!term) return connectors
+    return connectors.filter(
+      (connector) =>
+        connector.displayName.toLowerCase().includes(term) ||
+        connector.description.toLowerCase().includes(term)
+    )
+  }, [connectors, query])
+
+  const visibleCustomServers = useMemo<CustomServerView[]>(() => {
+    const term = query.trim().toLowerCase()
+    if (!term) return customServers
+    return customServers.filter(
+      (server) =>
+        server.name.toLowerCase().includes(term) ||
+        (server.description?.toLowerCase().includes(term) ?? false)
+    )
+  }, [customServers, query])
+
+  const startEditing = (): void => {
+    setEmailField(ncbi.contactEmail ?? '')
+    setKeyField('')
+    setEditing(true)
+  }
+
+  const save = async (): Promise<void> => {
+    await setNcbiCredentials({
+      contactEmail: emailField,
+      apiKey: keyField === '' ? undefined : keyField
+    })
+    setEditing(false)
+  }
+
+  const clearKey = async (): Promise<void> => {
+    await setNcbiCredentials({ contactEmail: emailField, apiKey: '' })
+    setKeyField('')
+  }
+
+  const showFeatured = filter === 'all' || filter === 'featured'
+  const showDirectory = filter === 'all' || filter === 'directory'
+  const showCustom = filter === 'all' || filter === 'custom'
+  const featuredConnectors = visibleConnectors.filter((c) => (c.group ?? 'featured') === 'featured')
+  const directoryConnectors = visibleConnectors.filter((c) => c.group === 'directory')
+  const customExpanded = !collapsed.custom
+
+  // Renders one collapsible bundled-connector section (Featured / Directory) with its rows.
+  const connectorGroup = (
+    groupKey: 'featured' | 'directory',
+    label: string,
+    subtitle: string,
+    rows: ConnectorView[]
+  ): React.JSX.Element => {
+    const expanded = !collapsed[groupKey]
+
+    return (
+      <div>
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setCollapsed((prev) => ({ ...prev, [groupKey]: !prev[groupKey] }))}
+          className="flex w-full flex-col items-start gap-0.5 text-left"
+        >
+          <span className="flex items-center gap-1 text-sm font-semibold text-foreground">
+            {label}
+            <ChevronDown
+              className={`size-4 shrink-0 text-muted-foreground transition-transform ${
+                expanded ? '' : '-rotate-90'
+              }`}
+              aria-hidden="true"
+            />
+          </span>
+          <span className="text-xs text-muted-foreground">{subtitle}</span>
+        </button>
+
+        {expanded ? (
+          rows.length > 0 ? (
+            <ul className="mt-2 flex flex-col divide-y divide-border">
+              {rows.map((connector) => (
+                <li key={connector.id} className="flex items-center gap-3 py-2.5">
+                  <ConnectorGlyph size={24} />
+                  <button
+                    type="button"
+                    onClick={() => onNavigate({ kind: 'detail', id: connector.id })}
+                    className="min-w-0 flex-1 text-left"
+                  >
+                    <span className="block truncate text-sm text-foreground">
+                      {connector.displayName}
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {connector.description}
+                    </span>
+                  </button>
+                  <SkillToggle
+                    enabled={connector.enabled}
+                    label={connector.displayName}
+                    onToggle={() => void setConnectorEnabled(connector.id, !connector.enabled)}
+                  />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-2 py-2 text-xs text-muted-foreground">
+              No connectors match your search.
+            </p>
+          )
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-5">
+      <div className="mb-4 rounded-lg border border-border bg-card p-4">
+        <h3 className="text-sm font-semibold text-foreground">Contact email</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          When allowed, shared with research data services that ask for a contact email (such as
+          those run by NCBI, EBI, and OurResearch) on requests made on your behalf.
+        </p>
+
+        {editing ? (
+          <div className="mt-3 flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <Input
+                type="email"
+                aria-label="Contact email"
+                placeholder="you@example.com"
+                value={emailField}
+                onChange={(event) => setEmailField(event.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Input
+                type="password"
+                aria-label="NCBI API key"
+                placeholder={ncbi.hasApiKey ? '••••••••' : 'Optional API key'}
+                value={keyField}
+                onChange={(event) => setKeyField(event.target.value)}
+              />
+              <span className="text-xs text-muted-foreground">
+                Higher NCBI rate limits (optional).
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void save()}
+                className="inline-flex h-8 items-center rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                Save
+              </button>
+              <button
+                type="button"
+                onClick={() => setEditing(false)}
+                className="inline-flex h-8 items-center rounded-lg border border-border bg-card px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+              >
+                Cancel
+              </button>
+              {ncbi.hasApiKey ? (
+                <button
+                  type="button"
+                  onClick={() => void clearKey()}
+                  className="ml-auto text-xs text-muted-foreground transition-colors hover:text-destructive"
+                >
+                  Clear key
+                </button>
+              ) : null}
+            </div>
+          </div>
+        ) : (
+          <div className="mt-3 flex items-center gap-2">
+            <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+              {ncbi.contactEmail ?? 'Not set'}
+            </span>
+            <button
+              type="button"
+              onClick={startEditing}
+              className="inline-flex h-8 shrink-0 items-center rounded-lg border border-border bg-card px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+            >
+              Edit
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="mb-4 flex items-center gap-2">
+        <Select value={filter} onValueChange={(value) => setFilter(value as GroupFilter)}>
+          <SelectTrigger aria-label="Filter connectors by group" className="w-36">
+            <span>{FILTER_LABELS[filter]}</span>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="featured">Featured</SelectItem>
+            <SelectItem value="directory">Directory</SelectItem>
+            <SelectItem value="custom">Custom</SelectItem>
+          </SelectContent>
+        </Select>
+        <div className="relative flex-1">
+          <Search
+            className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            type="search"
+            aria-label="Search connectors"
+            placeholder="Search connectors…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            className="pl-8"
+          />
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted">
+            <Plus className="size-4" aria-hidden="true" />
+            Add connector
+            <ChevronDown className="size-4 opacity-70" aria-hidden="true" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              className="gap-2.5"
+              onSelect={() => onNavigate({ kind: 'add', transport: 'local' })}
+            >
+              <Terminal className="size-4 shrink-0" aria-hidden="true" />
+              <span className="flex flex-col">
+                <span>Local command</span>
+                <span className="text-xs text-muted-foreground">
+                  Run an MCP server via a command
+                </span>
+              </span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="gap-2.5"
+              onSelect={() => onNavigate({ kind: 'add', transport: 'remote' })}
+            >
+              <Globe className="size-4 shrink-0" aria-hidden="true" />
+              <span className="flex flex-col">
+                <span>Remote server</span>
+                <span className="text-xs text-muted-foreground">Connect to an MCP server URL</span>
+              </span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {showFeatured
+          ? connectorGroup(
+              'featured',
+              'Featured',
+              'Research connectors from Anthropic',
+              featuredConnectors
+            )
+          : null}
+
+        {showDirectory
+          ? connectorGroup(
+              'directory',
+              'Directory',
+              'Syncs with the Claude Connectors Directory',
+              directoryConnectors
+            )
+          : null}
+
+        {showCustom ? (
+          <div>
+            <button
+              type="button"
+              aria-expanded={customExpanded}
+              onClick={() => setCollapsed((prev) => ({ ...prev, custom: !prev.custom }))}
+              className="flex w-full flex-col items-start gap-0.5 text-left"
+            >
+              <span className="flex items-center gap-1 text-sm font-semibold text-foreground">
+                Custom
+                <ChevronDown
+                  className={`size-4 shrink-0 text-muted-foreground transition-transform ${
+                    customExpanded ? '' : '-rotate-90'
+                  }`}
+                  aria-hidden="true"
+                />
+              </span>
+              <span className="text-xs text-muted-foreground">Connectors you added</span>
+            </button>
+
+            {customExpanded ? (
+              visibleCustomServers.length > 0 ? (
+                <ul className="mt-2 flex flex-col divide-y divide-border">
+                  {visibleCustomServers.map((server) => (
+                    <li key={server.id} className="flex items-center gap-3 py-2.5">
+                      <ConnectorGlyph size={24} />
+                      <div className="min-w-0 flex-1">
+                        <span className="block truncate text-sm text-foreground">
+                          {server.name}
+                        </span>
+                        {server.description ? (
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {server.description}
+                          </span>
+                        ) : null}
+                      </div>
+                      <button
+                        type="button"
+                        aria-label={`Edit ${server.name}`}
+                        onClick={() => onNavigate({ kind: 'edit', id: server.id })}
+                        className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      >
+                        <Pencil className="size-3.5" aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={`Remove ${server.name}`}
+                        onClick={() => void removeCustomServer(server.id)}
+                        className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
+                      >
+                        <Trash2 className="size-3.5" aria-hidden="true" />
+                      </button>
+                      <SkillToggle
+                        enabled={server.enabled}
+                        label={server.name}
+                        onToggle={() => void setCustomServerEnabled(server.id, !server.enabled)}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 py-2 text-xs text-muted-foreground">
+                  Add a custom connector to connect your own server.
+                </p>
+              )
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -38,6 +38,21 @@ const installApi = (): void => {
         author: 'Test Author',
         license: 'Test License',
         body: '# Alpha body'
+      }),
+      listConnectors: vi.fn().mockResolvedValue({
+        connectors: [
+          {
+            id: 'chemistry',
+            displayName: 'Chemistry',
+            description: 'Small-molecule chemistry via PubChem.',
+            sources: ['PubChem'],
+            requiresNcbi: false,
+            enabled: true,
+            autoAllow: false
+          }
+        ],
+        customServers: [],
+        ncbi: { hasApiKey: false }
       })
     },
     acp: {
@@ -82,10 +97,11 @@ describe('SettingsPage layout', () => {
     expect(nav?.textContent).toContain('Capabilities')
     expect(nav?.textContent).toContain('Workspace')
     const navItems = nav?.querySelectorAll('li') ?? []
-    expect(navItems).toHaveLength(3)
+    expect(navItems).toHaveLength(4)
     expect(navItems[0]?.textContent).toContain('Skills')
-    expect(navItems[1]?.textContent).toContain('Model')
-    expect(navItems[2]?.textContent).toContain('General')
+    expect(navItems[1]?.textContent).toContain('Connectors')
+    expect(navItems[2]?.textContent).toContain('Model')
+    expect(navItems[3]?.textContent).toContain('General')
     // Model is the default active panel.
     expect(nav?.querySelector('[aria-current="page"]')?.textContent).toContain('Model')
 
@@ -166,6 +182,30 @@ describe('SettingsPage layout', () => {
       (window as unknown as { api: { logs: { openFile: ReturnType<typeof vi.fn> } } }).api.logs
         .openFile
     ).toHaveBeenCalledTimes(1)
+  })
+
+  it('switches to the Connectors panel and lists bundled connectors', async () => {
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+
+    const connectorsTab = Array.from(
+      document.body.querySelectorAll('nav[aria-label="Settings"] button')
+    ).find((button) => /connectors/i.test(button.textContent ?? '')) as
+      HTMLButtonElement | undefined
+    expect(connectorsTab).not.toBeUndefined()
+
+    await act(async () => {
+      connectorsTab?.click()
+    })
+
+    // The Connectors panel loads and renders the bundled connector rows + contact-email section.
+    expect(
+      (window as unknown as { api: { settings: { listConnectors: ReturnType<typeof vi.fn> } } }).api
+        .settings.listConnectors
+    ).toHaveBeenCalled()
+    expect(document.body.textContent).toContain('Chemistry')
+    expect(document.body.textContent).toContain('Contact email')
   })
 
   it('shows a breadcrumb in the header when a skill detail is open, and returns on breadcrumb click', async () => {

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -18,6 +18,10 @@ import { ClaudeInstallCard } from './ClaudeInstallCard'
 import { ClaudeStatusCard } from './ClaudeStatusCard'
 import { GeneralPanel } from './GeneralPanel'
 import { SkillsPanel, type SkillsView } from './SkillsPanel'
+import { ConnectorsPanel, type ConnectorsView } from './ConnectorsPanel'
+import { ConnectorDetailView } from './ConnectorDetailView'
+import { ConnectorAddForm } from './ConnectorAddForm'
+import { ConnectorsNavIcon } from './connector-icons'
 import { resolveVendorModelsUrl } from '../../../../shared/provider-registry'
 import { ActiveModelSelect } from './ActiveModelSelect'
 import { ProviderForm } from './ProviderForm'
@@ -64,18 +68,21 @@ const toUpsertRequest = (
 
 // Left-nav panels, grouped in the sidebar. "Capabilities" holds agent extensions (Skills); "Workspace"
 // holds environment/config (Model manages Claude + providers, General holds app settings incl. logs).
-type SettingsPanelId = 'model' | 'skills' | 'general'
+type SettingsPanelId = 'model' | 'skills' | 'connectors' | 'general'
 
 type SettingsPanel = {
   id: SettingsPanelId
   label: string
-  Icon: typeof SlidersHorizontal
+  Icon: React.ComponentType<{ className?: string }>
 }
 
 const SETTINGS_GROUPS: ReadonlyArray<{ label: string; panels: ReadonlyArray<SettingsPanel> }> = [
   {
     label: 'Capabilities',
-    panels: [{ id: 'skills', label: 'Skills', Icon: ScrollText }]
+    panels: [
+      { id: 'skills', label: 'Skills', Icon: ScrollText },
+      { id: 'connectors', label: 'Connectors', Icon: ConnectorsNavIcon }
+    ]
   },
   {
     label: 'Workspace',
@@ -92,13 +99,20 @@ const SETTINGS_PANELS: ReadonlyArray<SettingsPanel> = SETTINGS_GROUPS.flatMap(
 )
 
 // One entry in the settings back/forward history: the active panel plus each panel's current sub-view
-// (skills: list / detail / create / edit / import; model: list / create / edit).
-type NavLocation = { panel: SettingsPanelId; skills: SkillsView; model: ModelView }
+// (skills: list / detail / create / edit / import; model: list / create / edit; connectors: list /
+// detail / add / edit). `connectors` is optional so panel switches that don't touch it stay terse.
+type NavLocation = {
+  panel: SettingsPanelId
+  skills: SkillsView
+  model: ModelView
+  connectors?: ConnectorsView
+}
 
 const INITIAL_LOCATION: NavLocation = {
   panel: 'model',
   skills: { kind: 'list' },
-  model: { kind: 'list' }
+  model: { kind: 'list' },
+  connectors: { kind: 'list' }
 }
 
 // App-level model settings surface. Reuses the onboarding cards/form; manages providers (CRUD +
@@ -127,6 +141,8 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   // Whether the dialog is enlarged to near-fullscreen via the maximize control.
   const [isExpanded, setIsExpanded] = useState(false)
   const skills = useSettingsStore((state) => state.skills)
+  const connectors = useSettingsStore((state) => state.connectors)
+  const customServers = useSettingsStore((state) => state.customServers)
   const [formValue, setFormValue] = useState<ProviderFormValue>(() =>
     createEmptyProviderFormValue()
   )
@@ -145,11 +161,13 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const activePanel = currentLocation.panel
   const skillsView = currentLocation.skills
   const modelView = currentLocation.model
+  const connectorsView: ConnectorsView = currentLocation.connectors ?? { kind: 'list' }
   const canGoBack = historyIndex > 0
   const canGoForward = historyIndex < history.length - 1
 
   // Pushes a new location, dropping any forward entries.
   const navigate = (location: NavLocation): void => {
+    const nextConnectors = location.connectors ?? { kind: 'list' }
     if (
       location.panel === activePanel &&
       location.skills.kind === skillsView.kind &&
@@ -157,7 +175,10 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
         ('id' in skillsView ? skillsView.id : undefined) &&
       location.model.kind === modelView.kind &&
       ('providerId' in location.model ? location.model.providerId : undefined) ===
-        ('providerId' in modelView ? modelView.providerId : undefined)
+        ('providerId' in modelView ? modelView.providerId : undefined) &&
+      nextConnectors.kind === connectorsView.kind &&
+      ('id' in nextConnectors ? nextConnectors.id : undefined) ===
+        ('id' in connectorsView ? connectorsView.id : undefined)
     ) {
       return
     }
@@ -167,7 +188,11 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
 
   // Navigates within the skills panel (list/detail/create/edit/import) as a history entry.
   const navigateSkills = (skills: SkillsView): void =>
-    navigate({ panel: 'skills', skills, model: modelView })
+    navigate({ panel: 'skills', skills, model: modelView, connectors: connectorsView })
+
+  // Navigates within the connectors panel (list/detail/add/edit) as a history entry.
+  const navigateConnectors = (connectors: ConnectorsView): void =>
+    navigate({ panel: 'connectors', skills: skillsView, model: modelView, connectors })
 
   // Shared header breadcrumb for a drilled-in sub-view (null when on a panel's list, so the plain
   // panel title shows). Covers both the skills and model panels.
@@ -203,6 +228,24 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
         rootLabel: 'Model',
         rootTo: { panel: 'model', skills: currentLocation.skills, model: { kind: 'list' } },
         leaf: modelView.kind === 'create' ? 'Add provider' : `Edit ${name}`.trim()
+      }
+    }
+    if (activePanel === 'connectors' && connectorsView.kind !== 'list') {
+      const leaf =
+        connectorsView.kind === 'add'
+          ? 'Add connector'
+          : connectorsView.kind === 'edit'
+            ? `Edit ${customServers.find((s) => s.id === connectorsView.id)?.name ?? 'connector'}`.trim()
+            : (connectors.find((c) => c.id === connectorsView.id)?.displayName ?? '')
+      return {
+        rootLabel: 'Connectors',
+        rootTo: {
+          panel: 'connectors',
+          skills: currentLocation.skills,
+          model: currentLocation.model,
+          connectors: { kind: 'list' }
+        },
+        leaf
       }
     }
     return null
@@ -454,6 +497,24 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
             <div className="min-h-0 flex-1 overflow-y-auto">
               {activePanel === 'skills' ? (
                 <SkillsPanel view={skillsView} onNavigate={navigateSkills} />
+              ) : activePanel === 'connectors' ? (
+                connectorsView.kind === 'detail' ? (
+                  <ConnectorDetailView id={connectorsView.id} />
+                ) : connectorsView.kind === 'add' ? (
+                  <ConnectorAddForm
+                    initialTransport={connectorsView.transport}
+                    onDone={() => navigateConnectors({ kind: 'list' })}
+                    onCancel={() => navigateConnectors({ kind: 'list' })}
+                  />
+                ) : connectorsView.kind === 'edit' ? (
+                  <ConnectorAddForm
+                    editServer={customServers.find((s) => s.id === connectorsView.id)}
+                    onDone={() => navigateConnectors({ kind: 'list' })}
+                    onCancel={() => navigateConnectors({ kind: 'list' })}
+                  />
+                ) : (
+                  <ConnectorsPanel onNavigate={navigateConnectors} />
+                )
               ) : activePanel === 'general' ? (
                 <GeneralPanel />
               ) : isProviderFormOpen ? (

--- a/src/renderer/src/pages/settings/ToolPermissionControl.render.test.tsx
+++ b/src/renderer/src/pages/settings/ToolPermissionControl.render.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ToolPermissionControl } from './ToolPermissionControl'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+const radio = (label: string): HTMLButtonElement | null =>
+  document.body.querySelector<HTMLButtonElement>(`[role="radio"][aria-label="${label}"]`)
+
+describe('ToolPermissionControl', () => {
+  it('renders three radios and checks the one matching value', () => {
+    act(() => {
+      root.render(
+        <ToolPermissionControl value="block" onChange={vi.fn()} label="Permission for list_marts" />
+      )
+    })
+
+    expect(document.body.querySelectorAll('[role="radio"]')).toHaveLength(3)
+    expect(radio('Always allow')?.getAttribute('aria-checked')).toBe('false')
+    expect(radio('Ask each time')?.getAttribute('aria-checked')).toBe('false')
+    expect(radio('Block')?.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('calls onChange("allow") when Always allow is clicked', () => {
+    const onChange = vi.fn()
+    act(() => {
+      root.render(
+        <ToolPermissionControl
+          value="block"
+          onChange={onChange}
+          label="Permission for list_marts"
+        />
+      )
+    })
+
+    act(() => radio('Always allow')?.click())
+    expect(onChange).toHaveBeenCalledWith('allow')
+  })
+
+  it('calls onChange("block") when Block is clicked', () => {
+    const onChange = vi.fn()
+    act(() => {
+      root.render(
+        <ToolPermissionControl
+          value="allow"
+          onChange={onChange}
+          label="Permission for list_marts"
+        />
+      )
+    })
+
+    act(() => radio('Block')?.click())
+    expect(onChange).toHaveBeenCalledWith('block')
+  })
+
+  it('calls onChange("ask") when Ask each time is clicked', () => {
+    const onChange = vi.fn()
+    act(() => {
+      root.render(
+        <ToolPermissionControl
+          value="allow"
+          onChange={onChange}
+          label="Permission for list_marts"
+        />
+      )
+    })
+
+    act(() => radio('Ask each time')?.click())
+    expect(onChange).toHaveBeenCalledWith('ask')
+  })
+})

--- a/src/renderer/src/pages/settings/ToolPermissionControl.tsx
+++ b/src/renderer/src/pages/settings/ToolPermissionControl.tsx
@@ -1,0 +1,82 @@
+import { Ban, CircleCheck, Hand } from 'lucide-react'
+
+import type { ToolPermission } from '../../../../shared/settings'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+
+type ToolPermissionControlProps = {
+  value: ToolPermission
+  onChange: (next: ToolPermission) => void
+  label: string // accessible group label, e.g. "Permission for list_marts"
+}
+
+// A 3-segment permission pill: "Always allow / Ask each time / Block". Each segment shows a hover
+// tooltip. "Ask each time" (the secure default) requires per-call approval before the tool runs.
+export function ToolPermissionControl({
+  value,
+  onChange,
+  label
+}: ToolPermissionControlProps): React.JSX.Element {
+  const segment = (active: boolean, allow: boolean): string => {
+    const base = 'grid h-6 w-7 place-items-center rounded-md transition-colors'
+    if (active) {
+      return `${base} bg-card shadow-sm ${allow ? 'text-emerald-600' : 'text-foreground'}`
+    }
+    return `${base} text-muted-foreground hover:text-foreground`
+  }
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div
+        role="radiogroup"
+        aria-label={label}
+        className="inline-flex shrink-0 gap-0.5 rounded-lg bg-muted p-0.5"
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={value === 'allow'}
+              aria-label="Always allow"
+              onClick={() => onChange('allow')}
+              className={segment(value === 'allow', true)}
+            >
+              <CircleCheck className="size-3.5" aria-hidden />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Always allow</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={value === 'ask'}
+              aria-label="Ask each time"
+              onClick={() => onChange('ask')}
+              className={segment(value === 'ask', false)}
+            >
+              <Hand className="size-3.5" aria-hidden />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Ask each time</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={value === 'block'}
+              aria-label="Block"
+              onClick={() => onChange('block')}
+              className={segment(value === 'block', false)}
+            >
+              <Ban className="size-3.5" aria-hidden />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Block</TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/src/renderer/src/pages/settings/connector-icons.tsx
+++ b/src/renderer/src/pages/settings/connector-icons.tsx
@@ -1,0 +1,42 @@
+import { Terminal } from 'lucide-react'
+
+// Blocks glyph for the "Connectors" left-nav item: three squares forming an L plus a smaller
+// detached module top-right (a connectable block). Outline style to match the other nav icons.
+export const ConnectorsNavIcon = ({ className }: { className?: string }): React.JSX.Element => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    aria-hidden="true"
+  >
+    <rect x="3" y="3" width="8" height="8" rx="1.7" />
+    <rect x="3" y="13" width="8" height="8" rx="1.7" />
+    <rect x="13" y="13" width="8" height="8" rx="1.7" />
+    <rect x="14.5" y="2" width="6.5" height="6.5" rx="1.5" />
+  </svg>
+)
+
+// Per-connector tile: a rounded white card (border + shadow) holding a terminal glyph, used in the
+// connector list rows and the detail header. `size` is the tile's edge length in px.
+export const ConnectorGlyph = ({
+  size = 24,
+  className
+}: {
+  size?: number
+  className?: string
+}): React.JSX.Element => (
+  <span
+    aria-hidden="true"
+    className={
+      'inline-flex shrink-0 items-center justify-center border border-border bg-card text-muted-foreground shadow-sm ' +
+      (className ?? '')
+    }
+    style={{ width: size, height: size, borderRadius: Math.round(size * 0.27) }}
+  >
+    <Terminal size={Math.round(size * 0.58)} strokeWidth={2} aria-hidden="true" />
+  </span>
+)

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SettingsSnapshot, ValidateProviderResult } from '../../../shared/settings'
+import type {
+  SettingsSnapshot,
+  ValidateProviderResult,
+  ConnectorView
+} from '../../../shared/settings'
 import {
   createInitialSettingsState,
   selectProviderModelOptions,
@@ -22,6 +26,17 @@ type SettingsApi = {
   markOnboardingComplete: ReturnType<typeof vi.fn>
   listSkills: ReturnType<typeof vi.fn>
   setSkillEnabled: ReturnType<typeof vi.fn>
+  listConnectors: ReturnType<typeof vi.fn>
+  getConnectorDetail: ReturnType<typeof vi.fn>
+  setConnectorEnabled: ReturnType<typeof vi.fn>
+  setConnectorAutoAllow: ReturnType<typeof vi.fn>
+  setToolPermission: ReturnType<typeof vi.fn>
+  setNcbiCredentials: ReturnType<typeof vi.fn>
+  addCustomServer: ReturnType<typeof vi.fn>
+  setCustomServerEnabled: ReturnType<typeof vi.fn>
+  removeCustomServer: ReturnType<typeof vi.fn>
+  updateCustomServer: ReturnType<typeof vi.fn>
+  respondConnectorApproval: ReturnType<typeof vi.fn>
 }
 
 // Minimal window.api.acp surface the provider-switch flow reads/uses.
@@ -71,7 +86,34 @@ beforeEach(() => {
       .fn()
       .mockResolvedValue({ ...snapshot([]), onboardingCompletedAt: 4242 }),
     listSkills: vi.fn().mockResolvedValue([]),
-    setSkillEnabled: vi.fn().mockResolvedValue([])
+    setSkillEnabled: vi.fn().mockResolvedValue([]),
+    listConnectors: vi
+      .fn()
+      .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
+    getConnectorDetail: vi.fn(),
+    setConnectorEnabled: vi
+      .fn()
+      .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
+    setConnectorAutoAllow: vi
+      .fn()
+      .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
+    setToolPermission: vi.fn(),
+    setNcbiCredentials: vi
+      .fn()
+      .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
+    addCustomServer: vi
+      .fn()
+      .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
+    setCustomServerEnabled: vi
+      .fn()
+      .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
+    removeCustomServer: vi
+      .fn()
+      .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
+    updateCustomServer: vi
+      .fn()
+      .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
+    respondConnectorApproval: vi.fn().mockResolvedValue(undefined)
   }
   acp = {
     getState: vi.fn().mockResolvedValue({ promptInFlightSessionIds: [] }),
@@ -439,5 +481,125 @@ describe('settings store: refreshProviderModels', () => {
     await useSettingsStore.getState().setSkillEnabled('demo', false)
     expect(api.setSkillEnabled).toHaveBeenCalledWith({ id: 'demo', enabled: false })
     expect(useSettingsStore.getState().skills[0].enabled).toBe(false)
+  })
+})
+
+describe('settings store: connectors slice', () => {
+  const connectorView = (id: string, enabled: boolean): ConnectorView => ({
+    id,
+    displayName: 'PubMed',
+    description: '',
+    sources: [],
+    requiresNcbi: true,
+    enabled,
+    autoAllow: false,
+    group: 'featured'
+  })
+
+  it('loadConnectors populates connectors and ncbi from the snapshot', async () => {
+    api.listConnectors.mockResolvedValue({
+      connectors: [connectorView('pubmed', true)],
+      customServers: [],
+      ncbi: { contactEmail: 'a@b.com', hasApiKey: true }
+    })
+
+    await useSettingsStore.getState().loadConnectors()
+
+    expect(useSettingsStore.getState().connectors[0].id).toBe('pubmed')
+    expect(useSettingsStore.getState().ncbi).toEqual({ contactEmail: 'a@b.com', hasApiKey: true })
+  })
+
+  it('setConnectorEnabled flips optimistically then reconciles from the returned snapshot', async () => {
+    api.listConnectors.mockResolvedValue({
+      connectors: [connectorView('pubmed', true)],
+      customServers: [],
+      ncbi: { hasApiKey: false }
+    })
+    api.setConnectorEnabled.mockResolvedValue({
+      connectors: [connectorView('pubmed', false)],
+      customServers: [],
+      ncbi: { hasApiKey: false }
+    })
+
+    await useSettingsStore.getState().loadConnectors()
+    expect(useSettingsStore.getState().connectors[0].enabled).toBe(true)
+
+    await useSettingsStore.getState().setConnectorEnabled('pubmed', false)
+    expect(api.setConnectorEnabled).toHaveBeenCalledWith({ id: 'pubmed', enabled: false })
+    expect(useSettingsStore.getState().connectors[0].enabled).toBe(false)
+  })
+
+  it('setNcbiCredentials reconciles the ncbi credential state', async () => {
+    api.setNcbiCredentials.mockResolvedValue({
+      connectors: [],
+      customServers: [],
+      ncbi: { contactEmail: 'me@lab.org', hasApiKey: true }
+    })
+
+    await useSettingsStore
+      .getState()
+      .setNcbiCredentials({ contactEmail: 'me@lab.org', apiKey: 'k' })
+
+    expect(api.setNcbiCredentials).toHaveBeenCalledWith({
+      contactEmail: 'me@lab.org',
+      apiKey: 'k'
+    })
+    expect(useSettingsStore.getState().ncbi).toEqual({
+      contactEmail: 'me@lab.org',
+      hasApiKey: true
+    })
+  })
+
+  it('addCustomServer and removeCustomServer reconcile the custom-server list', async () => {
+    const server = {
+      id: 'srv-1',
+      name: 'my-mem',
+      transport: 'stdio' as const,
+      enabled: true,
+      command: 'npx'
+    }
+    api.addCustomServer.mockResolvedValue({
+      connectors: [],
+      customServers: [server],
+      ncbi: { hasApiKey: false }
+    })
+    api.removeCustomServer.mockResolvedValue({
+      connectors: [],
+      customServers: [],
+      ncbi: { hasApiKey: false }
+    })
+
+    await useSettingsStore
+      .getState()
+      .addCustomServer({ name: 'my-mem', transport: 'stdio', command: 'npx' })
+    expect(api.addCustomServer).toHaveBeenCalledWith({
+      name: 'my-mem',
+      transport: 'stdio',
+      command: 'npx'
+    })
+    expect(useSettingsStore.getState().customServers).toEqual([server])
+
+    await useSettingsStore.getState().removeCustomServer('srv-1')
+    expect(api.removeCustomServer).toHaveBeenCalledWith({ id: 'srv-1' })
+    expect(useSettingsStore.getState().customServers).toEqual([])
+  })
+
+  it('enqueues an approval request and responds, clearing it from the queue', async () => {
+    const request = {
+      id: 'req-1',
+      connector: 'biomart',
+      method: 'get_data',
+      argsPreview: '{"x":1}'
+    }
+    useSettingsStore.getState().enqueueApproval(request)
+    expect(useSettingsStore.getState().pendingApprovals).toEqual([request])
+
+    // Duplicate ids are ignored.
+    useSettingsStore.getState().enqueueApproval(request)
+    expect(useSettingsStore.getState().pendingApprovals).toHaveLength(1)
+
+    await useSettingsStore.getState().respondApproval('req-1', 'allow')
+    expect(api.respondConnectorApproval).toHaveBeenCalledWith({ id: 'req-1', decision: 'allow' })
+    expect(useSettingsStore.getState().pendingApprovals).toEqual([])
   })
 })

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -20,7 +20,17 @@ import type {
   ScanRepoResult,
   UpsertProviderRequest,
   ValidateProviderRequest,
-  ValidateProviderResult
+  ValidateProviderResult,
+  ConnectorView,
+  ConnectorDetailView,
+  CustomServerView,
+  NcbiCredentialsView,
+  ToolPermission,
+  SetNcbiCredentialsRequest,
+  AddCustomServerRequest,
+  UpdateCustomServerRequest,
+  ConnectorApprovalRequest,
+  ApprovalDecision
 } from '../../../shared/settings'
 
 // Result of the combined onboarding save flow (create/edit -> validate -> activate).
@@ -39,6 +49,14 @@ type SettingsStoreData = {
   onboardingCompletedAt: number | undefined
   // Bundled skills with their enabled state, loaded lazily when the Skills panel opens.
   skills: SkillView[]
+  // Bundled connectors with their enabled/auto-allow state, loaded lazily when the Connectors panel opens.
+  connectors: ConnectorView[]
+  // User-added custom MCP servers, reconciled alongside the connectors list.
+  customServers: CustomServerView[]
+  // Pending per-call connector approval requests (external data-egress gate), oldest first.
+  pendingApprovals: ConnectorApprovalRequest[]
+  // Shared NCBI credential state (never the plaintext key), reconciled alongside the connectors list.
+  ncbi: NcbiCredentialsView
   preflight: Preflight
   // Latched true the first time both startup gates pass. Onboarding is a first-run gate, so once the
   // user has entered the app, later provider changes (which may momentarily flip a gate) must not send
@@ -96,6 +114,29 @@ type SettingsStore = SettingsStoreData & {
   previewSkillZip: (dataBase64: string) => Promise<SkillBundlePreview>
   // Scans a GitHub repo for importable skill directories (does not mutate state).
   scanRepoSkills: (repo: string) => Promise<ScanRepoResult>
+  // Loads the bundled-connector list (enabled/auto-allow + NCBI credential state) from main.
+  loadConnectors: () => Promise<void>
+  // Toggles one connector; optimistic, then reconciled with the authoritative snapshot from main.
+  setConnectorEnabled: (id: string, enabled: boolean) => Promise<void>
+  // Toggles a connector's "skip approvals" flag; optimistic, then reconciled from main.
+  setConnectorAutoAllow: (id: string, autoAllow: boolean) => Promise<void>
+  // Sets one tool's permission, returning the affected connector's refreshed detail view (held
+  // locally by the component, so nothing is stored here).
+  setToolPermission: (toolId: string, permission: ToolPermission) => Promise<ConnectorDetailView>
+  // Persists NCBI credentials and reconciles the connectors list + credential state from main.
+  setNcbiCredentials: (request: SetNcbiCredentialsRequest) => Promise<void>
+  // Adds a custom MCP server (add-time trust is confirmed in the UI), reconciling from main.
+  addCustomServer: (request: AddCustomServerRequest) => Promise<void>
+  // Edits an existing custom MCP server (name is immutable), reconciling from main.
+  updateCustomServer: (request: UpdateCustomServerRequest) => Promise<void>
+  // Enables/disables one custom MCP server; optimistic, then reconciled from main.
+  setCustomServerEnabled: (id: string, enabled: boolean) => Promise<void>
+  // Removes one custom MCP server, reconciling from main.
+  removeCustomServer: (id: string) => Promise<void>
+  // Queues an incoming approval request (from the main-process connector gate).
+  enqueueApproval: (request: ConnectorApprovalRequest) => void
+  // Sends the user's decision to main and drops the request from the queue.
+  respondApproval: (id: string, decision: ApprovalDecision) => Promise<void>
   // Persists the first-run completion marker and caches it so the startup gate falls through to Home.
   completeOnboarding: () => Promise<void>
 }
@@ -117,6 +158,10 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   providers: [],
   onboardingCompletedAt: undefined,
   skills: [],
+  connectors: [],
+  customServers: [],
+  pendingApprovals: [],
+  ncbi: { hasApiKey: false },
   preflight: createInitialPreflight(),
   hasEnteredApp: false,
   encryptionAvailable: true,
@@ -410,6 +455,92 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   previewSkillZip: async (dataBase64) => window.api.settings.previewSkillZip({ dataBase64 }),
 
   scanRepoSkills: async (repo) => window.api.settings.scanRepoSkills({ repo }),
+
+  loadConnectors: async () => {
+    const { connectors, customServers, ncbi } = await window.api.settings.listConnectors()
+    set({ connectors, customServers, ncbi })
+  },
+
+  // Optimistically flips the toggle, then reconciles with the authoritative snapshot from main.
+  setConnectorEnabled: async (id, enabled) => {
+    set((state) => ({
+      connectors: state.connectors.map((connector) =>
+        connector.id === id ? { ...connector, enabled } : connector
+      )
+    }))
+    const { connectors, customServers, ncbi } = await window.api.settings.setConnectorEnabled({
+      id,
+      enabled
+    })
+    set({ connectors, customServers, ncbi })
+  },
+
+  // Optimistically flips "skip approvals", then reconciles from main.
+  setConnectorAutoAllow: async (id, autoAllow) => {
+    set((state) => ({
+      connectors: state.connectors.map((connector) =>
+        connector.id === id ? { ...connector, autoAllow } : connector
+      )
+    }))
+    const { connectors, customServers, ncbi } = await window.api.settings.setConnectorAutoAllow({
+      id,
+      autoAllow
+    })
+    set({ connectors, customServers, ncbi })
+  },
+
+  setToolPermission: async (toolId, permission) =>
+    window.api.settings.setToolPermission({ toolId, permission }),
+
+  setNcbiCredentials: async (request) => {
+    const { connectors, customServers, ncbi } =
+      await window.api.settings.setNcbiCredentials(request)
+    set({ connectors, customServers, ncbi })
+  },
+
+  addCustomServer: async (request) => {
+    const { connectors, customServers, ncbi } = await window.api.settings.addCustomServer(request)
+    set({ connectors, customServers, ncbi })
+  },
+
+  updateCustomServer: async (request) => {
+    const { connectors, customServers, ncbi } =
+      await window.api.settings.updateCustomServer(request)
+    set({ connectors, customServers, ncbi })
+  },
+
+  // Optimistically flips the server toggle, then reconciles from main.
+  setCustomServerEnabled: async (id, enabled) => {
+    set((state) => ({
+      customServers: state.customServers.map((server) =>
+        server.id === id ? { ...server, enabled } : server
+      )
+    }))
+    const { connectors, customServers, ncbi } = await window.api.settings.setCustomServerEnabled({
+      id,
+      enabled
+    })
+    set({ connectors, customServers, ncbi })
+  },
+
+  removeCustomServer: async (id) => {
+    const { connectors, customServers, ncbi } = await window.api.settings.removeCustomServer({ id })
+    set({ connectors, customServers, ncbi })
+  },
+
+  enqueueApproval: (request) => {
+    set((state) =>
+      state.pendingApprovals.some((r) => r.id === request.id)
+        ? state
+        : { pendingApprovals: [...state.pendingApprovals, request] }
+    )
+  },
+
+  respondApproval: async (id, decision) => {
+    // Drop it from the queue immediately so the card can't be double-answered, then notify main.
+    set((state) => ({ pendingApprovals: state.pendingApprovals.filter((r) => r.id !== id) }))
+    await window.api.settings.respondConnectorApproval({ id, decision })
+  },
 
   completeOnboarding: async () => {
     const snapshot = await window.api.settings.markOnboardingComplete()

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -359,3 +359,110 @@ export type ImportSkillResult = {
   id: string
   skills: SkillView[]
 }
+
+// --- Connectors ---------------------------------------------------------------------------------
+
+// Per-tool permission. 'ask' is reserved for the future per-call approval flow and is not yet
+// functional — the UI renders it disabled and only 'allow'/'block' persist (to blockedToolIds).
+export type ToolPermission = 'allow' | 'ask' | 'block'
+
+// One tool within a connector, with its current permission (derived: 'block' if blocklisted).
+export type ConnectorToolView = {
+  id: string // "<connector>/<method>"
+  method: string
+  description: string
+  permission: ToolPermission
+}
+
+// Which section a bundled connector belongs to in the settings list.
+export type ConnectorGroup = 'featured' | 'directory'
+
+// Renderer-safe view of one bundled connector (no tool schemas).
+export type ConnectorView = {
+  id: string
+  displayName: string
+  description: string
+  sources: string[]
+  requiresNcbi: boolean
+  enabled: boolean // !disabledConnectorIds.includes(id)
+  autoAllow: boolean // autoAllowIds.includes(id) — "Skip approvals"
+  group: ConnectorGroup
+}
+
+// A connector view plus its tools and metadata, for the detail page.
+export type ConnectorDetailView = ConnectorView & {
+  useWhen: string
+  termsUrl?: string
+  tools: ConnectorToolView[]
+}
+
+// NCBI / research-service credential state surfaced to the renderer (never the plaintext key).
+export type NcbiCredentialsView = { contactEmail?: string; hasApiKey: boolean }
+
+// Transport for a user-added custom MCP server: stdio (local command) or a remote HTTP variant.
+export type CustomServerTransport = 'stdio' | 'streamable_http' | 'sse'
+
+// Renderer-safe view of one user-added custom MCP server (no secret env/header values).
+export type CustomServerView = {
+  id: string
+  name: string
+  description?: string
+  transport: CustomServerTransport
+  enabled: boolean
+  // Display-only config summary (the command that runs, its args, or the remote URL). env/headers
+  // are intentionally omitted — they may hold secrets and stay write-only from the UI.
+  command?: string
+  args?: string[]
+  url?: string
+}
+
+// The connectors list plus custom servers and shared credential state, returned by list/mutation calls.
+export type ConnectorsSnapshot = {
+  connectors: ConnectorView[]
+  customServers: CustomServerView[]
+  ncbi: NcbiCredentialsView
+}
+
+export type SetConnectorEnabledRequest = { id: string; enabled: boolean }
+export type SetConnectorAutoAllowRequest = { id: string; autoAllow: boolean }
+export type SetToolPermissionRequest = { toolId: string; permission: ToolPermission }
+export type SetNcbiCredentialsRequest = { contactEmail?: string; apiKey?: string }
+
+// Add a custom MCP server. stdio requires `command`; the remote transports require `url`.
+export type AddCustomServerRequest = {
+  name: string
+  description?: string
+  transport: CustomServerTransport
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  headers?: Record<string, string>
+}
+export type SetCustomServerEnabledRequest = { id: string; enabled: boolean }
+export type RemoveCustomServerRequest = { id: string }
+
+// Edit an existing custom MCP server. The name is immutable (it is the server's identity — host.mcp
+// routing, skill-doc name, and per-tool policy keys all depend on it). Omitted env/headers keep the
+// stored values; providing them replaces the set.
+export type UpdateCustomServerRequest = {
+  id: string
+  description?: string
+  transport: CustomServerTransport
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  headers?: Record<string, string>
+}
+
+// A per-call approval request for a connector tool invocation (external data-egress gate). Sent from
+// main to the renderer, which shows an approval card and responds with a decision.
+export type ConnectorApprovalRequest = {
+  id: string
+  connector: string // bundled connector id or custom server name
+  method: string
+  argsPreview: string // truncated JSON preview of the call arguments
+}
+export type ApprovalDecision = 'allow' | 'deny'
+export type RespondApprovalRequest = { id: string; decision: ApprovalDecision }


### PR DESCRIPTION
## Summary

Adds a Node-native **connector layer** that projects external life-sciences data sources — and user-added MCP servers — into the notebook kernel via `host.mcp`, discovered as **MCP-as-skill** docs rather than injected tools (keeps them out of the model context until needed).

### Bundled connectors
- Declarative `ParserEngine` (fetch + `url`/`parse`, `run()` escape hatch) with NCBI etiquette, a User-Agent, and credential redaction in error messages.
- **26 connectors** across the upstream groups (chemistry, literature, PubMed, genes, genomes, variants, clinical trials, structures, gnomAD, GEO, OpenAlex, ChEMBL, bioRxiv, openFDA, GWAS, GTEx, STRING, cBioPortal, Rfam, ArrayExpress, CellGuide, ENCODE, Antibody Registry, BioMart, ZINC, Open Targets).
- `ConnectorService` gate + `NotebookLocalRpcServer` `mcpCall` dispatch; `host.mcp` injected into the Python kernel over a loopback Bearer RPC.

### Custom MCP servers
- `McpClientManager` (stdio + streamable_http/sse). Add / **edit** / enable / remove custom servers from settings; the **name is immutable** (it is the `host.mcp` identity, skill-doc name, and policy key). Skill docs are generated from the server's live `listTools()`; secrets (env/headers, NCBI key) stay write-only via `safeStorage`.

### Settings UI (mirrors the Skills panel)
- Connectors panel with **Featured / Directory / Custom** groups, filter + search, a per-connector detail with expandable tool docs and **Allow / Ask / Block** permission controls, an NCBI contact-email / API-key section, and an Add/Edit connector form (command picker + multi-line env/headers).

### Per-call approval (data-egress gate)
- Tools default to **Allow**; a tool set to **Ask** (and not skip-approved) holds the call open and shows an approval card (**Allow once / Always allow / Deny**) with a timeout-deny. `ApprovalBroker` bridges main and renderer.

## Notes
- **Zero new runtime dependencies** (reuses the in-repo `@modelcontextprotocol/sdk`).
- Design specs live under `docs/internal` (git-ignored).
- History squashed to a single commit.

## Known follow-up (not in this PR)
The approval / block gate only applies to calls made through `host.mcp`. A notebook cell can still reach an external host with raw HTTP (e.g. `urllib`) and bypass the gate. Real enforcement needs **notebook network egress control** (an allowlist / forcing external calls through the connector layer) — tracked as a dedicated follow-up. The generated skill docs now explicitly instruct the agent to only use `host.mcp` and never reimplement calls with raw HTTP.

## Test plan
- `npm run lint`, `npm run typecheck` (node + web), `npx vitest run` — full suite green (1117 passed / 2 skipped).
- Manual: add a local stdio MCP server via **Add connector → Local command**, confirm it appears under **Custom**, generates `mcp-<name>/SKILL.md`, and is callable via `host.mcp(...)`; set a tool to **Ask** and confirm the approval card fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)