### PR TITLE
feat(connectors): expand the RNA connector capabilities

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -209,9 +209,9 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
   {
     id: 'rna',
     displayName: 'RNA',
-    description: 'Non-coding RNA family metadata via Rfam.',
+    description: 'Non-coding RNA family data (metadata, alignments, models, structures) via Rfam.',
     useWhen:
-      'Use when you need RNA family metadata — Rfam accession, family id, description, or RNA type (e.g. tRNA, rRNA, riboswitch) for an Rfam accession or family id.',
+      'Use for non-coding RNA families from Rfam (accession or family id, e.g. RF00005 / tRNA): family metadata (RNA type, seed/full counts, gathering/trusted/noise cutoffs, clan); the seed alignment (Stockholm or FASTA); the Infernal covariance model; the seed phylogenetic tree; full-region hits across sequence databases; PDB structure mappings; accession<->id conversion; and single-sequence cmscan search against all Rfam models.',
     sources: ['Rfam'],
     termsUrl: 'https://docs.rfam.org/en/latest/',
     requiresNcbi: false

--- a/src/main/connectors/descriptors/rna.test.ts
+++ b/src/main/connectors/descriptors/rna.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { createHash } from 'node:crypto'
 import { ParserEngine } from '../engine'
 import { RNA_TOOLS } from './rna'
 import type { ToolDescriptor } from '../types'
@@ -9,66 +10,370 @@ const jsonRes = (body: unknown): Response =>
 const textRes = (body: string): Response =>
   ({ ok: true, status: 200, text: async () => body }) as Response
 
+const sha = (text: string): string => createHash('sha256').update(text, 'utf8').digest('hex')
+
 describe('rna / rfam', () => {
-  it('rfam_get_family builds the URL and flattens the rfam envelope', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        rfam: {
-          acc: 'RF00005',
-          id: 'tRNA',
-          description: 'tRNA',
-          curation: { type: 'Gene; tRNA;' }
-        }
-      })
+  it('exposes exactly the 9 upstream tool ids', () => {
+    expect(RNA_TOOLS.map((t) => t.id).sort()).toEqual(
+      [
+        'accession_to_id',
+        'get_covariance_model',
+        'get_family',
+        'get_seed_alignment',
+        'get_sequence_regions',
+        'get_structure_mapping',
+        'get_tree',
+        'id_to_accession',
+        'search_sequence'
+      ].sort()
     )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('rfam_get_family'),
+    expect(RNA_TOOLS.every((t) => t.connector === 'rna')).toBe(true)
+    expect(RNA_TOOLS.every((t) => t.returns && t.example)).toBe(true)
+  })
+
+  it('get_family flattens the envelope, reads cm.cutoffs, and keeps raw', async () => {
+    const rfam = {
+      acc: 'RF00005',
+      id: 'tRNA',
+      description: 'tRNA',
+      comment: 'Transfer RNA',
+      clan: { id: null, acc: null },
+      curation: {
+        type: 'Gene; tRNA;',
+        num_seed: '954',
+        num_full: '5335975',
+        num_species: '14413',
+        structure_source: 'Published; PMID:8256282'
+      },
+      cm: { cutoffs: { trusted: 29.0, gathering: 29.0, noise: 28.9 } },
+      release: { number: '15.1', date: '2026-01-16' }
+    }
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ rfam }))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_family'),
       { family: 'RF00005' },
       {}
-    )
+    )) as Record<string, unknown>
     expect(fetchImpl.mock.calls[0][0]).toBe(
       'https://rfam.org/family/RF00005?content-type=application/json'
     )
-    expect(out).toEqual({
+    expect(out).toMatchObject({
       rfam_acc: 'RF00005',
-      id: 'tRNA',
+      rfam_id: 'tRNA',
       description: 'tRNA',
-      type: 'Gene; tRNA;'
+      comment: 'Transfer RNA',
+      clan_acc: null,
+      clan_id: null,
+      rna_type: 'Gene; tRNA;',
+      structure_source: 'Published; PMID:8256282',
+      num_seed: 954,
+      num_full: 5335975,
+      num_species: 14413,
+      gathering_cutoff: 29.0,
+      trusted_cutoff: 29.0,
+      noise_cutoff: 28.9,
+      release_number: '15.1',
+      release_date: '2026-01-16'
     })
+    // raw carries the whole upstream rfam record
+    expect(out.raw).toEqual(rfam)
   })
 
-  it('rfam_get_family accepts a family id and tolerates missing curation', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      jsonRes({
-        rfam: { acc: 'RF00005', id: 'tRNA', description: 'tRNA' }
-      })
-    )
-    const out = await new ParserEngine({ fetchImpl }).call(
-      tool('rfam_get_family'),
+  it('get_family accepts a family id and tolerates missing sub-objects', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonRes({ rfam: { acc: 'RF00005', id: 'tRNA', description: 'tRNA' } }))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_family'),
       { family: 'tRNA' },
       {}
-    )
+    )) as Record<string, unknown>
     expect(fetchImpl.mock.calls[0][0]).toBe(
       'https://rfam.org/family/tRNA?content-type=application/json'
     )
