### PR TITLE
test(acp): neutralize dev-path fixture and cover the Windows asar branch

### DIFF
--- a/src/main/acp/agent-process.test.ts
+++ b/src/main/acp/agent-process.test.ts
@@ -13,12 +13,24 @@ describe('ACP agent process packaging paths', () => {
     )
   })
 
+  it('unpacks asar paths that use Windows separators', () => {
+    // The regex accepts back-slashes too, so a packaged Windows install redirects into
+    // app.asar.unpacked the same way the POSIX case above does.
+    expect(
+      toUnpackedAsarPath(
+        'C:\\Program Files\\Open Science\\resources\\app.asar\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe'
+      )
+    ).toBe(
+      'C:\\Program Files\\Open Science\\resources\\app.asar.unpacked\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe'
+    )
+  })
+
   it('leaves development node_modules paths unchanged', () => {
     expect(
       toUnpackedAsarPath(
-        '/Users/lj/Desktop/cs/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude'
+        '/home/dev/project/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude'
       )
-    ).toBe('/Users/lj/Desktop/cs/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude')
+    ).toBe('/home/dev/project/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude')
   })
 })
 


### PR DESCRIPTION
## What

Two small changes to `src/main/acp/agent-process.test.ts`:

1. **Neutralize a leaked personal path.** The `toUnpackedAsarPath` "leaves development node_modules paths unchanged" case hardcoded a developer's local home path (`/Users/lj/Desktop/cs/...`). Replaced it with a neutral `/home/dev/project/...` fixture. The assertion is a string-replace passthrough (input === output), so there is no behavior change — this only stops leaking a personal path into the repo.

2. **Cover the Windows separator branch.** The source regex `([/\\])app\.asar([/\\])` deliberately accepts back-slashes, but only the POSIX (forward-slash) branch was exercised. Added a case for a packaged Windows path (`C:\...\app.asar\...` → `...\app.asar.unpacked\...`) so the redirect is verified on both separators.

## Why

Follow-up from a cross-platform (macOS / Windows / Linux) review of the CI test suite. The rest of the suite was already portable (injected `platform` deps, `posix.join`/`win32.join`, `mkdtemp(join(tmpdir(), …))`, `.gitattributes eol=lf`); this fixture was the only cleanup, and the Windows asar branch was the one genuine coverage gap found.

## Verification

- `npx vitest run src/main/acp/agent-process.test.ts` → 5/5 pass (incl. the new Windows case)
- `npx eslint --cache .` → exit 0 (pre-existing warnings only, in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)