### PR TITLE
fix(workspace): add Resume button to interrupted-session banner

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -6,6 +6,7 @@ import { createInitialSessionState, useSessionStore } from '../../stores/session
 import {
   createWorkspaceRuntimeEventProcessor,
   processVisibleWorkspaceRuntimeEvents,
+  resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage
 } from './useWorkspaceAgentRuntime'
 
@@ -504,5 +505,104 @@ describe('workspace agent message sending', () => {
       error: 'Agent session resume failed'
     })
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
+  })
+})
+
+describe('resuming an interrupted session on demand', () => {
+  beforeEach(() => {
+    useSessionStore.setState(createInitialSessionState())
+  })
+
+  // Seeds a restored interrupted session (detached from the runtime) via the hydration path, which
+  // is what sets the `interrupted` flag in production. An empty cwd models a missing workspace.
+  const seedDetachedSession = (cwd: string = '/workspace/project'): void => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'default-project',
+        title: 'Interrupted',
+        cwd,
+        status: 'error',
+        error: 'Session was interrupted before the app closed.',
+        permissionProfile: 'ask',
+        messages: [],
+        createdAt: 1,
+        updatedAt: 2
+      }
+    ])
+  }
+
+  it('re-attaches the session and unlocks the composer on success', async () => {
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi
+        .fn()
+        .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      sendPrompt: vi.fn()
+    }
+    seedDetachedSession()
+
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+
+    expect(runtime.resumeSession).toHaveBeenCalledWith(
+      'session-1',
+      '/workspace/project',
+      'default-project',
+      expect.any(String)
+    )
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({ status: 'idle' })
+    expect(useSessionStore.getState().sessions[0].error).toBeUndefined()
+    expect(useSessionStore.getState().sessions[0].interrupted).toBeUndefined()
+  })
+
+  it('keeps the error visible so a retry stays possible when resume fails', async () => {
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi.fn().mockRejectedValue(new Error('Internal error')),
+      sendPrompt: vi.fn()
+    }
+    seedDetachedSession()
+
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error: 'Agent session resume failed'
+    })
+  })
+
+  it('just clears the banner without re-resuming an already-attached session', async () => {
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+    seedDetachedSession()
+
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+
+    expect(runtime.resumeSession).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({ status: 'idle' })
+  })
+
+  it('surfaces an actionable message when the session has no workspace to resume into', async () => {
+    const runtime = {
+      state: { ...createSnapshot(), cwd: '' },
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+    seedDetachedSession('')
+
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+
+    expect(runtime.resumeSession).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error: 'Session workspace is missing; start a new conversation.'
+    })
   })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -404,7 +404,44 @@ const sendWorkspaceMessage = async (
   return pending
 }
 
