### PR TITLE
feat(connectors): expand the Research Resources connector capabilities

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -250,10 +250,11 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
   {
     id: 'research_resources',
     displayName: 'Research Resources',
-    description: 'Antibody catalog lookups via the Antibody Registry.',
+    description:
+      'Funding-opportunity search (Grants.gov) and antibody catalog lookups (Antibody Registry).',
     useWhen:
-      'Use when you need a research antibody by target, name, or catalog text — RRID, vendor, target, and clonality. Sourced from the Antibody Registry.',
-    sources: ['Antibody Registry'],
+      'Use when you need U.S. federal funding opportunities from Grants.gov (search by keyword, opportunity number, CFDA/ALN, agency such as NIH/NSF/FDA, status, eligibility, or funding category — complete, count-verified, with facet breakdowns) or research antibodies from the Antibody Registry (full-text search by target/name/catalog, lookup by RRID/accession, exact catalog-number matching, and registry statistics — with RRID, vendor, target, clone, and species). Sourced from Grants.gov and the Antibody Registry.',
+    sources: ['Grants.gov', 'Antibody Registry'],
     termsUrl: 'https://www.antibodyregistry.org/',
     requiresNcbi: false
   },

--- a/src/main/connectors/descriptors/research-resources.test.ts
+++ b/src/main/connectors/descriptors/research-resources.test.ts
@@ -6,137 +6,439 @@ import type { ToolDescriptor } from '../types'
 const tool = (id: string): ToolDescriptor => RESEARCH_RESOURCES_TOOLS.find((t) => t.id === id)!
 const jsonRes = (body: unknown): Response =>
   ({ ok: true, status: 200, json: async () => body }) as Response
+const engine = (fetchImpl: typeof fetch): ParserEngine => new ParserEngine({ fetchImpl })
+// The POST body the engine sent on the Nth fetch call.
+const bodyOf = (fetchImpl: ReturnType<typeof vi.fn>, n = 0): Record<string, unknown> =>
+  JSON.parse((fetchImpl.mock.calls[n][1] as RequestInit).body as string)
 
