### PR TITLE
fix(connectors): stop duplicate host.mcp calls and harden the notebook connector flow

### DIFF
--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -32,8 +32,9 @@ describe('renderCustomSkillDoc', () => {
     expect(md).toContain('search')
     expect(md).toContain('fetch')
     expect(md).toContain('"type": "object"')
-    expect(md).toContain('host.mcp("myserver", "search", ...)')
-    expect(md).toContain('host.mcp("myserver", "fetch", ...)')
+    // No-arg tools render without a third argument (a literal ... would reach the bridge as Ellipsis).
+    expect(md).toContain('host.mcp("myserver", "search")')
+    expect(md).toContain('host.mcp("myserver", "fetch")')
   })
 
   it('uses the server-provided description verbatim when present', () => {

--- a/src/main/connectors/descriptors/biomart.ts
+++ b/src/main/connectors/descriptors/biomart.ts
@@ -94,6 +94,7 @@ export const BIOMART_TOOLS: ToolDescriptor[] = [
     input: { type: 'object', properties: {} },
     returns:
       '`[ { "name": str, "displayName": str } ]` — array of registered BioMart marts; `[]` when the registry lists none.',
+    example: 'result = host.mcp("biomart", "biomart_list_marts", {})',
     format: 'text',
     url: () => `${MARTSERVICE}?type=registry`,
     parse: (raw) => {
@@ -128,6 +129,8 @@ export const BIOMART_TOOLS: ToolDescriptor[] = [
     required: ['dataset', 'attributes'],
     returns:
       '`{ "dataset": str, "columns": [str], "rows": [[str]] }` — `columns` echoes the requested attributes and each row is a string array in that column order. `rows` is sorted lexicographically and `[]` when nothing matches.',
+    example:
+      'result = host.mcp("biomart", "biomart_query", {"dataset": "hsapiens_gene_ensembl", "attributes": ["ensembl_gene_id", "external_gene_name"]})',
     run: async (ctx, a) => {
       const dataset = String(a.dataset)
       const attributes = (a.attributes as unknown[]).map(String)

--- a/src/main/connectors/descriptors/biorxiv.ts
+++ b/src/main/connectors/descriptors/biorxiv.ts
@@ -51,6 +51,7 @@ export const BIORXIV_TOOLS: ToolDescriptor[] = [
     required: ['doi'],
     returns:
       '`[ { "doi": str, "title": str, "authors": str, "date": str, "category": str, "published": str } ]` — array of matching preprint versions; `published` is "NA" until linked to a published journal article. `[]` when the DOI is unknown.',
+    example: 'result = host.mcp("biorxiv", "biorxiv_get_details", {"doi": "10.1101/339747"})',
     url: (a) => `${BASE}/details/${normalizeServer(a.server)}/${normalizeDoi(String(a.doi))}`,
     parse: (raw) => summarize((raw as BiorxivResponse).collection ?? [])
   },
@@ -73,6 +74,8 @@ export const BIORXIV_TOOLS: ToolDescriptor[] = [
     required: ['from', 'to'],
     returns:
       '`{ "total": str, "results": [ { "doi": str, "title": str, "authors": str, "date": str, "category": str, "published": str } ] }` — one page of up to 30 preprints; `total` (passthrough string count) is the full interval total. `published` is "NA" until linked to a journal article.',
+    example:
+      'result = host.mcp("biorxiv", "biorxiv_list_interval", {"from": "2024-01-01", "to": "2024-01-02"})',
     url: (a) => {
       const cursor = Number.isFinite(Number(a.cursor)) ? Math.max(0, Number(a.cursor)) : 0
       const path = `${BASE}/details/${normalizeServer(a.server)}/${encodeURIComponent(String(a.from))}/${encodeURIComponent(String(a.to))}/${cursor}`

--- a/src/main/connectors/descriptors/cancer-models.ts
+++ b/src/main/connectors/descriptors/cancer-models.ts
@@ -57,6 +57,7 @@ export const CANCER_MODELS_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`[ { "studyId": str, "name": str, "cancerType": str, "allSampleCount": int } ]` — up to `page_size` studies (default 10); `[]` when nothing matches.',
+    example: 'result = host.mcp("cancer_models", "cbioportal_search_studies", {"query": "breast"})',
     url: (a) =>
       `${CBIOPORTAL}/studies?keyword=${encodeURIComponent(String(a.query))}&projection=DETAILED&pageSize=${Number(a.page_size ?? DEFAULT_PAGE_SIZE)}&pageNumber=0`,
     parse: (raw) => ((raw as CBioStudy[] | null) ?? []).map(compactStudyRow)
@@ -74,6 +75,8 @@ export const CANCER_MODELS_TOOLS: ToolDescriptor[] = [
     required: ['study_id'],
     returns:
       '`{ "studyId": str, "name": str, "description": str, "cancerType": str, "cancerTypeId": str, "pmid": str, "citation": str, "referenceGenome": str, "allSampleCount": int, "sequencedSampleCount": int, "cnaSampleCount": int, "structuralVariantCount": int }` — a single study; fields are undefined when absent from the cBioPortal record.',
+    example:
+      'result = host.mcp("cancer_models", "cbioportal_get_study", {"study_id": "msk_impact_2017"})',
     url: (a) =>
       `${CBIOPORTAL}/studies/${encodeURIComponent(String(a.study_id))}?projection=DETAILED`,
     parse: (raw) => compactStudyDetail(raw as CBioStudy)

--- a/src/main/connectors/descriptors/cellguide.ts
+++ b/src/main/connectors/descriptors/cellguide.ts
@@ -108,6 +108,7 @@ export const CELLGUIDE_TOOLS: ToolDescriptor[] = [
     required: ['cellType'],
     returns:
       '`{ "id": str, "name": str, "synonyms": [ str ], "ontologyDescription": str, "description": str, "descriptionSource": str, "references": [ ... ], "canonicalMarkerGenes": [ { "symbol": str, "name": str, "tissue": str, "publication": str, "publicationTitle": str } ] }` — returns `{ "error": str }` when the CL id is not found; markers capped at 30; `descriptionSource` is `validated`, `gpt`, or `none` (with `description` empty).',
+    example: 'result = host.mcp("cellguide", "cellguide_cell_type", {"cellType": "CL:0000622"})',
     run: async (ctx, a) => {
       const cellType = String(a.cellType)
       const jsonId = toJsonFormat(cellType)

--- a/src/main/connectors/descriptors/chembl.ts
+++ b/src/main/connectors/descriptors/chembl.ts
@@ -33,6 +33,7 @@ export const CHEMBL_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`[ { "chembl_id": str, "pref_name": str|null, "max_phase": str|int|null, "molecule_type": str|null } ]` — array of compact molecule summaries (all matches ChEMBL returns, unbounded); `[]` when nothing matches.',
+    example: 'result = host.mcp("chembl", "chembl_search_molecule", {"query": "aspirin"})',
     url: (a) => `${CHEMBL}/molecule/search?q=${encodeURIComponent(String(a.query))}&format=json`,
     parse: (raw) => ((raw as ChemblSearchResponse).molecules ?? []).map(summarize)
   },
@@ -48,6 +49,7 @@ export const CHEMBL_TOOLS: ToolDescriptor[] = [
     required: ['chembl_id'],
     returns:
       '`{ "chembl_id": str, "pref_name": str|null, "max_phase": str|int|null, "molecule_type": str|null }` — a single molecule summary; fields are null/undefined when absent on the record.',
+    example: 'result = host.mcp("chembl", "chembl_get_molecule", {"chembl_id": "CHEMBL25"})',
     url: (a) => `${CHEMBL}/molecule/${encodeURIComponent(String(a.chembl_id))}?format=json`,
     parse: (raw) => summarize(raw as ChemblMolecule)
   }

--- a/src/main/connectors/descriptors/chemistry.test.ts
+++ b/src/main/connectors/descriptors/chemistry.test.ts
@@ -37,6 +37,21 @@ describe('chemistry / pubchem', () => {
     expect(fetchImpl.mock.calls[1][0]).toContain('/compound/cid/2519/property/')
     expect(out).toEqual({ query: 'caffeine', compounds: [{ CID: 2519 }] })
   })
+
+  it('pubchem_get_image builds the imgsrv URL without a network call', async () => {
+    const fetchImpl = vi.fn()
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('pubchem_get_image'),
+      { cid: 2244 },
+      {}
+    )
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(out).toEqual({
+      cid: 2244,
+      format: 'png',
+      url: 'https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=2244&t=l'
+    })
+  })
 })
 
 describe('chemistry / chebi', () => {

--- a/src/main/connectors/descriptors/chemistry.ts
+++ b/src/main/connectors/descriptors/chemistry.ts
@@ -75,6 +75,7 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
     required: ['cids'],
     returns:
       '`[ { "CID": int, "MolecularFormula": str, "MolecularWeight": str, "CanonicalSMILES": str, "IUPACName": str } ]` — passthrough of PubChem `PropertyTable.Properties`, one entry per resolvable CID; unknown CIDs are simply omitted.',
+    example: 'result = host.mcp("chemistry", "pubchem_get_properties", {"cids": [2244]})',
     url: (a) =>
       `${PUBCHEM}/compound/cid/${([] as unknown[]).concat(a.cids as never).join(',')}/property/${PROPS}/JSON`,
     parse: (raw) => (raw as Props).PropertyTable.Properties
@@ -91,6 +92,8 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`{ "query": str, "compounds": [ { "CID": int, "MolecularFormula": str, "MolecularWeight": str, "CanonicalSMILES": str, "IUPACName": str } ] }` — up to `max_cids` compounds (default 5); `compounds` is `[]` when the name matches nothing.',
+    example:
+      'result = host.mcp("chemistry", "pubchem_search_compounds", {"query": "caffeine", "max_cids": 5})',
     run: async (ctx, a) => {
       const cidRes = (await ctx.fetchJson(
         `${PUBCHEM}/compound/name/${encodeURIComponent(String(a.query))}/cids/JSON`
@@ -106,6 +109,29 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
     }
   },
   {
+    id: 'pubchem_get_image',
+    connector: 'chemistry',
+    description:
+      "Get the URL of a compound's 2D structure image (PNG) by PubChem CID; returns a URL the caller can download or save as an artifact.",
+    input: {
+      type: 'object',
+      properties: { cid: { type: 'integer' } },
+      required: ['cid']
+    },
+    required: ['cid'],
+    returns:
+      '`{ "cid": int, "format": "png", "url": str }` — a direct URL to the compound\'s 2D structure PNG (e.g. `https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=2244&t=l`).',
+    example: 'result = host.mcp("chemistry", "pubchem_get_image", {"cid": 2244})',
+    run: async (_ctx, a) => {
+      const cid = Number(a.cid)
+      return {
+        cid,
+        format: 'png',
+        url: `https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=${cid}&t=l`
+      }
+    }
+  },
+  {
     id: 'chebi_get_entity',
     connector: 'chemistry',
     description: 'Look up a ChEBI ontology entity by ID: name, formula, structure, definition.',
@@ -117,6 +143,7 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
     required: ['chebi_id'],
     returns:
       '`{ "chebi_accession": str, "name": str, "definition": str, "formula": str, "charge": str, "mass": str, "smiles": str, "inchi": str, "inchikey": str }` — any field may be null when absent from the ChEBI record (e.g. no structure or definition).',
+    example: 'result = host.mcp("chemistry", "chebi_get_entity", {"chebi_id": "CHEBI:27732"})',
     url: (a) => `${CHEBI_API}/compound/${normalizeChebiId(a.chebi_id)}/`,
     parse: (raw) => {
       const c = raw as ChebiCompound
@@ -145,6 +172,7 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
     required: ['rhea_id'],
     returns:
       '`{ "rhea_id": str, "equation": str, "status": str, "left_side": [ { "compound_accession": str, "name": str } ], "right_side": [ ... ] }` — throws if the id has no match; a participant `name` may be null when the compound has no label.',
+    example: 'result = host.mcp("chemistry", "rhea_get_reaction", {"rhea_id": "10280"})',
     run: async (ctx, a) => {
       const acc = normalizeRheaId(a.rhea_id)
       const query = `${RHEA_PREFIXES}SELECT ?equation ?status ?side ?cacc ?cname WHERE {
@@ -191,6 +219,8 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
     required: ['uniprot'],
     returns:
       '`{ "uniprot": str, "cutoff_nm": int, "n_rows": int, "affinities": [ { "target_name": str, "monomer_id": str, "smiles": str, "affinity_type": str, "affinity": str, "pmid": str, "doi": str } ] }` — `affinity` is a numeric value in nM as a string; `affinities` is `[]` and `n_rows` 0 when no ligand passes the cutoff; `n_rows` equals the returned count.',
+    example:
+      'result = host.mcp("chemistry", "bindingdb_affinities", {"uniprot": "P00533", "cutoff_nm": 100})',
     run: async (ctx, a) => {
       const uniprot = String(a.uniprot).trim().toUpperCase()
       if (!UNIPROT_RE.test(uniprot)) throw new Error(`not a UniProt accession: ${uniprot}`)

--- a/src/main/connectors/descriptors/clinical-genomics.ts
+++ b/src/main/connectors/descriptors/clinical-genomics.ts
@@ -141,6 +141,8 @@ export const CLINICAL_GENOMICS_TOOLS: ToolDescriptor[] = [
     required: ['gene'],
     returns:
       '`{ "gene_id": str, "symbol": str, "approved_name": str, "n_diseases_total": int, "returned": int, "diseases": [ { "disease_id": str, "disease_name": str, "score": float } ] }` — diseases ranked by association score, up to `limit` (default 10); `n_diseases_total` is the full count, usually larger than `returned`. Unresolved symbol or absent target yields `gene_id`/`symbol` null and `diseases: []`.',
+    example:
+      'result = host.mcp("clinical_genomics", "opentargets_target_diseases", {"gene": "EGFR", "limit": 10})',
     run: async (ctx, a) => {
       const gene = String(a.gene)
       const limit = Number(a.limit ?? DEFAULT_LIMIT)
@@ -200,6 +202,8 @@ export const CLINICAL_GENOMICS_TOOLS: ToolDescriptor[] = [
     required: ['chembl_id'],
     returns:
       '`{ "chembl_id": str, "name": str, "drug_type": str, "max_clinical_stage": str, "mechanisms_of_action": [ { "mechanism_of_action": str, "action_type": str, "targets": [ { "id": str, "approved_symbol": str } ] } ], "n_indications_total": int, "returned_indications": int, "indications": [ { "disease_id": str, "disease_name": str, "max_clinical_stage": str } ] }` — indications capped at `limit` (default 10); `n_indications_total` is the full count. Unknown ChEMBL id returns `{ "chembl_id": str, "found": false }`.',
+    example:
+      'result = host.mcp("clinical_genomics", "opentargets_drug", {"chembl_id": "CHEMBL1201583"})',
     run: async (ctx, a) => {
       const chemblId = String(a.chembl_id)
       const limit = Number(a.limit ?? DEFAULT_LIMIT)

--- a/src/main/connectors/descriptors/clinical-trials.ts
+++ b/src/main/connectors/descriptors/clinical-trials.ts
@@ -26,6 +26,8 @@ export const CLINICAL_TRIALS_TOOLS: ToolDescriptor[] = [
     required: ['nct_id'],
     returns:
       '`{ "nct_id": str, "title": str, "status": str, "phase": [str], "conditions": [str] }` — one study; `phase` and `conditions` are arrays (may be undefined when the study omits those modules).',
+    example:
+      'result = host.mcp("clinical_trials", "clinicaltrials_get_study", {"nct_id": "NCT00000419"})',
     url: (a) => `${STUDIES}/${encodeURIComponent(String(a.nct_id))}`,
     parse: (raw) => {
       const proto = (raw as Study).protocolSection ?? {}
@@ -51,6 +53,8 @@ export const CLINICAL_TRIALS_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`{ "studies": [ { "nct_id": str, "title": str, "status": str } ], "nextPageToken"?: str }` — up to `page_size` studies (default 10); `nextPageToken` is present only when more pages exist. `studies` is `[]` when nothing matches.',
+    example:
+      'result = host.mcp("clinical_trials", "clinicaltrials_search", {"query": "aspirin", "page_size": 10})',
     run: async (ctx, a) => {
       const url = `${STUDIES}?query.term=${encodeURIComponent(String(a.query))}&pageSize=${Number(a.page_size ?? 10)}`
       const res = (await ctx.fetchJson(url)) as SearchResponse

--- a/src/main/connectors/descriptors/drug-regulatory.ts
+++ b/src/main/connectors/descriptors/drug-regulatory.ts
@@ -46,6 +46,8 @@ export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`[ { "id": str, "brand_name": str, "generic_name": str, "manufacturer": str, "indications": str } ]` — up to `limit` label records (default 10); each field is the first openFDA array element and may be undefined. `[]` when nothing matches.',
+    example:
+      'result = host.mcp("drug_regulatory", "openfda_search_drug_label", {"query": \'openfda.brand_name:"Tylenol"\', "limit": 5})',
     url: (a) =>
       `${LABEL}?search=${encodeURIComponent(String(a.query))}&limit=${Number(a.limit ?? 10)}`,
     parse: (raw) =>
@@ -73,6 +75,8 @@ export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`[ { "safety_report_id": str, "receive_date": str, "serious": bool, "reactions": [str] } ]` — up to `limit` FAERS reports (default 10); `serious` is true when the upstream flag is "1", `reactions` lists MedDRA preferred terms (`[]` when none). `[]` when nothing matches.',
+    example:
+      'result = host.mcp("drug_regulatory", "openfda_search_adverse_events", {"query": \'patient.drug.medicinalproduct:"ASPIRIN"\', "limit": 3})',
     url: (a) =>
       `${EVENT}?search=${encodeURIComponent(String(a.query))}&limit=${Number(a.limit ?? 10)}`,
     parse: (raw) =>

--- a/src/main/connectors/descriptors/expression.ts
+++ b/src/main/connectors/descriptors/expression.ts
@@ -36,6 +36,7 @@ export const EXPRESSION_TOOLS: ToolDescriptor[] = [
     required: ['geneId'],
     returns:
       '`[ { "gene_symbol": str, "gencode_id": str, "gencode_version": str, "genome_build": str } ]` — array of matching gene references (usually one); `[]` when the gene isn\'t found. Fields are undefined if absent upstream.',
+    example: 'result = host.mcp("expression", "gtex_resolve_gene", {"geneId": "BRCA2"})',
     url: (a) => `${GTEX}/reference/gene?geneId=${encodeURIComponent(String(a.geneId))}`,
     parse: (raw) =>
       ((raw as GtexGeneRefResponse).data ?? []).map((g) => ({
@@ -61,6 +62,8 @@ export const EXPRESSION_TOOLS: ToolDescriptor[] = [
     required: ['gencodeId'],
     returns:
       '`[ { "tissue": str, "median_tpm": float, "unit": str } ]` — one row per GTEx tissue site; `median_tpm` in TPM. `[]` when the gencodeId is unknown for the dataset.',
+    example:
+      'result = host.mcp("expression", "gtex_gene_expression", {"gencodeId": "ENSG00000139618.14"})',
     url: (a) => {
       const dataset = String(a.datasetId ?? DEFAULT_DATASET)
       return `${GTEX}/expression/medianGeneExpression?gencodeId=${encodeURIComponent(String(a.gencodeId))}&datasetId=${encodeURIComponent(dataset)}`

--- a/src/main/connectors/descriptors/genes.ts
+++ b/src/main/connectors/descriptors/genes.ts
@@ -53,6 +53,7 @@ export const GENES_TOOLS: ToolDescriptor[] = [
     required: ['accession'],
     returns:
       '`{ "accession": str, "name": str, "gene": str, "function": str }` — any field may be null when the entry lacks it (e.g. no recommended name, gene, or FUNCTION comment).',
+    example: 'result = host.mcp("genes", "uniprot_get_entry", {"accession": "P04637"})',
     url: (a) => `${UNIPROT}/${encodeURIComponent(String(a.accession))}.json`,
     parse: (raw) => {
       const entry = raw as UniProtEntry
@@ -77,6 +78,7 @@ export const GENES_TOOLS: ToolDescriptor[] = [
     required: ['symbol'],
     returns:
       '`[ { "symbol": str, "name": str, "entrezgene": str, "ensembl": { "gene": str } | [ { "gene": str } ] } ]` — human hits only; `[]` when the symbol resolves to nothing; `ensembl` is an object or array depending on gene count.',
+    example: 'result = host.mcp("genes", "mygene_query", {"symbol": "TP53"})',
     url: (a) =>
       `${MYGENE}?q=${encodeURIComponent(String(a.symbol))}&species=human&fields=${MYGENE_FIELDS}`,
     parse: (raw) =>
@@ -99,6 +101,7 @@ export const GENES_TOOLS: ToolDescriptor[] = [
     required: ['id'],
     returns:
       '`{ "id": str, "label": str, "definition": str, "ontology": str }` — only the first matching OLS4 term is used; all fields are null when the GO id has no term match.',
+    example: 'result = host.mcp("genes", "go_get_term", {"id": "GO:0006281"})',
     // OLS4 `obo_id` lookup avoids double-encoding a full term IRI (see upstream ols_terms client).
     url: (a) => `${OLS}/ontologies/go/terms?obo_id=${encodeURIComponent(String(a.id))}`,
     parse: (raw) => {
@@ -130,6 +133,7 @@ export const GENES_TOOLS: ToolDescriptor[] = [
     required: ['identifier'],
     returns:
       '`[ { "pathway_id": str, "name": str } ]` — `[]` when the identifier maps to no Reactome pathways for the given species.',
+    example: 'result = host.mcp("genes", "reactome_pathways_for_gene", {"identifier": "P04637"})',
     url: (a) => {
       const resource = a.resource ? String(a.resource) : 'UniProt'
       const species = a.species ? String(a.species) : '9606'

--- a/src/main/connectors/descriptors/genomes.ts
+++ b/src/main/connectors/descriptors/genomes.ts
@@ -54,6 +54,7 @@ export const GENOMES_TOOLS: ToolDescriptor[] = [
     required: ['symbol'],
     returns:
       '`{ "id": str, "display_name": str, "biotype": str, "seq_region_name": str, "start": int, "end": int, "strand": int }` — single feature; `seq_region_name` is the chromosome, `strand` is 1 or -1. Fields undefined when absent upstream.',
+    example: 'result = host.mcp("genomes", "ensembl_lookup_symbol", {"symbol": "BRCA2"})',
     url: (a) => {
       const species = String(a.species ?? DEFAULT_SPECIES)
       const symbol = String(a.symbol)
@@ -74,6 +75,7 @@ export const GENOMES_TOOLS: ToolDescriptor[] = [
     required: ['id'],
     returns:
       '`{ "id": str, "display_name": str, "biotype": str, "seq_region_name": str, "start": int, "end": int, "strand": int }` — single feature; `seq_region_name` is the chromosome, `strand` is 1 or -1. Fields undefined when absent upstream.',
+    example: 'result = host.mcp("genomes", "ensembl_lookup_id", {"id": "ENSG00000139618"})',
     url: (a) =>
       `${ENSEMBL}/lookup/id/${encodeURIComponent(String(a.id))}?content-type=application/json`,
     parse: parseFeature

--- a/src/main/connectors/descriptors/geo.ts
+++ b/src/main/connectors/descriptors/geo.ts
@@ -29,6 +29,7 @@ export const GEO_TOOLS: ToolDescriptor[] = [
     required: ['term'],
     returns:
       '`{ "term": str, "count": int, "records": [ { "accession": str, "title": str, "summary": str, "taxon": str, "n_samples": int, "gdstype": str } ] }` — up to `retmax` records (default 5); `count` is the total number of GEO matches, usually far larger than the returned list. `records` is `[]` when nothing matches.',
+    example: 'result = host.mcp("geo", "geo_search", {"term": "asthma", "retmax": 5})',
     run: async (ctx, a) => {
       const q = ncbiEtiquette(ctx.credentials)
       const es = (await ctx.fetchJson(

--- a/src/main/connectors/descriptors/gnomad.ts
+++ b/src/main/connectors/descriptors/gnomad.ts
@@ -77,6 +77,8 @@ export const GNOMAD_TOOLS: ToolDescriptor[] = [
     required: ['gene_symbol'],
     returns:
       '`{ "gene_id": str, "symbol": str, "chrom": str, "start": int, "stop": int, "dataset": str, "n_variants_total": int, "returned": int, "variants": [ { "variant_id": str, "pos": int, "ref": str, "alt": str, "rsids": [str], "exome": { "ac": int, "an": int, "af": float }|null, "genome": {...}|null } ] }` — variants capped at `limit` (default 25); `n_variants_total` is the full count. `exome`/`genome` are null when absent. Unknown gene returns `{ "symbol": str, "dataset": str, "gene_id": null, "n_variants": 0, "variants": [] }`.',
+    example:
+      'result = host.mcp("gnomad", "gnomad_gene_variants", {"gene_symbol": "PCSK9", "limit": 25})',
     run: async (ctx, a) => {
       const symbol = String(a.gene_symbol)
       const dataset = String(a.dataset ?? DEFAULT_DATASET)

--- a/src/main/connectors/descriptors/human-genetics.ts
+++ b/src/main/connectors/descriptors/human-genetics.ts
@@ -56,6 +56,7 @@ export const HUMAN_GENETICS_TOOLS: ToolDescriptor[] = [
     required: ['gene'],
     returns:
       '`[ { "rsId": str, "pValue": float, "riskAllele": str, "mappedGenes": [ str ], "trait": str } ]` — up to 50 associations sorted by ascending p-value; `[]` when none match. `mappedGenes` may be empty; `trait` falls back to reported trait.',
+    example: 'result = host.mcp("human_genetics", "gwas_search_associations", {"gene": "APOE"})',
     url: (a) =>
       `${GWAS_ASSOCIATIONS}?mapped_gene=${encodeURIComponent(String(a.gene))}&size=${PAGE_SIZE}&sort=p_value&direction=asc`,
     parse: (raw) => flattenAssociations(raw)
@@ -75,6 +76,7 @@ export const HUMAN_GENETICS_TOOLS: ToolDescriptor[] = [
     required: ['rsId'],
     returns:
       '`[ { "rsId": str, "pValue": float, "riskAllele": str, "mappedGenes": [ str ], "trait": str } ]` — up to 50 associations sorted by ascending p-value; `[]` when none match. `mappedGenes` may be empty; `trait` falls back to reported trait.',
+    example: 'result = host.mcp("human_genetics", "gwas_variant_associations", {"rsId": "rs7412"})',
     url: (a) =>
       `${GWAS_ASSOCIATIONS}?rs_id=${encodeURIComponent(String(a.rsId))}&size=${PAGE_SIZE}&sort=p_value&direction=asc`,
     parse: (raw) => flattenAssociations(raw)

--- a/src/main/connectors/descriptors/literature.ts
+++ b/src/main/connectors/descriptors/literature.ts
@@ -17,6 +17,8 @@ export const LITERATURE_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`[ { "id": str, "title": str, "summary": str } ]` — up to `max_results` hits (default 5), parsed from arXiv Atom XML; `[]` when nothing matches.',
+    example:
+      'result = host.mcp("literature", "arxiv_search", {"query": "diffusion", "max_results": 5})',
     format: 'text',
     url: (a) =>
       `https://export.arxiv.org/api/query?search_query=all:${encodeURIComponent(String(a.query))}&max_results=${Number(a.max_results ?? 5)}`,

--- a/src/main/connectors/descriptors/omics-archives.ts
+++ b/src/main/connectors/descriptors/omics-archives.ts
@@ -45,6 +45,8 @@ export const OMICS_ARCHIVES_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`[ { "accession": str, "title": str, "type": str, "release_date": str } ]` — up to `pageSize` hits (default 20), newest release_date first; `[]` when nothing matches.',
+    example:
+      'result = host.mcp("omics_archives", "arrayexpress_search", {"query": "cancer", "pageSize": 20})',
     url: (a) => {
       const pageSize = Number(a.pageSize ?? DEFAULT_PAGE_SIZE)
       return (
@@ -73,6 +75,8 @@ export const OMICS_ARCHIVES_TOOLS: ToolDescriptor[] = [
     required: ['accession'],
     returns:
       '`{ "accession": str, "title": str, "release_date": str, "organism": str, "study_type": str, "description": str }` — single study; any field is undefined when its attribute is absent upstream.',
+    example:
+      'result = host.mcp("omics_archives", "arrayexpress_get_study", {"accession": "E-MTAB-17244"})',
     url: (a) => `${BIOSTUDIES}/studies/${encodeURIComponent(String(a.accession))}`,
     parse: (raw) => {
       const study = raw as BioStudiesStudy

--- a/src/main/connectors/descriptors/openalex.ts
+++ b/src/main/connectors/descriptors/openalex.ts
@@ -62,6 +62,8 @@ export const OPENALEX_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`[ { "id": str, "title": str, "publication_year": int, "doi": str, "cited_by_count": int, "authors": [ str ] } ]` — one entry per hit, up to `per_page` (default 5); `[]` when nothing matches. `authors` is capped at the first 5 names; `id` is the short OpenAlex W-id and any field may be null when absent upstream.',
+    example:
+      'result = host.mcp("openalex", "openalex_search_works", {"query": "open access", "per_page": 5})',
     url: (a) =>
       `${WORKS}?search=${encodeURIComponent(String(a.query))}&per_page=${Number(a.per_page ?? 5)}`,
     parse: (raw) => ((raw as OpenAlexWorksResponse).results ?? []).map(compactWork)
@@ -79,6 +81,7 @@ export const OPENALEX_TOOLS: ToolDescriptor[] = [
     required: ['id'],
     returns:
       '`{ "id": str, "title": str, "publication_year": int, "doi": str, "cited_by_count": int, "authors": [ str ] }` — one work; `authors` is capped at the first 5 names and `id` is the short OpenAlex W-id. Any field may be null when absent upstream.',
+    example: 'result = host.mcp("openalex", "openalex_get_work", {"id": "W2741809807"})',
     url: (a) => `${WORKS}/${encodeURIComponent(normalizeWorkId(String(a.id)))}`,
     parse: (raw) => compactWork(raw as OpenAlexWork)
   }

--- a/src/main/connectors/descriptors/protein-annotation.ts
+++ b/src/main/connectors/descriptors/protein-annotation.ts
@@ -26,6 +26,8 @@ export const PROTEIN_ANNOTATION_TOOLS: ToolDescriptor[] = [
     required: ['gene'],
     returns:
       '`[ { "partner": str, "score": float } ]` — up to `limit` partners (default 10) for the query gene, ranked by STRING combined score (0–1); `[]` when the gene is unknown or has no partners.',
+    example:
+      'result = host.mcp("protein_annotation", "string_interaction_partners", {"gene": "TP53", "limit": 10})',
     url: (a) => {
       const limit = typeof a.limit === 'number' ? a.limit : 10
       return `${STRING_BASE}/interaction_partners?identifiers=${encodeURIComponent(String(a.gene))}&species=${HUMAN_TAXON_ID}&limit=${limit}`
@@ -50,6 +52,8 @@ export const PROTEIN_ANNOTATION_TOOLS: ToolDescriptor[] = [
     required: ['genes'],
     returns:
       '`[ { "a": str, "b": str, "score": float } ]` — one entry per interaction edge among the input genes, `score` is the STRING combined score (0–1); `[]` when no edges are found. Only pairs with an interaction are returned, not every gene pair.',
+    example:
+      'result = host.mcp("protein_annotation", "string_network", {"genes": ["TP53", "MDM2"]})',
     url: (a) => {
       const genes = a.genes as string[]
       return `${STRING_BASE}/network?identifiers=${encodeURIComponent(genes.join(','))}&species=${HUMAN_TAXON_ID}`

--- a/src/main/connectors/descriptors/pubmed.ts
+++ b/src/main/connectors/descriptors/pubmed.ts
@@ -45,6 +45,8 @@ export const PUBMED_TOOLS: ToolDescriptor[] = [
     required: ['term'],
     returns:
       '`{ "term": str, "count": int, "articles": [ { "pmid": str, "title": str, "date": str } ] }` — up to `retmax` articles (default 5); `count` is the total number of PubMed matches and is usually far larger than the returned list. `articles` is `[]` when nothing matches.',
+    example:
+      'result = host.mcp("pubmed", "pubmed_search", {"term": "tumor progression", "retmax": 10})',
     run: async (ctx, a) => {
       const q = ncbiEtiquette(ctx.credentials)
       const es = (await ctx.fetchJson(
@@ -87,6 +89,7 @@ export const PUBMED_TOOLS: ToolDescriptor[] = [
     required: ['pmids'],
     returns:
       '`{ "pmids": [str], "articles": [ { "pmid": str, "title": str, "authors": [str], "journal": str, "date": str, "doi": str|null, "abstract": str|null } ] }` — one entry per requested PMID (order preserved); `doi`/`abstract` are null when PubMed has none, `authors` is `[]` when unlisted.',
+    example: 'result = host.mcp("pubmed", "pubmed_fetch", {"pmids": ["40302006", "31452104"]})',
     run: async (ctx, a) => {
       const ids = (Array.isArray(a.pmids) ? a.pmids : [a.pmids]).map((x) => String(x))
       const q = ncbiEtiquette(ctx.credentials)

--- a/src/main/connectors/descriptors/regulation.ts
+++ b/src/main/connectors/descriptors/regulation.ts
@@ -43,6 +43,7 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`[ { "accession": str, "assay_title": str, "biosample": str, "target": str, "status": str } ]` — one entry per matching experiment, up to `limit` (default 25); `[]` when nothing matches. `target`/`biosample` are null when the experiment has none.',
+    example: 'result = host.mcp("regulation", "encode_search", {"query": "CTCF", "limit": 25})',
     url: (a) => {
       const limit = typeof a.limit === 'number' && a.limit > 0 ? a.limit : DEFAULT_SEARCH_LIMIT
       return `${ENCODE}/search/?searchTerm=${encodeURIComponent(String(a.query))}&type=Experiment&format=json&limit=${limit}`
@@ -69,6 +70,8 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
     required: ['accession'],
     returns:
       '`{ "accession": str, "status": str, "assay_title": str, "assay_term_name": str, "biosample": str, "target": str, "description": str, "lab": str, "date_released": str }` — one experiment; `target`/`lab`/`biosample`/`date_released` are null when absent upstream.',
+    example:
+      'result = host.mcp("regulation", "encode_get_experiment", {"accession": "ENCSR613LSQ"})',
     url: (a) => `${ENCODE}/experiments/${encodeURIComponent(String(a.accession))}/?format=json`,
     parse: (raw) => {
       const e = raw as EncodeExperiment

--- a/src/main/connectors/descriptors/research-resources.ts
+++ b/src/main/connectors/descriptors/research-resources.ts
@@ -53,6 +53,7 @@ export const RESEARCH_RESOURCES_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`{ "total_elements": int, "items": [ { "ab_id": str, "name": str, "vendor": str, "target": str, "clonality": str } ] }` — `ab_id` is an `AB_<id>` RRID. `total_elements` is the full match count; `items` holds one page (default 10) and is `[]` when nothing matches. Anonymous paging past page*size > 500 fails upstream (HTTP 401).',
+    example: 'result = host.mcp("research_resources", "antibody_search", {"query": "TP53"})',
     url: (a) => {
       const page = Number.isFinite(Number(a.page)) ? Math.max(1, Number(a.page)) : 1
       const size = Number.isFinite(Number(a.size)) ? Math.max(1, Number(a.size)) : 10
@@ -79,6 +80,7 @@ export const RESEARCH_RESOURCES_TOOLS: ToolDescriptor[] = [
     required: ['ab_id'],
     returns:
       '`[ { "ab_id": str, "name": str, "vendor": str, "target": str, "clonality": str } ]` — an array because one accession can map to several curated records; `ab_id` is an `AB_<id>` RRID. Empty array when the id has no records.',
+    example: 'result = host.mcp("research_resources", "antibody_get", {"ab_id": "AB_3717446"})',
     url: (a) => `${BASE}/antibodies/${parseAbId(a.ab_id)}`,
     parse: (raw) => (raw as AntibodyRecord[]).map(compactAntibody)
   }

--- a/src/main/connectors/descriptors/rna.ts
+++ b/src/main/connectors/descriptors/rna.ts
@@ -29,6 +29,7 @@ export const RNA_TOOLS: ToolDescriptor[] = [
     required: ['family'],
     returns:
       '`{ "rfam_acc": str, "id": str, "description": str, "type": str }` — `rfam_acc` is the accession (RF#####), `id` the family name (e.g. tRNA), `type` the curated RNA type. Fields are missing/undefined when absent upstream.',
+    example: 'result = host.mcp("rna", "rfam_get_family", {"family": "RF00005"})',
     url: (a) =>
       `${RFAM}/family/${encodeURIComponent(String(a.family))}?content-type=application/json`,
     parse: (raw) => {
@@ -54,6 +55,7 @@ export const RNA_TOOLS: ToolDescriptor[] = [
     format: 'text',
     returns:
       '`{ "accession": str, "id": str }` — echoes the input `accession` and its resolved family `id` (upstream plain-text response, trimmed).',
+    example: 'result = host.mcp("rna", "rfam_acc_to_id", {"accession": "RF00005"})',
     url: (a) =>
       `${RFAM}/family/${encodeURIComponent(String(a.accession))}/id?content-type=text/plain`,
     parse: (raw, a) => ({ accession: String(a.accession), id: String(raw).trim() })

--- a/src/main/connectors/descriptors/structures.ts
+++ b/src/main/connectors/descriptors/structures.ts
@@ -71,6 +71,7 @@ export const STRUCTURES_TOOLS: ToolDescriptor[] = [
     required: ['pdb_id'],
     returns:
       '`{ "pdb_id": str, "title": str, "method": str, "resolution": float }` — a single PDB entry; `method` is the first experiment method and `resolution` is the first value of resolution_combined in Angstroms. Fields are undefined when absent from the RCSB record.',
+    example: 'result = host.mcp("structures", "pdb_get_entry", {"pdb_id": "1TUP"})',
     url: (a) => `${PDB_DATA}/entry/${encodeURIComponent(String(a.pdb_id).trim().toUpperCase())}`,
     parse: (raw) => {
       const entry = raw as PdbEntry
@@ -95,6 +96,7 @@ export const STRUCTURES_TOOLS: ToolDescriptor[] = [
     required: ['uniprot_accession'],
     returns:
       '`{ "uniprot": str, "model_url": str, "cif_url": str, "mean_plddt": float }` — the first AlphaFold model for the accession; `mean_plddt` is the global confidence score (0-100). All fields undefined when no prediction exists.',
+    example: 'result = host.mcp("structures", "alphafold_get", {"uniprot_accession": "P04637"})',
     url: (a) => `${ALPHAFOLD}/${encodeURIComponent(String(a.uniprot_accession).trim())}`,
     parse: (raw) => {
       const model = ((raw as AlphaFoldModel[]) ?? [])[0] ?? {}
@@ -123,6 +125,8 @@ export const STRUCTURES_TOOLS: ToolDescriptor[] = [
     required: ['query'],
     returns:
       '`{ "query": str, "total_elements": int, "returned": int, "interactions": [ { "interactor_a": str, "interactor_b": str, "molecule_a": str, "molecule_b": str, "interaction_type": str, "interaction_type_mi": str, "detection_method": str, "detection_method_mi": str, "mi_score": float, "pubmed_id": str } ] }` — up to `limit` interactions (default 25); `total_elements` is IntAct\'s full match count, usually larger than `returned`. `interactions` is `[]` when nothing matches.',
+    example:
+      'result = host.mcp("structures", "intact_interactions", {"query": "TP53", "limit": 25})',
     run: async (ctx, a) => {
       const query = String(a.query)
       const minMiScore = Number(a.min_mi_score ?? 0)

--- a/src/main/connectors/descriptors/variants.ts
+++ b/src/main/connectors/descriptors/variants.ts
@@ -36,6 +36,7 @@ export const VARIANTS_TOOLS: ToolDescriptor[] = [
     required: ['term'],
     returns:
       '`{ "term": str, "count": int, "records": [ { "uid": str, "title": str, "clinical_significance": str, "gene": str } ] }` — up to `retmax` records (default 5); `count` is the total ClinVar match count, usually larger than the returned list. `records` is `[]` when nothing matches; `clinical_significance` comes from the germline classification and per-record fields may be undefined.',
+    example: 'result = host.mcp("variants", "clinvar_search", {"term": "BRCA1", "retmax": 5})',
     run: async (ctx, a) => {
       const q = ncbiEtiquette(ctx.credentials)
       const es = (await ctx.fetchJson(
@@ -71,6 +72,7 @@ export const VARIANTS_TOOLS: ToolDescriptor[] = [
     required: ['rsid'],
     returns:
       '`{ "rsid": str, "chr": str, "pos": int, "alleles": str, "gene": str, "clinical_significance": str }` — `rsid` is normalized to `rs<id>`; `alleles` is `ref>alt` derived from the SPDI trail. Any field is undefined when missing upstream (e.g. `alleles`/`pos` absent, no clinical significance).',
+    example: 'result = host.mcp("variants", "dbsnp_get_variant", {"rsid": "rs7412"})',
     run: async (ctx, a) => {
       const q = ncbiEtiquette(ctx.credentials)
       const id = String(a.rsid).trim().replace(/^rs/i, '')

--- a/src/main/connectors/descriptors/zinc.ts
+++ b/src/main/connectors/descriptors/zinc.ts
@@ -271,6 +271,7 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
     required: ['zinc_ids'],
     returns:
       '`{ "query": { "zinc_ids": [str] }, "total_available": int, "returned_count": int, "truncated": bool, "records": [ { "zinc_id": str, "smiles": str, "tranche_name": str, "catalogs": any, "source": str } ] }` — records capped at `max_results` (default 50, cap 500); `truncated` is true when more were available. `source` is "zinc22"/"zinc20"; `records` is `[]` when no ids resolve.',
+    example: 'result = host.mcp("zinc", "zinc_search_by_id", {"zinc_ids": ["ZINC000000000012"]})',
     run: async (_ctx, a) => {
       const ids = normalizeZincIds(a.zinc_ids)
       const cap = clampMaxResults(a.max_results)

--- a/src/main/connectors/engine.test.ts
+++ b/src/main/connectors/engine.test.ts
@@ -41,9 +41,9 @@ describe('ParserEngine declarative path', () => {
     await expect(engine.call(desc, {}, {})).rejects.toThrow(/required arg: q/)
   })
 
-  it('throws on non-2xx', async () => {
+  it('retries transient 5xx and gives up after the configured retries', async () => {
     const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 503 } as Response)
-    const engine = new ParserEngine({ fetchImpl })
+    const engine = new ParserEngine({ fetchImpl, retries: 2, retryBackoffMs: 0 })
     const desc: ToolDescriptor = {
       id: 't',
       connector: 'c',
@@ -53,6 +53,58 @@ describe('ParserEngine declarative path', () => {
       parse: (r) => r
     }
     await expect(engine.call(desc, {}, {})).rejects.toThrow(/HTTP 503/)
+    expect(fetchImpl).toHaveBeenCalledTimes(3) // 1 initial + 2 retries
+  })
+
+  it('retries a transient 5xx then succeeds', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503 } as Response)
+      .mockResolvedValueOnce(jsonResponse({ value: 7 }))
+    const engine = new ParserEngine({ fetchImpl, retryBackoffMs: 0 })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://x.test',
+      parse: (raw) => (raw as { value: number }).value
+    }
+    expect(await engine.call(desc, {}, {})).toBe(7)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a network/timeout error then succeeds', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(jsonResponse({ value: 5 }))
+    const engine = new ParserEngine({ fetchImpl, retryBackoffMs: 0 })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://x.test',
+      parse: (raw) => (raw as { value: number }).value
+    }
+    expect(await engine.call(desc, {}, {})).toBe(5)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry a client error (4xx other than 429)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 400 } as Response)
+    const engine = new ParserEngine({ fetchImpl, retryBackoffMs: 0 })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://x.test',
+      parse: (r) => r
+    }
+    await expect(engine.call(desc, {}, {})).rejects.toThrow(/HTTP 400/)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 
   it('postJson sends a POST with a JSON body and parses the response', async () => {

--- a/src/main/connectors/engine.ts
+++ b/src/main/connectors/engine.ts
@@ -2,8 +2,18 @@ import type { ConnectorCredentials, ToolContext, ToolDescriptor } from './types'
 
 const DEFAULT_TIMEOUT_MS = 30_000
 
+// Transient-failure retry policy shared by every connector call. Public bio APIs (PubChem PUG-REST,
+// GTEx, NCBI) routinely return 429/5xx or a brief timeout under load; a couple of backed-off retries
+// turn those blips into successes instead of surfacing them to the notebook.
+const DEFAULT_RETRIES = 2
+const DEFAULT_BACKOFF_MS = 400
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504])
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
 // Some public APIs (e.g. AlphaFold EBI) reject requests without a User-Agent; send a stable one.
-const USER_AGENT = 'OpenScience/1.0 (+https://github.com/aipoch/open-science)'
+const USER_AGENT =
+  'Mozilla/5.0 (compatible; OpenScience/1.0; +https://github.com/aipoch/open-science)'
 
 // Builds the NCBI E-utilities etiquette query suffix; empty when unset (calls still work).
 export function ncbiEtiquette(credentials: ConnectorCredentials): string {
@@ -30,10 +40,19 @@ function redactUrl(url: string): string {
 export class ParserEngine {
   private readonly fetchImpl: typeof fetch
   private readonly timeoutMs: number
+  private readonly retries: number
+  private readonly backoffMs: number
 
-  constructor(opts?: { fetchImpl?: typeof fetch; timeoutMs?: number }) {
+  constructor(opts?: {
+    fetchImpl?: typeof fetch
+    timeoutMs?: number
+    retries?: number
+    retryBackoffMs?: number
+  }) {
     this.fetchImpl = opts?.fetchImpl ?? fetch
     this.timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    this.retries = opts?.retries ?? DEFAULT_RETRIES
+    this.backoffMs = opts?.retryBackoffMs ?? DEFAULT_BACKOFF_MS
   }
 
   async call(
@@ -55,19 +74,42 @@ export class ParserEngine {
   }
 
   private makeContext(credentials: ConnectorCredentials): ToolContext {
+    // Delay before the next attempt: honour a numeric Retry-After (seconds, capped), else exponential
+    // backoff with jitter off the configured base.
+    const nextDelay = (attempt: number, retryAfter: string | null): number => {
+      const ra = retryAfter ? Number(retryAfter) : NaN
+      if (Number.isFinite(ra) && ra >= 0) return Math.min(ra * 1000, 5_000)
+      return Math.min(this.backoffMs * 2 ** attempt, 4_000) + Math.random() * this.backoffMs
+    }
+
     const doFetch = async (url: string, accept: string, init?: RequestInit): Promise<Response> => {
-      const controller = new AbortController()
-      const timer = setTimeout(() => controller.abort(), this.timeoutMs)
-      try {
-        const res = await this.fetchImpl(url, {
-          ...init,
-          headers: { accept, 'user-agent': USER_AGENT, ...init?.headers },
-          signal: controller.signal
-        })
-        if (!res.ok) throw new Error(`HTTP ${res.status} for ${redactUrl(url)}`)
-        return res
-      } finally {
-        clearTimeout(timer)
+      for (let attempt = 0; ; attempt++) {
+        const controller = new AbortController()
+        const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+        let res: Response
+        try {
+          res = await this.fetchImpl(url, {
+            ...init,
+            headers: { accept, 'user-agent': USER_AGENT, ...init?.headers },
+            signal: controller.signal
+          })
+        } catch (err) {
+          // Network failure or timeout abort — retry a bounded number of times, then give up.
+          if (attempt < this.retries) {
+            await sleep(nextDelay(attempt, null))
+            continue
+          }
+          throw err
+        } finally {
+          clearTimeout(timer)
+        }
+        if (res.ok) return res
+        // Retry only transient upstream statuses; client errors (4xx except 429) fail fast.
+        if (attempt < this.retries && RETRYABLE_STATUS.has(res.status)) {
+          await sleep(nextDelay(attempt, res.headers?.get?.('retry-after') ?? null))
+          continue
+        }
+        throw new Error(`HTTP ${res.status} for ${redactUrl(url)}`)
       }
     }
     return {

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { renderSkillDoc } from './skill-doc'
+import { renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
 
 describe('renderSkillDoc', () => {
   it('renders frontmatter, conventions, and each tool', () => {
@@ -20,13 +20,53 @@ describe('renderSkillDoc', () => {
   it('throws for an unknown connector', () => {
     expect(() => renderSkillDoc('nope')).toThrow()
   })
-  it('renders a concrete, copyable dict example built from the tool schema', () => {
-    // The example mirrors the JSON Schema shown above it: required fields plus any defaulted field,
-    // passed as a dict, assigned to a variable to demonstrate the synchronous return.
+  it('renders a tool-authored example as a single realistic call, with no per-tool prose', () => {
+    // The example carries only realistic args (better than schema placeholders). General guidance
+    // (reuse across cells, return shape) lives once in the shared conventions template — it must NOT
+    // be duplicated into each tool's example.
     const md = renderSkillDoc('pubmed')
-    expect(md).toContain(
-      'result = host.mcp("pubmed", "pubmed_search", {"term": "...", "retmax": 5})'
+    const block = md.slice(md.indexOf('### pubmed_search'), md.indexOf('### pubmed_fetch'))
+    const py = block
+      .slice(block.indexOf('```python') + '```python'.length, block.lastIndexOf('```'))
+      .trim()
+    expect(py).toBe(
+      'result = host.mcp("pubmed", "pubmed_search", {"term": "tumor progression", "retmax": 10})'
     )
+    expect(py).not.toContain('#') // no per-tool comment/prose
+  })
+  it('does not hardcode a processing/display method in the doc', () => {
+    // Requirement: the skill doc states facts (shape lives in Returns, result is a Python value) but
+    // never prescribes how to handle it — so no `print(...)` or `json.dumps(...)` recipes.
+    const md = renderSkillDoc('pubmed')
+    expect(md).not.toContain('print(')
+    expect(md).not.toContain('json.dumps')
+    expect(md).not.toContain('json.loads')
+  })
+  it('falls back to a schema-built call example for tools without an authored example', () => {
+    // Custom MCP servers ship no `example`, so the doc must still render a concrete, copyable call.
+    const md = renderCustomSkillDoc(
+      { name: 'acme', description: 'Use when you need acme tools.' },
+      [
+        {
+          name: 'do_thing',
+          inputSchema: {
+            type: 'object',
+            properties: { q: { type: 'string' } },
+            required: ['q']
+          }
+        }
+      ]
+    )
+    expect(md).toContain('result = host.mcp("acme", "do_thing", {"q": "..."})')
+  })
+  it('renders a no-arg tool without a third argument (never a literal ...)', () => {
+    // A literal `...` as the args positional reaches the bridge as Ellipsis and raises; a no-arg tool
+    // must render as host.mcp(server, method) so the example is copy-runnable.
+    const md = renderCustomSkillDoc({ name: 'acme' }, [
+      { name: 'ping', inputSchema: { type: 'object', properties: {} } }
+    ])
+    expect(md).toContain('result = host.mcp("acme", "ping")')
+    expect(md).not.toContain('"ping", ...)') // never a literal Ellipsis as the args positional
   })
   it('frames the calling convention positively (assign the sync dict result)', () => {
     const md = renderSkillDoc('pubmed')
@@ -37,5 +77,24 @@ describe('renderSkillDoc', () => {
     expect(md).toContain('**Returns:**')
     // A return-shape field absent from the input schema — proves the Returns block is rendered.
     expect(md).toContain('"pmid"')
+  })
+  it('tells the agent the kernel persists so it reuses the result instead of re-calling', () => {
+    // Root cause of the observed double host.mcp call: the doc never said the kernel is a
+    // persistent shared session, so the agent re-issued the (rate-limited) call in a second cell
+    // instead of reusing the variable it had already assigned.
+    const md = renderSkillDoc('pubmed')
+    expect(md).toContain('persistent')
+    expect(md).toContain('native Python')
+    expect(md).toMatch(/reuse it instead of running the call again/)
+    expect(md).toMatch(/never re-(issue|call)/i)
+  })
+  it('gives custom MCP servers the same reuse guidance', () => {
+    // renderCustomSkillDoc shares the CONVENTIONS block, so the fix must reach custom servers too.
+    const md = renderCustomSkillDoc(
+      { name: 'acme', description: 'Use when you need acme tools.' },
+      [{ name: 'do_thing', inputSchema: { type: 'object', properties: { q: { type: 'string' } } } }]
+    )
+    expect(md).toContain('persistent')
+    expect(md).toMatch(/reuse it instead of running the call again/)
   })
 })

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -3,6 +3,8 @@ import { getConnectorTools } from './registry'
 
 const CONVENTIONS = [
   'Reach this service ONLY via `host.mcp` from the notebook kernel. It runs synchronously and returns the result directly — assign it: `result = host.mcp(server, method, {...})`. Arguments go as a dict, or as keywords (`host.mcp(server, method, term=...)`).',
+  "The result is a ready-to-use native Python value — a dict or list for most tools, sometimes a string or number. It is already parsed (not a JSON string). Each tool's **Returns** block gives its exact shape and field meanings; how you inspect or process it is up to you.",
+  'The notebook kernel is a persistent shared session: the variable you assign a result to stays available in later cells, so reuse it instead of running the call again. Each call hits the rate-limited upstream — never re-issue the same call to look at or reprocess a result you already have.',
   'Do NOT reimplement these calls with raw HTTP (urllib / requests / httpx / fetch) or hit the upstream endpoints directly — that bypasses the approval gate, per-tool policy, credentials, and rate limits, and can leak project data.',
   'Prefer bulk/list tools over per-item loops — the upstream API is rate-limited and shared across subagents.',
   'Pass large results between cells via `./handoff/*.json`, not the model context.'
@@ -55,10 +57,17 @@ function exampleArgs(schema: unknown): string | undefined {
   return entries.length ? `{${entries.join(', ')}}` : undefined
 }
 
-// Renders one tool's call example as a copyable python cell: `result = host.mcp(server, tool, {args})`,
-// with args drawn from the tool schema (or `...` when the schema names no concrete fields).
-function renderExample(server: string, tool: string, schema: unknown): string {
-  return `Example:\n\n\`\`\`python\nresult = host.mcp("${server}", "${tool}", ${exampleArgs(schema) ?? '...'})\n\`\`\`\n`
+// Renders one tool's usage example as a copyable python cell. Prefers the descriptor's hand-authored
+// `example` (a single call with realistic args); otherwise builds a bare call from the schema. A tool
+// with no concrete args renders as `host.mcp(server, method)` (no third argument) — passing a literal
+// `...` there would reach the bridge as Ellipsis and raise, so it must be omitted.
+function renderExample(server: string, tool: string, schema: unknown, example?: string): string {
+  if (example) return `Example:\n\n\`\`\`python\n${example}\n\`\`\`\n`
+  const args = exampleArgs(schema)
+  const call = args
+    ? `host.mcp("${server}", "${tool}", ${args})`
+    : `host.mcp("${server}", "${tool}")`
+  return `Example:\n\n\`\`\`python\nresult = ${call}\n\`\`\`\n`
 }
 
 // Renders one connector's tools as a searchable skill document (frontmatter + conventions + methods).
@@ -74,7 +83,7 @@ export function renderSkillDoc(connectorId: string): string {
       (t) =>
         `### ${t.id}\n\n${t.description}\n\n\`\`\`json\n${JSON.stringify(t.input, null, 2)}\n\`\`\`\n\n` +
         (t.returns ? `**Returns:** ${t.returns}\n\n` : '') +
-        renderExample(connectorId, t.id, t.input)
+        renderExample(connectorId, t.id, t.input, t.example)
     )
     .join('\n')
   return (

--- a/src/main/connectors/types.ts
+++ b/src/main/connectors/types.ts
@@ -17,6 +17,11 @@ export type ToolDescriptor = {
   // Human-readable shape of the returned value, shown as a "Returns:" block in the skill doc so an
   // agent knows the result structure without running a probe cell. Free-form (prose or a shape sketch).
   returns?: string
+  // A concrete, copy-runnable `host.mcp(...)` call for the skill doc, using realistic argument values
+  // (e.g. real PMIDs) instead of the schema-derived placeholders. Just the call — general guidance
+  // (result is reusable across cells, shape lives in Returns) belongs in the shared conventions
+  // template, not repeated here. When omitted, the doc renders a bare call built from `input`.
+  example?: string
   required?: string[]
   format?: 'json' | 'text'
   url?: (args: Record<string, unknown>) => string

--- a/src/main/notebook/python-executor.test.ts
+++ b/src/main/notebook/python-executor.test.ts
@@ -123,6 +123,111 @@ describe('notebook Python executor', () => {
   )
 
   itWithPython(
+    'echoes a trailing expression like Jupyter so a bare variable shows output',
+    async () => {
+      // Root-cause fix for the double host.mcp call: with a plain exec(), `result` on the last line
+      // produced no output, so the agent re-ran the call in a second cell just to print it. Echoing
+      // the trailing expression (repr) makes `result` visible in one cell, no explicit print needed.
+      const root = await createStorageRoot()
+      const executor = new NotebookPythonExecutor('python3')
+
+      const base = {
+        cwd: root,
+        notebookSessionRoot: join(root, 'notebooks', 'default-project', 'session-1'),
+        dataRoot: join(root, 'notebooks', 'default-project', 'session-1', 'data'),
+        runtimeRoot: join(root, 'runtime')
+      }
+
+      try {
+        // Assignment then a bare expression: only the trailing expression echoes, as its repr.
+        const echoed = await executor.execute({
+          ...base,
+          code: 'result = {"count": 0, "term": "肿瘤进展"}\nresult'
+        })
+        expect(echoed).toMatchObject({ status: 'completed' })
+        expect(echoed.stdout).toBe("{'count': 0, 'term': '肿瘤进展'}\n")
+
+        // A cell ending in a statement (assignment) echoes nothing.
+        const silent = await executor.execute({ ...base, code: 'y = 5' })
+        expect(silent).toMatchObject({ status: 'completed', stdout: '' })
+
+        // A trailing expression that evaluates to None echoes nothing (matches Jupyter).
+        const none = await executor.execute({ ...base, code: 'print("hi")\nNone' })
+        expect(none).toMatchObject({ status: 'completed', stdout: 'hi\n' })
+      } finally {
+        await executor.shutdown()
+      }
+    },
+    PYTHON_TEST_TIMEOUT_MS
+  )
+
+  itWithPython(
+    'suppresses matplotlib artist reprs in the trailing-expression echo',
+    async () => {
+      // Headless Agg can't render a figure inline, so a matplotlib artist (or a list/tuple of them,
+      // e.g. plt.plot(...) -> [Line2D]) at the end of a cell would echo a noisy object repr. Faking
+      // the module keeps the test independent of matplotlib being installed.
+      const root = await createStorageRoot()
+      const executor = new NotebookPythonExecutor('python3')
+      const base = {
+        cwd: root,
+        notebookSessionRoot: join(root, 'notebooks', 'default-project', 'session-1'),
+        dataRoot: join(root, 'notebooks', 'default-project', 'session-1', 'data'),
+        runtimeRoot: join(root, 'runtime')
+      }
+      const fakeArtist = ['class _A:\n    pass', "_A.__module__ = 'matplotlib.lines'"].join('\n')
+
+      try {
+        const artist = await executor.execute({ ...base, code: `${fakeArtist}\n_A()` })
+        expect(artist).toMatchObject({ status: 'completed', stdout: '' })
+
+        const artistList = await executor.execute({ ...base, code: `${fakeArtist}\n[_A(), _A()]` })
+        expect(artistList).toMatchObject({ status: 'completed', stdout: '' })
+
+        // Ordinary data is still echoed.
+        const data = await executor.execute({ ...base, code: "{'a': 1}" })
+        expect(data.stdout).toBe("{'a': 1}\n")
+      } finally {
+        await executor.shutdown()
+      }
+    },
+    PYTHON_TEST_TIMEOUT_MS
+  )
+
+  itWithPython(
+    'silences the headless matplotlib non-interactive show() warning',
+    async () => {
+      // Agg warns "FigureCanvasAgg is non-interactive, and thus cannot be shown" on every plt.show()
+      // in this headless notebook; the bridge filters that message. Emitting the same warning text
+      // keeps the test independent of matplotlib being installed.
+      const root = await createStorageRoot()
+      const executor = new NotebookPythonExecutor('python3')
+      const base = {
+        cwd: root,
+        notebookSessionRoot: join(root, 'notebooks', 'default-project', 'session-1'),
+        dataRoot: join(root, 'notebooks', 'default-project', 'session-1', 'data'),
+        runtimeRoot: join(root, 'runtime')
+      }
+
+      try {
+        const result = await executor.execute({
+          ...base,
+          code: [
+            'import warnings',
+            'warnings.warn("FigureCanvasAgg is non-interactive, and thus cannot be shown")',
+            'print("plotted")'
+          ].join('\n')
+        })
+        expect(result).toMatchObject({ status: 'completed', stdout: 'plotted\n' })
+        expect(result.stderr).not.toContain('non-interactive')
+      } finally {
+        await executor.shutdown()
+      }
+    },
+    PYTHON_TEST_TIMEOUT_MS
+  )
+
+  itWithPython(
     'runs with a non-interactive matplotlib backend so no GUI window opens',
     async () => {
       const root = await createStorageRoot()

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -22,6 +22,7 @@ const delay = (ms: number): Promise<void> =>
 
 // Small stdin/stdout bridge that keeps Python globals alive across executions in one process.
 const PYTHON_BRIDGE = String.raw`
+import ast
 import json
 import os
 import sys
@@ -29,6 +30,12 @@ import tempfile
 import traceback
 import urllib.error
 import urllib.request
+import warnings
+
+# The Agg backend warns "FigureCanvasAgg is non-interactive, and thus cannot be shown" on every
+# plt.show() in this headless notebook. Figures are saved as artifacts instead, so that message is
+# pure noise on stderr — silence just that one warning.
+warnings.filterwarnings("ignore", message=".*is non-interactive, and thus cannot be shown")
 
 class _Host:
     # Control-plane bridge to the main process connector service. Tool arguments accept either a
@@ -101,6 +108,38 @@ globals_ns["host"] = _Host()
 protocol_stdout = os.fdopen(os.dup(1), "w", buffering=1)
 
 
+# A real Jupyter inline backend renders a figure and suppresses the artist's text repr; we run headless
+# (Agg) and can't render inline, so echoing a matplotlib artist (or a list/tuple of them, e.g.
+# plt.plot(...) -> [Line2D] or plt.subplots() -> (Figure, Axes)) is pure noise. Skip those, matching the
+# inline backend's suppression.
+def _is_matplotlib_repr(value):
+    def _is_artist(v):
+        return type(v).__module__.split(".", 1)[0] == "matplotlib"
+    if _is_artist(value):
+        return True
+    if isinstance(value, (list, tuple)) and value:
+        return all(_is_artist(v) for v in value)
+    return False
+
+
+# Runs one cell like a Jupyter cell: execute every statement, then — if the cell ends in a bare
+# expression — echo that value's repr the way execute_result does. This is what lets "result" on the
+# last line show output without an explicit print, so the agent doesn't re-run the (rate-limited) call
+# in a second cell just to see the data. Assignments and other statements echo nothing (value is None
+# or not an expression), matching Jupyter.
+def _run_cell(code, ns):
+    block = ast.parse(code, mode="exec")
+    trailing = None
+    if block.body and isinstance(block.body[-1], ast.Expr):
+        trailing = ast.Expression(block.body.pop().value)
+        ast.fix_missing_locations(trailing)
+    exec(compile(block, "<cell>", "exec"), ns, ns)
+    if trailing is not None:
+        value = eval(compile(trailing, "<cell>", "eval"), ns, ns)
+        if value is not None and not _is_matplotlib_repr(value):
+            print(repr(value))
+
+
 # Captures Python prints plus direct subprocess fd writes while code executes.
 def execute_captured(code):
     stdout_file = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
@@ -117,7 +156,7 @@ def execute_captured(code):
         os.dup2(stderr_file.fileno(), 2)
 
         try:
-            exec(code, globals_ns, globals_ns)
+            _run_cell(code, globals_ns)
         except Exception:
             status = "failed"
             traceback_text = traceback.format_exc()


### PR DESCRIPTION
## Problem

The agent called the same rate-limited `host.mcp` tool **twice per query** — once to run it, then again in a second cell just to `json.dumps` / reformat the output. The root cause and several related notebook/connector rough edges are fixed together.

## Changes

**Notebook execution**
- Echo a cell's trailing expression like Jupyter's `execute_result`, so `result` on the last line shows output — the agent no longer re-runs the call in a second cell to see the data. (The kernel used a plain `exec()`, which discards the last expression's value.)
- Suppress matplotlib noise that is meaningless headless: artist reprs from `plt.plot()`/`plt.gca()`/… and the Agg `"FigureCanvasAgg is non-interactive, and thus cannot be shown"` warning from `plt.show()`.

**Skill docs (generated SKILL.md)**
- Document each tool's return shape and that the kernel persists across cells (reuse the bound `result`); state facts without prescribing a processing method.
- Render a copy-runnable example per tool with realistic arguments; no-arg tools omit the args entirely (a literal `...` would reach the bridge as `Ellipsis` and raise).

**Connector engine**
- Send a browser-compatible `User-Agent` so GTEx stops timing out (its WAF hung on the previous UA).
- Retry transient upstream failures (`429/500/502/503/504`, network/timeout) with exponential backoff; client errors still fail fast.

**New tool**
- `pubchem_get_image(cid)` returns a compound's 2D structure image URL, so the agent can obtain it through the approved MCP channel.

## Testing

- Full suite green; eslint (0 errors) + typecheck across node/web.
- Connector + notebook suites verified; executor tests spawn a real Python bridge (echo + matplotlib suppression) and the engine retry/UA paths are covered.
- End-to-end: GTEx `gtex_resolve_gene` returns data in-process after the UA fix; `pubchem_get_image` returns the URL object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)