### PR TITLE
fix(notebook): serialize cell runs on the shared interpreter

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -489,4 +489,60 @@ describe('notebook runtime service', () => {
     expect(document.runs).toHaveLength(2)
     expect(document.runs.every((run) => run.status === 'completed')).toBe(true)
   })
+
+  it('runs different sessions in parallel instead of serializing across sessions', async () => {
+    const root = await createStorageRoot()
+    let active = 0
+    let maxConcurrent = 0
+    const releases = new Map<string, () => void>()
+    const service = new NotebookRuntimeService({
+      storageRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      // Each session gets its own executor; the shared counter proves both can be in flight at once.
+      executorFactory: (sessionId) => ({
+        execute: async (request): Promise<NotebookExecutionResult> => {
+          active += 1
+          maxConcurrent = Math.max(maxConcurrent, active)
+
+          // Hold each session's execution open until released so both can overlap.
+          await new Promise<void>((resolve) => releases.set(sessionId, resolve))
+          active -= 1
+
+          return {
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: [],
+            workingFiles: []
+          }
+        },
+        shutdown: async () => undefined
+      })
+    })
+
+    const submit = (sessionId: string): Promise<unknown> =>
+      service.execute({
+        projectName: 'default-project',
+        sessionId,
+        workspaceCwd: '/workspace',
+        code: 'print(1)',
+        source: 'user',
+        inputKind: 'terminal'
+      })
+
+    const runA = submit('session-a')
+    const runB = submit('session-b')
+
+    // Both sessions should be inside their own executors at the same time — the per-session queue
+    // must not serialize one session behind another.
+    await vi.waitFor(() => expect(releases.size).toBe(2))
+    expect(maxConcurrent).toBe(2)
+
+    releases.get('session-a')?.()
+    releases.get('session-b')?.()
+    await Promise.all([runA, runB])
+  })
 })

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { NotebookExecutionRequest, NotebookExecutionResult } from './runtime-service'
 import { NotebookRuntimeService } from './runtime-service'
@@ -405,5 +405,88 @@ describe('notebook runtime service', () => {
       runtimeRoot: join(root, 'runtime'),
       runJsonPath: join(root, 'notebooks', 'default-project', 'restored-session', 'run.json')
     })
+  })
+
+  it('serializes overlapping runs on the shared interpreter instead of failing the second', async () => {
+    const root = await createStorageRoot()
+    let active = 0
+    let maxConcurrent = 0
+    const releases: Array<() => void> = []
+    const service = new NotebookRuntimeService({
+      storageRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => {
+          active += 1
+          maxConcurrent = Math.max(maxConcurrent, active)
+
+          // Mirror the real single-slot executor: a second concurrent execution is rejected.
+          if (active > 1) {
+            active -= 1
+            throw new Error('Notebook execution is already running.')
+          }
+
+          // Hold this execution open so a second run can attempt to overlap with it.
+          await new Promise<void>((resolve) => releases.push(resolve))
+          active -= 1
+
+          return {
+            status: 'completed',
+            stdout: `${request.code}\n`,
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: [],
+            workingFiles: []
+          }
+        },
+        shutdown: async () => undefined
+      })
+    })
+
+    const submit = (code: string): Promise<unknown> =>
+      service.execute({
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        workspaceCwd: '/workspace',
+        code,
+        source: 'user',
+        inputKind: 'terminal'
+      })
+
+    const first = submit("print('a')")
+    // Wait until the first run has actually entered the executor and is holding the single slot.
+    await vi.waitFor(() => expect(releases).toHaveLength(1))
+
+    const second = submit("print('b')")
+    // Give the second run a chance to (wrongly) reach the executor while the first is in flight.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    // With serialization the second run is still queued, so only the first has entered the executor.
+    expect(releases).toHaveLength(1)
+
+    // Drain the first run; the second should then take the freed slot and run on its own.
+    releases[0]()
+    await vi.waitFor(() => expect(releases).toHaveLength(2))
+    releases[1]()
+
+    const [firstSummary, secondSummary] = (await Promise.all([first, second])) as Array<{
+      status: string
+    }>
+
+    expect(maxConcurrent).toBe(1)
+    expect(firstSummary.status).toBe('completed')
+    expect(secondSummary.status).toBe('completed')
+
+    const rawRunJson = await readFile(
+      join(root, 'notebooks', 'default-project', 'session-1', 'run.json'),
+      'utf8'
+    )
+    const document = JSON.parse(rawRunJson) as Awaited<
+      ReturnType<NotebookRunRepository['loadOrCreate']>
+    >
+    expect(document.runs).toHaveLength(2)
+    expect(document.runs.every((run) => run.status === 'completed')).toBe(true)
   })
 })

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -87,6 +87,9 @@ type RuntimeSession = {
   activeRunId?: string
   executionCount: number
   executor: NotebookExecutor
+  // Tail of the serialized execution chain: the shared interpreter runs one cell at a time, so each
+  // run is queued behind the previous one instead of failing when the kernel is already busy.
+  executionQueue: Promise<unknown>
 }
 
 // Builds the compact plain text output list shown in the preview panel.
