### PR TITLE
fix(settings): surface provider error on failed connection test

### DIFF
--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -4,6 +4,7 @@ import {
   buildValidationRequest,
   classifyFetchError,
   classifyStatus,
+  extractProviderErrorMessage,
   validateProvider
 } from './validate'
 
@@ -64,6 +65,46 @@ describe('validate: classification', () => {
   })
 })
 
+describe('validate: error-body extraction', () => {
+  it('reads a nested error.message (Anthropic/OpenAI/DeepSeek shape)', () => {
+    expect(extractProviderErrorMessage('{"error":{"message":"Insufficient Balance"}}')).toBe(
+      'Insufficient Balance'
+    )
+  })
+
+  it('reads a bare string error or top-level message', () => {
+    expect(extractProviderErrorMessage('{"error":"rate limited"}')).toBe('rate limited')
+    expect(extractProviderErrorMessage('{"message":"model not deployed"}')).toBe(
+      'model not deployed'
+    )
+  })
+
+  it('falls back to the raw body for non-JSON, collapsing whitespace', () => {
+    expect(extractProviderErrorMessage('  Bad\n Gateway  ')).toBe('Bad Gateway')
+  })
+
+  it('suppresses an HTML/markup error page (5xx gateway page)', () => {
+    const html = '<html><head><title>502 Bad Gateway</title></head><body>nginx</body></html>'
+
+    expect(extractProviderErrorMessage(html)).toBeUndefined()
+  })
+
+  it('returns undefined for an empty or messageless body', () => {
+    expect(extractProviderErrorMessage('')).toBeUndefined()
+    expect(extractProviderErrorMessage('   ')).toBeUndefined()
+    expect(extractProviderErrorMessage('{"foo":"bar"}')).toBeUndefined()
+  })
+
+  it('truncates an overlong message', () => {
+    const message = extractProviderErrorMessage(
+      JSON.stringify({ error: { message: 'x'.repeat(500) } })
+    )
+
+    expect(message).toHaveLength(301)
+    expect(message?.endsWith('…')).toBe(true)
+  })
+})
+
 describe('validate: provider dispatch', () => {
   it('returns ok for a 200 custom response', async () => {
     const fetchImpl = vi.fn().mockResolvedValue({ status: 200 } as Response)
@@ -76,8 +117,13 @@ describe('validate: provider dispatch', () => {
     expect(result).toMatchObject({ ok: true, category: 'ok', status: 200 })
   })
 
-  it('classifies a 401 custom response as auth', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ status: 401 } as Response)
+  it('keeps the friendly auth guidance and does not surface a raw 401 body', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      status: 401,
+      // Even when the gateway returns a body, an auth failure keeps its targeted advice, so the raw
+      // text is deliberately ignored here.
+      text: () => Promise.resolve('{"error":{"message":"invalid api key"}}')
+    } as unknown as Response)
 
     const result = await validateProvider(
       { type: 'custom', baseUrl: 'https://g/v1', key: 'k' },
@@ -85,6 +131,61 @@ describe('validate: provider dispatch', () => {
     )
 
     expect(result).toMatchObject({ ok: false, category: 'auth', status: 401 })
+    expect(result.message).toBeUndefined()
+  })
+
+  it('surfaces the gateway error body on a billing 402 (DeepSeek insufficient balance)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      status: 402,
+      text: () =>
+        Promise.resolve('{"error":{"message":"Insufficient Balance","type":"unknown_error"}}')
+    } as unknown as Response)
+
+    const result = await validateProvider(
+      { type: 'custom', baseUrl: 'https://api.deepseek.com', key: 'k', model: 'deepseek-chat' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      category: 'unknown',
+      status: 402,
+      message: 'Insufficient Balance'
+    })
+  })
+
+  it('surfaces a JSON 5xx error message (e.g. an overloaded upstream)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      status: 503,
+      text: () => Promise.resolve('{"error":{"message":"Service temporarily unavailable"}}')
+    } as unknown as Response)
+
+    const result = await validateProvider(
+      { type: 'custom', baseUrl: 'https://g/v1', key: 'k' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      category: 'unknown',
+      status: 503,
+      message: 'Service temporarily unavailable'
+    })
+  })
+
+  it('tolerates an unreadable error body without throwing', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      status: 500,
+      text: () => Promise.reject(new Error('stream closed'))
+    } as unknown as Response)
+
+    const result = await validateProvider(
+      { type: 'custom', baseUrl: 'https://g/v1', key: 'k' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    )
+
+    expect(result).toMatchObject({ ok: false, category: 'unknown', status: 500 })
+    expect(result.message).toBeUndefined()
   })
 
   it('classifies a thrown fetch as network', async () => {

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -85,6 +85,60 @@ const toResult = (
   ...extra
 })
 
+// Cap on a surfaced provider error so a runaway HTML/error page can't flood the UI.
+const MAX_ERROR_MESSAGE_LENGTH = 300
+
+// Digs the human-readable error string out of a parsed error body. Anthropic- and
+// OpenAI/DeepSeek-compatible gateways nest it under `error.message`; some return a bare `message` or
+// a string `error` (e.g. DeepSeek's "Insufficient Balance" on a 402).
+const pickErrorMessage = (parsed: unknown): string | undefined => {
+  if (!parsed || typeof parsed !== 'object') return undefined
+
+  const { error, message } = parsed as { error?: unknown; message?: unknown }
+
+  if (typeof error === 'string') return error
+  if (error && typeof error === 'object') {
+    const nested = (error as { message?: unknown }).message
+    if (typeof nested === 'string') return nested
+  }
+  if (typeof message === 'string') return message
+
+  return undefined
+}
+
+// Turns a provider's raw error body into a short, single-line message, or undefined when it carries
+// nothing usable. Non-JSON bodies (an HTML/plain-text gateway error page) fall back to the raw text.
+const extractProviderErrorMessage = (bodyText: string): string | undefined => {
+  const trimmed = bodyText.trim()
+  if (!trimmed) return undefined
+
+  let message: string | undefined
+  try {
+    message = pickErrorMessage(JSON.parse(trimmed))
+  } catch {
+    // Not JSON — surface a short plain-text error, but skip an HTML/markup body (a 5xx gateway error
+    // page from nginx/Cloudflare) whose tags would be noise rather than a reason.
+    message = trimmed.startsWith('<') ? undefined : trimmed
+  }
+  if (!message) return undefined
+
+  const collapsed = message.replace(/\s+/g, ' ').trim()
+  if (!collapsed) return undefined
+
+  return collapsed.length > MAX_ERROR_MESSAGE_LENGTH
+    ? `${collapsed.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`
+    : collapsed
+}
+
+// Reads and extracts a failed response's error message, tolerating a body that can't be read.
+const readProviderErrorMessage = async (response: Response): Promise<string | undefined> => {
+  try {
+    return extractProviderErrorMessage(await response.text())
+  } catch {
+    return undefined
+  }
+}
+
 // Outcome of the one-shot claude-default probe. `timedOut` lets the UI show a timeout message instead
 // of a misleading auth failure when the local claude never responds.
 export type ClaudeProbeResult = {
@@ -126,6 +180,17 @@ const validateCustomProvider = async (
       signal: controller.signal
     })
     const category = classifyStatus(response.status)
+
+    // Only the catch-all 'unknown' status (402 billing, 429 rate limit, 5xx, …) lacks guidance of its
+    // own, so surface the gateway's error text there — whatever it actually says — rather than an
+    // assumed meaning. auth/model-not-found already map to targeted advice, so their raw bodies would
+    // only muddy it.
+    if (category === 'unknown') {
+      return toResult(category, {
+        status: response.status,
+        message: await readProviderErrorMessage(response)
+      })
+    }
 
     return toResult(category, { status: response.status })
   } catch (error) {
@@ -179,5 +244,6 @@ export {
   buildValidationRequest,
   classifyFetchError,
   classifyStatus,
+  extractProviderErrorMessage,
   validateProvider
 }

--- a/src/renderer/src/pages/settings/validation-message.test.ts
+++ b/src/renderer/src/pages/settings/validation-message.test.ts
@@ -18,4 +18,21 @@ describe('describeValidation', () => {
       'Authentication failed. Check the API key. (HTTP 401)'
     )
   })
