### PR TITLE
feat(connectors): expand the Expression connector capabilities

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -175,9 +175,9 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
   {
     id: 'expression',
     displayName: 'Expression',
-    description: 'Gene expression across human tissues via the GTEx Portal.',
+    description: 'Human tissue expression and eQTLs via the GTEx Portal.',
     useWhen:
-      'Use when you need gene expression levels across human tissues — resolving a gene symbol to its GTEx gencodeId, or median expression (TPM) by tissue for a gene. Sourced from GTEx.',
+      'Use for GTEx tissue expression and eQTL evidence — listing tissue sites or dataset releases, resolving gene symbols to versioned GENCODE ids, median or per-sample expression (TPM) by tissue, top-expressed genes per tissue, sample/donor metadata, and cis-eQTLs (eGenes, single-tissue, multi-tissue METASOFT, or on-the-fly calculation) for a gene or variant. Sourced from GTEx.',
     sources: ['GTEx'],
     termsUrl: 'https://gtexportal.org/home/license',
     requiresNcbi: false

--- a/src/main/connectors/descriptors/expression.test.ts
+++ b/src/main/connectors/descriptors/expression.test.ts
@@ -7,106 +7,631 @@ const tool = (id: string): ToolDescriptor => EXPRESSION_TOOLS.find((t) => t.id =
 const jsonRes = (body: unknown): Response =>
   ({ ok: true, status: 200, json: async () => body }) as Response
 
-describe('expression / gtex_resolve_gene', () => {
-  it('builds the reference/gene URL and parses gene rows', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        data: [
+// Wraps a list of rows in the standard GTEx paged envelope.
+const paged = (data: unknown[], total = data.length, numberOfPages = 1, page = 0): unknown => ({
+  data,
+  paging_info: { numberOfPages, page, maxItemsPerPage: 1000, totalNumberOfItems: total }
+})
+
+// Single-response call helper: returns the parsed output plus the first request URL.
+const call = (
+  id: string,
+  args: Record<string, unknown>,
+  body: unknown
+): Promise<{ out: unknown; url: string }> => {
+  const fetchImpl = vi.fn().mockResolvedValue(jsonRes(body))
+  return new ParserEngine({ fetchImpl })
+    .call(tool(id), args, {})
+    .then((out) => ({ out, url: fetchImpl.mock.calls[0][0] as string }))
+}
+
+// Multi-response call helper: hands each queued body to successive fetches and returns every URL.
+const callSeq = (
+  id: string,
+  args: Record<string, unknown>,
+  bodies: unknown[]
+): Promise<{ out: unknown; urls: string[] }> => {
+  const fetchImpl = vi.fn()
+  for (const b of bodies) fetchImpl.mockResolvedValueOnce(jsonRes(b))
+  return new ParserEngine({ fetchImpl })
+    .call(tool(id), args, {})
+    .then((out) => ({ out, urls: fetchImpl.mock.calls.map((c) => c[0] as string) }))
+}
+
+describe('expression / gtex_tissue_sites', () => {
+  it('builds the tissueSiteDetail URL and maps tissues + verified total', async () => {
+    const { out, url } = await call(
+      'gtex_tissue_sites',
+      { dataset_id: 'gtex_v8' },
+      paged(
+        [
           {
-            geneSymbol: 'BRCA2',
-            gencodeId: 'ENSG00000139618.14',
-            gencodeVersion: 'v26',
-            genomeBuild: 'GRCh38/hg38'
+            tissueSiteDetailId: 'Adipose_Subcutaneous',
+            tissueSiteDetail: 'Adipose - Subcutaneous',
+            tissueSite: 'Adipose Tissue',
+            tissueSiteDetailAbbr: 'ADPSBQ',
+            colorHex: 'FF6600',
+            colorRgb: '255,102,0',
+            eGeneCount: 15607,
+            sGeneCount: 5113,
+            expressedGeneCount: 28830,
+            rnaSeqSampleSummary: { totalCount: 663 },
+            eqtlSampleSummary: { totalCount: 581 },
+            ontologyId: 'UBERON:0002190'
           }
         ],
-        paging_info: { numberOfPages: 1, page: 0, maxItemsPerPage: 250, totalNumberOfItems: 1 }
-      })
+        54
+      )
     )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('gtex_resolve_gene'),
-      { geneId: 'BRCA2' },
-      {}
+    expect(url).toBe(
+      'https://gtexportal.org/api/v2/dataset/tissueSiteDetail?datasetId=gtex_v8&itemsPerPage=1000'
     )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://gtexportal.org/api/v2/reference/gene?geneId=BRCA2'
-    )
+    expect(out).toEqual({
+      total: 54,
+      tissues: [
+        {
+          tissue_site_detail_id: 'Adipose_Subcutaneous',
+          tissue_site_detail: 'Adipose - Subcutaneous',
+          tissue_site: 'Adipose Tissue',
+          abbreviation: 'ADPSBQ',
+          color_hex: 'FF6600',
+          color_rgb: '255,102,0',
+          egene_count: 15607,
+          sgene_count: 5113,
+          expressed_gene_count: 28830,
+          rnaseq_sample_count: 663,
+          eqtl_sample_count: 581,
+          ontology_id: 'UBERON:0002190'
+        }
+      ]
+    })
+  })
+})
+
+describe('expression / gtex_dataset_info', () => {
+  it('parses the bare-array metadata/dataset response', async () => {
+    const { out, url } = await call('gtex_dataset_info', {}, [
+      {
+        datasetId: 'gtex_v8',
+        displayName: 'GTEx Analysis v8',
+        gencodeVersion: 'v26',
+        genomeBuild: 'GRCh38/hg38',
+        dbSnpBuild: 151,
+        organization: 'GTEx Consortium',
+        rnaSeqSampleCount: 17382,
+        rnaSeqAndGenotypeSampleCount: 15201,
+        subjectCount: 948,
+        eqtlSubjectCount: 838,
+        eqtlTissuesCount: 49,
+        tissueCount: 54,
+        description: 'Current GTEx Release.'
+      }
+    ])
+    expect(url).toBe('https://gtexportal.org/api/v2/metadata/dataset')
     expect(out).toEqual([
       {
-        gene_symbol: 'BRCA2',
-        gencode_id: 'ENSG00000139618.14',
+        dataset_id: 'gtex_v8',
+        display_name: 'GTEx Analysis v8',
         gencode_version: 'v26',
-        genome_build: 'GRCh38/hg38'
+        genome_build: 'GRCh38/hg38',
+        dbsnp_build: 151,
+        organization: 'GTEx Consortium',
+        rnaseq_sample_count: 17382,
+        rnaseq_and_genotype_sample_count: 15201,
+        subject_count: 948,
+        eqtl_subject_count: 838,
+        eqtl_tissue_count: 49,
+        tissue_count: 54,
+        description: 'Current GTEx Release.'
       }
     ])
   })
+})
 
-  it('returns an empty array when there is no data', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ data: [] }))
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('gtex_resolve_gene'),
-      { geneId: 'NOPE' },
-      {}
+describe('expression / gtex_resolve_genes', () => {
+  it('sends repeated geneId params with the release GENCODE version and maps records', async () => {
+    const { out, url } = await call(
+      'gtex_resolve_genes',
+      { genes: ['GAPDH', 'BRCA2'] },
+      paged(
+        [
+          {
+            geneSymbol: 'GAPDH',
+            gencodeId: 'ENSG00000111640.14',
+            gencodeVersion: 'v26',
+            genomeBuild: 'GRCh38/hg38',
+            chromosome: 'chr12',
+            start: 6533927,
+            end: 6538374,
+            strand: '+',
+            entrezGeneId: 2597,
+            geneType: 'protein coding',
+            description: 'glyceraldehyde-3-phosphate dehydrogenase'
+          }
+        ],
+        1
+      )
     )
-    expect(out).toEqual([])
+    expect(url).toBe(
+      'https://gtexportal.org/api/v2/reference/gene?itemsPerPage=1000&geneId=GAPDH&geneId=BRCA2&gencodeVersion=v26'
+    )
+    expect(out).toEqual({
+      total: 1,
+      genes: [
+        {
+          gene_symbol: 'GAPDH',
+          gencode_id: 'ENSG00000111640.14',
+          ensembl_id: 'ENSG00000111640',
+          gencode_version: 'v26',
+          genome_build: 'GRCh38/hg38',
+          chromosome: 'chr12',
+          start: 6533927,
+          end: 6538374,
+          strand: '+',
+          entrez_gene_id: 2597,
+          gene_type: 'protein coding',
+          description: 'glyceraldehyde-3-phosphate dehydrogenase'
+        }
+      ]
+    })
+  })
+})
+
+describe('expression / gtex_median_expression', () => {
+  it('walks all pages and count-verifies (gene, tissue) rows', async () => {
+    const page0 = paged(
+      [
+        {
+          gencodeId: 'ENSG00000111640.14',
+          geneSymbol: 'GAPDH',
+          tissueSiteDetailId: 'Liver',
+          median: 512.029,
+          unit: 'TPM'
+        }
+      ],
+      2,
+      2,
+      0
+    )
+    const page1 = paged(
+      [
+        {
+          gencodeId: 'ENSG00000111640.14',
+          geneSymbol: 'GAPDH',
+          tissueSiteDetailId: 'Whole_Blood',
+          median: 1773.91,
+          unit: 'TPM'
+        }
+      ],
+      2,
+      2,
+      1
+    )
+    const { out, urls } = await callSeq(
+      'gtex_median_expression',
+      { gencode_ids: ['ENSG00000111640.14'], tissue_site_detail_ids: ['Liver', 'Whole_Blood'] },
+      [page0, page1]
+    )
+    expect(urls[0]).toBe(
+      'https://gtexportal.org/api/v2/expression/medianGeneExpression?datasetId=gtex_v8&gencodeId=ENSG00000111640.14&tissueSiteDetailId=Liver&tissueSiteDetailId=Whole_Blood&page=0&itemsPerPage=1000'
+    )
+    expect(urls[1]).toContain('page=1')
+    expect(out).toEqual({
+      total: 2,
+      returned: 2,
+      rows: [
+        {
+          gencode_id: 'ENSG00000111640.14',
+          gene_symbol: 'GAPDH',
+          tissue_site_detail_id: 'Liver',
+          median_tpm: 512.029,
+          unit: 'TPM'
+        },
+        {
+          gencode_id: 'ENSG00000111640.14',
+          gene_symbol: 'GAPDH',
+          tissue_site_detail_id: 'Whole_Blood',
+          median_tpm: 1773.91,
+          unit: 'TPM'
+        }
+      ]
+    })
+  })
+})
+
+describe('expression / gtex_expression_summary', () => {
+  it('auto-resolves the symbol, then ranks tissues by descending median TPM', async () => {
+    const ref = paged(
+      [
+        {
+          geneSymbol: 'GAPDH',
+          gencodeId: 'ENSG00000111640.14',
+          gencodeVersion: 'v26',
+          genomeBuild: 'GRCh38/hg38'
+        }
+      ],
+      1
+    )
+    const medians = paged([
+      { tissueSiteDetailId: 'Liver', median: 512.029, unit: 'TPM' },
+      { tissueSiteDetailId: 'Whole_Blood', median: 1773.91, unit: 'TPM' }
+    ])
+    const { out, urls } = await callSeq('gtex_expression_summary', { gene: 'GAPDH' }, [
+      ref,
+      medians
+    ])
+    expect(urls[0]).toBe(
+      'https://gtexportal.org/api/v2/reference/gene?geneId=GAPDH&gencodeVersion=v26'
+    )
+    expect(urls[1]).toContain(
+      'expression/medianGeneExpression?datasetId=gtex_v8&gencodeId=ENSG00000111640.14'
+    )
+    const res = out as { gene: { gencode_id: string }; total_tissues: number; tissues: unknown[] }
+    expect(res.gene.gencode_id).toBe('ENSG00000111640.14')
+    expect(res.total_tissues).toBe(2)
+    // Whole_Blood (1773.91) must rank above Liver (512.029).
+    expect(res.tissues).toEqual([
+      { tissue_site_detail_id: 'Whole_Blood', median_tpm: 1773.91, unit: 'TPM' },
+      { tissue_site_detail_id: 'Liver', median_tpm: 512.029, unit: 'TPM' }
+    ])
+  })
+
+  it('throws when the gene is not in the GTEx reference', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(paged([], 0)))
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('gtex_expression_summary'), { gene: 'NOPE' }, {})
+    ).rejects.toThrow(/not found/)
   })
 })
 
 describe('expression / gtex_gene_expression', () => {
-  it('builds the medianGeneExpression URL (with default dataset) and parses tissue medians', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        data: [
-          {
-            median: 0.578425,
-            tissueSiteDetailId: 'Adipose_Subcutaneous',
-            datasetId: 'gtex_v8',
-            gencodeId: 'ENSG00000139618.14',
-            geneSymbol: 'BRCA2',
-            unit: 'TPM'
-          },
-          {
-            median: 0.372348,
-            tissueSiteDetailId: 'Adipose_Visceral_Omentum',
-            datasetId: 'gtex_v8',
-            gencodeId: 'ENSG00000139618.14',
-            geneSymbol: 'BRCA2',
-            unit: 'TPM'
-          }
-        ]
-      })
+  it('builds the geneExpression URL and returns per-tissue TPM arrays with n_samples', async () => {
+    const { out, url } = await call(
+      'gtex_gene_expression',
+      { gencode_id: 'ENSG00000111640.14', tissue_site_detail_ids: ['Whole_Blood'] },
+      paged([
+        {
+          data: [1774.0, 1647.0, 3016.0],
+          tissueSiteDetailId: 'Whole_Blood',
+          gencodeId: 'ENSG00000111640.14',
+          geneSymbol: 'GAPDH',
+          unit: 'TPM'
+        }
+      ])
     )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('gtex_gene_expression'),
-      { gencodeId: 'ENSG00000139618.14' },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://gtexportal.org/api/v2/expression/medianGeneExpression?gencodeId=ENSG00000139618.14&datasetId=gtex_v8'
+    expect(url).toBe(
+      'https://gtexportal.org/api/v2/expression/geneExpression?datasetId=gtex_v8&gencodeId=ENSG00000111640.14&tissueSiteDetailId=Whole_Blood&itemsPerPage=1000'
     )
     expect(out).toEqual([
-      { tissue: 'Adipose_Subcutaneous', median_tpm: 0.578425, unit: 'TPM' },
-      { tissue: 'Adipose_Visceral_Omentum', median_tpm: 0.372348, unit: 'TPM' }
+      {
+        tissue_site_detail_id: 'Whole_Blood',
+        gencode_id: 'ENSG00000111640.14',
+        gene_symbol: 'GAPDH',
+        unit: 'TPM',
+        n_samples: 3,
+        expression: [1774.0, 1647.0, 3016.0]
+      }
     ])
   })
+})
 
