### PR TITLE
feat(connectors): expand Protein Annotation with InterPro, Pfam & HPA

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -189,10 +189,11 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
   {
     id: 'protein_annotation',
     displayName: 'Protein Annotation',
-    description: 'Protein-protein interaction data via STRING-DB.',
+    description:
+      'Protein domain architecture, family/clan membership, expression atlas and interaction networks via InterPro/Pfam, the Human Protein Atlas and STRING.',
     useWhen:
-      'Use when you need protein-protein interaction data — interaction partners for a gene/protein ranked by confidence score, or the interaction network among a set of genes/proteins. Sourced from STRING-DB.',
-    sources: ['STRING'],
+      "Use when you need protein annotation — a protein's complete InterPro/Pfam domain architecture, entry/family/clan search and detail, member proteins or proteomes of a Pfam family, Human Protein Atlas per-gene expression (tissue/subcellular/pathology/blood/brain) and bulk search, or STRING id mapping, interaction networks and homology similarity. Sourced from InterPro, Pfam, the Human Protein Atlas and STRING.",
+    sources: ['InterPro', 'Pfam', 'Human Protein Atlas', 'STRING'],
     termsUrl: 'https://string-db.org/cgi/access?footer_active_subpage=licensing',
     requiresNcbi: false
   },

--- a/src/main/connectors/descriptors/protein-annotation.test.ts
+++ b/src/main/connectors/descriptors/protein-annotation.test.ts
@@ -4,78 +4,593 @@ import { PROTEIN_ANNOTATION_TOOLS } from './protein-annotation'
 import type { ToolDescriptor } from '../types'
 
 const tool = (id: string): ToolDescriptor => PROTEIN_ANNOTATION_TOOLS.find((t) => t.id === id)!
-const jsonRes = (body: unknown): Response =>
-  ({ ok: true, status: 200, json: async () => body }) as Response
 
