### PR TITLE
fix(acp): remember Always by tool category and serialize permission prompts (#47)

### DIFF
--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -18,11 +18,14 @@ const createPermissionRequest = (sessionId = 'session-1'): RequestPermissionRequ
 })
 
 // Builds a notebook tool permission request that also offers an "always allow" option.
-const createNotebookPermissionRequest = (sessionId = 'session-1'): RequestPermissionRequest => ({
+const createNotebookPermissionRequest = (
+  sessionId = 'session-1',
+  title = 'mcp__open-science-notebook__notebook_execute'
+): RequestPermissionRequest => ({
   sessionId,
   toolCall: {
     toolCallId: `tool-${Math.random()}`,
-    title: 'mcp__open-science-notebook__notebook_execute',
+    title,
     status: 'pending'
   },
   options: [
@@ -31,6 +34,34 @@ const createNotebookPermissionRequest = (sessionId = 'session-1'): RequestPermis
     { optionId: 'reject-once', name: 'Reject once', kind: 'reject_once' }
   ]
 })
+
+// Builds a built-in tool request; provider tool name and execute kind emulate Claude Code metadata.
+const createToolPermissionRequest = (
+  options: {
+    sessionId?: string
+    title?: string
+    providerToolName?: string
+    kind?: RequestPermissionRequest['toolCall']['kind']
+  } = {}
+): RequestPermissionRequest => {
+  const { sessionId = 'session-1', title = 'Run tool', providerToolName, kind } = options
+
+  return {
+    sessionId,
+    toolCall: {
+      toolCallId: `tool-${Math.random()}`,
+      title,
+      status: 'pending',
+      kind,
+      _meta: providerToolName ? { claudeCode: { toolName: providerToolName } } : undefined
+    },
+    options: [
+      { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+      { optionId: 'allow-always', name: 'Always', kind: 'allow_always' },
+      { optionId: 'reject-once', name: 'Reject once', kind: 'reject_once' }
+    ]
+  }
+}
 
 describe('ACP permission broker', () => {
   it('emits a serializable permission request and resolves the selected option', async () => {
@@ -125,5 +156,111 @@ describe('ACP permission broker', () => {
         outcome: 'cancelled'
       }
     })
+  })
+
+  it('remembers Always for a built-in tool by tool name, while a different tool still prompts', async () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+
+    // Always on Write auto-approves later Write calls (different file title, same tool category).
+    const firstWrite = broker.requestPermission(
+      createToolPermissionRequest({ title: 'Write report.md', providerToolName: 'Write' })
+    )
+    broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
+    await firstWrite
+
+    const secondWrite = broker.requestPermission(
+      createToolPermissionRequest({ title: 'Write notes.md', providerToolName: 'Write' })
+    )
+    await expect(secondWrite).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(emittedRequests).toHaveLength(1)
+
+    // A different built-in (Edit) is a different category and still prompts.
+    broker.requestPermission(
+      createToolPermissionRequest({ title: 'Edit report.md', providerToolName: 'Edit' })
+    )
+    expect(emittedRequests).toHaveLength(2)
+  })
+
+  it('remembers Always for shell by leading executable, not the full command', async () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+
+    const firstBash = broker.requestPermission(
+      createToolPermissionRequest({ title: 'python a.py', providerToolName: 'Bash' })
+    )
+    broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
+    await firstBash
+
+    // Same executable, different arguments auto-approves.
+    const secondBash = broker.requestPermission(
+      createToolPermissionRequest({ title: 'python b.py', providerToolName: 'Bash' })
+    )
+    await expect(secondBash).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(emittedRequests).toHaveLength(1)
+
+    // A different executable still prompts.
+    broker.requestPermission(
+      createToolPermissionRequest({ title: 'rm -rf x', providerToolName: 'Bash' })
+    )
+    expect(emittedRequests).toHaveLength(2)
+  })
+
+  it('routes execute-kind shell calls by signature even without a provider tool name', async () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+
+    const firstBash = broker.requestPermission(
+      createToolPermissionRequest({ title: 'FOO=bar node build.js', kind: 'execute' })
+    )
+    broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
+    await firstBash
+
+    // Leading env assignments are skipped, so `node ...` groups under the same signature.
+    const secondBash = broker.requestPermission(
+      createToolPermissionRequest({ title: 'node serve.js', kind: 'execute' })
+    )
+    await expect(secondBash).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(emittedRequests).toHaveLength(1)
+  })
+
+  it('keeps prompting for a different notebook sub-tool after Always on another', async () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+
+    const firstResponse = broker.requestPermission(
+      createNotebookPermissionRequest('session-1', 'mcp__open-science-notebook__notebook_execute')
+    )
+    broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
+    await firstResponse
+
+    // A different notebook sub-tool is a distinct category and still prompts.
+    broker.requestPermission(
+      createNotebookPermissionRequest('session-1', 'mcp__open-science-notebook__notebook_edit')
+    )
+    expect(emittedRequests).toHaveLength(2)
+  })
+
+  it('does not remember Always across sessions for built-in tools', async () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+
+    const firstWrite = broker.requestPermission(
+      createToolPermissionRequest({ sessionId: 'session-1', providerToolName: 'Write' })
+    )
+    broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
+    await firstWrite
+
+    // The same category in a different session must still prompt.
+    broker.requestPermission(
+      createToolPermissionRequest({ sessionId: 'session-2', providerToolName: 'Write' })
+    )
+    expect(emittedRequests).toHaveLength(2)
   })
 })

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -2,29 +2,73 @@ import type { RequestPermissionRequest, RequestPermissionResponse } from '@agent
 import { randomUUID } from 'node:crypto'
 
 import type { AcpPermissionRequest, AcpPermissionResponse } from '../../shared/acp'
