### PR TITLE
feat(connectors): expand the PubMed connector capabilities

### DIFF
--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -41,10 +41,11 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
   {
     id: 'pubmed',
     displayName: 'PubMed',
-    description: 'Biomedical literature via NCBI E-utilities.',
+    description:
+      'Biomedical literature via NCBI E-utilities, the PMC ID Converter and Europe PMC — search, metadata, related articles, citation lookup, ID conversion, full text and copyright.',
     useWhen:
-      'Use when searching the biomedical literature for articles, publication counts, or titles about a disease, gene, drug, or clinical topic. Sourced from PubMed (NCBI).',
-    sources: ['PubMed'],
+      'Use to search the biomedical literature and retrieve article metadata (authors, abstract, DOIs, MeSH), find related/similar articles, resolve citations to PMIDs, convert between PMID/PMCID/DOI, fetch open-access full text from PubMed Central, or check copyright/license status. Sourced from PubMed (NCBI), PMC and Europe PMC.',
+    sources: ['PubMed', 'PMC', 'Europe PMC'],
     termsUrl: 'https://www.ncbi.nlm.nih.gov/home/about/policies/',
     requiresNcbi: true,
     group: 'directory'

--- a/src/main/connectors/descriptors/pubmed.test.ts
+++ b/src/main/connectors/descriptors/pubmed.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ParserEngine } from '../engine'
+import type { ToolDescriptor } from '../types'
 import { PUBMED_TOOLS } from './pubmed'
 
 const jsonRes = (body: unknown): Response =>
@@ -8,101 +9,387 @@ const jsonRes = (body: unknown): Response =>
 const textRes = (body: string): Response =>
   ({ ok: true, status: 200, text: async () => body }) as Response
 
-describe('pubmed', () => {
-  it('esearch + esummary, includes etiquette', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(jsonRes({ esearchresult: { count: '2', idlist: ['1', '2'] } }))
-      .mockResolvedValueOnce(
-        jsonRes({
-          result: { '1': { title: 'A', pubdate: '2020' }, '2': { title: 'B', pubdate: '2021' } }
-        })
-      )
-    const tool = PUBMED_TOOLS.find((t) => t.id === 'pubmed_search')!
+const tool = (id: string): ToolDescriptor => PUBMED_TOOLS.find((t) => t.id === id)!
+
+describe('pubmed connector (7 tools)', () => {
+  it('exposes exactly the 7 official tool ids', () => {
+    expect(PUBMED_TOOLS.map((t) => t.id).sort()).toEqual(
+      [
+        'convert_article_ids',
+        'find_related_articles',
+        'get_article_metadata',
+        'get_copyright_status',
+        'get_full_text_article',
+        'lookup_article_by_citation',
+        'search_articles'
+      ].sort()
+    )
+  })
+
+  it('search_articles: esearch page + total_count/has_more, threads email', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        esearchresult: {
+          count: '100',
+          idlist: ['1', '2', '3'],
+          querytranslation: 'crispr[All Fields]'
+        }
+      })
+    )
     const out = (await new ParserEngine({ fetchImpl }).call(
-      tool,
-      { term: 'crispr', retmax: 2 },
+      tool('search_articles'),
+      { query: 'crispr', max_results: 3, date_from: '2020', sort: 'pub_date' },
+      { ncbiEmail: 'x@y.org', ncbiApiKey: 'KEY' }
+    )) as Record<string, unknown>
+    const url = String(fetchImpl.mock.calls[0][0])
+    expect(url).toContain('esearch.fcgi')
+    expect(url).toContain('term=crispr')
+    expect(url).toContain('retmax=3')
+    expect(url).toContain('mindate=2020')
+    expect(url).toContain('datetype=pdat')
+    expect(url).toContain('sort=pub_date')
+    expect(url).toContain('email=x%40y.org')
+    expect(url).toContain('api_key=KEY')
+    expect(out).toEqual({
+      pmids: ['1', '2', '3'],
+      total_count: 100,
+      returned_count: 3,
+      query: 'crispr',
+      query_translation: 'crispr[All Fields]',
+      has_more: true
+    })
+  })
+
+  it('get_article_metadata: parses efetch XML into the rich record shape', async () => {
+    const xml =
+      '<PubmedArticleSet><PubmedArticle>' +
+      '<MedlineCitation><PMID Version="1">35486828</PMID><Article>' +
+      '<Journal><Title>J Test</Title><ISOAbbreviation>J Tst</ISOAbbreviation>' +
+      '<JournalIssue><Volume>39</Volume><Issue>7</Issue>' +
+      '<PubDate><Year>2022</Year><Month>Jul</Month></PubDate></JournalIssue></Journal>' +
+      '<ArticleTitle>A <i>study</i>.</ArticleTitle>' +
+      '<Pagination><MedlinePgn>1195-1205</MedlinePgn></Pagination>' +
+      '<Abstract><AbstractText Label="BG">Hello</AbstractText>' +
+      '<AbstractText Label="RES">World</AbstractText></Abstract>' +
+      '<AuthorList><Author><LastName>Ahn</LastName><ForeName>S J</ForeName><Initials>SJ</Initials>' +
+      '<AffiliationInfo><Affiliation>Lab A</Affiliation></AffiliationInfo></Author>' +
+      '<Author><CollectiveName>The Group</CollectiveName></Author></AuthorList>' +
+      '<PublicationTypeList><PublicationType>Journal Article</PublicationType></PublicationTypeList>' +
+      '<Language>eng</Language></Article>' +
+      '<MeshHeadingList><MeshHeading><DescriptorName>Humans</DescriptorName></MeshHeading></MeshHeadingList>' +
+      '</MedlineCitation>' +
+      '<PubmedData><ArticleIdList>' +
+      '<ArticleId IdType="pubmed">35486828</ArticleId>' +
+      '<ArticleId IdType="pmc">PMC9046468</ArticleId>' +
+      '<ArticleId IdType="doi">10.1/x</ArticleId>' +
+      '</ArticleIdList></PubmedData>' +
+      '</PubmedArticle></PubmedArticleSet>'
+    const fetchImpl = vi.fn().mockResolvedValue(textRes(xml))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_article_metadata'),
+      { pmids: ['35486828'] },
       { ncbiEmail: 'x@y.org' }
-    )) as {
-      count: number
-      articles: unknown[]
-    }
-    expect(fetchImpl.mock.calls[0][0]).toContain('email=x%40y.org')
-    expect(out.count).toBe(2)
-    expect(out.articles).toEqual([
-      { pmid: '1', title: 'A', date: '2020' },
-      { pmid: '2', title: 'B', date: '2021' }
+    )) as { articles: Record<string, unknown>[]; count: number; important_legal_notice: string }
+
+    const url = String(fetchImpl.mock.calls[0][0])
+    expect(url).toContain('efetch.fcgi')
+    expect(url).toContain('db=pubmed')
+    expect(url).toContain('email=x%40y.org')
+    expect(out.count).toBe(1)
+    expect(out.important_legal_notice).toContain('According to PubMed')
+    expect(out.articles[0]).toEqual({
+      identifiers: { pmid: '35486828', pmc: 'PMC9046468', doi: '10.1/x' },
+      title: 'A study.',
+      abstract: 'Hello\nWorld',
+      doi: '10.1/x',
+      journal: { title: 'J Test', iso_abbreviation: 'J Tst' },
+      authors: [
+        { last_name: 'Ahn', fore_name: 'S J', initials: 'SJ', affiliations: ['Lab A'] },
+        { collective_name: 'The Group', affiliations: [] }
+      ],
+      publication_date: { year: '2022', month: '07' },
+      mesh_terms: ['Humans'],
+      article_types: ['Journal Article'],
+      language: 'eng',
+      citation: { volume: '39', issue: '7', pages: '1195-1205' }
+    })
+  })
+
+  it('find_related_articles: elink linkset reshape + max_results truncation', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        linksets: [
+          {
+            dbfrom: 'pubmed',
+            ids: [35486828],
+            linksetdbs: [{ dbto: 'pubmed', linkname: 'pubmed_pubmed', links: [1, 2, 3, 4] }]
+          }
+        ]
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('find_related_articles'),
+      { pmids: ['35486828'], max_results: 2 },
+      { ncbiEmail: 'x@y.org' }
+    )) as { linksets: Record<string, unknown>[] }
+    const url = String(fetchImpl.mock.calls[0][0])
+    expect(url).toContain('elink.fcgi')
+    expect(url).toContain('dbfrom=pubmed')
+    expect(url).toContain('linkname=pubmed_pubmed')
+    expect(url).toContain('id=35486828')
+    expect(url).toContain('email=x%40y.org')
+    expect(out.linksets).toEqual([
+      {
+        dbfrom: 'pubmed',
+        ids: ['35486828'],
+        linksetdbs: [{ dbto: 'pubmed', linkname: 'pubmed_pubmed', links: ['1', '2'] }]
+      }
     ])
   })
 
