### PR TITLE
feat(connectors): expand the Drug Regulatory connector capabilities

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -155,9 +155,9 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
   {
     id: 'drug_regulatory',
     displayName: 'Drug Regulatory',
-    description: 'FDA drug labels and adverse event reports via openFDA.',
+    description: 'Drugs@FDA applications, labels, and corpus statistics via openFDA.',
     useWhen:
-      'Use when you need FDA regulatory data for a drug — product label sections (indications, brand/generic name, manufacturer) or adverse event reports (FAERS) by drug name or openFDA query.',
+      'Use when you need FDA drug regulatory data — searching or fetching Drugs@FDA applications (NDA/ANDA/BLA) by brand, generic, ingredient, sponsor, marketing status, or pharmacologic class; aggregate/corpus statistics; generic equivalents of a brand; or product label (SPL) sections such as indications and boxed warnings. Sourced from openFDA (Drugs@FDA + drug labels).',
     sources: ['openFDA'],
     termsUrl: 'https://open.fda.gov/terms/',
     requiresNcbi: false

--- a/src/main/connectors/descriptors/drug-regulatory.test.ts
+++ b/src/main/connectors/descriptors/drug-regulatory.test.ts
@@ -4,128 +4,410 @@ import { DRUG_REGULATORY_TOOLS } from './drug-regulatory'
 import type { ToolDescriptor } from '../types'
 
 const tool = (id: string): ToolDescriptor => DRUG_REGULATORY_TOOLS.find((t) => t.id === id)!
-const jsonRes = (body: unknown): Response =>
+
+const okJson = (body: unknown): Response =>
   ({ ok: true, status: 200, json: async () => body }) as Response
+// openFDA answers a zero-hit search with HTTP 404 (the engine turns that into an "HTTP 404" error).
+const notFound = (): Response =>
+  ({
+    ok: false,
+    status: 404,
+    headers: { get: () => null },
+    json: async () => ({})
+  }) as unknown as Response
 
-describe('drug_regulatory / openfda label', () => {
-  it('openfda_search_drug_label builds the search URL and parses compact fields', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        results: [
-          {
-            id: '22d94fd9-9488-a812-e063-6394a90a7ffc',
-            set_id: '015a6179-bacb-452d-b594-4de628ddc11d',
-            openfda: {
-              brand_name: ['TYLENOL Extra Strength'],
-              generic_name: ['ACETAMINOPHEN'],
-              manufacturer_name: ['Kenvue Brands LLC']
-            },
-            indications_and_usage: ['Uses temporarily relieves minor aches and pains.']
-          }
-        ]
-      })
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('openfda_search_drug_label'),
-      { query: 'openfda.brand_name:"Tylenol"', limit: 5 },
-      {}
-    )
-    const url = fetchImpl.mock.calls[0][0] as string
-    expect(url).toBe(
-      'https://api.fda.gov/drug/label.json?search=openfda.brand_name%3A%22Tylenol%22&limit=5'
-    )
-    expect(out).toEqual([
+// Drives a tool through a real ParserEngine with a queue of mocked responses, returning the parsed
+// output and the sequence of requested URLs.
+const run = async (
+  id: string,
+  args: Record<string, unknown>,
+  responses: Response[]
+): Promise<{ out: unknown; urls: string[] }> => {
+  const fetchImpl = vi.fn()
+  for (const r of responses) fetchImpl.mockResolvedValueOnce(r)
+  const out = await new ParserEngine({ fetchImpl }).call(tool(id), args, {})
+  return { out, urls: fetchImpl.mock.calls.map((c) => c[0] as string) }
+}
+
+const APP = 'https://api.fda.gov/drug/drugsfda.json'
+const LBL = 'https://api.fda.gov/drug/label.json'
+
+const LIPITOR: Record<string, unknown> = {
+  application_number: 'NDA020702',
+  sponsor_name: 'UPJOHN',
+  products: [
+    {
+      brand_name: 'LIPITOR',
+      active_ingredients: [{ name: 'ATORVASTATIN CALCIUM', strength: 'EQ 80MG BASE' }],
+      dosage_form: 'TABLET',
+      route: 'ORAL',
+      marketing_status: 'Prescription',
+      te_code: 'AB'
+    }
+  ],
+  submissions: [{ submission_type: 'ORIG', submission_status: 'AP' }],
+  openfda: {
+    generic_name: ['ATORVASTATIN CALCIUM'],
+    substance_name: ['ATORVASTATIN CALCIUM TRIHYDRATE'],
+    route: ['ORAL'],
+    manufacturer_name: ['Viatris Specialty LLC'],
+    product_type: ['HUMAN PRESCRIPTION DRUG']
+  }
+}
+
+describe('drug_regulatory / search_drug_applications', () => {
+  it('builds an ANDed search with a date range and shapes flattened openfda fields', async () => {
+    const { out, urls } = await run(
+      'search_drug_applications',
       {
-        id: '22d94fd9-9488-a812-e063-6394a90a7ffc',
-        brand_name: 'TYLENOL Extra Strength',
-        generic_name: 'ACETAMINOPHEN',
-        manufacturer: 'Kenvue Brands LLC',
-        indications: 'Uses temporarily relieves minor aches and pains.'
-      }
-    ])
+        generic: 'ATORVASTATIN CALCIUM',
+        marketing_status: 'Prescription',
+        submission_date_from: '2000-01-01',
+        max_records: 10
+      },
+      [okJson({ meta: { last_updated: '2026-07-14', results: { total: 1 } }, results: [LIPITOR] })]
+    )
+    expect(urls[0]).toBe(
+      `${APP}?search=${encodeURIComponent(
+        '(products.marketing_status:"Prescription" AND openfda.generic_name:"ATORVASTATIN CALCIUM") AND submissions.submission_status_date:[20000101 TO 30001231]'
+      )}&limit=10&skip=0`
+    )
+    expect(out).toEqual({
+      total: 1,
+      n_returned: 1,
+      truncated: false,
+      last_updated: '2026-07-14',
+      records: [
+        {
+          application_number: 'NDA020702',
+          sponsor_name: 'UPJOHN',
+          products: LIPITOR.products,
+          submissions: LIPITOR.submissions,
+          openfda_generic_name: ['ATORVASTATIN CALCIUM'],
+          openfda_pharm_class_epc: [],
+          openfda_pharm_class_moa: [],
+          openfda_pharm_class_cs: [],
+          openfda_pharm_class_pe: [],
+          openfda_substance_name: ['ATORVASTATIN CALCIUM TRIHYDRATE'],
+          openfda_route: ['ORAL'],
+          openfda_manufacturer_name: ['Viatris Specialty LLC'],
+          openfda_product_type: ['HUMAN PRESCRIPTION DRUG']
+        }
+      ]
+    })
   })
 
-  it('openfda_search_drug_label defaults limit to 10 and tolerates missing results', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({}))
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('openfda_search_drug_label'),
-      { query: 'aspirin' },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://api.fda.gov/drug/label.json?search=aspirin&limit=10'
-    )
-    expect(out).toEqual([])
+  it('sets truncated when fewer records than the total are returned', async () => {
+    const { out } = await run('search_drug_applications', { sponsor: 'UPJOHN', max_records: 1 }, [
+      okJson({ meta: { results: { total: 5 } }, results: [LIPITOR] })
+    ])
+    expect(out).toMatchObject({ total: 5, n_returned: 1, truncated: true })
   })
 
-  it('openfda_search_drug_label tolerates a result with no openfda block', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        results: [{ id: 'abc', indications_and_usage: undefined }]
-      })
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('openfda_search_drug_label'),
-      { query: 'abc' },
-      {}
-    )
-    expect(out).toEqual([
-      {
-        id: 'abc',
-        brand_name: undefined,
-        generic_name: undefined,
-        manufacturer: undefined,
-        indications: undefined
-      }
+  it('serves a broad search truncated with the true total instead of raising', async () => {
+    const { out } = await run('search_drug_applications', { dosage_form: 'TABLET' }, [
+      okJson({ meta: { results: { total: 40000 } }, results: [LIPITOR] })
     ])
+    expect(out).toMatchObject({ total: 40000, n_returned: 1, truncated: true })
+  })
+
+  it('raises only when asked for more records than openFDA can page to', async () => {
+    await expect(
+      run('search_drug_applications', { max_records: 30000 }, [
+        okJson({ meta: { results: { total: 40000 } }, results: [] })
+      ])
+    ).rejects.toThrow(/narrow with submission_date_from/)
+  })
+
+  it('honours an OR search_type and a verbatim raw_search override', async () => {
+    const { urls } = await run(
+      'search_drug_applications',
+      { brand: 'LIPITOR', sponsor: 'UPJOHN', search_type: 'or', max_records: 1 },
+      [okJson({ meta: { results: { total: 1 } }, results: [LIPITOR] })]
+    )
+    expect(decodeURIComponent(urls[0])).toContain(
+      'products.brand_name:"LIPITOR" OR sponsor_name:"UPJOHN"'
+    )
+    const raw = await run(
+      'search_drug_applications',
+      { raw_search: 'sponsor_name:"PFIZER"', brand: 'IGNORED', max_records: 1 },
+      [okJson({ meta: { results: { total: 1 } }, results: [LIPITOR] })]
+    )
+    expect(decodeURIComponent(raw.urls[0])).toContain('sponsor_name:"PFIZER"')
+    expect(decodeURIComponent(raw.urls[0])).not.toContain('IGNORED')
   })
 })
 