+import { extractProviderToolName } from './runtime-events'
 
 type PendingPermission = {
   request: AcpPermissionRequest
+  categoryKey: string
   resolve: (response: RequestPermissionResponse) => void
 }
 
 type EmitPermissionRequest = (request: AcpPermissionRequest) => void
 
-// Claude Code namespaces MCP tools as mcp__<server>__<tool>; this is the notebook server's prefix.
-// Notebook tool calls carry this prefix as their permission title (see runtime notes).
-const NOTEBOOK_TOOL_TITLE_PREFIX = 'mcp__open-science-notebook__'
+// Claude Code namespaces MCP tools as mcp__<server>__<tool>; notebook and other MCP tool calls carry
+// this prefix as their permission title, so their title alone is a stable per-tool category key.
+const MCP_TOOL_TITLE_PREFIX = 'mcp__'
 
 const ALLOW_ALWAYS_OPTION_KIND = 'allow_always'
 const ALLOW_ONCE_OPTION_KIND = 'allow_once'
 
-// Auto-allow is scoped to the local notebook the user opted into; shell/edit tools always prompt.
-const isNotebookToolTitle = (title: string): boolean => title.startsWith(NOTEBOOK_TOOL_TITLE_PREFIX)
+// Trivial `KEY=VALUE` env assignment prefixing a shell command (e.g. `FOO=bar python a.py`). Values
+// containing whitespace/quotes are not covered (already split away) and fall back to the raw token.
+const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=[^\s]*$/
+
+// Strips a single matching pair of surrounding quotes from a shell token.
+const stripSurroundingQuotes = (token: string): string => {
+  const match = token.match(/^(["'])(.*)\1$/)
+
+  return match ? match[2] : token
+}
+
+// Derives the command signature (leading executable) used to group shell/execute permissions. Leading
+// trivial env assignments are skipped so `FOO=bar python a.py` still groups under `python`.
+const leadingExecutable = (command: string): string => {
+  const tokens = command.trim().split(/\s+/)
+  let index = 0
+
+  while (index < tokens.length - 1 && ENV_ASSIGNMENT_PATTERN.test(tokens[index])) {
+    index += 1
+  }
+
+  return stripSurroundingQuotes(tokens[index] ?? command.trim())
+}
+
+// Derives a session-scoped "Always" category key from a permission request (first match wins):
+// 1. MCP/notebook tool (title starts with mcp__): keyed by title (the tool name, no args).
+// 2. Shell/execute tool (provider tool name Bash, or execute kind): keyed by leading executable.
+// 3. Other built-ins (Write/Edit/WebFetch/…): keyed by provider tool name (falls back to title).
+// The mcp__ check runs before the execute branch so a notebook execute-cell is not misrouted to Bash.
+const resolveCategoryKey = (params: RequestPermissionRequest): string => {
+  const { toolCall } = params
+  const title = toolCall.title ?? toolCall.toolCallId
+  const providerToolName = extractProviderToolName(toolCall)
+
+  if (title.startsWith(MCP_TOOL_TITLE_PREFIX)) {
+    return `tool:${title}`
+  }
+
+  if (providerToolName === 'Bash' || toolCall.kind === 'execute') {
+    return `bash:${leadingExecutable(title)}`
+  }
+
+  return `tool:${providerToolName ?? title}`
+}
 
 // Tracks permission requests until the renderer chooses an outcome.
 class AcpPermissionBroker {
   private pendingRequests = new Map<string, PendingPermission>()
-  // Per-session set of notebook tool titles the user chose to always allow this session.
-  private alwaysAllowedNotebookTools = new Map<string, Set<string>>()
+  // Per-session set of category keys the user chose to always allow this session.
+  private alwaysAllowedCategories = new Map<string, Set<string>>()
 
   // Accepts the callback used to publish new permission requests to listeners.
   constructor(private readonly emitPermissionRequest: EmitPermissionRequest) {}
@@ -51,8 +95,10 @@ class AcpPermissionBroker {
       raw: params
     }
 
-    // A prior "Always" choice on this notebook tool auto-approves without prompting again.
-    const autoAllowOptionId = this.resolveAutoAllowOptionId(request)
+    const categoryKey = resolveCategoryKey(params)
+
+    // A prior "Always" choice on this category auto-approves without prompting again.
+    const autoAllowOptionId = this.resolveAutoAllowOptionId(request, categoryKey)
 
     if (autoAllowOptionId) {
       return Promise.resolve({
@@ -62,7 +108,7 @@ class AcpPermissionBroker {
 
     // The returned promise is held open until the UI selects or cancels an option.
     return new Promise((resolve) => {
-      this.pendingRequests.set(requestId, { request, resolve })
+      this.pendingRequests.set(requestId, { request, categoryKey, resolve })
       this.emitPermissionRequest(request)
     })
   }
@@ -82,8 +128,8 @@ class AcpPermissionBroker {
       return true
     }
 
-    // "Always" on a notebook tool suppresses future prompts for that same tool this session.
-    this.rememberAlwaysAllowed(pending.request, response.optionId)
+    // "Always" on a tool suppresses future prompts for that same category this session.
+    this.rememberAlwaysAllowed(pending.request, pending.categoryKey, response.optionId)
 
     pending.resolve({
       outcome: {
@@ -95,10 +141,12 @@ class AcpPermissionBroker {
     return true
   }
 
-  // Returns an allow option id when this notebook tool was already always-allowed, else undefined.
-  private resolveAutoAllowOptionId(request: AcpPermissionRequest): string | undefined {
-    if (!isNotebookToolTitle(request.title)) return undefined
-    if (!this.alwaysAllowedNotebookTools.get(request.sessionId)?.has(request.title)) {
+  // Returns an allow option id when this category was already always-allowed, else undefined.
+  private resolveAutoAllowOptionId(
+    request: AcpPermissionRequest,
+    categoryKey: string
+  ): string | undefined {
+    if (!this.alwaysAllowedCategories.get(request.sessionId)?.has(categoryKey)) {
       return undefined
     }
 
@@ -110,18 +158,20 @@ class AcpPermissionBroker {
     return allowOption?.optionId
   }
 
-  // Records the notebook tool as always-allowed when the user picked its allow_always option.
-  private rememberAlwaysAllowed(request: AcpPermissionRequest, optionId: string): void {
-    if (!isNotebookToolTitle(request.title)) return
-
+  // Records the category as always-allowed when the user picked its allow_always option.
+  private rememberAlwaysAllowed(
+    request: AcpPermissionRequest,
+    categoryKey: string,
+    optionId: string
+  ): void {
     const chosen = request.options.find((option) => option.optionId === optionId)
 
     if (chosen?.kind.toLowerCase() !== ALLOW_ALWAYS_OPTION_KIND) return
 
-    const allowed = this.alwaysAllowedNotebookTools.get(request.sessionId) ?? new Set<string>()
+    const allowed = this.alwaysAllowedCategories.get(request.sessionId) ?? new Set<string>()
 
-    allowed.add(request.title)
-    this.alwaysAllowedNotebookTools.set(request.sessionId, allowed)
+    allowed.add(categoryKey)
+    this.alwaysAllowedCategories.set(request.sessionId, allowed)
   }
 
   // Cancels every pending request during full runtime teardown.
@@ -132,7 +182,7 @@ class AcpPermissionBroker {
       this.respond({ requestId, cancelled: true })
     }
 
-    this.alwaysAllowedNotebookTools.clear()
+    this.alwaysAllowedCategories.clear()
   }
 
   // Cancels pending requests for one session while leaving other sessions intact.
@@ -147,4 +197,4 @@ class AcpPermissionBroker {
   }
 }
 
-export { AcpPermissionBroker }
+export { AcpPermissionBroker, resolveCategoryKey }

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -46,6 +46,20 @@ const renderControls = (): string =>
     <PermissionApprovalControls requests={[permissionRequest]} onRespond={() => undefined} />
   )
 
+// A second queued request whose command/controls must stay hidden while the first is answered.
+const secondRequestTitle = 'Second queued command that must not render yet'
+const secondPermissionRequest: AcpPermissionRequest = {
+  requestId: 'permission-2',
+  sessionId: 'session-1',
+  toolCallId: 'tool-2',
+  title: secondRequestTitle,
+  options: [
+    { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+    { optionId: 'reject-once', name: 'Reject once', kind: 'reject_once' }
+  ],
+  raw: {}
+}
+
 describe('PermissionApprovalControls', () => {
   it('shows the full command with copy and keeps details off action labels', () => {
     const html = renderControls()
@@ -78,5 +92,17 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('border border-amber-300 bg-white')
     expect(html).toContain('hover:bg-amber-100')
     expect(html).toContain('flex flex-wrap items-center justify-end gap-1 w-full overflow-hidden')
+  })
+
+  it('serializes prompts by rendering only the first pending request', () => {
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[permissionRequest, secondPermissionRequest]}
+        onRespond={() => undefined}
+      />
+    )
+
+    expect(html).toContain(longRequestTitle)
+    expect(html).not.toContain(secondRequestTitle)
   })
 })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -93,48 +93,45 @@ const PermissionApprovalControls = ({
   requests,
   onRespond
 }: PermissionApprovalControlsProps): React.JSX.Element | null => {
-  if (requests.length === 0) return null
+  // Serialize prompts: show only the oldest pending request. The rest stay queued in the broker and
+  // surface one at a time as each is answered, so parallel tool calls don't stack simultaneous prompts.
+  const request = requests[0]
+
+  if (!request) return null
 
   return (
     <div className="mb-2 w-full max-w-full space-y-2 overflow-hidden rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] leading-5 text-amber-900">
-      {requests.map((request) => (
-        <div
-          key={request.requestId}
-          className="flex min-w-0 flex-col items-stretch gap-2 overflow-hidden"
-        >
-          <PermissionCommandBlock command={request.title} />
-          <span className="flex flex-wrap items-center justify-end gap-1 w-full overflow-hidden">
-            {getOrderedPermissionOptions(request.options).map((option) => {
-              const actionKind = getPermissionActionKind(option)
-              const actionLabel = getPermissionActionLabel(option, actionKind)
+      <div className="flex min-w-0 flex-col items-stretch gap-2 overflow-hidden">
+        <PermissionCommandBlock command={request.title} />
+        <span className="flex flex-wrap items-center justify-end gap-1 w-full overflow-hidden">
+          {getOrderedPermissionOptions(request.options).map((option) => {
+            const actionKind = getPermissionActionKind(option)
+            const actionLabel = getPermissionActionLabel(option, actionKind)
 
-              return (
-                <button
-                  key={option.optionId}
-                  type="button"
-                  className="max-w-full break-words rounded-md border border-amber-300 bg-white px-2 py-1 text-[12px] hover:bg-amber-100"
-                  aria-label={`${actionLabel}: ${request.title}`}
-                  onClick={() => onRespond(request.requestId, option.optionId)}
-                >
-                  <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
-                    {actionLabel}
-                  </span>
-                </button>
-              )
-            })}
-            <button
-              type="button"
-              className="max-w-full break-words rounded-md px-2 py-1 text-[12px] hover:bg-amber-100"
-              aria-label={`Cancel: ${request.title}`}
-              onClick={() => onRespond(request.requestId)}
-            >
-              <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
-                Cancel
-              </span>
-            </button>
-          </span>
-        </div>
-      ))}
+            return (
+              <button
+                key={option.optionId}
+                type="button"
+                className="max-w-full break-words rounded-md border border-amber-300 bg-white px-2 py-1 text-[12px] hover:bg-amber-100"
+                aria-label={`${actionLabel}: ${request.title}`}
+                onClick={() => onRespond(request.requestId, option.optionId)}
+              >
+                <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+                  {actionLabel}
+                </span>
+              </button>
+            )
+          })}
+          <button
+            type="button"
+            className="max-w-full break-words rounded-md px-2 py-1 text-[12px] hover:bg-amber-100"
+            aria-label={`Cancel: ${request.title}`}
+            onClick={() => onRespond(request.requestId)}
+          >
+            <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">Cancel</span>
+          </button>
+        </span>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Fixes the "too many authorization prompts" report in #47: while a task runs — especially when the agent writes/runs scripts — the client kept re-asking for authorization even after the user chose **Always**, and multiple prompts could stack up at once.

## Root cause

- `AcpPermissionBroker` only remembered an **Always** choice for notebook MCP tools, and keyed it by `request.title`. For Bash the title *is the full command string*, so every new command was a new key and re-prompted; built-in `Write`/`Edit`/`WebFetch` were never remembered at all.
- `PermissionApprovalControls` rendered every pending request at once, so parallel tool calls surfaced as simultaneous prompts.

(Connector/MCP-directory tools use a separate approval gate — Settings allow/ask/block — and are intentionally out of scope here.)

## Changes

- **Remember "Always" by tool category (session-scoped).** New `resolveCategoryKey` derives a stable key per request (first match wins):
  1. MCP/notebook tool (`mcp__…` title) → `tool:<title>`
  2. Shell/execute (`Bash` / `execute` kind) → `bash:<leading executable>` (by command signature, skipping trivial `KEY=VALUE` env prefixes)
  3. Other built-ins (Write/Edit/WebFetch/…) → `tool:<providerToolName>`
  The `mcp__` check runs before the execute branch so a notebook execute-cell is never misrouted to the Bash branch. Auto-approval still prefers returning a one-shot `allow_once` option so the agent keeps governing its own always-allow lifecycle. Grants are cleared on teardown (session only; nothing persisted to disk).
- **Serialize prompts.** `PermissionApprovalControls` now renders only the oldest pending request; the rest stay queued and surface one at a time.

## Security posture

- Bash stays gated **by signature**, not category — a genuinely new executable still prompts.
- Session-only, no disk persistence; a fresh session re-earns every grant.
- No connector changes.

## Testing

- `permission-broker.test.ts`: category-wide allow for built-ins, Bash by-signature (same executable allowed, different one still prompts), notebook no-regression, `allow_once` not remembered, session isolation.
- `PermissionApprovalControls.render.test.tsx`: only one of N pending requests renders.
- `npm run typecheck`, `npm run lint`, `npm run test` (full suite), `npm run build` — all green.
- Manual dev-run sanity of app boot.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)