### PR TITLE
fix(onboarding): progress bar for app-managed Claude install

### DIFF
--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
-import type { ClaudeInstallLogEvent } from '../../shared/settings'
+import type { ClaudeInstallEvent } from '../../shared/settings'
 import {
   detectNpmAvailable,
   getInstallSpawnSpec,
@@ -124,11 +124,11 @@ describe('claude-install: region-block detection', () => {
 describe('claude-install: run', () => {
   it('streams stdout/stderr and resolves ok on exit code 0', async () => {
     const child = new FakeChild()
-    const logs: ClaudeInstallLogEvent[] = []
+    const logs: ClaudeInstallEvent[] = []
     const promise = runInstall({
       source: 'npm',
       installId: 'install-1',
-      onLog: (event) => logs.push(event),
+      onEvent: (event) => logs.push(event),
       spawnImpl: () => child as never,
       npmPrefixWritable: () => Promise.resolve(true)
     })
@@ -143,9 +143,9 @@ describe('claude-install: run', () => {
 
     expect(result).toMatchObject({ installId: 'install-1', ok: true, exitCode: 0 })
     expect(
-      logs.some((log) => log.stream === 'stdout' && log.chunk.includes('adding package'))
+      logs.some((e) => e.kind === 'log' && e.stream === 'stdout' && e.chunk.includes('adding package'))
     ).toBe(true)
-    expect(logs.some((log) => log.stream === 'stderr')).toBe(true)
+    expect(logs.some((e) => e.kind === 'log' && e.stream === 'stderr')).toBe(true)
   })
 
   it('resolves not ok on a non-zero exit', async () => {
@@ -153,7 +153,7 @@ describe('claude-install: run', () => {
     const promise = runInstall({
       source: 'npm',
       installId: 'install-2',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       spawnImpl: () => child as never,
       npmPrefixWritable: () => Promise.resolve(true)
     })
@@ -167,7 +167,7 @@ describe('claude-install: run', () => {
     const result = await runInstall({
       source: 'npm',
       installId: 'install-3',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       npmPrefixWritable: () => Promise.resolve(true),
       spawnImpl: () => {
         throw new Error('spawn npm ENOENT')
@@ -183,7 +183,7 @@ describe('claude-install: run', () => {
     const promise = runInstall({
       source: 'official-script',
       installId: 'install-4',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       spawnImpl: () => child as never
     })
 
@@ -198,7 +198,7 @@ describe('claude-install: run', () => {
     const promise = runInstall({
       source: 'npm',
       installId: 'install-5',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       spawnImpl: () => child as never,
       npmPrefixWritable: () => Promise.resolve(true)
     })
@@ -221,12 +221,12 @@ describe('claude-install: run with region-block fallback', () => {
       bash: { stderr: "syntax error near unexpected token `<'", exit: 2 },
       npm: { stdout: 'added 1 package', exit: 0 }
     })
-    const logs: ClaudeInstallLogEvent[] = []
+    const logs: ClaudeInstallEvent[] = []
 
     const result = await runInstallWithFallback({
       source: 'official-script',
       installId: 'install-6',
-      onLog: (event) => logs.push(event),
+      onEvent: (event) => logs.push(event),
       spawnImpl: spawn as never,
       npmProbe: () => Promise.resolve(),
       npmPrefixWritable: () => Promise.resolve(true)
@@ -234,7 +234,7 @@ describe('claude-install: run with region-block fallback', () => {
 
     expect(commands).toEqual(['bash', 'npm'])
     expect(result.ok).toBe(true)
-    expect(logs.some((log) => log.stream === 'system' && /region/i.test(log.chunk))).toBe(true)
+    expect(logs.some((e) => e.kind === 'log' && e.stream === 'system' && /region/i.test(e.chunk))).toBe(true)
   })
 
   it('does not fall back when npm is unavailable', async () => {
@@ -245,7 +245,7 @@ describe('claude-install: run with region-block fallback', () => {
     const result = await runInstallWithFallback({
       source: 'official-script',
       installId: 'install-7',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       spawnImpl: spawn as never,
       npmProbe: () => Promise.reject(new Error('not found'))
     })
@@ -263,7 +263,7 @@ describe('claude-install: run with region-block fallback', () => {
     const result = await runInstallWithFallback({
       source: 'official-script',
       installId: 'install-8',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       spawnImpl: spawn as never,
       npmProbe: () => Promise.resolve()
     })
@@ -349,7 +349,7 @@ describe('claude-install: run redirects npm prefix only when needed', () => {
     await runInstall({
       source: 'npm',
       installId: 'install-prefix-1',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       spawnImpl: spawn as never,
       npmPrefixWritable: () => Promise.resolve(false)
     })
@@ -369,7 +369,7 @@ describe('claude-install: run redirects npm prefix only when needed', () => {
     await runInstall({
       source: 'npm',
       installId: 'install-prefix-2',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       spawnImpl: spawn as never,
       npmPrefixWritable: () => Promise.resolve(true)
     })

--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -33,9 +33,9 @@ const scriptedSpawn = (
     const script = scripts[command]
 
     setImmediate(() => {
-      if (script.stdout) child.stdout.emit('data', Buffer.from(script.stdout))
-      if (script.stderr) child.stderr.emit('data', Buffer.from(script.stderr))
-      child.emit('exit', script.exit)
+      if (script?.stdout) child.stdout.emit('data', Buffer.from(script.stdout))
+      if (script?.stderr) child.stderr.emit('data', Buffer.from(script.stderr))
+      child.emit('exit', script?.exit ?? 0)
     })
 
     return child
@@ -230,6 +230,7 @@ describe('claude-install: run with region-block fallback', () => {
       installId: 'install-6',
       onEvent: (event) => logs.push(event),
       spawnImpl: spawn as never,
+      platform: 'linux',
       npmProbe: () => Promise.resolve(),
       npmPrefixWritable: () => Promise.resolve(true)
     })
@@ -251,6 +252,7 @@ describe('claude-install: run with region-block fallback', () => {
       installId: 'install-7',
       onEvent: () => undefined,
       spawnImpl: spawn as never,
+      platform: 'linux',
       npmProbe: () => Promise.reject(new Error('not found'))
     })
 
@@ -269,6 +271,7 @@ describe('claude-install: run with region-block fallback', () => {
       installId: 'install-8',
       onEvent: () => undefined,
       spawnImpl: spawn as never,
+      platform: 'linux',
       npmProbe: () => Promise.resolve()
     })
 

--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -358,6 +358,7 @@ describe('claude-install: run redirects npm prefix only when needed', () => {
       installId: 'install-prefix-1',
       onEvent: () => undefined,
       spawnImpl: spawn as never,
+      platform: 'linux',
       npmPrefixWritable: () => Promise.resolve(false)
     })
 
@@ -378,6 +379,7 @@ describe('claude-install: run redirects npm prefix only when needed', () => {
       installId: 'install-prefix-2',
       onEvent: () => undefined,
       spawnImpl: spawn as never,
+      platform: 'linux',
       npmPrefixWritable: () => Promise.resolve(true)
     })
 

--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -143,7 +143,9 @@ describe('claude-install: run', () => {
 
     expect(result).toMatchObject({ installId: 'install-1', ok: true, exitCode: 0 })
     expect(
-      logs.some((e) => e.kind === 'log' && e.stream === 'stdout' && e.chunk.includes('adding package'))
+      logs.some(
+        (e) => e.kind === 'log' && e.stream === 'stdout' && e.chunk.includes('adding package')
+      )
     ).toBe(true)
     expect(logs.some((e) => e.kind === 'log' && e.stream === 'stderr')).toBe(true)
   })
@@ -234,7 +236,9 @@ describe('claude-install: run with region-block fallback', () => {
 
     expect(commands).toEqual(['bash', 'npm'])
     expect(result.ok).toBe(true)
-    expect(logs.some((e) => e.kind === 'log' && e.stream === 'system' && /region/i.test(e.chunk))).toBe(true)
+    expect(
+      logs.some((e) => e.kind === 'log' && e.stream === 'system' && /region/i.test(e.chunk))
+    ).toBe(true)
   })
 
   it('does not fall back when npm is unavailable', async () => {

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -7,7 +7,7 @@ import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 
 import type {
-  ClaudeInstallLogEvent,
+  ClaudeInstallEvent,
   ClaudeInstallResult,
   ClaudeInstallSource,
   NpmAvailability
@@ -154,7 +154,7 @@ const isNpmGlobalPrefixWritable = async ({
 export type RunInstallOptions = {
   source: ClaudeInstallSource
   installId: string
-  onLog: (event: ClaudeInstallLogEvent) => void
+  onEvent: (event: ClaudeInstallEvent) => void
   timeoutMs?: number
   // Injectable spawn so tests can drive stdout/stderr/exit without a real process. `options` carries
   // the spec's `shell` flag through to the real spawn.
@@ -193,7 +193,7 @@ const defaultInstallSpawn = (
 const runInstall = async ({
   source,
   installId,
-  onLog,
+  onEvent,
   timeoutMs = DEFAULT_INSTALL_TIMEOUT_MS,
   spawnImpl = defaultInstallSpawn,
   npmPrefixWritable = () => isNpmGlobalPrefixWritable()
@@ -208,7 +208,7 @@ const runInstall = async ({
 
   const spec = getInstallSpawnSpec(source, process.platform, npmPrefixOverride)
 
-  onLog({ installId, stream: 'system', chunk: `$ ${spec.command} ${spec.args.join(' ')}` })
+  onEvent({ kind: 'log', installId, stream: 'system', chunk: `$ ${spec.command} ${spec.args.join(' ')}` })
 
   return new Promise<ClaudeInstallResult>((resolve) => {
     let child: ChildProcessWithoutNullStreams
@@ -224,6 +224,9 @@ const runInstall = async ({
 
       return
     }
+
+    // No byte total for a shelled installer, so the bar runs indeterminate while it streams output.
+    onEvent({ kind: 'progress', installId, phase: 'installing' })
 
     let settled = false
     let timedOut = false
@@ -245,20 +248,20 @@ const runInstall = async ({
 
     const timer = setTimeout(() => {
       timedOut = true
-      onLog({ installId, stream: 'system', chunk: 'Install timed out; terminating.' })
+      onEvent({ kind: 'log', installId, stream: 'system', chunk: 'Install timed out; terminating.' })
       child.kill()
     }, timeoutMs)
 
     child.stdout.on('data', (data: Buffer) => {
       const chunk = data.toString('utf8')
       capture(chunk)
-      onLog({ installId, stream: 'stdout', chunk })
+      onEvent({ kind: 'log', installId, stream: 'stdout', chunk })
     })
 
     child.stderr.on('data', (data: Buffer) => {
       const chunk = data.toString('utf8')
       capture(chunk)
-      onLog({ installId, stream: 'stderr', chunk })
+      onEvent({ kind: 'log', installId, stream: 'stderr', chunk })
     })
 
     child.on('error', (error) => {
@@ -312,7 +315,7 @@ const detectNpmAvailable = async (
 const runInstallWithFallback = async ({
   source,
   installId,
-  onLog,
+  onEvent,
   timeoutMs,
   spawnImpl,
   npmProbe,
@@ -321,7 +324,7 @@ const runInstallWithFallback = async ({
   const result = await runInstall({
     source,
     installId,
-    onLog,
+    onEvent,
     timeoutMs,
     spawnImpl,
     npmPrefixWritable
@@ -333,13 +336,14 @@ const runInstallWithFallback = async ({
 
   if (!available) return result
 
-  onLog({
+  onEvent({
+    kind: 'log',
     installId,
     stream: 'system',
     chunk: 'Official installer looks unavailable in your region; falling back to npm…'
   })
 
-  return runInstall({ source: 'npm', installId, onLog, timeoutMs, spawnImpl, npmPrefixWritable })
+  return runInstall({ source: 'npm', installId, onEvent, timeoutMs, spawnImpl, npmPrefixWritable })
 }
 
 export {

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -156,6 +156,9 @@ export type RunInstallOptions = {
   installId: string
   onEvent: (event: ClaudeInstallEvent) => void
   timeoutMs?: number
+  // Host platform, injectable so tests exercise a fixed OS's spawn spec (e.g. bash vs powershell for
+  // the official script) regardless of the machine running them. Defaults to the real process.platform.
+  platform?: NodeJS.Platform
   // Injectable spawn so tests can drive stdout/stderr/exit without a real process. `options` carries
   // the spec's `shell` flag through to the real spawn.
   spawnImpl?: (
@@ -196,17 +199,18 @@ const runInstall = async ({
   onEvent,
   timeoutMs = DEFAULT_INSTALL_TIMEOUT_MS,
   spawnImpl = defaultInstallSpawn,
+  platform = process.platform,
   npmPrefixWritable = () => isNpmGlobalPrefixWritable()
 }: RunInstallOptions): Promise<ClaudeInstallResult> => {
   // Redirect npm's global install to a user-owned prefix only off Windows and only when the default
   // global prefix isn't writable (would otherwise need sudo). Homebrew/nvm/volta users keep a plain
   // `npm i -g` at their expected, PATH-visible location.
   const npmPrefixOverride =
-    source === 'npm' && process.platform !== 'win32' && !(await npmPrefixWritable())
+    source === 'npm' && platform !== 'win32' && !(await npmPrefixWritable())
       ? join(homedir(), '.local')
       : undefined
 
-  const spec = getInstallSpawnSpec(source, process.platform, npmPrefixOverride)
+  const spec = getInstallSpawnSpec(source, platform, npmPrefixOverride)
 
   onEvent({
     kind: 'log',
@@ -328,6 +332,7 @@ const runInstallWithFallback = async ({
   onEvent,
   timeoutMs,
   spawnImpl,
+  platform,
   npmProbe,
   npmPrefixWritable
 }: RunInstallWithFallbackOptions): Promise<ClaudeInstallResult> => {
@@ -337,6 +342,7 @@ const runInstallWithFallback = async ({
     onEvent,
     timeoutMs,
     spawnImpl,
+    platform,
     npmPrefixWritable
   })
 
@@ -353,7 +359,15 @@ const runInstallWithFallback = async ({
     chunk: 'Official installer looks unavailable in your region; falling back to npm…\n'
   })
 
-  return runInstall({ source: 'npm', installId, onEvent, timeoutMs, spawnImpl, npmPrefixWritable })
+  return runInstall({
+    source: 'npm',
+    installId,
+    onEvent,
+    timeoutMs,
+    spawnImpl,
+    platform,
+    npmPrefixWritable
+  })
 }
 
 export {

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -208,7 +208,12 @@ const runInstall = async ({
 
   const spec = getInstallSpawnSpec(source, process.platform, npmPrefixOverride)
 
-  onEvent({ kind: 'log', installId, stream: 'system', chunk: `$ ${spec.command} ${spec.args.join(' ')}` })
+  onEvent({
+    kind: 'log',
+    installId,
+    stream: 'system',
+    chunk: `$ ${spec.command} ${spec.args.join(' ')}\n`
+  })
 
   return new Promise<ClaudeInstallResult>((resolve) => {
     let child: ChildProcessWithoutNullStreams
@@ -248,7 +253,12 @@ const runInstall = async ({
 
     const timer = setTimeout(() => {
       timedOut = true
-      onEvent({ kind: 'log', installId, stream: 'system', chunk: 'Install timed out; terminating.' })
+      onEvent({
+        kind: 'log',
+        installId,
+        stream: 'system',
+        chunk: 'Install timed out; terminating.\n'
+      })
       child.kill()
     }, timeoutMs)
 
@@ -340,7 +350,7 @@ const runInstallWithFallback = async ({
     kind: 'log',
     installId,
     stream: 'system',
-    chunk: 'Official installer looks unavailable in your region; falling back to npm…'
+    chunk: 'Official installer looks unavailable in your region; falling back to npm…\n'
   })
 
   return runInstall({ source: 'npm', installId, onEvent, timeoutMs, spawnImpl, npmPrefixWritable })

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -9,6 +9,7 @@ import type {
   PreviewSkillZipRequest,
   ScanRepoRequest,
   InstallClaudeRequest,
+  ClaudeInstallEvent,
   RefreshProviderModelsRequest,
   SetActiveProviderRequest,
   AddCustomServerRequest,
@@ -27,6 +28,7 @@ import type {
 import { createDefaultSettingsService, SettingsService } from './service'
 
 // IPC channel names for the settings/onboarding surface. Kept together so preload and main agree.
+// Carries both log lines and progress ticks (a `ClaudeInstallEvent` discriminated union).
 const SETTINGS_INSTALL_LOG_CHANNEL = 'settings:install-log'
 
 export type SettingsIpcOptions = {
@@ -39,11 +41,11 @@ export type SettingsIpcOptions = {
   onConnectorsChanged?: () => void
 }
 
-// Streams one install log line to every open renderer window.
-const broadcastInstallLog = (payload: unknown): void => {
+// Streams one install event (log line or progress tick) to every open renderer window.
+const broadcastInstallEvent = (event: ClaudeInstallEvent): void => {
   for (const window of BrowserWindow.getAllWindows()) {
     if (!window.isDestroyed()) {
-      window.webContents.send(SETTINGS_INSTALL_LOG_CHANNEL, payload)
+      window.webContents.send(SETTINGS_INSTALL_LOG_CHANNEL, event)
     }
   }
 }
@@ -63,7 +65,7 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:detect-claude', () => service.detectClaude())
 
   ipcMain.handle('settings:install-claude', (_event, request: InstallClaudeRequest) =>
-    service.installClaude(request, broadcastInstallLog)
+    service.installClaude(request, broadcastInstallEvent)
   )
 
   ipcMain.handle('settings:upsert-provider', async (_event, request: UpsertProviderRequest) => {

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -6,7 +6,7 @@ import { createHash } from 'node:crypto'
 import { gzipSync } from 'node:zlib'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import type { ClaudeInstallLogEvent } from '../../shared/settings'
+import type { ClaudeInstallEvent } from '../../shared/settings'
 import {
   downloadAndVerify,
   extractFileFromTgz,
@@ -165,10 +165,31 @@ describe('managed-claude: download + verify', () => {
       integrity: sha512(payload),
       destPath: dest,
       installId: 'i1',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       fetchTarball: async () => ({ stream: Readable.from([payload]), totalBytes: payload.length })
     })
     expect((await readFile(dest)).equals(payload)).toBe(true)
+  })
+
+  it('emits determinate download progress ticks that finish at the total', async () => {
+    const chunks = [Buffer.alloc(100, 1), Buffer.alloc(100, 2), Buffer.alloc(100, 3), Buffer.alloc(100, 4)]
+    const payload = Buffer.concat(chunks)
+    const events: ClaudeInstallEvent[] = []
+    await downloadAndVerify({
+      url: 'https://reg/x.tgz',
+      integrity: sha512(payload),
+      destPath: join(dir, 'out.tgz'),
+      installId: 'i1',
+      onEvent: (e) => events.push(e),
+      fetchTarball: async () => ({ stream: Readable.from(chunks), totalBytes: payload.length })
+    })
+
+    const progress = events.filter((e) => e.kind === 'progress' && e.phase === 'downloading')
+    expect(progress.length).toBeGreaterThan(1)
+    // No raw byte lines leak into the log stream anymore.
+    expect(events.some((e) => e.kind === 'log')).toBe(false)
+    const last = progress.at(-1)
+    expect(last).toMatchObject({ receivedBytes: payload.length, totalBytes: payload.length })
   })
 
   it('rejects and removes the file on a sha512 mismatch', async () => {
@@ -179,7 +200,7 @@ describe('managed-claude: download + verify', () => {
         integrity: 'sha512-wrong',
         destPath: dest,
         installId: 'i1',
-        onLog: () => undefined,
+        onEvent: () => undefined,
         fetchTarball: async () => ({ stream: Readable.from([Buffer.from('bytes')]) })
       })
     ).rejects.toThrow(/integrity check/)
@@ -248,11 +269,11 @@ describe('managed-claude: install orchestration', () => {
 
   it('installs the binary and reports the resolved path + version', async () => {
     const { tgz, binary } = fixture()
-    const logs: ClaudeInstallLogEvent[] = []
+    const events: ClaudeInstallEvent[] = []
 
     const outcome = await installManagedClaude({
       installId: 'i1',
-      onLog: (e) => logs.push(e),
+      onEvent: (e) => events.push(e),
       dataRoot: root,
       registries: ['https://reg'],
       platform,
@@ -267,13 +288,21 @@ describe('managed-claude: install orchestration', () => {
     expect(outcome.version).toBe('2.1.209')
     expect(outcome.resolvedPath).toBe(join(root, 'claude-code', 'bin', 'claude'))
     expect((await readFile(outcome.resolvedPath as string)).equals(binary)).toBe(true)
+
+    const phases = events.filter((e) => e.kind === 'progress').map((e) => e.phase)
+    expect(phases).toEqual(expect.arrayContaining(['resolving', 'downloading', 'extracting']))
+    expect(
+      events.some(
+        (e) => e.kind === 'log' && e.stream === 'system' && /Installed Claude 2\.1\.209/.test(e.chunk)
+      )
+    ).toBe(true)
   })
 
   it('falls back to the next registry when the first fails', async () => {
     const { tgz } = fixture()
     const outcome = await installManagedClaude({
       installId: 'i2',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       dataRoot: root,
       registries: ['https://bad', 'https://good'],
       platform,
@@ -293,7 +322,7 @@ describe('managed-claude: install orchestration', () => {
   it('reports failure when every registry fails', async () => {
     const outcome = await installManagedClaude({
       installId: 'i3',
-      onLog: () => undefined,
+      onEvent: () => undefined,
       dataRoot: root,
       registries: ['https://bad'],
       platform,

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -172,7 +172,12 @@ describe('managed-claude: download + verify', () => {
   })
 
   it('emits determinate download progress ticks that finish at the total', async () => {
-    const chunks = [Buffer.alloc(100, 1), Buffer.alloc(100, 2), Buffer.alloc(100, 3), Buffer.alloc(100, 4)]
+    const chunks = [
+      Buffer.alloc(100, 1),
+      Buffer.alloc(100, 2),
+      Buffer.alloc(100, 3),
+      Buffer.alloc(100, 4)
+    ]
     const payload = Buffer.concat(chunks)
     const events: ClaudeInstallEvent[] = []
     await downloadAndVerify({
@@ -293,7 +298,8 @@ describe('managed-claude: install orchestration', () => {
     expect(phases).toEqual(expect.arrayContaining(['resolving', 'downloading', 'extracting']))
     expect(
       events.some(
-        (e) => e.kind === 'log' && e.stream === 'system' && /Installed Claude 2\.1\.209/.test(e.chunk)
+        (e) =>
+          e.kind === 'log' && e.stream === 'system' && /Installed Claude 2\.1\.209/.test(e.chunk)
       )
     ).toBe(true)
   })

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -202,7 +202,13 @@ const downloadAndVerify = async ({
         const percent = Math.floor((received / totalBytes) * 100)
         if (percent > lastPercent) {
           lastPercent = percent
-          onEvent({ kind: 'progress', installId, phase: 'downloading', receivedBytes: received, totalBytes })
+          onEvent({
+            kind: 'progress',
+            installId,
+            phase: 'downloading',
+            receivedBytes: received,
+            totalBytes
+          })
         }
       }
 
@@ -412,7 +418,12 @@ const installManagedClaude = async ({
 
     try {
       onEvent({ kind: 'progress', installId, phase: 'resolving' })
-      onEvent({ kind: 'log', installId, stream: 'system', chunk: `Resolving Claude from ${registry} …` })
+      onEvent({
+        kind: 'log',
+        installId,
+        stream: 'system',
+        chunk: `Resolving Claude from ${registry} …\n`
+      })
       const resolution = await resolveNativePackage({ registry, platform, version, fetchJson })
 
       await downloadAndVerify({
@@ -434,7 +445,12 @@ const installManagedClaude = async ({
       if (!found) throw new Error(`Native package did not contain ${platform.binName}`)
       if (process.platform !== 'win32') await chmod(destPath, 0o755)
 
-      onEvent({ kind: 'log', installId, stream: 'system', chunk: `Installed Claude ${resolution.version}.` })
+      onEvent({
+        kind: 'log',
+        installId,
+        stream: 'system',
+        chunk: `Installed Claude ${resolution.version}.\n`
+      })
 
       return {
         result: { installId, ok: true },
@@ -443,7 +459,12 @@ const installManagedClaude = async ({
       }
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error)
-      onEvent({ kind: 'log', installId, stream: 'system', chunk: `${registry} failed: ${lastError}` })
+      onEvent({
+        kind: 'log',
+        installId,
+        stream: 'system',
+        chunk: `${registry} failed: ${lastError}\n`
+      })
     } finally {
       await rm(tgzPath, { force: true }).catch(() => undefined)
     }

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -10,7 +10,7 @@ import { Transform, Writable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { createGunzip } from 'node:zlib'
 
-import type { ClaudeInstallLogEvent, ClaudeInstallResult } from '../../shared/settings'
+import type { ClaudeInstallEvent, ClaudeInstallResult } from '../../shared/settings'
 
 // App-managed Claude installer. The `@anthropic-ai/claude-code` npm package is a thin wrapper whose
 // real payload is a per-platform native binary shipped as an optionalDependency
@@ -165,41 +165,45 @@ const resolveNativePackage = async ({
 // ---- Download + verify -----------------------------------------------------------------------------
 
 // Streams a tarball to `destPath`, computing its sha512 as it goes and rejecting on an
-// integrity mismatch (the file is removed). Progress is logged, throttled to whole-percent / MB steps.
+// integrity mismatch (the file is removed). Emits `downloading` progress ticks, throttled to
+// whole-percent steps when the total size is known (indeterminate otherwise).
 const downloadAndVerify = async ({
   url,
   integrity,
   destPath,
   installId,
-  onLog,
+  onEvent,
   fetchTarball
 }: {
   url: string
   integrity: string
   destPath: string
   installId: string
-  onLog: (event: ClaudeInstallLogEvent) => void
+  onEvent: (event: ClaudeInstallEvent) => void
   fetchTarball: FetchTarball
 }): Promise<void> => {
   const { stream, totalBytes } = await fetchTarball(url)
   const hash = createHash('sha512')
   let received = 0
-  let lastLoggedMb = 0
+  let lastPercent = 0
+
+  // Kick off the download phase immediately so the bar switches from "resolving" without waiting for
+  // the first chunk (matters when the total is unknown and no percent ticks will follow).
+  onEvent({ kind: 'progress', installId, phase: 'downloading', receivedBytes: 0, totalBytes })
 
   const meter = new Transform({
     transform(chunk: Buffer, _enc, cb) {
       hash.update(chunk)
       received += chunk.length
 
-      const mb = Math.floor(received / (1024 * 1024))
-      if (mb > lastLoggedMb) {
-        lastLoggedMb = mb
-        const total = totalBytes ? ` / ${(totalBytes / (1024 * 1024)).toFixed(1)} MB` : ''
-        onLog({
-          installId,
-          stream: 'system',
-          chunk: `Downloading Claude — ${mb.toFixed(0)} MB${total}`
-        })
+      // Determinate: emit only when the whole-percent advances (≤100 ticks). Unknown total stays
+      // indeterminate and rides the initial event above (the bar animates on its own).
+      if (totalBytes) {
+        const percent = Math.floor((received / totalBytes) * 100)
+        if (percent > lastPercent) {
+          lastPercent = percent
+          onEvent({ kind: 'progress', installId, phase: 'downloading', receivedBytes: received, totalBytes })
+        }
       }
 
       cb(null, chunk)
@@ -374,7 +378,7 @@ export type ManagedInstallOutcome = {
 
 export type InstallManagedClaudeOptions = {
   installId: string
-  onLog: (event: ClaudeInstallLogEvent) => void
+  onEvent: (event: ClaudeInstallEvent) => void
   // Root under which the binary is placed (<dataRoot>/claude-code/bin/<binName>). Pass the app's
   // configurable storage root, not a hardcoded userData path.
   dataRoot: string
@@ -390,7 +394,7 @@ export type InstallManagedClaudeOptions = {
 // `onLog` and resolves (never rejects) with a structured outcome the service can persist.
 const installManagedClaude = async ({
   installId,
-  onLog,
+  onEvent,
   dataRoot,
   registries = DEFAULT_REGISTRIES,
   version,
@@ -407,7 +411,8 @@ const installManagedClaude = async ({
     const tgzPath = join(scratch, `claude-download-${Date.now()}.tgz`)
 
     try {
-      onLog({ installId, stream: 'system', chunk: `Resolving Claude from ${registry} …` })
+      onEvent({ kind: 'progress', installId, phase: 'resolving' })
+      onEvent({ kind: 'log', installId, stream: 'system', chunk: `Resolving Claude from ${registry} …` })
       const resolution = await resolveNativePackage({ registry, platform, version, fetchJson })
 
       await downloadAndVerify({
@@ -415,10 +420,11 @@ const installManagedClaude = async ({
         integrity: resolution.integrity,
         destPath: tgzPath,
         installId,
-        onLog,
+        onEvent,
         fetchTarball
       })
 
+      onEvent({ kind: 'progress', installId, phase: 'extracting' })
       const found = await extractFileFromTgz({
         tgzPath,
         entryName: `package/${platform.binName}`,
@@ -428,7 +434,7 @@ const installManagedClaude = async ({
       if (!found) throw new Error(`Native package did not contain ${platform.binName}`)
       if (process.platform !== 'win32') await chmod(destPath, 0o755)
 
-      onLog({ installId, stream: 'system', chunk: `Installed Claude ${resolution.version}.` })
+      onEvent({ kind: 'log', installId, stream: 'system', chunk: `Installed Claude ${resolution.version}.` })
 
       return {
         result: { installId, ok: true },
@@ -437,7 +443,7 @@ const installManagedClaude = async ({
       }
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error)
-      onLog({ installId, stream: 'system', chunk: `${registry} failed: ${lastError}` })
+      onEvent({ kind: 'log', installId, stream: 'system', chunk: `${registry} failed: ${lastError}` })
     } finally {
       await rm(tgzPath, { force: true }).catch(() => undefined)
     }

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -30,7 +30,7 @@ let repository: InstanceType<typeof SettingsRepository>
 
 type ManagedInstallImpl = (options: {
   installId: string
-  onLog: (event: { installId: string; stream: string; chunk: string }) => void
+  onEvent: (event: { kind: string; installId: string }) => void
   dataRoot: string
 }) => Promise<{
   result: { installId: string; ok: boolean; error?: string }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util'
 
 import type {
   ClaudeDetectResult,
-  ClaudeInstallLogEvent,
+  ClaudeInstallEvent,
   ClaudeInstallResult,
   ConnectorDetailView,
   ConnectorsSnapshot,
@@ -374,7 +374,7 @@ class SettingsService {
   // region-blocked) and rely on PATH re-detection.
   async installClaude(
     request: InstallClaudeRequest,
-    onLog: (event: ClaudeInstallLogEvent) => void
+    onEvent: (event: ClaudeInstallEvent) => void
   ): Promise<ClaudeInstallResult> {
     this.providerSequence += 1
     const installId = `install-${Date.now()}-${this.providerSequence}`
@@ -382,7 +382,7 @@ class SettingsService {
     if (request.source === 'managed') {
       const outcome = await this.installManagedClaudeImpl({
         installId,
-        onLog,
+        onEvent,
         dataRoot: this.storageRoot
       })
 
@@ -396,7 +396,7 @@ class SettingsService {
       return outcome.result
     }
 
-    const result = await runInstallWithFallback({ source: request.source, installId, onLog })
+    const result = await runInstallWithFallback({ source: request.source, installId, onEvent })
 
     if (result.ok) {
       await this.detectClaude()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -58,7 +58,7 @@ import type {
 } from '../shared/session-persistence'
 import type {
   ClaudeDetectResult,
-  ClaudeInstallLogEvent,
+  ClaudeInstallEvent,
   ClaudeInstallResult,
   DeleteProviderRequest,
   InstallClaudeRequest,
@@ -178,7 +178,7 @@ interface OpenScienceAPI {
     updateCustomServer(request: UpdateCustomServerRequest): Promise<ConnectorsSnapshot>
     onConnectorApprovalRequest(listener: AcpListener<ConnectorApprovalRequest>): RemoveListener
     respondConnectorApproval(request: RespondApprovalRequest): Promise<void>
-    onInstallLog(listener: AcpListener<ClaudeInstallLogEvent>): RemoveListener
+    onInstallLog(listener: AcpListener<ClaudeInstallEvent>): RemoveListener
   }
   logs: {
     getPath(): Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,7 +60,7 @@ import type {
 } from '../shared/session-persistence'
 import type {
   ClaudeDetectResult,
-  ClaudeInstallLogEvent,
+  ClaudeInstallEvent,
   ClaudeInstallResult,
   DeleteProviderRequest,
   InstallClaudeRequest,
@@ -193,7 +193,7 @@ type OpenScienceAPI = {
     updateCustomServer: (request: UpdateCustomServerRequest) => Promise<ConnectorsSnapshot>
     onConnectorApprovalRequest: (listener: AcpListener<ConnectorApprovalRequest>) => RemoveListener
     respondConnectorApproval: (request: RespondApprovalRequest) => Promise<void>
-    onInstallLog: (listener: AcpListener<ClaudeInstallLogEvent>) => RemoveListener
+    onInstallLog: (listener: AcpListener<ClaudeInstallEvent>) => RemoveListener
   }
   logs: {
     getPath: () => Promise<string | null>

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -163,4 +163,19 @@
       @apply block! w-full min-w-0 max-w-full!;
     }
   }
+
+  /* Indeterminate install progress bar: a short segment sweeping left→right while a shelled
+   * installer (npm/official) streams output with no byte total to report. */
+  @keyframes install-progress-indeterminate {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(400%);
+    }
+  }
+
+  .install-progress-indeterminate {
+    animation: install-progress-indeterminate 1.2s ease-in-out infinite;
+  }
 }

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -36,6 +36,8 @@ const OnboardingWizard = (): React.JSX.Element => {
   const isDetectingClaude = useSettingsStore((state) => state.isDetectingClaude)
   const isInstalling = useSettingsStore((state) => state.isInstalling)
   const installLogs = useSettingsStore((state) => state.installLogs)
+  const installProgress = useSettingsStore((state) => state.installProgress)
+  const installError = useSettingsStore((state) => state.installError)
   const npmAvailable = useSettingsStore((state) => state.npmAvailable)
   const encryptionAvailable = useSettingsStore((state) => state.encryptionAvailable)
   const load = useSettingsStore((state) => state.load)
@@ -129,6 +131,8 @@ const OnboardingWizard = (): React.JSX.Element => {
               <ClaudeInstallCard
                 isInstalling={isInstalling}
                 installLogs={installLogs}
+                installProgress={installProgress}
+                installError={installError}
                 npmAvailable={npmAvailable}
                 onInstall={(source) => void installClaude(source)}
               />

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.render.test.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.render.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ClaudeInstallCard } from './ClaudeInstallCard'
+import { describeInstallProgress } from './claude-install-progress'
 
 let container: HTMLDivElement
 let root: Root
@@ -89,5 +90,83 @@ describe('ClaudeInstallCard install-source picker', () => {
     })
 
     expect(onInstall).toHaveBeenCalledWith('managed')
+  })
+})
+
+const MB = 1024 * 1024
+
+describe('describeInstallProgress', () => {
+  it('reports a determinate fraction + byte label for a sized download', () => {
+    const r = describeInstallProgress({
+      kind: 'progress',
+      installId: 'i',
+      phase: 'downloading',
+      receivedBytes: 5 * MB,
+      totalBytes: 10 * MB
+    })
+    expect(r.fraction).toBeCloseTo(0.5)
+    expect(r.label).toContain('5.0')
+    expect(r.label).toContain('10.0')
+  })
+
+  it('is indeterminate (no fraction) for a phase without a total', () => {
+    expect(
+      describeInstallProgress({ kind: 'progress', installId: 'i', phase: 'installing' })
+    ).toEqual({
+      label: 'Installing…'
+    })
+    expect(
+      describeInstallProgress({ kind: 'progress', installId: 'i', phase: 'resolving' }).fraction
+    ).toBeUndefined()
+  })
+})
+
+describe('ClaudeInstallCard progress + log', () => {
+  it('renders a determinate progress bar from installProgress', () => {
+    render({
+      isInstalling: true,
+      installProgress: {
+        kind: 'progress',
+        installId: 'i',
+        phase: 'downloading',
+        receivedBytes: 5 * MB,
+        totalBytes: 10 * MB
+      }
+    })
+
+    const bar = container.querySelector('[role="progressbar"]')
+    expect(bar).not.toBeNull()
+    expect(bar?.getAttribute('aria-valuenow')).toBe('50')
+    expect(container.textContent).toContain('Downloading')
+  })
+
+  it('renders an indeterminate progress bar for a phase without a total', () => {
+    render({
+      isInstalling: true,
+      installProgress: { kind: 'progress', installId: 'i', phase: 'installing' }
+    })
+
+    const bar = container.querySelector('[role="progressbar"]')
+    expect(bar).not.toBeNull()
+    expect(bar?.getAttribute('aria-valuenow')).toBeNull()
+    expect(bar?.getAttribute('data-indeterminate')).toBe('true')
+    expect(container.textContent).toContain('Installing')
+  })
+
+  it('hides the install log on success behind a toggle', () => {
+    render({ installLogs: ['Installed Claude 2.1.209.\n'] })
+
+    expect(container.querySelector('[aria-label="Install log"]')).toBeNull()
+    const toggle = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Show log')
+    )
+    expect(toggle).toBeTruthy()
+  })
+
+  it('auto-shows the install log and error when the last install failed', () => {
+    render({ installLogs: ['registry failed: boom\n'], installError: 'registry failed: boom' })
+
+    expect(container.querySelector('[aria-label="Install log"]')).not.toBeNull()
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('boom')
   })
 })

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -117,14 +117,17 @@ const ClaudeInstallCard = ({
         </div>
       ) : null}
 
-      <button
-        type="button"
-        onClick={() => onInstall(source)}
-        disabled={isInstalling || npmMissing}
-        className="mt-3 rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
-      >
-        {isInstalling ? 'Installing…' : 'Install with one click'}
-      </button>
+      {/* Right-aligned primary action, matching the Re-detect / Save buttons elsewhere in Settings. */}
+      <div className="mt-3 flex justify-end">
+        <button
+          type="button"
+          onClick={() => onInstall(source)}
+          disabled={isInstalling || npmMissing}
+          className="rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+        >
+          {isInstalling ? 'Installing…' : 'Install with one click'}
+        </button>
+      </div>
 
       {progress ? (
         <div className="mt-3 space-y-1.5">

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -1,34 +1,55 @@
 import { useMemo, useState } from 'react'
 
 import { ExternalTextLink } from '@/components/ExternalTextLink'
-import type { ClaudeInstallSource } from '../../../../shared/settings'
+import type { ClaudeInstallProgressEvent, ClaudeInstallSource } from '../../../../shared/settings'
 import { getClaudeInstallSources, getNodeInstallHint } from '../../../../shared/settings'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
+import { describeInstallProgress } from './claude-install-progress'
 
 type ClaudeInstallCardProps = {
   isInstalling: boolean
   installLogs: string[]
+  // Latest progress tick driving the bar; null/undefined when no install is running.
+  installProgress?: ClaudeInstallProgressEvent | null
+  // Error from the last install attempt; when set, the log pane is force-shown for triage.
+  installError?: string
   // Whether npm is available on the host; disables/deprioritizes the npm source when false.
   npmAvailable: boolean
   onInstall: (source: ClaudeInstallSource) => void
 }
 
-// Source picker + one-click installer with a live log pane and an always-visible, copyable command so
-// manual installers are never blocked. Shared by the onboarding wizard and the settings page.
+// Source picker + one-click installer with a progress bar and an error-aware, collapsible log pane
+// (hidden on success, force-shown on failure) plus an always-visible, copyable command so manual
+// installers are never blocked. Shared by the onboarding wizard and the settings page.
 const ClaudeInstallCard = ({
   isInstalling,
   installLogs,
+  installProgress,
+  installError,
   npmAvailable,
   onInstall
 }: ClaudeInstallCardProps): React.JSX.Element => {
   // Default to the app-managed download — it needs no Node.js/npm and works behind region blocks.
   const [source, setSource] = useState<ClaudeInstallSource>('managed')
+  const [showLog, setShowLog] = useState(false)
   // Sources carry platform-specific copy (e.g. install.ps1 vs install.sh), so resolve them for the
   // host the app is running on.
   const installSources = useMemo(() => getClaudeInstallSources(window.api?.platform), [])
   const nodeHint = useMemo(() => getNodeInstallHint(window.api?.platform), [])
   const selectedSource = installSources.find((item) => item.id === source)
   const npmMissing = source === 'npm' && !npmAvailable
+
+  // Show the bar while an install runs; fall back to a generic indeterminate label before the first
+  // progress tick arrives.
+  const progress = installProgress
+    ? describeInstallProgress(installProgress)
+    : isInstalling
+      ? { label: 'Starting…' }
+      : null
+  const percent = progress?.fraction != null ? Math.round(progress.fraction * 100) : undefined
+
+  // A failed install force-shows the log for triage; otherwise it stays behind the toggle.
+  const logVisible = showLog || Boolean(installError)
 
   // Option label with an inline "(npm not found)" hint for sources that need npm when it's missing.
   const sourceLabel = (item: (typeof installSources)[number]): string =>
@@ -105,13 +126,59 @@ const ClaudeInstallCard = ({
         {isInstalling ? 'Installing…' : 'Install with one click'}
       </button>
 
+      {progress ? (
+        <div className="mt-3 space-y-1.5">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>{progress.label}</span>
+            {percent != null ? <span>{percent}%</span> : null}
+          </div>
+          <div
+            role="progressbar"
+            aria-label="Install progress"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={percent}
+            data-indeterminate={percent == null ? 'true' : undefined}
+            className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+          >
+            <div
+              className={
+                percent != null
+                  ? 'h-full rounded-full bg-primary transition-[width] duration-300'
+                  : 'install-progress-indeterminate h-full w-1/3 rounded-full bg-primary'
+              }
+              style={percent != null ? { width: `${percent}%` } : undefined}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {installError ? (
+        <p className="mt-3 text-xs text-destructive" role="alert">
+          {installError}
+        </p>
+      ) : null}
+
       {installLogs.length > 0 ? (
-        <pre
-          className="mt-3 max-h-48 overflow-auto rounded-lg bg-foreground/5 px-3 py-2 font-mono text-[11px] leading-relaxed whitespace-pre-wrap text-foreground/80"
-          aria-label="Install log"
-        >
-          {installLogs.join('')}
-        </pre>
+        <div className="mt-3">
+          {!installError ? (
+            <button
+              type="button"
+              onClick={() => setShowLog((visible) => !visible)}
+              className="text-xs font-medium text-muted-foreground hover:text-foreground"
+            >
+              {logVisible ? 'Hide log' : 'Show log'}
+            </button>
+          ) : null}
+          {logVisible ? (
+            <pre
+              className="mt-2 max-h-48 overflow-auto rounded-lg bg-foreground/5 px-3 py-2 font-mono text-[11px] leading-relaxed whitespace-pre-wrap text-foreground/80"
+              aria-label="Install log"
+            >
+              {installLogs.join('')}
+            </pre>
+          ) : null}
+        </div>
       ) : null}
     </div>
   )

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -125,6 +125,8 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const isDetectingClaude = useSettingsStore((state) => state.isDetectingClaude)
   const isInstalling = useSettingsStore((state) => state.isInstalling)
   const installLogs = useSettingsStore((state) => state.installLogs)
+  const installProgress = useSettingsStore((state) => state.installProgress)
+  const installError = useSettingsStore((state) => state.installError)
   const npmAvailable = useSettingsStore((state) => state.npmAvailable)
   const encryptionAvailable = useSettingsStore((state) => state.encryptionAvailable)
   const load = useSettingsStore((state) => state.load)
@@ -618,6 +620,8 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                         <ClaudeInstallCard
                           isInstalling={isInstalling}
                           installLogs={installLogs}
+                          installProgress={installProgress}
+                          installError={installError}
                           npmAvailable={npmAvailable}
                           onInstall={(source) => void installClaude(source)}
                         />

--- a/src/renderer/src/pages/settings/claude-install-progress.ts
+++ b/src/renderer/src/pages/settings/claude-install-progress.ts
@@ -1,0 +1,27 @@
+import type { ClaudeInstallProgressEvent } from '../../../../shared/settings'
+
+const mb = (bytes: number): string => (bytes / (1024 * 1024)).toFixed(1)
+
+// Maps one progress tick to a human label and (when determinate) a 0..1 fill fraction. A missing
+// fraction marks an indeterminate phase (npm/official, or an unknown download size). Pure so it can be
+// unit-tested and shared without pulling in the component (keeps ClaudeInstallCard fast-refresh-clean).
+export const describeInstallProgress = (
+  progress: ClaudeInstallProgressEvent
+): { label: string; fraction?: number } => {
+  switch (progress.phase) {
+    case 'resolving':
+      return { label: 'Resolving…' }
+    case 'downloading':
+      if (progress.totalBytes && progress.receivedBytes != null) {
+        return {
+          label: `Downloading — ${mb(progress.receivedBytes)} / ${mb(progress.totalBytes)} MB`,
+          fraction: progress.receivedBytes / progress.totalBytes
+        }
+      }
+      return { label: 'Downloading…' }
+    case 'extracting':
+      return { label: 'Extracting…' }
+    case 'installing':
+      return { label: 'Installing…' }
+  }
+}

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -5,6 +5,7 @@ import { providerValidationFailed } from '../../../shared/settings'
 import type {
   ClaudeDetectResult,
   ClaudeInfo,
+  ClaudeInstallProgressEvent,
   ClaudeInstallResult,
   ClaudeInstallSource,
   Preflight,
@@ -68,6 +69,11 @@ type SettingsStoreData = {
   isDetectingClaude: boolean
   isInstalling: boolean
   installLogs: string[]
+  // Latest progress tick driving the install progress bar; null when no install is active.
+  installProgress: ClaudeInstallProgressEvent | null
+  // Error message from the last install attempt; drives auto-expansion of the log pane. Undefined on
+  // success or before the first attempt.
+  installError: string | undefined
   // Whether the settings dialog is open (rendered at the app root, over Home/Workspace).
   isSettingsOpen: boolean
   // Skill to land on when the dialog opens from a skill mention; consumed once its detail is seeded.
@@ -175,6 +181,8 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   isDetectingClaude: false,
   isInstalling: false,
   installLogs: [],
+  installProgress: null,
+  installError: undefined,
   isSettingsOpen: false,
   pendingSkillId: undefined
 })
@@ -297,12 +305,17 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     }
   },
 
-  // Runs a one-click install, streaming output into installLogs, then refreshes settings/preflight.
+  // Runs a one-click install, streaming events into installProgress/installLogs, then refreshes
+  // settings/preflight. Log and progress share one channel, routed here by `kind`.
   installClaude: async (source) => {
-    set({ isInstalling: true, installLogs: [] })
+    set({ isInstalling: true, installLogs: [], installProgress: null, installError: undefined })
 
     const unsubscribe = window.api.settings.onInstallLog((event) => {
-      set((state) => ({ installLogs: [...state.installLogs, event.chunk] }))
+      if (event.kind === 'progress') {
+        set({ installProgress: event })
+      } else {
+        set((state) => ({ installLogs: [...state.installLogs, event.chunk] }))
+      }
     })
 
     try {
@@ -314,14 +327,19 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       set(applySnapshot(snapshot))
       await get().refreshPreflight()
 
+      set({ installError: result.ok ? undefined : (result.error ?? 'Install failed.') })
+
       return result
+    } catch (error) {
+      set({ installError: error instanceof Error ? error.message : 'Install failed.' })
+      throw error
     } finally {
       unsubscribe()
-      set({ isInstalling: false })
+      set({ isInstalling: false, installProgress: null })
     }
   },
 
-  clearInstallLogs: () => set({ installLogs: [] }),
+  clearInstallLogs: () => set({ installLogs: [], installProgress: null, installError: undefined }),
 
   // Persists a provider draft (create/update) and refreshes derived state, without testing it.
   persistProvider: async (request) => {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -233,10 +233,29 @@ export type InstallClaudeRequest = {
 
 // One streamed line of installer output. `installId` groups a single install run.
 export type ClaudeInstallLogEvent = {
+  kind: 'log'
   installId: string
   stream: 'stdout' | 'stderr' | 'system'
   chunk: string
 }
+
+// Coarse stage of an install run, used to label the progress bar.
+export type ClaudeInstallPhase = 'resolving' | 'downloading' | 'extracting' | 'installing'
+
+// One progress tick driving the install progress bar. `receivedBytes`/`totalBytes` are present only
+// for a determinate download (the app-managed source, when the server reports a content length); their
+// absence marks an indeterminate phase (npm/official-script, or an unknown download size).
+export type ClaudeInstallProgressEvent = {
+  kind: 'progress'
+  installId: string
+  phase: ClaudeInstallPhase
+  receivedBytes?: number
+  totalBytes?: number
+}
+
+// The single install-event stream: discrete log lines and progress ticks share one ordered channel,
+// discriminated by `kind`. The renderer routes by kind (progress → the bar, log → the log pane).
+export type ClaudeInstallEvent = ClaudeInstallLogEvent | ClaudeInstallProgressEvent
 
 // Final result of an install run; on success the caller re-detects claude.
 export type ClaudeInstallResult = {


### PR DESCRIPTION
## Problem

During the onboarding **app-managed download** of Claude, the UI showed one log line per whole megabyte downloaded (`Downloading Claude — X MB / Y MB`). Download progress was being pushed into the log stream instead of a progress bar, and the log render (`installLogs.join('')`) mashed newline-less chunks into one run-on blob. There was no separation between progress ticks and genuine log/status lines.

## Change

Split the install stream into a single discriminated event (`ClaudeInstallEvent = { kind: 'log' } | { kind: 'progress' }`) carried over the existing IPC channel, and rebuild the UI around it.

**Main process**
- `managed-claude.ts`: the downloader emits throttled `downloading` progress ticks (integer-percent steps, ≤100 events) instead of per-MB log lines, plus `resolving`/`extracting` phase ticks. Milestone lines stay as `kind: 'log'`.
- `claude-install.ts`: npm/official-script emit one indeterminate `installing` tick at spawn (no byte total). System log lines are newline-terminated at emit so the expanded log reads line-by-line.
- `service.ts` / `ipc.ts`: thread a single `onEvent` callback; broadcast typed `ClaudeInstallEvent` (channel name unchanged to bound blast radius).

**Renderer**
- Store routes events by `kind` into `installProgress` / `installLogs`, and records `installError` for the last attempt.
- `ClaudeInstallCard` (shared by onboarding + settings, all three sources) renders a **determinate** bar for the managed download (`Downloading — 12.3 / 40.1 MB` + percent) or an **indeterminate** bar for npm/official (`Installing…`), and collapses the log pane on success behind a `Show log` toggle, **auto-expanding it on failure** with the error. The pure `describeInstallProgress` helper lives in its own module to keep the component fast-refresh-clean.

## Test plan

- New unit tests: determinate download ticks that finish at the total + no log leakage; orchestration emits `resolving`/`downloading`/`extracting`.
- New render tests: determinate bar (`aria-valuenow`), indeterminate bar (`data-indeterminate`), log hidden on success behind toggle, log + error auto-shown on failure.
- Full suite: 1513 passed; `npm run typecheck`, `npm run lint`, and `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)