### PR TITLE
style(composer): use primary green for send button

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -38,7 +38,7 @@ const composerIconButtonClassName = cn(
 )
 
 const composerSendButtonClassName = cn(
-  'flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-action-primary text-white hover:bg-action-primary-hover disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-action-primary',
+  'flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-primary',
   composerInteractiveTransitionClassName
 )
 


### PR DESCRIPTION
## Summary

Unify the composer send button color with the green primary buttons used across Settings.

The send button previously used the orange `action-primary` color, which was inconsistent with the primary-action buttons in Settings (Save / Install / Add provider), all of which use `bg-primary` (green).

## Change

`ConversationPanel.tsx` — `composerSendButtonClassName`:

- `bg-action-primary text-white hover:bg-action-primary-hover` → `bg-primary text-primary-foreground hover:bg-primary/90`
- disabled hover updated accordingly (`disabled:hover:bg-primary`)

Single-line, style-only change. The running-session cancel button is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)