### PR TITLE
feat(connectors): expand Chemistry with ChEBI, Rhea & BindingDB tools

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -20,10 +20,10 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
   {
     id: 'chemistry',
     displayName: 'Chemistry',
-    description: 'Small-molecule chemistry via PubChem.',
+    description: 'Small-molecule chemistry via PubChem, ChEBI, Rhea and BindingDB.',
     useWhen:
-      'Use when a question needs authoritative data about a chemical compound or drug — molecular formula, molecular weight, SMILES/InChI, IUPAC name, or PubChem identifiers (e.g. aspirin, caffeine, ibuprofen). Sourced from PubChem.',
-    sources: ['PubChem'],
+      'Use when a question needs authoritative small-molecule chemistry data — PubChem compound properties (formula, weight, SMILES/InChI, IUPAC name), CID resolution and 2D similarity search, bioassay and GHS safety summaries; ChEBI ontology entities, roles and relations; Rhea enzyme reactions (by ChEBI participant, EC number, or equation text); or BindingDB binding affinities (Ki/Kd/IC50/EC50) by protein target or compound. Sourced from PubChem, ChEBI, Rhea and BindingDB.',
+    sources: ['PubChem', 'ChEBI', 'Rhea', 'BindingDB'],
     termsUrl: 'https://www.ncbi.nlm.nih.gov/home/about/policies/',
     requiresNcbi: false
   },

--- a/src/main/connectors/descriptors/chemistry.test.ts
+++ b/src/main/connectors/descriptors/chemistry.test.ts
@@ -6,196 +6,797 @@ import type { ToolDescriptor } from '../types'
 const tool = (id: string): ToolDescriptor => CHEMISTRY_TOOLS.find((t) => t.id === id)!
 const jsonRes = (body: unknown): Response =>
   ({ ok: true, status: 200, json: async () => body }) as Response