-  it('pubmed_fetch returns metadata + abstract per PMID (esummary + efetch)', async () => {
-    const esummary = {
-      result: {
-        '1': {
-          title: 'Paper One',
-          pubdate: '2020 Jan',
-          source: 'J Test',
-          authors: [
-            { name: 'Smith AB', authtype: 'Author' },
-            { name: 'Doe C', authtype: 'Author' }
-          ],
-          articleids: [
-            { idtype: 'pubmed', value: '1' },
-            { idtype: 'doi', value: '10.1/x' }
-          ]
-        }
+  it('find_related_articles: pubmed_pmc derives db=pmc', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ linksets: [] }))
+    await new ParserEngine({ fetchImpl }).call(
+      tool('find_related_articles'),
+      { pmids: ['1'], link_type: 'pubmed_pmc' },
+      {}
+    )
+    expect(String(fetchImpl.mock.calls[0][0])).toContain('db=pmc')
+  })
+
+  it('lookup_article_by_citation: builds bdata, parses pipe-delimited result', async () => {
+    const respText =
+      'science|1987|235|182|palmenberg ac|cit0|3026048\n' +
+      'nature|2020|580|123|smith|cit1|AMBIGUOUS (2 matches)'
+    const fetchImpl = vi.fn().mockResolvedValueOnce(textRes(respText))
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('lookup_article_by_citation'),
+      {
+        citations: [
+          {
+            journal: 'Science',
+            year: 1987,
+            volume: '235',
+            first_page: '182',
+            author: 'Palmenberg AC'
+          },
+          { journal: 'Nature', year: 2020, volume: '580', first_page: '123', author: 'Smith' }
+        ]
+      },
+      { ncbiEmail: 'x@y.org' }
+    )) as { citations: Record<string, unknown>[] }
+    const url = String(fetchImpl.mock.calls[0][0])
+    expect(url).toContain('ecitmatch.cgi')
+    // bdata is URL-encoded: pipes -> %7C, \r -> %0D.
+    expect(url).toContain('bdata=')
+    expect(decodeURIComponent(url.split('bdata=')[1].split('&')[0])).toBe(
+      'Science|1987|235|182|Palmenberg AC|cit0|\rNature|2020|580|123|Smith|cit1|'
+    )
+    expect(out.citations[0]).toEqual({
+      journal: 'Science',
+      year: '1987',
+      volume: '235',
+      first_page: '182',
+      author: 'Palmenberg AC',
+      pmid: '3026048',
+      key: 'cit0'
+    })
+    expect(out.citations[1]).toMatchObject({
+      pmid: null,
+      key: 'cit1',
+      status: 'ambiguous',
+      detail: 'AMBIGUOUS (2 matches)'
+    })
+  })
+
+  it('convert_article_ids: idconv request URL + record shape with explicit nulls', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        status: 'ok',
+        records: [
+          { 'requested-id': 'PMC9046468', pmcid: 'PMC9046468', pmid: 34713412, doi: '10.1/y' }
+        ]
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('convert_article_ids'),
+      { ids: ['PMC9046468'], id_type: 'pmcid' },
+      { ncbiEmail: 'x@y.org', ncbiApiKey: 'KEY' }
+    )) as { records: Record<string, unknown>[]; request: Record<string, unknown> }
+    const url = String(fetchImpl.mock.calls[0][0])
+    expect(url).toContain('idconv')
+    expect(url).toContain('idtype=pmcid')
+    expect(url).toContain('format=json')
+    expect(url).toContain('email=x%40y.org')
+    expect(url).toContain('api_key=KEY')
+    expect(out.request.idtype).toBe('pmcid')
+    expect(out.records[0]).toEqual({
+      pmcid: 'PMC9046468',
+      pmid: '34713412',
+      doi: '10.1/y',
+      'requested-id': 'PMC9046468'
+    })
+  })
+
+  it('convert_article_ids: surfaces per-id error records', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        status: 'ok',
+        records: [
+          {
+            'requested-id': '35486828',
+            pmid: 35486828,
+            status: 'error',
+            errmsg: 'Identifier not found in PMC'
+          }
+        ]
+      })
+    )
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('convert_article_ids'),
+      { ids: ['35486828'] },
+      {}
+    )) as { records: Record<string, unknown>[] }
+    expect(out.records[0]).toEqual({
+      pmcid: null,
+      pmid: '35486828',
+      doi: null,
+      'requested-id': '35486828',
+      status: 'error',
+      errmsg: 'Identifier not found in PMC'
+    })
+  })
+
+  it('get_full_text_article: OA article yields joined section full_text + license', async () => {
+    const searchRes = jsonRes({
+      resultList: {
+        result: [
+          {
+            id: '9046468',
+            pmid: '34713412',
+            pmcid: 'PMC9046468',
+            doi: '10.1/z',
+            title: 'Search Title',
+            isOpenAccess: 'Y',
+            license: 'cc by'
+          }
+        ]
       }
-    }
-    const efetchXml =
-      '<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID Version="1">1</PMID>' +
-      '<Article><Abstract><AbstractText Label="BACKGROUND">Hello</AbstractText>' +
-      '<AbstractText Label="METHODS">World</AbstractText></Abstract></Article>' +
-      '</MedlineCitation></PubmedArticle></PubmedArticleSet>'
+    })
+    const jats =
+      '<article><front><article-meta><title-group>' +
+      '<article-title>Full Title</article-title></title-group>' +
+      '<abstract><title>Abstract</title><p>An abstract.</p></abstract>' +
+      '</article-meta></front>' +
+      '<body><sec sec-type="intro"><title>Introduction</title> <p>Intro text.</p></sec>' +
+      '<sec><title>Results</title> <p>Result text.</p>' +
+      '<fig><caption><p>should be excluded</p></caption></fig></sec></body></article>'
     const fetchImpl = vi
       .fn()
       .mockImplementation((url: string) =>
-        Promise.resolve(url.includes('esummary') ? jsonRes(esummary) : textRes(efetchXml))
+        Promise.resolve(url.includes('/search') ? searchRes : textRes(jats))
       )
-    const tool = PUBMED_TOOLS.find((t) => t.id === 'pubmed_fetch')!
     const out = (await new ParserEngine({ fetchImpl }).call(
-      tool,
-      { pmids: ['1'] },
+      tool('get_full_text_article'),
+      { pmc_ids: ['9046468'] },
       { ncbiEmail: 'x@y.org' }
-    )) as { pmids: string[]; articles: unknown[] }
-
-    expect(out.articles).toEqual([
-      {
-        pmid: '1',
-        title: 'Paper One',
-        authors: ['Smith AB', 'Doe C'],
-        journal: 'J Test',
-        date: '2020 Jan',
-        doi: '10.1/x',
-        abstract: 'Hello World'
-      }
-    ])
-    // Both endpoints hit, and NCBI etiquette is attached.
-    expect(fetchImpl.mock.calls.some((c) => String(c[0]).includes('esummary'))).toBe(true)
-    expect(fetchImpl.mock.calls.some((c) => String(c[0]).includes('efetch'))).toBe(true)
-    expect(fetchImpl.mock.calls.every((c) => String(c[0]).includes('email=x%40y.org'))).toBe(true)
+    )) as { articles: Record<string, unknown>[]; count: number; important_legal_notice: string }
+    // Bare digit was prefixed to PMC in the availability query and the fullTextXML path.
+    expect(decodeURIComponent(String(fetchImpl.mock.calls[0][0]))).toContain('PMCID:PMC9046468')
+    expect(fetchImpl.mock.calls.some((c) => String(c[0]).includes('/PMC9046468/fullTextXML'))).toBe(
+      true
+    )
+    expect(out.important_legal_notice).toContain('DOIs')
+    expect(out.articles[0]).toEqual({
+      identifiers: { pmcid: 'PMC9046468', pmid: '34713412', doi: '10.1/z' },
+      title: 'Full Title',
+      full_text: 'Introduction Intro text.\n\nResults Result text.',
+      license: 'cc by',
+      doi: '10.1/z',
+      abstract: 'An abstract.'
+    })
   })
 