+
+  it('surfaces the gateway message for an unknown failure instead of the generic copy', () => {
+    expect(
+      describeValidation({
+        ok: false,
+        category: 'unknown',
+        status: 402,
+        message: 'Insufficient Balance'
+      })
+    ).toBe('Insufficient Balance (HTTP 402)')
+  })
+
+  it('falls back to the generic unknown copy when no message is present', () => {
+    expect(describeValidation({ ok: false, category: 'unknown', status: 402 })).toBe(
+      'Validation failed for an unknown reason. (HTTP 402)'
+    )
+  })
 })

--- a/src/renderer/src/pages/settings/validation-message.ts
+++ b/src/renderer/src/pages/settings/validation-message.ts
@@ -27,6 +27,12 @@ const describeValidation = (result: ValidateProviderResult): string => {
     return result.message
   }
 
+  // A gateway that rejected the probe with its own error text (e.g. "Insufficient Balance" on a
+  // billing 402) has already told us the reason — surface it instead of the generic "unknown" copy.
+  if (result.category === 'unknown' && result.message) {
+    return result.status ? `${result.message} (HTTP ${result.status})` : result.message
+  }
+
   if (result.message && MESSAGE_CATEGORIES.has(result.category)) {
     return `${base} (${result.message})`
   }


### PR DESCRIPTION
## Problem

