### PR TITLE
feat(acp): add per-conversation approval profiles

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -12,6 +12,7 @@ import type {
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
+  AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
@@ -129,6 +130,9 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntime => {
   )
   ipcMain.handle('acp:respond-permission', (_event, response: AcpPermissionResponse) =>
     runtime.respondToPermission(response)
+  )
+  ipcMain.handle('acp:set-permission-profile', (_event, request: AcpSetPermissionProfileRequest) =>
+    runtime.setPermissionProfile(request)
   )
 
   return runtime

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -64,6 +64,43 @@ const createToolPermissionRequest = (
 }
 
 describe('ACP permission broker', () => {
+  it('preserves structured tool metadata for risk-aware approval UI', () => {
+    const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const request = createToolPermissionRequest({
+      title: 'Edit results.csv',
+      providerToolName: 'Edit',
+      kind: 'edit'
+    })
+    request.toolCall.locations = [{ path: '/workspace/results.csv' }]
+    request.toolCall.rawInput = { file_path: '/workspace/results.csv', value: 'updated' }
+
+    void broker.requestPermission(request)
+
+    expect(emitted[0]).toMatchObject({
+      providerToolName: 'Edit',
+      toolKind: 'edit',
+      toolLocations: [{ path: '/workspace/results.csv' }],
+      rawInput: { file_path: '/workspace/results.csv', value: 'updated' }
+    })
+  })
+
+  it('auto-approves only conservative Auto operations accepted by policy', async () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+    const request = createToolPermissionRequest({ kind: 'read' })
+    request.toolCall.locations = [{ path: 'data/results.csv' }]
+
+    await expect(
+      broker.requestPermission(request, {
+        profile: 'auto',
+        autoReviewStrategy: 'conservative',
+        cwd: '/workspace'
+      })
+    ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow-once' } })
+    expect(emittedRequests).toEqual([])
+  })
+
   it('emits a serializable permission request and resolves the selected option', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 
 import type { AcpPermissionRequest, AcpPermissionResponse } from '../../shared/acp'
 import { extractProviderToolName } from './runtime-events'
+import { resolveAutomaticPermission, type PermissionPolicyContext } from './permission-policy'
 
 type PendingPermission = {
   request: AcpPermissionRequest
@@ -78,8 +79,17 @@ class AcpPermissionBroker {
     return Array.from(this.pendingRequests.values(), ({ request }) => request)
   }
 
+  hasPendingForSession(sessionId: string): boolean {
+    return Array.from(this.pendingRequests.values()).some(
+      ({ request }) => request.sessionId === sessionId
+    )
+  }
+
   // Stores a permission request and resolves it later from a renderer response.
-  requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
+  requestPermission(
+    params: RequestPermissionRequest,
+    policyContext?: PermissionPolicyContext
+  ): Promise<RequestPermissionResponse> {
     const requestId = randomUUID()
     const request: AcpPermissionRequest = {
       requestId,
@@ -87,6 +97,10 @@ class AcpPermissionBroker {
       toolCallId: params.toolCall.toolCallId,
       title: params.toolCall.title ?? params.toolCall.toolCallId,
       status: params.toolCall.status ?? undefined,
+      providerToolName: extractProviderToolName(params.toolCall),
+      toolKind: params.toolCall.kind ?? undefined,
+      toolLocations: params.toolCall.locations ?? undefined,
+      rawInput: params.toolCall.rawInput,
       options: params.options.map((option) => ({
         optionId: option.optionId,
         name: option.name,
@@ -96,6 +110,15 @@ class AcpPermissionBroker {
     }
 
     const categoryKey = resolveCategoryKey(params)
+
+    // A model-independent fallback auto-reviews only structured, workspace-contained low-risk tools.
+    const automaticOptionId = resolveAutomaticPermission(params, policyContext)
+
+    if (automaticOptionId) {
+      return Promise.resolve({
+        outcome: { outcome: 'selected', optionId: automaticOptionId }
+      })
+    }
 
     // A prior "Always" choice on this category auto-approves without prompting again.
     const autoAllowOptionId = this.resolveAutoAllowOptionId(request, categoryKey)

--- a/src/main/acp/permission-policy.test.ts
+++ b/src/main/acp/permission-policy.test.ts
@@ -1,0 +1,92 @@
+import type { RequestPermissionRequest, ToolKind } from '@agentclientprotocol/sdk'
+import { describe, expect, it } from 'vitest'
+
+import {
+  canConservativelyAutoApprove,
+  isWithinWorkspace,
+  resolveAutomaticPermission
+} from './permission-policy'
+
+const createPermissionRequest = (
+  kind: ToolKind,
+  locations?: Array<{ path: string }>
+): RequestPermissionRequest => ({
+  sessionId: 'session-1',
+  toolCall: {
+    toolCallId: 'tool-1',
+    title: 'Tool call',
+    kind,
+    locations
+  },
+  options: [
+    { optionId: 'allow', name: 'Allow once', kind: 'allow_once' },
+    { optionId: 'reject', name: 'Reject', kind: 'reject_once' }
+  ]
+})
+
+describe('permission policy', () => {
+  it('accepts only paths contained by the workspace', () => {
+    expect(isWithinWorkspace('src/index.ts', '/workspace/project')).toBe(true)
+    expect(isWithinWorkspace('/workspace/project/data.csv', '/workspace/project')).toBe(true)
+    expect(isWithinWorkspace('../secrets.txt', '/workspace/project')).toBe(false)
+    expect(isWithinWorkspace('/tmp/outside.txt', '/workspace/project')).toBe(false)
+  })
+
+  it('auto-approves structured workspace reads, searches, and edits', () => {
+    for (const kind of ['read', 'search', 'edit'] as const) {
+      expect(
+        canConservativelyAutoApprove(
+          createPermissionRequest(kind, [{ path: 'results/output.csv' }]),
+          '/workspace/project'
+        )
+      ).toBe(true)
+    }
+  })
+
+  it('never auto-approves shell, network, unlocated, or outside-workspace operations', () => {
+    expect(
+      canConservativelyAutoApprove(
+        createPermissionRequest('execute', [{ path: 'script.py' }]),
+        '/workspace/project'
+      )
+    ).toBe(false)
+    expect(
+      canConservativelyAutoApprove(createPermissionRequest('fetch'), '/workspace/project')
+    ).toBe(false)
+    expect(
+      canConservativelyAutoApprove(createPermissionRequest('read'), '/workspace/project')
+    ).toBe(false)
+    expect(
+      canConservativelyAutoApprove(
+        createPermissionRequest('edit', [{ path: '../outside.txt' }]),
+        '/workspace/project'
+      )
+    ).toBe(false)
+  })
+
+  it('activates fallback review only for conservative Auto', () => {
+    const request = createPermissionRequest('read', [{ path: 'data/input.csv' }])
+
+    expect(
+      resolveAutomaticPermission(request, {
+        profile: 'auto',
+        autoReviewStrategy: 'conservative',
+        cwd: '/workspace/project'
+      })
+    ).toBe('allow')
+    expect(
+      resolveAutomaticPermission(request, {
+        profile: 'ask',
+        autoReviewStrategy: 'conservative',
+        cwd: '/workspace/project'
+      })
+    ).toBeUndefined()
+    expect(
+      resolveAutomaticPermission(request, {
+        profile: 'auto',
+        autoReviewStrategy: 'native',
+        cwd: '/workspace/project'
+      })
+    ).toBeUndefined()
+  })
+})

--- a/src/main/acp/permission-policy.test.ts
+++ b/src/main/acp/permission-policy.test.ts
@@ -4,21 +4,26 @@ import { describe, expect, it } from 'vitest'
 import {
   canConservativelyAutoApprove,
   isWithinWorkspace,
+  resolveAllowOptionId,
   resolveAutomaticPermission
 } from './permission-policy'
 
 const createPermissionRequest = (
   kind: ToolKind,
-  locations?: Array<{ path: string }>
+  locations?: Array<{ path: string }>,
+  overrides?: {
+    title?: string
+    options?: RequestPermissionRequest['options']
+  }
 ): RequestPermissionRequest => ({
   sessionId: 'session-1',
   toolCall: {
     toolCallId: 'tool-1',
-    title: 'Tool call',
+    title: overrides?.title ?? 'Tool call',
     kind,
     locations
   },
-  options: [
+  options: overrides?.options ?? [
     { optionId: 'allow', name: 'Allow once', kind: 'allow_once' },
     { optionId: 'reject', name: 'Reject', kind: 'reject_once' }
   ]
@@ -62,6 +67,52 @@ describe('permission policy', () => {
         '/workspace/project'
       )
     ).toBe(false)
+  })
+
+  it('never auto-approves MCP tools even when they report a workspace-contained low-risk kind', () => {
+    expect(
+      canConservativelyAutoApprove(
+        createPermissionRequest('read', [{ path: 'results/output.csv' }], {
+          title: 'mcp__pencil__batch_get'
+        }),
+        '/workspace/project'
+      )
+    ).toBe(false)
+    expect(
+      canConservativelyAutoApprove(
+        createPermissionRequest('edit', [{ path: 'design.pen' }], {
+          title: 'mcp__pencil__batch_design'
+        }),
+        '/workspace/project'
+      )
+    ).toBe(false)
+  })
+
+  it('grants a single-use approval only, never escalating to allow_always', () => {
+    const request = createPermissionRequest('read', [{ path: 'data/input.csv' }])
+
+    expect(resolveAllowOptionId(request)).toBe('allow')
+    expect(
+      resolveAllowOptionId(
+        createPermissionRequest('read', [{ path: 'data/input.csv' }], {
+          options: [
+            { optionId: 'always', name: 'Allow always', kind: 'allow_always' },
+            { optionId: 'once', name: 'Allow once', kind: 'allow_once' },
+            { optionId: 'reject', name: 'Reject', kind: 'reject_once' }
+          ]
+        })
+      )
+    ).toBe('once')
+    expect(
+      resolveAllowOptionId(
+        createPermissionRequest('read', [{ path: 'data/input.csv' }], {
+          options: [
+            { optionId: 'always', name: 'Allow always', kind: 'allow_always' },
+            { optionId: 'reject', name: 'Reject', kind: 'reject_once' }
+          ]
+        })
+      )
+    ).toBeUndefined()
   })
 
   it('activates fallback review only for conservative Auto', () => {

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -5,6 +5,7 @@ import type {
   PermissionAutoReviewStrategy,
   PermissionProfileId
 } from '../../shared/permission-profiles'
+import { extractProviderToolName } from './runtime-events'
 
 type PermissionPolicyContext = {
   profile: PermissionProfileId
@@ -12,7 +13,9 @@ type PermissionPolicyContext = {
   cwd?: string
 }
 
-const ALLOW_OPTION_KINDS = new Set(['allow_once', 'allow_always'])
+// Claude Code namespaces MCP tools as mcp__<server>__<tool>; the prefix surfaces in both the
+// permission title and the provider tool name, so either is enough to identify an MCP origin.
+const MCP_TOOL_PREFIX = 'mcp__'
 
 // Tests whether a tool-reported path stays within the workspace after resolving relative paths.
 const isWithinWorkspace = (path: string, cwd: string): boolean => {
@@ -21,6 +24,18 @@ const isWithinWorkspace = (path: string, cwd: string): boolean => {
   const relation = relative(workspace, target)
 
   return relation === '' || (!relation.startsWith('..') && !isAbsolute(relation))
+}
+
+// MCP tools can report a benign kind (read/edit) while performing arbitrary side effects, so the
+// conservative fallback treats any MCP-originated call as out of scope regardless of its kind.
+const isMcpTool = (params: RequestPermissionRequest): boolean => {
+  const { toolCall } = params
+  const providerToolName = extractProviderToolName(toolCall)
+
+  return (
+    toolCall.title?.startsWith(MCP_TOOL_PREFIX) === true ||
+    providerToolName?.startsWith(MCP_TOOL_PREFIX) === true
+  )
 }
 
 // Conservative cross-model fallback used only when the Agent does not advertise native auto review.
@@ -32,6 +47,7 @@ const canConservativelyAutoApprove = (
 ): boolean => {
   const { kind, locations } = params.toolCall
 
+  if (isMcpTool(params)) return false
   if (kind === 'think') return true
   if (!cwd || !locations || locations.length === 0) return false
   if (kind !== 'read' && kind !== 'search' && kind !== 'edit') return false
@@ -39,8 +55,10 @@ const canConservativelyAutoApprove = (
   return locations.every((location) => isWithinWorkspace(location.path, cwd))
 }
 
+// The fallback grants a single-use approval only. It never selects allow_always, so an automatic
+// decision can never silently escalate a category to session-persistent access inside the Agent.
 const resolveAllowOptionId = (params: RequestPermissionRequest): string | undefined =>
-  params.options.find((option) => ALLOW_OPTION_KINDS.has(option.kind.toLowerCase()))?.optionId
+  params.options.find((option) => option.kind.toLowerCase() === 'allow_once')?.optionId
 
 // Returns an option only when the application can make a provider-neutral, fail-closed decision.
 // Native auto mode reviews inside the Agent; any request it escalates still belongs in the UI.

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -1,0 +1,68 @@
+import type { RequestPermissionRequest } from '@agentclientprotocol/sdk'
+import { isAbsolute, relative, resolve } from 'node:path'
+
+import type {
+  PermissionAutoReviewStrategy,
+  PermissionProfileId
+} from '../../shared/permission-profiles'
+
+type PermissionPolicyContext = {
+  profile: PermissionProfileId
+  autoReviewStrategy?: PermissionAutoReviewStrategy
+  cwd?: string
+}
+
+const ALLOW_OPTION_KINDS = new Set(['allow_once', 'allow_always'])
+
+// Tests whether a tool-reported path stays within the workspace after resolving relative paths.
+const isWithinWorkspace = (path: string, cwd: string): boolean => {
+  const workspace = resolve(cwd)
+  const target = isAbsolute(path) ? resolve(path) : resolve(workspace, path)
+  const relation = relative(workspace, target)
+
+  return relation === '' || (!relation.startsWith('..') && !isAbsolute(relation))
+}
+
+// Conservative cross-model fallback used only when the Agent does not advertise native auto review.
+// It never interprets model prose or shell source. Only explicitly located, workspace-contained
+// read/search/edit operations and side-effect-free thinking can pass without user review.
+const canConservativelyAutoApprove = (
+  params: RequestPermissionRequest,
+  cwd: string | undefined
+): boolean => {
+  const { kind, locations } = params.toolCall
+
+  if (kind === 'think') return true
+  if (!cwd || !locations || locations.length === 0) return false
+  if (kind !== 'read' && kind !== 'search' && kind !== 'edit') return false
+
+  return locations.every((location) => isWithinWorkspace(location.path, cwd))
+}
+
+const resolveAllowOptionId = (params: RequestPermissionRequest): string | undefined =>
+  params.options.find((option) => ALLOW_OPTION_KINDS.has(option.kind.toLowerCase()))?.optionId
+
+// Returns an option only when the application can make a provider-neutral, fail-closed decision.
+// Native auto mode reviews inside the Agent; any request it escalates still belongs in the UI.
+const resolveAutomaticPermission = (
+  params: RequestPermissionRequest,
+  context: PermissionPolicyContext | undefined
+): string | undefined => {
+  if (
+    context?.profile !== 'auto' ||
+    context.autoReviewStrategy !== 'conservative' ||
+    !canConservativelyAutoApprove(params, context.cwd)
+  ) {
+    return undefined
+  }
+
+  return resolveAllowOptionId(params)
+}
+
+export {
+  canConservativelyAutoApprove,
+  isWithinWorkspace,
+  resolveAutomaticPermission,
+  resolveAllowOptionId
+}
+export type { PermissionPolicyContext }

--- a/src/main/acp/permission-profile-controller.test.ts
+++ b/src/main/acp/permission-profile-controller.test.ts
@@ -1,0 +1,64 @@
+import type { SessionModeState } from '@agentclientprotocol/sdk'
+import { describe, expect, it } from 'vitest'
+
+import {
+  PermissionProfileUnavailableError,
+  applyCurrentModeUpdate,
+  resolvePermissionProfileApplication
+} from './permission-profile-controller'
+
+const createModes = (
+  ids: string[],
+  currentModeId: string = ids[0] ?? 'default'
+): SessionModeState => ({
+  currentModeId,
+  availableModes: ids.map((id) => ({ id, name: id }))
+})
+
+describe('permission profile controller', () => {
+  it('maps Ask and native Auto to advertised ACP modes', () => {
+    const modes = createModes(['default', 'auto', 'bypassPermissions'])
+
+    expect(resolvePermissionProfileApplication('ask', modes)).toMatchObject({
+      modeId: 'default',
+      state: { selectedProfile: 'ask', currentModeId: 'default', fullAccessAvailable: true }
+    })
+    expect(resolvePermissionProfileApplication('auto', modes)).toMatchObject({
+      modeId: 'auto',
+      state: { selectedProfile: 'auto', autoReviewStrategy: 'native' }
+    })
+  })
+
+  it('falls back to conservative review when native Auto is not advertised', () => {
+    const application = resolvePermissionProfileApplication(
+      'auto',
+      createModes(['default', 'bypassPermissions'])
+    )
+
+    expect(application.modeId).toBe('default')
+    expect(application.state.autoReviewStrategy).toBe('conservative')
+    expect(application.state.message).toContain('auto-approve only clearly low-risk')
+  })
+
+  it('uses real bypass mode for Full access and rejects it when unavailable', () => {
+    expect(
+      resolvePermissionProfileApplication('full', createModes(['default', 'bypassPermissions']))
+        .modeId
+    ).toBe('bypassPermissions')
+
+    expect(() => resolvePermissionProfileApplication('full', createModes(['default']))).toThrow(
+      PermissionProfileUnavailableError
+    )
+  })
+
+  it('keeps conservative Auto selected when the Agent reports default mode', () => {
+    const state = resolvePermissionProfileApplication('auto', createModes(['default'])).state
+
+    expect(applyCurrentModeUpdate(state, 'default')).toMatchObject({
+      selectedProfile: 'auto',
+      effectiveProfile: 'auto',
+      currentModeId: 'default',
+      autoReviewStrategy: 'conservative'
+    })
+  })
+})

--- a/src/main/acp/permission-profile-controller.ts
+++ b/src/main/acp/permission-profile-controller.ts
@@ -1,0 +1,136 @@
+import type { SessionModeState } from '@agentclientprotocol/sdk'
+
+import type {
+  PermissionProfileId,
+  SessionPermissionProfileState
+} from '../../shared/permission-profiles'
+
+const DEFAULT_MODE_ID = 'default'
+const AUTO_MODE_ID = 'auto'
+const FULL_ACCESS_MODE_ID = 'bypassPermissions'
+
+type PermissionProfileApplication = {
+  modeId?: string
+  state: SessionPermissionProfileState
+}
+
+class PermissionProfileUnavailableError extends Error {
+  constructor(profile: PermissionProfileId) {
+    super(
+      profile === 'full'
+        ? 'Full access is not available for the current Agent session.'
+        : `Permission profile is not available: ${profile}`
+    )
+    this.name = 'PermissionProfileUnavailableError'
+  }
+}
+
+const availableModeIds = (modes: SessionModeState | null | undefined): string[] =>
+  modes?.availableModes.map((mode) => mode.id) ?? []
+
+// Maps stable application semantics onto the modes advertised by the active Agent. Auto has a
+// conservative application fallback; Full access is offered only when bypass is genuinely available.
+const resolvePermissionProfileApplication = (
+  profile: PermissionProfileId,
+  modes: SessionModeState | null | undefined
+): PermissionProfileApplication => {
+  const modeIds = availableModeIds(modes)
+  const hasMode = (modeId: string): boolean => modeIds.includes(modeId)
+  const fullAccessAvailable = hasMode(FULL_ACCESS_MODE_ID)
+
+  if (profile === 'full' && !fullAccessAvailable) {
+    throw new PermissionProfileUnavailableError(profile)
+  }
+
+  if (profile === 'auto') {
+    const nativeAuto = hasMode(AUTO_MODE_ID)
+    const modeId = nativeAuto
+      ? AUTO_MODE_ID
+      : hasMode(DEFAULT_MODE_ID)
+        ? DEFAULT_MODE_ID
+        : undefined
+
+    return {
+      modeId,
+      state: {
+        selectedProfile: profile,
+        effectiveProfile: profile,
+        currentModeId: modeId ?? modes?.currentModeId,
+        availableModeIds: modeIds,
+        autoReviewStrategy: nativeAuto ? 'native' : 'conservative',
+        fullAccessAvailable,
+        ...(!nativeAuto
+          ? {
+              message:
+                'This model does not provide native auto review. Open Science will auto-approve only clearly low-risk workspace operations.'
+            }
+          : {})
+      }
+    }
+  }
+
+  const modeId = profile === 'full' ? FULL_ACCESS_MODE_ID : DEFAULT_MODE_ID
+  const canSetMode = hasMode(modeId)
+
+  return {
+    modeId: canSetMode ? modeId : undefined,
+    state: {
+      selectedProfile: profile,
+      effectiveProfile: profile,
+      currentModeId: canSetMode ? modeId : modes?.currentModeId,
+      availableModeIds: modeIds,
+      fullAccessAvailable
+    }
+  }
+}
+
+// Keeps effective state truthful if the Agent changes modes autonomously or clamps a model switch.
+const applyCurrentModeUpdate = (
+  state: SessionPermissionProfileState,
+  currentModeId: string
+): SessionPermissionProfileState => {
+  if (currentModeId === FULL_ACCESS_MODE_ID) {
+    return {
+      ...state,
+      selectedProfile: 'full',
+      effectiveProfile: 'full',
+      currentModeId,
+      autoReviewStrategy: undefined,
+      message: undefined
+    }
+  }
+
+  if (currentModeId === AUTO_MODE_ID) {
+    return {
+      ...state,
+      selectedProfile: 'auto',
+      effectiveProfile: 'auto',
+      currentModeId,
+      autoReviewStrategy: 'native',
+      message: undefined
+    }
+  }
+
+  if (currentModeId === DEFAULT_MODE_ID && state.selectedProfile !== 'auto') {
+    return {
+      ...state,
+      selectedProfile: 'ask',
+      effectiveProfile: 'ask',
+      currentModeId,
+      autoReviewStrategy: undefined,
+      message: undefined
+    }
+  }
+
+  return { ...state, currentModeId }
+}
+
+export {
+  AUTO_MODE_ID,
+  DEFAULT_MODE_ID,
+  FULL_ACCESS_MODE_ID,
+  PermissionProfileUnavailableError,
+  applyCurrentModeUpdate,
+  resolvePermissionProfileApplication
+}
+export type { PermissionProfileApplication }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1,5 +1,5 @@
 import * as acp from '@agentclientprotocol/sdk'
-import type { ContentBlock } from '@agentclientprotocol/sdk'
+import type { ContentBlock, SessionModeState } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
@@ -53,6 +53,7 @@ const startFakeAgent = (
   sessionIds: string[],
   options: {
     supportsResume?: boolean
+    modes?: SessionModeState
     // When true, the resume handler rejects with the ACP "Resource not found" (-32002) — the signal a
     // replaced agent (e.g. after a provider switch) gives for a session id it does not hold.
     resumeNotFound?: boolean
@@ -67,6 +68,8 @@ const startFakeAgent = (
   newSessions: Array<{ cwd: string; mcpServers: unknown[]; _meta?: unknown }>
   resumedSessions: Array<{ sessionId: string; cwd: string; mcpServers: unknown[]; _meta?: unknown }>
   closedSessions: string[]
+  modeChanges: Array<{ sessionId: string; modeId: string }>
+  actions: string[]
 } => {
   const prompts: Array<{ sessionId: string; text: string }> = []
   const newSessions: Array<{ cwd: string; mcpServers: unknown[]; _meta?: unknown }> = []
@@ -77,6 +80,8 @@ const startFakeAgent = (
     _meta?: unknown
   }> = []
   const closedSessions: string[] = []
+  const modeChanges: Array<{ sessionId: string; modeId: string }> = []
+  const actions: string[] = []
   let sessionIndex = 0
 
   acp
@@ -102,7 +107,7 @@ const startFakeAgent = (
       const sessionId = sessionIds[sessionIndex]
       sessionIndex += 1
 
-      return { sessionId }
+      return { sessionId, modes: options.modes }
     })
     .onRequest(acp.methods.agent.session.resume, (ctx) => {
       if (options.resumeNotFound) {
@@ -116,6 +121,11 @@ const startFakeAgent = (
         ...(ctx.params._meta === undefined ? {} : { _meta: ctx.params._meta })
       })
 
+      return { modes: options.modes }
+    })
+    .onRequest(acp.methods.agent.session.setMode, (ctx) => {
+      modeChanges.push({ sessionId: ctx.params.sessionId, modeId: ctx.params.modeId })
+      actions.push(`mode:${ctx.params.modeId}`)
       return {}
     })
     .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
@@ -125,6 +135,7 @@ const startFakeAgent = (
         .join('')
 
       prompts.push({ sessionId: ctx.params.sessionId, text })
+      actions.push(`prompt:${text}`)
       await options.onPrompt?.({ sessionId: ctx.params.sessionId, text, prompt: ctx.params.prompt })
       // Stream one assistant chunk through the client callback path before stopping.
       await ctx.client.notify(acp.methods.client.session.update, {
@@ -153,8 +164,16 @@ const startFakeAgent = (
       )
     )
 
-  return { prompts, newSessions, resumedSessions, closedSessions }
+  return { prompts, newSessions, resumedSessions, closedSessions, modeChanges, actions }
 }
+
+const createModes = (
+  ids: string[],
+  currentModeId: string = ids[0] ?? 'default'
+): SessionModeState => ({
+  currentModeId,
+  availableModes: ids.map((id) => ({ id, name: id }))
+})
 
 let temporaryRoot: string | undefined
 
@@ -192,6 +211,70 @@ afterEach(async () => {
 })
 
 describe('ACP runtime session management', () => {
+  it('applies native Full access before the first prompt', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['full-session'], {
+      modes: createModes(['default', 'bypassPermissions'])
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'full' })
+
+    expect(runtime.getSnapshot().permissionProfiles[session.sessionId]).toMatchObject({
+      selectedProfile: 'full',
+      effectiveProfile: 'full',
+      currentModeId: 'bypassPermissions',
+      fullAccessAvailable: true
+    })
+    expect(fakeAgent.modeChanges).toEqual([
+      { sessionId: 'full-session', modeId: 'bypassPermissions' }
+    ])
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'continue' })
+
+    expect(fakeAgent.actions).toEqual(['mode:bypassPermissions', 'prompt:continue'])
+  })
+
+  it('reports conservative Auto when the Agent has no native auto mode', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['auto-session'], {
+      modes: createModes(['default', 'bypassPermissions'])
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'auto' })
+
+    expect(fakeAgent.modeChanges).toEqual([])
+    expect(runtime.getSnapshot().permissionProfiles[session.sessionId]).toMatchObject({
+      selectedProfile: 'auto',
+      currentModeId: 'default',
+      autoReviewStrategy: 'conservative'
+    })
+  })
+
+  it('rejects Full access when native bypass is not advertised', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['full-session'], { modes: createModes(['default']) })
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await expect(
+      runtime.createSession({ cwd: '/workspace', permissionProfile: 'full' })
+    ).rejects.toThrow('Full access is not available')
+    expect(runtime.getSnapshot().sessionIds).toEqual([])
+  })
+
   it('creates protocol sessions and routes prompts by session id', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['remote-session-1', 'remote-session-2'])

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -7,6 +7,7 @@ import type {
   PromptResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
+  SessionModeState,
   SessionNotification
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
@@ -26,8 +27,15 @@ import type {
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
+  AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
+import {
+  DEFAULT_PERMISSION_PROFILE,
+  normalizePermissionProfile,
+  type PermissionProfileId,
+  type SessionPermissionProfileState
+} from '../../shared/permission-profiles'
 import { spawnClaudeAgentAcp, type SpawnClaudeAgentAcpOptions } from './agent-process'
 import { createLogger } from '../logger'
 import {
@@ -37,6 +45,10 @@ import {
 } from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { AcpPermissionBroker } from './permission-broker'
+import {
+  applyCurrentModeUpdate,
+  resolvePermissionProfileApplication
+} from './permission-profile-controller'
 import { createArtifactMcpServerConfig } from '../artifacts/mcp-server'
 import { ArtifactRepository, getArtifactCurrentRunFilePath } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
@@ -113,7 +125,7 @@ type AcpRuntimeNotebookOptions = {
 
 type SessionAttachmentResponse = {
   sessionId: string
-  modes?: unknown
+  modes?: SessionModeState | null
   configOptions?: unknown
   _meta?: unknown
 }
@@ -191,6 +203,7 @@ class AcpRuntime {
   // Per-session artifact/notebook storage project; keeps run activation and claims in the same subtree.
   private readonly sessionProjectNames = new Map<string, string>()
   private readonly promptInFlightSessionIds = new Set<string>()
+  private readonly permissionProfiles = new Map<string, SessionPermissionProfileState>()
   // A provider change requested while a prompt was running, applied when the session next goes idle.
   private pendingProviderReconnect = false
   private pendingSkillsReload = false
@@ -256,9 +269,38 @@ class AcpRuntime {
       error: this.error,
       events: [...this.events],
       pendingPermissions: this.permissionBroker.getPendingRequests(),
+      permissionProfiles: Object.fromEntries(this.permissionProfiles),
       promptInFlight: promptInFlightSessionIds.length > 0,
       promptInFlightSessionIds
     }
+  }
+
+  // Resolves an application profile against per-session ACP capabilities and applies the real Agent
+  // mode before any prompt is sent. The selected/effective projection is then shared with the UI and
+  // the conservative fallback reviewer.
+  private async configurePermissionProfile(
+    appSessionId: string,
+    session: ActiveSession,
+    profile: PermissionProfileId
+  ): Promise<void> {
+    const application = resolvePermissionProfileApplication(profile, session.modes)
+
+    if (application.modeId && application.modeId !== session.modes?.currentModeId) {
+      if (!this.connection) throw new Error('ACP connection is not available.')
+
+      await this.connection.agent.request(acp.methods.agent.session.setMode, {
+        sessionId: session.sessionId,
+        modeId: application.modeId
+      })
+    }
+
+    this.permissionProfiles.set(appSessionId, application.state)
+    log.info('permission profile applied', {
+      sessionId: appSessionId,
+      selectedProfile: profile,
+      effectiveMode: application.state.currentModeId,
+      autoReviewStrategy: application.state.autoReviewStrategy
+    })
   }
 
   // Starts a fresh agent process connection and initializes protocol capabilities.
@@ -393,6 +435,17 @@ class AcpRuntime {
       })
       .start()
 
+    try {
+      await this.configurePermissionProfile(
+        session.sessionId,
+        session,
+        normalizePermissionProfile(request.permissionProfile)
+      )
+    } catch (error) {
+      session.dispose()
+      throw error
+    }
+
     this.sessions.set(session.sessionId, session)
     this.sessionCwds.set(session.sessionId, sessionCwd)
     this.sessionProjectNames.set(session.sessionId, projectName)
@@ -441,7 +494,18 @@ class AcpRuntime {
     const projectName = this.normalizeProjectName(request.projectName)
 
     // If the runtime already attached this session, only refresh routing metadata.
-    if (this.sessions.has(request.sessionId)) {
+    const attachedSession = this.sessions.get(request.sessionId)
+
+    if (attachedSession) {
+      await this.configurePermissionProfile(
+        request.sessionId,
+        attachedSession,
+        normalizePermissionProfile(
+          request.permissionProfile ??
+            this.permissionProfiles.get(request.sessionId)?.selectedProfile ??
+            DEFAULT_PERMISSION_PROFILE
+        )
+      )
       this.currentSessionId = request.sessionId
       this.cwd = sessionCwd
       this.sessionCwds.set(request.sessionId, sessionCwd)
@@ -494,6 +558,17 @@ class AcpRuntime {
         })
         .start()
 
+      try {
+        await this.configurePermissionProfile(
+          request.sessionId,
+          adopted,
+          normalizePermissionProfile(request.permissionProfile)
+        )
+      } catch (error) {
+        adopted.dispose()
+        throw error
+      }
+
       this.adoptSession(request.sessionId, adopted, sessionCwd, projectName)
       this.emitState()
 
@@ -505,6 +580,17 @@ class AcpRuntime {
       sessionId: request.sessionId,
       ...resumeResponse
     })
+
+    try {
+      await this.configurePermissionProfile(
+        request.sessionId,
+        session,
+        normalizePermissionProfile(request.permissionProfile)
+      )
+    } catch (error) {
+      session.dispose()
+      throw error
+    }
 
     this.sessions.set(request.sessionId, session)
     this.sessionCwds.set(request.sessionId, sessionCwd)
@@ -522,6 +608,25 @@ class AcpRuntime {
     this.emitState()
 
     return { sessionId: request.sessionId, cwd: sessionCwd }
+  }
+
+  // Changes approval behavior only while the conversation is idle. Applying the ACP mode before the
+  // next prompt guarantees Full access cannot show a first-tool permission race.
+  async setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<AcpStateSnapshot> {
+    const session = this.sessions.get(request.sessionId)
+
+    if (!session) throw new Error(`ACP session not found: ${request.sessionId}`)
+    if (this.promptInFlightSessionIds.has(request.sessionId)) {
+      throw new Error('Permission profile cannot be changed while the Agent is running.')
+    }
+    if (this.permissionBroker.hasPendingForSession(request.sessionId)) {
+      throw new Error('Resolve the pending permission request before changing profiles.')
+    }
+
+    await this.configurePermissionProfile(request.sessionId, session, request.profile)
+    this.emitState()
+
+    return this.getSnapshot()
   }
 
   // Tears down every local session route and closes the underlying agent process.
@@ -587,6 +692,7 @@ class AcpRuntime {
     this.sessions.clear()
     this.sessionCwds.clear()
     this.sessionProjectNames.clear()
+    this.permissionProfiles.clear()
     this.artifactSessionIds.clear()
     this.agentToAppSessionId.clear()
     this.currentSessionId = undefined
@@ -667,10 +773,18 @@ class AcpRuntime {
         // Capture routing before the disconnect clears it, so the resume lands on the same conversation.
         const sessionCwd = this.sessionCwds.get(request.sessionId) ?? this.cwd
         const projectName = this.resolveSessionProjectName(request.sessionId)
+        const permissionProfile =
+          this.permissionProfiles.get(request.sessionId)?.selectedProfile ??
+          DEFAULT_PERMISSION_PROFILE
         this.skillsHooks.setTurnForced(forced)
         didForceReload = true
         await this.disconnect(false)
-        await this.resumeSession({ sessionId: request.sessionId, cwd: sessionCwd, projectName })
+        await this.resumeSession({
+          sessionId: request.sessionId,
+          cwd: sessionCwd,
+          projectName,
+          permissionProfile
+        })
 
         const reloaded = this.sessions.get(request.sessionId)
         if (!reloaded) {
@@ -830,6 +944,7 @@ class AcpRuntime {
       this.sessions.delete(request.sessionId)
       this.sessionCwds.delete(request.sessionId)
       this.sessionProjectNames.delete(request.sessionId)
+      this.permissionProfiles.delete(request.sessionId)
       this.artifactSessionIds.delete(request.sessionId)
       this.promptInFlightSessionIds.delete(request.sessionId)
       this.currentSessionId =
@@ -1322,11 +1437,22 @@ class AcpRuntime {
     })
 
     try {
-      if (!this.sessions.has(params.sessionId)) {
-        throw new Error(`Unknown ACP session: ${params.sessionId}`)
+      const appSessionId = this.agentToAppSessionId.get(params.sessionId) ?? params.sessionId
+
+      if (!this.sessions.has(appSessionId)) {
+        throw new Error(`Unknown ACP session: ${appSessionId}`)
       }
 
-      return await this.permissionBroker.requestPermission(params)
+      const profileState = this.permissionProfiles.get(appSessionId)
+
+      return await this.permissionBroker.requestPermission(
+        appSessionId === params.sessionId ? params : { ...params, sessionId: appSessionId },
+        {
+          profile: profileState?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE,
+          autoReviewStrategy: profileState?.autoReviewStrategy,
+          cwd: this.sessionCwds.get(appSessionId)
+        }
+      )
     } catch (error) {
       log.error('permission request failed', {
         message: errorMessage(error),
@@ -1346,6 +1472,19 @@ class AcpRuntime {
       appSessionId && appSessionId !== notification.sessionId
         ? { ...notification, sessionId: appSessionId }
         : notification
+
+    if (routed.update.sessionUpdate === 'current_mode_update') {
+      const profileState = this.permissionProfiles.get(routed.sessionId)
+
+      if (profileState) {
+        this.permissionProfiles.set(
+          routed.sessionId,
+          applyCurrentModeUpdate(profileState, routed.update.currentModeId)
+        )
+        this.emitState()
+      }
+    }
+
     const event = toAcpRuntimeEvent(routed, this.nextEventId())
 
     // Tool results (e.g. WebFetch's claude.ai domain-safety preflight, a failed Bash command) stream as

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -9,6 +9,7 @@ import type {
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
+  AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../shared/acp'
 import type {
@@ -125,6 +126,7 @@ interface OpenScienceAPI {
     cancel(request: AcpCancelPromptRequest): Promise<AcpStateSnapshot>
     deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot>
     respondToPermission(response: AcpPermissionResponse): Promise<AcpStateSnapshot>
+    setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<AcpStateSnapshot>
     onState(listener: AcpListener<AcpStateSnapshot>): RemoveListener
     onEvent(listener: AcpListener<AcpRuntimeEvent>): RemoveListener
     onPermissionRequest(listener: AcpListener<AcpPermissionRequest>): RemoveListener

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,7 @@ import type {
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
+  AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../shared/acp'
 import type {
@@ -140,6 +141,7 @@ type OpenScienceAPI = {
     cancel: (request: AcpCancelPromptRequest) => Promise<AcpStateSnapshot>
     deleteSession: (request: AcpDeleteSessionRequest) => Promise<AcpStateSnapshot>
     respondToPermission: (response: AcpPermissionResponse) => Promise<AcpStateSnapshot>
+    setPermissionProfile: (request: AcpSetPermissionProfileRequest) => Promise<AcpStateSnapshot>
     onState: (listener: AcpListener<AcpStateSnapshot>) => RemoveListener
     onEvent: (listener: AcpListener<AcpRuntimeEvent>) => RemoveListener
     onPermissionRequest: (listener: AcpListener<AcpPermissionRequest>) => RemoveListener
@@ -290,6 +292,8 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('acp:delete-session', request) as Promise<AcpStateSnapshot>,
     respondToPermission: (response) =>
       ipcRenderer.invoke('acp:respond-permission', response) as Promise<AcpStateSnapshot>,
+    setPermissionProfile: (request) =>
+      ipcRenderer.invoke('acp:set-permission-profile', request) as Promise<AcpStateSnapshot>,
     onState: (listener) => onIpcMessage('acp:state', listener),
     onEvent: (listener) => onIpcMessage('acp:event', listener),
     onPermissionRequest: (listener) => onIpcMessage('acp:permission-request', listener)

--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -45,6 +45,7 @@ const createSnapshot = (overrides: Partial<AcpStateSnapshot> = {}): AcpStateSnap
   sessionIds: [],
   events: [],
   pendingPermissions: [],
+  permissionProfiles: {},
   promptInFlight: false,
   promptInFlightSessionIds: [],
   ...overrides

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -3,8 +3,10 @@ import type {
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
+  AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../../../shared/acp'
+import type { PermissionProfileId } from '../../../../shared/permission-profiles'
 import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react'
 
 // Provides a stable renderer fallback before the first main-process snapshot arrives.
@@ -14,6 +16,7 @@ const emptyAcpState: AcpStateSnapshot = {
   sessionIds: [],
   events: [],
   pendingPermissions: [],
+  permissionProfiles: {},
   promptInFlight: false,
   promptInFlightSessionIds: []
 }
@@ -36,11 +39,16 @@ const useAcpRuntime = (): {
   isDisconnecting: boolean
   connect: (cwd?: string) => Promise<AcpStateSnapshot | undefined>
   disconnect: () => Promise<AcpStateSnapshot | undefined>
-  createSession: (cwd?: string, projectName?: string) => Promise<AcpCreateSessionResponse>
+  createSession: (
+    cwd?: string,
+    projectName?: string,
+    permissionProfile?: PermissionProfileId
+  ) => Promise<AcpCreateSessionResponse>
   resumeSession: (
     sessionId: AcpResumeSessionRequest['sessionId'],
     cwd: AcpResumeSessionRequest['cwd'],
-    projectName?: string
+    projectName?: string,
+    permissionProfile?: PermissionProfileId
   ) => Promise<AcpCreateSessionResponse>
   deleteSession: (sessionId: string) => Promise<AcpStateSnapshot | undefined>
   cancel: (sessionId: string) => Promise<AcpStateSnapshot | undefined>
@@ -53,6 +61,10 @@ const useAcpRuntime = (): {
   respondToPermission: (
     requestId: string,
     optionId?: string
+  ) => Promise<AcpStateSnapshot | undefined>
+  setPermissionProfile: (
+    sessionId: string,
+    profile: PermissionProfileId
   ) => Promise<AcpStateSnapshot | undefined>
 } => {
   const [state, setState] = useState<AcpStateSnapshot>(emptyAcpState)
@@ -154,8 +166,10 @@ const useAcpRuntime = (): {
 
   // Creates a protocol session and returns the runtime-provided id.
   const createSession = useCallback(
-    (cwd?: string, projectName?: string) =>
-      runValueAction(setIsConnecting, () => window.api.acp.createSession({ cwd, projectName })),
+    (cwd?: string, projectName?: string, permissionProfile?: PermissionProfileId) =>
+      runValueAction(setIsConnecting, () =>
+        window.api.acp.createSession({ cwd, projectName, permissionProfile })
+      ),
     [runValueAction]
   )
 
@@ -164,10 +178,11 @@ const useAcpRuntime = (): {
     (
       sessionId: AcpResumeSessionRequest['sessionId'],
       cwd: AcpResumeSessionRequest['cwd'],
-      projectName?: string
+      projectName?: string,
+      permissionProfile?: PermissionProfileId
     ) =>
       runValueAction(setIsConnecting, () =>
-        window.api.acp.resumeSession({ sessionId, cwd, projectName })
+        window.api.acp.resumeSession({ sessionId, cwd, projectName, permissionProfile })
       ),
     [runValueAction]
   )
@@ -219,6 +234,15 @@ const useAcpRuntime = (): {
     [runSnapshotAction]
   )
 
+  const setPermissionProfile = useCallback(
+    (sessionId: string, profile: PermissionProfileId) => {
+      const request: AcpSetPermissionProfileRequest = { sessionId, profile }
+
+      return runSnapshotAction(undefined, () => window.api.acp.setPermissionProfile(request))
+    },
+    [runSnapshotAction]
+  )
+
   return {
     state,
     actionError,
@@ -231,7 +255,8 @@ const useAcpRuntime = (): {
     deleteSession,
     cancel,
     sendPrompt,
-    respondToPermission
+    respondToPermission,
+    setPermissionProfile
   }
 }
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -24,6 +24,7 @@ const createSnapshot = (sessionIds: string[] = []): AcpStateSnapshot => ({
   sessionIds,
   events: [],
   pendingPermissions: [],
+  permissionProfiles: {},
   promptInFlight: false,
   promptInFlightSessionIds: []
 })
@@ -216,7 +217,7 @@ describe('workspace agent message sending', () => {
       cwd: '/workspace/project'
     })
 
-    expect(runtime.createSession).toHaveBeenCalledWith('/workspace/project', undefined)
+    expect(runtime.createSession).toHaveBeenCalledWith('/workspace/project', undefined, 'ask')
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       id: sent?.sessionId,

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef } from 'react'
 
 import type { AcpPermissionRequest, AcpRuntimeEvent } from '../../../../shared/acp'
+import {
+  DEFAULT_PERMISSION_PROFILE,
+  type PermissionProfileId,
+  type SessionPermissionProfileState
+} from '../../../../shared/permission-profiles'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import { useSessionStore } from '../../stores/session-store'
 import { useAcpRuntime } from './useAcpRuntime'
@@ -15,6 +20,7 @@ type SendWorkspaceMessageInput = {
   projectId?: string
   // Storage project the artifact/notebook MCP servers write under (usually the same value).
   projectName?: string
+  permissionProfile?: PermissionProfileId
   // Skills the user picked in the composer; force-loaded and nudged for this turn only.
   forcedSkillIds?: string[]
 }
@@ -164,10 +170,19 @@ const startPendingSessionPrompt = (
   attachments: UploadedAttachment[],
   cwd: string | undefined,
   projectName: string | undefined,
+  permissionProfile: PermissionProfileId,
   forcedSkillIds: string[] | undefined
 ): void => {
   void (async () => {
-    const createdSession = await runtime.createSession(cwd, projectName).catch(() => undefined)
+    let createdSession
+
+    try {
+      createdSession = await runtime.createSession(cwd, projectName, permissionProfile)
+    } catch (error) {
+      useSessionStore.getState().failRun(pending.sessionId, getErrorMessage(error))
+      return
+    }
+
     const runtimeSessionId = createdSession?.sessionId
 
     if (!runtimeSessionId) {
@@ -224,6 +239,7 @@ const sendWorkspaceMessage = async (
     cwd,
     projectId,
     projectName,
+    permissionProfile,
     forcedSkillIds
   }: SendWorkspaceMessageInput
 ): Promise<SendWorkspaceMessageResult | undefined> => {
@@ -266,6 +282,7 @@ const sendWorkspaceMessage = async (
         attachments,
         retryCwd,
         sessionProjectName,
+        currentSession.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
         forcedSkillIds
       )
       return appended
@@ -299,7 +316,12 @@ const sendWorkspaceMessage = async (
     // Persisted sessions are marked running locally before async resume closes duplicate submits.
     if (resumeCwd) {
       try {
-        await runtime.resumeSession(targetSessionId, resumeCwd, sessionProjectName)
+        await runtime.resumeSession(
+          targetSessionId,
+          resumeCwd,
+          sessionProjectName,
+          currentSession?.permissionProfile ?? permissionProfile
+        )
       } catch (error) {
         useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
         return appended
@@ -343,7 +365,8 @@ const sendWorkspaceMessage = async (
     content,
     attachments,
     cwd: targetCwd ?? runtime.state.cwd,
-    projectId
+    projectId,
+    permissionProfile
   })
 
   if (!pending) return undefined
@@ -356,6 +379,7 @@ const sendWorkspaceMessage = async (
     attachments,
     targetCwd ?? runtime.state.cwd,
     projectName,
+    permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
     forcedSkillIds
   )
 
@@ -367,10 +391,12 @@ const useWorkspaceAgentRuntime = (): {
   actionError: string | null
   isConnecting: boolean
   pendingPermissions: AcpPermissionRequest[]
+  permissionProfiles: Record<string, SessionPermissionProfileState>
   sendMessage: (input: SendWorkspaceMessageInput) => Promise<SendWorkspaceMessageResult | undefined>
   cancelRun: (sessionId: string) => Promise<void>
   deleteRuntimeSession: (sessionId: string) => Promise<void>
   respondToPermission: (requestId: string, optionId?: string) => Promise<void>
+  setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => Promise<boolean>
 } => {
   const runtime = useAcpRuntime()
   const eventProcessor = useRef(createWorkspaceRuntimeEventProcessor())
@@ -435,14 +461,32 @@ const useWorkspaceAgentRuntime = (): {
     [runtime]
   )
 
+  // Applies attached-session mode changes before persisting the selection. Detached sessions store
+  // the preference now and reapply it during resume before their next prompt.
+  const setPermissionProfile = useCallback(
+    async (sessionId: string, profile: PermissionProfileId): Promise<boolean> => {
+      if (runtime.state.sessionIds.includes(sessionId)) {
+        const snapshot = await runtime.setPermissionProfile(sessionId, profile)
+
+        if (!snapshot) return false
+      }
+
+      useSessionStore.getState().setPermissionProfile(sessionId, profile)
+      return true
+    },
+    [runtime]
+  )
+
   return {
     actionError: runtime.actionError,
     isConnecting: runtime.isConnecting,
     pendingPermissions: runtime.state.pendingPermissions,
+    permissionProfiles: runtime.state.permissionProfiles,
     sendMessage,
     cancelRun,
     deleteRuntimeSession,
-    respondToPermission
+    respondToPermission,
+    setPermissionProfile
   }
 }
 

--- a/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.interaction.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { act, type PropsWithChildren } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ComposerPermissionProfilePicker } from './ComposerPermissionProfilePicker'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: PropsWithChildren): React.JSX.Element => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: PropsWithChildren): React.JSX.Element => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: PropsWithChildren): React.JSX.Element => <>{children}</>,
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onSelect
+  }: PropsWithChildren<{ disabled?: boolean; onSelect?: () => void }>): React.JSX.Element => (
+    <button type="button" disabled={disabled} onClick={onSelect}>
+      {children}
+    </button>
+  )
+}))
+
+vi.mock('radix-ui', () => ({
+  AlertDialog: {
+    Root: ({ open, children }: PropsWithChildren<{ open?: boolean }>): React.JSX.Element | null =>
+      open ? <div>{children}</div> : null,
+    Portal: ({ children }: PropsWithChildren): React.JSX.Element => <>{children}</>,
+    Overlay: (): React.JSX.Element => <div />,
+    Content: ({ children }: PropsWithChildren): React.JSX.Element => <div>{children}</div>,
+    Title: ({ children }: PropsWithChildren): React.JSX.Element => <h2>{children}</h2>,
+    Description: ({ children }: PropsWithChildren): React.JSX.Element => <p>{children}</p>,
+    Cancel: ({ children }: PropsWithChildren): React.JSX.Element => <>{children}</>,
+    Action: ({ children }: PropsWithChildren): React.JSX.Element => <>{children}</>
+  }
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const findButton = (label: string): HTMLButtonElement => {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent?.trim() === label
+  )
+
+  if (!button) throw new Error(`button not found: ${label}`)
+
+  return button
+}
+
+describe('ComposerPermissionProfilePicker', () => {
+  it('changes Ask and Auto directly without a risk dialog', () => {
+    const onChange = vi.fn()
+
+    act(() => {
+      root.render(
+        <ComposerPermissionProfilePicker value="ask" onChange={onChange} disabled={false} />
+      )
+    })
+    act(() => findButton('Approve for meAutomatically approve only low-risk operations.').click())
+
+    expect(onChange).toHaveBeenCalledWith('auto')
+    expect(container.textContent).not.toContain('Enable Full access?')
+  })
+
+  it('requires explicit confirmation before enabling Full access', () => {
+    const onChange = vi.fn()
+
+    act(() => {
+      root.render(<ComposerPermissionProfilePicker value="ask" onChange={onChange} />)
+    })
+    act(() => findButton('Full accessRun without approval prompts in this conversation.').click())
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('Enable Full access?')
+
+    act(() => findButton('Enable Full access').click())
+    expect(onChange).toHaveBeenCalledWith('full')
+  })
+
+  it('disables Full access when the attached Agent does not advertise bypass mode', () => {
+    act(() => {
+      root.render(
+        <ComposerPermissionProfilePicker
+          value="ask"
+          state={{
+            selectedProfile: 'ask',
+            effectiveProfile: 'ask',
+            currentModeId: 'default',
+            availableModeIds: ['default'],
+            fullAccessAvailable: false
+          }}
+          onChange={vi.fn()}
+        />
+      )
+    })
+
+    expect(
+      findButton('Full accessThe current agent does not support native bypass mode.').disabled
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.tsx
@@ -1,0 +1,171 @@
+import type {
+  PermissionProfileId,
+  SessionPermissionProfileState
+} from '../../../../shared/permission-profiles'
+import { AlertTriangle, Check, ChevronUp, Shield, ShieldCheck, Zap } from 'lucide-react'
+import { useState } from 'react'
+import { AlertDialog } from 'radix-ui'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+
+type ComposerPermissionProfilePickerProps = {
+  value: PermissionProfileId
+  state?: SessionPermissionProfileState
+  disabled?: boolean
+  onChange: (profile: PermissionProfileId) => void
+}
+
+const permissionProfiles: Array<{
+  id: PermissionProfileId
+  label: string
+  description: string
+  icon: typeof Shield
+}> = [
+  {
+    id: 'ask',
+    label: 'Ask for approval',
+    description: 'Ask before risky commands, file changes, or network access.',
+    icon: Shield
+  },
+  {
+    id: 'auto',
+    label: 'Approve for me',
+    description: 'Automatically approve only low-risk operations.',
+    icon: ShieldCheck
+  },
+  {
+    id: 'full',
+    label: 'Full access',
+    description: 'Run without approval prompts in this conversation.',
+    icon: Zap
+  }
+]
+
+const ComposerPermissionProfilePicker = ({
+  value,
+  state,
+  disabled = false,
+  onChange
+}: ComposerPermissionProfilePickerProps): React.JSX.Element => {
+  const [confirmFullAccess, setConfirmFullAccess] = useState(false)
+  const selectedProfile = permissionProfiles.find((profile) => profile.id === value)!
+  const SelectedIcon = selectedProfile.icon
+  const fullAccessUnavailable = state?.fullAccessAvailable === false
+
+  const selectProfile = (profile: PermissionProfileId): void => {
+    if (profile === value) return
+
+    if (profile === 'full') {
+      setConfirmFullAccess(true)
+      return
+    }
+
+    onChange(profile)
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild disabled={disabled}>
+          <button
+            type="button"
+            className="flex h-8 min-w-0 items-center gap-1.5 rounded-md px-2 text-[12px] text-text-100 transition-colors duration-200 ease-out hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label={`Permission mode: ${selectedProfile.label}`}
+          >
+            <SelectedIcon className="size-3.5 shrink-0" strokeWidth={2} aria-hidden="true" />
+            <span className="max-w-32 truncate">{selectedProfile.label}</span>
+            <ChevronUp className="size-3 shrink-0" strokeWidth={2} aria-hidden="true" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-80 p-1.5">
+          {permissionProfiles.map((profile) => {
+            const ProfileIcon = profile.icon
+            const isSelected = profile.id === value
+            const isDisabled = profile.id === 'full' && fullAccessUnavailable
+
+            return (
+              <DropdownMenuItem
+                key={profile.id}
+                disabled={isDisabled}
+                className="items-start gap-2.5 px-2.5 py-2"
+                onSelect={() => selectProfile(profile.id)}
+              >
+                <ProfileIcon
+                  className="mt-0.5 size-4 shrink-0 text-text-200"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[13px] font-medium leading-5">{profile.label}</span>
+                  <span className="block text-[11px] leading-4 text-text-300">
+                    {isDisabled
+                      ? 'The current agent does not support native bypass mode.'
+                      : profile.description}
+                  </span>
+                </span>
+                {isSelected ? (
+                  <Check className="mt-0.5 size-4 shrink-0" strokeWidth={2} aria-hidden="true" />
+                ) : null}
+              </DropdownMenuItem>
+            )
+          })}
+          {value === 'auto' && state?.autoReviewStrategy === 'conservative' ? (
+            <div className="mx-1 mt-1 rounded-md bg-bg-200 px-2 py-1.5 text-[11px] leading-4 text-text-200">
+              This agent has no native auto mode. Only structured reads, searches, and workspace
+              edits are approved automatically.
+            </div>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog.Root open={confirmFullAccess} onOpenChange={setConfirmFullAccess}>
+        <AlertDialog.Portal>
+          <AlertDialog.Overlay className="fixed inset-0 z-50 bg-black/25 backdrop-blur-[2px]" />
+          <AlertDialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(440px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-bg-000 p-6 text-text-000 shadow-dialog">
+            <div className="flex items-start gap-3">
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700">
+                <AlertTriangle className="size-5" strokeWidth={2} aria-hidden="true" />
+              </span>
+              <div className="min-w-0">
+                <AlertDialog.Title className="text-base font-semibold">
+                  Enable Full access?
+                </AlertDialog.Title>
+                <AlertDialog.Description className="mt-2 text-sm leading-relaxed text-text-100">
+                  The agent can run commands, change files, execute notebook code, and make network
+                  requests without asking first. Authentication failures and execution errors can
+                  still stop the run.
+                </AlertDialog.Description>
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+              <AlertDialog.Cancel asChild>
+                <button
+                  type="button"
+                  className="rounded-lg border border-border-200 px-3 py-2 text-sm hover:bg-bg-200"
+                >
+                  Cancel
+                </button>
+              </AlertDialog.Cancel>
+              <AlertDialog.Action asChild>
+                <button
+                  type="button"
+                  className="rounded-lg bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-700"
+                  onClick={() => onChange('full')}
+                >
+                  Enable Full access
+                </button>
+              </AlertDialog.Action>
+            </div>
+          </AlertDialog.Content>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+    </>
+  )
+}
+
+export { ComposerPermissionProfilePicker }

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -50,6 +50,9 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         isUploadingAttachments={false}
         notebookReference={undefined}
         pendingPermissions={[]}
+        permissionProfile="ask"
+        permissionProfileState={undefined}
+        canChangePermissionProfile
         onDraftDocChange={vi.fn()}
         onSendMessage={vi.fn()}
         onStageAttachmentFiles={onStageAttachmentFiles}
@@ -58,6 +61,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         onOpenNotebook={vi.fn()}
         onTogglePreviewPanel={vi.fn()}
         onRespondToPermission={vi.fn()}
+        onPermissionProfileChange={vi.fn()}
         {...props}
       />
     )

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1,5 +1,9 @@
 import type { AcpPermissionRequest } from '../../../../shared/acp'
 import type { NotebookSessionReference } from '../../../../shared/notebook'
+import type {
+  PermissionProfileId,
+  SessionPermissionProfileState
+} from '../../../../shared/permission-profiles'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import {
   ArrowUp,
@@ -22,6 +26,7 @@ import type { ChatSession } from '@/stores/session-store'
 import { ComposerEditor } from './composer/ComposerEditor'
 import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
 import { ComposerModelPicker } from './ComposerModelPicker'
+import { ComposerPermissionProfilePicker } from './ComposerPermissionProfilePicker'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
 import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'
 
@@ -71,6 +76,9 @@ type ConversationPanelProps = {
   isUploadingAttachments: boolean
   notebookReference: NotebookSessionReference | undefined
   pendingPermissions: AcpPermissionRequest[]
+  permissionProfile: PermissionProfileId
+  permissionProfileState: SessionPermissionProfileState | undefined
+  canChangePermissionProfile: boolean
   onDraftDocChange: (doc: ComposerDoc) => void
   onSendMessage: (forcedSkillIds: string[]) => void
   onStageAttachmentFiles: (files: File[]) => void
@@ -79,6 +87,7 @@ type ConversationPanelProps = {
   onOpenNotebook: (notebook: NotebookSessionReference) => void
   onTogglePreviewPanel: () => void
   onRespondToPermission: (requestId: string, optionId?: string) => void
+  onPermissionProfileChange: (profile: PermissionProfileId) => void
 }
 
 // Middle chat surface owns the visible conversation and local message composer UI.
@@ -93,6 +102,9 @@ const ConversationPanel = ({
   isUploadingAttachments,
   notebookReference,
   pendingPermissions,
+  permissionProfile,
+  permissionProfileState,
+  canChangePermissionProfile,
   onDraftDocChange,
   onSendMessage,
   onStageAttachmentFiles,
@@ -100,7 +112,8 @@ const ConversationPanel = ({
   onCancelRun,
   onOpenNotebook,
   onTogglePreviewPanel,
-  onRespondToPermission
+  onRespondToPermission,
+  onPermissionProfileChange
 }: ConversationPanelProps): React.JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -293,6 +306,13 @@ const ConversationPanel = ({
                           className="hidden"
                           tabIndex={-1}
                           onChange={handleAttachmentInputChange}
+                        />
+
+                        <ComposerPermissionProfilePicker
+                          value={permissionProfile}
+                          state={permissionProfileState}
+                          disabled={!canChangePermissionProfile}
+                          onChange={onPermissionProfileChange}
                         />
 
                         <div className="flex-1" />

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -89,6 +89,35 @@ const PermissionCommandBlock = ({ command }: { command: string }): React.JSX.Ele
   )
 }
 
+const getPermissionRiskLabel = (request: AcpPermissionRequest): string => {
+  if (request.providerToolName === 'notebook_execute') return 'Notebook execution'
+
+  switch (request.toolKind) {
+    case 'execute':
+      return 'Command execution'
+    case 'edit':
+    case 'delete':
+    case 'move':
+      return 'File change'
+    case 'fetch':
+      return 'Network access'
+    case 'read':
+    case 'search':
+      return 'File access'
+    default:
+      return 'Tool access'
+  }
+}
+
+const getNotebookCode = (request: AcpPermissionRequest): string | undefined => {
+  if (request.providerToolName !== 'notebook_execute') return undefined
+  if (!request.rawInput || typeof request.rawInput !== 'object') return undefined
+
+  const code = (request.rawInput as Record<string, unknown>).code
+
+  return typeof code === 'string' && code.trim() ? code : undefined
+}
+
 const PermissionApprovalControls = ({
   requests,
   onRespond
@@ -99,10 +128,21 @@ const PermissionApprovalControls = ({
 
   if (!request) return null
 
+  const notebookCode = getNotebookCode(request)
+
   return (
     <div className="mb-2 w-full max-w-full space-y-2 overflow-hidden rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] leading-5 text-amber-900">
       <div className="flex min-w-0 flex-col items-stretch gap-2 overflow-hidden">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="font-semibold">{getPermissionRiskLabel(request)}</span>
+          {request.toolLocations?.length ? (
+            <span className="min-w-0 truncate text-[11px] text-amber-800">
+              {request.toolLocations.map((location) => location.path).join(', ')}
+            </span>
+          ) : null}
+        </div>
         <PermissionCommandBlock command={request.title} />
+        {notebookCode ? <PermissionCommandBlock command={notebookCode} /> : null}
         <span className="flex flex-wrap items-center justify-end gap-1 w-full overflow-hidden">
           {getOrderedPermissionOptions(request.options).map((option) => {
             const actionKind = getPermissionActionKind(option)

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -3,6 +3,10 @@ import { animate } from 'motion'
 import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
 
 import type { NotebookSessionReference } from '../../../../shared/notebook'
+import {
+  DEFAULT_PERMISSION_PROFILE,
+  type PermissionProfileId
+} from '../../../../shared/permission-profiles'
 import { ResizableHandle, ResizablePanelGroup } from '@/components/ui/resizable'
 import { useWorkspaceAgentRuntime } from '@/lib/acp/useWorkspaceAgentRuntime'
 import { usePreviewPersistence } from '@/lib/preview-persistence/preview-persistence'
@@ -128,12 +132,16 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const {
     actionError,
     pendingPermissions,
+    permissionProfiles,
     sendMessage,
     cancelRun,
     deleteRuntimeSession,
-    respondToPermission
+    respondToPermission,
+    setPermissionProfile
   } = useWorkspaceAgentRuntime()
   const [draftDoc, setDraftDoc] = useState<ComposerDoc>(emptyDoc)
+  const [newConversationPermissionProfile, setNewConversationPermissionProfile] =
+    useState<PermissionProfileId>(DEFAULT_PERMISSION_PROFILE)
   // Unsent composer state (rich doc + staged attachments) is kept per session (and per new conversation)
   // so switching away and back restores it. The active key's state is live; this map holds inactive keys.
   const composerDraftsRef = useRef<
@@ -159,6 +167,11 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     [activeSession?.id, pendingPermissions]
   )
   const activeNotebookReference = activeSession ? notebookReferences[activeSession.id] : undefined
+  const activePermissionProfile =
+    activeSession?.permissionProfile ?? newConversationPermissionProfile
+  const activePermissionProfileState = activeSession
+    ? permissionProfiles?.[activeSession.id]
+    : undefined
   // Composer controls follow only the selected session and persistence readiness.
   const canEditDraft = isSessionPersistenceReady
   // Sending is disabled while the current session is running or awaiting a decision.
@@ -166,6 +179,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     isSessionPersistenceReady &&
     !isUploadingAttachments &&
     (!docIsEmpty(draftDoc) || attachments.length > 0) &&
+    activeSession?.status !== 'running' &&
+    activeSession?.status !== 'waiting-permission'
+  const canChangePermissionProfile =
+    isSessionPersistenceReady &&
     activeSession?.status !== 'running' &&
     activeSession?.status !== 'waiting-permission'
   const visibleActionError = attachmentError ?? (activeSession ? null : actionError)
@@ -374,6 +391,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
 
     // The draft effect saves the outgoing doc/attachments and restores the new-conversation state.
     setAttachmentError(null)
+    setNewConversationPermissionProfile(DEFAULT_PERMISSION_PROFILE)
     clearSelection()
   }
 
@@ -453,6 +471,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
       cwd: activeSession?.cwd,
       projectId: activeSession?.projectId ?? scopedProjectId,
       projectName: activeSession?.projectId ?? scopedProjectId,
+      permissionProfile: activePermissionProfile,
       forcedSkillIds
     }).then((result) => {
       if (!result) {
@@ -519,6 +538,19 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     void respondToPermission(requestId, optionId)
   }
 
+  // Runtime mode is changed before the durable session preference, so a failed capability check
+  // leaves the current selection untouched. New conversations apply their choice during creation.
+  const changePermissionProfile = (profile: PermissionProfileId): void => {
+    if (!canChangePermissionProfile) return
+
+    if (!activeSession) {
+      setNewConversationPermissionProfile(profile)
+      return
+    }
+
+    void setPermissionProfile(activeSession.id, profile)
+  }
+
   // Opens the right preview on demand instead of stealing focus when the agent first uses notebook.
   const openNotebookPreview = (notebook: NotebookSessionReference): void => {
     upsertAndActivatePreviewItem(createNotebookPreviewItem(notebook))
@@ -565,6 +597,9 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             isUploadingAttachments={isUploadingAttachments}
             notebookReference={activeNotebookReference}
             pendingPermissions={visiblePermissionRequests}
+            permissionProfile={activePermissionProfile}
+            permissionProfileState={activePermissionProfileState}
+            canChangePermissionProfile={canChangePermissionProfile}
             onDraftDocChange={setDraftDoc}
             onSendMessage={sendCurrentMessage}
             onStageAttachmentFiles={stageAttachmentFiles}
@@ -573,6 +608,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             onOpenNotebook={openNotebookPreview}
             onTogglePreviewPanel={togglePreviewPanel}
             onRespondToPermission={respondToVisiblePermission}
+            onPermissionProfileChange={changePermissionProfile}
           />
 
           <ResizableHandle

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1095,6 +1095,24 @@ describe('session store', () => {
     expect(persisted).not.toHaveProperty('isPending')
   })
 
+  it('stores and persists the conversation approval profile', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Run this',
+      cwd: '/workspace/project',
+      projectId: 'project-a',
+      permissionProfile: 'auto'
+    })
+
+    expect(useSessionStore.getState().sessions[0].permissionProfile).toBe('auto')
+
+    useSessionStore.getState().setPermissionProfile('transport-session-1', 'full')
+
+    expect(toPersistedSession(useSessionStore.getState().sessions[0]).permissionProfile).toBe(
+      'full'
+    )
+  })
+
   it('marks unbound pending sessions so persistence can skip them', () => {
     useSessionStore.getState().appendPendingUserMessage({
       content: 'Save after ACP creates the session',

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -8,6 +8,10 @@ import type {
 
 import type { ArtifactFile } from '../../../shared/artifacts'
 import {
+  DEFAULT_PERMISSION_PROFILE,
+  type PermissionProfileId
+} from '../../../shared/permission-profiles'
+import {
   sanitizeToolActivity,
   type PersistedActiveRun,
   type PersistedArtifact,
@@ -47,7 +51,11 @@ export type ToolActivity = {
   createdAt: number
   updatedAt: number
 }
-export type ChatSession = Omit<PersistedChatSession, 'messages' | 'activities'> & {
+export type ChatSession = Omit<
+  PersistedChatSession,
+  'messages' | 'activities' | 'permissionProfile'
+> & {
+  permissionProfile?: PermissionProfileId
   messages: ChatMessage[]
   activities?: ToolActivity[]
   isPending?: boolean
@@ -64,6 +72,7 @@ type AppendUserMessageInput = {
   attachments?: PersistedUploadedAttachment[]
   cwd?: string
   projectId?: string
+  permissionProfile?: PermissionProfileId
   isPending?: boolean
 }
 
@@ -72,6 +81,7 @@ type AppendPendingUserMessageInput = {
   attachments?: PersistedUploadedAttachment[]
   cwd?: string
   projectId?: string
+  permissionProfile?: PermissionProfileId
 }
 
 type BindPendingSessionInput = {
@@ -147,6 +157,7 @@ type SessionStore = SessionStoreData & {
   upsertToolActivity: (input: UpsertToolActivityInput) => void
   setPermissionPending: (sessionId: string) => void
   clearPermissionPending: (sessionId: string) => void
+  setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => void
   renameSession: (sessionId: string, title: string) => void
   deleteSession: (sessionId: string) => void
   removeSessionsForProject: (projectId: string) => void
@@ -202,6 +213,7 @@ const hydrateToolActivity = (activity: PersistedToolActivity): ToolActivity => (
 // Maps a persisted session (with bounded activities) back into the in-memory chat session shape.
 const hydrateSession = (session: PersistedChatSession): ChatSession => ({
   ...session,
+  permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
   activities: session.activities?.map(hydrateToolActivity)
 })
 
@@ -431,7 +443,15 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   },
 
   // Appends a user prompt, creating the session if this is its first message.
-  appendUserMessage: ({ sessionId, content, attachments = [], cwd, projectId, isPending }) => {
+  appendUserMessage: ({
+    sessionId,
+    content,
+    attachments = [],
+    cwd,
+    projectId,
+    permissionProfile,
+    isPending
+  }) => {
     const trimmedContent = content.trim()
     const uploads = attachments.map(createPersistedUpload)
 
@@ -472,6 +492,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         title: createTitleFromMessage(trimmedContent || createTitleFromUploads(uploads)),
         cwd: cwd ?? '',
         status: 'running',
+        permissionProfile: permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
         messages: [userMessage],
         activeRun,
         createdAt: now,
@@ -488,13 +509,14 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   },
 
   // Creates a visible local conversation before ACP returns the durable session id.
-  appendPendingUserMessage: ({ content, attachments = [], cwd, projectId }) => {
+  appendPendingUserMessage: ({ content, attachments = [], cwd, projectId, permissionProfile }) => {
     return get().appendUserMessage({
       sessionId: createPendingSessionId(),
       content,
       attachments,
       cwd,
       projectId,
+      permissionProfile,
       isPending: true
     })
   },
@@ -971,6 +993,21 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           ? {
               ...session,
               status: session.activeRun ? 'running' : 'idle',
+              updatedAt: Date.now()
+            }
+          : session
+      )
+    }))
+  },
+
+  // Stores the approval posture with the conversation so resumes and provider switches reapply it.
+  setPermissionProfile: (sessionId, profile) => {
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId
+          ? {
+              ...session,
+              permissionProfile: profile,
               updatedAt: Date.now()
             }
           : session

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -1,6 +1,7 @@
 import type { ToolCallContent, ToolCallLocation, ToolKind } from '@agentclientprotocol/sdk'
 import type { ArtifactFile } from './artifacts'
 import type { UploadedAttachment } from './uploads'
+import type { PermissionProfileId, SessionPermissionProfileState } from './permission-profiles'
 
 export type AcpConnectionStatus = 'idle' | 'connecting' | 'connected' | 'error' | 'closed'
 
@@ -60,6 +61,10 @@ export type AcpPermissionRequest = {
   toolCallId: string
   title: string
   status?: string
+  providerToolName?: string
+  toolKind?: ToolKind
+  toolLocations?: ToolCallLocation[]
+  rawInput?: unknown
   options: AcpPermissionOption[]
   raw: unknown
 }
@@ -72,6 +77,7 @@ export type AcpStateSnapshot = {
   error?: string
   events: AcpRuntimeEvent[]
   pendingPermissions: AcpPermissionRequest[]
+  permissionProfiles: Record<string, SessionPermissionProfileState>
   promptInFlight: boolean
   promptInFlightSessionIds: string[]
 }
@@ -84,6 +90,7 @@ export type AcpCreateSessionRequest = {
   cwd?: string
   // Scopes generated artifacts / notebooks to a project's storage subtree. Defaults per runtime.
   projectName?: string
+  permissionProfile?: PermissionProfileId
 }
 
 export type AcpCreateSessionResponse = {
@@ -95,6 +102,12 @@ export type AcpResumeSessionRequest = {
   sessionId: string
   cwd: string
   projectName?: string
+  permissionProfile?: PermissionProfileId
+}
+
+export type AcpSetPermissionProfileRequest = {
+  sessionId: string
+  profile: PermissionProfileId
 }
 
 export type AcpPromptRequest = {

--- a/src/shared/permission-profiles.ts
+++ b/src/shared/permission-profiles.ts
@@ -1,0 +1,27 @@
+// Provider-neutral approval profiles shown in the composer. These are application semantics rather
+// than Claude-specific mode ids; the ACP runtime maps them onto capabilities advertised per session.
+export const PERMISSION_PROFILE_IDS = ['ask', 'auto', 'full'] as const
+
+export type PermissionProfileId = (typeof PERMISSION_PROFILE_IDS)[number]
+
+export const DEFAULT_PERMISSION_PROFILE: PermissionProfileId = 'ask'
+
+export type PermissionAutoReviewStrategy = 'native' | 'conservative'
+
+// Runtime capability/effective-state projection for one attached session. The selected profile is
+// durable chat state; this projection says how the current Agent can actually enforce it.
+export type SessionPermissionProfileState = {
+  selectedProfile: PermissionProfileId
+  effectiveProfile: PermissionProfileId
+  currentModeId?: string
+  availableModeIds: string[]
+  autoReviewStrategy?: PermissionAutoReviewStrategy
+  fullAccessAvailable: boolean
+  message?: string
+}
+
+export const isPermissionProfileId = (value: unknown): value is PermissionProfileId =>
+  typeof value === 'string' && PERMISSION_PROFILE_IDS.includes(value as PermissionProfileId)
+
+export const normalizePermissionProfile = (value: unknown): PermissionProfileId =>
+  isPermissionProfileId(value) ? value : DEFAULT_PERMISSION_PROFILE

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -6,7 +6,7 @@ import {
   type PersistedChatSession
 } from './session-persistence'
 
-const createSessionWithActivity = (activity: unknown): unknown => ({
+const createSessionWithActivity = (activity: unknown): Record<string, unknown> => ({
   id: 'session-1',
   projectId: 'project-a',
   title: 'Session',
@@ -142,5 +142,22 @@ describe('normalizeSessionFile with activities', () => {
     })
 
     expect(session?.activities).toBeUndefined()
+    expect(session?.permissionProfile).toBe('ask')
+  })
+
+  it('keeps known approval profiles and safely defaults unknown values', () => {
+    const full = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined,
+      permissionProfile: 'full'
+    })
+    const unknown = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined,
+      permissionProfile: 'untrusted-profile'
+    })
+
+    expect(full?.permissionProfile).toBe('full')
+    expect(unknown?.permissionProfile).toBe('ask')
   })
 })

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -1,4 +1,9 @@
 import type { UploadedAttachment } from './uploads'
+import {
+  DEFAULT_PERMISSION_PROFILE,
+  normalizePermissionProfile,
+  type PermissionProfileId
+} from './permission-profiles'
 
 // One JSON file per session (sessions/<projectId>/<sessionId>.json) carries this envelope version.
 export const SESSION_FILE_VERSION = 1
@@ -84,6 +89,8 @@ export type PersistedChatSession = {
   title: string
   cwd: string
   status: PersistedSessionStatus
+  // Per-conversation approval posture. Older session files omit it and safely restore to Ask.
+  permissionProfile?: PermissionProfileId
   messages: PersistedChatMessage[]
   activities?: PersistedToolActivity[]
   activeRun?: PersistedActiveRun
@@ -515,6 +522,10 @@ const sanitizeSession = (session: unknown): PersistedChatSession | undefined => 
     title: asString(session.title) ?? id,
     cwd: asString(session.cwd) ?? '',
     status: asSessionStatus(session.status),
+    permissionProfile:
+      session.permissionProfile === undefined
+        ? DEFAULT_PERMISSION_PROFILE
+        : normalizePermissionProfile(session.permissionProfile),
     messages: Array.isArray(session.messages)
       ? session.messages.map(sanitizeMessage).filter((item): item is PersistedChatMessage => !!item)
       : [],


### PR DESCRIPTION
## Summary

Adds three provider-neutral, per-conversation approval profiles to the workspace composer:

- **Ask for approval** keeps the existing approval behavior and remains the safe default.
- **Approve for me** uses the Agent's native ACP auto mode when advertised. Otherwise, Open Science applies a conservative fallback that auto-approves only structured thinking plus workspace-contained read, search, and edit operations.
- **Full access** uses the Agent's real ACP bypassPermissions mode. It is disabled when the active Agent does not advertise that capability and requires an explicit risk confirmation before activation.

## Why

Long-running research workflows may combine local file access, notebook execution, shell commands, dataset downloads, literature access, and MCP tools. Repeated prompts can interrupt an otherwise autonomous run, while blindly clicking every Allow response would misrepresent the provider's security model.

This change exposes a clear approval posture without coupling the UI to model text or to one provider's response format.

## Implementation

- Introduces stable application-level profile IDs and maps them to modes advertised by each ACP session.
- Applies the selected mode before the first or resumed prompt, preventing a first-tool permission race.
- Persists the profile per conversation; legacy sessions safely default to **Ask for approval**.
- Prevents profile changes while a prompt is running or a permission request is pending.
- Keeps Full access fail-closed: unsupported sessions reject/disable it instead of simulating repeated Allow choices.
- Adds a provider-neutral fallback policy for Agents without native auto review:
  - may approve structured think operations;
  - may approve read, search, and edit only when every reported path resolves inside the workspace;
  - never auto-approves shell/execute, network/fetch, unlocated, MCP, or outside-workspace operations.
- Preserves tool kind, provider tool name, locations, and raw input in permission requests so the existing approval UI can show useful risk context and notebook code.
- Leaves prompt construction, generated content, notebook execution, and artifact generation behavior unchanged.

## Safety and compatibility

- Profiles are application semantics, not Claude-specific strings.
- Native behavior is selected only from modes advertised by the active ACP session.
- No model prose parsing is used.
- Full access is never emulated.
- Provider/model reconnects and resumed sessions reapply the persisted profile before execution.
- An Agent-driven mode update is reflected in runtime state.

## Validation

Automated checks:

- npm run typecheck
- npm run lint
- npm test -- --run — 160 test files passed, 1 skipped; 1,148 tests passed, 2 skipped
- npm run build

Manual Electron validation:

- verified all three composer selections;
- verified the Full access risk confirmation and unsupported-state behavior;
- reopened the most recent differential-expression analysis conversation;
- selected Full access and sent “继续运行”;
- confirmed bypassPermissions was applied before the prompt;
- completed the run without approval dialogs;
- generated and finalized nine artifacts and returned the session to Idle.

## Out of scope

Two non-blocking behaviors observed during the manual run are independent of this approval change and are intentionally not modified here:

- the current @agentclientprotocol/claude-agent-acp adapter logs unknown command_lifecycle events to stderr;
- an artifact thumbnail may briefly request its old .pending path while finalization moves the file to message-owned storage.

Both are candidates for focused follow-up fixes with their own tests.

