### PR TITLE
feat(security): steer the agent away from reading skill files via the system prompt

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -744,8 +744,16 @@ describe('ACP runtime session management', () => {
         sessionId: 'remote-session-1',
         cwd: resolve('/workspace'),
         mcpServers: [],
-        // Every session (new or resumed) is restricted to the app-owned "user" settings scope.
-        _meta: { claudeCode: { options: { settingSources: ['user'] } } }
+        // Every session (new or resumed) is restricted to the app-owned "user" settings scope, and
+        // carries the always-on skill-privacy guardrail in its system prompt.
+        _meta: {
+          claudeCode: { options: { settingSources: ['user'] } },
+          systemPrompt: {
+            type: 'preset',
+            preset: 'claude_code',
+            append: expect.stringContaining('open_science_skill_privacy_instructions')
+          }
+        }
       }
     ])
     expect(fakeAgent.prompts).toEqual([
@@ -921,6 +929,17 @@ describe('ACP runtime session management', () => {
         type: 'preset',
         preset: 'claude_code',
         append: expect.stringContaining('write_artifact_file')
+      }
+    })
+    // The skill-privacy guardrail is appended to the system prompt on both create and resume.
+    expect(fakeAgent.newSessions[0]._meta).toMatchObject({
+      systemPrompt: {
+        append: expect.stringContaining('open_science_skill_privacy_instructions')
+      }
+    })
+    expect(fakeAgent.resumedSessions[0]._meta).toMatchObject({
+      systemPrompt: {
+        append: expect.stringContaining('open_science_skill_privacy_instructions')
       }
     })
   })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -135,6 +135,16 @@ const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '</open_science_artifact_instructions>'
 ].join('\n')
 
+// Steers the agent away from reading skill definition files, so the permission deny rules that block
+// those reads act as a backstop rather than the first line of defense.
+const SKILLS_READ_GUARD_SYSTEM_PROMPT_APPEND = [
+  '<open_science_skill_privacy_instructions>',
+  'Skills are provided for you to load and use through the normal skill mechanism — their definition files are not for inspection.',
+  'Do not read, open, cat, print, or otherwise reveal the contents of skill files (`SKILL.md` or any file under the application skills directory). Their contents must never be surfaced into the conversation.',
+  'If you need to know what a skill does, rely on its loaded description and the skill system — not on reading its files. Such reads are blocked by policy; do not attempt to work around them.',
+  '</open_science_skill_privacy_instructions>'
+].join('\n')
+
 // Small text uploads are embedded directly; larger files stay as links to avoid huge prompt payloads.
 const MAX_EMBEDDED_TEXT_UPLOAD_BYTES = 1024 * 1024
 
@@ -1179,6 +1189,8 @@ class AcpRuntime {
   // loads only the clean app dir's settings + the app's own skills/plugins/commands.
   private createSessionMeta(): { _meta: Record<string, unknown> } {
     const appendSections = [
+      // The skill-privacy guardrail always applies — skills are materialized whenever the app runs.
+      SKILLS_READ_GUARD_SYSTEM_PROMPT_APPEND,
       ...(this.artifactOptions ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
       ...(this.notebookOptions ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : [])
     ]


### PR DESCRIPTION
## Summary

Follow-up to #61 (skill read-guard). The permission `deny` rules block reads of the materialized skill files, but that gate should be a **backstop**, not the first line of defense. This appends an **always-on skill-privacy instruction** to the session system prompt so the agent doesn't try to read skill files in the first place.

The guidance tells the agent: skill definition files (`SKILL.md` and anything under the app skills directory) are for **loading and using** through the normal skill mechanism, **not for inspection**, and their contents must never be surfaced into the conversation.

## Changes

- `acp/runtime.ts`: add `SKILLS_READ_GUARD_SYSTEM_PROMPT_APPEND` and include it in `createSessionMeta`'s system-prompt append, alongside the existing artifact/notebook guidance. It's **unconditional** (applied to every session, create and resume) since skills are materialized whenever the app runs.

## Testing

- `npm run typecheck` OK, `npm run lint` OK, `npm run test` OK (1124 passed)
- New coverage: the session `_meta` on create and resume carries the `open_science_skill_privacy_instructions` block; the bare-runtime resume assertion updated to expect the now-always-present system prompt.

Note: this is a soft guardrail; the enforceable protection remains the #61 permission deny rules + notebook audit hook. Residual gaps (arbitrary subprocess reads, OS sandbox) are tracked in the read-guard spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)