Testing a custom provider (e.g. DeepSeek) whose account is in arrears returned a useless message:

> Validation failed for an unknown reason. (HTTP 402)

The validation code only inspected the HTTP **status** and threw away the response **body**. Any status outside the `auth` (401/403) and `model-not-found` (400/404) buckets collapsed to the generic `unknown` copy, hiding the gateway's real reason — for a 402 that's DeepSeek's `Insufficient Balance`.

## Fix

This is **not** 402-specific — we stopped interpreting the status code and started quoting the provider:

- For the catch-all `unknown` category (402 billing, 429 rate limit, 5xx), read the response body and extract the provider's own error message from the common shapes: nested `error.message` (Anthropic/OpenAI/DeepSeek), a bare string `error`, or a top-level `message`.
- **HTML/markup error pages** (nginx/Cloudflare 5xx) and unreadable bodies are suppressed, so the UI falls back to a clean `(HTTP xxx)` instead of tag soup. Messages are whitespace-collapsed and capped at 300 chars.
- `describeValidation` now leads with that message instead of the generic "unknown reason" text.
- `auth` / `model-not-found` keep their targeted guidance — their raw bodies are deliberately **not** surfaced, so friendly "check the API key" advice is preserved.

## Result

| Status | Before | After |
|---|---|---|
| 402 (DeepSeek arrears) | `Validation failed for an unknown reason. (HTTP 402)` | `Insufficient Balance (HTTP 402)` |
| 429 / JSON 5xx | generic unknown | provider's message |
| HTML 5xx page | — | clean `(HTTP 502)`, no HTML |
| 401 / 403 / 400 / 404 | friendly guidance | unchanged |

## Tests

24 tests pass (`validate.test.ts` + `validation-message.test.ts`): message extraction across all shapes, HTML suppression, unreadable-body tolerance, 402/503 dispatch, and that auth failures still keep their guidance. Full local gate (lint + typecheck + coverage + build) is green.