### PR TITLE
feat(update): show condensed release-note highlights in the update dialog

### DIFF
--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -50,7 +50,10 @@ jobs:
           node-version: 20
 
       # Build version.json from the downloaded files. Missing platforms warn (not fail) inside the
-      # script, so a partial release still yields a usable manifest.
+      # script, so a partial release still yields a usable manifest. Notes/date are pulled from the
+      # release itself (via gh), not the event payload, so a manual workflow_dispatch backfill gets the
+      # real body/date too — not just the release-published event. The script condenses the body to the
+      # curated highlights sections.
       - name: Generate version.json
         env:
           DIST_DIR: dist-assets
@@ -58,9 +61,13 @@ jobs:
           VERSION: ${{ steps.ref.outputs.version }}
           CDN_BASE_URL: ${{ vars.CDN_BASE_URL }}
           S3_PREFIX: ${{ vars.S3_PREFIX }}
-          NOTES: ${{ github.event.release.body }}
-          RELEASE_DATE: ${{ github.event.release.published_at }}
-        run: node scripts/generate-version-manifest.mjs
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ref.outputs.tag }}
+        run: |
+          NOTES="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body)"
+          RELEASE_DATE="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json publishedAt --jq .publishedAt)"
+          export NOTES RELEASE_DATE
+          node scripts/generate-version-manifest.mjs
 
       # Credentials + region for aws-cli. The region alone lets aws-cli resolve the correct AWS S3
       # endpoint on its own — do NOT pass --endpoint-url: a bucket/website-style endpoint there makes