-describe('research_resources / antibody registry', () => {
-  it('antibody_search builds the fts-antibodies URL and parses compact hits', async () => {
+// ------------------------------------------------------------------ Grants.gov
+
+describe('research_resources / search_grants', () => {
+  const oppHit = (id: string, number: string): Record<string, unknown> => ({
+    id,
+    number,
+    title: `Opp ${number}`,
+    agencyCode: 'HHS-NIH11',
+    agency: 'National Institutes of Health',
+    oppStatus: 'posted',
+    openDate: '01/01/2026',
+    closeDate: '',
+    docType: 'synopsis',
+    cfdaList: ['93.399']
+  })
+  const facets = {
+    oppStatusOptions: [{ value: 'posted', count: 2 }],
+    agencies: [{ value: 'HHS-NIH11', count: 2 }],
+    eligibilities: [],
+    fundingCategories: [],
+    fundingInstruments: [],
+    dateRangeOptions: []
+  }
+
+  it('walks the full result set and passes records through verbatim', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        errorcode: 0,
+        data: { hitCount: 2, oppHits: [oppHit('1', 'A-1'), oppHit('2', 'A-2')], ...facets }
+      })
+    )
+    const out = (await engine(fetchImpl).call(
+      tool('search_grants'),
+      { keyword: 'cancer', agencies: ['HHS-NIH11'] },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://api.grants.gov/v1/api/search2')
+    expect(bodyOf(fetchImpl)).toEqual({
+      rows: 1000,
+      startRecordNum: 0,
+      oppStatuses: 'forecasted|posted',
+      sortBy: 'oppNum|asc',
+      keyword: 'cancer',
+      agencies: 'HHS-NIH11'
+    })
+    expect(out.hit_count).toBe(2)
+    expect(out.n_returned).toBe(2)
+    expect(out.truncated).toBe(false)
+    expect(out.records).toEqual([oppHit('1', 'A-1'), oppHit('2', 'A-2')])
+    expect((out.facets as Record<string, unknown>).dateRangeOptions).toEqual([])
+  })
+
+  it('paginates via startRecordNum until hitCount is reached', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonRes({ errorcode: 0, data: { hitCount: 2, oppHits: [oppHit('1', 'A-1')], ...facets } })
+      )
+      .mockResolvedValueOnce(
+        jsonRes({ errorcode: 0, data: { hitCount: 2, oppHits: [oppHit('2', 'A-2')] } })
+      )
+    const out = (await engine(fetchImpl).call(
+      tool('search_grants'),
+      { keyword: 'cancer' },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(bodyOf(fetchImpl, 1).startRecordNum).toBe(1)
+    expect(out.n_returned).toBe(2)
+    expect(out.hit_count).toBe(2)
+  })
+
+  it('caps records at max_records and flags truncated after a complete walk', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        errorcode: 0,
+        data: {
+          hitCount: 3,
+          oppHits: [oppHit('1', 'A-1'), oppHit('2', 'A-2'), oppHit('3', 'A-3')],
+          ...facets
+        }
+      })
+    )
+    const out = (await engine(fetchImpl).call(
+      tool('search_grants'),
+      { keyword: 'cancer', max_records: 2 },
+      {}
+    )) as Record<string, unknown>
+    expect(out.n_returned).toBe(2)
+    expect(out.truncated).toBe(true)
+    expect((out.records as unknown[]).length).toBe(2)
+  })
+
+  it('count_only posts rows=0 and returns hit count + count facets (no dateRangeOptions)', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ errorcode: 0, data: { hitCount: 114, oppHits: [], ...facets } }))
+    const out = (await engine(fetchImpl).call(
+      tool('search_grants'),
+      { keyword: 'cancer', count_only: true },
+      {}
+    )) as Record<string, unknown>
+    expect(bodyOf(fetchImpl).rows).toBe(0)
+    expect(out).toMatchObject({ hit_count: 114, n_returned: 0, truncated: false, records: [] })
+    const outFacets = out.facets as Record<string, unknown>
+    expect('dateRangeOptions' in outFacets).toBe(false)
+    expect('oppStatusOptions' in outFacets).toBe(true)
+  })
+
+  it('omits facets when include_facets is false', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ errorcode: 0, data: { hitCount: 0, oppHits: [], ...facets } }))
+    const out = (await engine(fetchImpl).call(
+      tool('search_grants'),
+      { keyword: 'cancer', include_facets: false },
+      {}
+    )) as Record<string, unknown>
+    expect('facets' in out).toBe(false)
+  })
+
+  it('maps aln to cfda and pipe-joins list filters', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ errorcode: 0, data: { hitCount: 0, oppHits: [], ...facets } }))
+    await engine(fetchImpl).call(
+      tool('search_grants'),
+      {
+        aln: '93.866',
+        agencies: ['HHS-NIH11', 'HHS-FDA'],
+        opportunity_statuses: ['posted', 'closed'],
+        eligibilities: ['25']
+      },
+      {}
+    )
+    expect(bodyOf(fetchImpl)).toMatchObject({
+      cfda: '93.866',
+      agencies: 'HHS-NIH11|HHS-FDA',
+      oppStatuses: 'posted|closed',
+      eligibilities: '25'
+    })
+  })
+
+  it('rejects a call with no search criterion', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      engine(fetchImpl).call(tool('search_grants'), { opportunity_statuses: ['posted'] }, {})
+    ).rejects.toThrow(/at least one search criterion/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid opportunity status', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      engine(fetchImpl).call(
+        tool('search_grants'),
+        { keyword: 'cancer', opportunity_statuses: ['bogus'] },
+        {}
+      )
+    ).rejects.toThrow(/invalid oppStatus/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('raises on a non-zero errorcode envelope', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ errorcode: 2, msg: 'bad request', data: null }))
+    await expect(
+      engine(fetchImpl).call(tool('search_grants'), { keyword: 'cancer' }, {})
+    ).rejects.toThrow(/errorcode 2/)
+  })
+
+  it('raises IncompleteRetrieval when duplicate ids never reconcile with hitCount', async () => {
+    const dup = oppHit('1', 'A-1')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        jsonRes({ errorcode: 0, data: { hitCount: 2, oppHits: [dup], ...facets } })
+      )
+    await expect(
+      engine(fetchImpl).call(tool('search_grants'), { keyword: 'cancer' }, {})
+    ).rejects.toThrow(/incomplete grants.gov retrieval/)
+    // two full walk attempts before giving up (2 pages each)
+    expect(fetchImpl).toHaveBeenCalledTimes(4)
+  })
+})
+
+// --------------------------------------------------------- Antibody Registry
+
+// A registry record carrying volatile fields that must be stripped from output.
+const abRecord = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  abId: 3676740,
+  abName: 'CD8, Liquid Concentrate',
+  abTarget: 'CD8',
+  catalogNum: 'CD8-4B11-L-U',
+  catAlt: 'NCL-L-CD8-4B11-U',
+  vendorName: 'Leica Biosystems',
+  cloneId: '4B11',
+  sourceOrganism: 'Mouse',
+  targetSpecies: ['human'],
+  // volatile — stripped by _norm parity:
+  curateTime: '2025-03-06T21:30:22.099Z',
+  lastEditTime: null,
+  ix: 3612196,
+  showLink: null,
+  feedback: '',
+  numOfCitation: 0,
+  ...over
+})
+const stripped = (over: Record<string, unknown> = {}): Record<string, unknown> => {
+  const r = abRecord(over)
+  for (const k of ['curateTime', 'lastEditTime', 'ix', 'showLink', 'feedback', 'numOfCitation']) {
+    delete r[k]
+  }
+  return r
+}
+
+describe('research_resources / search_antibodies', () => {
+  it('walks pages, strips volatile fields, and reports unique_ab_ids', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ totalElements: 2, items: [abRecord({ abId: 1 })] }))
+      .mockResolvedValueOnce(jsonRes({ totalElements: 2, items: [abRecord({ abId: 2 })] }))
+    const out = (await engine(fetchImpl).call(
+      tool('search_antibodies'),
+      { query: 'CD8', page_size: 1 },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.antibodyregistry.org/api/fts-antibodies?q=CD8&page=1&size=1'
+    )
+    expect(fetchImpl.mock.calls[1][0]).toContain('page=2&size=1')
+    expect(out).toMatchObject({
+      query: 'CD8',
+      total_elements: 2,
+      retrieved: 2,
+      unique_ab_ids: 2,
+      complete: true,
+      truncated_at_max_records: false,
+      anonymous_limit_hit: false
+    })
+    expect((out.items as Record<string, unknown>[])[0]).toEqual(stripped({ abId: 1 }))
+    expect('curateTime' in (out.items as Record<string, unknown>[])[0]).toBe(false)
+  })
+
+  it('flags anonymous_limit_hit when the walk reaches the 500-row cap', async () => {
+    // page_size 300: page 1 fetched (300 <= 500), page 2 would be 600 > 500 -> stop.
+    const items = Array.from({ length: 300 }, (_, i) => abRecord({ abId: i }))
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ totalElements: 700, items }))
+    const out = (await engine(fetchImpl).call(
+      tool('search_antibodies'),
+      { query: 'CD4', page_size: 300 },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(out).toMatchObject({
+      total_elements: 700,
+      retrieved: 300,
+      complete: false,
+      anonymous_limit_hit: true,
+      truncated_at_max_records: false
+    })
+  })
+
+  it('flags truncated_at_max_records when max_records stops the walk before the cap', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => abRecord({ abId: i }))
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ totalElements: 400, items }))
+    const out = (await engine(fetchImpl).call(
+      tool('search_antibodies'),
+      { query: 'CD4', page_size: 100, max_records: 100 },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(out).toMatchObject({
+      retrieved: 100,
+      complete: false,
+      truncated_at_max_records: true,
+      anonymous_limit_hit: false
+    })
+  })
+
+  it('single-page mode returns the page-shaped result', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ totalElements: 1, items: [abRecord()] }))
+    const out = (await engine(fetchImpl).call(
+      tool('search_antibodies'),
+      { query: 'CD8', page: 1, page_size: 10 },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.antibodyregistry.org/api/fts-antibodies?q=CD8&page=1&size=10'
+    )
+    expect(out).toMatchObject({
+      query: 'CD8',
+      page: 1,
+      total_elements: 1,
+      retrieved: 1,
+      complete: true
+    })
+    expect('anonymous_limit_hit' in out).toBe(false)
+  })
+
+  it('rejects single-page requests past the anonymous row limit', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      engine(fetchImpl).call(
+        tool('search_antibodies'),
+        { query: 'CD4', page: 6, page_size: 100 },
+        {}
+      )
+    ).rejects.toThrow(/anonymous row limit/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty query', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      engine(fetchImpl).call(tool('search_antibodies'), { query: '   ' }, {})
+    ).rejects.toThrow(/query must be non-empty/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('research_resources / get_antibody', () => {
+  it('parses a numeric id into ab_id/rrid/record_count with stripped records', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([abRecord({ abId: 3643095 })]))
+    const out = (await engine(fetchImpl).call(
+      tool('get_antibody'),
+      { antibody_id: '3643095' },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.antibodyregistry.org/api/antibodies/3643095'
+    )
+    expect(out.ab_id).toBe(3643095)
+    expect(out.rrid).toBe('AB_3643095')
+    expect(out.record_count).toBe(1)
+    expect((out.records as Record<string, unknown>[])[0]).toEqual(stripped({ abId: 3643095 }))
+  })
+
+  it('accepts "AB_<id>" and "RRID:AB_<id>" forms', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
+    await engine(fetchImpl).call(tool('get_antibody'), { antibody_id: 'AB_3643095' }, {})
+    await engine(fetchImpl).call(tool('get_antibody'), { antibody_id: 'RRID:AB_3643095' }, {})
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://www.antibodyregistry.org/api/antibodies/3643095'
+    )
+    expect(fetchImpl.mock.calls[1][0]).toBe(
+      'https://www.antibodyregistry.org/api/antibodies/3643095'
+    )
+  })
+
+  it('returns record_count 0 for a nonexistent id (upstream 200 + [])', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
+    const out = (await engine(fetchImpl).call(
+      tool('get_antibody'),
+      { antibody_id: '1' },
+      {}
+    )) as Record<string, unknown>
+    expect(out).toEqual({ ab_id: 1, rrid: 'AB_1', record_count: 0, records: [] })
+  })
+
+  it('rejects a malformed id without fetching', async () => {
+    const fetchImpl = vi.fn()
+    await expect(
+      engine(fetchImpl).call(tool('get_antibody'), { antibody_id: 'not-an-id' }, {})
+    ).rejects.toThrow(/not a valid antibody id/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('research_resources / find_antibodies_by_catalog', () => {
+  it('keeps only exact catalog matches (via catalogNum or catAlt) and reports the search total', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        totalElements: 3,
+        items: [
+          abRecord({ abId: 1, catalogNum: 'ab32572', catAlt: '' }),
+          abRecord({ abId: 2, catalogNum: 'OTHER-1', catAlt: 'foo; ab32572' }),
+          abRecord({ abId: 3, catalogNum: 'unrelated', catAlt: '' })
+        ]
+      })
+    )
+    const out = (await engine(fetchImpl).call(
+      tool('find_antibodies_by_catalog'),
+      { catalog_number: 'AB32572' },
+      {}
+    )) as Record<string, unknown>
+    expect(out.catalog_num).toBe('AB32572')
+    expect(out.match_count).toBe(2)
+    expect(out.search_total_elements).toBe(3)
+    expect((out.matches as Record<string, unknown>[]).map((m) => m.abId)).toEqual([1, 2])
+  })
+
+  it('applies an exact case-insensitive vendor filter', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       jsonRes({
         totalElements: 2,
         items: [
-          {
-            abId: 3717446,
-            abName: 'Tumor Protein P53 Peptide 2',
-            abTarget: 'TP53',
-            vendorName: 'DSHB',
-            clonality: 'recombinant monoclonal'
-          },
-          {
-            abId: 2877664,
-            abName: 'Rabbit monoclonal anti-TP53',
-            abTarget: 'TP53',
-            vendorName: 'DSHB',
-            clonality: 'monoclonal'
-          }
+          abRecord({ abId: 1, catalogNum: 'ab32572', vendorName: 'Abcam' }),
+          abRecord({ abId: 2, catalogNum: 'ab32572', vendorName: 'Novus' })
         ]
       })
     )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('antibody_search'),
-      { query: 'TP53' },
+    const out = (await engine(fetchImpl).call(
+      tool('find_antibodies_by_catalog'),
+      { catalog_number: 'ab32572', vendor: 'abcam' },
       {}
-    )
-    const url = fetchImpl.mock.calls[0][0] as string
-    expect(url).toBe('https://www.antibodyregistry.org/api/fts-antibodies?q=TP53&page=1&size=10')
-    expect(out).toEqual({
-      total_elements: 2,
-      items: [
-        {
-          ab_id: 'AB_3717446',
-          name: 'Tumor Protein P53 Peptide 2',
-          vendor: 'DSHB',
-          target: 'TP53',
-          clonality: 'recombinant monoclonal'
-        },
-        {
-          ab_id: 'AB_2877664',
-          name: 'Rabbit monoclonal anti-TP53',
-          vendor: 'DSHB',
-          target: 'TP53',
-          clonality: 'monoclonal'
-        }
-      ]
-    })
+    )) as Record<string, unknown>
+    expect(out.match_count).toBe(1)
+    expect((out.matches as Record<string, unknown>[])[0].abId).toBe(1)
   })
 
