### PR TITLE
feat(connectors): expand Cancer Models with mutation, CNA & clinical tools

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -197,7 +197,7 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
     displayName: 'Cancer Models',
     description: 'Cancer genomics study records via the cBioPortal REST API.',
     useWhen:
-      'Use when you need cancer genomics study data — searching cBioPortal cancer studies by keyword (cancer type, cohort name), or looking up a known study by its cBioPortal study id (cancer type, sample counts, citation).',
+      "Use when you need cancer genomics data from cBioPortal — listing or looking up cancer studies (cancer type, sample counts, citation), the mutations of a gene in a study (recurrent protein changes, mutation types), a gene's mutation frequency across several studies, discrete copy-number alterations (deletions/amplifications) of a gene, or a study's clinical attributes and survival endpoints.",
     sources: ['cBioPortal'],
     termsUrl: 'https://www.cbioportal.org/faq',
     requiresNcbi: false

--- a/src/main/connectors/descriptors/cancer-models.test.ts
+++ b/src/main/connectors/descriptors/cancer-models.test.ts
@@ -6,129 +6,606 @@ import type { ToolDescriptor } from '../types'
 const tool = (id: string): ToolDescriptor => CANCER_MODELS_TOOLS.find((t) => t.id === id)!
 const jsonRes = (body: unknown): Response =>
   ({ ok: true, status: 200, json: async () => body }) as Response
+const notFound = (url: string): Response =>
+  ({
+    ok: false,
+    status: 404,
+    json: async () => ({}),
+    text: async () => '',
+    headers: undefined,
+    url
+  }) as unknown as Response
 