-// Bridges the protocol runtime to the neutral workspace session store.
+// Explicitly re-attaches an interrupted session's ACP runtime so the user can keep chatting. On
+// success the composer is unlocked; on failure the interrupted banner stays so a retry stays possible.
+const resumeInterruptedWorkspaceSession = async (
+  runtime: WorkspaceMessageRuntime,
+  sessionId: string
+): Promise<void> => {
+  const session = useSessionStore.getState().sessions.find((item) => item.id === sessionId)
+
+  if (!session) return
+
+  // Already attached (e.g. a redundant click after a prior resume): just clear the banner.
+  if (runtime.state.sessionIds.includes(sessionId)) {
+    useSessionStore.getState().markResumed(sessionId)
+    return
+  }
+
+  const resumeCwd = session.cwd || runtime.state.cwd
+
+  if (!resumeCwd) {
+    useSessionStore
+      .getState()
+      .failRun(sessionId, 'Session workspace is missing; start a new conversation.')
+    return
+  }
+
+  try {
+    await runtime.resumeSession(
+      sessionId,
+      resumeCwd,
+      session.projectId,
+      session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
+    )
+    useSessionStore.getState().markResumed(sessionId)
+  } catch (error) {
+    useSessionStore.getState().failRun(sessionId, getResumeFailureMessage(error))
+  }
+}
+
 const useWorkspaceAgentRuntime = (): {
   actionError: string | null
   isConnecting: boolean
@@ -413,6 +450,7 @@ const useWorkspaceAgentRuntime = (): {
   permissionGrants: Record<string, AcpPermissionGrant[]>
   sendMessage: (input: SendWorkspaceMessageInput) => Promise<SendWorkspaceMessageResult | undefined>
   cancelRun: (sessionId: string) => Promise<void>
+  resumeInterruptedSession: (sessionId: string) => Promise<void>
   deleteRuntimeSession: (sessionId: string) => Promise<void>
   respondToPermission: (requestId: string, optionId?: string) => Promise<void>
   setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => Promise<boolean>
@@ -435,6 +473,13 @@ const useWorkspaceAgentRuntime = (): {
   const sendMessage = useCallback(
     (input: SendWorkspaceMessageInput): Promise<SendWorkspaceMessageResult | undefined> =>
       sendWorkspaceMessage(runtime, input),
+    [runtime]
+  )
+
+  // Explicitly re-attaches an interrupted session's ACP runtime so the user can keep chatting. On
+  // success the composer is unlocked; on failure the interrupted banner stays so a retry stays possible.
+  const resumeInterruptedSession = useCallback(
+    (sessionId: string): Promise<void> => resumeInterruptedWorkspaceSession(runtime, sessionId),
     [runtime]
   )
 
@@ -517,6 +562,7 @@ const useWorkspaceAgentRuntime = (): {
     permissionGrants: runtime.state.permissionGrants,
     sendMessage,
     cancelRun,
+    resumeInterruptedSession,
     deleteRuntimeSession,
     respondToPermission,
     setPermissionProfile,
@@ -527,6 +573,7 @@ const useWorkspaceAgentRuntime = (): {
 export {
   createWorkspaceRuntimeEventProcessor,
   processVisibleWorkspaceRuntimeEvents,
+  resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage,
   useWorkspaceAgentRuntime
 }

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -59,6 +59,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         onStageAttachmentFiles={onStageAttachmentFiles}
         onRemoveAttachment={vi.fn()}
         onCancelRun={vi.fn()}
+        onResumeSession={vi.fn().mockResolvedValue(undefined)}
         onOpenNotebook={vi.fn()}
         onTogglePreviewPanel={vi.fn()}
         onRespondToPermission={vi.fn()}

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -15,7 +15,7 @@ import {
   Square,
   X
 } from 'lucide-react'
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 
 import { FileDropOverlay } from '@/components/FileDropOverlay'
 import { ResizablePanel } from '@/components/ui/resizable'
@@ -28,6 +28,7 @@ import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { ComposerPermissionProfilePicker } from './ComposerPermissionProfilePicker'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
+import { SessionInterruptedBanner } from './SessionInterruptedBanner'
 import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'
 
 const composerInteractiveTransitionClassName = 'transition-colors duration-200 ease-out'
@@ -85,6 +86,7 @@ type ConversationPanelProps = {
   onStageAttachmentFiles: (files: File[]) => void
   onRemoveAttachment: (attachment: UploadedAttachment) => void
   onCancelRun: () => void
+  onResumeSession: () => Promise<void>
   onOpenNotebook: (notebook: NotebookSessionReference) => void
   onTogglePreviewPanel: () => void
   onRespondToPermission: (requestId: string, optionId?: string) => void
@@ -114,6 +116,7 @@ const ConversationPanel = ({
   onStageAttachmentFiles,
   onRemoveAttachment,
   onCancelRun,
+  onResumeSession,
   onOpenNotebook,
   onTogglePreviewPanel,
   onRespondToPermission,
@@ -122,6 +125,20 @@ const ConversationPanel = ({
   onClearPermissionGrants
 }: ConversationPanelProps): React.JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
+  // Local so the interrupted banner can show a spinner and block a double-resume until the request settles.
+  const [isResuming, setIsResuming] = useState(false)
+
+  // Re-attaches the interrupted session; on success the banner unmounts, so guard the state update.
+  const handleResume = async (): Promise<void> => {
+    if (isResuming) return
+
+    setIsResuming(true)
+    try {
+      await onResumeSession()
+    } finally {
+      setIsResuming(false)
+    }
+  }
 
   // Drag-and-drop shares the same staging callback as the picker and paste paths.
   const { isDragging, dropZoneProps } = useFileDropZone({
@@ -197,7 +214,15 @@ const ConversationPanel = ({
             {/* Runtime and session errors stay near the composer so recovery is visible. */}
             <div className={composerContentClassName}>
               <div className="px-1 md:px-3">
-                {actionError || activeSession?.error ? (
+                {/* Interrupted sessions get a neutral banner with a Resume action instead of the
+                    red error box, so the user can re-attach the runtime and keep chatting. */}
+                {activeSession?.interrupted ? (
+                  <SessionInterruptedBanner
+                    message={activeSession.error ?? 'This session was interrupted.'}
+                    isResuming={isResuming}
+                    onResume={() => void handleResume()}
+                  />
+                ) : actionError || activeSession?.error ? (
                   <div className="mb-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-700">
                     {actionError ?? activeSession?.error}
                   </div>

--- a/src/renderer/src/pages/workspace/SessionInterruptedBanner.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionInterruptedBanner.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SessionInterruptedBanner } from './SessionInterruptedBanner'
+
+// React's act() refuses to run unless the environment opts in to act-aware scheduling.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.clearAllMocks()
+})
+
+const getResumeButton = (): HTMLButtonElement => {
+  const button = container.querySelector('button')
+  if (!button) throw new Error('resume button not found')
+  return button as HTMLButtonElement
+}
+
+describe('SessionInterruptedBanner', () => {
+  it('shows the message and resumes when the enabled button is clicked', () => {
+    const onResume = vi.fn()
+    act(() => {
+      root.render(
+        <SessionInterruptedBanner
+          message="Session was interrupted before the app closed."
+          isResuming={false}
+          onResume={onResume}
+        />
+      )
+    })
+
+    expect(container.textContent).toContain('Session was interrupted before the app closed.')
+    const button = getResumeButton()
+    expect(button.disabled).toBe(false)
+    expect(button.textContent).toContain('Resume')
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the button and ignores clicks while a resume is in flight', () => {
+    const onResume = vi.fn()
+    act(() => {
+      root.render(
+        <SessionInterruptedBanner message="Interrupted." isResuming onResume={onResume} />
+      )
+    })
+
+    const button = getResumeButton()
+    expect(button.disabled).toBe(true)
+    expect(button.textContent).toContain('Resuming')
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/pages/workspace/SessionInterruptedBanner.tsx
+++ b/src/renderer/src/pages/workspace/SessionInterruptedBanner.tsx
@@ -1,0 +1,43 @@
+import { Loader2, Play } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+type SessionInterruptedBannerProps = {
+  message: string
+  isResuming: boolean
+  onResume: () => void
+}
+
+const resumeButtonClassName = cn(
+  'flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] font-medium text-text-000',
+  'cursor-pointer transition-colors duration-200 ease-out hover:bg-bg-300',
+  'disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent'
+)
+
+// Neutral recovery banner for a session interrupted by an app restart. The Resume button re-attaches
+// the ACP runtime; while that request is in flight it is disabled so a second click cannot double-resume.
+const SessionInterruptedBanner = ({
+  message,
+  isResuming,
+  onResume
+}: SessionInterruptedBannerProps): React.JSX.Element => (
+  <div className="mb-2 flex items-center gap-3 rounded-lg border border-border-200 bg-bg-200 px-3 py-2">
+    <p className="min-w-0 flex-1 text-[12px] leading-5 text-text-100">{message}</p>
+    <button
+      type="button"
+      className={resumeButtonClassName}
+      onClick={onResume}
+      disabled={isResuming}
+      aria-label="Resume session"
+    >
+      {isResuming ? (
+        <Loader2 className="size-3.5 animate-spin" strokeWidth={2} aria-hidden="true" />
+      ) : (
+        <Play className="size-3.5" strokeWidth={2} aria-hidden="true" />
+      )}
+      {isResuming ? 'Resuming…' : 'Resume'}
+    </button>
+  </div>
+)
+
+export { SessionInterruptedBanner }

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -142,6 +142,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     permissionGrants,
     sendMessage,
     cancelRun,
+    resumeInterruptedSession,
     deleteRuntimeSession,
     respondToPermission,
     setPermissionProfile,
@@ -547,6 +548,11 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     if (activeSession) void cancelRun(activeSession.id)
   }
 
+  // Re-attaches the visible interrupted session so the user can keep chatting; awaited by the banner.
+  const resumeActiveSession = async (): Promise<void> => {
+    if (activeSession) await resumeInterruptedSession(activeSession.id)
+  }
+
   // Forwards visible permission decisions to the runtime bridge.
   const respondToVisiblePermission = (requestId: string, optionId?: string): void => {
     void respondToPermission(requestId, optionId)
@@ -642,6 +648,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             onStageAttachmentFiles={stageAttachmentFiles}
             onRemoveAttachment={removeComposerAttachment}
             onCancelRun={cancelActiveRun}
+            onResumeSession={resumeActiveSession}
             onOpenNotebook={openNotebookPreview}
             onTogglePreviewPanel={togglePreviewPanel}
             onRespondToPermission={respondToVisiblePermission}

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ArtifactFile } from '../../../shared/artifacts'
-import { SESSION_MANIFEST_VERSION } from '../../../shared/session-persistence'
+import {
+  INTERRUPTED_SESSION_ERROR,
+  SESSION_MANIFEST_VERSION,
+  type PersistedChatSession
+} from '../../../shared/session-persistence'
 import type { UploadedAttachment } from '../../../shared/uploads'
 import { createInitialSessionState, toPersistedSession, useSessionStore } from './session-store'
 
@@ -1166,5 +1170,58 @@ describe('session store', () => {
       ]
     })
     expect(persisted).not.toHaveProperty('isPending')
+  })
+
+  describe('interrupted session resume', () => {
+    const hydrateInterrupted = (overrides: Partial<PersistedChatSession> = {}): void => {
+      useSessionStore.getState().hydrateSessions(
+        [
+          {
+            id: 'resumable-session',
+            projectId: 'default',
+            title: 'Interrupted',
+            cwd: '/workspace',
+            status: 'error',
+            error: INTERRUPTED_SESSION_ERROR,
+            messages: [],
+            createdAt: 1,
+            updatedAt: 2,
+            ...overrides
+          }
+        ],
+        { version: SESSION_MANIFEST_VERSION, lastSessionId: 'resumable-session' }
+      )
+    }
+
+    it('flags a restored interrupted session so the UI can offer resume', () => {
+      hydrateInterrupted()
+
+      expect(useSessionStore.getState().sessions[0].interrupted).toBe(true)
+    })
+
+    it('leaves the flag unset when the error is not the interrupted marker', () => {
+      hydrateInterrupted({ error: 'Something else failed' })
+
+      expect(useSessionStore.getState().sessions[0].interrupted).toBeUndefined()
+    })
+
+    it('never persists the transient interrupted flag', () => {
+      hydrateInterrupted()
+
+      const persisted = toPersistedSession(useSessionStore.getState().sessions[0])
+
+      expect(persisted).not.toHaveProperty('interrupted')
+    })
+
+    it('markResumed clears the interrupted state so the composer is usable', () => {
+      hydrateInterrupted()
+
+      useSessionStore.getState().markResumed('resumable-session')
+      const session = useSessionStore.getState().sessions[0]
+
+      expect(session.interrupted).toBeUndefined()
+      expect(session.error).toBeUndefined()
+      expect(session.status).toBe('idle')
+    })
   })
 })

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -12,6 +12,7 @@ import {
   type PermissionProfileId
 } from '../../../shared/permission-profiles'
 import {
+  INTERRUPTED_SESSION_ERROR,
   sanitizeToolActivity,
   type MessagePart,
   type PersistedActiveRun,
@@ -60,6 +61,9 @@ export type ChatSession = Omit<
   messages: ChatMessage[]
   activities?: ToolActivity[]
   isPending?: boolean
+  // Transient: set at hydration when a session was interrupted by an app restart, so the UI can
+  // offer an explicit Resume affordance. Never persisted (stripped in stripTransientSessionState).
+  interrupted?: boolean
 }
 
 type SessionStoreData = {
@@ -157,6 +161,7 @@ type SessionStore = SessionStoreData & {
   hydrateSessions: (sessions: PersistedChatSession[], manifest?: PersistedSessionManifest) => void
   finishRun: (sessionId: string) => void
   failRun: (sessionId: string, error: string) => void
+  markResumed: (sessionId: string) => void
   upsertToolActivity: (input: UpsertToolActivityInput) => void
   setPermissionPending: (sessionId: string) => void
   clearPermissionPending: (sessionId: string) => void
@@ -187,9 +192,10 @@ const stripTransientMessageState = (message: ChatMessage): PersistedChatMessage 
 }
 
 const stripTransientSessionState = (session: ChatSession): PersistedChatSession => {
-  const { activities, isPending, messages, ...persistedSession } = session
+  const { activities, isPending, interrupted, messages, ...persistedSession } = session
 
   void isPending
+  void interrupted
 
   // Persist a bounded projection of tool activities so the transcript survives restarts.
   const persistedActivities = activities
@@ -217,7 +223,10 @@ const hydrateToolActivity = (activity: PersistedToolActivity): ToolActivity => (
 const hydrateSession = (session: PersistedChatSession): ChatSession => ({
   ...session,
   permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
-  activities: session.activities?.map(hydrateToolActivity)
+  activities: session.activities?.map(hydrateToolActivity),
+  // Sessions restored as interrupted (see normalizeSessionAfterRestore) carry this exact error;
+  // flag them so the composer can surface a Resume button instead of a dead-end error.
+  interrupted: session.error === INTERRUPTED_SESSION_ERROR ? true : undefined
 })
 
 // Serializes one in-memory session into the durable per-file projection saved by the main process.
@@ -986,6 +995,23 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               error: message,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
+              updatedAt: Date.now()
+            }
+          : session
+      )
+    }))
+  },
+
+  // Clears the interrupted/error state after a successful resume so the composer is usable again.
+  markResumed: (sessionId) => {
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId
+          ? {
+              ...session,
+              status: 'idle',
+              error: undefined,
+              interrupted: undefined,
               updatedAt: Date.now()
             }
           : session

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -117,7 +117,8 @@ export type PersistedChatSession = {
   updatedAt: number
 }
 
-const INTERRUPTED_SESSION_ERROR = 'Session was interrupted before the app closed.'
+// Restored interrupted sessions carry this error verbatim; the renderer keys its resume banner off it.
+export const INTERRUPTED_SESSION_ERROR = 'Session was interrupted before the app closed.'
 
 const MESSAGE_ROLES = new Set<PersistedMessageRole>(['user', 'agent'])
 const MESSAGE_STATUSES = new Set<PersistedMessageStatus>(['complete', 'streaming', 'error'])


### PR DESCRIPTION
## Problem

After the app restarts mid-turn, a running / waiting-permission session is restored as an `error` state with the message *"Session was interrupted before the app closed."*. It surfaced in the near-composer banner as a dead-end red error — the only way to recover was to blindly send another message (which triggers an implicit resume). There was no explicit, discoverable **Resume** affordance.

## Change

Restored interrupted sessions now show a **neutral banner with a Resume button** (matching the reference style). Clicking it re-attaches the ACP runtime so the user can keep chatting.

- Derive a transient `interrupted` flag on `ChatSession` at hydration from the exported `INTERRUPTED_SESSION_ERROR`; the string comparison lives in one place and is stripped before persistence.
- Add a `markResumed` store action and a standalone `resumeInterruptedSession` runtime handler (success → unlock composer; failure → keep the banner so a retry stays possible; missing workspace → actionable message).
- Extract `SessionInterruptedBanner`; the Resume button is disabled while the resume request is in flight to block a double-resume, and shows a spinner.
- Wire `onResumeSession` through `WorkspacePage`.

## Scope

This is the **UI affordance** only. The separate `acp:resume-session … RequestError: Internal error` runtime failure (where resume only recovers from *session-not-found*) is tracked as a follow-up.

## Tests

- `interrupted` flag hydrate + strip, `markResumed` (session-store).
- `resumeInterruptedSession` branches: success / failure / already-attached / missing-workspace.
- `SessionInterruptedBanner` clickable-vs-disabled behavior.
- Full suite: 1264 passed / 4 skipped; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)