+const notFoundRes = (): Response => ({ ok: false, status: 404 }) as Response
+const engine = (fetchImpl: unknown): ParserEngine =>
+  new ParserEngine({ fetchImpl: fetchImpl as typeof fetch })
+
+describe('chemistry tool set', () => {
+  it('exposes exactly the 12 upstream tools and drops the removed ones', () => {
+    expect(CHEMISTRY_TOOLS.map((t) => t.id).sort()).toEqual(
+      [
+        'bindingdb_ligands_by_target',
+        'bindingdb_targets_by_compound',
+        'chebi_get_entity',
+        'chebi_get_ontology',
+        'chebi_search',
+        'pubchem_get_bioassay_summary',
+        'pubchem_get_compounds',
+        'pubchem_get_safety',
+        'pubchem_search_compounds',
+        'pubchem_similarity_search',
+        'rhea_get_reaction',
+        'rhea_search_reactions'
+      ].sort()
+    )
+    for (const removed of ['pubchem_get_properties', 'pubchem_get_image']) {
+      expect(CHEMISTRY_TOOLS.find((t) => t.id === removed)).toBeUndefined()
+    }
+    expect(CHEMISTRY_TOOLS.every((t) => t.connector === 'chemistry')).toBe(true)
+  })
+})
 
 describe('chemistry / pubchem', () => {
-  it('pubchem_get_properties parses PropertyTable', async () => {
+  it('pubchem_search_compounds resolves cids then fetches properties, honouring the cap', async () => {
     const fetchImpl = vi
       .fn()
-      .mockResolvedValue(
+      .mockResolvedValueOnce(jsonRes({ IdentifierList: { CID: [2244, 999, 1000] } }))
+      .mockResolvedValueOnce(jsonRes({ PropertyTable: { Properties: [{ CID: 2244 }] } }))
+    const out = (await engine(fetchImpl).call(
+      tool('pubchem_search_compounds'),
+      { query: 'aspirin', max_cids: 1 },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toContain('/compound/name/aspirin/cids/JSON')
+    expect(fetchImpl.mock.calls[1][0]).toContain('/compound/cid/2244/property/')
+    expect(fetchImpl.mock.calls[1][0]).toContain('ConnectivitySMILES')
+    expect(out).toMatchObject({
+      query: 'aspirin',
+      namespace: 'name',
+      n_cids_total: 3,
+      truncated: true,
+      cids: [2244],
+      properties: [{ CID: 2244 }]
+    })
+  })
+
+  it('pubchem_search_compounds sends SMILES via a query param and returns [] on no match', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(notFoundRes())
+    const out = (await engine(fetchImpl).call(
+      tool('pubchem_search_compounds'),
+      { query: 'C#N/weird', namespace: 'smiles', with_properties: true },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toContain('/compound/smiles/cids/JSON?smiles=')
+    expect(fetchImpl).toHaveBeenCalledTimes(1) // no property call when cids empty
+    expect(out).toMatchObject({ n_cids_total: 0, cids: [], properties: [] })
+  })
+
+  it('pubchem_search_compounds rejects an unknown namespace', async () => {
+    await expect(
+      engine(vi.fn()).call(tool('pubchem_search_compounds'), { query: 'x', namespace: 'foo' }, {})
+    ).rejects.toThrow(/namespace must be one of/)
+  })
+
+  it('pubchem_get_compounds dedupes, reports duplicates and not_found, and attaches synonyms', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
         jsonRes({ PropertyTable: { Properties: [{ CID: 2244, MolecularFormula: 'C9H8O4' }] } })
       )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('pubchem_get_properties'),
-      { cids: [2244] },
+      .mockResolvedValueOnce(
+        jsonRes({
+          InformationList: { Information: [{ CID: 2244, Synonym: ['aspirin', 'a', 'b'] }] }
+        })
+      )
+    const out = (await engine(fetchImpl).call(
+      tool('pubchem_get_compounds'),
+      { cids: [2244, 2244, 999], include_synonyms: true, max_synonyms: 2 },
       {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toContain('/compound/cid/2244/property/')
-    expect(out).toEqual([{ CID: 2244, MolecularFormula: 'C9H8O4' }])
-  })
-
-  it('pubchem_search_compounds resolves name -> cids -> properties', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(jsonRes({ IdentifierList: { CID: [2519, 999] } }))
-      .mockResolvedValueOnce(jsonRes({ PropertyTable: { Properties: [{ CID: 2519 }] } }))
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('pubchem_search_compounds'),
-      { query: 'caffeine', max_cids: 1 },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toContain('/compound/name/caffeine/cids/JSON')
-    expect(fetchImpl.mock.calls[1][0]).toContain('/compound/cid/2519/property/')
-    expect(out).toEqual({ query: 'caffeine', compounds: [{ CID: 2519 }] })
-  })
-
-  it('pubchem_get_image builds the imgsrv URL without a network call', async () => {
-    const fetchImpl = vi.fn()
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('pubchem_get_image'),
-      { cid: 2244 },
-      {}
-    )
-    expect(fetchImpl).not.toHaveBeenCalled()
-    expect(out).toEqual({
-      cid: 2244,
-      format: 'png',
-      url: 'https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=2244&t=l'
-    })
-  })
-})
-
-describe('chemistry / chebi', () => {
-  it('chebi_get_entity normalizes the compound record', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        chebi_accession: 'CHEBI:27732',
-        name: 'caffeine',
-        definition: 'A trimethylxanthine.',
-        chemical_data: { formula: 'C8H10N4O2', charge: '0', mass: '194.19' },
-        default_structure: {
-          smiles: 'CN1C=NC2=C1C(=O)N(C(=O)N2C)C',
-          standard_inchi: 'InChI=1S/C8H10N4O2',
-          standard_inchi_key: 'RYYVLZVUVIJVGH-UHFFFAOYSA-N'
-        }
-      })
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('chebi_get_entity'),
-      { chebi_id: 'CHEBI:27732' },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://www.ebi.ac.uk/chebi/backend/api/public/compound/27732/'
-    )
-    expect(out).toEqual({
-      chebi_accession: 'CHEBI:27732',
-      name: 'caffeine',
-      definition: 'A trimethylxanthine.',
-      formula: 'C8H10N4O2',
-      charge: '0',
-      mass: '194.19',
-      smiles: 'CN1C=NC2=C1C(=O)N(C(=O)N2C)C',
-      inchi: 'InChI=1S/C8H10N4O2',
-      inchikey: 'RYYVLZVUVIJVGH-UHFFFAOYSA-N'
-    })
-  })
-
-  it('chebi_get_entity accepts a bare numeric id and rejects a malformed one', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ chebi_accession: 'CHEBI:27732' }))
-    await new ParserEngine({ fetchImpl }).call(tool('chebi_get_entity'), { chebi_id: '27732' }, {})
-    expect(fetchImpl.mock.calls[0][0]).toContain('/compound/27732/')
-    await expect(
-      new ParserEngine({ fetchImpl }).call(tool('chebi_get_entity'), { chebi_id: 'nope' }, {})
-    ).rejects.toThrow(/not a ChEBI ID/)
-  })
-})
-
-describe('chemistry / rhea', () => {
-  it('rhea_get_reaction parses SPARQL bindings into equation + sides', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        results: {
-          bindings: [
-            {
-              side: { value: 'http://rdf.rhea-db.org/10280_L' },
-              status: { value: 'http://rdf.rhea-db.org/Approved' },
-              equation: { value: 'A + B = C + D' },
-              cacc: { value: 'CHEBI:1' },
-              cname: { value: 'A' }
-            },
-            {
-              side: { value: 'http://rdf.rhea-db.org/10280_R' },
-              status: { value: 'http://rdf.rhea-db.org/Approved' },
-              equation: { value: 'A + B = C + D' },
-              cacc: { value: 'CHEBI:2' },
-              cname: { value: 'C' }
-            }
-          ]
-        }
-      })
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('rhea_get_reaction'),
-      { rhea_id: '10280' },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toContain('https://sparql.rhea-db.org/sparql?query=')
-    expect(out).toEqual({
-      rhea_id: 'RHEA:10280',
-      equation: 'A + B = C + D',
-      status: 'Approved',
-      left_side: [{ compound_accession: 'CHEBI:1', name: 'A' }],
-      right_side: [{ compound_accession: 'CHEBI:2', name: 'C' }]
-    })
-  })
-
-  it('rhea_get_reaction throws when no bindings come back', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ results: { bindings: [] } }))
-    await expect(
-      new ParserEngine({ fetchImpl }).call(tool('rhea_get_reaction'), { rhea_id: '999999' }, {})
-    ).rejects.toThrow(/no Rhea reaction/)
-  })
-})
-
-describe('chemistry / bindingdb', () => {
-  it('bindingdb_affinities unwraps the misspelled root key and normalizes rows', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        getLindsByUniprotsResponse: {
-          affinities: [
-            {
-              query: 'Epidermal growth factor receptor',
-              monomerid: 3032,
-              smile: 'COc1cc2ncnc(Nc3cccc(Br)c3)c2cc1OC',
-              affinity_type: 'Ki',
-              affinity: '0.006',
-              pmid: 18077363,
-              doi: '10.1073/pnas.0708800104'
-            }
-          ]
-        }
-      })
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('bindingdb_affinities'),
-      { uniprot: 'p00533', cutoff_nm: 100 },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toContain('uniprot=P00533')
-    expect(fetchImpl.mock.calls[0][0]).toContain('cutoff=100')
-    expect(out).toEqual({
-      uniprot: 'P00533',
-      cutoff_nm: 100,
-      n_rows: 1,
-      affinities: [
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toContain('/compound/cid/2244,999/property/')
+    expect(fetchImpl.mock.calls[1][0]).toContain('/compound/cid/2244,999/synonyms/JSON')
+    expect(out).toMatchObject({
+      n_requested: 3,
+      duplicates: [2244],
+      not_found: [999],
+      records: [
         {
-          target_name: 'Epidermal growth factor receptor',
-          monomer_id: '3032',
-          smiles: 'COc1cc2ncnc(Nc3cccc(Br)c3)c2cc1OC',
-          affinity_type: 'Ki',
-          affinity: '0.006',
-          pmid: '18077363',
-          doi: '10.1073/pnas.0708800104'
+          CID: 2244,
+          MolecularFormula: 'C9H8O4',
+          synonyms: ['aspirin', 'a'],
+          n_synonyms_total: 3,
+          synonyms_truncated: true
         }
       ]
     })
   })
 
-  it('bindingdb_affinities rejects a malformed UniProt accession', async () => {
+  it('pubchem_similarity_search flags may_be_truncated when the cap fills', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ IdentifierList: { CID: [2244, 2] } }))
+    const out = (await engine(fetchImpl).call(
+      tool('pubchem_similarity_search'),
+      { smiles: 'CC(=O)O', threshold: 95, max_records: 2 },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toContain('/compound/fastsimilarity_2d/smiles/cids/JSON')
+    expect(fetchImpl.mock.calls[0][0]).toContain('Threshold=95')
+    expect(fetchImpl.mock.calls[0][0]).toContain('MaxRecords=2')
+    expect(out).toMatchObject({ n_cids: 2, may_be_truncated: true, cids: [2244, 2] })
+  })
+
+  it('pubchem_get_bioassay_summary maps columns, filters active before the cap', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        Table: {
+          Columns: { Column: ['AID', 'Activity Outcome', 'Assay Name'] },
+          Row: [
+            { Cell: ['1', 'Active', 'Assay A'] },
+            { Cell: ['2', 'Inactive', 'Assay B'] },
+            { Cell: ['3', 'Active', 'Assay C'] }
+          ]
+        }
+      })
+    )
+    const out = (await engine(fetchImpl).call(
+      tool('pubchem_get_bioassay_summary'),
+      { cid: 2244, active_only: true, max_rows: 1 },
+      {}
+    )) as Record<string, unknown>
+    expect(out).toMatchObject({
+      cid: 2244,
+      active_only: true,
+      n_rows_total: 2,
+      truncated: true,
+      rows: [{ AID: '1', 'Activity Outcome': 'Active', 'Assay Name': 'Assay A' }]
+    })
+  })
+
+  it('pubchem_get_bioassay_summary returns [] when the compound has no assay data', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(notFoundRes())
+    const out = (await engine(fetchImpl).call(
+      tool('pubchem_get_bioassay_summary'),
+      { cid: 999999999 },
+      {}
+    )) as Record<string, unknown>
+    expect(out).toMatchObject({ n_rows_total: 0, rows: [] })
+  })
+
+  it('pubchem_get_safety parses the GHS Classification section from PUG-View', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        Record: {
+          RecordTitle: 'Aspirin',
+          Reference: [{}, {}],
+          Section: [
+            {
+              TOCHeading: 'Safety and Hazards',
+              Section: [
+                {
+                  TOCHeading: 'GHS Classification',
+                  Information: [
+                    { Name: 'Signal', Value: { StringWithMarkup: [{ String: 'Warning' }] } },
+                    {
+                      Name: 'Pictogram(s)',
+                      Value: { StringWithMarkup: [{ Markup: [{ Extra: 'Irritant' }] }] }
+                    },
+                    {
+                      Name: 'GHS Hazard Statements',
+                      Value: { StringWithMarkup: [{ String: 'H302 (95%): Harmful if swallowed' }] }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      })
+    )
+    const out = (await engine(fetchImpl).call(tool('pubchem_get_safety'), { cid: 2244 }, {})) as {
+      cid: number
+      found: boolean
+      ghs: Record<string, unknown>
+    }
+    expect(fetchImpl.mock.calls[0][0]).toContain('/pug_view/data/compound/2244/JSON?heading=')
+    expect(out.found).toBe(true)
+    expect(out.ghs).toMatchObject({
+      cid: 2244,
+      record_title: 'Aspirin',
+      signals: ['Warning'],
+      pictograms: ['Irritant'],
+      hazard_statements: ['H302 (95%): Harmful if swallowed'],
+      n_source_references: 2
+    })
+  })
+
+  it('pubchem_get_safety returns found=false / ghs=null when PubChem has no GHS section', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(notFoundRes())
+    const out = (await engine(fetchImpl).call(
+      tool('pubchem_get_safety'),
+      { cid: 1 },
+      {}
+    )) as Record<string, unknown>
+    expect(out).toEqual({ cid: 1, found: false, ghs: null })
+  })
+})
+
+describe('chemistry / chebi', () => {
+  it('chebi_search maps es_search hits and carries the api_total', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        total: 18,
+        number_pages: 9,
+        results: [
+          {
+            _score: 12.3,
+            _source: {
+              chebi_accession: 'CHEBI:27732',
+              name: 'caffeine',
+              formula: 'C8H10N4O2',
+              charge: 0,
+              mass: 194.194,
+              monoisotopicmass: 194.08,
+              smiles: 'Cn1...',
+              inchikey: 'RYYVLZVUVIJVGH-UHFFFAOYSA-N',
+              stars: 3
+            }
+          }
+        ]
+      })
+    )
+    const out = (await engine(fetchImpl).call(
+      tool('chebi_search'),
+      { term: 'caffeine', max_results: 2 },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toContain('/es_search/?term=caffeine&size=2&page=1')
+    expect(out).toMatchObject({
+      term: 'caffeine',
+      api_total: 18,
+      number_pages: 9,
+      results: [
+        {
+          chebi_accession: 'CHEBI:27732',
+          name: 'caffeine',
+          monoisotopic_mass: 194.08,
+          relevance: 12.3
+        }
+      ]
+    })
+  })
+
+  it('chebi_get_entity normalizes names, roles, xrefs and caps synonyms', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        chebi_accession: 'CHEBI:27732',
+        name: 'caffeine',
+        definition: 'A trimethylxanthine.',
+        stars: 3,
+        modified_on: '2021-09-20T10:57:24Z',
+        is_released: true,
+        secondary_ids: ['CHEBI:3295'],
+        names: {
+          SYNONYM: [{ name: 'guaranine' }, { name: 'thein' }, { name: 'methyltheobromine' }],
+          'IUPAC NAME': [{ name: '1,3,7-trimethylpurine-2,6-dione' }]
+        },
+        chemical_data: {
+          formula: 'C8H10N4O2',
+          charge: 0,
+          mass: '194.19',
+          monoisotopic_mass: '194.08'
+        },
+        default_structure: {
+          smiles: 'Cn1...',
+          standard_inchi: 'InChI=1S/...',
+          standard_inchi_key: 'RYYVLZVUVIJVGH-UHFFFAOYSA-N'
+        },
+        database_accessions: {
+          CITATION: [
+            { accession_number: '10213372', source_name: 'PubMed', url: 'http://europepmc.org/x' }
+          ]
+        },
+        roles_classification: [
+          { chebi_accession: 'CHEBI:76946', name: 'fungal metabolite', definition: 'x' }
+        ]
+      })
+    )
+    const out = (await engine(fetchImpl).call(
+      tool('chebi_get_entity'),
+      { chebi_id: 'CHEBI:27732', max_synonyms: 2 },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      `${'https://www.ebi.ac.uk/chebi/backend/api/public'}/compound/27732/`
+    )
+    expect(out).toMatchObject({
+      chebi_accession: 'CHEBI:27732',
+      formula: 'C8H10N4O2',
+      monoisotopic_mass: '194.08',
+      inchikey: 'RYYVLZVUVIJVGH-UHFFFAOYSA-N',
+      iupac_names: ['1,3,7-trimethylpurine-2,6-dione'],
+      synonyms: ['guaranine', 'thein'],
+      n_synonyms_total: 3,
+      synonyms_truncated: true,
+      secondary_ids: ['CHEBI:3295'],
+      xrefs: [
+        { type: 'CITATION', accession: '10213372', source: 'PubMed', url: 'http://europepmc.org/x' }
+      ],
+      n_xrefs_total: 1,
+      roles: [{ chebi_accession: 'CHEBI:76946', name: 'fungal metabolite' }],
+      is_released: true
+    })
+  })
+
+  it('chebi_get_entity throws a not-found error for an unknown id', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(notFoundRes())
+    await expect(
+      engine(fetchImpl).call(tool('chebi_get_entity'), { chebi_id: '99999999' }, {})
+    ).rejects.toThrow(/no ChEBI entity/)
+  })
+
+  it('chebi_get_entity rejects a malformed id without a network call', async () => {
     const fetchImpl = vi.fn()
     await expect(
-      new ParserEngine({ fetchImpl }).call(tool('bindingdb_affinities'), { uniprot: 'nope' }, {})
+      engine(fetchImpl).call(tool('chebi_get_entity'), { chebi_id: 'nope' }, {})
+    ).rejects.toThrow(/not a ChEBI ID/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('chebi_get_ontology splits outgoing/incoming relations and applies a type filter', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        chebi_accession: 'CHEBI:27732',
+        name: 'caffeine',
+        ontology_relations: {
+          outgoing_relations: [
+            {
+              relation_type: 'has role',
+              init_id: 27732,
+              init_name: 'caffeine',
+              final_id: 35705,
+              final_name: 'immunosuppressive agent'
+            },
+            {
+              relation_type: 'is a',
+              init_id: 27732,
+              init_name: 'caffeine',
+              final_id: 26385,
+              final_name: 'purine alkaloid'
+            }
+          ],
+          incoming_relations: [
+            {
+              relation_type: 'has part',
+              init_id: 1,
+              init_name: 'x',
+              final_id: 27732,
+              final_name: 'caffeine'
+            }
+          ]
+        }
+      })
+    )
+    const out = (await engine(fetchImpl).call(
+      tool('chebi_get_ontology'),
+      { chebi_id: '27732', relation_type: 'has role' },
+      {}
+    )) as Record<string, unknown>
+    expect(out).toMatchObject({
+      chebi_accession: 'CHEBI:27732',
+      relation_type_filter: 'has role',
+      outgoing_relations: [
+        {
+          relation_type: 'has role',
+          init_chebi_id: 27732,
+          final_chebi_id: 35705,
+          final_name: 'immunosuppressive agent'
+        }
+      ],
+      n_outgoing_total: 1,
+      incoming_relations: [],
+      n_incoming_total: 0
+    })
+  })
+})
+
+describe('chemistry / rhea', () => {
+  const chebiRow = {
+    accession: { value: 'RHEA:10280' },
+    equation: { value: 'A = B' },
+    status: { value: 'http://rdf.rhea-db.org/Approved' }
+  }
+
+  it('rhea_search_reactions detects a ChEBI query and runs a COUNT companion', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ results: { bindings: [chebiRow] } }))
+      .mockResolvedValueOnce(jsonRes({ results: { bindings: [{ n: { value: '3' } }] } }))
+    const out = (await engine(fetchImpl).call(
+      tool('rhea_search_reactions'),
+      { query: 'CHEBI:27732', limit: 1 },
+      {}
+    )) as Record<string, unknown>
+    expect(decodeURIComponent(String(fetchImpl.mock.calls[0][0]))).toContain('SELECT DISTINCT')
+    expect(decodeURIComponent(String(fetchImpl.mock.calls[0][0]))).toContain('CHEBI_27732')
+    expect(decodeURIComponent(String(fetchImpl.mock.calls[1][0]))).toContain('COUNT(DISTINCT')
+    expect(out).toMatchObject({
+      query: 'CHEBI:27732',
+      query_type: 'chebi',
+      api_total: 3,
+      n_returned: 1,
+      truncated: true,
+      reactions: [{ rhea_id: 'RHEA:10280', equation: 'A = B', status: 'Approved' }]
+    })
+  })
+
+  it('rhea_search_reactions detects a full EC number', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ results: { bindings: [] } }))
+      .mockResolvedValueOnce(jsonRes({ results: { bindings: [{ n: { value: '0' } }] } }))
+    const out = (await engine(fetchImpl).call(
+      tool('rhea_search_reactions'),
+      { query: '2.1.1.160' },
+      {}
+    )) as Record<string, unknown>
+    expect(decodeURIComponent(String(fetchImpl.mock.calls[0][0]))).toContain(
+      'http://purl.uniprot.org/enzyme/2.1.1.160'
+    )
+    expect(out).toMatchObject({ query_type: 'ec', api_total: 0, reactions: [] })
+  })
+
+  it('rhea_search_reactions does a case-insensitive text search otherwise', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ results: { bindings: [chebiRow] } }))
+      .mockResolvedValueOnce(jsonRes({ results: { bindings: [{ n: { value: '1' } }] } }))
+    const out = (await engine(fetchImpl).call(
+      tool('rhea_search_reactions'),
+      { query: 'Caffeine' },
+      {}
+    )) as Record<string, unknown>
+    const q = decodeURIComponent(String(fetchImpl.mock.calls[0][0]))
+    expect(q).toContain('CONTAINS(LCASE(STR(?equation)), "caffeine")')
+    expect(out).toMatchObject({ query_type: 'text', api_total: 1 })
+  })
+
+  it('rhea_search_reactions rejects a partial EC class without a network call', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      engine(fetchImpl).call(tool('rhea_search_reactions'), { query: '2.1.1.-' }, {})
+    ).rejects.toThrow(/not a full EC number/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('rhea_get_reaction assembles predicates and participants', async () => {
+    const preds = {
+      results: {
+        bindings: [
+          { p: { value: 'http://rdf.rhea-db.org/equation' }, o: { value: 'A = B' } },
+          {
+            p: { value: 'http://rdf.rhea-db.org/status' },
+            o: { value: 'http://rdf.rhea-db.org/Approved' }
+          },
+          { p: { value: 'http://rdf.rhea-db.org/isTransport' }, o: { value: 'false' } },
+          { p: { value: 'http://rdf.rhea-db.org/isChemicallyBalanced' }, o: { value: 'true' } },
+          {
+            p: { value: 'http://rdf.rhea-db.org/ec' },
+            o: { value: 'http://purl.uniprot.org/enzyme/2.1.1.160' }
+          },
+          {
+            p: { value: 'http://rdf.rhea-db.org/citation' },
+            o: { value: 'http://rdf.ncbi.nlm.nih.gov/pubmed/10984041' }
+          },
+          {
+            p: { value: 'http://rdf.rhea-db.org/directionalReaction' },
+            o: { value: 'http://rdf.rhea-db.org/10281' }
+          },
+          {
+            p: { value: 'http://rdf.rhea-db.org/bidirectionalReaction' },
+            o: { value: 'http://rdf.rhea-db.org/10283' }
+          }
+        ]
+      }
+    }
+    const parts = {
+      results: {
+        bindings: [
+          {
+            side: { value: 'http://rdf.rhea-db.org/10280_R' },
+            coefProp: { value: 'http://rdf.rhea-db.org/contains1' },
+            cacc: { value: 'CHEBI:27732' },
+            cname: { value: 'caffeine' }
+          },
+          {
+            side: { value: 'http://rdf.rhea-db.org/10280_L' },
+            coefProp: { value: 'http://rdf.rhea-db.org/contains2' },
+            cacc: { value: 'CHEBI:25858' },
+            cname: { value: '1,7-dimethylxanthine' }
+          }
+        ]
+      }
+    }
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(preds))
+      .mockResolvedValueOnce(jsonRes(parts))
+    const out = (await engine(fetchImpl).call(
+      tool('rhea_get_reaction'),
+      { rhea_id: '10280' },
+      {}
+    )) as Record<string, unknown>
+    expect(out).toMatchObject({
+      rhea_id: 'RHEA:10280',
+      equation: 'A = B',
+      status: 'Approved',
+      is_transport: false,
+      is_chemically_balanced: true,
+      ec_numbers: ['2.1.1.160'],
+      pubmed_ids: ['10984041'],
+      directional_reactions: ['RHEA:10281'],
+      bidirectional_reaction: 'RHEA:10283',
+      left_side: [
+        { compound_accession: 'CHEBI:25858', name: '1,7-dimethylxanthine', coefficient: '2' }
+      ],
+      right_side: [{ compound_accession: 'CHEBI:27732', name: 'caffeine', coefficient: '1' }]
+    })
+  })
+
+  it('rhea_get_reaction throws when the accession has no bindings', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ results: { bindings: [] } }))
+    await expect(
+      engine(fetchImpl).call(tool('rhea_get_reaction'), { rhea_id: '999999' }, {})
+    ).rejects.toThrow(/no Rhea reaction/)
+  })
+})
+
+describe('chemistry / bindingdb', () => {
+  it('bindingdb_ligands_by_target unwraps the misspelled root, sorts and caps', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        getLindsByUniprotsResponse: {
+          affinities: [
+            {
+              query: 'EGFR',
+              monomerid: 10,
+              smile: 'X',
+              affinity_type: 'Ki',
+              affinity: '50',
+              pmid: 1,
+              doi: 'd1'
+            },
+            {
+              query: 'EGFR',
+              monomerid: 11,
+              smile: 'Y',
+              affinity_type: 'IC50',
+              affinity: '5',
+              pmid: 2,
+              doi: 'd2'
+            },
+            {
+              query: 'EGFR',
+              monomerid: 12,
+              smile: 'Z',
+              affinity_type: 'Ki',
+              affinity: '0.006',
+              pmid: 3,
+              doi: 'd3'
+            }
+          ]
+        }
+      })
+    )
+    const out = (await engine(fetchImpl).call(
+      tool('bindingdb_ligands_by_target'),
+      { uniprot: 'p00533', affinity_cutoff_nm: 100, max_rows: 2 },
+      {}
+    )) as {
+      rows: Array<Record<string, unknown>>
+      n_rows_total: number
+      truncated: boolean
+      uniprot: string
+    }
+    expect(fetchImpl.mock.calls[0][0]).toContain('uniprot=P00533')
+    expect(fetchImpl.mock.calls[0][0]).toContain('cutoff=100')
+    expect(out.uniprot).toBe('P00533')
+    expect(out.n_rows_total).toBe(3)
+    expect(out.truncated).toBe(true)
+    // Sorted by (affinity_type, numeric affinity): IC50/5 first, then Ki/0.006.
+    expect(out.rows.map((r) => r.monomer_id)).toEqual(['11', '12'])
+    expect(out.rows[0]).toMatchObject({
+      affinity_type: 'IC50',
+      affinity: '5',
+      pmid: '2',
+      doi: 'd2'
+    })
+  })
+
+  it('bindingdb_ligands_by_target rejects a malformed UniProt accession', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      engine(fetchImpl).call(tool('bindingdb_ligands_by_target'), { uniprot: 'nope' }, {})
     ).rejects.toThrow(/not a UniProt accession/)
     expect(fetchImpl).not.toHaveBeenCalled()
   })