-  it('honors an explicit datasetId override', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ data: [] }))
-    await new ParserEngine({ fetchImpl }).call(
-      tool('gtex_gene_expression'),
-      { gencodeId: 'ENSG00000139618.14', datasetId: 'gtex_v10' },
-      {}
+describe('expression / gtex_top_expressed_genes', () => {
+  it('caps at n across pages and reports the full ranking size', async () => {
+    const page0 = paged(
+      [
+        { gencodeId: 'ENSG00000244734.3', geneSymbol: 'HBB', median: 267405.0, unit: 'TPM' },
+        { gencodeId: 'ENSG00000206172.8', geneSymbol: 'HBA1', median: 100000.0, unit: 'TPM' }
+      ],
+      56163,
+      28082,
+      0
     )
-    const url = fetchImpl.mock.calls[0][0] as string
-    expect(url).toContain('datasetId=gtex_v10')
+    const { out, urls } = await callSeq(
+      'gtex_top_expressed_genes',
+      { tissue_site_detail_id: 'Whole_Blood', n: 2 },
+      [page0]
+    )
+    expect(urls[0]).toBe(
+      'https://gtexportal.org/api/v2/expression/topExpressedGene?datasetId=gtex_v8&tissueSiteDetailId=Whole_Blood&filterMtGene=true&page=0&itemsPerPage=1000'
+    )
+    // n=2 satisfied by the first page → no second request.
+    expect(urls).toHaveLength(1)
+    expect(out).toEqual({
+      tissue_site_detail_id: 'Whole_Blood',
+      total_genes_in_ranking: 56163,
+      returned: 2,
+      genes: [
+        { gencode_id: 'ENSG00000244734.3', gene_symbol: 'HBB', median_tpm: 267405.0, unit: 'TPM' },
+        { gencode_id: 'ENSG00000206172.8', gene_symbol: 'HBA1', median_tpm: 100000.0, unit: 'TPM' }
+      ]
+    })
   })
 
-  it('returns an empty array when there is no data', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ data: [] }))
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('gtex_gene_expression'),
-      { gencodeId: 'ENSG00000000000.0' },
-      {}
+  it('honors filter_mt_gene=false', async () => {
+    const { urls } = await callSeq(
+      'gtex_top_expressed_genes',
+      { tissue_site_detail_id: 'Liver', n: 1, filter_mt_gene: false },
+      [paged([{ gencodeId: 'x', geneSymbol: 'MT-CO1', median: 1, unit: 'TPM' }], 100)]
     )
-    expect(out).toEqual([])
+    expect(urls[0]).toContain('filterMtGene=false')
+  })
+})
+
+describe('expression / gtex_eqtl_genes', () => {
+  it('walks pages, count-verifies the eGene total, and truncates at max_genes', async () => {
+    const page0 = paged(
+      [
+        {
+          gencodeId: 'ENSG00000227232.5',
+          geneSymbol: 'WASH7P',
+          empiricalPValue: 0.000432357,
+          pValue: 5.78285e-7,
+          pValueThreshold: 0.000212424,
+          qValue: 0.000656924,
+          log2AllelicFoldChange: 0.77278
+        }
+      ],
+      9660,
+      9660,
+      0
+    )
+    const { out, urls } = await callSeq(
+      'gtex_eqtl_genes',
+      { tissue_site_detail_id: 'Pancreas', max_genes: 1 },
+      [page0]
+    )
+    expect(urls[0]).toBe(
+      'https://gtexportal.org/api/v2/association/egene?datasetId=gtex_v8&tissueSiteDetailId=Pancreas&page=0&itemsPerPage=1000'
+    )
+    expect(out).toEqual({
+      total: 9660,
+      returned: 1,
+      truncated: true,
+      genes: [
+        {
+          gencode_id: 'ENSG00000227232.5',
+          gene_symbol: 'WASH7P',
+          empirical_p_value: 0.000432357,
+          p_value: 5.78285e-7,
+          p_value_threshold: 0.000212424,
+          q_value: 0.000656924,
+          log2_allelic_fold_change: 0.77278
+        }
+      ]
+    })
+  })
+})
+
+describe('expression / gtex_single_tissue_eqtls', () => {
+  it('requires gencode_id and/or variant_id', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('gtex_single_tissue_eqtls'), {}, {})
+    ).rejects.toThrow(/gencode_id and\/or variant_id/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('builds the URL from gencode_id and maps significant associations', async () => {
+    const { out, urls } = await callSeq(
+      'gtex_single_tissue_eqtls',
+      { gencode_id: 'ENSG00000111640.14' },
+      [
+        paged([
+          {
+            gencodeId: 'ENSG00000111640.14',
+            geneSymbol: 'GAPDH',
+            variantId: 'chr12_6452899_G_A_b38',
+            snpId: 'rs2286721',
+            chromosome: 'chr12',
+            pos: 6452899,
+            tissueSiteDetailId: 'Heart_Left_Ventricle',
+            pValue: 3.88343e-5,
+            nes: -0.162677
+          }
+        ])
+      ]
+    )
+    expect(urls[0]).toBe(
+      'https://gtexportal.org/api/v2/association/singleTissueEqtl?datasetId=gtex_v8&gencodeId=ENSG00000111640.14&page=0&itemsPerPage=1000'
+    )
+    expect(out).toEqual({
+      total: 1,
+      returned: 1,
+      truncated: false,
+      eqtls: [
+        {
+          gencode_id: 'ENSG00000111640.14',
+          gene_symbol: 'GAPDH',
+          variant_id: 'chr12_6452899_G_A_b38',
+          snp_id: 'rs2286721',
+          chromosome: 'chr12',
+          pos: 6452899,
+          tissue_site_detail_id: 'Heart_Left_Ventricle',
+          p_value: 3.88343e-5,
+          nes: -0.162677
+        }
+      ]
+    })
+  })
+})
+
+describe('expression / gtex_multi_tissue_eqtls', () => {
+  it('maps METASOFT rows and renames per-tissue metric blocks', async () => {
+    const { out, urls } = await callSeq(
+      'gtex_multi_tissue_eqtls',
+      { gencode_id: 'ENSG00000111640.14' },
+      [
+        paged([
+          {
+            gencodeId: 'ENSG00000111640.14',
+            variantId: 'chr12_6496645_G_A_b38',
+            metaP: 4.13541e-47,
+            tissues: { Thyroid: { mValue: 1.0, pValue: 1.2817e-8, se: 0.0267655, nes: -0.154811 } }
+          }
+        ])
+      ]
+    )
+    expect(urls[0]).toBe(
+      'https://gtexportal.org/api/v2/association/metasoft?datasetId=gtex_v8&gencodeId=ENSG00000111640.14&page=0&itemsPerPage=1000'
+    )
+    expect(out).toEqual({
+      total: 1,
+      returned: 1,
+      variants: [
+        {
+          gencode_id: 'ENSG00000111640.14',
+          variant_id: 'chr12_6496645_G_A_b38',
+          meta_p: 4.13541e-47,
+          tissues: {
+            Thyroid: { m_value: 1.0, nes: -0.154811, p_value: 1.2817e-8, se: 0.0267655 }
+          }
+        }
+      ]
+    })
+  })
+})
+
+describe('expression / gtex_calculate_eqtl', () => {
+  it('builds the dyneqtl URL and sorts samples by (genotype, expression)', async () => {
+    const { out, url } = await call(
+      'gtex_calculate_eqtl',
+      {
+        gencode_id: 'ENSG00000111640.14',
+        variant_id: 'chr12_6452899_G_A_b38',
+        tissue_site_detail_id: 'Whole_Blood'
+      },
+      {
+        gencodeId: 'ENSG00000111640.14',
+        geneSymbol: 'GAPDH',
+        variantId: 'chr12_6452899_G_A_b38',
+        tissueSiteDetailId: 'Whole_Blood',
+        pValue: 0.5128,
+        nes: -0.0122,
+        tStatistic: -0.6548,
+        maf: 0.1642,
+        homoRefCount: 470,
+        hetCount: 180,
+        homoAltCount: 20,
+        // Deliberately unsorted upstream order.
+        genotypes: [1, 0, 1, 0],
+        data: [5.0, 9.0, 2.0, 3.0]
+      }
+    )
+    expect(url).toBe(
+      'https://gtexportal.org/api/v2/association/dyneqtl?datasetId=gtex_v8&gencodeId=ENSG00000111640.14&variantId=chr12_6452899_G_A_b38&tissueSiteDetailId=Whole_Blood'
+    )
+    expect(out).toEqual({
+      gencode_id: 'ENSG00000111640.14',
+      gene_symbol: 'GAPDH',
+      variant_id: 'chr12_6452899_G_A_b38',
+      tissue_site_detail_id: 'Whole_Blood',
+      p_value: 0.5128,
+      nes: -0.0122,
+      t_statistic: -0.6548,
+      maf: 0.1642,
+      hom_ref_count: 470,
+      het_count: 180,
+      hom_alt_count: 20,
+      n_samples: 4,
+      samples: [
+        { genotype: 0, expression: 3.0 },
+        { genotype: 0, expression: 9.0 },
+        { genotype: 1, expression: 2.0 },
+        { genotype: 1, expression: 5.0 }
+      ]
+    })
+  })
+})
+
+describe('expression / gtex_sample_info', () => {
+  it('builds a filtered /dataset/sample URL and caps at max_samples with truncation', async () => {
+    const row = {
+      sampleId: 'GTEX-1192X-0526-SM-5H12P',
+      subjectId: 'GTEX-1192X',
+      tissueSiteDetailId: 'Liver',
+      tissueSiteDetail: 'Liver',
+      dataType: 'RNASEQ',
+      sex: 'male',
+      ageBracket: '60-69',
+      hardyScale: 0,
+      ischemicTime: 889,
+      rin: 7.2,
+      autolysisScore: 1,
+      pathologyNotes: 'cirrhosis',
+      uberonId: 'UBERON:0002107'
+    }
+    const { out, url } = await call(
+      'gtex_sample_info',
+      {
+        tissue_site_detail_id: 'Liver',
+        data_type: 'RNASEQ',
+        max_samples: 1,
+        dataset_id: 'gtex_v8'
+      },
+      paged([row, { ...row, sampleId: 'GTEX-OTHER' }], 251)
+    )
+    expect(url).toContain('/dataset/sample?datasetId=gtex_v8')
+    expect(url).toContain('tissueSiteDetailId=Liver')
+    expect(url).toContain('dataType=RNASEQ')
+    expect(out).toMatchObject({
+      total: 251,
+      returned: 1,
+      truncated: true,
+      samples: [
+        {
+          sample_id: 'GTEX-1192X-0526-SM-5H12P',
+          subject_id: 'GTEX-1192X',
+          tissue_site_detail_id: 'Liver',
+          data_type: 'RNASEQ',
+          hardy_scale: 0,
+          rin: 7.2
+        }
+      ]
+    })
+  })
+})
+
+describe('expression / dataset pinning (dataset_id honoured)', () => {
+  it('gtex_resolve_genes maps dataset_id gtex_v10 to gencodeVersion v39', async () => {
+    const { url } = await call(
+      'gtex_resolve_genes',
+      { genes: ['GAPDH'], dataset_id: 'gtex_v10' },
+      paged([])
+    )
+    expect(url).toContain('gencodeVersion=v39')
+  })
+  it('gtex_median_expression passes dataset_id through to the query', async () => {
+    const { urls } = await callSeq(
+      'gtex_median_expression',
+      { gencode_ids: ['ENSG00000111640.14'], dataset_id: 'gtex_v10' },
+      [paged([])]
+    )
+    expect(urls[0]).toContain('datasetId=gtex_v10')
+  })
+})
+
+describe('expression / gtex_expression_summary exact match', () => {
+  it('selects the exact gene symbol among multiple reference hits', async () => {
+    const { out } = await callSeq('gtex_expression_summary', { gene: 'GAPDH' }, [
+      paged([
+        { geneSymbol: 'GAPDHS', gencodeId: 'ENSG00000105679.12', gencodeVersion: 'v26' },
+        { geneSymbol: 'GAPDH', gencodeId: 'ENSG00000111640.14', gencodeVersion: 'v26' }
+      ]),
+      paged([{ tissueSiteDetailId: 'Liver', median: 500, unit: 'TPM' }])
+    ])
+    expect(out).toMatchObject({
+      gene: { gene_symbol: 'GAPDH', gencode_id: 'ENSG00000111640.14' },
+      total_tissues: 1
+    })
+  })
+})
+
+describe('expression / count verification', () => {
+  it('raises when an uncapped walk under-delivers vs the API total', async () => {
+    await expect(
+      callSeq('gtex_median_expression', { gencode_ids: ['ENSG00000111640.14'] }, [
+        paged([{ tissueSiteDetailId: 'Liver', median: 1, unit: 'TPM' }], 5, 1)
+      ])
+    ).rejects.toThrow(/count mismatch/)
   })
 })

