### PR TITLE
feat(connectors): expand CellGuide with search, markers, tissues & sources

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -225,9 +225,10 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
   {
     id: 'cellguide',
     displayName: 'CellGuide',
-    description: 'Cell-type identity and canonical marker genes via CELLxGENE CellGuide.',
+    description:
+      'Cell-type identity, marker genes, source datasets, and tissues via CELLxGENE CellGuide.',
     useWhen:
-      'Use when you need cell-type identity, description, or canonical marker genes for a Cell Ontology (CL) id. Sourced from CELLxGENE CellGuide.',
+      'Use for cell-type biology from CELLxGENE CellGuide — searching cell types by name/synonym, or (by Cell Ontology id or name) getting identity/description, computational or canonical marker genes, contributing source datasets/publications, and the anatomical tissues a cell type is found in.',
     sources: ['CELLxGENE'],
     termsUrl: 'https://cellxgene.cziscience.com/',
     requiresNcbi: false

--- a/src/main/connectors/descriptors/cellguide.test.ts
+++ b/src/main/connectors/descriptors/cellguide.test.ts
@@ -6,17 +6,22 @@ import type { ToolDescriptor } from '../types'
 const tool = (id: string): ToolDescriptor => CELLGUIDE_TOOLS.find((t) => t.id === id)!
 
 const SNAPSHOT = '1763135102'
-const ACINAR_METADATA = {
+const METADATA = {
   'CL:0000622': {
     name: 'acinar cell',
     id: 'CL:0000622',
     clDescription: 'A secretory cell that ... releases zymogen granules.',
     synonyms: ['acinic cell', 'acinous cell']
+  },
+  'CL:0000084': {
+    name: 'T cell',
+    id: 'CL:0000084',
+    clDescription: 'A type of lymphocyte.',
+    synonyms: ['T-cell', 'T lymphocyte']
   }
 }
-// Live shape confirmed against the CDN (2026-07-12): {tissue, symbol, name, publication,
-// publication_titles} — no marker_score/groupby_dims (those only exist on
-// computational_marker_genes; client.py's shared formatter assumes them incorrectly).
+// Live shape confirmed against the CDN (2026-07-14): {tissue, symbol, name, publication,
+// publication_titles} — no score field (canonical markers are literature-curated).
 const CANONICAL_MARKERS = [
   {
     tissue: 'pancreas',
@@ -31,6 +36,54 @@ const CANONICAL_MARKERS = [
     name: 'carboxypeptidase A1',
     publication: 'PMID:12345',
     publication_titles: 'Some paper title'
+  }
+]
+// Live shape confirmed against the CDN (2026-07-14): {me, pc, marker_score, specificity,
+// gene_ontology_term_id, symbol, name, groupby_dims}.
+const COMPUTATIONAL_MARKERS = [
+  {
+    me: 3.12,
+    pc: 0.84,
+    marker_score: 1.92,
+    specificity: 0.99,
+    gene_ontology_term_id: 'ENSMUSG00000071553',
+    symbol: 'Cpa2',
+    name: 'carboxypeptidase A2, pancreatic',
+    groupby_dims: { organism_ontology_term_label: 'Mus musculus' }
+  },
+  {
+    me: 4.62,
+    pc: 0.91,
+    marker_score: 2.72,
+    specificity: 1.0,
+    gene_ontology_term_id: 'ENSMUSG00000042179',
+    symbol: 'Pnliprp1',
+    name: 'pancreatic lipase related protein 1',
+    groupby_dims: { organism_ontology_term_label: 'Mus musculus' }
+  }
+]
+// Live shape confirmed against the CDN (2026-07-14).
+const SOURCE_COLLECTIONS = [
+  {
+    collection_name: 'Human Pancreas Aging',
+    collection_url: 'https://cellxgene.cziscience.com/collections/aaa',
+    publication_url: '10.1016/j.cell.2017.09.004',
+    publication_title: 'Enge et al. (2017) Cell',
+    tissue: [{ label: 'pancreas', ontology_term_id: 'UBERON:0001264' }],
+    disease: [{ label: 'normal', ontology_term_id: 'PATO:0000461' }],
+    organism: [{ label: 'Homo sapiens', ontology_term_id: 'NCBITaxon:9606' }]
+  },
+  {
+    collection_name: 'Muraro Pancreas',
+    collection_url: 'https://cellxgene.cziscience.com/collections/bbb',
+    publication_url: '',
+    publication_title: '',
+    tissue: [
+      { label: 'pancreas', ontology_term_id: 'UBERON:0001264' },
+      { label: 'blood', ontology_term_id: 'UBERON:0000178' }
+    ],
+    disease: [],
+    organism: [{ label: 'Homo sapiens', ontology_term_id: 'NCBITaxon:9606' }]
   }
 ]
 
@@ -48,8 +101,8 @@ function mockFetch(
     return {
       ok: status < 400,
       status,
-      // Mirror real fetch: .json() on an empty body throws (no 'json' provided means "parse the
-      // text field"), matching the CDN's 200-with-empty-body response for uncurated cell types.
+      // Mirror real fetch: .json() on an empty body throws, matching the CDN's 200-with-empty-body
+      // response for cell types with no curated/computed data.
       json: async () => {
         if ('json' in r) return r.json
         if (!r.text) throw new SyntaxError('Unexpected end of JSON input')
@@ -60,19 +113,20 @@ function mockFetch(
   }) as unknown as typeof fetch
 }
 
-describe('cellguide / cellguide_cell_type', () => {
-  it('fetches snapshot, metadata, description, and canonical markers for a CL id', async () => {
+const engine = (fetchImpl: typeof fetch): ParserEngine => new ParserEngine({ fetchImpl })
+
+describe('cellguide / get_cell_type_info', () => {
+  it('resolves a CL id to name, synonyms, ontology + curated description', async () => {
     const fetchImpl = mockFetch({
       latest_snapshot_identifier: { text: SNAPSHOT },
-      '/celltype_metadata.json': { json: ACINAR_METADATA },
+      '/celltype_metadata.json': { json: METADATA },
       '/validated_descriptions/CL_0000622.json': {
         json: { description: 'Acinar cells secrete digestive enzymes.', references: ['PMID:123'] }
-      },
-      '/canonical_marker_genes/CL_0000622.json': { json: CANONICAL_MARKERS }
+      }
     })
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('cellguide_cell_type'),
-      { cellType: 'CL:0000622' },
+    const out = await engine(fetchImpl).call(
+      tool('get_cell_type_info'),
+      { cell_type: 'CL:0000622' },
       {}
     )
     expect(out).toEqual({
@@ -82,134 +136,307 @@ describe('cellguide / cellguide_cell_type', () => {
       ontologyDescription: 'A secretory cell that ... releases zymogen granules.',
       description: 'Acinar cells secrete digestive enzymes.',
       descriptionSource: 'validated',
-      references: ['PMID:123'],
-      canonicalMarkerGenes: [
-        {
-          symbol: 'PRSS1',
-          name: 'trypsinogen',
-          tissue: 'pancreas',
-          publication: undefined,
-          publicationTitle: undefined
-        },
-        {
-          symbol: 'CPA1',
-          name: 'carboxypeptidase A1',
-          tissue: 'pancreas',
-          publication: 'PMID:12345',
-          publicationTitle: 'Some paper title'
-        }
-      ]
+      references: ['PMID:123']
     })
   })
 
-  it('builds the CDN urls with snapshot id and URL-format (underscore) cell id', async () => {
+  it('resolves a free-text name/synonym to its CL id', async () => {
     const fetchImpl = mockFetch({
       latest_snapshot_identifier: { text: SNAPSHOT },
-      '/celltype_metadata.json': { json: ACINAR_METADATA },
-      '/validated_descriptions/CL_0000622.json': { json: { description: 'x', references: [] } },
-      '/canonical_marker_genes/CL_0000622.json': { json: [] }
+      '/celltype_metadata.json': { json: METADATA },
+      '/validated_descriptions/CL_0000622.json': { json: { description: 'x', references: [] } }
     })
-    await new ParserEngine({ fetchImpl }).call(
-      tool('cellguide_cell_type'),
-      { cellType: 'CL:0000622' },
+    const out = (await engine(fetchImpl).call(
+      tool('get_cell_type_info'),
+      { cell_type: 'acinous cell' },
       {}
-    )
-    const calls = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]))
-    expect(calls[0]).toBe('https://cellguide.cellxgene.cziscience.com/latest_snapshot_identifier')
-    expect(calls[1]).toBe(
-      `https://cellguide.cellxgene.cziscience.com/${SNAPSHOT}/celltype_metadata.json`
-    )
-    expect(calls[2]).toBe(
-      'https://cellguide.cellxgene.cziscience.com/validated_descriptions/CL_0000622.json'
-    )
-    expect(calls[3]).toBe(
-      `https://cellguide.cellxgene.cziscience.com/${SNAPSHOT}/canonical_marker_genes/CL_0000622.json`
-    )
-  })
-
-  it('returns an error and skips further fetches when the cell type is not in metadata', async () => {
-    const fetchImpl = mockFetch({
-      latest_snapshot_identifier: { text: SNAPSHOT },
-      '/celltype_metadata.json': { json: ACINAR_METADATA }
-    })
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('cellguide_cell_type'),
-      { cellType: 'CL:9999999' },
-      {}
-    )
-    expect(out).toEqual({ error: "Cell type 'CL:9999999' not found" })
-    expect((fetchImpl as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2)
+    )) as { id: string; name: string }
+    expect(out.id).toBe('CL:0000622')
+    expect(out.name).toBe('acinar cell')
   })
 
   it('falls back to the GPT description when no validated description exists', async () => {
     const fetchImpl = mockFetch({
       latest_snapshot_identifier: { text: SNAPSHOT },
-      '/celltype_metadata.json': { json: ACINAR_METADATA },
+      '/celltype_metadata.json': { json: METADATA },
       '/validated_descriptions/CL_0000622.json': { status: 404 },
-      '/gpt_descriptions/CL_0000622.json': { json: 'A GPT-generated description.' },
-      '/canonical_marker_genes/CL_0000622.json': { json: [] }
+      '/gpt_descriptions/CL_0000622.json': { json: 'A GPT-generated description.' }
     })
-    const out = (await new ParserEngine({ fetchImpl }).call(
-      tool('cellguide_cell_type'),
-      { cellType: 'CL:0000622' },
+    const out = (await engine(fetchImpl).call(
+      tool('get_cell_type_info'),
+      { cell_type: 'CL:0000622' },
       {}
-    )) as { description: string; descriptionSource: string; references: unknown[] }
+    )) as { description: string; descriptionSource: string }
     expect(out.description).toBe('A GPT-generated description.')
     expect(out.descriptionSource).toBe('gpt')
-    expect(out.references).toEqual([])
   })
 
-  it('returns an empty marker list when the canonical markers file is missing (404)', async () => {
+  it('returns an error and skips the description fetch when the cell type is unknown', async () => {
     const fetchImpl = mockFetch({
       latest_snapshot_identifier: { text: SNAPSHOT },
-      '/celltype_metadata.json': { json: ACINAR_METADATA },
-      '/validated_descriptions/CL_0000622.json': { json: { description: 'x', references: [] } },
-      '/canonical_marker_genes/CL_0000622.json': { status: 404 }
+      '/celltype_metadata.json': { json: METADATA }
     })
-    const out = (await new ParserEngine({ fetchImpl }).call(
-      tool('cellguide_cell_type'),
-      { cellType: 'CL:0000622' },
+    const out = await engine(fetchImpl).call(
+      tool('get_cell_type_info'),
+      { cell_type: 'CL:9999999' },
       {}
-    )) as { canonicalMarkerGenes: unknown[] }
-    expect(out.canonicalMarkerGenes).toEqual([])
+    )
+    expect(out).toEqual({ error: "Cell type 'CL:9999999' not found" })
+    expect((fetchImpl as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2)
   })
+})
 
-  it('returns an empty marker list on a 200 with an empty body (live CDN behavior for cell types with no curated canonical markers)', async () => {
+describe('cellguide / search_cell_types', () => {
+  it('filters metadata by name/synonym substring and caps at limit', async () => {
     const fetchImpl = mockFetch({
       latest_snapshot_identifier: { text: SNAPSHOT },
-      '/celltype_metadata.json': { json: ACINAR_METADATA },
-      '/validated_descriptions/CL_0000622.json': { json: { description: 'x', references: [] } },
-      // json: undefined -> JSON.stringify(undefined) is not valid JSON; simulate the real CDN's
-      // empty-string body, whose .json() parse throws and is swallowed by tryFetchJson.
-      '/canonical_marker_genes/CL_0000622.json': { text: '' }
+      '/celltype_metadata.json': { json: METADATA }
     })
-    const out = (await new ParserEngine({ fetchImpl }).call(
-      tool('cellguide_cell_type'),
-      { cellType: 'CL:0000622' },
+    const out = (await engine(fetchImpl).call(
+      tool('search_cell_types'),
+      { query: 'T cell', limit: 10 },
       {}
-    )) as { canonicalMarkerGenes: unknown[] }
-    expect(out.canonicalMarkerGenes).toEqual([])
+    )) as { result: Array<{ id: string; name: string; ontology_description: string }> }
+    expect(out.result).toEqual([
+      {
+        id: 'CL:0000084',
+        name: 'T cell',
+        synonyms: ['T-cell', 'T lymphocyte'],
+        ontology_description: 'A type of lymphocyte.'
+      }
+    ])
   })
 
-  it('normalizes CL_ and bare-digit id formats to CL: for lookup', async () => {
+  it('matches synonyms case-insensitively', async () => {
     const fetchImpl = mockFetch({
       latest_snapshot_identifier: { text: SNAPSHOT },
-      '/celltype_metadata.json': { json: ACINAR_METADATA },
-      '/validated_descriptions/CL_0000622.json': { json: { description: 'x', references: [] } },
-      '/canonical_marker_genes/CL_0000622.json': { json: [] }
+      '/celltype_metadata.json': { json: METADATA }
     })
-    const out1 = (await new ParserEngine({ fetchImpl }).call(
-      tool('cellguide_cell_type'),
-      { cellType: 'CL_0000622' },
+    const out = (await engine(fetchImpl).call(
+      tool('search_cell_types'),
+      { query: 'ACINIC' },
       {}
-    )) as { id: string }
-    expect(out1.id).toBe('CL:0000622')
-
-    const out2 = (await new ParserEngine({ fetchImpl }).call(
-      tool('cellguide_cell_type'),
-      { cellType: '0000622' },
-      {}
-    )) as { id: string }
-    expect(out2.id).toBe('CL:0000622')
+    )) as {
+      result: Array<{ id: string }>
+    }
+    expect(out.result.map((r) => r.id)).toEqual(['CL:0000622'])
   })
+
+  it('respects the limit', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: METADATA }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('search_cell_types'),
+      { query: 'cell', limit: 1 },
+      {}
+    )) as { result: unknown[] }
+    expect(out.result).toHaveLength(1)
+  })
+})
+
+describe('cellguide / get_marker_genes', () => {
+  it('returns canonical markers with the literature-curated shape', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: METADATA },
+      '/canonical_marker_genes/CL_0000622.json': { json: CANONICAL_MARKERS }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_marker_genes'),
+      { cell_type: 'CL:0000622', marker_type: 'canonical' },
+      {}
+    )) as { markerType: string; returned: number; markerGenes: unknown[] }
+    expect(out.markerType).toBe('canonical')
+    expect(out.returned).toBe(2)
+    expect(out.markerGenes[0]).toEqual({
+      symbol: 'PRSS1',
+      name: 'trypsinogen',
+      tissue: 'pancreas',
+      publication: undefined,
+      publicationTitle: undefined
+    })
+  })
+
+  it('defaults to computational markers, sorted by marker_score desc and capped at limit', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: METADATA },
+      '/computational_marker_genes/CL_0000622.json': { json: COMPUTATIONAL_MARKERS }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_marker_genes'),
+      { cell_type: 'CL:0000622', limit: 1 },
+      {}
+    )) as { markerType: string; returned: number; markerGenes: Array<Record<string, unknown>> }
+    expect(out.markerType).toBe('computational')
+    expect(out.returned).toBe(1)
+    // Pnliprp1 has the higher marker_score (2.72), so it sorts first.
+    expect(out.markerGenes[0]).toEqual({
+      symbol: 'Pnliprp1',
+      name: 'pancreatic lipase related protein 1',
+      geneId: 'ENSMUSG00000042179',
+      markerScore: 2.72,
+      specificity: 1.0,
+      meanExpression: 4.62,
+      percentExpressing: 0.91,
+      groupbyDims: { organism_ontology_term_label: 'Mus musculus' }
+    })
+  })
+
+  it('returns an empty marker list on a 200 with an empty body', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: METADATA },
+      '/computational_marker_genes/CL_0000622.json': { text: '' }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_marker_genes'),
+      { cell_type: 'CL:0000622' },
+      {}
+    )) as { markerGenes: unknown[]; returned: number }
+    expect(out.markerGenes).toEqual([])
+    expect(out.returned).toBe(0)
+  })
+
+  it('errors when the cell type is unknown', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: METADATA }
+    })
+    const out = await engine(fetchImpl).call(tool('get_marker_genes'), { cell_type: 'nope' }, {})
+    expect(out).toEqual({ error: "Cell type 'nope' not found" })
+  })
+})
+
+describe('cellguide / get_source_data', () => {
+  it('returns source collections with tissues/diseases/organisms', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: METADATA },
+      '/source_collections/CL_0000622.json': { json: SOURCE_COLLECTIONS }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_source_data'),
+      { cell_type: 'acinar cell' },
+      {}
+    )) as { id: string; count: number; sources: Array<Record<string, unknown>> }
+    expect(out.id).toBe('CL:0000622')
+    expect(out.count).toBe(2)
+    expect(out.sources[0]).toEqual({
+      collectionName: 'Human Pancreas Aging',
+      collectionUrl: 'https://cellxgene.cziscience.com/collections/aaa',
+      publicationUrl: '10.1016/j.cell.2017.09.004',
+      publicationTitle: 'Enge et al. (2017) Cell',
+      tissues: [{ id: 'UBERON:0001264', label: 'pancreas' }],
+      diseases: [{ id: 'PATO:0000461', label: 'normal' }],
+      organisms: [{ id: 'NCBITaxon:9606', label: 'Homo sapiens' }]
+    })
+    // Blank publication fields collapse to undefined.
+    expect(out.sources[1].publicationUrl).toBeUndefined()
+  })
+
+  it('returns an empty source list on an empty body', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: METADATA },
+      '/source_collections/CL_0000622.json': { text: '' }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_source_data'),
+      { cell_type: 'CL:0000622' },
+      {}
+    )) as { sources: unknown[]; count: number }
+    expect(out.sources).toEqual([])
+    expect(out.count).toBe(0)
+  })
+})
+
+describe('cellguide / get_cell_tissues', () => {
+  it('aggregates and dedupes tissues across source collections, sorted by label', async () => {
+    const fetchImpl = mockFetch({
+      latest_snapshot_identifier: { text: SNAPSHOT },
+      '/celltype_metadata.json': { json: METADATA },
+      '/source_collections/CL_0000622.json': { json: SOURCE_COLLECTIONS }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_cell_tissues'),
+      { cell_type: 'CL:0000622' },
+      {}
+    )) as { count: number; tissues: Array<{ id: string; label: string }> }
+    // pancreas appears in both collections but is deduped; blood is unique. Sorted by label.
+    expect(out.count).toBe(2)
+    expect(out.tissues).toEqual([
+      { id: 'UBERON:0000178', label: 'blood' },
+      { id: 'UBERON:0001264', label: 'pancreas' }
+    ])
+  })
+})
+
+// Live CDN integration tests — opt-in via LIVE_API=1 so CI stays offline.
+const live = process.env.LIVE_API ? describe : describe.skip
+live('cellguide / LIVE CDN', () => {
+  const call = (id: string, args: Record<string, unknown>): Promise<unknown> =>
+    new ParserEngine().call(tool(id), args, {})
+
+  it('get_cell_type_info resolves both a CL id and a name', async () => {
+    const byId = (await call('get_cell_type_info', { cell_type: 'CL:0000622' })) as {
+      id: string
+      name: string
+    }
+    expect(byId.id).toBe('CL:0000622')
+    expect(byId.name).toBe('acinar cell')
+    const byName = (await call('get_cell_type_info', { cell_type: 'acinar cell' })) as {
+      id: string
+    }
+    expect(byName.id).toBe('CL:0000622')
+  }, 30_000)
+
+  it('search_cell_types finds T cell', async () => {
+    const out = (await call('search_cell_types', { query: 'T cell', limit: 5 })) as {
+      result: Array<{ id: string; name: string }>
+    }
+    expect(out.result.length).toBeGreaterThan(0)
+    expect(out.result.some((r) => r.name.toLowerCase().includes('t cell'))).toBe(true)
+  }, 30_000)
+
+  it('get_marker_genes returns computational markers with scores', async () => {
+    const out = (await call('get_marker_genes', {
+      cell_type: 'CL:0000622',
+      marker_type: 'computational',
+      limit: 5
+    })) as { markerGenes: Array<{ symbol: string; markerScore: number }> }
+    expect(out.markerGenes.length).toBeGreaterThan(0)
+    expect(typeof out.markerGenes[0].symbol).toBe('string')
+    expect(typeof out.markerGenes[0].markerScore).toBe('number')
+  }, 30_000)
+
+  it('get_marker_genes returns canonical markers for a cell type that has them', async () => {
+    const out = (await call('get_marker_genes', {
+      cell_type: 'CL:0000084',
+      marker_type: 'canonical',
+      limit: 5
+    })) as { markerGenes: Array<{ symbol: string }> }
+    expect(out.markerGenes.length).toBeGreaterThan(0)
+    expect(typeof out.markerGenes[0].symbol).toBe('string')
+  }, 30_000)
+
+  it('get_source_data returns collections with publications', async () => {
+    const out = (await call('get_source_data', { cell_type: 'CL:0000622' })) as {
+      count: number
+      sources: Array<{ collectionName: string }>
+    }
+    expect(out.count).toBeGreaterThan(0)
+    expect(typeof out.sources[0].collectionName).toBe('string')
+  }, 30_000)
+
+  it('get_cell_tissues returns anatomical tissues', async () => {
+    const out = (await call('get_cell_tissues', { cell_type: 'T cell' })) as {
+      count: number
+      tissues: Array<{ id: string; label: string }>
+    }
+    expect(out.count).toBeGreaterThan(0)
+    expect(out.tissues.some((t) => (t.id ?? '').startsWith('UBERON:'))).toBe(true)
+  }, 30_000)
 })

