### PR TITLE
fix(settings): store API keys with reduced-protection fallback when keychain is unavailable

### DIFF
--- a/src/main/settings/crypto.test.ts
+++ b/src/main/settings/crypto.test.ts
@@ -1,12 +1,23 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Toggleable keychain state so the reduced-protection fallback (keychain unavailable) can be tested
+// alongside the normal encrypted path. Hoisted so the vi.mock factory can read it.
+const keychain = vi.hoisted(() => ({ available: true }))
 
 // Fake safeStorage: a reversible "encryption" so the crypto wrapper's base64/prefix handling and
-// round-trip contract can be tested without a real OS keychain.
+// round-trip contract can be tested without a real OS keychain. encryptString mirrors Electron by
+// throwing when encryption is unavailable, so the wrapper's fallback branch is exercised faithfully.
 vi.mock('electron', () => ({
   safeStorage: {
-    isEncryptionAvailable: () => true,
-    encryptString: (plaintext: string) => Buffer.from(`cipher:${plaintext}`, 'utf8'),
+    isEncryptionAvailable: () => keychain.available,
+    encryptString: (plaintext: string) => {
+      if (!keychain.available) throw new Error('Encryption is not available.')
+
+      return Buffer.from(`cipher:${plaintext}`, 'utf8')
+    },
     decryptString: (buffer: Buffer) => {
+      if (!keychain.available) throw new Error('Encryption is not available.')
+
       const decoded = buffer.toString('utf8')
 
       if (!decoded.startsWith('cipher:')) {
@@ -19,6 +30,10 @@ vi.mock('electron', () => ({
 }))
 
 const { decryptKey, encryptKey, maskKey, tryDecryptKey } = await import('./crypto')
+
+afterEach(() => {
+  keychain.available = true
+})
 
 describe('crypto', () => {
   it('round-trips a key through encrypt/decrypt with the enc: prefix', () => {
@@ -35,6 +50,29 @@ describe('crypto', () => {
   it('tryDecryptKey returns undefined instead of throwing on bad input', () => {
     expect(tryDecryptKey(undefined)).toBeUndefined()
     expect(tryDecryptKey('enc:' + Buffer.from('garbage').toString('base64'))).toBeUndefined()
+  })
+
+  // When the OS keychain is unavailable, the wrapper must not throw: it stores a reduced-protection
+  // base64 ref (the behavior the onboarding/settings UI already promises) so key storage keeps working.
+  it('falls back to a plain: ref when encryption is unavailable, still round-tripping', () => {
+    keychain.available = false
+
+    const keyRef = encryptKey('sk-secret-value')
+
+    expect(keyRef.startsWith('plain:')).toBe(true)
+    expect(keyRef).not.toContain('sk-secret-value') // base64, not raw plaintext
+    expect(decryptKey(keyRef)).toBe('sk-secret-value')
+    expect(tryDecryptKey(keyRef)).toBe('sk-secret-value')
+  })
+
+  // A key stored while degraded must stay readable even after the keychain comes back (and vice
+  // versa), so a self-describing prefix — not the current keychain state — decides the codec.
+  it('decrypts a plain: ref regardless of whether encryption is currently available', () => {
+    keychain.available = false
+    const degradedRef = encryptKey('sk-degraded')
+
+    keychain.available = true
+    expect(tryDecryptKey(degradedRef)).toBe('sk-degraded')
   })
 
   it('masks long keys as prefix…suffix and short keys as bullets', () => {

--- a/src/main/settings/crypto.ts
+++ b/src/main/settings/crypto.ts
@@ -7,19 +7,38 @@ import { safeStorage } from 'electron'
 // Stored ciphertext is base64 with this prefix so the on-disk shape is self-describing.
 const KEY_REF_PREFIX = 'enc:'
 
+// Reduced-protection fallback used only when the OS keychain is unavailable (safeStorage reports
+// not-available, e.g. a locked/denied keychain). The key is base64-encoded, NOT encrypted — the
+// onboarding and settings UI warn the user that storage is degraded in this case. Without this the
+// app would hard-fail on save despite promising a fallback, leaving keyless machines unable to add a
+// provider. The prefix keeps the on-disk shape self-describing so decoding never depends on the
+// keychain state at read time (a key saved while degraded stays readable once the keychain returns).
+const PLAIN_REF_PREFIX = 'plain:'
+
 // Reports whether the OS keychain backing safeStorage is usable on this machine.
 const isEncryptionAvailable = (): boolean => safeStorage.isEncryptionAvailable()
 
-// Encrypts a plaintext key into a prefixed base64 keyRef for storage.
+// Turns a plaintext key into a stored keyRef. Uses OS encryption when the keychain is available;
+// otherwise falls back to a base64 "reduced protection" ref (see PLAIN_REF_PREFIX) so key storage
+// still works instead of throwing.
 const encryptKey = (plaintext: string): string => {
+  if (!isEncryptionAvailable()) {
+    return `${PLAIN_REF_PREFIX}${Buffer.from(plaintext, 'utf8').toString('base64')}`
+  }
+
   const ciphertext = safeStorage.encryptString(plaintext)
 
   return `${KEY_REF_PREFIX}${ciphertext.toString('base64')}`
 }
 
-// Decrypts a stored keyRef back to plaintext. Throws when the ref is malformed or undecryptable
-// (e.g. the keychain changed), which the service maps to a "needs re-entry" provider state.
+// Decrypts a stored keyRef back to plaintext. A reduced-protection (plain:) ref is base64-decoded
+// directly; an encrypted (enc:) ref goes through safeStorage and throws when the ref is malformed or
+// undecryptable (e.g. the keychain changed), which the service maps to a "needs re-entry" state.
 const decryptKey = (keyRef: string): string => {
+  if (keyRef.startsWith(PLAIN_REF_PREFIX)) {
+    return Buffer.from(keyRef.slice(PLAIN_REF_PREFIX.length), 'base64').toString('utf8')
+  }
+
   if (!keyRef.startsWith(KEY_REF_PREFIX)) {
     throw new Error('Malformed key reference.')
   }

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -244,6 +244,36 @@ describe('SettingsPage layout', () => {
     expect(document.body.querySelector('[aria-label="Back to skills"]')).toBeNull()
   })
 
+  it('warns about reduced-protection storage in the provider form when encryption is unavailable', async () => {
+    // The store loads encryptionAvailable from this call when the dialog opens.
+    ;(
+      window as unknown as {
+        api: { settings: { isEncryptionAvailable: ReturnType<typeof vi.fn> } }
+      }
+    ).api.settings.isEncryptionAvailable.mockResolvedValue(false)
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // No warning on the provider list itself…
+    expect(document.body.textContent).not.toContain('reduced protection')
+
+    const addProvider = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button')
+    ).find((button) => button.textContent?.trim() === 'Add provider')
+    await act(async () => {
+      addProvider?.click()
+    })
+
+    // …but the Add provider sub-page warns before the user saves a key.
+    expect(document.body.textContent).toContain('Secure key storage is unavailable')
+    expect(document.body.textContent).toContain('reduced protection')
+  })
+
   it('does not render when closed', () => {
     act(() => {
       root.render(<SettingsPage open={false} onClose={vi.fn()} />)

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -126,6 +126,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const isInstalling = useSettingsStore((state) => state.isInstalling)
   const installLogs = useSettingsStore((state) => state.installLogs)
   const npmAvailable = useSettingsStore((state) => state.npmAvailable)
+  const encryptionAvailable = useSettingsStore((state) => state.encryptionAvailable)
   const load = useSettingsStore((state) => state.load)
   const detectClaude = useSettingsStore((state) => state.detectClaude)
   const installClaude = useSettingsStore((state) => state.installClaude)
@@ -520,6 +521,14 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
               ) : isProviderFormOpen ? (
                 // Add/edit provider is a secondary page reached via the shared back/forward arrows.
                 <div className="p-5">
+                  {/* Keys are stored with OS encryption; warn (as onboarding does) when the keychain
+                      is unavailable so the reduced-protection fallback is never a silent surprise. */}
+                  {!encryptionAvailable ? (
+                    <p className="mb-4 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                      Secure key storage is unavailable on this machine. Your key will be stored
+                      with reduced protection.
+                    </p>
+                  ) : null}
                   <ProviderForm
                     value={formValue}
                     onChange={(patch) => setFormValue((current) => ({ ...current, ...patch }))}


### PR DESCRIPTION
Closes #67

## Problem

When Electron `safeStorage` is unavailable on a machine (locked or denied OS keychain — common after a version update that changes the app's keychain-accessible identity), two failures compound:

- Saving a provider key throws `Error while encrypting the text provided to safeStorage.encryptString. Encryption is not available.`, surfaced raw on **Settings → Model → Add provider**.
- Existing `enc:` keys can no longer be decrypted, so the provider shows "The stored key could not be decrypted. Enter it again."

Together these trap the user in a loop: re-enter key → Save → encryption error → key still unsaved. This matches the report in #67 (v0.2.0 update, DeepSeek provider on macOS).

## Root cause

The onboarding UI already promises "your key will be stored with reduced protection" when encryption is unavailable, but that fallback was **never implemented** — `encryptKey` unconditionally called `safeStorage.encryptString`, which throws. The Settings provider form also had no `encryptionAvailable` guard (unlike onboarding).

The underlying trigger (keychain unavailable) is environmental, but the code defect is the missing fallback + missing guard.

## Changes

- **`crypto.ts`**: add a self-describing `plain:` keyRef (base64, not encrypted) used **only** when `isEncryptionAvailable()` is `false`. `decryptKey` decodes it based on the prefix, independent of the current keychain state, so a key saved while degraded stays readable — and a key saved normally keeps using the unchanged `enc:` path. This makes storage succeed instead of throwing, honoring the "reduced protection" promise the UI already shows.
- **`SettingsPage.tsx`**: mirror onboarding's reduced-protection warning banner above the provider form so degraded storage is never a silent surprise.

## Security note

In the fallback path the key is stored as base64 (obfuscated, not encrypted) — the "reduced protection" the UI explicitly warns about. When the keychain is available, behavior is unchanged (full OS encryption). Existing `enc:` keys that can no longer be decrypted are not auto-recoverable; the user re-enters the key once and it now saves and sticks.

## Tests

- `crypto.test.ts`: fallback round-trip when encryption is unavailable, and that a `plain:` ref decodes regardless of current keychain state.
- `SettingsPage.render.test.tsx`: the reduced-protection warning renders in the provider form when encryption is unavailable.
- `typecheck` clean; `eslint` clean on changed files; full settings/store suite passes (327 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)