--- a/src/main/connectors/descriptors/expression.ts
+++ b/src/main/connectors/descriptors/expression.ts
@@ -1,78 +1,590 @@
-import type { ToolDescriptor } from '../types'
+import type { ToolContext, ToolDescriptor } from '../types'
 
 const GTEX = 'https://gtexportal.org/api/v2'
 const DEFAULT_DATASET = 'gtex_v8'
+// GTEx caps a single page at 1000 rows; use it to minimise round-trips when walking paged routes.
+const PAGE_SIZE = 1000
 
-type GtexGeneRef = {
-  geneSymbol?: string
-  gencodeId?: string
-  gencodeVersion?: string
-  genomeBuild?: string
+// A pinned dataset release maps to a fixed GENCODE version; the /reference/gene route keys off the
+// GENCODE version (it has no datasetId param) so gene resolution can be pinned to the release.
+const DATASET_GENCODE_VERSION: Record<string, string> = {
+  gtex_v7: 'v19',
+  gtex_v8: 'v26',
+  gtex_v10: 'v39'
 }
 
-type GtexGeneRefResponse = { data?: GtexGeneRef[] }
+// Standard GTEx v2 paged envelope: rows under `data`, page counts under `paging_info`.
+type PagingInfo = { numberOfPages?: number; page?: number; totalNumberOfItems?: number }
+type PagedResponse = { data?: Record<string, unknown>[]; paging_info?: PagingInfo }
 
-type GtexMedianExpressionRow = {
-  tissueSiteDetailId?: string
-  median?: number
-  unit?: string
+// Reads a top-level `dataset_id` arg, falling back to the default release.
+function datasetOf(args: Record<string, unknown>): string {
+  return String(args.dataset_id ?? DEFAULT_DATASET)
 }
 
-type GtexMedianExpressionResponse = { data?: GtexMedianExpressionRow[] }
+// Renders repeated query params for a list-valued arg (GTEx accepts `name=a&name=b`); '' when empty.
+function repeatParam(name: string, value: unknown): string {
+  if (value == null) return ''
+  const values = Array.isArray(value) ? value : [value]
+  return values.map((v) => `&${name}=${encodeURIComponent(String(v))}`).join('')
+}
 
-// GTEx Portal API v2: read-only gene reference resolution + median tissue expression (bulk RNA-seq).
-// Both routes wrap their rows in a top-level `data` array (confirmed live against v2).
+// Walks every page of a GTEx paged route and returns the collected rows plus the API-reported total.
+// Stops early once `cap` rows are gathered (then `truncated` reflects that more rows exist upstream).
+async function walkPages(
+  ctx: ToolContext,
+  baseUrl: string,
+  cap?: number
+): Promise<{ rows: Record<string, unknown>[]; total: number; truncated: boolean }> {
+  const rows: Record<string, unknown>[] = []
+  let total = 0
+  for (let page = 0; ; page++) {
+    const sep = baseUrl.includes('?') ? '&' : '?'
+    const res = (await ctx.fetchJson(
+      `${baseUrl}${sep}page=${page}&itemsPerPage=${PAGE_SIZE}`
+    )) as PagedResponse
+    const data = res.data ?? []
+    total = res.paging_info?.totalNumberOfItems ?? total
+    for (const row of data) {
+      rows.push(row)
+      if (cap != null && rows.length >= cap) return { rows, total, truncated: total > rows.length }
+    }
+    const numPages = res.paging_info?.numberOfPages ?? 1
+    if (data.length === 0 || page + 1 >= numPages) break
+  }
+  // A complete (uncapped) walk is count-verified against the API's own total, mirroring upstream.
+  if (cap == null && total > 0 && rows.length !== total) {
+    throw new Error(`GTEx paging count mismatch: collected ${rows.length} of ${total} rows`)
+  }
+  return { rows, total, truncated: cap != null && total > rows.length }
+}
+
+// Maps a raw /reference/gene record to the curated gene reference shape shared by resolve + summary.
+function geneRecord(g: Record<string, unknown>): Record<string, unknown> {
+  return {
+    gene_symbol: g.geneSymbol,
+    gencode_id: g.gencodeId,
+    ensembl_id: typeof g.gencodeId === 'string' ? g.gencodeId.split('.')[0] : undefined,
+    gencode_version: g.gencodeVersion,
+    genome_build: g.genomeBuild,
+    chromosome: g.chromosome,
+    start: g.start,
+    end: g.end,
+    strand: g.strand,
+    entrez_gene_id: g.entrezGeneId,
+    gene_type: g.geneType,
+    description: g.description
+  }
+}
+
+// GTEx Portal API v2 (https://gtexportal.org/api/v2): read-only tissue/sample metadata, bulk RNA-seq
+// expression, and precomputed/on-the-fly eQTL associations. Tool ids mirror the official openscience
+// GTEx surface; paged routes are walked to a count-verified `total`.
 export const EXPRESSION_TOOLS: ToolDescriptor[] = [
   {
-    id: 'gtex_resolve_gene',
+    id: 'gtex_tissue_sites',
     connector: 'expression',
     description:
-      'Resolve a gene symbol (or unversioned Ensembl id) to its versioned GTEx gencodeId, e.g. BRCA2 -> ENSG00000139618.14.',
+      'List all tissue sites with metadata for a pinned GTEx release (54 in gtex_v8): sample counts, eGene/sGene counts, colour codes, and UBERON ontology ids.',
     input: {
       type: 'object',
-      properties: { geneId: { type: 'string' } },
-      required: ['geneId']
+      properties: { dataset_id: { type: 'string', default: DEFAULT_DATASET } }
     },
-    required: ['geneId'],
     returns:
-      '`[ { "gene_symbol": str, "gencode_id": str, "gencode_version": str, "genome_build": str } ]` — array of matching gene references (usually one); `[]` when the gene isn\'t found. Fields are undefined if absent upstream.',
-    example: 'result = host.mcp("expression", "gtex_resolve_gene", {"geneId": "BRCA2"})',
-    url: (a) => `${GTEX}/reference/gene?geneId=${encodeURIComponent(String(a.geneId))}`,
-    parse: (raw) =>
-      ((raw as GtexGeneRefResponse).data ?? []).map((g) => ({
-        gene_symbol: g.geneSymbol,
-        gencode_id: g.gencodeId,
-        gencode_version: g.gencodeVersion,
-        genome_build: g.genomeBuild
+      '`{ "total": int, "tissues": [ { "tissue_site_detail_id": str, "tissue_site_detail": str, "tissue_site": str, "abbreviation": str, "color_hex": str, "color_rgb": str, "egene_count": int, "sgene_count": int, "expressed_gene_count": int, "rnaseq_sample_count": int, "eqtl_sample_count": int, "ontology_id": str } ] }` — `total` is the API-verified row count (54 for gtex_v8).',
+    example: 'result = host.mcp("expression", "gtex_tissue_sites", {"dataset_id": "gtex_v8"})',
+    url: (a) =>
+      `${GTEX}/dataset/tissueSiteDetail?datasetId=${encodeURIComponent(String(a.dataset_id ?? DEFAULT_DATASET))}&itemsPerPage=${PAGE_SIZE}`,
+    parse: (raw) => {
+      const res = raw as PagedResponse
+      const tissues = (res.data ?? []).map((t) => ({
+        tissue_site_detail_id: t.tissueSiteDetailId,
+        tissue_site_detail: t.tissueSiteDetail,
+        tissue_site: t.tissueSite,
+        abbreviation: t.tissueSiteDetailAbbr,
+        color_hex: t.colorHex,
+        color_rgb: t.colorRgb,
+        egene_count: t.eGeneCount,
+        sgene_count: t.sGeneCount,
+        expressed_gene_count: t.expressedGeneCount,
+        rnaseq_sample_count: (t.rnaSeqSampleSummary as { totalCount?: number } | undefined)
+          ?.totalCount,
+        eqtl_sample_count: (t.eqtlSampleSummary as { totalCount?: number } | undefined)?.totalCount,
+        ontology_id: t.ontologyId
       }))
+      return { total: res.paging_info?.totalNumberOfItems ?? tissues.length, tissues }
+    }
+  },
+  {
+    id: 'gtex_dataset_info',
+    connector: 'expression',
+    description:
+      'List all GTEx dataset releases with metadata: datasetId, GENCODE version, genome build, dbSNP build, and sample/subject/tissue counts.',
+    input: {
+      type: 'object',
+      properties: { dataset_id: { type: 'string' }, organization_name: { type: 'string' } }
+    },
+    returns:
+      '`[ { "dataset_id": str, "display_name": str, "gencode_version": str, "genome_build": str, "dbsnp_build": int, "organization": str, "rnaseq_sample_count": int, "rnaseq_and_genotype_sample_count": int, "subject_count": int, "eqtl_subject_count": int, "eqtl_tissue_count": int, "tissue_count": int, "description": str } ]` — one row per release (e.g. gtex_v7, gtex_v8).',
+    example: 'result = host.mcp("expression", "gtex_dataset_info", {})',
+    url: (a) => {
+      const params = [
+        a.dataset_id ? `datasetId=${encodeURIComponent(String(a.dataset_id))}` : '',
+        a.organization_name
+          ? `organizationName=${encodeURIComponent(String(a.organization_name))}`
+          : ''
+      ].filter(Boolean)
+      return `${GTEX}/metadata/dataset${params.length ? `?${params.join('&')}` : ''}`
+    },
+    // This route returns a bare array (no `data`/`paging_info` envelope), unlike the paged routes.
+    parse: (raw) =>
+      (raw as Record<string, unknown>[]).map((d) => ({
+        dataset_id: d.datasetId,
+        display_name: d.displayName,
+        gencode_version: d.gencodeVersion,
+        genome_build: d.genomeBuild,
+        dbsnp_build: d.dbSnpBuild,
+        organization: d.organization,
+        rnaseq_sample_count: d.rnaSeqSampleCount,
+        rnaseq_and_genotype_sample_count: d.rnaSeqAndGenotypeSampleCount,
+        subject_count: d.subjectCount,
+        eqtl_subject_count: d.eqtlSubjectCount,
+        eqtl_tissue_count: d.eqtlTissuesCount,
+        tissue_count: d.tissueCount,
+        description: d.description
+      }))
+  },
+  {
+    id: 'gtex_sample_info',
+    connector: 'expression',
+    description:
+      'Sample and donor metadata for a pinned GTEx release, optionally filtered by tissue_site_detail_id, data_type (e.g. RNASEQ, WGS), or subject_id. Paged and count-verified; an unfiltered call matches tens of thousands of samples, so filter or set max_samples.',
+    input: {
+      type: 'object',
+      properties: {
+        tissue_site_detail_id: { type: 'string' },
+        data_type: { type: 'string' },
+        subject_id: { type: 'string' },
+        max_samples: { type: 'integer' },
+        dataset_id: { type: 'string', default: DEFAULT_DATASET }
+      }
+    },
+    returns:
+      '`{ "total": int, "returned": int, "truncated": bool, "samples": [ { "sample_id": str, "subject_id": str, "tissue_site_detail_id": str, "tissue_site_detail": str, "data_type": str, "sex": str, "age_bracket": str, "hardy_scale": int, "ischemic_time": int, "rin": float, "autolysis_score": int, "pathology_notes": str, "uberon_id": str } ] }` — `total` is the API-verified match count; `truncated` is true when capped by max_samples.',
+    example:
+      'result = host.mcp("expression", "gtex_sample_info", {"tissue_site_detail_id": "Liver", "data_type": "RNASEQ", "max_samples": 100})',
+    run: async (ctx, a) => {
+      const cap = a.max_samples != null ? Math.max(1, Number(a.max_samples)) : undefined
+      const base =
+        `${GTEX}/dataset/sample?datasetId=${encodeURIComponent(datasetOf(a))}` +
+        repeatParam('tissueSiteDetailId', a.tissue_site_detail_id) +
+        repeatParam('dataType', a.data_type) +
+        repeatParam('subjectId', a.subject_id)
+      const { rows, total, truncated } = await walkPages(ctx, base, cap)
+      return {
+        total,
+        returned: rows.length,
+        truncated,
+        samples: rows.map((r) => ({
+          sample_id: r.sampleId,
+          subject_id: r.subjectId,
+          tissue_site_detail_id: r.tissueSiteDetailId,
+          tissue_site_detail: r.tissueSiteDetail,
+          data_type: r.dataType,
+          sex: r.sex,
+          age_bracket: r.ageBracket,
+          hardy_scale: r.hardyScale,
+          ischemic_time: r.ischemicTime,
+          rin: r.rin,
+          autolysis_score: r.autolysisScore,
+          pathology_notes: r.pathologyNotes,
+          uberon_id: r.uberonId
+        }))
+      }
+    }
+  },
+  {
+    id: 'gtex_resolve_genes',
+    connector: 'expression',
+    description:
+      'Resolve gene symbols or unversioned Ensembl ids to versioned GENCODE ids for a pinned release, e.g. GAPDH -> ENSG00000111640.14. Feed the ids to the expression / eQTL tools.',
+    input: {
+      type: 'object',
+      properties: {
+        genes: { type: 'array', items: { type: 'string' } },
+        dataset_id: { type: 'string', default: DEFAULT_DATASET }
+      },
+      required: ['genes']
+    },
+    required: ['genes'],
+    returns:
+      '`{ "total": int, "genes": [ { "gene_symbol": str, "gencode_id": str, "ensembl_id": str, "gencode_version": str, "genome_build": str, "chromosome": str, "start": int, "end": int, "strand": str, "entrez_gene_id": int, "gene_type": str, "description": str } ] }` — one record per matched reference gene; unmatched inputs are simply absent.',
+    example: 'result = host.mcp("expression", "gtex_resolve_genes", {"genes": ["GAPDH", "BRCA2"]})',
+    url: (a) => {
+      const version = DATASET_GENCODE_VERSION[datasetOf(a)]
+      return (
+        `${GTEX}/reference/gene?itemsPerPage=${PAGE_SIZE}` +
+        repeatParam('geneId', a.genes) +
+        (version ? `&gencodeVersion=${encodeURIComponent(version)}` : '')
+      )
+    },
+    parse: (raw) => {
+      const res = raw as PagedResponse
+      const genes = (res.data ?? []).map(geneRecord)
+      return { total: res.paging_info?.totalNumberOfItems ?? genes.length, genes }
+    }
+  },
+  {
+    id: 'gtex_median_expression',
+    connector: 'expression',
+    description:
+      'Median gene expression (TPM) for one or more VERSIONED GENCODE ids across tissues (omit tissues for all). Paged and count-verified over (gene, tissue) rows.',
+    input: {
+      type: 'object',
+      properties: {
+        gencode_ids: { type: 'array', items: { type: 'string' } },
+        tissue_site_detail_ids: { type: 'array', items: { type: 'string' } },
+        dataset_id: { type: 'string', default: DEFAULT_DATASET }
+      },
+      required: ['gencode_ids']
+    },
+    required: ['gencode_ids'],
+    returns:
+      '`{ "total": int, "returned": int, "rows": [ { "gencode_id": str, "gene_symbol": str, "tissue_site_detail_id": str, "median_tpm": float, "unit": str } ] }` — one row per (gene, tissue); `total` is the API-verified row count.',
+    example:
+      'result = host.mcp("expression", "gtex_median_expression", {"gencode_ids": ["ENSG00000111640.14"]})',
+    run: async (ctx, a) => {
+      const base =
+        `${GTEX}/expression/medianGeneExpression?datasetId=${encodeURIComponent(datasetOf(a))}` +
+        repeatParam('gencodeId', a.gencode_ids) +
+        repeatParam('tissueSiteDetailId', a.tissue_site_detail_ids)
+      const { rows, total } = await walkPages(ctx, base)
+      return {
+        total,
+        returned: rows.length,
+        rows: rows.map((r) => ({
+          gencode_id: r.gencodeId,
+          gene_symbol: r.geneSymbol,
+          tissue_site_detail_id: r.tissueSiteDetailId,
+          median_tpm: r.median,
+          unit: r.unit
+        }))
+      }
+    }
+  },
+  {
+    id: 'gtex_expression_summary',
+    connector: 'expression',
+    description:
+      'Summarize a gene’s expression across ALL tissues ranked by descending median TPM. Accepts a symbol or Ensembl id and auto-resolves it to a versioned GENCODE id first.',
+    input: {
+      type: 'object',
+      properties: {
+        gene: { type: 'string' },
+        dataset_id: { type: 'string', default: DEFAULT_DATASET }
+      },
+      required: ['gene']
+    },
+    required: ['gene'],
+    returns:
+      '`{ "gene": { gene reference record }, "total_tissues": int, "tissues": [ { "tissue_site_detail_id": str, "median_tpm": float, "unit": str } ] }` — tissues sorted by descending median TPM. Raises if the gene is not in the GTEx reference.',
+    example: 'result = host.mcp("expression", "gtex_expression_summary", {"gene": "GAPDH"})',
+    // Multi-step: resolve the symbol, then rank its per-tissue medians.
+    run: async (ctx, a) => {
+      const version = DATASET_GENCODE_VERSION[datasetOf(a)]
+      const refUrl =
+        `${GTEX}/reference/gene?geneId=${encodeURIComponent(String(a.gene))}` +
+        (version ? `&gencodeVersion=${encodeURIComponent(version)}` : '')
+      const ref = (await ctx.fetchJson(refUrl)) as PagedResponse
+      const query = String(a.gene)
+      const q = query.toUpperCase()
+      const qBare = q.split('.')[0]
+      // Mirror upstream: pick the exact symbol / gencode / unversioned-Ensembl match, not just row 0.
+      const first = (ref.data ?? []).find((g) => {
+        const sym = String(g.geneSymbol ?? '').toUpperCase()
+        const gid = String(g.gencodeId ?? '')
+        return sym === q || gid === query || gid.split('.')[0].toUpperCase() === qBare
+      })
+      if (!first) throw new Error(`gene not found in GTEx reference: ${query}`)
+      const gencodeId = String(first.gencodeId)
+      const medUrl =
+        `${GTEX}/expression/medianGeneExpression?datasetId=${encodeURIComponent(datasetOf(a))}` +
+        `&gencodeId=${encodeURIComponent(gencodeId)}`
+      const { rows } = await walkPages(ctx, medUrl)
+      const tissues = rows
+        .map((r) => ({
+          tissue_site_detail_id: r.tissueSiteDetailId,
+          median_tpm: r.median,
+          unit: r.unit
+        }))
+        .sort((x, y) => Number(y.median_tpm ?? 0) - Number(x.median_tpm ?? 0))
+      return { gene: geneRecord(first), total_tissues: tissues.length, tissues }
+    }
   },
   {
     id: 'gtex_gene_expression',
     connector: 'expression',
     description:
-      'Median gene expression (TPM) across GTEx tissues for a versioned GENCODE id (use gtex_resolve_gene first to get one from a gene symbol).',
+      'Sample-level (not aggregated) expression TPM arrays for one VERSIONED GENCODE id, per tissue (omit tissues for all). Returns the full per-sample TPM array and n_samples for each tissue.',
     input: {
       type: 'object',
       properties: {
-        gencodeId: { type: 'string' },
-        datasetId: { type: 'string', default: DEFAULT_DATASET }
+        gencode_id: { type: 'string' },
+        tissue_site_detail_ids: { type: 'array', items: { type: 'string' } },
+        dataset_id: { type: 'string', default: DEFAULT_DATASET }
       },
-      required: ['gencodeId']
+      required: ['gencode_id']
     },
-    required: ['gencodeId'],
+    required: ['gencode_id'],
     returns:
-      '`[ { "tissue": str, "median_tpm": float, "unit": str } ]` — one row per GTEx tissue site; `median_tpm` in TPM. `[]` when the gencodeId is unknown for the dataset.',
+      '`[ { "tissue_site_detail_id": str, "gencode_id": str, "gene_symbol": str, "unit": str, "n_samples": int, "expression": [float] } ]` — one entry per tissue; `expression` is the raw per-sample TPM array.',
     example:
-      'result = host.mcp("expression", "gtex_gene_expression", {"gencodeId": "ENSG00000139618.14"})',
-    url: (a) => {
-      const dataset = String(a.datasetId ?? DEFAULT_DATASET)
-      return `${GTEX}/expression/medianGeneExpression?gencodeId=${encodeURIComponent(String(a.gencodeId))}&datasetId=${encodeURIComponent(dataset)}`
+      'result = host.mcp("expression", "gtex_gene_expression", {"gencode_id": "ENSG00000111640.14", "tissue_site_detail_ids": ["Whole_Blood"]})',
+    url: (a) =>
+      `${GTEX}/expression/geneExpression?datasetId=${encodeURIComponent(datasetOf(a))}` +
+      `&gencodeId=${encodeURIComponent(String(a.gencode_id))}` +
+      repeatParam('tissueSiteDetailId', a.tissue_site_detail_ids) +
+      `&itemsPerPage=${PAGE_SIZE}`,
+    parse: (raw) => {
+      const res = raw as PagedResponse
+      return (res.data ?? []).map((r) => {
+        const expression = (r.data as number[] | undefined) ?? []
+        return {
+          tissue_site_detail_id: r.tissueSiteDetailId,
+          gencode_id: r.gencodeId,
+          gene_symbol: r.geneSymbol,
+          unit: r.unit,
+          n_samples: expression.length,
+          expression
+        }
+      })
+    }
+  },
+  {
+    id: 'gtex_top_expressed_genes',
+    connector: 'expression',
+    description:
+      'Top-n genes by median TPM in one tissue, using the API-side ranking. filter_mt_gene (default true) drops mitochondrial genes from the ranking.',
+    input: {
+      type: 'object',
+      properties: {
+        tissue_site_detail_id: { type: 'string' },
+        n: { type: 'integer', default: 100 },
+        filter_mt_gene: { type: 'boolean', default: true },
+        dataset_id: { type: 'string', default: DEFAULT_DATASET }
+      },
+      required: ['tissue_site_detail_id']
     },
-    parse: (raw) =>
-      ((raw as GtexMedianExpressionResponse).data ?? []).map((r) => ({
-        tissue: r.tissueSiteDetailId,
-        median_tpm: r.median,
-        unit: r.unit
-      }))
+    required: ['tissue_site_detail_id'],
+    returns:
+      '`{ "tissue_site_detail_id": str, "total_genes_in_ranking": int, "returned": int, "genes": [ { "gencode_id": str, "gene_symbol": str, "median_tpm": float, "unit": str } ] }` — genes in rank order; `total_genes_in_ranking` is the full ranking size (~56k).',
+    example:
+      'result = host.mcp("expression", "gtex_top_expressed_genes", {"tissue_site_detail_id": "Whole_Blood", "n": 20})',
+    run: async (ctx, a) => {
+      const n = Math.max(0, Number(a.n ?? 100))
+      const filterMt = a.filter_mt_gene ?? true
+      const base =
+        `${GTEX}/expression/topExpressedGene?datasetId=${encodeURIComponent(datasetOf(a))}` +
+        `&tissueSiteDetailId=${encodeURIComponent(String(a.tissue_site_detail_id))}` +
+        `&filterMtGene=${filterMt ? 'true' : 'false'}`
+      const { rows, total } = await walkPages(ctx, base, n)
+      return {
+        tissue_site_detail_id: a.tissue_site_detail_id,
+        total_genes_in_ranking: total,
+        returned: rows.length,
+        genes: rows.map((r) => ({
+          gencode_id: r.gencodeId,
+          gene_symbol: r.geneSymbol,
+          median_tpm: r.median,
+          unit: r.unit
+        }))
+      }
+    }
+  },
+  {
+    id: 'gtex_eqtl_genes',
+    connector: 'expression',
+    description:
+      'All eGenes (genes with ≥1 significant cis-eQTL) for a tissue. Walked page-by-page and count-verified (e.g. Pancreas gtex_v8 = 9,660). max_genes caps how many rows are returned.',
+    input: {
+      type: 'object',
+      properties: {
+        tissue_site_detail_id: { type: 'string' },
+        max_genes: { type: 'integer' },
+        dataset_id: { type: 'string', default: DEFAULT_DATASET }
+      },
+      required: ['tissue_site_detail_id']
+    },
+    required: ['tissue_site_detail_id'],
+    returns:
+      '`{ "total": int, "returned": int, "truncated": bool, "genes": [ { "gencode_id": str, "gene_symbol": str, "empirical_p_value": float, "p_value": float, "p_value_threshold": float, "q_value": float, "log2_allelic_fold_change": float } ] }` — `total` is exact even when truncated by max_genes.',
+    example:
+      'result = host.mcp("expression", "gtex_eqtl_genes", {"tissue_site_detail_id": "Pancreas", "max_genes": 100})',
+    run: async (ctx, a) => {
+      const cap = a.max_genes != null ? Number(a.max_genes) : undefined
+      const base =
+        `${GTEX}/association/egene?datasetId=${encodeURIComponent(datasetOf(a))}` +
+        `&tissueSiteDetailId=${encodeURIComponent(String(a.tissue_site_detail_id))}`
+      const { rows, total, truncated } = await walkPages(ctx, base, cap)
+      return {
+        total,
+        returned: rows.length,
+        truncated,
+        genes: rows.map((r) => ({
+          gencode_id: r.gencodeId,
+          gene_symbol: r.geneSymbol,
+          empirical_p_value: r.empiricalPValue,
+          p_value: r.pValue,
+          p_value_threshold: r.pValueThreshold,
+          q_value: r.qValue,
+          log2_allelic_fold_change: r.log2AllelicFoldChange
+        }))
+      }
+    }
+  },
+  {
+    id: 'gtex_single_tissue_eqtls',
+    connector: 'expression',
+    description:
+      'Significant single-tissue cis-eQTL associations for a gene and/or a variant (precomputed). Provide gencode_id and/or variant_id; tissue_site_detail_id optionally narrows. Paged and count-verified.',
+    input: {
+      type: 'object',
+      properties: {
+        gencode_id: { type: 'string' },
+        variant_id: { type: 'string' },
+        tissue_site_detail_id: { type: 'string' },
+        max_results: { type: 'integer' },
+        dataset_id: { type: 'string', default: DEFAULT_DATASET }
+      }
+    },
+    returns:
+      '`{ "total": int, "returned": int, "truncated": bool, "eqtls": [ { "gencode_id": str, "gene_symbol": str, "variant_id": str, "snp_id": str, "chromosome": str, "pos": int, "tissue_site_detail_id": str, "p_value": float, "nes": float } ] }` — precomputed significant associations.',
+    example:
+      'result = host.mcp("expression", "gtex_single_tissue_eqtls", {"gencode_id": "ENSG00000111640.14"})',
+    run: async (ctx, a) => {
+      if (a.gencode_id == null && a.variant_id == null) {
+        throw new Error('gtex_single_tissue_eqtls requires gencode_id and/or variant_id')
+      }
+      const cap = a.max_results != null ? Number(a.max_results) : undefined
+      const base =
+        `${GTEX}/association/singleTissueEqtl?datasetId=${encodeURIComponent(datasetOf(a))}` +
+        (a.gencode_id ? `&gencodeId=${encodeURIComponent(String(a.gencode_id))}` : '') +
+        (a.variant_id ? `&variantId=${encodeURIComponent(String(a.variant_id))}` : '') +
+        (a.tissue_site_detail_id
+          ? `&tissueSiteDetailId=${encodeURIComponent(String(a.tissue_site_detail_id))}`
+          : '')
+      const { rows, total, truncated } = await walkPages(ctx, base, cap)
+      return {
+        total,
+        returned: rows.length,
+        truncated,
+        eqtls: rows.map((r) => ({
+          gencode_id: r.gencodeId,
+          gene_symbol: r.geneSymbol,
+          variant_id: r.variantId,
+          snp_id: r.snpId,
+          chromosome: r.chromosome,
+          pos: r.pos,
+          tissue_site_detail_id: r.tissueSiteDetailId,
+          p_value: r.pValue,
+          nes: r.nes
+        }))
+      }
+    }
+  },
+  {
+    id: 'gtex_multi_tissue_eqtls',
+    connector: 'expression',
+    description:
+      'Multi-tissue cis-eQTL meta-analysis (METASOFT) for a VERSIONED GENCODE id. variant_id optionally narrows to one variant. Returns per-variant rows with per-tissue m-values, NES, p-values, and SEs.',
+    input: {
+      type: 'object',
+      properties: {
+        gencode_id: { type: 'string' },
+        variant_id: { type: 'string' },
+        dataset_id: { type: 'string', default: DEFAULT_DATASET }
+      },
+      required: ['gencode_id']
+    },
+    required: ['gencode_id'],
+    returns:
+      '`{ "total": int, "returned": int, "variants": [ { "gencode_id": str, "variant_id": str, "meta_p": float, "tissues": { <tissue_site_detail_id>: { "m_value": float, "nes": float, "p_value": float, "se": float } } } ] }` — one row per variant tested for the gene; `total` is the variant count.',
+    example:
+      'result = host.mcp("expression", "gtex_multi_tissue_eqtls", {"gencode_id": "ENSG00000111640.14"})',
+    run: async (ctx, a) => {
+      const base =
+        `${GTEX}/association/metasoft?datasetId=${encodeURIComponent(datasetOf(a))}` +
+        `&gencodeId=${encodeURIComponent(String(a.gencode_id))}` +
+        (a.variant_id ? `&variantId=${encodeURIComponent(String(a.variant_id))}` : '')
+      const { rows, total } = await walkPages(ctx, base)
+      return {
+        total,
+        returned: rows.length,
+        variants: rows.map((r) => {
+          // Rename each per-tissue metric block from upstream camelCase to snake_case.
+          const tissuesRaw = (r.tissues ?? {}) as Record<string, Record<string, unknown>>
+          const tissues: Record<string, unknown> = {}
+          for (const [name, m] of Object.entries(tissuesRaw)) {
+            tissues[name] = { m_value: m.mValue, nes: m.nes, p_value: m.pValue, se: m.se }
+          }
+          return {
+            gencode_id: r.gencodeId,
+            variant_id: r.variantId,
+            meta_p: r.metaP,
+            tissues
+          }
+        })
+      }
+    }
+  },
+  {
+    id: 'gtex_calculate_eqtl',
+    connector: 'expression',
+    description:
+      'Calculate an eQTL on the fly for any gene-variant pair in one tissue, including non-significant pairs. Returns p-value, NES, t-statistic, MAF, and the per-sample genotype/expression arrays.',
+    input: {
+      type: 'object',
+      properties: {
+        gencode_id: { type: 'string' },
+        variant_id: { type: 'string' },
+        tissue_site_detail_id: { type: 'string' },
+        dataset_id: { type: 'string', default: DEFAULT_DATASET }
+      },
+      required: ['gencode_id', 'variant_id', 'tissue_site_detail_id']
+    },
+    required: ['gencode_id', 'variant_id', 'tissue_site_detail_id'],
+    returns:
+      '`{ "gencode_id": str, "gene_symbol": str, "variant_id": str, "tissue_site_detail_id": str, "p_value": float, "nes": float, "t_statistic": float, "maf": float, "hom_ref_count": int, "het_count": int, "hom_alt_count": int, "n_samples": int, "samples": [ { "genotype": float, "expression": float } ] }` — `samples` sorted by (genotype, expression).',
+    example:
+      'result = host.mcp("expression", "gtex_calculate_eqtl", {"gencode_id": "ENSG00000111640.14", "variant_id": "chr12_6452899_G_A_b38", "tissue_site_detail_id": "Whole_Blood"})',
+    url: (a) =>
+      `${GTEX}/association/dyneqtl?datasetId=${encodeURIComponent(datasetOf(a))}` +
+      `&gencodeId=${encodeURIComponent(String(a.gencode_id))}` +
+      `&variantId=${encodeURIComponent(String(a.variant_id))}` +
+      `&tissueSiteDetailId=${encodeURIComponent(String(a.tissue_site_detail_id))}`,
+    parse: (raw) => {
+      const d = raw as Record<string, unknown>
+      const genotypes = (d.genotypes as number[] | undefined) ?? []
+      const expression = (d.data as number[] | undefined) ?? []
+      // Upstream returns genotype/expression in random order; pair and sort deterministically.
+      const samples = genotypes
+        .map((genotype, i) => ({ genotype, expression: expression[i] }))
+        .sort((x, y) => x.genotype - y.genotype || x.expression - y.expression)
+      return {
+        gencode_id: d.gencodeId,
+        gene_symbol: d.geneSymbol,
+        variant_id: d.variantId,
+        tissue_site_detail_id: d.tissueSiteDetailId,
+        p_value: d.pValue,
+        nes: d.nes,
+        t_statistic: d.tStatistic,
+        maf: d.maf,
+        hom_ref_count: d.homoRefCount,
+        het_count: d.hetCount,
+        hom_alt_count: d.homoAltCount,
+        n_samples: samples.length,
+        samples
+      }
+    }
   }
 ]


### PR DESCRIPTION
Rounds out the Expression connector to the full GTEx v2 workflow: tissue /
dataset / sample metadata, gene resolution to versioned GENCODE ids, median and
sample-level expression, API-side top-expressed ranking, and the cis-eQTL family
(eGenes, single/multi-tissue, on-the-fly).

Paged routes are walked to a count-verified total with truncation flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)