### PR TITLE
fix(acp): diagnostic logging for permission and tool-call failures

### DIFF
--- a/src/main/acp/agent-process.ts
+++ b/src/main/acp/agent-process.ts
@@ -100,6 +100,12 @@ const spawnClaudeAgentAcp = ({
     baseUrl: env.ANTHROPIC_BASE_URL,
     model: env.ANTHROPIC_MODEL,
     configDir: env.CLAUDE_CONFIG_DIR,
+    // Proxy presence only (never the values): a Finder-launched packaged app inherits no login shell, so
+    // these being false is the usual cause of in-app network failures (curl/WebFetch) while the terminal works.
+    hasHttpProxy: Boolean(env.http_proxy || env.HTTP_PROXY),
+    hasHttpsProxy: Boolean(env.https_proxy || env.HTTPS_PROXY),
+    hasAllProxy: Boolean(env.all_proxy || env.ALL_PROXY),
+    hasNoProxy: Boolean(env.no_proxy || env.NO_PROXY),
     // PATH is not secret; provider credentials are never logged.
     path: env.PATH
   })

--- a/src/main/acp/runtime-events.test.ts
+++ b/src/main/acp/runtime-events.test.ts
@@ -1,7 +1,7 @@
-import type { SessionNotification } from '@agentclientprotocol/sdk'
+import type { SessionNotification, ToolCallContent } from '@agentclientprotocol/sdk'
 import { describe, expect, it } from 'vitest'
 
-import { toAcpRuntimeEvent } from './runtime-events'
+import { extractToolFailureText, toAcpRuntimeEvent } from './runtime-events'
 
 describe('ACP runtime event normalization', () => {
   it('maps assistant text chunks into readable runtime events', () => {
@@ -165,5 +165,38 @@ describe('ACP runtime event normalization', () => {
       terminalOutput: 'hello world',
       terminalExitCode: 0
     })
+  })
+})
+
+describe('extractToolFailureText', () => {
+  const textContent = (text: string): ToolCallContent => ({
+    type: 'content',
+    content: { type: 'text', text }
+  })
+
+  it('joins text blocks and ignores non-text content to keep raw output out of the log', () => {
+    const content: ToolCallContent[] = [
+      textContent('Unable to verify if domain example.com is safe to fetch.'),
+      { type: 'terminal', terminalId: 'term-1' } as unknown as ToolCallContent
+    ]
+
+    expect(extractToolFailureText(content)).toBe(
+      'Unable to verify if domain example.com is safe to fetch.'
+    )
+  })
+
+  it('truncates long reasons so large tool output cannot flood the log', () => {
+    const result = extractToolFailureText([textContent('x'.repeat(500))])
+
+    expect(result).toHaveLength(301)
+    expect(result?.endsWith('…')).toBe(true)
+  })
+
+  it('returns undefined when there is no content or no text', () => {
+    expect(extractToolFailureText(undefined)).toBeUndefined()
+    expect(extractToolFailureText([])).toBeUndefined()
+    expect(
+      extractToolFailureText([{ type: 'terminal', terminalId: 't' } as unknown as ToolCallContent])
+    ).toBeUndefined()
   })
 })

--- a/src/main/acp/runtime-events.ts
+++ b/src/main/acp/runtime-events.ts
@@ -19,9 +19,10 @@ const trimProviderValue = (value: unknown): string | undefined => {
   return trimmedValue ? trimmedValue : undefined
 }
 
