### PR TITLE
fix(settings): disable Claude Code bundled skills in app user scope

### DIFF
--- a/src/main/settings/claude-config-provision.test.ts
+++ b/src/main/settings/claude-config-provision.test.ts
@@ -87,6 +87,16 @@ describe('provisionAppClaudeConfigDir', () => {
     }
   })
 
+  it('disables Claude Code bundled skills in the app user scope', async () => {
+    root = await mkdtemp(join(tmpdir(), 'os-claude-config-'))
+    const configDir = join(root, 'claude')
+
+    await provisionAppClaudeConfigDir(configDir)
+
+    const settings = JSON.parse(await readFile(join(configDir, 'settings.json'), 'utf8'))
+    expect(settings.disableBundledSkills).toBe(true)
+  })
+
   it('merges guard deny rules into a pre-existing settings.json without dropping entries', async () => {
     root = await mkdtemp(join(tmpdir(), 'os-claude-config-'))
     const configDir = join(root, 'claude')
@@ -101,6 +111,7 @@ describe('provisionAppClaudeConfigDir', () => {
 
     const settings = JSON.parse(await readFile(join(configDir, 'settings.json'), 'utf8'))
     expect(settings.model).toBe('keep-me')
+    expect(settings.disableBundledSkills).toBe(true)
     expect(settings.permissions.deny).toContain('Bash(rm:*)')
     for (const rule of configDenyRules(configDir)) {
       expect(settings.permissions.deny).toContain(rule)

--- a/src/main/settings/claude-config-provision.ts
+++ b/src/main/settings/claude-config-provision.ts
@@ -26,10 +26,12 @@ const configDenyRules = (configDir: string): string[] => {
   return GUARDED_FILE_TOOLS.map((tool) => `${tool}(//${abs}/**)`)
 }
 
-// Writes/merges `<configDir>/settings.json` so its permissions.deny includes the guard rules, keeping
-// any settings and deny entries already present. Loaded because the agent runs with settingSources:
-// ['user'], i.e. this app-owned config dir is the user scope.
-const writeGuardSettings = async (configDir: string): Promise<void> => {
+// Writes/merges `<configDir>/settings.json` for the app-owned user scope (the agent runs with
+// settingSources: ['user']). Two things are enforced here, merge-preserving any settings already
+// present: the permissions.deny guard rules, and disableBundledSkills so Claude Code's own bundled
+// skills/workflows (dataviz, deep-research, …) never leak in — the app injects its OWN curated skill
+// set into `<configDir>/skills`, which disableBundledSkills leaves untouched.
+const writeAppSettings = async (configDir: string): Promise<void> => {
   const settingsPath = join(configDir, 'settings.json')
 
   let settings: Record<string, unknown> = {}
@@ -48,6 +50,7 @@ const writeGuardSettings = async (configDir: string): Promise<void> => {
   const deny = [...new Set([...existingDeny, ...configDenyRules(configDir)])]
 
   settings.permissions = { ...permissions, deny }
+  settings.disableBundledSkills = true
   await writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
 }
 
@@ -70,7 +73,7 @@ const provisionAppClaudeConfigDir = async (
     APP_ASSET_SUBDIRS.map((sub) => mkdir(join(configDir, sub), { recursive: true }))
   )
 
-  await writeGuardSettings(configDir)
+  await writeAppSettings(configDir)
 
   const materializer = options.materializer ?? new ClaudeCodeSkillMaterializer()
   const skills = options.skills ?? (await new SkillRegistry().list())


### PR DESCRIPTION
## Problem

The app launches claude-code via ACP with `settingSources: ['user']`, where the app-owned config dir (`<storageRoot>/claude`) is the user scope. Claude Code's own **bundled** skills (e.g. `dataviz`) were auto-triggering inside the notebook agent — a prompt like "draw a chart" would launch `dataviz`, leaking an external skill the app never curated into its agent.

## Fix

`provisionAppClaudeConfigDir` now writes `disableBundledSkills: true` into the app-owned `settings.json` (merge-preserving existing keys, alongside the existing `permissions.deny` guard rules). As a result:

- Claude Code's bundled skills/workflows (`dataviz`, `deep-research`, `pptx`, …) no longer load in the ACP-spawned agent.
- The app's **own** materialized skills under `<configDir>/skills` are unaffected (`disableBundledSkills` explicitly leaves `.claude/skills/` alone).
- Existing config dirs pick up the flag on the next spawn (provisioning is idempotent and merge-preserving).

## Verification

- Unit tests assert the provisioned `settings.json` contains `disableBundledSkills: true` and still preserves the `permissions.deny` guard rules and any pre-existing keys.
- `typecheck` (node + web), `eslint`, and the provision test suite pass.
- Verified live in `npm run dev`: after a session spawn, `~/.open-science-project/claude/settings.json` contains `disableBundledSkills: true` with the deny rules intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)