-  it('antibody_search honors page/size overrides', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ totalElements: 0, items: [] }))
-    await new ParserEngine({ fetchImpl }).call(
-      tool('antibody_search'),
-      { query: 'p53', page: 2, size: 25 },
-      {}
-    )
-    const url = fetchImpl.mock.calls[0][0] as string
-    expect(url).toBe('https://www.antibodyregistry.org/api/fts-antibodies?q=p53&page=2&size=25')
-  })
-
-  it('antibody_search returns an empty list when there are no items', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ totalElements: 0 }))
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('antibody_search'),
-      { query: 'nonexistent' },
-      {}
-    )
-    expect(out).toEqual({ total_elements: 0, items: [] })
-  })
-
-  it('antibody_get accepts a plain numeric id and parses the list response', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes([
-        {
-          abId: 3717446,
-          abName: 'Tumor Protein P53 Peptide 2',
-          abTarget: 'TP53',
-          vendorName: 'DSHB',
-          clonality: 'recombinant monoclonal'
-        }
-      ])
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('antibody_get'),
-      { ab_id: '3717446' },
-      {}
-    )
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://www.antibodyregistry.org/api/antibodies/3717446'
-    )
-    expect(out).toEqual([
-      {
-        ab_id: 'AB_3717446',
-        name: 'Tumor Protein P53 Peptide 2',
-        vendor: 'DSHB',
-        target: 'TP53',
-        clonality: 'recombinant monoclonal'
-      }
-    ])
-  })
-
-  it('antibody_get accepts "AB_<id>" and "RRID:AB_<id>" forms', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
-    await new ParserEngine({ fetchImpl }).call(tool('antibody_get'), { ab_id: 'AB_3717446' }, {})
-    expect(fetchImpl.mock.calls[0][0]).toBe(
-      'https://www.antibodyregistry.org/api/antibodies/3717446'
-    )
-    await new ParserEngine({ fetchImpl }).call(
-      tool('antibody_get'),
-      { ab_id: 'RRID:AB_3717446' },
-      {}
-    )
-    expect(fetchImpl.mock.calls[1][0]).toBe(
-      'https://www.antibodyregistry.org/api/antibodies/3717446'
-    )
-  })
-
-  it('antibody_get returns an empty array for a nonexistent id (upstream 200 + [])', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes([]))
-    const out = await new ParserEngine({ fetchImpl }).call(tool('antibody_get'), { ab_id: '1' }, {})
-    expect(out).toEqual([])
-  })
-
-  it('antibody_get rejects a malformed id', async () => {
+  it('rejects an empty catalog number', async () => {
     const fetchImpl = vi.fn()
     await expect(
-      new ParserEngine({ fetchImpl }).call(tool('antibody_get'), { ab_id: 'not-an-id' }, {})
-    ).rejects.toThrow(/not a valid antibody id/)
+      engine(fetchImpl).call(tool('find_antibodies_by_catalog'), { catalog_number: '  ' }, {})
+    ).rejects.toThrow(/catalog_number must be non-empty/)
     expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('research_resources / get_antibody_registry_stats', () => {
+  it('returns the datainfo payload verbatim', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ total: 3186453, lastupdate: '2026-07-14' }))
+    const out = await engine(fetchImpl).call(tool('get_antibody_registry_stats'), {}, {})
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://www.antibodyregistry.org/api/datainfo')
+    expect(out).toEqual({ total: 3186453, lastupdate: '2026-07-14' })
   })
 })