-// Extracts a safe tool identity from ACP extension metadata without exposing arguments.
-const extractProviderToolName = (update: SessionNotification['update']): string | undefined => {
-  const meta = (update as { _meta?: unknown })._meta
+// Extracts a safe tool identity (e.g. "WebFetch") from ACP extension metadata without exposing
+// arguments. Accepts anything carrying `_meta`, so both stream updates and permission tool calls reuse it.
+const extractProviderToolName = (source: { _meta?: unknown } | undefined): string | undefined => {
+  const meta = source?._meta
 
   if (!isRecord(meta)) return undefined
 
@@ -208,4 +209,4 @@ const toAcpRuntimeEvent = (
   }
 }
 
-export { extractToolFailureText, toAcpRuntimeEvent }
+export { extractProviderToolName, extractToolFailureText, toAcpRuntimeEvent }

--- a/src/main/acp/runtime-events.ts
+++ b/src/main/acp/runtime-events.ts
@@ -1,6 +1,10 @@
-import type { ContentBlock, SessionNotification } from '@agentclientprotocol/sdk'
+import type { ContentBlock, SessionNotification, ToolCallContent } from '@agentclientprotocol/sdk'
 
 import type { AcpRuntimeEvent } from '../../shared/acp'
+
+// Bounds how much of a failed tool's result text reaches the log, so large or sensitive tool output
+// cannot flood it. Tuned to fit a typical error message (e.g. WebFetch's domain-safety preflight).
+const TOOL_FAILURE_TEXT_LIMIT = 300
 
 // Narrows protocol extension values before reading provider-specific metadata.
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -76,6 +80,23 @@ const contentToText = (content: ContentBlock): string => {
     default:
       return '[content]'
   }
+}
+
+// Extracts a bounded, text-only reason from a failed tool call's content for logging. Only text blocks
+// are read (never raw arguments, diffs, or terminal output) and the result is truncated, so a failure is
+// diagnosable without spilling large or sensitive tool output into the log.
+const extractToolFailureText = (content: ToolCallContent[] | undefined): string | undefined => {
+  if (!content) return undefined
+
+  const text = content
+    .map((item) => (item.type === 'content' ? contentToText(item.content) : ''))
+    .filter(Boolean)
+    .join(' ')
+    .trim()
+
+  if (!text) return undefined
+
+  return text.length > TOOL_FAILURE_TEXT_LIMIT ? `${text.slice(0, TOOL_FAILURE_TEXT_LIMIT)}…` : text
 }
 
 // Normalizes protocol session notifications into a renderer-friendly event shape.
@@ -187,4 +208,4 @@ const toAcpRuntimeEvent = (
   }
 }
 
-export { toAcpRuntimeEvent }
+export { extractToolFailureText, toAcpRuntimeEvent }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -30,7 +30,7 @@ import type {
 } from '../../shared/acp'
 import { spawnClaudeAgentAcp, type SpawnClaudeAgentAcpOptions } from './agent-process'
 import { createLogger } from '../logger'
-import { toAcpRuntimeEvent } from './runtime-events'
+import { extractToolFailureText, toAcpRuntimeEvent } from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { AcpPermissionBroker } from './permission-broker'
 import { createArtifactMcpServerConfig } from '../artifacts/mcp-server'
@@ -1319,6 +1319,19 @@ class AcpRuntime {
         ? { ...notification, sessionId: appSessionId }
         : notification
     const event = toAcpRuntimeEvent(routed, this.nextEventId())
+
+    // Tool results (e.g. WebFetch's claude.ai domain-safety preflight, a failed Bash command) stream as
+    // tool_call_update content, which the session-update log omits — so a tool that runs and fails leaves
+    // no trace. Surface failures with the tool name and a bounded, text-only reason; never the arguments,
+    // raw output, or the URL/command-bearing title, to keep user data out of the log.
+    if (event.kind === 'tool' && event.status === 'failed') {
+      log.warn('tool call failed', {
+        tool: event.providerToolName ?? event.toolKind,
+        toolCallId: event.toolCallId,
+        sessionId: event.sessionId,
+        reason: extractToolFailureText(event.toolContent)
+      })
+    }
 
     if ((event.kind === 'message' || event.kind === 'thought') && !event.text) {
       return

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1277,15 +1277,37 @@ class AcpRuntime {
     })
   }
 