-    expect(out).toEqual({
+    expect(out).toMatchObject({
       rfam_acc: 'RF00005',
-      id: 'tRNA',
-      description: 'tRNA',
-      type: undefined
+      rfam_id: 'tRNA',
+      num_seed: null,
+      gathering_cutoff: null,
+      trusted_cutoff: null,
+      noise_cutoff: null
     })
   })
 
-  it('rfam_acc_to_id builds the URL and trims the text response', async () => {
+  it('get_seed_alignment (stockholm) returns names, counts and sha256', async () => {
+    const align = '# STOCKHOLM 1.0\n#=GF AC RF00162\nSEQ1 ACGU\nSEQ2 ACGA\nSEQ1 UUUU\n//\n'
+    const fetchImpl = vi.fn().mockResolvedValue(textRes(align))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_seed_alignment'),
+      { family: 'RF00162' },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rfam.org/family/RF00162/alignment?content-type=text/plain'
+    )
+    expect(out).toEqual({
+      family: 'RF00162',
+      format: 'stockholm',
+      num_sequences: 2,
+      sequence_names: ['SEQ1', 'SEQ2'],
+      sha256: sha(align),
+      alignment: align
+    })
+  })
+
+  it('get_seed_alignment (fasta) hits the /fasta route and parses > names', async () => {
+    const align = '>AF027868.1/5245-5154 desc\nACGU\n>X12345.1/1-4\nUGCA\n'
+    const fetchImpl = vi.fn().mockResolvedValue(textRes(align))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_seed_alignment'),
+      { family: 'RF00162', fmt: 'fasta' },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rfam.org/family/RF00162/alignment/fasta?content-type=text/plain'
+    )
+    expect(out.format).toBe('fasta')
+    expect(out.sequence_names).toEqual(['AF027868.1/5245-5154', 'X12345.1/1-4'])
+    expect(out.num_sequences).toBe(2)
+  })
+
+  it('get_seed_alignment omits the body past max_bytes but keeps sha256/counts', async () => {
+    const align = 'SEQ1 ' + 'A'.repeat(5000) + '\nSEQ2 ' + 'C'.repeat(5000) + '\n'
+    const fetchImpl = vi.fn().mockResolvedValue(textRes(align))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_seed_alignment'),
+      { family: 'RF00005', max_bytes: 1000 },
+      {}
+    )) as Record<string, unknown>
+    expect(out.alignment).toBeUndefined()
+    expect(out.alignment_omitted).toContain('max_bytes=1000')
+    expect(out.size_bytes).toBe(Buffer.byteLength(align))
+    expect(out.sha256).toBe(sha(align))
+    expect(out.num_sequences).toBe(2)
+    expect(out.sequence_names).toEqual(['SEQ1', 'SEQ2'])
+  })
+
+  it('get_covariance_model parses the header and always returns size_bytes/sha256', async () => {
+    const cm = [
+      'INFERNAL1/a [1.1.4 | Dec 2020]',
+      'NAME     SAM',
+      'ACC      RF00162',
+      'DESC     SAM riboswitch',
+      'STATES   338',
+      'NODES    85',
+      'CLEN     108',
+      'W        186',
+      'ALPH     RNA',
+      'CM',
+      '  [ model matrix ]',
+      '//'
+    ].join('\n')
+    const fetchImpl = vi.fn().mockResolvedValue(textRes(cm))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_covariance_model'),
+      { family: 'RF00162' },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rfam.org/family/RF00162/cm?content-type=text/plain'
+    )
+    expect(out.header).toEqual({
+      NAME: 'SAM',
+      ACC: 'RF00162',
+      DESC: 'SAM riboswitch',
+      STATES: 338,
+      NODES: 85,
+      CLEN: 108,
+      W: 186,
+      ALPH: 'RNA'
+    })
+    expect(out.size_bytes).toBe(Buffer.byteLength(cm))
+    expect(out.sha256).toBe(sha(cm))
+    expect(out.cm).toBe(cm)
+  })
+
+  it('get_covariance_model omits cm past max_bytes, header/size/sha256 survive', async () => {
+    const cm = 'NAME  SAM\nACC   RF00162\nCLEN  108\nCM\n' + 'x'.repeat(5000)
+    const fetchImpl = vi.fn().mockResolvedValue(textRes(cm))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_covariance_model'),
+      { family: 'RF00162', max_bytes: 500 },
+      {}
+    )) as Record<string, unknown>
+    expect(out.cm).toBeUndefined()
+    expect(out.cm_omitted).toContain('max_bytes=500')
+    expect(out.size_bytes).toBe(Buffer.byteLength(cm))
+    expect(out.sha256).toBe(sha(cm))
+    expect(out.header).toMatchObject({ NAME: 'SAM', ACC: 'RF00162', CLEN: 108 })
+  })
+
+  it('get_tree counts leaf labels and returns sha256', async () => {
+    const tree = '((A:0.1,B:0.2)0.9:0.3,C:0.4);'
+    const fetchImpl = vi.fn().mockResolvedValue(textRes(tree))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_tree'),
+      { family: 'RF00162' },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rfam.org/family/RF00162/tree?content-type=text/plain'
+    )
+    expect(out.num_leaf_labels).toBe(3)
+    expect(out.sha256).toBe(sha(tree))
+    expect(out.tree).toBe(tree)
+  })
+
+  it('get_sequence_regions parses declared_count and TSV rows', async () => {
+    const tsv = [
+      '# Rfam regions for family SAM (RF00162)',
+      '# file built 05:11:37 15-Jul-2026 using Rfam version 15.1',
+      '# found 9625 regions',
+      '# columns: ...',
+      'FOYF01000003.1\t108.7\t195245\t195351\tBacillus sp. cl95\tBacillus sp. cl95\t1761761',
+      'CP042243.1\t108.1\t950145\t950256\tCrassaminicella\tCrassaminicella thermophila\t2599308'
+    ].join('\n')
+    const fetchImpl = vi.fn().mockResolvedValue(textRes(tsv))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_sequence_regions'),
+      { family: 'RF00162' },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rfam.org/family/RF00162/regions?content-type=text/plain'
+    )
+    expect(out.declared_count).toBe(9625)
+    expect(out.num_regions).toBe(2)
+    expect((out.regions as Record<string, string>[])[0]).toEqual({
+      sequence_accession: 'FOYF01000003.1',
+      bits_score: '108.7',
+      region_start: '195245',
+      region_end: '195351',
+      sequence_description: 'Bacillus sp. cl95',
+      species: 'Bacillus sp. cl95',
+      ncbi_tax_id: '1761761'
+    })
+  })
+
+  it('get_sequence_regions surfaces an upstream 403 as-is', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 403, headers: new Headers() })
+    await expect(
+      new ParserEngine({ fetchImpl, retries: 0 }).call(
+        tool('get_sequence_regions'),
+        { family: 'RF00005' },
+        {}
+      )
+    ).rejects.toThrow('HTTP 403')
+  })
+
+  it('get_structure_mapping sorts rows deterministically and collects pdb ids', async () => {
+    const mapping = [
+      { pdb_id: '5fkf', chain: 'A', pdb_start: 1, pdb_end: 93, cm_start: 1, cm_end: 108 },
+      { pdb_id: '3gx5', chain: 'A', pdb_start: 1, pdb_end: 93, cm_start: 1, cm_end: 108 },
+      { pdb_id: '3gx5', chain: 'B', pdb_start: 1, pdb_end: 93, cm_start: 1, cm_end: 108 }
+    ]
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ mapping }))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_structure_mapping'),
+      { family: 'RF00162' },
+      {}
+    )) as Record<string, unknown>
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rfam.org/family/RF00162/structures?content-type=application/json'
+    )
+    expect(out.num_mappings).toBe(3)
+    expect(out.num_pdb_ids).toBe(2)
+    expect(out.pdb_ids).toEqual(['3gx5', '5fkf'])
+    // sorted by (pdb_id, chain, ...): 3gx5/A, 3gx5/B, 5fkf/A
+    expect((out.mapping as Record<string, unknown>[]).map((m) => `${m.pdb_id}/${m.chain}`)).toEqual(
+      ['3gx5/A', '3gx5/B', '5fkf/A']
+    )
+  })
+
+  it('get_structure_mapping tolerates an empty mapping', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({}))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_structure_mapping'),
+      { family: 'RF99999' },
+      {}
+    )) as Record<string, unknown>
+    expect(out).toMatchObject({ num_mappings: 0, num_pdb_ids: 0, pdb_ids: [], mapping: [] })
+  })
+
+  it('accession_to_id resolves RF##### -> id', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(textRes('tRNA\n'))
     const out = await new ParserEngine({ fetchImpl }).call(
-      tool('rfam_acc_to_id'),
+      tool('accession_to_id'),
       { accession: 'RF00005' },
       {}
     )
     expect(fetchImpl.mock.calls[0][0]).toBe(
       'https://rfam.org/family/RF00005/id?content-type=text/plain'
     )
-    expect(out).toEqual({ accession: 'RF00005', id: 'tRNA' })
+    expect(out).toEqual({ accession: 'RF00005', rfam_id: 'tRNA' })
+  })
+
+  it('id_to_accession resolves id -> RF##### and validates the shape', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(textRes('RF00005\n'))
+    const out = await new ParserEngine({ fetchImpl }).call(
+      tool('id_to_accession'),
+      { family_id: 'tRNA' },
+      {}
+    )
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://rfam.org/family/tRNA/acc?content-type=text/plain'
+    )
+    expect(out).toEqual({ rfam_id: 'tRNA', accession: 'RF00005' })
+  })
+
+  it('id_to_accession throws when no accession resolves', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(textRes('not-an-accession\n'))
+    await expect(
+      new ParserEngine({ fetchImpl }).call(tool('id_to_accession'), { family_id: 'nope' }, {})
+    ).rejects.toThrow('no accession resolved')
+  })
+
+  it('search_sequence submits then polls until hits are present', async () => {
+    const hits = {
+      SAM: [{ E: 1e-10, score: 80 }],
+      tRNA: [
+        { E: 1e-5, score: 40 },
+        { E: 2e-5, score: 38 }
+      ]
+    }
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonRes({ jobId: 'job-1', resultURL: 'https://rfam.org/search/result/job-1' })
+      )
+      .mockResolvedValueOnce(jsonRes({ status: 'PEND' }))
+      .mockResolvedValueOnce(jsonRes({ searchSequence: 'GGUUCC', hits }))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('search_sequence'),
+      { sequence: 'GGUUCC', poll_interval_s: 0, max_wait_s: 5 },
+      {}
+    )) as Record<string, unknown>
+    // First call POSTs the sequence, subsequent calls poll the resultURL
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://rfam.org/search/sequence')
+    expect(fetchImpl.mock.calls[0][1]).toMatchObject({ method: 'POST' })
+    expect(fetchImpl.mock.calls[1][0]).toBe('https://rfam.org/search/result/job-1')
+    expect(out).toEqual({
+      job_id: 'job-1',
+      num_hits: 3,
+      families: ['SAM', 'tRNA'],
+      hits,
+      search_sequence: 'GGUUCC'
+    })
+  })
+
+  it('search_sequence surfaces a submit-side error as-is (backend down)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 500, headers: new Headers() })
+    await expect(
+      new ParserEngine({ fetchImpl, retries: 0 }).call(
+        tool('search_sequence'),
+        { sequence: 'GGUUCC' },
+        {}
+      )
+    ).rejects.toThrow('HTTP 500')
   })
 })