--- a/scripts/generate-version-manifest.mjs
+++ b/scripts/generate-version-manifest.mjs
@@ -81,6 +81,55 @@ export function buildManifest({ dir, version, notes, releaseDate, cdnBase, prefi
   return { version, releaseDate, notes, downloads }
 }
 
+// --- Release-notes condensation -----------------------------------------------------------------
+
+// H2 sections kept in the in-app "what's new" notes, matched case-insensitively by heading text with
+// emoji/punctuation stripped. Everything else in a release body (install steps, maturity notes,
+// acknowledgements, the auto-generated "What's Changed"/contributors) is dropped.
+const NOTE_SECTIONS = new Set(['highlights', 'new features', 'improvements', 'bug fixes'])
+
+// Normalize a `## …` heading to its comparable label: drop the leading #'s and any emoji/punctuation,
+// collapse whitespace, lowercase. `## 🐛 Bug Fixes` -> `bug fixes`.
+function headingLabel(line) {
+  return line
+    .replace(/^#+\s*/, '')
+    .replace(/[^\p{L}\p{N} ]+/gu, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+}
+
+// Condense a full GitHub release body into concise "what's new" notes: keep only the allowlisted H2
+// sections, in document order. Falls back to the preamble (text before the first H2, minus the H1
+// title) when no allowlisted section is present, and to '' for an empty body.
+export function extractHighlights(body) {
+  if (!body || !body.trim()) return ''
+
+  const sections = []
+  let current = { label: null, lines: [] } // label null = preamble before the first H2
+  for (const line of body.split('\n')) {
+    if (/^##\s+/.test(line)) {
+      sections.push(current)
+      current = { label: headingLabel(line), lines: [line] }
+    } else {
+      current.lines.push(line)
+    }
+  }
+  sections.push(current)
+
+  const kept = sections
+    .filter((section) => section.label && NOTE_SECTIONS.has(section.label))
+    .map((section) => section.lines.join('\n').trim())
+    .filter(Boolean)
+  if (kept.length > 0) return kept.join('\n\n')
+
+  // Fallback: the preamble before the first H2, without the H1 title line.
+  return (sections[0]?.lines ?? [])
+    .filter((line) => !/^#\s+/.test(line))
+    .join('\n')
+    .trim()
+}
+
 // CLI entry: only runs when the file is executed directly, not when imported by the test.
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const dir = process.argv[2] || process.env.DIST_DIR || 'dist-assets'
@@ -97,7 +146,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   const manifest = buildManifest({
     dir,
     version,
-    notes: process.env.NOTES ?? '',
+    notes: extractHighlights(process.env.NOTES ?? ''),
     releaseDate: process.env.RELEASE_DATE ?? '',
     cdnBase,
     prefix

--- a/scripts/generate-version-manifest.test.ts
+++ b/scripts/generate-version-manifest.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { buildManifest, parseSha256Sums } from './generate-version-manifest.mjs'
+import { buildManifest, extractHighlights, parseSha256Sums } from './generate-version-manifest.mjs'
 
 const VERSION = '0.1.2'
 const CDN = 'https://cdn.example.com'
@@ -54,6 +54,72 @@ describe('parseSha256Sums', () => {
     const map = parseSha256Sums(`${'c'.repeat(64)} *app.AppImage\nnot a checksum line\n`)
     expect(map['app.AppImage']).toBe('c'.repeat(64))
     expect(Object.keys(map)).toHaveLength(1)
+  })
+})
+
+describe('extractHighlights', () => {
+  const body = [
+    '# Open Science v0.2.0',
+    '',
+    '> one-line tagline',
+    '',
+    'Intro paragraph.',
+    '',
+    '## ✨ Highlights',
+    '',
+    '- Point one (#1)',
+    '- Point two',
+    '',
+    '## 🚀 New Features',
+    '',
+    '- Feature A',
+    '',
+    '## 🔧 Improvements',
+    '',
+    '- Improvement A',
+    '',
+    '## 🐛 Bug Fixes',
+    '',
+    '- Fix A',
+    '',
+    '## 📦 Install',
+    '',
+    'Download the build for your platform.',
+    '',
+    "## What's Changed",
+    '',
+    '- chore: bump deps'
+  ].join('\n')
+
+  it('keeps only the allowlisted sections, in document order', () => {
+    const notes = extractHighlights(body)
+
+    expect(notes).toContain('## ✨ Highlights')
+    expect(notes).toContain('## 🚀 New Features')
+    expect(notes).toContain('## 🔧 Improvements')
+    expect(notes).toContain('## 🐛 Bug Fixes')
+    // Dropped sections and their content.
+    expect(notes).not.toContain('## 📦 Install')
+    expect(notes).not.toContain('Download the build')
+    expect(notes).not.toContain("What's Changed")
+    expect(notes).not.toContain('bump deps')
+    // Order preserved.
+    expect(notes.indexOf('Highlights')).toBeLessThan(notes.indexOf('Bug Fixes'))
+  })
+
+  it('returns an empty string for an empty or blank body', () => {
+    expect(extractHighlights('')).toBe('')
+    expect(extractHighlights('   \n  \n')).toBe('')
+    expect(extractHighlights(undefined)).toBe('')
+  })
+
+  it('falls back to the preamble (minus the H1 title) when no allowlisted section exists', () => {
+    const plain = '# Title\n\n> tagline\n\nSome intro without standard sections.'
+    const notes = extractHighlights(plain)
+
+    expect(notes).not.toContain('# Title')
+    expect(notes).toContain('tagline')
+    expect(notes).toContain('Some intro without standard sections.')
   })
 })
 

--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -6,6 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useUpdateStore } from '@/stores/update-store'
 import { UpdateDialog } from './UpdateDialog'
 
+// Markdown rendering is covered by AgentMarkdown's own tests; stub it to a plain passthrough so this
+// render test stays deterministic and independent of the streamdown pipeline.
+vi.mock('@/components/streamdown/AgentMarkdown', () => ({
+  AgentMarkdown: ({ content }: { content: string }) => <div data-slot="markdown">{content}</div>
+}))
+
 let container: HTMLDivElement
 let root: Root
 

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -2,6 +2,7 @@ import { Download, ExternalLink, X } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 
 import { ExternalTextLink } from '@/components/ExternalTextLink'
+import { AgentMarkdown } from '@/components/streamdown/AgentMarkdown'
 import { useUpdateStore } from '@/stores/update-store'
 import { APP } from '../../../shared/app-config'
 
@@ -30,7 +31,7 @@ const UpdateDialog = (): React.JSX.Element | null => {
     >
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/50" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 z-[60] w-[min(440px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-card p-5 text-foreground shadow-dialog">
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-[60] w-[min(560px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-card p-5 text-foreground shadow-dialog">
           <div className="flex items-start justify-between gap-3">
             <div>
               <Dialog.Title className="text-base font-semibold">Update available</Dialog.Title>
@@ -49,9 +50,9 @@ const UpdateDialog = (): React.JSX.Element | null => {
           {status.notes ? (
             <div className="mt-3">
               <p className="mb-1 text-xs font-medium text-muted-foreground">What&apos;s new</p>
-              <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-lg bg-muted px-3 py-2 text-xs text-foreground">
-                {status.notes}
-              </pre>
+              <div className="max-h-96 overflow-auto rounded-lg bg-muted px-3 py-2">
+                <AgentMarkdown content={status.notes} />
+              </div>
               <ExternalTextLink href={releaseUrl} className="mt-2 text-xs">
                 View full release notes on GitHub
               </ExternalTextLink>


### PR DESCRIPTION
## Summary

Show concise, readable "what's new" notes in the in-app update dialog, and fix the pipeline so the CDN manifest carries them.

- **`scripts/generate-version-manifest.mjs`** — new `extractHighlights()` condenses a full GitHub release body down to the curated **Highlights / New Features / Improvements / Bug Fixes** sections (dropping install steps, maturity notes, acknowledgements, and the auto-generated "What's Changed"/contributors). Applied at the manifest CLI entry; `buildManifest` stays a pure passthrough. On the real v0.2.0 body this trims ~10.5 KB → ~3 KB.
- **`.github/workflows/mirror-to-website.yml`** — the "Generate version.json" step now pulls the release body/date via `gh release view "$TAG"` instead of the `github.event.release.*` payload. That payload is empty on a manual `workflow_dispatch`, which is why the current 0.2.0 manifest has blank `notes`/`releaseDate` even though the release itself has a full body. Fetching from the release fixes both triggers.
- **`UpdateDialog`** — renders `notes` as markdown via the app's `AgentMarkdown` in a roomier dialog (560px, taller scroll area), and always offers "View full release notes on GitHub". When notes are absent it falls back to the link only.

## Notes source precedence

Manifest `notes` (now the condensed highlights) → rendered in-app. If the manifest has none, the dialog shows the GitHub-release link. No new runtime dependency (reuses `AgentMarkdown`).

## Testing

- `npm run lint` — clean
- `npm run typecheck` — clean (node + web)
- `npm run test` — 1197 passed, 4 skipped (incl. 3 new `extractHighlights` cases + the dialog render test)
- Manually previewed the dialog rendering the real condensed v0.2.0 notes via `npm run dev`.

## Follow-up

After merge, re-run **Mirror to website** (`workflow_dispatch`, tag `v0.2.0`) so the live `version.json` gets the condensed notes and the in-app dialog shows them for the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
