### PR TITLE
feat(connectors): expand the Clinical Genomics connector capabilities

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -93,10 +93,11 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
   {
     id: 'clinical_genomics',
     displayName: 'Clinical Genomics',
-    description: 'Target-disease associations and drug mechanisms via Open Targets.',
+    description:
+      'Clinical genomics knowledge bases: ClinGen curations, CIViC clinical evidence, and the Open Targets Platform.',
     useWhen:
-      "Use when you need target-disease association scores for a gene (which diseases are most linked to a target), or a drug's mechanism of action and clinical indications by ChEMBL id. Sourced from the Open Targets Platform.",
-    sources: ['Open Targets'],
+      "Use when you need clinical interpretation of genes and variants — ClinGen gene-disease validity, dosage sensitivity, clinical actionability, and expert-panel (VCEP) variant pathogenicity classifications; CIViC clinical evidence, assertions, molecular profiles, diseases, and therapies for a gene or variant in cancer; or Open Targets target-disease association scores, a disease's known drugs/associated targets, a drug's mechanism of action, and arbitrary Open Targets GraphQL. Sourced from ClinGen, CIViC, and the Open Targets Platform.",
+    sources: ['ClinGen', 'CIViC', 'Open Targets'],
     termsUrl: 'https://platform-docs.opentargets.org/licence',
     requiresNcbi: false
   },

--- a/src/main/connectors/descriptors/clinical-genomics.test.ts
+++ b/src/main/connectors/descriptors/clinical-genomics.test.ts
@@ -1,291 +1,537 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ParserEngine } from '../engine'
 import { CLINICAL_GENOMICS_TOOLS } from './clinical-genomics'
+import type { ToolDescriptor } from '../types'
 
+const tool = (id: string): ToolDescriptor => CLINICAL_GENOMICS_TOOLS.find((t) => t.id === id)!
 const jsonRes = (body: unknown): Response =>
   ({ ok: true, status: 200, json: async () => body }) as Response
+// Parse the JSON body of the nth fetch call (POST connectors send {query, variables}).
+const bodyOf = (
+  fetchImpl: ReturnType<typeof vi.fn>,
+  i = 0
+): { query: string; variables: unknown } =>
+  JSON.parse((fetchImpl.mock.calls[i][1] as RequestInit).body as string)
 
-const OT_API = 'https://api.platform.opentargets.org/api/v4/graphql'
+describe('clinical_genomics — has exactly the 20 upstream tools', () => {
+  it('exposes the ClinGen + CIViC + Open Targets ids', () => {
+    expect(CLINICAL_GENOMICS_TOOLS.map((t) => t.id).sort()).toEqual(
+      [
+        'clingen_actionability',
+        'clingen_dosage_sensitivity',
+        'clingen_gene_validity',
+        'clingen_variant_classifications',
+        'civic_gene_variants',
+        'civic_get_assertion',
+        'civic_get_evidence_item',
+        'civic_get_molecular_profile',
+        'civic_get_variant',
+        'civic_search_assertions',
+        'civic_search_diseases',
+        'civic_search_evidence',
+        'civic_search_genes',
+        'civic_search_molecular_profiles',
+        'civic_search_therapies',
+        'civic_search_variants',
+        'open_targets_disease_drugs',
+        'open_targets_disease_targets',
+        'open_targets_drug',
+        'open_targets_graphql'
+      ].sort()
+    )
+    expect(CLINICAL_GENOMICS_TOOLS.every((t) => t.connector === 'clinical_genomics')).toBe(true)
+    expect(CLINICAL_GENOMICS_TOOLS.every((t) => t.returns && t.example)).toBeTruthy()
+  })
+})
 
-describe('clinical-genomics (Open Targets)', () => {
-  describe('opentargets_target_diseases', () => {
-    const tool = CLINICAL_GENOMICS_TOOLS.find((t) => t.id === 'opentargets_target_diseases')!
-
-    it('resolves a gene symbol via search, then POSTs the target diseases query', async () => {
-      const fetchImpl = vi
-        .fn()
-        .mockResolvedValueOnce(
-          jsonRes({
-            data: {
-              search: {
-                hits: [
-                  { id: 'ENSG00000224057', entity: 'target', name: 'EGFR-AS1' },
-                  { id: 'ENSG00000146648', entity: 'target', name: 'EGFR' }
-                ]
-              }
-            }
-          })
-        )
-        .mockResolvedValueOnce(
-          jsonRes({
-            data: {
-              target: {
-                id: 'ENSG00000146648',
-                approvedSymbol: 'EGFR',
-                approvedName: 'epidermal growth factor receptor',
-                associatedDiseases: {
-                  count: 6459,
-                  rows: [
-                    {
-                      score: 0.8525670184292347,
-                      disease: { id: 'MONDO_0005233', name: 'non-small cell lung carcinoma' }
-                    },
-                    {
-                      score: 0.7744435748658476,
-                      disease: { id: 'MONDO_0005061', name: 'lung adenocarcinoma' }
-                    }
-                  ]
-                }
-              }
-            }
-          })
-        )
-
-      const out = (await new ParserEngine({ fetchImpl }).call(tool, { gene: 'EGFR' }, {})) as {
-        gene_id: string
-        symbol: string
-        approved_name: string
-        n_diseases_total: number
-        returned: number
-        diseases: Array<{ disease_id: string; disease_name: string; score: number }>
-      }
-
-      expect(fetchImpl).toHaveBeenCalledTimes(2)
-      const [searchUrl, searchInit] = fetchImpl.mock.calls[0] as [string, RequestInit]
-      expect(searchUrl).toBe(OT_API)
-      const searchBody = JSON.parse(searchInit.body as string) as {
-        query: string
-        variables: unknown
-      }
-      expect(searchBody.query).toContain('search(queryString: $q')
-      expect(searchBody.variables).toEqual({ q: 'EGFR' })
-
-      const [diseasesUrl, diseasesInit] = fetchImpl.mock.calls[1] as [string, RequestInit]
-      expect(diseasesUrl).toBe(OT_API)
-      const diseasesBody = JSON.parse(diseasesInit.body as string) as {
-        query: string
-        variables: unknown
-      }
-      expect(diseasesBody.query).toContain('target(ensemblId: $ensemblId)')
-      expect(diseasesBody.query).toContain('associatedDiseases(page: { size: $size, index: 0 })')
-      // Picks the exact-name hit ("EGFR"), not the first hit ("EGFR-AS1").
-      expect(diseasesBody.variables).toEqual({ ensemblId: 'ENSG00000146648', size: 10 })
-
-      expect(out.gene_id).toBe('ENSG00000146648')
-      expect(out.symbol).toBe('EGFR')
-      expect(out.approved_name).toBe('epidermal growth factor receptor')
-      expect(out.n_diseases_total).toBe(6459)
-      expect(out.returned).toBe(2)
-      expect(out.diseases).toEqual([
-        {
-          disease_id: 'MONDO_0005233',
-          disease_name: 'non-small cell lung carcinoma',
-          score: 0.8525670184292347
-        },
-        {
-          disease_id: 'MONDO_0005061',
-          disease_name: 'lung adenocarcinoma',
-          score: 0.7744435748658476
-        }
-      ])
+describe('clinical_genomics — ClinGen', () => {
+  it('clingen_gene_validity verifies count, maps + filters + sorts records', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        total: 2,
+        rows: [
+          {
+            symbol: 'BRCA2',
+            hgnc_id: 'HGNC:1101',
+            disease_name: 'Fanconi anemia  ',
+            mondo: 'MONDO:0019391',
+            moi: 'AR',
+            sop: 'SOP8',
+            classification: 'Definitive ',
+            ep: 'Hereditary Breast/Ovarian Cancer VCEP',
+            affiliate_id: '40023',
+            animal_model_only: 0,
+            perm_id: 'CGGV:assertion_x',
+            date: '2020-01-01'
+          },
+          { symbol: 'TP53', hgnc_id: 'HGNC:11998', classification: 'Definitive', perm_id: 'y' }
+        ]
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('clingen_gene_validity'),
+      { gene: 'brca2' },
+      {}
+    )) as { total: number; records: Array<Record<string, unknown>>; source: string }
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://search.clinicalgenome.org/api/validity')
+    expect(out.total).toBe(1)
+    expect(out.records[0]).toEqual({
+      gene_symbol: 'BRCA2',
+      hgnc_id: 'HGNC:1101',
+      disease_label: 'Fanconi anemia',
+      mondo_id: 'MONDO:0019391',
+      moi: 'AR',
+      sop: 'SOP8',
+      classification: 'Definitive',
+      expert_panel: 'Hereditary Breast/Ovarian Cancer VCEP',
+      affiliate_id: '40023',
+      animal_model_only: false,
+      assertion_id: 'CGGV:assertion_x'
     })
+    expect(out.source).toContain('search.clinicalgenome.org/api/validity')
+  })
 
-    it('skips the search round-trip when given an Ensembl gene id directly', async () => {
-      const fetchImpl = vi.fn().mockResolvedValueOnce(
-        jsonRes({
-          data: {
-            target: {
-              id: 'ENSG00000146648',
-              approvedSymbol: 'EGFR',
-              associatedDiseases: {
-                count: 1,
-                rows: [{ score: 0.5, disease: { id: 'D1', name: 'disease one' } }]
-              }
-            }
+  it('clingen_gene_validity throws on a total/rows count mismatch', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ total: 5, rows: [{ symbol: 'A' }] }))
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('clingen_gene_validity'), {}, {})
+    ).rejects.toThrow(/count mismatch/)
+  })
+
+  it('clingen_dosage_sensitivity excludes regions by default and normalizes assertions', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        total: 2,
+        rows: [
+          {
+            symbol: 'A4GALT',
+            hgnc_id: 'HGNC:18149',
+            type: 0,
+            location: '22q13.2',
+            grch37: 'chr22:1-2',
+            grch38: 'chr22:3-4',
+            haplo_assertion: 30,
+            triplo_assertion: 0,
+            omim: 'Yes',
+            morbid: 'Yes'
+          },
+          {
+            symbol: '2p11.2 recurrent region',
+            hgnc_id: 'ISCA-46754',
+            type: 1,
+            haplo_assertion: '0',
+            triplo_assertion: '0'
           }
-        })
-      )
-      await new ParserEngine({ fetchImpl }).call(tool, { gene: 'ENSG00000146648' }, {})
-
-      expect(fetchImpl).toHaveBeenCalledTimes(1)
-      const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
-      const body = JSON.parse(init.body as string) as { variables: { ensemblId: string } }
-      expect(body.variables.ensemblId).toBe('ENSG00000146648')
+        ]
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('clingen_dosage_sensitivity'),
+      {},
+      {}
+    )) as { total: number; records: Array<Record<string, unknown>> }
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://search.clinicalgenome.org/api/dosage')
+    expect(out.total).toBe(1)
+    expect(out.records[0].record_type).toBe('gene')
+    expect(out.records[0].haploinsufficiency).toEqual({
+      code: '30',
+      label: 'Gene Associated with Autosomal Recessive Phenotype'
     })
+    expect(out.records[0].triplosensitivity).toEqual({ code: '0', label: 'No Evidence' })
+  })
 