--- a/src/main/connectors/descriptors/research-resources.ts
+++ b/src/main/connectors/descriptors/research-resources.ts
@@ -1,87 +1,425 @@
-import type { ToolDescriptor } from '../types'
+import type { ToolContext, ToolDescriptor } from '../types'
 
-const BASE = 'https://www.antibodyregistry.org/api'
+// Research Resources aggregates two read-only registries:
+//  * Grants.gov search2 (POST-only funding-opportunity search, complete + count-verified).
+//  * The Antibody Registry (antibodyregistry.org, ~3.2M full-text antibody records).
+// Both mirror the upstream mcp-research-resources server (grants_gov_search + antibody_registry).
+
+// ------------------------------------------------------------------ Grants.gov
+
+const GRANTS_URL = 'https://api.grants.gov/v1/api/search2'
+// search2 has no documented page-size limit; the upstream client walks 1000 rows per POST.
+const GRANTS_ROWS_PER_PAGE = 1000
+// Valid oppStatuses; an invalid value is silently accepted upstream and yields empty pages.
+const VALID_STATUSES = ['forecasted', 'posted', 'closed', 'archived']
+// The API's own default status set when oppStatuses is omitted (current opportunities).
+const DEFAULT_STATUSES = 'forecasted|posted'
+// Facet blocks returned by search2 (each ignores the filter on its own dimension); the count route
+// omits dateRangeOptions.
+const SEARCH_FACET_KEYS = [
+  'oppStatusOptions',
+  'agencies',
+  'eligibilities',
+  'fundingCategories',
+  'fundingInstruments',
+  'dateRangeOptions'
+]
+const COUNT_FACET_KEYS = SEARCH_FACET_KEYS.filter((k) => k !== 'dateRangeOptions')
+
+type OppHit = { id?: string; number?: string } & Record<string, unknown>
+type Search2Data = { hitCount: number; oppHits: OppHit[] } & Record<string, unknown>
+type Search2Envelope = { errorcode?: number; msg?: string; data?: Search2Data }
+
+// Accepts a string, an array of values, or null/undefined; returns the pipe-joined string ("" empty).
+const pipeJoin = (value: unknown): string => {
+  if (value == null) return ''
+  if (Array.isArray(value)) return value.map((v) => String(v)).join('|')
+  return String(value)
+}
+
+// Builds one search2 POST body from the tool args (mirrors GrantsSearchSpec.to_payload).
+const grantsPayload = (
+  a: Record<string, unknown>,
+  statuses: string,
+  rows: number,
+  start: number
+): Record<string, unknown> => {
+  const body: Record<string, unknown> = {
+    rows,
+    startRecordNum: start,
+    oppStatuses: statuses,
+    sortBy: 'oppNum|asc'
+  }
+  if (a.keyword) body.keyword = String(a.keyword)
+  if (a.opportunity_number) body.oppNum = String(a.opportunity_number)
+  if (a.aln) body.cfda = String(a.aln)
+  const agencies = pipeJoin(a.agencies)
+  if (agencies) body.agencies = agencies
+  const eligibilities = pipeJoin(a.eligibilities)
+  if (eligibilities) body.eligibilities = eligibilities
+  const fundingCategories = pipeJoin(a.funding_categories)
+  if (fundingCategories) body.fundingCategories = fundingCategories
+  const fundingInstruments = pipeJoin(a.funding_instruments)
+  if (fundingInstruments) body.fundingInstruments = fundingInstruments
+  return body
+}
+
+// One throttled POST to search2; unwraps the envelope and raises on a non-zero errorcode.
+const postSearch2 = async (
+  ctx: ToolContext,
+  body: Record<string, unknown>
+): Promise<Search2Data> => {
+  const env = (await ctx.postJson(GRANTS_URL, body)) as Search2Envelope
+  if (env.errorcode !== 0) {
+    throw new Error(`grants.gov errorcode ${env.errorcode}: ${env.msg ?? ''}`)
+  }
+  if (!env.data) throw new Error('grants.gov response missing data envelope')
+  return env.data
+}
+
+// Pulls the requested facet blocks out of a search2 data payload.
+const pickFacets = (data: Search2Data, keys: string[]): Record<string, unknown> =>
+  Object.fromEntries(keys.map((k) => [k, data[k]]))
+
+// Full retrieval: walk startRecordNum until every hit is fetched, then verify completeness
+// (len == hitCount, ids unique). One automatic re-walk on mismatch (the live corpus can move
+// mid-walk); a persistent mismatch raises, mirroring IncompleteRetrievalError.
+const walkGrants = async (
+  ctx: ToolContext,
+  a: Record<string, unknown>,
+  statuses: string
+): Promise<{ records: OppHit[]; hitCount: number; facets: Record<string, unknown> }> => {
+  let records: OppHit[] = []
+  let ids: string[] = []
+  let hitCount = 0
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    records = []
+    let facets: Record<string, unknown> = {}
+    let start = 0
+    hitCount = 0
+    let first = true
+    for (;;) {
+      const data = await postSearch2(ctx, grantsPayload(a, statuses, GRANTS_ROWS_PER_PAGE, start))
+      if (first) {
+        hitCount = data.hitCount
+        facets = pickFacets(data, SEARCH_FACET_KEYS)
+        first = false
+      }
+      const hits = data.oppHits ?? []
+      records.push(...hits)
+      start += hits.length
+      if (start >= data.hitCount || hits.length === 0) break
+    }
+    ids = records.map((r) => String(r.id))
+    if (records.length === hitCount && new Set(ids).size === records.length) {
+      return { records, hitCount, facets }
+    }
+  }
+  throw new Error(
+    `incomplete grants.gov retrieval: ${records.length} records (${new Set(ids).size} unique ids) ` +
+      `vs hitCount ${hitCount} after retry — check sortBy validity / corpus motion`
+  )
+}
+
+// --------------------------------------------------------- Antibody Registry
+
+const AB_BASE = 'https://www.antibodyregistry.org/api'
+// Deepest row reachable without authentication on /fts-antibodies (page*size beyond this -> HTTP 401).
+const ANON_ROW_LIMIT = 500
+// Fields that change as the registry re-curates records; stripped from returned records (upstream _norm).
+const VOLATILE_FIELDS = new Set([
+  'curateTime',
+  'lastEditTime',
+  'ix',
+  'showLink',
+  'feedback',
+  'numOfCitation'
+])
 
 type AntibodyRecord = {
   abId?: number
-  abName?: string
-  abTarget?: string
+  catalogNum?: string
+  catAlt?: string
   vendorName?: string
-  clonality?: string
-}
+} & Record<string, unknown>
+type FtsResponse = { totalElements?: number; items?: AntibodyRecord[] }
 
