### PR TITLE
fix(security): block reading materialized skill files from the conversation

### DIFF
--- a/src/main/acp/filesystem.test.ts
+++ b/src/main/acp/filesystem.test.ts
@@ -1,5 +1,5 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -42,6 +42,28 @@ describe('ACP workspace filesystem adapter', () => {
     })
 
     await expect(readFile(filePath, 'utf8')).resolves.toBe('saved')
+  })
+
+  it('rejects reads inside a protected directory even when within the workspace', async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'open-science-acp-'))
+    const protectedRoot = join(workspaceRoot, 'claude')
+    const skillFile = join(protectedRoot, 'skills', 'os-demo', 'SKILL.md')
+    await mkdir(dirname(skillFile), { recursive: true })
+    await writeFile(skillFile, 'secret skill body', 'utf8')
+
+    // The protected root is inside the workspace, so containment passes; the protected guard blocks it.
+    await expect(
+      readWorkspaceTextFile(workspaceRoot, { sessionId: 'session-1', path: skillFile }, [
+        protectedRoot
+      ])
+    ).rejects.toThrow(/protected application directory/)
+
+    // A file outside the protected root still reads.
+    const ok = join(workspaceRoot, 'notes.txt')
+    await writeFile(ok, 'hello', 'utf8')
+    await expect(
+      readWorkspaceTextFile(workspaceRoot, { sessionId: 'session-1', path: ok }, [protectedRoot])
+    ).resolves.toEqual({ content: 'hello' })
   })
 
   it('rejects writes outside the workspace', async () => {

--- a/src/main/acp/filesystem.ts
+++ b/src/main/acp/filesystem.ts
@@ -7,7 +7,7 @@ import type {
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
-import { assertWorkspacePath } from './workspace-path'
+import { assertWorkspacePath, isPathInsideWorkspace } from './workspace-path'
 
 // Returns the requested line window while preserving full content by default.
 const sliceLines = (content: string, line?: number | null, limit?: number | null): string => {
@@ -22,13 +22,28 @@ const sliceLines = (content: string, line?: number | null, limit?: number | null
   return lines.slice(startIndex, endIndex).join('\n')
 }
 
-// Reads a text file after constraining the requested path to the active workspace.
+// Rejects reads that resolve inside an app-owned protected directory — e.g. the CLAUDE_CONFIG_DIR
+// that holds materialized skill files — so bundled skill contents can never be surfaced verbatim
+// through the Read tool. (Workspace containment already blocks most of these; this is belt-and-
+// suspenders for sessions whose cwd is unusually broad.)
+const assertNotProtected = (filePath: string, protectedRoots: string[]): void => {
+  for (const root of protectedRoots) {
+    if (isPathInsideWorkspace(root, filePath)) {
+      throw new Error('This file belongs to a protected application directory and cannot be read.')
+    }
+  }
+}
+
+// Reads a text file after constraining the requested path to the active workspace and rejecting
+// app-owned protected directories.
 const readWorkspaceTextFile = async (
   workspaceRoot: string,
-  params: ReadTextFileRequest
+  params: ReadTextFileRequest,
+  protectedRoots: string[] = []
 ): Promise<ReadTextFileResponse> => {
   // ACP paths are absolute, but resolve again here so path traversal is checked in one place.
   const filePath = assertWorkspacePath(workspaceRoot, params.path)
+  assertNotProtected(filePath, protectedRoots)
   const content = await readFile(filePath, 'utf8')
 
   return {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -46,6 +46,7 @@ import {
   type NotebookRpcConnection
 } from '../notebook/mcp-server'
 import { getNotebookSessionRoot } from '../notebook/repository'
+import { getAppClaudeConfigDir } from '../settings/provider-env'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import { buildImageContentData, extractPdfText } from '../uploads/attachment-media'
@@ -1009,7 +1010,11 @@ class AcpRuntime {
         this.handlePermissionRequest(ctx.params)
       )
       .onRequest(acp.methods.client.fs.readTextFile, (ctx) =>
-        readWorkspaceTextFile(this.resolveSessionCwd(ctx.params.sessionId), ctx.params)
+        readWorkspaceTextFile(
+          this.resolveSessionCwd(ctx.params.sessionId),
+          ctx.params,
+          this.protectedReadRoots()
+        )
       )
       .onRequest(acp.methods.client.fs.writeTextFile, (ctx) =>
         writeWorkspaceTextFile(this.resolveSessionCwd(ctx.params.sessionId), ctx.params)
@@ -1026,6 +1031,12 @@ class AcpRuntime {
     }
 
     return sessionCwd
+  }
+
+  // App-owned directories the agent's Read tool must never read: the CLAUDE_CONFIG_DIR holds the
+  // materialized skill files, whose (bundled/MCP) contents must not be surfaced into the conversation.
+  private protectedReadRoots(): string[] {
+    return this.artifactOptions ? [getAppClaudeConfigDir(this.artifactOptions.storageRoot)] : []
   }
 
   // Creates an app-owned artifact session id so new ACP sessions never decide their storage directory.

--- a/src/main/notebook/python-executor.test.ts
+++ b/src/main/notebook/python-executor.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -46,6 +46,47 @@ describe('notebook Python executor', () => {
   })
 
   const itWithPython = hasPython3() ? it : it.skip
+
+  itWithPython(
+    'blocks reading files inside a protected directory but allows others',
+    async () => {
+      const root = await createStorageRoot()
+      const protectedDir = join(root, 'claude')
+      const secret = join(protectedDir, 'skills', 'os-demo', 'SKILL.md')
+      await mkdir(dirname(secret), { recursive: true })
+      await writeFile(secret, 'secret skill body', 'utf8')
+      const executor = new NotebookPythonExecutor('python3')
+
+      const base = {
+        cwd: root,
+        notebookSessionRoot: join(root, 'notebooks', 'default-project', 'session-1'),
+        dataRoot: join(root, 'notebooks', 'default-project', 'session-1', 'data'),
+        runtimeRoot: join(root, 'runtime'),
+        protectedDirs: [protectedDir]
+      }
+
+      try {
+        const blocked = await executor.execute({
+          ...base,
+          code: `open(${JSON.stringify(secret)}).read()`
+        })
+        expect(blocked.status).toBe('failed')
+        expect(blocked.traceback).toContain('PermissionError')
+
+        // A file outside the protected directory still reads normally.
+        const allowedFile = join(root, 'ok.txt')
+        await writeFile(allowedFile, 'fine', 'utf8')
+        const allowed = await executor.execute({
+          ...base,
+          code: `print(open(${JSON.stringify(allowedFile)}).read())`
+        })
+        expect(allowed).toMatchObject({ status: 'completed', stdout: 'fine\n' })
+      } finally {
+        await executor.shutdown()
+      }
+    },
+    PYTHON_TEST_TIMEOUT_MS
+  )
 
   itWithPython(
     'keeps Python variables across executions in one executor',

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
+import { delimiter } from 'node:path'
 import { createInterface, type Interface } from 'node:readline'
 
 import { resolvePythonCommand } from './python-command'
@@ -53,6 +54,34 @@ class _Host:
         if body.get("error"):
             raise RuntimeError("host.mcp error: " + str(body["error"]))
         return body["result"]
+
+# Block reads of app-owned protected directories (e.g. the CLAUDE_CONFIG_DIR holding materialized
+# skill files) so their contents can't be surfaced through notebook code. CPython audit hooks cannot
+# be removed once installed, so in-process reads (open/io.open/os.open/pathlib) are reliably blocked;
+# a separately spawned subprocess is the residual gap (see the read-guard spec).
+_protected_dirs = [
+    os.path.abspath(entry)
+    for entry in os.environ.get("OPEN_SCIENCE_PROTECTED_DIRS", "").split(os.pathsep)
+    if entry
+]
+
+
+def _protected_paths_audit(event, args):
+    if event != "open" or not _protected_dirs or not args:
+        return
+    target = args[0]
+    if target is None or isinstance(target, int):
+        return
+    try:
+        resolved = os.path.abspath(os.fspath(target))
+    except (TypeError, ValueError):
+        return
+    for directory in _protected_dirs:
+        if resolved == directory or resolved.startswith(directory + os.sep):
+            raise PermissionError("Access to protected application files is not allowed.")
+
+
+sys.addaudithook(_protected_paths_audit)
 
 # Reuse a single global namespace so variables survive across notebook runs.
 globals_ns = {"__name__": "__main__"}
@@ -305,7 +334,9 @@ class NotebookPythonExecutor implements NotebookExecutor {
         ...(request.mcpRpcEndpoint
           ? { OPEN_SCIENCE_MCP_RPC_ENDPOINT: request.mcpRpcEndpoint }
           : {}),
-        ...(request.mcpRpcToken ? { OPEN_SCIENCE_MCP_RPC_TOKEN: request.mcpRpcToken } : {})
+        ...(request.mcpRpcToken ? { OPEN_SCIENCE_MCP_RPC_TOKEN: request.mcpRpcToken } : {}),
+        // App-owned directories the notebook kernel must not read (e.g. materialized skill files).
+        OPEN_SCIENCE_PROTECTED_DIRS: (request.protectedDirs ?? []).join(delimiter)
       }
     })
 

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -20,6 +20,7 @@ import type {
 } from '../../shared/notebook'
 import { NotebookPythonExecutor } from './python-executor'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
+import { getAppClaudeConfigDir } from '../settings/provider-env'
 
 type NotebookExecutionRequest = {
   code: string
@@ -27,6 +28,8 @@ type NotebookExecutionRequest = {
   notebookSessionRoot: string
   dataRoot: string
   runtimeRoot: string
+  // App-owned directories the kernel must not read (e.g. the CLAUDE_CONFIG_DIR with skill files).
+  protectedDirs?: string[]
   timeoutMs?: number
   // Connector RPC connection injected into the kernel spawn env for host.mcp().
   mcpRpcEndpoint?: string
@@ -287,6 +290,7 @@ class NotebookRuntimeService {
         notebookSessionRoot: session.notebookSessionRoot,
         dataRoot: session.dataRoot,
         runtimeRoot: session.runtimeRoot,
+        protectedDirs: [getAppClaudeConfigDir(this.options.storageRoot)],
         timeoutMs: request.timeoutMs,
         mcpRpcEndpoint: mcpRpc?.endpoint,
         mcpRpcToken: mcpRpc?.token

--- a/src/main/settings/claude-config-provision.test.ts
+++ b/src/main/settings/claude-config-provision.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -6,7 +6,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { SkillRegistry } from '../skills/registry'
 import { ClaudeCodeSkillMaterializer } from '../skills/materializer'
-import { APP_ASSET_SUBDIRS, provisionAppClaudeConfigDir } from './claude-config-provision'
+import {
+  APP_ASSET_SUBDIRS,
+  configDenyRules,
+  provisionAppClaudeConfigDir
+} from './claude-config-provision'
 
 // The default (no-registry) call path builds a SkillRegistry() that resolves the bundled-skills root via
 // electron's app; point it at a nonexistent dir so the registry lists nothing instead of touching a real
@@ -66,6 +70,41 @@ describe('provisionAppClaudeConfigDir', () => {
 
     await provisionAppClaudeConfigDir(configDir)
     await expect(provisionAppClaudeConfigDir(configDir)).resolves.toBeUndefined()
+  })
+
+  it('writes permission deny rules fencing the file tools out of the config dir', async () => {
+    root = await mkdtemp(join(tmpdir(), 'os-claude-config-'))
+    const configDir = join(root, 'claude')
+
+    await provisionAppClaudeConfigDir(configDir)
+
+    const settings = JSON.parse(await readFile(join(configDir, 'settings.json'), 'utf8'))
+    const deny: string[] = settings.permissions.deny
+    expect(deny).toEqual(configDenyRules(configDir))
+    // Each rule is an absolute-path (`//`) recursive deny for one of the guarded file tools.
+    for (const tool of ['Read', 'Edit', 'Glob', 'Grep']) {
+      expect(deny.some((rule) => rule.startsWith(`${tool}(//`) && rule.endsWith('/**)'))).toBe(true)
+    }
+  })
+
+  it('merges guard deny rules into a pre-existing settings.json without dropping entries', async () => {
+    root = await mkdtemp(join(tmpdir(), 'os-claude-config-'))
+    const configDir = join(root, 'claude')
+    await mkdir(configDir, { recursive: true })
+    await writeFile(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ permissions: { deny: ['Bash(rm:*)'] }, model: 'keep-me' }),
+      'utf8'
+    )
+
+    await provisionAppClaudeConfigDir(configDir)
+
+    const settings = JSON.parse(await readFile(join(configDir, 'settings.json'), 'utf8'))
+    expect(settings.model).toBe('keep-me')
+    expect(settings.permissions.deny).toContain('Bash(rm:*)')
+    for (const rule of configDenyRules(configDir)) {
+      expect(settings.permissions.deny).toContain(rule)
+    }
   })
 
   it('materializes enabled bundled skills, honoring disabledSkillIds', async () => {

--- a/src/main/settings/claude-config-provision.ts
+++ b/src/main/settings/claude-config-provision.ts
@@ -1,4 +1,4 @@
-import { mkdir } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { ClaudeCodeSkillMaterializer, type SkillMaterializer } from '../skills/materializer'
@@ -11,6 +11,46 @@ import { SkillRegistry, type BundledSkill } from '../skills/registry'
 // Subdirs claude loads app-scoped assets from. App-owned; never synced with ~/.claude.
 const APP_ASSET_SUBDIRS = ['skills', 'plugins', 'commands'] as const
 
+// The agent's own file tools must not read (or search) the app config dir — it holds the materialized
+// skill files, whose (bundled / MCP) contents must never be surfaced verbatim into the conversation.
+// Skill *loading* is internal to the agent and unaffected by these tool-level deny rules. The kernel
+// (bash/subprocess) is guarded separately; see the notebook audit hook and read-guard spec.
+const GUARDED_FILE_TOOLS = ['Read', 'Edit', 'Glob', 'Grep'] as const
+
+// Builds the claude-code permission deny rules that fence the agent's file tools out of `configDir`.
+// Claude Code permission paths are gitignore-style with forward slashes, where a `//<abs>` prefix
+// denotes an absolute filesystem path. Normalize Windows backslashes and collapse the leading slash
+// so both POSIX (`/Users/…` -> `//Users/…`) and Windows (`C:\…` -> `//C:/…`) yield the `//` form.
+const configDenyRules = (configDir: string): string[] => {
+  const abs = configDir.replace(/\\/g, '/').replace(/^\/+/, '')
+  return GUARDED_FILE_TOOLS.map((tool) => `${tool}(//${abs}/**)`)
+}
+
+// Writes/merges `<configDir>/settings.json` so its permissions.deny includes the guard rules, keeping
+// any settings and deny entries already present. Loaded because the agent runs with settingSources:
+// ['user'], i.e. this app-owned config dir is the user scope.
+const writeGuardSettings = async (configDir: string): Promise<void> => {
+  const settingsPath = join(configDir, 'settings.json')
+
+  let settings: Record<string, unknown> = {}
+  try {
+    const parsed = JSON.parse(await readFile(settingsPath, 'utf8')) as unknown
+    if (typeof parsed === 'object' && parsed !== null) settings = parsed as Record<string, unknown>
+  } catch {
+    settings = {}
+  }
+
+  const permissions =
+    typeof settings.permissions === 'object' && settings.permissions !== null
+      ? (settings.permissions as Record<string, unknown>)
+      : {}
+  const existingDeny = Array.isArray(permissions.deny) ? (permissions.deny as string[]) : []
+  const deny = [...new Set([...existingDeny, ...configDenyRules(configDir)])]
+
+  settings.permissions = { ...permissions, deny }
+  await writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
+}
+
 type ProvisionOptions = {
   // The full skill catalog (featured + imported + personal). Defaults to bundled skills only.
   skills?: BundledSkill[]
@@ -18,9 +58,9 @@ type ProvisionOptions = {
   disabledSkillIds?: string[]
 }
 
-// Ensures the app config dir + asset subdirs exist, then materializes the enabled skill set into
-// `<configDir>/skills`. Idempotent and safe to call before each agent spawn. Skill materialization
-// failures are swallowed by the materializer so a bad skill never blocks the spawn.
+// Ensures the app config dir + asset subdirs exist, writes the file-tool deny rules, then materializes
+// the enabled skill set into `<configDir>/skills`. Idempotent and safe to call before each agent spawn.
+// Skill materialization failures are swallowed by the materializer so a bad skill never blocks the spawn.
 const provisionAppClaudeConfigDir = async (
   configDir: string,
   options: ProvisionOptions = {}
@@ -30,6 +70,8 @@ const provisionAppClaudeConfigDir = async (
     APP_ASSET_SUBDIRS.map((sub) => mkdir(join(configDir, sub), { recursive: true }))
   )
 
+  await writeGuardSettings(configDir)
+
   const materializer = options.materializer ?? new ClaudeCodeSkillMaterializer()
   const skills = options.skills ?? (await new SkillRegistry().list())
   const disabled = new Set(options.disabledSkillIds ?? [])
@@ -38,4 +80,4 @@ const provisionAppClaudeConfigDir = async (
   await materializer.sync(configDir, enabled)
 }
 
-export { APP_ASSET_SUBDIRS, provisionAppClaudeConfigDir }
+export { APP_ASSET_SUBDIRS, configDenyRules, provisionAppClaudeConfigDir }


### PR DESCRIPTION
## Problem

Bundled **featured** / **MCP** skill instructions are materialized under the app-owned CLAUDE_CONFIG_DIR (`<storageRoot>/claude/skills/`) so the agent can load them — but the agent's tools could read those files and echo the raw `SKILL.md` (curated / IP content) straight into the conversation.

The app's ACP `fs.readTextFile` guard alone did **not** stop it: the agent's own **Read tool reads in the agent process**, not via the client's `fs.readTextFile`. The fix has to govern the agent's own tools.

## Three layers

1. **Claude permission deny rules (primary).** Provisioning writes `<configDir>/settings.json` with `permissions.deny = Read/Edit/Glob/Grep(//<configDir>/**)` (absolute `//` form). Loaded because the agent runs with `settingSources: ['user']`. Governs the agent's built-in Read tool and, per Claude Code docs, the Bash file commands it recognizes (`cat`/`head`/`tail`/`sed`).
2. **Notebook Python kernel `sys.addaudithook`** raises on `open()` of a protected path (threaded via `OPEN_SCIENCE_PROTECTED_DIRS`). CPython audit hooks can't be removed once installed.
3. **App ACP `fs.readTextFile` guard** rejects protected paths — defense-in-depth for that path.

Skill *loading* by the agent is internal and unaffected by these tool-level rules.

### Residual gap / follow-ups (tracked in the read-guard spec)

- Arbitrary **subprocess / script** reads bypass the deny rules and the notebook hook. Full coverage needs OS-level kernel sandboxing — a larger, separate effort.
- **System-prompt-level guidance** (preferred next step): instruct the agent not to read/inspect skill files, so the permission gate is a backstop rather than the first line.

## Testing

- `npm run typecheck` OK, `npm run lint` OK, `npm run test` OK (1124 passed; +4 new)
- New coverage: provisioning writes/merges the deny rules; the notebook kernel blocks a protected read (`PermissionError`) while a normal file still reads; `readWorkspaceTextFile` rejects a protected path.
- Manual `npm run dev`: notebook read -> `PermissionError`; agent Read tool of a skill file -> denied (content no longer surfaced). Rebased onto #59/#60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
