### PR TITLE
fix(onboarding): sudo-free npm install and region-block fallback

### DIFF
--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -2,7 +2,13 @@ import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ClaudeInstallLogEvent } from '../../shared/settings'
-import { detectNpmAvailable, getInstallSpawnSpec, runInstall } from './claude-install'
+import {
+  detectNpmAvailable,
+  getInstallSpawnSpec,
+  isRegionBlockedOutput,
+  runInstall,
+  runInstallWithFallback
+} from './claude-install'
 
 // Minimal fake child process exposing the stdout/stderr/exit surface runInstall consumes.
 class FakeChild extends EventEmitter {
@@ -11,14 +17,58 @@ class FakeChild extends EventEmitter {
   kill = vi.fn()
 }
 
+// Per-command scripted spawn: emits the given stdout/stderr then exits on the next tick, so
+// runInstall's listeners are attached before the events fire. Records the commands spawned.
+type SpawnScript = { stdout?: string; stderr?: string; exit: number }
+const scriptedSpawn = (
+  scripts: Record<string, SpawnScript>
+): { spawn: (command: string, args: string[]) => FakeChild; commands: string[] } => {
+  const commands: string[] = []
+  const spawn = (command: string): FakeChild => {
+    commands.push(command)
+    const child = new FakeChild()
+    const script = scripts[command]
+
+    setImmediate(() => {
+      if (script.stdout) child.stdout.emit('data', Buffer.from(script.stdout))
+      if (script.stderr) child.stderr.emit('data', Buffer.from(script.stderr))
+      child.emit('exit', script.exit)
+    })
+
+    return child
+  }
+
+  return { spawn, commands }
+}
+
 describe('claude-install: command construction', () => {
-  it('runs a plain global npm install without a mirror registry', () => {
-    const spec = getInstallSpawnSpec('npm', 'linux')
+  it('runs a global npm install into a user-writable prefix (no sudo) on Unix', () => {
+    const spec = getInstallSpawnSpec('npm', 'linux', '/home/tester')
 
     expect(spec.command).toBe('npm')
-    expect(spec.args).toEqual(['i', '-g', '@anthropic-ai/claude-code'])
+    // --prefix ~/.local keeps the global install out of the system prefix, so no sudo is needed;
+    // ~/.local/bin is already probed by detection and on the augmented PATH.
+    expect(spec.args).toEqual([
+      'i',
+      '-g',
+      '@anthropic-ai/claude-code',
+      '--prefix',
+      '/home/tester/.local'
+    ])
     expect(spec.args.some((arg) => arg.includes('--registry'))).toBe(false)
     expect(spec.shell).toBeFalsy()
+  })
+
+  it('uses the same user prefix on macOS', () => {
+    const spec = getInstallSpawnSpec('npm', 'darwin', '/Users/tester')
+
+    expect(spec.args).toEqual([
+      'i',
+      '-g',
+      '@anthropic-ai/claude-code',
+      '--prefix',
+      '/Users/tester/.local'
+    ])
   })
 
   it('pipes the official installer through bash on Unix', () => {
@@ -28,10 +78,11 @@ describe('claude-install: command construction', () => {
     expect(spec.args.at(-1)).toContain('curl -fsSL https://claude.ai/install.sh | bash')
   })
 
-  it('runs npm through a shell on Windows (npm.cmd shim)', () => {
-    const spec = getInstallSpawnSpec('npm', 'win32')
+  it('runs npm through a shell on Windows (npm.cmd shim) without a prefix override', () => {
+    const spec = getInstallSpawnSpec('npm', 'win32', 'C:\\Users\\tester')
 
     expect(spec.command).toBe('npm')
+    // Windows global npm bin (%APPDATA%\npm) is already user-writable, so no --prefix is needed.
     expect(spec.args).toEqual(['i', '-g', '@anthropic-ai/claude-code'])
     expect(spec.shell).toBe(true)
   })
@@ -41,6 +92,22 @@ describe('claude-install: command construction', () => {
 
     expect(spec.command).toBe('powershell')
     expect(spec.args.at(-1)).toContain('irm https://claude.ai/install.ps1 | iex')
+  })
+})
+
+describe('claude-install: region-block detection', () => {
+  it('flags piped-HTML region-block output', () => {
+    expect(isRegionBlockedOutput('<!DOCTYPE html><html>App unavailable in region</html>')).toBe(
+      true
+    )
+    expect(isRegionBlockedOutput("bash: line 1: syntax error near unexpected token `<'")).toBe(true)
+    expect(isRegionBlockedOutput('App unavailable in region | Claude by Anthropic')).toBe(true)
+  })
+
+  it('does not flag ordinary installer output', () => {
+    expect(isRegionBlockedOutput('added 1 package in 3s')).toBe(false)
+    expect(isRegionBlockedOutput('npm warn deprecated foo@1.0.0')).toBe(false)
+    expect(isRegionBlockedOutput('')).toBe(false)
   })
 })
 
@@ -94,6 +161,96 @@ describe('claude-install: run', () => {
 
     expect(result).toMatchObject({ ok: false })
     expect(result.error).toContain('ENOENT')
+  })
+
+  it('marks an official-script failure region-blocked when it pipes HTML', async () => {
+    const child = new FakeChild()
+    const promise = runInstall({
+      source: 'official-script',
+      installId: 'install-4',
+      onLog: () => undefined,
+      spawnImpl: () => child as never
+    })
+
+    child.stderr.emit('data', Buffer.from("bash: line 1: syntax error near unexpected token `<'"))
+    child.emit('exit', 2)
+
+    await expect(promise).resolves.toMatchObject({ ok: false, regionBlocked: true })
+  })
+
+  it('does not mark an ordinary npm failure region-blocked', async () => {
+    const child = new FakeChild()
+    const promise = runInstall({
+      source: 'npm',
+      installId: 'install-5',
+      onLog: () => undefined,
+      spawnImpl: () => child as never
+    })
+
+    child.stderr.emit('data', Buffer.from('npm error code EACCES'))
+    child.emit('exit', 1)
+
+    const result = await promise
+
+    expect(result.ok).toBe(false)
+    expect(result.regionBlocked).toBeFalsy()
+  })
+})
+
+describe('claude-install: run with region-block fallback', () => {
+  it('falls back to npm when the official script is region-blocked and npm is available', async () => {
+    const { spawn, commands } = scriptedSpawn({
+      bash: { stderr: "syntax error near unexpected token `<'", exit: 2 },
+      npm: { stdout: 'added 1 package', exit: 0 }
+    })
+    const logs: ClaudeInstallLogEvent[] = []
+
+    const result = await runInstallWithFallback({
+      source: 'official-script',
+      installId: 'install-6',
+      onLog: (event) => logs.push(event),
+      spawnImpl: spawn as never,
+      npmProbe: () => Promise.resolve()
+    })
+
+    expect(commands).toEqual(['bash', 'npm'])
+    expect(result.ok).toBe(true)
+    expect(logs.some((log) => log.stream === 'system' && /region/i.test(log.chunk))).toBe(true)
+  })
+
+  it('does not fall back when npm is unavailable', async () => {
+    const { spawn, commands } = scriptedSpawn({
+      bash: { stderr: "syntax error near unexpected token `<'", exit: 2 }
+    })
+
+    const result = await runInstallWithFallback({
+      source: 'official-script',
+      installId: 'install-7',
+      onLog: () => undefined,
+      spawnImpl: spawn as never,
+      npmProbe: () => Promise.reject(new Error('not found'))
+    })
+
+    expect(commands).toEqual(['bash'])
+    expect(result.ok).toBe(false)
+    expect(result.regionBlocked).toBe(true)
+  })
+
+  it('does not fall back on a non-region-block failure', async () => {
+    const { spawn, commands } = scriptedSpawn({
+      bash: { stderr: 'curl: (7) Failed to connect', exit: 1 }
+    })
+
+    const result = await runInstallWithFallback({
+      source: 'official-script',
+      installId: 'install-8',
+      onLog: () => undefined,
+      spawnImpl: spawn as never,
+      npmProbe: () => Promise.resolve()
+    })
+
+    expect(commands).toEqual(['bash'])
+    expect(result.ok).toBe(false)
   })
 })
 

--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -1,10 +1,13 @@
 import { EventEmitter } from 'node:events'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ClaudeInstallLogEvent } from '../../shared/settings'
 import {
   detectNpmAvailable,
   getInstallSpawnSpec,
+  isNpmGlobalPrefixWritable,
   isRegionBlockedOutput,
   runInstall,
   runInstallWithFallback
@@ -42,12 +45,21 @@ const scriptedSpawn = (
 }
 
 describe('claude-install: command construction', () => {
-  it('runs a global npm install into a user-writable prefix (no sudo) on Unix', () => {
-    const spec = getInstallSpawnSpec('npm', 'linux', '/home/tester')
+  it('runs a plain global npm install (no --prefix) on Unix by default', () => {
+    const spec = getInstallSpawnSpec('npm', 'linux')
 
     expect(spec.command).toBe('npm')
-    // --prefix ~/.local keeps the global install out of the system prefix, so no sudo is needed;
-    // ~/.local/bin is already probed by detection and on the augmented PATH.
+    // With a writable default global prefix (Homebrew/nvm/volta), no override is needed.
+    expect(spec.args).toEqual(['i', '-g', '@anthropic-ai/claude-code'])
+    expect(spec.args.includes('--prefix')).toBe(false)
+    expect(spec.args.some((arg) => arg.includes('--registry'))).toBe(false)
+    expect(spec.shell).toBeFalsy()
+  })
+
+  it('appends --prefix when a user-writable override is provided on Unix', () => {
+    const spec = getInstallSpawnSpec('npm', 'linux', '/home/tester/.local')
+
+    // The override is used only when the caller determined the default prefix needs sudo.
     expect(spec.args).toEqual([
       'i',
       '-g',
@@ -55,12 +67,10 @@ describe('claude-install: command construction', () => {
       '--prefix',
       '/home/tester/.local'
     ])
-    expect(spec.args.some((arg) => arg.includes('--registry'))).toBe(false)
-    expect(spec.shell).toBeFalsy()
   })
 
-  it('uses the same user prefix on macOS', () => {
-    const spec = getInstallSpawnSpec('npm', 'darwin', '/Users/tester')
+  it('honours the override on macOS too', () => {
+    const spec = getInstallSpawnSpec('npm', 'darwin', '/Users/tester/.local')
 
     expect(spec.args).toEqual([
       'i',
@@ -78,11 +88,11 @@ describe('claude-install: command construction', () => {
     expect(spec.args.at(-1)).toContain('curl -fsSL https://claude.ai/install.sh | bash')
   })
 
-  it('runs npm through a shell on Windows (npm.cmd shim) without a prefix override', () => {
-    const spec = getInstallSpawnSpec('npm', 'win32', 'C:\\Users\\tester')
+  it('runs npm through a shell on Windows (npm.cmd shim) and never adds a --prefix', () => {
+    // Even if an override is passed, Windows must ignore it (%APPDATA%\npm is already user-writable).
+    const spec = getInstallSpawnSpec('npm', 'win32', 'C:\\Users\\tester\\.local')
 
     expect(spec.command).toBe('npm')
-    // Windows global npm bin (%APPDATA%\npm) is already user-writable, so no --prefix is needed.
     expect(spec.args).toEqual(['i', '-g', '@anthropic-ai/claude-code'])
     expect(spec.shell).toBe(true)
   })
@@ -119,12 +129,15 @@ describe('claude-install: run', () => {
       source: 'npm',
       installId: 'install-1',
       onLog: (event) => logs.push(event),
-      spawnImpl: () => child as never
+      spawnImpl: () => child as never,
+      npmPrefixWritable: () => Promise.resolve(true)
     })
 
-    child.stdout.emit('data', Buffer.from('adding package\n'))
-    child.stderr.emit('data', Buffer.from('warn\n'))
-    child.emit('exit', 0)
+    setImmediate(() => {
+      child.stdout.emit('data', Buffer.from('adding package\n'))
+      child.stderr.emit('data', Buffer.from('warn\n'))
+      child.emit('exit', 0)
+    })
 
     const result = await promise
 
@@ -141,10 +154,11 @@ describe('claude-install: run', () => {
       source: 'npm',
       installId: 'install-2',
       onLog: () => undefined,
-      spawnImpl: () => child as never
+      spawnImpl: () => child as never,
+      npmPrefixWritable: () => Promise.resolve(true)
     })
 
-    child.emit('exit', 1)
+    setImmediate(() => child.emit('exit', 1))
 
     await expect(promise).resolves.toMatchObject({ ok: false, exitCode: 1 })
   })
@@ -154,6 +168,7 @@ describe('claude-install: run', () => {
       source: 'npm',
       installId: 'install-3',
       onLog: () => undefined,
+      npmPrefixWritable: () => Promise.resolve(true),
       spawnImpl: () => {
         throw new Error('spawn npm ENOENT')
       }
@@ -184,11 +199,14 @@ describe('claude-install: run', () => {
       source: 'npm',
       installId: 'install-5',
       onLog: () => undefined,
-      spawnImpl: () => child as never
+      spawnImpl: () => child as never,
+      npmPrefixWritable: () => Promise.resolve(true)
     })
 
-    child.stderr.emit('data', Buffer.from('npm error code EACCES'))
-    child.emit('exit', 1)
+    setImmediate(() => {
+      child.stderr.emit('data', Buffer.from('npm error code EACCES'))
+      child.emit('exit', 1)
+    })
 
     const result = await promise
 
@@ -210,7 +228,8 @@ describe('claude-install: run with region-block fallback', () => {
       installId: 'install-6',
       onLog: (event) => logs.push(event),
       spawnImpl: spawn as never,
-      npmProbe: () => Promise.resolve()
+      npmProbe: () => Promise.resolve(),
+      npmPrefixWritable: () => Promise.resolve(true)
     })
 
     expect(commands).toEqual(['bash', 'npm'])
@@ -263,5 +282,99 @@ describe('claude-install: npm availability', () => {
     await expect(detectNpmAvailable(() => Promise.reject(new Error('not found')))).resolves.toEqual(
       { available: false }
     )
+  })
+})
+
+describe('claude-install: npm global prefix writability', () => {
+  it('reports writable when the prefix resolves and fs.access succeeds', async () => {
+    await expect(
+      isNpmGlobalPrefixWritable({
+        runNpmPrefix: () => Promise.resolve({ stdout: '/opt/homebrew\n' }),
+        access: () => Promise.resolve()
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('reports not writable when fs.access rejects (root-owned prefix)', async () => {
+    await expect(
+      isNpmGlobalPrefixWritable({
+        runNpmPrefix: () => Promise.resolve({ stdout: '/usr/local\n' }),
+        access: () => Promise.reject(new Error('EACCES'))
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('reports not writable when `npm prefix -g` fails (safe fallback)', async () => {
+    await expect(
+      isNpmGlobalPrefixWritable({
+        runNpmPrefix: () => Promise.reject(new Error('npm not found')),
+        access: () => Promise.resolve()
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('reports not writable when the resolved prefix is empty', async () => {
+    await expect(
+      isNpmGlobalPrefixWritable({
+        runNpmPrefix: () => Promise.resolve({ stdout: '   \n' }),
+        access: () => Promise.resolve()
+      })
+    ).resolves.toBe(false)
+  })
+})
+
+describe('claude-install: run redirects npm prefix only when needed', () => {
+  // Captures the args passed to the spawned command, then exits 0 on the next tick so runInstall's
+  // listeners (attached after the async prefix probe) are already in place.
+  const capturingSpawn = (): {
+    spawn: (command: string, args: string[]) => FakeChild
+    args: () => string[]
+  } => {
+    let captured: string[] = []
+    const spawn = (_command: string, args: string[]): FakeChild => {
+      captured = args
+      const child = new FakeChild()
+
+      setImmediate(() => child.emit('exit', 0))
+
+      return child
+    }
+
+    return { spawn, args: () => captured }
+  }
+
+  it('adds --prefix ~/.local when the global prefix is not writable', async () => {
+    const { spawn, args } = capturingSpawn()
+
+    await runInstall({
+      source: 'npm',
+      installId: 'install-prefix-1',
+      onLog: () => undefined,
+      spawnImpl: spawn as never,
+      npmPrefixWritable: () => Promise.resolve(false)
+    })
+
+    expect(args()).toEqual([
+      'i',
+      '-g',
+      '@anthropic-ai/claude-code',
+      '--prefix',
+      join(homedir(), '.local')
+    ])
+  })
+
+  it('omits --prefix when the global prefix is writable', async () => {
+    const { spawn, args } = capturingSpawn()
+
+    await runInstall({
+      source: 'npm',
+      installId: 'install-prefix-2',
+      onLog: () => undefined,
+      spawnImpl: spawn as never,
+      npmPrefixWritable: () => Promise.resolve(true)
+    })
+
+    expect(args()).toEqual(['i', '-g', '@anthropic-ai/claude-code'])
+    expect(args().includes('--prefix')).toBe(false)
   })
 })

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -1,5 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { execFile } from 'node:child_process'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import { promisify } from 'node:util'
 
 import type {
@@ -27,18 +29,24 @@ type InstallSpawnSpec = {
 
 // Builds the exact spawn command/args for a source on a given platform. Windows: npm runs through the
 // shell (npm.cmd), and the official installer is the PowerShell script (install.ps1); other platforms
-// keep npm bare and pipe the shell script through bash. All args are hard-coded constants, so shell
-// use here carries no injection risk.
+// keep npm bare and pipe the shell script through bash. On Unix, npm's global install is redirected to
+// a user-writable `~/.local` prefix so it never needs sudo (the system prefix is often root-owned); the
+// resulting `~/.local/bin/claude` is already probed by detection and on the augmented PATH. Windows'
+// global npm bin (%APPDATA%\npm) is already user-writable, so no prefix override is needed there. All
+// args are hard-coded constants, so shell use here carries no injection risk.
 const getInstallSpawnSpec = (
   source: ClaudeInstallSource,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  homePath: string = homedir()
 ): InstallSpawnSpec => {
   const isWindows = platform === 'win32'
 
   if (source === 'npm') {
     return {
       command: 'npm',
-      args: ['i', '-g', '@anthropic-ai/claude-code'],
+      args: isWindows
+        ? ['i', '-g', '@anthropic-ai/claude-code']
+        : ['i', '-g', '@anthropic-ai/claude-code', '--prefix', join(homePath, '.local')],
       shell: isWindows
     }
   }
@@ -63,6 +71,27 @@ const getInstallSpawnSpec = (
 // Default guard so a hung network install cannot block the wizard forever.
 const DEFAULT_INSTALL_TIMEOUT_MS = 5 * 60 * 1000
 
+// Cap on retained installer output used only for region-block detection (keeps memory bounded on a
+// chatty install while still holding enough tail to spot the HTML signature).
+const REGION_BLOCK_SCAN_LIMIT = 16 * 1024
+
+// Signatures of the official installer being served a region-block HTML page instead of the shell
+// script: `curl … | bash` then pipes HTML into bash, which fails with a syntax error near `<`. Any of
+// these in the output means the download was blocked, not that the machine is misconfigured.
+const REGION_BLOCK_MARKERS = [
+  '<!doctype html',
+  '<html',
+  'app unavailable in region',
+  'syntax error near unexpected token'
+]
+
+// Whether installer output looks like the region-block HTML page (used to trigger the npm fallback).
+const isRegionBlockedOutput = (text: string): boolean => {
+  const haystack = text.toLowerCase()
+
+  return REGION_BLOCK_MARKERS.some((marker) => haystack.includes(marker))
+}
+
 export type RunInstallOptions = {
   source: ClaudeInstallSource
   installId: string
@@ -75,6 +104,12 @@ export type RunInstallOptions = {
     args: string[],
     options?: { shell?: boolean }
   ) => ChildProcessWithoutNullStreams
+}
+
+// Options for the region-block-aware install. Extends the run options with an injectable npm probe so
+// the fallback's availability check can be driven in tests without shelling out to a real npm.
+export type RunInstallWithFallbackOptions = RunInstallOptions & {
+  npmProbe?: () => Promise<unknown>
 }
 
 // Real installer spawn with piped stdio. PATH is augmented so a GUI-launched app can still find npm,
@@ -121,6 +156,12 @@ const runInstall = ({
 
     let settled = false
     let timedOut = false
+    // Bounded tail of stdout+stderr, scanned on failure to spot a region-block HTML page.
+    let captured = ''
+
+    const capture = (chunk: string): void => {
+      captured = (captured + chunk).slice(-REGION_BLOCK_SCAN_LIMIT)
+    }
 
     // Ensures we resolve exactly once across exit/error/timeout races.
     const settle = (result: ClaudeInstallResult): void => {
@@ -138,11 +179,15 @@ const runInstall = ({
     }, timeoutMs)
 
     child.stdout.on('data', (data: Buffer) => {
-      onLog({ installId, stream: 'stdout', chunk: data.toString('utf8') })
+      const chunk = data.toString('utf8')
+      capture(chunk)
+      onLog({ installId, stream: 'stdout', chunk })
     })
 
     child.stderr.on('data', (data: Buffer) => {
-      onLog({ installId, stream: 'stderr', chunk: data.toString('utf8') })
+      const chunk = data.toString('utf8')
+      capture(chunk)
+      onLog({ installId, stream: 'stderr', chunk })
     })
 
     child.on('error', (error) => {
@@ -150,11 +195,17 @@ const runInstall = ({
     })
 
     child.on('exit', (code) => {
+      const ok = !timedOut && code === 0
+
       settle({
         installId,
-        ok: !timedOut && code === 0,
+        ok,
         exitCode: code ?? undefined,
-        timedOut: timedOut || undefined
+        timedOut: timedOut || undefined,
+        // Only the official script can be served the region-block page; flag it so callers can retry
+        // with npm instead of surfacing a cryptic `syntax error near '<'`.
+        regionBlocked:
+          !ok && source === 'official-script' && isRegionBlockedOutput(captured) ? true : undefined
       })
     })
   })
@@ -181,4 +232,40 @@ const detectNpmAvailable = async (
   }
 }
 
-export { DEFAULT_INSTALL_TIMEOUT_MS, detectNpmAvailable, getInstallSpawnSpec, runInstall }
+// Runs the chosen install source and, when the official script comes back region-blocked, transparently
+// retries with npm (which after the ~/.local prefix change needs no sudo). The fallback only fires when
+// npm is actually available, so a machine without npm still gets the original, honest failure plus its
+// copyable manual commands. Deps mirror runInstall/detectNpmAvailable so the whole flow stays testable.
+const runInstallWithFallback = async ({
+  source,
+  installId,
+  onLog,
+  timeoutMs,
+  spawnImpl,
+  npmProbe
+}: RunInstallWithFallbackOptions): Promise<ClaudeInstallResult> => {
+  const result = await runInstall({ source, installId, onLog, timeoutMs, spawnImpl })
+
+  if (result.ok || source !== 'official-script' || !result.regionBlocked) return result
+
+  const { available } = await detectNpmAvailable(npmProbe)
+
+  if (!available) return result
+
+  onLog({
+    installId,
+    stream: 'system',
+    chunk: 'Official installer looks unavailable in your region; falling back to npm…'
+  })
+
+  return runInstall({ source: 'npm', installId, onLog, timeoutMs, spawnImpl })
+}
+
+export {
+  DEFAULT_INSTALL_TIMEOUT_MS,
+  detectNpmAvailable,
+  getInstallSpawnSpec,
+  isRegionBlockedOutput,
+  runInstall,
+  runInstallWithFallback
+}

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -1,7 +1,9 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { execFile } from 'node:child_process'
+import { constants as fsConstants } from 'node:fs'
+import { access as fsAccess } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 
 import type {
@@ -30,23 +32,26 @@ type InstallSpawnSpec = {
 // Builds the exact spawn command/args for a source on a given platform. Windows: npm runs through the
 // shell (npm.cmd), and the official installer is the PowerShell script (install.ps1); other platforms
 // keep npm bare and pipe the shell script through bash. On Unix, npm's global install is redirected to
-// a user-writable `~/.local` prefix so it never needs sudo (the system prefix is often root-owned); the
-// resulting `~/.local/bin/claude` is already probed by detection and on the augmented PATH. Windows'
-// global npm bin (%APPDATA%\npm) is already user-writable, so no prefix override is needed there. All
-// args are hard-coded constants, so shell use here carries no injection risk.
+// a user-writable prefix (`npmPrefixOverride`, e.g. `~/.local`) ONLY when the caller has determined the
+// default global prefix is not user-writable — otherwise a plain `npm i -g` is used so Homebrew/nvm/volta
+// users keep their expected, PATH-visible location. Windows' global npm bin (%APPDATA%\npm) is already
+// user-writable, so no prefix override is ever added there. All args are hard-coded constants (the
+// override is a resolved directory path, not user input), so shell use here carries no injection risk.
 const getInstallSpawnSpec = (
   source: ClaudeInstallSource,
   platform: NodeJS.Platform = process.platform,
-  homePath: string = homedir()
+  npmPrefixOverride?: string
 ): InstallSpawnSpec => {
   const isWindows = platform === 'win32'
 
   if (source === 'npm') {
+    const baseArgs = ['i', '-g', '@anthropic-ai/claude-code']
+
     return {
       command: 'npm',
-      args: isWindows
-        ? ['i', '-g', '@anthropic-ai/claude-code']
-        : ['i', '-g', '@anthropic-ai/claude-code', '--prefix', join(homePath, '.local')],
+      // Redirect to the fallback prefix only off Windows and only when the caller supplied one.
+      args:
+        !isWindows && npmPrefixOverride ? [...baseArgs, '--prefix', npmPrefixOverride] : baseArgs,
       shell: isWindows
     }
   }
@@ -92,6 +97,60 @@ const isRegionBlockedOutput = (text: string): boolean => {
   return REGION_BLOCK_MARKERS.some((marker) => haystack.includes(marker))
 }
 
+// Injectable deps for the npm-global-prefix writability probe. Both default to real npm/fs but are
+// swappable so tests run offline without shelling out or touching the filesystem.
+type NpmGlobalPrefixWritableDeps = {
+  // Resolves npm's global prefix by running `npm prefix -g`, mirroring how detectNpmAvailable runs npm.
+  runNpmPrefix?: () => Promise<{ stdout: string }>
+  // Access check against a mode (F_OK for existence, W_OK for writability).
+  access?: (path: string, mode: number) => Promise<void>
+}
+
+// Reports whether npm's default global prefix is writable by the current user, i.e. whether a plain
+// `npm i -g` would succeed without sudo. On Unix `-g` writes module dirs under <prefix>/lib/node_modules;
+// if that leaf doesn't exist yet npm creates it, so we probe the nearest existing ancestor's writability.
+// Any error or uncertainty (npm missing, empty prefix, access denied) is treated as NOT writable so the
+// caller safely falls back to a user-owned prefix instead of failing with EACCES.
+const isNpmGlobalPrefixWritable = async ({
+  runNpmPrefix = () =>
+    execFileAsync('npm', ['prefix', '-g'], {
+      timeout: 10_000,
+      // On Windows npm is an `npm.cmd` shim that execFile can't launch without a shell.
+      shell: process.platform === 'win32',
+      windowsHide: true,
+      env: augmentedPathEnv()
+    }),
+  access = fsAccess
+}: NpmGlobalPrefixWritableDeps = {}): Promise<boolean> => {
+  try {
+    const { stdout } = await runNpmPrefix()
+    const prefix = stdout.trim()
+
+    if (!prefix) return false
+
+    // Walk up from <prefix>/lib/node_modules to the nearest directory that already exists; npm will
+    // create any missing leaves, so the meaningful permission is on that existing ancestor.
+    let target = join(prefix, 'lib', 'node_modules')
+
+    for (;;) {
+      try {
+        await access(target, fsConstants.F_OK)
+        break
+      } catch {
+        const parent = dirname(target)
+        if (parent === target) return false
+        target = parent
+      }
+    }
+
+    await access(target, fsConstants.W_OK)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
 export type RunInstallOptions = {
   source: ClaudeInstallSource
   installId: string
@@ -104,6 +163,9 @@ export type RunInstallOptions = {
     args: string[],
     options?: { shell?: boolean }
   ) => ChildProcessWithoutNullStreams
+  // Injectable probe for whether npm's default global prefix is user-writable. When it is NOT (a
+  // root-owned system prefix), the npm install is redirected to ~/.local so it never needs sudo.
+  npmPrefixWritable?: () => Promise<boolean>
 }
 
 // Options for the region-block-aware install. Extends the run options with an injectable npm probe so
@@ -128,14 +190,23 @@ const defaultInstallSpawn = (
 
 // Runs an install source to completion, forwarding every stdout/stderr chunk through onLog and
 // enforcing a timeout. Resolves (never rejects) with a structured result the service can act on.
-const runInstall = ({
+const runInstall = async ({
   source,
   installId,
   onLog,
   timeoutMs = DEFAULT_INSTALL_TIMEOUT_MS,
-  spawnImpl = defaultInstallSpawn
+  spawnImpl = defaultInstallSpawn,
+  npmPrefixWritable = () => isNpmGlobalPrefixWritable()
 }: RunInstallOptions): Promise<ClaudeInstallResult> => {
-  const spec = getInstallSpawnSpec(source)
+  // Redirect npm's global install to a user-owned prefix only off Windows and only when the default
+  // global prefix isn't writable (would otherwise need sudo). Homebrew/nvm/volta users keep a plain
+  // `npm i -g` at their expected, PATH-visible location.
+  const npmPrefixOverride =
+    source === 'npm' && process.platform !== 'win32' && !(await npmPrefixWritable())
+      ? join(homedir(), '.local')
+      : undefined
+
+  const spec = getInstallSpawnSpec(source, process.platform, npmPrefixOverride)
 
   onLog({ installId, stream: 'system', chunk: `$ ${spec.command} ${spec.args.join(' ')}` })
 
@@ -233,18 +304,28 @@ const detectNpmAvailable = async (
 }
 
 // Runs the chosen install source and, when the official script comes back region-blocked, transparently
-// retries with npm (which after the ~/.local prefix change needs no sudo). The fallback only fires when
-// npm is actually available, so a machine without npm still gets the original, honest failure plus its
-// copyable manual commands. Deps mirror runInstall/detectNpmAvailable so the whole flow stays testable.
+// retries with npm. The npm retry redirects to a user-owned prefix only when the default global prefix
+// isn't writable, so it needs no sudo while still respecting a writable Homebrew/nvm prefix. The fallback
+// only fires when npm is actually available, so a machine without npm still gets the original, honest
+// failure plus its copyable manual commands. Deps mirror runInstall/detectNpmAvailable so the whole flow
+// stays testable.
 const runInstallWithFallback = async ({
   source,
   installId,
   onLog,
   timeoutMs,
   spawnImpl,
-  npmProbe
+  npmProbe,
+  npmPrefixWritable
 }: RunInstallWithFallbackOptions): Promise<ClaudeInstallResult> => {
-  const result = await runInstall({ source, installId, onLog, timeoutMs, spawnImpl })
+  const result = await runInstall({
+    source,
+    installId,
+    onLog,
+    timeoutMs,
+    spawnImpl,
+    npmPrefixWritable
+  })
 
   if (result.ok || source !== 'official-script' || !result.regionBlocked) return result
 
@@ -258,13 +339,14 @@ const runInstallWithFallback = async ({
     chunk: 'Official installer looks unavailable in your region; falling back to npm…'
   })
 
-  return runInstall({ source: 'npm', installId, onLog, timeoutMs, spawnImpl })
+  return runInstall({ source: 'npm', installId, onLog, timeoutMs, spawnImpl, npmPrefixWritable })
 }
 
 export {
   DEFAULT_INSTALL_TIMEOUT_MS,
   detectNpmAvailable,
   getInstallSpawnSpec,
+  isNpmGlobalPrefixWritable,
   isRegionBlockedOutput,
   runInstall,
   runInstallWithFallback

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -57,7 +57,7 @@ import {
 import { resolveStorageRoot } from '../storage-root'
 import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
-import { detectNpmAvailable, runInstall } from './claude-install'
+import { detectNpmAvailable, runInstallWithFallback } from './claude-install'
 import {
   installManagedClaude,
   managedClaudeDir,
@@ -370,7 +370,8 @@ class SettingsService {
 
   // Runs the one-click installer, then re-detects claude so a success immediately unblocks the gate.
   // The app-managed source downloads the native binary itself and persists its exact path; the npm and
-  // official-script sources shell out and rely on PATH re-detection.
+  // official-script sources shell out (with an automatic npm fallback when the official script is
+  // region-blocked) and rely on PATH re-detection.
   async installClaude(
     request: InstallClaudeRequest,
     onLog: (event: ClaudeInstallLogEvent) => void
@@ -395,7 +396,7 @@ class SettingsService {
       return outcome.result
     }
 
-    const result = await runInstall({ source: request.source, installId, onLog })
+    const result = await runInstallWithFallback({ source: request.source, installId, onLog })
 
     if (result.ok) {
       await this.detectClaude()

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -245,6 +245,9 @@ export type ClaudeInstallResult = {
   exitCode?: number
   timedOut?: boolean
   error?: string
+  // The official installer returned a region-block HTML page instead of the script (common in
+  // regions where claude.ai is unavailable); the installer auto-falls-back to npm when it can.
+  regionBlocked?: boolean
 }
 
 // Availability of npm on the host, used to gate the npm source.


### PR DESCRIPTION
Fixes two ways the one-click Claude installer failed during onboarding.

**Sudo-free npm install (macOS/Linux).** A global `npm i -g` targets the npm global prefix, which is root-owned when Node was installed from the nodejs.org pkg (`/usr/local/lib/node_modules`) — so it dies with EACCES and demands sudo, which the app cannot provide. The installer now probes whether the global prefix is user-writable (`npm prefix -g` + `fs.access(W_OK)`, walking to the nearest existing ancestor) and only then redirects to `--prefix ~/.local` (already on the augmented PATH and probed by detection). When the prefix is already writable (Homebrew/nvm/fnm/volta/asdf), it stays a plain `npm i -g`. Windows is unchanged (its global npm bin is already user-writable).

**Region-block fallback.** Where claude.ai is blocked, `curl -fsSL https://claude.ai/install.sh | bash` is served an HTML "unavailable in region" page, which bash chokes on (`syntax error near unexpected token '<'`). `runInstall` now detects that HTML signature and flags the result `regionBlocked`; the service transparently retries with npm (when npm is available), logging a system line so the fallback is visible.

Adds `isRegionBlockedOutput`, `isNpmGlobalPrefixWritable`, and `runInstallWithFallback` with full unit coverage. All dependencies (spawn, npm probe, fs) are injectable, so the suite stays offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)