-    it('honors an explicit limit as the GraphQL page size', async () => {
-      const fetchImpl = vi
-        .fn()
-        .mockResolvedValueOnce(
-          jsonRes({ data: { target: { id: 'ENSG1', associatedDiseases: { count: 0, rows: [] } } } })
-        )
-      await new ParserEngine({ fetchImpl }).call(tool, { gene: 'ENSG00000146648', limit: 3 }, {})
-      const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
-      const body = JSON.parse(init.body as string) as { variables: { size: number } }
-      expect(body.variables.size).toBe(3)
-    })
-
-    it('returns an empty compact result when the search finds no target hits', async () => {
-      const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ data: { search: { hits: [] } } }))
-      const out = (await new ParserEngine({ fetchImpl }).call(tool, { gene: 'NOPEGENE' }, {})) as {
-        gene: string
-        gene_id: null
-        n_diseases_total: number
-        diseases: unknown[]
-      }
-      expect(fetchImpl).toHaveBeenCalledTimes(1)
-      expect(out.gene).toBe('NOPEGENE')
-      expect(out.gene_id).toBeNull()
-      expect(out.n_diseases_total).toBe(0)
-      expect(out.diseases).toEqual([])
-    })
-
-    it('returns an empty compact result when the target itself is absent (data null)', async () => {
-      const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ data: { target: null } }))
-      const out = (await new ParserEngine({ fetchImpl }).call(
-        tool,
-        { gene: 'ENSG00000000000' },
-        {}
-      )) as { gene_id: string; n_diseases_total: number; diseases: unknown[] }
-      expect(out.gene_id).toBe('ENSG00000000000')
-      expect(out.n_diseases_total).toBe(0)
-      expect(out.diseases).toEqual([])
-    })
-
-    it('throws on a GraphQL error from the target diseases query', async () => {
-      const fetchImpl = vi
-        .fn()
-        .mockResolvedValueOnce(jsonRes({ errors: [{ message: "Cannot query field 'nope'" }] }))
-      await expect(
-        new ParserEngine({ fetchImpl }).call(tool, { gene: 'ENSG00000146648' }, {})
-      ).rejects.toThrow(/Cannot query field/)
+  it('clingen_dosage_sensitivity include_regions keeps ISCA region records', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        total: 1,
+        rows: [{ symbol: 'reg', hgnc_id: 'ISCA-1', type: 1, haplo_assertion: '40: x' }]
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('clingen_dosage_sensitivity'),
+      { include_regions: true },
+      {}
+    )) as { total: number; records: Array<Record<string, unknown>> }
+    expect(out.total).toBe(1)
+    expect(out.records[0].record_type).toBe('region')
+    expect(out.records[0].haploinsufficiency).toEqual({
+      code: '40',
+      label: 'Dosage Sensitivity Unlikely'
     })
   })
 
-  describe('opentargets_drug', () => {
-    const tool = CLINICAL_GENOMICS_TOOLS.find((t) => t.id === 'opentargets_drug')!
+  it('clingen_actionability fetches both contexts and filters multi-gene topics', async () => {
+    const table = (ctx: string): unknown => ({
+      columns: [
+        'docId',
+        'context',
+        'geneOrVariant',
+        'disease',
+        'outcome',
+        'intervention',
+        'overall'
+      ],
+      rows: [['AC001', ctx, 'BRCA1, BRCA2', 'HBOC', 'Cancer', 'Surveillance', '10CC']]
+    })
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation((url: string) =>
+        Promise.resolve(jsonRes(url.includes('/Adult/') ? table('Adult') : table('Pediatric')))
+      )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('clingen_actionability'),
+      { gene: 'brca2', context: 'both' },
+      {}
+    )) as Record<string, { total: number; records: Array<Record<string, unknown>> }> & {
+      source: string
+    }
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://actionability.clinicalgenome.org/ac/Adult/api/summ?flavor=flat'
+    )
+    expect(fetchImpl.mock.calls[1][0]).toBe(
+      'https://actionability.clinicalgenome.org/ac/Pediatric/api/summ?flavor=flat'
+    )
+    expect(out.adult.total).toBe(1)
+    expect(out.adult.records[0].genes).toEqual(['BRCA1', 'BRCA2'])
+    expect(out.adult.records[0].overall_score).toBe('10CC')
+    expect(out.pediatric.total).toBe(1)
+    expect(out.source).toContain('actionability.clinicalgenome.org')
+  })
 
-    it('POSTs the chembl id and parses mechanism of action + indications, capped to limit', async () => {
-      const fetchImpl = vi.fn().mockResolvedValueOnce(
-        jsonRes({
-          data: {
-            drug: {
-              id: 'CHEMBL1201583',
-              name: 'BEVACIZUMAB',
-              drugType: 'Antibody',
-              maximumClinicalStage: 'APPROVAL',
-              mechanismsOfAction: {
-                rows: [
+  it('clingen_variant_classifications builds the ERepo URL and maps guidelines/agents', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        variantInterpretations: [
+          {
+            '@id': 'https://erepo.genome.network/.../092',
+            uuid: 'u1',
+            caid: 'CAR:CA000895',
+            variationId: '13961',
+            gene: { label: 'BRCA1', NCBI_id: '672' },
+            condition: { '@id': 'MONDO:0011450', label: 'BRCA1-related cancer' },
+            hgvs: ['b', 'a'],
+            evidenceLinks: [],
+            publishedDate: '2023-10',
+            guidelines: [
+              {
+                '@id': 'GN092',
+                label: 'ENIGMA',
+                outcome: { label: 'Pathogenic' },
+                agents: [
                   {
-                    mechanismOfAction: 'Vascular endothelial growth factor A inhibitor',
-                    actionType: 'INHIBITOR',
-                    targets: [{ id: 'ENSG00000112715', approvedSymbol: 'VEGFA' }]
-                  }
-                ]
-              },
-              indications: {
-                count: 275,
-                rows: [
-                  {
-                    disease: { id: 'MONDO_0005401', name: 'colonic neoplasm' },
-                    maxClinicalStage: 'APPROVAL'
-                  },
-                  {
-                    disease: { id: 'MONDO_0007254', name: 'breast cancer' },
-                    maxClinicalStage: 'APPROVAL'
-                  },
-                  {
-                    disease: { id: 'MONDO_0021211', name: 'brain neoplasm' },
-                    maxClinicalStage: 'PHASE_2'
+                    '@id': 'AG1',
+                    affiliation: 'ENIGMA VCEP',
+                    outcome: { label: 'Pathogenic' },
+                    evidenceCodes: [
+                      { label: 'PVS1', status: 'Met' },
+                      { label: 'PM2', status: 'Not Met' }
+                    ]
                   }
                 ]
               }
+            ]
+          }
+        ]
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('clingen_variant_classifications'),
+      { gene: 'BRCA1' },
+      {}
+    )) as { total: number; records: Array<Record<string, unknown>>; query: unknown }
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://erepo.genome.network/evrepo/api/classifications?gene=BRCA1&matchMode=exact&matchLimit=none'
+    )
+    expect(out.total).toBe(1)
+    expect(out.query).toEqual({ gene: 'BRCA1' })
+    const rec = out.records[0]
+    expect(rec.caid).toBe('CAR:CA000895')
+    expect(rec.hgvs).toEqual(['a', 'b'])
+    const guidelines = rec.guidelines as Array<Record<string, unknown>>
+    const agent = (guidelines[0].agents as Array<Record<string, unknown>>)[0]
+    expect(agent.evidence_codes_met).toEqual(['PVS1'])
+    expect(agent.evidence_codes_not_met).toEqual(['PM2'])
+  })
+
+  it('clingen_variant_classifications requires exactly one of gene/caid/hgvs', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('clingen_variant_classifications'), {}, {})
+    ).rejects.toThrow(/exactly one/)
+    await expect(
+      new ParserEngine({ fetchImpl }).call(
+        tool('clingen_variant_classifications'),
+        { gene: 'A', caid: 'B' },
+        {}
+      )
+    ).rejects.toThrow(/exactly one/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('clinical_genomics — CIViC', () => {
+  it('civic_search_genes posts the entrezSymbols query and sorts aliases', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        data: {
+          conn: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: 'MQ' },
+            nodes: [
+              {
+                id: 5,
+                name: 'BRAF',
+                entrezId: 673,
+                fullName: 'B-Raf',
+                featureAliases: ['RAFB1', 'B-RAF1'],
+                description: 'd',
+                link: '/features/5'
+              }
+            ]
+          }
+        }
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('civic_search_genes'),
+      { entrez_symbol: 'BRAF' },
+      {}
+    )) as {
+      total_count: number
+      pages_fetched: number
+      records: Array<Record<string, unknown>>
+      query: unknown
+    }
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://civicdb.org/api/graphql')
+    const body = bodyOf(fetchImpl)
+    expect(body.query).toContain('entrezSymbols: $sym')
+    expect(body.variables).toMatchObject({ sym: ['BRAF'], first: 100, after: null })
+    expect(out.total_count).toBe(1)
+    expect(out.pages_fetched).toBe(1)
+    expect(out.records[0].featureAliases).toEqual(['B-RAF1', 'RAFB1'])
+    expect(out.query).toEqual({ mode: 'search_genes', entrez_symbol: 'BRAF' })
+  })
+
+  it('civic_search_diseases walks cursor pagination to completion and sorts by id', async () => {
+    const node = (id: number): Record<string, unknown> => ({
+      id,
+      name: `D${id}`,
+      displayName: `D${id}`,
+      doid: `${id}`,
+      diseaseUrl: '',
+      diseaseAliases: [],
+      link: `/diseases/${id}`
+    })
+    const fetchImpl = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      const vars = JSON.parse(init.body as string).variables as { after: string | null }
+      if (!vars.after) {
+        return Promise.resolve(
+          jsonRes({
+            data: {
+              conn: {
+                totalCount: 3,
+                pageInfo: { hasNextPage: true, endCursor: 'C1' },
+                nodes: [node(2), node(1)]
+              }
+            }
+          })
+        )
+      }
+      return Promise.resolve(
+        jsonRes({
+          data: {
+            conn: {
+              totalCount: 3,
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [node(3)]
             }
           }
         })
       )
+    })
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('civic_search_diseases'),
+      { name: 'melanoma' },
+      {}
+    )) as { total_count: number; pages_fetched: number; records: Array<Record<string, unknown>> }
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(bodyOf(fetchImpl, 1).variables).toMatchObject({ after: 'C1' })
+    expect(out.total_count).toBe(3)
+    expect(out.pages_fetched).toBe(2)
+    expect(out.records.map((r) => r.id)).toEqual([1, 2, 3])
+  })
 