-describe('drug_regulatory / openfda adverse events', () => {
-  it('openfda_search_adverse_events builds the search URL and parses compact fields', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        results: [
-          {
-            safetyreportid: '10003304',
-            receivedate: '20140312',
-            serious: '1',
-            patient: {
-              reaction: [
-                { reactionmeddrapt: 'Drug hypersensitivity' },
-                { reactionmeddrapt: 'Nausea' }
-              ]
-            }
-          }
-        ]
-      })
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('openfda_search_adverse_events'),
-      { query: 'patient.drug.medicinalproduct:"ASPIRIN"', limit: 3 },
-      {}
-    )
-    const url = fetchImpl.mock.calls[0][0] as string
-    expect(url).toBe(
-      'https://api.fda.gov/drug/event.json?search=patient.drug.medicinalproduct%3A%22ASPIRIN%22&limit=3'
-    )
-    expect(out).toEqual([
-      {
-        safety_report_id: '10003304',
-        receive_date: '20140312',
-        serious: true,
-        reactions: ['Drug hypersensitivity', 'Nausea']
-      }
+describe('drug_regulatory / get_drug_application', () => {
+  it('fetches one application by number', async () => {
+    const { out, urls } = await run('get_drug_application', { application_number: 'NDA020702' }, [
+      okJson({ meta: { results: { total: 1 } }, results: [LIPITOR] })
     ])
+    expect(urls[0]).toBe(
+      `${APP}?search=${encodeURIComponent('application_number:"NDA020702"')}&limit=1`
+    )
+    expect(out).toEqual({ application_number: 'NDA020702', found: true, record: LIPITOR })
   })
 
-  it('openfda_search_adverse_events returns an empty array when there are no results', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ results: [] }))
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('openfda_search_adverse_events'),
-      { query: 'NOPE' },
-      {}
+  it('returns found:false and a null record on a 404 not-found', async () => {
+    const { out } = await run('get_drug_application', { application_number: 'NDA999999' }, [
+      notFound()
+    ])
+    expect(out).toEqual({ application_number: 'NDA999999', found: false, record: null })
+  })
+})
+
+describe('drug_regulatory / count_drug_applications', () => {
+  it('resolves a friendly count field, sums buckets, and reports the api field', async () => {
+    const { out, urls } = await run('count_drug_applications', { count_field: 'dosage_form' }, [
+      okJson({
+        results: [
+          { term: 'TABLET', count: 10710 },
+          { term: 'INJECTABLE', count: 5411 }
+        ]
+      })
+    ])
+    expect(urls[0]).toBe(
+      `${APP}?count=${encodeURIComponent('products.dosage_form.exact')}&limit=100`
     )
-    expect(out).toEqual([])
+    expect(out).toEqual({
+      count_field: 'dosage_form',
+      api_field: 'products.dosage_form.exact',
+      n_buckets: 2,
+      bucket_sum: 16121,
+      buckets: [
+        { term: 'TABLET', count: 10710 },
+        { term: 'INJECTABLE', count: 5411 }
+      ]
+    })
+  })
+
+  it('ANDs an optional filter into the count search and caps max_buckets at 1000', async () => {
+    const { urls } = await run(
+      'count_drug_applications',
+      { count_field: 'products.te_code', marketing_status: 'Prescription', max_buckets: 5000 },
+      [okJson({ results: [{ term: 'AB', count: 1 }] })]
+    )
+    expect(urls[0]).toBe(
+      `${APP}?search=${encodeURIComponent('products.marketing_status:"Prescription"')}` +
+        `&count=${encodeURIComponent('products.te_code')}&limit=1000`
+    )
+  })
+})
+
+describe('drug_regulatory / get_drug_statistics', () => {
+  it('assembles corpus stats from a base query plus four count queries', async () => {
+    const { out, urls } = await run('get_drug_statistics', {}, [
+      okJson({
+        meta: { last_updated: '2026-07-14', results: { total: 29207 } },
+        results: [LIPITOR]
+      }),
+      okJson({
+        results: [
+          { term: 'Discontinued', count: 14750 },
+          { term: 'Prescription', count: 13338 }
+        ]
+      }),
+      okJson({
+        results: [
+          { term: 'TABLET', count: 10710 },
+          { term: 'INJECTABLE', count: 5411 }
+        ]
+      }),
+      okJson({ results: [{ term: 'ORAL', count: 17491 }] }),
+      okJson({ results: [{ term: 'WATSON LABS', count: 902 }] })
+    ])
+    expect(urls[0]).toBe(`${APP}?limit=1`)
+    expect(urls[1]).toBe(`${APP}?count=products.marketing_status&limit=1000`)
+    expect(urls[2]).toBe(
+      `${APP}?count=${encodeURIComponent('products.dosage_form.exact')}&limit=1000`
+    )
+    expect(urls[3]).toBe(`${APP}?count=${encodeURIComponent('products.route.exact')}&limit=1000`)
+    expect(urls[4]).toBe(`${APP}?count=sponsor_name&limit=25`)
+    expect(out).toMatchObject({
+      total_applications: 29207,
+      last_updated: '2026-07-14',
+      marketing_status: [
+        { term: 'Discontinued', count: 14750 },
+        { term: 'Prescription', count: 13338 }
+      ],
+      dosage_form_distinct: 2,
+      route_distinct: 1,
+      sponsor_top: [{ term: 'WATSON LABS', count: 902 }]
+    })
+  })
+})
+
+describe('drug_regulatory / list_pharmacologic_classes', () => {
+  it('counts the harmonized pharm-class field for the chosen class type', async () => {
+    const { out, urls } = await run(
+      'list_pharmacologic_classes',
+      { class_type: 'moa', max_buckets: 2 },
+      [
+        okJson({
+          results: [
+            { term: 'Corticosteroid Hormone Receptor Agonists [MoA]', count: 329 },
+            { term: 'Cyclooxygenase Inhibitors [MoA]', count: 238 }
+          ]
+        })
+      ]
+    )
+    expect(urls[0]).toBe(
+      `${APP}?count=${encodeURIComponent('openfda.pharm_class_moa.exact')}&limit=2`
+    )
+    expect(out).toEqual({
+      class_type: 'moa',
+      n_classes: 2,
+      classes: [
+        { term: 'Corticosteroid Hormone Receptor Agonists [MoA]', count: 329 },
+        { term: 'Cyclooxygenase Inhibitors [MoA]', count: 238 }
+      ]
+    })
+  })
+
+  it('defaults to the epc class type', async () => {
+    const { out, urls } = await run('list_pharmacologic_classes', {}, [okJson({ results: [] })])
+    expect(urls[0]).toBe(
+      `${APP}?count=${encodeURIComponent('openfda.pharm_class_epc.exact')}&limit=100`
+    )
+    expect(out).toMatchObject({ class_type: 'epc', n_classes: 0, classes: [] })
+  })
+})
+
+describe('drug_regulatory / get_generic_equivalents', () => {
+  it('resolves the brand, extracts the ingredient set, and keeps exact-set matches', async () => {
+    const generic: Record<string, unknown> = {
+      application_number: 'ANDA076543',
+      sponsor_name: 'GENERIC CO',
+      products: [
+        {
+          brand_name: 'ATORVASTATIN CALCIUM',
+          active_ingredients: [{ name: 'ATORVASTATIN CALCIUM' }],
+          te_code: 'AB',
+          marketing_status: 'Prescription'
+        }
+      ]
+    }
+    // A combination product shares the ingredient but has an extra one, so its set must not match.
+    const combo: Record<string, unknown> = {
+      application_number: 'NDA021540',
+      products: [
+        {
+          brand_name: 'CADUET',
+          active_ingredients: [{ name: 'AMLODIPINE BESYLATE' }, { name: 'ATORVASTATIN CALCIUM' }]
+        }
+      ]
+    }
+    const { out, urls } = await run('get_generic_equivalents', { brand: 'Lipitor' }, [
+      okJson({ results: [LIPITOR] }),
+      okJson({ results: [LIPITOR, generic, combo] })
+    ])
+    expect(urls[0]).toBe(
+      `${APP}?search=${encodeURIComponent('products.brand_name:"Lipitor"')}&limit=100`
+    )
+    expect(urls[1]).toBe(
+      `${APP}?search=${encodeURIComponent('products.active_ingredients.name:"ATORVASTATIN CALCIUM"')}&limit=1000`
+    )
+    expect(out).toEqual({
+      brand: 'Lipitor',
+      reference_applications: ['NDA020702'],
+      active_ingredient_sets: [['ATORVASTATIN CALCIUM']],
+      equivalents: [LIPITOR, generic]
+    })
+  })
+
+  it('returns empty sets and equivalents when the brand is unknown (404)', async () => {
+    const { out } = await run('get_generic_equivalents', { brand: 'NOPEDRUG' }, [notFound()])
+    expect(out).toEqual({
+      brand: 'NOPEDRUG',
+      reference_applications: [],
+      active_ingredient_sets: [],
+      equivalents: []
+    })
+  })
+})
+
+describe('drug_regulatory / search_drug_labels', () => {
+  const TYLENOL: Record<string, unknown> = {
+    set_id: '015a6179-bacb-452d-b594-4de628ddc11d',
+    version: 11,
+    effective_time: '20241107',
+    warnings: ['Some warning text.'],
+    indications_and_usage: ['Uses temporarily relieves minor aches and pains.'],
+    openfda: {
+      brand_name: ['TYLENOL Extra Strength'],
+      generic_name: ['ACETAMINOPHEN'],
+      substance_name: ['ACETAMINOPHEN'],
+      manufacturer_name: ['Kenvue Brands LLC'],
+      route: ['ORAL'],
+      product_type: ['HUMAN OTC DRUG'],
+      application_number: ['M013']
+    }
+  }
+
+  it('builds the label search and returns the default structured record', async () => {
+    const { out, urls } = await run(
+      'search_drug_labels',
+      { brand_name: 'Tylenol', max_records: 5 },
+      [okJson({ meta: { results: { total: 118 } }, results: [TYLENOL] })]
+    )
+    expect(urls[0]).toBe(
+      `${LBL}?search=${encodeURIComponent('openfda.brand_name:"Tylenol"')}&limit=5&skip=0`
+    )
+    expect(out).toEqual({
+      search: 'openfda.brand_name:"Tylenol"',
+      total: 118,
+      n_returned: 1,
+      truncated: true,
+      records: [
+        {
+          identification: {
+            set_id: '015a6179-bacb-452d-b594-4de628ddc11d',
+            spl_version: 11,
+            effective_time: '20241107',
+            brand_name: ['TYLENOL Extra Strength'],
+            generic_name: ['ACETAMINOPHEN'],
+            substance_name: ['ACETAMINOPHEN'],
+            manufacturer: ['Kenvue Brands LLC'],
+            route: ['ORAL'],
+            product_type: ['HUMAN OTC DRUG'],
+            application_number: ['M013']
+          },
+          has_boxed_warning: false,
+          warning_sections: ['warnings'],
+          indications_and_usage: 'Uses temporarily relieves minor aches and pains.'
+        }
+      ]
+    })
+  })
+
+  it('queries .exact fields when exact is set', async () => {
+    const { urls } = await run(
+      'search_drug_labels',
+      { active_ingredient: 'ACETAMINOPHEN', exact: true, max_records: 1 },
+      [okJson({ meta: { results: { total: 1 } }, results: [TYLENOL] })]
+    )
+    expect(decodeURIComponent(urls[0])).toContain('openfda.substance_name.exact:"ACETAMINOPHEN"')
+  })
+
+  it('extracts requested raw sections instead of the default record', async () => {
+    const { out } = await run(
+      'search_drug_labels',
+      { brand_name: 'Tylenol', sections: ['warnings', 'indications_and_usage'], max_records: 1 },
+      [okJson({ meta: { results: { total: 1 } }, results: [TYLENOL] })]
+    )
+    expect(out).toMatchObject({
+      records: [
+        {
+          set_id: '015a6179-bacb-452d-b594-4de628ddc11d',
+          brand_name: ['TYLENOL Extra Strength'],
+          generic_name: ['ACETAMINOPHEN'],
+          sections: {
+            warnings: 'Some warning text.',
+            indications_and_usage: 'Uses temporarily relieves minor aches and pains.'
+          }
+        }
+      ]
+    })
   })
 })

