### PR TITLE
feat(acp): refine approval profiles and make per-session grants visible

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -12,6 +12,7 @@ import type {
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
+  AcpRevokePermissionGrantRequest,
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
@@ -133,6 +134,10 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntime => {
   )
   ipcMain.handle('acp:set-permission-profile', (_event, request: AcpSetPermissionProfileRequest) =>
     runtime.setPermissionProfile(request)
+  )
+  ipcMain.handle(
+    'acp:revoke-permission-grant',
+    (_event, request: AcpRevokePermissionGrantRequest) => runtime.revokePermissionGrant(request)
   )
 
   return runtime

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -221,7 +221,7 @@ describe('ACP permission broker', () => {
     expect(emittedRequests).toHaveLength(2)
   })
 
-  it('remembers Always for shell by leading executable, not the full command', async () => {
+  it('remembers Always for shell by full command signature, not just the executable', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
 
@@ -231,23 +231,23 @@ describe('ACP permission broker', () => {
     broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
     await firstBash
 
-    // Same executable, different arguments auto-approves.
-    const secondBash = broker.requestPermission(
-      createToolPermissionRequest({ title: 'python b.py', providerToolName: 'Bash' })
+    // The exact same command auto-approves.
+    const sameBash = broker.requestPermission(
+      createToolPermissionRequest({ title: 'python a.py', providerToolName: 'Bash' })
     )
-    await expect(secondBash).resolves.toEqual({
+    await expect(sameBash).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
     expect(emittedRequests).toHaveLength(1)
 
-    // A different executable still prompts.
+    // Different arguments to the same executable are a distinct signature and still prompt.
     broker.requestPermission(
-      createToolPermissionRequest({ title: 'rm -rf x', providerToolName: 'Bash' })
+      createToolPermissionRequest({ title: 'python b.py', providerToolName: 'Bash' })
     )
     expect(emittedRequests).toHaveLength(2)
   })
 
-  it('routes execute-kind shell calls by signature even without a provider tool name', async () => {
+  it('normalizes leading env assignments in the shell command signature', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
 
@@ -257,14 +257,20 @@ describe('ACP permission broker', () => {
     broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
     await firstBash
 
-    // Leading env assignments are skipped, so `node ...` groups under the same signature.
+    // The same command without the leading env assignment shares the signature and auto-approves.
     const secondBash = broker.requestPermission(
-      createToolPermissionRequest({ title: 'node serve.js', kind: 'execute' })
+      createToolPermissionRequest({ title: 'node build.js', kind: 'execute' })
     )
     await expect(secondBash).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
     expect(emittedRequests).toHaveLength(1)
+
+    // A different command still prompts.
+    broker.requestPermission(
+      createToolPermissionRequest({ title: 'node serve.js', kind: 'execute' })
+    )
+    expect(emittedRequests).toHaveLength(2)
   })
 
   it('keeps prompting for a different notebook sub-tool after Always on another', async () => {
@@ -284,6 +290,50 @@ describe('ACP permission broker', () => {
     expect(emittedRequests).toHaveLength(2)
   })
 
+  it('keeps a per-tool Always grant even when the composer profile changes between calls', async () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+
+    // Under Ask, the user grants Always for a shell executable.
+    const firstBash = broker.requestPermission(
+      createToolPermissionRequest({ title: 'python train.py', providerToolName: 'Bash' }),
+      { profile: 'ask' }
+    )
+    broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
+    await firstBash
+
+    // Switching to conservative Auto must not drop the grant. Conservative Auto never approves a
+    // shell command on its own, so an auto-approval here proves the per-tool grant survived the switch.
+    const secondBash = broker.requestPermission(
+      createToolPermissionRequest({ title: 'python train.py', providerToolName: 'Bash' }),
+      { profile: 'auto', autoReviewStrategy: 'conservative', cwd: '/workspace' }
+    )
+    await expect(secondBash).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(emittedRequests).toHaveLength(1)
+  })
+
+  it('never auto-approves an MCP tool under conservative Auto, even for a workspace read', () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+
+    const request = createToolPermissionRequest({
+      title: 'mcp__pencil__batch_get',
+      kind: 'read'
+    })
+    request.toolCall.locations = [{ path: 'data/results.csv' }]
+
+    void broker.requestPermission(request, {
+      profile: 'auto',
+      autoReviewStrategy: 'conservative',
+      cwd: '/workspace'
+    })
+
+    // MCP is excluded from the conservative fallback, so a prompt is still surfaced to the user.
+    expect(emittedRequests).toHaveLength(1)
+  })
+
   it('does not remember Always across sessions for built-in tools', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
@@ -299,5 +349,52 @@ describe('ACP permission broker', () => {
       createToolPermissionRequest({ sessionId: 'session-2', providerToolName: 'Write' })
     )
     expect(emittedRequests).toHaveLength(2)
+  })
+
+  it('lists per-session grants with display labels and revokes them individually', async () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+
+    const write = broker.requestPermission(
+      createToolPermissionRequest({ title: 'Write report.md', providerToolName: 'Write' })
+    )
+    broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
+    await write
+
+    const bash = broker.requestPermission(
+      createToolPermissionRequest({ title: 'python a.py', providerToolName: 'Bash' })
+    )
+    broker.respond({ requestId: emittedRequests[1], optionId: 'allow-always' })
+    await bash
+
+    const notebook = broker.requestPermission(
+      createNotebookPermissionRequest('session-1', 'mcp__open-science-notebook__notebook_execute')
+    )
+    broker.respond({ requestId: emittedRequests[2], optionId: 'allow-always' })
+    await notebook
+
+    expect(broker.listGrants('session-1')).toEqual(
+      expect.arrayContaining([
+        { categoryKey: 'tool:Write', kind: 'tool', label: 'Write' },
+        { categoryKey: 'bash:python a.py', kind: 'shell', label: 'python a.py' },
+        {
+          categoryKey: 'tool:mcp__open-science-notebook__notebook_execute',
+          kind: 'mcp',
+          label: 'mcp__open-science-notebook__notebook_execute'
+        }
+      ])
+    )
+
+    // Revoking one grant removes only it and makes that tool prompt again.
+    broker.revokeGrant('session-1', 'tool:Write')
+    expect(broker.listGrants('session-1').map((grant) => grant.categoryKey).sort()).toEqual(
+      ['bash:python a.py', 'tool:mcp__open-science-notebook__notebook_execute'].sort()
+    )
+
+    const countBeforeWrite = emittedRequests.length
+    broker.requestPermission(
+      createToolPermissionRequest({ title: 'Write notes.md', providerToolName: 'Write' })
+    )
+    expect(emittedRequests).toHaveLength(countBeforeWrite + 1)
   })
 })

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -1,7 +1,7 @@
 import type { RequestPermissionRequest, RequestPermissionResponse } from '@agentclientprotocol/sdk'
 import { randomUUID } from 'node:crypto'
 
-import type { AcpPermissionRequest, AcpPermissionResponse } from '../../shared/acp'
+import type { AcpPermissionGrant, AcpPermissionRequest, AcpPermissionResponse } from '../../shared/acp'
 import { extractProviderToolName } from './runtime-events'
 import { resolveAutomaticPermission, type PermissionPolicyContext } from './permission-policy'
 
@@ -24,16 +24,11 @@ const ALLOW_ONCE_OPTION_KIND = 'allow_once'
 // containing whitespace/quotes are not covered (already split away) and fall back to the raw token.
 const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=[^\s]*$/
 
-// Strips a single matching pair of surrounding quotes from a shell token.
-const stripSurroundingQuotes = (token: string): string => {
-  const match = token.match(/^(["'])(.*)\1$/)
-
-  return match ? match[2] : token
-}
-
-// Derives the command signature (leading executable) used to group shell/execute permissions. Leading
-// trivial env assignments are skipped so `FOO=bar python a.py` still groups under `python`.
-const leadingExecutable = (command: string): string => {
+// Derives the command signature used to group shell/execute permissions. Leading trivial env
+// assignments are dropped, then the remaining command (executable plus its arguments) is normalized
+// to single-spaced form. Keying on the full command — not just the executable — keeps "Always" on
+// `python a.py` from also allowing `python b.py`.
+const commandSignature = (command: string): string => {
   const tokens = command.trim().split(/\s+/)
   let index = 0
 
@@ -41,12 +36,14 @@ const leadingExecutable = (command: string): string => {
     index += 1
   }
 
-  return stripSurroundingQuotes(tokens[index] ?? command.trim())
+  const rest = tokens.slice(index)
+
+  return rest.length > 0 ? rest.join(' ') : command.trim()
 }
 
 // Derives a session-scoped "Always" category key from a permission request (first match wins):
 // 1. MCP/notebook tool (title starts with mcp__): keyed by title (the tool name, no args).
-// 2. Shell/execute tool (provider tool name Bash, or execute kind): keyed by leading executable.
+// 2. Shell/execute tool (provider tool name Bash, or execute kind): keyed by full command signature.
 // 3. Other built-ins (Write/Edit/WebFetch/…): keyed by provider tool name (falls back to title).
 // The mcp__ check runs before the execute branch so a notebook execute-cell is not misrouted to Bash.
 const resolveCategoryKey = (params: RequestPermissionRequest): string => {
@@ -59,10 +56,25 @@ const resolveCategoryKey = (params: RequestPermissionRequest): string => {
   }
 
   if (providerToolName === 'Bash' || toolCall.kind === 'execute') {
-    return `bash:${leadingExecutable(title)}`
+    return `bash:${commandSignature(title)}`
   }
 
   return `tool:${providerToolName ?? title}`
+}
+
+// Projects an opaque category key into the display grant shown in the composer.
+const describeGrant = (categoryKey: string): AcpPermissionGrant => {
+  if (categoryKey.startsWith('bash:')) {
+    return { categoryKey, kind: 'shell', label: categoryKey.slice('bash:'.length) }
+  }
+
+  if (categoryKey.startsWith('tool:')) {
+    const label = categoryKey.slice('tool:'.length)
+
+    return { categoryKey, kind: label.startsWith(MCP_TOOL_TITLE_PREFIX) ? 'mcp' : 'tool', label }
+  }
+
+  return { categoryKey, kind: 'tool', label: categoryKey }
 }
 
 // Tracks permission requests until the renderer chooses an outcome.
@@ -83,6 +95,18 @@ class AcpPermissionBroker {
     return Array.from(this.pendingRequests.values()).some(
       ({ request }) => request.sessionId === sessionId
     )
+  }
+
+  // Lists the session's always-allow grants so the composer can show and revoke them.
+  listGrants(sessionId: string): AcpPermissionGrant[] {
+    const categories = this.alwaysAllowedCategories.get(sessionId)
+
+    return categories ? Array.from(categories, describeGrant) : []
+  }
+
+  // Removes one always-allow grant so its tool prompts again on the next call.
+  revokeGrant(sessionId: string, categoryKey: string): void {
+    this.alwaysAllowedCategories.get(sessionId)?.delete(categoryKey)
   }
 
   // Stores a permission request and resolves it later from a renderer response.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -27,6 +27,7 @@ import type {
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
+  AcpRevokePermissionGrantRequest,
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
@@ -270,6 +271,9 @@ class AcpRuntime {
       events: [...this.events],
       pendingPermissions: this.permissionBroker.getPendingRequests(),
       permissionProfiles: Object.fromEntries(this.permissionProfiles),
+      permissionGrants: Object.fromEntries(
+        sessionIds.map((sessionId) => [sessionId, this.permissionBroker.listGrants(sessionId)])
+      ),
       promptInFlight: promptInFlightSessionIds.length > 0,
       promptInFlightSessionIds
     }
@@ -624,6 +628,14 @@ class AcpRuntime {
     }
 
     await this.configurePermissionProfile(request.sessionId, session, request.profile)
+    this.emitState()
+
+    return this.getSnapshot()
+  }
+
+  // Revokes a remembered "Always" grant for a session so the next matching tool call prompts again.
+  revokePermissionGrant(request: AcpRevokePermissionGrantRequest): AcpStateSnapshot {
+    this.permissionBroker.revokeGrant(request.sessionId, request.categoryKey)
     this.emitState()
 
     return this.getSnapshot()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -9,6 +9,7 @@ import type {
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
+  AcpRevokePermissionGrantRequest,
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../shared/acp'
@@ -128,6 +129,7 @@ interface OpenScienceAPI {
     deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot>
     respondToPermission(response: AcpPermissionResponse): Promise<AcpStateSnapshot>
     setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<AcpStateSnapshot>
+    revokePermissionGrant(request: AcpRevokePermissionGrantRequest): Promise<AcpStateSnapshot>
     onState(listener: AcpListener<AcpStateSnapshot>): RemoveListener
     onEvent(listener: AcpListener<AcpRuntimeEvent>): RemoveListener
     onPermissionRequest(listener: AcpListener<AcpPermissionRequest>): RemoveListener

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,7 @@ import type {
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
+  AcpRevokePermissionGrantRequest,
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../shared/acp'
@@ -143,6 +144,7 @@ type OpenScienceAPI = {
     deleteSession: (request: AcpDeleteSessionRequest) => Promise<AcpStateSnapshot>
     respondToPermission: (response: AcpPermissionResponse) => Promise<AcpStateSnapshot>
     setPermissionProfile: (request: AcpSetPermissionProfileRequest) => Promise<AcpStateSnapshot>
+    revokePermissionGrant: (request: AcpRevokePermissionGrantRequest) => Promise<AcpStateSnapshot>
     onState: (listener: AcpListener<AcpStateSnapshot>) => RemoveListener
     onEvent: (listener: AcpListener<AcpRuntimeEvent>) => RemoveListener
     onPermissionRequest: (listener: AcpListener<AcpPermissionRequest>) => RemoveListener
@@ -304,6 +306,8 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('acp:respond-permission', response) as Promise<AcpStateSnapshot>,
     setPermissionProfile: (request) =>
       ipcRenderer.invoke('acp:set-permission-profile', request) as Promise<AcpStateSnapshot>,
+    revokePermissionGrant: (request) =>
+      ipcRenderer.invoke('acp:revoke-permission-grant', request) as Promise<AcpStateSnapshot>,
     onState: (listener) => onIpcMessage('acp:state', listener),
     onEvent: (listener) => onIpcMessage('acp:event', listener),
     onPermissionRequest: (listener) => onIpcMessage('acp:permission-request', listener)

--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -46,6 +46,7 @@ const createSnapshot = (overrides: Partial<AcpStateSnapshot> = {}): AcpStateSnap
   events: [],
   pendingPermissions: [],
   permissionProfiles: {},
+  permissionGrants: {},
   promptInFlight: false,
   promptInFlightSessionIds: [],
   ...overrides

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -3,6 +3,7 @@ import type {
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
+  AcpRevokePermissionGrantRequest,
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../../../shared/acp'
@@ -17,6 +18,7 @@ const emptyAcpState: AcpStateSnapshot = {
   events: [],
   pendingPermissions: [],
   permissionProfiles: {},
+  permissionGrants: {},
   promptInFlight: false,
   promptInFlightSessionIds: []
 }
@@ -65,6 +67,10 @@ const useAcpRuntime = (): {
   setPermissionProfile: (
     sessionId: string,
     profile: PermissionProfileId
+  ) => Promise<AcpStateSnapshot | undefined>
+  revokePermissionGrant: (
+    sessionId: string,
+    categoryKey: string
   ) => Promise<AcpStateSnapshot | undefined>
 } => {
   const [state, setState] = useState<AcpStateSnapshot>(emptyAcpState)
@@ -243,6 +249,16 @@ const useAcpRuntime = (): {
     [runSnapshotAction]
   )
 
+  // Drops one always-allow grant for a session and applies the returned snapshot.
+  const revokePermissionGrant = useCallback(
+    (sessionId: string, categoryKey: string) => {
+      const request: AcpRevokePermissionGrantRequest = { sessionId, categoryKey }
+
+      return runSnapshotAction(undefined, () => window.api.acp.revokePermissionGrant(request))
+    },
+    [runSnapshotAction]
+  )
+
   return {
     state,
     actionError,
@@ -256,7 +272,8 @@ const useAcpRuntime = (): {
     cancel,
     sendPrompt,
     respondToPermission,
-    setPermissionProfile
+    setPermissionProfile,
+    revokePermissionGrant
   }
 }
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -25,6 +25,7 @@ const createSnapshot = (sessionIds: string[] = []): AcpStateSnapshot => ({
   events: [],
   pendingPermissions: [],
   permissionProfiles: {},
+  permissionGrants: {},
   promptInFlight: false,
   promptInFlightSessionIds: []
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef } from 'react'
 
-import type { AcpPermissionRequest, AcpRuntimeEvent } from '../../../../shared/acp'
+import type {
+  AcpPermissionGrant,
+  AcpPermissionRequest,
+  AcpRuntimeEvent
+} from '../../../../shared/acp'
 import {
   DEFAULT_PERMISSION_PROFILE,
   type PermissionProfileId,
@@ -392,11 +396,13 @@ const useWorkspaceAgentRuntime = (): {
   isConnecting: boolean
   pendingPermissions: AcpPermissionRequest[]
   permissionProfiles: Record<string, SessionPermissionProfileState>
+  permissionGrants: Record<string, AcpPermissionGrant[]>
   sendMessage: (input: SendWorkspaceMessageInput) => Promise<SendWorkspaceMessageResult | undefined>
   cancelRun: (sessionId: string) => Promise<void>
   deleteRuntimeSession: (sessionId: string) => Promise<void>
   respondToPermission: (requestId: string, optionId?: string) => Promise<void>
   setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => Promise<boolean>
+  revokePermissionGrant: (sessionId: string, categoryKey: string) => Promise<void>
 } => {
   const runtime = useAcpRuntime()
   const eventProcessor = useRef(createWorkspaceRuntimeEventProcessor())
@@ -477,16 +483,30 @@ const useWorkspaceAgentRuntime = (): {
     [runtime]
   )
 
+  // Revokes one always-allow grant; the returned snapshot refreshes the visible grant list.
+  const revokePermissionGrant = useCallback(
+    async (sessionId: string, categoryKey: string): Promise<void> => {
+      const snapshot = await runtime.revokePermissionGrant(sessionId, categoryKey)
+
+      if (!snapshot) {
+        useSessionStore.getState().failRun(sessionId, 'Permission revoke failed')
+      }
+    },
+    [runtime]
+  )
+
   return {
     actionError: runtime.actionError,
     isConnecting: runtime.isConnecting,
     pendingPermissions: runtime.state.pendingPermissions,
     permissionProfiles: runtime.state.permissionProfiles,
+    permissionGrants: runtime.state.permissionGrants,
     sendMessage,
     cancelRun,
     deleteRuntimeSession,
     respondToPermission,
-    setPermissionProfile
+    setPermissionProfile,
+    revokePermissionGrant
   }
 }
 

--- a/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.interaction.test.tsx
@@ -71,7 +71,11 @@ describe('ComposerPermissionProfilePicker', () => {
         <ComposerPermissionProfilePicker value="ask" onChange={onChange} disabled={false} />
       )
     })
-    act(() => findButton('Approve for meAutomatically approve only low-risk operations.').click())
+    act(() =>
+      findButton(
+        'Auto-approve editsAuto-approve edits to files in the workspace. Still ask before commands, network, and MCP.'
+      ).click()
+    )
 
     expect(onChange).toHaveBeenCalledWith('auto')
     expect(container.textContent).not.toContain('Enable Full access?')
@@ -83,12 +87,16 @@ describe('ComposerPermissionProfilePicker', () => {
     act(() => {
       root.render(<ComposerPermissionProfilePicker value="ask" onChange={onChange} />)
     })
-    act(() => findButton('Full accessRun without approval prompts in this conversation.').click())
+    act(() =>
+      findButton(
+        'Full accessRun everything without prompts, including commands and network.'
+      ).click()
+    )
 
     expect(onChange).not.toHaveBeenCalled()
     expect(container.textContent).toContain('Enable Full access?')
 
-    act(() => findButton('Enable Full access').click())
+    act(() => findButton('Enable').click())
     expect(onChange).toHaveBeenCalledWith('full')
   })
 
@@ -112,5 +120,64 @@ describe('ComposerPermissionProfilePicker', () => {
     expect(
       findButton('Full accessThe current agent does not support native bypass mode.').disabled
     ).toBe(true)
+  })
+
+  it('lists session grants and revokes the clicked one', () => {
+    const onRevokeGrant = vi.fn()
+
+    act(() => {
+      root.render(
+        <ComposerPermissionProfilePicker
+          value="ask"
+          grants={[
+            { categoryKey: 'shell:git', label: 'git status', kind: 'shell' },
+            { categoryKey: 'mcp:search', label: 'search papers', kind: 'mcp' }
+          ]}
+          onChange={vi.fn()}
+          onRevokeGrant={onRevokeGrant}
+        />
+      )
+    })
+
+    expect(container.textContent).toContain('Always allowed this session')
+    expect(container.textContent).toContain('git status')
+
+    const revokeButton = Array.from(container.querySelectorAll('button')).find(
+      (candidate) => candidate.getAttribute('aria-label') === 'Revoke always-allow for git status'
+    )
+
+    if (!revokeButton) throw new Error('revoke button not found')
+
+    act(() => revokeButton.click())
+
+    expect(onRevokeGrant).toHaveBeenCalledWith('shell:git')
+  })
+
+  it('clears all grants when Clear all is clicked', () => {
+    const onClearGrants = vi.fn()
+
+    act(() => {
+      root.render(
+        <ComposerPermissionProfilePicker
+          value="ask"
+          grants={[
+            { categoryKey: 'shell:git', label: 'git status', kind: 'shell' },
+            { categoryKey: 'tool:Write', label: 'Write', kind: 'tool' }
+          ]}
+          onChange={vi.fn()}
+          onClearGrants={onClearGrants}
+        />
+      )
+    })
+
+    const clearButton = Array.from(container.querySelectorAll('button')).find(
+      (candidate) => candidate.getAttribute('aria-label') === 'Clear all always-allow grants'
+    )
+
+    if (!clearButton) throw new Error('clear button not found')
+
+    act(() => clearButton.click())
+
+    expect(onClearGrants).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.tsx
@@ -2,7 +2,8 @@ import type {
   PermissionProfileId,
   SessionPermissionProfileState
 } from '../../../../shared/permission-profiles'
-import { AlertTriangle, Check, ChevronUp, Shield, ShieldCheck, Zap } from 'lucide-react'
+import type { AcpPermissionGrant } from '../../../../shared/acp'
+import { AlertTriangle, Check, ChevronUp, Shield, ShieldAlert, ShieldCheck, X } from 'lucide-react'
 import { useState } from 'react'
 import { AlertDialog } from 'radix-ui'
 
@@ -16,8 +17,11 @@ import {
 type ComposerPermissionProfilePickerProps = {
   value: PermissionProfileId
   state?: SessionPermissionProfileState
+  grants?: AcpPermissionGrant[]
   disabled?: boolean
   onChange: (profile: PermissionProfileId) => void
+  onRevokeGrant?: (categoryKey: string) => void
+  onClearGrants?: () => void
 }
 
 const permissionProfiles: Array<{
@@ -29,33 +33,39 @@ const permissionProfiles: Array<{
   {
     id: 'ask',
     label: 'Ask for approval',
-    description: 'Ask before risky commands, file changes, or network access.',
+    description: 'Ask before file edits, commands, network, and MCP tools.',
     icon: Shield
   },
   {
     id: 'auto',
-    label: 'Approve for me',
-    description: 'Automatically approve only low-risk operations.',
+    label: 'Auto-approve edits',
+    description:
+      'Auto-approve edits to files in the workspace. Still ask before commands, network, and MCP.',
     icon: ShieldCheck
   },
   {
     id: 'full',
     label: 'Full access',
-    description: 'Run without approval prompts in this conversation.',
-    icon: Zap
+    description: 'Run everything without prompts, including commands and network.',
+    icon: ShieldAlert
   }
 ]
 
 const ComposerPermissionProfilePicker = ({
   value,
   state,
+  grants,
   disabled = false,
-  onChange
+  onChange,
+  onRevokeGrant,
+  onClearGrants
 }: ComposerPermissionProfilePickerProps): React.JSX.Element => {
   const [confirmFullAccess, setConfirmFullAccess] = useState(false)
   const selectedProfile = permissionProfiles.find((profile) => profile.id === value)!
   const SelectedIcon = selectedProfile.icon
   const fullAccessUnavailable = state?.fullAccessAvailable === false
+  // Grants only apply while asking for approval; the count pill hints at active always-allows.
+  const hasGrants = value === 'ask' && (grants?.length ?? 0) > 0
 
   const selectProfile = (profile: PermissionProfileId): void => {
     if (profile === value) return
@@ -78,8 +88,23 @@ const ComposerPermissionProfilePicker = ({
             aria-label={`Permission mode: ${selectedProfile.label}`}
           >
             <SelectedIcon className="size-3.5 shrink-0" strokeWidth={2} aria-hidden="true" />
-            <span className="max-w-32 truncate">{selectedProfile.label}</span>
-            <ChevronUp className="size-3 shrink-0" strokeWidth={2} aria-hidden="true" />
+            {/* Count pill stays visible even when the label collapses so grants aren't hidden. */}
+            {hasGrants ? (
+              <span
+                className="flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-bg-300 px-1 text-[10px] font-medium leading-none text-text-100"
+                aria-label={`${grants!.length} always-allowed this session`}
+              >
+                {grants!.length}
+              </span>
+            ) : null}
+            <span className="max-w-32 truncate @max-[28rem]/composer:hidden">
+              {selectedProfile.label}
+            </span>
+            <ChevronUp
+              className="size-3 shrink-0 @max-[28rem]/composer:hidden"
+              strokeWidth={2}
+              aria-hidden="true"
+            />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-80 p-1.5">
@@ -92,11 +117,11 @@ const ComposerPermissionProfilePicker = ({
               <DropdownMenuItem
                 key={profile.id}
                 disabled={isDisabled}
-                className="items-start gap-2.5 px-2.5 py-2"
+                className="items-center gap-2.5 px-2.5 py-2"
                 onSelect={() => selectProfile(profile.id)}
               >
                 <ProfileIcon
-                  className="mt-0.5 size-4 shrink-0 text-text-200"
+                  className="size-4 shrink-0 text-text-200"
                   strokeWidth={2}
                   aria-hidden="true"
                 />
@@ -109,15 +134,66 @@ const ComposerPermissionProfilePicker = ({
                   </span>
                 </span>
                 {isSelected ? (
-                  <Check className="mt-0.5 size-4 shrink-0" strokeWidth={2} aria-hidden="true" />
+                  <Check className="size-4 shrink-0" strokeWidth={2} aria-hidden="true" />
                 ) : null}
               </DropdownMenuItem>
             )
           })}
           {value === 'auto' && state?.autoReviewStrategy === 'conservative' ? (
             <div className="mx-1 mt-1 rounded-md bg-bg-200 px-2 py-1.5 text-[11px] leading-4 text-text-200">
-              This agent has no native auto mode. Only structured reads, searches, and workspace
-              edits are approved automatically.
+              This agent has no native auto mode. Open Science auto-approves only edits to files
+              inside the workspace — commands, network, and MCP tools still ask.
+            </div>
+          ) : null}
+          {hasGrants ? (
+            <div className="mt-1 border-t border-border-200 pt-1.5">
+              <div className="flex items-center justify-between px-2.5 pb-1">
+                <span className="text-[11px] font-medium uppercase tracking-wide text-text-300">
+                  Always allowed this session
+                </span>
+                {/* One-click clear for a long session; swallow the event so the menu stays open. */}
+                <button
+                  type="button"
+                  className="shrink-0 text-[11px] text-text-300 hover:text-text-000"
+                  aria-label="Clear all always-allow grants"
+                  onClick={(event) => {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    onClearGrants?.()
+                  }}
+                >
+                  Clear all
+                </button>
+              </div>
+              {/* Cap the list so a long session of grants scrolls instead of stretching the menu. */}
+              <div className="max-h-40 overflow-y-auto">
+                {grants!.map((grant) => (
+                  <div
+                    key={grant.categoryKey}
+                    className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-[11px] text-text-200"
+                  >
+                    <span
+                      className="min-w-0 flex-1 truncate font-mono leading-4"
+                      title={grant.label}
+                    >
+                      {grant.label}
+                    </span>
+                    {/* Revoke must not close the menu or re-select a profile, so swallow the event. */}
+                    <button
+                      type="button"
+                      className="flex size-5 shrink-0 items-center justify-center rounded text-text-300 hover:bg-bg-200 hover:text-text-000"
+                      aria-label={`Revoke always-allow for ${grant.label}`}
+                      onClick={(event) => {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        onRevokeGrant?.(grant.categoryKey)
+                      }}
+                    >
+                      <X className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                    </button>
+                  </div>
+                ))}
+              </div>
             </div>
           ) : null}
         </DropdownMenuContent>
@@ -157,7 +233,7 @@ const ComposerPermissionProfilePicker = ({
                   className="rounded-lg bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-700"
                   onClick={() => onChange('full')}
                 >
-                  Enable Full access
+                  Enable
                 </button>
               </AlertDialog.Action>
             </div>

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -52,6 +52,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         pendingPermissions={[]}
         permissionProfile="ask"
         permissionProfileState={undefined}
+        permissionGrants={[]}
         canChangePermissionProfile
         onDraftDocChange={vi.fn()}
         onSendMessage={vi.fn()}
@@ -62,6 +63,8 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         onTogglePreviewPanel={vi.fn()}
         onRespondToPermission={vi.fn()}
         onPermissionProfileChange={vi.fn()}
+        onRevokePermissionGrant={vi.fn()}
+        onClearPermissionGrants={vi.fn()}
         {...props}
       />
     )

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1,4 +1,4 @@
-import type { AcpPermissionRequest } from '../../../../shared/acp'
+import type { AcpPermissionGrant, AcpPermissionRequest } from '../../../../shared/acp'
 import type { NotebookSessionReference } from '../../../../shared/notebook'
 import type {
   PermissionProfileId,
@@ -78,6 +78,7 @@ type ConversationPanelProps = {
   pendingPermissions: AcpPermissionRequest[]
   permissionProfile: PermissionProfileId
   permissionProfileState: SessionPermissionProfileState | undefined
+  permissionGrants: AcpPermissionGrant[]
   canChangePermissionProfile: boolean
   onDraftDocChange: (doc: ComposerDoc) => void
   onSendMessage: (forcedSkillIds: string[]) => void
@@ -88,6 +89,8 @@ type ConversationPanelProps = {
   onTogglePreviewPanel: () => void
   onRespondToPermission: (requestId: string, optionId?: string) => void
   onPermissionProfileChange: (profile: PermissionProfileId) => void
+  onRevokePermissionGrant: (categoryKey: string) => void
+  onClearPermissionGrants: () => void
 }
 
 // Middle chat surface owns the visible conversation and local message composer UI.
@@ -104,6 +107,7 @@ const ConversationPanel = ({
   pendingPermissions,
   permissionProfile,
   permissionProfileState,
+  permissionGrants,
   canChangePermissionProfile,
   onDraftDocChange,
   onSendMessage,
@@ -113,7 +117,9 @@ const ConversationPanel = ({
   onOpenNotebook,
   onTogglePreviewPanel,
   onRespondToPermission,
-  onPermissionProfileChange
+  onPermissionProfileChange,
+  onRevokePermissionGrant,
+  onClearPermissionGrants
 }: ConversationPanelProps): React.JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -288,7 +294,7 @@ const ConversationPanel = ({
                         />
                       </div>
 
-                      <div className="flex items-center gap-1">
+                      <div className="@container/composer flex items-center gap-1">
                         <button
                           type="button"
                           disabled={!canEditDraft || isUploadingAttachments}
@@ -311,8 +317,11 @@ const ConversationPanel = ({
                         <ComposerPermissionProfilePicker
                           value={permissionProfile}
                           state={permissionProfileState}
+                          grants={permissionGrants}
                           disabled={!canChangePermissionProfile}
                           onChange={onPermissionProfileChange}
+                          onRevokeGrant={onRevokePermissionGrant}
+                          onClearGrants={onClearPermissionGrants}
                         />
 
                         <div className="flex-1" />

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -133,11 +133,13 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     actionError,
     pendingPermissions,
     permissionProfiles,
+    permissionGrants,
     sendMessage,
     cancelRun,
     deleteRuntimeSession,
     respondToPermission,
-    setPermissionProfile
+    setPermissionProfile,
+    revokePermissionGrant
   } = useWorkspaceAgentRuntime()
   const [draftDoc, setDraftDoc] = useState<ComposerDoc>(emptyDoc)
   const [newConversationPermissionProfile, setNewConversationPermissionProfile] =
@@ -172,6 +174,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const activePermissionProfileState = activeSession
     ? permissionProfiles?.[activeSession.id]
     : undefined
+  // Always-allow grants only exist for a bound session; new conversations have none yet.
+  const activePermissionGrants = activeSession ? (permissionGrants?.[activeSession.id] ?? []) : []
   // Composer controls follow only the selected session and persistence readiness.
   const canEditDraft = isSessionPersistenceReady
   // Sending is disabled while the current session is running or awaiting a decision.
@@ -551,6 +555,28 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     void setPermissionProfile(activeSession.id, profile)
   }
 
+  // Revokes one always-allow grant for the visible session; new conversations have no grants.
+  const revokeActivePermissionGrant = (categoryKey: string): void => {
+    if (!activeSession) return
+
+    void revokePermissionGrant(activeSession.id, categoryKey)
+  }
+
+  // Clears every always-allow grant for the visible session. Revokes are awaited in sequence so the
+  // final snapshot reflects the emptied set rather than a partial one racing back from the broker.
+  const clearActivePermissionGrants = (): void => {
+    if (!activeSession) return
+
+    const sessionId = activeSession.id
+    const categoryKeys = activePermissionGrants.map((grant) => grant.categoryKey)
+
+    void (async () => {
+      for (const categoryKey of categoryKeys) {
+        await revokePermissionGrant(sessionId, categoryKey)
+      }
+    })()
+  }
+
   // Opens the right preview on demand instead of stealing focus when the agent first uses notebook.
   const openNotebookPreview = (notebook: NotebookSessionReference): void => {
     upsertAndActivatePreviewItem(createNotebookPreviewItem(notebook))
@@ -599,6 +625,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             pendingPermissions={visiblePermissionRequests}
             permissionProfile={activePermissionProfile}
             permissionProfileState={activePermissionProfileState}
+            permissionGrants={activePermissionGrants}
             canChangePermissionProfile={canChangePermissionProfile}
             onDraftDocChange={setDraftDoc}
             onSendMessage={sendCurrentMessage}
@@ -609,6 +636,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             onTogglePreviewPanel={togglePreviewPanel}
             onRespondToPermission={respondToVisiblePermission}
             onPermissionProfileChange={changePermissionProfile}
+            onRevokePermissionGrant={revokeActivePermissionGrant}
+            onClearPermissionGrants={clearActivePermissionGrants}
           />
 
           <ResizableHandle

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -69,6 +69,14 @@ export type AcpPermissionRequest = {
   raw: unknown
 }
 
+// A tool category the user chose to always-allow for the rest of a session. `categoryKey` is the
+// broker's opaque grouping key; `label`/`kind` are the display projection shown in the composer.
+export type AcpPermissionGrant = {
+  categoryKey: string
+  label: string
+  kind: 'shell' | 'mcp' | 'tool'
+}
+
 export type AcpStateSnapshot = {
   status: AcpConnectionStatus
   cwd: string
@@ -78,6 +86,8 @@ export type AcpStateSnapshot = {
   events: AcpRuntimeEvent[]
   pendingPermissions: AcpPermissionRequest[]
   permissionProfiles: Record<string, SessionPermissionProfileState>
+  // Per-session always-allow grants (from per-request "Always"), so the UI can show and revoke them.
+  permissionGrants: Record<string, AcpPermissionGrant[]>
   promptInFlight: boolean
   promptInFlightSessionIds: string[]
 }
@@ -130,4 +140,9 @@ export type AcpPermissionResponse = {
   requestId: string
   optionId?: string
   cancelled?: boolean
+}
+
+export type AcpRevokePermissionGrantRequest = {
+  sessionId: string
+  categoryKey: string
 }


### PR DESCRIPTION
## Summary

Refines the per-conversation approval profiles (from #66) and closes the biggest usability gap in the per-tool "Always" mechanism: it was invisible and irrevocable. Also clarifies the boundary between the two approval tiers and tightens shell-grant scope.

The model, stated once: **the composer owns the global posture; a per-request "Always" only ever grants a single tool category.** Nothing in a per-request prompt is broader than one tool.

## Changes

**Composer profiles**
- Rename the middle profile `Approve for me` → **`Auto-approve edits`** and rewrite all three descriptions on one consistent axis (workspace edits = safe; commands, network, and MCP = still asked). The old copy hid that the only practical difference from *Ask* is auto-approving workspace file edits.
- Use `ShieldAlert` for **Full access** (a shield + exclamation) instead of a lightning bolt, so the three icons form a coherent shield family; vertically center the row icons.
- Collapse the composer pill to **icon-only** in a narrow window (container query), while the dropdown always shows full labels + descriptions.
- Shorten the Full access confirmation button to **"Enable"** (the title already carries the context).

**Per-request vs. composer boundary**
- Pin the two-tier model with tests: a per-tool "Always" grant **survives a composer profile switch**, and the conservative Auto fallback **never auto-approves MCP tools** (even a workspace-contained read).

**Per-tool grants**
- **Tighten shell grant scope**: key shell/execute grants by the *full command signature* (leading `ENV=` assignments stripped) instead of just the executable, so "Always" on `python a.py` no longer blankets every `python …` invocation.
- **Make grants visible and manageable** under Ask: a count badge on the pill, and a scrollable **"Always allowed this session"** list with per-item revoke and a one-click **Clear all**. The broker exposes `listGrants`/`revokeGrant`, plumbed through the runtime snapshot, a new `acp:revoke-permission-grant` IPC channel, and the renderer runtime/store chain.

## Out of scope (tracked separately)

- Notebook-layer gating for `notebook_execute` under native auto (the app's own MCP server can enforce independently of the ACP mode).
- Connector egress hardening.

## Validation

- `npm run typecheck` (node + web), `npm run lint`, `npm run build`
- `npm test` — **1199 passed / 4 skipped**
- Manual Electron dev run: all three profiles, per-tool Always → badge → per-item revoke and Clear all, shell `a.py` vs `b.py` distinct grants, MCP still prompting under Auto, narrow-window icon collapse, Full access confirm dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