-  // Hands permission requests to the broker so the renderer can answer later.
-  private handlePermissionRequest(
+  // Hands permission requests to the broker so the renderer can answer later. Any failure is logged with
+  // its real message before it propagates: the ACP SDK collapses a thrown handler error into a bare
+  // -32603 "Internal error" (real detail buried in `data.details`), so this is the only place the true
+  // cause is captured in the app log. The error is rethrown unchanged to preserve protocol behavior.
+  private async handlePermissionRequest(
     params: RequestPermissionRequest
   ): Promise<RequestPermissionResponse> {
-    if (!this.sessions.has(params.sessionId)) {
-      throw new Error(`Unknown ACP session: ${params.sessionId}`)
-    }
+    // Fork point: a WebFetch/server-side tool that never reaches this line means the "Internal error"
+    // originated elsewhere. Debug level keeps it out of normal runs; ids and a count are enough to trace.
+    log.debug('permission request received', {
+      title: params.toolCall?.title,
+      toolCallId: params.toolCall?.toolCallId,
+      sessionId: params.sessionId,
+      optionCount: params.options?.length
+    })
 
-    return this.permissionBroker.requestPermission(params)
+    try {
+      if (!this.sessions.has(params.sessionId)) {
+        throw new Error(`Unknown ACP session: ${params.sessionId}`)
+      }
+
+      return await this.permissionBroker.requestPermission(params)
+    } catch (error) {
+      log.error('permission request failed', {
+        message: errorMessage(error),
+        title: params.toolCall?.title,
+        toolCallId: params.toolCall?.toolCallId,
+        sessionId: params.sessionId
+      })
+      throw error
+    }
   }
 
   // Normalizes low-level session notifications into runtime/workspace events.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -30,7 +30,11 @@ import type {
 } from '../../shared/acp'
 import { spawnClaudeAgentAcp, type SpawnClaudeAgentAcpOptions } from './agent-process'
 import { createLogger } from '../logger'
-import { extractToolFailureText, toAcpRuntimeEvent } from './runtime-events'
+import {
+  extractProviderToolName,
+  extractToolFailureText,
+  toAcpRuntimeEvent
+} from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { AcpPermissionBroker } from './permission-broker'
 import { createArtifactMcpServerConfig } from '../artifacts/mcp-server'
@@ -1285,9 +1289,10 @@ class AcpRuntime {
     params: RequestPermissionRequest
   ): Promise<RequestPermissionResponse> {
     // Fork point: a WebFetch/server-side tool that never reaches this line means the "Internal error"
-    // originated elsewhere. Debug level keeps it out of normal runs; ids and a count are enough to trace.
+    // originated elsewhere. Debug level keeps it out of normal runs. Log the tool identity (name/kind),
+    // never the title — a WebFetch title is the full URL with query params (user data).
     log.debug('permission request received', {
-      title: params.toolCall?.title,
+      tool: extractProviderToolName(params.toolCall) ?? params.toolCall?.kind,
       toolCallId: params.toolCall?.toolCallId,
       sessionId: params.sessionId,
       optionCount: params.options?.length
@@ -1302,7 +1307,7 @@ class AcpRuntime {
     } catch (error) {
       log.error('permission request failed', {
         message: errorMessage(error),
-        title: params.toolCall?.title,
+        tool: extractProviderToolName(params.toolCall) ?? params.toolCall?.kind,
         toolCallId: params.toolCall?.toolCallId,
         sessionId: params.sessionId
       })


### PR DESCRIPTION
## Problem

In-app tool failures surfaced only as an opaque UI message with nothing actionable in the app log. Two blind spots:

- A thrown ACP permission handler error is collapsed by the SDK into a bare JSON-RPC `-32603` "Internal error" (the real message is buried in `data.details`), so the app log showed nothing.
- Tool results (a failed WebFetch, a failed Bash command) stream as `tool_call_update` content, which the session-update log omitted — so a tool that ran and failed left no trace.

Investigation (via this logging) showed WebFetch fails at its own claude.ai domain-safety preflight on restricted networks — not in our permission path — which the model's provider gateway masks because that preflight bypasses `ANTHROPIC_BASE_URL`.

## Changes (diagnostic logging only — no behavior change)

- Log the real permission-request error before the SDK masks it, and a debug line when a request arrives (the fork that shows whether a server-side tool even reaches the handler). Rethrows unchanged.
- Log failed tool calls (`kind === 'tool' && status === 'failed'`) with the tool name and a bounded, text-only reason via a new `extractToolFailureText` helper.
- Log proxy-presence booleans at agent spawn (whether the spawned agent inherited any proxy config — a common cause of in-app network failures on a Finder-launched packaged build).

## Privacy

- Never logs proxy values, raw tool arguments/output, diffs, or terminal output.
- Permission logs record the tool identity (provider tool name, else `ToolKind`) — never the `title`, which for WebFetch is the full URL with query params.
- Failure reason is text-only and truncated (300 chars).

## Verification

- `lint`, `typecheck`, and full test suite pass (+ new unit tests for `extractToolFailureText`).
- Verified in dev: `permission request received/failed`, `tool call failed`, and the spawn proxy booleans all emit; no URL/title leaks in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)