-      const out = (await new ParserEngine({ fetchImpl }).call(
-        tool,
-        { chembl_id: 'CHEMBL1201583', limit: 2 },
-        {}
-      )) as {
-        chembl_id: string
-        name: string
-        drug_type: string
-        max_clinical_stage: string
-        mechanisms_of_action: Array<{
-          mechanism_of_action: string
-          action_type: string
-          targets: Array<{ id: string; approved_symbol: string }>
-        }>
-        n_indications_total: number
-        returned_indications: number
-        indications: Array<{ disease_id: string; disease_name: string; max_clinical_stage: string }>
-      }
-
-      const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
-      expect(url).toBe(OT_API)
-      const body = JSON.parse(init.body as string) as { query: string; variables: unknown }
-      expect(body.query).toContain('drug(chemblId: $chemblId)')
-      expect(body.query).toContain('maxClinicalStage')
-      expect(body.variables).toEqual({ chemblId: 'CHEMBL1201583' })
-
-      expect(out.chembl_id).toBe('CHEMBL1201583')
-      expect(out.name).toBe('BEVACIZUMAB')
-      expect(out.drug_type).toBe('Antibody')
-      expect(out.max_clinical_stage).toBe('APPROVAL')
-      expect(out.mechanisms_of_action).toEqual([
-        {
-          mechanism_of_action: 'Vascular endothelial growth factor A inhibitor',
-          action_type: 'INHIBITOR',
-          targets: [{ id: 'ENSG00000112715', approved_symbol: 'VEGFA' }]
+  it('civic paged walk throws when the retrieved count != totalCount', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        data: {
+          conn: {
+            totalCount: 9,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ id: 1 }]
+          }
         }
-      ])
-      expect(out.n_indications_total).toBe(275)
-      expect(out.returned_indications).toBe(2)
-      expect(out.indications).toEqual([
-        {
-          disease_id: 'MONDO_0005401',
-          disease_name: 'colonic neoplasm',
-          max_clinical_stage: 'APPROVAL'
-        },
-        {
-          disease_id: 'MONDO_0007254',
-          disease_name: 'breast cancer',
-          max_clinical_stage: 'APPROVAL'
+      })
+    )
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('civic_search_diseases'), { name: 'x' }, {})
+    ).rejects.toThrow(/retrieved 1 nodes but totalCount=9/)
+  })
+
+  it('civic_get_variant returns found/record for a hit', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        jsonRes({ data: { node: { id: 12, name: 'V600E', variantAliases: ['b', 'a'] } } })
+      )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('civic_get_variant'),
+      { variant_id: 12 },
+      {}
+    )) as { query: unknown; found: boolean; record: Record<string, unknown> }
+    expect(bodyOf(fetchImpl).variables).toEqual({ id: 12 })
+    expect(out.query).toEqual({ mode: 'variant', id: 12 })
+    expect(out.found).toBe(true)
+    expect(out.record.variantAliases).toEqual(['a', 'b'])
+  })
+
+  it('civic_get_evidence_item returns found=false when the node is null', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ data: { node: null } }))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('civic_get_evidence_item'),
+      { evidence_id: 999999 },
+      {}
+    )) as { found: boolean; record: unknown }
+    expect(out.found).toBe(false)
+    expect(out.record).toBeNull()
+  })
+
+  it('civic_search_evidence encodes only provided filters + the ID ASC sort', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        data: {
+          conn: { totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] }
         }
-      ])
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('civic_search_evidence'),
+      { disease_name: 'melanoma', evidence_level: 'A' },
+      {}
+    )) as { query: { mode: string; filters: unknown } }
+    const body = bodyOf(fetchImpl)
+    expect(body.query).toContain('$f_diseaseName: String')
+    expect(body.query).toContain('diseaseName: $f_diseaseName')
+    expect(body.query).toContain('$f_evidenceLevel: EvidenceLevel')
+    expect(body.query).toContain('sortBy: $sb')
+    expect(body.query).not.toContain('therapyName')
+    expect(body.variables).toMatchObject({
+      f_diseaseName: 'melanoma',
+      f_evidenceLevel: 'A',
+      sb: { column: 'ID', direction: 'ASC' }
     })
+    expect(out.query).toEqual({
+      mode: 'search_evidence',
+      filters: { disease_name: 'melanoma', evidence_level: 'A' }
+    })
+  })
 
-    it('returns found=false when the drug is absent (data null)', async () => {
-      const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ data: { drug: null } }))
-      const out = (await new ParserEngine({ fetchImpl }).call(
-        tool,
-        { chembl_id: 'CHEMBL_NOPE' },
-        {}
-      )) as { chembl_id: string; found: boolean }
-      expect(out.chembl_id).toBe('CHEMBL_NOPE')
-      expect(out.found).toBe(false)
-    })
+  it('civic_get_variant surfaces GraphQL errors instead of silently returning null', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ errors: [{ message: 'bad field' }] }))
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('civic_get_variant'), { variant_id: 1 }, {})
+    ).rejects.toThrow(/CIViC GraphQL error/)
+  })
+})
 
-    it('throws on a GraphQL error from the drug query', async () => {
-      const fetchImpl = vi
-        .fn()
-        .mockResolvedValueOnce(jsonRes({ errors: [{ message: 'Internal server error' }] }))
-      await expect(
-        new ParserEngine({ fetchImpl }).call(tool, { chembl_id: 'CHEMBL1201583' }, {})
-      ).rejects.toThrow(/Internal server error/)
-    })
+describe('clinical_genomics — Open Targets', () => {
+  it('open_targets_graphql passes query+variables through and returns {data, attempts}', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ data: { target: { approvedSymbol: 'TP53' } } }))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('open_targets_graphql'),
+      {
+        query: 'query($id: String!){ target(ensemblId: $id){ approvedSymbol } }',
+        variables: { id: 'ENSG00000141510' }
+      },
+      {}
+    )) as { data: unknown; attempts: number }
+    const body = bodyOf(fetchImpl)
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://api.platform.opentargets.org/api/v4/graphql')
+    expect(body.variables).toEqual({ id: 'ENSG00000141510' })
+    expect(out.data).toEqual({ target: { approvedSymbol: 'TP53' } })
+    expect(out.attempts).toBe(1)
+  })
+
+  it('open_targets_graphql retries the transient HTTP-200 internal-server error', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ errors: [{ message: 'Internal server error' }] }))
+      .mockResolvedValueOnce(jsonRes({ data: { target: { approvedSymbol: 'BRAF' } } }))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('open_targets_graphql'),
+      { query: '{ target(ensemblId: "x"){ approvedSymbol } }' },
+      {}
+    )) as { data: unknown; attempts: number; errors?: unknown }
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(out.attempts).toBe(2)
+    expect(out.errors).toBeUndefined()
+    expect(out.data).toEqual({ target: { approvedSymbol: 'BRAF' } })
+  })
+
+  it('open_targets_disease_targets returns the disease node with the size variable', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        data: {
+          disease: {
+            id: 'MONDO_0004992',
+            name: 'cancer',
+            associatedTargets: {
+              count: 22581,
+              rows: [{ score: 0.94, target: { id: 'ENSG00000139618', approvedSymbol: 'BRCA2' } }]
+            }
+          }
+        }
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('open_targets_disease_targets'),
+      { efo_id: 'MONDO_0004992', size: 3 },
+      {}
+    )) as Record<string, unknown>
+    expect(bodyOf(fetchImpl).variables).toEqual({ id: 'MONDO_0004992', size: 3 })
+    expect(out.id).toBe('MONDO_0004992')
+    expect((out.associatedTargets as { count: number }).count).toBe(22581)
+  })
+
+  it('open_targets_disease_drugs slices rows to size', async () => {
+    const rows = [1, 2, 3, 4].map((n) => ({
+      id: `r${n}`,
+      maxClinicalStage: 'Phase III',
+      drug: { id: `d${n}`, name: `D${n}`, drugType: 'x' }
+    }))
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        data: { disease: { id: 'E', name: 'e', drugAndClinicalCandidates: { count: 4, rows } } }
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('open_targets_disease_drugs'),
+      { efo_id: 'E', size: 2 },
+      {}
+    )) as { drugAndClinicalCandidates: { count: number; rows: unknown[] } }
+    expect(out.drugAndClinicalCandidates.count).toBe(4)
+    expect(out.drugAndClinicalCandidates.rows).toHaveLength(2)
+  })
+
+  it('open_targets_drug returns {errors} when the drug is unknown (null root)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ data: { drug: null } }))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('open_targets_drug'),
+      { chembl_id: 'CHEMBL_NOPE' },
+      {}
+    )) as { errors: unknown }
+    expect(Array.isArray(out.errors)).toBe(true)
   })
 })

--- a/src/main/connectors/descriptors/clinical-genomics.ts
+++ b/src/main/connectors/descriptors/clinical-genomics.ts
@@ -1,246 +1,1121 @@
-import type { ToolDescriptor } from '../types'
+import type { ToolContext, ToolDescriptor } from '../types'
 
-const OPEN_TARGETS_API = 'https://api.platform.opentargets.org/api/v4/graphql'
-// Top disease/indication rows can run into the hundreds — bound the response like gnomad's
-// variant limit, rather than returning every row unbounded.
-const DEFAULT_LIMIT = 10
+// Three clinical-genomics knowledge bases behind one connector (faithful port of the upstream
+// mcp-clinical-genomics server): ClinGen curations (REST), CIViC clinical evidence (GraphQL, fully
+// paginated + count-verified), and the Open Targets Platform GraphQL API. All tools are read-only.
+const CLINGEN_SEARCH = 'https://search.clinicalgenome.org'
+const CLINGEN_ACTIONABILITY = 'https://actionability.clinicalgenome.org'
+const CLINGEN_EREPO = 'https://erepo.genome.network/evrepo/api'
+const CIVIC_API = 'https://civicdb.org/api/graphql'
+const OT_API = 'https://api.platform.opentargets.org/api/v4/graphql'
 
-// Resolves a free-text gene symbol to an Ensembl target id via the platform's cross-entity
-// search (transcribed from the upstream open_targets_graphql docstring example query shape).
-const SEARCH_TARGET_QUERY = `
-query SearchTarget($q: String!) {
-  search(queryString: $q, entityNames: ["target"]) {
-    hits { id entity name }
+// ---------------------------------------------------------------------------
+// Small shared helpers
+// ---------------------------------------------------------------------------
+
+// Coerce an unknown into a plain object / array so record extractors can index it without casts.
+const asObj = (x: unknown): Record<string, unknown> =>
+  x !== null && typeof x === 'object' && !Array.isArray(x) ? (x as Record<string, unknown>) : {}
+const asArr = (x: unknown): unknown[] => (Array.isArray(x) ? x : [])
+
+// Null-safe string comparator; drives the tuple sorts that mirror the upstream's `sorted(key=...)`.
+function strCmp(a: unknown, b: unknown): number {
+  const x = a == null ? '' : String(a)
+  const y = b == null ? '' : String(b)
+  return x < y ? -1 : x > y ? 1 : 0
+}
+
+// Build a lexicographic comparator over one or more string-valued getters (upstream sort keys).
+function byKeys(
+  ...getters: ((r: Record<string, unknown>) => unknown)[]
+): (a: Record<string, unknown>, b: Record<string, unknown>) => number {
+  return (a, b) => {
+    for (const g of getters) {
+      const c = strCmp(g(a), g(b))
+      if (c) return c
+    }
+    return 0
   }
 }
-`
 
