### PR TITLE
feat(onboarding): app-managed Claude install (no Node/npm required)

### DIFF
--- a/src/main/settings/claude-detect.ts
+++ b/src/main/settings/claude-detect.ts
@@ -27,6 +27,8 @@ export type ClaudeDetectDeps = {
   getVersion: (path: string) => Promise<string | undefined>
   // Extra bin directories to probe (e.g. `npm prefix -g`); resolved lazily and tolerant of failure.
   resolveNpmBinDirs: () => Promise<string[]>
+  // Extra fixed directories to probe (e.g. the app-managed install dir), searched after PATH/home.
+  extraDirs?: string[]
 }
 
 // Path semantics follow the injected platform, not the host running the code. Production wires
@@ -67,7 +69,13 @@ const collectCandidateDirs = async (deps: ClaudeDetectDeps): Promise<string[]> =
 
   // De-duplicate while preserving first-seen order so the first real hit wins.
   return Array.from(
-    new Set([...pathDirs, localBin, ...wellKnownDirs(deps.platform, deps.env), ...npmBinDirs])
+    new Set([
+      ...pathDirs,
+      localBin,
+      ...(deps.extraDirs ?? []),
+      ...wellKnownDirs(deps.platform, deps.env),
+      ...npmBinDirs
+    ])
   )
 }
 

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -1,0 +1,309 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import { createHash } from 'node:crypto'
+import { gzipSync } from 'node:zlib'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { ClaudeInstallLogEvent } from '../../shared/settings'
+import {
+  downloadAndVerify,
+  extractFileFromTgz,
+  getManagedPlatform,
+  installManagedClaude,
+  resolveNativePackage
+} from './managed-claude'
+
+// Builds one 512-byte ustar header + content padded to a 512 boundary — enough to synthesize the npm
+// tarball shape the extractor consumes, without depending on a tar library.
+const tarEntry = (name: string, content: Buffer): Buffer => {
+  const header = Buffer.alloc(512)
+  header.write(name, 0, 'utf8')
+  header.write('0000755\0', 100, 'ascii')
+  header.write('0000000\0', 108, 'ascii')
+  header.write('0000000\0', 116, 'ascii')
+  header.write(`${content.length.toString(8).padStart(11, '0')}\0`, 124, 'ascii')
+  header.write('00000000000\0', 136, 'ascii')
+  header.write('0', 156, 'ascii') // typeflag: regular file
+  header.write('ustar\0', 257, 'ascii')
+  header.write('00', 263, 'ascii')
+  // Checksum: sum of all bytes with the checksum field treated as spaces.
+  header.write('        ', 148, 'ascii')
+  let sum = 0
+  for (const byte of header) sum += byte
+  header.write(`${sum.toString(8).padStart(6, '0')}\0 `, 148, 'ascii')
+
+  const padded = Buffer.alloc(Math.ceil(content.length / 512) * 512)
+  content.copy(padded)
+
+  return Buffer.concat([header, padded])
+}
+
+const buildTgz = (entries: { name: string; content: Buffer }[]): Buffer => {
+  const blocks = entries.map((entry) => tarEntry(entry.name, entry.content))
+  // Two trailing zero blocks mark end-of-archive.
+  return gzipSync(Buffer.concat([...blocks, Buffer.alloc(1024)]))
+}
+
+const sha512 = (data: Buffer): string =>
+  `sha512-${createHash('sha512').update(data).digest('base64')}`
+
+describe('managed-claude: platform key', () => {
+  it('maps darwin arm64', () => {
+    const p = getManagedPlatform({ platform: 'darwin', arch: 'arm64' })
+    expect(p).toEqual({
+      key: 'darwin-arm64',
+      pkg: '@anthropic-ai/claude-code-darwin-arm64',
+      binName: 'claude'
+    })
+  })
+
+  it('keeps darwin x64 when not translated', () => {
+    const p = getManagedPlatform({ platform: 'darwin', arch: 'x64', isRosetta: () => false })
+    expect(p.key).toBe('darwin-x64')
+  })
+
+  it('prefers arm64 for x64 under Rosetta', () => {
+    const p = getManagedPlatform({ platform: 'darwin', arch: 'x64', isRosetta: () => true })
+    expect(p.key).toBe('darwin-arm64')
+  })
+
+  it('detects musl on linux (no glibcVersionRuntime)', () => {
+    const p = getManagedPlatform({
+      platform: 'linux',
+      arch: 'x64',
+      getReport: () => ({ header: {} })
+    })
+    expect(p.key).toBe('linux-x64-musl')
+  })
+
+  it('uses glibc linux when glibcVersionRuntime is present', () => {
+    const p = getManagedPlatform({
+      platform: 'linux',
+      arch: 'arm64',
+      getReport: () => ({ header: { glibcVersionRuntime: '2.31' } })
+    })
+    expect(p.key).toBe('linux-arm64')
+  })
+
+  it('uses the .exe binary name on Windows', () => {
+    const p = getManagedPlatform({ platform: 'win32', arch: 'x64' })
+    expect(p).toMatchObject({ key: 'win32-x64', binName: 'claude.exe' })
+  })
+
+  it('throws on an unsupported platform', () => {
+    expect(() =>
+      getManagedPlatform({ platform: 'freebsd' as NodeJS.Platform, arch: 'x64' })
+    ).toThrow(/Unsupported platform/)
+  })
+})
+
+describe('managed-claude: registry resolution', () => {
+  const platform = {
+    key: 'linux-x64',
+    pkg: '@anthropic-ai/claude-code-linux-x64',
+    binName: 'claude'
+  }
+
+  it('resolves latest version then tarball + integrity', async () => {
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/@anthropic-ai%2fclaude-code'))
+        return { 'dist-tags': { latest: '2.1.209' } }
+      expect(url).toContain('@anthropic-ai%2fclaude-code-linux-x64/2.1.209')
+      return { dist: { tarball: 'https://reg/x.tgz', integrity: 'sha512-abc' } }
+    }
+
+    const res = await resolveNativePackage({ registry: 'https://reg', platform, fetchJson })
+    expect(res).toEqual({
+      version: '2.1.209',
+      tarball: 'https://reg/x.tgz',
+      integrity: 'sha512-abc',
+      registry: 'https://reg'
+    })
+  })
+
+  it('uses a pinned version without querying dist-tags', async () => {
+    let latestQueried = false
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/@anthropic-ai%2fclaude-code')) latestQueried = true
+      return { dist: { tarball: 'https://reg/x.tgz', integrity: 'sha512-abc' } }
+    }
+
+    const res = await resolveNativePackage({
+      registry: 'https://reg',
+      platform,
+      version: '2.0.0',
+      fetchJson
+    })
+    expect(res.version).toBe('2.0.0')
+    expect(latestQueried).toBe(false)
+  })
+
+  it('throws when metadata lacks tarball/integrity', async () => {
+    const fetchJson = async (): Promise<unknown> => ({ dist: {} })
+    await expect(
+      resolveNativePackage({ registry: 'https://reg', platform, version: '1.0.0', fetchJson })
+    ).rejects.toThrow(/Incomplete registry metadata/)
+  })
+})
+
+describe('managed-claude: download + verify', () => {
+  let dir: string
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'managed-claude-dl-'))
+  })
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('writes the file when the sha512 matches', async () => {
+    const payload = Buffer.from('a-native-binary')
+    const dest = join(dir, 'out.tgz')
+    await downloadAndVerify({
+      url: 'https://reg/x.tgz',
+      integrity: sha512(payload),
+      destPath: dest,
+      installId: 'i1',
+      onLog: () => undefined,
+      fetchTarball: async () => ({ stream: Readable.from([payload]), totalBytes: payload.length })
+    })
+    expect((await readFile(dest)).equals(payload)).toBe(true)
+  })
+
+  it('rejects and removes the file on a sha512 mismatch', async () => {
+    const dest = join(dir, 'out.tgz')
+    await expect(
+      downloadAndVerify({
+        url: 'https://reg/x.tgz',
+        integrity: 'sha512-wrong',
+        destPath: dest,
+        installId: 'i1',
+        onLog: () => undefined,
+        fetchTarball: async () => ({ stream: Readable.from([Buffer.from('bytes')]) })
+      })
+    ).rejects.toThrow(/integrity check/)
+    await expect(readFile(dest)).rejects.toThrow()
+  })
+})
+
+describe('managed-claude: tgz extraction', () => {
+  let dir: string
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'managed-claude-ex-'))
+  })
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('extracts the target entry across block boundaries', async () => {
+    // A payload larger than one 512 block to exercise multi-block bodies.
+    const binary = Buffer.from('CLAUDE-BINARY-'.repeat(200))
+    const tgz = buildTgz([
+      { name: 'package/README.md', content: Buffer.from('hi') },
+      { name: 'package/claude', content: binary }
+    ])
+    const tgzPath = join(dir, 'pkg.tgz')
+    await writeFile(tgzPath, tgz)
+
+    const dest = join(dir, 'bin', 'claude')
+    const found = await extractFileFromTgz({ tgzPath, entryName: 'package/claude', destPath: dest })
+
+    expect(found).toBe(true)
+    expect((await readFile(dest)).equals(binary)).toBe(true)
+  })
+
+  it('returns false and leaves no file when the entry is absent', async () => {
+    const tgz = buildTgz([{ name: 'package/other', content: Buffer.from('x') }])
+    const tgzPath = join(dir, 'pkg.tgz')
+    await writeFile(tgzPath, tgz)
+
+    const dest = join(dir, 'bin', 'claude')
+    const found = await extractFileFromTgz({ tgzPath, entryName: 'package/claude', destPath: dest })
+
+    expect(found).toBe(false)
+    await expect(readFile(dest)).rejects.toThrow()
+  })
+})
+
+describe('managed-claude: install orchestration', () => {
+  let root: string
+  const platform = {
+    key: 'linux-x64',
+    pkg: '@anthropic-ai/claude-code-linux-x64',
+    binName: 'claude'
+  }
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-claude-root-'))
+  })
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  const fixture = (): { tgz: Buffer; binary: Buffer } => {
+    const binary = Buffer.from('NATIVE-CLAUDE-'.repeat(100))
+    return { tgz: buildTgz([{ name: 'package/claude', content: binary }]), binary }
+  }
+
+  it('installs the binary and reports the resolved path + version', async () => {
+    const { tgz, binary } = fixture()
+    const logs: ClaudeInstallLogEvent[] = []
+
+    const outcome = await installManagedClaude({
+      installId: 'i1',
+      onLog: (e) => logs.push(e),
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform,
+      fetchJson: async (url) =>
+        url.endsWith('claude-code-linux-x64/2.1.209')
+          ? { dist: { tarball: 'https://reg/x.tgz', integrity: sha512(tgz) } }
+          : { 'dist-tags': { latest: '2.1.209' } },
+      fetchTarball: async () => ({ stream: Readable.from([tgz]), totalBytes: tgz.length })
+    })
+
+    expect(outcome.result.ok).toBe(true)
+    expect(outcome.version).toBe('2.1.209')
+    expect(outcome.resolvedPath).toBe(join(root, 'claude-code', 'bin', 'claude'))
+    expect((await readFile(outcome.resolvedPath as string)).equals(binary)).toBe(true)
+  })
+
+  it('falls back to the next registry when the first fails', async () => {
+    const { tgz } = fixture()
+    const outcome = await installManagedClaude({
+      installId: 'i2',
+      onLog: () => undefined,
+      dataRoot: root,
+      registries: ['https://bad', 'https://good'],
+      platform,
+      fetchJson: async (url) => {
+        if (url.startsWith('https://bad')) throw new Error('network down')
+        return url.includes('claude-code-linux-x64')
+          ? { dist: { tarball: 'https://good/x.tgz', integrity: sha512(tgz) } }
+          : { 'dist-tags': { latest: '2.1.209' } }
+      },
+      fetchTarball: async () => ({ stream: Readable.from([tgz]) })
+    })
+
+    expect(outcome.result.ok).toBe(true)
+    expect(outcome.version).toBe('2.1.209')
+  })
+
+  it('reports failure when every registry fails', async () => {
+    const outcome = await installManagedClaude({
+      installId: 'i3',
+      onLog: () => undefined,
+      dataRoot: root,
+      registries: ['https://bad'],
+      platform,
+      fetchJson: async () => {
+        throw new Error('boom')
+      },
+      fetchTarball: async () => ({ stream: Readable.from([Buffer.from('x')]) })
+    })
+
+    expect(outcome.result.ok).toBe(false)
+    expect(outcome.result.error).toContain('boom')
+  })
+})

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -1,0 +1,510 @@
+import { createHash } from 'node:crypto'
+import { createReadStream, createWriteStream } from 'node:fs'
+import { chmod, mkdir, rm } from 'node:fs/promises'
+import { get } from 'node:https'
+import type { IncomingMessage } from 'node:http'
+import { arch as osArch } from 'node:os'
+import { dirname, join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { Transform, Writable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import { createGunzip } from 'node:zlib'
+
+import type { ClaudeInstallLogEvent, ClaudeInstallResult } from '../../shared/settings'
+
+// App-managed Claude installer. The `@anthropic-ai/claude-code` npm package is a thin wrapper whose
+// real payload is a per-platform native binary shipped as an optionalDependency
+// (`@anthropic-ai/claude-code-<platform>-<arch>[-musl]`). That native binary runs with no Node.js at
+// runtime, so the app can install Claude for a user who has neither Node nor npm: resolve the native
+// package for the host, download its tarball from a registry (verifying the registry's sha512), and
+// extract the single binary into the app's data dir. Every side-effecting dependency (network, fs
+// platform probes) is injectable so the whole flow is unit-tested offline.
+
+const PACKAGE_PREFIX = '@anthropic-ai/claude-code'
+// URL-encoded scoped name (`/` -> `%2f`) for registry metadata endpoints.
+const ENCODED_WRAPPER = '@anthropic-ai%2fclaude-code'
+
+// Official registry first, China-friendly mirror second. Tried in order; a failure at any step
+// (resolve/download/verify) falls through to the next registry.
+const DEFAULT_REGISTRIES = ['https://registry.npmjs.org', 'https://registry.npmmirror.com']
+
+// Native binary packages by `${platform}-${arch}[-musl]` key, mirroring the wrapper's own install.cjs.
+// Windows binaries carry the `.exe` extension; every other platform is a bare `claude`.
+const NATIVE_PLATFORMS: Record<string, { bin: string }> = {
+  'darwin-arm64': { bin: 'claude' },
+  'darwin-x64': { bin: 'claude' },
+  'linux-x64': { bin: 'claude' },
+  'linux-arm64': { bin: 'claude' },
+  'linux-x64-musl': { bin: 'claude' },
+  'linux-arm64-musl': { bin: 'claude' },
+  'win32-x64': { bin: 'claude.exe' },
+  'win32-arm64': { bin: 'claude.exe' }
+}
+
+export type ManagedPlatform = { key: string; pkg: string; binName: string }
+
+// Injectable probes for the two platform ambiguities: musl vs glibc on Linux, and Rosetta-translated
+// x64 Node on Apple Silicon (which should still get the arm64 binary — the x64 build needs AVX).
+export type ManagedPlatformDeps = {
+  platform?: NodeJS.Platform
+  arch?: string
+  // Returns Node's process report (or null); musl is inferred from a missing glibcVersionRuntime.
+  getReport?: () => { header?: { glibcVersionRuntime?: string } } | null
+  // True when an x64 process is running under Rosetta 2 on Apple Silicon.
+  isRosetta?: () => boolean
+}
+
+const toPlatform = (key: string): ManagedPlatform => {
+  const info = NATIVE_PLATFORMS[key]
+
+  if (!info) {
+    throw new Error(`Unsupported platform for the app-managed Claude install: ${key}`)
+  }
+
+  return { key, pkg: `${PACKAGE_PREFIX}-${key}`, binName: info.bin }
+}
+
+const detectMusl = (getReport?: ManagedPlatformDeps['getReport']): boolean => {
+  const report = getReport
+    ? getReport()
+    : typeof process.report?.getReport === 'function'
+      ? (process.report.getReport() as { header?: { glibcVersionRuntime?: string } })
+      : null
+
+  return report != null && report.header?.glibcVersionRuntime === undefined
+}
+
+const defaultIsRosetta = (): boolean => {
+  try {
+    const result = spawnSync('sysctl', ['-n', 'sysctl.proc_translated'], { encoding: 'utf8' })
+
+    return result.stdout?.trim() === '1'
+  } catch {
+    return false
+  }
+}
+
+// Resolves the native package descriptor for the host, applying the musl and Rosetta rules.
+const getManagedPlatform = (deps: ManagedPlatformDeps = {}): ManagedPlatform => {
+  const platform = deps.platform ?? process.platform
+  let cpu = deps.arch ?? osArch()
+
+  if (platform === 'linux') {
+    return toPlatform(`linux-${cpu}${detectMusl(deps.getReport) ? '-musl' : ''}`)
+  }
+
+  if (platform === 'darwin' && cpu === 'x64') {
+    const rosetta = deps.isRosetta ? deps.isRosetta() : defaultIsRosetta()
+    if (rosetta) cpu = 'arm64'
+  }
+
+  return toPlatform(`${platform}-${cpu}`)
+}
+
+// Stable on-disk location for the managed binary. Kept version-independent (overwritten on upgrade) so
+// detection and PATH augmentation can point at one fixed directory without symlinks (portable to
+// Windows). The resolved version is recorded separately in the persisted ClaudeInfo.
+const managedClaudeDir = (dataRoot: string): string => join(dataRoot, 'claude-code', 'bin')
+
+// ---- Registry metadata -----------------------------------------------------------------------------
+
+export type FetchJson = (url: string) => Promise<unknown>
+export type FetchTarball = (
+  url: string
+) => Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }>
+
+export type NativeResolution = {
+  version: string
+  tarball: string
+  integrity: string
+  registry: string
+}
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+
+// Reads the wrapper package's `dist-tags.latest` from a registry.
+const fetchLatestVersion = async (registry: string, fetchJson: FetchJson): Promise<string> => {
+  const meta = asRecord(await fetchJson(`${registry}/${ENCODED_WRAPPER}`))
+  const latest = asRecord(meta['dist-tags']).latest
+
+  if (typeof latest !== 'string' || latest.length === 0) {
+    throw new Error('Registry did not report a latest claude-code version')
+  }
+
+  return latest
+}
+
+// Resolves the native package's tarball URL + sha512 integrity from a single registry. Uses the
+// pinned `version` when given, otherwise the wrapper's latest.
+const resolveNativePackage = async ({
+  registry,
+  platform,
+  version,
+  fetchJson
+}: {
+  registry: string
+  platform: ManagedPlatform
+  version?: string
+  fetchJson: FetchJson
+}): Promise<NativeResolution> => {
+  const resolvedVersion = version ?? (await fetchLatestVersion(registry, fetchJson))
+  const encodedPkg = `${ENCODED_WRAPPER}-${platform.key}`
+  const meta = asRecord(await fetchJson(`${registry}/${encodedPkg}/${resolvedVersion}`))
+  const dist = asRecord(meta.dist)
+  const tarball = dist.tarball
+  const integrity = dist.integrity
+
+  if (typeof tarball !== 'string' || typeof integrity !== 'string') {
+    throw new Error(`Incomplete registry metadata for ${platform.pkg}@${resolvedVersion}`)
+  }
+
+  return { version: resolvedVersion, tarball, integrity, registry }
+}
+
+// ---- Download + verify -----------------------------------------------------------------------------
+
+// Streams a tarball to `destPath`, computing its sha512 as it goes and rejecting on an
+// integrity mismatch (the file is removed). Progress is logged, throttled to whole-percent / MB steps.
+const downloadAndVerify = async ({
+  url,
+  integrity,
+  destPath,
+  installId,
+  onLog,
+  fetchTarball
+}: {
+  url: string
+  integrity: string
+  destPath: string
+  installId: string
+  onLog: (event: ClaudeInstallLogEvent) => void
+  fetchTarball: FetchTarball
+}): Promise<void> => {
+  const { stream, totalBytes } = await fetchTarball(url)
+  const hash = createHash('sha512')
+  let received = 0
+  let lastLoggedMb = 0
+
+  const meter = new Transform({
+    transform(chunk: Buffer, _enc, cb) {
+      hash.update(chunk)
+      received += chunk.length
+
+      const mb = Math.floor(received / (1024 * 1024))
+      if (mb > lastLoggedMb) {
+        lastLoggedMb = mb
+        const total = totalBytes ? ` / ${(totalBytes / (1024 * 1024)).toFixed(1)} MB` : ''
+        onLog({
+          installId,
+          stream: 'system',
+          chunk: `Downloading Claude — ${mb.toFixed(0)} MB${total}`
+        })
+      }
+
+      cb(null, chunk)
+    }
+  })
+
+  await mkdir(dirname(destPath), { recursive: true })
+  await pipeline(stream, meter, createWriteStream(destPath))
+
+  const digest = `sha512-${hash.digest('base64')}`
+  if (digest !== integrity) {
+    await rm(destPath, { force: true })
+    throw new Error('Downloaded Claude failed its integrity check (sha512 mismatch)')
+  }
+}
+
+// ---- Tar extraction (minimal, single entry) --------------------------------------------------------
+
+const TAR_BLOCK = 512
+
+const isZeroBlock = (block: Buffer): boolean => {
+  for (const byte of block) if (byte !== 0) return false
+  return true
+}
+
+const readTarName = (header: Buffer): string => {
+  const trim = (buf: Buffer): string => {
+    const end = buf.indexOf(0)
+    return buf.toString('utf8', 0, end === -1 ? buf.length : end)
+  }
+  const name = trim(header.subarray(0, 100))
+  const prefix = trim(header.subarray(345, 500))
+
+  return prefix ? `${prefix}/${name}` : name
+}
+
+const readTarSize = (header: Buffer): number => {
+  const raw = header.toString('utf8', 124, 136).replace(/\0/g, '').trim()
+  return raw ? parseInt(raw, 8) : 0
+}
+
+// Streaming Writable that extracts exactly one entry (`entryName`) from an uncompressed tar stream,
+// forwarding its bytes through `onData` (which returns a Promise, giving natural backpressure to the
+// destination file). All other entries are skipped. Handles entry/data spanning arbitrary chunk sizes.
+class SingleEntrySink extends Writable {
+  private leftover: Buffer = Buffer.alloc(0)
+  private mode: 'header' | 'body' = 'header'
+  private remaining = 0
+  private padding = 0
+  private capturing = false
+  private found = false
+
+  constructor(
+    private readonly entryName: string,
+    private readonly onData: (chunk: Buffer) => Promise<void>
+  ) {
+    super()
+  }
+
+  isFound(): boolean {
+    return this.found
+  }
+
+  async _write(
+    chunk: Buffer,
+    _enc: BufferEncoding,
+    cb: (error?: Error | null) => void
+  ): Promise<void> {
+    try {
+      this.leftover = this.leftover.length ? Buffer.concat([this.leftover, chunk]) : chunk
+      await this.consume()
+      cb()
+    } catch (error) {
+      cb(error as Error)
+    }
+  }
+
+  private async consume(): Promise<void> {
+    for (;;) {
+      if (this.mode === 'header') {
+        if (this.leftover.length < TAR_BLOCK) return
+
+        const header = this.leftover.subarray(0, TAR_BLOCK)
+        this.leftover = this.leftover.subarray(TAR_BLOCK)
+
+        if (isZeroBlock(header)) continue // end-of-archive marker(s)
+
+        const size = readTarSize(header)
+        this.remaining = size
+        this.padding = (TAR_BLOCK - (size % TAR_BLOCK)) % TAR_BLOCK
+        this.capturing = !this.found && readTarName(header) === this.entryName
+        this.mode = 'body'
+        continue
+      }
+
+      if (this.remaining > 0) {
+        if (this.leftover.length === 0) return
+        const take = Math.min(this.remaining, this.leftover.length)
+        const piece = this.leftover.subarray(0, take)
+        this.leftover = this.leftover.subarray(take)
+        this.remaining -= take
+        if (this.capturing) await this.onData(piece)
+        continue
+      }
+
+      if (this.padding > 0) {
+        if (this.leftover.length === 0) return
+        const skip = Math.min(this.padding, this.leftover.length)
+        this.leftover = this.leftover.subarray(skip)
+        this.padding -= skip
+        continue
+      }
+
+      if (this.capturing) this.found = true
+      this.capturing = false
+      this.mode = 'header'
+    }
+  }
+}
+
+// Extracts `entryName` from a gzipped tar at `tgzPath` into `destPath`. Returns whether the entry was
+// present; a miss leaves no partial file behind.
+const extractFileFromTgz = async ({
+  tgzPath,
+  entryName,
+  destPath
+}: {
+  tgzPath: string
+  entryName: string
+  destPath: string
+}): Promise<boolean> => {
+  await mkdir(dirname(destPath), { recursive: true })
+
+  const out = createWriteStream(destPath)
+  const write = (chunk: Buffer): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const onError = (error: Error): void => reject(error)
+      out.once('error', onError)
+      if (out.write(chunk)) {
+        out.removeListener('error', onError)
+        resolve()
+      } else {
+        out.once('drain', () => {
+          out.removeListener('error', onError)
+          resolve()
+        })
+      }
+    })
+
+  const sink = new SingleEntrySink(entryName, write)
+
+  await pipeline(createReadStream(tgzPath), createGunzip(), sink)
+  await new Promise<void>((resolve, reject) =>
+    out.end((error?: Error | null) => (error ? reject(error) : resolve()))
+  )
+
+  if (!sink.isFound()) {
+    await rm(destPath, { force: true })
+    return false
+  }
+
+  return true
+}
+
+// ---- Orchestration ---------------------------------------------------------------------------------
+
+export type ManagedInstallOutcome = {
+  result: ClaudeInstallResult
+  resolvedPath?: string
+  version?: string
+}
+
+export type InstallManagedClaudeOptions = {
+  installId: string
+  onLog: (event: ClaudeInstallLogEvent) => void
+  // Root under which the binary is placed (<dataRoot>/claude-code/bin/<binName>). Pass the app's
+  // configurable storage root, not a hardcoded userData path.
+  dataRoot: string
+  registries?: string[]
+  version?: string
+  platform?: ManagedPlatform
+  fetchJson?: FetchJson
+  fetchTarball?: FetchTarball
+  tmpDir?: string
+}
+
+// Downloads + installs the managed Claude binary, trying each registry in order. Streams progress via
+// `onLog` and resolves (never rejects) with a structured outcome the service can persist.
+const installManagedClaude = async ({
+  installId,
+  onLog,
+  dataRoot,
+  registries = DEFAULT_REGISTRIES,
+  version,
+  platform = getManagedPlatform(),
+  fetchJson = defaultFetchJson,
+  fetchTarball = defaultFetchTarball,
+  tmpDir
+}: InstallManagedClaudeOptions): Promise<ManagedInstallOutcome> => {
+  const destPath = join(managedClaudeDir(dataRoot), platform.binName)
+  const scratch = tmpDir ?? managedClaudeDir(dataRoot)
+  let lastError = 'no registries configured'
+
+  for (const registry of registries) {
+    const tgzPath = join(scratch, `claude-download-${Date.now()}.tgz`)
+
+    try {
+      onLog({ installId, stream: 'system', chunk: `Resolving Claude from ${registry} …` })
+      const resolution = await resolveNativePackage({ registry, platform, version, fetchJson })
+
+      await downloadAndVerify({
+        url: resolution.tarball,
+        integrity: resolution.integrity,
+        destPath: tgzPath,
+        installId,
+        onLog,
+        fetchTarball
+      })
+
+      const found = await extractFileFromTgz({
+        tgzPath,
+        entryName: `package/${platform.binName}`,
+        destPath
+      })
+
+      if (!found) throw new Error(`Native package did not contain ${platform.binName}`)
+      if (process.platform !== 'win32') await chmod(destPath, 0o755)
+
+      onLog({ installId, stream: 'system', chunk: `Installed Claude ${resolution.version}.` })
+
+      return {
+        result: { installId, ok: true },
+        resolvedPath: destPath,
+        version: resolution.version
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+      onLog({ installId, stream: 'system', chunk: `${registry} failed: ${lastError}` })
+    } finally {
+      await rm(tgzPath, { force: true }).catch(() => undefined)
+    }
+  }
+
+  return { result: { installId, ok: false, error: lastError } }
+}
+
+// ---- Default HTTPS transport (redirect-following) --------------------------------------------------
+
+const httpsGetFollow = (
+  url: string,
+  { timeoutMs = 20_000, maxRedirects = 5 } = {}
+): Promise<IncomingMessage> =>
+  new Promise((resolve, reject) => {
+    const visit = (target: string, redirectsLeft: number): void => {
+      const req = get(target, (res) => {
+        const status = res.statusCode ?? 0
+
+        if (status >= 300 && status < 400 && res.headers.location) {
+          res.resume()
+          if (redirectsLeft <= 0) {
+            reject(new Error(`Too many redirects for ${target}`))
+            return
+          }
+          visit(new URL(res.headers.location, target).toString(), redirectsLeft - 1)
+          return
+        }
+
+        if (status < 200 || status >= 300) {
+          res.resume()
+          reject(new Error(`HTTP ${status} for ${target}`))
+          return
+        }
+
+        resolve(res)
+      })
+
+      req.setTimeout(timeoutMs, () => req.destroy(new Error(`Request timed out for ${target}`)))
+      req.on('error', reject)
+    }
+
+    visit(url, maxRedirects)
+  })
+
+const defaultFetchJson: FetchJson = async (url) => {
+  const res = await httpsGetFollow(url)
+  const chunks: Buffer[] = []
+
+  for await (const chunk of res) chunks.push(chunk as Buffer)
+
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'))
+}
+
+const defaultFetchTarball: FetchTarball = async (url) => {
+  const res = await httpsGetFollow(url)
+  const length = Number(res.headers['content-length'])
+
+  return { stream: res, totalBytes: Number.isFinite(length) ? length : undefined }
+}
+
+export {
+  DEFAULT_REGISTRIES,
+  downloadAndVerify,
+  extractFileFromTgz,
+  getManagedPlatform,
+  installManagedClaude,
+  managedClaudeDir,
+  resolveNativePackage
+}

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -28,11 +28,22 @@ const { SkillRegistry } = await import('../skills/registry')
 let storageRoot: string
 let repository: InstanceType<typeof SettingsRepository>
 
+type ManagedInstallImpl = (options: {
+  installId: string
+  onLog: (event: { installId: string; stream: string; chunk: string }) => void
+  dataRoot: string
+}) => Promise<{
+  result: { installId: string; ok: boolean; error?: string }
+  resolvedPath?: string
+  version?: string
+}>
+
 const createService = (
   detectResult = { found: true, path: '/bin/claude', version: '2.1.0' },
   options: {
     userClaudeDir?: string
     executeClaudeProbe?: (executablePath: string, env: NodeJS.ProcessEnv) => Promise<void>
+    installManagedClaudeImpl?: ManagedInstallImpl
   } = {}
 ): InstanceType<typeof SettingsService> =>
   new SettingsService({
@@ -41,6 +52,8 @@ const createService = (
     // Point at a non-existent user Claude dir so tests never read the real ~/.claude for local auth.
     userClaudeDir: options.userClaudeDir ?? join(storageRoot, 'no-user-claude'),
     executeClaudeProbe: options.executeClaudeProbe,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installManagedClaudeImpl: options.installManagedClaudeImpl as any,
     detectDeps: {
       env: {},
       homePath: '/home',
@@ -716,5 +729,40 @@ describe('SettingsService: skills', () => {
       'My Skill',
       'Demo'
     ])
+  })
+})
+
+describe('installClaude (app-managed source)', () => {
+  it('routes managed installs through the managed installer and persists the resolved path', async () => {
+    const service = createService(undefined, {
+      installManagedClaudeImpl: async ({ installId }) => ({
+        result: { installId, ok: true },
+        resolvedPath: '/data/claude-code/bin/claude',
+        version: '2.1.209'
+      })
+    })
+
+    const result = await service.installClaude({ source: 'managed' }, () => undefined)
+
+    expect(result.ok).toBe(true)
+    const snapshot = await service.getSettingsView()
+    expect(snapshot.claude).toEqual({
+      resolvedPath: '/data/claude-code/bin/claude',
+      version: '2.1.209'
+    })
+  })
+
+  it('does not persist claude info when the managed install fails', async () => {
+    const service = createService(undefined, {
+      installManagedClaudeImpl: async ({ installId }) => ({
+        result: { installId, ok: false, error: 'all registries failed' }
+      })
+    })
+
+    const result = await service.installClaude({ source: 'managed' }, () => undefined)
+
+    expect(result.ok).toBe(false)
+    const snapshot = await service.getSettingsView()
+    expect(snapshot.claude).toEqual({})
   })
 })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -58,6 +58,12 @@ import { resolveStorageRoot } from '../storage-root'
 import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import { detectNpmAvailable, runInstall } from './claude-install'
+import {
+  installManagedClaude,
+  managedClaudeDir,
+  type InstallManagedClaudeOptions,
+  type ManagedInstallOutcome
+} from './managed-claude'
 import { encryptKey, isEncryptionAvailable, maskKey, tryDecryptKey } from './crypto'
 import { applyLocalClaudeAuth, defaultUserClaudeDir } from './local-claude-auth'
 import { computePreflight } from './preflight'
@@ -127,6 +133,10 @@ export type SettingsServiceOptions = {
   userSkills?: UserSkillRepository
   // One-shot Claude command runner, injectable so validation tests can inspect the exact auth env.
   executeClaudeProbe?: ExecuteClaudeProbe
+  // One-shot managed Claude installer, injectable so tests avoid real network/fs.
+  installManagedClaudeImpl?: (
+    options: InstallManagedClaudeOptions
+  ) => Promise<ManagedInstallOutcome>
 }
 
 // Orchestrates the settings units (repository + crypto + detect/install + validate) behind one
@@ -140,6 +150,9 @@ class SettingsService {
   private readonly skillRegistry: SkillRegistry
   private readonly userSkills: UserSkillRepository
   private readonly executeClaudeProbe: ExecuteClaudeProbe
+  private readonly installManagedClaudeImpl: (
+    options: InstallManagedClaudeOptions
+  ) => Promise<ManagedInstallOutcome>
   private providerSequence = 0
   // Skills force-loaded for the current turn: subtracted from the stored disabled set at spawn time so
   // a picked-but-disabled skill materializes for this prompt only, without mutating stored settings.
@@ -148,11 +161,18 @@ class SettingsService {
   constructor(options: SettingsServiceOptions = {}) {
     this.storageRoot = options.storageRoot ?? resolveStorageRoot()
     this.repository = options.repository ?? new SettingsRepository(this.storageRoot)
-    this.detectDeps = options.detectDeps ?? createDefaultDetectDeps()
+    // Probe the app-managed install dir too, so a managed Claude is re-detected even if the cached
+    // path is ever cleared (e.g. a manual re-detect).
+    const baseDetectDeps = options.detectDeps ?? createDefaultDetectDeps()
+    this.detectDeps = {
+      ...baseDetectDeps,
+      extraDirs: [...(baseDetectDeps.extraDirs ?? []), managedClaudeDir(this.storageRoot)]
+    }
     this.userClaudeDir = options.userClaudeDir ?? defaultUserClaudeDir()
     this.skillRegistry = options.skillRegistry ?? new SkillRegistry()
     this.userSkills = options.userSkills ?? new UserSkillRepository(this.storageRoot)
     this.executeClaudeProbe = options.executeClaudeProbe ?? executeClaudeProbe
+    this.installManagedClaudeImpl = options.installManagedClaudeImpl ?? installManagedClaude
   }
 
   // Returns the renderer-safe (masked) snapshot of settings.
@@ -349,12 +369,32 @@ class SettingsService {
   }
 
   // Runs the one-click installer, then re-detects claude so a success immediately unblocks the gate.
+  // The app-managed source downloads the native binary itself and persists its exact path; the npm and
+  // official-script sources shell out and rely on PATH re-detection.
   async installClaude(
     request: InstallClaudeRequest,
     onLog: (event: ClaudeInstallLogEvent) => void
   ): Promise<ClaudeInstallResult> {
     this.providerSequence += 1
     const installId = `install-${Date.now()}-${this.providerSequence}`
+
+    if (request.source === 'managed') {
+      const outcome = await this.installManagedClaudeImpl({
+        installId,
+        onLog,
+        dataRoot: this.storageRoot
+      })
+
+      if (outcome.result.ok && outcome.resolvedPath) {
+        await this.repository.setClaudeInfo({
+          resolvedPath: outcome.resolvedPath,
+          version: outcome.version
+        })
+      }
+
+      return outcome.result
+    }
+
     const result = await runInstall({ source: request.source, installId, onLog })
 
     if (result.ok) {

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.render.test.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.render.test.tsx
@@ -55,28 +55,26 @@ describe('ClaudeInstallCard install-source picker', () => {
     expect(trigger?.getAttribute('role')).toBe('combobox')
   })
 
-  it('defaults to npm and shows its copyable command when npm is available', () => {
+  it('defaults to the app-managed download and shows its description, not a command', () => {
     render({ npmAvailable: true })
 
     const trigger = container.querySelector('[aria-label="Install source"]')
 
-    expect(trigger?.textContent).toContain('npm (global install)')
-    expect(container.querySelector('[aria-label="Install command"]')?.textContent).toContain(
-      'npm i -g @anthropic-ai/claude-code'
-    )
+    expect(trigger?.textContent).toContain('App-managed download (recommended)')
+    // The managed source is app-driven, so no copyable shell command is shown — just its description.
+    expect(container.querySelector('[aria-label="Install command"]')).toBeNull()
+    expect(container.textContent).toContain('no Node.js or npm required')
   })
 
-  it('defaults to the official installer when npm is unavailable', () => {
+  it('stays on the app-managed download even when npm is unavailable', () => {
     render({ npmAvailable: false })
 
     const trigger = container.querySelector('[aria-label="Install source"]')
 
-    // Falls back to the script installer (no npm needed) and shows its command; the npm-missing note
-    // only appears when npm itself is the selected source, so it stays hidden here.
-    expect(trigger?.textContent).toContain('Official install.sh')
-    expect(container.querySelector('[aria-label="Install command"]')?.textContent).toContain(
-      'curl -fsSL https://claude.ai/install.sh'
-    )
+    // The managed source needs neither npm nor Node, so it is the default regardless of npm presence,
+    // and the npm-missing note (which only applies to the npm source) stays hidden.
+    expect(trigger?.textContent).toContain('App-managed download (recommended)')
+    expect(container.querySelector('[role="alert"]')).toBeNull()
   })
 
   it('installs the currently selected source when the button is clicked', () => {
@@ -90,6 +88,6 @@ describe('ClaudeInstallCard install-source picker', () => {
       button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(onInstall).toHaveBeenCalledWith('npm')
+    expect(onInstall).toHaveBeenCalledWith('managed')
   })
 })

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -21,9 +21,8 @@ const ClaudeInstallCard = ({
   npmAvailable,
   onInstall
 }: ClaudeInstallCardProps): React.JSX.Element => {
-  const [source, setSource] = useState<ClaudeInstallSource>(
-    npmAvailable ? 'npm' : 'official-script'
-  )
+  // Default to the app-managed download — it needs no Node.js/npm and works behind region blocks.
+  const [source, setSource] = useState<ClaudeInstallSource>('managed')
   // Sources carry platform-specific copy (e.g. install.ps1 vs install.sh), so resolve them for the
   // host the app is running on.
   const installSources = useMemo(() => getClaudeInstallSources(window.api?.platform), [])
@@ -59,7 +58,11 @@ const ClaudeInstallCard = ({
         </Select>
       </div>
 
-      {selectedSource ? (
+      {selectedSource?.description ? (
+        <p className="mt-3 text-xs text-muted-foreground">{selectedSource.description}</p>
+      ) : null}
+
+      {selectedSource && selectedSource.displayCommand ? (
         <div className="mt-3">
           <span className="text-xs font-medium text-muted-foreground">Command</span>
           <pre

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -153,27 +153,39 @@ export type RefreshProviderModelsResult = {
   message?: string
 }
 
-// Selectable install sources for the one-click claude installer.
-export type ClaudeInstallSource = 'npm' | 'official-script'
+// Selectable install sources for the one-click claude installer. `managed` is the app-driven download
+// (no user Node/npm needed) and is the default; the other two are manual/advanced fallbacks.
+export type ClaudeInstallSource = 'managed' | 'npm' | 'official-script'
 
 // Static, non-secret description of an install source shown in the UI (command is copyable).
 export type ClaudeInstallSourceInfo = {
   id: ClaudeInstallSource
   label: string
-  // Human-readable command shown in the UI and safe to copy/paste.
+  // Human-readable command shown in the UI and safe to copy/paste. Empty for the app-managed source,
+  // which has no shell command (the app performs the install itself).
   displayCommand: string
   // Whether this source needs npm on PATH (drives default selection + disabled state).
   requiresNpm: boolean
+  // Optional one-line explanation shown under the picker (used by the app-managed source).
+  description?: string
 }
 
-// The ordered install sources for a given host platform; a plain global npm install is the default
-// when npm is available. The npm command is identical everywhere, but the official installer differs:
-// Windows uses the PowerShell script (install.ps1), other platforms use the shell script (install.sh).
-// Pass the host platform (e.g. `window.api.platform`) so the copyable command matches what runs.
+// The ordered install sources for a given host platform. The app-managed download is the default and
+// recommended path (self-contained binary, no user Node/npm). npm and the official installer follow as
+// manual fallbacks: the npm command is identical everywhere, while the official installer differs —
+// Windows uses install.ps1, other platforms install.sh. Pass the host platform (e.g.
+// `window.api.platform`) so the copyable command matches what runs.
 export const getClaudeInstallSources = (platform: string = 'linux'): ClaudeInstallSourceInfo[] => {
   const isWindows = platform === 'win32'
 
   return [
+    {
+      id: 'managed',
+      label: 'App-managed download (recommended)',
+      displayCommand: '',
+      requiresNpm: false,
+      description: 'Downloads a self-contained Claude — no Node.js or npm required.'
+    },
     {
       id: 'npm',
       label: 'npm (global install)',


### PR DESCRIPTION
Adds a third onboarding install source, "App-managed download", and makes it the default/recommended option. It removes the need for the user to have Node or npm, and works where claude.ai is region-blocked.

The `@anthropic-ai/claude-code` npm package is a thin wrapper whose real payload is a per-platform native binary that runs with no Node.js at runtime. The app now installs Claude itself:

- New `managed-claude.ts`: resolves the host platform (musl + Rosetta rules ported from the package's own install.cjs), fetches the native package tarball + sha512 from the registry (official npmjs first, npmmirror fallback), streams the download while verifying the hash, and extracts the single binary into `<dataRoot>/claude-code/bin` via a small dependency-free gunzip + ustar reader.
- `service.installClaude` routes the `managed` source to the installer and persists the exact resolved path/version; `claude-detect` gains an optional `extraDirs` so a managed install is re-detected on later launches.
- `ClaudeInstallCard` defaults to the managed source and shows a description instead of a copyable shell command; npm/official-script remain as manual fallbacks.

All side effects (network, fs, platform probes) are injectable and unit-tested offline; a real end-to-end install was verified against the live registry (240MB native binary, `claude --version` => 2.1.209).

🤖 Generated with [Claude Code](https://claude.com/claude-code)