### PR TITLE
fix(acp): recover session resume from a generic Internal error

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -57,6 +57,9 @@ const startFakeAgent = (
     // When true, the resume handler rejects with the ACP "Resource not found" (-32002) — the signal a
     // replaced agent (e.g. after a provider switch) gives for a session id it does not hold.
     resumeNotFound?: boolean
+    // When true, the resume handler rejects with a generic "Internal error" (-32603) — what some
+    // agents return instead of a clean not-found after their process was replaced by an app restart.
+    resumeInternalError?: boolean
     onPrompt?: (context: {
       sessionId: string
       text: string
@@ -112,6 +115,10 @@ const startFakeAgent = (
     .onRequest(acp.methods.agent.session.resume, (ctx) => {
       if (options.resumeNotFound) {
         throw acp.RequestError.resourceNotFound(ctx.params.sessionId)
+      }
+
+      if (options.resumeInternalError) {
+        throw acp.RequestError.internalError()
       }
 
       resumedSessions.push({
@@ -1001,6 +1008,37 @@ describe('ACP runtime session management', () => {
     expect(events).toEqual(
       expect.arrayContaining([
         { sessionId: 'switched-session', text: 'reply for adopted-session-1' }
+      ])
+    )
+  })
+
+  it('adopts a fresh session when the agent returns a generic Internal error on resume', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['adopted-session-1'], { resumeInternalError: true })
+    const events: Array<{ sessionId?: string; text?: string }> = []
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: {
+        onEvent: (event) => events.push({ sessionId: event.sessionId, text: event.text })
+      }
+    })
+
+    // Resume fails with -32603 "Internal error" (what a restarted agent returns instead of a clean
+    // not-found). It must still be adopted onto a fresh agent session so the thread is not dead-ended.
+    const resumed = await runtime.resumeSession({
+      sessionId: 'restarted-session',
+      cwd: '/workspace'
+    })
+    expect(resumed.sessionId).toBe('restarted-session')
+
+    await runtime.sendPrompt({ sessionId: 'restarted-session', text: 'keep going' })
+
+    expect(fakeAgent.prompts).toEqual([{ sessionId: 'adopted-session-1', text: 'keep going' }])
+    expect(events).toEqual(
+      expect.arrayContaining([
+        { sessionId: 'restarted-session', text: 'reply for adopted-session-1' }
       ])
     )
   })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -173,14 +173,23 @@ const errorMessage = (error: unknown): string => {
 
 const log = createLogger('acp')
 
-// Detects the ACP JSON-RPC "Resource not found" (-32002) the agent returns when a resumed session id
-// is unknown to the current process — the signal that the agent was replaced (e.g. provider switch).
-const isSessionNotFoundError = (error: unknown): boolean => {
+// Detects an agent-side resume failure that means the session cannot be reattached, so the thread
+// should adopt a fresh agent session instead of dead-ending. A spec-compliant agent returns
+// "Resource not found" (-32002) for a session id it no longer holds (e.g. after a provider switch);
+// some agents instead return a generic "Internal error" (-32603) after an app restart replaced their
+// process. Both mean resume is impossible here. Other failures (invalid params, transport errors)
+// still propagate so genuinely fatal problems stay visible.
+const isUnresumableSessionError = (error: unknown): boolean => {
   if (typeof error !== 'object' || error === null) return false
 
   const candidate = error as { code?: number; message?: string }
+  const message = candidate.message ?? ''
 
-  return candidate.code === -32002 || /resource not found/i.test(candidate.message ?? '')
+  return (
+    candidate.code === -32002 ||
+    candidate.code === -32603 ||
+    /resource not found|internal error/i.test(message)
+  )
 }
 
 // Owns the agent process, protocol connection, and all active protocol sessions.
@@ -541,14 +550,17 @@ class AcpRuntime {
         ...this.createSessionMeta()
       })
     } catch (error) {
-      if (!isSessionNotFoundError(error)) throw error
+      if (!isUnresumableSessionError(error)) throw error
 
-      // A provider switch replaces the agent process, so the fresh agent no longer holds this session
-      // (and it may live under a different provider's config dir). Rather than dead-end the thread,
-      // adopt a brand-new agent session under the SAME app id so the user can keep chatting on the new
-      // provider — earlier turns stay visible; only agent-side context resets, which is expected when
-      // moving to a different model.
-      log.info('resumed session adopted onto replaced agent', { sessionId: request.sessionId })
+      // The agent could not resume this session (it was replaced by a provider switch, or an app
+      // restart spawned a fresh agent process that no longer holds it — surfacing as -32002 not-found
+      // or a generic -32603 Internal error). Rather than dead-end the thread, adopt a brand-new agent
+      // session under the SAME app id so the user can keep chatting — earlier turns stay visible; only
+      // agent-side context resets, which is expected after a restart or model switch.
+      log.info('resumed session adopted after unrecoverable resume error', {
+        sessionId: request.sessionId,
+        reason: error instanceof Error ? error.message : String(error)
+      })
 
       const adopted = await connection.agent
         .buildSession({


### PR DESCRIPTION
## Problem

After an app restart, the agent process is new and no longer holds the prior session. A spec-compliant agent reports this as JSON-RPC `-32002 "Resource not found"`, which the runtime already recovers from by adopting a fresh session. But some agents (observed on the packaged Windows build) instead return a generic `-32603 "Internal error"`. That code fell through the recovery guard and re-threw, dead-ending the thread:

```
Error invoking remote method 'acp:resume-session': RequestError: Internal error
```

## Change

Broaden the resume-recovery guard (`isSessionNotFoundError` → `isUnresumableSessionError` in `src/main/acp/runtime.ts`) so both `-32002` and `-32603` (and their message forms) adopt a brand-new agent session under the **same app id**, keeping earlier turns visible — only agent-side context resets, which is expected after a restart.

Other resume failures (invalid params `-32602`, transport errors) still propagate, so genuinely fatal problems stay visible. The original error is logged as the adoption reason for diagnosability.

This also lets the interrupted-session **Resume** button (#87) succeed on this path instead of showing "Agent session resume failed".

## Tests

New runtime integration test: a real `AcpRuntime` against a fake agent that throws `-32603` on resume, asserting it adopts a fresh session and routes the next prompt/reply to the app-facing id (red → green). Mirrors the existing `-32002` adoption test.

Full suite: 1265 passed / 4 skipped; typecheck + lint clean.

## Scope

Companion to #87 (the UI affordance). This PR is the underlying runtime recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)