--- a/src/main/connectors/descriptors/cellguide.ts
+++ b/src/main/connectors/descriptors/cellguide.ts
@@ -1,13 +1,16 @@
 import type { ToolContext, ToolDescriptor } from '../types'
 
 // CellGuide (CELLxGENE) serves static, snapshot-versioned JSON blobs from this CDN — no live
-// query API (endpoints/snapshot-id indirection mirror upstream mcp_cellguide/client.py; the
-// canonical_marker_genes record shape below was corrected against a live fetch — client.py
-// applies the *computational* marker shape {marker_score, specificity, me, pc, groupby_dims} to
-// canonical markers too, but the live canonical_marker_genes/<CL_id>.json blobs are actually
-// literature-curated {tissue, symbol, name, publication, publication_titles} records with no
-// score field, so client.py's marker_score-descending sort on canonical is a no-op there).
+// query/search API. Everything is a GET of a snapshot-scoped blob keyed by Cell Ontology (CL) id,
+// so "search" is done client-side over celltype_metadata.json and there is no name->id endpoint
+// (names are resolved against that same metadata). The canonical vs computational marker blobs have
+// different record shapes: computational markers are data-derived {marker_score, specificity, me,
+// pc, groupby_dims}, while canonical markers are literature-curated {tissue, symbol, name,
+// publication, publication_titles} with no score field.
 const BASE_URL = 'https://cellguide.cellxgene.cziscience.com'