@@ -239,6 +242,23 @@ class NotebookRuntimeService {
       throw new Error(`Notebook cell is still receiving code: ${cell.id}`)
     }
 
+    // Serialize execution on the shared interpreter: chain this run after any in-flight run so the
+    // single kernel processes one cell at a time instead of failing the overlapping request.
+    const run = session.executionQueue.then(() => this.runCellExclusive(session, cell, request))
+    // Keep the queue tail settled so a failing run never wedges the runs waiting behind it.
+    session.executionQueue = run.catch(() => undefined)
+
+    return run
+  }
+
+  // Runs one cell to completion while holding the session's single execution slot. Only ever invoked
+  // through the serialized executionQueue so activeRunId, execution counts, and the shared interpreter
+  // stay consistent across overlapping run requests.
+  private async runCellExclusive(
+    session: RuntimeSession,
+    cell: NotebookCell,
+    request: RunNotebookCellRequest
+  ): Promise<NotebookRunSummary> {
     this.notifyNotebookAvailable(session, request.source ?? 'agent')
     this.runSequence += 1
     session.executionCount += 1
@@ -480,7 +500,8 @@ class NotebookRuntimeService {
       runJsonPath: getNotebookRunJsonPath(this.options.storageRoot, projectName, request.sessionId),
       cells: [],
       executionCount: document.runs.length,
-      executor: this.createExecutor(request.sessionId)
+      executor: this.createExecutor(request.sessionId),
+      executionQueue: Promise.resolve()
     }
 
     this.sessions.set(request.sessionId, session)


### PR DESCRIPTION
## Problem

The notebook runs a single shared Python interpreter per session, but the agent (via the local RPC server) and the user terminal feed it independently. Concurrency was only enforced by the executor throwing `Notebook execution is already running.` at `python-executor.ts:242` — by which point `runCell` had already persisted a `running` record, so the throw was caught, converted into a **failed run**, and stored in history as red traceback text. It also clobbered `session.activeRunId` between the two runs. The renderer's `activeRunId` guard is best-effort and races against stale state, and the agent path had no guard at all.

## Fix

Serialize execution per session with an `executionQueue` promise chain, so overlapping runs are processed one at a time (Jupyter-style, matching how a single kernel sequences `execute_request`s) instead of failing the second. The queue tail is kept settled on rejection so a failing run never wedges the runs waiting behind it.

Serialization is intentionally **per session**: different sessions keep running in parallel (separate interpreter processes, separate queues, separate `run.json` files).

## Tests

- Overlapping runs on one session now queue and both complete cleanly, with no failed history entry.
- Two different sessions are proven to execute in parallel (`maxConcurrent === 2`), locking in that the queue never serializes across sessions.

Full suite passes (1204 tests), lint clean, typecheck clean.