### PR TITLE
fix(artifacts): recover a finalized artifact when a preview holds its pending path

### DIFF
--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -1,4 +1,13 @@
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  writeFile
+} from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -263,6 +272,62 @@ describe('artifact repository', () => {
     await expect(
       readdir(join(root, 'artifacts', 'default-project', 'session-1', '.pending'))
     ).resolves.not.toContain('run-1')
+  })
+
+  it('recovers a finalized file when a preview still references its old pending path', async () => {
+    // Root cause of the transient "Failed to read artifact preview ENOENT": the renderer keeps the
+    // `.pending/<run>/` path while finalizeRunArtifacts moves the file into the message directory.
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      filename: 'plot.png',
+      source: createInlineSource('img-bytes')
+    })
+    const pendingPath = join(
+      root,
+      'artifacts',
+      'default-project',
+      'session-1',
+      '.pending',
+      'run-1',
+      'plot.png'
+    )
+
+    await repository.finalizeRunArtifacts({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      messageId: 'message-7'
+    })
+
+    // The pending path is gone, but resolving/previewing it recovers the finalized copy.
+    const resolved = await repository.resolveManagedFilePath({ path: pendingPath })
+    const expected = await realpath(
+      join(root, 'artifacts', 'default-project', 'session-1', 'message-7', 'plot.png')
+    )
+    expect(resolved).toBe(expected)
+
+    const preview = await repository.readManagedFilePreview({ path: pendingPath })
+    expect(preview.content).toContain('img-bytes')
+  })
+
+  it('still throws for a missing artifact path that was never finalized', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+    const missing = join(
+      root,
+      'artifacts',
+      'default-project',
+      'session-1',
+      '.pending',
+      'run-1',
+      'nope.png'
+    )
+    await expect(repository.resolveManagedFilePath({ path: missing })).rejects.toThrow()
   })
 
   it('finalizes pending files from an internal artifact session scope', async () => {

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -10,7 +10,7 @@ import {
   writeFile
 } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
-import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 import type {
@@ -338,7 +338,18 @@ class ArtifactRepository {
     assertPathInsideArtifactRoot(artifactRoot, requestedPath)
 
     const resolvedArtifactRoot = await realpath(artifactRoot)
-    const resolvedFilePath = await realpath(requestedPath)
+    let resolvedFilePath: string
+    try {
+      resolvedFilePath = await realpath(requestedPath)
+    } catch (error) {
+      // A preview/open can hold a `.pending/<run>/<file>` path that finalizeRunArtifacts has already
+      // moved to `<session>/<messageId>/<file>`. Recover the finalized copy so the pending->message
+      // transition does not surface as a spurious ENOENT.
+      if (!isMissingFileError(error)) throw error
+      const recovered = await this.recoverFinalizedPendingPath(requestedPath)
+      if (!recovered) throw error
+      resolvedFilePath = await realpath(recovered)
+    }
 
     assertPathInsideArtifactRoot(resolvedArtifactRoot, resolvedFilePath)
 
@@ -349,6 +360,31 @@ class ArtifactRepository {
     }
 
     return resolvedFilePath
+  }
+
+  // Given a now-missing `.pending/<run>/<file>` artifact path, finds the same file after finalize moved
+  // it into a sibling message directory (`<session>/<messageId>/<file>`). Returns the newest match, or
+  // undefined when the path is not a pending path or no finalized copy exists. Path safety is still
+  // enforced by resolveManagedFilePath's root check on the returned path.
+  private async recoverFinalizedPendingPath(requestedPath: string): Promise<string | undefined> {
+    const pendingDir = dirname(dirname(requestedPath)) // <session>/.pending
+    if (basename(pendingDir) !== PENDING_DIR) return undefined
+    const sessionDir = dirname(pendingDir)
+    const filename = basename(requestedPath)
+
+    const entries = await readdir(sessionDir, { withFileTypes: true }).catch(() => null)
+    if (!entries) return undefined
+
+    const matches: Array<{ path: string; mtimeMs: number }> = []
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name === PENDING_DIR || entry.name === METADATA_DIR)
+        continue
+      const candidate = join(sessionDir, entry.name, filename)
+      const candidateStat = await stat(candidate).catch(() => undefined)
+      if (candidateStat?.isFile()) matches.push({ path: candidate, mtimeMs: candidateStat.mtimeMs })
+    }
+    matches.sort((left, right) => right.mtimeMs - left.mtimeMs)
+    return matches[0]?.path
   }
 
   // Reads a small text preview from a managed artifact without exposing arbitrary filesystem reads.


### PR DESCRIPTION
## Problem

When an assistant turn finalizes, `finalizeRunArtifacts` moves each generated file from `.pending/<run>/<file>` into `<session>/<messageId>/<file>` and deletes the pending directory. The renderer can still hold the old pending path, so a preview read (`artifacts:read-preview`, also `open-file` / `read-bytes`) races the move and fails:

```
Failed to read artifact preview Error: ... ENOENT: no such file or directory, realpath '.../.pending/<run>/sine_plot.png'
```

The file is actually saved and rendered fine — the error is a transient stale-path race during the pending→message transition.

## Change

`resolveManagedFilePath` now falls back, when a missing path is a `.pending/<run>/<file>` path, to the finalized copy in a sibling message directory (newest match). The pending→message transition no longer surfaces a spurious ENOENT. Truly missing paths still throw, and the recovered path is still validated against the artifact root.

Cross-platform: uses node `path` utilities only (no hardcoded separators); CI runs macOS / Ubuntu / Windows.

## Testing

- New repository tests: resolving/previewing an old pending path recovers the finalized file; a path that was never finalized still throws.
- Full suite green; eslint (0 errors) + typecheck across node/web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)