+
+  it('bindingdb_targets_by_compound maps the bdb.* fields and api_hit_count', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        getLindsByUniprotResponse: {
+          'bdb.hit': 2,
+          'bdb.affinities': [
+            {
+              'bdb.monomerid': 22360,
+              'bdb.smiles': 'CC',
+              'bdb.inhibitor': 'lig',
+              'bdb.target': 'B target',
+              'bdb.species': 'Human',
+              'bdb.affinity_type': 'IC50',
+              'bdb.affinity': '>133000'
+            },
+            {
+              'bdb.monomerid': 22361,
+              'bdb.smiles': 'CCC',
+              'bdb.inhibitor': 'lig2',
+              'bdb.target': 'A target',
+              'bdb.species': 'Human',
+              'bdb.affinity_type': 'Ki',
+              'bdb.affinity': '10',
+              'bdb.tanimoto': '0.9'
+            }
+          ]
+        }
+      })
+    )
+    const out = (await engine(fetchImpl).call(
+      tool('bindingdb_targets_by_compound'),
+      { smiles: 'CC(=O)O', similarity: 0.85 },
+      {}
+    )) as { rows: Array<Record<string, unknown>>; api_hit_count: number; n_rows_total: number }
+    expect(fetchImpl.mock.calls[0][0]).toContain('/getTargetByCompound?smiles=')
+    expect(fetchImpl.mock.calls[0][0]).toContain('cutoff=0.85')
+    expect(out.api_hit_count).toBe(2)
+    expect(out.n_rows_total).toBe(2)
+    // Sorted by target_name: "A target" before "B target".
+    expect(out.rows.map((r) => r.target_name)).toEqual(['A target', 'B target'])
+    expect(out.rows[0]).toMatchObject({
+      monomer_id: '22361',
+      ligand_name: 'lig2',
+      affinity_type: 'Ki',
+      affinity: '10',
+      tanimoto: '0.9'
+    })
+  })
+})
+
+// Live smoke tests against the real backends — opt in with LIVE_API=1. Kept minimal (rate-limited).
+describe.skipIf(!process.env.LIVE_API)('chemistry / LIVE', () => {
+  const live = new ParserEngine()
+  const call = (id: string, args: Record<string, unknown>): Promise<unknown> =>
+    live.call(tool(id), args, {})
+
+  it('pubchem_search_compounds returns aspirin properties', async () => {
+    const out = (await call('pubchem_search_compounds', { query: 'aspirin', max_cids: 3 })) as {
+      cids: number[]
+      properties: Array<Record<string, unknown>>
+    }
+    expect(out.cids).toContain(2244)
+    expect(out.properties[0]).toHaveProperty('ConnectivitySMILES')
+    expect(out.properties[0]).toHaveProperty('MolecularFormula')
+  }, 30000)
+
+  it('pubchem_get_compounds returns full records for 2244 and 2519', async () => {
+    const out = (await call('pubchem_get_compounds', { cids: [2244, 2519] })) as {
+      records: Array<Record<string, unknown>>
+      not_found: number[]
+    }
+    expect(out.records.length).toBe(2)
+    expect(out.records[0]).toHaveProperty('InChIKey')
+    expect(out.not_found).toEqual([])
+  }, 30000)
+
+  it('pubchem_similarity_search finds analogs of aspirin', async () => {
+    const out = (await call('pubchem_similarity_search', {
+      smiles: 'CC(=O)OC1=CC=CC=C1C(=O)O',
+      threshold: 95,
+      max_records: 5
+    })) as { cids: number[] }
+    expect(out.cids).toContain(2244)
+  }, 30000)
+
+  it('pubchem_get_bioassay_summary returns rows for aspirin', async () => {
+    const out = (await call('pubchem_get_bioassay_summary', { cid: 2244, max_rows: 5 })) as {
+      n_rows_total: number
+      rows: Array<Record<string, unknown>>
+    }
+    expect(out.n_rows_total).toBeGreaterThan(0)
+    expect(out.rows[0]).toHaveProperty('AID')
+  }, 30000)
+
+  it('pubchem_get_safety returns a GHS block for aspirin', async () => {
+    const out = (await call('pubchem_get_safety', { cid: 2244 })) as {
+      found: boolean
+      ghs: Record<string, unknown> | null
+    }
+    expect(out.found).toBe(true)
+    expect(out.ghs).toHaveProperty('hazard_statements')
+  }, 30000)
+
+  it('chebi_search finds caffeine', async () => {
+    const out = (await call('chebi_search', { term: 'caffeine', max_results: 3 })) as {
+      api_total: number
+      results: Array<Record<string, unknown>>
+    }
+    expect(out.api_total).toBeGreaterThan(0)
+    expect(out.results.some((r) => r.chebi_accession === 'CHEBI:27732')).toBe(true)
+  }, 30000)
+
+  it('chebi_get_entity returns the caffeine record', async () => {
+    const out = (await call('chebi_get_entity', { chebi_id: 'CHEBI:27732' })) as {
+      name: string
+      formula: string
+      roles: unknown[]
+    }
+    expect(out.name).toBe('caffeine')
+    expect(out.formula).toBe('C8H10N4O2')
+    expect(out.roles.length).toBeGreaterThan(0)
+  }, 30000)
+
+  it('chebi_get_ontology returns relations for caffeine', async () => {
+    const out = (await call('chebi_get_ontology', { chebi_id: '27732' })) as {
+      n_outgoing_total: number
+    }
+    expect(out.n_outgoing_total).toBeGreaterThan(0)
+  }, 30000)
+
+  it('rhea_search_reactions works for chebi, ec and text queries', async () => {
+    const byChebi = (await call('rhea_search_reactions', { query: 'CHEBI:27732', limit: 5 })) as {
+      query_type: string
+      api_total: number
+    }
+    expect(byChebi.query_type).toBe('chebi')
+    expect(byChebi.api_total).toBeGreaterThan(0)
+    const byEc = (await call('rhea_search_reactions', { query: '2.1.1.160', limit: 5 })) as {
+      query_type: string
+      api_total: number
+    }
+    expect(byEc.query_type).toBe('ec')
+    expect(byEc.api_total).toBeGreaterThan(0)
+    const byText = (await call('rhea_search_reactions', { query: 'caffeine', limit: 5 })) as {
+      query_type: string
+      api_total: number
+    }
+    expect(byText.query_type).toBe('text')
+    expect(byText.api_total).toBeGreaterThan(0)
+  }, 45000)
+
+  it('rhea_get_reaction returns the full record for 10280', async () => {
+    const out = (await call('rhea_get_reaction', { rhea_id: '10280' })) as {
+      ec_numbers: string[]
+      left_side: unknown[]
+      right_side: unknown[]
+    }
+    expect(out.ec_numbers).toContain('2.1.1.160')
+    expect(out.left_side.length).toBeGreaterThan(0)
+    expect(out.right_side.length).toBeGreaterThan(0)
+  }, 30000)
+
+  it('bindingdb_ligands_by_target returns potent EGFR binders', async () => {
+    const out = (await call('bindingdb_ligands_by_target', {
+      uniprot: 'P00533',
+      affinity_cutoff_nm: 100,
+      max_rows: 5
+    })) as { n_rows_total: number; rows: Array<Record<string, unknown>> }
+    expect(out.n_rows_total).toBeGreaterThan(0)
+    expect(out.rows[0]).toHaveProperty('affinity_type')
+  }, 45000)
+
+  it('bindingdb_targets_by_compound returns targets for aspirin', async () => {
+    const out = (await call('bindingdb_targets_by_compound', {
+      smiles: 'CC(=O)OC1=CC=CC=C1C(=O)O',
+      similarity: 0.85,
+      max_rows: 5
+    })) as { n_rows_total: number; api_hit_count: number | null }
+    expect(out.n_rows_total).toBeGreaterThan(0)
+  }, 45000)
 })

