### PR TITLE
fix(settings): disable built-in WebSearch tool for the ACP agent

### DIFF
--- a/src/main/settings/claude-config-provision.test.ts
+++ b/src/main/settings/claude-config-provision.test.ts
@@ -8,6 +8,7 @@ import { SkillRegistry } from '../skills/registry'
 import { ClaudeCodeSkillMaterializer } from '../skills/materializer'
 import {
   APP_ASSET_SUBDIRS,
+  DENIED_BUILTIN_TOOLS,
   configDenyRules,
   provisionAppClaudeConfigDir
 } from './claude-config-provision'
@@ -80,11 +81,21 @@ describe('provisionAppClaudeConfigDir', () => {
 
     const settings = JSON.parse(await readFile(join(configDir, 'settings.json'), 'utf8'))
     const deny: string[] = settings.permissions.deny
-    expect(deny).toEqual(configDenyRules(configDir))
+    expect(deny).toEqual([...configDenyRules(configDir), ...DENIED_BUILTIN_TOOLS])
     // Each rule is an absolute-path (`//`) recursive deny for one of the guarded file tools.
     for (const tool of ['Read', 'Edit', 'Glob', 'Grep']) {
       expect(deny.some((rule) => rule.startsWith(`${tool}(//`) && rule.endsWith('/**)'))).toBe(true)
     }
+  })
+
+  it('disables the built-in WebSearch tool in the app user scope', async () => {
+    root = await mkdtemp(join(tmpdir(), 'os-claude-config-'))
+    const configDir = join(root, 'claude')
+
+    await provisionAppClaudeConfigDir(configDir)
+
+    const settings = JSON.parse(await readFile(join(configDir, 'settings.json'), 'utf8'))
+    expect(settings.permissions.deny).toContain('WebSearch')
   })
 
   it('disables Claude Code bundled skills in the app user scope', async () => {

--- a/src/main/settings/claude-config-provision.ts
+++ b/src/main/settings/claude-config-provision.ts
@@ -17,6 +17,10 @@ const APP_ASSET_SUBDIRS = ['skills', 'plugins', 'commands'] as const
 // (bash/subprocess) is guarded separately; see the notebook audit hook and read-guard spec.
 const GUARDED_FILE_TOOLS = ['Read', 'Edit', 'Glob', 'Grep'] as const
 
+// Built-in agent tools disabled outright in this app. Web search is off by policy: the agent gets its
+// external data through the curated MCP research connectors, not the model's open-web search.
+const DENIED_BUILTIN_TOOLS = ['WebSearch'] as const
+
 // Builds the claude-code permission deny rules that fence the agent's file tools out of `configDir`.
 // Claude Code permission paths are gitignore-style with forward slashes, where a `//<abs>` prefix
 // denotes an absolute filesystem path. Normalize Windows backslashes and collapse the leading slash
@@ -27,10 +31,11 @@ const configDenyRules = (configDir: string): string[] => {
 }
 
 // Writes/merges `<configDir>/settings.json` for the app-owned user scope (the agent runs with
-// settingSources: ['user']). Two things are enforced here, merge-preserving any settings already
-// present: the permissions.deny guard rules, and disableBundledSkills so Claude Code's own bundled
-// skills/workflows (dataviz, deep-research, …) never leak in — the app injects its OWN curated skill
-// set into `<configDir>/skills`, which disableBundledSkills leaves untouched.
+// settingSources: ['user']). Three things are enforced here, merge-preserving any settings already
+// present: the permissions.deny guard rules (file-tool fence + disabled built-in tools like WebSearch),
+// and disableBundledSkills so Claude Code's own bundled skills/workflows (dataviz, deep-research, …)
+// never leak in — the app injects its OWN curated skill set into `<configDir>/skills`, which
+// disableBundledSkills leaves untouched.
 const writeAppSettings = async (configDir: string): Promise<void> => {
   const settingsPath = join(configDir, 'settings.json')
 
@@ -47,7 +52,9 @@ const writeAppSettings = async (configDir: string): Promise<void> => {
       ? (settings.permissions as Record<string, unknown>)
       : {}
   const existingDeny = Array.isArray(permissions.deny) ? (permissions.deny as string[]) : []
-  const deny = [...new Set([...existingDeny, ...configDenyRules(configDir)])]
+  const deny = [
+    ...new Set([...existingDeny, ...configDenyRules(configDir), ...DENIED_BUILTIN_TOOLS])
+  ]
 
   settings.permissions = { ...permissions, deny }
   settings.disableBundledSkills = true
@@ -83,4 +90,4 @@ const provisionAppClaudeConfigDir = async (
   await materializer.sync(configDir, enabled)
 }
 
-export { APP_ASSET_SUBDIRS, configDenyRules, provisionAppClaudeConfigDir }
+export { APP_ASSET_SUBDIRS, DENIED_BUILTIN_TOOLS, configDenyRules, provisionAppClaudeConfigDir }


### PR DESCRIPTION
## Summary

Disables the model's built-in **WebSearch** tool for the ACP agent as a security-hardening measure.

Uncontrolled open-web search is a data-exfiltration channel: the model could push conversation or workspace contents out through search queries. External data should instead flow through the app's curated, auditable MCP research connectors — not the model's general web search.

## Change

- Add `WebSearch` to the `permissions.deny` set written into the app-owned Claude config scope (`<storageRoot>/claude/settings.json`) by `writeAppSettings()` in `claude-config-provision.ts`.
- Reuses the existing deny mechanism already fencing the file tools out of the config dir, so it is enforced merge-preserving on **every agent spawn** (idempotent; existing installs pick it up on next spawn).
- `WebFetch` is intentionally left enabled — this PR scopes to web *search* only.

## Verification

- `claude-config-provision.test.ts`: 7 passed (updated the deny-equality assertion; added a case asserting `WebSearch` is denied).
- `npm run lint` (changed files) and `npm run typecheck`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)