-// Transcribed from the upstream mcp_clinical_genomics open_targets_graphql docstring example
-// (target(ensemblId:$id){approvedSymbol associatedDiseases{count}}), extended with the disease
-// rows/score fields symmetric to the upstream open_targets_disease_targets query.
-const TARGET_DISEASES_QUERY = `
-query TargetDiseases($ensemblId: String!, $size: Int!) {
-  target(ensemblId: $ensemblId) {
-    id
-    approvedSymbol
-    approvedName
-    associatedDiseases(page: { size: $size, index: 0 }) {
+// ---------------------------------------------------------------------------
+// ClinGen record extractors (port of clingen_curations/records.py)
+// ---------------------------------------------------------------------------
+
+// Numeric dosage assertion codes -> human labels (verified against the ClinGen dosage CSVs).
+const DOSAGE_ASSERTION_LABELS: Record<string, string> = {
+  '0': 'No Evidence',
+  '1': 'Little Evidence',
+  '2': 'Emerging Evidence',
+  '3': 'Sufficient Evidence',
+  '30': 'Gene Associated with Autosomal Recessive Phenotype',
+  '40': 'Dosage Sensitivity Unlikely',
+  '-5': 'Not yet evaluated'
+}
+
+// Normalize a raw haplo/triplo assertion (int, digit string, "40: ...", "Not yet evaluated", null)
+// to {code, label}; keep the raw text as the label for any code we don't recognise.
+function normalizeDosageAssertion(value: unknown): { code: string; label: string } | null {
+  if (value == null) return null
+  const s = String(value).trim()
+  if (!s) return null
+  const code = s === 'Not yet evaluated' ? '-5' : s.split(':')[0].trim()
+  const label = DOSAGE_ASSERTION_LABELS[code]
+  return label === undefined ? { code, label: s } : { code, label }
+}
+
+// Stable record from one /api/validity row (volatile date/order/report bookkeeping dropped).
+function validityRecord(row: Record<string, unknown>): Record<string, unknown> {
+  return {
+    gene_symbol: row.symbol,
+    hgnc_id: row.hgnc_id,
+    disease_label: String(row.disease_name ?? '').trim(),
+    mondo_id: row.mondo ?? null,
+    moi: row.moi ?? null,
+    sop: row.sop ?? null,
+    classification: String(row.classification ?? '').trim(),
+    expert_panel: String(row.ep ?? '').trim(),
+    affiliate_id: row.affiliate_id ?? null,
+    animal_model_only: Boolean(row.animal_model_only),
+    assertion_id: row.perm_id ?? null
+  }
+}
+
+// Stable record from one /api/dosage row (external computed scores + history/date fields dropped).
+function dosageRecord(row: Record<string, unknown>): Record<string, unknown> {
+  const isRegion = row.type === 1
+  return {
+    record_type: isRegion ? 'region' : 'gene',
+    symbol: String(row.symbol ?? '').trim(),
+    id: row.hgnc_id ?? null, // HGNC:n for genes, ISCA-n for regions
+    cytoband: row.location ?? null,
+    grch37: row.grch37 ?? null,
+    grch38: row.grch38 ?? null,
+    haploinsufficiency: normalizeDosageAssertion(row.haplo_assertion),
+    triplosensitivity: normalizeDosageAssertion(row.triplo_assertion),
+    haplo_disease: row.haplo_disease ?? null,
+    haplo_mondo: row.haplo_mondo ?? null,
+    triplo_disease: row.triplo_disease ?? null,
+    triplo_mondo: row.triplo_mondo ?? null,
+    omim: row.omim ?? null,
+    morbid: row.morbid ?? null
+  }
+}
+
+// Stable record from one actionability flat-table row (dict(zip(columns, row)) minus bookkeeping).
+function actionabilityRecord(columns: string[], row: unknown[]): Record<string, unknown> {
+  const d: Record<string, unknown> = {}
+  columns.forEach((c, i) => (d[c] = row[i]))
+  const genes = String(d.geneOrVariant ?? '')
+    .split(',')
+    .map((g) => g.trim())
+    .filter(Boolean)
+  return {
+    doc_id: d.docId ?? null,
+    curation_type: d.curationType ?? null,
+    context: d.context ?? null,
+    release: d.release ?? null,
+    release_date: d.releaseDate ?? null,
+    genes,
+    gene_omim: d.geneOmim ?? null,
+    disease: d.disease ?? null,
+    disease_omim: d.omim ?? null,
+    status_overall: d['status-overall'] ?? null,
+    outcome: d.outcome ?? null,
+    outcome_scoring_group: d.outcomeScoringGroup ?? null,
+    intervention: d.intervention ?? null,
+    intervention_scoring_group: d.interventionScoringGroup ?? null,
+    severity: d.severity ?? null,
+    likelihood: d.likelihood ?? null,
+    nature_of_intervention: d.natureOfIntervention ?? null,
+    effectiveness: d.effectiveness ?? null,
+    overall_score: d.overall ?? null
+  }
+}
+
+// Stable record from one ERepo variantInterpretation (guidelines/agents nested, collections sorted).
+function erepoRecord(interp: Record<string, unknown>): Record<string, unknown> {
+  const guidelines = asArr(interp.guidelines)
+    .map((gRaw) => {
+      const g = asObj(gRaw)
+      const agents = asArr(g.agents)
+        .map((aRaw) => {
+          const ag = asObj(aRaw)
+          const met: unknown[] = []
+          const notMet: unknown[] = []
+          for (const ecRaw of asArr(ag.evidenceCodes)) {
+            const ec = asObj(ecRaw)
+            ;(ec.status === 'Met' ? met : notMet).push(ec.label)
+          }
+          return {
+            agent_id: ag['@id'] ?? null,
+            affiliation: ag.affiliation ?? null,
+            outcome: asObj(ag.outcome).label ?? null,
+            evidence_codes_met: [...met].sort(strCmp),
+            evidence_codes_not_met: [...notMet].sort(strCmp)
+          }
+        })
+        .sort(byKeys((x) => x.agent_id))
+      return {
+        guideline: g.label ?? null,
+        guideline_id: g['@id'] ?? null,
+        outcome: asObj(g.outcome).label ?? null,
+        agents
+      }
+    })
+    .sort(byKeys((x) => x.guideline_id))
+  const cond = asObj(interp.condition)
+  const gene = asObj(interp.gene)
+  return {
+    interpretation_id: interp['@id'] ?? null,
+    uuid: interp.uuid ?? null,
+    caid: interp.caid ?? null,
+    clinvar_variation_id: interp.variationId ?? null,
+    gene_symbol: gene.label ?? null,
+    gene_ncbi_id: gene.NCBI_id ?? null,
+    condition_id: cond['@id'] ?? null,
+    condition_label: cond.label ?? null,
+    hgvs: [...asArr(interp.hgvs)].sort(strCmp),
+    evidence_links: asArr(interp.evidenceLinks)
+      .map((e) => asObj(e)['@id'] ?? '')
+      .sort(strCmp),
+    published_date: interp.publishedDate ?? null,
+    guidelines
+  }
+}
+
+// Resolve the single ClinGen ERepo lookup key (exactly one of gene/caid/hgvs must be present).
+function erepoKey(a: Record<string, unknown>): [string, string] {
+  const given = (['gene', 'caid', 'hgvs'] as const)
+    .map((k) => [k, a[k]] as const)
+    .filter(([, v]) => v != null && v !== '')
+  if (given.length !== 1) throw new Error('provide exactly one of gene=, caid=, hgvs=')
+  return [given[0][0], String(given[0][1])]
+}
+
+// ---------------------------------------------------------------------------
+// CIViC GraphQL (port of civic_evidence: field selections, normalize, paged walk)
+// ---------------------------------------------------------------------------
+
+// Scientifically meaningful, volatile-free field selections (no events/revisions/comments/flags).
+const GENE_FIELDS = 'id name entrezId fullName featureAliases description link'
+const VARIANT_FIELDS = `
+  id name link variantAliases
+  variantTypes { id name soid }
+  feature { id name }
+  singleVariantMolecularProfileId
+  ... on GeneVariant {
+    alleleRegistryId clinvarIds hgvsDescriptions
+    coordinates {
+      chromosome start stop referenceBases variantBases
+      referenceBuild ensemblVersion representativeTranscript
+    }
+  }`
+const EVIDENCE_FIELDS = `
+  id name status evidenceLevel evidenceType evidenceDirection significance
+  evidenceRating variantOrigin therapyInteractionType description link
+  disease { id name doid displayName }
+  therapies { id name ncitId }
+  molecularProfile { id name }
+  source { id sourceType citationId citation }
+  phenotypes { id hpoId name }`
+const ASSERTION_FIELDS = `
+  id name status assertionType assertionDirection significance ampLevel
+  summary description link variantOrigin therapyInteractionType
+  regulatoryApproval fdaCompanionTest
+  nccnGuideline { id name }
+  nccnGuidelineVersion
+  acmgCodes { id code }
+  clingenCodes { id code }
+  disease { id name doid displayName }
+  therapies { id name ncitId }
+  molecularProfile { id name }
+  phenotypes { id hpoId name }
+  evidenceItemsCount`
+const MOLECULAR_PROFILE_FIELDS = `
+  id name rawName link description molecularProfileScore
+  isComplex isMultiVariant molecularProfileAliases
+  variants { id name feature { id name } }
+  evidenceCountsByStatus { acceptedCount submittedCount rejectedCount }`
+const DISEASE_FIELDS = 'id name displayName doid diseaseUrl diseaseAliases link'
+const THERAPY_FIELDS = 'id name ncitId therapyUrl therapyAliases link'
+
+// Unordered collections are sorted for order-stable output (mirrors records.py::normalize).
+const CIVIC_STRING_LIST_FIELDS = new Set([
+  'featureAliases',
+  'variantAliases',
+  'hgvsDescriptions',
+  'clinvarIds',
+  'molecularProfileAliases',
+  'diseaseAliases',
+  'therapyAliases'
+])
+const CIVIC_DICT_LIST_SORT: Record<string, (d: Record<string, unknown>) => unknown[]> = {
+  variantTypes: (d) => [d.soid ?? '', d.id ?? 0],
+  therapies: (d) => [d.id ?? 0],
+  phenotypes: (d) => [d.id ?? 0],
+  acmgCodes: (d) => [d.code ?? ''],
+  clingenCodes: (d) => [d.code ?? ''],
+  variants: (d) => [d.id ?? 0]
+}
+
+// Element-wise comparison of two sort-key tuples (numbers compared numerically, else lexically).
+function cmpTuple(a: unknown[], b: unknown[]): number {
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]
+    const y = b[i]
+    if (x === y) continue
+    if (typeof x === 'number' && typeof y === 'number') return x - y
+    return String(x) < String(y) ? -1 : 1
+  }
+  return 0
+}
+
+// Recursively sort unordered collections so a record's byte shape is stable across fetches.
+function civicNormalize(obj: unknown, parentKey?: string): unknown {
+  if (Array.isArray(obj)) {
+    const items = obj.map((v) => civicNormalize(v, parentKey))
+    if (parentKey && CIVIC_STRING_LIST_FIELDS.has(parentKey)) {
+      return [...items].sort((a, b) => {
+        if (a == null && b == null) return 0
+        if (a == null) return 1
+        if (b == null) return -1
+        return String(a) < String(b) ? -1 : String(a) > String(b) ? 1 : 0
+      })
+    }
+    const keyFn = parentKey ? CIVIC_DICT_LIST_SORT[parentKey] : undefined
+    if (keyFn && items.every((i) => i !== null && typeof i === 'object' && !Array.isArray(i))) {
+      return [...items].sort((a, b) =>
+        cmpTuple(keyFn(a as Record<string, unknown>), keyFn(b as Record<string, unknown>))
+      )
+    }
+    return items
+  }
+  if (obj !== null && typeof obj === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(obj as Record<string, unknown>))
+      out[k] = civicNormalize(v, k)
+    return out
+  }
+  return obj
+}
+
+// The server caps `first` at 100 regardless of the requested value, so 100 is the page size.
+const CIVIC_PAGE_SIZE = 100
+// Hard ceiling so a mis-reported hasNextPage can never loop unbounded (the largest CIViC corpus,
+// evidence items, is ~100 pages — 500 leaves generous headroom without being open-ended).
+const CIVIC_MAX_PAGES = 500
+
+type CivicBody = { data?: Record<string, unknown> | null; errors?: unknown }
+
+// POST one CIViC operation; surface GraphQL errors (deterministic, so not retried) and return `data`.
+async function civicExecute(
+  ctx: ToolContext,
+  query: string,
+  variables: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const body = (await ctx.postJson(CIVIC_API, { query, variables })) as CivicBody
+  if (body.errors && (!Array.isArray(body.errors) || body.errors.length)) {
+    throw new Error(`CIViC GraphQL error: ${JSON.stringify(body.errors).slice(0, 500)}`)
+  }
+  return body.data ?? {}
+}
+
+// Walk one Relay connection to completion and verify the retrieved count against totalCount.
+async function civicPaged(
+  ctx: ToolContext,
+  field: string,
+  argDecls: string,
+  argRefs: string,
+  variables: Record<string, unknown>,
+  nodeFields: string
+): Promise<{ total_count: number; pages_fetched: number; records: Record<string, unknown>[] }> {
+  const query = `
+    query Paged($first: Int, $after: String${argDecls}) {
+      conn: ${field}(first: $first, after: $after${argRefs}) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes { ${nodeFields} }
+      }
+    }`
+  const nodes: unknown[] = []
+  let after: string | null = null
+  let total = 0
+  let pages = 0
+  for (;;) {
+    const data = await civicExecute(ctx, query, { ...variables, first: CIVIC_PAGE_SIZE, after })
+    const conn = asObj(data.conn)
+    const page = asObj(conn.pageInfo)
+    total = Number(conn.totalCount ?? 0)
+    nodes.push(...asArr(conn.nodes))
+    pages += 1
+    if (!page.hasNextPage) break
+    if (pages >= CIVIC_MAX_PAGES) {
+      throw new Error(`${field}: exceeded ${CIVIC_MAX_PAGES} pages (${nodes.length}/${total})`)
+    }
+    after = (page.endCursor as string | null) ?? null
+  }
+  if (nodes.length !== total) {
+    throw new Error(`${field}: retrieved ${nodes.length} nodes but totalCount=${total}`)
+  }
+  return {
+    total_count: total,
+    pages_fetched: pages,
+    records: nodes.map((n) => civicNormalize(n) as Record<string, unknown>)
+  }
+}
+
+// Fetch one entity by CIViC id; found=false (record=null) when the id does not exist.
+async function civicSingle(
+  ctx: ToolContext,
+  field: string,
+  id: number,
+  nodeFields: string
+): Promise<{ query: Record<string, unknown>; found: boolean; record: unknown }> {
+  const query = `query Single($id: Int!) { node: ${field}(id: $id) { ${nodeFields} } }`
+  const data = await civicExecute(ctx, query, { id })
+  const rec = data.node ?? null
+  return {
+    query: { mode: field, id },
+    found: rec !== null,
+    record: rec !== null ? civicNormalize(rec) : null
+  }
+}
+
+// python kwarg -> [GraphQL arg, GraphQL type]; a type of "Int" also drives the JSON-schema type.
+const EVIDENCE_FILTERS: Record<string, [string, string]> = {
+  disease_name: ['diseaseName', 'String'],
+  therapy_name: ['therapyName', 'String'],
+  evidence_level: ['evidenceLevel', 'EvidenceLevel'],
+  evidence_type: ['evidenceType', 'EvidenceType'],
+  evidence_direction: ['evidenceDirection', 'EvidenceDirection'],
+  significance: ['significance', 'EvidenceSignificance'],
+  variant_origin: ['variantOrigin', 'VariantOrigin'],
+  evidence_rating: ['evidenceRating', 'Int'],
+  status: ['status', 'EvidenceStatusFilter'],
+  molecular_profile_name: ['molecularProfileName', 'String'],
+  molecular_profile_id: ['molecularProfileId', 'Int'],
+  variant_id: ['variantId', 'Int'],
+  disease_id: ['diseaseId', 'Int'],
+  therapy_id: ['therapyId', 'Int'],
+  phenotype_id: ['phenotypeId', 'Int'],
+  source_id: ['sourceId', 'Int'],
+  assertion_id: ['assertionId', 'Int']
+}
+const ASSERTION_FILTERS: Record<string, [string, string]> = {
+  disease_name: ['diseaseName', 'String'],
+  therapy_name: ['therapyName', 'String'],
+  assertion_type: ['assertionType', 'EvidenceType'],
+  assertion_direction: ['assertionDirection', 'EvidenceDirection'],
+  significance: ['significance', 'AssertionSignificance'],
+  amp_level: ['ampLevel', 'AmpLevel'],
+  status: ['status', 'EvidenceStatusFilter'],
+  molecular_profile_name: ['molecularProfileName', 'String'],
+  molecular_profile_id: ['molecularProfileId', 'Int'],
+  variant_id: ['variantId', 'Int'],
+  variant_name: ['variantName', 'String'],
+  disease_id: ['diseaseId', 'Int'],
+  therapy_id: ['therapyId', 'Int'],
+  phenotype_id: ['phenotypeId', 'Int'],
+  evidence_id: ['evidenceId', 'Int'],
+  summary: ['summary', 'String']
+}
+
+// Turn a filter table into a JSON-Schema `input` (Int -> integer, everything else -> string).
+function filterInput(table: Record<string, [string, string]>): Record<string, unknown> {
+  const properties: Record<string, unknown> = {}
+  for (const [key, [, gqlType]] of Object.entries(table)) {
+    properties[key] = { type: gqlType === 'Int' ? 'integer' : 'string' }
+  }
+  return { type: 'object', properties }
+}
+
+// Paginated filtered search (evidence/assertions): build GraphQL args from the provided filters,
+// always sort by ascending id for deterministic output.
+async function civicFilteredSearch(
+  ctx: ToolContext,
+  field: string,
+  args: Record<string, unknown>,
+  table: Record<string, [string, string]>,
+  nodeFields: string,
+  sortType: string,
+  mode: string
+): Promise<Record<string, unknown>> {
+  const decls: string[] = []
+  const refs: string[] = []
+  const variables: Record<string, unknown> = {}
+  const used: Record<string, unknown> = {}
+  for (const [key, [gqlArg, gqlType]] of Object.entries(table)) {
+    const value = args[key]
+    if (value == null) continue
+    const vname = `f_${gqlArg}`
+    decls.push(`, $${vname}: ${gqlType}`)
+    refs.push(`, ${gqlArg}: $${vname}`)
+    variables[vname] = value
+    used[key] = value
+  }
+  decls.push(`, $sb: ${sortType}`)
+  refs.push(', sortBy: $sb')
+  variables.sb = { column: 'ID', direction: 'ASC' }
+  const out = await civicPaged(ctx, field, decls.join(''), refs.join(''), variables, nodeFields)
+  return { ...out, query: { mode, filters: used } }
+}
+
+// Sort CIViC records in place by ascending numeric id (the id-keyed order the gate expects).
+function sortById(records: Record<string, unknown>[]): Record<string, unknown>[] {
+  return records.sort((a, b) => Number(a.id) - Number(b.id))
+}
+
+// ---------------------------------------------------------------------------
+// Open Targets Platform GraphQL (port of mcp_clinical_genomics/open_targets.py + server queries)
+// ---------------------------------------------------------------------------
+
+const OT_MAX_ATTEMPTS = 3
+
+const OT_DISEASE_DRUGS_Q = `query($id: String!) {
+  disease(efoId: $id) {
+    id name
+    drugAndClinicalCandidates {
       count
-      rows { score disease { id name } }
+      rows { id maxClinicalStage drug { id name drugType } }
     }
   }
-}
-`
-
-// Transcribed from the upstream _OT_DRUG_Q document (mcp_clinical_genomics/server.py), extended
-// with indications (live-introspected field name is maxClinicalStage, not maxPhaseForIndication).
-const DRUG_QUERY = `
-query DrugDetail($chemblId: String!) {
-  drug(chemblId: $chemblId) {
-    id
-    name
-    drugType
-    maximumClinicalStage
+}`
+const OT_DISEASE_TARGETS_Q = `query($id: String!, $size: Int!) {
+  disease(efoId: $id) {
+    id name
+    associatedTargets(page: {size: $size, index: 0}) {
+      count
+      rows { score target { id approvedSymbol } }
+    }
+  }
+}`
+const OT_DRUG_Q = `query($id: String!) {
+  drug(chemblId: $id) {
+    id name drugType maximumClinicalStage
     mechanismsOfAction {
       rows { mechanismOfAction actionType targets { id approvedSymbol } }
     }
-    indications {
-      count
-      rows { disease { id name } maxClinicalStage }
+  }
+}`
+
+// True when every GraphQL error looks like the platform's transient HTTP-200 "Internal server error".
+function otTransient(errors: unknown): boolean {
+  if (!Array.isArray(errors) || !errors.length) return false
+  const msgs = errors
+    .filter((e) => e !== null && typeof e === 'object')
+    .map((e) => String((e as Record<string, unknown>).message ?? '').toLowerCase())
+  return msgs.length > 0 && msgs.every((m) => m.includes('internal server error'))
+}
+
+type OtResult = { data: unknown; attempts: number; errors?: unknown }
+
+// POST one Open Targets operation; retry only the transient internal-server quirk (deterministic
+// GraphQL errors are returned honestly). HTTP 429/5xx retries are handled by the engine.
+async function otExecute(
+  ctx: ToolContext,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<OtResult> {
+  let last: { data: unknown; errors?: unknown } = { data: null }
+  for (let attempt = 1; attempt <= OT_MAX_ATTEMPTS; attempt++) {
+    const body = (await ctx.postJson(OT_API, variables ? { query, variables } : { query })) as {
+      data?: unknown
+      errors?: unknown
+    }
+    const errors = body.errors
+    if (errors && otTransient(errors) && attempt < OT_MAX_ATTEMPTS) {
+      last = { data: body.data ?? null, errors }
+      continue
+    }
+    const out: OtResult = { data: body.data ?? null, attempts: attempt }
+    if (errors) out.errors = errors
+    return out
+  }
+  return { ...last, attempts: OT_MAX_ATTEMPTS }
+}
+
+// Run a curated Open Targets query and return data[root], or {errors} when it is null / errored.
+async function otQuery(
+  ctx: ToolContext,
+  query: string,
+  variables: Record<string, unknown>,
+  root: string
+): Promise<Record<string, unknown>> {
+  const result = await otExecute(ctx, query, variables)
+  const node = asObj(result.data)[root]
+  if (node == null) {
+    return {
+      errors: result.errors ?? [{ message: `${root} not found for ${JSON.stringify(variables)}` }]
     }
   }
-}
-`
-
-type SearchHit = { id: string; entity: string; name?: string }
-type SearchResponse = {
-  data?: { search?: { hits?: SearchHit[] | null } | null }
-  errors?: Array<{ message?: string }>
+  return node as Record<string, unknown>
 }
 
-type DiseaseRow = { score?: number; disease?: { id?: string; name?: string } | null }
-type TargetDiseasesResponse = {
-  data?: {
-    target?: {
-      id: string
-      approvedSymbol?: string
-      approvedName?: string
-      associatedDiseases?: { count?: number; rows?: DiseaseRow[] | null } | null
-    } | null
-  }
-  errors?: Array<{ message?: string }>
-}
+// ---------------------------------------------------------------------------
+// Tool descriptors
+// ---------------------------------------------------------------------------
 
-type MoaRow = {
-  mechanismOfAction?: string
-  actionType?: string
-  targets?: Array<{ id?: string; approvedSymbol?: string }> | null
-}
-type IndicationRow = {
-  disease?: { id?: string; name?: string } | null
-  maxClinicalStage?: string
-}
-type DrugResponse = {
-  data?: {
-    drug?: {
-      id: string
-      name?: string
-      drugType?: string
-      maximumClinicalStage?: string
-      mechanismsOfAction?: { rows?: MoaRow[] | null } | null
-      indications?: { count?: number; rows?: IndicationRow[] | null } | null
-    } | null
-  }
-  errors?: Array<{ message?: string }>
-}
-
-function throwOnErrors(errors: Array<{ message?: string }> | undefined, label: string): void {
-  if (errors?.length) {
-    throw new Error(
-      `Open Targets GraphQL error (${label}): ${errors.map((e) => e.message).join('; ')}`
-    )
-  }
-}
-
-// Ensembl human gene ids look like ENSG00000146648 — skip the search round-trip when already given one.
-const ENSEMBL_GENE_ID = /^ensg\d+$/i
-
-async function resolveEnsemblId(
-  postJson: (url: string, body: unknown) => Promise<unknown>,
-  gene: string
-): Promise<string | null> {
-  if (ENSEMBL_GENE_ID.test(gene)) return gene.toUpperCase()
-  const result = (await postJson(OPEN_TARGETS_API, {
-    query: SEARCH_TARGET_QUERY,
-    variables: { q: gene }
-  })) as SearchResponse
-  throwOnErrors(result.errors, 'search')
-  const hits = (result.data?.search?.hits ?? []).filter((h) => h.entity === 'target')
-  if (!hits.length) return null
-  const exact = hits.find((h) => (h.name ?? '').toLowerCase() === gene.toLowerCase())
-  return (exact ?? hits[0]).id
-}
-
-// Open Targets Platform GraphQL API: every call is a POST of {query, variables} to a single
-// endpoint. Unlike gnomAD, an absent entity comes back as `data: { target: null }` / `{ drug:
-// null }` with no accompanying "not found" error — so there's no error-message allowlist to check.
 export const CLINICAL_GENOMICS_TOOLS: ToolDescriptor[] = [
+  // ------------------------------------------------------------- ClinGen --
   {
-    id: 'opentargets_target_diseases',
+    id: 'clingen_gene_validity',
     connector: 'clinical_genomics',
     description:
-      'Open Targets: top diseases associated with a gene/target (by symbol or Ensembl gene id), ranked by overall association score.',
+      'ClinGen gene-disease validity curations (how strong the evidence is that variation in a gene causes a disease: Definitive/Strong/Moderate/Limited/Disputed/Refuted/No Known Disease Relationship). Omit gene to list all 3,600+ curations.',
     input: {
       type: 'object',
-      properties: {
-        gene: { type: 'string' },
-        limit: { type: 'integer', default: DEFAULT_LIMIT }
-      },
-      required: ['gene']
+      properties: { gene: { type: 'string' } }
     },
-    required: ['gene'],
     returns:
-      '`{ "gene_id": str, "symbol": str, "approved_name": str, "n_diseases_total": int, "returned": int, "diseases": [ { "disease_id": str, "disease_name": str, "score": float } ] }` — diseases ranked by association score, up to `limit` (default 10); `n_diseases_total` is the full count, usually larger than `returned`. Unresolved symbol or absent target yields `gene_id`/`symbol` null and `diseases: []`.',
-    example:
-      'result = host.mcp("clinical_genomics", "opentargets_target_diseases", {"gene": "EGFR", "limit": 10})',
-    run: async (ctx, a) => {
-      const gene = String(a.gene)
-      const limit = Number(a.limit ?? DEFAULT_LIMIT)
-
-      const ensemblId = await resolveEnsemblId(ctx.postJson, gene)
-      if (!ensemblId) {
-        // Free-text symbol had no matching target hit — compact empty result, no error thrown.
-        return { gene, gene_id: null, symbol: null, n_diseases_total: 0, returned: 0, diseases: [] }
+      '`{ "total": int, "records": [ { "gene_symbol": str, "hgnc_id": str, "disease_label": str, "mondo_id": str, "moi": str, "sop": str, "classification": str, "expert_panel": str, "affiliate_id": str, "animal_model_only": bool, "assertion_id": str } ], "source": str }` — records filtered to the gene (exact, case-insensitive) or the full table when gene is omitted.',
+    example: 'result = host.mcp("clinical_genomics", "clingen_gene_validity", {"gene": "BRCA2"})',
+    url: () => `${CLINGEN_SEARCH}/api/validity`,
+    parse: (raw, a) => {
+      const d = raw as { total: number; rows: Record<string, unknown>[] }
+      if (d.total !== d.rows.length) {
+        throw new Error(`validity count mismatch: total=${d.total} rows=${d.rows.length}`)
       }
-
-      const result = (await ctx.postJson(OPEN_TARGETS_API, {
-        query: TARGET_DISEASES_QUERY,
-        variables: { ensemblId, size: limit }
-      })) as TargetDiseasesResponse
-      throwOnErrors(result.errors, 'target_diseases')
-
-      const target = result.data?.target
-      if (!target) {
-        return {
-          gene,
-          gene_id: ensemblId,
-          symbol: null,
-          n_diseases_total: 0,
-          returned: 0,
-          diseases: []
-        }
-      }
-
-      const rows = target.associatedDiseases?.rows ?? []
+      let records = d.rows.map(validityRecord)
+      const gene = a.gene ? String(a.gene).trim().toUpperCase() : null
+      if (gene) records = records.filter((r) => String(r.gene_symbol).toUpperCase() === gene)
+      records.sort(
+        byKeys(
+          (r) => r.gene_symbol,
+          (r) => r.assertion_id ?? ''
+        )
+      )
       return {
-        gene_id: target.id,
-        symbol: target.approvedSymbol ?? gene,
-        approved_name: target.approvedName,
-        n_diseases_total: target.associatedDiseases?.count ?? rows.length,
-        returned: rows.length,
-        diseases: rows.map((r) => ({
-          disease_id: r.disease?.id,
-          disease_name: r.disease?.name,
-          score: r.score
-        }))
+        total: records.length,
+        records,
+        source: 'ClinGen Gene-Disease Validity (search.clinicalgenome.org/api/validity)'
       }
     }
   },
   {
-    id: 'opentargets_drug',
+    id: 'clingen_dosage_sensitivity',
     connector: 'clinical_genomics',
     description:
-      "Open Targets: a drug's mechanism of action (target, action type) and clinical indications, by ChEMBL id.",
+      'ClinGen dosage sensitivity curations: haploinsufficiency and triplosensitivity assertions for genes (and optionally ISCA genomic/CNV regions). A gene symbol or an ISCA region id filters exactly; omit for the full table.',
     input: {
       type: 'object',
       properties: {
-        chembl_id: { type: 'string' },
-        limit: { type: 'integer', default: DEFAULT_LIMIT }
+        gene: { type: 'string' },
+        include_regions: { type: 'boolean', default: false }
+      }
+    },
+    returns:
+      '`{ "total": int, "records": [ { "record_type": "gene"|"region", "symbol": str, "id": str, "cytoband": str, "grch37": str, "grch38": str, "haploinsufficiency": { "code": str, "label": str }|null, "triplosensitivity": {...}|null, "haplo_disease": str, "haplo_mondo": str, "triplo_disease": str, "triplo_mondo": str, "omim": str, "morbid": str } ], "source": str }`.',
+    example:
+      'result = host.mcp("clinical_genomics", "clingen_dosage_sensitivity", {"gene": "TP53"})',
+    url: () => `${CLINGEN_SEARCH}/api/dosage`,
+    parse: (raw, a) => {
+      const d = raw as { total: number; rows: Record<string, unknown>[] }
+      if (d.total !== d.rows.length) {
+        throw new Error(`dosage count mismatch: total=${d.total} rows=${d.rows.length}`)
+      }
+      let records = d.rows.map(dosageRecord)
+      const includeRegions = Boolean(a.include_regions)
+      if (!includeRegions && a.gene == null) {
+        records = records.filter((r) => r.record_type === 'gene')
+      }
+      const gene = a.gene ? String(a.gene).trim().toUpperCase() : null
+      if (gene) {
+        records = records.filter(
+          (r) =>
+            String(r.symbol).toUpperCase() === gene || String(r.id ?? '').toUpperCase() === gene
+        )
+      }
+      records.sort(
+        byKeys(
+          (r) => r.record_type,
+          (r) => r.symbol,
+          (r) => r.id ?? ''
+        )
+      )
+      return {
+        total: records.length,
+        records,
+        source: 'ClinGen Dosage Sensitivity (search.clinicalgenome.org/api/dosage)'
+      }
+    }
+  },
+  {
+    id: 'clingen_actionability',
+    connector: 'clinical_genomics',
+    description:
+      'ClinGen clinical actionability curations: for disorders associated with a gene, whether early intervention in pre-symptomatic carriers is actionable (intervention/outcome pairs with severity, likelihood, effectiveness, nature-of-intervention component scores and the total score). Gene filter matches any member of multi-gene topics.',
+    input: {
+      type: 'object',
+      properties: {
+        gene: { type: 'string' },
+        context: { type: 'string', enum: ['adult', 'pediatric', 'both'], default: 'both' }
+      }
+    },
+    returns:
+      '`{ "adult"?: { "total": int, "records": [...] }, "pediatric"?: { "total": int, "records": [...] }, "source": str }` — one block per requested context; each record has doc_id, genes, disease, outcome, intervention, severity, likelihood, nature_of_intervention, effectiveness, overall_score, release/release_date.',
+    example:
+      'result = host.mcp("clinical_genomics", "clingen_actionability", {"gene": "BRCA1", "context": "adult"})',
+    run: async (ctx, a) => {
+      const ctxMap: Record<string, string[]> = {
+        adult: ['Adult'],
+        pediatric: ['Pediatric'],
+        both: ['Adult', 'Pediatric']
+      }
+      const context = String(a.context ?? 'both')
+      const contexts = ctxMap[context]
+      if (!contexts) throw new Error("context must be 'adult', 'pediatric' or 'both'")
+      const gene = a.gene ? String(a.gene).trim().toUpperCase() : null
+      const out: Record<string, unknown> = {}
+      for (const c of contexts) {
+        const d = (await ctx.fetchJson(
+          `${CLINGEN_ACTIONABILITY}/ac/${c}/api/summ?flavor=flat`
+        )) as { columns?: string[]; rows?: unknown[][] }
+        if (!Array.isArray(d.columns) || !Array.isArray(d.rows)) {
+          throw new Error(`unexpected actionability payload shape for ${c}`)
+        }
+        const columns = d.columns
+        let records = d.rows.map((row) => actionabilityRecord(columns, row))
+        if (gene) {
+          records = records.filter((r) =>
+            (r.genes as string[]).map((x) => x.toUpperCase()).includes(gene)
+          )
+        }
+        records.sort(
+          byKeys(
+            (r) => r.doc_id ?? '',
+            (r) => r.outcome ?? '',
+            (r) => r.intervention ?? ''
+          )
+        )
+        out[c.toLowerCase()] = { total: records.length, records }
+      }
+      out.source =
+        'ClinGen Clinical Actionability (actionability.clinicalgenome.org flat summaries)'
+      return out
+    }
+  },
+  {
+    id: 'clingen_variant_classifications',
+    connector: 'clinical_genomics',
+    description:
+      'ClinGen Evidence Repository (ERepo) expert-panel variant pathogenicity classifications (VCEP interpretations under ACMG criteria). Provide EXACTLY ONE of gene (HGNC symbol), caid (ClinGen canonical allele id, e.g. CA114360), or hgvs (e.g. NM_000277.2:c.1222C>T). Complete retrieval (matchLimit=none).',
+    input: {
+      type: 'object',
+      properties: {
+        gene: { type: 'string' },
+        caid: { type: 'string' },
+        hgvs: { type: 'string' }
+      }
+    },
+    returns:
+      '`{ "total": int, "records": [ { "interpretation_id": str, "uuid": str, "caid": str, "clinvar_variation_id": str, "gene_symbol": str, "gene_ncbi_id": str, "condition_id": str, "condition_label": str, "hgvs": [str], "evidence_links": [str], "published_date": str, "guidelines": [ { "guideline": str, "guideline_id": str, "outcome": str, "agents": [ { "agent_id": str, "affiliation": str, "outcome": str, "evidence_codes_met": [str], "evidence_codes_not_met": [str] } ] } ] } ], "query": { <gene|caid|hgvs>: str }, "source": str }`.',
+    example:
+      'result = host.mcp("clinical_genomics", "clingen_variant_classifications", {"gene": "BRCA1"})',
+    url: (a) => {
+      const [param, value] = erepoKey(a)
+      const qs = new URLSearchParams({ [param]: value, matchMode: 'exact', matchLimit: 'none' })
+      return `${CLINGEN_EREPO}/classifications?${qs.toString()}`
+    },
+    parse: (raw, a) => {
+      const [param, value] = erepoKey(a)
+      const d = raw as { variantInterpretations?: Record<string, unknown>[] }
+      const records = (d.variantInterpretations ?? []).map(erepoRecord)
+      records.sort(byKeys((r) => r.interpretation_id ?? ''))
+      return {
+        total: records.length,
+        records,
+        query: { [param]: value },
+        source: 'ClinGen Evidence Repository (erepo.genome.network/evrepo/api)'
+      }
+    }
+  },
+  // --------------------------------------------------------------- CIViC --
+  {
+    id: 'civic_search_genes',
+    connector: 'clinical_genomics',
+    description:
+      'Find CIViC gene records by exact Entrez symbol (e.g. "BRAF"). Fully paginated, count-verified. Use the returned CIViC gene id with civic_gene_variants.',
+    input: {
+      type: 'object',
+      properties: { entrez_symbol: { type: 'string' } },
+      required: ['entrez_symbol']
+    },
+    required: ['entrez_symbol'],
+    returns:
+      '`{ "total_count": int, "pages_fetched": int, "records": [ { "id": int, "name": str, "entrezId": int, "fullName": str, "featureAliases": [str], "description": str, "link": str } ], "query": { "mode": "search_genes", "entrez_symbol": str } }`.',
+    example:
+      'result = host.mcp("clinical_genomics", "civic_search_genes", {"entrez_symbol": "BRAF"})',
+    run: async (ctx, a) => {
+      const out = await civicPaged(
+        ctx,
+        'genes',
+        ', $sym: [String!]',
+        ', entrezSymbols: $sym',
+        { sym: [String(a.entrez_symbol)] },
+        GENE_FIELDS
+      )
+      return { ...out, query: { mode: 'search_genes', entrez_symbol: a.entrez_symbol } }
+    }
+  },
+  {
+    id: 'civic_gene_variants',
+    connector: 'clinical_genomics',
+    description:
+      'All variants of one CIViC gene (by CIViC gene id), fully paginated — complete even for genes with hundreds of variants. Sorted by variant id.',
+    input: {
+      type: 'object',
+      properties: { gene_id: { type: 'integer' } },
+      required: ['gene_id']
+    },
+    required: ['gene_id'],
+    returns:
+      '`{ "total_count": int, "pages_fetched": int, "records": [ { "id": int, "name": str, "link": str, "variantAliases": [str], "variantTypes": [{ "id": int, "name": str, "soid": str }], "feature": { "id": int, "name": str }, "singleVariantMolecularProfileId": int, "alleleRegistryId"?: str, "clinvarIds"?: [str], "hgvsDescriptions"?: [str], "coordinates"?: {...} } ], "query": {...} }`.',
+    example: 'result = host.mcp("clinical_genomics", "civic_gene_variants", {"gene_id": 5})',
+    run: async (ctx, a) => {
+      const out = await civicPaged(
+        ctx,
+        'variants',
+        ', $gid: Int',
+        ', geneId: $gid',
+        { gid: Number(a.gene_id) },
+        VARIANT_FIELDS
+      )
+      return {
+        ...out,
+        records: sortById(out.records),
+        query: { mode: 'gene_variants', gene_id: Number(a.gene_id) }
+      }
+    }
+  },
+  {
+    id: 'civic_get_variant',
+    connector: 'clinical_genomics',
+    description:
+      'One CIViC variant by its CIViC variant id (aliases, variant types, feature/gene linkage, coordinates for gene variants). Returns found=false if absent.',
+    input: {
+      type: 'object',
+      properties: { variant_id: { type: 'integer' } },
+      required: ['variant_id']
+    },
+    required: ['variant_id'],
+    returns:
+      '`{ "query": { "mode": "variant", "id": int }, "found": bool, "record": { "id": int, "name": str, "variantTypes": [...], "feature": {...}, "coordinates"?: {...}, ... }|null }`.',
+    example: 'result = host.mcp("clinical_genomics", "civic_get_variant", {"variant_id": 12})',
+    run: async (ctx, a) => civicSingle(ctx, 'variant', Number(a.variant_id), VARIANT_FIELDS)
+  },
+  {
+    id: 'civic_search_variants',
+    connector: 'clinical_genomics',
+    description:
+      'Search CIViC variants by name substring (e.g. "V600"), optionally scoped to a CIViC gene id. Fully paginated; sorted by variant id.',
+    input: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        gene_id: { type: 'integer' }
       },
+      required: ['name']
+    },
+    required: ['name'],
+    returns:
+      '`{ "total_count": int, "pages_fetched": int, "records": [ <variant record> ], "query": { "mode": "search_variants", "name": str, "gene_id": int|null } }`.',
+    example:
+      'result = host.mcp("clinical_genomics", "civic_search_variants", {"name": "V600", "gene_id": 5})',
+    run: async (ctx, a) => {
+      let decls = ', $name: String'
+      let refs = ', name: $name'
+      const variables: Record<string, unknown> = { name: String(a.name) }
+      const geneId = a.gene_id == null ? null : Number(a.gene_id)
+      if (geneId != null) {
+        decls += ', $gid: Int'
+        refs += ', geneId: $gid'
+        variables.gid = geneId
+      }
+      const out = await civicPaged(ctx, 'variants', decls, refs, variables, VARIANT_FIELDS)
+      return {
+        ...out,
+        records: sortById(out.records),
+        query: { mode: 'search_variants', name: a.name, gene_id: geneId }
+      }
+    }
+  },
+  {
+    id: 'civic_get_evidence_item',
+    connector: 'clinical_genomics',
+    description:
+      'One CIViC evidence item by id: clinical significance of a molecular profile in a disease/therapy context (evidence level A-E, type, direction, significance, rating, disease, therapies, source). Returns found=false if absent.',
+    input: {
+      type: 'object',
+      properties: { evidence_id: { type: 'integer' } },
+      required: ['evidence_id']
+    },
+    required: ['evidence_id'],
+    returns:
+      '`{ "query": { "mode": "evidenceItem", "id": int }, "found": bool, "record": { "id": int, "evidenceLevel": str, "evidenceType": str, "evidenceDirection": str, "significance": str, "evidenceRating": int, "disease": {...}, "therapies": [...], "molecularProfile": {...}, "source": {...}, ... }|null }`.',
+    example:
+      'result = host.mcp("clinical_genomics", "civic_get_evidence_item", {"evidence_id": 1409})',
+    run: async (ctx, a) => civicSingle(ctx, 'evidenceItem', Number(a.evidence_id), EVIDENCE_FIELDS)
+  },
+  {
+    id: 'civic_search_evidence',
+    connector: 'clinical_genomics',
+    description:
+      'Search CIViC evidence items by any combination of filters; fully paginated, count-verified, sorted by ascending evidence id. Enum filters take CIViC GraphQL enum values verbatim (evidence_level "A".."E"; evidence_type PREDICTIVE|PROGNOSTIC|DIAGNOSTIC|PREDISPOSING|ONCOGENIC|FUNCTIONAL; evidence_direction SUPPORTS|DOES_NOT_SUPPORT; status ACCEPTED|SUBMITTED|REJECTED|ALL). Provide at least one filter — no filters walks the entire 10k+ corpus.',
+    input: filterInput(EVIDENCE_FILTERS),
+    returns:
+      '`{ "total_count": int, "pages_fetched": int, "records": [ <evidence record> ], "query": { "mode": "search_evidence", "filters": {...} } }` — records sorted by ascending evidence id.',
+    example:
+      'result = host.mcp("clinical_genomics", "civic_search_evidence", {"disease_name": "melanoma", "evidence_level": "A"})',
+    run: async (ctx, a) =>
+      civicFilteredSearch(
+        ctx,
+        'evidenceItems',
+        a,
+        EVIDENCE_FILTERS,
+        EVIDENCE_FIELDS,
+        'EvidenceSort',
+        'search_evidence'
+      )
+  },
+  {
+    id: 'civic_get_assertion',
+    connector: 'clinical_genomics',
+    description:
+      'One CIViC assertion by id: an expert-curated summary claim (AMP/ASCO/CAP tier, ACMG/ClinGen codes, FDA companion-test flags) aggregating evidence for a molecular profile in a disease/therapy context. Returns found=false if absent.',
+    input: {
+      type: 'object',
+      properties: { assertion_id: { type: 'integer' } },
+      required: ['assertion_id']
+    },
+    required: ['assertion_id'],
+    returns:
+      '`{ "query": { "mode": "assertion", "id": int }, "found": bool, "record": { "id": int, "assertionType": str, "assertionDirection": str, "significance": str, "ampLevel": str, "summary": str, "acmgCodes": [...], "clingenCodes": [...], "disease": {...}, "therapies": [...], "evidenceItemsCount": int, ... }|null }`.',
+    example: 'result = host.mcp("clinical_genomics", "civic_get_assertion", {"assertion_id": 7})',
+    run: async (ctx, a) => civicSingle(ctx, 'assertion', Number(a.assertion_id), ASSERTION_FIELDS)
+  },
+  {
+    id: 'civic_search_assertions',
+    connector: 'clinical_genomics',
+    description:
+      'Search CIViC assertions by any combination of filters; fully paginated, count-verified, sorted by ascending assertion id. assertion_type PREDICTIVE|PROGNOSTIC|DIAGNOSTIC|PREDISPOSING|ONCOGENIC; assertion_direction SUPPORTS|DOES_NOT_SUPPORT; amp_level e.g. TIER_I_LEVEL_A; status ACCEPTED|SUBMITTED|REJECTED|ALL. No filters walks the full corpus.',
+    input: filterInput(ASSERTION_FILTERS),
+    returns:
+      '`{ "total_count": int, "pages_fetched": int, "records": [ <assertion record> ], "query": { "mode": "search_assertions", "filters": {...} } }` — records sorted by ascending assertion id.',
+    example:
+      'result = host.mcp("clinical_genomics", "civic_search_assertions", {"disease_name": "melanoma"})',
+    run: async (ctx, a) =>
+      civicFilteredSearch(
+        ctx,
+        'assertions',
+        a,
+        ASSERTION_FILTERS,
+        ASSERTION_FIELDS,
+        'AssertionSort',
+        'search_assertions'
+      )
+  },
+  {
+    id: 'civic_get_molecular_profile',
+    connector: 'clinical_genomics',
+    description:
+      'One CIViC molecular profile by id (variant combination that evidence/assertions attach to), incl. parsed name, score, and component variants. Returns found=false if absent.',
+    input: {
+      type: 'object',
+      properties: { mp_id: { type: 'integer' } },
+      required: ['mp_id']
+    },
+    required: ['mp_id'],
+    returns:
+      '`{ "query": { "mode": "molecularProfile", "id": int }, "found": bool, "record": { "id": int, "name": str, "rawName": str, "molecularProfileScore": float, "isComplex": bool, "isMultiVariant": bool, "molecularProfileAliases": [str], "variants": [{ "id": int, "name": str, "feature": {...} }], "evidenceCountsByStatus": {...} }|null }`.',
+    example: 'result = host.mcp("clinical_genomics", "civic_get_molecular_profile", {"mp_id": 12})',
+    run: async (ctx, a) =>
+      civicSingle(ctx, 'molecularProfile', Number(a.mp_id), MOLECULAR_PROFILE_FIELDS)
+  },
+  {
+    id: 'civic_search_molecular_profiles',
+    connector: 'clinical_genomics',
+    description:
+      'Search CIViC molecular profiles by name substring (e.g. "BRAF V600E"). Fully paginated; sorted by id.',
+    input: {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name']
+    },
+    required: ['name'],
+    returns:
+      '`{ "total_count": int, "pages_fetched": int, "records": [ <molecular profile record> ], "query": { "mode": "search_molecular_profiles", "name": str } }`.',
+    example:
+      'result = host.mcp("clinical_genomics", "civic_search_molecular_profiles", {"name": "BRAF V600E"})',
+    run: async (ctx, a) => {
+      const out = await civicPaged(
+        ctx,
+        'molecularProfiles',
+        ', $name: String',
+        ', name: $name',
+        { name: String(a.name) },
+        MOLECULAR_PROFILE_FIELDS
+      )
+      return {
+        ...out,
+        records: sortById(out.records),
+        query: { mode: 'search_molecular_profiles', name: a.name }
+      }
+    }
+  },
+  {
+    id: 'civic_search_diseases',
+    connector: 'clinical_genomics',
+    description:
+      'Search CIViC disease records by name substring (e.g. "melanoma"). Returns DOIDs + display names; fully paginated; sorted by id.',
+    input: {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name']
+    },
+    required: ['name'],
+    returns:
+      '`{ "total_count": int, "pages_fetched": int, "records": [ { "id": int, "name": str, "displayName": str, "doid": str, "diseaseUrl": str, "diseaseAliases": [str], "link": str } ], "query": { "mode": "search_diseases", "name": str } }`.',
+    example:
+      'result = host.mcp("clinical_genomics", "civic_search_diseases", {"name": "melanoma"})',
+    run: async (ctx, a) => {
+      const out = await civicPaged(
+        ctx,
+        'diseases',
+        ', $name: String',
+        ', name: $name',
+        { name: String(a.name) },
+        DISEASE_FIELDS
+      )
+      return {
+        ...out,
+        records: sortById(out.records),
+        query: { mode: 'search_diseases', name: a.name }
+      }
+    }
+  },
+  {
+    id: 'civic_search_therapies',
+    connector: 'clinical_genomics',
+    description:
+      'Search CIViC therapy records by name substring (e.g. "vemurafenib"). Returns NCIt ids + names; fully paginated; sorted by id.',
+    input: {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name']
+    },
+    required: ['name'],
+    returns:
+      '`{ "total_count": int, "pages_fetched": int, "records": [ { "id": int, "name": str, "ncitId": str, "therapyUrl": str, "therapyAliases": [str], "link": str } ], "query": { "mode": "search_therapies", "name": str } }`.',
+    example:
+      'result = host.mcp("clinical_genomics", "civic_search_therapies", {"name": "vemurafenib"})',
+    run: async (ctx, a) => {
+      const out = await civicPaged(
+        ctx,
+        'therapies',
+        ', $name: String',
+        ', name: $name',
+        { name: String(a.name) },
+        THERAPY_FIELDS
+      )
+      return {
+        ...out,
+        records: sortById(out.records),
+        query: { mode: 'search_therapies', name: a.name }
+      }
+    }
+  },
+  // --------------------------------------------------------- Open Targets --
+  {
+    id: 'open_targets_graphql',
+    connector: 'clinical_genomics',
+    description:
+      'Run an arbitrary GraphQL query against the Open Targets Platform API (targets, diseases, drugs, target-disease association scores, evidence, tractability, safety, known drugs). Introspection queries work for schema discovery. Note knownDrugs was renamed to drugAndClinicalCandidates upstream.',
+    input: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        variables: { type: 'object' }
+      },
+      required: ['query']
+    },
+    required: ['query'],
+    returns:
+      '`{ "data": {...}|null, "attempts": int, "errors"?: [ { "message": str } ] }` — the raw GraphQL data payload; transient HTTP-200 "Internal server error" responses are retried up to 3 attempts before being surfaced in errors.',
+    example:
+      'result = host.mcp("clinical_genomics", "open_targets_graphql", {"query": "query($id: String!){ target(ensemblId: $id){ approvedSymbol associatedDiseases{ count } } }", "variables": {"id": "ENSG00000157764"}})',
+    run: async (ctx, a) => {
+      const variables = asObj(a.variables)
+      return otExecute(ctx, String(a.query), Object.keys(variables).length ? variables : undefined)
+    }
+  },
+  {
+    id: 'open_targets_disease_drugs',
+    connector: 'clinical_genomics',
+    description:
+      'Known/investigational drugs for a disease (Open Targets Platform) — wraps Disease.drugAndClinicalCandidates. efo_id is a disease ontology id (EFO/MONDO/etc., e.g. "MONDO_0004992").',
+    input: {
+      type: 'object',
+      properties: {
+        efo_id: { type: 'string' },
+        size: { type: 'integer', default: 25 }
+      },
+      required: ['efo_id']
+    },
+    required: ['efo_id'],
+    returns:
+      '`{ "id": str, "name": str, "drugAndClinicalCandidates": { "count": int, "rows": [ { "id": str, "maxClinicalStage": str, "drug": { "id": str, "name": str, "drugType": str } } ] } }` (rows capped at `size`, default 25), or `{ "errors": [...] }` on GraphQL error / unknown id.',
+    example:
+      'result = host.mcp("clinical_genomics", "open_targets_disease_drugs", {"efo_id": "MONDO_0004992", "size": 25})',
+    run: async (ctx, a) => {
+      const size = Number(a.size ?? 25)
+      const node = await otQuery(ctx, OT_DISEASE_DRUGS_Q, { id: String(a.efo_id) }, 'disease')
+      const cand = node.drugAndClinicalCandidates as { rows?: unknown[] } | undefined
+      if (cand && Array.isArray(cand.rows)) cand.rows = cand.rows.slice(0, size)
+      return node
+    }
+  },
+  {
+    id: 'open_targets_disease_targets',
+    connector: 'clinical_genomics',
+    description:
+      'Top associated targets for a disease, ranked by Open Targets overall association score — wraps Disease.associatedTargets. efo_id is a disease ontology id (EFO/MONDO/etc.).',
+    input: {
+      type: 'object',
+      properties: {
+        efo_id: { type: 'string' },
+        size: { type: 'integer', default: 25 }
+      },
+      required: ['efo_id']
+    },
+    required: ['efo_id'],
+    returns:
+      '`{ "id": str, "name": str, "associatedTargets": { "count": int, "rows": [ { "score": float, "target": { "id": str, "approvedSymbol": str } } ] } }` (up to `size` rows, default 25), or `{ "errors": [...] }` on GraphQL error / unknown id.',
+    example:
+      'result = host.mcp("clinical_genomics", "open_targets_disease_targets", {"efo_id": "MONDO_0004992", "size": 25})',
+    run: async (ctx, a) =>
+      otQuery(
+        ctx,
+        OT_DISEASE_TARGETS_Q,
+        { id: String(a.efo_id), size: Number(a.size ?? 25) },
+        'disease'
+      )
+  },
+  {
+    id: 'open_targets_drug',
+    connector: 'clinical_genomics',
+    description:
+      'Drug details by ChEMBL id (Open Targets Platform) — name, type, maximum clinical stage, and mechanisms of action (target + action type). chembl_id e.g. "CHEMBL1201583".',
+    input: {
+      type: 'object',
+      properties: { chembl_id: { type: 'string' } },
       required: ['chembl_id']
     },
     required: ['chembl_id'],
     returns:
-      '`{ "chembl_id": str, "name": str, "drug_type": str, "max_clinical_stage": str, "mechanisms_of_action": [ { "mechanism_of_action": str, "action_type": str, "targets": [ { "id": str, "approved_symbol": str } ] } ], "n_indications_total": int, "returned_indications": int, "indications": [ { "disease_id": str, "disease_name": str, "max_clinical_stage": str } ] }` — indications capped at `limit` (default 10); `n_indications_total` is the full count. Unknown ChEMBL id returns `{ "chembl_id": str, "found": false }`.',
+      '`{ "id": str, "name": str, "drugType": str, "maximumClinicalStage": str, "mechanismsOfAction": { "rows": [ { "mechanismOfAction": str, "actionType": str, "targets": [ { "id": str, "approvedSymbol": str } ] } ] } }`, or `{ "errors": [...] }` on GraphQL error / unknown id.',
     example:
-      'result = host.mcp("clinical_genomics", "opentargets_drug", {"chembl_id": "CHEMBL1201583"})',
-    run: async (ctx, a) => {
-      const chemblId = String(a.chembl_id)
-      const limit = Number(a.limit ?? DEFAULT_LIMIT)
-
-      const result = (await ctx.postJson(OPEN_TARGETS_API, {
-        query: DRUG_QUERY,
-        variables: { chemblId }
-      })) as DrugResponse
-      throwOnErrors(result.errors, 'drug')
-
-      const drug = result.data?.drug
-      if (!drug) {
-        return { chembl_id: chemblId, found: false }
-      }
-
-      const moaRows = drug.mechanismsOfAction?.rows ?? []
-      const allIndications = drug.indications?.rows ?? []
-      const indications = allIndications.slice(0, limit)
-
-      return {
-        chembl_id: drug.id,
-        name: drug.name,
-        drug_type: drug.drugType,
-        max_clinical_stage: drug.maximumClinicalStage,
-        mechanisms_of_action: moaRows.map((r) => ({
-          mechanism_of_action: r.mechanismOfAction,
-          action_type: r.actionType,
-          targets: (r.targets ?? []).map((t) => ({ id: t.id, approved_symbol: t.approvedSymbol }))
-        })),
-        n_indications_total: drug.indications?.count ?? allIndications.length,
-        returned_indications: indications.length,
-        indications: indications.map((i) => ({
-          disease_id: i.disease?.id,
-          disease_name: i.disease?.name,
-          max_clinical_stage: i.maxClinicalStage
-        }))
-      }
-    }
+      'result = host.mcp("clinical_genomics", "open_targets_drug", {"chembl_id": "CHEMBL1201583"})',
+    run: async (ctx, a) => otQuery(ctx, OT_DRUG_Q, { id: String(a.chembl_id) }, 'drug')
   }
 ]


### PR DESCRIPTION
Rounds out the Clinical Genomics connector across three curated sources —
ClinGen (gene validity, dosage sensitivity, actionability, variant
classifications), CIViC (gene / variant / evidence / assertion / molecular-
profile / disease / therapy search and lookup), and Open Targets (disease
targets & drugs, drug lookup, and an arbitrary GraphQL passthrough).

All tools are read-only; CIViC searches walk cursor pagination to a
count-verified total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)