--- a/src/main/connectors/descriptors/chemistry.ts
+++ b/src/main/connectors/descriptors/chemistry.ts
@@ -1,14 +1,22 @@
-import type { ToolDescriptor } from '../types'
+import type { ToolContext, ToolDescriptor } from '../types'
 
+// PubChem PUG REST + PUG-View. Structure/name inputs go via GET query params so slashes and
+// other path-reserved characters in SMILES survive intact (the engine only offers GET + JSON POST).
 const PUBCHEM = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug'
-const PROPS = 'MolecularFormula,MolecularWeight,CanonicalSMILES,IUPACName'
+const PUBCHEM_VIEW = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug_view'
+// The 2025 PUG REST property names: `SMILES` is the full (isomeric) SMILES, `ConnectivitySMILES`
+// the stereo-stripped one (formerly CanonicalSMILES).
+const PUBCHEM_PROPS =
+  'MolecularFormula,MolecularWeight,SMILES,ConnectivitySMILES,InChI,InChIKey,IUPACName,XLogP,' +
+  'ExactMass,TPSA,Charge,HBondDonorCount,HBondAcceptorCount,RotatableBondCount,HeavyAtomCount'
+const PUBCHEM_NAMESPACES = ['name', 'smiles', 'inchikey', 'cid'] as const
 
 // ChEBI's 2024+ website backend: keyless JSON REST (the legacy SOAP service is being retired).
 const CHEBI_API = 'https://www.ebi.ac.uk/chebi/backend/api/public'
 
-// Rhea has no plain REST lookup; the DB is served via SPARQL. GET with an `Accept: application/
-// json` header returns `application/sparql-results+json` bindings, so a single SELECT works
-// through the same fetchJson path as every other tool here.
+// Rhea has no plain REST lookup; the DB is served via SPARQL. A GET with `?query=` and an
+// `Accept: application/json` header (the engine's fetchJson default) returns
+// `application/sparql-results+json` bindings, so every SELECT rides the same fetchJson path.
 const RHEA_SPARQL = 'https://sparql.rhea-db.org/sparql'
 const RHEA_PREFIXES =
   'PREFIX rh: <http://rdf.rhea-db.org/>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n'
