### PR TITLE
fix(notebook): host.mcp dict args + richer connector skill docs & pubmed_fetch

### DIFF
--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -44,6 +44,21 @@ describe('renderCustomSkillDoc', () => {
     const frontmatter = md.slice(0, md.indexOf('---', 3))
     expect(frontmatter).toContain('Use when the user asks about widgets.')
   })
+
+  it('renders a concrete dict example from a custom tool inputSchema', () => {
+    const md = renderCustomSkillDoc({ name: 'myserver' }, [
+      {
+        name: 'lookup',
+        description: 'Look up a record',
+        inputSchema: {
+          type: 'object',
+          properties: { id: { type: 'string' }, limit: { type: 'integer', default: 10 } },
+          required: ['id']
+        }
+      }
+    ])
+    expect(md).toContain('result = host.mcp("myserver", "lookup", {"id": "...", "limit": 10})')
+  })
 })
 
 describe('syncCustomServerSkillDocs', () => {

--- a/src/main/connectors/descriptors/biomart.ts
+++ b/src/main/connectors/descriptors/biomart.ts
@@ -92,6 +92,8 @@ export const BIOMART_TOOLS: ToolDescriptor[] = [
     description:
       'List available Ensembl BioMart marts (name and display name) from the martservice registry.',
     input: { type: 'object', properties: {} },
+    returns:
+      '`[ { "name": str, "displayName": str } ]` — array of registered BioMart marts; `[]` when the registry lists none.',
     format: 'text',
     url: () => `${MARTSERVICE}?type=registry`,
     parse: (raw) => {
@@ -124,6 +126,8 @@ export const BIOMART_TOOLS: ToolDescriptor[] = [
       required: ['dataset', 'attributes']
     },
     required: ['dataset', 'attributes'],
+    returns:
+      '`{ "dataset": str, "columns": [str], "rows": [[str]] }` — `columns` echoes the requested attributes and each row is a string array in that column order. `rows` is sorted lexicographically and `[]` when nothing matches.',
     run: async (ctx, a) => {
       const dataset = String(a.dataset)
       const attributes = (a.attributes as unknown[]).map(String)

--- a/src/main/connectors/descriptors/biorxiv.ts
+++ b/src/main/connectors/descriptors/biorxiv.ts
@@ -49,6 +49,8 @@ export const BIORXIV_TOOLS: ToolDescriptor[] = [
       required: ['doi']
     },
     required: ['doi'],
+    returns:
+      '`[ { "doi": str, "title": str, "authors": str, "date": str, "category": str, "published": str } ]` — array of matching preprint versions; `published` is "NA" until linked to a published journal article. `[]` when the DOI is unknown.',
     url: (a) => `${BASE}/details/${normalizeServer(a.server)}/${normalizeDoi(String(a.doi))}`,
     parse: (raw) => summarize((raw as BiorxivResponse).collection ?? [])
   },
@@ -69,6 +71,8 @@ export const BIORXIV_TOOLS: ToolDescriptor[] = [
       required: ['from', 'to']
     },
     required: ['from', 'to'],
+    returns:
+      '`{ "total": str, "results": [ { "doi": str, "title": str, "authors": str, "date": str, "category": str, "published": str } ] }` — one page of up to 30 preprints; `total` (passthrough string count) is the full interval total. `published` is "NA" until linked to a journal article.',
     url: (a) => {
       const cursor = Number.isFinite(Number(a.cursor)) ? Math.max(0, Number(a.cursor)) : 0
       const path = `${BASE}/details/${normalizeServer(a.server)}/${encodeURIComponent(String(a.from))}/${encodeURIComponent(String(a.to))}/${cursor}`

--- a/src/main/connectors/descriptors/cancer-models.ts
+++ b/src/main/connectors/descriptors/cancer-models.ts
@@ -55,6 +55,8 @@ export const CANCER_MODELS_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`[ { "studyId": str, "name": str, "cancerType": str, "allSampleCount": int } ]` — up to `page_size` studies (default 10); `[]` when nothing matches.',
     url: (a) =>
       `${CBIOPORTAL}/studies?keyword=${encodeURIComponent(String(a.query))}&projection=DETAILED&pageSize=${Number(a.page_size ?? DEFAULT_PAGE_SIZE)}&pageNumber=0`,
     parse: (raw) => ((raw as CBioStudy[] | null) ?? []).map(compactStudyRow)
@@ -70,6 +72,8 @@ export const CANCER_MODELS_TOOLS: ToolDescriptor[] = [
       required: ['study_id']
     },
     required: ['study_id'],
+    returns:
+      '`{ "studyId": str, "name": str, "description": str, "cancerType": str, "cancerTypeId": str, "pmid": str, "citation": str, "referenceGenome": str, "allSampleCount": int, "sequencedSampleCount": int, "cnaSampleCount": int, "structuralVariantCount": int }` — a single study; fields are undefined when absent from the cBioPortal record.',
     url: (a) =>
       `${CBIOPORTAL}/studies/${encodeURIComponent(String(a.study_id))}?projection=DETAILED`,
     parse: (raw) => compactStudyDetail(raw as CBioStudy)

--- a/src/main/connectors/descriptors/cellguide.ts
+++ b/src/main/connectors/descriptors/cellguide.ts
@@ -106,6 +106,8 @@ export const CELLGUIDE_TOOLS: ToolDescriptor[] = [
       required: ['cellType']
     },
     required: ['cellType'],
+    returns:
+      '`{ "id": str, "name": str, "synonyms": [ str ], "ontologyDescription": str, "description": str, "descriptionSource": str, "references": [ ... ], "canonicalMarkerGenes": [ { "symbol": str, "name": str, "tissue": str, "publication": str, "publicationTitle": str } ] }` — returns `{ "error": str }` when the CL id is not found; markers capped at 30; `descriptionSource` is `validated`, `gpt`, or `none` (with `description` empty).',
     run: async (ctx, a) => {
       const cellType = String(a.cellType)
       const jsonId = toJsonFormat(cellType)

--- a/src/main/connectors/descriptors/chembl.ts
+++ b/src/main/connectors/descriptors/chembl.ts
@@ -31,6 +31,8 @@ export const CHEMBL_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`[ { "chembl_id": str, "pref_name": str|null, "max_phase": str|int|null, "molecule_type": str|null } ]` — array of compact molecule summaries (all matches ChEMBL returns, unbounded); `[]` when nothing matches.',
     url: (a) => `${CHEMBL}/molecule/search?q=${encodeURIComponent(String(a.query))}&format=json`,
     parse: (raw) => ((raw as ChemblSearchResponse).molecules ?? []).map(summarize)
   },
@@ -44,6 +46,8 @@ export const CHEMBL_TOOLS: ToolDescriptor[] = [
       required: ['chembl_id']
     },
     required: ['chembl_id'],
+    returns:
+      '`{ "chembl_id": str, "pref_name": str|null, "max_phase": str|int|null, "molecule_type": str|null }` — a single molecule summary; fields are null/undefined when absent on the record.',
     url: (a) => `${CHEMBL}/molecule/${encodeURIComponent(String(a.chembl_id))}?format=json`,
     parse: (raw) => summarize(raw as ChemblMolecule)
   }

--- a/src/main/connectors/descriptors/chemistry.ts
+++ b/src/main/connectors/descriptors/chemistry.ts
@@ -73,6 +73,8 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
       required: ['cids']
     },
     required: ['cids'],
+    returns:
+      '`[ { "CID": int, "MolecularFormula": str, "MolecularWeight": str, "CanonicalSMILES": str, "IUPACName": str } ]` — passthrough of PubChem `PropertyTable.Properties`, one entry per resolvable CID; unknown CIDs are simply omitted.',
     url: (a) =>
       `${PUBCHEM}/compound/cid/${([] as unknown[]).concat(a.cids as never).join(',')}/property/${PROPS}/JSON`,
     parse: (raw) => (raw as Props).PropertyTable.Properties
@@ -87,6 +89,8 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`{ "query": str, "compounds": [ { "CID": int, "MolecularFormula": str, "MolecularWeight": str, "CanonicalSMILES": str, "IUPACName": str } ] }` — up to `max_cids` compounds (default 5); `compounds` is `[]` when the name matches nothing.',
     run: async (ctx, a) => {
       const cidRes = (await ctx.fetchJson(
         `${PUBCHEM}/compound/name/${encodeURIComponent(String(a.query))}/cids/JSON`
@@ -111,6 +115,8 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
       required: ['chebi_id']
     },
     required: ['chebi_id'],
+    returns:
+      '`{ "chebi_accession": str, "name": str, "definition": str, "formula": str, "charge": str, "mass": str, "smiles": str, "inchi": str, "inchikey": str }` — any field may be null when absent from the ChEBI record (e.g. no structure or definition).',
     url: (a) => `${CHEBI_API}/compound/${normalizeChebiId(a.chebi_id)}/`,
     parse: (raw) => {
       const c = raw as ChebiCompound
@@ -137,6 +143,8 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
       required: ['rhea_id']
     },
     required: ['rhea_id'],
+    returns:
+      '`{ "rhea_id": str, "equation": str, "status": str, "left_side": [ { "compound_accession": str, "name": str } ], "right_side": [ ... ] }` — throws if the id has no match; a participant `name` may be null when the compound has no label.',
     run: async (ctx, a) => {
       const acc = normalizeRheaId(a.rhea_id)
       const query = `${RHEA_PREFIXES}SELECT ?equation ?status ?side ?cacc ?cname WHERE {
@@ -181,6 +189,8 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
       required: ['uniprot']
     },
     required: ['uniprot'],
+    returns:
+      '`{ "uniprot": str, "cutoff_nm": int, "n_rows": int, "affinities": [ { "target_name": str, "monomer_id": str, "smiles": str, "affinity_type": str, "affinity": str, "pmid": str, "doi": str } ] }` — `affinity` is a numeric value in nM as a string; `affinities` is `[]` and `n_rows` 0 when no ligand passes the cutoff; `n_rows` equals the returned count.',
     run: async (ctx, a) => {
       const uniprot = String(a.uniprot).trim().toUpperCase()
       if (!UNIPROT_RE.test(uniprot)) throw new Error(`not a UniProt accession: ${uniprot}`)

--- a/src/main/connectors/descriptors/clinical-genomics.ts
+++ b/src/main/connectors/descriptors/clinical-genomics.ts
@@ -139,6 +139,8 @@ export const CLINICAL_GENOMICS_TOOLS: ToolDescriptor[] = [
       required: ['gene']
     },
     required: ['gene'],
+    returns:
+      '`{ "gene_id": str, "symbol": str, "approved_name": str, "n_diseases_total": int, "returned": int, "diseases": [ { "disease_id": str, "disease_name": str, "score": float } ] }` — diseases ranked by association score, up to `limit` (default 10); `n_diseases_total` is the full count, usually larger than `returned`. Unresolved symbol or absent target yields `gene_id`/`symbol` null and `diseases: []`.',
     run: async (ctx, a) => {
       const gene = String(a.gene)
       const limit = Number(a.limit ?? DEFAULT_LIMIT)
@@ -196,6 +198,8 @@ export const CLINICAL_GENOMICS_TOOLS: ToolDescriptor[] = [
       required: ['chembl_id']
     },
     required: ['chembl_id'],
+    returns:
+      '`{ "chembl_id": str, "name": str, "drug_type": str, "max_clinical_stage": str, "mechanisms_of_action": [ { "mechanism_of_action": str, "action_type": str, "targets": [ { "id": str, "approved_symbol": str } ] } ], "n_indications_total": int, "returned_indications": int, "indications": [ { "disease_id": str, "disease_name": str, "max_clinical_stage": str } ] }` — indications capped at `limit` (default 10); `n_indications_total` is the full count. Unknown ChEMBL id returns `{ "chembl_id": str, "found": false }`.',
     run: async (ctx, a) => {
       const chemblId = String(a.chembl_id)
       const limit = Number(a.limit ?? DEFAULT_LIMIT)

--- a/src/main/connectors/descriptors/clinical-trials.ts
+++ b/src/main/connectors/descriptors/clinical-trials.ts
@@ -24,6 +24,8 @@ export const CLINICAL_TRIALS_TOOLS: ToolDescriptor[] = [
       required: ['nct_id']
     },
     required: ['nct_id'],
+    returns:
+      '`{ "nct_id": str, "title": str, "status": str, "phase": [str], "conditions": [str] }` — one study; `phase` and `conditions` are arrays (may be undefined when the study omits those modules).',
     url: (a) => `${STUDIES}/${encodeURIComponent(String(a.nct_id))}`,
     parse: (raw) => {
       const proto = (raw as Study).protocolSection ?? {}
@@ -47,6 +49,8 @@ export const CLINICAL_TRIALS_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`{ "studies": [ { "nct_id": str, "title": str, "status": str } ], "nextPageToken"?: str }` — up to `page_size` studies (default 10); `nextPageToken` is present only when more pages exist. `studies` is `[]` when nothing matches.',
     run: async (ctx, a) => {
       const url = `${STUDIES}?query.term=${encodeURIComponent(String(a.query))}&pageSize=${Number(a.page_size ?? 10)}`
       const res = (await ctx.fetchJson(url)) as SearchResponse

--- a/src/main/connectors/descriptors/drug-regulatory.ts
+++ b/src/main/connectors/descriptors/drug-regulatory.ts
@@ -44,6 +44,8 @@ export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`[ { "id": str, "brand_name": str, "generic_name": str, "manufacturer": str, "indications": str } ]` — up to `limit` label records (default 10); each field is the first openFDA array element and may be undefined. `[]` when nothing matches.',
     url: (a) =>
       `${LABEL}?search=${encodeURIComponent(String(a.query))}&limit=${Number(a.limit ?? 10)}`,
     parse: (raw) =>
@@ -69,6 +71,8 @@ export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`[ { "safety_report_id": str, "receive_date": str, "serious": bool, "reactions": [str] } ]` — up to `limit` FAERS reports (default 10); `serious` is true when the upstream flag is "1", `reactions` lists MedDRA preferred terms (`[]` when none). `[]` when nothing matches.',
     url: (a) =>
       `${EVENT}?search=${encodeURIComponent(String(a.query))}&limit=${Number(a.limit ?? 10)}`,
     parse: (raw) =>

--- a/src/main/connectors/descriptors/expression.ts
+++ b/src/main/connectors/descriptors/expression.ts
@@ -34,6 +34,8 @@ export const EXPRESSION_TOOLS: ToolDescriptor[] = [
       required: ['geneId']
     },
     required: ['geneId'],
+    returns:
+      '`[ { "gene_symbol": str, "gencode_id": str, "gencode_version": str, "genome_build": str } ]` — array of matching gene references (usually one); `[]` when the gene isn\'t found. Fields are undefined if absent upstream.',
     url: (a) => `${GTEX}/reference/gene?geneId=${encodeURIComponent(String(a.geneId))}`,
     parse: (raw) =>
       ((raw as GtexGeneRefResponse).data ?? []).map((g) => ({
@@ -57,6 +59,8 @@ export const EXPRESSION_TOOLS: ToolDescriptor[] = [
       required: ['gencodeId']
     },
     required: ['gencodeId'],
+    returns:
+      '`[ { "tissue": str, "median_tpm": float, "unit": str } ]` — one row per GTEx tissue site; `median_tpm` in TPM. `[]` when the gencodeId is unknown for the dataset.',
     url: (a) => {
       const dataset = String(a.datasetId ?? DEFAULT_DATASET)
       return `${GTEX}/expression/medianGeneExpression?gencodeId=${encodeURIComponent(String(a.gencodeId))}&datasetId=${encodeURIComponent(dataset)}`

--- a/src/main/connectors/descriptors/genes.ts
+++ b/src/main/connectors/descriptors/genes.ts
@@ -51,6 +51,8 @@ export const GENES_TOOLS: ToolDescriptor[] = [
       required: ['accession']
     },
     required: ['accession'],
+    returns:
+      '`{ "accession": str, "name": str, "gene": str, "function": str }` — any field may be null when the entry lacks it (e.g. no recommended name, gene, or FUNCTION comment).',
     url: (a) => `${UNIPROT}/${encodeURIComponent(String(a.accession))}.json`,
     parse: (raw) => {
       const entry = raw as UniProtEntry
@@ -73,6 +75,8 @@ export const GENES_TOOLS: ToolDescriptor[] = [
       required: ['symbol']
     },
     required: ['symbol'],
+    returns:
+      '`[ { "symbol": str, "name": str, "entrezgene": str, "ensembl": { "gene": str } | [ { "gene": str } ] } ]` — human hits only; `[]` when the symbol resolves to nothing; `ensembl` is an object or array depending on gene count.',
     url: (a) =>
       `${MYGENE}?q=${encodeURIComponent(String(a.symbol))}&species=human&fields=${MYGENE_FIELDS}`,
     parse: (raw) =>
@@ -93,6 +97,8 @@ export const GENES_TOOLS: ToolDescriptor[] = [
       required: ['id']
     },
     required: ['id'],
+    returns:
+      '`{ "id": str, "label": str, "definition": str, "ontology": str }` — only the first matching OLS4 term is used; all fields are null when the GO id has no term match.',
     // OLS4 `obo_id` lookup avoids double-encoding a full term IRI (see upstream ols_terms client).
     url: (a) => `${OLS}/ontologies/go/terms?obo_id=${encodeURIComponent(String(a.id))}`,
     parse: (raw) => {
@@ -122,6 +128,8 @@ export const GENES_TOOLS: ToolDescriptor[] = [
       required: ['identifier']
     },
     required: ['identifier'],
+    returns:
+      '`[ { "pathway_id": str, "name": str } ]` — `[]` when the identifier maps to no Reactome pathways for the given species.',
     url: (a) => {
       const resource = a.resource ? String(a.resource) : 'UniProt'
       const species = a.species ? String(a.species) : '9606'

--- a/src/main/connectors/descriptors/genomes.ts
+++ b/src/main/connectors/descriptors/genomes.ts
@@ -52,6 +52,8 @@ export const GENOMES_TOOLS: ToolDescriptor[] = [
       required: ['symbol']
     },
     required: ['symbol'],
+    returns:
+      '`{ "id": str, "display_name": str, "biotype": str, "seq_region_name": str, "start": int, "end": int, "strand": int }` — single feature; `seq_region_name` is the chromosome, `strand` is 1 or -1. Fields undefined when absent upstream.',
     url: (a) => {
       const species = String(a.species ?? DEFAULT_SPECIES)
       const symbol = String(a.symbol)
@@ -70,6 +72,8 @@ export const GENOMES_TOOLS: ToolDescriptor[] = [
       required: ['id']
     },
     required: ['id'],
+    returns:
+      '`{ "id": str, "display_name": str, "biotype": str, "seq_region_name": str, "start": int, "end": int, "strand": int }` — single feature; `seq_region_name` is the chromosome, `strand` is 1 or -1. Fields undefined when absent upstream.',
     url: (a) =>
       `${ENSEMBL}/lookup/id/${encodeURIComponent(String(a.id))}?content-type=application/json`,
     parse: parseFeature

--- a/src/main/connectors/descriptors/geo.ts
+++ b/src/main/connectors/descriptors/geo.ts
@@ -27,6 +27,8 @@ export const GEO_TOOLS: ToolDescriptor[] = [
       required: ['term']
     },
     required: ['term'],
+    returns:
+      '`{ "term": str, "count": int, "records": [ { "accession": str, "title": str, "summary": str, "taxon": str, "n_samples": int, "gdstype": str } ] }` — up to `retmax` records (default 5); `count` is the total number of GEO matches, usually far larger than the returned list. `records` is `[]` when nothing matches.',
     run: async (ctx, a) => {
       const q = ncbiEtiquette(ctx.credentials)
       const es = (await ctx.fetchJson(

--- a/src/main/connectors/descriptors/gnomad.ts
+++ b/src/main/connectors/descriptors/gnomad.ts
@@ -75,6 +75,8 @@ export const GNOMAD_TOOLS: ToolDescriptor[] = [
       required: ['gene_symbol']
     },
     required: ['gene_symbol'],
+    returns:
+      '`{ "gene_id": str, "symbol": str, "chrom": str, "start": int, "stop": int, "dataset": str, "n_variants_total": int, "returned": int, "variants": [ { "variant_id": str, "pos": int, "ref": str, "alt": str, "rsids": [str], "exome": { "ac": int, "an": int, "af": float }|null, "genome": {...}|null } ] }` — variants capped at `limit` (default 25); `n_variants_total` is the full count. `exome`/`genome` are null when absent. Unknown gene returns `{ "symbol": str, "dataset": str, "gene_id": null, "n_variants": 0, "variants": [] }`.',
     run: async (ctx, a) => {
       const symbol = String(a.gene_symbol)
       const dataset = String(a.dataset ?? DEFAULT_DATASET)

--- a/src/main/connectors/descriptors/human-genetics.ts
+++ b/src/main/connectors/descriptors/human-genetics.ts
@@ -54,6 +54,8 @@ export const HUMAN_GENETICS_TOOLS: ToolDescriptor[] = [
       required: ['gene']
     },
     required: ['gene'],
+    returns:
+      '`[ { "rsId": str, "pValue": float, "riskAllele": str, "mappedGenes": [ str ], "trait": str } ]` — up to 50 associations sorted by ascending p-value; `[]` when none match. `mappedGenes` may be empty; `trait` falls back to reported trait.',
     url: (a) =>
       `${GWAS_ASSOCIATIONS}?mapped_gene=${encodeURIComponent(String(a.gene))}&size=${PAGE_SIZE}&sort=p_value&direction=asc`,
     parse: (raw) => flattenAssociations(raw)
@@ -71,6 +73,8 @@ export const HUMAN_GENETICS_TOOLS: ToolDescriptor[] = [
       required: ['rsId']
     },
     required: ['rsId'],
+    returns:
+      '`[ { "rsId": str, "pValue": float, "riskAllele": str, "mappedGenes": [ str ], "trait": str } ]` — up to 50 associations sorted by ascending p-value; `[]` when none match. `mappedGenes` may be empty; `trait` falls back to reported trait.',
     url: (a) =>
       `${GWAS_ASSOCIATIONS}?rs_id=${encodeURIComponent(String(a.rsId))}&size=${PAGE_SIZE}&sort=p_value&direction=asc`,
     parse: (raw) => flattenAssociations(raw)

--- a/src/main/connectors/descriptors/literature.ts
+++ b/src/main/connectors/descriptors/literature.ts
@@ -15,6 +15,8 @@ export const LITERATURE_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`[ { "id": str, "title": str, "summary": str } ]` — up to `max_results` hits (default 5), parsed from arXiv Atom XML; `[]` when nothing matches.',
     format: 'text',
     url: (a) =>
       `https://export.arxiv.org/api/query?search_query=all:${encodeURIComponent(String(a.query))}&max_results=${Number(a.max_results ?? 5)}`,

--- a/src/main/connectors/descriptors/omics-archives.ts
+++ b/src/main/connectors/descriptors/omics-archives.ts
@@ -43,6 +43,8 @@ export const OMICS_ARCHIVES_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`[ { "accession": str, "title": str, "type": str, "release_date": str } ]` — up to `pageSize` hits (default 20), newest release_date first; `[]` when nothing matches.',
     url: (a) => {
       const pageSize = Number(a.pageSize ?? DEFAULT_PAGE_SIZE)
       return (
@@ -69,6 +71,8 @@ export const OMICS_ARCHIVES_TOOLS: ToolDescriptor[] = [
       required: ['accession']
     },
     required: ['accession'],
+    returns:
+      '`{ "accession": str, "title": str, "release_date": str, "organism": str, "study_type": str, "description": str }` — single study; any field is undefined when its attribute is absent upstream.',
     url: (a) => `${BIOSTUDIES}/studies/${encodeURIComponent(String(a.accession))}`,
     parse: (raw) => {
       const study = raw as BioStudiesStudy

--- a/src/main/connectors/descriptors/openalex.ts
+++ b/src/main/connectors/descriptors/openalex.ts
@@ -60,6 +60,8 @@ export const OPENALEX_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`[ { "id": str, "title": str, "publication_year": int, "doi": str, "cited_by_count": int, "authors": [ str ] } ]` — one entry per hit, up to `per_page` (default 5); `[]` when nothing matches. `authors` is capped at the first 5 names; `id` is the short OpenAlex W-id and any field may be null when absent upstream.',
     url: (a) =>
       `${WORKS}?search=${encodeURIComponent(String(a.query))}&per_page=${Number(a.per_page ?? 5)}`,
     parse: (raw) => ((raw as OpenAlexWorksResponse).results ?? []).map(compactWork)
@@ -75,6 +77,8 @@ export const OPENALEX_TOOLS: ToolDescriptor[] = [
       required: ['id']
     },
     required: ['id'],
+    returns:
+      '`{ "id": str, "title": str, "publication_year": int, "doi": str, "cited_by_count": int, "authors": [ str ] }` — one work; `authors` is capped at the first 5 names and `id` is the short OpenAlex W-id. Any field may be null when absent upstream.',
     url: (a) => `${WORKS}/${encodeURIComponent(normalizeWorkId(String(a.id)))}`,
     parse: (raw) => compactWork(raw as OpenAlexWork)
   }

--- a/src/main/connectors/descriptors/protein-annotation.ts
+++ b/src/main/connectors/descriptors/protein-annotation.ts
@@ -24,6 +24,8 @@ export const PROTEIN_ANNOTATION_TOOLS: ToolDescriptor[] = [
       required: ['gene']
     },
     required: ['gene'],
+    returns:
+      '`[ { "partner": str, "score": float } ]` — up to `limit` partners (default 10) for the query gene, ranked by STRING combined score (0–1); `[]` when the gene is unknown or has no partners.',
     url: (a) => {
       const limit = typeof a.limit === 'number' ? a.limit : 10
       return `${STRING_BASE}/interaction_partners?identifiers=${encodeURIComponent(String(a.gene))}&species=${HUMAN_TAXON_ID}&limit=${limit}`
@@ -46,6 +48,8 @@ export const PROTEIN_ANNOTATION_TOOLS: ToolDescriptor[] = [
       required: ['genes']
     },
     required: ['genes'],
+    returns:
+      '`[ { "a": str, "b": str, "score": float } ]` — one entry per interaction edge among the input genes, `score` is the STRING combined score (0–1); `[]` when no edges are found. Only pairs with an interaction are returned, not every gene pair.',
     url: (a) => {
       const genes = a.genes as string[]
       return `${STRING_BASE}/network?identifiers=${encodeURIComponent(genes.join(','))}&species=${HUMAN_TAXON_ID}`

--- a/src/main/connectors/descriptors/pubmed.test.ts
+++ b/src/main/connectors/descriptors/pubmed.test.ts
@@ -5,6 +5,9 @@ import { PUBMED_TOOLS } from './pubmed'
 const jsonRes = (body: unknown): Response =>
   ({ ok: true, status: 200, json: async () => body }) as Response
 
+const textRes = (body: string): Response =>
+  ({ ok: true, status: 200, text: async () => body }) as Response
+
 describe('pubmed', () => {
   it('esearch + esummary, includes etiquette', async () => {
     const fetchImpl = vi
@@ -30,5 +33,76 @@ describe('pubmed', () => {
       { pmid: '1', title: 'A', date: '2020' },
       { pmid: '2', title: 'B', date: '2021' }
     ])
+  })
+
+  it('pubmed_fetch returns metadata + abstract per PMID (esummary + efetch)', async () => {
+    const esummary = {
+      result: {
+        '1': {
+          title: 'Paper One',
+          pubdate: '2020 Jan',
+          source: 'J Test',
+          authors: [
+            { name: 'Smith AB', authtype: 'Author' },
+            { name: 'Doe C', authtype: 'Author' }
+          ],
+          articleids: [
+            { idtype: 'pubmed', value: '1' },
+            { idtype: 'doi', value: '10.1/x' }
+          ]
+        }
+      }
+    }
+    const efetchXml =
+      '<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID Version="1">1</PMID>' +
+      '<Article><Abstract><AbstractText Label="BACKGROUND">Hello</AbstractText>' +
+      '<AbstractText Label="METHODS">World</AbstractText></Abstract></Article>' +
+      '</MedlineCitation></PubmedArticle></PubmedArticleSet>'
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation((url: string) =>
+        Promise.resolve(url.includes('esummary') ? jsonRes(esummary) : textRes(efetchXml))
+      )
+    const tool = PUBMED_TOOLS.find((t) => t.id === 'pubmed_fetch')!
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool,
+      { pmids: ['1'] },
+      { ncbiEmail: 'x@y.org' }
+    )) as { pmids: string[]; articles: unknown[] }
+
+    expect(out.articles).toEqual([
+      {
+        pmid: '1',
+        title: 'Paper One',
+        authors: ['Smith AB', 'Doe C'],
+        journal: 'J Test',
+        date: '2020 Jan',
+        doi: '10.1/x',
+        abstract: 'Hello World'
+      }
+    ])
+    // Both endpoints hit, and NCBI etiquette is attached.
+    expect(fetchImpl.mock.calls.some((c) => String(c[0]).includes('esummary'))).toBe(true)
+    expect(fetchImpl.mock.calls.some((c) => String(c[0]).includes('efetch'))).toBe(true)
+    expect(fetchImpl.mock.calls.every((c) => String(c[0]).includes('email=x%40y.org'))).toBe(true)
+  })
+
+  it('pubmed_fetch yields null abstract/doi when PubMed has none', async () => {
+    const fetchImpl = vi.fn().mockImplementation((url: string) =>
+      Promise.resolve(
+        url.includes('esummary')
+          ? jsonRes({
+              result: { '9': { title: 'T', pubdate: '2021', source: 'J', authors: [] } }
+            })
+          : textRes('<PubmedArticleSet></PubmedArticleSet>')
+      )
+    )
+    const tool = PUBMED_TOOLS.find((t) => t.id === 'pubmed_fetch')!
+    const out = (await new ParserEngine({ fetchImpl }).call(tool, { pmids: ['9'] }, {})) as {
+      articles: Array<{ doi: unknown; abstract: unknown; authors: unknown }>
+    }
+    expect(out.articles[0].doi).toBeNull()
+    expect(out.articles[0].abstract).toBeNull()
+    expect(out.articles[0].authors).toEqual([])
   })
 })

--- a/src/main/connectors/descriptors/pubmed.ts
+++ b/src/main/connectors/descriptors/pubmed.ts
@@ -1,7 +1,34 @@
+import { DOMParser } from '@xmldom/xmldom'
 import { ncbiEtiquette } from '../engine'
 import type { ToolDescriptor } from '../types'
 
 const EUTILS = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils'
+
+// One PubMed record as returned by esummary (JSON). Only the fields pubmed_fetch surfaces are typed.
+type PubmedSummary = {
+  title?: string
+  pubdate?: string
+  source?: string
+  authors?: { name?: string; authtype?: string }[]
+  articleids?: { idtype?: string; value?: string }[]
+}
+
+// Maps each PMID to its abstract text from an efetch XML document. Labeled sections (BACKGROUND,
+// METHODS, ...) are concatenated in order; PMID/abstract are read within one <PubmedArticle> so they
+// never cross-match between articles.
+const parseAbstracts = (xml: string): Record<string, string> => {
+  const out: Record<string, string> = {}
+  const doc = new DOMParser().parseFromString(xml, 'text/xml')
+  for (const article of Array.from(doc.getElementsByTagName('PubmedArticle'))) {
+    const pmid = article.getElementsByTagName('PMID')[0]?.textContent?.trim()
+    if (!pmid) continue
+    const parts = Array.from(article.getElementsByTagName('AbstractText'))
+      .map((el) => el.textContent?.trim())
+      .filter((t): t is string => Boolean(t))
+    if (parts.length) out[pmid] = parts.join(' ')
+  }
+  return out
+}
 
 // NCBI E-utilities in JSON mode (no biopython/XML needed): esearch -> esummary.
 export const PUBMED_TOOLS: ToolDescriptor[] = [
@@ -9,7 +36,7 @@ export const PUBMED_TOOLS: ToolDescriptor[] = [
     id: 'pubmed_search',
     connector: 'pubmed',
     description:
-      'Search PubMed (biomedical & life-sciences literature) for articles matching a query; returns the total match count plus the top article titles/dates. Search-only: it does NOT return abstracts, authors, or journals, and there is no fetch-by-PMID tool in this connector. PubMed does not index physics / CS / math / pure-chemistry papers (use other connectors for those).',
+      'Search PubMed (biomedical & life-sciences literature) for articles matching a query; returns the total match count plus the top article titles/dates. For a specific article’s authors, journal, DOI, or abstract, pass its PMID to `pubmed_fetch`. PubMed does not index physics / CS / math / pure-chemistry papers (use other connectors for those).',
     input: {
       type: 'object',
       properties: { term: { type: 'string' }, retmax: { type: 'integer', default: 5 } },
@@ -38,6 +65,57 @@ export const PUBMED_TOOLS: ToolDescriptor[] = [
           title: sum.result[id]?.title,
           date: sum.result[id]?.pubdate
         }))
+      }
+    }
+  },
+  {
+    id: 'pubmed_fetch',
+    connector: 'pubmed',
+    description:
+      'Fetch full details for one or more PubMed articles by PMID (bulk): title, authors, journal, DOI, and the abstract text. Use this after `pubmed_search` when you need more than the title. Prefer one call with many PMIDs over one call per PMID.',
+    input: {
+      type: 'object',
+      properties: {
+        pmids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'One or more PubMed IDs, e.g. ["40302006", "31452104"].'
+        }
+      },
+      required: ['pmids']
+    },
+    required: ['pmids'],
+    returns:
+      '`{ "pmids": [str], "articles": [ { "pmid": str, "title": str, "authors": [str], "journal": str, "date": str, "doi": str|null, "abstract": str|null } ] }` — one entry per requested PMID (order preserved); `doi`/`abstract` are null when PubMed has none, `authors` is `[]` when unlisted.',
+    run: async (ctx, a) => {
+      const ids = (Array.isArray(a.pmids) ? a.pmids : [a.pmids]).map((x) => String(x))
+      const q = ncbiEtiquette(ctx.credentials)
+      const [sum, xml] = await Promise.all([
+        ctx.fetchJson(
+          `${EUTILS}/esummary.fcgi?db=pubmed&retmode=json&id=${ids.join(',')}${q}`
+        ) as Promise<{ result?: Record<string, PubmedSummary> }>,
+        ctx.fetchText(
+          `${EUTILS}/efetch.fcgi?db=pubmed&retmode=xml&rettype=abstract&id=${ids.join(',')}${q}`
+        )
+      ])
+      const abstracts = parseAbstracts(xml)
+      const result = sum.result ?? {}
+      return {
+        pmids: ids,
+        articles: ids.map((id) => {
+          const r = result[id]
+          return {
+            pmid: id,
+            title: r?.title,
+            authors: (r?.authors ?? [])
+              .filter((x) => x.authtype === 'Author' && x.name)
+              .map((x) => x.name as string),
+            journal: r?.source,
+            date: r?.pubdate,
+            doi: r?.articleids?.find((x) => x.idtype === 'doi')?.value ?? null,
+            abstract: abstracts[id] ?? null
+          }
+        })
       }
     }
   }

--- a/src/main/connectors/descriptors/pubmed.ts
+++ b/src/main/connectors/descriptors/pubmed.ts
@@ -8,13 +8,16 @@ export const PUBMED_TOOLS: ToolDescriptor[] = [
   {
     id: 'pubmed_search',
     connector: 'pubmed',
-    description: 'Search PubMed; returns total count and article titles/dates.',
+    description:
+      'Search PubMed (biomedical & life-sciences literature) for articles matching a query; returns the total match count plus the top article titles/dates. Search-only: it does NOT return abstracts, authors, or journals, and there is no fetch-by-PMID tool in this connector. PubMed does not index physics / CS / math / pure-chemistry papers (use other connectors for those).',
     input: {
       type: 'object',
       properties: { term: { type: 'string' }, retmax: { type: 'integer', default: 5 } },
       required: ['term']
     },
     required: ['term'],
+    returns:
+      '`{ "term": str, "count": int, "articles": [ { "pmid": str, "title": str, "date": str } ] }` — up to `retmax` articles (default 5); `count` is the total number of PubMed matches and is usually far larger than the returned list. `articles` is `[]` when nothing matches.',
     run: async (ctx, a) => {
       const q = ncbiEtiquette(ctx.credentials)
       const es = (await ctx.fetchJson(

--- a/src/main/connectors/descriptors/regulation.ts
+++ b/src/main/connectors/descriptors/regulation.ts
@@ -41,6 +41,8 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`[ { "accession": str, "assay_title": str, "biosample": str, "target": str, "status": str } ]` — one entry per matching experiment, up to `limit` (default 25); `[]` when nothing matches. `target`/`biosample` are null when the experiment has none.',
     url: (a) => {
       const limit = typeof a.limit === 'number' && a.limit > 0 ? a.limit : DEFAULT_SEARCH_LIMIT
       return `${ENCODE}/search/?searchTerm=${encodeURIComponent(String(a.query))}&type=Experiment&format=json&limit=${limit}`
@@ -65,6 +67,8 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
       required: ['accession']
     },
     required: ['accession'],
+    returns:
+      '`{ "accession": str, "status": str, "assay_title": str, "assay_term_name": str, "biosample": str, "target": str, "description": str, "lab": str, "date_released": str }` — one experiment; `target`/`lab`/`biosample`/`date_released` are null when absent upstream.',
     url: (a) => `${ENCODE}/experiments/${encodeURIComponent(String(a.accession))}/?format=json`,
     parse: (raw) => {
       const e = raw as EncodeExperiment

--- a/src/main/connectors/descriptors/research-resources.ts
+++ b/src/main/connectors/descriptors/research-resources.ts
@@ -51,6 +51,8 @@ export const RESEARCH_RESOURCES_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`{ "total_elements": int, "items": [ { "ab_id": str, "name": str, "vendor": str, "target": str, "clonality": str } ] }` — `ab_id` is an `AB_<id>` RRID. `total_elements` is the full match count; `items` holds one page (default 10) and is `[]` when nothing matches. Anonymous paging past page*size > 500 fails upstream (HTTP 401).',
     url: (a) => {
       const page = Number.isFinite(Number(a.page)) ? Math.max(1, Number(a.page)) : 1
       const size = Number.isFinite(Number(a.size)) ? Math.max(1, Number(a.size)) : 10
@@ -75,6 +77,8 @@ export const RESEARCH_RESOURCES_TOOLS: ToolDescriptor[] = [
       required: ['ab_id']
     },
     required: ['ab_id'],
+    returns:
+      '`[ { "ab_id": str, "name": str, "vendor": str, "target": str, "clonality": str } ]` — an array because one accession can map to several curated records; `ab_id` is an `AB_<id>` RRID. Empty array when the id has no records.',
     url: (a) => `${BASE}/antibodies/${parseAbId(a.ab_id)}`,
     parse: (raw) => (raw as AntibodyRecord[]).map(compactAntibody)
   }

--- a/src/main/connectors/descriptors/rna.ts
+++ b/src/main/connectors/descriptors/rna.ts
@@ -27,6 +27,8 @@ export const RNA_TOOLS: ToolDescriptor[] = [
       required: ['family']
     },
     required: ['family'],
+    returns:
+      '`{ "rfam_acc": str, "id": str, "description": str, "type": str }` — `rfam_acc` is the accession (RF#####), `id` the family name (e.g. tRNA), `type` the curated RNA type. Fields are missing/undefined when absent upstream.',
     url: (a) =>
       `${RFAM}/family/${encodeURIComponent(String(a.family))}?content-type=application/json`,
     parse: (raw) => {
@@ -50,6 +52,8 @@ export const RNA_TOOLS: ToolDescriptor[] = [
     },
     required: ['accession'],
     format: 'text',
+    returns:
+      '`{ "accession": str, "id": str }` — echoes the input `accession` and its resolved family `id` (upstream plain-text response, trimmed).',
     url: (a) =>
       `${RFAM}/family/${encodeURIComponent(String(a.accession))}/id?content-type=text/plain`,
     parse: (raw, a) => ({ accession: String(a.accession), id: String(raw).trim() })

--- a/src/main/connectors/descriptors/structures.ts
+++ b/src/main/connectors/descriptors/structures.ts
@@ -69,6 +69,8 @@ export const STRUCTURES_TOOLS: ToolDescriptor[] = [
       required: ['pdb_id']
     },
     required: ['pdb_id'],
+    returns:
+      '`{ "pdb_id": str, "title": str, "method": str, "resolution": float }` — a single PDB entry; `method` is the first experiment method and `resolution` is the first value of resolution_combined in Angstroms. Fields are undefined when absent from the RCSB record.',
     url: (a) => `${PDB_DATA}/entry/${encodeURIComponent(String(a.pdb_id).trim().toUpperCase())}`,
     parse: (raw) => {
       const entry = raw as PdbEntry
@@ -91,6 +93,8 @@ export const STRUCTURES_TOOLS: ToolDescriptor[] = [
       required: ['uniprot_accession']
     },
     required: ['uniprot_accession'],
+    returns:
+      '`{ "uniprot": str, "model_url": str, "cif_url": str, "mean_plddt": float }` — the first AlphaFold model for the accession; `mean_plddt` is the global confidence score (0-100). All fields undefined when no prediction exists.',
     url: (a) => `${ALPHAFOLD}/${encodeURIComponent(String(a.uniprot_accession).trim())}`,
     parse: (raw) => {
       const model = ((raw as AlphaFoldModel[]) ?? [])[0] ?? {}
@@ -117,6 +121,8 @@ export const STRUCTURES_TOOLS: ToolDescriptor[] = [
       required: ['query']
     },
     required: ['query'],
+    returns:
+      '`{ "query": str, "total_elements": int, "returned": int, "interactions": [ { "interactor_a": str, "interactor_b": str, "molecule_a": str, "molecule_b": str, "interaction_type": str, "interaction_type_mi": str, "detection_method": str, "detection_method_mi": str, "mi_score": float, "pubmed_id": str } ] }` — up to `limit` interactions (default 25); `total_elements` is IntAct\'s full match count, usually larger than `returned`. `interactions` is `[]` when nothing matches.',
     run: async (ctx, a) => {
       const query = String(a.query)
       const minMiScore = Number(a.min_mi_score ?? 0)

--- a/src/main/connectors/descriptors/variants.ts
+++ b/src/main/connectors/descriptors/variants.ts
@@ -34,6 +34,8 @@ export const VARIANTS_TOOLS: ToolDescriptor[] = [
       required: ['term']
     },
     required: ['term'],
+    returns:
+      '`{ "term": str, "count": int, "records": [ { "uid": str, "title": str, "clinical_significance": str, "gene": str } ] }` — up to `retmax` records (default 5); `count` is the total ClinVar match count, usually larger than the returned list. `records` is `[]` when nothing matches; `clinical_significance` comes from the germline classification and per-record fields may be undefined.',
     run: async (ctx, a) => {
       const q = ncbiEtiquette(ctx.credentials)
       const es = (await ctx.fetchJson(
@@ -67,6 +69,8 @@ export const VARIANTS_TOOLS: ToolDescriptor[] = [
       required: ['rsid']
     },
     required: ['rsid'],
+    returns:
+      '`{ "rsid": str, "chr": str, "pos": int, "alleles": str, "gene": str, "clinical_significance": str }` — `rsid` is normalized to `rs<id>`; `alleles` is `ref>alt` derived from the SPDI trail. Any field is undefined when missing upstream (e.g. `alleles`/`pos` absent, no clinical significance).',
     run: async (ctx, a) => {
       const q = ncbiEtiquette(ctx.credentials)
       const id = String(a.rsid).trim().replace(/^rs/i, '')

--- a/src/main/connectors/descriptors/zinc.ts
+++ b/src/main/connectors/descriptors/zinc.ts
@@ -269,6 +269,8 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       required: ['zinc_ids']
     },
     required: ['zinc_ids'],
+    returns:
+      '`{ "query": { "zinc_ids": [str] }, "total_available": int, "returned_count": int, "truncated": bool, "records": [ { "zinc_id": str, "smiles": str, "tranche_name": str, "catalogs": any, "source": str } ] }` — records capped at `max_results` (default 50, cap 500); `truncated` is true when more were available. `source` is "zinc22"/"zinc20"; `records` is `[]` when no ids resolve.',
     run: async (_ctx, a) => {
       const ids = normalizeZincIds(a.zinc_ids)
       const cap = clampMaxResults(a.max_results)

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -20,4 +20,16 @@ describe('renderSkillDoc', () => {
   it('throws for an unknown connector', () => {
     expect(() => renderSkillDoc('nope')).toThrow()
   })
+  it('renders a concrete, copyable dict example built from the tool schema', () => {
+    // The example mirrors the JSON Schema shown above it: required fields plus any defaulted field,
+    // passed as a dict, assigned to a variable to demonstrate the synchronous return.
+    const md = renderSkillDoc('pubmed')
+    expect(md).toContain(
+      'result = host.mcp("pubmed", "pubmed_search", {"term": "...", "retmax": 5})'
+    )
+  })
+  it('frames the calling convention positively (assign the sync dict result)', () => {
+    const md = renderSkillDoc('pubmed')
+    expect(md).toContain('result = host.mcp(server, method, {...})')
+  })
 })

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -32,4 +32,10 @@ describe('renderSkillDoc', () => {
     const md = renderSkillDoc('pubmed')
     expect(md).toContain('result = host.mcp(server, method, {...})')
   })
+  it('documents the return shape so agents need not probe it', () => {
+    const md = renderSkillDoc('pubmed')
+    expect(md).toContain('**Returns:**')
+    // A return-shape field absent from the input schema — proves the Returns block is rendered.
+    expect(md).toContain('"pmid"')
+  })
 })

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -2,11 +2,64 @@ import { CONNECTOR_CATALOG } from './catalog'
 import { getConnectorTools } from './registry'
 
 const CONVENTIONS = [
-  'Reach this service ONLY via `host.mcp(server, method, **kwargs)` from the notebook kernel — arguments may also be passed as a dict: `host.mcp(server, method, {...})`. It is synchronous; do not `await` it.',
+  'Reach this service ONLY via `host.mcp` from the notebook kernel. It runs synchronously and returns the result directly — assign it: `result = host.mcp(server, method, {...})`. Arguments go as a dict, or as keywords (`host.mcp(server, method, term=...)`).',
   'Do NOT reimplement these calls with raw HTTP (urllib / requests / httpx / fetch) or hit the upstream endpoints directly — that bypasses the approval gate, per-tool policy, credentials, and rate limits, and can leak project data.',
   'Prefer bulk/list tools over per-item loops — the upstream API is rate-limited and shared across subagents.',
   'Pass large results between cells via `./handoff/*.json`, not the model context.'
 ].join('\n')
+
+// Placeholder value for one JSON-Schema field in a call example: an enum's first choice or the field's
+// own default when present, otherwise a type-keyed stand-in. Rendered as a JSON literal.
+function sampleValue(spec: { type?: unknown; default?: unknown; enum?: unknown }): string {
+  if (Array.isArray(spec.enum) && spec.enum.length) return JSON.stringify(spec.enum[0])
+  if ('default' in spec) return JSON.stringify(spec.default)
+  switch (spec.type) {
+    case 'integer':
+    case 'number':
+      return '0'
+    case 'boolean':
+      return 'false'
+    case 'array':
+      return '[]'
+    case 'object':
+      return '{}'
+    default:
+      return '"..."'
+  }
+}
+
+// Builds a compact, copyable sample-args dict from a tool's JSON Schema: the required fields plus any
+// field that declares a default, so the example shows the real argument names and call shape without
+// inventing data. Returns undefined when the schema exposes no such fields, so callers fall back to a
+// generic `...` (e.g. a custom tool that ships only `{ "type": "object" }` or no schema at all).
+function exampleArgs(schema: unknown): string | undefined {
+  if (typeof schema !== 'object' || schema === null) return undefined
+  const props = (schema as { properties?: unknown }).properties
+  if (typeof props !== 'object' || props === null) return undefined
+  const requiredList = (schema as { required?: unknown }).required
+  const required = new Set(
+    Array.isArray(requiredList)
+      ? requiredList.filter((r): r is string => typeof r === 'string')
+      : []
+  )
+  const entries: string[] = []
+  for (const [key, raw] of Object.entries(props as Record<string, unknown>)) {
+    const spec = (typeof raw === 'object' && raw !== null ? raw : {}) as {
+      type?: unknown
+      default?: unknown
+      enum?: unknown
+    }
+    if (!required.has(key) && !('default' in spec)) continue
+    entries.push(`"${key}": ${sampleValue(spec)}`)
+  }
+  return entries.length ? `{${entries.join(', ')}}` : undefined
+}
+
+// Renders one tool's call example as a copyable python cell: `result = host.mcp(server, tool, {args})`,
+// with args drawn from the tool schema (or `...` when the schema names no concrete fields).
+function renderExample(server: string, tool: string, schema: unknown): string {
+  return `Example:\n\n\`\`\`python\nresult = host.mcp("${server}", "${tool}", ${exampleArgs(schema) ?? '...'})\n\`\`\`\n`
+}
 
 // Renders one connector's tools as a searchable skill document (frontmatter + conventions + methods).
 // The frontmatter description is the trigger-style `useWhen` so Claude Code auto-discovers the skill
@@ -20,7 +73,7 @@ export function renderSkillDoc(connectorId: string): string {
     .map(
       (t) =>
         `### ${t.id}\n\n${t.description}\n\n\`\`\`json\n${JSON.stringify(t.input, null, 2)}\n\`\`\`\n\n` +
-        `Example: \`host.mcp("${connectorId}", "${t.id}", ...)\`\n`
+        renderExample(connectorId, t.id, t.input)
     )
     .join('\n')
   return (
@@ -47,7 +100,7 @@ export function renderCustomSkillDoc(
     .map(
       (t) =>
         `### ${t.name}\n\n${t.description ?? ''}\n\n\`\`\`json\n${JSON.stringify(t.inputSchema ?? {}, null, 2)}\n\`\`\`\n\n` +
-        `Example: \`host.mcp("${server.name}", "${t.name}", ...)\`\n`
+        renderExample(server.name, t.name, t.inputSchema)
     )
     .join('\n')
   return (

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -2,7 +2,7 @@ import { CONNECTOR_CATALOG } from './catalog'
 import { getConnectorTools } from './registry'
 
 const CONVENTIONS = [
-  'Reach this service ONLY via `host.mcp(server, method, **kwargs)` from the notebook kernel.',
+  'Reach this service ONLY via `host.mcp(server, method, **kwargs)` from the notebook kernel — arguments may also be passed as a dict: `host.mcp(server, method, {...})`. It is synchronous; do not `await` it.',
   'Do NOT reimplement these calls with raw HTTP (urllib / requests / httpx / fetch) or hit the upstream endpoints directly — that bypasses the approval gate, per-tool policy, credentials, and rate limits, and can leak project data.',
   'Prefer bulk/list tools over per-item loops — the upstream API is rate-limited and shared across subagents.',
   'Pass large results between cells via `./handoff/*.json`, not the model context.'

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -73,6 +73,7 @@ export function renderSkillDoc(connectorId: string): string {
     .map(
       (t) =>
         `### ${t.id}\n\n${t.description}\n\n\`\`\`json\n${JSON.stringify(t.input, null, 2)}\n\`\`\`\n\n` +
+        (t.returns ? `**Returns:** ${t.returns}\n\n` : '') +
         renderExample(connectorId, t.id, t.input)
     )
     .join('\n')

--- a/src/main/connectors/types.ts
+++ b/src/main/connectors/types.ts
@@ -14,6 +14,9 @@ export type ToolDescriptor = {
   connector: string
   description: string
   input: Record<string, unknown> // JSON Schema for the tool args (also used by docs)
+  // Human-readable shape of the returned value, shown as a "Returns:" block in the skill doc so an
+  // agent knows the result structure without running a probe cell. Free-form (prose or a shape sketch).
+  returns?: string
   required?: string[]
   format?: 'json' | 'text'
   url?: (args: Record<string, unknown>) => string

--- a/src/main/notebook/host-mcp.integration.test.ts
+++ b/src/main/notebook/host-mcp.integration.test.ts
@@ -33,6 +33,56 @@ describe.skipIf(!process.env.RUN_KERNEL)('kernel host.mcp', () => {
     expect(result.stdout).toContain('True')
   })
 
+  it('host.mcp accepts a positional args dict (MCP-idiomatic style)', async () => {
+    // Stub RPC endpoint that echoes back the args it received so the test can assert forwarding.
+    const { createServer } = await import('node:http')
+    let received: { params?: { args?: unknown } } = {}
+    const server = createServer((req, res) => {
+      let body = ''
+      req.on('data', (c) => (body += c))
+      req.on('end', () => {
+        received = JSON.parse(body)
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ result: { echoedArgs: received.params?.args } }))
+      })
+    })
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
+    const addr = server.address() as { port: number }
+    const exec = new NotebookPythonExecutor()
+    const result = await exec.execute({
+      code: 'r = host.mcp("chemistry","pubchem_get_properties", {"cids": [1, 2]}); print(r["echoedArgs"]["cids"])',
+      cwd: process.cwd(),
+      notebookSessionRoot: '',
+      dataRoot: '',
+      runtimeRoot: '',
+      mcpRpcEndpoint: `http://127.0.0.1:${addr.port}`,
+      mcpRpcToken: 'tok'
+    } as never)
+    await exec.shutdown()
+    server.close()
+    expect(result.status).toBe('completed')
+    expect(result.stdout).toContain('[1, 2]')
+    expect(received.params?.args).toEqual({ cids: [1, 2] })
+  })
+
+  it('host.mcp rejects mixing a positional args dict with keyword arguments', async () => {
+    // The guard fires in Python before any HTTP call, so no live RPC endpoint is needed.
+    const exec = new NotebookPythonExecutor()
+    const result = await exec.execute({
+      code: 'host.mcp("chemistry","pubchem_get_properties", {"cids": [1]}, retmax=5)',
+      cwd: process.cwd(),
+      notebookSessionRoot: '',
+      dataRoot: '',
+      runtimeRoot: '',
+      mcpRpcEndpoint: 'http://127.0.0.1:9',
+      mcpRpcToken: 'tok'
+    } as never)
+    await exec.shutdown()
+    expect(result.status).toBe('failed')
+    expect(result.traceback).toContain('not both')
+  })
+
   it('surfaces the RPC server error message when host.mcp gets a non-2xx response', async () => {
     // Stub RPC endpoint mirroring NotebookLocalRpcServer's failure shape: HTTP 500 + {"error": ...}.
     const { createServer } = await import('node:http')

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -31,13 +31,24 @@ import urllib.error
 import urllib.request
 
 class _Host:
-    # Control-plane bridge to the main process connector service.
-    def mcp(self, server, method, **kwargs):
+    # Control-plane bridge to the main process connector service. Tool arguments accept either a
+    # positional dict (host.mcp("s", "m", {...})) or keyword arguments (host.mcp("s", "m", term=...));
+    # server/method/args are positional-only so a tool whose own argument is named one of these still
+    # routes through **kwargs.
+    def mcp(self, server, method, args=None, /, **kwargs):
+        if args is not None:
+            if not isinstance(args, dict):
+                raise TypeError("host.mcp arguments must be a dict or keyword arguments")
+            if kwargs:
+                raise TypeError("host.mcp: pass arguments as a dict or as keywords, not both")
+            call_args = args
+        else:
+            call_args = kwargs
         endpoint = os.environ.get("OPEN_SCIENCE_MCP_RPC_ENDPOINT")
         token = os.environ.get("OPEN_SCIENCE_MCP_RPC_TOKEN")
         if not endpoint:
             raise RuntimeError("host.mcp is unavailable: connector RPC endpoint not set")
-        payload = json.dumps({"method": "mcpCall", "params": {"server": server, "method": method, "args": kwargs}}).encode("utf-8")
+        payload = json.dumps({"method": "mcpCall", "params": {"server": server, "method": method, "args": call_args}}).encode("utf-8")
         req = urllib.request.Request(endpoint, data=payload, method="POST",
             headers={"content-type": "application/json", "authorization": "Bearer " + (token or "")})
         try:


### PR DESCRIPTION
## Summary

Fixes cryptic `host.mcp` failures and makes connector skill docs self-explanatory, so notebook agents stop trial-and-erroring on the connector API.

- **Accept dict-style args** — `host.mcp("pubmed", "pubmed_search", {...})` now works alongside kwargs (server/method/args are positional-only; mixing a dict with keywords errors clearly). Previously the MCP-idiomatic dict form threw `takes 3 positional arguments but 4 were given`.
- **Concrete call examples** — each per-tool skill-doc example now renders a copyable `result = host.mcp(...)` with a dict built from the tool's schema; the conventions line is reframed positively (assign the synchronous result; dict or kwargs) instead of "do not await".
- **Return-shape docs** — new optional `returns` on `ToolDescriptor` renders a **Returns:** block. Documented for all 53 bundled tools, so an agent knows the result structure without a probe cell.
- **`pubmed_fetch`** — new tool: fetch title / authors / journal / DOI / abstract by PMID (bulk esummary + efetch XML via `@xmldom`), closing the search-only gap that forced raw-HTTP fallbacks.

## Verification

- TDD throughout (red → green); the `host.mcp` mechanism is covered by kernel integration tests.
- Whole repo: eslint clean, typecheck (node + web) clean, vitest **1136 passed**.
- `pubmed_fetch` verified against live NCBI (single + bulk; abstracts extracted).
- `returns` accuracy spot-checked against each tool's `run` / `parse`.

## Notes

- Skill docs are regenerated into the app's skills dir at startup and on connector change — no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
