### PR TITLE
fix(artifacts): make the import-root rejection actionable

### DIFF
--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -128,18 +128,21 @@ describe('artifact repository', () => {
 
     const repository = new ArtifactRepository(root)
 
-    await expect(
-      repository.writePendingFile(
-        {
-          projectName: 'default-project',
-          sessionId: 'session-1',
-          runId: 'run-1',
-          filename: 'outside.txt',
-          source: { kind: 'localPath', path: sourcePath }
-        },
-        { allowedImportRoots: [allowedRoot] }
-      )
-    ).rejects.toThrow(/outside allowed artifact import roots/)
+    const attempt = repository.writePendingFile(
+      {
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        filename: 'outside.txt',
+        source: { kind: 'localPath', path: sourcePath }
+      },
+      { allowedImportRoots: [allowedRoot] }
+    )
+    await expect(attempt).rejects.toThrow(/outside allowed artifact import roots/)
+    // The rejection is actionable: it names the offending path and the allowed root so the agent can
+    // re-save inside the sandbox instead of retrying blindly.
+    await expect(attempt).rejects.toThrow(sourcePath)
+    await expect(attempt).rejects.toThrow(allowedRoot)
   })
 
   it('rejects path-like project, session, run, and filename segments', async () => {

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -114,12 +114,25 @@ const isPathInsideRoot = (root: string, filePath: string): boolean => {
     : false
 }
 
+// Builds an actionable rejection: name the allowed roots so the agent can re-save the file inside one
+// of them (e.g. the notebook session workspace) or fall back to inline content, instead of retrying
+// blindly against a path outside the sandbox (e.g. /tmp).
+const importRootsError = (filePath: string, allowedImportRoots: string[]): Error => {
+  const guidance =
+    allowedImportRoots.length > 0
+      ? ` Write the file under one of these directories and pass that path, or use inline content instead: ${allowedImportRoots.join(', ')}`
+      : ' No import roots are configured; use inline content instead.'
+  return new Error(
+    `Artifact local source path is outside allowed artifact import roots (got "${filePath}").${guidance}`
+  )
+}
+
 const resolveAllowedImportFilePath = async (
   filePath: string,
   allowedImportRoots: string[]
 ): Promise<string> => {
   if (allowedImportRoots.length === 0) {
-    throw new Error('Artifact local source path is outside allowed artifact import roots.')
+    throw importRootsError(filePath, allowedImportRoots)
   }
 
   const resolvedFilePath = await realpath(resolve(filePath))
@@ -138,7 +151,7 @@ const resolveAllowedImportFilePath = async (
   const isAllowed = resolvedRoots.some((root) => isPathInsideRoot(root, resolvedFilePath))
 
   if (!isAllowed) {
-    throw new Error('Artifact local source path is outside allowed artifact import roots.')
+    throw importRootsError(filePath, allowedImportRoots)
   }
 
   const fileStat = await stat(resolvedFilePath)


### PR DESCRIPTION
## Problem

`write_artifact_file` with a `localPath` outside the allowed import roots (e.g. `/tmp/foo.html`) failed with a generic message:

> Artifact local source path is outside allowed artifact import roots.

The agent had no way to know *where* it was allowed to write, so it retried blindly against paths outside the sandbox instead of saving into the notebook session workspace.

## Change

The rejection is now actionable — it names the offending path and the allowed roots (the notebook session workspace), and points at inline content as the fallback:

> Artifact local source path is outside allowed artifact import roots (got "/tmp/foo.html"). Write the file under one of these directories and pass that path, or use inline content instead: /Users/…/.open-science/notebooks/default-project/<sessionId>

The path sandbox itself is unchanged — this only improves the error so the agent can self-correct.

## Testing

- `src/main/artifacts/repository.test.ts` now asserts the rejection names the offending path and the allowed root.
- Full suite green; eslint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)