@@ -17,29 +25,21 @@ const BINDINGDB_API = 'https://bindingdb.org/rest'
 const UNIPROT_RE = /^[OPQ][0-9][A-Z0-9]{3}[0-9]$|^[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$/i
 const CHEBI_ID_RE = /^(?:CHEBI:)?(\d+)$/i
 const RHEA_ID_RE = /^(?:RHEA:)?(\d+)$/i
+// Query-type detection for rhea_search_reactions: bare/prefixed ChEBI id, then a full EC number.
+const EC_FULL_RE = /^\d+\.\d+\.\d+\.n?\d+$/
 
-type Props = { PropertyTable: { Properties: unknown[] } }
-
-type ChebiCompound = {
-  chebi_accession?: string
-  name?: string
-  definition?: string
-  chemical_data?: { formula?: string; charge?: string; mass?: string }
-  default_structure?: { smiles?: string; standard_inchi?: string; standard_inchi_key?: string }
+type CidList = { IdentifierList?: { CID?: number[] } }
+type PropRow = Record<string, unknown> & { CID?: number }
+type PropTable = { PropertyTable?: { Properties?: PropRow[] } }
+type SynonymList = {
+  InformationList?: { Information?: Array<{ CID?: number; Synonym?: string[] }> }
+}
+type AssayTable = {
+  Table?: { Columns?: { Column?: string[] }; Row?: Array<{ Cell?: string[] }> }
 }
 
 type SparqlBinding = Record<string, { value?: string }>
 type SparqlResponse = { results?: { bindings?: SparqlBinding[] } }
-
-type BindingDbAffinity = {
-  query?: string
-  monomerid?: string | number
-  smile?: string
-  affinity_type?: string
-  affinity?: string | number
-  pmid?: string | number
-  doi?: string
-}
 
 // Accept `CHEBI:27732` / `27732` / 27732; return the bare numeric id string.
 function normalizeChebiId(id: unknown): string {
@@ -61,58 +61,324 @@ function localName(uri?: string): string | undefined {
   return uri.replace(/\/$/, '').split(/[/#]/).pop()
 }
 
-// PubChem PUG REST: read-only compound lookups.
+// The engine surfaces PubChem's "no match" 404 (PUGREST.NotFound) as a generic HTTP 404 error;
+// PubChem signals absent records this way, which several tools treat as an empty result, not a throw.
+function isNotFound(err: unknown): boolean {
+  return err instanceof Error && /\bHTTP 404\b/.test(err.message)
+}
+
+// Clamp a listing to `cap`, reporting whether anything was dropped. A non-positive cap means "none".
+function capRows<T>(rows: T[], cap: number): { rows: T[]; truncated: boolean } {
+  const n = Math.max(0, cap)
+  return rows.length > n ? { rows: rows.slice(0, n), truncated: true } : { rows, truncated: false }
+}
+
+// Resolve an identifier to PubChem CIDs; a no-match 404 is an empty list, not an error.
+async function pubchemSearchCids(
+  ctx: ToolContext,
+  query: string,
+  namespace: string
+): Promise<number[]> {
+  const q = query.trim()
+  const url =
+    namespace === 'smiles'
+      ? `${PUBCHEM}/compound/smiles/cids/JSON?smiles=${encodeURIComponent(q)}`
+      : `${PUBCHEM}/compound/${namespace}/${encodeURIComponent(q)}/cids/JSON`
+  try {
+    const raw = (await ctx.fetchJson(url)) as CidList
+    return raw.IdentifierList?.CID ?? []
+  } catch (err) {
+    if (isNotFound(err)) return []
+    throw err
+  }
+}
+
+// Computed properties for a batch of CIDs (one request); all-unknown batches 404 -> [].
+async function pubchemProperties(ctx: ToolContext, cids: number[]): Promise<PropRow[]> {
+  if (!cids.length) return []
+  try {
+    const raw = (await ctx.fetchJson(
+      `${PUBCHEM}/compound/cid/${cids.join(',')}/property/${PUBCHEM_PROPS}/JSON`
+    )) as PropTable
+    return raw.PropertyTable?.Properties ?? []
+  } catch (err) {
+    if (isNotFound(err)) return []
+    throw err
+  }
+}
+
+// Run a Rhea SPARQL SELECT and return its raw bindings.
+async function rheaSelect(ctx: ToolContext, query: string): Promise<SparqlBinding[]> {
+  const raw = (await ctx.fetchJson(
+    `${RHEA_SPARQL}?query=${encodeURIComponent(RHEA_PREFIXES + query)}`
+  )) as SparqlResponse
+  return raw.results?.bindings ?? []
+}
+
+// A capped Rhea search plus a companion COUNT query, so `api_total` is the true match count.
+async function rheaRunSearch(
+  ctx: ToolContext,
+  where: string,
+  limit: number,
+  distinct: boolean
+): Promise<{ api_total: number; n_returned: number; truncated: boolean; reactions: unknown[] }> {
+  const kw = distinct ? 'DISTINCT ' : ''
+  const rows = await rheaSelect(
+    ctx,
+    `SELECT ${kw}?accession ?equation ?status WHERE {\n${where}\n} ORDER BY ?accession LIMIT ${limit}`
+  )
+  const countRows = await rheaSelect(
+    ctx,
+    `SELECT (COUNT(DISTINCT ?accession) AS ?n) WHERE {\n${where}\n}`
+  )
+  const total = countRows.length ? Number(countRows[0].n?.value ?? 0) : 0
+  const reactions = rows.map((r) => ({
+    rhea_id: r.accession?.value,
+    equation: r.equation?.value,
+    status: localName(r.status?.value)
+  }))
+  return {
+    api_total: total,
+    n_returned: reactions.length,
+    truncated: total > reactions.length,
+    reactions
+  }
+}
+
+// Escape a value for a single-line SPARQL string literal (raw controls are grammar-forbidden).
+function sparqlEscape(text: string): string {
+  return (
+    text
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\t/g, '\\t')
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\u0000-\u001f]/g, '')
+  )
+}
+
+// http://rdf.rhea-db.org/contains2 -> "2"; containsN -> "N"; contains2n -> "2n"; contains1 -> "1".
+function coefficient(coefPropUri?: string): string {
+  return (localName(coefPropUri) ?? '').replace(/^contains/, '') || '1'
+}
+
+// Numeric sort key for affinity strings like "10000", ">133000", "<0.5"; missing sorts last.
+function affinitySortKey(affinity?: string): number {
+  if (!affinity) return Number.POSITIVE_INFINITY
+  const m = /[\d.]+(?:[eE][+-]?\d+)?/.exec(affinity)
+  const n = m ? Number(m[0]) : NaN
+  return Number.isFinite(n) ? n : Number.POSITIVE_INFINITY
+}
+
+const asStr = (v: unknown): string | undefined => {
+  if (v == null) return undefined
+  const s = String(v).trim()
+  return s || undefined
+}
+
+// PubChem PUG REST/PUG-View, ChEBI backend API, Rhea SPARQL and BindingDB REST: read-only
+// small-molecule chemistry — compounds, similarity, bioassays, safety, ontology, reactions, affinities.
 export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
-  {
-    id: 'pubchem_get_properties',
-    connector: 'chemistry',
-    description: 'Get molecular properties for one or more PubChem CIDs.',
-    input: {
-      type: 'object',
-      properties: { cids: { type: 'array', items: { type: 'integer' } } },
-      required: ['cids']
-    },
-    required: ['cids'],
-    returns:
-      '`[ { "CID": int, "MolecularFormula": str, "MolecularWeight": str, "CanonicalSMILES": str, "IUPACName": str } ]` — passthrough of PubChem `PropertyTable.Properties`, one entry per resolvable CID; unknown CIDs are simply omitted.',
-    example: 'result = host.mcp("chemistry", "pubchem_get_properties", {"cids": [2244]})',
-    url: (a) =>
-      `${PUBCHEM}/compound/cid/${([] as unknown[]).concat(a.cids as never).join(',')}/property/${PROPS}/JSON`,
-    parse: (raw) => (raw as Props).PropertyTable.Properties
-  },
   {
     id: 'pubchem_search_compounds',
     connector: 'chemistry',
-    description: 'Search PubChem compounds by name; returns matched CIDs with properties.',
+    description:
+      'Resolve a chemical identifier (name, SMILES, InChIKey, or CID) to PubChem CIDs, optionally with core computed properties for the top hits.',
     input: {
       type: 'object',
-      properties: { query: { type: 'string' }, max_cids: { type: 'integer', default: 5 } },
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Identifier matching `namespace`, e.g. "aspirin", a SMILES, or an InChIKey.'
+        },
+        namespace: { type: 'string', enum: [...PUBCHEM_NAMESPACES], default: 'name' },
+        max_cids: { type: 'integer', default: 25, minimum: 1, maximum: 100 },
+        with_properties: { type: 'boolean', default: true }
+      },
       required: ['query']
     },
     required: ['query'],
     returns:
-      '`{ "query": str, "compounds": [ { "CID": int, "MolecularFormula": str, "MolecularWeight": str, "CanonicalSMILES": str, "IUPACName": str } ] }` — up to `max_cids` compounds (default 5); `compounds` is `[]` when the name matches nothing.',
+      '`{ "query": str, "namespace": str, "n_cids_total": int, "truncated": bool, "cids": [int], "properties": [ {...} ] }` — `n_cids_total` is the full match count, `cids` capped at `max_cids`. `cids` is `[]` when nothing matches (not an error). `properties` rows use PubChem 2025 field names (CID, MolecularFormula, MolecularWeight, `SMILES` = isomeric, `ConnectivitySMILES` = stereo-stripped, InChI, InChIKey, IUPACName, XLogP, ExactMass, TPSA, Charge, H-bond/rotatable-bond/heavy-atom counts).',
     example:
-      'result = host.mcp("chemistry", "pubchem_search_compounds", {"query": "caffeine", "max_cids": 5})',
+      'result = host.mcp("chemistry", "pubchem_search_compounds", {"query": "aspirin", "max_cids": 25})',
     run: async (ctx, a) => {
-      const cidRes = (await ctx.fetchJson(
-        `${PUBCHEM}/compound/name/${encodeURIComponent(String(a.query))}/cids/JSON`
-      )) as {
-        IdentifierList?: { CID?: number[] }
+      const namespace = String(a.namespace ?? 'name')
+      if (!PUBCHEM_NAMESPACES.includes(namespace as (typeof PUBCHEM_NAMESPACES)[number])) {
+        throw new Error(`namespace must be one of ${PUBCHEM_NAMESPACES.join(', ')}`)
       }
-      const cids = (cidRes.IdentifierList?.CID ?? []).slice(0, Number(a.max_cids ?? 5))
-      if (!cids.length) return { query: a.query, compounds: [] }
-      const propRes = (await ctx.fetchJson(
-        `${PUBCHEM}/compound/cid/${cids.join(',')}/property/${PROPS}/JSON`
-      )) as Props
-      return { query: a.query, compounds: propRes.PropertyTable.Properties }
+      const maxCids = Number(a.max_cids ?? 25)
+      if (!(maxCids >= 1 && maxCids <= 100)) throw new Error('max_cids must be in [1, 100]')
+      const withProperties = a.with_properties !== false
+
+      const allCids = await pubchemSearchCids(ctx, String(a.query), namespace)
+      const { rows: cids, truncated } = capRows(allCids, maxCids)
+      const properties = withProperties && cids.length ? await pubchemProperties(ctx, cids) : []
+      return {
+        query: a.query,
+        namespace,
+        n_cids_total: allCids.length,
+        truncated,
+        cids,
+        properties
+      }
     }
   },
   {
-    id: 'pubchem_get_image',
+    id: 'pubchem_get_compounds',
     connector: 'chemistry',
     description:
-      "Get the URL of a compound's 2D structure image (PNG) by PubChem CID; returns a URL the caller can download or save as an artifact.",
+      'Full computed-property records for a batch of PubChem CIDs, with optional capped synonym lists.',
+    input: {
+      type: 'object',
+      properties: {
+        cids: { type: 'array', items: { type: 'integer' }, minItems: 1, maxItems: 50 },
+        include_synonyms: { type: 'boolean', default: false },
+        max_synonyms: { type: 'integer', default: 30 }
+      },
+      required: ['cids']
+    },
+    required: ['cids'],
+    returns:
+      '`{ "n_requested": int, "duplicates": [int], "records": [ {...} ], "not_found": [int] }` — one record per distinct CID (repeats disclosed in `duplicates`, first-occurrence order). Each record carries CID, MolecularFormula, MolecularWeight, SMILES (isomeric), ConnectivitySMILES, InChI, InChIKey, IUPACName, XLogP, ExactMass, TPSA, Charge, HBondDonorCount, HBondAcceptorCount, RotatableBondCount, HeavyAtomCount — plus `synonyms`/`n_synonyms_total`/`synonyms_truncated` when `include_synonyms`. CIDs the API does not know appear in `not_found`.',
+    example:
+      'result = host.mcp("chemistry", "pubchem_get_compounds", {"cids": [2244, 2519], "include_synonyms": false})',
+    run: async (ctx, a) => {
+      const raw = ([] as unknown[]).concat(a.cids as never).map((c) => Number(c))
+      if (!raw.length) throw new Error('cids must be non-empty')
+      if (raw.length > 50) throw new Error('at most 50 CIDs per call')
+
+      // One record per distinct CID; repeats are disclosed, not re-emitted.
+      const unique = [...new Set(raw)]
+      const duplicates = unique.filter((c) => raw.filter((x) => x === c).length > 1)
+      const records = await pubchemProperties(ctx, unique)
+      const byCid = new Map<number, PropRow>(records.map((r) => [Number(r.CID), { ...r }]))
+
+      if (a.include_synonyms) {
+        const maxSyn = Number(a.max_synonyms ?? 30)
+        const raw2 = await pubchemSynonyms(ctx, unique)
+        for (const [cid, rec] of byCid) {
+          const syns = raw2.get(cid) ?? []
+          const capped = capRows(syns, maxSyn)
+          rec.synonyms = capped.rows
+          rec.n_synonyms_total = syns.length
+          rec.synonyms_truncated = capped.truncated
+        }
+      }
+
+      const ordered = unique.filter((c) => byCid.has(c)).map((c) => byCid.get(c)!)
+      const notFound = unique.filter((c) => !byCid.has(c))
+      return { n_requested: raw.length, duplicates, records: ordered, not_found: notFound }
+    }
+  },
+  {
+    id: 'pubchem_similarity_search',
+    connector: 'chemistry',
+    description:
+      '2D Tanimoto similarity search over all of PubChem for a query SMILES (synchronous fastsimilarity_2d route, no job polling).',
+    input: {
+      type: 'object',
+      properties: {
+        smiles: { type: 'string' },
+        threshold: { type: 'integer', default: 90, minimum: 1, maximum: 100 },
+        max_records: { type: 'integer', default: 50, minimum: 1, maximum: 200 },
+        with_properties: { type: 'boolean', default: false }
+      },
+      required: ['smiles']
+    },
+    required: ['smiles'],
+    returns:
+      '`{ "smiles": str, "threshold": int, "n_cids": int, "may_be_truncated": bool, "cids": [int], "properties": [ {...} ] }` — CIDs in upstream relevance order (the query compound is usually first). `threshold` is percent Tanimoto. The API does not report an uncapped total, so `may_be_truncated` is true exactly when the cap was filled. `properties` (when `with_properties`) covers the first 10 hits.',
+    example:
+      'result = host.mcp("chemistry", "pubchem_similarity_search", {"smiles": "CC(=O)OC1=CC=CC=C1C(=O)O", "threshold": 90})',
+    run: async (ctx, a) => {
+      const smiles = String(a.smiles).trim()
+      if (!smiles) throw new Error('smiles must be non-empty')
+      const threshold = Number(a.threshold ?? 90)
+      if (!(threshold >= 1 && threshold <= 100)) throw new Error('threshold must be in [1, 100]')
+      const maxRecords = Number(a.max_records ?? 50)
+      if (!(maxRecords >= 1 && maxRecords <= 200))
+        throw new Error('max_records must be in [1, 200]')
+
+      let cids: number[]
+      try {
+        const raw = (await ctx.fetchJson(
+          `${PUBCHEM}/compound/fastsimilarity_2d/smiles/cids/JSON?smiles=${encodeURIComponent(smiles)}&Threshold=${threshold}&MaxRecords=${maxRecords}`
+        )) as CidList
+        cids = raw.IdentifierList?.CID ?? []
+      } catch (err) {
+        if (isNotFound(err)) cids = []
+        else throw err
+      }
+      const properties =
+        a.with_properties && cids.length ? await pubchemProperties(ctx, cids.slice(0, 10)) : []
+      return {
+        smiles,
+        threshold,
+        n_cids: cids.length,
+        may_be_truncated: cids.length >= maxRecords,
+        cids,
+        properties
+      }
+    }
+  },
+  {
+    id: 'pubchem_get_bioassay_summary',
+    connector: 'chemistry',
+    description:
+      'Bioassay activity summary for one PubChem compound — which assays tested it, against which targets, with what outcome and potency.',
+    input: {
+      type: 'object',
+      properties: {
+        cid: { type: 'integer' },
+        active_only: { type: 'boolean', default: false },
+        max_rows: { type: 'integer', default: 100, minimum: 1, maximum: 1000 }
+      },
+      required: ['cid']
+    },
+    required: ['cid'],
+    returns:
+      '`{ "cid": int, "active_only": bool, "n_rows_total": int, "truncated": bool, "rows": [ {...} ] }` — each row maps the upstream columns: AID, SID, CID, "Activity Outcome" (Active/Inactive/Unspecified/Inconclusive), "Target Accession", "Target GeneID", "Activity Value [uM]", "Activity Name", "Assay Name", "Assay Type", "PubMed ID". Filtering by `active_only` happens BEFORE the cap, so `n_rows_total` is the true (filtered) count. `rows` is `[]` for compounds with no assay data (not an error).',
+    example:
+      'result = host.mcp("chemistry", "pubchem_get_bioassay_summary", {"cid": 2244, "active_only": true})',
+    run: async (ctx, a) => {
+      const cid = Number(a.cid)
+      const maxRows = Number(a.max_rows ?? 100)
+      if (!(maxRows >= 1 && maxRows <= 1000)) throw new Error('max_rows must be in [1, 1000]')
+
+      let rows: Array<Record<string, string>>
+      try {
+        const raw = (await ctx.fetchJson(
+          `${PUBCHEM}/compound/cid/${cid}/assaysummary/JSON`
+        )) as AssayTable
+        const columns = raw.Table?.Columns?.Column ?? []
+        rows = (raw.Table?.Row ?? []).map((row) => {
+          const cells = row.Cell ?? []
+          return Object.fromEntries(columns.map((col, i) => [col, cells[i]]))
+        })
+      } catch (err) {
+        if (isNotFound(err)) rows = []
+        else throw err
+      }
+      const activeOnly = a.active_only === true
+      const filtered = activeOnly ? rows.filter((r) => r['Activity Outcome'] === 'Active') : rows
+      const { rows: capped, truncated } = capRows(filtered, maxRows)
+      return {
+        cid,
+        active_only: activeOnly,
+        n_rows_total: filtered.length,
+        truncated,
+        rows: capped
+      }
+    }
+  },
+  {
+    id: 'pubchem_get_safety',
+    connector: 'chemistry',
+    description:
+      "GHS safety classification for one PubChem compound (PUG-View 'GHS Classification' heading), aggregated across reporting sources.",
     input: {
       type: 'object',
       properties: { cid: { type: 'integer' } },
@@ -120,50 +386,288 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
     },
     required: ['cid'],
     returns:
-      '`{ "cid": int, "format": "png", "url": str }` — a direct URL to the compound\'s 2D structure PNG (e.g. `https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=2244&t=l`).',
-    example: 'result = host.mcp("chemistry", "pubchem_get_image", {"cid": 2244})',
-    run: async (_ctx, a) => {
+      '`{ "cid": int, "found": bool, "ghs": {...} | null }` — `ghs` is null when PubChem has no GHS section. Otherwise `{ cid, record_title, signals (e.g. ["Danger"]), pictograms (e.g. ["Flammable", "Irritant"]), hazard_statements (H-codes with occurrence percentages), precautionary_statement_codes, notes, n_source_references }`. Percentages in the hazard text show how many indexed sources report each hazard.',
+    example: 'result = host.mcp("chemistry", "pubchem_get_safety", {"cid": 702})',
+    run: async (ctx, a) => {
       const cid = Number(a.cid)
+      let ghs: unknown = null
+      try {
+        const raw = (await ctx.fetchJson(
+          `${PUBCHEM_VIEW}/data/compound/${cid}/JSON?heading=${encodeURIComponent('GHS Classification')}`
+        )) as PugViewRecord
+        ghs = parseGhs(cid, raw.Record)
+      } catch (err) {
+        if (!isNotFound(err)) throw err
+      }
+      return { cid, found: ghs !== null, ghs }
+    }
+  },
+  {
+    id: 'chebi_search',
+    connector: 'chemistry',
+    description: 'Full-text search over ChEBI entities (names, synonyms, formulae, InChIKeys).',
+    input: {
+      type: 'object',
+      properties: {
+        term: { type: 'string' },
+        max_results: { type: 'integer', default: 20, minimum: 1, maximum: 100 },
+        page: { type: 'integer', default: 1, minimum: 1 }
+      },
+      required: ['term']
+    },
+    required: ['term'],
+    returns:
+      '`{ "term": str, "page": int, "size": int, "api_total": int, "number_pages": int, "results": [ {...} ] }` — `api_total` is ChEBI\'s own hit count (further pages exist iff `api_total > page*size`). Each result: chebi_accession, name, definition, stars (3 = manually curated), formula, charge, mass, monoisotopic_mass, smiles, inchikey, relevance.',
+    example:
+      'result = host.mcp("chemistry", "chebi_search", {"term": "caffeine", "max_results": 20})',
+    run: async (ctx, a) => {
+      const term = String(a.term).trim()
+      if (!term) throw new Error('term must be non-empty')
+      const size = Number(a.max_results ?? 20)
+      if (!(size >= 1 && size <= 100)) throw new Error('max_results must be in [1, 100]')
+      const page = Number(a.page ?? 1)
+
+      const raw = (await ctx.fetchJson(
+        `${CHEBI_API}/es_search/?term=${encodeURIComponent(term)}&size=${size}&page=${page}`
+      )) as ChebiSearchResponse
+      const results = (raw.results ?? []).map((hit) => {
+        const s = hit._source ?? {}
+        return {
+          chebi_accession: s.chebi_accession,
+          name: s.name,
+          definition: s.definition,
+          stars: s.stars,
+          formula: s.formula,
+          charge: s.charge,
+          mass: s.mass,
+          monoisotopic_mass: s.monoisotopicmass,
+          smiles: s.smiles,
+          inchikey: s.inchikey,
+          relevance: hit._score
+        }
+      })
       return {
-        cid,
-        format: 'png',
-        url: `https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=${cid}&t=l`
+        term,
+        page,
+        size,
+        api_total: raw.total,
+        number_pages: raw.number_pages,
+        results
       }
     }
   },
   {
     id: 'chebi_get_entity',
     connector: 'chemistry',
-    description: 'Look up a ChEBI ontology entity by ID: name, formula, structure, definition.',
+    description:
+      'Full ChEBI entity record: names, structure, chemical data, roles and cross-references.',
     input: {
       type: 'object',
-      properties: { chebi_id: { type: 'string' } },
+      properties: {
+        chebi_id: { type: 'string' },
+        max_synonyms: { type: 'integer', default: 30 },
+        max_xrefs: { type: 'integer', default: 50 }
+      },
       required: ['chebi_id']
     },
     required: ['chebi_id'],
     returns:
-      '`{ "chebi_accession": str, "name": str, "definition": str, "formula": str, "charge": str, "mass": str, "smiles": str, "inchi": str, "inchikey": str }` — any field may be null when absent from the ChEBI record (e.g. no structure or definition).',
+      '`{ chebi_accession, name, definition, stars, formula, charge, mass, monoisotopic_mass, smiles, inchi, inchikey, iupac_names, synonyms, n_synonyms_total, synonyms_truncated, secondary_ids, xrefs ({type, accession, source, url}), n_xrefs_total, xrefs_truncated, roles ({chebi_accession, name, definition}), modified_on, is_released }` — accepts `CHEBI:27732` or bare `27732`; secondary (merged) ids resolve to the primary record. Ontology parents/children live in `chebi_get_ontology`. Unknown ids throw a not-found error.',
     example: 'result = host.mcp("chemistry", "chebi_get_entity", {"chebi_id": "CHEBI:27732"})',
-    url: (a) => `${CHEBI_API}/compound/${normalizeChebiId(a.chebi_id)}/`,
-    parse: (raw) => {
-      const c = raw as ChebiCompound
-      return {
-        chebi_accession: c.chebi_accession,
-        name: c.name,
-        definition: c.definition,
-        formula: c.chemical_data?.formula,
-        charge: c.chemical_data?.charge,
-        mass: c.chemical_data?.mass,
-        smiles: c.default_structure?.smiles,
-        inchi: c.default_structure?.standard_inchi,
-        inchikey: c.default_structure?.standard_inchi_key
+    run: async (ctx, a) => {
+      const num = normalizeChebiId(a.chebi_id)
+      const maxSyn = Number(a.max_synonyms ?? 30)
+      const maxXrefs = Number(a.max_xrefs ?? 50)
+
+      let raw: ChebiCompound
+      try {
+        raw = (await ctx.fetchJson(`${CHEBI_API}/compound/${num}/`)) as ChebiCompound
+      } catch (err) {
+        if (isNotFound(err)) throw new Error(`no ChEBI entity CHEBI:${num}`)
+        throw err
       }
+
+      const names = raw.names ?? {}
+      const synonyms = (names.SYNONYM ?? []).map((n) => n.name).filter((x): x is string => !!x)
+      const iupacNames = (names['IUPAC NAME'] ?? [])
+        .map((n) => n.name)
+        .filter((x): x is string => !!x)
+      const chem = raw.chemical_data ?? {}
+      const structure = raw.default_structure ?? {}
+
+      const xrefs: Array<Record<string, unknown>> = []
+      for (const type of Object.keys(raw.database_accessions ?? {}).sort()) {
+        for (const entry of raw.database_accessions![type]) {
+          xrefs.push({
+            type,
+            accession: entry.accession_number,
+            source: entry.source_name,
+            url: entry.url
+          })
+        }
+      }
+      const roles = (raw.roles_classification ?? []).map((r) => ({
+        chebi_accession: r.chebi_accession,
+        name: r.name,
+        definition: r.definition
+      }))
+
+      const synCap = capRows(synonyms, maxSyn)
+      const xrefCap = capRows(xrefs, maxXrefs)
+      return {
+        chebi_accession: raw.chebi_accession,
+        name: raw.name,
+        definition: raw.definition,
+        stars: raw.stars,
+        formula: chem.formula,
+        charge: chem.charge,
+        mass: chem.mass,
+        monoisotopic_mass: chem.monoisotopic_mass,
+        smiles: structure.smiles,
+        inchi: structure.standard_inchi,
+        inchikey: structure.standard_inchi_key,
+        iupac_names: iupacNames,
+        synonyms: synCap.rows,
+        n_synonyms_total: synonyms.length,
+        synonyms_truncated: synCap.truncated,
+        secondary_ids: raw.secondary_ids ?? [],
+        xrefs: xrefCap.rows,
+        n_xrefs_total: xrefs.length,
+        xrefs_truncated: xrefCap.truncated,
+        roles,
+        modified_on: raw.modified_on,
+        is_released: raw.is_released
+      }
+    }
+  },
+  {
+    id: 'chebi_get_ontology',
+    connector: 'chemistry',
+    description:
+      'Ontology relations of a ChEBI entity — what it IS (outgoing: is a / has role / conjugate acid...) and what points AT it (incoming: children/derivatives).',
+    input: {
+      type: 'object',
+      properties: {
+        chebi_id: { type: 'string' },
+        relation_type: {
+          type: 'string',
+          description: 'Optional exact filter, e.g. "is a", "has role", "has part".'
+        },
+        max_relations: { type: 'integer', default: 100 }
+      },
+      required: ['chebi_id']
+    },
+    required: ['chebi_id'],
+    returns:
+      '`{ chebi_accession, name, relation_type_filter, outgoing_relations, n_outgoing_total, outgoing_truncated, incoming_relations, n_incoming_total, incoming_truncated }` — each relation `{ relation_type, init_chebi_id, init_name, final_chebi_id, final_name }` reads "init --relation--> final" (for outgoing, init is this entity; for incoming, final is this entity). `max_relations` caps per direction.',
+    example:
+      'result = host.mcp("chemistry", "chebi_get_ontology", {"chebi_id": "CHEBI:27732", "relation_type": "has role"})',
+    run: async (ctx, a) => {
+      const num = normalizeChebiId(a.chebi_id)
+      const maxRel = Number(a.max_relations ?? 100)
+      const relFilter = a.relation_type != null ? String(a.relation_type) : null
+
+      let raw: ChebiCompound
+      try {
+        raw = (await ctx.fetchJson(`${CHEBI_API}/compound/${num}/`)) as ChebiCompound
+      } catch (err) {
+        if (isNotFound(err)) throw new Error(`no ChEBI entity CHEBI:${num}`)
+        throw err
+      }
+
+      const rel = raw.ontology_relations ?? {}
+      const norm = (r: ChebiRelation): Record<string, unknown> => ({
+        relation_type: r.relation_type,
+        init_chebi_id: r.init_id,
+        init_name: r.init_name,
+        final_chebi_id: r.final_id,
+        final_name: r.final_name
+      })
+      let outgoing = (rel.outgoing_relations ?? []).map(norm)
+      let incoming = (rel.incoming_relations ?? []).map(norm)
+      if (relFilter) {
+        outgoing = outgoing.filter((r) => r.relation_type === relFilter)
+        incoming = incoming.filter((r) => r.relation_type === relFilter)
+      }
+      const outCap = capRows(outgoing, maxRel)
+      const inCap = capRows(incoming, maxRel)
+      return {
+        chebi_accession: raw.chebi_accession,
+        name: raw.name,
+        relation_type_filter: relFilter,
+        outgoing_relations: outCap.rows,
+        n_outgoing_total: outgoing.length,
+        outgoing_truncated: outCap.truncated,
+        incoming_relations: inCap.rows,
+        n_incoming_total: incoming.length,
+        incoming_truncated: inCap.truncated
+      }
+    }
+  },
+  {
+    id: 'rhea_search_reactions',
+    connector: 'chemistry',
+    description:
+      'Search Rhea master reactions by equation text, participant ChEBI id, or EC number (query type auto-detected).',
+    input: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'A ChEBI id (participant), a full EC number (enzyme reactions), or free text matched against the equation.'
+        },
+        limit: { type: 'integer', default: 50, minimum: 1, maximum: 500 }
+      },
+      required: ['query']
+    },
+    required: ['query'],
+    returns:
+      '`{ "query": str, "query_type": "chebi"|"ec"|"text", "api_total": int, "n_returned": int, "truncated": bool, "reactions": [ { "rhea_id": str, "equation": str, "status": "Approved"|"Preliminary"|"Obsolete" } ] }` — reactions ordered by rhea_id; `api_total` (a companion COUNT query) is the true match count. A ChEBI id matches reactions with that participant; a full EC matches enzyme reactions (partial ECs like "2.1.1.-" are rejected); anything else is a case-insensitive substring match on equation text.',
+    example:
+      'result = host.mcp("chemistry", "rhea_search_reactions", {"query": "caffeine", "limit": 50})',
+    run: async (ctx, a) => {
+      const q = String(a.query).trim()
+      if (!q) throw new Error('query must be non-empty')
+      const limit = Number(a.limit ?? 50)
+      if (!(limit >= 1 && limit <= 500)) throw new Error('limit must be in [1, 500]')
+
+      const base = `  ?r rdfs:subClassOf rh:Reaction ; rh:accession ?accession ;\n     rh:equation ?equation ; rh:status ?status`
+
+      const chebiMatch = CHEBI_ID_RE.exec(q)
+      if (chebiMatch) {
+        const uri = `<http://purl.obolibrary.org/obo/CHEBI_${chebiMatch[1]}>`
+        const where =
+          `${base} ;\n     rh:side/rh:contains/rh:compound ?c .\n` +
+          `  { ?c rh:chebi ${uri} }\n` +
+          `  UNION { ?c rh:reactivePart/rh:chebi ${uri} }\n` +
+          `  UNION { ?c rh:underlyingChebi ${uri} }`
+        const result = await rheaRunSearch(ctx, where, limit, true)
+        return { query: q, query_type: 'chebi', ...result }
+      }
+
+      if (EC_FULL_RE.test(q)) {
+        const where = `${base} ;\n     rh:ec <http://purl.uniprot.org/enzyme/${q}> .`
+        const result = await rheaRunSearch(ctx, where, limit, false)
+        return { query: q, query_type: 'ec', ...result }
+      }
+
+      // Partial/subclass EC notation (e.g. "2.1.1.-") — reject with guidance rather than a
+      // confident api_total=0 from a substring search that can never match.
+      if (/^\d+\.(?:\d+|-)(?:\.(?:\d+|-)){0,2}$/.test(q)) {
+        throw new Error(`not a full EC number: ${q} (partial EC classes are not supported)`)
+      }
+
+      const where = `${base} .\n  FILTER(CONTAINS(LCASE(STR(?equation)), "${sparqlEscape(q.toLowerCase())}"))`
+      const result = await rheaRunSearch(ctx, where, limit, false)
+      return { query: q, query_type: 'text', ...result }
     }
   },
   {
     id: 'rhea_get_reaction',
     connector: 'chemistry',
-    description: 'Look up a Rhea reaction by ID: chemical equation and left/right participants.',
+    description:
+      'Full record for one Rhea reaction: equation, participants with ChEBI ids and stoichiometry, EC links, direction family and literature.',
     input: {
       type: 'object',
       properties: { rhea_id: { type: 'string' } },
@@ -171,76 +675,344 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
     },
     required: ['rhea_id'],
     returns:
-      '`{ "rhea_id": str, "equation": str, "status": str, "left_side": [ { "compound_accession": str, "name": str } ], "right_side": [ ... ] }` — throws if the id has no match; a participant `name` may be null when the compound has no label.',
+      '`{ rhea_id, equation, status, is_transport, is_chemically_balanced, ec_numbers, pubmed_ids, directional_reactions, bidirectional_reaction, left_side, right_side }` — each side lists participants `{ compound_accession, name, coefficient }` (coefficient "1", "2", ... or symbolic "N"/"2n"). Accepts `RHEA:10280` or bare `10280`; unknown ids throw a not-found error.',
     example: 'result = host.mcp("chemistry", "rhea_get_reaction", {"rhea_id": "10280"})',
     run: async (ctx, a) => {
       const acc = normalizeRheaId(a.rhea_id)
-      const query = `${RHEA_PREFIXES}SELECT ?equation ?status ?side ?cacc ?cname WHERE {
-  ?r rh:accession "${acc}" ; rh:equation ?equation ; rh:status ?status ; rh:side ?side .
+
+      const preds = await rheaSelect(
+        ctx,
+        `SELECT ?p ?o WHERE { ?r rh:accession "${acc}" . ?r ?p ?o . }`
+      )
+      if (!preds.length) throw new Error(`no Rhea reaction ${acc}`)
+
+      const record: Record<string, unknown> = {
+        rhea_id: acc,
+        equation: null,
+        status: null,
+        is_transport: null,
+        is_chemically_balanced: null,
+        ec_numbers: [] as string[],
+        pubmed_ids: [] as string[],
+        directional_reactions: [] as string[],
+        bidirectional_reaction: null
+      }
+      for (const row of preds) {
+        const p = localName(row.p?.value)
+        const o = row.o?.value ?? ''
+        if (p === 'equation') record.equation = o
+        else if (p === 'status') record.status = localName(o)
+        else if (p === 'isTransport') record.is_transport = o === 'true'
+        else if (p === 'isChemicallyBalanced') record.is_chemically_balanced = o === 'true'
+        else if (p === 'ec') (record.ec_numbers as string[]).push(o.split('/').pop() ?? o)
+        else if (p === 'citation') (record.pubmed_ids as string[]).push(o.split('/').pop() ?? o)
+        else if (p === 'directionalReaction')
+          (record.directional_reactions as string[]).push(`RHEA:${o.split('/').pop()}`)
+        else if (p === 'bidirectionalReaction')
+          record.bidirectional_reaction = `RHEA:${o.split('/').pop()}`
+      }
+      ;(record.ec_numbers as string[]).sort()
+      ;(record.pubmed_ids as string[]).sort()
+      ;(record.directional_reactions as string[]).sort()
+
+      const parts = await rheaSelect(
+        ctx,
+        `SELECT ?side ?coefProp ?cacc ?cname WHERE {
+  ?r rh:accession "${acc}" ; rh:side ?side .
   ?side ?coefProp ?part . ?coefProp rdfs:subPropertyOf rh:contains .
   ?part rh:compound ?c . ?c rh:accession ?cacc .
   OPTIONAL { ?c rh:name ?cname }
 }`
-      const res = (await ctx.fetchJson(
-        `${RHEA_SPARQL}?query=${encodeURIComponent(query)}`
-      )) as SparqlResponse
-      const rows = res.results?.bindings ?? []
-      if (!rows.length) throw new Error(`no Rhea reaction ${acc}`)
-
-      const left: Array<{ compound_accession?: string; name?: string }> = []
-      const right: Array<{ compound_accession?: string; name?: string }> = []
-      for (const row of rows) {
-        const entry = { compound_accession: row.cacc?.value, name: row.cname?.value }
+      )
+      const left: Array<Record<string, unknown>> = []
+      const right: Array<Record<string, unknown>> = []
+      for (const row of parts) {
+        const entry = {
+          compound_accession: row.cacc?.value,
+          name: row.cname?.value,
+          coefficient: coefficient(row.coefProp?.value)
+        }
         if (row.side?.value?.endsWith('_L')) left.push(entry)
         else if (row.side?.value?.endsWith('_R')) right.push(entry)
       }
-      return {
-        rhea_id: acc,
-        equation: rows[0].equation?.value,
-        status: localName(rows[0].status?.value),
-        left_side: left,
-        right_side: right
-      }
+      const byKey = (e: Record<string, unknown>): string =>
+        `${(e.compound_accession as string) ?? ''}\u0000${(e.name as string) ?? ''}`
+      left.sort((x, y) => byKey(x).localeCompare(byKey(y)))
+      right.sort((x, y) => byKey(x).localeCompare(byKey(y)))
+      record.left_side = left
+      record.right_side = right
+      return record
     }
   },
   {
-    id: 'bindingdb_affinities',
+    id: 'bindingdb_ligands_by_target',
     connector: 'chemistry',
     description:
-      'Get BindingDB ligand binding affinities for a UniProt target, filtered to a max affinity (nM).',
+      'Measured binding affinities (Ki/Kd/IC50/EC50) of all BindingDB ligands against one protein target, by UniProt accession.',
     input: {
       type: 'object',
       properties: {
         uniprot: { type: 'string' },
-        cutoff_nm: { type: 'integer', default: 1000 }
+        affinity_cutoff_nm: { type: 'number', default: 10000 },
+        max_rows: { type: 'integer', default: 100, minimum: 1, maximum: 1000 }
       },
       required: ['uniprot']
     },
     required: ['uniprot'],
     returns:
-      '`{ "uniprot": str, "cutoff_nm": int, "n_rows": int, "affinities": [ { "target_name": str, "monomer_id": str, "smiles": str, "affinity_type": str, "affinity": str, "pmid": str, "doi": str } ] }` — `affinity` is a numeric value in nM as a string; `affinities` is `[]` and `n_rows` 0 when no ligand passes the cutoff; `n_rows` equals the returned count.',
+      '`{ "uniprot": str, "affinity_cutoff_nm": num, "n_rows_total": int, "truncated": bool, "rows": [ { target_name, monomer_id, smiles, affinity_type, affinity, pmid, doi } ] }` — only measurements with value <= `affinity_cutoff_nm`. The full match set is downloaded and counted, so `n_rows_total` is the true count; rows are capped at `max_rows`, sorted by (affinity_type, numeric affinity ascending). `affinity` is a STRING (may carry `>`/`<`, in nM). No hits returns `n_rows_total=0`.',
     example:
-      'result = host.mcp("chemistry", "bindingdb_affinities", {"uniprot": "P00533", "cutoff_nm": 100})',
+      'result = host.mcp("chemistry", "bindingdb_ligands_by_target", {"uniprot": "P00533", "affinity_cutoff_nm": 100})',
     run: async (ctx, a) => {
       const uniprot = String(a.uniprot).trim().toUpperCase()
       if (!UNIPROT_RE.test(uniprot)) throw new Error(`not a UniProt accession: ${uniprot}`)
-      const cutoff = Number(a.cutoff_nm ?? 1000)
-      const raw = (await ctx.fetchJson(
+      const cutoff = Number(a.affinity_cutoff_nm ?? 10000)
+      const maxRows = Number(a.max_rows ?? 100)
+      if (!(maxRows >= 1 && maxRows <= 1000)) throw new Error('max_rows must be in [1, 1000]')
+
+      const root = await bindingdbRoot(
+        ctx,
         `${BINDINGDB_API}/getLigandsByUniprots?uniprot=${encodeURIComponent(uniprot)}&cutoff=${cutoff}&code=0&response=application/json`
-      )) as Record<string, { affinities?: BindingDbAffinity[] }>
-      // Response root key is misspelled upstream (getLindsByUniprotsResponse) and varies by
-      // route; unwrap by taking the single value rather than depending on the exact spelling.
-      const root = Object.values(raw)[0] ?? {}
-      const rows = (root.affinities ?? []).map((r) => ({
+      )
+      const rows = ((root.affinities as BindingDbLigandRow[] | undefined) ?? []).map((r) => ({
         target_name: r.query,
-        monomer_id: r.monomerid != null ? String(r.monomerid) : undefined,
+        monomer_id: asStr(r.monomerid),
         smiles: r.smile,
         affinity_type: r.affinity_type,
-        affinity: r.affinity != null ? String(r.affinity) : undefined,
-        pmid: r.pmid != null ? String(r.pmid) : undefined,
-        doi: r.doi
+        affinity: asStr(r.affinity),
+        pmid: asStr(r.pmid),
+        doi: r.doi || undefined
       }))
-      return { uniprot, cutoff_nm: cutoff, n_rows: rows.length, affinities: rows }
+      rows.sort(
+        (x, y) =>
+          (x.affinity_type ?? '').localeCompare(y.affinity_type ?? '') ||
+          affinitySortKey(x.affinity) - affinitySortKey(y.affinity) ||
+          (x.monomer_id ?? '').localeCompare(y.monomer_id ?? '')
+      )
+      const { rows: capped, truncated } = capRows(rows, maxRows)
+      return {
+        uniprot,
+        affinity_cutoff_nm: cutoff,
+        n_rows_total: rows.length,
+        truncated,
+        rows: capped
+      }
+    }
+  },
+  {
+    id: 'bindingdb_targets_by_compound',
+    connector: 'chemistry',
+    description:
+      'Protein targets with measured affinities for compounds 2D-similar to a query SMILES — "what does this molecule (or its close analogs) bind?".',
+    input: {
+      type: 'object',
+      properties: {
+        smiles: { type: 'string' },
+        similarity: { type: 'number', default: 0.85, minimum: 0.5, maximum: 1.0 },
+        max_rows: { type: 'integer', default: 100, minimum: 1, maximum: 1000 }
+      },
+      required: ['smiles']
+    },
+    required: ['smiles'],
+    returns:
+      '`{ "smiles": str, "similarity": num, "api_hit_count": int, "n_rows_total": int, "truncated": bool, "rows": [ { monomer_id, smiles, ligand_name, target_name, species, affinity_type, affinity, tanimoto } ] }` — `smiles` per row is the matched analog. `api_hit_count` is the upstream matching-compound count (not row-for-row comparable with `n_rows_total`, which counts per-measurement rows). Rows capped at `max_rows`, sorted by (target_name, affinity_type, numeric affinity). `affinity` is a STRING (may carry `>`/`<`, in nM). No hits returns `n_rows_total=0`.',
+    example:
+      'result = host.mcp("chemistry", "bindingdb_targets_by_compound", {"smiles": "CC(=O)OC1=CC=CC=C1C(=O)O", "similarity": 0.85})',
+    run: async (ctx, a) => {
+      const smiles = String(a.smiles).trim()
+      if (!smiles) throw new Error('smiles must be non-empty')
+      const similarity = Number(a.similarity ?? 0.85)
+      if (!(similarity >= 0.5 && similarity <= 1.0))
+        throw new Error('similarity must be in [0.5, 1.0]')
+      const maxRows = Number(a.max_rows ?? 100)
+      if (!(maxRows >= 1 && maxRows <= 1000)) throw new Error('max_rows must be in [1, 1000]')
+
+      const root = await bindingdbRoot(
+        ctx,
+        `${BINDINGDB_API}/getTargetByCompound?smiles=${encodeURIComponent(smiles)}&cutoff=${similarity}&response=application/json`
+      )
+      const rows = ((root['bdb.affinities'] as BindingDbTargetRow[] | undefined) ?? []).map(
+        (r) => ({
+          monomer_id: asStr(r['bdb.monomerid']),
+          smiles: r['bdb.smiles'],
+          ligand_name: r['bdb.inhibitor'],
+          target_name: r['bdb.target'],
+          species: r['bdb.species'],
+          affinity_type: r['bdb.affinity_type'],
+          affinity: asStr(r['bdb.affinity']),
+          tanimoto: asStr(r['bdb.tanimoto'])
+        })
+      )
+      rows.sort(
+        (x, y) =>
+          (x.target_name ?? '').localeCompare(y.target_name ?? '') ||
+          (x.affinity_type ?? '').localeCompare(y.affinity_type ?? '') ||
+          affinitySortKey(x.affinity) - affinitySortKey(y.affinity) ||
+          (x.monomer_id ?? '').localeCompare(y.monomer_id ?? '')
+      )
+      const hit = asStr(root['bdb.hit'])
+      const { rows: capped, truncated } = capRows(rows, maxRows)
+      return {
+        smiles,
+        similarity,
+        api_hit_count: hit && /^\d+$/.test(hit) ? Number(hit) : null,
+        n_rows_total: rows.length,
+        truncated,
+        rows: capped
+      }
     }
   }
 ]
+
+// --- PubChem synonyms + GHS (PUG-View) helpers -------------------------------------------------
+
+async function pubchemSynonyms(ctx: ToolContext, cids: number[]): Promise<Map<number, string[]>> {
+  const out = new Map<number, string[]>()
+  if (!cids.length) return out
+  try {
+    const raw = (await ctx.fetchJson(
+      `${PUBCHEM}/compound/cid/${cids.join(',')}/synonyms/JSON`
+    )) as SynonymList
+    for (const info of raw.InformationList?.Information ?? []) {
+      if (info.CID != null) out.set(Number(info.CID), info.Synonym ?? [])
+    }
+  } catch (err) {
+    if (!isNotFound(err)) throw err
+  }
+  return out
+}
+
+type PugViewSection = {
+  TOCHeading?: string
+  Section?: PugViewSection[]
+  Information?: Array<{
+    Name?: string
+    Value?: { StringWithMarkup?: Array<{ String?: string; Markup?: Array<{ Extra?: string }> }> }
+  }>
+}
+type PugViewRecord = {
+  Record?: { RecordTitle?: string; Section?: PugViewSection[]; Reference?: unknown[] }
+}
+
+function findSection(sections: PugViewSection[], heading: string): PugViewSection | null {
+  for (const sec of sections) {
+    if (sec.TOCHeading === heading) return sec
+    const found = findSection(sec.Section ?? [], heading)
+    if (found) return found
+  }
+  return null
+}
+
+function addUnique(acc: string[], item: string): void {
+  const trimmed = item.trim()
+  if (trimmed && !acc.includes(trimmed)) acc.push(trimmed)
+}
+
+// Aggregate the GHS Classification section across every reporting source (None when absent).
+function parseGhs(cid: number, record: PugViewRecord['Record']): Record<string, unknown> | null {
+  if (!record) return null
+  const section = findSection(record.Section ?? [], 'GHS Classification')
+  if (!section) return null
+
+  const signals: string[] = []
+  const pictograms: string[] = []
+  const hazards: string[] = []
+  const precautionary: string[] = []
+  const notes: string[] = []
+  for (const info of section.Information ?? []) {
+    const strings = info.Value?.StringWithMarkup ?? []
+    if (info.Name === 'Signal') for (const s of strings) addUnique(signals, s.String ?? '')
+    else if (info.Name === 'Pictogram(s)')
+      for (const s of strings) for (const m of s.Markup ?? []) addUnique(pictograms, m.Extra ?? '')
+    else if (info.Name === 'GHS Hazard Statements')
+      for (const s of strings) addUnique(hazards, s.String ?? '')
+    else if (info.Name === 'Precautionary Statement Codes')
+      for (const s of strings) addUnique(precautionary, s.String ?? '')
+    else if (info.Name === 'Note') for (const s of strings) addUnique(notes, s.String ?? '')
+  }
+  return {
+    cid,
+    record_title: record.RecordTitle,
+    signals,
+    pictograms,
+    hazard_statements: hazards,
+    precautionary_statement_codes: precautionary,
+    notes,
+    n_source_references: (record.Reference ?? []).length
+  }
+}
+
+// --- ChEBI + BindingDB response types ----------------------------------------------------------
+
+type ChebiName = { name?: string }
+type ChebiRelation = {
+  relation_type?: string
+  init_id?: number
+  init_name?: string
+  final_id?: number
+  final_name?: string
+}
+type ChebiCompound = {
+  chebi_accession?: string
+  name?: string
+  definition?: string
+  stars?: number
+  modified_on?: string
+  is_released?: boolean
+  secondary_ids?: string[]
+  names?: Record<string, ChebiName[]>
+  chemical_data?: { formula?: string; charge?: number; mass?: string; monoisotopic_mass?: string }
+  default_structure?: { smiles?: string; standard_inchi?: string; standard_inchi_key?: string }
+  database_accessions?: Record<
+    string,
+    Array<{ accession_number?: string; source_name?: string; url?: string }>
+  >
+  ontology_relations?: {
+    outgoing_relations?: ChebiRelation[]
+    incoming_relations?: ChebiRelation[]
+  }
+  roles_classification?: Array<{ chebi_accession?: string; name?: string; definition?: string }>
+}
+type ChebiSearchSource = {
+  chebi_accession?: string
+  name?: string
+  definition?: string
+  stars?: number
+  formula?: string
+  charge?: number
+  mass?: number
+  monoisotopicmass?: number
+  smiles?: string
+  inchikey?: string
+}
+type ChebiSearchResponse = {
+  total?: number
+  number_pages?: number
+  results?: Array<{ _score?: number; _source?: ChebiSearchSource }>
+}
+
+type BindingDbLigandRow = {
+  query?: string
+  monomerid?: string | number
+  smile?: string
+  affinity_type?: string
+  affinity?: string | number
+  pmid?: string | number
+  doi?: string
+}
+type BindingDbTargetRow = {
+  'bdb.monomerid'?: string | number
+  'bdb.smiles'?: string
+  'bdb.inhibitor'?: string
+  'bdb.target'?: string
+  'bdb.species'?: string
+  'bdb.affinity_type'?: string
+  'bdb.affinity'?: string | number
+  'bdb.tanimoto'?: string | number
+}
+
+// Unwrap BindingDB's single (often misspelled) route-specific root key without depending on its spelling.
+async function bindingdbRoot(ctx: ToolContext, url: string): Promise<Record<string, unknown>> {
+  const raw = (await ctx.fetchJson(url)) as Record<string, unknown>
+  return (Object.values(raw)[0] as Record<string, unknown>) ?? {}
+}

--- a/src/main/connectors/registry.test.ts
+++ b/src/main/connectors/registry.test.ts
@@ -4,7 +4,7 @@ import { CONNECTOR_CATALOG } from './catalog'
 
 describe('registry + catalog', () => {
   it('resolves a tool by connector+method', () => {
-    expect(getDescriptor('chemistry', 'pubchem_get_properties')?.id).toBe('pubchem_get_properties')
+    expect(getDescriptor('chemistry', 'pubchem_get_compounds')?.id).toBe('pubchem_get_compounds')
     expect(getDescriptor('chemistry', 'nope')).toBeUndefined()
   })
   it('lists tools for a connector', () => {

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -15,7 +15,7 @@ describe('ConnectorService', () => {
       }),
       resolveApiKey: () => undefined
     })
-    await expect(svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })).rejects.toThrow(
+    await expect(svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })).rejects.toThrow(
       /not enabled/
     )
   })
@@ -48,19 +48,19 @@ describe('ConnectorService', () => {
       }),
       resolveApiKey: (ref) => (ref === 'ref' ? 'SECRET' : undefined)
     })
-    const out = await svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })
-    expect(out).toEqual([{ CID: 1 }])
+    const out = await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })
+    expect(out).toEqual({ n_requested: 1, duplicates: [], records: [{ CID: 1 }], not_found: [] })
   })
   it('rejects a blocked tool', async () => {
     const svc = new ConnectorService({
       getConnectors: () => ({
         enabledIds: ['chemistry'],
         autoAllowIds: [],
-        blockedToolIds: ['chemistry/pubchem_get_properties']
+        blockedToolIds: ['chemistry/pubchem_get_compounds']
       }),
       resolveApiKey: () => undefined
     })
-    await expect(svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })).rejects.toThrow(
+    await expect(svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })).rejects.toThrow(
       /blocked by policy/
     )
   })
@@ -75,16 +75,16 @@ describe('ConnectorService', () => {
       getConnectors: () => ({
         enabledIds: [],
         autoAllowIds: [],
-        askToolIds: ['chemistry/pubchem_get_properties']
+        askToolIds: ['chemistry/pubchem_get_compounds']
       }),
       resolveApiKey: () => undefined,
       requestApproval
     })
-    const out = await svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })
-    expect(out).toEqual([{ CID: 1 }])
+    const out = await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })
+    expect(out).toEqual({ n_requested: 1, duplicates: [], records: [{ CID: 1 }], not_found: [] })
     expect(requestApproval).toHaveBeenCalledWith({
       connector: 'chemistry',
-      method: 'pubchem_get_properties',
+      method: 'pubchem_get_compounds',
       args: { cids: [1] }
     })
   })
@@ -97,12 +97,12 @@ describe('ConnectorService', () => {
       getConnectors: () => ({
         enabledIds: [],
         autoAllowIds: [],
-        askToolIds: ['chemistry/pubchem_get_properties']
+        askToolIds: ['chemistry/pubchem_get_compounds']
       }),
       resolveApiKey: () => undefined,
       requestApproval
     })
-    await expect(svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })).rejects.toThrow(
+    await expect(svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })).rejects.toThrow(
       /denied by user/
     )
     expect(fetchImpl).not.toHaveBeenCalled()
@@ -119,7 +119,7 @@ describe('ConnectorService', () => {
       resolveApiKey: () => undefined,
       requestApproval
     })
-    await svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })
+    await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })
     expect(requestApproval).not.toHaveBeenCalled()
   })
 
@@ -133,12 +133,12 @@ describe('ConnectorService', () => {
       getConnectors: () => ({
         enabledIds: [],
         autoAllowIds: ['chemistry'],
-        askToolIds: ['chemistry/pubchem_get_properties']
+        askToolIds: ['chemistry/pubchem_get_compounds']
       }),
       resolveApiKey: () => undefined,
       requestApproval
     })
-    await svc.call('chemistry', 'pubchem_get_properties', { cids: [1] })
+    await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })
     expect(requestApproval).not.toHaveBeenCalled()
   })
 

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -7,7 +7,7 @@ describe('renderSkillDoc', () => {
     expect(md).toContain('name: mcp-chemistry')
     expect(md).toContain('source: connector')
     expect(md).toContain('host.mcp(')
-    expect(md).toContain('pubchem_get_properties')
+    expect(md).toContain('pubchem_get_compounds')
     expect(md).toContain('rate-limited') // rate warning present
   })
   it('uses the trigger-style useWhen as the frontmatter description for auto-discovery', () => {


### PR DESCRIPTION
Enhances the Chemistry connector from 6 tools to 12, deepening PubChem coverage and adding three new data sources.

## New capabilities
- PubChem: `pubchem_search_compounds` (multi-namespace), `pubchem_get_compounds` (batch records + synonyms), `pubchem_similarity_search` (2D Tanimoto), `pubchem_get_bioassay_summary`, `pubchem_get_safety` (GHS).
- ChEBI: `chebi_search`, `chebi_get_entity`, `chebi_get_ontology`.
- Rhea: `rhea_search_reactions`, `rhea_get_reaction`.
- BindingDB: `bindingdb_ligands_by_target`, `bindingdb_targets_by_compound`.

## Notes
- Removes `pubchem_get_properties` (subsumed by `pubchem_get_compounds`) and `pubchem_get_image`.
- `sources` updated to PubChem / ChEBI / Rhea / BindingDB.

## Verification
- Full `src/main/connectors` suite green (mock unit tests) + live integration tests (`LIVE_API`-gated) against each real backend.
- lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)