--- a/src/main/connectors/descriptors/rna.ts
+++ b/src/main/connectors/descriptors/rna.ts
@@ -1,26 +1,228 @@
-import type { ToolDescriptor } from '../types'
+import { createHash } from 'node:crypto'
+import type { ToolContext, ToolDescriptor } from '../types'
 
+// Rfam REST API (https://rfam.org): read-only RNA family data. Mirrors the 9 upstream
+// tooluniverse/rfam methods — family metadata, seed alignment (Stockholm/FASTA), covariance
+// model, phylogenetic tree, sequence regions, PDB structure mapping, accession<->id conversion,
+// and async single-sequence cmscan search. Every /family route resolves an accession (RF00005)
+// or a family id (tRNA) interchangeably.
 const RFAM = 'https://rfam.org'
 
-// Rfam /family JSON wraps everything under a top-level "rfam" key
-// (rfam.acc, rfam.id, rfam.description, rfam.curation.type, ...).
+// Default text-payload cap: alignment/CM texts of large families (e.g. tRNA) run to multiple MB
+// and blow past the notebook transport limit — omit the body past this size but keep metadata.
+const DEFAULT_MAX_BYTES = 400_000
+
+// Rfam accession shape (RF + 5 digits); id_to_accession validates the resolved value against it.
+const ACC_RE = /^RF\d{5}$/
+
+// Encode one argument as a single URL path segment (upstream uses urllib.quote(safe="")).
+const seg = (value: unknown): string => encodeURIComponent(String(value))
+
+const sha256Text = (text: string): string => createHash('sha256').update(text, 'utf8').digest('hex')
+
+const toInt = (v: unknown): number | null => {
+  if (v == null) return null
+  const n = Number(v)
+  return Number.isFinite(n) ? Math.trunc(n) : null
+}
+
+const toFloat = (v: unknown): number | null => {
+  if (v == null) return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+// rfam.org /family JSON wraps the record under a top-level "rfam" key.
 type RfamFamilyPayload = {
-  rfam?: {
-    acc?: string
-    id?: string
-    description?: string
-    curation?: { type?: string }
+  rfam?: Record<string, unknown>
+} & Record<string, unknown>
+
+// Flatten the /family JSON envelope into a stable record. Field names mirror the upstream
+// family_record(); gathering/trusted/noise cutoffs are read from cm.cutoffs (the live shape).
+function familyRecord(payload: RfamFamilyPayload): Record<string, unknown> {
+  const rfam = (payload.rfam ?? payload) as Record<string, unknown>
+  const cur = (rfam.curation ?? {}) as Record<string, unknown>
+  const cm = (rfam.cm ?? {}) as Record<string, unknown>
+  const rel = (rfam.release ?? {}) as Record<string, unknown>
+  const clan = (rfam.clan ?? {}) as Record<string, unknown>
+  const cutoffs = (cm.cutoffs ?? {}) as Record<string, unknown>
+  const threshold = (cm.threshold ?? {}) as Record<string, unknown>
+  return {
+    rfam_acc: rfam.acc,
+    rfam_id: rfam.id,
+    description: rfam.description,
+    comment: rfam.comment,
+    clan_acc: clan.acc,
+    clan_id: clan.id,
+    rna_type: cur.type,
+    structure_source: cur.structure_source,
+    num_seed: toInt(cur.num_seed),
+    num_full: toInt(cur.num_full),
+    num_species: toInt(cur.num_species),
+    gathering_cutoff: toFloat(cutoffs.gathering ?? threshold.gathering ?? cur.ga),
+    trusted_cutoff: toFloat(cutoffs.trusted ?? threshold.trusted ?? cur.tc),
+    noise_cutoff: toFloat(cutoffs.noise ?? threshold.noise ?? cur.nc),
+    release_number: rel.number,
+    release_date: rel.date
   }
 }
 
-// Rfam REST API: read-only RNA family lookups. Accepts either an Rfam
-// accession (RF00005) or a family id (tRNA) — the upstream routes resolve both.
+// Unique sequence names from a Stockholm alignment, in first-seen order.
+function parseStockholmSeqNames(text: string): string[] {
+  const names: string[] = []
+  const seen = new Set<string>()
+  for (const line of text.split('\n')) {
+    if (!line || line.startsWith('#') || line.startsWith('//')) continue
+    const name = line.split(/\s+/, 1)[0]
+    if (name && !seen.has(name)) {
+      seen.add(name)
+      names.push(name)
+    }
+  }
+  return names
+}
+
+// Sequence names from an aligned-FASTA alignment (the token after ">").
+function parseFastaSeqNames(text: string): string[] {
+  return text
+    .split('\n')
+    .filter((l) => l.startsWith('>'))
+    .map((l) => l.slice(1).trim().split(/\s+/, 1)[0])
+}
+
+const CM_HEADER_KEYS = new Set([
+  'NAME',
+  'ACC',
+  'DESC',
+  'STATES',
+  'NODES',
+  'CLEN',
+  'W',
+  'ALPH',
+  'GA',
+  'TC',
+  'NC'
+])
+const CM_INT_KEYS = ['STATES', 'NODES', 'CLEN', 'W'] as const
+
+// Key header fields from an Infernal CM file (1.1.x). Reads only the leading header block,
+// stopping at the "CM" model-section marker; first occurrence of each wanted key wins.
+function parseCmHeader(text: string): Record<string, unknown> {
+  const fields: Record<string, unknown> = {}
+  for (const line of text.split('\n')) {
+    if (line.trim() === 'CM') break
+    const idx = line.search(/\s/)
+    if (idx <= 0) continue
+    const key = line.slice(0, idx)
+    if (CM_HEADER_KEYS.has(key) && !(key in fields)) {
+      fields[key] = line.slice(idx).trim()
+    }
+  }
+  for (const k of CM_INT_KEYS) {
+    if (k in fields) {
+      const n = Number(fields[k])
+      if (Number.isFinite(n)) fields[k] = Math.trunc(n)
+    }
+  }
+  return fields
+}
+
+const REGION_COLUMNS = [
+  'sequence_accession',
+  'bits_score',
+  'region_start',
+  'region_end',
+  'sequence_description',
+  'species',
+  'ncbi_tax_id'
+] as const
+
+// Parse the /regions TSV payload: the "# found N regions" header value plus verbatim data rows
+// (comment lines carry a volatile build timestamp and are dropped).
+function parseRegions(text: string): {
+  declared_count: number | null
+  regions: Record<string, string>[]
+} {
+  let declared: number | null = null
+  const regions: Record<string, string>[] = []
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue
+    if (line.startsWith('#')) {
+      const low = line.toLowerCase()
+      if (low.includes('found') && low.includes('region')) {
+        for (const tok of line.split(/\s+/)) {
+          if (/^\d+$/.test(tok)) {
+            declared = Number(tok)
+            break
+          }
+        }
+      }
+      continue
+    }
+    const parts = line.split('\t')
+    const row: Record<string, string> = {}
+    REGION_COLUMNS.forEach((col, i) => {
+      if (i < parts.length) row[col] = parts[i]
+    })
+    regions.push(row)
+  }
+  return { declared_count: declared, regions }
+}
+
+type StructureRow = Record<string, unknown>
+
+// Deterministic order for /structures rows (server array order is nondeterministic upstream).
+function sortStructureMapping(mapping: StructureRow[]): StructureRow[] {
+  const key = (m: StructureRow): [string, string, number, number, number] => [
+    String(m.pdb_id),
+    String(m.chain),
+    toInt(m.pdb_start) ?? 0,
+    toInt(m.pdb_end) ?? 0,
+    toInt(m.cm_start) ?? 0
+  ]
+  return [...mapping].sort((a, b) => {
+    const ka = key(a)
+    const kb = key(b)
+    for (let i = 0; i < ka.length; i++) {
+      if (ka[i] < kb[i]) return -1
+      if (ka[i] > kb[i]) return 1
+    }
+    return 0
+  })
+}
+
+// Omit a huge text field instead of overflowing the transport limit; metadata + sha256 survive,
+// and the caller can re-request with a larger max_bytes.
+function capTextPayload(
+  result: Record<string, unknown>,
+  field: string,
+  maxBytes: number
+): Record<string, unknown> {
+  const text = result[field]
+  if (typeof text === 'string' && Buffer.byteLength(text) > maxBytes) {
+    const size = Buffer.byteLength(text)
+    const out = { ...result }
+    delete out[field]
+    out[`${field}_omitted`] =
+      `${field} is ${size} bytes > max_bytes=${maxBytes}; metadata and sha256 are ` +
+      `included — re-call with a larger max_bytes to get the full text`
+    if (out.size_bytes == null) out.size_bytes = size
+    return out
+  }
+  return result
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+type SearchSubmission = { resultURL?: string; jobId?: string; opened?: string }
+type SearchResult = { hits?: Record<string, unknown[]>; searchSequence?: string }
+
 export const RNA_TOOLS: ToolDescriptor[] = [
   {
-    id: 'rfam_get_family',
+    id: 'get_family',
     connector: 'rna',
     description:
-      'Get Rfam family metadata (accession, id, description, RNA type) for an Rfam accession or family id.',
+      'Rfam family metadata for an accession (RF00005) or family id (tRNA) — both resolve. Flattened record plus the full upstream JSON in "raw".',
     input: {
       type: 'object',
       properties: { family: { type: 'string' } },
@@ -28,24 +230,174 @@ export const RNA_TOOLS: ToolDescriptor[] = [
     },
     required: ['family'],
     returns:
-      '`{ "rfam_acc": str, "id": str, "description": str, "type": str }` — `rfam_acc` is the accession (RF#####), `id` the family name (e.g. tRNA), `type` the curated RNA type. Fields are missing/undefined when absent upstream.',
-    example: 'result = host.mcp("rna", "rfam_get_family", {"family": "RF00005"})',
-    url: (a) =>
-      `${RFAM}/family/${encodeURIComponent(String(a.family))}?content-type=application/json`,
+      '`{ "rfam_acc": str, "rfam_id": str, "description": str, "comment": str, "clan_acc": str|null, "clan_id": str|null, "rna_type": str, "structure_source": str, "num_seed": int, "num_full": int, "num_species": int, "gathering_cutoff": float, "trusted_cutoff": float, "noise_cutoff": float, "release_number": str, "release_date": str, "raw": {…} }` — flattened metadata; `raw` is the complete upstream `rfam` record. Absent fields are `null`/`undefined`.',
+    example: 'result = host.mcp("rna", "get_family", {"family": "RF00005"})',
+    url: (a) => `${RFAM}/family/${seg(a.family)}?content-type=application/json`,
     parse: (raw) => {
-      const rfam = (raw as RfamFamilyPayload).rfam ?? {}
+      const payload = raw as RfamFamilyPayload
+      const rec = familyRecord(payload)
+      rec.raw = payload.rfam ?? payload
+      return rec
+    }
+  },
+  {
+    id: 'get_seed_alignment',
+    connector: 'rna',
+    description:
+      'Seed alignment of an Rfam family in Stockholm (default, with consensus secondary-structure line) or aligned gapped FASTA.',
+    input: {
+      type: 'object',
+      properties: {
+        family: { type: 'string' },
+        fmt: { type: 'string', enum: ['stockholm', 'fasta'], default: 'stockholm' },
+        max_bytes: { type: 'integer', default: DEFAULT_MAX_BYTES }
+      },
+      required: ['family']
+    },
+    required: ['family'],
+    format: 'text',
+    returns:
+      '`{ "family": str, "format": str, "num_sequences": int, "sequence_names": [str], "sha256": str, "alignment": str }` — when the alignment exceeds `max_bytes` (default 400000) "alignment" is dropped and replaced by "alignment_omitted"/"size_bytes"; metadata, counts and sha256 are always present. Raise `max_bytes` to force the full body.',
+    example:
+      'result = host.mcp("rna", "get_seed_alignment", {"family": "RF00162", "fmt": "stockholm"})',
+    url: (a) => {
+      const fmt = String(a.fmt ?? 'stockholm')
+      if (fmt === 'stockholm')
+        return `${RFAM}/family/${seg(a.family)}/alignment?content-type=text/plain`
+      if (fmt === 'fasta')
+        return `${RFAM}/family/${seg(a.family)}/alignment/fasta?content-type=text/plain`
+      throw new Error(`unsupported alignment format: ${fmt}`)
+    },
+    parse: (raw, a) => {
+      const text = String(raw)
+      const fmt = String(a.fmt ?? 'stockholm')
+      const names = fmt === 'fasta' ? parseFastaSeqNames(text) : parseStockholmSeqNames(text)
+      const result = {
+        family: String(a.family),
+        format: fmt,
+        num_sequences: names.length,
+        sequence_names: names,
+        sha256: sha256Text(text),
+        alignment: text
+      }
+      return capTextPayload(result, 'alignment', Number(a.max_bytes ?? DEFAULT_MAX_BYTES))
+    }
+  },
+  {
+    id: 'get_covariance_model',
+    connector: 'rna',
+    description:
+      'Infernal covariance model (CM file) of an Rfam family, usable directly with cmsearch/cmscan, plus parsed header fields.',
+    input: {
+      type: 'object',
+      properties: {
+        family: { type: 'string' },
+        max_bytes: { type: 'integer', default: DEFAULT_MAX_BYTES }
+      },
+      required: ['family']
+    },
+    required: ['family'],
+    format: 'text',
+    returns:
+      '`{ "family": str, "header": { "NAME": str, "ACC": str, "STATES": int, "CLEN": int, "W": int, … }, "size_bytes": int, "sha256": str, "cm": str }` — when the CM exceeds `max_bytes` (default 400000) "cm" is dropped for "cm_omitted"; header, size_bytes and sha256 are always present.',
+    example: 'result = host.mcp("rna", "get_covariance_model", {"family": "RF00162"})',
+    url: (a) => `${RFAM}/family/${seg(a.family)}/cm?content-type=text/plain`,
+    parse: (raw, a) => {
+      const text = String(raw)
+      const result = {
+        family: String(a.family),
+        header: parseCmHeader(text),
+        size_bytes: Buffer.byteLength(text),
+        sha256: sha256Text(text),
+        cm: text
+      }
+      return capTextPayload(result, 'cm', Number(a.max_bytes ?? DEFAULT_MAX_BYTES))
+    }
+  },
+  {
+    id: 'get_tree',
+    connector: 'rna',
+    description: 'Seed phylogenetic tree of an Rfam family (NHX/Newick text).',
+    input: {
+      type: 'object',
+      properties: { family: { type: 'string' } },
+      required: ['family']
+    },
+    required: ['family'],
+    format: 'text',
+    returns:
+      '`{ "family": str, "num_leaf_labels": int, "sha256": str, "tree": str }` — `tree` is NHX/Newick text; `num_leaf_labels` counts labelled leaves.',
+    example: 'result = host.mcp("rna", "get_tree", {"family": "RF00162"})',
+    url: (a) => `${RFAM}/family/${seg(a.family)}/tree?content-type=text/plain`,
+    parse: (raw, a) => {
+      const text = String(raw)
+      const leaves = text.match(/[(,]\s*[^(),:]+:/g)
       return {
-        rfam_acc: rfam.acc,
-        id: rfam.id,
-        description: rfam.description,
-        type: rfam.curation?.type
+        family: String(a.family),
+        num_leaf_labels: leaves ? leaves.length : 0,
+        sha256: sha256Text(text),
+        tree: text
       }
     }
   },
   {
-    id: 'rfam_acc_to_id',
+    id: 'get_sequence_regions',
     connector: 'rna',
-    description: 'Resolve an Rfam accession (RF00005) to its family id (e.g. tRNA).',
+    description:
+      'All full-region hits of an Rfam family across sequence databases (parsed TSV). Check num_full via get_family first — rfam.org 403s this route for very large families (e.g. RF00005).',
+    input: {
+      type: 'object',
+      properties: { family: { type: 'string' } },
+      required: ['family']
+    },
+    required: ['family'],
+    format: 'text',
+    returns:
+      '`{ "family": str, "declared_count": int|null, "num_regions": int, "regions": [ { "sequence_accession": str, "bits_score": str, "region_start": str, "region_end": str, "sequence_description": str, "species": str, "ncbi_tax_id": str } ] }` — `declared_count` is the server\'s own "# found N regions" header. Very large families surface an HTTP 403 error as-is.',
+    example: 'result = host.mcp("rna", "get_sequence_regions", {"family": "RF00162"})',
+    url: (a) => `${RFAM}/family/${seg(a.family)}/regions?content-type=text/plain`,
+    parse: (raw, a) => {
+      const parsed = parseRegions(String(raw))
+      return {
+        family: String(a.family),
+        declared_count: parsed.declared_count,
+        num_regions: parsed.regions.length,
+        regions: parsed.regions
+      }
+    }
+  },
+  {
+    id: 'get_structure_mapping',
+    connector: 'rna',
+    description:
+      'PDB residue-level structure mappings of an Rfam family, deterministically sorted.',
+    input: {
+      type: 'object',
+      properties: { family: { type: 'string' } },
+      required: ['family']
+    },
+    required: ['family'],
+    returns:
+      '`{ "family": str, "num_mappings": int, "num_pdb_ids": int, "pdb_ids": [str], "mapping": [ { "pdb_id": str, "chain": str, "pdb_start": int, "pdb_end": int, "cm_start": int, "cm_end": int, "bit_score": float, "evalue_score": str, "rfam_acc": str } ] }` — rows sorted by (pdb_id, chain, pdb_start, pdb_end, cm_start); exact per-row fields follow upstream. `mapping` is `[]` when no structures exist.',
+    example: 'result = host.mcp("rna", "get_structure_mapping", {"family": "RF00162"})',
+    url: (a) => `${RFAM}/family/${seg(a.family)}/structures?content-type=application/json`,
+    parse: (raw, a) => {
+      const payload = (raw ?? {}) as { mapping?: StructureRow[] }
+      const rows = sortStructureMapping(payload.mapping ?? [])
+      const pdbIds = [...new Set(rows.map((r) => String(r.pdb_id)))].sort()
+      return {
+        family: String(a.family),
+        num_mappings: rows.length,
+        num_pdb_ids: pdbIds.length,
+        pdb_ids: pdbIds,
+        mapping: rows
+      }
+    }
+  },
+  {
+    id: 'accession_to_id',
+    connector: 'rna',
+    description: 'Convert an Rfam accession to its family id (e.g. RF00005 -> "tRNA").',
     input: {
       type: 'object',
       properties: { accession: { type: 'string' } },
@@ -54,10 +406,95 @@ export const RNA_TOOLS: ToolDescriptor[] = [
     required: ['accession'],
     format: 'text',
     returns:
-      '`{ "accession": str, "id": str }` — echoes the input `accession` and its resolved family `id` (upstream plain-text response, trimmed).',
-    example: 'result = host.mcp("rna", "rfam_acc_to_id", {"accession": "RF00005"})',
-    url: (a) =>
-      `${RFAM}/family/${encodeURIComponent(String(a.accession))}/id?content-type=text/plain`,
-    parse: (raw, a) => ({ accession: String(a.accession), id: String(raw).trim() })
+      '`{ "accession": str, "rfam_id": str }` — echoes the input accession and its resolved family id.',
+    example: 'result = host.mcp("rna", "accession_to_id", {"accession": "RF00005"})',
+    url: (a) => `${RFAM}/family/${seg(a.accession)}/id?content-type=text/plain`,
+    parse: (raw, a) => ({ accession: String(a.accession), rfam_id: String(raw).trim() })
+  },
+  {
+    id: 'id_to_accession',
+    connector: 'rna',
+    description: 'Convert an Rfam family id to its accession (e.g. "tRNA" -> RF00005).',
+    input: {
+      type: 'object',
+      properties: { family_id: { type: 'string' } },
+      required: ['family_id']
+    },
+    required: ['family_id'],
+    format: 'text',
+    returns:
+      '`{ "rfam_id": str, "accession": str }` — echoes the input id and its resolved RF##### accession. Throws when no accession resolves.',
+    example: 'result = host.mcp("rna", "id_to_accession", {"family_id": "tRNA"})',
+    url: (a) => `${RFAM}/family/${seg(a.family_id)}/acc?content-type=text/plain`,
+    parse: (raw, a) => {
+      const acc = String(raw).trim()
+      if (!ACC_RE.test(acc)) {
+        throw new Error(`no accession resolved for ${JSON.stringify(String(a.family_id))}`)
+      }
+      return { rfam_id: String(a.family_id), accession: acc }
+    }
+  },
+  {
+    id: 'search_sequence',
+    connector: 'rna',
+    description:
+      'Search a single RNA/DNA sequence against all Rfam covariance models (async cmscan): submit to rfam.org and poll until done. Known upstream limitation: the job backend may be down (valid submissions return "SearchUnavailable … come back later"; invalid sequences still get a 400) — the error is surfaced as-is.',
+    input: {
+      type: 'object',
+      properties: {
+        sequence: { type: 'string' },
+        max_wait_s: { type: 'number', default: 300 },
+        poll_interval_s: { type: 'number', default: 5 }
+      },
+      required: ['sequence']
+    },
+    required: ['sequence'],
+    returns:
+      '`{ "job_id": str, "num_hits": int, "families": [str], "hits": { family_id: [ { e-value, score, alignment blocks, … } ] }, "search_sequence": str }` — hits grouped by matching family id. Surfaces upstream SearchUnavailable/400/timeout errors as-is; no local fallback.',
+    example:
+      'result = host.mcp("rna", "search_sequence", {"sequence": "GGUUCCGGGAAGGCAGCAGGUGGAAACCUGCCA"})',
+    run: async (ctx: ToolContext, a) => {
+      const sequence = String(a.sequence)
+      const maxWaitS = Number(a.max_wait_s ?? 300)
+      const pollIntervalS = Number(a.poll_interval_s ?? 5)
+      // Submit the async cmscan job (upstream posts { seq }). The engine surfaces a 400 (invalid
+      // sequence) or 5xx (backend down) as an HTTP error, matching the upstream pass-through.
+      const sub = (await ctx.postJson(`${RFAM}/search/sequence`, {
+        seq: sequence
+      })) as SearchSubmission
+      const resultUrl = sub.resultURL
+      if (!resultUrl)
+        throw new Error(`submission response missing resultURL: ${JSON.stringify(sub)}`)
+      // Bounded poll loop: rfam.org holds the result behind the submission's resultURL until the
+      // job finishes. Cap total polls by max_wait_s / poll_interval_s (and a hard ceiling).
+      const deadline = Date.now() + maxWaitS * 1000
+      const maxPolls = Math.min(
+        Math.max(1, Math.ceil(maxWaitS / Math.max(pollIntervalS, 0.001))),
+        120
+      )
+      let res: SearchResult | null = null
+      for (let poll = 0; poll < maxPolls; poll++) {
+        const payload = (await ctx.fetchJson(resultUrl)) as SearchResult
+        if (payload && typeof payload === 'object' && payload.hits != null) {
+          res = payload
+          break
+        }
+        if (Date.now() >= deadline) break
+        await delay(pollIntervalS * 1000)
+      }
+      if (!res || res.hits == null) {
+        throw new Error(`Rfam sequence search not finished after ${maxWaitS}s (${resultUrl})`)
+      }
+      const hits = res.hits ?? {}
+      const families = Object.keys(hits).sort()
+      const numHits = families.reduce((acc, fam) => acc + (hits[fam]?.length ?? 0), 0)
+      return {
+        job_id: sub.jobId,
+        num_hits: numHits,
+        families,
+        hits,
+        search_sequence: res.searchSequence
+      }
+    }
   }
 ]


### PR DESCRIPTION
Rounds out the RNA connector to the full Rfam surface: family metadata, seed alignments (Stockholm/FASTA), Infernal covariance models, seed trees, full-region hits, PDB structure mappings, accession/id resolution, and an async cmscan sequence search.

Large text payloads are sha256-stamped and omitted above a byte cap (metadata always returned). All tools are read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)