-describe('protein_annotation / string-db', () => {
-  it('string_interaction_partners builds the URL and parses partners + scores', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes([
-        {
-          stringId_A: '9606.ENSP00000269305',
-          stringId_B: '9606.ENSP00000340989',
-          preferredName_A: 'TP53',
-          preferredName_B: 'SFN',
-          ncbiTaxonId: 9606,
-          score: 0.999
-        },
-        {
-          stringId_A: '9606.ENSP00000269305',
-          stringId_B: '9606.ENSP00000263253',
-          preferredName_A: 'TP53',
-          preferredName_B: 'EP300',
-          ncbiTaxonId: 9606,
-          score: 0.999
+// Map a URL to a mock Response; .json()/.text() mirror real fetch (empty body → 204-style null/'').
+type MockEntry = { json?: unknown; text?: string; status?: number }
+function mockFetch(routes: Record<string, MockEntry>): typeof fetch {
+  return vi.fn(async (url: string) => {
+    const key = Object.keys(routes).find((k) => url.includes(k))
+    const r = key ? routes[key] : { text: '' }
+    const status = r.status ?? 200
+    const body = 'json' in r ? JSON.stringify(r.json) : (r.text ?? '')
+    return {
+      ok: status < 400,
+      status,
+      json: async () => {
+        if ('json' in r) return r.json
+        if (!r.text) throw new SyntaxError('Unexpected end of JSON input')
+        return JSON.parse(r.text)
+      },
+      text: async () => body
+    } as Response
+  }) as unknown as typeof fetch
+}
+
+const engine = (fetchImpl: typeof fetch): ParserEngine => new ParserEngine({ fetchImpl })
+const calls = (fetchImpl: typeof fetch): unknown[][] =>
+  (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls
+
+describe('protein_annotation / tool set', () => {
+  it('exposes exactly the 13 upstream tool ids and drops the old string_* ids', () => {
+    expect(PROTEIN_ANNOTATION_TOOLS.map((t) => t.id).sort()).toEqual(
+      [
+        'get_domain_architecture',
+        'get_interpro_entry',
+        'get_pfam_clan',
+        'get_pfam_family_proteins',
+        'get_pfam_family_proteomes',
+        'get_protein_atlas_gene',
+        'get_string_best_similarity_hits',
+        'get_string_network',
+        'get_string_similarity_scores',
+        'map_string_ids',
+        'search_interpro_entries',
+        'search_pfam_clans',
+        'search_protein_atlas'
+      ].sort()
+    )
+    const ids = PROTEIN_ANNOTATION_TOOLS.map((t) => t.id)
+    expect(ids).not.toContain('string_interaction_partners')
+    expect(ids).not.toContain('string_network')
+    expect(PROTEIN_ANNOTATION_TOOLS.every((t) => t.connector === 'protein_annotation')).toBe(true)
+  })
+})
+
+describe('protein_annotation / InterPro', () => {
+  it('get_domain_architecture walks pages, verifies count, and shapes a deterministic summary', async () => {
+    const page2 =
+      'https://www.ebi.ac.uk/interpro/api/entry/interpro/protein/uniprot/P04637/?page_size=200&cursor=x'
+    const fetchImpl = mockFetch({
+      '/entry/interpro/protein/uniprot/P04637/?page_size=200&cursor=x': {
+        json: {
+          count: 2,
+          next: null,
+          results: [
+            {
+              metadata: {
+                accession: 'IPR002117',
+                name: 'p53 tumour suppressor family',
+                type: 'family',
+                member_databases: { pfam: { PF00870: 'P53' } }
+              },
+              proteins: [
+                {
+                  accession: 'P04637',
+                  protein_length: 393,
+                  entry_protein_locations: [{ fragments: [{ start: 95, end: 288 }] }]
+                }
+              ]
+            }
+          ]
         }
-      ])
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('string_interaction_partners'),
-      { gene: 'TP53', limit: 2 },
+      },
+      '/entry/interpro/protein/uniprot/P04637/?page_size=200': {
+        json: {
+          count: 2,
+          next: page2,
+          results: [
+            {
+              metadata: {
+                accession: 'IPR011615',
+                name: 'p53, DNA-binding domain',
+                type: 'domain',
+                member_databases: {}
+              },
+              proteins: [
+                {
+                  accession: 'P04637',
+                  protein_length: 393,
+                  entry_protein_locations: [{ fragments: [{ start: 94, end: 292 }] }]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_domain_architecture'),
+      { accessions: ['P04637'] },
       {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://string-db.org/api/json/interaction_partners?identifiers=TP53&species=9606&limit=2'
-    )
-    expect(out).toEqual([
-      { partner: 'SFN', score: 0.999 },
-      { partner: 'EP300', score: 0.999 }
+    )) as {
+      summaries: Record<string, { protein: string; entry_count: number; entries: unknown[] }>
+      stats: { http_requests: number }
+    }
+    const s = out.summaries.P04637
+    expect(s.protein).toBe('P04637')
+    expect(s.entry_count).toBe(2)
+    // family sorts before domain (type-order rank)
+    expect(s.entries.map((e) => (e as { accession: string }).accession)).toEqual([
+      'IPR002117',
+      'IPR011615'
     ])
+    expect((s.entries[0] as { member_db_signatures: unknown[] }).member_db_signatures).toEqual([
+      { database: 'pfam', accession: 'PF00870', name: 'P53' }
+    ])
+    expect(out.stats.http_requests).toBe(2)
   })
 
-  it('string_interaction_partners defaults limit to 10 when omitted', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
-    await new ParserEngine({ fetchImpl }).call(
-      tool('string_interaction_partners'),
+  it('get_domain_architecture treats an empty (204) protein as entry_count 0', async () => {
+    const fetchImpl = mockFetch({ '/entry/interpro/protein/uniprot/Q00000/': { text: '' } })
+    const out = (await engine(fetchImpl).call(
+      tool('get_domain_architecture'),
+      { accessions: ['Q00000'] },
+      {}
+    )) as { summaries: Record<string, { entry_count: number; entries: unknown[] }> }
+    expect(out.summaries.Q00000.entry_count).toBe(0)
+    expect(out.summaries.Q00000.entries).toEqual([])
+  })
+
+  it('search_interpro_entries sorts rows by accession and carries the API count', async () => {
+    const fetchImpl = mockFetch({
+      '/entry/pfam/': {
+        json: {
+          count: 2,
+          next: null,
+          results: [
+            {
+              metadata: {
+                accession: 'PF00069',
+                name: 'Protein kinase domain',
+                type: 'domain',
+                source_database: 'pfam',
+                integrated: 'IPR000719'
+              }
+            },
+            {
+              metadata: {
+                accession: 'PF00047',
+                name: 'Immunoglobulin domain',
+                type: 'domain',
+                source_database: 'pfam',
+                integrated: null
+              }
+            }
+          ]
+        }
+      }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('search_interpro_entries'),
+      { query: 'kinase', source_db: 'pfam' },
+      {}
+    )) as { count: number; results: Array<{ accession: string }> }
+    expect(calls(fetchImpl)[0][0]).toContain('/entry/pfam/?search=kinase')
+    expect(out.count).toBe(2)
+    expect(out.results.map((r) => r.accession)).toEqual(['PF00047', 'PF00069'])
+  })
+
+  it('get_interpro_entry routes PF accessions to the pfam endpoint and shapes name/set_info', async () => {
+    const fetchImpl = mockFetch({
+      '/entry/pfam/PF00069/': {
+        json: {
+          metadata: {
+            accession: 'PF00069',
+            name: { name: 'Protein kinase domain', short: 'Pkinase' },
+            type: 'domain',
+            source_database: 'pfam',
+            integrated: 'IPR000719',
+            set_info: { accession: 'CL0016' },
+            go_terms: [{ identifier: 'GO:0004672' }],
+            literature: [{}, {}]
+          }
+        }
+      }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_interpro_entry'),
+      { accession: 'pf00069' },
+      {}
+    )) as {
+      accession: string
+      name: { name: string; short: string }
+      set_info: unknown
+      n_literature_refs: number
+    }
+    expect(calls(fetchImpl)[0][0]).toContain('/entry/pfam/PF00069/')
+    expect(out.accession).toBe('PF00069')
+    expect(out.name).toEqual({ name: 'Protein kinase domain', short: 'Pkinase' })
+    expect(out.set_info).toEqual({ accession: 'CL0016' })
+    expect(out.n_literature_refs).toBe(2)
+  })
+
+  it('get_pfam_clan reads relationships.nodes as the sorted member list', async () => {
+    const fetchImpl = mockFetch({
+      '/set/pfam/CL0016/': {
+        json: {
+          metadata: {
+            accession: 'CL0016',
+            name: 'Protein kinase superfamily',
+            source_database: 'pfam',
+            relationships: {
+              nodes: [
+                { accession: 'PF00069', name: 'Pkinase', short_name: 'Pkinase', type: 'family' },
+                { accession: 'PF00027', name: 'cNMP_binding', short_name: 'cNMP', type: 'family' }
+              ]
+            }
+          }
+        }
+      }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_pfam_clan'),
+      { clan_accession: 'CL0016' },
+      {}
+    )) as { member_count: number; members: Array<{ accession: string }> }
+    expect(out.member_count).toBe(2)
+    expect(out.members.map((m) => m.accession)).toEqual(['PF00027', 'PF00069'])
+  })
+
+  it('get_pfam_family_proteins count_only issues one page_size=1 request and returns null results', async () => {
+    const fetchImpl = mockFetch({
+      '/protein/uniprot/entry/pfam/PF00069/': { json: { count: 1500000, results: [] } }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_pfam_family_proteins'),
+      { pfam_accession: 'PF00069', count_only: true },
+      {}
+    )) as { count: number; results: unknown }
+    expect(calls(fetchImpl)[0][0]).toContain('page_size=1')
+    expect(out).toEqual({ count: 1500000, results: null })
+  })
+
+  it('get_pfam_family_proteomes defaults to count_only', async () => {
+    const fetchImpl = mockFetch({
+      '/proteome/uniprot/entry/pfam/PF00069/': { json: { count: 4200, results: [] } }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_pfam_family_proteomes'),
+      { pfam_accession: 'PF00069' },
+      {}
+    )) as { count: number; results: unknown }
+    expect(calls(fetchImpl)[0][0]).toContain('page_size=1')
+    expect(out).toEqual({ count: 4200, results: null })
+  })
+})
+
+describe('protein_annotation / Human Protein Atlas', () => {
+  it('get_protein_atlas_gene resolves a symbol then groups the record into sections', async () => {
+    const fetchImpl = mockFetch({
+      '/api/search_download.php': {
+        json: [{ Gene: 'TP53', Ensembl: 'ENSG00000141510', 'Gene synonym': ['p53'] }]
+      },
+      '/ENSG00000141510.json': {
+        json: {
+          Gene: 'TP53',
+          Ensembl: 'ENSG00000141510',
+          'Subcellular main location': ['Nucleoplasm'],
+          'Cancer prognostics - Breast cancer': { prognostic: 'unfavorable' }
+        }
+      }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_protein_atlas_gene'),
       { gene: 'TP53' },
       {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://string-db.org/api/json/interaction_partners?identifiers=TP53&species=9606&limit=10'
-    )
+    )) as {
+      identity: Record<string, unknown>
+      subcellular: Record<string, unknown>
+      pathology: { prognostics: Record<string, unknown> }
+    }
+    expect(out.identity.Gene).toBe('TP53')
+    expect(out.subcellular['Subcellular main location']).toEqual(['Nucleoplasm'])
+    expect(out.pathology.prognostics['Breast cancer']).toEqual({ prognostic: 'unfavorable' })
   })
 
-  it('string_network builds the URL and parses edges', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes([
-        {
-          stringId_A: '9606.ENSP00000258149',
-          stringId_B: '9606.ENSP00000269305',
-          preferredName_A: 'MDM2',
-          preferredName_B: 'TP53',
-          ncbiTaxonId: '9606',
-          score: 0.999
-        }
-      ])
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('string_network'),
-      { genes: ['TP53', 'MDM2'] },
+  it('get_protein_atlas_gene full=true returns the raw record and skips grouping', async () => {
+    const fetchImpl = mockFetch({
+      '/ENSG00000141510.json': { json: { Gene: 'TP53', foo: 'bar' } }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_protein_atlas_gene'),
+      { gene: 'ENSG00000141510', full: true },
       {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://string-db.org/api/json/network?identifiers=TP53%2CMDM2&species=9606'
-    )
-    expect(out).toEqual([{ a: 'MDM2', b: 'TP53', score: 0.999 }])
+    )) as Record<string, unknown>
+    expect(out).toEqual({ Gene: 'TP53', foo: 'bar' })
   })
+
+  it('search_protein_atlas passes the query/columns and returns the raw rows', async () => {
+    const fetchImpl = mockFetch({
+      '/api/search_download.php': { json: [{ Gene: 'TP53' }, { Gene: 'TP63' }] }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('search_protein_atlas'),
+      { query: 'kinase', columns: 'g,eg' },
+      {}
+    )) as Array<{ Gene: string }>
+    expect(calls(fetchImpl)[0][0]).toContain('columns=g%2Ceg')
+    expect(out.map((r) => r.Gene)).toEqual(['TP53', 'TP63'])
+  })
+})
+
+describe('protein_annotation / STRING', () => {
+  it('map_string_ids partitions input into mapped and unmapped by queryIndex', async () => {
+    const fetchImpl = mockFetch({
+      '/json/version': {
+        json: [{ string_version: '12.0', stable_address: 'https://version-12-0.string-db.org' }]
+      },
+      '/json/get_string_ids': {
+        json: [
+          {
+            queryIndex: 0,
+            stringId: '9606.ENSP00000269305',
+            preferredName: 'TP53',
+            ncbiTaxonId: 9606
+          },
+          {
+            queryIndex: 2,
+            stringId: '9606.ENSP00000275493',
+            preferredName: 'EGFR',
+            ncbiTaxonId: 9606
+          }
+        ]
+      }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('map_string_ids'),
+      { symbols: ['TP53', 'NOTAGENE', 'EGFR'] },
+      {}
+    )) as {
+      string_version: { string_version: string }
+      mapped: Array<{ query: string }>
+      unmapped: string[]
+    }
+    expect(out.string_version.string_version).toBe('12.0')
+    expect(out.mapped.map((m) => m.query)).toEqual(['TP53', 'EGFR'])
+    expect(out.unmapped).toEqual(['NOTAGENE'])
+  })
+
+  it('get_string_network parses the TSV, orients + dedupes edges, and builds nodes/summary', async () => {
+    const tsv =
+      'stringId_A\tstringId_B\tpreferredName_A\tpreferredName_B\tncbiTaxonId\tscore\tnscore\tfscore\tpscore\tascore\tescore\tdscore\ttscore\n' +
+      '9606.ENSP00000258149\t9606.ENSP00000269305\tMDM2\tTP53\t9606\t0.999\t0\t0\t0\t0\t0.9\t0\t0.5\n'
+    const fetchImpl = mockFetch({
+      '/json/version': { json: [{ string_version: '12.0', stable_address: 'x' }] },
+      '/json/get_string_ids': {
+        json: [
+          {
+            queryIndex: 0,
+            stringId: '9606.ENSP00000269305',
+            preferredName: 'TP53',
+            ncbiTaxonId: 9606
+          },
+          {
+            queryIndex: 1,
+            stringId: '9606.ENSP00000258149',
+            preferredName: 'MDM2',
+            ncbiTaxonId: 9606
+          }
+        ]
+      },
+      '/tsv/network': { text: tsv }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_string_network'),
+      { symbols: ['TP53', 'MDM2'], required_score: 700 },
+      {}
+    )) as {
+      edges: Array<{ a: string; b: string; score: number; evidence: Record<string, number> }>
+      nodes: Array<{ name: string; degree: number }>
+      summary: { n_edges: number; n_nodes: number }
+      unmapped: string[]
+    }
+    expect(out.edges).toHaveLength(1)
+    // oriented so (name_a, id_a) <= (name_b, id_b): MDM2 before TP53
+    expect(out.edges[0]).toMatchObject({ a: 'MDM2', b: 'TP53', score: 0.999 })
+    expect(out.edges[0].evidence).toEqual({ escore: 0.9, tscore: 0.5 })
+    expect(out.summary).toMatchObject({ n_edges: 1, n_nodes: 2 })
+    expect(out.nodes.map((n) => n.degree)).toEqual([1, 1])
+    expect(out.unmapped).toEqual([])
+  })
+
+  it('get_string_similarity_scores canonicalizes homology pairs (id_a <= id_b, self flagged)', async () => {
+    const fetchImpl = mockFetch({
+      '/json/version': { json: [{ string_version: '12.0' }] },
+      '/json/get_string_ids': {
+        json: [
+          {
+            queryIndex: 0,
+            stringId: '9606.ENSP00000269305',
+            preferredName: 'TP53',
+            ncbiTaxonId: 9606
+          },
+          {
+            queryIndex: 1,
+            stringId: '9606.ENSP00000258149',
+            preferredName: 'MDM2',
+            ncbiTaxonId: 9606
+          }
+        ]
+      },
+      '/json/homology': {
+        json: [
+          {
+            stringId_A: '9606.ENSP00000269305',
+            stringId_B: '9606.ENSP00000269305',
+            ncbiTaxonId_A: 9606,
+            ncbiTaxonId_B: 9606,
+            bitscore: '806.2'
+          },
+          {
+            stringId_A: '9606.ENSP00000269305',
+            stringId_B: '9606.ENSP00000258149',
+            ncbiTaxonId_A: 9606,
+            ncbiTaxonId_B: 9606,
+            bitscore: '55.1'
+          },
+          {
+            stringId_A: '9606.ENSP00000258149',
+            stringId_B: '9606.ENSP00000269305',
+            ncbiTaxonId_A: 9606,
+            ncbiTaxonId_B: 9606,
+            bitscore: '55.1'
+          }
+        ]
+      }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_string_similarity_scores'),
+      { symbols: ['TP53', 'MDM2'] },
+      {}
+    )) as {
+      n_pairs: number
+      n_self: number
+      pairs: Array<{ id_a: string; id_b: string; self: boolean; name_a: string }>
+    }
+    expect(out.n_pairs).toBe(2)
+    expect(out.n_self).toBe(1)
+    // pairs sorted by (id_a, id_b); ...258149 < ...269305
+    expect(out.pairs[0].id_a).toBe('9606.ENSP00000258149')
+    expect(out.pairs[0].name_a).toBe('MDM2')
+  })
+
+  it('get_string_best_similarity_hits maps hits and sorts by query id', async () => {
+    const fetchImpl = mockFetch({
+      '/json/version': { json: [{ string_version: '12.0' }] },
+      '/json/get_string_ids': {
+        json: [
+          {
+            queryIndex: 0,
+            stringId: '9606.ENSP00000269305',
+            preferredName: 'TP53',
+            ncbiTaxonId: 9606
+          }
+        ]
+      },
+      '/json/homology_best': {
+        json: [
+          {
+            stringId_A: '9606.ENSP00000269305',
+            stringId_B: '10090.ENSMUSP00000104298',
+            ncbiTaxonId_A: 9606,
+            ncbiTaxonId_B: 10090,
+            bitscore: 598.2
+          }
+        ]
+      }
+    })
+    const out = (await engine(fetchImpl).call(
+      tool('get_string_best_similarity_hits'),
+      { symbols: ['TP53'], target_species: 10090 },
+      {}
+    )) as {
+      species_b: number
+      n_hits: number
+      hits: Array<{ query_name: string; hit_id: string; bitscore: number }>
+    }
+    expect(calls(fetchImpl).some((c) => String(c[0]).includes('species_b=10090'))).toBe(true)
+    expect(out.species_b).toBe(10090)
+    expect(out.n_hits).toBe(1)
+    expect(out.hits[0]).toMatchObject({
+      query_name: 'TP53',
+      hit_id: '10090.ENSMUSP00000104298',
+      bitscore: 598.2
+    })
+  })
+})
+
+// Live self-tests against the real public endpoints. Off by default; run with LIVE_API=1.
+describe.skipIf(!process.env.LIVE_API)('protein_annotation / LIVE', () => {
+  const live = new ParserEngine()
+
+  it('get_domain_architecture P04637 returns InterPro entries with a verified count', async () => {
+    const out = (await live.call(
+      tool('get_domain_architecture'),
+      { accessions: ['P04637'] },
+      {}
+    )) as {
+      summaries: Record<string, { entry_count: number; entries: unknown[]; protein_length: number }>
+    }
+    const s = out.summaries.P04637
+    expect(s.entry_count).toBe(s.entries.length)
+    expect(s.protein_length).toBeGreaterThan(300)
+  }, 60000)
+
+  it('search_interpro_entries "kinase" returns count-verified rows sorted by accession', async () => {
+    const out = (await live.call(
+      tool('search_interpro_entries'),
+      { query: 'kinase', source_db: 'pfam' },
+      {}
+    )) as { count: number; results: Array<{ accession: string }> }
+    expect(out.results.length).toBe(out.count)
+    const accs = out.results.map((r) => r.accession)
+    expect([...accs].sort()).toEqual(accs)
+  }, 120000)
+
+  it('get_interpro_entry serves both an IPR and a PF accession', async () => {
+    const ipr = (await live.call(tool('get_interpro_entry'), { accession: 'IPR000719' }, {})) as {
+      accession: string
+    }
+    const pf = (await live.call(tool('get_interpro_entry'), { accession: 'PF00069' }, {})) as {
+      accession: string
+    }
+    expect(ipr.accession).toBe('IPR000719')
+    expect(pf.accession).toBe('PF00069')
+  }, 60000)
+
+  it('get_pfam_clan CL0016 lists member families', async () => {
+    const out = (await live.call(tool('get_pfam_clan'), { clan_accession: 'CL0016' }, {})) as {
+      member_count: number
+      members: unknown[]
+    }
+    expect(out.member_count).toBe(out.members.length)
+    expect(out.member_count).toBeGreaterThan(0)
+  }, 60000)
+
+  it('get_pfam_family_proteins PF00069 count_only returns a large count', async () => {
+    const out = (await live.call(
+      tool('get_pfam_family_proteins'),
+      { pfam_accession: 'PF00069', count_only: true },
+      {}
+    )) as { count: number; results: unknown }
+    expect(out.results).toBeNull()
+    expect(out.count).toBeGreaterThan(1000)
+  }, 60000)
+
+  it('get_protein_atlas_gene TP53 groups the record', async () => {
+    const out = (await live.call(tool('get_protein_atlas_gene'), { gene: 'TP53' }, {})) as {
+      identity: Record<string, unknown>
+    }
+    expect(String(out.identity.Gene)).toBe('TP53')
+  }, 60000)
+
+  it('map_string_ids + get_string_network resolve TP53/BRCA1/EGFR and return edges', async () => {
+    const mapped = (await live.call(
+      tool('map_string_ids'),
+      { symbols: ['TP53', 'BRCA1', 'EGFR'] },
+      {}
+    )) as {
+      mapped: unknown[]
+      unmapped: string[]
+    }
+    expect(mapped.mapped.length).toBe(3)
+    expect(mapped.unmapped).toEqual([])
+    const net = (await live.call(
+      tool('get_string_network'),
+      { symbols: ['TP53', 'BRCA1', 'EGFR'] },
+      {}
+    )) as { nodes: unknown[]; edges: unknown[] }
+    expect(net.nodes.length).toBe(3)
+    expect(Array.isArray(net.edges)).toBe(true)
+  }, 60000)
 })

--- a/src/main/connectors/descriptors/protein-annotation.ts
+++ b/src/main/connectors/descriptors/protein-annotation.ts
@@ -1,68 +1,1289 @@
-import type { ToolDescriptor } from '../types'
+import type { ToolContext, ToolDescriptor } from '../types'
 
-const STRING_BASE = 'https://string-db.org/api/json'
-const HUMAN_TAXON_ID = 9606
+// Public, version-pinned endpoints (ported from the upstream mcp_protein_annotation fleet libs).
+const INTERPRO_BASE = 'https://www.ebi.ac.uk/interpro/api'
+const HPA_BASE = 'https://v25.proteinatlas.org' // Human Protein Atlas release 25.x (pinned host)
+const STRING_BASE = 'https://version-12-0.string-db.org/api' // STRING v12.0 (pinned)
+const STRING_CALLER = 'bio-tools-string-network'
+const DEFAULT_SPECIES = 9606 // human
+const PAGE_SIZE = 200 // InterPro honours >=200 per page
 
-type StringEdge = {
-  preferredName_A?: string
-  preferredName_B?: string
-  score?: number
+// ---------------------------------------------------------------------------
+// shared HTTP helpers
+// ---------------------------------------------------------------------------
+
+// Byte size of a response body (UTF-8), used to mirror the fleet's request accounting.
+const byteLen = (text: string): number => Buffer.byteLength(text, 'utf8')
+
+// Build a query string from ordered [key, value] pairs, skipping null/undefined values.
+function qs(pairs: Array<[string, unknown]>): string {
+  const parts = pairs
+    .filter(([, v]) => v !== null && v !== undefined)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`)
+  return parts.length ? `?${parts.join('&')}` : ''
 }
 
-// STRING-DB REST (JSON output): protein-protein interaction lookups for human (taxon 9606).
+// GET JSON via fetchText so an empty body (HTTP 204) is a legitimate null, not a JSON parse error.
+async function getJsonMaybe(
+  ctx: ToolContext,
+  url: string
+): Promise<{ data: unknown; bytes: number }> {
+  const text = await ctx.fetchText(url)
+  const trimmed = text.trim()
+  return { data: trimmed ? JSON.parse(trimmed) : null, bytes: byteLen(text) }
+}
+
+// Follow InterPro cursor pagination to completion and verify the accumulated rows match the API count.
+async function walkEntries(
+  ctx: ToolContext,
+  startUrl: string,
+  stats?: { requests: number; bytes: number }
+): Promise<{ count: number; results: unknown[] }> {
+  let url: string | null = startUrl
+  const results: unknown[] = []
+  let count = 0
+  let pages = 0
+  while (url) {
+    const { data, bytes } = await getJsonMaybe(ctx, url)
+    pages += 1
+    if (stats) {
+      stats.requests += 1
+      stats.bytes += bytes
+    }
+    if (data === null) {
+      if (pages === 1) return { count: 0, results: [] } // 204 on first page — legitimately empty
+      // 204 mid-pagination is an upstream defect (e.g. the proteome route): never return a partial set.
+      throw new Error(
+        `InterPro returned HTTP 204 mid-pagination (page ${pages}) — incomplete result set (${results.length} of ${count} rows)`
+      )
+    }
+    const payload = data as { count?: number; results?: unknown[]; next?: string | null }
+    count = payload.count ?? 0
+    results.push(...(payload.results ?? []))
+    url = payload.next ?? null
+  }
+  if (results.length !== count) {
+    throw new Error(
+      `pagination incomplete: accumulated ${results.length} results but API count is ${count}`
+    )
+  }
+  return { count, results }
+}
+
+// ---------------------------------------------------------------------------
+// InterPro summary shaping (ports of interpro_domains.summary / interpro_entry_search.summary)
+// ---------------------------------------------------------------------------
+
+type Metadata = Record<string, unknown>
+const meta = (row: Record<string, unknown>): Metadata =>
+  ((row.metadata as Metadata) ?? row) as Metadata
+
+// Flatten {db: {acc: name}} into a list of signature dicts sorted by (database, accession).
+function memberSignatures(memberDatabases: unknown): Array<Record<string, unknown>> | null {
+  if (!memberDatabases || typeof memberDatabases !== 'object') return null
+  const flat: Array<{ database: string; accession: string; name: unknown }> = []
+  for (const [db, sigs] of Object.entries(memberDatabases as Record<string, unknown>)) {
+    for (const [acc, name] of Object.entries((sigs as Record<string, unknown>) ?? {})) {
+      flat.push({ database: db, accession: acc, name })
+    }
+  }
+  if (!flat.length) return null
+  flat.sort(
+    (a, b) => a.database.localeCompare(b.database) || a.accession.localeCompare(b.accession)
+  )
+  return flat
+}
+
+// GO terms sorted by identifier; null when absent/empty.
+function sortedGo(goTerms: unknown): unknown[] | null {
+  if (!Array.isArray(goTerms) || !goTerms.length) return null
+  return [...goTerms].sort((a, b) =>
+    String((a as Record<string, unknown>).identifier ?? '').localeCompare(
+      String((b as Record<string, unknown>).identifier ?? '')
+    )
+  )
+}
+
+function summarizeEntryRow(row: Record<string, unknown>): Record<string, unknown> {
+  const md = meta(row)
+  const out: Record<string, unknown> = {
+    accession: md.accession,
+    name: md.name,
+    type: md.type,
+    source_database: md.source_database,
+    integrated: md.integrated
+  }
+  const sigs = memberSignatures(md.member_databases)
+  if (sigs !== null) out.member_db_signatures = sigs
+  const go = sortedGo(md.go_terms)
+  if (go !== null) out.go_terms = go
+  return out
+}
+
+function summarizeSearch(fetched: { count: number; results: unknown[] }): Record<string, unknown> {
+  const rows = (fetched.results ?? []).map((r) => summarizeEntryRow(r as Record<string, unknown>))
+  rows.sort((a, b) => String(a.accession ?? '').localeCompare(String(b.accession ?? '')))
+  return { count: fetched.count ?? 0, results: rows }
+}
+
+function summarizeEntryDetail(payload: Record<string, unknown>): Record<string, unknown> {
+  const md = meta(payload)
+  const rawName = md.name
+  const name =
+    rawName && typeof rawName === 'object'
+      ? {
+          name: (rawName as Record<string, unknown>).name,
+          short: (rawName as Record<string, unknown>).short
+        }
+      : { name: rawName, short: null }
+  const out: Record<string, unknown> = {
+    accession: md.accession,
+    name,
+    type: md.type,
+    source_database: md.source_database,
+    integrated: md.integrated,
+    hierarchy: md.hierarchy,
+    set_info: md.set_info
+  }
+  const sigs = memberSignatures(md.member_databases)
+  if (sigs !== null) out.member_db_signatures = sigs
+  const go = sortedGo(md.go_terms)
+  if (go !== null) out.go_terms = go
+  if (Array.isArray(md.literature) && md.literature.length)
+    out.n_literature_refs = md.literature.length
+  return out
+}
+
+function summarizeClanDetail(payload: Record<string, unknown>): Record<string, unknown> {
+  const md = meta(payload)
+  const rawName = md.name
+  const name =
+    rawName && typeof rawName === 'object' ? (rawName as Record<string, unknown>).name : rawName
+  const nodes =
+    ((md.relationships as Record<string, unknown>)?.nodes as Array<Record<string, unknown>>) ?? []
+  const members = nodes
+    .map((n) => ({
+      accession: n.accession,
+      name: n.name,
+      short_name: n.short_name,
+      type: n.type
+    }))
+    .sort((a, b) => String(a.accession ?? '').localeCompare(String(b.accession ?? '')))
+  return {
+    accession: md.accession,
+    name,
+    source_database: md.source_database,
+    member_count: members.length,
+    members
+  }
+}
+
+function summarizeClanSearch(fetched: {
+  count: number
+  results: unknown[]
+}): Record<string, unknown> {
+  const rows = (fetched.results ?? []).map((r) => {
+    const md = meta(r as Record<string, unknown>)
+    const rawName = md.name
+    return {
+      accession: md.accession,
+      name:
+        rawName && typeof rawName === 'object'
+          ? (rawName as Record<string, unknown>).name
+          : rawName,
+      source_database: md.source_database
+    }
+  })
+  rows.sort((a, b) => String(a.accession ?? '').localeCompare(String(b.accession ?? '')))
+  return { count: fetched.count ?? 0, results: rows }
+}
+
+function summarizeProteins(fetched: {
+  count: number
+  results: unknown[] | null
+}): Record<string, unknown> {
+  if (fetched.results === null) return { count: fetched.count ?? 0, results: null }
+  const rows = fetched.results.map((r) => {
+    const md = meta(r as Record<string, unknown>)
+    const org = (md.source_organism as Record<string, unknown>) ?? {}
+    return {
+      accession: md.accession,
+      name: md.name,
+      source_database: md.source_database,
+      length: md.length,
+      tax_id: org.taxId,
+      organism: org.scientificName
+    }
+  })
+  rows.sort((a, b) => String(a.accession ?? '').localeCompare(String(b.accession ?? '')))
+  return { count: fetched.count ?? 0, results: rows }
+}
+
+function summarizeProteomes(fetched: {
+  count: number
+  results: unknown[] | null
+}): Record<string, unknown> {
+  if (fetched.results === null) return { count: fetched.count ?? 0, results: null }
+  const rows = fetched.results.map((r) => {
+    const md = meta(r as Record<string, unknown>)
+    return {
+      accession: md.accession,
+      name: md.name,
+      is_reference: md.is_reference,
+      taxonomy: md.taxonomy
+    }
+  })
+  rows.sort((a, b) => String(a.accession ?? '').localeCompare(String(b.accession ?? '')))
+  return { count: fetched.count ?? 0, results: rows }
+}
+
+// ---------------------------------------------------------------------------
+// Domain architecture shaping (port of interpro_domains.summary.build_summary)
+// ---------------------------------------------------------------------------
+
+const TYPE_ORDER = [
+  'family',
+  'domain',
+  'repeat',
+  'homologous_superfamily',
+  'conserved_site',
+  'active_site',
+  'binding_site',
+  'ptm'
+]
+const typeRank = (t: unknown): number => {
+  const i = TYPE_ORDER.indexOf(String(t))
+  return i === -1 ? TYPE_ORDER.length : i
+}
+
+function fragmentDict(frag: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { start: frag.start, end: frag.end }
+  const dc = frag['dc-status']
+  if (dc !== null && dc !== undefined && dc !== 'CONTINUOUS') out.dc_status = dc
+  return out
+}
+
+function sortedLocations(locs: unknown): Array<Record<string, unknown>> {
+  const locations = (Array.isArray(locs) ? locs : []).map((loc) => {
+    const l = loc as Record<string, unknown>
+    const fragments = ((l.fragments as Array<Record<string, unknown>>) ?? [])
+      .map(fragmentDict)
+      .sort(
+        (a, b) =>
+          Number(a.start ?? -1) - Number(b.start ?? -1) || Number(a.end ?? -1) - Number(b.end ?? -1)
+      )
+    const out: Record<string, unknown> = { fragments }
+    if (l.representative) out.representative = true
+    if (l.model !== null && l.model !== undefined) out.model = l.model
+    if (l.score !== null && l.score !== undefined) out.score = l.score
+    return out
+  })
+  locations.sort((a, b) => {
+    const fa = a.fragments as Array<Record<string, unknown>>
+    const fb = b.fragments as Array<Record<string, unknown>>
+    const sa = fa.length ? Number(fa[0].start ?? -1) : -1
+    const sb = fb.length ? Number(fb[0].start ?? -1) : -1
+    if (sa !== sb) return sa - sb
+    const ea = fa.length ? Number(fa[fa.length - 1].end ?? -1) : -1
+    const eb = fb.length ? Number(fb[fb.length - 1].end ?? -1) : -1
+    return ea - eb
+  })
+  return locations
+}
+
+function buildDomainSummary(
+  accession: string,
+  count: number,
+  results: Array<Record<string, unknown>>
+): Record<string, unknown> {
+  let proteinLength: unknown = null
+  const entries = results.map((item) => {
+    const md = (item.metadata as Metadata) ?? {}
+    const proteins = (item.proteins as Array<Record<string, unknown>>) ?? []
+    let match = proteins.find(
+      (p) => String(p.accession ?? '').toUpperCase() === accession.toUpperCase()
+    )
+    if (!match && proteins.length) match = proteins[0]
+    if (match && proteinLength === null) proteinLength = match.protein_length
+    return {
+      accession: md.accession,
+      name: md.name,
+      type: md.type,
+      member_db_signatures: memberSignatures(md.member_databases) ?? [],
+      locations: sortedLocations((match ?? {}).entry_protein_locations)
+    }
+  })
+  entries.sort(
+    (a, b) =>
+      typeRank(a.type) - typeRank(b.type) ||
+      String(a.accession ?? '').localeCompare(String(b.accession ?? ''))
+  )
+  return {
+    protein: accession.toUpperCase(),
+    protein_length: proteinLength,
+    entry_count: count,
+    entries
+  }
+}
+
+// Domain-architecture walk mirrors interpro_domains.client.get_protein_entries:
+// 204 means the protein has no InterPro entries (count 0), not a mid-page defect.
+async function walkProteinEntries(
+  ctx: ToolContext,
+  accession: string,
+  stats: { requests: number; bytes: number }
+): Promise<{ count: number; results: Array<Record<string, unknown>> }> {
+  const acc = encodeURIComponent(accession)
+  let url: string | null =
+    `${INTERPRO_BASE}/entry/interpro/protein/uniprot/${acc}/?page_size=${PAGE_SIZE}`
+  const results: Array<Record<string, unknown>> = []
+  let count = 0
+  while (url) {
+    const { data, bytes } = await getJsonMaybe(ctx, url)
+    stats.requests += 1
+    stats.bytes += bytes
+    if (data === null) {
+      count = 0
+      break
+    }
+    const payload = data as { count?: number; results?: unknown[]; next?: string | null }
+    count = payload.count ?? 0
+    results.push(...((payload.results as Array<Record<string, unknown>>) ?? []))
+    url = payload.next ?? null
+  }
+  if (results.length !== count) {
+    throw new Error(
+      `${accession}: pagination incomplete — accumulated ${results.length} results but API count is ${count}`
+    )
+  }
+  return { count, results }
+}
+
+// ---------------------------------------------------------------------------
+// STRING helpers (ports of string_network.core / .homology)
+// ---------------------------------------------------------------------------
+
+type StringMapped = {
+  query: string
+  string_id: string
+  preferred_name: string
+  ncbi_taxon_id: number
+}
+type StringIdRow = {
+  queryIndex?: number | string
+  stringId?: string
+  preferredName?: string
+  ncbiTaxonId?: number | string
+}
+type RequestLogEntry = { endpoint: string; bytes: number }
+
+const round3 = (x: number): number => Math.round(x * 1000) / 1000
+const round1 = (x: number): number => Math.round(x * 10) / 10
+
+async function stringGetJson(
+  ctx: ToolContext,
+  outputFormat: string,
+  endpoint: string,
+  params: Array<[string, unknown]>
+): Promise<{ data: unknown; bytes: number; endpoint: string }> {
+  const withCaller: Array<[string, unknown]> = [...params, ['caller_identity', STRING_CALLER]]
+  const url = `${STRING_BASE}/${outputFormat}/${endpoint}${qs(withCaller)}`
+  const text = await ctx.fetchText(url)
+  const trimmed = text.trim()
+  return {
+    data: outputFormat === 'json' ? (trimmed ? JSON.parse(trimmed) : []) : text,
+    bytes: byteLen(text),
+    endpoint: `${outputFormat}/${endpoint}`
+  }
+}
+
+// STRING version dict {string_version, stable_address} (first element of the version array).
+async function stringVersion(
+  ctx: ToolContext
+): Promise<{ version: Record<string, unknown>; log: RequestLogEntry }> {
+  const { data, bytes, endpoint } = await stringGetJson(ctx, 'json', 'version', [])
+  const v = (data as Array<Record<string, unknown>>)[0] ?? {}
+  return {
+    version: { string_version: v.string_version, stable_address: v.stable_address },
+    log: { endpoint, bytes }
+  }
+}
+
+// Map symbols to STRING IDs (get_string_ids, limit=1, echo_query=1); mapped/unmapped partition input.
+async function mapStringIds(
+  ctx: ToolContext,
+  symbols: string[],
+  species: number
+): Promise<{ mapped: StringMapped[]; unmapped: string[]; log: RequestLogEntry }> {
+  const { data, bytes, endpoint } = await stringGetJson(ctx, 'json', 'get_string_ids', [
+    ['identifiers', symbols.join('\r')],
+    ['species', species],
+    ['limit', 1],
+    ['echo_query', 1]
+  ])
+  const rows = (data as StringIdRow[]) ?? []
+  const byIndex = new Map<number, StringIdRow>()
+  for (const row of rows) {
+    const idx = Number(row.queryIndex)
+    if (!byIndex.has(idx)) byIndex.set(idx, row)
+  }
+  const mapped: StringMapped[] = []
+  const unmapped: string[] = []
+  symbols.forEach((symbol, i) => {
+    const row = byIndex.get(i)
+    if (!row) unmapped.push(symbol)
+    else
+      mapped.push({
+        query: symbol,
+        string_id: String(row.stringId),
+        preferred_name: String(row.preferredName),
+        ncbi_taxon_id: Number(row.ncbiTaxonId)
+      })
+  })
+  return { mapped, unmapped, log: { endpoint, bytes } }
+}
+
+const NETWORK_COLUMNS = [
+  'stringId_A',
+  'stringId_B',
+  'preferredName_A',
+  'preferredName_B',
+  'ncbiTaxonId',
+  'score'
+]
+const EVIDENCE_CHANNELS = ['nscore', 'fscore', 'pscore', 'ascore', 'escore', 'dscore', 'tscore']
+
+function parseNetworkTsv(text: string): Array<Record<string, string>> {
+  const lines = text
+    .trim()
+    .split('\n')
+    .filter((l) => l.trim())
+  if (!lines.length) return []
+  const header = lines[0].split('\t')
+  const missing = [...NETWORK_COLUMNS, ...EVIDENCE_CHANNELS].filter((c) => !header.includes(c))
+  if (missing.length)
+    throw new Error(`network TSV is missing expected columns: ${missing.join(', ')}`)
+  return lines.slice(1).map((line) => {
+    const values = line.split('\t')
+    const row: Record<string, string> = {}
+    header.forEach((h, i) => (row[h] = values[i]))
+    return row
+  })
+}
+
+// Deterministically oriented, de-duplicated, trimmed edges (port of core.canonical_edges).
+function canonicalEdges(rows: Array<Record<string, string>>): Array<Record<string, unknown>> {
+  const tupleLt = (a: [string, string], b: [string, string]): boolean =>
+    a[0] !== b[0] ? a[0] < b[0] : a[1] < b[1]
+  const dedup = new Map<string, Record<string, unknown>>()
+  for (const row of rows) {
+    let a: [string, string] = [row.preferredName_A, row.stringId_A]
+    let b: [string, string] = [row.preferredName_B, row.stringId_B]
+    if (tupleLt(b, a)) [a, b] = [b, a]
+    const evidence: Record<string, number> = {}
+    for (const channel of EVIDENCE_CHANNELS) {
+      const value = round3(Number(row[channel]))
+      if (value > 0) evidence[channel] = value
+    }
+    const edge = {
+      _sort: [a[0], b[0], a[1], b[1]] as [string, string, string, string],
+      a: a[0],
+      b: b[0],
+      score: round3(Number(row.score)),
+      evidence
+    }
+    const key = [a[1], b[1]].sort().join(' ')
+    const existing = dedup.get(key)
+    if (!existing || edge.score > (existing.score as number)) dedup.set(key, edge)
+  }
+  const ordered = [...dedup.values()].sort((x, y) => {
+    const sx = x._sort as [string, string, string, string]
+    const sy = y._sort as [string, string, string, string]
+    for (let i = 0; i < 4; i++) if (sx[i] !== sy[i]) return sx[i] < sy[i] ? -1 : 1
+    return 0
+  })
+  return ordered.map((e) => {
+    const { _sort, ...rest } = e
+    void _sort
+    return rest
+  })
+}
+
+function degreesByName(
+  mapped: StringMapped[],
+  edges: Array<Record<string, unknown>>
+): Map<string, number> {
+  const degree = new Map<string, number>()
+  for (const m of mapped) degree.set(m.preferred_name, 0)
+  for (const edge of edges)
+    for (const name of [edge.a as string, edge.b as string])
+      degree.set(name, (degree.get(name) ?? 0) + 1)
+  return degree
+}
+
+function nodeTable(
+  mapped: StringMapped[],
+  edges: Array<Record<string, unknown>>
+): Array<Record<string, unknown>> {
+  const degree = degreesByName(mapped, edges)
+  return mapped
+    .map((m) => ({
+      query: m.query,
+      name: m.preferred_name,
+      string_id: m.string_id,
+      degree: degree.get(m.preferred_name) ?? 0
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name) || a.string_id.localeCompare(b.string_id))
+}
+
+function summarizeNetwork(
+  mapped: StringMapped[],
+  unmapped: string[],
+  edges: Array<Record<string, unknown>>
+): Record<string, unknown> {
+  const degree = degreesByName(mapped, edges)
+  const scores = edges.map((e) => e.score as number)
+  const nConnected = [...degree.values()].filter((d) => d > 0).length
+  return {
+    n_input_symbols: mapped.length + unmapped.length,
+    n_mapped: mapped.length,
+    n_unmapped: unmapped.length,
+    n_nodes: mapped.length,
+    n_connected_nodes: nConnected,
+    n_isolated_nodes: mapped.length - nConnected,
+    n_edges: edges.length,
+    mean_score: scores.length
+      ? Math.round((scores.reduce((s, v) => s + v, 0) / scores.length) * 10000) / 10000
+      : null,
+    min_score: scores.length ? Math.min(...scores) : null,
+    max_score: scores.length ? Math.max(...scores) : null
+  }
+}
+
+// Canonicalize /homology rows: one record per unordered pair (id_a <= id_b), verify symmetric bitscore.
+function parseHomologyRows(rows: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const seen = new Map<string, Record<string, unknown>>()
+  const idTaxLt = (idA: string, taxA: number, idB: string, taxB: number): boolean =>
+    idA !== idB ? idA < idB : taxA < taxB
+  for (const row of rows) {
+    let idA = String(row.stringId_A)
+    let idB = String(row.stringId_B)
+    let taxA = Number(row.ncbiTaxonId_A)
+    let taxB = Number(row.ncbiTaxonId_B)
+    const score = round1(Number(row.bitscore))
+    if (idTaxLt(idB, taxB, idA, taxA)) {
+      ;[idA, idB] = [idB, idA]
+      ;[taxA, taxB] = [taxB, taxA]
+    }
+    const key = `${idA} ${idB}`
+    const rec = {
+      id_a: idA,
+      id_b: idB,
+      taxon_a: taxA,
+      taxon_b: taxB,
+      bitscore: score,
+      self: idA === idB
+    }
+    const prev = seen.get(key)
+    if (prev && prev.bitscore !== score)
+      throw new Error(`asymmetric homology bitscore for ${key}: ${prev.bitscore} vs ${score}`)
+    seen.set(key, rec)
+  }
+  return [...seen.values()].sort(
+    (a, b) =>
+      String(a.id_a).localeCompare(String(b.id_a)) || String(a.id_b).localeCompare(String(b.id_b))
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Human Protein Atlas helpers (ports of protein_atlas.api / .records)
+// ---------------------------------------------------------------------------
+
+const ENSG_RE = /^ENSG\d{11}$/
+
+const HPA_SUMMARY_FIELDS: Record<string, string[]> = {
+  identity: [
+    'Gene',
+    'Gene synonym',
+    'Ensembl',
+    'Gene description',
+    'Uniprot',
+    'Chromosome',
+    'Position',
+    'Protein class',
+    'Biological process',
+    'Molecular function',
+    'Disease involvement',
+    'Evidence',
+    'HPA evidence',
+    'UniProt evidence',
+    'NeXtProt evidence'
+  ],
+  tissue_expression: [
+    'RNA tissue specificity',
+    'RNA tissue distribution',
+    'RNA tissue specificity score',
+    'RNA tissue specific nTPM',
+    'RNA tissue cell type enrichment',
+    'Tissue expression cluster',
+    'Protein tissue specificity',
+    'Protein tissue distribution',
+    'Protein tissue specificity score',
+    'Protein tissue specific Intensity'
+  ],
+  single_cell_expression: [
+    'RNA single cell type specificity',
+    'RNA single cell type distribution',
+    'RNA single cell type specificity score',
+    'RNA single cell type specific nCPM',
+    'Single cell expression cluster'
+  ],
+  blood_expression: [
+    'RNA blood cell specificity',
+    'RNA blood cell distribution',
+    'RNA blood cell specificity score',
+    'RNA blood cell specific nTPM',
+    'RNA blood lineage specificity',
+    'RNA blood lineage distribution',
+    'RNA blood lineage specific nTPM',
+    'Blood expression cluster',
+    'Blood concentration - Conc. blood IM [pg/L]',
+    'Blood concentration - Conc. blood MS [pg/L]'
+  ],
+  brain_expression: [
+    'RNA brain regional specificity',
+    'RNA brain regional distribution',
+    'RNA brain regional specificity score',
+    'RNA brain regional specific nTPM',
+    'Brain expression cluster'
+  ],
+  cancer_expression: [
+    'RNA cancer specificity',
+    'RNA cancer distribution',
+    'RNA cancer specificity score',
+    'RNA cancer specific pTPM'
+  ],
+  subcellular: [
+    'Subcellular location',
+    'Subcellular main location',
+    'Subcellular additional location',
+    'Reliability (IF)',
+    'Secretome location',
+    'Secretome function',
+    'CCD Protein',
+    'CCD Transcript'
+  ],
+  antibody: [
+    'Antibody',
+    'Antibody RRID',
+    'Reliability (IH)',
+    'Reliability (Mouse Brain)',
+    'Reliability (IF)'
+  ]
+}
+const PROGNOSTICS_PREFIX = 'Cancer prognostics - '
+
+// Group the stable subset of a per-gene record into sections; fold per-cancer prognostics keys.
+function summarizeHpa(record: Record<string, unknown>): Record<string, unknown> {
+  const summary: Record<string, unknown> = {}
+  for (const [section, names] of Object.entries(HPA_SUMMARY_FIELDS)) {
+    const block: Record<string, unknown> = {}
+    for (const k of names) if (k in record) block[k] = record[k]
+    summary[section] = block
+  }
+  const prognostics: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(record))
+    if (k.startsWith(PROGNOSTICS_PREFIX)) prognostics[k.slice(PROGNOSTICS_PREFIX.length)] = v
+  summary.pathology = { prognostics }
+  return summary
+}
+
+// Resolve a gene symbol (or synonym) to its Ensembl gene ID via search_download (columns g,gs,eg).
+async function resolveHpaSymbol(ctx: ToolContext, symbol: string): Promise<string> {
+  const rows = (await ctx.fetchJson(
+    `${HPA_BASE}/api/search_download.php${qs([
+      ['search', symbol],
+      ['format', 'json'],
+      ['columns', 'g,gs,eg'],
+      ['compress', 'no']
+    ])}`
+  )) as Array<Record<string, unknown>>
+  const want = symbol.toUpperCase()
+  let exact = rows.filter((r) => String(r.Gene ?? '').toUpperCase() === want && r.Ensembl)
+  if (!exact.length) {
+    exact = rows.filter(
+      (r) =>
+        r.Ensembl &&
+        (Array.isArray(r['Gene synonym']) ? (r['Gene synonym'] as unknown[]) : []).some(
+          (s) => String(s).toUpperCase() === want
+        )
+    )
+  }
+  const ensgs = [...new Set(exact.map((r) => String(r.Ensembl)))].sort()
+  if (!ensgs.length) throw new Error(`no HPA gene with symbol or synonym '${symbol}'`)
+  if (ensgs.length > 1)
+    throw new Error(`symbol '${symbol}' matches multiple genes: ${ensgs.join(', ')}`)
+  return ensgs[0]
+}
+
+// ---------------------------------------------------------------------------
+// Descriptors — connector 'protein_annotation' (InterPro/Pfam, Human Protein Atlas, STRING v12.0)
+// ---------------------------------------------------------------------------
 export const PROTEIN_ANNOTATION_TOOLS: ToolDescriptor[] = [
   {
-    id: 'string_interaction_partners',
+    id: 'get_domain_architecture',
     connector: 'protein_annotation',
-    description: 'List STRING-DB interaction partners for a gene/protein, ranked by score.',
+    description:
+      'Complete InterPro domain architecture for one or more UniProt proteins (all matching entries, member-DB signatures, fragment coordinates), with pagination verified against the API count.',
     input: {
       type: 'object',
       properties: {
-        gene: { type: 'string' },
-        limit: { type: 'number', description: 'Max partners to return (default 10).' }
+        accessions: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'UniProt accessions, e.g. ["P04637"].'
+        }
+      },
+      required: ['accessions']
+    },
+    required: ['accessions'],
+    returns:
+      '`{ "summaries": { <accession>: { "protein": str, "protein_length": int, "entry_count": int, "entries": [ { "accession": str, "name": str, "type": str, "member_db_signatures": [ { "database": str, "accession": str, "name": str } ], "locations": [ { "fragments": [ { "start": int, "end": int } ], ... } ] } ] } }, "stats": { "http_requests": int, "bytes_downloaded": int } }` — entries sorted by (type, accession); default location fields (model/score/representative, fragment dc_status "CONTINUOUS") are omitted.',
+    example:
+      'result = host.mcp("protein_annotation", "get_domain_architecture", {"accessions": ["P04637"]})',
+    run: async (ctx, a) => {
+      const accessions = (a.accessions as string[]).map(String)
+      const stats = { requests: 0, bytes: 0 }
+      const summaries: Record<string, unknown> = {}
+      for (const acc of accessions) {
+        const fetched = await walkProteinEntries(ctx, acc, stats)
+        summaries[acc] = buildDomainSummary(acc, fetched.count, fetched.results)
+      }
+      return { summaries, stats: { http_requests: stats.requests, bytes_downloaded: stats.bytes } }
+    }
+  },
+  {
+    id: 'search_interpro_entries',
+    connector: 'protein_annotation',
+    description:
+      'Keyword search over InterPro or member-database entries (Pfam, SMART, PROSITE, PANTHER, CDD), complete cursor walk verified against the API count.',
+    input: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Free-text keyword, e.g. "kinase". Optional if go_term is given.'
+        },
+        entry_type: {
+          type: 'string',
+          description:
+            'family | domain | repeat | homologous_superfamily | conserved_site | active_site | binding_site | ptm'
+        },
+        source_db: {
+          type: 'string',
+          default: 'interpro',
+          description: 'interpro (default) or a member DB: pfam, smart, prosite, panther, cdd.'
+        },
+        go_term: { type: 'string', description: 'GO identifier filter, e.g. "GO:0004672".' }
+      }
+    },
+    returns:
+      '`{ "count": int, "results": [ { "accession": str, "name": str, "type": str, "source_database": str, "integrated": str|null, "member_db_signatures"?: [...], "go_terms"?: [...] } ] }` — rows sorted by accession; `count` is the API total.',
+    example:
+      'result = host.mcp("protein_annotation", "search_interpro_entries", {"query": "kinase", "source_db": "pfam"})',
+    run: async (ctx, a) => {
+      const sourceDb = String(a.source_db ?? 'interpro')
+      const url = `${INTERPRO_BASE}/entry/${encodeURIComponent(sourceDb)}/${qs([
+        ['search', a.query ?? null],
+        ['type', a.entry_type ?? null],
+        ['go_term', a.go_term ?? null],
+        ['page_size', PAGE_SIZE]
+      ])}`
+      return summarizeSearch(await walkEntries(ctx, url))
+    }
+  },
+  {
+    id: 'get_interpro_entry',
+    connector: 'protein_annotation',
+    description:
+      'Detail record for an InterPro entry (IPRxxxxxx) or Pfam family (PFxxxxx) — route chosen by accession prefix.',
+    input: {
+      type: 'object',
+      properties: {
+        accession: {
+          type: 'string',
+          description: 'InterPro (IPRxxxxxx) or Pfam (PFxxxxx) accession.'
+        }
+      },
+      required: ['accession']
+    },
+    required: ['accession'],
+    returns:
+      '`{ "accession": str, "name": { "name": str, "short": str|null }, "type": str, "source_database": str, "integrated": str|null, "hierarchy": ..., "set_info": ..., "member_db_signatures"?: [...], "go_terms"?: [...], "n_literature_refs"?: int }` — a Pfam family\'s clan appears under `set_info`.',
+    example:
+      'result = host.mcp("protein_annotation", "get_interpro_entry", {"accession": "IPR000719"})',
+    run: async (ctx, a) => {
+      const acc = String(a.accession).trim().toUpperCase()
+      const db = acc.startsWith('IPR') ? 'interpro' : acc.startsWith('PF') ? 'pfam' : null
+      if (!db)
+        throw new Error(`unrecognized entry accession (want IPR... or PF...): ${a.accession}`)
+      const { data } = await getJsonMaybe(
+        ctx,
+        `${INTERPRO_BASE}/entry/${db}/${encodeURIComponent(acc)}/`
+      )
+      if (data === null) throw new Error(`empty response for entry ${acc}`)
+      return summarizeEntryDetail(data as Record<string, unknown>)
+    }
+  },
+  {
+    id: 'search_pfam_clans',
+    connector: 'protein_annotation',
+    description: 'Keyword search over Pfam clans (InterPro sets, accessions CLxxxx).',
+    input: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Free-text keyword; omit to list all clans.' }
+      }
+    },
+    returns:
+      '`{ "count": int, "results": [ { "accession": str, "name": str, "source_database": str } ] }` — rows sorted by accession; an empty upstream result yields count 0.',
+    example: 'result = host.mcp("protein_annotation", "search_pfam_clans", {"query": "kinase"})',
+    run: async (ctx, a) => {
+      const url = `${INTERPRO_BASE}/set/pfam/${qs([
+        ['search', a.query ?? null],
+        ['page_size', PAGE_SIZE]
+      ])}`
+      return summarizeClanSearch(await walkEntries(ctx, url))
+    }
+  },
+  {
+    id: 'get_pfam_clan',
+    connector: 'protein_annotation',
+    description: 'Pfam clan detail including the complete sorted member-family list.',
+    input: {
+      type: 'object',
+      properties: {
+        clan_accession: { type: 'string', description: 'Clan accession, e.g. "CL0016".' }
+      },
+      required: ['clan_accession']
+    },
+    required: ['clan_accession'],
+    returns:
+      '`{ "accession": str, "name": str, "source_database": str, "member_count": int, "members": [ { "accession": str, "name": str, "short_name": str, "type": str } ] }` — members sorted by accession.',
+    example:
+      'result = host.mcp("protein_annotation", "get_pfam_clan", {"clan_accession": "CL0016"})',
+    run: async (ctx, a) => {
+      const acc = String(a.clan_accession).trim().toUpperCase()
+      const { data } = await getJsonMaybe(
+        ctx,
+        `${INTERPRO_BASE}/set/pfam/${encodeURIComponent(acc)}/`
+      )
+      if (data === null) throw new Error(`empty response for clan ${acc}`)
+      return summarizeClanDetail(data as Record<string, unknown>)
+    }
+  },
+  {
+    id: 'get_pfam_family_proteins',
+    connector: 'protein_annotation',
+    description:
+      'Member proteins of a Pfam family (complete count-verified walk or count only). Use count_only for very large families.',
+    input: {
+      type: 'object',
+      properties: {
+        pfam_accession: { type: 'string', description: 'Pfam family accession, e.g. "PF00069".' },
+        reviewed_only: {
+          type: 'boolean',
+          default: false,
+          description: 'Restrict to reviewed (Swiss-Prot) proteins.'
+        },
+        tax_id: { type: 'integer', description: 'Restrict to an NCBI taxon, e.g. 9606 for human.' },
+        count_only: {
+          type: 'boolean',
+          default: false,
+          description:
+            'Return only the match count — REQUIRED for very large families (e.g. unfiltered PF00069).'
+        }
+      },
+      required: ['pfam_accession']
+    },
+    required: ['pfam_accession'],
+    returns:
+      '`{ "count": int, "results": [ { "accession": str, "name": str, "source_database": str, "length": int, "tax_id": int, "organism": str } ] | null }` — `results` is null in count_only mode; otherwise sorted by accession.',
+    example:
+      'result = host.mcp("protein_annotation", "get_pfam_family_proteins", {"pfam_accession": "PF00069", "count_only": True})',
+    run: async (ctx, a) => {
+      const acc = String(a.pfam_accession).trim().toUpperCase()
+      const db = a.reviewed_only ? 'reviewed' : 'uniprot'
+      const base = `${INTERPRO_BASE}/protein/${db}/entry/pfam/${encodeURIComponent(acc)}/`
+      const taxId = a.tax_id ?? null
+      if (a.count_only) {
+        const { data } = await getJsonMaybe(
+          ctx,
+          base +
+            qs([
+              ['tax_id', taxId],
+              ['page_size', 1]
+            ])
+        )
+        return summarizeProteins({ count: (data as { count?: number })?.count ?? 0, results: null })
+      }
+      const fetched = await walkEntries(
+        ctx,
+        base +
+          qs([
+            ['tax_id', taxId],
+            ['page_size', PAGE_SIZE]
+          ])
+      )
+      return summarizeProteins(fetched)
+    }
+  },
+  {
+    id: 'get_pfam_family_proteomes',
+    connector: 'protein_annotation',
+    description:
+      'Proteomes containing members of a Pfam family. count_only defaults true — the upstream proteome cursor pagination is defective for deep walks.',
+    input: {
+      type: 'object',
+      properties: {
+        pfam_accession: { type: 'string', description: 'Pfam family accession, e.g. "PF00069".' },
+        count_only: {
+          type: 'boolean',
+          default: true,
+          description: 'Default true (reliable count). Set false only for small families.'
+        }
+      },
+      required: ['pfam_accession']
+    },
+    required: ['pfam_accession'],
+    returns:
+      '`{ "count": int, "results": [ { "accession": str, "name": str, "is_reference": bool, "taxonomy": ... } ] | null }` — `results` is null in count_only mode; a full walk raises if upstream pagination is defective.',
+    example:
+      'result = host.mcp("protein_annotation", "get_pfam_family_proteomes", {"pfam_accession": "PF00069"})',
+    run: async (ctx, a) => {
+      const acc = String(a.pfam_accession).trim().toUpperCase()
+      const base = `${INTERPRO_BASE}/proteome/uniprot/entry/pfam/${encodeURIComponent(acc)}/`
+      const countOnly = a.count_only ?? true
+      if (countOnly) {
+        const { data } = await getJsonMaybe(ctx, base + qs([['page_size', 1]]))
+        return summarizeProteomes({
+          count: (data as { count?: number })?.count ?? 0,
+          results: null
+        })
+      }
+      return summarizeProteomes(await walkEntries(ctx, base + qs([['page_size', PAGE_SIZE]])))
+    }
+  },
+  {
+    id: 'get_protein_atlas_gene',
+    connector: 'protein_annotation',
+    description:
+      'Human Protein Atlas per-gene record (release 25.x): tissue/subcellular/pathology/blood/brain expression and antibody info. Accepts an Ensembl gene ID or a gene symbol.',
+    input: {
+      type: 'object',
+      properties: {
+        gene: {
+          type: 'string',
+          description: 'Ensembl gene ID ("ENSG00000141510") or gene symbol ("TP53").'
+        },
+        full: {
+          type: 'boolean',
+          default: false,
+          description:
+            "False (default) returns a grouped summary; true returns HPA's complete raw record."
+        }
       },
       required: ['gene']
     },
     required: ['gene'],
     returns:
-      '`[ { "partner": str, "score": float } ]` — up to `limit` partners (default 10) for the query gene, ranked by STRING combined score (0–1); `[]` when the gene is unknown or has no partners.',
-    example:
-      'result = host.mcp("protein_annotation", "string_interaction_partners", {"gene": "TP53", "limit": 10})',
-    url: (a) => {
-      const limit = typeof a.limit === 'number' ? a.limit : 10
-      return `${STRING_BASE}/interaction_partners?identifiers=${encodeURIComponent(String(a.gene))}&species=${HUMAN_TAXON_ID}&limit=${limit}`
-    },
-    parse: (raw) =>
-      (raw as StringEdge[]).map((e) => ({
-        partner: e.preferredName_B,
-        score: e.score
-      }))
+      '`full=false`: `{ "identity": {...}, "tissue_expression": {...}, "single_cell_expression": {...}, "blood_expression": {...}, "brain_expression": {...}, "cancer_expression": {...}, "subcellular": {...}, "antibody": {...}, "pathology": { "prognostics": { <cancer>: ... } } }`. `full=true`: HPA\'s complete raw ~119-key per-gene record.',
+    example: 'result = host.mcp("protein_annotation", "get_protein_atlas_gene", {"gene": "TP53"})',
+    run: async (ctx, a) => {
+      const gene = String(a.gene).trim()
+      const ensg = ENSG_RE.test(gene) ? gene : await resolveHpaSymbol(ctx, gene)
+      const record = (await ctx.fetchJson(
+        `${HPA_BASE}/${encodeURIComponent(ensg)}.json`
+      )) as Record<string, unknown>
+      return a.full ? record : summarizeHpa(record)
+    }
   },
   {
-    id: 'string_network',
+    id: 'search_protein_atlas',
     connector: 'protein_annotation',
-    description: 'Get the STRING-DB interaction network among a set of genes/proteins.',
+    description: 'Column-selected bulk search over the Human Protein Atlas (search_download).',
     input: {
       type: 'object',
       properties: {
-        genes: { type: 'array', items: { type: 'string' } }
+        query: {
+          type: 'string',
+          description: 'Free-text search (gene symbol, description keyword, ...).'
+        },
+        columns: {
+          type: 'string',
+          default: 'g,gs,eg,gd,up,chr,chrp,scl',
+          description:
+            'Comma-separated HPA column codes: g=Gene, gs=synonym, eg=Ensembl, gd=description, up=Uniprot, chr=Chromosome, chrp=Position, scl=Subcellular location, ab=Antibody, pc=Protein class, di=Disease.'
+        }
       },
-      required: ['genes']
+      required: ['query']
     },
-    required: ['genes'],
+    required: ['query'],
     returns:
-      '`[ { "a": str, "b": str, "score": float } ]` — one entry per interaction edge among the input genes, `score` is the STRING combined score (0–1); `[]` when no edges are found. Only pairs with an interaction are returned, not every gene pair.',
-    example:
-      'result = host.mcp("protein_annotation", "string_network", {"genes": ["TP53", "MDM2"]})',
-    url: (a) => {
-      const genes = a.genes as string[]
-      return `${STRING_BASE}/network?identifiers=${encodeURIComponent(genes.join(','))}&species=${HUMAN_TAXON_ID}`
+      '`[ { <HPA field name>: value } ]` — a list of row dicts keyed by the human-readable field names selected via `columns`; `[]` when nothing matches.',
+    example: 'result = host.mcp("protein_annotation", "search_protein_atlas", {"query": "kinase"})',
+    run: async (ctx, a) => {
+      const columns = String(a.columns ?? 'g,gs,eg,gd,up,chr,chrp,scl')
+      return ctx.fetchJson(
+        `${HPA_BASE}/api/search_download.php${qs([
+          ['search', a.query],
+          ['format', 'json'],
+          ['columns', columns],
+          ['compress', 'no']
+        ])}`
+      )
+    }
+  },
+  {
+    id: 'map_string_ids',
+    connector: 'protein_annotation',
+    description:
+      'Map gene symbols/aliases to STRING protein identifiers (v12.0). Every input symbol is either mapped or listed in unmapped — the two partition the input.',
+    input: {
+      type: 'object',
+      properties: {
+        symbols: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Gene symbols or aliases, e.g. ["TP53", "PD-1"].'
+        },
+        species: {
+          type: 'integer',
+          default: DEFAULT_SPECIES,
+          description: 'NCBI taxonomy ID (9606 = human).'
+        }
+      },
+      required: ['symbols']
     },
-    parse: (raw) =>
-      (raw as StringEdge[]).map((e) => ({
-        a: e.preferredName_A,
-        b: e.preferredName_B,
-        score: e.score
-      }))
+    required: ['symbols'],
+    returns:
+      '`{ "string_version": { "string_version": str, "stable_address": str }, "species": int, "mapped": [ { "query": str, "string_id": str, "preferred_name": str, "ncbi_taxon_id": int } ], "unmapped": [ str ] }`.',
+    example:
+      'result = host.mcp("protein_annotation", "map_string_ids", {"symbols": ["TP53", "BRCA1", "EGFR"]})',
+    run: async (ctx, a) => {
+      const species = Number(a.species ?? DEFAULT_SPECIES)
+      const { version } = await stringVersion(ctx)
+      const { mapped, unmapped } = await mapStringIds(
+        ctx,
+        (a.symbols as string[]).map(String),
+        species
+      )
+      return { string_version: version, species, mapped, unmapped }
+    }
+  },
+  {
+    id: 'get_string_network',
+    connector: 'protein_annotation',
+    description:
+      'STRING protein-protein interaction network for a gene list (v12.0) at a confidence threshold. Maps symbols first (unmapped reported), then retrieves nodes, edges, summary and provenance.',
+    input: {
+      type: 'object',
+      properties: {
+        symbols: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Gene symbols, e.g. ["TP53", "BRCA1", "EGFR"].'
+        },
+        species: {
+          type: 'integer',
+          default: DEFAULT_SPECIES,
+          description: 'NCBI taxonomy ID (9606 = human).'
+        },
+        required_score: {
+          type: 'integer',
+          default: 700,
+          description: 'Minimum combined score 0-1000 (400 medium, 700 high, 900 highest).'
+        }
+      },
+      required: ['symbols']
+    },
+    required: ['symbols'],
+    returns:
+      '`{ "tool", "tool_version", "query", "string_version", "nodes": [ { "query", "name", "string_id", "degree" } ], "unmapped": [ str ], "edges": [ { "a": str, "b": str, "score": float, "evidence": { <channel>: float } } ], "summary": { node/edge counts, score stats }, "provenance": {...} }` — edges deterministically ordered; isolated nodes visible (degree 0).',
+    example:
+      'result = host.mcp("protein_annotation", "get_string_network", {"symbols": ["TP53", "BRCA1", "EGFR"], "required_score": 700})',
+    run: async (ctx, a) => {
+      const species = Number(a.species ?? DEFAULT_SPECIES)
+      const requiredScore = Number(a.required_score ?? 700)
+      const symbols = [
+        ...new Set((a.symbols as string[]).map((s) => String(s).trim()).filter(Boolean))
+      ]
+      if (!symbols.length) throw new Error('no input symbols provided')
+      const requests: RequestLogEntry[] = []
+      const ver = await stringVersion(ctx)
+      requests.push(ver.log)
+      const m = await mapStringIds(ctx, symbols, species)
+      requests.push(m.log)
+      let edges: Array<Record<string, unknown>> = []
+      const stringIds = m.mapped.map((x) => x.string_id)
+      if (stringIds.length) {
+        const url = `${STRING_BASE}/tsv/network${qs([
+          ['identifiers', stringIds.join('\r')],
+          ['species', species],
+          ['required_score', requiredScore],
+          ['caller_identity', STRING_CALLER]
+        ])}`
+        const text = await ctx.fetchText(url)
+        edges = canonicalEdges(parseNetworkTsv(text))
+        requests.push({ endpoint: 'tsv/network', bytes: byteLen(text) })
+      }
+      return {
+        tool: 'string-network',
+        tool_version: '0.3.0',
+        query: { symbols, species, required_score: requiredScore },
+        string_version: ver.version,
+        nodes: nodeTable(m.mapped, edges),
+        unmapped: m.unmapped,
+        edges,
+        summary: summarizeNetwork(m.mapped, m.unmapped, edges),
+        provenance: {
+          api_base_url: STRING_BASE,
+          caller_identity: STRING_CALLER,
+          endpoints_used: ['json/version', 'json/get_string_ids', 'tsv/network'],
+          parameters: {
+            species,
+            required_score: requiredScore,
+            network_type: 'functional',
+            'get_string_ids.limit': 1,
+            'get_string_ids.echo_query': 1,
+            'network.add_nodes': 0
+          },
+          retrieved_at: new Date().toISOString(),
+          n_http_requests: requests.length,
+          bytes_downloaded: requests.reduce((s, r) => s + r.bytes, 0),
+          requests
+        }
+      }
+    }
+  },
+  {
+    id: 'get_string_similarity_scores',
+    connector: 'protein_annotation',
+    description:
+      "Smith-Waterman protein similarity bitscores among a gene set (STRING /homology). Sparse: pairs absent from STRING's data are not listed (absence means no recorded similarity, not zero).",
+    input: {
+      type: 'object',
+      properties: {
+        symbols: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Gene symbols in the source species.'
+        },
+        species: {
+          type: 'integer',
+          default: DEFAULT_SPECIES,
+          description: 'NCBI taxonomy ID (9606 = human).'
+        }
+      },
+      required: ['symbols']
+    },
+    required: ['symbols'],
+    returns:
+      '`{ "species": int, "mapped": [...], "unmapped": [ str ], "n_pairs": int, "n_self": int, "pairs": [ { "id_a": str, "id_b": str, "taxon_a": int, "taxon_b": int, "bitscore": float, "self": bool, "name_a": str, "name_b": str } ] }` — one record per reported unordered pair (incl. self-scores), id_a <= id_b.',
+    example:
+      'result = host.mcp("protein_annotation", "get_string_similarity_scores", {"symbols": ["TP53", "MDM2", "MDM4"]})',
+    run: async (ctx, a) => {
+      const species = Number(a.species ?? DEFAULT_SPECIES)
+      const { mapped, unmapped } = await mapStringIds(
+        ctx,
+        (a.symbols as string[]).map(String),
+        species
+      )
+      let pairs: Array<Record<string, unknown>> = []
+      if (mapped.length) {
+        const { data } = await stringGetJson(ctx, 'json', 'homology', [
+          ['identifiers', mapped.map((m) => m.string_id).join('\r')],
+          ['species', species]
+        ])
+        pairs = parseHomologyRows((data as Array<Record<string, unknown>>) ?? [])
+      }
+      const nameById = new Map(mapped.map((m) => [m.string_id, m.preferred_name]))
+      for (const rec of pairs) {
+        rec.name_a = nameById.get(String(rec.id_a))
+        rec.name_b = nameById.get(String(rec.id_b))
+      }
+      return {
+        species,
+        mapped,
+        unmapped,
+        n_pairs: pairs.length,
+        n_self: pairs.filter((p) => p.self).length,
+        pairs
+      }
+    }
+  },
+  {
+    id: 'get_string_best_similarity_hits',
+    connector: 'protein_annotation',
+    description:
+      'Best homology hit per input protein in a target species (STRING /homology_best). target_species=null asks for the best hit across all species.',
+    input: {
+      type: 'object',
+      properties: {
+        symbols: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Gene symbols in the source species.'
+        },
+        species: {
+          type: 'integer',
+          default: DEFAULT_SPECIES,
+          description: 'Source NCBI taxonomy ID (9606 = human).'
+        },
+        target_species: {
+          type: 'integer',
+          description: 'Target NCBI taxonomy ID; omit for best hit across all species.'
+        }
+      },
+      required: ['symbols']
+    },
+    required: ['symbols'],
+    returns:
+      '`{ "species": int, "species_b": int|null, "mapped": [...], "unmapped": [ str ], "n_hits": int, "hits": [ { "query_id": str, "query_name": str, "query_taxon": int, "hit_id": str, "hit_taxon": int, "bitscore": float } ] }` — one best-hit record per query protein, sorted by query STRING ID.',
+    example:
+      'result = host.mcp("protein_annotation", "get_string_best_similarity_hits", {"symbols": ["TP53"], "target_species": 10090})',
+    run: async (ctx, a) => {
+      const species = Number(a.species ?? DEFAULT_SPECIES)
+      const targetSpecies = a.target_species != null ? Number(a.target_species) : null
+      const { mapped, unmapped } = await mapStringIds(
+        ctx,
+        (a.symbols as string[]).map(String),
+        species
+      )
+      let hits: Array<Record<string, unknown>> = []
+      if (mapped.length) {
+        const nameById = new Map(mapped.map((m) => [m.string_id, m.preferred_name]))
+        const params: Array<[string, unknown]> = [
+          ['identifiers', mapped.map((m) => m.string_id).join('\r')],
+          ['species', species]
+        ]
+        if (targetSpecies !== null) params.push(['species_b', targetSpecies])
+        const { data } = await stringGetJson(ctx, 'json', 'homology_best', params)
+        hits = ((data as Array<Record<string, unknown>>) ?? []).map((row) => ({
+          query_id: String(row.stringId_A),
+          query_name: nameById.get(String(row.stringId_A)),
+          query_taxon: Number(row.ncbiTaxonId_A),
+          hit_id: String(row.stringId_B),
+          hit_taxon: Number(row.ncbiTaxonId_B),
+          bitscore: round1(Number(row.bitscore))
+        }))
+        hits.sort(
+          (x, y) =>
+            String(x.query_id).localeCompare(String(y.query_id)) ||
+            String(x.hit_id).localeCompare(String(y.hit_id))
+        )
+      }
+      return { species, species_b: targetSpecies, mapped, unmapped, n_hits: hits.length, hits }
+    }
   }
 ]


### PR DESCRIPTION
Enhances the Protein Annotation connector from 2 STRING tools to 13, adding domain/family annotation and expression atlases alongside a fuller STRING toolset.

## New capabilities
- InterPro/Pfam: `get_domain_architecture`, `search_interpro_entries`, `get_interpro_entry`, `search_pfam_clans`, `get_pfam_clan`, `get_pfam_family_proteins`, `get_pfam_family_proteomes`
- Human Protein Atlas: `get_protein_atlas_gene`, `search_protein_atlas`
- STRING: `map_string_ids`, `get_string_network`, `get_string_similarity_scores`, `get_string_best_similarity_hits`

## Notes
- Replaces the previous `string_interaction_partners` / `string_network` tools with the fuller STRING set above.
- Cursor pagination is walked to completion and verified against the API's own count throughout.
- `sources` updated to InterPro / Pfam / Human Protein Atlas / STRING.

## Verification
- Full `src/main/connectors` suite green + live integration tests (`LIVE_API`-gated) against each real endpoint.
- lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)