### PR TITLE
chore: release 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ Thumbs.db
 
 # Internal docs
 docs/internal/
+docs/superpowers/
 
 # Local-only scripts and tooling
 local/

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ So let's be direct about where each project actually stands, instead of hand-wav
 | **Compute**                       | SSH/HPC access plus Modal for on-demand GPUs                              | Pluggable compute fabric — any HPC scheduler, any cloud GPU provider (planned)                                                                                          |
 | **Reviewer / verification agent** | Yes, shipping today                                                       | Yes, planned as an open, inspectable layer ([Phase 4](#roadmap))                                                                                                        |
 | **Customization**                 | Configure agents inside Anthropic's product surface                       | Every layer — gateway, skill runtime, compute broker, reviewer — is inspectable and replaceable                                                                         |
-| **Maturity**                      | A shipping, polished product, in use today                                | Early alpha: working core loop with downloadable desktop builds; the differentiating layers are still ahead (see [Roadmap](#roadmap))                                                                                                      |
+| **Maturity**                      | A shipping, polished product, in use today                                | Early alpha: working core loop with downloadable desktop builds, plus first-cut agent skills and life-science / MCP data connectors; the deeper differentiating layers are still ahead (see [Roadmap](#roadmap))                                                                                                      |
 
 The Maturity row matters most, so we won't bury it: if you need a working AI research assistant today, Claude Science is the more capable choice. Open Science's advantage isn't feature parity yet — it's the structural ceiling underneath.
 
@@ -233,8 +233,8 @@ flowchart TB
     end
 
     Core --> Models["Model Layer (planned)<br/>Claude · GPT · Gemini · DeepSeek · Qwen · local"]
-    Core --> Skills["Skills Commons (planned)<br/>versioned, forkable agent skills"]
-    Core --> Data["Data & Knowledge Layer (planned)<br/>PubMed · UniProt · PDB · ChEMBL · GEO · private data"]
+    Core --> Skills["Skills Commons (early)<br/>versioned, forkable agent skills"]
+    Core --> Data["Data & Knowledge Layer (early)<br/>PubMed · UniProt · PDB · ChEMBL · GEO · private data"]
     Core --> Compute["Compute Fabric (planned)<br/>laptop → HPC/Slurm → cloud GPU"]
 
     Specialists --> Artifacts["Scientific Artifacts & Notebooks (shipping)<br/>notebook kernel · file previews · artifact storage"]
@@ -246,8 +246,8 @@ flowchart TB
 
 - **Agent Harness / Orchestration Core.** A coordinating agent that plans multi-step research tasks and executes tool calls, with typed activity visualization and a permission gate for higher-risk actions. _Shipping today_ via an Agent Client Protocol (ACP) runtime. Specialist sub-agents (genomics, proteomics, structural biology, cheminformatics, and — unlike most current tools in this space — non-life-science domains like social science and economics) and a dedicated reviewer agent are planned.
 - **Model Layer.** A unified gateway in front of any LLM provider or self-hosted model, with per-agent routing — a cheap fast model for grunt-work sub-tasks, a frontier model for synthesis and writing, a local model for anything that can't leave the building. _Planned_ — today's runtime is wired to a single agent backend.
-- **Skills Commons.** An open, versioned registry of agent skills — protocol design, statistical review, literature synthesis, figure generation, and domain-specific analysis pipelines — designed to interoperate with [aipoch/medical-research-skills](https://github.com/aipoch/medical-research-skills) as its first and largest skill pack. _Planned._
-- **Data & Knowledge Layer.** Connectors to the open scientific commons — PubMed/PMC, UniProt, PDB, Ensembl, Reactome, ClinVar, ChEMBL, GEO, arXiv/bioRxiv/medRxiv, OpenAlex — plus a connector framework for institutional and proprietary datasets that never leave the researcher's access boundary. _Planned._
+- **Skills Commons.** An open, versioned registry of agent skills — protocol design, statistical review, literature synthesis, figure generation, and domain-specific analysis pipelines — designed to interoperate with [aipoch/medical-research-skills](https://github.com/aipoch/medical-research-skills) as its first and largest skill pack. _Early:_ file-based skill management ships today — create, edit, and import (zip) skills and pull them into a session through a `/` selector — but the open, shareable public commons is still planned.
+- **Data & Knowledge Layer.** Connectors to the open scientific commons — PubMed/PMC, UniProt, PDB, Ensembl, Reactome, ClinVar, ChEMBL, GEO, arXiv/bioRxiv/medRxiv, OpenAlex — plus a connector framework for institutional and proprietary datasets that never leave the researcher's access boundary. _Early:_ a first set of life-science data connectors and support for custom MCP servers ship today (callable from agent sessions behind the permission gate); broader coverage and the general connector framework are planned.
 - **Compute Fabric.** A broker that scales a job from a laptop kernel, to an institutional Slurm/HPC cluster, to on-demand cloud GPUs, with job submission, monitoring, and cost guardrails handled automatically instead of hand-written SSH scripts. _Planned_ — all execution today runs locally.
 - **Scientific Artifacts & Notebooks.** _Shipping today_: a persistent Python notebook kernel with durable run history, artifact file storage organized by project/session/message/run, and in-app rendering for CSV, FASTA, HTML, image, JSON, Markdown, and text files. Native structure/genome/chemical viewers and reproducible manuscript/figure generation with inline citations are planned.
 - **Verification & Provenance Layer.** A lineage graph connecting every claim back to the figure, code, and dataset version that generated it, with automated checks for citation accuracy, unit consistency, and statistical-method appropriateness. _Planned._
@@ -255,7 +255,7 @@ flowchart TB
 
 ## Current Status
 
-Open Science is **early alpha**. The core "plan → execute → produce → preview" loop — desktop app, agent runtime, notebook execution, artifact storage, in-app previews — works end to end today. The properties that would make this a genuinely differentiated, science-grade tool — multi-model routing, provenance, a connector ecosystem, remote compute, a skills commons — are mostly still ahead. We'd rather ship a slower, honest path to the full vision than fake a finished product.
+Open Science is **early alpha**. The core "plan → execute → produce → preview" loop — desktop app, agent runtime, notebook execution, artifact storage, in-app previews — works end to end today, and a first layer of the differentiating capabilities has started to land: file-based agent skills and an initial set of life-science / MCP data connectors. The properties that would make this a genuinely differentiated, science-grade tool — multi-model routing, provenance, remote compute, and a public skills commons — are mostly still ahead. We'd rather ship a slower, honest path to the full vision than fake a finished product.
 
 The authoritative, kept-up-to-date breakdown of what's shipping versus still ahead lives in `ROADMAP.md`, not here, so this list doesn't quietly drift out of sync as the project moves:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ flowchart LR
 
 ## Where We Are Today
 
-The current codebase is an early, working implementation of the first stretch of Horizon 1 and Horizon 2 — a single-agent desktop workbench with real project/session persistence, a notebook execution kernel, and an artifact library, running today (not "coming soon"). It's honest to describe it as **early alpha**: the core "plan → execute → produce → preview" loop works end to end, but the properties that would make this a genuinely open, science-grade tool — reproducibility guarantees, multi-model routing, a connector ecosystem, remote compute, a skills commons — are mostly still ahead of us.
+The current codebase is an early, working implementation of the first stretch of Horizon 1 and Horizon 2 — a single-agent desktop workbench with real project/session persistence, a notebook execution kernel, an artifact library, file-based agent skills, and a first set of scientific data connectors, running today (not "coming soon"). It's honest to describe it as **early alpha**: the core "plan → execute → produce → preview" loop works end to end, but the properties that would make this a genuinely open, science-grade tool — reproducibility guarantees, multi-model routing, remote compute, and a public skills commons — are mostly still ahead of us.
 
 **Working today:**
 - ✅ Agent runtime with a full plan/execute/tool-call loop, wrapped over the Agent Client Protocol (ACP)
@@ -52,13 +52,15 @@ The current codebase is an early, working implementation of the first stretch of
 - ✅ Artifact file storage organized by session / message / run
 - ✅ Rich in-app file previews (CSV, FASTA, HTML, image, JSON, Markdown, plain text, notebook cells)
 - ✅ Attachment uploads and a permission-approval UI for tool calls
+- ✅ File-based agent skills — create, edit, and import (zip) skills, pull them into a session through a `/` selector in the composer, with materialized skill directories kept read-only
+- ✅ A first set of life-science data connectors plus custom MCP servers, callable from agent sessions behind the permission gate
 - ✅ Packaged desktop installers for macOS (Apple Silicon + Intel), Windows, and Linux, plus a nightly build channel off `main`
 
 **Not yet built — the hardest, most differentiating work is still ahead:**
 - ⬜ A truly model-agnostic gateway; multi-provider selection ships today (see below), but every provider is reached over an Anthropic-compatible endpoint — native non-Anthropic protocols (e.g. OpenAI's own API) are not yet wired
 - ⬜ Artifact versioning and a provenance chain (code + execution log + dependency graph + environment snapshot + conversation context) tied to every output
 - ⬜ Additional execution kernels (R, a REPL control plane) and Conda-style environment management
-- ⬜ A skills commons and pre-built life-science data connectors
+- ⬜ A public skills commons — versioned, forkable, shareable skills with lexical discovery; local file-based skill management ships today (see above), the shared commons and a broader connector framework do not
 - ⬜ Remote compute (SSH / Slurm / cloud GPU), an async notification bus, and sub-agent fan-out
 - ⬜ Network sandboxing, a credential vault, and scoped (single-use / session / project / global) permissions
 - ⬜ A reviewer / verifier agent that checks citations, units, and statistical methods before output ships
@@ -77,11 +79,11 @@ The product is organized into cooperating layers (see [`docs/PRD.md`](docs/PRD.m
 | **Environment Management** | Create, switch, snapshot, and register reproducible compute environments | Uses a single managed runtime directory; no environment CRUD or snapshotting | ⬜ |
 | **Artifacts & Provenance** | Versioned outputs with full lineage (code, logs, dependencies, environment, conversation) | Artifact files saved and organized by session/message/run; no versioning or lineage tracking yet | 🟡 |
 | **File Preview & Viewers** | Native, in-app rendering of scientific artifacts | Multi-format renderers (CSV, FASTA, HTML, image, JSON, Markdown, text) plus a project file library and notebook preview | ✅ |
-| **Skills Commons** | Versioned, forkable, file-based skills with lexical discovery and explicit loading | Not implemented | ⬜ |
-| **Data & MCP Connectors** | Pre-built connectors to open scientific databases, callable from an isolated execution context | Internal MCP infrastructure exists for artifacts/notebook tooling; no external data connectors yet | 🟡 |
+| **Skills Commons** | Versioned, forkable, file-based skills with lexical discovery and explicit loading | File-based skill management (create/edit/import, `/`-selector discovery in the composer, read-only materialized dirs); no public registry, sharing, or version pinning yet | 🟡 |
+| **Data & MCP Connectors** | Pre-built connectors to open scientific databases, callable from an isolated execution context | A first set of life-science data connectors plus custom MCP server support, callable from agent sessions behind the permission gate; breadth is still early and there is no general connector framework yet | 🟡 |
 | **Remote Compute & Async Tasks** | Job submission to HPC/cloud, async completion notifications, parallel sub-agent fan-out | Not implemented; all execution is local and synchronous today | ⬜ |
 | **Security & Permissions** | Scoped permission gates, network allowlisting, directory-level file access control, credential vault | Tool-call permission gate with an approval UI; no scoping tiers, network sandbox, or credential vault | 🟡 |
-| **Context Management** | Layered system rules, attachment ingestion, skill-aware context injection, history compaction | File/attachment upload wired into prompts; no automatic skill injection or compaction yet | 🟡 |
+| **Context Management** | Layered system rules, attachment ingestion, skill-aware context injection, history compaction | File/attachment upload wired into prompts and explicit `/`-selector skill injection; no automatic skill-aware injection or history compaction yet | 🟡 |
 | **Interactive Annotations** | Spatially-anchored feedback on images, PDFs, text, and HTML surfaces | Not implemented | ⬜ |
 
 ## Delivery Phases
@@ -99,9 +101,9 @@ flowchart LR
 ```
 
 - **Phase 0 — Vision & Architecture (done).** This roadmap, the [PRD](docs/PRD.md), the design system, and initial community formation.
-- **Phase 1 — Core Loop (in progress).** Desktop shell, single-agent runtime, project/session persistence, a single execution kernel, artifact storage, rich in-app previews, and packaged installers for macOS/Windows/Linux — all shipping today. Multi-provider model configuration with per-model selection also ships now, though only across Anthropic-compatible endpoints. Still open in this phase: a truly model-agnostic gateway (native non-Anthropic protocols), a CLI/SDK entry point, and a file-based skill runtime.
+- **Phase 1 — Core Loop (in progress).** Desktop shell, single-agent runtime, project/session persistence, a single execution kernel, artifact storage, rich in-app previews, file-based agent skills, a first set of life-science / MCP data connectors, and packaged installers for macOS/Windows/Linux — all shipping today. Multi-provider model configuration with per-model selection also ships now, though only across Anthropic-compatible endpoints. Still open in this phase: a truly model-agnostic gateway (native non-Anthropic protocols) and a CLI/SDK entry point.
 - **Phase 2 — Reproducibility & Multi-Agent.** Artifact versioning with a full provenance chain; additional kernels (R, a REPL control plane) and environment management; specialist sub-agents alongside the generalist coordinator. This is the project's core differentiation from a generic coding agent, and the highest-priority phase for contributors who want to make the biggest structural dent.
-- **Phase 3 — Knowledge & Connectors.** A skills commons with versioned, forkable skills and lexical discovery; pre-built connectors to open scientific databases and literature; savable "specialist" roles (instructions + skills + connectors + permissions bundled together).
+- **Phase 3 — Knowledge & Connectors.** A public skills commons with versioned, forkable skills and lexical discovery; a broader connector framework reaching more open scientific databases and literature; savable "specialist" roles (instructions + skills + connectors + permissions bundled together). Early pieces have already landed in Phase 1 — local file-based skill management and a first set of data / MCP connectors — but the shared commons and the general connector framework remain.
 - **Phase 4 — Compute & Trust.** Remote compute as a first-class primitive (SSH/Slurm/cloud GPU) with async job notifications and sub-agent fan-out; a reviewer/verifier agent; the full security stack (scoped permissions, network allowlisting, directory-level file sandboxing, a credential vault); a pluggable multi-agent-framework backend so the runtime isn't locked to one agent implementation.
 - **Phase 5 — Commons & Interaction.** A public skills marketplace, an optional hosted offering, and institutional governance/audit features; spatially-anchored annotations; interactive scientific viewers; dynamic, skill-aware context injection and history compaction.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-science",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-science",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-science",
   "productName": "Open Science",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Open Science — an open-source, model-agnostic AI workbench for scientific discovery.",
   "main": "./out/main/index.js",
   "author": "aipoch",


### PR DESCRIPTION
## Summary

Prepare the **0.2.0** release: bump the app version and refresh the release-facing docs so they reflect what actually shipped since `0.1.2` (#41–#63).

Two subsystems moved from *planned* to *early/shipping* in this window and the docs now say so:
- **File-based agent skills** — create / edit / import (zip) skills, a `/` selector in the composer, read-only materialized skill dirs (#44, #49, #50, #53, #55, #57).
- **Life-science data connectors + custom MCP servers**, callable from agent sessions behind the permission gate (#59).

## Changes

- **`package.json` / `package-lock.json`** — version `0.1.2` → `0.2.0` (root package only; no dependency changes).
- **`ROADMAP.md`**
  - *Where We Are Today*: added ✅ entries for agent skills and the first data / MCP connectors.
  - *Capability Map*: **Skills Commons** ⬜ → 🟡; refreshed **Data & MCP Connectors** and **Context Management** rows.
  - *Delivery Phases*: dropped "file-based skill runtime" from Phase 1's open items; noted the early skills/connectors pieces under Phase 3.
- **`README.md`** — Skills Commons and Data & Knowledge Layer moved from *Planned* to *Early* (prose + architecture diagram); *Current Status* and the vs-Claude-Science **Maturity** row updated.
- **`.gitignore`** — ignore `docs/superpowers/`.

## Notes

- `0.1.x` strings left untouched in test fixtures, the issue-template placeholder, and workflow examples — those aren't the app version.
- Wording kept deliberately measured/honest: skills + connectors are described as an early first cut, not feature-complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)