-describe('cancer_models / search studies', () => {
-  it('cbioportal_search_studies builds the search URL and parses compact rows', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes([
-        {
-          studyId: 'brca_pareja_msk_2020',
-          name: 'Breast Cancer (MSK, Clinical Cancer Res 2020)',
-          description: 'Whole-exome and MSK-IMPACT sequencing of 60 tumor/normal matched samples.',
-          cancerTypeId: 'brca',
-          cancerType: { name: 'Invasive Breast Carcinoma' },
-          allSampleCount: 60,
-          sequencedSampleCount: 60
-        },
-        {
-          studyId: 'brca_hta9_htan_2022',
-          name: 'Breast Cancer (HTAN, 2022)',
-          cancerTypeId: 'brca',
-          cancerType: { name: 'Invasive Breast Carcinoma' },
-          allSampleCount: 5,
-          sequencedSampleCount: 5
-        }
-      ])
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('cbioportal_search_studies'),
-      { query: 'breast' },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://www.cbioportal.org/api/studies?keyword=breast&projection=DETAILED&pageSize=10&pageNumber=0'
-    )
-    expect(out).toEqual([
-      {
-        studyId: 'brca_pareja_msk_2020',
-        name: 'Breast Cancer (MSK, Clinical Cancer Res 2020)',
-        cancerType: 'Invasive Breast Carcinoma',
-        allSampleCount: 60
-      },
-      {
-        studyId: 'brca_hta9_htan_2022',
-        name: 'Breast Cancer (HTAN, 2022)',
-        cancerType: 'Invasive Breast Carcinoma',
-        allSampleCount: 5
+// Routes a fetch mock by URL substring; on nested paths (e.g. /molecular-profiles/X/mutations) the
+// needle starting latest in the URL wins, so the most specific endpoint matches. Unmatched throws.
+const router =
+  (routes: Array<[string, unknown]>) =>
+  async (url: string): Promise<Response> => {
+    let best: unknown
+    let bestIdx = -1
+    for (const [needle, body] of routes) {
+      const idx = url.indexOf(needle)
+      if (idx > bestIdx) {
+        bestIdx = idx
+        best = body
       }
-    ])
+    }
+    if (bestIdx < 0) throw new Error(`unexpected fetch: ${url}`)
+    return best === '__404__' ? notFound(url) : jsonRes(best)
+  }
+
+const run = (
+  id: string,
+  args: Record<string, unknown>,
+  fetchImpl: typeof fetch
+): Promise<unknown> => new ParserEngine({ fetchImpl, retries: 0 }).call(tool(id), args, {})
+
+describe('cancer_models / list_studies', () => {
+  it('fetches all matching studies, filters by cancer_type_id, and sorts by study_id', async () => {
+    const fetchImpl = vi.fn(
+      router([
+        [
+          '/studies?',
+          [
+            {
+              studyId: 'gbm_b',
+              name: 'GBM B',
+              description: 'x'.repeat(300),
+              cancerTypeId: 'gbm',
+              cancerType: { name: 'Glioblastoma' },
+              referenceGenome: 'hg19',
+              pmid: '1',
+              citation: 'C1',
+              sequencedSampleCount: 10,
+              cnaSampleCount: 8,
+              structuralVariantCount: 2,
+              allSampleCount: 12
+            },
+            {
+              studyId: 'gbm_a',
+              name: 'GBM A',
+              cancerTypeId: 'gbm',
+              cancerType: { name: 'Glioblastoma' },
+              sequencedSampleCount: 5
+            },
+            {
+              studyId: 'brca_x',
+              name: 'Breast',
+              cancerTypeId: 'brca',
+              cancerType: { name: 'Breast' }
+            }
+          ]
+        ]
+      ]) as unknown as typeof fetch
+    )
+    const out = (await run(
+      'cbioportal_list_studies',
+      { keyword: 'glioma', cancer_type_id: 'gbm' },
+      fetchImpl as unknown as typeof fetch
+    )) as Record<string, unknown>
+
+    expect(fetchImpl.mock.calls[0][0] as string).toContain('keyword=glioma')
+    expect(out.api_total_for_keyword).toBe(3)
+    expect(out.count).toBe(2)
+    expect(out.truncated).toBe(false)
+    const studies = out.studies as Record<string, unknown>[]
+    expect(studies.map((s) => s.study_id)).toEqual(['gbm_a', 'gbm_b'])
+    // allSampleCount is deliberately omitted; description is trimmed to ~240 chars with an ellipsis.
+    expect(studies[1]).not.toHaveProperty('all_sample_count')
+    expect(String(studies[1].description)).toHaveLength(241)
+    expect(String(studies[1].description).endsWith('…')).toBe(true)
   })
 
-  it('respects a custom page_size and returns an empty array for no matches', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('cbioportal_search_studies'),
-      { query: 'nonexistent-cancer-xyz', page_size: 5 },
-      {}
+  it('omits the keyword param and honors max_records truncation', async () => {
+    const fetchImpl = vi.fn(
+      router([
+        [
+          '/studies?',
+          [
+            { studyId: 's1', cancerTypeId: 'a' },
+            { studyId: 's2', cancerTypeId: 'a' }
+          ]
+        ]
+      ]) as unknown as typeof fetch
     )
-    expect(fetchImpl.mock.calls[0][0]).toContain('pageSize=5')
-    expect(out).toEqual([])
-  })
-
-  it('encodes special characters in the query', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
-    await new ParserEngine({ fetchImpl }).call(
-      tool('cbioportal_search_studies'),
-      { query: 'a b&c' },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://www.cbioportal.org/api/studies?keyword=a%20b%26c&projection=DETAILED&pageSize=10&pageNumber=0'
-    )
+    const out = (await run(
+      'cbioportal_list_studies',
+      { max_records: 1 },
+      fetchImpl as unknown as typeof fetch
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0] as string).not.toContain('keyword=')
+    expect(out.keyword).toBeNull()
+    expect(out.count).toBe(2)
+    expect(out.truncated).toBe(true)
+    expect((out.studies as unknown[]).length).toBe(1)
   })
 })
 
-describe('cancer_models / get study', () => {
-  it('cbioportal_get_study builds the record URL and parses a compact summary', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        studyId: 'msk_impact_2017',
-        name: 'MSK-IMPACT Clinical Sequencing Cohort (MSK, Nat Med 2017)',
-        description: 'Targeted sequencing of tumor/normal pairs.',
-        cancerTypeId: 'mixed',
-        cancerType: { name: 'Mixed Cancer Types' },
-        pmid: '28481359',
-        citation: 'Zehir et al. Nat Med 2017',
-        referenceGenome: 'hg19',
-        allSampleCount: 10945,
-        sequencedSampleCount: 10945,
-        cnaSampleCount: 10336,
-        structuralVariantCount: 0
-      })
+describe('cancer_models / get_study', () => {
+  it('assembles metadata, true collection counts, and sorted profiles', async () => {
+    const fetchImpl = vi.fn(
+      router([
+        [
+          '/studies/msk_impact_2017?',
+          {
+            studyId: 'msk_impact_2017',
+            name: 'MSK-IMPACT',
+            description: 'd',
+            cancerTypeId: 'mixed',
+            cancerType: { name: 'Mixed' },
+            referenceGenome: 'hg19',
+            pmid: '28481359',
+            citation: 'Zehir 2017',
+            publicStudy: true,
+            groups: 'PUBLIC',
+            importDate: '2026-01-01',
+            sequencedSampleCount: 10945,
+            cnaSampleCount: 10336,
+            structuralVariantCount: 0,
+            treatmentCount: 0,
+            allSampleCount: 1
+          }
+        ],
+        [
+          '/molecular-profiles',
+          [
+            {
+              molecularProfileId: 'msk_impact_2017_mutations',
+              molecularAlterationType: 'MUTATION_EXTENDED',
+              datatype: 'MAF',
+              name: 'Mutations'
+            },
+            {
+              molecularProfileId: 'msk_impact_2017_cna',
+              molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+              datatype: 'DISCRETE',
+              name: 'CNA'
+            }
+          ]
+        ],
+        ['/samples?', [{ sampleId: 'a' }, { sampleId: 'b' }, { sampleId: 'c' }]],
+        ['/patients?', [{ patientId: 'p1' }, { patientId: 'p2' }]]
+      ]) as unknown as typeof fetch
     )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('cbioportal_get_study'),
+    const out = (await run(
+      'cbioportal_get_study',
       { study_id: 'msk_impact_2017' },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://www.cbioportal.org/api/studies/msk_impact_2017?projection=DETAILED'
-    )
-    expect(out).toEqual({
-      studyId: 'msk_impact_2017',
-      name: 'MSK-IMPACT Clinical Sequencing Cohort (MSK, Nat Med 2017)',
-      description: 'Targeted sequencing of tumor/normal pairs.',
-      cancerType: 'Mixed Cancer Types',
-      cancerTypeId: 'mixed',
-      pmid: '28481359',
-      citation: 'Zehir et al. Nat Med 2017',
-      referenceGenome: 'hg19',
-      allSampleCount: 10945,
-      sequencedSampleCount: 10945,
-      cnaSampleCount: 10336,
-      structuralVariantCount: 0
-    })
+      fetchImpl as unknown as typeof fetch
+    )) as Record<string, unknown>
+
+    expect(out.sample_count).toBe(3)
+    expect(out.patient_count).toBe(2)
+    expect(out.cancer_type).toBe('Mixed')
+    expect(out.public).toBe(true)
+    const profiles = out.molecular_profiles as Record<string, unknown>[]
+    expect(profiles.map((p) => p.molecular_profile_id)).toEqual([
+      'msk_impact_2017_cna',
+      'msk_impact_2017_mutations'
+    ])
+    expect(out).not.toHaveProperty('all_sample_count')
   })
 
-  it('encodes special characters in the study id', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ studyId: 'a/b' }))
-    await new ParserEngine({ fetchImpl }).call(
-      tool('cbioportal_get_study'),
-      { study_id: 'a b' },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://www.cbioportal.org/api/studies/a%20b?projection=DETAILED'
-    )
+  it('throws "Study not found" on a 404', async () => {
+    const fetchImpl = vi.fn(router([['/studies/nope?', '__404__']]) as unknown as typeof fetch)
+    await expect(
+      run('cbioportal_get_study', { study_id: 'nope' }, fetchImpl as unknown as typeof fetch)
+    ).rejects.toThrow('Study not found')
   })
+})
+
+describe('cancer_models / mutations_in_gene', () => {
+  const genePlusProfiles = (mutations: unknown[]): Array<[string, unknown]> => [
+    ['/genes/IDH1', { entrezGeneId: 3417, hugoGeneSymbol: 'IDH1' }],
+    [
+      '/molecular-profiles',
+      [
+        {
+          molecularProfileId: 'difg_msk_2023_mutations',
+          molecularAlterationType: 'MUTATION_EXTENDED'
+        }
+      ]
+    ],
+    [
+      '/sample-lists',
+      [{ sampleListId: 'difg_msk_2023_sequenced', category: 'all_cases_with_mutation_data' }]
+    ],
+    ['/mutations?', mutations]
+  ]
+
+  it('aggregates recurrence and sorts mutations by genomic position', async () => {
+    const fetchImpl = vi.fn(
+      router(
+        genePlusProfiles([
+          {
+            sampleId: 's1',
+            proteinChange: 'R132H',
+            mutationType: 'Missense_Mutation',
+            chr: '2',
+            startPosition: 209113112
+          },
+          {
+            sampleId: 's2',
+            proteinChange: 'R132H',
+            mutationType: 'Missense_Mutation',
+            chr: '2',
+            startPosition: 209113100
+          },
+          {
+            sampleId: 's2',
+            proteinChange: 'R132C',
+            mutationType: 'Missense_Mutation',
+            chr: '2',
+            startPosition: 209113113
+          }
+        ])
+      ) as unknown as typeof fetch
+    )
+    const out = (await run(
+      'cbioportal_mutations_in_gene',
+      { gene_symbol: 'IDH1', study_id: 'difg_msk_2023', max_records: 2 },
+      fetchImpl as unknown as typeof fetch
+    )) as Record<string, unknown>
+
+    expect(out.total_mutations).toBe(3)
+    expect(out.mutated_sample_count).toBe(2)
+    expect(out.distinct_protein_changes).toBe(2)
+    expect(out.top_protein_changes).toEqual({ R132H: 2, R132C: 1 })
+    expect(out.truncated).toBe(true)
+    const muts = out.mutations as Record<string, unknown>[]
+    expect(muts.length).toBe(2)
+    // Sorted by start position within chr 2.
+    expect(muts[0].start_position).toBe(209113100)
+    expect((out.gene as Record<string, unknown>).entrez_gene_id).toBe(3417)
+  })
+
+  it('throws listing alteration types when the study lacks mutation data', async () => {
+    const fetchImpl = vi.fn(
+      router([
+        ['/genes/IDH1', { entrezGeneId: 3417, hugoGeneSymbol: 'IDH1' }],
+        [
+          '/molecular-profiles',
+          [{ molecularProfileId: 'x_cna', molecularAlterationType: 'COPY_NUMBER_ALTERATION' }]
+        ]
+      ]) as unknown as typeof fetch
+    )
+    await expect(
+      run(
+        'cbioportal_mutations_in_gene',
+        { gene_symbol: 'IDH1', study_id: 'x' },
+        fetchImpl as unknown as typeof fetch
+      )
+    ).rejects.toThrow(/no mutation data.*COPY_NUMBER_ALTERATION/)
+  })
+
+  it('throws "Gene not found" on unknown gene', async () => {
+    const fetchImpl = vi.fn(router([['/genes/ZZZ', '__404__']]) as unknown as typeof fetch)
+    await expect(
+      run(
+        'cbioportal_mutations_in_gene',
+        { gene_symbol: 'ZZZ', study_id: 'x' },
+        fetchImpl as unknown as typeof fetch
+      )
+    ).rejects.toThrow('Gene not found')
+  })
+})
+
+describe('cancer_models / mutation_frequency', () => {
+  it('computes frequency per study and buckets unknown / no-data ids, ranked by frequency', async () => {
+    const fetchImpl = vi.fn(
+      router([
+        ['/genes/KRAS', { entrezGeneId: 3845, hugoGeneSymbol: 'KRAS' }],
+        ['/studies/study_hi?', { studyId: 'study_hi', name: 'Hi', sequencedSampleCount: 10 }],
+        ['/studies/study_lo?', { studyId: 'study_lo', name: 'Lo', sequencedSampleCount: 100 }],
+        [
+          '/studies/study_nodata?',
+          { studyId: 'study_nodata', name: 'No', sequencedSampleCount: 5 }
+        ],
+        ['/studies/study_unknown?', '__404__'],
+        [
+          '/studies/study_hi/molecular-profiles',
+          [
+            {
+              molecularProfileId: 'study_hi_mutations',
+              molecularAlterationType: 'MUTATION_EXTENDED'
+            }
+          ]
+        ],
+        [
+          '/studies/study_lo/molecular-profiles',
+          [
+            {
+              molecularProfileId: 'study_lo_mutations',
+              molecularAlterationType: 'MUTATION_EXTENDED'
+            }
+          ]
+        ],
+        [
+          '/studies/study_nodata/molecular-profiles',
+          [
+            {
+              molecularProfileId: 'study_nodata_cna',
+              molecularAlterationType: 'COPY_NUMBER_ALTERATION'
+            }
+          ]
+        ],
+        [
+          '/studies/study_hi/sample-lists',
+          [{ sampleListId: 'study_hi_sequenced', category: 'all_cases_with_mutation_data' }]
+        ],
+        [
+          '/studies/study_lo/sample-lists',
+          [{ sampleListId: 'study_lo_sequenced', category: 'all_cases_with_mutation_data' }]
+        ],
+        [
+          'study_hi_mutations/mutations?',
+          [{ sampleId: 'a' }, { sampleId: 'b' }, { sampleId: 'b' }]
+        ],
+        ['study_lo_mutations/mutations?', [{ sampleId: 'a' }, { sampleId: 'b' }]]
+      ]) as unknown as typeof fetch
+    )
+    const out = (await run(
+      'cbioportal_mutation_frequency',
+      {
+        gene_symbol: 'KRAS',
+        study_ids: ['study_hi', 'study_lo', 'study_nodata', 'study_unknown']
+      },
+      fetchImpl as unknown as typeof fetch
+    )) as Record<string, unknown>
+
+    expect(out.unknown_studies).toEqual(['study_unknown'])
+    expect(out.no_mutation_data).toEqual(['study_nodata'])
+    const freqs = out.frequencies as Record<string, unknown>[]
+    expect(out.count).toBe(2)
+    // study_hi: 2 mutated / 10 sequenced = 0.2 > study_lo: 2/100 = 0.02.
+    expect(freqs.map((f) => f.study_id)).toEqual(['study_hi', 'study_lo'])
+    expect(freqs[0].frequency).toBe(0.2)
+    expect(freqs[0].mutated_samples).toBe(2)
+    expect(freqs[1].frequency).toBe(0.02)
+  })
+})
+
+describe('cancer_models / cna_in_gene', () => {
+  const baseRoutes = (cnaRows: unknown[]): Array<[string, unknown]> => [
+    ['/genes/CDKN2A', { entrezGeneId: 1029, hugoGeneSymbol: 'CDKN2A' }],
+    [
+      '/molecular-profiles',
+      [
+        {
+          molecularProfileId: 'msk_impact_2017_cna',
+          molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+          datatype: 'DISCRETE'
+        }
+      ]
+    ],
+    [
+      '/sample-lists',
+      [{ sampleListId: 'msk_impact_2017_cna', category: 'all_cases_with_cna_data' }]
+    ],
+    ['/discrete-copy-number/fetch', cnaRows]
+  ]
+
+  it('buckets events by type and tallies the full distribution (default HOMDEL_AND_AMP)', async () => {
+    const fetchImpl = vi.fn(
+      router(
+        baseRoutes([
+          { sampleId: 's1', patientId: 'p1', alteration: -2 },
+          { sampleId: 's2', patientId: 'p2', alteration: 2 },
+          { sampleId: 's3', patientId: 'p3', alteration: 0 },
+          { sampleId: 's4', patientId: 'p4', alteration: 1 }
+        ])
+      ) as unknown as typeof fetch
+    )
+    const out = (await run(
+      'cbioportal_cna_in_gene',
+      { gene_symbol: 'CDKN2A', study_id: 'msk_impact_2017' },
+      fetchImpl as unknown as typeof fetch
+    )) as Record<string, unknown>
+
+    // POST body carries the gene filter the GET endpoint ignores.
+    const postArgs = fetchImpl.mock.calls.find((c) => String(c[0]).includes('/fetch'))
+    expect(JSON.parse((postArgs![1] as RequestInit).body as string)).toEqual({
+      sampleListId: 'msk_impact_2017_cna',
+      entrezGeneIds: [1029]
+    })
+    expect(out.event_type).toBe('HOMDEL_AND_AMP')
+    expect(out.total_events).toBe(2)
+    expect(out.altered_sample_count).toBe(2)
+    expect(out.alteration_counts).toEqual({
+      deep_deletion: 1,
+      amplification: 1,
+      diploid: 1,
+      gain: 1
+    })
+    const events = out.events as Record<string, unknown>[]
+    expect(events.map((e) => e.alteration_label)).toEqual(['deep_deletion', 'amplification'])
+  })
+
+  it('respects a non-default event_type filter (AMP only)', async () => {
+    const fetchImpl = vi.fn(
+      router(
+        baseRoutes([
+          { sampleId: 's1', alteration: -2 },
+          { sampleId: 's2', alteration: 2 }
+        ])
+      ) as unknown as typeof fetch
+    )
+    const out = (await run(
+      'cbioportal_cna_in_gene',
+      { gene_symbol: 'CDKN2A', study_id: 'msk_impact_2017', event_type: 'AMP' },
+      fetchImpl as unknown as typeof fetch
+    )) as Record<string, unknown>
+    expect(out.total_events).toBe(1)
+    expect((out.events as Record<string, unknown>[])[0].alteration_label).toBe('amplification')
+  })
+
+  it('throws listing alteration types when the study lacks discrete CNA', async () => {
+    const fetchImpl = vi.fn(
+      router([
+        ['/genes/CDKN2A', { entrezGeneId: 1029, hugoGeneSymbol: 'CDKN2A' }],
+        [
+          '/molecular-profiles',
+          [{ molecularProfileId: 'x_mut', molecularAlterationType: 'MUTATION_EXTENDED' }]
+        ]
+      ]) as unknown as typeof fetch
+    )
+    await expect(
+      run(
+        'cbioportal_cna_in_gene',
+        { gene_symbol: 'CDKN2A', study_id: 'x' },
+        fetchImpl as unknown as typeof fetch
+      )
+    ).rejects.toThrow(/no discrete copy-number data.*MUTATION_EXTENDED/)
+  })
+})
+
+describe('cancer_models / clinical_attributes', () => {
+  it('summarizes survival endpoints and levels, sorted by attribute id', async () => {
+    const fetchImpl = vi.fn(
+      router([
+        [
+          '/clinical-attributes',
+          [
+            {
+              clinicalAttributeId: 'OS_STATUS',
+              displayName: 'OS Status',
+              datatype: 'STRING',
+              patientAttribute: true,
+              priority: '1'
+            },
+            {
+              clinicalAttributeId: 'OS_MONTHS',
+              displayName: 'OS Months',
+              datatype: 'NUMBER',
+              patientAttribute: true,
+              priority: '1'
+            },
+            {
+              clinicalAttributeId: 'AGE',
+              displayName: 'Age',
+              datatype: 'NUMBER',
+              patientAttribute: true,
+              priority: '1'
+            },
+            {
+              clinicalAttributeId: 'SAMPLE_TYPE',
+              displayName: 'Sample Type',
+              datatype: 'STRING',
+              patientAttribute: false,
+              priority: '1'
+            }
+          ]
+        ]
+      ]) as unknown as typeof fetch
+    )
+    const out = (await run(
+      'cbioportal_clinical_attributes',
+      { study_id: 'brca_tcga_pan_can_atlas_2018' },
+      fetchImpl as unknown as typeof fetch
+    )) as Record<string, unknown>
+
+    expect(out.total_attributes).toBe(4)
+    expect(out.patient_level_count).toBe(3)
+    expect(out.sample_level_count).toBe(1)
+    expect(out.survival_attributes).toEqual(['OS_MONTHS', 'OS_STATUS'])
+    expect(out.has_overall_survival).toBe(true)
+    const attrs = out.attributes as Record<string, unknown>[]
+    expect(attrs.map((x) => x.attribute_id)).toEqual([
+      'AGE',
+      'OS_MONTHS',
+      'OS_STATUS',
+      'SAMPLE_TYPE'
+    ])
+    expect(attrs[0].level).toBe('patient')
+    expect(attrs[3].level).toBe('sample')
+    expect(attrs[0].priority).toBe(1)
+  })
+
+  it('throws "Study not found" on a 404', async () => {
+    const fetchImpl = vi.fn(
+      router([['/clinical-attributes', '__404__']]) as unknown as typeof fetch
+    )
+    await expect(
+      run(
+        'cbioportal_clinical_attributes',
+        { study_id: 'nope' },
+        fetchImpl as unknown as typeof fetch
+      )
+    ).rejects.toThrow('Study not found')
+  })
+})
+
+// Live integration tests against the real cBioPortal API. Opt-in via LIVE_API=1 to keep the default
+// suite offline and to respect upstream rate limits (each block hits the network a handful of times).
+describe.skipIf(!process.env.LIVE_API)('cancer_models / LIVE cBioPortal', () => {
+  const live = (id: string, args: Record<string, unknown>): Promise<unknown> =>
+    new ParserEngine().call(tool(id), args, {})
+
+  it('list_studies finds gliomas and reports an API total', async () => {
+    const out = (await live('cbioportal_list_studies', { keyword: 'glioma' })) as Record<
+      string,
+      unknown
+    >
+    expect(out.api_total_for_keyword as number).toBeGreaterThan(0)
+    expect((out.studies as unknown[]).length).toBeGreaterThan(0)
+    const first = (out.studies as Record<string, unknown>[])[0]
+    expect(first).toHaveProperty('study_id')
+    expect(first).not.toHaveProperty('all_sample_count')
+  }, 30000)
+
+  it('get_study returns true counts and molecular profiles for msk_impact_2017', async () => {
+    const out = (await live('cbioportal_get_study', { study_id: 'msk_impact_2017' })) as Record<
+      string,
+      unknown
+    >
+    expect(out.study_id).toBe('msk_impact_2017')
+    expect(out.sample_count as number).toBeGreaterThan(10000)
+    expect((out.molecular_profiles as unknown[]).length).toBeGreaterThan(0)
+  }, 60000)
+
+  it('get_study throws for an unknown study', async () => {
+    await expect(
+      live('cbioportal_get_study', { study_id: 'definitely_not_a_study_xyz' })
+    ).rejects.toThrow('Study not found')
+  }, 30000)
+
+  it('mutations_in_gene aggregates IDH1 in a small glioma cohort', async () => {
+    const out = (await live('cbioportal_mutations_in_gene', {
+      gene_symbol: 'IDH1',
+      study_id: 'difg_msk_2023'
+    })) as Record<string, unknown>
+    expect((out.gene as Record<string, unknown>).entrez_gene_id).toBe(3417)
+    expect(out.total_mutations as number).toBeGreaterThan(0)
+    expect(Object.keys(out.top_protein_changes as object)).toContain('R132H')
+  }, 30000)
+
+  it('mutation_frequency ranks KRAS across studies', async () => {
+    const out = (await live('cbioportal_mutation_frequency', {
+      gene_symbol: 'KRAS',
+      study_ids: ['msk_impact_2017', 'difg_msk_2023']
+    })) as Record<string, unknown>
+    expect((out.frequencies as unknown[]).length).toBeGreaterThan(0)
+    for (const f of out.frequencies as Record<string, unknown>[]) {
+      expect(f).toHaveProperty('frequency')
+      expect(f).toHaveProperty('sequenced_samples')
+    }
+  }, 60000)
+
+  it('cna_in_gene finds CDKN2A deletions/amplifications in msk_impact_2017', async () => {
+    const out = (await live('cbioportal_cna_in_gene', {
+      gene_symbol: 'CDKN2A',
+      study_id: 'msk_impact_2017'
+    })) as Record<string, unknown>
+    expect(out.event_type).toBe('HOMDEL_AND_AMP')
+    expect(out.total_events as number).toBeGreaterThan(0)
+    expect(out.alteration_counts).toHaveProperty('deep_deletion')
+  }, 60000)
+
+  it('clinical_attributes reports OS endpoints for a TCGA PanCan study', async () => {
+    const out = (await live('cbioportal_clinical_attributes', {
+      study_id: 'brca_tcga_pan_can_atlas_2018'
+    })) as Record<string, unknown>
+    expect(out.total_attributes as number).toBeGreaterThan(0)
+    expect(out.has_overall_survival).toBe(true)
+    expect(out.survival_attributes as string[]).toContain('OS_STATUS')
+  }, 30000)
 })

--- a/src/main/connectors/descriptors/cancer-models.ts
+++ b/src/main/connectors/descriptors/cancer-models.ts
@@ -1,72 +1,270 @@
-import type { ToolDescriptor } from '../types'
+import type { ToolContext, ToolDescriptor } from '../types'
 
 const CBIOPORTAL = 'https://www.cbioportal.org/api'
-const DEFAULT_PAGE_SIZE = 10
+// cBioPortal exposes no total-count in the JSON body (only in a header we can't read), so every
+// "verify against the API total" is done by pulling the full collection in a single large page.
+const FULL_PAGE = 10_000_000
+const DESC_MAX = 240
+const TOP_PROTEIN_CHANGES = 25
 
-type CBioCancerType = { name?: string }
-
+type CBioCancerType = { id?: string; name?: string }
 type CBioStudy = {
   studyId?: string
   name?: string
   description?: string
   cancerTypeId?: string
   cancerType?: CBioCancerType
+  referenceGenome?: string
   pmid?: string
   citation?: string
-  referenceGenome?: string
-  allSampleCount?: number
+  publicStudy?: boolean
+  groups?: string
+  importDate?: string
   sequencedSampleCount?: number
   cnaSampleCount?: number
+  mrnaRnaSeqSampleCount?: number
+  mrnaRnaSeqV2SampleCount?: number
+  mrnaMicroarraySampleCount?: number
+  miRnaSampleCount?: number
+  methylationHm27SampleCount?: number
+  rppaSampleCount?: number
+  massSpectrometrySampleCount?: number
+  completeSampleCount?: number
+  treatmentCount?: number
   structuralVariantCount?: number
 }
+type CBioGene = { entrezGeneId?: number; hugoGeneSymbol?: string; type?: string }
+type CBioMolecularProfile = {
+  molecularProfileId?: string
+  molecularAlterationType?: string
+  datatype?: string
+  name?: string
+  description?: string
+}
+type CBioSampleList = {
+  sampleListId?: string
+  category?: string
+  name?: string
+  sampleCount?: number
+}
+type CBioIdRecord = { sampleId?: string; patientId?: string }
+type CBioMutation = {
+  sampleId?: string
+  patientId?: string
+  proteinChange?: string
+  mutationType?: string
+  mutationStatus?: string
+  chr?: string
+  startPosition?: number
+  endPosition?: number
+  referenceAllele?: string
+  variantAllele?: string
+  variantType?: string
+  ncbiBuild?: string
+  proteinPosStart?: number
+  proteinPosEnd?: number
+  tumorAltCount?: number
+  tumorRefCount?: number
+  refseqMrnaId?: string
+}
+type CBioCna = { sampleId?: string; patientId?: string; alteration?: number }
+type CBioClinicalAttr = {
+  clinicalAttributeId?: string
+  displayName?: string
+  description?: string
+  datatype?: string
+  patientAttribute?: boolean
+  priority?: string
+}
 
-const compactStudyRow = (s: CBioStudy): Record<string, unknown> => ({
-  studyId: s.studyId,
-  name: s.name,
-  cancerType: s.cancerType?.name,
-  allSampleCount: s.allSampleCount
+// The engine surfaces a non-2xx response as `HTTP <status> for <url>`; a 404 is cBioPortal's way of
+// saying the study/gene id is unknown, which we translate into a friendly "not found" error.
+const isNotFound = (err: unknown): boolean => err instanceof Error && /HTTP 404/.test(err.message)
+
+async function fetchStudyRecord(ctx: ToolContext, studyId: string): Promise<CBioStudy> {
+  try {
+    return (await ctx.fetchJson(
+      `${CBIOPORTAL}/studies/${encodeURIComponent(studyId)}?projection=DETAILED`
+    )) as CBioStudy
+  } catch (err) {
+    if (isNotFound(err)) throw new Error(`Study not found: ${studyId}`)
+    throw err
+  }
+}
+
+async function resolveGene(ctx: ToolContext, symbol: string): Promise<CBioGene> {
+  try {
+    return (await ctx.fetchJson(`${CBIOPORTAL}/genes/${encodeURIComponent(symbol)}`)) as CBioGene
+  } catch (err) {
+    if (isNotFound(err)) throw new Error(`Gene not found: ${symbol}`)
+    throw err
+  }
+}
+
+const fetchProfiles = async (ctx: ToolContext, studyId: string): Promise<CBioMolecularProfile[]> =>
+  ((await ctx.fetchJson(
+    `${CBIOPORTAL}/studies/${encodeURIComponent(studyId)}/molecular-profiles`
+  )) as CBioMolecularProfile[]) ?? []
+
+const fetchSampleLists = async (ctx: ToolContext, studyId: string): Promise<CBioSampleList[]> =>
+  ((await ctx.fetchJson(
+    `${CBIOPORTAL}/studies/${encodeURIComponent(studyId)}/sample-lists`
+  )) as CBioSampleList[]) ?? []
+
+// Distinct alteration types a study actually carries — used to explain a "no <X> data" error.
+const alterationTypes = (profiles: CBioMolecularProfile[]): string[] =>
+  [...new Set(profiles.map((p) => p.molecularAlterationType).filter(Boolean))] as string[]
+
+const pickProfile = (
+  profiles: CBioMolecularProfile[],
+  alterationType: string,
+  datatype?: string
+): CBioMolecularProfile | undefined =>
+  profiles.find(
+    (p) => p.molecularAlterationType === alterationType && (!datatype || p.datatype === datatype)
+  )
+
+// First sample list matching one of the preferred categories, in priority order.
+const pickSampleList = (
+  lists: CBioSampleList[],
+  categories: string[]
+): CBioSampleList | undefined => {
+  for (const category of categories) {
+    const match = lists.find((l) => l.category === category)
+    if (match) return match
+  }
+  return undefined
+}
+
+const round4 = (x: number): number => Math.round(x * 10_000) / 10_000
+const trimDescription = (d?: string): string | undefined =>
+  d && d.length > DESC_MAX ? `${d.slice(0, DESC_MAX).trimEnd()}…` : d
+
+// Order genomic positions as chr 1..22, X, Y, MT, then anything else.
+const chrOrder = (chr?: string): number => {
+  if (!chr) return 100
+  const n = Number.parseInt(chr, 10)
+  if (Number.isFinite(n) && String(n) === chr.replace(/^chr/i, '')) return n
+  const u = chr.replace(/^chr/i, '').toUpperCase()
+  if (u === 'X') return 23
+  if (u === 'Y') return 24
+  if (u === 'M' || u === 'MT') return 25
+  return 99
+}
+
+// Tally string values, returned as an object ordered by descending count (ties: alphabetical).
+const countBy = (values: (string | undefined)[]): Record<string, number> => {
+  const counts = new Map<string, number>()
+  for (const v of values) if (v) counts.set(v, (counts.get(v) ?? 0) + 1)
+  return Object.fromEntries(
+    [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+  )
+}
+
+// Discrete copy-number values and the labels/event-type buckets cBioPortal uses for them.
+const CNA_LABEL: Record<number, string> = {
+  [-2]: 'deep_deletion',
+  [-1]: 'shallow_deletion',
+  0: 'diploid',
+  1: 'gain',
+  2: 'amplification'
+}
+const EVENT_ALTERATIONS: Record<string, number[]> = {
+  HOMDEL_AND_AMP: [-2, 2],
+  HOMDEL: [-2],
+  AMP: [2],
+  GAIN: [1],
+  HETLOSS: [-1],
+  DIPLOID: [0],
+  ALL: [-2, -1, 0, 1, 2]
+}
+
+const mapMutation = (m: CBioMutation): Record<string, unknown> => ({
+  sample_id: m.sampleId,
+  patient_id: m.patientId,
+  protein_change: m.proteinChange,
+  mutation_type: m.mutationType,
+  mutation_status: m.mutationStatus,
+  chromosome: m.chr,
+  start_position: m.startPosition,
+  end_position: m.endPosition,
+  reference_allele: m.referenceAllele,
+  variant_allele: m.variantAllele,
+  variant_type: m.variantType,
+  ncbi_build: m.ncbiBuild,
+  protein_pos_start: m.proteinPosStart,
+  protein_pos_end: m.proteinPosEnd,
+  tumor_alt_count: m.tumorAltCount,
+  tumor_ref_count: m.tumorRefCount,
+  refseq_mrna_id: m.refseqMrnaId
 })
 
-const compactStudyDetail = (s: CBioStudy): Record<string, unknown> => ({
-  studyId: s.studyId,
-  name: s.name,
-  description: s.description,
-  cancerType: s.cancerType?.name,
-  cancerTypeId: s.cancerTypeId,
-  pmid: s.pmid,
-  citation: s.citation,
-  referenceGenome: s.referenceGenome,
-  allSampleCount: s.allSampleCount,
-  sequencedSampleCount: s.sequencedSampleCount,
-  cnaSampleCount: s.cnaSampleCount,
-  structuralVariantCount: s.structuralVariantCount
-})
-
-// cBioPortal public REST API (keyless): read-only cancer study search/lookup.
+// cBioPortal public REST API (keyless): read-only cancer-genomics studies, mutations, CNA, and
+// clinical-attribute lookups. Profile/sample-list ids are never assumed — always resolved from the
+// study's own /molecular-profiles and /sample-lists collections.
 export const CANCER_MODELS_TOOLS: ToolDescriptor[] = [
   {
-    id: 'cbioportal_search_studies',
+    id: 'cbioportal_list_studies',
     connector: 'cancer_models',
     description:
-      'Search cBioPortal cancer studies by keyword (name/description/cancer type); returns study id, name, cancer type, and sample count per hit.',
+      'List cBioPortal cancer studies, optionally filtered by a free-text keyword (name/description/cancer type) and/or an exact cancer-type id; returns study id, name, cancer type, reference genome, citation, and per-data-type sample counts.',
     input: {
       type: 'object',
-      properties: { query: { type: 'string' }, page_size: { type: 'integer', default: 10 } },
-      required: ['query']
+      properties: {
+        keyword: { type: 'string', description: 'Free-text match on name/description/cancer type' },
+        cancer_type_id: {
+          type: 'string',
+          description: 'Exact cancer-type id filter (client-side), e.g. brca, difg'
+        },
+        max_records: { type: 'integer', default: 500 }
+      }
     },
-    required: ['query'],
     returns:
-      '`[ { "studyId": str, "name": str, "cancerType": str, "allSampleCount": int } ]` — up to `page_size` studies (default 10); `[]` when nothing matches.',
-    example: 'result = host.mcp("cancer_models", "cbioportal_search_studies", {"query": "breast"})',
-    url: (a) =>
-      `${CBIOPORTAL}/studies?keyword=${encodeURIComponent(String(a.query))}&projection=DETAILED&pageSize=${Number(a.page_size ?? DEFAULT_PAGE_SIZE)}&pageNumber=0`,
-    parse: (raw) => ((raw as CBioStudy[] | null) ?? []).map(compactStudyRow)
+      '`{ "keyword": str|null, "cancer_type_id": str|null, "api_total_for_keyword": int, "count": int, "truncated": bool, "studies": [ { "study_id": str, "name": str, "description": str, "cancer_type_id": str, "cancer_type": str, "reference_genome": str, "pmid": str, "citation": str, "sequenced_sample_count": int, "cna_sample_count": int, "structural_variant_count": int } ] }` — `api_total_for_keyword` is every study the keyword matched (before the `cancer_type_id` filter); `count` is after it; `studies` are sorted by `study_id`, capped at `max_records` (default 500), and `truncated` is true when `count` exceeds the cap.',
+    example: 'result = host.mcp("cancer_models", "cbioportal_list_studies", {"keyword": "glioma"})',
+    run: async (ctx, a) => {
+      const keyword = a.keyword != null ? String(a.keyword) : undefined
+      const cancerTypeId = a.cancer_type_id != null ? String(a.cancer_type_id) : undefined
+      const maxRecords = Number(a.max_records ?? 500)
+
+      let url = `${CBIOPORTAL}/studies?projection=DETAILED&pageSize=${FULL_PAGE}&pageNumber=0`
+      if (keyword) url += `&keyword=${encodeURIComponent(keyword)}`
+      const matched = ((await ctx.fetchJson(url)) as CBioStudy[]) ?? []
+
+      const filtered = cancerTypeId
+        ? matched.filter((s) => s.cancerTypeId === cancerTypeId)
+        : matched
+      const sorted = filtered
+        .slice()
+        .sort((x, y) => (x.studyId ?? '').localeCompare(y.studyId ?? ''))
+
+      return {
+        keyword: keyword ?? null,
+        cancer_type_id: cancerTypeId ?? null,
+        api_total_for_keyword: matched.length,
+        count: filtered.length,
+        truncated: filtered.length > maxRecords,
+        studies: sorted.slice(0, maxRecords).map((s) => ({
+          study_id: s.studyId,
+          name: s.name,
+          description: trimDescription(s.description),
+          cancer_type_id: s.cancerTypeId,
+          cancer_type: s.cancerType?.name,
+          reference_genome: s.referenceGenome,
+          pmid: s.pmid,
+          citation: s.citation,
+          sequenced_sample_count: s.sequencedSampleCount,
+          cna_sample_count: s.cnaSampleCount,
+          structural_variant_count: s.structuralVariantCount
+        }))
+      }
+    }
   },
   {
     id: 'cbioportal_get_study',
     connector: 'cancer_models',
     description:
-      'Get a cBioPortal cancer study by study id; returns name, description, cancer type, citation, and sample counts.',
+      'Get a cBioPortal cancer study by id: metadata, per-data-type sample counts, true sample/patient counts (from the study collections, not the display field), and its molecular profiles.',
     input: {
       type: 'object',
       properties: { study_id: { type: 'string' } },
@@ -74,11 +272,363 @@ export const CANCER_MODELS_TOOLS: ToolDescriptor[] = [
     },
     required: ['study_id'],
     returns:
-      '`{ "studyId": str, "name": str, "description": str, "cancerType": str, "cancerTypeId": str, "pmid": str, "citation": str, "referenceGenome": str, "allSampleCount": int, "sequencedSampleCount": int, "cnaSampleCount": int, "structuralVariantCount": int }` — a single study; fields are undefined when absent from the cBioPortal record.',
+      '`{ "study_id": str, "name": str, "description": str, "cancer_type": str, "cancer_type_id": str, "reference_genome": str, "pmid": str, "citation": str, "public": bool, "groups": str, "import_date": str, "sample_count": int, "patient_count": int, "sequenced_sample_count": int, "cna_sample_count": int, "mrna_rnaseq_v2_sample_count": int, "rppa_sample_count": int, "structural_variant_count": int, "treatment_count": int, ..., "molecular_profiles": [ { "molecular_profile_id": str, "alteration_type": str, "datatype": str, "name": str, "description": str } ] }` — `sample_count`/`patient_count` are the real collection sizes; `molecular_profiles` are sorted by id. Unknown study id throws "Study not found".',
     example:
       'result = host.mcp("cancer_models", "cbioportal_get_study", {"study_id": "msk_impact_2017"})',
-    url: (a) =>
-      `${CBIOPORTAL}/studies/${encodeURIComponent(String(a.study_id))}?projection=DETAILED`,
-    parse: (raw) => compactStudyDetail(raw as CBioStudy)
+    run: async (ctx, a) => {
+      const studyId = String(a.study_id)
+      const study = await fetchStudyRecord(ctx, studyId)
+      const [profiles, samples, patients] = await Promise.all([
+        fetchProfiles(ctx, studyId),
+        ctx.fetchJson(
+          `${CBIOPORTAL}/studies/${encodeURIComponent(studyId)}/samples?projection=ID`
+        ) as Promise<CBioIdRecord[]>,
+        ctx.fetchJson(
+          `${CBIOPORTAL}/studies/${encodeURIComponent(studyId)}/patients?projection=ID`
+        ) as Promise<CBioIdRecord[]>
+      ])
+
+      return {
+        study_id: study.studyId,
+        name: study.name,
+        description: study.description,
+        cancer_type: study.cancerType?.name,
+        cancer_type_id: study.cancerTypeId,
+        reference_genome: study.referenceGenome,
+        pmid: study.pmid,
+        citation: study.citation,
+        public: study.publicStudy,
+        groups: study.groups,
+        import_date: study.importDate,
+        sample_count: (samples ?? []).length,
+        patient_count: (patients ?? []).length,
+        sequenced_sample_count: study.sequencedSampleCount,
+        cna_sample_count: study.cnaSampleCount,
+        mrna_rnaseq_sample_count: study.mrnaRnaSeqSampleCount,
+        mrna_rnaseq_v2_sample_count: study.mrnaRnaSeqV2SampleCount,
+        mrna_microarray_sample_count: study.mrnaMicroarraySampleCount,
+        mirna_sample_count: study.miRnaSampleCount,
+        methylation_hm27_sample_count: study.methylationHm27SampleCount,
+        rppa_sample_count: study.rppaSampleCount,
+        mass_spectrometry_sample_count: study.massSpectrometrySampleCount,
+        complete_sample_count: study.completeSampleCount,
+        treatment_count: study.treatmentCount,
+        structural_variant_count: study.structuralVariantCount,
+        molecular_profiles: (profiles ?? [])
+          .slice()
+          .sort((x, y) => (x.molecularProfileId ?? '').localeCompare(y.molecularProfileId ?? ''))
+          .map((p) => ({
+            molecular_profile_id: p.molecularProfileId,
+            alteration_type: p.molecularAlterationType,
+            datatype: p.datatype,
+            name: p.name,
+            description: p.description
+          }))
+      }
+    }
+  },
+  {
+    id: 'cbioportal_mutations_in_gene',
+    connector: 'cancer_models',
+    description:
+      'All mutations of one gene (HUGO symbol) in a cBioPortal study, with recurrence aggregates: total mutations, mutated-sample count, mutation-type and protein-change distributions, and the most recurrent protein changes.',
+    input: {
+      type: 'object',
+      properties: {
+        gene_symbol: { type: 'string', description: 'HUGO gene symbol, e.g. KRAS, IDH1' },
+        study_id: { type: 'string' },
+        max_records: { type: 'integer', default: 100 }
+      },
+      required: ['gene_symbol', 'study_id']
+    },
+    required: ['gene_symbol', 'study_id'],
+    returns:
+      '`{ "gene": { "symbol": str, "entrez_gene_id": int }, "study_id": str, "molecular_profile_id": str, "total_mutations": int, "mutated_sample_count": int, "mutation_type_counts": { str: int }, "distinct_protein_changes": int, "top_protein_changes": { str: int }, "truncated": bool, "mutations": [ { "sample_id": str, "patient_id": str, "protein_change": str, "mutation_type": str, "mutation_status": str, "chromosome": str, "start_position": int, "end_position": int, "reference_allele": str, "variant_allele": str, "variant_type": str, "ncbi_build": str, "protein_pos_start": int, "protein_pos_end": int, "tumor_alt_count": int, "tumor_ref_count": int, "refseq_mrna_id": str } ] }` — aggregates cover every mutation; `mutations` are sorted by genomic position and capped at `max_records` (default 100), with `truncated` set when they exceed it. `top_protein_changes` holds the 25 most recurrent. Unknown gene throws "Gene not found"; a study without mutation data throws, listing the alteration types it does have.',
+    example:
+      'result = host.mcp("cancer_models", "cbioportal_mutations_in_gene", {"gene_symbol": "IDH1", "study_id": "difg_msk_2023"})',
+    run: async (ctx, a) => {
+      const symbol = String(a.gene_symbol)
+      const studyId = String(a.study_id)
+      const maxRecords = Number(a.max_records ?? 100)
+
+      const gene = await resolveGene(ctx, symbol)
+      const profiles = await fetchProfiles(ctx, studyId)
+      const profile = pickProfile(profiles, 'MUTATION_EXTENDED')
+      if (!profile?.molecularProfileId) {
+        throw new Error(
+          `Study ${studyId} has no mutation data. Available alteration types: ${
+            alterationTypes(profiles).join(', ') || 'none'
+          }`
+        )
+      }
+      const lists = await fetchSampleLists(ctx, studyId)
+      const sampleList = pickSampleList(lists, [
+        'all_cases_with_mutation_data',
+        'all_cases_in_study'
+      ])
+      if (!sampleList?.sampleListId) throw new Error(`Study ${studyId} has no usable sample list`)
+
+      const rows =
+        ((await ctx.fetchJson(
+          `${CBIOPORTAL}/molecular-profiles/${encodeURIComponent(profile.molecularProfileId)}/mutations` +
+            `?sampleListId=${encodeURIComponent(sampleList.sampleListId)}` +
+            `&entrezGeneId=${gene.entrezGeneId}&projection=DETAILED&pageSize=${FULL_PAGE}&pageNumber=0`
+        )) as CBioMutation[]) ?? []
+
+      const sorted = rows
+        .slice()
+        .sort(
+          (x, y) =>
+            chrOrder(x.chr) - chrOrder(y.chr) || (x.startPosition ?? 0) - (y.startPosition ?? 0)
+        )
+      const proteinCounts = countBy(rows.map((m) => m.proteinChange))
+
+      return {
+        gene: { symbol: gene.hugoGeneSymbol, entrez_gene_id: gene.entrezGeneId },
+        study_id: studyId,
+        molecular_profile_id: profile.molecularProfileId,
+        total_mutations: rows.length,
+        mutated_sample_count: new Set(rows.map((m) => m.sampleId)).size,
+        mutation_type_counts: countBy(rows.map((m) => m.mutationType)),
+        distinct_protein_changes: Object.keys(proteinCounts).length,
+        top_protein_changes: Object.fromEntries(
+          Object.entries(proteinCounts).slice(0, TOP_PROTEIN_CHANGES)
+        ),
+        truncated: rows.length > maxRecords,
+        mutations: sorted.slice(0, maxRecords).map(mapMutation)
+      }
+    }
+  },
+  {
+    id: 'cbioportal_mutation_frequency',
+    connector: 'cancer_models',
+    description:
+      'Mutation frequency of one gene across several cBioPortal studies (1–12): mutated-sample fraction of the sequenced cohort per study, ranked most-frequent first.',
+    input: {
+      type: 'object',
+      properties: {
+        gene_symbol: { type: 'string' },
+        study_ids: { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 12 }
+      },
+      required: ['gene_symbol', 'study_ids']
+    },
+    required: ['gene_symbol', 'study_ids'],
+    returns:
+      '`{ "gene": { "symbol": str, "entrez_gene_id": int }, "count": int, "frequencies": [ { "study_id": str, "study_name": str, "molecular_profile_id": str, "mutation_count": int, "mutated_samples": int, "sequenced_samples": int, "frequency": float } ], "unknown_studies": [ str ], "no_mutation_data": [ str ] }` — `frequencies` are sorted by descending `frequency` (4-dp, null when the study reports 0 sequenced samples); ids the API does not know go to `unknown_studies`, studies without a mutation profile / sample list to `no_mutation_data`. At most 12 ids are considered. Unknown gene throws "Gene not found".',
+    example:
+      'result = host.mcp("cancer_models", "cbioportal_mutation_frequency", {"gene_symbol": "KRAS", "study_ids": ["msk_impact_2017", "difg_msk_2023"]})',
+    run: async (ctx, a) => {
+      const symbol = String(a.gene_symbol)
+      const studyIds = (Array.isArray(a.study_ids) ? a.study_ids : []).map(String).slice(0, 12)
+      const gene = await resolveGene(ctx, symbol)
+
+      const frequencies: Record<string, unknown>[] = []
+      const unknownStudies: string[] = []
+      const noMutationData: string[] = []
+
+      for (const studyId of studyIds) {
+        let study: CBioStudy
+        try {
+          study = await fetchStudyRecord(ctx, studyId)
+        } catch (err) {
+          // fetchStudyRecord maps a 404 to a "Study not found" message — treat either as unknown.
+          if (err instanceof Error && /HTTP 404|Study not found/.test(err.message)) {
+            unknownStudies.push(studyId)
+            continue
+          }
+          throw err
+        }
+        const profiles = await fetchProfiles(ctx, studyId)
+        const profile = pickProfile(profiles, 'MUTATION_EXTENDED')
+        if (!profile?.molecularProfileId) {
+          noMutationData.push(studyId)
+          continue
+        }
+        const lists = await fetchSampleLists(ctx, studyId)
+        const sampleList = pickSampleList(lists, [
+          'all_cases_with_mutation_data',
+          'all_cases_in_study'
+        ])
+        if (!sampleList?.sampleListId) {
+          noMutationData.push(studyId)
+          continue
+        }
+
+        const rows =
+          ((await ctx.fetchJson(
+            `${CBIOPORTAL}/molecular-profiles/${encodeURIComponent(profile.molecularProfileId)}/mutations` +
+              `?sampleListId=${encodeURIComponent(sampleList.sampleListId)}` +
+              `&entrezGeneId=${gene.entrezGeneId}&projection=DETAILED&pageSize=${FULL_PAGE}&pageNumber=0`
+          )) as CBioMutation[]) ?? []
+        const sequenced = study.sequencedSampleCount ?? 0
+        const mutatedSamples = new Set(rows.map((m) => m.sampleId)).size
+        frequencies.push({
+          study_id: studyId,
+          study_name: study.name,
+          molecular_profile_id: profile.molecularProfileId,
+          mutation_count: rows.length,
+          mutated_samples: mutatedSamples,
+          sequenced_samples: sequenced,
+          frequency: sequenced > 0 ? round4(mutatedSamples / sequenced) : null
+        })
+      }
+
+      frequencies.sort((x, y) => {
+        const fx = x.frequency as number | null
+        const fy = y.frequency as number | null
+        if (fx === fy) return (x.study_id as string).localeCompare(y.study_id as string)
+        if (fx == null) return 1
+        if (fy == null) return -1
+        return fy - fx
+      })
+
+      return {
+        gene: { symbol: gene.hugoGeneSymbol, entrez_gene_id: gene.entrezGeneId },
+        count: frequencies.length,
+        frequencies,
+        unknown_studies: unknownStudies,
+        no_mutation_data: noMutationData
+      }
+    }
+  },
+  {
+    id: 'cbioportal_cna_in_gene',
+    connector: 'cancer_models',
+    description:
+      'Discrete copy-number alterations of one gene in a cBioPortal study, filtered by event type (deep deletion / amplification by default), with the full per-sample alteration distribution.',
+    input: {
+      type: 'object',
+      properties: {
+        gene_symbol: { type: 'string' },
+        study_id: { type: 'string' },
+        event_type: {
+          type: 'string',
+          enum: ['HOMDEL_AND_AMP', 'HOMDEL', 'AMP', 'GAIN', 'HETLOSS', 'DIPLOID', 'ALL'],
+          default: 'HOMDEL_AND_AMP'
+        },
+        max_records: { type: 'integer', default: 100 }
+      },
+      required: ['gene_symbol', 'study_id']
+    },
+    required: ['gene_symbol', 'study_id'],
+    returns:
+      '`{ "gene": { "symbol": str, "entrez_gene_id": int }, "study_id": str, "molecular_profile_id": str, "event_type": str, "total_events": int, "altered_sample_count": int, "alteration_counts": { str: int }, "truncated": bool, "events": [ { "sample_id": str, "patient_id": str, "alteration": int, "alteration_label": str } ] }` — `alteration_counts` is the complete per-label distribution over the gene (deep_deletion/shallow_deletion/diploid/gain/amplification); `total_events`/`events` cover only rows matching `event_type` (default HOMDEL_AND_AMP), sorted by sample id and capped at `max_records`. Unknown gene throws "Gene not found"; a study without discrete CNA throws, listing its alteration types.',
+    example:
+      'result = host.mcp("cancer_models", "cbioportal_cna_in_gene", {"gene_symbol": "CDKN2A", "study_id": "msk_impact_2017"})',
+    run: async (ctx, a) => {
+      const symbol = String(a.gene_symbol)
+      const studyId = String(a.study_id)
+      const eventType = String(a.event_type ?? 'HOMDEL_AND_AMP')
+      const maxRecords = Number(a.max_records ?? 100)
+      const wanted = new Set(EVENT_ALTERATIONS[eventType] ?? EVENT_ALTERATIONS.HOMDEL_AND_AMP)
+
+      const gene = await resolveGene(ctx, symbol)
+      const profiles = await fetchProfiles(ctx, studyId)
+      const profile = pickProfile(profiles, 'COPY_NUMBER_ALTERATION', 'DISCRETE')
+      if (!profile?.molecularProfileId) {
+        throw new Error(
+          `Study ${studyId} has no discrete copy-number data. Available alteration types: ${
+            alterationTypes(profiles).join(', ') || 'none'
+          }`
+        )
+      }
+      const lists = await fetchSampleLists(ctx, studyId)
+      const sampleList = pickSampleList(lists, ['all_cases_with_cna_data', 'all_cases_in_study'])
+      if (!sampleList?.sampleListId) throw new Error(`Study ${studyId} has no usable sample list`)
+
+      // GET discrete-copy-number ignores the gene filter, so fetch the gene's full per-sample vector
+      // via the POST /fetch endpoint (read-only) and bucket it client-side by event type.
+      const rows =
+        ((await ctx.postJson(
+          `${CBIOPORTAL}/molecular-profiles/${encodeURIComponent(profile.molecularProfileId)}/discrete-copy-number/fetch` +
+            `?discreteCopyNumberEventType=ALL&projection=DETAILED`,
+          { sampleListId: sampleList.sampleListId, entrezGeneIds: [gene.entrezGeneId] }
+        )) as CBioCna[]) ?? []
+
+      const alterationCounts = countBy(
+        rows.map((r) => (r.alteration != null ? CNA_LABEL[r.alteration] : undefined))
+      )
+      const matching = rows
+        .filter((r) => r.alteration != null && wanted.has(r.alteration))
+        .sort((x, y) => (x.sampleId ?? '').localeCompare(y.sampleId ?? ''))
+
+      return {
+        gene: { symbol: gene.hugoGeneSymbol, entrez_gene_id: gene.entrezGeneId },
+        study_id: studyId,
+        molecular_profile_id: profile.molecularProfileId,
+        event_type: eventType,
+        total_events: matching.length,
+        altered_sample_count: new Set(matching.map((r) => r.sampleId)).size,
+        alteration_counts: alterationCounts,
+        truncated: matching.length > maxRecords,
+        events: matching.slice(0, maxRecords).map((r) => ({
+          sample_id: r.sampleId,
+          patient_id: r.patientId,
+          alteration: r.alteration,
+          alteration_label: r.alteration != null ? CNA_LABEL[r.alteration] : undefined
+        }))
+      }
+    }
+  },
+  {
+    id: 'cbioportal_clinical_attributes',
+    connector: 'cancer_models',
+    description:
+      'Clinical attributes defined in a cBioPortal study (patient- and sample-level fields), highlighting survival endpoints and whether overall-survival data is present.',
+    input: {
+      type: 'object',
+      properties: {
+        study_id: { type: 'string' },
+        max_records: { type: 'integer', default: 200 }
+      },
+      required: ['study_id']
+    },
+    required: ['study_id'],
+    returns:
+      '`{ "study_id": str, "total_attributes": int, "patient_level_count": int, "sample_level_count": int, "survival_attributes": [ str ], "has_overall_survival": bool, "truncated": bool, "attributes": [ { "attribute_id": str, "display_name": str, "description": str, "datatype": "STRING"|"NUMBER", "level": "patient"|"sample", "priority": int } ] }` — `survival_attributes` are every OS_/DFS_/PFS_/DSS_ attribute id; `has_overall_survival` is true when both OS_STATUS and OS_MONTHS exist; `attributes` are sorted by id and capped at `max_records` (default 200).',
+    example:
+      'result = host.mcp("cancer_models", "cbioportal_clinical_attributes", {"study_id": "brca_tcga_pan_can_atlas_2018"})',
+    run: async (ctx, a) => {
+      const studyId = String(a.study_id)
+      const maxRecords = Number(a.max_records ?? 200)
+
+      let raw: CBioClinicalAttr[]
+      try {
+        raw =
+          ((await ctx.fetchJson(
+            `${CBIOPORTAL}/studies/${encodeURIComponent(studyId)}/clinical-attributes`
+          )) as CBioClinicalAttr[]) ?? []
+      } catch (err) {
+        if (isNotFound(err)) throw new Error(`Study not found: ${studyId}`)
+        throw err
+      }
+
+      const ids = new Set(raw.map((r) => r.clinicalAttributeId))
+      const survivalAttributes = [...ids]
+        .filter((id): id is string => !!id && /^(OS|DFS|PFS|DSS)_/.test(id))
+        .sort((x, y) => x.localeCompare(y))
+      const attributes = raw
+        .slice()
+        .sort((x, y) => (x.clinicalAttributeId ?? '').localeCompare(y.clinicalAttributeId ?? ''))
+        .map((r) => ({
+          attribute_id: r.clinicalAttributeId,
+          display_name: r.displayName,
+          description: r.description,
+          datatype: r.datatype,
+          level: r.patientAttribute ? 'patient' : 'sample',
+          priority: r.priority != null ? Number(r.priority) : undefined
+        }))
+
+      return {
+        study_id: studyId,
+        total_attributes: raw.length,
+        patient_level_count: raw.filter((r) => r.patientAttribute).length,
+        sample_level_count: raw.filter((r) => !r.patientAttribute).length,
+        survival_attributes: survivalAttributes,
+        has_overall_survival: ids.has('OS_STATUS') && ids.has('OS_MONTHS'),
+        truncated: raw.length > maxRecords,
+        attributes: attributes.slice(0, maxRecords)
+      }
+    }
   }
 ]


### PR DESCRIPTION
Enhances the Cancer Models (cBioPortal) connector from 2 tools to 6, giving the agent gene- and cohort-level cancer genomics beyond study lookup.

## New capabilities
- `cbioportal_list_studies` — keyword/cancer-type study search with verified totals and truncation flags.
- `cbioportal_get_study` — full study record plus available molecular profiles and true sample/patient counts.
- `cbioportal_mutations_in_gene` — per-gene somatic mutations in a study with complete aggregates (type counts, recurrent protein changes) and a capped listing.
- `cbioportal_mutation_frequency` — a gene's mutation prevalence compared across up to 12 cohorts.
- `cbioportal_cna_in_gene` — discrete copy-number events (GISTIC-style calls) per gene.
- `cbioportal_clinical_attributes` — a study's clinical data dictionary (survival endpoints, stage, subtype, ...).

## Notes
- Gene-filtered CNA uses the read-only POST `/discrete-copy-number/fetch` endpoint (the GET path ignores the gene id).
- Broken upstream `allSampleCount` deliberately omitted in favor of verified counts.

## Verification
- Full `src/main/connectors` suite green (mock unit tests) + live integration tests (`LIVE_API`-gated) against the real cBioPortal API.
- lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)