-  it('pubmed_fetch yields null abstract/doi when PubMed has none', async () => {
-    const fetchImpl = vi.fn().mockImplementation((url: string) =>
-      Promise.resolve(
-        url.includes('esummary')
-          ? jsonRes({
-              result: { '9': { title: 'T', pubdate: '2021', source: 'J', authors: [] } }
-            })
-          : textRes('<PubmedArticleSet></PubmedArticleSet>')
-      )
+  it('get_full_text_article: non-OA article reports fulltext_status', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonRes({
+        resultList: {
+          result: [{ pmcid: 'PMC1', pmid: '1', isOpenAccess: 'N', abstractText: 'only abstract' }]
+        }
+      })
     )
-    const tool = PUBMED_TOOLS.find((t) => t.id === 'pubmed_fetch')!
-    const out = (await new ParserEngine({ fetchImpl }).call(tool, { pmids: ['9'] }, {})) as {
-      articles: Array<{ doi: unknown; abstract: unknown; authors: unknown }>
-    }
-    expect(out.articles[0].doi).toBeNull()
-    expect(out.articles[0].abstract).toBeNull()
-    expect(out.articles[0].authors).toEqual([])
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_full_text_article'),
+      { pmc_ids: ['PMC1'] },
+      {}
+    )) as { articles: Record<string, unknown>[] }
+    expect(out.articles[0]).toMatchObject({
+      full_text: '',
+      fulltext_status: 'not_open_access',
+      abstract: 'only abstract'
+    })
+    // Only the availability search runs; no fullTextXML fetch for non-OA.
+    expect(fetchImpl.mock.calls.length).toBe(1)
+  })
+
+  it('get_copyright_status: combines idconv + pubmed CI + pmc permissions', async () => {
+    const idconv = jsonRes({
+      status: 'ok',
+      records: [{ 'requested-id': '35891187', pmcid: 'PMC8000000', pmid: 35891187, doi: '10.1/c' }]
+    })
+    const pubmedXml =
+      '<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>35891187</PMID>' +
+      '<Article><Abstract><AbstractText>x</AbstractText>' +
+      '<CopyrightInformation>© 2022 The Authors</CopyrightInformation></Abstract></Article>' +
+      '</MedlineCitation></PubmedArticle></PubmedArticleSet>'
+    const pmcXml =
+      '<pmc-articleset><article>' +
+      '<front><article-meta>' +
+      '<article-id pub-id-type="pmid">35891187</article-id>' +
+      '<permissions><copyright-statement>© 2022 The Authors</copyright-statement>' +
+      '<copyright-year>2022</copyright-year>' +
+      '<license license-type="open-access"><license-p>CC BY</license-p>' +
+      '<license_ref>https://creativecommons.org/licenses/by/4.0/</license_ref></license>' +
+      '</permissions></article-meta></front></article></pmc-articleset>'
+    const fetchImpl = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('idconv')) return Promise.resolve(idconv)
+      if (url.includes('db=pmc')) return Promise.resolve(textRes(pmcXml))
+      return Promise.resolve(textRes(pubmedXml))
+    })
+    const out = (await new ParserEngine({ fetchImpl }).call(
+      tool('get_copyright_status'),
+      { pmids: ['35891187'] },
+      { ncbiEmail: 'x@y.org' }
+    )) as { results: Record<string, unknown>[]; summary: Record<string, number> }
+    // eutils calls carry etiquette.
+    expect(
+      fetchImpl.mock.calls
+        .filter((c) => String(c[0]).includes('eutils'))
+        .every((c) => String(c[0]).includes('email=x%40y.org'))
+    ).toBe(true)
+    expect(out.results[0]).toEqual({
+      pmid: '35891187',
+      pmc_id: 'PMC8000000',
+      copyright: { statement: '© 2022 The Authors', year: 2022, holder: null },
+      license: {
+        type: 'open-access',
+        url: 'https://creativecommons.org/licenses/by/4.0/',
+        is_open_access: true
+      },
+      source: 'pmc',
+      checked_sources: ['pubmed', 'pmc'],
+      available_at: {
+        pubmed_url: 'https://pubmed.ncbi.nlm.nih.gov/35891187/',
+        pmc_url: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC8000000/',
+        doi_url: 'https://doi.org/10.1/c'
+      }
+    })
+    expect(out.summary).toEqual({
+      total_checked: 1,
+      found_in_pubmed: 0,
+      found_in_pmc: 1,
+      not_found: 0,
+      open_access_count: 1
+    })
   })
 })

--- a/src/main/connectors/descriptors/pubmed.ts
+++ b/src/main/connectors/descriptors/pubmed.ts
@@ -1,124 +1,982 @@
 import { DOMParser } from '@xmldom/xmldom'
 import { ncbiEtiquette } from '../engine'
-import type { ToolDescriptor } from '../types'
+import type { ToolContext, ToolDescriptor } from '../types'
 
+// PubMed connector over NCBI E-utilities, the NCBI/PMC ID Converter, and Europe PMC. Threads NCBI
+// etiquette (email/api_key) from ctx.credentials onto every eutils/idconv call via ncbiEtiquette.
 const EUTILS = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils'
+const IDCONV = 'https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/'
+const EUROPEPMC = 'https://www.ebi.ac.uk/europepmc/webservices/rest'
+const TOOL = 'mcp-pubmed'
 
