### PR TITLE
style(acp): fix prettier formatting in permission-broker

### DIFF
--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -387,9 +387,12 @@ describe('ACP permission broker', () => {
 
     // Revoking one grant removes only it and makes that tool prompt again.
     broker.revokeGrant('session-1', 'tool:Write')
-    expect(broker.listGrants('session-1').map((grant) => grant.categoryKey).sort()).toEqual(
-      ['bash:python a.py', 'tool:mcp__open-science-notebook__notebook_execute'].sort()
-    )
+    expect(
+      broker
+        .listGrants('session-1')
+        .map((grant) => grant.categoryKey)
+        .sort()
+    ).toEqual(['bash:python a.py', 'tool:mcp__open-science-notebook__notebook_execute'].sort())
 
     const countBeforeWrite = emittedRequests.length
     broker.requestPermission(

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -1,7 +1,11 @@
 import type { RequestPermissionRequest, RequestPermissionResponse } from '@agentclientprotocol/sdk'
 import { randomUUID } from 'node:crypto'
 
-import type { AcpPermissionGrant, AcpPermissionRequest, AcpPermissionResponse } from '../../shared/acp'
+import type {
+  AcpPermissionGrant,
+  AcpPermissionRequest,
+  AcpPermissionResponse
+} from '../../shared/acp'
 import { extractProviderToolName } from './runtime-events'
 import { resolveAutomaticPermission, type PermissionPolicyContext } from './permission-policy'
 


### PR DESCRIPTION
## What

Reformat two spots in the ACP permission-broker files to satisfy `prettier/prettier`:

- `permission-broker.ts` — split the multi-name `import type { … }` from `../../shared/acp` onto separate lines.
- `permission-broker.test.ts` — break the `listGrants().map().sort()` chain across lines and collapse the `toEqual([...].sort())` argument onto one line.

## Why

These were the two ESLint annotations surfaced on the permission-broker files. They are `warning`-level `prettier/prettier` only, so they never failed the lint gate (`eslint --cache .`, no `--max-warnings 0`) — this just clears the noise so the annotations don't reappear on future PRs touching these files.

## Scope

Formatting only. No logic, behavior, or public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)