-type FtsAntibodiesResponse = { totalElements?: number; items?: AntibodyRecord[] }
+// Drops volatile fields from a record (does not reorder — key order is immaterial to callers/tests).
+const normAntibody = (r: AntibodyRecord): Record<string, unknown> =>
+  Object.fromEntries(Object.entries(r).filter(([k]) => !VOLATILE_FIELDS.has(k)))
 
-const toRrid = (abId: number | undefined): string | undefined =>
-  abId === undefined ? undefined : `AB_${abId}`
+const toRrid = (num: number): string => `AB_${num}`
 
-const compactAntibody = (r: AntibodyRecord): Record<string, unknown> => ({
-  ab_id: toRrid(r.abId),
-  name: r.abName,
-  vendor: r.vendorName,
-  target: r.abTarget,
-  clonality: r.clonality
-})
-
-// Accepts a plain integer, "AB_<id>" or "RRID:AB_<id>" and returns the bare numeric id
-// (mirrors the upstream Python client's parse_ab_id).
-const parseAbId = (value: unknown): string => {
+// Accepts 3643095, "3643095", "AB_3643095" or "RRID:AB_3643095"; returns the bare numeric id.
+const parseAbId = (value: unknown): number => {
   const s = String(value).trim()
   const m = /^(?:RRID:)?AB_(\d+)$/i.exec(s)
-  if (m) return m[1]
-  if (/^\d+$/.test(s)) return s
-  throw new Error(`not a valid antibody id / RRID: ${s}`)
+  if (m) return Number(m[1])
+  if (/^\d+$/.test(s)) return Number(s)
+  throw new Error(`not a valid antibody id / RRID: ${String(value)}`)
 }
 
-// Antibody Registry (antibodyregistry.org) REST API: read-only antibody catalog lookups.
-// Anonymous depth cap upstream: fts-antibodies returns HTTP 401 once page*size > 500.
+const ftsUrl = (q: string, page: number, size: number): string =>
+  `${AB_BASE}/fts-antibodies?q=${encodeURIComponent(q)}&page=${page}&size=${size}`
+
+// Walks all fts-antibodies pages up to max_records or the anonymous depth cap. Rows beyond offset 500
+// need authentication (HTTP 401) — the walk stops and flags anonymous_limit_hit, never silently
+// dropping. Mirrors AntibodyRegistryClient.search_antibodies (page=None branch).
+const walkAntibodies = async (
+  ctx: ToolContext,
+  q: string,
+  size: number,
+  maxRecords: number
+): Promise<{
+  total: number | undefined
+  items: Record<string, unknown>[]
+  limitHit: boolean
+}> => {
+  const items: Record<string, unknown>[] = []
+  let total: number | undefined
+  let limitHit = false
+  let pg = 1
+  for (;;) {
+    if (pg * size > ANON_ROW_LIMIT) {
+      limitHit = true
+      break
+    }
+    const data = (await ctx.fetchJson(ftsUrl(q, pg, size))) as FtsResponse
+    total = data.totalElements
+    const batch = data.items ?? []
+    if (batch.length === 0) break
+    items.push(...batch.map(normAntibody))
+    if (items.length >= Math.min(total ?? 0, maxRecords)) break
+    pg += 1
+  }
+  return { total, items, limitHit }
+}
+
 export const RESEARCH_RESOURCES_TOOLS: ToolDescriptor[] = [
   {
-    id: 'antibody_search',
+    id: 'search_grants',
     connector: 'research_resources',
     description:
-      'Full-text search the Antibody Registry by target/name/catalog text; returns RRID, name, vendor, target, and clonality per hit.',
+      'Search Grants.gov funding opportunities via the search2 API (complete, count-verified retrieval). At least one criterion is required (keyword, opportunity_number, aln/CFDA, agencies, eligibilities, funding_categories, or funding_instruments). opportunity_statuses defaults to ["forecasted","posted"] (current opportunities); add "closed"/"archived" for historical ones. agencies takes codes like ["HHS-NIH11"] (NIH), ["HHS-FDA"], ["NSF"]. Set count_only for just the hit count + facets; max_records caps returned records (the walk still retrieves the complete set and flags truncated).',
+    input: {
+      type: 'object',
+      properties: {
+        keyword: { type: 'string' },
+        opportunity_number: { type: 'string' },
+        aln: { type: 'string' },
+        agencies: { type: 'array', items: { type: 'string' } },
+        opportunity_statuses: {
+          type: 'array',
+          items: { type: 'string', enum: ['forecasted', 'posted', 'closed', 'archived'] }
+        },
+        eligibilities: { type: 'array', items: { type: 'string' } },
+        funding_categories: { type: 'array', items: { type: 'string' } },
+        funding_instruments: { type: 'array', items: { type: 'string' } },
+        count_only: { type: 'boolean', default: false },
+        max_records: { type: 'integer', default: 100 },
+        include_facets: { type: 'boolean', default: true }
+      }
+    },
+    returns:
+      '`{ hit_count, n_returned, truncated, records: [ { id, number, title, agencyCode, agency, oppStatus, openDate, closeDate, docType, cfdaList } ], facets? }` — records are the raw search2 hits (verbatim, sorted by oppNum). `truncated` is true when `hit_count` exceeds the returned count. `facets` (when include_facets) holds oppStatusOptions/agencies/eligibilities/fundingCategories/fundingInstruments/dateRangeOptions value counts. With `count_only`, records is [] and n_returned 0.',
+    example:
+      'result = host.mcp("research_resources", "search_grants", {"keyword": "cancer", "agencies": ["HHS-NIH11"], "max_records": 25})',
+    run: async (ctx, a) => {
+      const statuses = pipeJoin(a.opportunity_statuses) || DEFAULT_STATUSES
+      for (const s of statuses.split('|')) {
+        if (!VALID_STATUSES.includes(s)) {
+          throw new Error(`invalid oppStatus '${s}'; valid: ${VALID_STATUSES.join(', ')}`)
+        }
+      }
+      // At least one search criterion (statuses alone is not a criterion).
+      const hasCriterion =
+        Boolean(a.keyword) ||
+        Boolean(a.opportunity_number) ||
+        Boolean(a.aln) ||
+        Boolean(pipeJoin(a.agencies)) ||
+        Boolean(pipeJoin(a.eligibilities)) ||
+        Boolean(pipeJoin(a.funding_categories)) ||
+        Boolean(pipeJoin(a.funding_instruments))
+      if (!hasCriterion) throw new Error('search_grants needs at least one search criterion')
+      const includeFacets = a.include_facets !== false
+
+      if (a.count_only === true) {
+        const data = await postSearch2(ctx, grantsPayload(a, statuses, 0, 0))
+        const out: Record<string, unknown> = {
+          hit_count: data.hitCount,
+          n_returned: 0,
+          truncated: false,
+          records: []
+        }
+        if (includeFacets) out.facets = pickFacets(data, COUNT_FACET_KEYS)
+        return out
+      }
+
+      const { records, hitCount, facets } = await walkGrants(ctx, a, statuses)
+      const maxRecords = Math.max(0, Number(a.max_records ?? 100))
+      const kept = records.slice(0, maxRecords)
+      const out: Record<string, unknown> = {
+        hit_count: hitCount,
+        n_returned: kept.length,
+        truncated: hitCount > kept.length,
+        records: kept
+      }
+      if (includeFacets) out.facets = facets
+      return out
+    }
+  },
+  {
+    id: 'search_antibodies',
+    connector: 'research_resources',
+    description:
+      'Full-text search the Antibody Registry (antibodyregistry.org, ~3.2M records). Token-based matching against antibody name/target/catalog text ("TP53" and "p53" are different queries). With page omitted, all pages are walked up to max_records or the anonymous depth cap (rows beyond offset 500 need authentication upstream, flagged as anonymous_limit_hit — never silently dropped). Pass a 1-based page for single-page retrieval (page*page_size must stay <= 500).',
     input: {
       type: 'object',
       properties: {
         query: { type: 'string' },
-        page: { type: 'integer', default: 1 },
-        size: { type: 'integer', default: 10 }
+        page: { type: 'integer' },
+        page_size: { type: 'integer', default: 100 },
+        max_records: { type: 'integer', default: 500 }
       },
       required: ['query']
     },
     required: ['query'],
     returns:
-      '`{ "total_elements": int, "items": [ { "ab_id": str, "name": str, "vendor": str, "target": str, "clonality": str } ] }` — `ab_id` is an `AB_<id>` RRID. `total_elements` is the full match count; `items` holds one page (default 10) and is `[]` when nothing matches. Anonymous paging past page*size > 500 fails upstream (HTTP 401).',
-    example: 'result = host.mcp("research_resources", "antibody_search", {"query": "TP53"})',
-    url: (a) => {
-      const page = Number.isFinite(Number(a.page)) ? Math.max(1, Number(a.page)) : 1
-      const size = Number.isFinite(Number(a.size)) ? Math.max(1, Number(a.size)) : 10
-      return `${BASE}/fts-antibodies?q=${encodeURIComponent(String(a.query))}&page=${page}&size=${size}`
-    },
-    parse: (raw) => {
-      const r = raw as FtsAntibodiesResponse
+      'Walk mode (page omitted): `{ query, total_elements, retrieved, unique_ab_ids, complete, truncated_at_max_records, anonymous_limit_hit, items: [ { abId, abName, abTarget, catalogNum, vendorName, cloneId, sourceOrganism, targetSpecies, ... } ] }`. `total_elements` counts index rows (not unique antibodies). Single-page mode (page given): `{ query, page, total_elements, retrieved, complete, items }`.',
+    example:
+      'result = host.mcp("research_resources", "search_antibodies", {"query": "CD4", "max_records": 100})',
+    run: async (ctx, a) => {
+      const q = String(a.query ?? '').trim()
+      if (!q) throw new Error('query must be non-empty')
+      const size = Math.max(1, Number(a.page_size ?? 100))
+
+      if (a.page != null) {
+        const page = Math.max(1, Number(a.page))
+        if (page * size > ANON_ROW_LIMIT) {
+          throw new Error(
+            `page*size=${page * size} exceeds the anonymous row limit (${ANON_ROW_LIMIT}); ` +
+              'upstream returns HTTP 401 beyond it'
+          )
+        }
+        const data = (await ctx.fetchJson(ftsUrl(q, page, size))) as FtsResponse
+        const items = (data.items ?? []).map(normAntibody)
+        return {
+          query: q,
+          page,
+          total_elements: data.totalElements,
+          retrieved: items.length,
+          complete: items.length === data.totalElements,
+          items
+        }
+      }
+
+      const maxRecords = Math.max(1, Number(a.max_records ?? 500))
+      const { total, items, limitHit } = await walkAntibodies(ctx, q, size, maxRecords)
+      const truncated = total != null && items.length < total
       return {
-        total_elements: r.totalElements,
-        items: (r.items ?? []).map(compactAntibody)
+        query: q,
+        total_elements: total,
+        retrieved: items.length,
+        unique_ab_ids: new Set(items.map((r) => r.abId)).size,
+        complete: !truncated,
+        truncated_at_max_records: truncated && !limitHit,
+        anonymous_limit_hit: limitHit,
+        items
       }
     }
   },
   {
-    id: 'antibody_get',
+    id: 'get_antibody',
     connector: 'research_resources',
     description:
-      'Get Antibody Registry record(s) for an accession/RRID (plain id, "AB_<id>", or "RRID:AB_<id>"); an accession can map to several curated records.',
+      'Fetch Antibody Registry detail record(s) for one antibody accession / RRID. Accepts a plain number ("3643095"), "AB_3643095", or "RRID:AB_3643095". The upstream route is list-valued (an accession can map to several curated records, e.g. multi-vendor duplicates). A nonexistent id yields record_count 0, not an error.',
     input: {
       type: 'object',
-      properties: { ab_id: { type: 'string' } },
-      required: ['ab_id']
+      properties: { antibody_id: { type: 'string' } },
+      required: ['antibody_id']
     },
-    required: ['ab_id'],
+    required: ['antibody_id'],
     returns:
-      '`[ { "ab_id": str, "name": str, "vendor": str, "target": str, "clonality": str } ]` — an array because one accession can map to several curated records; `ab_id` is an `AB_<id>` RRID. Empty array when the id has no records.',
-    example: 'result = host.mcp("research_resources", "antibody_get", {"ab_id": "AB_3717446"})',
-    url: (a) => `${BASE}/antibodies/${parseAbId(a.ab_id)}`,
-    parse: (raw) => (raw as AntibodyRecord[]).map(compactAntibody)
+      '`{ ab_id (numeric), rrid ("AB_<id>"), record_count, records: [ full antibody records ] }`. `record_count` is 0 (with records []) when the accession has no records.',
+    example:
+      'result = host.mcp("research_resources", "get_antibody", {"antibody_id": "RRID:AB_3643095"})',
+    url: (a) => `${AB_BASE}/antibodies/${parseAbId(a.antibody_id)}`,
+    parse: (raw, a) => {
+      const num = parseAbId(a.antibody_id)
+      const records = (Array.isArray(raw) ? raw : [raw]) as AntibodyRecord[]
+      return {
+        ab_id: num,
+        rrid: toRrid(num),
+        record_count: records.length,
+        records: records.map(normAntibody)
+      }
+    }
+  },
+  {
+    id: 'find_antibodies_by_catalog',
+    connector: 'research_resources',
+    description:
+      'Find antibodies by vendor catalog number (exact, case-insensitive). Implemented as a full-text search plus client-side exact matching on the catalog number (or its listed alternatives), because the upstream column-filter route returns HTTP 500 for every key. Pass an optional vendor name (exact, case-insensitive) to further narrow the matches.',
+    input: {
+      type: 'object',
+      properties: {
+        catalog_number: { type: 'string' },
+        vendor: { type: 'string' },
+        page_size: { type: 'integer', default: 100 }
+      },
+      required: ['catalog_number']
+    },
+    required: ['catalog_number'],
+    returns:
+      '`{ catalog_num, vendor, match_count, search_total_elements, matches: [ full antibody records ] }`. `search_total_elements` is the underlying full-text hit count; `matches` are the exact catalog-number matches.',
+    example:
+      'result = host.mcp("research_resources", "find_antibodies_by_catalog", {"catalog_number": "ab32572"})',
+    run: async (ctx, a) => {
+      const catalog = String(a.catalog_number ?? '').trim()
+      if (!catalog) throw new Error('catalog_number must be non-empty')
+      const size = Math.max(1, Number(a.page_size ?? 100))
+      const vendor = a.vendor != null ? String(a.vendor) : null
+      const want = catalog.toLowerCase()
+      // Walk the full-text search, then keep exact catalog-number matches (upstream default max 5000).
+      const { total, items } = await walkAntibodies(ctx, catalog, size, 5000)
+      const wantVendor = vendor != null ? vendor.trim().toLowerCase() : null
+      const matches = items.filter((r) => {
+        const cat = String(r.catalogNum ?? '')
+          .trim()
+          .toLowerCase()
+        const alts = new Set(
+          String(r.catAlt ?? '')
+            .split(/[,;]/)
+            .map((s) => s.trim().toLowerCase())
+            .filter(Boolean)
+        )
+        if (want !== cat && !alts.has(want)) return false
+        if (wantVendor == null) return true
+        return (
+          String(r.vendorName ?? '')
+            .trim()
+            .toLowerCase() === wantVendor
+        )
+      })
+      return {
+        catalog_num: catalog,
+        vendor,
+        match_count: matches.length,
+        search_total_elements: total,
+        matches
+      }
+    }
+  },
+  {
+    id: 'get_antibody_registry_stats',
+    connector: 'research_resources',
+    description:
+      'Antibody Registry statistics: total antibody count and last-update date. Returns the upstream /api/datainfo payload.',
+    input: { type: 'object', properties: {} },
+    returns:
+      '`{ total (registry size), lastupdate (YYYY-MM-DD) }` — the upstream /api/datainfo payload.',
+    example: 'result = host.mcp("research_resources", "get_antibody_registry_stats", {})',
+    url: () => `${AB_BASE}/datainfo`,
+    parse: (raw) => raw
   }
 ]


### PR DESCRIPTION
Rounds out the Research Resources connector across two sources — Grants.gov funding-opportunity search (count-verified walk with facets, status/criterion validation, and truncation) and the Antibody Registry (full-text antibody search with an honest anonymous-depth cap, accession/RRID lookup, catalog-number matching, and registry statistics).

All tools are read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)