+
+// Bound list-returning tools like the other connectors, rather than returning every row unbounded.
+const DEFAULT_LIMIT = 25
 
 type CellTypeMetadataEntry = {
   name?: string
@@ -23,6 +26,28 @@ type CanonicalMarkerGene = {
   name?: string
   publication?: string
   publication_titles?: string
+}
+
+type ComputationalMarkerGene = {
+  me?: number
+  pc?: number
+  marker_score?: number
+  specificity?: number
+  gene_ontology_term_id?: string
+  symbol?: string
+  name?: string
+  groupby_dims?: Record<string, unknown>
+}
+
+type OntologyRef = { label?: string; ontology_term_id?: string }
+type SourceCollection = {
+  collection_name?: string
+  collection_url?: string
+  publication_url?: string
+  publication_title?: string
+  tissue?: OntologyRef[]
+  disease?: OntologyRef[]
+  organism?: OntologyRef[]
 }
 
 type ValidatedDescription = { description?: string; references?: unknown[] }
@@ -46,14 +71,50 @@ async function fetchSnapshotId(ctx: ToolContext): Promise<string> {
   return (await ctx.fetchText(`${BASE_URL}/latest_snapshot_identifier`)).trim()
 }
 
-// client.py swallows fetch failures for the optional blobs (description/markers may not exist
-// for every cell type) and falls back to empty results; mirror that instead of failing the call.
+// client.py swallows fetch failures for the optional blobs (description/markers/sources may not
+// exist for every cell type) and falls back to empty results; mirror that instead of failing.
 async function tryFetchJson(ctx: ToolContext, url: string): Promise<unknown | undefined> {
   try {
     return await ctx.fetchJson(url)
   } catch {
     return undefined
   }
+}
+
+// The CDN has no name->id endpoint, so both an id (any of CL:x / CL_x / bare digits) and a free-text
+// name/synonym are resolved against celltype_metadata.json: try a direct id lookup first, then fall
+// back to a case-insensitive name/synonym match.
+function resolveCellId(
+  metadata: CellTypeMetadata,
+  input: string
+): { id: string; entry: CellTypeMetadataEntry } | undefined {
+  const jsonId = toJsonFormat(input)
+  const direct = metadata[jsonId]
+  if (direct) return { id: jsonId, entry: direct }
+  const q = input.trim().toLowerCase()
+  for (const [id, entry] of Object.entries(metadata)) {
+    if ((entry.name ?? '').toLowerCase() === q) return { id, entry }
+    if ((entry.synonyms ?? []).some((s) => s.toLowerCase() === q)) return { id, entry }
+  }
+  return undefined
+}
+
+// Shared preamble for the four cell-type tools: fetch the snapshot + metadata and resolve the
+// id-or-name argument, returning an { error } sentinel when the cell type is unknown.
+async function loadCellType(
+  ctx: ToolContext,
+  input: string
+): Promise<
+  | { snapshot: string; jsonId: string; urlId: string; entry: CellTypeMetadataEntry }
+  | { error: string }
+> {
+  const snapshot = await fetchSnapshotId(ctx)
+  const metadata = (await ctx.fetchJson(
+    `${BASE_URL}/${snapshot}/celltype_metadata.json`
+  )) as CellTypeMetadata
+  const resolved = resolveCellId(metadata, input)
+  if (!resolved) return { error: `Cell type '${input}' not found` }
+  return { snapshot, jsonId: resolved.id, urlId: toUrlFormat(resolved.id), entry: resolved.entry }
 }
 
 async function fetchDescription(
@@ -77,7 +138,7 @@ async function fetchDescription(
   return { description: '', references: [], source: 'none' }
 }
 
-function formatMarkerGene(g: CanonicalMarkerGene): Record<string, unknown> {
+function formatCanonicalMarker(g: CanonicalMarkerGene): Record<string, unknown> {
   return {
     symbol: g.symbol,
     name: g.name,
@@ -87,59 +148,247 @@ function formatMarkerGene(g: CanonicalMarkerGene): Record<string, unknown> {
   }
 }
 
-// CellGuide CDN: cell-type metadata + validated/GPT description + canonical marker genes,
-// keyed by Cell Ontology (CL) id. No search endpoint on the CDN — pass a CL id directly.
+function formatComputationalMarker(g: ComputationalMarkerGene): Record<string, unknown> {
+  return {
+    symbol: g.symbol,
+    name: g.name,
+    geneId: g.gene_ontology_term_id,
+    markerScore: g.marker_score,
+    specificity: g.specificity,
+    meanExpression: g.me,
+    percentExpressing: g.pc,
+    groupbyDims: g.groupby_dims
+  }
+}
+
+function refList(refs: OntologyRef[] | undefined): Array<{ id?: string; label?: string }> {
+  return (refs ?? []).map((r) => ({ id: r.ontology_term_id, label: r.label }))
+}
+
+// CellGuide CDN tools: cell-type identity/description, client-side name search, canonical or
+// computational marker genes, source datasets/publications, and the anatomical tissues a cell type
+// is observed in (aggregated from the source collections, since there is no per-cell tissue blob).
 export const CELLGUIDE_TOOLS: ToolDescriptor[] = [
   {
-    id: 'cellguide_cell_type',
+    id: 'get_cell_type_info',
     connector: 'cellguide',
     description:
-      'Get CellGuide (CELLxGENE) info for a Cell Ontology id: name, synonyms, description, and canonical marker genes.',
+      'CellGuide (CELLxGENE) cell-type info by Cell Ontology id or name: name, synonyms, ontology description, and curated/GPT description.',
     input: {
       type: 'object',
       properties: {
-        cellType: {
+        cell_type: {
           type: 'string',
-          description: 'Cell Ontology id, e.g. CL:0000622 (CL:x, CL_x, or bare digits all accepted)'
+          description:
+            "Cell Ontology id (CL:0000622, CL_0000622, or 0000622) or a cell-type name/synonym (e.g. 'acinar cell')"
         }
       },
-      required: ['cellType']
+      required: ['cell_type']
     },
-    required: ['cellType'],
+    required: ['cell_type'],
     returns:
-      '`{ "id": str, "name": str, "synonyms": [ str ], "ontologyDescription": str, "description": str, "descriptionSource": str, "references": [ ... ], "canonicalMarkerGenes": [ { "symbol": str, "name": str, "tissue": str, "publication": str, "publicationTitle": str } ] }` — returns `{ "error": str }` when the CL id is not found; markers capped at 30; `descriptionSource` is `validated`, `gpt`, or `none` (with `description` empty).',
-    example: 'result = host.mcp("cellguide", "cellguide_cell_type", {"cellType": "CL:0000622"})',
+      '`{ "id": str, "name": str, "synonyms": [ str ], "ontologyDescription": str, "description": str, "descriptionSource": str, "references": [ ... ] }` — `descriptionSource` is `validated`, `gpt`, or `none` (with `description` empty). Returns `{ "error": str }` when the cell type is not found.',
+    example: 'result = host.mcp("cellguide", "get_cell_type_info", {"cell_type": "acinar cell"})',
     run: async (ctx, a) => {
-      const cellType = String(a.cellType)
-      const jsonId = toJsonFormat(cellType)
-      const urlId = toUrlFormat(cellType)
+      const input = String(a.cell_type)
+      const loaded = await loadCellType(ctx, input)
+      if ('error' in loaded) return loaded
+
+      const description = await fetchDescription(ctx, loaded.urlId)
+      return {
+        id: loaded.jsonId,
+        name: loaded.entry.name,
+        synonyms: loaded.entry.synonyms ?? [],
+        ontologyDescription: loaded.entry.clDescription,
+        description: description.description,
+        descriptionSource: description.source,
+        references: description.references
+      }
+    }
+  },
+  {
+    id: 'search_cell_types',
+    connector: 'cellguide',
+    description:
+      'Search CellGuide cell types by free text over name and synonyms (the CDN has no search endpoint, so celltype_metadata.json is filtered client-side).',
+    input: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        limit: { type: 'integer', default: DEFAULT_LIMIT }
+      },
+      required: ['query']
+    },
+    required: ['query'],
+    returns:
+      '`{ "result": [ { "id": str, "name": str, "synonyms": [ str ], "ontology_description": str } ] }` — cell types whose name or a synonym contains `query` (case-insensitive), capped at `limit` (default 25).',
+    example:
+      'result = host.mcp("cellguide", "search_cell_types", {"query": "T cell", "limit": 25})',
+    run: async (ctx, a) => {
+      const query = String(a.query).trim().toLowerCase()
+      const limit = Number(a.limit ?? DEFAULT_LIMIT)
 
       const snapshot = await fetchSnapshotId(ctx)
       const metadata = (await ctx.fetchJson(
         `${BASE_URL}/${snapshot}/celltype_metadata.json`
       )) as CellTypeMetadata
-      const info = metadata[jsonId]
-      if (!info) return { error: `Cell type '${cellType}' not found` }
 
-      const description = await fetchDescription(ctx, urlId)
-      const markersRaw = await tryFetchJson(
+      const matches: Array<{
+        id: string
+        name?: string
+        synonyms: string[]
+        ontology_description?: string
+      }> = []
+      for (const [id, entry] of Object.entries(metadata)) {
+        const synonyms = entry.synonyms ?? []
+        const hit =
+          (entry.name ?? '').toLowerCase().includes(query) ||
+          synonyms.some((s) => s.toLowerCase().includes(query))
+        if (!hit) continue
+        matches.push({ id, name: entry.name, synonyms, ontology_description: entry.clDescription })
+        if (matches.length >= limit) break
+      }
+      return { result: matches }
+    }
+  },
+  {
+    id: 'get_marker_genes',
+    connector: 'cellguide',
+    description:
+      'CellGuide marker genes for a cell type (id or name): computational (data-derived, scored) or canonical (literature-curated).',
+    input: {
+      type: 'object',
+      properties: {
+        cell_type: { type: 'string' },
+        marker_type: {
+          type: 'string',
+          enum: ['computational', 'canonical'],
+          default: 'computational'
+        },
+        limit: { type: 'integer', default: DEFAULT_LIMIT }
+      },
+      required: ['cell_type']
+    },
+    required: ['cell_type'],
+    returns:
+      '`{ "id": str, "name": str, "markerType": str, "returned": int, "markerGenes": [ ... ] }`. Computational items: `{ "symbol": str, "name": str, "geneId": str, "markerScore": float, "specificity": float, "meanExpression": float, "percentExpressing": float, "groupbyDims": { ... } }` sorted by `markerScore` desc. Canonical items: `{ "symbol": str, "name": str, "tissue": str, "publication": str, "publicationTitle": str }`. Capped at `limit` (default 25); an empty list means no markers are curated/computed for this cell type. `{ "error": str }` when the cell type is not found.',
+    example:
+      'result = host.mcp("cellguide", "get_marker_genes", {"cell_type": "CL:0000084", "marker_type": "computational", "limit": 25})',
+    run: async (ctx, a) => {
+      const input = String(a.cell_type)
+      const markerType = a.marker_type === 'canonical' ? 'canonical' : 'computational'
+      const limit = Number(a.limit ?? DEFAULT_LIMIT)
+
+      const loaded = await loadCellType(ctx, input)
+      if ('error' in loaded) return loaded
+
+      const path =
+        markerType === 'canonical' ? 'canonical_marker_genes' : 'computational_marker_genes'
+      const raw = await tryFetchJson(
         ctx,
-        `${BASE_URL}/${snapshot}/canonical_marker_genes/${encodeURIComponent(urlId)}.json`
+        `${BASE_URL}/${loaded.snapshot}/${path}/${encodeURIComponent(loaded.urlId)}.json`
       )
-      // Empty body (no curated canonical markers for this cell type) fails .json() parsing;
-      // tryFetchJson already folds that into undefined, same as a 404.
-      const markers = Array.isArray(markersRaw) ? (markersRaw as CanonicalMarkerGene[]) : []
+      const rows = Array.isArray(raw) ? raw : []
+
+      let markerGenes: Array<Record<string, unknown>>
+      if (markerType === 'canonical') {
+        markerGenes = (rows as CanonicalMarkerGene[]).slice(0, limit).map(formatCanonicalMarker)
+      } else {
+        // Data-derived markers carry a marker_score; surface the strongest ones first.
+        markerGenes = (rows as ComputationalMarkerGene[])
+          .slice()
+          .sort((x, y) => (y.marker_score ?? 0) - (x.marker_score ?? 0))
+          .slice(0, limit)
+          .map(formatComputationalMarker)
+      }
 
       return {
-        id: jsonId,
-        name: info.name,
-        synonyms: info.synonyms ?? [],
-        ontologyDescription: info.clDescription,
-        description: description.description,
-        descriptionSource: description.source,
-        references: description.references,
-        canonicalMarkerGenes: markers.slice(0, 30).map(formatMarkerGene)
+        id: loaded.jsonId,
+        name: loaded.entry.name,
+        markerType,
+        returned: markerGenes.length,
+        markerGenes
       }
+    }
+  },
+  {
+    id: 'get_source_data',
+    connector: 'cellguide',
+    description:
+      'CellGuide source datasets and publications contributing to a cell type (id or name): collection name/url, publication, and the tissues/diseases/organisms each covers.',
+    input: {
+      type: 'object',
+      properties: {
+        cell_type: { type: 'string' }
+      },
+      required: ['cell_type']
+    },
+    required: ['cell_type'],
+    returns:
+      '`{ "id": str, "name": str, "count": int, "sources": [ { "collectionName": str, "collectionUrl": str, "publicationUrl": str, "publicationTitle": str, "tissues": [ { "id": str, "label": str } ], "diseases": [ { "id": str, "label": str } ], "organisms": [ { "id": str, "label": str } ] } ] }` — empty `sources` when no source collections exist. `{ "error": str }` when the cell type is not found.',
+    example: 'result = host.mcp("cellguide", "get_source_data", {"cell_type": "CL:0000622"})',
+    run: async (ctx, a) => {
+      const input = String(a.cell_type)
+      const loaded = await loadCellType(ctx, input)
+      if ('error' in loaded) return loaded
+
+      const raw = await tryFetchJson(
+        ctx,
+        `${BASE_URL}/${loaded.snapshot}/source_collections/${encodeURIComponent(loaded.urlId)}.json`
+      )
+      const collections = Array.isArray(raw) ? (raw as SourceCollection[]) : []
+
+      const sources = collections.map((c) => ({
+        collectionName: c.collection_name,
+        collectionUrl: c.collection_url,
+        publicationUrl: c.publication_url || undefined,
+        publicationTitle: c.publication_title || undefined,
+        tissues: refList(c.tissue),
+        diseases: refList(c.disease),
+        organisms: refList(c.organism)
+      }))
+      return { id: loaded.jsonId, name: loaded.entry.name, count: sources.length, sources }
+    }
+  },
+  {
+    id: 'get_cell_tissues',
+    connector: 'cellguide',
+    description:
+      'Anatomical tissues where a cell type (id or name) is observed, aggregated (deduplicated) across CellGuide source collections.',
+    input: {
+      type: 'object',
+      properties: {
+        cell_type: { type: 'string' }
+      },
+      required: ['cell_type']
+    },
+    required: ['cell_type'],
+    returns:
+      '`{ "id": str, "name": str, "count": int, "tissues": [ { "id": str, "label": str } ] }` — unique UBERON tissues (by ontology term id) the cell type appears in, sorted by label. `{ "error": str }` when the cell type is not found.',
+    example: 'result = host.mcp("cellguide", "get_cell_tissues", {"cell_type": "T cell"})',
+    run: async (ctx, a) => {
+      const input = String(a.cell_type)
+      const loaded = await loadCellType(ctx, input)
+      if ('error' in loaded) return loaded
+
+      const raw = await tryFetchJson(
+        ctx,
+        `${BASE_URL}/${loaded.snapshot}/source_collections/${encodeURIComponent(loaded.urlId)}.json`
+      )
+      const collections = Array.isArray(raw) ? (raw as SourceCollection[]) : []
+
+      // No per-cell tissue blob exists; dedupe the tissue refs across every source collection.
+      const byId = new Map<string, { id?: string; label?: string }>()
+      for (const c of collections) {
+        for (const t of c.tissue ?? []) {
+          const key = t.ontology_term_id ?? t.label ?? ''
+          if (key && !byId.has(key)) byId.set(key, { id: t.ontology_term_id, label: t.label })
+        }
+      }
+      const tissues = [...byId.values()].sort((x, y) =>
+        (x.label ?? '').localeCompare(y.label ?? '')
+      )
+      return { id: loaded.jsonId, name: loaded.entry.name, count: tissues.length, tissues }
     }
   }
 ]


### PR DESCRIPTION
Enhances the CellGuide (CELLxGENE) connector from 1 tool to 5, covering discovery and provenance beyond a single cell-type lookup.

## New capabilities
- `get_cell_type_info` — cell-type identity, description, synonyms, metadata (accepts a CL id **or** a name).
- `search_cell_types` — name/synonym search over the cell-type catalogue.
- `get_marker_genes` — computational (data-derived) or canonical (literature) marker genes.
- `get_source_data` — source datasets and publications for a cell type.
- `get_cell_tissues` — anatomical tissues where a cell type is found.

## Notes
- The CDN has no query API; search and name→CL-id resolution filter the snapshot metadata client-side.
- Tissues are aggregated/deduped from the source collections' UBERON refs (no per-cell tissue blob exists upstream).

## Verification
- Full `src/main/connectors` suite green (mock unit tests) + live integration tests (`LIVE_API`-gated) against the real CellGuide CDN.
- lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)