### PR TITLE
feat(connectors): expand the BioMart connector capabilities

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -264,9 +264,9 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
   {
     id: 'biomart',
     displayName: 'BioMart',
-    description: 'Ensembl BioMart identifier translation and attribute queries.',
+    description: 'Ensembl BioMart attribute queries and identifier translation.',
     useWhen:
-      'Use when you need Ensembl BioMart data — listing available marts, or querying gene attributes / cross-references (identifier translation) for a dataset with filters.',
+      'Use when you need Ensembl BioMart data — browsing the marts → datasets → attributes/filters hierarchy, running attribute queries (get_data) for a dataset with filters, or translating gene/transcript identifiers between attribute types (e.g. HGNC symbol → Ensembl gene ID).',
     sources: ['Ensembl BioMart'],
     termsUrl: 'https://www.ensembl.org/info/about/legal/disclaimer.html',
     requiresNcbi: false

--- a/src/main/connectors/descriptors/biomart.test.ts
+++ b/src/main/connectors/descriptors/biomart.test.ts
@@ -6,100 +6,232 @@ import type { ToolDescriptor } from '../types'
 const tool = (id: string): ToolDescriptor => BIOMART_TOOLS.find((t) => t.id === id)!
 const textRes = (body: string): Response =>
   ({ ok: true, status: 200, text: async () => body }) as Response
+const call = (id: string, args: Record<string, unknown>, body: string): Promise<unknown> => {
+  const fetchImpl = vi.fn().mockResolvedValue(textRes(body))
+  const engine = new ParserEngine({ fetchImpl })
+  return engine.call(tool(id), args, {}).then((out) => ({ out, url: fetchImpl.mock.calls[0][0] }))
+}
 
 const REGISTRY_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <MartRegistry>
-  <MartURLLocation database="ensembl_mart_115" default="1" displayName="Ensembl Genes 115" host="www.ensembl.org" name="ENSEMBL_MART_ENSEMBL" path="/biomart/martservice" port="443" serverVirtualSchema="default" visible="1" />
-  <MartURLLocation database="ensembl_mart_snp_115" default="0" displayName="Ensembl Variation 115" host="www.ensembl.org" name="ENSEMBL_MART_SNP" path="/biomart/martservice" port="443" serverVirtualSchema="default" visible="1" />
+  <MartURLLocation database="ensembl_mart_115" displayName="Ensembl Genes 115" name="ENSEMBL_MART_ENSEMBL" visible="1" />
+  <MartURLLocation database="ensembl_mart_snp_115" displayName="Ensembl Variation 115" name="ENSEMBL_MART_SNP" visible="1" />
+  <MartURLLocation database="hidden_mart" displayName="Hidden" name="HIDDEN" visible="0" />
 </MartRegistry>`
 
 describe('biomart / list_marts', () => {
-  it('parses the registry XML into name/displayName records', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(textRes(REGISTRY_XML))
-    const out = await new ParserEngine({ fetchImpl }).call(tool('biomart_list_marts'), {}, {})
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://www.ensembl.org/biomart/martservice?type=registry'
+  it('parses the registry XML into a name,display_name,description CSV, skipping hidden marts', async () => {
+    const { out, url } = (await call('list_marts', {}, REGISTRY_XML)) as {
+      out: string
+      url: string
+    }
+    expect(url).toBe('https://www.ensembl.org/biomart/martservice?type=registry')
+    expect(out).toBe(
+      'name,display_name,description\n' +
+        'ENSEMBL_MART_ENSEMBL,Ensembl Genes 115,Ensembl Genes 115\n' +
+        'ENSEMBL_MART_SNP,Ensembl Variation 115,Ensembl Variation 115'
     )
-    expect(out).toEqual([
-      { name: 'ENSEMBL_MART_ENSEMBL', displayName: 'Ensembl Genes 115' },
-      { name: 'ENSEMBL_MART_SNP', displayName: 'Ensembl Variation 115' }
-    ])
-  })
-
-  it('returns an empty array when the registry has no marts', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValue(textRes('<?xml version="1.0"?><MartRegistry></MartRegistry>'))
-    const out = await new ParserEngine({ fetchImpl }).call(tool('biomart_list_marts'), {}, {})
-    expect(out).toEqual([])
   })
 })
 
-describe('biomart / query', () => {
-  it('builds a GET query URL and parses sorted TSV rows', async () => {
-    const raw = 'ENSG00000141510\tTP53\nENSG00000012048\tBRCA1\n[success]\n'
-    const fetchImpl = vi.fn().mockResolvedValue(textRes(raw))
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('biomart_query'),
-      { dataset: 'hsapiens_gene_ensembl', attributes: ['ensembl_gene_id', 'external_gene_name'] },
-      {}
+describe('biomart / list_datasets', () => {
+  it('builds the datasets URL and parses TableSet rows into CSV (quoting commas)', async () => {
+    const body =
+      '\n' +
+      'TableSet\thsapiens_gene_ensembl\tHuman genes (GRCh38.p14)\t1\tGRCh38.p14\t200\t50000\tdefault\t2026-04-30\n' +
+      'TableSet\tmmusculus_gene_ensembl\tMouse genes, strain\t1\tGRCm39\t200\t50000\tdefault\t2026-04-30\n'
+    const { out, url } = (await call('list_datasets', { mart: 'ENSEMBL_MART_ENSEMBL' }, body)) as {
+      out: string
+      url: string
+    }
+    expect(url).toBe(
+      'https://www.ensembl.org/biomart/martservice?type=datasets&mart=ENSEMBL_MART_ENSEMBL'
     )
-    const url = fetchImpl.mock.calls[0][0] as string
+    expect(out).toBe(
+      'name,display_name,description\n' +
+        'hsapiens_gene_ensembl,Human genes (GRCh38.p14),GRCh38.p14\n' +
+        'mmusculus_gene_ensembl,"Mouse genes, strain",GRCm39'
+    )
+  })
+})
+
+const ATTRIBUTES_TSV =
+  'ensembl_gene_id\tGene stable ID\tStable ID of the Gene\tfeature_page\thtml\ttbl\tkey\n' +
+  'cdna_coding_start\tcDNA coding start\t\tfeature_page\thtml\ttbl\tkey\n' +
+  'ensembl_gene_id\tGene stable ID\t\tstructure\thtml\ttbl\tkey\n' +
+  'mmusculus_homolog_ensembl_gene\tMouse gene stable ID\t\thomologs\thtml\ttbl\tkey\n' +
+  'affy_hg_u133_plus_2\tAFFY HG U133 Plus 2 probe\t\tfeature_page\thtml\ttbl\tkey\n'
+
+describe('biomart / list_common_attributes', () => {
+  it('keeps only curated common attributes, deduped across pages', async () => {
+    const { out, url } = (await call(
+      'list_common_attributes',
+      { mart: 'ENSEMBL_MART_ENSEMBL', dataset: 'hsapiens_gene_ensembl' },
+      ATTRIBUTES_TSV
+    )) as { out: string; url: string }
+    expect(url).toBe(
+      'https://www.ensembl.org/biomart/martservice?type=attributes&dataset=hsapiens_gene_ensembl'
+    )
+    expect(out).toBe(
+      'name,display_name,description\nensembl_gene_id,Gene stable ID,Stable ID of the Gene'
+    )
+  })
+})
+
+describe('biomart / list_all_attributes', () => {
+  it('drops homologs and microarray probes, dedupes, and keeps the rest', async () => {
+    const { out } = (await call(
+      'list_all_attributes',
+      { mart: 'ENSEMBL_MART_ENSEMBL', dataset: 'hsapiens_gene_ensembl' },
+      ATTRIBUTES_TSV
+    )) as { out: string }
+    expect(out).toBe(
+      'name,display_name,description\n' +
+        'ensembl_gene_id,Gene stable ID,Stable ID of the Gene\n' +
+        'cdna_coding_start,cDNA coding start,'
+    )
+  })
+})
+
+describe('biomart / list_filters', () => {
+  it('parses filters into a name,description CSV', async () => {
+    const body =
+      'chromosome_name\tChromosome/scaffold name\t[1,2,3]\t\tfilters\ttext\t=\ttbl\tkey\n' +
+      'biotype\tGene type\t[protein_coding]\t\tfilters\ttext\t=\ttbl\tkey\n' +
+      'chromosome_name\tChromosome/scaffold name\t[1,2,3]\t\tfilters\ttext\t=\ttbl2\tkey\n'
+    const { out, url } = (await call(
+      'list_filters',
+      { mart: 'ENSEMBL_MART_ENSEMBL', dataset: 'hsapiens_gene_ensembl' },
+      body
+    )) as { out: string; url: string }
+    expect(url).toBe(
+      'https://www.ensembl.org/biomart/martservice?type=filters&dataset=hsapiens_gene_ensembl'
+    )
+    expect(out).toBe(
+      'name,description\nchromosome_name,Chromosome/scaffold name\nbiotype,Gene type'
+    )
+  })
+})
+
+describe('biomart / get_data', () => {
+  it('builds the query XML (attributes + filters) and returns a CSV with an attribute header', async () => {
+    const { out, url } = (await call(
+      'get_data',
+      {
+        mart: 'ENSEMBL_MART_ENSEMBL',
+        dataset: 'hsapiens_gene_ensembl',
+        attributes: ['ensembl_gene_id', 'external_gene_name'],
+        filters: { chromosome_name: 'Y', biotype: true }
+      },
+      'ENSG00000292363\tCRLF2\nENSG00000292344\tPLCXD1\n[success]\n'
+    )) as { out: string; url: string }
     expect(url.startsWith('https://www.ensembl.org/biomart/martservice?query=')).toBe(true)
     const xml = decodeURIComponent(url.split('query=')[1])
     expect(xml).toContain('<Dataset name="hsapiens_gene_ensembl" interface="default">')
     expect(xml).toContain('<Attribute name="ensembl_gene_id" />')
     expect(xml).toContain('<Attribute name="external_gene_name" />')
-    expect(xml).toContain('formatter="TSV"')
+    expect(xml).toContain('<Filter name="chromosome_name" value="Y" />')
+    expect(xml).toContain('<Filter name="biotype" value="only" />')
     expect(xml).toContain('completionStamp="1"')
-    expect(out).toEqual({
-      dataset: 'hsapiens_gene_ensembl',
-      columns: ['ensembl_gene_id', 'external_gene_name'],
-      rows: [
-        ['ENSG00000012048', 'BRCA1'],
-        ['ENSG00000141510', 'TP53']
-      ]
-    })
+    expect(out).toBe(
+      'ensembl_gene_id,external_gene_name\nENSG00000292363,CRLF2\nENSG00000292344,PLCXD1'
+    )
   })
 
-  it('includes filters in the query XML', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(textRes('[success]\n'))
-    await new ParserEngine({ fetchImpl }).call(
-      tool('biomart_query'),
+  it('returns a header-only CSV when nothing matches', async () => {
+    const { out } = (await call(
+      'get_data',
       {
+        mart: 'ENSEMBL_MART_ENSEMBL',
         dataset: 'hsapiens_gene_ensembl',
-        attributes: ['ensembl_gene_id'],
-        filters: { chromosome_name: '17', biotype: true }
+        attributes: ['ensembl_gene_id']
       },
-      {}
-    )
-    const url = fetchImpl.mock.calls[0][0] as string
-    const xml = decodeURIComponent(url.split('query=')[1])
-    expect(xml).toContain('<Filter name="chromosome_name" value="17" />')
-    expect(xml).toContain('<Filter name="biotype" value="only" />')
+      '[success]\n'
+    )) as { out: string }
+    expect(out).toBe('ensembl_gene_id')
   })
 
   it('throws on a rejected query (Query ERROR body)', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValue(textRes('Query ERROR: caught BioMart::Exception::Usage: bad attribute'))
     await expect(
-      new ParserEngine({ fetchImpl }).call(
-        tool('biomart_query'),
-        { dataset: 'hsapiens_gene_ensembl', attributes: ['ensembl_gene_id'] },
-        {}
+      call(
+        'get_data',
+        { mart: 'ENSEMBL_MART_ENSEMBL', dataset: 'hsapiens_gene_ensembl', attributes: ['bad'] },
+        'Query ERROR: caught BioMart::Exception::Usage: bad attribute'
       )
     ).rejects.toThrow(/BioMart query rejected/)
   })
 
   it('throws on a truncated response missing the completion stamp', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(textRes('ENSG00000141510'))
     await expect(
-      new ParserEngine({ fetchImpl }).call(
-        tool('biomart_query'),
-        { dataset: 'hsapiens_gene_ensembl', attributes: ['ensembl_gene_id'] },
-        {}
+      call(
+        'get_data',
+        {
+          mart: 'ENSEMBL_MART_ENSEMBL',
+          dataset: 'hsapiens_gene_ensembl',
+          attributes: ['ensembl_gene_id']
+        },
+        'ENSG00000141510'
       )
     ).rejects.toThrow(/completion stamp/)
+  })
+})
+
+describe('biomart / get_translation', () => {
+  it('builds a two-attribute query filtered by the source id and returns the mapped value', async () => {
+    const { out, url } = (await call(
+      'get_translation',
+      {
+        mart: 'ENSEMBL_MART_ENSEMBL',
+        dataset: 'hsapiens_gene_ensembl',
+        from_attr: 'hgnc_symbol',
+        to_attr: 'ensembl_gene_id',
+        target: 'TP53'
+      },
+      'TP53\tENSG00000141510\n[success]\n'
+    )) as { out: string; url: string }
+    const xml = decodeURIComponent(url.split('query=')[1])
+    expect(xml).toContain('<Filter name="hgnc_symbol" value="TP53" />')
+    expect(xml).toContain('<Attribute name="hgnc_symbol" />')
+    expect(xml).toContain('<Attribute name="ensembl_gene_id" />')
+    expect(out).toBe('ENSG00000141510')
+  })
+
+  it('returns a not-found message when the source id has no mapping', async () => {
+    const { out } = (await call(
+      'get_translation',
+      {
+        mart: 'ENSEMBL_MART_ENSEMBL',
+        dataset: 'hsapiens_gene_ensembl',
+        from_attr: 'hgnc_symbol',
+        to_attr: 'ensembl_gene_id',
+        target: 'NOPE'
+      },
+      '[success]\n'
+    )) as { out: string }
+    expect(out).toBe("No translation found for 'NOPE' (hgnc_symbol -> ensembl_gene_id).")
+  })
+})
+
+describe('biomart / batch_translate', () => {
+  it('maps found ids and reports the not-found ones', async () => {
+    const { out, url } = (await call(
+      'batch_translate',
+      {
+        mart: 'ENSEMBL_MART_ENSEMBL',
+        dataset: 'hsapiens_gene_ensembl',
+        from_attr: 'hgnc_symbol',
+        to_attr: 'ensembl_gene_id',
+        targets: ['TP53', 'BRCA1', 'BRCA2']
+      },
+      'TP53\tENSG00000141510\nBRCA1\tENSG00000012048\n[success]\n'
+    )) as { out: Record<string, unknown>; url: string }
+    const xml = decodeURIComponent(url.split('query=')[1])
+    expect(xml).toContain('<Filter name="hgnc_symbol" value="TP53,BRCA1,BRCA2" />')
+    expect(out).toEqual({
+      translations: { TP53: 'ENSG00000141510', BRCA1: 'ENSG00000012048' },
+      not_found: ['BRCA2'],
+      found_count: 2,
+      not_found_count: 1
+    })
   })
 })

--- a/src/main/connectors/descriptors/biomart.ts
+++ b/src/main/connectors/descriptors/biomart.ts
@@ -3,6 +3,49 @@ import type { ToolDescriptor } from '../types'
 
 const MARTSERVICE = 'https://www.ensembl.org/biomart/martservice'
 const COMPLETION_STAMP = '[success]'
+// Ensembl marts share a single virtual schema; the martservice attribute/filter/query endpoints key
+// off the dataset name, so `mart` is part of the tool signature only for datasets discovery + parity.
+const VIRTUAL_SCHEMA = 'default'
+
+// Curated set of the most-used gene attributes, surfaced by list_common_attributes so the model gets a
+// short, high-signal menu instead of the full (hundreds-long) attribute list from list_all_attributes.
+const COMMON_ATTRIBUTES = new Set<string>([
+  'ensembl_gene_id',
+  'ensembl_gene_id_version',
+  'ensembl_transcript_id',
+  'ensembl_transcript_id_version',
+  'ensembl_peptide_id',
+  'ensembl_peptide_id_version',
+  'external_gene_name',
+  'external_transcript_name',
+  'description',
+  'chromosome_name',
+  'start_position',
+  'end_position',
+  'strand',
+  'band',
+  'gene_biotype',
+  'transcript_biotype',
+  'source',
+  'hgnc_id',
+  'hgnc_symbol',
+  'entrezgene_id',
+  'entrezgene_accession',
+  'uniprotswissprot',
+  'uniprot_gn_id',
+  'refseq_mrna',
+  'refseq_peptide',
+  'refseq_ncrna',
+  'go_id',
+  'name_1006',
+  'transcript_length',
+  'percentage_gene_gc_content',
+  'ccds'
+])
+
+// Microarray probe attributes are bulky and rarely needed; list_all_attributes drops them (and the
+// homologs page) to keep the response manageable.
+const PROBE_PREFIX = /^(affy|agilent|illumina|codelink|phalanx)_/
 
 // Escapes a value for use inside a double-quoted XML attribute (mirrors the upstream Python
 // build_query_xml, which relies on ElementTree's own attribute escaping).
@@ -22,13 +65,12 @@ function filterValue(value: unknown): string {
   return String(value)
 }
 
-// Builds a martservice <Query> XML document (transcribed from upstream biomart_query.client's
-// build_query_xml: header=0/uniqueRows=0 defaults, completionStamp always requested).
+// Builds a martservice <Query> XML document (header=0/uniqueRows=0 defaults, completionStamp always
+// requested so a truncated download can be detected).
 function buildQueryXml(
   dataset: string,
   attributes: string[],
-  filters: Record<string, unknown>,
-  virtualSchema: string
+  filters: Record<string, unknown>
 ): string {
   const filterXml = Object.entries(filters)
     .map(
@@ -39,16 +81,20 @@ function buildQueryXml(
   const attrXml = attributes.map((a) => `<Attribute name="${escapeXmlAttr(a)}" />`).join('')
   return (
     '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Query>' +
-    `<Query virtualSchemaName="${escapeXmlAttr(virtualSchema)}" formatter="TSV" header="0" uniqueRows="0" datasetConfigVersion="0.6" completionStamp="1">` +
+    `<Query virtualSchemaName="${VIRTUAL_SCHEMA}" formatter="TSV" header="0" uniqueRows="0" datasetConfigVersion="0.6" completionStamp="1">` +
     `<Dataset name="${escapeXmlAttr(dataset)}" interface="default">${filterXml}${attrXml}</Dataset>` +
     '</Query>'
   )
 }
 
-// Parses a completed martservice TSV body into rows, validating the completion stamp and column
-// count (mirrors upstream biomart_query.client._post + _parse_tsv). Throws on a rejected query
-// (BioMart returns 200 with a "Query ERROR" / exception body for bad attribute/filter combos) or
-// a truncated response (missing the trailing [success] marker).
+// The GET form of the martservice query: the XML document passed as a `query` URL parameter.
+function queryUrl(dataset: string, attributes: string[], filters: Record<string, unknown>): string {
+  return `${MARTSERVICE}?query=${encodeURIComponent(buildQueryXml(dataset, attributes, filters))}`
+}
+
+// Parses a completed martservice TSV body into rows, validating the completion stamp and column count
+// (mirrors upstream _post + _parse_tsv). Throws on a rejected query (BioMart returns 200 with a
+// "Query ERROR" / exception body for bad attribute/filter combos) or a truncated response.
 function parseTsvBody(text: string, nCols: number): string[][] {
   const head = text.slice(0, 2000)
   if (
@@ -82,68 +128,279 @@ function parseTsvBody(text: string, nCols: number): string[][] {
   return rows
 }
 
-type Mart = { name: string; displayName: string }
+// Splits a martservice registry-style TSV body (list endpoints) into non-empty tab-delimited rows.
+function tsvRows(raw: unknown): string[][] {
+  return String(raw)
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line) => line.split('\t'))
+}
 
-// Ensembl BioMart martservice: XML query registry + TSV attribute queries (read-only).
+// martservice lists an attribute/filter once per config page it appears on; collapse to the first
+// occurrence by name (col0, which carries the richest description) so list_* tools return a
+// deduplicated menu instead of the same id repeated across pages.
+function dedupeByName(rows: string[][]): string[][] {
+  const seen = new Set<string>()
+  return rows.filter((r) => {
+    const key = r[0] ?? ''
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+// Quotes a CSV field only when it contains a comma, quote, or newline (RFC-4180 minimal quoting).
+function csvField(value: string): string {
+  return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
+}
+
+// Renders a header + rows as a CSV string — the return shape every list_*/get_data tool produces.
+function toCsv(header: string[], rows: string[][]): string {
+  return [header, ...rows].map((row) => row.map(csvField).join(',')).join('\n')
+}
+
+// Ensembl BioMart martservice: a MART -> DATASET -> ATTRIBUTES/FILTERS registry plus TSV attribute
+// queries and identifier translation (read-only). Tool names and shapes mirror the openscience BioMart
+// connector: list endpoints and get_data return CSV strings; translations return a value / mapping.
 export const BIOMART_TOOLS: ToolDescriptor[] = [
   {
-    id: 'biomart_list_marts',
+    id: 'list_marts',
     connector: 'biomart',
     description:
-      'List available Ensembl BioMart marts (name and display name) from the martservice registry.',
+      'List available Ensembl BioMart marts (databases). BioMart organizes data as MART -> DATASET -> ATTRIBUTES/FILTERS; a mart name feeds list_datasets.',
     input: { type: 'object', properties: {} },
     returns:
-      '`[ { "name": str, "displayName": str } ]` — array of registered BioMart marts; `[]` when the registry lists none.',
-    example: 'result = host.mcp("biomart", "biomart_list_marts", {})',
+      'CSV string with header `name,display_name,description` — one row per mart (e.g. `ENSEMBL_MART_ENSEMBL,Ensembl Genes 116,...`). Header-only when the registry lists no marts.',
+    example: 'result = host.mcp("biomart", "list_marts", {})',
     format: 'text',
     url: () => `${MARTSERVICE}?type=registry`,
     parse: (raw) => {
       const doc = new DOMParser().parseFromString(String(raw), 'text/xml')
-      const marts: Mart[] = []
       const locs = doc.getElementsByTagName('MartURLLocation')
+      const rows: string[][] = []
       for (let i = 0; i < locs.length; i++) {
         const el = locs[i]
-        marts.push({
-          name: el.getAttribute('name') ?? '',
-          displayName: el.getAttribute('displayName') ?? ''
-        })
+        if (el.getAttribute('visible') === '0') continue
+        const name = el.getAttribute('name') ?? ''
+        const display = el.getAttribute('displayName') ?? ''
+        rows.push([name, display, display])
       }
-      return marts
+      return toCsv(['name', 'display_name', 'description'], rows)
     }
   },
   {
-    id: 'biomart_query',
+    id: 'list_datasets',
     connector: 'biomart',
     description:
-      'Run a BioMart attribute query against a dataset (e.g. hsapiens_gene_ensembl) with optional filters; returns parsed TSV rows in request column order.',
+      'List the datasets available in a given mart (e.g. hsapiens_gene_ensembl for human genes). A dataset name feeds the attribute/filter/query tools.',
+    input: {
+      type: 'object',
+      properties: { mart: { type: 'string' } },
+      required: ['mart']
+    },
+    required: ['mart'],
+    returns:
+      'CSV string with header `name,display_name,description` — one row per dataset (`description` is the assembly/version, e.g. `GRCh38.p14`).',
+    example: 'result = host.mcp("biomart", "list_datasets", {"mart": "ENSEMBL_MART_ENSEMBL"})',
+    format: 'text',
+    url: (a) => `${MARTSERVICE}?type=datasets&mart=${encodeURIComponent(String(a.mart))}`,
+    parse: (raw) => {
+      const rows = tsvRows(raw)
+        .filter((f) => f[0] === 'TableSet')
+        .map((f) => [f[1] ?? '', f[2] ?? '', f[4] ?? ''])
+      return toCsv(['name', 'display_name', 'description'], rows)
+    }
+  },
+  {
+    id: 'list_common_attributes',
+    connector: 'biomart',
+    description:
+      'List the commonly used attributes for a dataset (a curated high-signal subset). Use this before list_all_attributes to pick attributes for get_data.',
+    input: {
+      type: 'object',
+      properties: { mart: { type: 'string' }, dataset: { type: 'string' } },
+      required: ['mart', 'dataset']
+    },
+    required: ['mart', 'dataset'],
+    returns:
+      'CSV string with header `name,display_name,description` — the subset of the dataset’s attributes that are commonly used identifiers/annotations.',
+    example:
+      'result = host.mcp("biomart", "list_common_attributes", {"mart": "ENSEMBL_MART_ENSEMBL", "dataset": "hsapiens_gene_ensembl"})',
+    format: 'text',
+    url: (a) => `${MARTSERVICE}?type=attributes&dataset=${encodeURIComponent(String(a.dataset))}`,
+    parse: (raw) => {
+      const rows = dedupeByName(
+        tsvRows(raw)
+          .filter((f) => COMMON_ATTRIBUTES.has(f[0] ?? ''))
+          .map((f) => [f[0] ?? '', f[1] ?? '', f[2] ?? ''])
+      )
+      return toCsv(['name', 'display_name', 'description'], rows)
+    }
+  },
+  {
+    id: 'list_all_attributes',
+    connector: 'biomart',
+    description:
+      'List all attributes available for a dataset, minus homologs and microarray probes (which are bulky and rarely needed). Can be large; prefer list_common_attributes first.',
+    input: {
+      type: 'object',
+      properties: { mart: { type: 'string' }, dataset: { type: 'string' } },
+      required: ['mart', 'dataset']
+    },
+    required: ['mart', 'dataset'],
+    returns:
+      'CSV string with header `name,display_name,description` — every attribute except the homologs page and microarray-probe attributes.',
+    example:
+      'result = host.mcp("biomart", "list_all_attributes", {"mart": "ENSEMBL_MART_ENSEMBL", "dataset": "hsapiens_gene_ensembl"})',
+    format: 'text',
+    url: (a) => `${MARTSERVICE}?type=attributes&dataset=${encodeURIComponent(String(a.dataset))}`,
+    parse: (raw) => {
+      const rows = dedupeByName(
+        tsvRows(raw)
+          .filter((f) => {
+            const name = f[0] ?? ''
+            const page = f[3] ?? ''
+            return page !== 'homologs' && !name.includes('homolog') && !PROBE_PREFIX.test(name)
+          })
+          .map((f) => [f[0] ?? '', f[1] ?? '', f[2] ?? ''])
+      )
+      return toCsv(['name', 'display_name', 'description'], rows)
+    }
+  },
+  {
+    id: 'list_filters',
+    connector: 'biomart',
+    description:
+      'List the filters available for a dataset. Filters narrow a get_data query (e.g. chromosome_name, biotype) and are passed to get_data as a filters dict.',
+    input: {
+      type: 'object',
+      properties: { mart: { type: 'string' }, dataset: { type: 'string' } },
+      required: ['mart', 'dataset']
+    },
+    required: ['mart', 'dataset'],
+    returns:
+      'CSV string with header `name,description` — one row per filter name and its human-readable label.',
+    example:
+      'result = host.mcp("biomart", "list_filters", {"mart": "ENSEMBL_MART_ENSEMBL", "dataset": "hsapiens_gene_ensembl"})',
+    format: 'text',
+    url: (a) => `${MARTSERVICE}?type=filters&dataset=${encodeURIComponent(String(a.dataset))}`,
+    parse: (raw) => {
+      const rows = dedupeByName(tsvRows(raw).map((f) => [f[0] ?? '', f[1] ?? '']))
+      return toCsv(['name', 'description'], rows)
+    }
+  },
+  {
+    id: 'get_data',
+    connector: 'biomart',
+    description:
+      'Run a BioMart query: retrieve the requested attributes for a dataset, optionally narrowed by filters. This is the main data-retrieval tool.',
     input: {
       type: 'object',
       properties: {
+        mart: { type: 'string' },
         dataset: { type: 'string' },
         attributes: { type: 'array', items: { type: 'string' } },
-        filters: { type: 'object' },
-        virtual_schema: { type: 'string', default: 'default' }
+        filters: { type: 'object' }
       },
-      required: ['dataset', 'attributes']
+      required: ['mart', 'dataset', 'attributes']
     },
-    required: ['dataset', 'attributes'],
+    required: ['mart', 'dataset', 'attributes'],
     returns:
-      '`{ "dataset": str, "columns": [str], "rows": [[str]] }` — `columns` echoes the requested attributes and each row is a string array in that column order. `rows` is sorted lexicographically and `[]` when nothing matches.',
+      'CSV string whose header row is the requested attributes, followed by one row per matching record (in BioMart order). Header-only when nothing matches.',
     example:
-      'result = host.mcp("biomart", "biomart_query", {"dataset": "hsapiens_gene_ensembl", "attributes": ["ensembl_gene_id", "external_gene_name"]})',
-    run: async (ctx, a) => {
-      const dataset = String(a.dataset)
+      'result = host.mcp("biomart", "get_data", {"mart": "ENSEMBL_MART_ENSEMBL", "dataset": "hsapiens_gene_ensembl", "attributes": ["ensembl_gene_id", "external_gene_name", "chromosome_name"], "filters": {"chromosome_name": "Y", "biotype": "protein_coding"}})',
+    format: 'text',
+    url: (a) =>
+      queryUrl(
+        String(a.dataset),
+        (a.attributes as unknown[]).map(String),
+        (a.filters ?? {}) as Record<string, unknown>
+      ),
+    parse: (raw, a) => {
       const attributes = (a.attributes as unknown[]).map(String)
-      const filters = (a.filters ?? {}) as Record<string, unknown>
-      const virtualSchema = String(a.virtual_schema ?? 'default')
-      const xml = buildQueryXml(dataset, attributes, filters, virtualSchema)
-      // martservice's documented GET form: the XML query as a `query` URL parameter (equivalent
-      // to upstream's POST body={"query": xml}; avoids needing a raw form-POST context method).
-      const url = `${MARTSERVICE}?query=${encodeURIComponent(xml)}`
-      const text = await ctx.fetchText(url)
-      const rows = parseTsvBody(text, attributes.length)
-      rows.sort((x, y) => (x.join('\t') < y.join('\t') ? -1 : x.join('\t') > y.join('\t') ? 1 : 0))
-      return { dataset, columns: attributes, rows }
+      const rows = parseTsvBody(String(raw), attributes.length)
+      return toCsv(attributes, rows)
+    }
+  },
+  {
+    id: 'get_translation',
+    connector: 'biomart',
+    description:
+      'Translate a single identifier from one attribute type to another (e.g. an HGNC symbol to an Ensembl gene ID) within a dataset.',
+    input: {
+      type: 'object',
+      properties: {
+        mart: { type: 'string' },
+        dataset: { type: 'string' },
+        from_attr: { type: 'string' },
+        to_attr: { type: 'string' },
+        target: { type: 'string' }
+      },
+      required: ['mart', 'dataset', 'from_attr', 'to_attr', 'target']
+    },
+    required: ['mart', 'dataset', 'from_attr', 'to_attr', 'target'],
+    returns:
+      'The translated identifier as a string, or a `No translation found ...` message string when the source id has no mapping.',
+    example:
+      'result = host.mcp("biomart", "get_translation", {"mart": "ENSEMBL_MART_ENSEMBL", "dataset": "hsapiens_gene_ensembl", "from_attr": "hgnc_symbol", "to_attr": "ensembl_gene_id", "target": "TP53"})',
+    format: 'text',
+    url: (a) =>
+      queryUrl(String(a.dataset), [String(a.from_attr), String(a.to_attr)], {
+        [String(a.from_attr)]: String(a.target)
+      }),
+    parse: (raw, a) => {
+      const target = String(a.target)
+      const rows = parseTsvBody(String(raw), 2)
+      const match = rows.find((r) => r[0] === target && r[1]) ?? rows.find((r) => r[1])
+      return (
+        match?.[1] ??
+        `No translation found for '${target}' (${String(a.from_attr)} -> ${String(a.to_attr)}).`
+      )
+    }
+  },
+  {
+    id: 'batch_translate',
+    connector: 'biomart',
+    description:
+      'Translate many identifiers from one attribute type to another in a single query — more efficient than repeated get_translation calls.',
+    input: {
+      type: 'object',
+      properties: {
+        mart: { type: 'string' },
+        dataset: { type: 'string' },
+        from_attr: { type: 'string' },
+        to_attr: { type: 'string' },
+        targets: { type: 'array', items: { type: 'string' } }
+      },
+      required: ['mart', 'dataset', 'from_attr', 'to_attr', 'targets']
+    },
+    required: ['mart', 'dataset', 'from_attr', 'to_attr', 'targets'],
+    returns:
+      '`{ "translations": { <input>: <translated> }, "not_found": [str], "found_count": int, "not_found_count": int }` — `translations` maps each resolved input id to its target id.',
+    example:
+      'result = host.mcp("biomart", "batch_translate", {"mart": "ENSEMBL_MART_ENSEMBL", "dataset": "hsapiens_gene_ensembl", "from_attr": "hgnc_symbol", "to_attr": "ensembl_gene_id", "targets": ["TP53", "BRCA1", "BRCA2"]})',
+    format: 'text',
+    url: (a) => {
+      const targets = (a.targets as unknown[]).map(String)
+      return queryUrl(String(a.dataset), [String(a.from_attr), String(a.to_attr)], {
+        [String(a.from_attr)]: targets
+      })
+    },
+    parse: (raw, a) => {
+      const targets = (a.targets as unknown[]).map(String)
+      const rows = parseTsvBody(String(raw), 2)
+      const translations: Record<string, string> = {}
+      for (const [from, to] of rows) {
+        if (from && to && !(from in translations)) translations[from] = to
+      }
+      const notFound = targets.filter((t) => !(t in translations))
+      return {
+        translations,
+        not_found: notFound,
+        found_count: Object.keys(translations).length,
+        not_found_count: notFound.length
+      }
     }
   }
 ]


### PR DESCRIPTION
Rounds out the Ensembl BioMart connector so it exposes the full BioMart
workflow instead of a minimal slice.

Capabilities added:
- Browse the mart → dataset → attribute/filter hierarchy: `list_marts`,
  `list_datasets`, `list_common_attributes`, `list_all_attributes`, `list_filters`.
- Run attribute queries with filters: `get_data`.
- Translate identifiers between attribute types: `get_translation`, `batch_translate`.

All tools are read-only against the Ensembl martservice and return CSV / dict
results matching the connector's documented shapes. List tools de-duplicate
Ensembl's per-page entries. Unit tests cover every tool; the catalog entry is
updated to describe the fuller capability set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)