--- a/src/main/connectors/descriptors/drug-regulatory.ts
+++ b/src/main/connectors/descriptors/drug-regulatory.ts
@@ -1,90 +1,604 @@
-import type { ToolDescriptor } from '../types'
+import type { ToolContext, ToolDescriptor } from '../types'
 
-const LABEL = 'https://api.fda.gov/drug/label.json'
-const EVENT = 'https://api.fda.gov/drug/event.json'
+// Drugs@FDA applications (NDA/ANDA/BLA) and product labels (SPL), both served by openFDA. Read-only;
+// anonymous rate limits apply (the engine retries 429/5xx). openFDA envelope: { meta, results }.
+const APPLICATIONS = 'https://api.fda.gov/drug/drugsfda.json'
+const LABELS = 'https://api.fda.gov/drug/label.json'
 
-type OpenFdaBlock = {
+// openFDA can only page while skip+limit stays under ~26k; larger result sets must be narrowed first.
+const MAX_PAGEABLE = 26_000
+// openFDA caps a count aggregation at 1000 buckets.
+const MAX_BUCKETS = 1000
+
+type ActiveIngredient = { name?: string; strength?: string }
+type Product = {
+  brand_name?: string
+  active_ingredients?: ActiveIngredient[]
+  dosage_form?: string
+  route?: string
+  marketing_status?: string
+  te_code?: string
+}
+type OpenFdaAppBlock = {
+  generic_name?: string[]
+  pharm_class_epc?: string[]
+  pharm_class_moa?: string[]
+  pharm_class_cs?: string[]
+  pharm_class_pe?: string[]
+  substance_name?: string[]
+  route?: string[]
+  manufacturer_name?: string[]
+  product_type?: string[]
+}
+type Application = {
+  application_number?: string
+  sponsor_name?: string
+  products?: Product[]
+  submissions?: unknown[]
+  openfda?: OpenFdaAppBlock
+}
+
+type OpenFdaLabelBlock = {
   brand_name?: string[]
   generic_name?: string[]
+  substance_name?: string[]
   manufacturer_name?: string[]
+  route?: string[]
+  product_type?: string[]
+  application_number?: string[]
 }
-
-type LabelResult = {
-  id?: string
-  openfda?: OpenFdaBlock
+type LabelRecord = {
+  set_id?: string
+  version?: number
+  effective_time?: string
+  boxed_warning?: string[]
   indications_and_usage?: string[]
+  openfda?: OpenFdaLabelBlock
+} & Record<string, unknown>
+
+type CountBucket = { term?: string; count?: number }
+type OpenFdaMeta = {
+  last_updated?: string
+  results?: { total?: number; skip?: number; limit?: number }
+}
+type OpenFdaResults<T> = { meta?: OpenFdaMeta; results?: T[] }
+
+// openFDA answers a zero-hit search with HTTP 404; the engine surfaces that as an "HTTP 404" error.
+function isNotFound(err: unknown): boolean {
+  return err instanceof Error && err.message.includes('HTTP 404')
 }
 
-type LabelSearchResponse = { results?: LabelResult[] }
+// Encodes a full openFDA search/count expression for the query string. openFDA accepts %20 for spaces
+// and %20AND%20 / %20OR%20 as boolean separators, so the whole expression can be encoded verbatim.
+const enc = (s: string): string => encodeURIComponent(s)
 
-type Reaction = { reactionmeddrapt?: string }
+// Wraps a filter value as an openFDA exact phrase, neutralising embedded double quotes that would
+// otherwise close the phrase and inject boolean logic into the query.
+const phrase = (value: unknown): string => `"${String(value).replace(/"/g, ' ')}"`
 
-type EventResult = {
-  safetyreportid?: string
-  receivedate?: string
-  serious?: string
-  patient?: { reaction?: Reaction[] }
+// Drugs@FDA search filters that map onto always-present product/top-level fields. generic and pharm
+// class instead hit the harmonized openfda.* block (absent on older applications, so silently skipped
+// upstream); they are added separately.
+const APP_FILTER_FIELDS: Record<string, string> = {
+  brand: 'products.brand_name',
+  active_ingredient: 'products.active_ingredients.name',
+  sponsor: 'sponsor_name',
+  marketing_status: 'products.marketing_status',
+  dosage_form: 'products.dosage_form',
+  route: 'products.route'
 }
 
-type EventSearchResponse = { results?: EventResult[] }
+// Normalizes a pharm-class type arg to one of openFDA's four class axes.
+function classType(value: unknown): 'epc' | 'moa' | 'cs' | 'pe' {
+  const t = String(value ?? 'epc').toLowerCase()
+  return t === 'moa' || t === 'cs' || t === 'pe' ? t : 'epc'
+}
 
-// openFDA (drug/label + drug/event): read-only regulatory search, anonymous rate limits apply.
+// Builds the [from TO to] status-date range clause, defaulting the open side to a wide bound.
+function dateRange(from: unknown, to: unknown): string {
+  if (from == null && to == null) return ''
+  const f = from != null ? String(from).replace(/-/g, '') : '19000101'
+  const t = to != null ? String(to).replace(/-/g, '') : '30001231'
+  return `submissions.submission_status_date:[${f} TO ${t}]`
+}
+
+// Assembles the openFDA search= expression for the applications tools from the shared filter args. A
+// verbatim raw_search overrides every mapped filter; the submission-date range is always ANDed on.
+function appSearchExpr(a: Record<string, unknown>): string {
+  const range = dateRange(a.submission_date_from, a.submission_date_to)
+  if (a.raw_search != null && a.raw_search !== '') {
+    const raw = String(a.raw_search)
+    return range ? `(${raw}) AND ${range}` : raw
+  }
+  const op = String(a.search_type ?? 'and').toLowerCase() === 'or' ? ' OR ' : ' AND '
+  const clauses: string[] = []
+  for (const [key, field] of Object.entries(APP_FILTER_FIELDS)) {
+    if (a[key] != null && a[key] !== '') clauses.push(`${field}:${phrase(a[key])}`)
+  }
+  if (a.generic != null && a.generic !== '')
+    clauses.push(`openfda.generic_name:${phrase(a.generic)}`)
+  if (a.pharm_class != null && a.pharm_class !== '') {
+    clauses.push(`openfda.pharm_class_${classType(a.pharm_class_type)}:${phrase(a.pharm_class)}`)
+  }
+  const expr = clauses.join(op)
+  if (!range) return expr
+  return expr ? `(${expr}) AND ${range}` : range
+}
+
+// Friendly count-field names mapped to their openFDA field paths (with .exact where the field is
+// analyzed and must be counted on its keyword variant). An unknown name is passed through verbatim so
+// a caller can supply any raw openFDA field path.
+const COUNT_FIELDS: Record<string, string> = {
+  sponsor_name: 'sponsor_name',
+  application_number: 'application_number',
+  dosage_form: 'products.dosage_form.exact',
+  route: 'products.route.exact',
+  marketing_status: 'products.marketing_status',
+  te_code: 'products.te_code',
+  pharm_class_epc: 'openfda.pharm_class_epc.exact',
+  pharm_class_moa: 'openfda.pharm_class_moa.exact',
+  pharm_class_cs: 'openfda.pharm_class_cs.exact',
+  pharm_class_pe: 'openfda.pharm_class_pe.exact'
+}
+
+// The distinct, sorted, upper-cased active-ingredient name set of one product.
+function ingredientSet(product: Product): string[] {
+  const names = (product.active_ingredients ?? [])
+    .map((i) => (i.name ?? '').trim().toUpperCase())
+    .filter(Boolean)
+  return [...new Set(names)].sort()
+}
+
+// Flattens the harmonized openfda block into convenience arrays alongside the raw application fields.
+function shapeApplication(app: Application): Record<string, unknown> {
+  const of = app.openfda ?? {}
+  return {
+    application_number: app.application_number,
+    sponsor_name: app.sponsor_name,
+    products: app.products ?? [],
+    submissions: app.submissions ?? [],
+    openfda_generic_name: of.generic_name ?? [],
+    openfda_pharm_class_epc: of.pharm_class_epc ?? [],
+    openfda_pharm_class_moa: of.pharm_class_moa ?? [],
+    openfda_pharm_class_cs: of.pharm_class_cs ?? [],
+    openfda_pharm_class_pe: of.pharm_class_pe ?? [],
+    openfda_substance_name: of.substance_name ?? [],
+    openfda_route: of.route ?? [],
+    openfda_manufacturer_name: of.manufacturer_name ?? [],
+    openfda_product_type: of.product_type ?? []
+  }
+}
+
+// Pages an openFDA endpoint until max_records is reached or the result set is exhausted, tolerating a
+// zero-hit 404. openFDA caps skip+limit at MAX_PAGEABLE, so paging never advances past it; when
+// guarding, only a request that wants MORE records than that cap over a larger result set raises with
+// guidance — a capped request always succeeds and flags `truncated`.
+async function fetchPaged<T>(
+  ctx: ToolContext,
+  endpoint: string,
+  expr: string,
+  maxRecords: number,
+  guard: boolean
+): Promise<{ total: number; lastUpdated?: string; records: T[] }> {
+  const searchParam = expr ? `search=${enc(expr)}&` : ''
+  const records: T[] = []
+  let total = 0
+  let lastUpdated: string | undefined
+  let skip = 0
+  let checked = false
+  while (records.length < maxRecords && skip < MAX_PAGEABLE) {
+    const pageLimit = Math.min(1000, maxRecords - records.length, MAX_PAGEABLE - skip)
+    let resp: OpenFdaResults<T>
+    try {
+      resp = (await ctx.fetchJson(
+        `${endpoint}?${searchParam}limit=${pageLimit}&skip=${skip}`
+      )) as OpenFdaResults<T>
+    } catch (err) {
+      if (isNotFound(err)) break
+      throw err
+    }
+    total = resp.meta?.results?.total ?? 0
+    lastUpdated = resp.meta?.last_updated
+    // Only raise when the caller asked for more records than openFDA can page to; a capped request is
+    // served (truncated) with the true total, so a broad search with a small max_records still works.
+    if (guard && !checked && maxRecords > MAX_PAGEABLE && total > MAX_PAGEABLE) {
+      throw new Error(
+        `search matches ${total} applications; narrow with submission_date_from/to or more filters to stay under ${MAX_PAGEABLE}`
+      )
+    }
+    checked = true
+    const batch = resp.results ?? []
+    records.push(...batch)
+    skip += batch.length
+    if (!batch.length || batch.length < pageLimit || skip >= total) break
+  }
+  return { total, lastUpdated, records }
+}
+
+// Runs a single count aggregation and returns its buckets (empty on a zero-hit 404).
+async function countBuckets(
+  ctx: ToolContext,
+  apiField: string,
+  searchExpr: string,
+  maxBuckets: number
+): Promise<{ term?: string; count?: number }[]> {
+  const searchParam = searchExpr ? `search=${enc(searchExpr)}&` : ''
+  const url = `${APPLICATIONS}?${searchParam}count=${enc(apiField)}&limit=${maxBuckets}`
+  try {
+    const resp = (await ctx.fetchJson(url)) as OpenFdaResults<CountBucket>
+    return (resp.results ?? []).map((b) => ({ term: b.term, count: b.count }))
+  } catch (err) {
+    if (isNotFound(err)) return []
+    throw err
+  }
+}
+
+// Label sections that carry warning/precaution text; search_drug_labels reports which exist per label.
+const WARNING_SECTIONS = [
+  'boxed_warning',
+  'warnings',
+  'warnings_and_cautions',
+  'precautions',
+  'user_safety_warnings',
+  'general_precautions'
+]
+
+// Label filter args mapped onto their openfda.* label fields.
+const LABEL_FILTER_FIELDS: Record<string, string> = {
+  active_ingredient: 'openfda.substance_name',
+  generic_name: 'openfda.generic_name',
+  brand_name: 'openfda.brand_name',
+  route: 'openfda.route',
+  product_type: 'openfda.product_type'
+}
+
+// Builds the label search expression; raw_search overrides the mapped filters, exact swaps to the
+// non-analyzed .exact field variants.
+function labelSearchExpr(a: Record<string, unknown>): string {
+  if (a.raw_search != null && a.raw_search !== '') return String(a.raw_search)
+  const exact = a.exact === true
+  const clauses: string[] = []
+  for (const [key, field] of Object.entries(LABEL_FILTER_FIELDS)) {
+    if (a[key] != null && a[key] !== '') {
+      clauses.push(`${exact ? `${field}.exact` : field}:${phrase(a[key])}`)
+    }
+  }
+  return clauses.join(' AND ')
+}
+
+// Joins an SPL section value (openFDA stores section text as a string array) into a single string.
+function joinText(value: unknown): string {
+  return Array.isArray(value) ? value.map(String).join('\n\n') : value == null ? '' : String(value)
+}
+
+// The default structured label record: identity block, boxed-warning presence, which warning-type
+// sections exist, and the indications text.
+function defaultLabelRecord(r: LabelRecord): Record<string, unknown> {
+  const of = r.openfda ?? {}
+  return {
+    identification: {
+      set_id: r.set_id,
+      spl_version: r.version,
+      effective_time: r.effective_time,
+      brand_name: of.brand_name ?? [],
+      generic_name: of.generic_name ?? [],
+      substance_name: of.substance_name ?? [],
+      manufacturer: of.manufacturer_name ?? [],
+      route: of.route ?? [],
+      product_type: of.product_type ?? [],
+      application_number: of.application_number ?? []
+    },
+    has_boxed_warning: Array.isArray(r.boxed_warning) && r.boxed_warning.length > 0,
+    warning_sections: WARNING_SECTIONS.filter((s) => s in r),
+    indications_and_usage: joinText(r.indications_and_usage)
+  }
+}
+
+// A label record reduced to caller-requested raw sections instead of the default structured shape.
+function sectionLabelRecord(r: LabelRecord, sections: string[]): Record<string, unknown> {
+  const of = r.openfda ?? {}
+  return {
+    set_id: r.set_id,
+    brand_name: of.brand_name ?? [],
+    generic_name: of.generic_name ?? [],
+    sections: Object.fromEntries(sections.map((s) => [s, joinText(r[s])]))
+  }
+}
+
 export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
   {
-    id: 'openfda_search_drug_label',
+    id: 'search_drug_applications',
     connector: 'drug_regulatory',
     description:
-      'Search FDA drug product labels (SPL) by an openFDA query, e.g. openfda.brand_name:"Tylenol".',
+      'Search Drugs@FDA applications (NDA/ANDA/BLA) by any combination of exact-phrase filters (brand, generic, active_ingredient, sponsor, marketing_status, dosage_form, route, pharm_class). generic and pharm_class query the harmonized openfda block (absent on older applications, so silently skipped there). A broad search returns the first max_records with the true total and truncated=true; to page beyond ~26,000 records, narrow with submission_date_from/to.',
     input: {
       type: 'object',
       properties: {
-        query: { type: 'string' },
-        limit: { type: 'integer', default: 10 }
-      },
-      required: ['query']
+        brand: { type: 'string' },
+        generic: { type: 'string' },
+        active_ingredient: { type: 'string' },
+        sponsor: { type: 'string' },
+        marketing_status: {
+          type: 'string',
+          enum: ['Prescription', 'Over-the-counter', 'Discontinued', 'None (Tentative Approval)']
+        },
+        dosage_form: { type: 'string' },
+        route: { type: 'string' },
+        pharm_class: { type: 'string' },
+        pharm_class_type: { type: 'string', enum: ['epc', 'moa', 'cs', 'pe'] },
+        search_type: { type: 'string', enum: ['and', 'or'], default: 'and' },
+        submission_date_from: { type: 'string' },
+        submission_date_to: { type: 'string' },
+        raw_search: { type: 'string' },
+        max_records: { type: 'integer', default: 50 }
+      }
     },
-    required: ['query'],
     returns:
-      '`[ { "id": str, "brand_name": str, "generic_name": str, "manufacturer": str, "indications": str } ]` — up to `limit` label records (default 10); each field is the first openFDA array element and may be undefined. `[]` when nothing matches.',
+      '`{ total (API meta count), n_returned, truncated, last_updated, records: [ { application_number, sponsor_name, products: [...], submissions: [...], openfda_generic_name, openfda_pharm_class_epc, openfda_pharm_class_moa, openfda_pharm_class_cs, openfda_pharm_class_pe, openfda_substance_name, openfda_route, openfda_manufacturer_name, openfda_product_type } ] }`. `truncated` is true when fewer than `total` records were returned.',
     example:
-      'result = host.mcp("drug_regulatory", "openfda_search_drug_label", {"query": \'openfda.brand_name:"Tylenol"\', "limit": 5})',
-    url: (a) =>
-      `${LABEL}?search=${encodeURIComponent(String(a.query))}&limit=${Number(a.limit ?? 10)}`,
-    parse: (raw) =>
-      ((raw as LabelSearchResponse).results ?? []).map((r) => ({
-        id: r.id,
-        brand_name: r.openfda?.brand_name?.[0],
-        generic_name: r.openfda?.generic_name?.[0],
-        manufacturer: r.openfda?.manufacturer_name?.[0],
-        indications: r.indications_and_usage?.[0]
-      }))
+      'result = host.mcp("drug_regulatory", "search_drug_applications", {"generic": "ATORVASTATIN CALCIUM", "marketing_status": "Prescription", "max_records": 25})',
+    run: async (ctx, a) => {
+      const expr = appSearchExpr(a)
+      const maxRecords = Math.max(1, Number(a.max_records ?? 50))
+      const { total, lastUpdated, records } = await fetchPaged<Application>(
+        ctx,
+        APPLICATIONS,
+        expr,
+        maxRecords,
+        true
+      )
+      return {
+        total,
+        n_returned: records.length,
+        truncated: records.length < total,
+        last_updated: lastUpdated,
+        records: records.map(shapeApplication)
+      }
+    }
   },
   {
-    id: 'openfda_search_adverse_events',
+    id: 'get_drug_application',
     connector: 'drug_regulatory',
     description:
-      'Search FDA adverse event reports (FAERS) by an openFDA query, e.g. patient.drug.medicinalproduct:"ASPIRIN".',
+      'Fetch one Drugs@FDA application by its number (e.g. "NDA020702", "ANDA076543", "BLA125514"). Returns the full record — sponsor, products (brand, active ingredients + strengths, dosage form, route, marketing status, TE code), complete submissions history, and harmonized openfda fields when present.',
+    input: {
+      type: 'object',
+      properties: { application_number: { type: 'string' } },
+      required: ['application_number']
+    },
+    required: ['application_number'],
+    returns:
+      '`{ application_number, found (bool), record }`. `record` is the full Drugs@FDA application object (sponsor_name, products, submissions, openfda); it is null and `found` false when the number does not exist.',
+    example:
+      'result = host.mcp("drug_regulatory", "get_drug_application", {"application_number": "NDA020702"})',
+    run: async (ctx, a) => {
+      const num = String(a.application_number)
+      const url = `${APPLICATIONS}?search=${enc(`application_number:${phrase(num)}`)}&limit=1`
+      try {
+        const resp = (await ctx.fetchJson(url)) as OpenFdaResults<Application>
+        const record = resp.results?.[0]
+        if (!record) return { application_number: num, found: false, record: null }
+        return { application_number: num, found: true, record }
+      } catch (err) {
+        if (isNotFound(err)) return { application_number: num, found: false, record: null }
+        throw err
+      }
+    }
+  },
+  {
+    id: 'count_drug_applications',
+    connector: 'drug_regulatory',
+    description:
+      'Aggregate Drugs@FDA bucket counts over one field, optionally narrowed by the same filters as search_drug_applications. count_field accepts friendly names (sponsor_name, application_number, dosage_form, route, marketing_status, te_code, pharm_class_epc/moa/cs/pe) or a raw openFDA field path (append .exact yourself for analyzed fields).',
     input: {
       type: 'object',
       properties: {
-        query: { type: 'string' },
-        limit: { type: 'integer', default: 10 }
+        count_field: { type: 'string' },
+        brand: { type: 'string' },
+        generic: { type: 'string' },
+        active_ingredient: { type: 'string' },
+        sponsor: { type: 'string' },
+        marketing_status: { type: 'string' },
+        dosage_form: { type: 'string' },
+        route: { type: 'string' },
+        pharm_class: { type: 'string' },
+        pharm_class_type: { type: 'string', enum: ['epc', 'moa', 'cs', 'pe'] },
+        search_type: { type: 'string', enum: ['and', 'or'], default: 'and' },
+        submission_date_from: { type: 'string' },
+        submission_date_to: { type: 'string' },
+        raw_search: { type: 'string' },
+        max_buckets: { type: 'integer', default: 100 }
       },
-      required: ['query']
+      required: ['count_field']
     },
-    required: ['query'],
+    required: ['count_field'],
     returns:
-      '`[ { "safety_report_id": str, "receive_date": str, "serious": bool, "reactions": [str] } ]` — up to `limit` FAERS reports (default 10); `serious` is true when the upstream flag is "1", `reactions` lists MedDRA preferred terms (`[]` when none). `[]` when nothing matches.',
+      '`{ count_field, api_field (resolved openFDA path), n_buckets, bucket_sum, buckets: [ { term, count } ] }` — buckets are descending by count.',
     example:
-      'result = host.mcp("drug_regulatory", "openfda_search_adverse_events", {"query": \'patient.drug.medicinalproduct:"ASPIRIN"\', "limit": 3})',
-    url: (a) =>
-      `${EVENT}?search=${encodeURIComponent(String(a.query))}&limit=${Number(a.limit ?? 10)}`,
-    parse: (raw) =>
-      ((raw as EventSearchResponse).results ?? []).map((r) => ({
-        safety_report_id: r.safetyreportid,
-        receive_date: r.receivedate,
-        serious: r.serious === '1',
-        reactions: (r.patient?.reaction ?? []).map((rx) => rx.reactionmeddrapt).filter(Boolean)
+      'result = host.mcp("drug_regulatory", "count_drug_applications", {"count_field": "marketing_status"})',
+    run: async (ctx, a) => {
+      const countField = String(a.count_field)
+      const apiField = COUNT_FIELDS[countField] ?? countField
+      const maxBuckets = Math.min(Math.max(1, Number(a.max_buckets ?? 100)), MAX_BUCKETS)
+      const buckets = await countBuckets(ctx, apiField, appSearchExpr(a), maxBuckets)
+      return {
+        count_field: countField,
+        api_field: apiField,
+        n_buckets: buckets.length,
+        bucket_sum: buckets.reduce((sum, b) => sum + (b.count ?? 0), 0),
+        buckets
+      }
+    }
+  },
+  {
+    id: 'get_drug_statistics',
+    connector: 'drug_regulatory',
+    description:
+      'Corpus-level Drugs@FDA statistics in one call — total applications, marketing-status split, top dosage forms and routes (with distinct counts), and top sponsors by application count.',
+    input: { type: 'object', properties: {} },
+    returns:
+      '`{ total_applications, last_updated, marketing_status: [ { term, count } ], dosage_form_top (top 25), dosage_form_distinct, route_top (top 25), route_distinct, sponsor_top (top 25 by application count) }`.',
+    example: 'result = host.mcp("drug_regulatory", "get_drug_statistics", {})',
+    run: async (ctx) => {
+      // Base query only for the total count and last-updated stamp (count queries omit results.total).
+      const base = (await ctx.fetchJson(`${APPLICATIONS}?limit=1`)) as OpenFdaResults<Application>
+      const marketingStatus = await countBuckets(ctx, 'products.marketing_status', '', MAX_BUCKETS)
+      const dosageForm = await countBuckets(ctx, 'products.dosage_form.exact', '', MAX_BUCKETS)
+      const route = await countBuckets(ctx, 'products.route.exact', '', MAX_BUCKETS)
+      const sponsor = await countBuckets(ctx, 'sponsor_name', '', 25)
+      return {
+        total_applications: base.meta?.results?.total ?? 0,
+        last_updated: base.meta?.last_updated,
+        marketing_status: marketingStatus,
+        dosage_form_top: dosageForm.slice(0, 25),
+        dosage_form_distinct: dosageForm.length,
+        route_top: route.slice(0, 25),
+        route_distinct: route.length,
+        sponsor_top: sponsor
+      }
+    }
+  },
+  {
+    id: 'list_pharmacologic_classes',
+    connector: 'drug_regulatory',
+    description:
+      'Enumerate pharmacologic classes with their application counts, counted over the harmonized openfda.pharm_class_<type> block. Counts reflect only applications carrying that block.',
+    input: {
+      type: 'object',
+      properties: {
+        class_type: { type: 'string', enum: ['epc', 'moa', 'cs', 'pe'], default: 'epc' },
+        max_buckets: { type: 'integer', default: 100 }
+      }
+    },
+    returns:
+      '`{ class_type, n_classes, classes: [ { term, count } ] }` — classes descending by count.',
+    example:
+      'result = host.mcp("drug_regulatory", "list_pharmacologic_classes", {"class_type": "epc", "max_buckets": 50})',
+    url: (a) => {
+      const max = Math.min(Math.max(1, Number(a.max_buckets ?? 100)), MAX_BUCKETS)
+      return `${APPLICATIONS}?count=${enc(`openfda.pharm_class_${classType(a.class_type)}.exact`)}&limit=${max}`
+    },
+    parse: (raw, a) => {
+      const classes = ((raw as OpenFdaResults<CountBucket>).results ?? []).map((b) => ({
+        term: b.term,
+        count: b.count
       }))
+      return { class_type: classType(a.class_type), n_classes: classes.length, classes }
+    }
+  },
+  {
+    id: 'get_generic_equivalents',
+    connector: 'drug_regulatory',
+    description:
+      'Find generic equivalents of a brand drug: resolve the brand to its reference application(s), extract the exact active-ingredient name set(s), then return every Drugs@FDA application with a product whose active-ingredient set matches (including TE codes and marketing status).',
+    input: {
+      type: 'object',
+      properties: { brand: { type: 'string' } },
+      required: ['brand']
+    },
+    required: ['brand'],
+    returns:
+      '`{ brand, reference_applications: [appnums], active_ingredient_sets: [[names]], equivalents: [ full application records ] }`.',
+    example:
+      'result = host.mcp("drug_regulatory", "get_generic_equivalents", {"brand": "Lipitor"})',
+    run: async (ctx, a) => {
+      const brand = String(a.brand)
+      // Step 1: resolve the brand to its applications and their distinct active-ingredient sets.
+      const refUrl = `${APPLICATIONS}?search=${enc(`products.brand_name:${phrase(brand)}`)}&limit=100`
+      let refApps: Application[] = []
+      try {
+        refApps = ((await ctx.fetchJson(refUrl)) as OpenFdaResults<Application>).results ?? []
+      } catch (err) {
+        if (!isNotFound(err)) throw err
+      }
+      const referenceApplications: string[] = []
+      const sets: string[][] = []
+      const seenSets = new Set<string>()
+      for (const app of refApps) {
+        if (app.application_number) referenceApplications.push(app.application_number)
+        for (const product of app.products ?? []) {
+          if ((product.brand_name ?? '').toUpperCase() !== brand.toUpperCase()) continue
+          const names = ingredientSet(product)
+          const key = names.join('|')
+          if (names.length && !seenSets.has(key)) {
+            seenSets.add(key)
+            sets.push(names)
+          }
+        }
+      }
+      // Step 2: for each ingredient set, gather candidates and keep exact-set matches (deduped by app).
+      const equivalents: Application[] = []
+      const seenApps = new Set<string>()
+      for (const names of sets) {
+        const expr = names.map((n) => `products.active_ingredients.name:${phrase(n)}`).join(' AND ')
+        let candidates: Application[] = []
+        try {
+          candidates =
+            (
+              (await ctx.fetchJson(
+                `${APPLICATIONS}?search=${enc(expr)}&limit=1000`
+              )) as OpenFdaResults<Application>
+            ).results ?? []
+        } catch (err) {
+          if (!isNotFound(err)) throw err
+        }
+        const target = names.join('|')
+        for (const app of candidates) {
+          const matches = (app.products ?? []).some((p) => ingredientSet(p).join('|') === target)
+          if (matches && app.application_number && !seenApps.has(app.application_number)) {
+            seenApps.add(app.application_number)
+            equivalents.push(app)
+          }
+        }
+      }
+      return {
+        brand,
+        reference_applications: referenceApplications,
+        active_ingredient_sets: sets,
+        equivalents
+      }
+    }
+  },
+  {
+    id: 'search_drug_labels',
+    connector: 'drug_regulatory',
+    description:
+      'Retrieve FDA drug product labels (SPL) by ingredient/name/route with targeted section extraction. Filters (active_ingredient, generic_name, brand_name, route, product_type) hit the openfda label block; set exact to query the non-analyzed .exact variants. Pass sections to extract raw openFDA label sections instead of the default structured record. raw_search is mutually exclusive with the mapped filters.',
+    input: {
+      type: 'object',
+      properties: {
+        active_ingredient: { type: 'string' },
+        generic_name: { type: 'string' },
+        brand_name: { type: 'string' },
+        route: { type: 'string' },
+        product_type: {
+          type: 'string',
+          enum: ['HUMAN PRESCRIPTION DRUG', 'HUMAN OTC DRUG']
+        },
+        exact: { type: 'boolean', default: false },
+        raw_search: { type: 'string' },
+        sections: { type: 'array', items: { type: 'string' } },
+        max_records: { type: 'integer', default: 25 }
+      }
+    },
+    returns:
+      'Default: `{ search, total (API count), n_returned, truncated, records: [ { identification: { set_id, spl_version, effective_time, brand_name, generic_name, substance_name, manufacturer, route, product_type, application_number }, has_boxed_warning, warning_sections: [str], indications_and_usage } ] }`. When `sections` is given, each record is `{ set_id, brand_name, generic_name, sections: { <name>: text } }`.',
+    example:
+      'result = host.mcp("drug_regulatory", "search_drug_labels", {"brand_name": "Tylenol", "max_records": 5})',
+    run: async (ctx, a) => {
+      const expr = labelSearchExpr(a)
+      const maxRecords = Math.max(1, Number(a.max_records ?? 25))
+      const sections = Array.isArray(a.sections) ? a.sections.map(String) : null
+      const { total, records } = await fetchPaged<LabelRecord>(ctx, LABELS, expr, maxRecords, false)
+      return {
+        search: expr,
+        total,
+        n_returned: records.length,
+        truncated: records.length < total,
+        records: records.map((r) =>
+          sections ? sectionLabelRecord(r, sections) : defaultLabelRecord(r)
+        )
+      }
+    }
   }
 ]


### PR DESCRIPTION
Rounds out the Drug Regulatory connector to the full openFDA Drugs@FDA + labels
workflow: multi-field application search, single-application lookup, bucket
aggregations, corpus statistics, pharmacologic-class enumeration, active-
ingredient-set generic equivalents, and SPL label search with section extraction.

All tools are read-only and return count-verified results with truncation flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)