### PR TITLE
feat(composer): @ artifact mentions with clickable, styled message bubbles

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -425,6 +425,127 @@ describe('ACP runtime session management', () => {
     // is markedly slower on a cold Windows CI runner and can exceed the 5s default there.
   }, 30000)
 
+  it('appends referenced artifacts as content blocks by file type', async () => {
+    const root = await createTemporaryRoot()
+    const uploadRepository = new UploadRepository(root)
+    const artifactRepository = new ArtifactRepository(root)
+
+    // A referenced upload (an already-staged file) resolves through the upload path validator.
+    const [uploadRef] = await uploadRepository.stageFiles({
+      files: [
+        {
+          name: 'summary.txt',
+          mimeType: 'text/plain',
+          content: Buffer.from('referenced upload text').toString('base64')
+        }
+      ]
+    })
+
+    // A referenced image output resolves through the artifact path validator and inlines its pixels.
+    const imageArtifact = await artifactRepository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'remote-session-1',
+      runId: 'run-1',
+      filename: 'chart.png',
+      mimeType: 'image/png',
+      source: {
+        kind: 'inline',
+        content: Buffer.from('png-bytes').toString('base64'),
+        encoding: 'base64'
+      }
+    })
+
+    // A referenced binary output has no rich representation, so it falls through to a resource link.
+    const binaryArtifact = await artifactRepository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'remote-session-1',
+      runId: 'run-1',
+      filename: 'data.bin',
+      mimeType: 'application/octet-stream',
+      source: {
+        kind: 'inline',
+        content: Buffer.from([0, 1, 2, 3]).toString('base64'),
+        encoding: 'base64'
+      }
+    })
+
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploadRepository },
+      artifacts: {
+        storageRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: artifactRepository
+      }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'use these files',
+      referencedArtifacts: [
+        {
+          id: 'u1',
+          name: uploadRef.originalName,
+          path: uploadRef.path,
+          source: 'upload',
+          mimeType: uploadRef.mimeType
+        },
+        {
+          id: 'a1',
+          name: imageArtifact.name,
+          path: imageArtifact.path,
+          source: 'artifact',
+          mimeType: imageArtifact.mimeType
+        },
+        {
+          id: 'a2',
+          name: binaryArtifact.name,
+          path: binaryArtifact.path,
+          source: 'artifact',
+          mimeType: binaryArtifact.mimeType
+        }
+      ]
+    })
+
+    expect(receivedPrompts).toHaveLength(1)
+    expect(receivedPrompts[0][0]).toEqual({ type: 'text', text: 'use these files' })
+    // Referenced upload text file -> inline resource with its contents.
+    expect(receivedPrompts[0][1]).toMatchObject({
+      type: 'resource',
+      resource: {
+        mimeType: 'text/plain',
+        text: 'referenced upload text',
+        uri: expect.stringContaining('summary.txt')
+      }
+    })
+    // Referenced image artifact -> base64 image block.
+    expect(receivedPrompts[0][2]).toMatchObject({
+      type: 'image',
+      mimeType: 'image/png',
+      data: Buffer.from('png-bytes').toString('base64'),
+      uri: expect.stringContaining('chart.png')
+    })
+    // Referenced binary artifact -> resource link.
+    expect(receivedPrompts[0][3]).toMatchObject({
+      type: 'resource_link',
+      name: 'data.bin',
+      title: 'data.bin',
+      mimeType: 'application/octet-stream',
+      uri: expect.stringContaining('data.bin')
+    })
+  })
+
   it('allows prompts from different sessions to run concurrently', async () => {
     const process = new FakeAgentProcess()
     const promptCanStopBySession = new Map<string, ReturnType<typeof createDeferred>>()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -11,7 +11,7 @@ import type {
   SessionNotification
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { pathToFileURL } from 'node:url'
@@ -62,6 +62,7 @@ import { getNotebookSessionRoot } from '../notebook/repository'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
+import type { ArtifactReference } from '../../shared/artifacts'
 import { buildImageContentData, extractPdfText } from '../uploads/attachment-media'
 
 type AcpRuntimeCallbacks = {
@@ -1007,22 +1008,32 @@ class AcpRuntime {
     request: AcpPromptRequest
   ): Promise<string | ContentBlock[]> {
     const attachments = request.attachments ?? []
+    const referencedArtifacts = request.referencedArtifacts ?? []
 
-    if (attachments.length === 0) return request.text
-    if (!this.uploadRepository) throw new Error('Upload storage is not configured.')
+    if (attachments.length === 0 && referencedArtifacts.length === 0) return request.text
 
-    // The runtime owns the durable session id, so it is the final authority for upload ownership.
-    const finalizedAttachments = await this.uploadRepository.finalizePendingSessionUploads(
-      sessionId,
-      attachments
-    )
     const contentBlocks: ContentBlock[] = request.text.trim()
       ? [{ type: 'text', text: request.text }]
       : []
 
-    // Keep the user's text first, then append files in the same order they were added.
-    for (const attachment of finalizedAttachments) {
-      contentBlocks.push(await this.createAttachmentContentBlock(attachment))
+    // Staged uploads own the durable session id here, so finalize before turning them into blocks.
+    if (attachments.length > 0) {
+      if (!this.uploadRepository) throw new Error('Upload storage is not configured.')
+
+      const finalizedAttachments = await this.uploadRepository.finalizePendingSessionUploads(
+        sessionId,
+        attachments
+      )
+
+      // Keep the user's text first, then append files in the same order they were added.
+      for (const attachment of finalizedAttachments) {
+        contentBlocks.push(await this.createAttachmentContentBlock(attachment))
+      }
+    }
+
+    // `@`-mentioned artifacts reuse the same per-type block builder as uploads, in mention order.
+    for (const reference of referencedArtifacts) {
+      contentBlocks.push(await this.createReferencedArtifactContentBlock(reference))
     }
 
     return contentBlocks
@@ -1035,37 +1046,83 @@ class AcpRuntime {
     if (!this.uploadRepository) throw new Error('Upload storage is not configured.')
 
     const filePath = await this.uploadRepository.resolveManagedUploadPath({ path: attachment.path })
-    const uri = pathToFileURL(filePath).href
+
+    return this.buildFileContentBlock({
+      absolutePath: filePath,
+      uri: pathToFileURL(filePath).href,
+      name: attachment.originalName || attachment.name,
+      mimeType: attachment.mimeType,
+      size: attachment.size
+    })
+  }
+
+  // Converts one `@`-mentioned artifact into the same content block an equivalent upload produces.
+  private async createReferencedArtifactContentBlock(
+    reference: ArtifactReference
+  ): Promise<ContentBlock> {
+    const filePath = await this.resolveReferencedArtifactPath(reference)
+    const { size } = await stat(filePath)
+
+    return this.buildFileContentBlock({
+      absolutePath: filePath,
+      uri: pathToFileURL(filePath).href,
+      name: reference.name,
+      mimeType: reference.mimeType,
+      size
+    })
+  }
+
+  // Resolves a referenced file through the managed-path validator for its owning repository.
+  private async resolveReferencedArtifactPath(reference: ArtifactReference): Promise<string> {
+    if (reference.source === 'upload') {
+      if (!this.uploadRepository) throw new Error('Upload storage is not configured.')
+      return this.uploadRepository.resolveManagedUploadPath({ path: reference.path })
+    }
+
+    if (!this.artifactRepository) throw new Error('Artifact storage is not configured.')
+    return this.artifactRepository.resolveManagedFilePath({ path: reference.path })
+  }
+
+  // Builds the richest ACP content block that is safe for a resolved file, shared by uploads and
+  // `@`-mentioned artifacts so both reach the agent through identical per-type logic.
+  private async buildFileContentBlock(descriptor: {
+    absolutePath: string
+    uri: string
+    name: string
+    mimeType?: string
+    size: number
+  }): Promise<ContentBlock> {
+    const { absolutePath, uri, name, mimeType, size } = descriptor
 
     // Images are embedded as base64 so vision-capable agents receive the actual pixels.
-    // Large images are downscaled/re-encoded first so one upload cannot overflow the request.
-    if (attachment.mimeType?.startsWith('image/')) {
-      const { data, mimeType } = await buildImageContentData(
-        filePath,
-        attachment.mimeType,
-        attachment.size
+    // Large images are downscaled/re-encoded first so one file cannot overflow the request.
+    if (mimeType?.startsWith('image/')) {
+      const { data, mimeType: outMimeType } = await buildImageContentData(
+        absolutePath,
+        mimeType,
+        size
       )
 
-      return { type: 'image', data, mimeType, uri }
+      return { type: 'image', data, mimeType: outMimeType, uri }
     }
 
     // PDFs are never inlined as base64 (a 20MB file overflows the 32MB request limit); instead we
     // extract selectable text so the model reads readable content. Page images are a future option.
-    if (this.isPdfAttachment(attachment)) {
-      return this.createPdfContentBlock(attachment, filePath, uri)
+    if (this.isPdfFile(name, mimeType)) {
+      return this.createPdfContentBlock(name, absolutePath, uri)
     }
 
     // Small text-like files are embedded for direct reading; oversized text falls through to a link.
     if (
-      (attachment.mimeType?.startsWith('text/') || attachment.mimeType === 'application/json') &&
-      attachment.size <= MAX_EMBEDDED_TEXT_UPLOAD_BYTES
+      (mimeType?.startsWith('text/') || mimeType === 'application/json') &&
+      size <= MAX_EMBEDDED_TEXT_UPLOAD_BYTES
     ) {
       return {
         type: 'resource',
         resource: {
           uri,
-          mimeType: attachment.mimeType,
-          text: await readFile(filePath, 'utf8')
+          mimeType,
+          text: await readFile(absolutePath, 'utf8')
         }
       }
     }
@@ -1074,30 +1131,27 @@ class AcpRuntime {
     return {
       type: 'resource_link',
       uri,
-      name: attachment.originalName || attachment.name,
-      title: attachment.originalName || attachment.name,
-      mimeType: attachment.mimeType,
-      size: attachment.size
+      name,
+      title: name,
+      mimeType,
+      size
     }
   }
 
   // Recognizes PDFs by MIME type or extension since the renderer does not always send a MIME type.
-  private isPdfAttachment(attachment: UploadedAttachment): boolean {
-    if (attachment.mimeType === 'application/pdf') return true
+  private isPdfFile(name: string, mimeType?: string): boolean {
+    if (mimeType === 'application/pdf') return true
 
-    const name = attachment.originalName || attachment.name
     return name.toLowerCase().endsWith('.pdf')
   }
 
   // Turns a PDF into a text resource block, degrading to an explanatory note when extraction fails
   // or yields nothing (e.g. scanned/image-only PDFs) rather than ever inlining the raw file.
   private async createPdfContentBlock(
-    attachment: UploadedAttachment,
+    name: string,
     filePath: string,
     uri: string
   ): Promise<ContentBlock> {
-    const name = attachment.originalName || attachment.name
-
     const toResource = (text: string): ContentBlock => ({
       type: 'resource',
       resource: { uri, mimeType: 'text/plain', text }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -43,6 +43,8 @@
   --color-action-panel-toggle: var(--action-panel-toggle);
   --color-surface-control-hover: var(--surface-control-hover);
   --color-message-user-text: var(--message-user-text);
+  --color-mention-chip: var(--mention-chip);
+  --color-mention-chip-foreground: var(--mention-chip-foreground);
   --color-rail-card-bg: hsl(var(--rail-card-bg));
   --shadow-card: 0 0 0 1px rgb(10 10 10 / 0.06), 0 4px 24px rgb(10 10 10 / 0.04);
   --shadow-card-opaque: 0 0 0 1px rgb(10 10 10 / 0.08), 0 8px 28px rgb(10 10 10 / 0.1);
@@ -74,6 +76,9 @@
   --action-panel-toggle: hsl(0 0% 42%);
   --surface-control-hover: hsl(38 20% 90%);
   --message-user-text: hsl(0 0% 12%);
+  /* Green pill for composer artifact/upload `@` mention chips, distinct from the blue skill chip. */
+  --mention-chip: hsl(110 42% 90%);
+  --mention-chip-foreground: hsl(140 55% 30%);
   --always-black: 0 0% 0%;
   --background: oklch(0.985 0.01 96);
   --foreground: oklch(0.19 0.025 236);

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -45,6 +45,8 @@
   --color-message-user-text: var(--message-user-text);
   --color-mention-chip: var(--mention-chip);
   --color-mention-chip-foreground: var(--mention-chip-foreground);
+  --color-skill-chip: var(--skill-chip);
+  --color-skill-chip-foreground: var(--skill-chip-foreground);
   --color-rail-card-bg: hsl(var(--rail-card-bg));
   --shadow-card: 0 0 0 1px rgb(10 10 10 / 0.06), 0 4px 24px rgb(10 10 10 / 0.04);
   --shadow-card-opaque: 0 0 0 1px rgb(10 10 10 / 0.08), 0 8px 28px rgb(10 10 10 / 0.1);
@@ -79,6 +81,9 @@
   /* Green pill for composer artifact/upload `@` mention chips, distinct from the blue skill chip. */
   --mention-chip: hsl(110 42% 90%);
   --mention-chip-foreground: hsl(140 55% 30%);
+  /* Blue pill for composer skill `/` mention chips. */
+  --skill-chip: hsl(214 95% 90%);
+  --skill-chip-foreground: hsl(222 63% 47%);
   --always-black: 0 0% 0%;
   --background: oklch(0.985 0.01 96);
   --foreground: oklch(0.19 0.025 236);

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -58,7 +58,8 @@ const useAcpRuntime = (): {
     sessionId: string,
     text: string,
     attachments?: AcpPromptRequest['attachments'],
-    forcedSkillIds?: string[]
+    forcedSkillIds?: string[],
+    referencedArtifacts?: AcpPromptRequest['referencedArtifacts']
   ) => Promise<AcpStateSnapshot | undefined>
   respondToPermission: (
     requestId: string,
@@ -212,7 +213,8 @@ const useAcpRuntime = (): {
       sessionId: AcpPromptRequest['sessionId'],
       text: AcpPromptRequest['text'],
       attachments?: AcpPromptRequest['attachments'],
-      forcedSkillIds?: string[]
+      forcedSkillIds?: string[],
+      referencedArtifacts?: AcpPromptRequest['referencedArtifacts']
     ) =>
       runSnapshotAction(undefined, () =>
         window.api.acp.sendPrompt({
@@ -220,7 +222,9 @@ const useAcpRuntime = (): {
           text,
           attachments,
           // Omit the field entirely when no skills were picked so the request stays minimal.
-          ...(forcedSkillIds && forcedSkillIds.length > 0 ? { forcedSkillIds } : {})
+          ...(forcedSkillIds && forcedSkillIds.length > 0 ? { forcedSkillIds } : {}),
+          // Same minimal-request rule for `@`-mentioned artifacts.
+          ...(referencedArtifacts && referencedArtifacts.length > 0 ? { referencedArtifacts } : {})
         })
       ),
     [runSnapshotAction]

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -255,6 +255,7 @@ describe('workspace agent message sending', () => {
       'transport-session-1',
       'Help me inspect this notebook',
       [],
+      undefined,
       undefined
     )
   })
@@ -318,6 +319,7 @@ describe('workspace agent message sending', () => {
       'transport-session-1',
       '',
       [finalizedAttachment],
+      undefined,
       undefined
     )
   })
@@ -364,6 +366,7 @@ describe('workspace agent message sending', () => {
       'transport-session-1',
       'Try again',
       [],
+      undefined,
       undefined
     )
     expect(useSessionStore.getState().selectedSessionId).toBe('transport-session-1')

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -11,6 +11,8 @@ import {
   type SessionPermissionProfileState
 } from '../../../../shared/permission-profiles'
 import type { UploadedAttachment } from '../../../../shared/uploads'
+import type { ArtifactReference } from '../../../../shared/artifacts'
+import type { MessagePart } from '../../../../shared/session-persistence'
 import { useSessionStore } from '../../stores/session-store'
 import { useAcpRuntime } from './useAcpRuntime'
 import { applyWorkspaceRuntimeEvent, syncWorkspacePermissionState } from './workspace-events'
@@ -27,6 +29,10 @@ type SendWorkspaceMessageInput = {
   permissionProfile?: PermissionProfileId
   // Skills the user picked in the composer; force-loaded and nudged for this turn only.
   forcedSkillIds?: string[]
+  // Existing files referenced via `@` mentions; attached to the prompt as content blocks.
+  referencedArtifacts?: ArtifactReference[]
+  // Structured mention segments of the draft, persisted so the sent bubble renders styled pills.
+  parts?: MessagePart[]
 }
 
 type SendWorkspaceMessageResult = {
@@ -175,7 +181,8 @@ const startPendingSessionPrompt = (
   cwd: string | undefined,
   projectName: string | undefined,
   permissionProfile: PermissionProfileId,
-  forcedSkillIds: string[] | undefined
+  forcedSkillIds: string[] | undefined,
+  referencedArtifacts: ArtifactReference[] | undefined
 ): void => {
   void (async () => {
     let createdSession
@@ -219,7 +226,7 @@ const startPendingSessionPrompt = (
     }
 
     void runtime
-      .sendPrompt(runtimeSessionId, content, promptAttachments, forcedSkillIds)
+      .sendPrompt(runtimeSessionId, content, promptAttachments, forcedSkillIds, referencedArtifacts)
       .then((snapshot) => {
         if (!snapshot) {
           useSessionStore.getState().failRun(runtimeSessionId, 'Agent run failed')
@@ -244,7 +251,9 @@ const sendWorkspaceMessage = async (
     projectId,
     projectName,
     permissionProfile,
-    forcedSkillIds
+    forcedSkillIds,
+    referencedArtifacts,
+    parts
   }: SendWorkspaceMessageInput
 ): Promise<SendWorkspaceMessageResult | undefined> => {
   const content = text.trim()
@@ -273,6 +282,7 @@ const sendWorkspaceMessage = async (
         sessionId: currentSession.id,
         content,
         attachments,
+        parts,
         cwd: retryCwd,
         projectId: projectId ?? currentSession.projectId
       })
@@ -287,7 +297,8 @@ const sendWorkspaceMessage = async (
         retryCwd,
         sessionProjectName,
         currentSession.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
-        forcedSkillIds
+        forcedSkillIds,
+        referencedArtifacts
       )
       return appended
     }
@@ -310,6 +321,7 @@ const sendWorkspaceMessage = async (
       sessionId: targetSessionId,
       content,
       attachments,
+      parts,
       cwd: targetCwd,
       projectId: projectId ?? currentSession?.projectId
     })
@@ -350,7 +362,7 @@ const sendWorkspaceMessage = async (
 
     // The hook returns after local state is updated; event listeners handle the streamed result.
     void runtime
-      .sendPrompt(targetSessionId, content, promptAttachments, forcedSkillIds)
+      .sendPrompt(targetSessionId, content, promptAttachments, forcedSkillIds, referencedArtifacts)
       .then((snapshot) => {
         if (!snapshot) {
           useSessionStore.getState().failRun(targetSessionId, 'Agent run failed')
@@ -368,6 +380,7 @@ const sendWorkspaceMessage = async (
   const pending = useSessionStore.getState().appendPendingUserMessage({
     content,
     attachments,
+    parts,
     cwd: targetCwd ?? runtime.state.cwd,
     projectId,
     permissionProfile
@@ -384,7 +397,8 @@ const sendWorkspaceMessage = async (
     targetCwd ?? runtime.state.cwd,
     projectName,
     permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
-    forcedSkillIds
+    forcedSkillIds,
+    referencedArtifacts
   )
 
   return pending

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -244,6 +244,29 @@ describe('SettingsPage layout', () => {
     expect(document.body.querySelector('[aria-label="Back to skills"]')).toBeNull()
   })
 
+  it('opens directly on a skill detail when the store has a pending skill', async () => {
+    // A skill mention sets the pending id before the dialog opens.
+    useSettingsStore.setState({ pendingSkillId: 'alpha' })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    // Flush the seeding effect, the skills-list load, and the skill-detail fetch.
+    await act(async () => {
+      await Promise.resolve()
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Landed on the skill's detail page (breadcrumb + detail), not the default Model panel.
+    expect(document.body.querySelector('[aria-label="Back to skills"]')).not.toBeNull()
+    expect(document.body.textContent).toContain('Alpha')
+    expect(document.body.querySelector('section[aria-label="Providers"]')).toBeNull()
+    // The pending id is consumed so a later normal open won't jump back to it.
+    expect(useSettingsStore.getState().pendingSkillId).toBeUndefined()
+  })
+
   it('warns about reduced-protection storage in the provider form when encryption is unavailable', async () => {
     // The store loads encryptionAvailable from this call when the dialog opens.
     ;(

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -134,6 +134,8 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const deleteProvider = useSettingsStore((state) => state.deleteProvider)
   const validateProvider = useSettingsStore((state) => state.validateProvider)
   const refreshProviderModels = useSettingsStore((state) => state.refreshProviderModels)
+  const pendingSkillId = useSettingsStore((state) => state.pendingSkillId)
+  const consumePendingSkill = useSettingsStore((state) => state.consumePendingSkill)
 
   // Settings navigation history (browser-like back/forward). Panel switches and drill-downs push a
   // new location; the active panel and open sub-views are derived from the current entry.
@@ -157,6 +159,32 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   useEffect(() => {
     if (open) void load()
   }, [open, load])
+
+  // When opened from a skill mention, seed the history straight to that skill's detail page. This is
+  // the derive-state-during-render pattern (guarded so it runs once per request); the guard resets on
+  // close so reopening the same skill re-seeds. The Skills panel loads its list on mount, so the
+  // breadcrumb name resolves once that arrives.
+  const [seededSkillId, setSeededSkillId] = useState<string | undefined>(undefined)
+  if (open && pendingSkillId !== undefined && pendingSkillId !== seededSkillId) {
+    setSeededSkillId(pendingSkillId)
+    setHistory([
+      {
+        panel: 'skills',
+        skills: { kind: 'detail', id: pendingSkillId },
+        model: { kind: 'list' },
+        connectors: { kind: 'list' }
+      }
+    ])
+    setHistoryIndex(0)
+  }
+  if (!open && seededSkillId !== undefined) {
+    setSeededSkillId(undefined)
+  }
+
+  // Clear the store's pending flag after it has been applied, so a later normal open starts fresh.
+  useEffect(() => {
+    if (pendingSkillId !== undefined) consumePendingSkill()
+  }, [pendingSkillId, consumePendingSkill])
 
   const currentLocation = history[historyIndex]
   const activePanel = currentLocation.panel

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -289,7 +289,7 @@ const ConversationPanel = ({
                           onSubmit={handleSubmit}
                           onPaste={handleMessageDraftPaste}
                           disabled={!canEditDraft}
-                          placeholder="Ask anything — / for skills"
+                          placeholder="Ask anything — / for skills, @ for artifacts"
                           ariaLabel="Ask anything"
                         />
                       </div>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { JSX, PropsWithChildren } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChatMessage } from '@/stores/session-store'
+
+import { WorkspaceMessageItem } from './WorkspaceMessageItem'
+
+// Keep the transcript row and markdown surface as thin wrappers so the test never loads Shiki.
+vi.mock('@/components/ui/message-scroller', () => ({
+  MessageScrollerItem: ({ children }: PropsWithChildren): JSX.Element => <div>{children}</div>
+}))
+
+vi.mock('@/components/streamdown/AgentMarkdown', () => ({
+  AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+const createMessage = (overrides: Partial<ChatMessage>): ChatMessage => ({
+  id: 'message-1',
+  role: 'user',
+  content: 'Prompt',
+  status: 'complete',
+  eventIds: [],
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000,
+  ...overrides
+})
+
+const noop = (): void => {}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+const mentionMessage = createMessage({
+  content: 'Run /forecast on @clinical trial03.pdf',
+  parts: [
+    { type: 'text', text: 'Run ' },
+    { type: 'skill', id: 'skill-forecast', name: 'forecast' },
+    { type: 'text', text: ' on ' },
+    {
+      type: 'artifact',
+      id: 'artifact-1',
+      name: 'clinical trial03.pdf',
+      path: '/p/clinical trial03.pdf',
+      source: 'artifact'
+    }
+  ]
+})
+
+const clickButton = (label: string): void => {
+  const button = document.body.querySelector<HTMLButtonElement>(`[aria-label="${label}"]`)
+
+  act(() => {
+    button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+describe('WorkspaceMessageItem mention pills', () => {
+  it('invokes the skill handler with the skill id when a skill pill is clicked', () => {
+    const onOpenSkillMention = vi.fn()
+
+    act(() => {
+      root.render(
+        <WorkspaceMessageItem
+          message={mentionMessage}
+          onPreviewArtifact={noop}
+          onPreviewUploadAttachment={noop}
+          onOpenSkillMention={onOpenSkillMention}
+          onPreviewMentionArtifact={noop}
+        />
+      )
+    })
+
+    clickButton('Open skill forecast')
+
+    expect(onOpenSkillMention).toHaveBeenCalledWith('skill-forecast', 'forecast')
+  })
+
+  it('invokes the artifact handler with the mention part when an artifact pill is clicked', () => {
+    const onPreviewMentionArtifact = vi.fn()
+
+    act(() => {
+      root.render(
+        <WorkspaceMessageItem
+          message={mentionMessage}
+          onPreviewArtifact={noop}
+          onPreviewUploadAttachment={noop}
+          onOpenSkillMention={noop}
+          onPreviewMentionArtifact={onPreviewMentionArtifact}
+        />
+      )
+    })
+
+    clickButton('Preview clinical trial03.pdf')
+
+    expect(onPreviewMentionArtifact).toHaveBeenCalledWith({
+      type: 'artifact',
+      id: 'artifact-1',
+      name: 'clinical trial03.pdf',
+      path: '/p/clinical trial03.pdf',
+      source: 'artifact'
+    })
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -48,9 +48,10 @@ const userMessageBubbleClassName =
 // Staged uploads render as gray file pills inside the sent bubble.
 const uploadedAttachmentButtonClassName =
   'inline-flex max-w-full items-center gap-1.5 rounded-md border border-border-200 bg-bg-200 px-2 py-0.5 text-left text-[13px] leading-5 text-text-000 transition-colors hover:bg-bg-000 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
-// Shared pill shape for inline skill/artifact mentions in the sent bubble.
+// Shared pill shape for inline skill/artifact mentions in the sent bubble. Capped width + truncation
+// keeps a long file/skill name from overflowing the bubble.
 const mentionPillClassName =
-  'inline-flex items-center rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium'
+  'inline-block max-w-[220px] truncate align-middle rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium'
 // Interactive additions layered onto the pill shape when a mention resolves to a clickable target.
 const mentionButtonClassName =
   'cursor-pointer hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -3,8 +3,10 @@ import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { cn, formatByteSize } from '@/lib/utils'
 import type { ChatMessage, ChatSession } from '@/stores/session-store'
 import { Collapsible } from 'radix-ui'
+import { FileText, Image as ImageIcon } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import type { ArtifactPreviewResult } from '../../../../shared/artifacts'
+import type { MessagePart } from '../../../../shared/session-persistence'
 import { getUploadedAttachmentName } from '../../../../shared/uploads'
 
 import { ArtifactPreview } from './artifact-preview'
@@ -40,8 +42,12 @@ const artifactGalleryClassName = 'grid max-w-full grid-cols-[repeat(auto-fill,12
 
 const userMessageBubbleClassName =
   'max-w-[90%] break-words rounded-2xl bg-bg-300 px-3.5 py-2 text-sm text-message-user-text md:max-w-[min(85%,56rem)] md:px-4 md:py-2.5 md:text-[15px]'
+// Staged uploads render as gray file pills inside the sent bubble.
 const uploadedAttachmentButtonClassName =
-  'inline-flex max-w-full items-center rounded-md border border-border-200 bg-bg-000/70 px-1.5 py-0.5 text-left text-[13px] leading-5 text-text-000 transition-colors hover:bg-bg-000 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
+  'inline-flex max-w-full items-center gap-1.5 rounded-md border border-border-200 bg-bg-200 px-2 py-0.5 text-left text-[13px] leading-5 text-text-000 transition-colors hover:bg-bg-000 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
+// Shared pill shape for inline skill/artifact mentions in the sent bubble.
+const mentionPillClassName =
+  'inline-flex items-center rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium'
 
 const assistantMessageSurfaceClassName =
   'relative w-full max-w-[56rem] text-sm leading-relaxed text-text-000 md:text-[15px]'
@@ -207,7 +213,7 @@ const MessageArtifactList = ({
   )
 }
 
-// Renders uploaded files inside the sent user bubble as preview-opening filename buttons.
+// Renders uploaded files inside the sent user bubble as gray file pills that open a preview.
 const MessageUploadAttachmentList = ({
   attachments,
   onPreviewUploadAttachment
@@ -218,10 +224,11 @@ const MessageUploadAttachmentList = ({
   if (attachments.length === 0) return null
 
   return (
-    <div className="mb-1.5 flex flex-col items-start gap-1">
+    <div className="mb-1.5 flex flex-wrap items-start gap-1.5">
       {attachments.map((attachment) => {
         // Use the original display name so pasted/renamed files match the composer chip.
         const attachmentName = getUploadedAttachmentName(attachment)
+        const Icon = attachment.mimeType?.startsWith('image/') ? ImageIcon : FileText
 
         return (
           <button
@@ -234,13 +241,45 @@ const MessageUploadAttachmentList = ({
             aria-label={`Preview uploaded attachment ${attachmentName}`}
             title={attachment.path}
           >
-            <span className="min-w-0 truncate">@{attachmentName}</span>
+            <Icon className="h-3.5 w-3.5 shrink-0 text-text-300" aria-hidden="true" />
+            <span className="min-w-0 truncate">{attachmentName}</span>
           </button>
         )
       })}
     </div>
   )
 }
+
+// Renders a user message's structured mention segments as inline styled pills.
+const MessagePartsContent = ({ parts }: { parts: MessagePart[] }): React.JSX.Element => (
+  <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+    {parts.map((part, index) => {
+      if (part.type === 'skill') {
+        return (
+          <span key={index} className={cn(mentionPillClassName, 'bg-primary/15 text-primary')}>
+            /{part.name}
+          </span>
+        )
+      }
+      if (part.type === 'artifact') {
+        return (
+          <span
+            key={index}
+            className={cn(mentionPillClassName, 'bg-mention-chip text-mention-chip-foreground')}
+          >
+            @{part.name}
+          </span>
+        )
+      }
+
+      return (
+        <span key={index} className="whitespace-pre-wrap">
+          {part.text}
+        </span>
+      )
+    })}
+  </p>
+)
 
 // Renders one chat message with user bubbles and full-width assistant markdown surfaces.
 const WorkspaceMessageItem = ({
@@ -268,7 +307,10 @@ const WorkspaceMessageItem = ({
                 attachments={uploads}
                 onPreviewUploadAttachment={onPreviewUploadAttachment}
               />
-              {message.content ? (
+              {/* Structured parts drive styled pills; plain content is the backward-compatible fallback. */}
+              {message.parts && message.parts.length > 0 ? (
+                <MessagePartsContent parts={message.parts} />
+              ) : message.content ? (
                 <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
                   {message.content}
                 </p>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -276,7 +276,7 @@ const MessagePartsContent = ({
             className={cn(
               mentionPillClassName,
               mentionButtonClassName,
-              'bg-primary/15 text-primary'
+              'bg-skill-chip text-skill-chip-foreground'
             )}
             onClick={() => onOpenSkillMention(part.id, part.name)}
             aria-label={`Open skill ${part.name}`}

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -21,6 +21,7 @@ import {
 
 type MessageArtifact = NonNullable<ChatSession['artifacts']>[number]
 type MessageUploadAttachment = NonNullable<ChatMessage['uploads']>[number]
+type ArtifactMentionPart = Extract<MessagePart, { type: 'artifact' }>
 type ArtifactPreviewState = Record<string, ArtifactPreviewResult | undefined>
 type ArtifactPreviewCache = {
   key: string
@@ -31,6 +32,8 @@ type WorkspaceMessageItemProps = {
   message: ChatMessage
   onPreviewArtifact: (artifact: MessageArtifact) => void
   onPreviewUploadAttachment: (attachment: MessageUploadAttachment) => void
+  onOpenSkillMention: (skillId: string, name: string) => void
+  onPreviewMentionArtifact: (part: ArtifactMentionPart) => void
   artifacts?: MessageArtifact[]
 }
 
@@ -48,6 +51,9 @@ const uploadedAttachmentButtonClassName =
 // Shared pill shape for inline skill/artifact mentions in the sent bubble.
 const mentionPillClassName =
   'inline-flex items-center rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium'
+// Interactive additions layered onto the pill shape when a mention resolves to a clickable target.
+const mentionButtonClassName =
+  'cursor-pointer hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
 
 const assistantMessageSurfaceClassName =
   'relative w-full max-w-[56rem] text-sm leading-relaxed text-text-000 md:text-[15px]'
@@ -251,24 +257,49 @@ const MessageUploadAttachmentList = ({
 }
 
 // Renders a user message's structured mention segments as inline styled pills.
-const MessagePartsContent = ({ parts }: { parts: MessagePart[] }): React.JSX.Element => (
+const MessagePartsContent = ({
+  parts,
+  onOpenSkillMention,
+  onPreviewMentionArtifact
+}: {
+  parts: MessagePart[]
+  onOpenSkillMention: (skillId: string, name: string) => void
+  onPreviewMentionArtifact: (part: ArtifactMentionPart) => void
+}): React.JSX.Element => (
   <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
     {parts.map((part, index) => {
       if (part.type === 'skill') {
         return (
-          <span key={index} className={cn(mentionPillClassName, 'bg-primary/15 text-primary')}>
+          <button
+            key={index}
+            type="button"
+            className={cn(
+              mentionPillClassName,
+              mentionButtonClassName,
+              'bg-primary/15 text-primary'
+            )}
+            onClick={() => onOpenSkillMention(part.id, part.name)}
+            aria-label={`Open skill ${part.name}`}
+          >
             /{part.name}
-          </span>
+          </button>
         )
       }
       if (part.type === 'artifact') {
         return (
-          <span
+          <button
             key={index}
-            className={cn(mentionPillClassName, 'bg-mention-chip text-mention-chip-foreground')}
+            type="button"
+            className={cn(
+              mentionPillClassName,
+              mentionButtonClassName,
+              'bg-mention-chip text-mention-chip-foreground'
+            )}
+            onClick={() => onPreviewMentionArtifact(part)}
+            aria-label={`Preview ${part.name}`}
           >
             @{part.name}
-          </span>
+          </button>
         )
       }
 
@@ -286,6 +317,8 @@ const WorkspaceMessageItem = ({
   message,
   onPreviewArtifact,
   onPreviewUploadAttachment,
+  onOpenSkillMention,
+  onPreviewMentionArtifact,
   artifacts = []
 }: WorkspaceMessageItemProps): React.JSX.Element => {
   const isUserMessage = message.role === 'user'
@@ -309,7 +342,11 @@ const WorkspaceMessageItem = ({
               />
               {/* Structured parts drive styled pills; plain content is the backward-compatible fallback. */}
               {message.parts && message.parts.length > 0 ? (
-                <MessagePartsContent parts={message.parts} />
+                <MessagePartsContent
+                  parts={message.parts}
+                  onOpenSkillMention={onOpenSkillMention}
+                  onPreviewMentionArtifact={onPreviewMentionArtifact}
+                />
               ) : message.content ? (
                 <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
                   {message.content}
@@ -329,3 +366,4 @@ const WorkspaceMessageItem = ({
 }
 
 export { WorkspaceMessageItem }
+export type { ArtifactMentionPart }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -314,8 +314,8 @@ describe('WorkspaceMessageScroller loading render', () => {
       })
     )
 
-    const firstIndex = html.indexOf('@pasted-image-2026-07-08T06-17-13.png')
-    const secondIndex = html.indexOf('@pasted-image-2026-07-08T06-17-25.png')
+    const firstIndex = html.indexOf('pasted-image-2026-07-08T06-17-13.png')
+    const secondIndex = html.indexOf('pasted-image-2026-07-08T06-17-25.png', firstIndex + 1)
     const textIndex = html.indexOf('What is in the first image')
 
     expect(firstIndex).toBeGreaterThan(-1)
@@ -324,6 +324,82 @@ describe('WorkspaceMessageScroller loading render', () => {
     expect(html).toContain(
       'aria-label="Preview uploaded attachment pasted-image-2026-07-08T06-17-13.png"'
     )
+    // Uploads are gray file pills without the legacy leading @ prefix.
+    expect(html).toContain('bg-bg-200')
+    expect(html).not.toContain('@pasted-image-2026-07-08T06-17-13.png')
+  })
+
+  it('renders user message parts as styled skill and artifact pills', async () => {
+    const html = await renderScroller(
+      createSession({
+        status: 'idle',
+        messages: [
+          createMessage({
+            id: 'prompt-1',
+            content: 'Run /forecast on @clinical trial03.pdf',
+            parts: [
+              { type: 'text', text: 'Run ' },
+              { type: 'skill', id: 'skill-forecast', name: 'forecast' },
+              { type: 'text', text: ' on ' },
+              {
+                type: 'artifact',
+                id: 'artifact-1',
+                name: 'clinical trial03.pdf',
+                path: '/p/clinical trial03.pdf',
+                source: 'artifact'
+              }
+            ]
+          })
+        ]
+      })
+    )
+
+    // Skill pill is blue; artifact pill is green; labels keep their / and @ markers.
+    expect(html).toContain('text-primary')
+    expect(html).toContain('/forecast')
+    expect(html).toContain('bg-mention-chip')
+    expect(html).toContain('text-mention-chip-foreground')
+    expect(html).toContain('@clinical trial03.pdf')
+  })
+
+  it('renders plain content for user messages without structured parts', async () => {
+    const html = await renderScroller(
+      createSession({
+        status: 'idle',
+        messages: [createMessage({ id: 'prompt-1', content: 'Just plain text' })]
+      })
+    )
+
+    expect(html).toContain('Just plain text')
+    expect(html).not.toContain('text-mention-chip-foreground')
+  })
+
+  it('renders uploads as gray pills labeled by filename', async () => {
+    const html = await renderScroller(
+      createSession({
+        status: 'idle',
+        messages: [
+          createMessage({
+            id: 'prompt-1',
+            content: 'Look at this',
+            uploads: [
+              createUpload({
+                id: 'upload-1',
+                name: 'report.pdf',
+                originalName: 'report.pdf',
+                mimeType: 'application/pdf',
+                path: '/p/report.pdf'
+              })
+            ]
+          })
+        ]
+      })
+    )
+
+    expect(html).toContain('bg-bg-200')
+    expect(html).toContain('report.pdf')
+    expect(html).not.toContain('@report.pdf')
+    expect(html).toContain('aria-label="Preview uploaded attachment report.pdf"')
   })
 
   it('renders search activities as compact chips with details collapsed by default', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -355,7 +355,7 @@ describe('WorkspaceMessageScroller loading render', () => {
     )
 
     // Skill pill is blue; artifact pill is green; labels keep their / and @ markers.
-    expect(html).toContain('text-primary')
+    expect(html).toContain('text-skill-chip-foreground')
     expect(html).toContain('/forecast')
     expect(html).toContain('bg-mention-chip')
     expect(html).toContain('text-mention-chip-foreground')

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -6,17 +6,20 @@ import {
   MessageScrollerViewport
 } from '@/components/ui/message-scroller'
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import type { ChatSession } from '@/stores/session-store'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { shouldShowAgentLoadingMessage } from './agent-loading-message'
 import {
   createPreviewFileItemFromArtifact,
+  createPreviewFileItemFromMention,
   createPreviewFileItemFromUpload
 } from './preview-file-item'
 import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
 import { WorkspaceAgentLoadingRow } from './WorkspaceAgentLoadingRow'
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
+import type { ArtifactMentionPart } from './WorkspaceMessageItem'
 import { createConversationItems } from './workspace-conversation-items'
 import { groupConversationItems } from './workspace-tool-activity-groups'
 import type { ActivityExpansionOverrides } from './workspace-tool-activity-groups'
@@ -38,6 +41,8 @@ type SessionScopedActivityExpansionState = {
 type MessageArtifact = NonNullable<ChatSession['artifacts']>[number]
 type MessageUploadAttachment = NonNullable<ChatSession['messages'][number]['uploads']>[number]
 const conversationContentClassName = 'relative mx-auto w-full max-w-4xl pb-[56px]'
+// How long a "no longer available" mention notice stays visible before auto-dismissing.
+const MENTION_NOTICE_TIMEOUT_MS = 3000
 
 // Resolves a message's artifact ids against the session-level artifact metadata store.
 const getMessageArtifacts = (
@@ -97,6 +102,33 @@ const WorkspaceMessageScroller = ({
   const conversationItems = groupConversationItems(createConversationItems(activeSession))
   const showAgentLoadingMessage = shouldShowAgentLoadingMessage(activeSession)
 
+  // Transient "no longer available" pill shown when a mention target can't be opened.
+  const [mentionNotice, setMentionNotice] = useState<string | null>(null)
+  const mentionNoticeTimerRef = useRef<number | undefined>(undefined)
+
+  // Clears any pending auto-dismiss timer so unmounting never fires setState on a dead component.
+  useEffect(
+    () => () => {
+      if (mentionNoticeTimerRef.current !== undefined) {
+        window.clearTimeout(mentionNoticeTimerRef.current)
+      }
+    },
+    []
+  )
+
+  // Shows a transient notice and schedules its auto-dismiss, replacing any in-flight timer.
+  const showMentionNotice = (message: string): void => {
+    if (mentionNoticeTimerRef.current !== undefined) {
+      window.clearTimeout(mentionNoticeTimerRef.current)
+    }
+
+    setMentionNotice(message)
+    mentionNoticeTimerRef.current = window.setTimeout(() => {
+      setMentionNotice(null)
+      mentionNoticeTimerRef.current = undefined
+    }, MENTION_NOTICE_TIMEOUT_MS)
+  }
+
   // Routes a generated-file click to the preview workbench, scoped to the active session.
   const onPreviewArtifact = (artifact: MessageArtifact): void => {
     if (currentSessionId) previewArtifact(artifact, currentSessionId)
@@ -105,6 +137,37 @@ const WorkspaceMessageScroller = ({
   // Routes a sent-message upload click to the preview workbench for the active session.
   const onPreviewUploadAttachment = (attachment: MessageUploadAttachment): void => {
     if (currentSessionId) previewUploadAttachment(attachment, currentSessionId)
+  }
+
+  // Opens an artifact mention in the preview panel, probing existence first so a stale link warns.
+  const onPreviewMentionArtifact = async (part: ArtifactMentionPart): Promise<void> => {
+    if (!currentSessionId) return
+
+    const read =
+      part.source === 'upload' ? window.api.uploads.readPreview : window.api.artifacts.readPreview
+
+    try {
+      await read({ path: part.path, maxBytes: 1, encoding: 'utf8' })
+    } catch {
+      showMentionNotice(`"${part.name}" is no longer available.`)
+      return
+    }
+
+    usePreviewWorkbenchStore
+      .getState()
+      .upsertAndActivateItem(createPreviewFileItemFromMention(part, currentSessionId))
+  }
+
+  // Opens Settings on a skill mention's detail, warning instead when the skill no longer exists.
+  const onOpenSkillMention = async (skillId: string, name: string): Promise<void> => {
+    const detail = await window.api.settings.getSkillDetail(skillId).catch(() => null)
+
+    if (!detail) {
+      showMentionNotice(`Skill "${name}" is no longer available.`)
+      return
+    }
+
+    useSettingsStore.getState().openSettingsToSkill(skillId)
   }
 
   // Toggles a whole adjacent tool-activity group without affecting other sessions.
@@ -172,6 +235,8 @@ const WorkspaceMessageScroller = ({
                       message={item.message}
                       onPreviewArtifact={onPreviewArtifact}
                       onPreviewUploadAttachment={onPreviewUploadAttachment}
+                      onOpenSkillMention={onOpenSkillMention}
+                      onPreviewMentionArtifact={onPreviewMentionArtifact}
                       artifacts={artifacts}
                     />
                   )
@@ -197,6 +262,18 @@ const WorkspaceMessageScroller = ({
         </MessageScrollerViewport>
 
         <MessageScrollerButton className="z-10 border-border-200 bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3" />
+
+        {/* Transient warning shown when a mention target no longer resolves to a file or skill. */}
+        {mentionNotice ? (
+          <div
+            role="status"
+            className="pointer-events-none absolute inset-x-0 bottom-14 z-10 flex justify-center px-4"
+          >
+            <span className="rounded-full border border-border-200 bg-bg-000 px-3 py-1 text-[13px] text-text-100 shadow-card">
+              {mentionNotice}
+            </span>
+          </div>
+        ) : null}
       </MessageScroller>
     </MessageScrollerProvider>
   )

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -24,7 +24,13 @@ import { useSessionStore } from '@/stores/session-store'
 import type { StageUploadFile, UploadedAttachment } from '../../../../shared/uploads'
 
 import { planComposerAttachmentIntake } from './composer-attachment-intake'
-import { docIsEmpty, docToText, emptyDoc, type ComposerDoc } from './composer/composer-doc'
+import {
+  docIsEmpty,
+  docToArtifactRefs,
+  docToText,
+  emptyDoc,
+  type ComposerDoc
+} from './composer/composer-doc'
 import { ConversationPanel } from './ConversationPanel'
 import { DeleteSessionDialog } from './DeleteSessionDialog'
 import { PreviewPanel } from './PreviewPanel'
@@ -472,6 +478,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
       sessionId: activeSession?.id,
       text: docToText(doc),
       attachments: attachmentsForSend,
+      // Existing files the user referenced via `@`; the runtime attaches each as a content block.
+      referencedArtifacts: docToArtifactRefs(doc),
+      // Persist the draft's structural segments so the sent bubble renders styled mention pills.
+      parts: doc.nodes,
       cwd: activeSession?.cwd,
       projectId: activeSession?.projectId ?? scopedProjectId,
       projectName: activeSession?.projectId ?? scopedProjectId,

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ArtifactMentionPopup } from './ArtifactMentionPopup'
+import { useNavigationStore } from '@/stores/navigation-store'
+import {
+  createInitialSessionState,
+  type ChatMessage,
+  type ChatSession
+} from '@/stores/session-store'
+import { useSessionStore } from '@/stores/session-store'
+
+let container: HTMLDivElement
+let root: Root
+
+const createMessage = (overrides: Partial<ChatMessage>): ChatMessage => ({
+  id: 'message-1',
+  role: 'user',
+  content: 'Prompt',
+  status: 'complete',
+  eventIds: [],
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000,
+  ...overrides
+})
+
+const createSession = (overrides: Partial<ChatSession>): ChatSession => ({
+  id: 'session-1',
+  projectId: 'default',
+  title: 'Analysis session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [],
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000,
+  ...overrides
+})
+
+// A project with one uploaded file and one generated output artifact.
+const seedProjectFiles = (): void => {
+  useSessionStore.setState({
+    ...createInitialSessionState(),
+    sessions: [
+      createSession({
+        messages: [
+          createMessage({
+            uploads: [
+              {
+                id: 'up-1',
+                sessionId: 'session-1',
+                name: 'safe-sequence.csv',
+                originalName: 'sequence.csv',
+                path: '/uploads/session-1/sequence.csv',
+                mimeType: 'text/csv',
+                size: 2048
+              }
+            ]
+          })
+        ],
+        artifacts: [
+          {
+            id: 'art-1',
+            kind: 'managed-file',
+            path: '/workspace/report.pdf',
+            fileUrl: 'file:///workspace/report.pdf',
+            name: 'report.pdf',
+            mimeType: 'application/pdf',
+            size: 4096,
+            mtimeMs: 1710000002000
+          }
+        ]
+      })
+    ]
+  })
+  useNavigationStore.setState({ activeProjectId: 'default' })
+}
+
+beforeEach(() => {
+  // Non-image rows never read previews, but stub the api so an accidental read never throws.
+  ;(window as unknown as { api: unknown }).api = {
+    uploads: {
+      readPreview: vi.fn().mockResolvedValue({ content: '', encoding: 'base64', size: 0 })
+    },
+    artifacts: {
+      readPreview: vi.fn().mockResolvedValue({ content: '', encoding: 'base64', size: 0 })
+    }
+  }
+  seedProjectFiles()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+const options = (): HTMLElement[] =>
+  Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]'))
+
+const pressKey = (key: string): void => {
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }))
+  })
+}
+
+describe('ArtifactMentionPopup', () => {
+  it('renders both sections with rows and tags', () => {
+    act(() => {
+      root.render(<ArtifactMentionPopup query="" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    expect(options()).toHaveLength(2)
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('User uploads')
+    expect(text).toContain('Other artifacts')
+    expect(text).toContain('sequence.csv')
+    expect(text).toContain('report.pdf')
+    // Section tags distinguish upload vs generated output.
+    expect(text).toContain('upload')
+    expect(text).toContain('output')
+  })
+
+  it('filters rows by a case-insensitive filename query', () => {
+    act(() => {
+      root.render(<ArtifactMentionPopup query="REPORT" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    const rendered = options()
+    expect(rendered).toHaveLength(1)
+    expect(document.body.textContent).toContain('report.pdf')
+    expect(document.body.textContent).not.toContain('sequence.csv')
+  })
+
+  it('selects the highlighted row on Enter with the picked reference shape', () => {
+    const onSelect = vi.fn()
+    act(() => {
+      root.render(<ArtifactMentionPopup query="" onSelect={onSelect} onClose={vi.fn()} />)
+    })
+
+    // First row is the upload.
+    pressKey('Enter')
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'upload:up-1',
+        name: 'sequence.csv',
+        path: '/uploads/session-1/sequence.csv',
+        source: 'upload'
+      })
+    )
+  })
+
+  it('selects an artifact row on click', () => {
+    const onSelect = vi.fn()
+    act(() => {
+      root.render(<ArtifactMentionPopup query="" onSelect={onSelect} onClose={vi.fn()} />)
+    })
+
+    const artifactRow = options()[1]
+    act(() => artifactRow.click())
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'art-1',
+        name: 'report.pdf',
+        path: '/workspace/report.pdf',
+        source: 'artifact'
+      })
+    )
+  })
+
+  it('shows an empty state when the project has no artifacts', () => {
+    useSessionStore.setState({ ...createInitialSessionState(), sessions: [] })
+    act(() => {
+      root.render(<ArtifactMentionPopup query="" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    expect(options()).toHaveLength(0)
+    expect(document.body.textContent).toContain('No artifacts yet')
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    act(() => {
+      root.render(<ArtifactMentionPopup query="" onSelect={vi.fn()} onClose={onClose} />)
+    })
+
+    pressKey('Escape')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useId, useMemo, useState } from 'react'
+
+import { formatByteSize } from '@/lib/utils'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { useSessionStore } from '@/stores/session-store'
+
+import { ArtifactFileIcon } from './artifact-file-icon'
+import { buildProjectFileLibrary } from '../project-files-library'
+
+// The reference passed back to the composer when an artifact row is picked.
+export type PickedArtifact = {
+  id: string
+  name: string
+  path: string
+  source: 'upload' | 'artifact'
+  mimeType?: string
+  versionId?: string
+}
+
+// Popup that suggests project artifacts for the composer's `@` mention trigger. Like the skill popup
+// the composer keeps caret focus, so this listens for navigation keys on document while mounted.
+type ArtifactMentionPopupProps = {
+  query: string
+  onSelect: (ref: PickedArtifact) => void
+  onClose: () => void
+}
+
+// One suggestion row: a picked artifact plus the display size and its section tag.
+type ArtifactRow = PickedArtifact & {
+  size?: number
+  tag: 'upload' | 'output'
+}
+
+// Human-readable section headers, ordered as they render.
+const SECTION_UPLOADS = 'User uploads'
+const SECTION_ARTIFACTS = 'Other artifacts'
+
+export const ArtifactMentionPopup = ({
+  query,
+  onSelect,
+  onClose
+}: ArtifactMentionPopupProps): React.JSX.Element | null => {
+  const sessions = useSessionStore((state) => state.sessions)
+  const activeProjectId = useNavigationStore((state) => state.activeProjectId)
+  const listboxId = useId()
+
+  // Derive the project's artifact library the same way the Files panel does: uploads then outputs.
+  const rows = useMemo<ArtifactRow[]>(() => {
+    const projectSessions = sessions.filter((session) => session.projectId === activeProjectId)
+    const library = buildProjectFileLibrary(projectSessions)
+
+    const uploadRows: ArtifactRow[] = library.uploadFiles.map((file) => ({
+      id: file.id,
+      name: file.name,
+      path: file.attachment.path,
+      source: 'upload',
+      mimeType: file.attachment.mimeType,
+      size: file.size,
+      tag: 'upload'
+    }))
+
+    const artifactRows: ArtifactRow[] = library.artifactGroups.flatMap((group) =>
+      group.files.map((file) => ({
+        id: file.id,
+        name: file.name,
+        path: file.artifact.path,
+        source: 'artifact',
+        mimeType: file.artifact.mimeType,
+        size: file.size,
+        tag: 'output'
+      }))
+    )
+
+    return [...uploadRows, ...artifactRows]
+  }, [sessions, activeProjectId])
+
+  // Case-insensitive filename match; empty query shows every artifact.
+  const matches = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    if (needle.length === 0) return rows
+    return rows.filter((row) => row.name.toLowerCase().includes(needle))
+  }, [rows, query])
+
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  // Reset the highlight to the top when the query changes (setState-during-render pattern).
+  const [lastQuery, setLastQuery] = useState(query)
+  if (lastQuery !== query) {
+    setLastQuery(query)
+    setActiveIndex(0)
+  }
+
+  // Keep the highlight within the current match set even after filtering shrinks it.
+  const safeIndex = matches.length === 0 ? 0 : Math.min(activeIndex, matches.length - 1)
+
+  // Handle navigation keys at the document level while mounted, since focus stays in the editor.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        if (matches.length > 0) setActiveIndex((safeIndex + 1) % matches.length)
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        if (matches.length > 0) setActiveIndex((safeIndex - 1 + matches.length) % matches.length)
+      } else if (event.key === 'Enter') {
+        const active = matches[safeIndex]
+        if (active) {
+          event.preventDefault()
+          onSelect(toPicked(active))
+        }
+      } else if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [matches, safeIndex, onSelect, onClose])
+
+  // Split the flat match list back into its two sections, preserving the flat highlight index.
+  const uploadMatches = matches.filter((row) => row.tag === 'upload')
+  const artifactMatches = matches.filter((row) => row.tag === 'output')
+
+  const renderRow = (row: ArtifactRow, index: number): React.JSX.Element => {
+    const isActive = index === safeIndex
+    const size = formatByteSize(row.size)
+    return (
+      <li
+        key={`${row.source}:${row.id}`}
+        id={`${listboxId}-option-${index}`}
+        role="option"
+        aria-selected={isActive}
+        onMouseEnter={() => setActiveIndex(index)}
+        // Keep the editor focused/caret intact so the mention stays open long enough for the click.
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={() => onSelect(toPicked(row))}
+        className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-sm text-text-100 hover:bg-bg-200 hover:text-text-000 transition-colors cursor-pointer${
+          isActive ? ' bg-bg-200 !text-text-000' : ''
+        }`}
+      >
+        <ArtifactFileIcon
+          name={row.name}
+          mimeType={row.mimeType}
+          path={row.path}
+          source={row.source}
+        />
+        <span className="flex-1 min-w-0 truncate font-medium">{row.name}</span>
+        {size ? <span className="text-xs text-text-300 shrink-0">{size}</span> : null}
+        <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent text-accent-foreground shrink-0">
+          {row.tag}
+        </span>
+      </li>
+    )
+  }
+
+  return (
+    <div className="absolute bottom-full left-0 mb-1 z-50 bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)] overflow-hidden">
+      {matches.length === 0 ? (
+        <div className="px-2 py-1.5 text-sm text-text-300">No artifacts yet</div>
+      ) : (
+        <ul
+          id={`${listboxId}-listbox`}
+          role="listbox"
+          aria-label="Artifact suggestions"
+          className="overflow-y-auto max-h-[min(45vh,18rem)]"
+        >
+          {uploadMatches.length > 0 ? (
+            <>
+              <li
+                aria-hidden="true"
+                className="px-2 pt-1 pb-0.5 text-[11px] font-medium uppercase tracking-wide text-text-400 select-none"
+              >
+                {SECTION_UPLOADS}
+              </li>
+              {uploadMatches.map((row, index) => renderRow(row, index))}
+            </>
+          ) : null}
+          {artifactMatches.length > 0 ? (
+            <>
+              <li
+                aria-hidden="true"
+                className="px-2 pt-1 pb-0.5 text-[11px] font-medium uppercase tracking-wide text-text-400 select-none"
+              >
+                {SECTION_ARTIFACTS}
+              </li>
+              {artifactMatches.map((row, index) => renderRow(row, uploadMatches.length + index))}
+            </>
+          ) : null}
+        </ul>
+      )}
+      <div className="mt-1 -mx-1.5 -mb-1.5 px-3.5 pt-1.5 pb-2 border-t border-border-300 flex items-center gap-3 text-[11px] text-text-400 select-none">
+        <span>
+          <span className="text-text-300">↑↓</span> navigate
+        </span>
+        <span>
+          <span className="text-text-300">Enter</span> select
+        </span>
+        <span>
+          <span className="text-text-300">Esc</span> close
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// Narrow a row down to the reference shape handed back to the composer.
+const toPicked = (row: ArtifactRow): PickedArtifact => ({
+  id: row.id,
+  name: row.name,
+  path: row.path,
+  source: row.source,
+  mimeType: row.mimeType,
+  versionId: row.versionId
+})

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -184,6 +184,26 @@ const dispatchKey = (target: EventTarget, key: string, init: KeyboardEventInit =
 }
 
 describe('ComposerEditor', () => {
+  it('shows the placeholder when the doc is empty and hides it once there is content', () => {
+    renderEditor({ doc: emptyDoc })
+    // The only aria-hidden node in the editor is the placeholder overlay.
+    expect(document.body.querySelector('[aria-hidden="true"]')?.textContent).toBe('Ask anything')
+
+    act(() => {
+      root.render(
+        <ComposerEditor
+          doc={{ nodes: [{ type: 'text', text: 'hi' }] }}
+          onDocChange={noop}
+          onSubmit={noop}
+          onPaste={noop}
+          placeholder="Ask anything"
+          ariaLabel="Ask anything"
+        />
+      )
+    })
+    expect(document.body.querySelector('[aria-hidden="true"]')).toBeNull()
+  })
+
   it('emits the typed text as a doc on input', () => {
     const onDocChange = vi.fn()
     renderEditor({ onDocChange })

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -6,6 +6,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ComposerEditor } from './ComposerEditor'
 import { emptyDoc, type ComposerDoc } from './composer-doc'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { useNavigationStore } from '@/stores/navigation-store'
+import {
+  createInitialSessionState,
+  useSessionStore,
+  type ChatMessage,
+  type ChatSession
+} from '@/stores/session-store'
 
 let container: HTMLDivElement
 let root: Root
@@ -43,8 +50,80 @@ const seedSkills = [
   }
 ]
 
+const createMessage = (overrides: Partial<ChatMessage>): ChatMessage => ({
+  id: 'message-1',
+  role: 'user',
+  content: 'Prompt',
+  status: 'complete',
+  eventIds: [],
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000,
+  ...overrides
+})
+
+const createSession = (overrides: Partial<ChatSession>): ChatSession => ({
+  id: 'session-1',
+  projectId: 'default',
+  title: 'Analysis session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [],
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000,
+  ...overrides
+})
+
+// A project with one uploaded file and one generated output artifact for the `@` popup.
+const seedProjectFiles = (): void => {
+  useSessionStore.setState({
+    ...createInitialSessionState(),
+    sessions: [
+      createSession({
+        messages: [
+          createMessage({
+            uploads: [
+              {
+                id: 'up-1',
+                sessionId: 'session-1',
+                name: 'safe-sequence.csv',
+                originalName: 'sequence.csv',
+                path: '/uploads/session-1/sequence.csv',
+                mimeType: 'text/csv',
+                size: 2048
+              }
+            ]
+          })
+        ],
+        artifacts: [
+          {
+            id: 'art-1',
+            kind: 'managed-file',
+            path: '/workspace/report.pdf',
+            fileUrl: 'file:///workspace/report.pdf',
+            name: 'report.pdf',
+            mimeType: 'application/pdf',
+            size: 4096,
+            mtimeMs: 1710000002000
+          }
+        ]
+      })
+    ]
+  })
+  useNavigationStore.setState({ activeProjectId: 'default' })
+}
+
 beforeEach(() => {
   useSettingsStore.setState({ ...createInitialSettingsState(), skills: seedSkills })
+  seedProjectFiles()
+  // The artifact popup icon may read image previews; stub the api so it never throws.
+  ;(window as unknown as { api: unknown }).api = {
+    uploads: {
+      readPreview: vi.fn().mockResolvedValue({ content: '', encoding: 'base64', size: 0 })
+    },
+    artifacts: {
+      readPreview: vi.fn().mockResolvedValue({ content: '', encoding: 'base64', size: 0 })
+    }
+  }
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -257,5 +336,113 @@ describe('ComposerEditor', () => {
 
     dispatchKey(editor(), 'Enter')
     expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('inserts a green artifact chip when an artifact is chosen from the `@` popup', () => {
+    const onDocChange = vi.fn()
+    renderEditor({ onDocChange })
+
+    // Type "@seq": place the token and caret at its end, then let the mention hook read the selection.
+    const textNode = document.createTextNode('@seq')
+    editor().appendChild(textNode)
+    setCaret(textNode, 4)
+    act(() => {
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    // The artifact popup opens and shows the matching upload.
+    expect(document.body.querySelector('[role="listbox"]')).not.toBeNull()
+
+    // Enter selects the highlighted row; the editor swaps the token for a green artifact chip.
+    dispatchKey(document, 'Enter')
+
+    const chip = editor().querySelector('[data-mention-type="artifact"]')
+    expect(chip).not.toBeNull()
+    expect(chip?.textContent).toBe('@sequence.csv')
+    expect(chip?.getAttribute('data-mention-path')).toBe('/uploads/session-1/sequence.csv')
+    expect(chip?.getAttribute('data-mention-source')).toBe('upload')
+    expect(chip?.className).toContain('bg-mention-chip')
+
+    const lastCall = onDocChange.mock.calls.at(-1)?.[0] as ComposerDoc
+    expect(
+      lastCall.nodes.some((node) => node.type === 'artifact' && node.id === 'upload:up-1')
+    ).toBe(true)
+  })
+
+  it('allows multiple artifact chips in one message', () => {
+    const onDocChange = vi.fn()
+    renderEditor({
+      doc: {
+        nodes: [
+          {
+            type: 'artifact',
+            id: 'up-1',
+            name: 'sequence.csv',
+            path: '/uploads/session-1/sequence.csv',
+            source: 'upload'
+          }
+        ]
+      },
+      onDocChange
+    })
+
+    // Type "@rep" after the existing chip and select the generated artifact.
+    const textNode = document.createTextNode('@rep')
+    editor().appendChild(textNode)
+    setCaret(textNode, 4)
+    act(() => {
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    dispatchKey(document, 'Enter')
+
+    const chips = editor().querySelectorAll('[data-mention-type="artifact"]')
+    expect(chips).toHaveLength(2)
+    expect(chips[1]?.getAttribute('data-mention-path')).toBe('/workspace/report.pdf')
+  })
+
+  it('suppresses the `@` popup once the artifact mention cap is reached', () => {
+    const cappedNodes = Array.from({ length: 10 }, (_, index) => ({
+      type: 'artifact' as const,
+      id: `art-${index}`,
+      name: `file-${index}.csv`,
+      path: `/workspace/file-${index}.csv`,
+      source: 'artifact' as const
+    }))
+    renderEditor({ doc: { nodes: cappedNodes } })
+
+    // Type "@" after the ten chips — the trigger is suppressed, so no popup opens.
+    const at = document.createTextNode('@')
+    editor().appendChild(at)
+    setCaret(at, 1)
+    act(() => {
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(document.body.querySelector('[role="listbox"]')).toBeNull()
+  })
+
+  it('deletes the whole artifact chip on Backspace when the caret is right after it', () => {
+    const onDocChange = vi.fn()
+    renderEditor({
+      doc: {
+        nodes: [
+          {
+            type: 'artifact',
+            id: 'up-1',
+            name: 'sequence.csv',
+            path: '/uploads/session-1/sequence.csv',
+            source: 'upload'
+          }
+        ]
+      },
+      onDocChange
+    })
+
+    // Caret at editor offset 1 sits right after the chip (the editor's only child).
+    setCaret(editor(), 1)
+    dispatchKey(editor(), 'Backspace')
+
+    expect(editor().querySelector('[data-mention-type="artifact"]')).toBeNull()
+    expect(onDocChange).toHaveBeenLastCalledWith(emptyDoc)
   })
 })

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -3,7 +3,15 @@ import { useCallback, useLayoutEffect, useRef } from 'react'
 import type { SkillView } from '../../../../../shared/settings'
 import { cn } from '@/lib/utils'
 
-import { applyDocToDom, domToDoc, type ComposerDoc, type ComposerNode } from './composer-doc'
+import { ArtifactMentionPopup, type PickedArtifact } from './ArtifactMentionPopup'
+import {
+  applyDocToDom,
+  docArtifactCount,
+  domToDoc,
+  MAX_COMPOSER_ARTIFACT_MENTIONS,
+  type ComposerDoc,
+  type ComposerNode
+} from './composer-doc'
 import { SkillMentionPopup } from './SkillMentionPopup'
 import { useMentionTrigger } from './useMentionTrigger'
 
@@ -34,6 +42,15 @@ const nodesEqual = (a: ComposerNode[], b: ComposerNode[]): boolean => {
     if (node.type === 'skill' && other.type === 'skill') {
       return node.id === other.id && node.name === other.name
     }
+    if (node.type === 'artifact' && other.type === 'artifact') {
+      return (
+        node.id === other.id &&
+        node.name === other.name &&
+        node.path === other.path &&
+        node.source === other.source &&
+        node.versionId === other.versionId
+      )
+    }
     return false
   })
 }
@@ -53,15 +70,14 @@ const insertPlainTextAtCaret = (text: string): void => {
   selection.addRange(range)
 }
 
-// A rendered skill chip element (atomic, non-editable token).
-const asSkillChip = (node: Node | null): HTMLElement | null =>
-  node?.nodeType === Node.ELEMENT_NODE &&
-  (node as HTMLElement).getAttribute('data-mention-type') === 'skill'
+// A rendered mention chip element (skill or artifact) — any atomic, non-editable token span.
+const asMentionChip = (node: Node | null): HTMLElement | null =>
+  node?.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).hasAttribute('data-mention-type')
     ? (node as HTMLElement)
     : null
 
-// Find the skill chip immediately on one side of a collapsed caret, so Backspace/Delete can remove the
-// whole chip instead of letting the browser edit into it character by character.
+// Find the mention chip immediately on one side of a collapsed caret, so Backspace/Delete can remove
+// the whole chip instead of letting the browser edit into it character by character.
 const chipBesideCaret = (root: HTMLElement, side: 'before' | 'after'): HTMLElement | null => {
   const selection = window.getSelection()
   if (!selection || selection.rangeCount === 0) return null
@@ -71,12 +87,12 @@ const chipBesideCaret = (root: HTMLElement, side: 'before' | 'after'): HTMLEleme
   const offset = range.startOffset
 
   if (node.nodeType === Node.TEXT_NODE) {
-    if (side === 'before') return offset === 0 ? asSkillChip(node.previousSibling) : null
-    return offset === (node.textContent ?? '').length ? asSkillChip(node.nextSibling) : null
+    if (side === 'before') return offset === 0 ? asMentionChip(node.previousSibling) : null
+    return offset === (node.textContent ?? '').length ? asMentionChip(node.nextSibling) : null
   }
   if (node.nodeType === Node.ELEMENT_NODE) {
     const index = side === 'before' ? offset - 1 : offset
-    return asSkillChip(node.childNodes[index] ?? null)
+    return asMentionChip(node.childNodes[index] ?? null)
   }
   return null
 }
@@ -107,6 +123,13 @@ export const ComposerEditor = ({
     disabled: disabled || hasSkill
   })
 
+  // A parallel `@` trigger for artifact mentions, self-suppressing once the per-message cap is reached.
+  const artifactMention = useMentionTrigger({
+    editorRef: editorRef as React.RefObject<HTMLElement>,
+    trigger: '@',
+    disabled: disabled || docArtifactCount(doc) >= MAX_COMPOSER_ARTIFACT_MENTIONS
+  })
+
   // Read the live DOM back into a doc and notify the parent.
   const emitDocFromDom = useCallback((): void => {
     const root = editorRef.current
@@ -125,8 +148,8 @@ export const ComposerEditor = ({
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
     if (disabled) return
-    // While the mention popup is open it owns Enter/arrow keys; leave them to its document listener.
-    if (mention.active) return
+    // While either mention popup is open it owns Enter/arrow keys; leave them to its document listener.
+    if (mention.active || artifactMention.active) return
     // Backspace/Delete next to a chip removes the whole chip atomically (never edits its label).
     if (event.key === 'Backspace' || event.key === 'Delete') {
       const root = editorRef.current
@@ -164,6 +187,19 @@ export const ComposerEditor = ({
     mention.cancel()
   }
 
+  // Replace the active `@query` token with an artifact chip, then close the popup.
+  const handleSelectArtifact = (ref: PickedArtifact): void => {
+    artifactMention.replaceTokenWith({
+      type: 'artifact',
+      id: ref.id,
+      name: ref.name,
+      path: ref.path,
+      source: ref.source,
+      versionId: ref.versionId
+    })
+    artifactMention.cancel()
+  }
+
   return (
     <div className="relative min-w-0">
       <div
@@ -192,6 +228,13 @@ export const ComposerEditor = ({
           query={mention.query}
           onSelect={handleSelectSkill}
           onClose={mention.cancel}
+        />
+      ) : null}
+      {artifactMention.active ? (
+        <ArtifactMentionPopup
+          query={artifactMention.query}
+          onSelect={handleSelectArtifact}
+          onClose={artifactMention.cancel}
         />
       ) : null}
     </div>

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -7,6 +7,7 @@ import { ArtifactMentionPopup, type PickedArtifact } from './ArtifactMentionPopu
 import {
   applyDocToDom,
   docArtifactCount,
+  docIsEmpty,
   domToDoc,
   MAX_COMPOSER_ARTIFACT_MENTIONS,
   type ComposerDoc,
@@ -15,10 +16,15 @@ import {
 import { SkillMentionPopup } from './SkillMentionPopup'
 import { useMentionTrigger } from './useMentionTrigger'
 
-// Base editor styling: mirrors the sizing/leading of the legacy composer textarea and adds the
-// mockup's empty:before placeholder technique so the hint shows only while the doc is empty.
+// Base editor styling: mirrors the sizing/leading of the legacy composer textarea. The placeholder is
+// rendered as a model-driven overlay (see below) rather than a CSS :empty hint, so it shows whenever
+// the doc is empty — including when the editor is blurred or retains a stray browser-inserted node.
 const composerEditorClassName =
-  'min-h-[36px] max-h-[200px] w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent py-1.5 text-[15px] leading-relaxed text-text-000 outline-none empty:before:content-[attr(data-placeholder)] empty:before:text-text-300 empty:before:pointer-events-none empty:before:whitespace-nowrap empty:before:overflow-hidden empty:before:text-ellipsis empty:before:max-w-full'
+  'min-h-[36px] max-h-[200px] w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent py-1.5 text-[15px] leading-relaxed text-text-000 outline-none'
+
+// Placeholder overlay aligned to the editor's text start; pointer-events-none lets clicks reach the box.
+const composerPlaceholderClassName =
+  'pointer-events-none absolute inset-x-0 top-0 truncate py-1.5 text-[15px] leading-relaxed text-text-300'
 
 type ComposerEditorProps = {
   doc: ComposerDoc
@@ -223,6 +229,12 @@ export const ComposerEditor = ({
           composingRef.current = false
         }}
       />
+      {/* Show the placeholder whenever the doc is empty, regardless of focus. */}
+      {docIsEmpty(doc) ? (
+        <div aria-hidden="true" className={composerPlaceholderClassName}>
+          {placeholder}
+        </div>
+      ) : null}
       {mention.active ? (
         <SkillMentionPopup
           query={mention.query}

--- a/src/renderer/src/pages/workspace/composer/artifact-file-icon.tsx
+++ b/src/renderer/src/pages/workspace/composer/artifact-file-icon.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react'
+import {
+  File,
+  FileImage,
+  FileSpreadsheet,
+  FileText,
+  Presentation,
+  type LucideIcon
+} from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+import { getFileExtension, getImageMimeTypeForExtension } from '../preview-support'
+
+type ArtifactSource = 'upload' | 'artifact'
+
+type ArtifactFileIconProps = {
+  name: string
+  mimeType?: string
+  path: string
+  source: ArtifactSource
+  className?: string
+}
+
+// Keep the per-row thumbnail read tiny; the popup only needs a small preview image.
+const THUMBNAIL_MAX_BYTES = 256 * 1024
+
+// Mirrors isImageArtifact: an image/* mime type or a known image extension.
+const isImageFile = (name: string, mimeType?: string): boolean =>
+  Boolean(mimeType?.startsWith('image/')) || /\.(avif|gif|jpe?g|png|svg|tiff?|webp)$/i.test(name)
+
+// Category SVG plus a distinct accent color, keyed by file extension.
+const iconForExtension = (extension: string): { Icon: LucideIcon; color: string } => {
+  switch (extension) {
+    case 'pdf':
+      return { Icon: FileText, color: 'text-red-500' }
+    case 'csv':
+    case 'tsv':
+      return { Icon: FileSpreadsheet, color: 'text-green-600' }
+    case 'xls':
+    case 'xlsx':
+      return { Icon: FileSpreadsheet, color: 'text-emerald-600' }
+    case 'ppt':
+    case 'pptx':
+      return { Icon: Presentation, color: 'text-orange-500' }
+    case 'doc':
+    case 'docx':
+      return { Icon: FileText, color: 'text-blue-500' }
+    case 'txt':
+    case 'md':
+      return { Icon: FileText, color: 'text-text-300' }
+    default:
+      return { Icon: File, color: 'text-text-300' }
+  }
+}
+
+// Fixed 20px slot so image thumbnails and category glyphs line up across rows.
+const iconSlotClassName = 'flex h-5 w-5 shrink-0 items-center justify-center'
+
+// Reads a small image preview and renders a real thumbnail; falls back to the image glyph while
+// loading or when the read fails.
+const ArtifactThumbnail = ({
+  name,
+  mimeType,
+  path,
+  source,
+  className
+}: ArtifactFileIconProps): React.JSX.Element => {
+  const requestKey = `${source}:${path}`
+  // State is keyed by the request so a path change reads as loading without a synchronous reset.
+  const [state, setState] = useState<{ key: string; dataUrl: string | null; failed: boolean }>({
+    key: requestKey,
+    dataUrl: null,
+    failed: false
+  })
+
+  useEffect(() => {
+    let canceled = false
+
+    const readPreview =
+      source === 'upload' ? window.api.uploads.readPreview : window.api.artifacts.readPreview
+
+    void readPreview({ path, maxBytes: THUMBNAIL_MAX_BYTES, encoding: 'base64' })
+      .then((preview) => {
+        if (canceled) return
+        const mime = mimeType || getImageMimeTypeForExtension(getFileExtension(name)) || 'image/png'
+        setState({
+          key: requestKey,
+          dataUrl: `data:${mime};base64,${preview.content}`,
+          failed: false
+        })
+      })
+      .catch(() => {
+        if (!canceled) setState({ key: requestKey, dataUrl: null, failed: true })
+      })
+
+    return () => {
+      canceled = true
+    }
+  }, [name, mimeType, path, source, requestKey])
+
+  const current = state.key === requestKey ? state : { dataUrl: null, failed: false }
+
+  if (current.dataUrl && !current.failed) {
+    return (
+      <span className={cn(iconSlotClassName, className)}>
+        <img src={current.dataUrl} alt={name} className="h-5 w-5 rounded object-cover" />
+      </span>
+    )
+  }
+
+  return (
+    <span className={cn(iconSlotClassName, className)}>
+      <FileImage className="h-4 w-4 text-text-300" />
+    </span>
+  )
+}
+
+// Per-row artifact icon: a thumbnail for image files, a category glyph otherwise.
+export const ArtifactFileIcon = (props: ArtifactFileIconProps): React.JSX.Element => {
+  if (isImageFile(props.name, props.mimeType)) {
+    return <ArtifactThumbnail {...props} />
+  }
+
+  const { Icon, color } = iconForExtension(getFileExtension(props.name))
+  return (
+    <span className={cn(iconSlotClassName, props.className)}>
+      <Icon className={cn('h-4 w-4', color)} />
+    </span>
+  )
+}

--- a/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest'
 
 import {
   applyDocToDom,
+  docArtifactCount,
   docFromText,
   docIsEmpty,
+  docToArtifactRefs,
   docToSkillIds,
   docToText,
   domToDoc,
@@ -22,6 +24,24 @@ describe('docToText', () => {
       ]
     }
     expect(docToText(doc)).toBe('run /TDD now')
+  })
+
+  it('renders artifact nodes as @<name>', () => {
+    const doc: ComposerDoc = {
+      nodes: [
+        { type: 'text', text: 'compare ' },
+        { type: 'artifact', id: 'a1', name: 'fig1.png', path: '/p/fig1.png', source: 'artifact' },
+        { type: 'text', text: ' and ' },
+        {
+          type: 'artifact',
+          id: 'u1',
+          name: 'clinical trial03.pdf',
+          path: '/u/clinical trial03.pdf',
+          source: 'upload'
+        }
+      ]
+    }
+    expect(docToText(doc)).toBe('compare @fig1.png and @clinical trial03.pdf')
   })
 
   it('returns an empty string for the empty doc', () => {
@@ -44,6 +64,41 @@ describe('docToSkillIds', () => {
 
   it('returns an empty array when there are no skill nodes', () => {
     expect(docToSkillIds(docFromText('plain text'))).toEqual([])
+  })
+})
+
+describe('docToArtifactRefs', () => {
+  it('collects artifact refs in order and de-duplicates by path', () => {
+    const doc: ComposerDoc = {
+      nodes: [
+        { type: 'artifact', id: 'a1', name: 'fig1.png', path: '/p/fig1.png', source: 'artifact' },
+        { type: 'text', text: ' and ' },
+        { type: 'artifact', id: 'u1', name: 'notes.md', path: '/u/notes.md', source: 'upload' },
+        // Same path as the first, mentioned again with a different chip id — collapsed.
+        { type: 'artifact', id: 'a1b', name: 'fig1.png', path: '/p/fig1.png', source: 'artifact' }
+      ]
+    }
+    expect(docToArtifactRefs(doc)).toEqual([
+      { id: 'a1', name: 'fig1.png', path: '/p/fig1.png', source: 'artifact', versionId: undefined },
+      { id: 'u1', name: 'notes.md', path: '/u/notes.md', source: 'upload', versionId: undefined }
+    ])
+  })
+
+  it('returns an empty array when there are no artifact nodes', () => {
+    expect(docToArtifactRefs(docFromText('plain text'))).toEqual([])
+  })
+})
+
+describe('docArtifactCount', () => {
+  it('counts artifact chips including path duplicates', () => {
+    const doc: ComposerDoc = {
+      nodes: [
+        { type: 'artifact', id: 'a1', name: 'fig1.png', path: '/p/fig1.png', source: 'artifact' },
+        { type: 'skill', id: 's', name: 'S' },
+        { type: 'artifact', id: 'a1b', name: 'fig1.png', path: '/p/fig1.png', source: 'artifact' }
+      ]
+    }
+    expect(docArtifactCount(doc)).toBe(2)
   })
 })
 
@@ -149,5 +204,45 @@ describe('applyDocToDom + domToDoc round-trip', () => {
     expect(chip?.getAttribute('data-skill-id')).toBe('tdd')
     expect(chip?.getAttribute('contenteditable')).toBe('false')
     expect(chip?.textContent).toBe('/TDD')
+  })
+
+  it('round-trips artifact chips, preserving path/source and filenames with spaces', () => {
+    const doc: ComposerDoc = {
+      nodes: [
+        { type: 'text', text: 'use ' },
+        {
+          type: 'artifact',
+          id: 'u1',
+          name: 'clinical trial03.pdf',
+          path: '/u/clinical trial03.pdf',
+          source: 'upload'
+        },
+        { type: 'text', text: ' plus ' },
+        {
+          type: 'artifact',
+          id: 'a1',
+          name: 'fig2_cooccurrence.png',
+          path: '/p/fig2_cooccurrence.png',
+          source: 'artifact',
+          versionId: 'v9'
+        }
+      ]
+    }
+    const root = document.createElement('div')
+    applyDocToDom(root, doc)
+    expect(domToDoc(root)).toEqual(doc)
+  })
+
+  it('renders an artifact chip with the green mention attributes and @ label', () => {
+    const root = document.createElement('div')
+    applyDocToDom(root, {
+      nodes: [{ type: 'artifact', id: 'a1', name: 'fig.png', path: '/p/fig.png', source: 'artifact' }]
+    })
+    const chip = root.querySelector('span[data-mention-type="artifact"]')
+    expect(chip?.getAttribute('data-mention-path')).toBe('/p/fig.png')
+    expect(chip?.getAttribute('data-mention-source')).toBe('artifact')
+    expect(chip?.getAttribute('data-mention-filename')).toBe('fig.png')
+    expect(chip?.getAttribute('contenteditable')).toBe('false')
+    expect(chip?.textContent).toBe('@fig.png')
   })
 })

--- a/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
@@ -236,7 +236,9 @@ describe('applyDocToDom + domToDoc round-trip', () => {
   it('renders an artifact chip with the green mention attributes and @ label', () => {
     const root = document.createElement('div')
     applyDocToDom(root, {
-      nodes: [{ type: 'artifact', id: 'a1', name: 'fig.png', path: '/p/fig.png', source: 'artifact' }]
+      nodes: [
+        { type: 'artifact', id: 'a1', name: 'fig.png', path: '/p/fig.png', source: 'artifact' }
+      ]
     })
     const chip = root.querySelector('span[data-mention-type="artifact"]')
     expect(chip?.getAttribute('data-mention-path')).toBe('/p/fig.png')

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -128,9 +128,11 @@ export const domToDoc = (root: HTMLElement): ComposerDoc => {
   return nodes.length === 0 ? emptyDoc : { nodes }
 }
 
-// Shared chip base styling; select-all keeps a chip atomic to text selection.
+// Shared chip base styling; a capped width with truncation keeps a long name from stretching the
+// composer, and select-all keeps a chip atomic to text selection. Truncation is visual only, so
+// domToDoc still reads the full name back from textContent / the stored filename attribute.
 const CHIP_BASE_CLASS =
-  'inline-flex items-center rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium select-all'
+  'inline-block max-w-[220px] truncate align-middle rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium select-all'
 
 // Render a skill chip span: an atomic, non-editable blue mention token. Exported so the mention hook
 // inserts the exact same markup it re-renders here, and the styling can never drift between the two.

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -1,17 +1,42 @@
-// Pure serialization model for the composer: a document is an ordered list of text runs and
-// skill chips. Task 1 functions are DOM-free; domToDoc/applyDocToDom bridge to contenteditable.
+// Pure serialization model for the composer: a document is an ordered list of text runs, skill
+// chips, and artifact chips. These functions are DOM-free except domToDoc/applyDocToDom, which
+// bridge the model to the contenteditable editor.
+
+import type { ArtifactReference } from '../../../../../shared/artifacts'
+
+// One artifact/upload reference chip in the composer doc. Mirrors ArtifactReference plus the DOM
+// label; `source` distinguishes a user upload from a generated output for the runtime resolver.
+export type ComposerArtifactNode = {
+  type: 'artifact'
+  id: string
+  name: string
+  path: string
+  source: 'upload' | 'artifact'
+  versionId?: string
+}
 
 export type ComposerNode =
-  { type: 'text'; text: string } | { type: 'skill'; id: string; name: string }
+  | { type: 'text'; text: string }
+  | { type: 'skill'; id: string; name: string }
+  | ComposerArtifactNode
 
 export type ComposerDoc = { nodes: ComposerNode[] }
+
+// Max artifact `@` mentions per message, mirroring the composer upload attachment cap.
+export const MAX_COMPOSER_ARTIFACT_MENTIONS = 10
 
 // Shared canonical empty document.
 export const emptyDoc: ComposerDoc = { nodes: [] }
 
-// Render the document as plain text; a skill chip serializes to its `/<name>` label.
-export const docToText = (doc: ComposerDoc): string =>
-  doc.nodes.map((node) => (node.type === 'text' ? node.text : `/${node.name}`)).join('')
+// Render a single node as its plain-text form: skills as `/<name>`, artifacts as `@<name>`.
+const nodeToText = (node: ComposerNode): string => {
+  if (node.type === 'text') return node.text
+  if (node.type === 'skill') return `/${node.name}`
+  return `@${node.name}`
+}
+
+// Render the document as plain text; chips serialize to their `/` or `@` label.
+export const docToText = (doc: ComposerDoc): string => doc.nodes.map(nodeToText).join('')
 
 // Collect picked skill ids in document order, dropping duplicates.
 export const docToSkillIds = (doc: ComposerDoc): string[] => {
@@ -22,18 +47,54 @@ export const docToSkillIds = (doc: ComposerDoc): string[] => {
   return ids
 }
 
+// Collect referenced artifacts in document order, de-duplicated by path so the runtime attaches
+// each underlying file once even if the user mentions it twice.
+export const docToArtifactRefs = (doc: ComposerDoc): ArtifactReference[] => {
+  const refs: ArtifactReference[] = []
+  const seenPaths = new Set<string>()
+  for (const node of doc.nodes) {
+    if (node.type !== 'artifact' || seenPaths.has(node.path)) continue
+    seenPaths.add(node.path)
+    refs.push({
+      id: node.id,
+      name: node.name,
+      path: node.path,
+      source: node.source,
+      versionId: node.versionId
+    })
+  }
+  return refs
+}
+
+// Count artifact chips, used to enforce the per-message mention cap.
+export const docArtifactCount = (doc: ComposerDoc): number =>
+  doc.nodes.reduce((total, node) => (node.type === 'artifact' ? total + 1 : total), 0)
+
 // Hydrate a plain-text draft into a single text node; empty text yields the empty doc.
 export const docFromText = (text: string): ComposerDoc =>
   text === '' ? emptyDoc : { nodes: [{ type: 'text', text }] }
 
-// A doc is empty when it has no skill chips and no non-whitespace text.
+// A doc is empty when it has no chips and no non-whitespace text.
 export const docIsEmpty = (doc: ComposerDoc): boolean =>
   doc.nodes.every((node) => node.type === 'text' && node.text.trim() === '')
 
-// Chip markers on the contenteditable span.
+// Chip markers on the contenteditable spans.
 const SKILL_MENTION_TYPE = 'skill'
+const ARTIFACT_MENTION_TYPE = 'artifact'
 
-// Read a contenteditable root into a doc, mapping chip spans to skill nodes and collapsing
+// Read one artifact chip element back into a node; returns null when required attributes are missing.
+const artifactNodeFromEl = (el: HTMLElement): ComposerArtifactNode | null => {
+  const id = el.getAttribute('data-mention-id')
+  const path = el.getAttribute('data-mention-path')
+  if (id === null || path === null) return null
+  const source = el.getAttribute('data-mention-source') === 'upload' ? 'upload' : 'artifact'
+  // Prefer the stored filename; fall back to the visible label with its leading `@` stripped.
+  const name = el.getAttribute('data-mention-filename') ?? (el.textContent ?? '').replace(/^@/, '')
+  const versionId = el.getAttribute('data-mention-version-id') ?? undefined
+  return { type: 'artifact', id, name, path, source, versionId }
+}
+
+// Read a contenteditable root into a doc, mapping chip spans to skill/artifact nodes and collapsing
 // runs of adjacent text into a single text node.
 export const domToDoc = (root: HTMLElement): ComposerDoc => {
   const nodes: ComposerNode[] = []
@@ -48,16 +109,28 @@ export const domToDoc = (root: HTMLElement): ComposerDoc => {
     }
     if (child.nodeType === Node.ELEMENT_NODE) {
       const el = child as HTMLElement
-      const id = el.getAttribute('data-skill-id')
-      if (id !== null && el.getAttribute('data-mention-type') === SKILL_MENTION_TYPE) {
-        // Chip label is `/<name>`; strip the leading slash to recover the display name.
-        const label = el.textContent ?? ''
-        nodes.push({ type: 'skill', id, name: label.replace(/^\//, '') })
+      const mentionType = el.getAttribute('data-mention-type')
+      if (mentionType === SKILL_MENTION_TYPE) {
+        const id = el.getAttribute('data-skill-id')
+        if (id !== null) {
+          // Chip label is `/<name>`; strip the leading slash to recover the display name.
+          const label = el.textContent ?? ''
+          nodes.push({ type: 'skill', id, name: label.replace(/^\//, '') })
+        }
+        continue
+      }
+      if (mentionType === ARTIFACT_MENTION_TYPE) {
+        const node = artifactNodeFromEl(el)
+        if (node) nodes.push(node)
       }
     }
   }
   return nodes.length === 0 ? emptyDoc : { nodes }
 }
+
+// Shared chip base styling; select-all keeps a chip atomic to text selection.
+const CHIP_BASE_CLASS =
+  'inline-flex items-center rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium select-all'
 
 // Render a skill chip span: an atomic, non-editable blue mention token. Exported so the mention hook
 // inserts the exact same markup it re-renders here, and the styling can never drift between the two.
@@ -66,10 +139,26 @@ export const createSkillChip = (node: { id: string; name: string }): HTMLSpanEle
   span.setAttribute('contenteditable', 'false')
   span.setAttribute('data-mention-type', SKILL_MENTION_TYPE)
   span.setAttribute('data-skill-id', node.id)
-  // Blue mention pill using the interactive `primary` token; select-all keeps it atomic to selection.
-  span.className =
-    'inline-flex items-center rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium bg-primary/15 text-primary select-all'
+  // Blue mention pill using the interactive `primary` token.
+  span.className = `${CHIP_BASE_CLASS} bg-primary/15 text-primary`
   span.textContent = `/${node.name}`
+  return span
+}
+
+// Render an artifact chip span: an atomic, non-editable green mention token carrying the path/source
+// needed to round-trip through the DOM and resolve the file on send.
+export const createArtifactChip = (node: ComposerArtifactNode): HTMLSpanElement => {
+  const span = document.createElement('span')
+  span.setAttribute('contenteditable', 'false')
+  span.setAttribute('data-mention-type', ARTIFACT_MENTION_TYPE)
+  span.setAttribute('data-mention-id', node.id)
+  span.setAttribute('data-mention-path', node.path)
+  span.setAttribute('data-mention-source', node.source)
+  span.setAttribute('data-mention-filename', node.name)
+  if (node.versionId) span.setAttribute('data-mention-version-id', node.versionId)
+  // Green mention pill, distinct from the blue skill chip.
+  span.className = `${CHIP_BASE_CLASS} bg-mention-chip text-mention-chip-foreground`
+  span.textContent = `@${node.name}`
   return span
 }
 
@@ -78,6 +167,7 @@ export const applyDocToDom = (root: HTMLElement, doc: ComposerDoc): void => {
   root.textContent = ''
   for (const node of doc.nodes) {
     if (node.type === 'text') root.appendChild(document.createTextNode(node.text))
-    else root.appendChild(createSkillChip(node))
+    else if (node.type === 'skill') root.appendChild(createSkillChip(node))
+    else root.appendChild(createArtifactChip(node))
   }
 }

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -139,8 +139,8 @@ export const createSkillChip = (node: { id: string; name: string }): HTMLSpanEle
   span.setAttribute('contenteditable', 'false')
   span.setAttribute('data-mention-type', SKILL_MENTION_TYPE)
   span.setAttribute('data-skill-id', node.id)
-  // Blue mention pill using the interactive `primary` token.
-  span.className = `${CHIP_BASE_CLASS} bg-primary/15 text-primary`
+  // Blue mention pill using the dedicated skill-chip token.
+  span.className = `${CHIP_BASE_CLASS} bg-skill-chip text-skill-chip-foreground`
   span.textContent = `/${node.name}`
   return span
 }

--- a/src/renderer/src/pages/workspace/composer/useMentionTrigger.ts
+++ b/src/renderer/src/pages/workspace/composer/useMentionTrigger.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { createSkillChip, type ComposerNode } from './composer-doc'
+import { createArtifactChip, createSkillChip, type ComposerNode } from './composer-doc'
 
 // A trigger match derived purely from the text before the caret.
 export type TriggerMatch = { active: boolean; query: string }
@@ -142,7 +142,11 @@ export const useMentionTrigger = ({
 
       // Insert the replacement, then collapse the caret immediately after it.
       const inserted =
-        node.type === 'skill' ? createSkillChip(node) : document.createTextNode(node.text)
+        node.type === 'skill'
+          ? createSkillChip(node)
+          : node.type === 'artifact'
+            ? createArtifactChip(node)
+            : document.createTextNode(node.text)
       range.insertNode(inserted)
       const after = document.createRange()
       after.setStartAfter(inserted)

--- a/src/renderer/src/pages/workspace/preview-file-item.test.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ChatSession } from '@/stores/session-store'
+import type { MessagePart } from '../../../../shared/session-persistence'
 
 import {
   createPreviewFileItemFromArtifact,
+  createPreviewFileItemFromMention,
   createPreviewFileItemFromUpload
 } from './preview-file-item'
 
 type MessageArtifact = NonNullable<ChatSession['artifacts']>[number]
 type MessageUploadAttachment = NonNullable<ChatSession['messages'][number]['uploads']>[number]
+type ArtifactMentionPart = Extract<MessagePart, { type: 'artifact' }>
 
 const createManagedArtifact = (overrides: Partial<MessageArtifact> = {}): MessageArtifact => ({
   id: 'artifact-1',
@@ -32,6 +35,15 @@ const createUploadAttachment = (
   path: '/Users/example/.open-science/uploads/default-project/session-1/safe-name.png',
   mimeType: 'image/png',
   size: 2048,
+  ...overrides
+})
+
+const createMentionPart = (overrides: Partial<ArtifactMentionPart> = {}): ArtifactMentionPart => ({
+  type: 'artifact',
+  id: 'artifact-9',
+  name: 'summary.md',
+  path: '/workspace/results/summary.md',
+  source: 'artifact',
   ...overrides
 })
 
@@ -103,6 +115,37 @@ describe('preview file item helpers', () => {
       title: 'rendered-report',
       name: 'rendered-report',
       format: 'html'
+    })
+  })
+
+  it('creates artifact mention preview items without an explicit source', () => {
+    expect(createPreviewFileItemFromMention(createMentionPart(), 'session-1')).toEqual({
+      id: 'artifact-9',
+      sessionId: 'session-1',
+      title: 'summary.md',
+      type: 'file',
+      path: '/workspace/results/summary.md',
+      name: 'summary.md',
+      format: 'markdown'
+    })
+  })
+
+  it('preserves the mention id and marks upload-sourced mentions as uploads', () => {
+    const item = createPreviewFileItemFromMention(
+      createMentionPart({
+        id: 'upload-mention-3',
+        name: 'scan.png',
+        path: '/uploads/scan.png',
+        source: 'upload'
+      }),
+      'session-1'
+    )
+
+    expect(item).toMatchObject({
+      id: 'upload-mention-3',
+      source: 'upload',
+      name: 'scan.png',
+      format: 'image'
     })
   })
 })

--- a/src/renderer/src/pages/workspace/preview-file-item.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.ts
@@ -1,5 +1,6 @@
 import type { PreviewFileItem, PreviewFileSource } from '@/stores/preview-workbench-store'
 import type { ChatSession } from '@/stores/session-store'
+import type { MessagePart } from '../../../../shared/session-persistence'
 import { getUploadedAttachmentName } from '../../../../shared/uploads'
 
 import { getArtifactExtension, getArtifactName } from './artifact-preview-utils'
@@ -9,6 +10,7 @@ export type MessageArtifact = NonNullable<ChatSession['artifacts']>[number]
 export type MessageUploadAttachment = NonNullable<
   ChatSession['messages'][number]['uploads']
 >[number]
+type ArtifactMentionPart = Extract<MessagePart, { type: 'artifact' }>
 
 // Builds the common preview workbench file item for generated artifacts and user uploads.
 export const createPreviewFileItem = ({
@@ -80,3 +82,17 @@ export const createPreviewFileItemFromUpload = (
     mimeType: attachment.mimeType
   })
 }
+
+// Converts a sent-message artifact mention into the same preview shape used by its source panel.
+export const createPreviewFileItemFromMention = (
+  part: ArtifactMentionPart,
+  sessionId: string
+): PreviewFileItem =>
+  createPreviewFileItem({
+    id: part.id,
+    sessionId,
+    path: part.path,
+    name: part.name,
+    extension: getFileExtension(part.name),
+    source: part.source === 'upload' ? 'upload' : undefined
+  })

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -313,7 +313,7 @@ describe('conversation message scroller integration', () => {
     expect(workspaceMessageScrollerSource).not.toContain('renderWebSearchDetails(')
     expect(workspaceMessageScrollerSource).not.toContain('formatActivityDetails(activity)')
     expect(workspaceMessageScrollerSource).toContain('conversationItems.map((item)')
-    expect(workspaceMessageScrollerSource).toContain("import { useState } from 'react'")
+    expect(workspaceMessageScrollerSource).toMatch(/import \{[^}]*\buseState\b[^}]*\} from 'react'/)
     expect(workspaceMessageScrollerSource).toContain('const currentSessionId = activeSession?.id')
     expect(workspaceMessageScrollerSource).toContain(
       'collapsedActivityGroupState.sessionId === currentSessionId'

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../shared/permission-profiles'
 import {
   sanitizeToolActivity,
+  type MessagePart,
   type PersistedActiveRun,
   type PersistedArtifact,
   type PersistedChatMessage,
@@ -70,6 +71,7 @@ type AppendUserMessageInput = {
   sessionId: string
   content: string
   attachments?: PersistedUploadedAttachment[]
+  parts?: MessagePart[]
   cwd?: string
   projectId?: string
   permissionProfile?: PermissionProfileId
@@ -79,6 +81,7 @@ type AppendUserMessageInput = {
 type AppendPendingUserMessageInput = {
   content: string
   attachments?: PersistedUploadedAttachment[]
+  parts?: MessagePart[]
   cwd?: string
   projectId?: string
   permissionProfile?: PermissionProfileId
@@ -271,7 +274,8 @@ const createMessage = (
   status: ChatMessageStatus,
   streamId?: string,
   eventIds: string[] = [],
-  uploads: PersistedUploadedAttachment[] = []
+  uploads: PersistedUploadedAttachment[] = [],
+  parts?: MessagePart[]
 ): ChatMessage => {
   const now = Date.now()
   // Normalize upload references before attaching them to durable message state.
@@ -285,6 +289,8 @@ const createMessage = (
     streamId,
     eventIds,
     uploads: persistedUploads.length > 0 ? persistedUploads : undefined,
+    // Structured mention segments drive the styled bubble; omit them when absent.
+    parts: parts && parts.length > 0 ? parts : undefined,
     sortIndex: createSortIndex(),
     createdAt: now,
     updatedAt: now
@@ -447,6 +453,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     sessionId,
     content,
     attachments = [],
+    parts,
     cwd,
     projectId,
     permissionProfile,
@@ -460,7 +467,15 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     const state = get()
     const existingSession = state.sessions.find((session) => session.id === sessionId)
     const now = Date.now()
-    const userMessage = createMessage('user', trimmedContent, 'complete', undefined, [], uploads)
+    const userMessage = createMessage(
+      'user',
+      trimmedContent,
+      'complete',
+      undefined,
+      [],
+      uploads,
+      parts
+    )
     const activeRun: ActiveRun = {
       promptMessageId: userMessage.id,
       startedAt: now
@@ -509,11 +524,19 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   },
 
   // Creates a visible local conversation before ACP returns the durable session id.
-  appendPendingUserMessage: ({ content, attachments = [], cwd, projectId, permissionProfile }) => {
+  appendPendingUserMessage: ({
+    content,
+    attachments = [],
+    parts,
+    cwd,
+    projectId,
+    permissionProfile
+  }) => {
     return get().appendUserMessage({
       sessionId: createPendingSessionId(),
       content,
       attachments,
+      parts,
       cwd,
       projectId,
       permissionProfile,

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -484,6 +484,23 @@ describe('settings store: refreshProviderModels', () => {
   })
 })
 
+describe('settings store: openSettingsToSkill', () => {
+  it('opens the dialog on a skill; consume and close both clear the pending id', () => {
+    useSettingsStore.getState().openSettingsToSkill('x')
+    expect(useSettingsStore.getState().isSettingsOpen).toBe(true)
+    expect(useSettingsStore.getState().pendingSkillId).toBe('x')
+
+    useSettingsStore.getState().consumePendingSkill()
+    expect(useSettingsStore.getState().pendingSkillId).toBeUndefined()
+
+    // Closing after a fresh open-to-skill clears the pending id so a later open starts fresh.
+    useSettingsStore.getState().openSettingsToSkill('y')
+    useSettingsStore.getState().closeSettings()
+    expect(useSettingsStore.getState().isSettingsOpen).toBe(false)
+    expect(useSettingsStore.getState().pendingSkillId).toBeUndefined()
+  })
+})
+
 describe('settings store: connectors slice', () => {
   const connectorView = (id: string, enabled: boolean): ConnectorView => ({
     id,

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -70,6 +70,8 @@ type SettingsStoreData = {
   installLogs: string[]
   // Whether the settings dialog is open (rendered at the app root, over Home/Workspace).
   isSettingsOpen: boolean
+  // Skill to land on when the dialog opens from a skill mention; consumed once its detail is seeded.
+  pendingSkillId?: string
 }
 
 type SettingsStore = SettingsStoreData & {
@@ -94,6 +96,10 @@ type SettingsStore = SettingsStoreData & {
   deleteProvider: (providerId: string) => Promise<void>
   openSettings: () => void
   closeSettings: () => void
+  // Opens the dialog straight onto a skill's detail page (used by clickable skill mentions).
+  openSettingsToSkill: (skillId: string) => void
+  // Clears the pending skill once its detail view has been seeded, so a later open starts fresh.
+  consumePendingSkill: () => void
   // Loads the bundled-skill list (enabled state included) from the main process.
   loadSkills: () => Promise<void>
   // Toggles one skill; optimistic, then reconciled with the authoritative list from main.
@@ -169,7 +175,8 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   isDetectingClaude: false,
   isInstalling: false,
   installLogs: [],
-  isSettingsOpen: false
+  isSettingsOpen: false,
+  pendingSkillId: undefined
 })
 
 // Applies a fresh main-process snapshot to the renderer cache.
@@ -409,7 +416,12 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
   openSettings: () => set({ isSettingsOpen: true }),
 
-  closeSettings: () => set({ isSettingsOpen: false }),
+  // Clearing the pending skill on close stops a later normal open from jumping back to a stale skill.
+  closeSettings: () => set({ isSettingsOpen: false, pendingSkillId: undefined }),
+
+  openSettingsToSkill: (skillId) => set({ isSettingsOpen: true, pendingSkillId: skillId }),
+
+  consumePendingSkill: () => set({ pendingSkillId: undefined }),
 
   loadSkills: async () => {
     const skills = await window.api.settings.listSkills()

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -1,5 +1,5 @@
 import type { ToolCallContent, ToolCallLocation, ToolKind } from '@agentclientprotocol/sdk'
-import type { ArtifactFile } from './artifacts'
+import type { ArtifactFile, ArtifactReference } from './artifacts'
 import type { UploadedAttachment } from './uploads'
 import type { PermissionProfileId, SessionPermissionProfileState } from './permission-profiles'
 
@@ -126,6 +126,8 @@ export type AcpPromptRequest = {
   attachments?: UploadedAttachment[]
   // Skills the user explicitly picked in the composer; the runtime force-loads and nudges them.
   forcedSkillIds?: string[]
+  // Existing files referenced via composer `@` mentions; appended as prompt content blocks.
+  referencedArtifacts?: ArtifactReference[]
 }
 
 export type AcpCancelPromptRequest = {

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -13,6 +13,18 @@ export type ArtifactFile = {
   mtimeMs: number
 }
 
+// A user-picked reference to an existing file (upload or generated output) inserted via the
+// composer `@` mention. Carries the durable path so the runtime can resolve and attach the file.
+export type ArtifactReference = {
+  id: string
+  name: string
+  path: string
+  source: 'upload' | 'artifact'
+  mimeType?: string
+  // Reserved for a future version switcher; no version UI ships yet.
+  versionId?: string
+}
+
 export type ArtifactWriteEncoding = 'utf8' | 'base64'
 
 export type ArtifactWriteSource =

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -32,6 +32,21 @@ export type PersistedArtifact = {
 // Stores uploaded file references on the user message that submitted them.
 export type PersistedUploadedAttachment = UploadedAttachment
 
+// Ordered structural segments of a user message, letting the bubble re-render skill/artifact
+// mentions as styled pills instead of plain text. Structurally mirrors the renderer ComposerNode
+// (shared cannot import renderer code). Absent on older messages, which fall back to plain content.
+export type MessagePart =
+  | { type: 'text'; text: string }
+  | { type: 'skill'; id: string; name: string }
+  | {
+      type: 'artifact'
+      id: string
+      name: string
+      path: string
+      source: 'upload' | 'artifact'
+      versionId?: string
+    }
+
 export type PersistedChatMessage = {
   id: string
   role: PersistedMessageRole
@@ -43,6 +58,8 @@ export type PersistedChatMessage = {
   // Links a message to session-level artifact metadata without duplicating file records per message.
   artifactIds?: string[]
   uploads?: PersistedUploadedAttachment[]
+  // Structured mention segments for the styled user bubble; optional for backward compatibility.
+  parts?: MessagePart[]
   createdAt: number
   updatedAt: number
 }

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -469,6 +469,40 @@ const normalizeActivityAfterRestore = (activity: PersistedToolActivity): Persist
     ? { ...activity, status: 'failed' }
     : activity
 
+// Rebuilds one structured mention segment, dropping malformed entries so the bubble stays renderable.
+const sanitizeMessagePart = (part: unknown): MessagePart | undefined => {
+  if (!isRecord(part)) return undefined
+
+  switch (asString(part.type)) {
+    case 'text': {
+      const text = asString(part.text)
+
+      return text !== undefined ? { type: 'text', text } : undefined
+    }
+    case 'skill': {
+      const id = asString(part.id)
+      const name = asString(part.name)
+
+      return id && name ? { type: 'skill', id, name } : undefined
+    }
+    case 'artifact': {
+      const id = asString(part.id)
+      const name = asString(part.name)
+      const path = asString(part.path)
+      const source = asString(part.source)
+
+      if (!id || !name || !path || (source !== 'upload' && source !== 'artifact')) return undefined
+
+      const sanitized: MessagePart = { type: 'artifact', id, name, path, source }
+      const versionId = asString(part.versionId)
+
+      return versionId ? { ...sanitized, versionId } : sanitized
+    }
+    default:
+      return undefined
+  }
+}
+
 // Rebuilds a message from durable UI fields and strips unknown renderer payload.
 const sanitizeMessage = (message: unknown): PersistedChatMessage | undefined => {
   if (!isRecord(message)) return undefined
@@ -496,11 +530,15 @@ const sanitizeMessage = (message: unknown): PersistedChatMessage | undefined => 
         .map(sanitizeUploadedAttachment)
         .filter((item): item is PersistedUploadedAttachment => !!item)
     : []
+  const parts = Array.isArray(message.parts)
+    ? message.parts.map(sanitizeMessagePart).filter((item): item is MessagePart => !!item)
+    : []
 
   if (streamId) sanitized.streamId = streamId
   if (responseToMessageId) sanitized.responseToMessageId = responseToMessageId
   if (artifactIds.length > 0) sanitized.artifactIds = artifactIds
   if (uploads.length > 0) sanitized.uploads = uploads
+  if (parts.length > 0) sanitized.parts = parts
 
   return sanitized
 }


### PR DESCRIPTION
## Summary

Adds an `@` mention in the composer to reference existing **artifacts** (uploaded
files and generated outputs), mirroring the existing `/` skill mention, and makes
sent-message mentions styled and interactive.

## What's included

- **Composer `@` popup** — lists the active project's uploads ("User uploads") and
  generated outputs ("Other artifacts") from the same source the Files panel uses.
  Category SVG icons for pdf/csv/excel/ppt/word and real thumbnails for images;
  keyboard nav + query filter. Selecting inserts a green artifact chip; up to 10
  per message.
- **Structured send** — referenced artifacts are attached to the prompt as typed
  content blocks (image pixels / pdf text / inline text / resource link), resolved
  via the real upload and artifact repositories (reuses the upload plumbing).
- **Styled message bubble** — the sent user bubble renders mentions as pills
  (blue skill / green artifact) and uploads as gray file pills, driven by persisted
  message parts. Skills now render styled too (previously plain text).
- **Clickable mentions** — clicking an artifact/upload pill opens the file in the
  preview panel; clicking a skill pill opens its Settings detail. A missing target
  shows a transient "no longer available" notice instead of a broken view.
- **Polish** — blue skill-chip color token; long mention names truncate with an
  ellipsis; the composer placeholder now shows whenever the input is empty
  (including unfocused), replacing the fragile CSS `:empty` technique.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test` — 1254 passed
- `npm run build` — clean
- Ran the app via `npm run dev` and confirmed it boots and prompts complete end to end.

Backward compatible: `parts` on the persisted message is optional, so older
conversations fall back to plain-text rendering (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