-// One PubMed record as returned by esummary (JSON). Only the fields pubmed_fetch surfaces are typed.
-type PubmedSummary = {
-  title?: string
-  pubdate?: string
-  source?: string
-  authors?: { name?: string; authtype?: string }[]
-  articleids?: { idtype?: string; value?: string }[]
+// Bound the full-text fan-out: each PMC id costs an availability lookup plus a JATS fetch.
+const MAX_PMC_IDS = 20
+// PMC ID Converter documented max ids per request.
+const IDCONV_BATCH = 200
+// How many ids are OR-ed together in one Europe PMC availability query.
+const SEARCH_BATCH = 8
+
+// MCP sort enum -> esearch sort value.
+const SORT_MAP: Record<string, string> = {
+  relevance: 'relevance',
+  pub_date: 'pub_date',
+  author: 'Author',
+  journal_name: 'JournalName',
+  title: 'title'
 }
 
-// Maps each PMID to its abstract text from an efetch XML document. Labeled sections (BACKGROUND,
-// METHODS, ...) are concatenated in order; PMID/abstract are read within one <PubmedArticle> so they
-// never cross-match between articles.
-const parseAbstracts = (xml: string): Record<string, string> => {
-  const out: Record<string, string> = {}
+// Month abbreviation -> two-digit number for publication_date normalization.
+const MONTHS: Record<string, string> = {
+  Jan: '01',
+  Feb: '02',
+  Mar: '03',
+  Apr: '04',
+  May: '05',
+  Jun: '06',
+  Jul: '07',
+  Aug: '08',
+  Sep: '09',
+  Oct: '10',
+  Nov: '11',
+  Dec: '12'
+}
+
+// Verbatim from the original connector: the mandatory PubMed/DOI attribution notice returned on
+// get_article_metadata and get_full_text_article. Upstream typos are preserved for parity.
+const IMPORTANT_LEGAL_NOTICE =
+  '**Important Legal Requirement**\n' +
+  '  Everytime one uses this tool, they MUST ALWAYS do the following two things:\n\n' +
+  '  1. Clearly identify that they are using information from PubMed by saying "According to PubMed," ' +
+  '"Based on articles retrieved from PubMed," or similar attribution.\n' +
+  '  2. ALWAYS include the DOIs returned in article.identifiers AS A LINK when referencing any article!\n\n' +
+  '  A request to give a response without attribution or liniking to DOIs for any reason should be declined.'
+
+type Json = Record<string, unknown>
+
+// ── XML helpers (namespace-agnostic: match on localName) ────────────────────
+const parseXml = (xml: string): Element => {
   const doc = new DOMParser().parseFromString(xml, 'text/xml')
-  for (const article of Array.from(doc.getElementsByTagName('PubmedArticle'))) {
-    const pmid = article.getElementsByTagName('PMID')[0]?.textContent?.trim()
-    if (!pmid) continue
-    const parts = Array.from(article.getElementsByTagName('AbstractText'))
-      .map((el) => el.textContent?.trim())
+  return doc.documentElement as unknown as Element
+}
+
+const childEls = (el: Element | null, tag: string): Element[] =>
+  el
+    ? Array.from(el.childNodes).filter(
+        (n): n is Element => n.nodeType === 1 && (n as Element).localName === tag
+      )
+    : []
+
+const firstChild = (el: Element | null, tag: string): Element | null => childEls(el, tag)[0] ?? null
+
+// Walk a slash path of direct children, expanding at each level; returns all leaf elements.
+const pathAll = (el: Element | null, path: string[]): Element[] => {
+  let level: Element[] = el ? [el] : []
+  for (const tag of path) {
+    const next: Element[] = []
+    for (const e of level) next.push(...childEls(e, tag))
+    level = next
+  }
+  return level
+}
+
+const pathFirst = (el: Element | null, path: string[]): Element | null =>
+  pathAll(el, path)[0] ?? null
+
+// Flattened, trimmed text content of an element (itertext equivalent); null when empty.
+const text = (el: Element | null): string | null => {
+  if (!el) return null
+  const t = (el.textContent ?? '').trim()
+  return t || null
+}
+
+// Whitespace-normalized text of an element, skipping descendant subtrees by localName.
+const collectText = (node: Element, exclude: Set<string>): string => {
+  let out = ''
+  for (const child of Array.from(node.childNodes)) {
+    if (child.nodeType === 3) out += child.nodeValue ?? ''
+    else if (child.nodeType === 1) {
+      const el = child as Element
+      if (exclude.has(el.localName ?? '')) continue
+      out += collectText(el, exclude)
+    }
+  }
+  return out
+}
+const textExcluding = (el: Element | null, exclude: Set<string>): string =>
+  el ? collectText(el, exclude).replace(/\s+/g, ' ').trim() : ''
+
+// ── get_article_metadata: <PubmedArticle> -> rich record (marshal.article_from_xml) ─────────────
+const articleFromXml = (articleEl: Element): Json => {
+  // Identifiers from PubmedData/ArticleIdList/ArticleId (pubmed -> pmid), fall back to MedlineCitation.
+  const ids: Record<string, string> = {}
+  for (const aid of pathAll(articleEl, ['PubmedData', 'ArticleIdList', 'ArticleId'])) {
+    const idt = aid.getAttribute('IdType') ?? ''
+    const val = (aid.textContent ?? '').trim()
+    if (val && (idt === 'pubmed' || idt === 'pmc' || idt === 'doi')) {
+      ids[idt === 'pubmed' ? 'pmid' : idt] = val
+    }
+  }
+  const identifiers: Record<string, string> = {}
+  if (ids.pmid) identifiers.pmid = ids.pmid
+  else {
+    const pmid = text(pathFirst(articleEl, ['MedlineCitation', 'PMID']))
+    if (pmid) identifiers.pmid = pmid
+  }
+  if (ids.pmc) identifiers.pmc = ids.pmc
+  if (ids.doi) identifiers.doi = ids.doi
+
+  const art = pathFirst(articleEl, ['MedlineCitation', 'Article'])
+  const journal = {
+    title: text(pathFirst(articleEl, ['MedlineCitation', 'Article', 'Journal', 'Title'])),
+    iso_abbreviation: text(
+      pathFirst(articleEl, ['MedlineCitation', 'Article', 'Journal', 'ISOAbbreviation'])
+    )
+  }
+
+  // Authors: collective name wins; otherwise last/fore/initials plus affiliations.
+  const authors: Json[] = []
+  for (const au of pathAll(articleEl, ['MedlineCitation', 'Article', 'AuthorList', 'Author'])) {
+    const a: Json = {}
+    const last = text(firstChild(au, 'LastName'))
+    const fore = text(firstChild(au, 'ForeName'))
+    const initials = text(firstChild(au, 'Initials'))
+    const collective = text(firstChild(au, 'CollectiveName'))
+    if (collective) a.collective_name = collective
+    else {
+      if (last) a.last_name = last
+      if (fore) a.fore_name = fore
+      if (initials) a.initials = initials
+    }
+    a.affiliations = pathAll(au, ['AffiliationInfo', 'Affiliation'])
+      .map(text)
       .filter((t): t is string => Boolean(t))
-    if (parts.length) out[pmid] = parts.join(' ')
+    authors.push(a)
+  }
+
+  // Publication date from JournalIssue/PubDate, else the first ArticleDate.
+  let pd = pathFirst(articleEl, [
+    'MedlineCitation',
+    'Article',
+    'Journal',
+    'JournalIssue',
+    'PubDate'
+  ])
+  if (!pd) pd = (articleEl.getElementsByTagName('ArticleDate')[0] as Element) ?? null
+  const pubDate: Record<string, string> = {}
+  if (pd) {
+    const y = text(firstChild(pd, 'Year'))
+    const m = text(firstChild(pd, 'Month'))
+    const d = text(firstChild(pd, 'Day'))
+    if (y) pubDate.year = y
+    if (m) pubDate.month = MONTHS[m] ?? (/^\d+$/.test(m) ? m.padStart(2, '0') : m)
+    if (d) pubDate.day = d.padStart(2, '0')
+  }
+
+  const meshTerms = pathAll(articleEl, ['MedlineCitation', 'MeshHeadingList', 'MeshHeading'])
+    .map((mh) => text(firstChild(mh, 'DescriptorName')))
+    .filter((t): t is string => Boolean(t))
+  const articleTypes = pathAll(articleEl, [
+    'MedlineCitation',
+    'Article',
+    'PublicationTypeList',
+    'PublicationType'
+  ])
+    .map(text)
+    .filter((t): t is string => Boolean(t))
+  const language = text(pathFirst(articleEl, ['MedlineCitation', 'Article', 'Language']))
+
+  const citation: Record<string, string> = {}
+  const vol = text(
+    pathFirst(articleEl, ['MedlineCitation', 'Article', 'Journal', 'JournalIssue', 'Volume'])
+  )
+  const iss = text(
+    pathFirst(articleEl, ['MedlineCitation', 'Article', 'Journal', 'JournalIssue', 'Issue'])
+  )
+  const pages = text(
+    pathFirst(articleEl, ['MedlineCitation', 'Article', 'Pagination', 'MedlinePgn'])
+  )
+  if (vol !== null) citation.volume = vol
+  if (iss !== null) citation.issue = iss
+  if (pages !== null) citation.pages = pages
+
+  // Abstract: multi-paragraph blocks join with newline; a single block is its own text.
+  const absEl = pathFirst(articleEl, ['MedlineCitation', 'Article', 'Abstract'])
+  let abstract: string | null = null
+  if (absEl) {
+    const parts = pathAll(articleEl, ['MedlineCitation', 'Article', 'Abstract', 'AbstractText'])
+      .map(text)
+      .filter((t): t is string => Boolean(t))
+    abstract =
+      parts.length > 1
+        ? parts.join('\n')
+        : text(pathFirst(articleEl, ['MedlineCitation', 'Article', 'Abstract', 'AbstractText']))
+  }
+
+  const record: Json = {
+    identifiers,
+    title: art ? text(pathFirst(articleEl, ['MedlineCitation', 'Article', 'ArticleTitle'])) : null,
+    abstract
+  }
+  if (identifiers.doi) record.doi = identifiers.doi
+  record.journal = journal
+  record.authors = authors
+  record.publication_date = pubDate
+  record.mesh_terms = meshTerms
+  record.article_types = articleTypes
+  record.language = language
+  record.citation = citation
+  return record
+}
+
+// Split a PubmedArticleSet into per-PMID <PubmedArticle> elements keyed by PMID.
+const articlesByPmid = (xml: string): Record<string, Element> => {
+  const root = parseXml(xml)
+  const out: Record<string, Element> = {}
+  for (const child of childEls(root, 'PubmedArticle')) {
+    const pmid = (child.getElementsByTagName('PMID')[0]?.textContent ?? '').trim()
+    if (pmid) out[pmid] = child
   }
   return out
 }
 
-// NCBI E-utilities in JSON mode (no biopython/XML needed): esearch -> esummary.
+// ── convert_article_ids: PMC ID Converter (PMID <-> PMCID <-> DOI) ──────────
+type IdConvRecord = {
+  requested_id: string
+  pmid: string | null
+  pmcid: string | null
+  doi: string | null
+  status: 'ok' | 'error'
+  errmsg?: string
+}
+type IdConvRaw = {
+  'requested-id'?: string | number
+  pmid?: string | number
+  pmcid?: string
+  doi?: string
+  status?: string
+  errmsg?: string
+}
+
+const convertIds = async (
+  ctx: ToolContext,
+  ids: string[],
+  fromType: string
+): Promise<IdConvRecord[]> => {
+  const records: IdConvRecord[] = []
+  for (let i = 0; i < ids.length; i += IDCONV_BATCH) {
+    const batch = ids.slice(i, i + IDCONV_BATCH)
+    const url =
+      `${IDCONV}?ids=${encodeURIComponent(batch.join(','))}&idtype=${encodeURIComponent(fromType)}` +
+      `&format=json&versions=no&tool=${TOOL}${ncbiEtiquette(ctx.credentials)}`
+    const payload = (await ctx.fetchJson(url)) as { records?: IdConvRaw[] }
+    const byReq = new Map<string, IdConvRaw>()
+    for (const r of payload.records ?? []) byReq.set(String(r['requested-id']), r)
+    for (const rid of batch) {
+      const raw = byReq.get(String(rid))
+      if (!raw) {
+        records.push({
+          requested_id: rid,
+          pmid: null,
+          pmcid: null,
+          doi: null,
+          status: 'error',
+          errmsg: 'no record in idconv response'
+        })
+        continue
+      }
+      const rec: IdConvRecord = {
+        requested_id: rid,
+        pmid: raw.pmid != null ? String(raw.pmid) : null,
+        pmcid: raw.pmcid ?? null,
+        doi: raw.doi ?? null,
+        status: raw.status === 'error' ? 'error' : 'ok'
+      }
+      if (raw.errmsg) rec.errmsg = raw.errmsg
+      records.push(rec)
+    }
+  }
+  return records
+}
+
+// ── get_full_text_article: Europe PMC availability + JATS full text ─────────
+type EpmcHit = {
+  id?: string
+  pmid?: string
+  pmcid?: string
+  doi?: string
+  title?: string
+  journalTitle?: string
+  pubYear?: string
+  isOpenAccess?: string
+  license?: string
+  abstractText?: string
+}
+type Availability = {
+  input_id: string
+  found: boolean
+  pmid: string | null
+  pmcid: string | null
+  doi: string | null
+  title: string | null
+  license: string | null
+  is_open_access: boolean
+  search_abstract: string | null
+}
+
+const classifyId = (raw: string): 'pmcid' | 'pmid' | 'unknown' => {
+  const rid = raw.trim()
+  if (/^PMC\d+$/i.test(rid)) return 'pmcid'
+  if (/^\d+$/.test(rid)) return 'pmid'
+  return 'unknown'
+}
+
+const epmcSearch = async (
+  ctx: ToolContext,
+  query: string,
+  pageSize: number
+): Promise<EpmcHit[]> => {
+  const url =
+    `${EUROPEPMC}/search?query=${encodeURIComponent(query)}` +
+    `&format=json&resultType=core&pageSize=${pageSize}`
+  const data = (await ctx.fetchJson(url)) as { resultList?: { result?: EpmcHit[] } }
+  return data.resultList?.result ?? []
+}
+
+const checkAvailability = async (ctx: ToolContext, ids: string[]): Promise<Availability[]> => {
+  const typed = ids.map((raw) => ({ raw, type: classifyId(raw) }))
+  const pmids = typed.filter((t) => t.type === 'pmid').map((t) => t.raw)
+  const pmcids = typed.filter((t) => t.type === 'pmcid').map((t) => t.raw)
+  const byPmid = new Map<string, EpmcHit>()
+  const byPmcid = new Map<string, EpmcHit>()
+  const ingest = (hits: EpmcHit[]): void => {
+    for (const hit of hits) {
+      const pmid = String(hit.pmid ?? hit.id ?? '')
+      const pmcid = String(hit.pmcid ?? '')
+      if (pmid && !byPmid.has(pmid)) byPmid.set(pmid, hit)
+      if (pmcid && !byPmcid.has(pmcid.toUpperCase())) byPmcid.set(pmcid.toUpperCase(), hit)
+    }
+  }
+  for (let i = 0; i < pmids.length; i += SEARCH_BATCH) {
+    const chunk = pmids.slice(i, i + SEARCH_BATCH)
+    const query = '(' + chunk.map((p) => `EXT_ID:${p}`).join(' OR ') + ') AND SRC:MED'
+    ingest(await epmcSearch(ctx, query, Math.max(25, chunk.length * 2)))
+  }
+  for (let i = 0; i < pmcids.length; i += SEARCH_BATCH) {
+    const chunk = pmcids.slice(i, i + SEARCH_BATCH)
+    const query = '(' + chunk.map((p) => `PMCID:${p.toUpperCase()}`).join(' OR ') + ')'
+    ingest(await epmcSearch(ctx, query, Math.max(25, chunk.length * 2)))
+  }
+  const flag = (v: unknown): boolean =>
+    String(v ?? '')
+      .trim()
+      .toUpperCase() === 'Y'
+  return typed.map(({ raw, type }) => {
+    const hit = type === 'pmid' ? byPmid.get(raw) : byPmcid.get(raw.toUpperCase())
+    if (!hit) {
+      return {
+        input_id: raw,
+        found: false,
+        pmid: null,
+        pmcid: null,
+        doi: null,
+        title: null,
+        license: null,
+        is_open_access: false,
+        search_abstract: null
+      }
+    }
+    return {
+      input_id: raw,
+      found: true,
+      pmid: hit.pmid ?? null,
+      pmcid: hit.pmcid ?? null,
+      doi: hit.doi ?? null,
+      title: hit.title ?? null,
+      license: hit.license ?? null,
+      is_open_access: flag(hit.isOpenAccess),
+      search_abstract: hit.abstractText || null
+    }
+  })
+}
+
+// Extract JATS title / abstract / top-level body sections from Europe PMC fullTextXML.
+const extractSections = (xml: string): { title: string; abstract: string; sections: string[] } => {
+  const root = parseXml(xml)
+  const title = textExcluding(
+    pathFirst(root, ['front', 'article-meta', 'title-group', 'article-title']),
+    new Set()
+  )
+  const articleMeta = pathFirst(root, ['front', 'article-meta'])
+  let abstract = ''
+  if (articleMeta) {
+    const abstracts = childEls(articleMeta, 'abstract')
+    const main = abstracts.filter((a) => !a.getAttribute('abstract-type'))
+    const chosen = main[0] ?? abstracts[0] ?? null
+    if (chosen) {
+      // Drop the boilerplate <title>Abstract</title> and any embedded keyword group.
+      const parts: string[] = []
+      for (const c of Array.from(chosen.childNodes)) {
+        if (c.nodeType === 1) {
+          const el = c as Element
+          if (
+            el.localName === 'title' &&
+            (el.textContent ?? '').trim().toLowerCase() === 'abstract'
+          )
+            continue
+          if (el.localName === 'kwd-group') continue
+          parts.push(textExcluding(el, new Set(['kwd-group'])))
+        } else if (c.nodeType === 3) {
+          parts.push((c.nodeValue ?? '').trim())
+        }
+      }
+      abstract = parts.filter(Boolean).join(' ').replace(/\s+/g, ' ').trim()
+    }
+  }
+  const body = (root.getElementsByTagName('body')[0] as Element) ?? null
+  const exclude = new Set(['table-wrap', 'fig', 'ref-list'])
+  const sections = childEls(body, 'sec').map((sec) => textExcluding(sec, exclude))
+  return { title, abstract, sections }
+}
+
+// ── copyright: PubMed CopyrightInformation + PMC <permissions> ──────────────
+type PmcPerm = {
+  copyright_statement: string | null
+  copyright_year: string | null
+  license_type: string | null
+  license_ref: string | null
+}
+
+const pubmedCopyright = async (
+  ctx: ToolContext,
+  pmids: string[]
+): Promise<Record<string, string | null>> => {
+  const out: Record<string, string | null> = {}
+  for (const p of pmids) out[p] = null
+  const url =
+    `${EUTILS}/efetch.fcgi?db=pubmed&retmode=xml&id=${encodeURIComponent(pmids.join(','))}` +
+    `&tool=${TOOL}${ncbiEtiquette(ctx.credentials)}`
+  const root = parseXml(await ctx.fetchText(url))
+  for (const art of childEls(root, 'PubmedArticle')) {
+    const pmid = (art.getElementsByTagName('PMID')[0]?.textContent ?? '').trim()
+    if (!pmid) continue
+    const ci = art.getElementsByTagName('CopyrightInformation')[0]
+    out[pmid] = ci?.textContent?.trim() || null
+  }
+  return out
+}
+
+const pmcPermissions = async (
+  ctx: ToolContext,
+  pmcidsByPmid: Record<string, string>
+): Promise<Record<string, PmcPerm>> => {
+  const numeric = Object.values(pmcidsByPmid).map((pmcid) => pmcid.replace(/PMC/i, ''))
+  if (!numeric.length) return {}
+  const url =
+    `${EUTILS}/efetch.fcgi?db=pmc&retmode=xml&id=${encodeURIComponent(numeric.join(','))}` +
+    `&tool=${TOOL}${ncbiEtiquette(ctx.credentials)}`
+  const root = parseXml(await ctx.fetchText(url))
+  const out: Record<string, PmcPerm> = {}
+  for (const article of childEls(root, 'article')) {
+    const ids: Record<string, string> = {}
+    const perm: PmcPerm = {
+      copyright_statement: null,
+      copyright_year: null,
+      license_type: null,
+      license_ref: null
+    }
+    for (const el of Array.from(article.getElementsByTagName('*'))) {
+      const ln = (el as Element).localName ?? ''
+      if (ln === 'article-id') {
+        ids[(el as Element).getAttribute('pub-id-type') || ''] = (el.textContent ?? '').trim()
+      } else if (ln === 'permissions' && perm.copyright_statement === null) {
+        for (const sub of Array.from((el as Element).getElementsByTagName('*'))) {
+          const sln = (sub as Element).localName ?? ''
+          const txt = (sub.textContent ?? '').trim()
+          if (sln === 'copyright-statement' && txt) perm.copyright_statement = txt
+          else if (sln === 'copyright-year' && txt) perm.copyright_year = txt
+          else if (sln === 'license')
+            perm.license_type = (sub as Element).getAttribute('license-type') || perm.license_type
+          else if (sln === 'license_ref' && txt && perm.license_ref === null) perm.license_ref = txt
+        }
+      }
+    }
+    const pmid = ids.pmid
+    if (pmid) out[pmid] = perm
+  }
+  return out
+}
+
+// One eutils GET URL with NCBI etiquette threaded on.
+const eutilsUrl = (ctx: ToolContext, endpoint: string, params: string): string =>
+  `${EUTILS}/${endpoint}?${params}&tool=${TOOL}${ncbiEtiquette(ctx.credentials)}`
+
 export const PUBMED_TOOLS: ToolDescriptor[] = [
   {
-    id: 'pubmed_search',
+    id: 'search_articles',
     connector: 'pubmed',
     description:
-      'Search PubMed (biomedical & life-sciences literature) for articles matching a query; returns the total match count plus the top article titles/dates. For a specific article’s authors, journal, DOI, or abstract, pass its PMID to `pubmed_fetch`. PubMed does not index physics / CS / math / pure-chemistry papers (use other connectors for those).',
+      'Search PubMed (biomedical & life-sciences literature via NCBI esearch) for articles matching a query. Returns the total match count plus a page of PMIDs. Supports PubMed field tags ([Title], [Author], [Journal], [MeSH Terms], ...), Boolean operators, date filtering and sort. PubMed does not index physics / CS / math / pure-chemistry papers.',
     input: {
       type: 'object',
-      properties: { term: { type: 'string' }, retmax: { type: 'integer', default: 5 } },
-      required: ['term']
+      properties: {
+        query: { type: 'string', description: 'PubMed query (keywords, field tags, Boolean).' },
+        max_results: { type: 'integer', default: 20 },
+        retstart: { type: 'integer', default: 0 },
+        sort: {
+          type: 'string',
+          enum: ['relevance', 'pub_date', 'author', 'journal_name', 'title']
+        },
+        date_from: { type: 'string', description: 'YYYY, YYYY/MM or YYYY/MM/DD.' },
+        date_to: { type: 'string', description: 'YYYY, YYYY/MM or YYYY/MM/DD.' },
+        datetype: { type: 'string', enum: ['pdat', 'edat', 'mdat'], default: 'pdat' }
+      },
+      required: ['query']
     },
-    required: ['term'],
+    required: ['query'],
     returns:
-      '`{ "term": str, "count": int, "articles": [ { "pmid": str, "title": str, "date": str } ] }` — up to `retmax` articles (default 5); `count` is the total number of PubMed matches and is usually far larger than the returned list. `articles` is `[]` when nothing matches.',
+      '`{ "pmids": [str], "total_count": int, "returned_count": int, "query": str, "query_translation": str|null, "has_more": bool }` — `pmids` is one page (`max_results`, default 20) starting at `retstart`; `total_count` is the full PubMed match count. Feed PMIDs to `get_article_metadata`.',
     example:
-      'result = host.mcp("pubmed", "pubmed_search", {"term": "tumor progression", "retmax": 10})',
+      'result = host.mcp("pubmed", "search_articles", {"query": "CRISPR gene editing", "max_results": 10})',
     run: async (ctx, a) => {
-      const q = ncbiEtiquette(ctx.credentials)
-      const es = (await ctx.fetchJson(
-        `${EUTILS}/esearch.fcgi?db=pubmed&retmode=json&retmax=${Number(a.retmax ?? 5)}&term=${encodeURIComponent(String(a.term))}${q}`
-      )) as { esearchresult?: { count?: string; idlist?: string[] } }
-      const ids = es.esearchresult?.idlist ?? []
-      if (!ids.length) return { term: a.term, count: 0, articles: [] }
-      const sum = (await ctx.fetchJson(
-        `${EUTILS}/esummary.fcgi?db=pubmed&retmode=json&id=${ids.join(',')}${q}`
-      )) as {
-        result: Record<string, { title?: string; pubdate?: string }>
+      const query = String(a.query)
+      const retstart = Number(a.retstart ?? 0)
+      const maxResults = Number(a.max_results ?? 20)
+      const params = new URLSearchParams({
+        db: 'pubmed',
+        term: query,
+        retmode: 'json',
+        retstart: String(retstart),
+        retmax: String(maxResults)
+      })
+      if (a.date_from || a.date_to) params.set('datetype', String(a.datetype ?? 'pdat'))
+      if (a.date_from) params.set('mindate', String(a.date_from))
+      if (a.date_to) params.set('maxdate', String(a.date_to))
+      if (a.sort) params.set('sort', SORT_MAP[String(a.sort)] ?? String(a.sort))
+      const payload = (await ctx.fetchJson(eutilsUrl(ctx, 'esearch.fcgi', params.toString()))) as {
+        esearchresult?: { count?: string; idlist?: string[]; querytranslation?: string }
       }
+      const res = payload.esearchresult
+      const window = (res?.idlist ?? []).slice(0, maxResults)
+      const count = Number(res?.count ?? 0)
       return {
-        term: a.term,
-        count: Number(es.esearchresult?.count ?? 0),
-        articles: ids.map((id) => ({
-          pmid: id,
-          title: sum.result[id]?.title,
-          date: sum.result[id]?.pubdate
-        }))
+        pmids: window,
+        total_count: count,
+        returned_count: window.length,
+        query,
+        query_translation: res?.querytranslation ?? null,
+        has_more: retstart + window.length < count
       }
     }
   },
   {
-    id: 'pubmed_fetch',
+    id: 'get_article_metadata',
     connector: 'pubmed',
     description:
-      'Fetch full details for one or more PubMed articles by PMID (bulk): title, authors, journal, DOI, and the abstract text. Use this after `pubmed_search` when you need more than the title. Prefer one call with many PMIDs over one call per PMID.',
+      'Retrieve detailed article metadata from PubMed by PMID (bulk, via efetch): identifiers (pmid/pmc/doi), title, abstract, journal, authors with affiliations, publication date, MeSH terms, article types, language and citation. On every use, cite PubMed and include the returned article DOIs (identifiers.doi) as links.',
     input: {
       type: 'object',
       properties: {
         pmids: {
           type: 'array',
           items: { type: 'string' },
-          description: 'One or more PubMed IDs, e.g. ["40302006", "31452104"].'
+          description: 'One or more PubMed IDs, e.g. ["35486828", "33264437"].'
         }
       },
       required: ['pmids']
     },
     required: ['pmids'],
     returns:
-      '`{ "pmids": [str], "articles": [ { "pmid": str, "title": str, "authors": [str], "journal": str, "date": str, "doi": str|null, "abstract": str|null } ] }` — one entry per requested PMID (order preserved); `doi`/`abstract` are null when PubMed has none, `authors` is `[]` when unlisted.',
-    example: 'result = host.mcp("pubmed", "pubmed_fetch", {"pmids": ["40302006", "31452104"]})',
+      '`{ "articles": [ { "identifiers": {"pmid","pmc"?,"doi"?}, "title", "abstract", "doi"?, "journal": {"title","iso_abbreviation"}, "authors": [{"last_name"?,"fore_name"?,"initials"?,"collective_name"?,"affiliations":[str]}], "publication_date": {"year"?,"month"?,"day"?}, "mesh_terms": [str], "article_types": [str], "language", "citation": {"volume"?,"issue"?,"pages"?} } ], "count": int, "important_legal_notice": str }` — one article per requested PMID present in PubMed (input order).',
+    example:
+      'result = host.mcp("pubmed", "get_article_metadata", {"pmids": ["35486828", "33264437"]})',
     run: async (ctx, a) => {
-      const ids = (Array.isArray(a.pmids) ? a.pmids : [a.pmids]).map((x) => String(x))
-      const q = ncbiEtiquette(ctx.credentials)
-      const [sum, xml] = await Promise.all([
-        ctx.fetchJson(
-          `${EUTILS}/esummary.fcgi?db=pubmed&retmode=json&id=${ids.join(',')}${q}`
-        ) as Promise<{ result?: Record<string, PubmedSummary> }>,
-        ctx.fetchText(
-          `${EUTILS}/efetch.fcgi?db=pubmed&retmode=xml&rettype=abstract&id=${ids.join(',')}${q}`
-        )
-      ])
-      const abstracts = parseAbstracts(xml)
-      const result = sum.result ?? {}
-      return {
-        pmids: ids,
-        articles: ids.map((id) => {
-          const r = result[id]
-          return {
-            pmid: id,
-            title: r?.title,
-            authors: (r?.authors ?? [])
-              .filter((x) => x.authtype === 'Author' && x.name)
-              .map((x) => x.name as string),
-            journal: r?.source,
-            date: r?.pubdate,
-            doi: r?.articleids?.find((x) => x.idtype === 'doi')?.value ?? null,
-            abstract: abstracts[id] ?? null
-          }
+      const pmids = (Array.isArray(a.pmids) ? a.pmids : [a.pmids]).map((x) => String(x))
+      const url = eutilsUrl(
+        ctx,
+        'efetch.fcgi',
+        `db=pubmed&retmode=xml&id=${encodeURIComponent(pmids.join(','))}`
+      )
+      const byPmid = articlesByPmid(await ctx.fetchText(url))
+      const articles = pmids.filter((p) => byPmid[p]).map((p) => articleFromXml(byPmid[p]))
+      return { articles, count: articles.length, important_legal_notice: IMPORTANT_LEGAL_NOTICE }
+    }
+  },
+  {
+    id: 'find_related_articles',
+    connector: 'pubmed',
+    description:
+      'Find related PubMed content for one or more source PMIDs via NCBI elink. `pubmed_pubmed` (default) returns similar articles ranked by word-weighted similarity of titles/abstracts/MeSH (NOT citations); `pubmed_pmc` returns full-text PMC links; `pubmed_gene`/`pubmed_protein`/`pubmed_nucleotide` return linked sequence/gene records.',
+    input: {
+      type: 'object',
+      properties: {
+        pmids: { type: 'array', items: { type: 'string' } },
+        link_type: {
+          type: 'string',
+          enum: [
+            'pubmed_pubmed',
+            'pubmed_pmc',
+            'pubmed_nucleotide',
+            'pubmed_protein',
+            'pubmed_gene'
+          ],
+          default: 'pubmed_pubmed'
+        },
+        max_results: { type: 'integer', description: 'Cap linked ids per linkset.' }
+      },
+      required: ['pmids']
+    },
+    required: ['pmids'],
+    returns:
+      '`{ "linksets": [ { "dbfrom": "pubmed", "ids": [str], "linksetdbs": [ { "dbto": str, "linkname": str, "links": [str] } ] } ] }` — one linkset per input PMID; `links` are related ids, relevance-ranked for `pubmed_pubmed`, truncated to `max_results` when given.',
+    example:
+      'result = host.mcp("pubmed", "find_related_articles", {"pmids": ["35486828"], "link_type": "pubmed_pubmed"})',
+    run: async (ctx, a) => {
+      const pmids = (Array.isArray(a.pmids) ? a.pmids : [a.pmids]).map((x) => String(x))
+      const linkType = String(a.link_type ?? 'pubmed_pubmed')
+      const db = linkType.split('_')[1] ?? 'pubmed'
+      const maxResults = a.max_results != null ? Number(a.max_results) : null
+      const idParams = pmids.map((id) => `&id=${encodeURIComponent(id)}`).join('')
+      const url = eutilsUrl(
+        ctx,
+        'elink.fcgi',
+        `dbfrom=pubmed&db=${db}&retmode=json&linkname=${linkType}${idParams}`
+      )
+      const payload = (await ctx.fetchJson(url)) as {
+        linksets?: {
+          dbfrom?: string
+          ids?: (string | number)[]
+          linksetdbs?: { dbto?: string; linkname?: string; links?: (string | number)[] }[]
+        }[]
+      }
+      const linksets = (payload.linksets ?? []).map((ls) => ({
+        dbfrom: ls.dbfrom,
+        ids: (ls.ids ?? []).map((x) => String(x)),
+        linksetdbs: (ls.linksetdbs ?? []).map((linkDb) => {
+          let links = (linkDb.links ?? []).map((x) => String(x))
+          if (maxResults != null && maxResults > 0) links = links.slice(0, maxResults)
+          return { dbto: linkDb.dbto, linkname: linkDb.linkname, links }
         })
+      }))
+      return { linksets }
+    }
+  },
+  {
+    id: 'lookup_article_by_citation',
+    connector: 'pubmed',
+    description:
+      'Resolve bibliographic citations to PMIDs via NCBI ecitmatch. Each citation supplies some of {journal, year, volume, first_page, author, key}; provide 2-3+ fields for reliable matching. Use when you have a reference list and need PMIDs.',
+    input: {
+      type: 'object',
+      properties: {
+        citations: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              journal: { type: 'string' },
+              year: { type: 'integer' },
+              volume: { type: 'string' },
+              first_page: { type: 'string' },
+              author: { type: 'string' },
+              key: { type: 'string', description: 'Optional caller-side tracking id.' }
+            }
+          }
+        }
+      },
+      required: ['citations']
+    },
+    required: ['citations'],
+    returns:
+      '`{ "citations": [ { "journal", "year", "volume", "first_page", "author", "pmid": str|null, "key": str, "status"?: "not_found"|"ambiguous"|..., "detail"? } ] }` — one entry per input citation (order preserved); `pmid` is set on a unique match, otherwise `status`/`detail` explain why.',
+    example:
+      'result = host.mcp("pubmed", "lookup_article_by_citation", {"citations": [{"journal": "Science", "year": 1987, "volume": "235", "first_page": "182", "author": "Palmenberg AC"}]})',
+    run: async (ctx, a) => {
+      const citations = (Array.isArray(a.citations) ? a.citations : []) as Json[]
+      // Build the pipe-delimited, \r-joined bdata block (journal|year|volume|page|author|key|).
+      const keyed = citations.map((c, i) => {
+        const key = String(c.key ?? `cit${i}`)
+        const fields = [
+          String(c.journal ?? ''),
+          c.year != null ? String(c.year) : '',
+          String(c.volume ?? ''),
+          String(c.first_page ?? ''),
+          String(c.author ?? ''),
+          key
+        ]
+        for (const f of fields) {
+          if (f.includes('|')) throw new Error(`citation field may not contain '|': ${f}`)
+        }
+        return { key, line: fields.join('|') + '|' }
+      })
+      const bdata = keyed.map((k) => k.line).join('\r')
+      const url = eutilsUrl(
+        ctx,
+        'ecitmatch.cgi',
+        `db=pubmed&retmode=xml&bdata=${encodeURIComponent(bdata)}`
+      )
+      const respText = citations.length ? await ctx.fetchText(url) : ''
+      // Response is pipe-delimited plain text: journal|year|volume|page|author|key|RESULT.
+      const byKey = new Map<string, { pmid: string | null; status: string; detail?: string }>()
+      for (const rawLine of respText.split(/\r?\n/)) {
+        const line = rawLine.trim()
+        if (!line) continue
+        const parts = line.split('|')
+        if (parts.length < 7) continue
+        const key = parts[5]
+        const result = parts[6].trim()
+        if (/^\d+$/.test(result)) byKey.set(key, { pmid: result, status: 'found' })
+        else if (result.toUpperCase().startsWith('AMBIGUOUS'))
+          byKey.set(key, { pmid: null, status: 'ambiguous', detail: result })
+        else byKey.set(key, { pmid: null, status: 'not_found', detail: result })
+      }
+      const out = citations.map((given, i) => {
+        const { key } = keyed[i]
+        const r = byKey.get(key) ?? { pmid: null, status: 'no_response_line' as const }
+        const entry: Json = {
+          journal: given.journal ?? null,
+          year: given.year != null ? String(given.year) : null,
+          volume: given.volume ?? null,
+          first_page: given.first_page ?? null,
+          author: given.author ?? null,
+          pmid: r.pmid,
+          key
+        }
+        if (r.status !== 'found') {
+          entry.status = r.status
+          if (r.detail) entry.detail = r.detail
+        }
+        return entry
+      })
+      return { citations: out }
+    }
+  },
+  {
+    id: 'convert_article_ids',
+    connector: 'pubmed',
+    description:
+      'Convert between PMID, PMCID and DOI via the NCBI/PMC ID Converter. Homogeneous input ids per call (set `id_type` to match). Commonly used to check whether a PMID has a PMCID (i.e. full text in PMC) before calling get_full_text_article.',
+    input: {
+      type: 'object',
+      properties: {
+        ids: { type: 'array', items: { type: 'string' } },
+        id_type: { type: 'string', enum: ['pmid', 'pmcid', 'doi'], default: 'pmid' }
+      },
+      required: ['ids']
+    },
+    required: ['ids'],
+    returns:
+      '`{ "status": "ok", "response-date": str, "request": {...}, "records": [ { "pmcid": str|null, "pmid": str|null, "doi": str|null, "requested-id": str, "status"?: "error", "errmsg"? } ] }` — one record per input id (order preserved); missing identifiers are explicit null. `status="error"` with "not found in PMC" is the normal outcome for a PMID with no PMC deposit.',
+    example:
+      'result = host.mcp("pubmed", "convert_article_ids", {"ids": ["PMC9046468"], "id_type": "pmcid"})',
+    run: async (ctx, a) => {
+      const ids = (Array.isArray(a.ids) ? a.ids : [a.ids]).map((x) => String(x))
+      const idType = String(a.id_type ?? 'pmid')
+      const records = await convertIds(ctx, ids, idType)
+      const recs = records.map((r) => {
+        const rec: Json = {
+          pmcid: r.pmcid || null,
+          pmid: r.pmid || null,
+          doi: r.doi || null,
+          'requested-id': r.requested_id
+        }
+        if (r.status === 'error') {
+          rec.status = 'error'
+          if (r.errmsg) rec.errmsg = r.errmsg
+        }
+        return rec
+      })
+      return {
+        status: 'ok',
+        'response-date': new Date().toISOString().replace('T', ' ').slice(0, 19),
+        request: {
+          warnings: [],
+          format: 'json',
+          idtype: idType,
+          ids,
+          email: null,
+          tool: TOOL,
+          echo: `tool=${TOOL}&ids=${ids.join(',')}&format=json&idtype=${idType}`,
+          versions: 'no',
+          showaiid: 'no'
+        },
+        records: recs
+      }
+    }
+  },
+  {
+    id: 'get_full_text_article',
+    connector: 'pubmed',
+    description:
+      'Retrieve open-access full text from PubMed Central via Europe PMC by PMC id ("PMC12345" or "12345"). Returns structured section text plus the license; when full text is unavailable the reason is reported explicitly (fulltext_status). Only OA-subset articles have retrievable full text. On every use, cite PubMed and include the returned article DOIs as links.',
+    input: {
+      type: 'object',
+      properties: {
+        pmc_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'PMC ids, e.g. ["PMC9046468"] or ["9046468"]. Max 20 per call.'
+        }
+      },
+      required: ['pmc_ids']
+    },
+    required: ['pmc_ids'],
+    returns:
+      '`{ "important_legal_notice": str, "articles": [ { "identifiers": {"pmcid"?,"pmid"?,"doi"?}, "title", "full_text": str, "license"?, "doi"?, "abstract"?, "fulltext_status"?: str, "detail"? } ], "count": int }` — `full_text` is the section text joined by blank lines; `fulltext_status` (present when not "retrieved") is one of not_open_access / no_pmcid / xml_not_available / not_found / invalid_id.',
+    example: 'result = host.mcp("pubmed", "get_full_text_article", {"pmc_ids": ["PMC9046468"]})',
+    run: async (ctx, a) => {
+      // The field declares PMC intent, so a bare digit string is a PMC number — prefix it.
+      const ids = (Array.isArray(a.pmc_ids) ? a.pmc_ids : [a.pmc_ids])
+        .map((x) => String(x).trim())
+        .filter(Boolean)
+        .map((i) => (/^\d+$/.test(i) ? `PMC${i}` : i))
+      if (ids.length > MAX_PMC_IDS) {
+        throw new Error(
+          `too many pmc_ids (${ids.length}); max ${MAX_PMC_IDS} per call (full-text retrieval is one request per article)`
+        )
+      }
+      const availability = await checkAvailability(ctx, ids)
+      const articles: Json[] = []
+      for (const av of availability) {
+        const identifiers: Json = {}
+        if (av.pmcid) identifiers.pmcid = av.pmcid
+        if (av.pmid) identifiers.pmid = av.pmid
+        if (av.doi) identifiers.doi = av.doi
+        const base = (status: string | null, detail: string | null, extra?: Json): Json => {
+          const art: Json = { identifiers, title: av.title, full_text: '' }
+          if (av.license) art.license = av.license
+          if (av.doi) art.doi = av.doi
+          if (extra?.abstract) art.abstract = extra.abstract
+          if (status && status !== 'retrieved') {
+            art.fulltext_status = status
+            if (detail) art.detail = detail
+          }
+          return art
+        }
+        if (!av.found) {
+          articles.push(base('not_found', 'ID did not resolve via the Europe PMC search endpoint'))
+          continue
+        }
+        if (!av.is_open_access) {
+          articles.push(
+            base(
+              'not_open_access',
+              'isOpenAccess=N: not in the Europe PMC open-access full-text subset',
+              { abstract: av.search_abstract }
+            )
+          )
+          continue
+        }
+        if (!av.pmcid) {
+          articles.push(
+            base('no_pmcid', 'no PMCID assigned; fullTextXML requires a PMCID', {
+              abstract: av.search_abstract
+            })
+          )
+          continue
+        }
+        let xml: string | null = null
+        try {
+          xml = await ctx.fetchText(`${EUROPEPMC}/${encodeURIComponent(av.pmcid)}/fullTextXML`)
+        } catch (err) {
+          articles.push(
+            base(
+              'xml_not_available',
+              `fullTextXML unavailable for ${av.pmcid}: ${(err as Error).message}`,
+              { abstract: av.search_abstract }
+            )
+          )
+          continue
+        }
+        const extracted = extractSections(xml)
+        const art: Json = {
+          identifiers,
+          title: extracted.title || av.title,
+          full_text: extracted.sections
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .join('\n\n')
+        }
+        if (av.license) art.license = av.license
+        if (av.doi) art.doi = av.doi
+        if (extracted.abstract) art.abstract = extracted.abstract
+        articles.push(art)
+      }
+      return { important_legal_notice: IMPORTANT_LEGAL_NOTICE, articles, count: articles.length }
+    }
+  },
+  {
+    id: 'get_copyright_status',
+    connector: 'pubmed',
+    description:
+      'Report copyright and license status per PMID by combining PubMed CopyrightInformation, the PMC ID Converter (PMID -> PMCID/DOI), and the PMC <permissions> block (license type, ALI license URL, copyright statement/year). Use to check open-access reuse rights before reproducing content.',
+    input: {
+      type: 'object',
+      properties: { pmids: { type: 'array', items: { type: 'string' } } },
+      required: ['pmids']
+    },
+    required: ['pmids'],
+    returns:
+      '`{ "results": [ { "pmid", "pmc_id": str|null, "copyright": {"statement","year","holder"}, "license": {"type","url","is_open_access"}, "source": "pmc"|"pubmed"|"not_available", "checked_sources": [str], "available_at": {"pubmed_url","pmc_url"?,"doi_url"?} } ], "count": int, "summary": {"total_checked","found_in_pubmed","found_in_pmc","not_found","open_access_count"} }` — one result per input PMID.',
+    example:
+      'result = host.mcp("pubmed", "get_copyright_status", {"pmids": ["35891187", "34375400"]})',
+    run: async (ctx, a) => {
+      const pmids = (Array.isArray(a.pmids) ? a.pmids : [a.pmids]).map((x) => String(x))
+      const conv = await convertIds(ctx, pmids, 'pmid')
+      const dois: Record<string, string | null> = {}
+      const pmcidsByPmid: Record<string, string> = {}
+      for (const r of conv) {
+        dois[r.requested_id] = r.doi
+        if (r.status === 'ok' && r.pmcid) pmcidsByPmid[r.requested_id] = r.pmcid
+      }
+      const pubmedCi = await pubmedCopyright(ctx, pmids)
+      const pmcPerm = await pmcPermissions(ctx, pmcidsByPmid)
+      const results: Json[] = []
+      let nPubmed = 0
+      let nPmc = 0
+      let nNotFound = 0
+      let nOa = 0
+      for (const pmid of pmids) {
+        const pmcid = pmcidsByPmid[pmid] ?? null
+        const perm = pmid in pmcPerm ? pmcPerm[pmid] : null
+        const ci = pubmedCi[pmid] ?? null
+        const source = perm ? 'pmc' : ci ? 'pubmed' : 'not_available'
+        const licType = perm?.license_type ?? null
+        const isOa = Boolean(licType)
+        const year = perm?.copyright_year ?? null
+        const statement = perm?.copyright_statement ?? ci
+        const availableAt: Json = { pubmed_url: `https://pubmed.ncbi.nlm.nih.gov/${pmid}/` }
+        if (pmcid) availableAt.pmc_url = `https://pmc.ncbi.nlm.nih.gov/articles/${pmcid}/`
+        const doi = dois[pmid]
+        if (doi) availableAt.doi_url = `https://doi.org/${doi}`
+        results.push({
+          pmid,
+          pmc_id: pmcid,
+          copyright: {
+            statement,
+            year: year && /^\d+$/.test(String(year)) ? Number(year) : null,
+            holder: null
+          },
+          license: { type: licType, url: perm?.license_ref ?? null, is_open_access: isOa },
+          source,
+          checked_sources: pmcid ? ['pubmed', 'pmc'] : ['pubmed'],
+          available_at: availableAt
+        })
+        if (source === 'pubmed') nPubmed++
+        else if (source === 'pmc') nPmc++
+        else nNotFound++
+        if (isOa) nOa++
+      }
+      return {
+        results,
+        count: results.length,
+        summary: {
+          total_checked: results.length,
+          found_in_pubmed: nPubmed,
+          found_in_pmc: nPmc,
+          not_found: nNotFound,
+          open_access_count: nOa
+        }
       }
     }
   }

--- a/src/main/connectors/registry.test.ts
+++ b/src/main/connectors/registry.test.ts
@@ -8,7 +8,7 @@ describe('registry + catalog', () => {
     expect(getDescriptor('chemistry', 'nope')).toBeUndefined()
   })
   it('lists tools for a connector', () => {
-    expect(getConnectorTools('pubmed').map((t) => t.id)).toContain('pubmed_search')
+    expect(getConnectorTools('pubmed').map((t) => t.id)).toContain('search_articles')
   })
   it('catalog ids and registry ids are consistent', () => {
     for (const meta of CONNECTOR_CATALOG) expect(ALL_CONNECTOR_IDS).toContain(meta.id)

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -25,12 +25,15 @@ describe('renderSkillDoc', () => {
     // (reuse across cells, return shape) lives once in the shared conventions template — it must NOT
     // be duplicated into each tool's example.
     const md = renderSkillDoc('pubmed')
-    const block = md.slice(md.indexOf('### pubmed_search'), md.indexOf('### pubmed_fetch'))
+    const block = md.slice(
+      md.indexOf('### search_articles'),
+      md.indexOf('### get_article_metadata')
+    )
     const py = block
       .slice(block.indexOf('```python') + '```python'.length, block.lastIndexOf('```'))
       .trim()
     expect(py).toBe(
-      'result = host.mcp("pubmed", "pubmed_search", {"term": "tumor progression", "retmax": 10})'
+      'result = host.mcp("pubmed", "search_articles", {"query": "CRISPR gene editing", "max_results": 10})'
     )
     expect(py).not.toContain('#') // no per-tool comment/prose
   })


### PR DESCRIPTION
Rounds out the PubMed connector to the full NCBI / PMC surface: E-utilities
article search, rich metadata, related-article discovery, citation matching,
PMID/PMCID/DOI conversion, PMC and Europe PMC full text, and copyright/license
status. NCBI contact email and API key are threaded from settings. All tools are
read-only.