### PR TITLE
feat(ketcher): interactive Ketcher Chemistry sketcher app + molecule viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -326,7 +326,6 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -832,7 +831,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -877,7 +875,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1446,6 +1443,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1465,6 +1463,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1479,6 +1478,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1491,6 +1491,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1580,7 +1581,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1624,7 +1624,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2864,7 +2863,6 @@
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -5443,7 +5441,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -5723,6 +5722,27 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -6204,7 +6224,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -6217,7 +6236,6 @@
     "node_modules/@types/node": {
       "version": "22.20.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6245,7 +6263,6 @@
     "node_modules/@types/react": {
       "version": "19.2.17",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6254,7 +6271,6 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6344,7 +6360,6 @@
       "version": "8.62.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -6792,7 +6807,6 @@
       "version": "8.17.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7368,6 +7382,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/babel-plugin-macros/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "dev": true,
@@ -7504,7 +7527,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -8185,7 +8207,8 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -8247,7 +8270,6 @@
       "version": "3.34.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8606,7 +8628,6 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9053,7 +9074,6 @@
       "version": "26.15.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -9525,7 +9545,6 @@
       "version": "39.8.10",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -9744,6 +9763,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -9762,6 +9782,7 @@
       "version": "7.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -10120,7 +10141,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10179,7 +10199,6 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10726,7 +10745,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
@@ -11680,7 +11700,6 @@
     "node_modules/hono": {
       "version": "4.12.27",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12526,6 +12545,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -12741,6 +12761,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -13439,6 +13460,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -14321,7 +14343,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -14927,8 +14948,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -15061,6 +15081,7 @@
       "version": "0.5.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -16145,6 +16166,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -16160,6 +16182,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -16187,7 +16210,6 @@
       "version": "3.9.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16228,7 +16250,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -16568,7 +16589,6 @@
     "node_modules/react": {
       "version": "19.2.7",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16621,7 +16641,6 @@
     "node_modules/react-dom": {
       "version": "19.2.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16890,8 +16909,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-logger": {
       "version": "3.0.6",
@@ -17308,6 +17326,7 @@
       "version": "2.6.3",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -17944,6 +17963,7 @@
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
@@ -18339,8 +18359,7 @@
     "node_modules/tailwindcss": {
       "version": "4.3.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -18381,6 +18400,7 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -18599,7 +18619,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -18797,7 +18818,6 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18898,7 +18918,6 @@
       "version": "11.0.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -19272,7 +19291,6 @@
       "version": "7.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -19828,7 +19846,6 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -20166,12 +20183,21 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {
@@ -20263,7 +20289,6 @@
     "node_modules/zod": {
       "version": "4.4.3",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@prisma/client": "^6.19.3",
         "electron-updater": "^6.3.9",
+        "ketcher-core": "^3.17.0",
+        "ketcher-react": "^3.17.0",
+        "ketcher-standalone": "^3.17.0",
         "pdfjs-dist": "^4.10.38",
         "zod": "^4.4.3"
       },
@@ -163,9 +166,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -178,9 +178,6 @@
       "integrity": "sha512-91fgdG4aTnQ29sKOcUqgH4+tKCW2ut6PWGRSYmXNDbROasJm1rAlPdzC5brdu/e4c0CDSNV6TWyE5JCjaS/jlQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -195,9 +192,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -210,9 +204,6 @@
       "integrity": "sha512-vvsb7GlnA8CTSVvvTkrXjcSeRKqxSM7p/tU3Od9ICAZeWHglptekEyzLEApzLuLbI5ewfFF/F0q3NwOBbo18dg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -313,7 +304,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -336,6 +326,7 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -363,7 +354,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -424,7 +414,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -444,7 +433,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.7",
@@ -519,7 +507,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -527,7 +514,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -555,7 +541,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -693,14 +678,12 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -713,7 +696,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -730,7 +712,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -851,6 +832,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -895,6 +877,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1463,7 +1446,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1483,7 +1465,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1498,7 +1479,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1511,10 +1491,184 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -2178,28 +2332,46 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "dev": true,
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "dev": true,
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.20",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.20.tgz",
+      "integrity": "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "dev": true,
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
+        "@floating-ui/dom": "^1.8.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2207,8 +2379,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "dev": true,
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
@@ -2305,7 +2478,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2323,7 +2495,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2331,16 +2502,287 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lexical/clipboard": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.40.0.tgz",
+      "integrity": "sha512-FWyAKwbGbmwLbG6biyxB/MQkELzcbd6E89Xufarbx/1VZ2pX/BMaeVD4J7ojHgIZ4omTNI6nKH26K4wWySCIGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/html": "0.40.0",
+        "@lexical/list": "0.40.0",
+        "@lexical/selection": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/code": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.40.0.tgz",
+      "integrity": "sha512-xbo3lW3OC7sz0UnoME0tXQcgnekmuvsGAb1HZpFHAF0ZUCquB6/yK0+9QzknrTBH9y3Urqx0vM54xAqNQISOtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0",
+        "prismjs": "^1.30.0"
+      }
+    },
+    "node_modules/@lexical/devtools-core": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.40.0.tgz",
+      "integrity": "sha512-qOlN4CYXHkdVxAzrZ1Cdu7bAYf1se+R3y7MfjWa6WFFukf7n6+RAoNIWTzpTLM7h7fOrsJLyP0Goi5IZI9wAOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/html": "0.40.0",
+        "@lexical/link": "0.40.0",
+        "@lexical/mark": "0.40.0",
+        "@lexical/table": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.x",
+        "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/dragon": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.40.0.tgz",
+      "integrity": "sha512-QWBZw89CAkw2b3Fl942DxJ7M8/XxFFvVubw9Z7Ac6wgUkGgtF2wrK9F0H8cPZ3pzbUqL1v1EtwW1/XhlLfmQqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/extension": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.40.0.tgz",
+      "integrity": "sha512-kipdm0f+xe8ctxHt9S3NPZazMX3ILqIk5xMWxX2svdsRc7qIeMkl+5SLWnBqQA+e5ztLJqa7GSA4WMqu/dBZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.40.0",
+        "@preact/signals-core": "^1.11.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/hashtag": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.40.0.tgz",
+      "integrity": "sha512-k4PKWa8xyMHnnh+ewUboeFr8wKemk1GoMZ6LKN4qnqNKGCHANyJKeHRVUzyLjbiSwcXTrBqtUTV4ZrJXGRIkEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/text": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/history": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.40.0.tgz",
+      "integrity": "sha512-Jo/9Z1fPlv+IpBkUaVstyKminXWjM1A1yR9UPZv4a3B3e8Rn0gqa+EaY5CXSvscnmh2EHSD8I4s59D4rirUy8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/html": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.40.0.tgz",
+      "integrity": "sha512-5EZeHbp9Q3Op2KRoVfFvX4QyMizYW5SJkrWkGG6h6g/Z9EDNjb3C7Wjqx7ZosCHcFze6Pgic/0yEaCc2fSUcEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/link": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.40.0.tgz",
+      "integrity": "sha512-4EVMJQ6tKJR+1+YAJ2mhVsRR6Edk6b81hWKjnMZITKhEOKjylxO7bwuXYVYPEckBzL2mXkEhYX5aFnig5+HkMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/list": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.40.0.tgz",
+      "integrity": "sha512-YHStiN56DOc6tDu/3LwalPtHH8/1R+peiDF+/ePpla9aSDJclAqhxRBYsqSZhO6Hu5QhAEIi2Me7Gi+uZdmCTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.40.0",
+        "@lexical/selection": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/mark": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.40.0.tgz",
+      "integrity": "sha512-9XJ0PQmeq5tDSgathAQs1ePMM5zaCBCbD4ShMXJf3fW1udI7e/Swn0Loxw9/VnER9fnVkyejGMC2oMWDQ80FVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/markdown": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.40.0.tgz",
+      "integrity": "sha512-J0vO4jSPZaazBgFafJhLYaJPBxSMk1nhGnNiu6+TojqOe3tx/0vukCafowNxBDruZFns+r7HsSs+vkmGJtGsrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/code": "0.40.0",
+        "@lexical/link": "0.40.0",
+        "@lexical/list": "0.40.0",
+        "@lexical/rich-text": "0.40.0",
+        "@lexical/text": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/offset": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.40.0.tgz",
+      "integrity": "sha512-USytxiqB/mU6tKy2nXs4jhgCES90l8N5lCYxVbho2L/cVXAzBCp1epG///B6Vgm+twSj+jQjhGZioktILnG+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/overflow": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.40.0.tgz",
+      "integrity": "sha512-T1LE8R7LloV9t8m+5IQ7Djkqcbd4mOoX85Jh8cKQ58TFHbkwi8nSe+FJUi3fucOI2atDq9QZCJnpRUCHw4eEwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/plain-text": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.40.0.tgz",
+      "integrity": "sha512-mr6J1Fu34MwUNOPkzn3l/fZBpD91HLAxs6RBAQ6mfSW7jLXBVDlvhiB4ez9ud/jZ0bgLaY8EG7ooT7htdlkBUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.40.0",
+        "@lexical/dragon": "0.40.0",
+        "@lexical/selection": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/react": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.40.0.tgz",
+      "integrity": "sha512-+J73I21LNT659f1IMTbxe055mKnt4H2SkHp3UDxrmWmkWmDaPcq7XG07i8/xCPtYz15aEXUQycqaWQc5pAqF5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.16",
+        "@lexical/devtools-core": "0.40.0",
+        "@lexical/dragon": "0.40.0",
+        "@lexical/extension": "0.40.0",
+        "@lexical/hashtag": "0.40.0",
+        "@lexical/history": "0.40.0",
+        "@lexical/link": "0.40.0",
+        "@lexical/list": "0.40.0",
+        "@lexical/mark": "0.40.0",
+        "@lexical/markdown": "0.40.0",
+        "@lexical/overflow": "0.40.0",
+        "@lexical/plain-text": "0.40.0",
+        "@lexical/rich-text": "0.40.0",
+        "@lexical/table": "0.40.0",
+        "@lexical/text": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "@lexical/yjs": "0.40.0",
+        "lexical": "0.40.0",
+        "react-error-boundary": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.x",
+        "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/rich-text": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.40.0.tgz",
+      "integrity": "sha512-aHW9gSYGzEfZNxx14j2xJhihrnKaWA1aoudteP4r7TkNlbfJ3xG9dxp7ItwrAKJlfvI0gkMc1/aZOUIqESbAkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.40.0",
+        "@lexical/dragon": "0.40.0",
+        "@lexical/selection": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/selection": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.40.0.tgz",
+      "integrity": "sha512-iFwZufMlIx9fZ+K3NQip9oxoHzuP+V9rVdkLnfUWC7aO4HNxVPSryEfUnbAs+F5xlOzyVHsu7Xa+CMHfIL8/gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/table": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.40.0.tgz",
+      "integrity": "sha512-pn5T7Uc80dH8LR2d/sepKc8SjiKKir40AF+5hW0MJAOYfoizd10x72AxPcM6iBYvI0rdW7rD7Lhko1qLmZ0pOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.40.0",
+        "@lexical/extension": "0.40.0",
+        "@lexical/utils": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/text": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.40.0.tgz",
+      "integrity": "sha512-cTMBrHPzlIRQUkopIUhPwSzcqQDGsCEdjpStylJficwMav9vG+/sJNSG4PFO+4ss5BZ/x7AoM3KH/P2SOzqdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/utils": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.40.0.tgz",
+      "integrity": "sha512-3wkzgQxeb137GtaGWZI23XYB+omGjfYlrvAPJOqcb5z8yS7iAiuHwWULdmi1/jPBClS7z9N8pkNzq06BP8QlZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.40.0",
+        "lexical": "0.40.0"
+      }
+    },
+    "node_modules/@lexical/yjs": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.40.0.tgz",
+      "integrity": "sha512-wpasbrlfzBnHhyuUunxZcGwOH+bqfxUuavGgwxDlTTlHJMnyF5bUG7ADcuqd3gFLB+dpABL0lWo6VxdSOo7fdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/offset": "0.40.0",
+        "@lexical/selection": "0.40.0",
+        "lexical": "0.40.0"
+      },
+      "peerDependencies": {
+        "yjs": ">=13.5.22"
       }
     },
     "node_modules/@malept/cross-spawn-promise": {
@@ -2422,6 +2864,7 @@
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2456,6 +2899,217 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
+      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
+      "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/core-downloads-tracker": "^5.18.0",
+        "@mui/system": "^5.18.0",
+        "@mui/types": "~7.2.15",
+        "@mui/utils": "^5.17.1",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT"
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
+      "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/utils": "^5.17.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
+      "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
+      "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/private-theming": "^5.17.1",
+        "@mui/styled-engine": "^5.18.0",
+        "@mui/types": "~7.2.15",
+        "@mui/utils": "^5.17.1",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
+      "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/types": "~7.2.15",
+        "@types/prop-types": "^15.7.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.100",
@@ -2803,6 +3457,26 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@prisma/client": {
@@ -4769,8 +5443,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -5050,27 +5723,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -5552,6 +6204,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -5564,6 +6217,7 @@
     "node_modules/@types/node": {
       "version": "22.20.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5576,10 +6230,22 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5588,8 +6254,18 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -5608,6 +6284,12 @@
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -5662,6 +6344,7 @@
       "version": "8.62.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -6109,6 +6792,7 @@
       "version": "8.17.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6122,6 +6806,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/agent-base": {
@@ -6483,6 +7176,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+      "integrity": "sha512-Ej9qjcXY+8Tuy1cNqiwNMwFRXOy9UwgTeMA8LxreodygIPV48lx8PU1ecFxb5ZeU1DpMKxiq6vGLTxcitWZPbA=="
+    },
     "node_modules/asn1js": {
       "version": "3.0.10",
       "dev": true,
@@ -6494,6 +7192,19 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
       }
     },
     "node_modules/assertion-error": {
@@ -6578,9 +7289,17 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -6597,6 +7316,58 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "dev": true,
@@ -6608,7 +7379,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6697,7 +7467,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6735,6 +7504,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -6917,7 +7687,6 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6959,7 +7728,6 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6991,6 +7759,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/chai": {
@@ -7116,7 +7897,6 @@
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -7164,7 +7944,6 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7390,12 +8169,23 @@
         }
       }
     },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7451,13 +8241,13 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
       "version": "3.34.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7499,7 +8289,6 @@
     },
     "node_modules/d3": {
       "version": "7.9.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "3",
@@ -7539,7 +8328,6 @@
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
@@ -7550,7 +8338,6 @@
     },
     "node_modules/d3-axis": {
       "version": "3.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7558,7 +8345,6 @@
     },
     "node_modules/d3-brush": {
       "version": "3.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -7573,7 +8359,6 @@
     },
     "node_modules/d3-chord": {
       "version": "3.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -7584,7 +8369,6 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7592,7 +8376,6 @@
     },
     "node_modules/d3-contour": {
       "version": "4.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "^3.2.0"
@@ -7603,7 +8386,6 @@
     },
     "node_modules/d3-delaunay": {
       "version": "6.0.4",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "delaunator": "5"
@@ -7614,7 +8396,6 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7622,7 +8403,6 @@
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -7634,7 +8414,6 @@
     },
     "node_modules/d3-dsv": {
       "version": "3.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "commander": "7",
@@ -7658,7 +8437,6 @@
     },
     "node_modules/d3-dsv/node_modules/commander": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -7666,7 +8444,6 @@
     },
     "node_modules/d3-dsv/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7677,7 +8454,6 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -7685,7 +8461,6 @@
     },
     "node_modules/d3-fetch": {
       "version": "3.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dsv": "1 - 3"
@@ -7696,7 +8471,6 @@
     },
     "node_modules/d3-force": {
       "version": "3.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -7709,7 +8483,6 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.2",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7717,7 +8490,6 @@
     },
     "node_modules/d3-geo": {
       "version": "3.1.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
@@ -7728,7 +8500,6 @@
     },
     "node_modules/d3-hierarchy": {
       "version": "3.1.2",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7736,7 +8507,6 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
@@ -7747,7 +8517,6 @@
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7755,7 +8524,6 @@
     },
     "node_modules/d3-polygon": {
       "version": "3.0.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7763,7 +8531,6 @@
     },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7771,7 +8538,6 @@
     },
     "node_modules/d3-random": {
       "version": "3.0.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7814,7 +8580,6 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.10.0 - 3",
@@ -7829,7 +8594,6 @@
     },
     "node_modules/d3-scale-chromatic": {
       "version": "3.1.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -7841,15 +8605,14 @@
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
-      "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "^3.1.0"
@@ -7860,7 +8623,6 @@
     },
     "node_modules/d3-time": {
       "version": "3.1.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2 - 3"
@@ -7871,7 +8633,6 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-time": "1 - 3"
@@ -7882,7 +8643,6 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7890,7 +8650,6 @@
     },
     "node_modules/d3-transition": {
       "version": "3.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -7908,7 +8667,6 @@
     },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -8077,6 +8835,13 @@
         }
       }
     },
+    "node_modules/deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -8133,7 +8898,6 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -8160,7 +8924,6 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -8181,7 +8944,6 @@
     },
     "node_modules/delaunator": {
       "version": "5.1.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
@@ -8291,6 +9053,7 @@
       "version": "26.15.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -8341,6 +9104,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.4.11",
       "dev": true,
@@ -8386,6 +9159,319 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dpdm": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dpdm/-/dpdm-4.2.0.tgz",
+      "integrity": "sha512-Vq862fZ9UE66rlr2VcMhU8ZstTH3ItqmniLSCtAeg6T2AYeB2oD3Z6lGjiFDjyUvxLbfLyBBNWagCLMehpmo5g==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "fs-extra": "^11.3.3",
+        "glob": "^13.0.0",
+        "ora": "^9.1.0",
+        "tslib": "^2.8.1",
+        "typescript": "^5.9.3",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "dpdm": "lib/bin/dpdm.js"
+      }
+    },
+    "node_modules/dpdm/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/dpdm/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/dpdm/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/dpdm/node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dpdm/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/dpdm/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dpdm/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/dpdm/node_modules/fs-extra": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/dpdm/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/dpdm/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/dpdm/node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dpdm/node_modules/ora": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.2",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dpdm/node_modules/stdin-discarder": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dpdm/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dpdm/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/dpdm/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/dpdm/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/dpdm/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dpdm/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/dpdm/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/dpdm/node_modules/yargs/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dunder-proto": {
@@ -8439,6 +9525,7 @@
       "version": "39.8.10",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -8657,7 +9744,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -8676,7 +9762,6 @@
       "version": "7.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -8685,6 +9770,12 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
+    },
+    "node_modules/element-closest-polyfill": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/element-closest-polyfill/-/element-closest-polyfill-1.0.7.tgz",
+      "integrity": "sha512-SX7RrUUEybUllkGjVf5XJR5I0Fl2L0iawK/caX/yJu94xW/WoRRD8Fky65gKpvqhU9PLBKOliIy4Ly2rDRzdUQ==",
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -8762,7 +9853,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -9007,7 +10097,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9019,7 +10108,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9032,6 +10120,7 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9090,6 +10179,7 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9374,6 +10464,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eve-raphael": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
+      "integrity": "sha512-jrxnPsCGqng1UZuEp9DecX/AuSyAszATSjf4oEcRxvfxa1Oux4KkIPKBAAWWnpdwfARtr+Q0o9aPYWjsROD7ug=="
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "license": "MIT",
@@ -9631,8 +10726,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense",
-      "peer": true
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
@@ -9704,6 +10798,24 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
+    "node_modules/file-selector": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.4.0.tgz",
+      "integrity": "sha512-iACCiXeMYOvZqlF1kTiYINzgepRBymz1wwjiuup9u9nayhb6g4fSwiyJ/6adli+EPwrWtpgQAh2PoS7HukEGEg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "dev": true,
@@ -9766,6 +10878,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "dev": true,
@@ -9798,9 +10916,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/font-face-observer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/font-face-observer/-/font-face-observer-1.0.0.tgz",
+      "integrity": "sha512-GHeQVlm05gBswpLECTYd3vnsGMyTPkkOSu1dRjfF3VGjCZ1omtjWjVaJw2WjgqegBFKWZOAfj50YEou/WlcmAg==",
+      "license": "BSD",
+      "dependencies": {
+        "promise": "^6.1.0"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -9940,7 +11066,6 @@
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9956,7 +11081,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -9964,7 +11088,6 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10241,7 +11364,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -10276,7 +11398,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -10547,9 +11668,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/hono": {
       "version": "4.12.27",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10706,7 +11837,6 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -10735,6 +11865,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/indigo-ketcher": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.45.0.tgz",
+      "integrity": "sha512-ilq2cZtB237g3lVC5ry1evk6TMmNxfLYevLxPO07aelTeKPCf9Tu1wnijiMsaOiGytAFJ2mU11wkroe1iHYfSg==",
+      "license": "Apache-2.0"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -10769,11 +11905,17 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/intersection-observer": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.2.tgz",
+      "integrity": "sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==",
+      "deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
+      "license": "Apache-2.0"
     },
     "node_modules/iobuffer": {
       "version": "5.4.0",
@@ -10816,6 +11958,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "dev": true,
@@ -10834,7 +11992,6 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -10886,7 +12043,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10897,7 +12053,6 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -11009,7 +12164,6 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -11075,7 +12229,6 @@
     },
     "node_modules/is-interactive": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11088,6 +12241,22 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -11159,7 +12328,6 @@
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11254,7 +12422,6 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -11268,7 +12435,6 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11353,6 +12519,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -11443,7 +12619,6 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -11545,7 +12720,6 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -11560,7 +12734,6 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-to-ts": {
@@ -11568,7 +12741,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -11613,6 +12785,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonschema": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "dev": true,
@@ -11648,6 +12829,563 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ketcher-core": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/ketcher-core/-/ketcher-core-3.17.0.tgz",
+      "integrity": "sha512-xONVbx3xfjHLwACYh8JaZudiOYIVXhVxf3pSc5pZ3Die7yN9TTRAFMcK5Hxu3ziNrn4OdhSyUZGnS8sJKAimVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "assert": "^2.0.0",
+        "d3": "^7.8.5",
+        "dpdm": "^4.2.0",
+        "file-saver": "^2.0.5",
+        "lodash": "^4.18.1",
+        "paper": "^0.12.18",
+        "raphael": "^2.3.0",
+        "react-device-detect": "^2.2.2",
+        "svgpath": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=24.14.1"
+      }
+    },
+    "node_modules/ketcher-react": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/ketcher-react/-/ketcher-react-3.17.0.tgz",
+      "integrity": "sha512-cGcJZvnzRyUJk+6EjROIkp/mIfbDmmY30ghKsox3P+jd1aWVatXGeyUceUC8maZ5TpLwkGFGLwCR07l34rTdLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.14.1",
+        "@lexical/react": "^0.40.0",
+        "@lexical/rich-text": "^0.40.0",
+        "@lexical/selection": "^0.40.0",
+        "@mui/material": "^5.18.0",
+        "cfb": "^1.2.2",
+        "clsx": "^1.1.1",
+        "dpdm": "^4.2.0",
+        "element-closest-polyfill": "^1.0.2",
+        "file-saver": "^2.0.2",
+        "font-face-observer": "^1.0.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "intersection-observer": "^0.12.2",
+        "jsonschema": "^1.5.0",
+        "ketcher-core": "*",
+        "lexical": "^0.40.0",
+        "lodash": "^4.18.1",
+        "miew-react": "0.11.0",
+        "paper": "^0.12.18",
+        "react-colorful": "^5.4.0",
+        "react-contexify": "^6.0.0",
+        "react-device-detect": "^2.2.2",
+        "react-dropzone": "^11.7.1",
+        "react-intersection-observer": "^9.16.0",
+        "react-redux": "^9.2.0",
+        "react-virtualized": "^9.22.6",
+        "redux": "^5.0.1",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^3.1.0",
+        "regenerator-runtime": "^0.13.7",
+        "remark-gfm": "^1.0.0",
+        "remark-parse": "^9.0.0",
+        "reselect": "^4.0.0",
+        "subscription": "^3.0.0",
+        "url-search-params-polyfill": "^8.1.1",
+        "use-resize-observer": "^7.0.0",
+        "whatwg-fetch": "^3.4.1"
+      },
+      "engines": {
+        "node": ">=24.14.1"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/@types/mdast": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/ketcher-react/node_modules/ccount": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
+      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "license": "MIT",
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/mdast-util-find-and-replace": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
+      "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/mdast-util-from-markdown": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/mdast-util-gfm": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
+      "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-gfm-autolink-literal": "^0.1.0",
+        "mdast-util-gfm-strikethrough": "^0.2.0",
+        "mdast-util-gfm-table": "^0.1.0",
+        "mdast-util-gfm-task-list-item": "^0.1.0",
+        "mdast-util-to-markdown": "^0.6.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
+      "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
+      "license": "MIT",
+      "dependencies": {
+        "ccount": "^1.0.0",
+        "mdast-util-find-and-replace": "^1.1.0",
+        "micromark": "^2.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/mdast-util-gfm-strikethrough": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
+      "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown": "^0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/mdast-util-gfm-table": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+      "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "markdown-table": "^2.0.0",
+        "mdast-util-to-markdown": "~0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/mdast-util-gfm-task-list-item": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+      "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown": "~0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/mdast-util-to-markdown": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.0.0",
+        "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/micromark": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "parse-entities": "^2.0.0"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/micromark-extension-gfm": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
+      "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "~2.11.0",
+        "micromark-extension-gfm-autolink-literal": "~0.5.0",
+        "micromark-extension-gfm-strikethrough": "~0.6.5",
+        "micromark-extension-gfm-table": "~0.4.0",
+        "micromark-extension-gfm-tagfilter": "~0.3.0",
+        "micromark-extension-gfm-task-list-item": "~0.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
+      "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "~2.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
+      "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/micromark-extension-gfm-table": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
+      "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
+      "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
+      "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/miew-react": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/miew-react/-/miew-react-0.11.0.tgz",
+      "integrity": "sha512-IdJYzrbkpotS4Hx0JYg7KyOcpwyTdGRS1hnc504Y//Xvdl24Ft6uahuf9mbCEI2PNVPDARLc+hqzMTbpDWD88A==",
+      "license": "MIT",
+      "dependencies": {
+        "miew": "^0.11.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/remark-gfm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
+      "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-gfm": "^0.1.0",
+        "micromark-extension-gfm": "^0.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/remark-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ketcher-react/node_modules/zwitch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ketcher-standalone": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/ketcher-standalone/-/ketcher-standalone-3.17.0.tgz",
+      "integrity": "sha512-MBpMC90UintTKuRrCsaQYs1WwDlX2tIm6+Cr6gohvWay0x/o5YFP0o5nZaYZNqQAvyI+TxHSwBqpPm+SIFsrqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "indigo-ketcher": "1.45.0",
+        "ketcher-core": "*"
+      },
+      "engines": {
+        "node": ">=24.14.1"
       }
     },
     "node_modules/keyv": {
@@ -11688,6 +13426,33 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lexical": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.40.0.tgz",
+      "integrity": "sha512-wNvd/AY13h/QJYvx565M/FSdRjy0l99W5/MFA2x+mbK3KnKa5BifZbHZ1J4/YssCkdyZhSlLwFkyDaYi7l2Dsw==",
+      "license": "MIT"
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lightningcss": {
@@ -11949,7 +13714,6 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -11968,7 +13732,6 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -12037,7 +13800,6 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -12559,6 +14321,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -13164,7 +14927,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -13187,6 +14951,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/miew": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/miew/-/miew-0.11.1.tgz",
+      "integrity": "sha512-CIhZfI9eB0P/covNrst45Y8Xd+MUncyxjNLkZULr+dcyS1ALxjtb+W2icbZEHEsn7zZJJ4ybIMIwQGnzS25IbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "three": "0.153.0"
       }
     },
     "node_modules/mime": {
@@ -13229,7 +15003,6 @@
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13247,7 +15020,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -13269,7 +15041,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -13290,7 +15061,6 @@
       "version": "0.5.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -13597,9 +15367,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13615,7 +15400,6 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -13949,9 +15733,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/paper": {
+      "version": "0.12.18",
+      "resolved": "https://registry.npmjs.org/paper/-/paper-0.12.18.tgz",
+      "integrity": "sha512-ZSLIEejQTJZuYHhSSqAf4jXOnii0kPhCJGAnYAANtdS72aNwXJ9cP95tZHgq1tnNpvEwgQhggy+4OarviqTCGw==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -13985,7 +15780,6 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -14064,8 +15858,32 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
@@ -14073,6 +15891,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -14116,7 +15943,6 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -14270,7 +16096,6 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -14320,7 +16145,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -14336,7 +16160,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -14364,6 +16187,7 @@
       "version": "3.9.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14404,6 +16228,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -14421,6 +16246,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/proc-log": {
@@ -14441,6 +16275,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+      "integrity": "sha512-O+uwGKreKNKkshzZv2P7N64lk6EP17iXBn0PbUnNQhk+Q0AHLstiTrjkx3v5YBd3cxUe7Sq6KyRhl/A0xUjk7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "asap": "~1.0.0"
       }
     },
     "node_modules/promise-retry": {
@@ -14477,7 +16320,6 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -14692,6 +16534,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/raphael": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
+      "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eve-raphael": "0.5.0"
+      }
+    },
     "node_modules/raw-body": {
       "version": "3.0.2",
       "license": "MIT",
@@ -14716,16 +16567,61 @@
     },
     "node_modules/react": {
       "version": "19.2.7",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-colorful": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.8.0.tgz",
+      "integrity": "sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-contexify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-contexify/-/react-contexify-6.0.0.tgz",
+      "integrity": "sha512-jMhz6yZI81Jv3UDj7TXqCkhdkCFEEmvwGCPXsQuA2ZUC8EbCuVQ6Cy8FzKMXa0y454XTDClBN2YFvvmoFlrFkg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-contexify/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-device-detect": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+      "integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
+      "license": "MIT",
+      "dependencies": {
+        "ua-parser-js": "^1.0.33"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0",
+        "react-dom": ">= 0.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.7",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14733,10 +16629,79 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-dropzone": {
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.7.1.tgz",
+      "integrity": "sha512-zxCMwhfPy1olUEbw3FLNPLhAm/HnaYH5aELIEglRbqabizKAdHs0h+WuyOpmA+v1JXn0++fpQDdNfUagWt5hJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.4.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.2.tgz",
+      "integrity": "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
+      "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -14821,6 +16786,49 @@
         }
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-virtualized": {
+      "version": "9.22.6",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.6.tgz",
+      "integrity": "sha512-U5j7KuUQt3AaMatlMJ0UJddqSiX+Km0YJxSqbAzIiGw5EmNz0khMyqP2hzgu4+QUtm+QPIrxzUX4raJxmVJnHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "clsx": "^1.0.4",
+        "dom-helpers": "^5.1.3",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-virtualized/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
       "dev": true,
@@ -14878,6 +16886,31 @@
         "node": ">= 4"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-diff": "^0.3.5"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "dev": true,
@@ -14898,6 +16931,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/regex": {
       "version": "6.1.0",
@@ -15116,6 +17155,15 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "dev": true,
@@ -15147,6 +17195,18 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
       "dev": true,
@@ -15175,7 +17235,6 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -15193,7 +17252,6 @@
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^7.0.0",
@@ -15208,7 +17266,6 @@
     },
     "node_modules/restore-cursor/node_modules/onetime": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -15222,7 +17279,6 @@
     },
     "node_modules/restore-cursor/node_modules/signal-exit": {
       "version": "4.1.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -15252,7 +17308,6 @@
       "version": "2.6.3",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -15278,7 +17333,6 @@
     },
     "node_modules/robust-predicates": {
       "version": "3.0.3",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/rollup": {
@@ -15384,7 +17438,6 @@
     },
     "node_modules/rw": {
       "version": "1.3.3",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
@@ -15427,7 +17480,6 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -15473,7 +17525,6 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -15566,7 +17617,6 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -15894,7 +17944,6 @@
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
@@ -16182,6 +18231,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/subscription": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/subscription/-/subscription-3.0.0.tgz",
+      "integrity": "sha512-W0xDn7QYcDo9HhHqsmoj4U8pJVqYqnggBUoJixAQXc2MoX71Ef551Np9tyTMX+9Ta6br9MdTbvdpQ/+JP31uPQ==",
+      "license": "MIT"
+    },
     "node_modules/sumchecker": {
       "version": "3.0.1",
       "license": "Apache-2.0",
@@ -16205,13 +18260,21 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svgpath": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.6.0.tgz",
+      "integrity": "sha512-OIWR6bKzXvdXYyO4DK/UWa1VA1JeKq8E+0ug2DG98Y/vOmMpfZNj+TIG988HjfYSqtcy/hFOtZq/n/j5GSESNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/fontello/svg2ttf?sponsor=1"
       }
     },
     "node_modules/symbol-tree": {
@@ -16258,6 +18321,12 @@
         "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "dev": true,
@@ -16270,7 +18339,8 @@
     "node_modules/tailwindcss": {
       "version": "4.3.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -16311,7 +18381,6 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -16360,6 +18429,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/three": {
+      "version": "0.153.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.153.0.tgz",
+      "integrity": "sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg==",
+      "license": "MIT"
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
@@ -16524,8 +18599,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -16570,7 +18644,6 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tw-animate-css": {
@@ -16723,8 +18796,8 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16753,6 +18826,32 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/unbox-primitive": {
@@ -16799,6 +18898,7 @@
       "version": "11.0.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -17010,6 +19110,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-search-params-polyfill": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.2.5.tgz",
+      "integrity": "sha512-FOEojW4XReTmtZOB7xqSHmJZhrNTmClhBriwLTmle4iA7bwuCo6ldSfbtsFSb8bTf3E0a3XpfonAdaur9vqq8A==",
+      "license": "MIT"
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "dev": true,
@@ -17028,6 +19134,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-resize-observer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-7.0.1.tgz",
+      "integrity": "sha512-tJESENDoVXfzkv1Cl9dJ13ySgENcKjvEKSU7QwjckjxjXg/MV2zW1CjEUtLpmXY084womIxJROUR3L1SuqlvOw==",
+      "license": "MIT",
+      "dependencies": {
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/use-sidecar": {
@@ -17051,10 +19170,32 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "dev": true,
       "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -17131,6 +19272,7 @@
       "version": "7.3.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -17686,6 +19828,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -17810,6 +19953,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
+    },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "dev": true,
@@ -17908,7 +20057,6 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -18007,7 +20155,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -18017,6 +20164,15 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.3",
@@ -18051,6 +20207,24 @@
         "fd-slicer": "~1.1.0"
       }
     },
+    "node_modules/yjs": {
+      "version": "13.6.31",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
+      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "dev": true,
@@ -18078,7 +20252,6 @@
     },
     "node_modules/yoctocolors": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -18090,6 +20263,7 @@
     "node_modules/zod": {
       "version": "4.4.3",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@prisma/client": "^6.19.3",
     "electron-updater": "^6.3.9",
+    "ketcher-core": "^3.17.0",
+    "ketcher-react": "^3.17.0",
+    "ketcher-standalone": "^3.17.0",
     "pdfjs-dist": "^4.10.38",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
-    "build": "npm run typecheck && electron-vite build",
+    "build": "npm run typecheck && node --max-old-space-size=4096 node_modules/electron-vite/bin/electron-vite.js build",
     "postinstall": "prisma generate && electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",
-    "build:mac": "electron-vite build && electron-builder --mac",
-    "build:linux": "electron-vite build && electron-builder --linux",
-    "build:win": "electron-vite build && electron-builder --win",
+    "build:mac": "node --max-old-space-size=4096 node_modules/electron-vite/bin/electron-vite.js build && electron-builder --mac",
+    "build:linux": "node --max-old-space-size=4096 node_modules/electron-vite/bin/electron-vite.js build && electron-builder --linux",
+    "build:win": "node --max-old-space-size=4096 node_modules/electron-vite/bin/electron-vite.js build && electron-builder --win",
     "predev": "node scripts/dev-app-branding.cjs"
   },
   "dependencies": {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -232,6 +232,10 @@ class AcpRuntime {
   private artifactSessionSequence = 0
   private artifactRunSequence = 0
   private notebookSessionSequence = 0
+  // The artifact run of the turn currently being prompted, exposed so the main-process Ketcher tool host
+  // can attribute its generated .ket artifacts to the same run (host.mcp calls carry no session context).
+  private activeArtifactRun: ActiveArtifactRun | undefined
+  private activeArtifactRunSessionId: string | undefined
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -832,6 +836,8 @@ class AcpRuntime {
     try {
       // Create a fresh run context before prompting so MCP writes can be attributed to this turn.
       artifactRun = await this.activateArtifactRun(request.sessionId)
+      this.activeArtifactRun = artifactRun
+      this.activeArtifactRunSessionId = request.sessionId
       // Prepend a short steering nudge naming the picked skills. It goes only into the content sent to
       // the agent; the user-facing message event keeps the original text (which already shows /Name).
       const promptText = await this.applySkillNudge(request.text, forced)
@@ -914,6 +920,8 @@ class AcpRuntime {
           text: errorMessage(error)
         })
       }
+      this.activeArtifactRun = undefined
+      this.activeArtifactRunSessionId = undefined
       this.promptInFlightSessionIds.delete(request.sessionId)
       this.emitState()
       // A disabled skill forced for this turn is restored now: clear the force set, then schedule a
@@ -1424,6 +1432,22 @@ class AcpRuntime {
       projectName,
       artifactSessionId
     )
+  }
+
+  // Exposes the active turn's artifact run context so the Ketcher tool host can write its .ket artifacts
+  // into the same pending run (they are then finalized onto the turn's message like any generated file).
+  // Undefined between turns, so a sketcher tool called outside a prompt fails with a clear error.
+  getActiveArtifactRunContext():
+    | { projectName: string; sessionId: string; artifactSessionId: string; runId: string }
+    | undefined {
+    if (!this.activeArtifactRun || !this.activeArtifactRunSessionId) return undefined
+
+    return {
+      projectName: this.resolveSessionProjectName(this.activeArtifactRunSessionId),
+      sessionId: this.activeArtifactRunSessionId,
+      artifactSessionId: this.activeArtifactRun.artifactSessionId,
+      runId: this.activeArtifactRun.runId
+    }
   }
 
   // Marks a new assistant turn as the active artifact run before the model can call the MCP tool.

--- a/src/main/connectors/catalog.ts
+++ b/src/main/connectors/catalog.ts
@@ -28,6 +28,17 @@ export const CONNECTOR_CATALOG: ConnectorMeta[] = [
     requiresNcbi: false
   },
   {
+    id: 'ketcher',
+    displayName: 'Ketcher Chemistry',
+    description:
+      'Interactive 2D molecule sketcher — open an editable Ketcher canvas and read structures back.',
+    useWhen:
+      'Use when you want to draw, show, or edit a 2D chemical structure interactively for the user — open a live Ketcher sketcher (optionally seeded from SMILES, a molfile, a reaction, or KET), replace the structure on the canvas, highlight specific atoms or bonds, or read the current structure back as KET/molfile/SMILES. Powered by the in-app Ketcher editor with the standalone Indigo (WASM) backend.',
+    sources: ['Ketcher', 'Indigo'],
+    termsUrl: 'https://github.com/epam/ketcher/blob/master/LICENSE',
+    requiresNcbi: false
+  },
+  {
     id: 'literature',
     displayName: 'Literature Graph',
     description:

--- a/src/main/connectors/descriptors/ketcher.ts
+++ b/src/main/connectors/descriptors/ketcher.ts
@@ -1,0 +1,103 @@
+import type { ToolDescriptor } from '../types'
+
+// The interactive Ketcher app: unlike the read-only HTTP connectors, these four tools do NOT run through
+// ParserEngine. They are registered here so the settings UI, per-tool policy and skill doc treat Ketcher
+// like any other connector; ConnectorService.callBundled special-cases `ketcher` and routes dispatch to
+// the main-process KetcherService (which drives a live sketcher tile) instead of an upstream API.
+export const KETCHER_TOOLS: ToolDescriptor[] = [
+  {
+    id: 'open_sketcher',
+    connector: 'ketcher',
+    description:
+      'Open an interactive 2D molecule sketcher tile for the user, seeded from an optional structure. Creates a .ket artifact and mounts an editable Ketcher canvas; returns the artifact_id used by the other ketcher tools.',
+    input: {
+      type: 'object',
+      properties: {
+        ket: { type: 'string', description: 'Initial structure as Ketcher KET JSON.' },
+        molfile: { type: 'string', description: 'Initial structure as an MDL molfile.' },
+        rxn: { type: 'string', description: 'Initial reaction as an MDL rxnfile.' },
+        smiles: { type: 'string', description: 'Initial structure as a SMILES string.' },
+        filename: {
+          type: 'string',
+          description: 'Optional display filename for the artifact (a .ket extension is enforced).'
+        }
+      }
+    },
+    returns:
+      '`{ "artifact_id": str, "filename": str }` — `artifact_id` identifies the mounted sketcher tile; pass it to set_structure / highlight_atoms / get_structure. When no seed is given the canvas opens blank.',
+    example: 'result = host.mcp("ketcher", "open_sketcher", {"smiles": "CC(=O)OC1=CC=CC=C1C(=O)O"})'
+  },
+  {
+    id: 'set_structure',
+    connector: 'ketcher',
+    description:
+      'Replace the structure on a mounted sketcher canvas. Errors clearly when the artifact_id has no mounted tile (open a sketcher first).',
+    input: {
+      type: 'object',
+      properties: {
+        artifact_id: { type: 'string', description: 'Id returned by open_sketcher.' },
+        ket: { type: 'string', description: 'New structure as Ketcher KET JSON.' },
+        molfile: { type: 'string', description: 'New structure as an MDL molfile.' },
+        smiles: { type: 'string', description: 'New structure as a SMILES string.' }
+      },
+      required: ['artifact_id']
+    },
+    required: ['artifact_id'],
+    returns:
+      '`{ "ok": true }` on success; raises if the tile is not mounted or no structure is given.',
+    example:
+      'result = host.mcp("ketcher", "set_structure", {"artifact_id": "...", "smiles": "c1ccccc1"})'
+  },
+  {
+    id: 'highlight_atoms',
+    connector: 'ketcher',
+    description:
+      'Highlight atoms (and optionally bonds) on a mounted sketcher canvas by their 0-based indices.',
+    input: {
+      type: 'object',
+      properties: {
+        artifact_id: { type: 'string', description: 'Id returned by open_sketcher.' },
+        atoms: {
+          type: 'array',
+          items: { type: 'integer' },
+          description: '0-based atom indices to highlight.'
+        },
+        bonds: {
+          type: 'array',
+          items: { type: 'integer' },
+          description: 'Optional 0-based bond indices to highlight.'
+        },
+        color: { type: 'string', description: 'Optional CSS color (default a light red).' }
+      },
+      required: ['artifact_id', 'atoms']
+    },
+    required: ['artifact_id', 'atoms'],
+    returns: '`{ "ok": true }` on success; raises if the tile is not mounted.',
+    example:
+      'result = host.mcp("ketcher", "highlight_atoms", {"artifact_id": "...", "atoms": [0, 1, 2], "color": "#ffd54f"})'
+  },
+  {
+    id: 'get_structure',
+    connector: 'ketcher',
+    description:
+      'Read the current structure back from a mounted sketcher canvas in the requested format.',
+    input: {
+      type: 'object',
+      properties: {
+        artifact_id: { type: 'string', description: 'Id returned by open_sketcher.' },
+        format: {
+          type: 'string',
+          enum: ['ket', 'molfile', 'smiles'],
+          default: 'ket',
+          description: 'Serialization to return.'
+        }
+      },
+      required: ['artifact_id']
+    },
+    required: ['artifact_id'],
+    returns:
+      '`{ "artifact_id": str, "format": str, "structure": str }` — `structure` is the canvas serialized in `format`. Raises if the tile is not mounted.',
+    example:
+      'result = host.mcp("ketcher", "get_structure", {"artifact_id": "...", "format": "smiles"})'
+  }
+]

--- a/src/main/connectors/registry.ts
+++ b/src/main/connectors/registry.ts
@@ -11,6 +11,7 @@ import { EXPRESSION_TOOLS } from './descriptors/expression'
 import { GENES_TOOLS } from './descriptors/genes'
 import { GENOMES_TOOLS } from './descriptors/genomes'
 import { HUMAN_GENETICS_TOOLS } from './descriptors/human-genetics'
+import { KETCHER_TOOLS } from './descriptors/ketcher'
 import { LITERATURE_TOOLS } from './descriptors/literature'
 import { OMICS_ARCHIVES_TOOLS } from './descriptors/omics-archives'
 import { PROTEIN_ANNOTATION_TOOLS } from './descriptors/protein-annotation'
@@ -37,6 +38,7 @@ const ALL_TOOLS: ToolDescriptor[] = [
   ...GENES_TOOLS,
   ...GENOMES_TOOLS,
   ...HUMAN_GENETICS_TOOLS,
+  ...KETCHER_TOOLS,
   ...LITERATURE_TOOLS,
   ...OMICS_ARCHIVES_TOOLS,
   ...PROTEIN_ANNOTATION_TOOLS,

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -263,4 +263,65 @@ describe('ConnectorService', () => {
       await expect(svc.call('nope', 'do_thing', {})).rejects.toThrow(/not enabled/)
     })
   })
+
+  describe('ketcher app connector', () => {
+    it('runs the gate then diverts an enabled ketcher call to the injected ketcherService', async () => {
+      const call = vi.fn().mockResolvedValue({ artifact_id: 'a:1:x.ket', filename: 'x.ket' })
+      const svc = new ConnectorService({
+        ketcherService: { call },
+        getConnectors: () => ({ enabledIds: [], autoAllowIds: [] }),
+        resolveApiKey: () => undefined
+      })
+      const out = await svc.call('ketcher', 'open_sketcher', { smiles: 'CCO' })
+      expect(out).toEqual({ artifact_id: 'a:1:x.ket', filename: 'x.ket' })
+      expect(call).toHaveBeenCalledWith('open_sketcher', { smiles: 'CCO' })
+    })
+
+    it('rejects a blocked ketcher tool before diverting', async () => {
+      const call = vi.fn()
+      const svc = new ConnectorService({
+        ketcherService: { call },
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          blockedToolIds: ['ketcher/open_sketcher']
+        }),
+        resolveApiKey: () => undefined
+      })
+      await expect(svc.call('ketcher', 'open_sketcher', {})).rejects.toThrow(/blocked by policy/)
+      expect(call).not.toHaveBeenCalled()
+    })
+
+    it('requests approval for an ask-flagged ketcher tool before diverting', async () => {
+      const call = vi.fn().mockResolvedValue({ ok: true })
+      const requestApproval = vi.fn().mockResolvedValue('allow')
+      const svc = new ConnectorService({
+        ketcherService: { call },
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          askToolIds: ['ketcher/set_structure']
+        }),
+        resolveApiKey: () => undefined,
+        requestApproval
+      })
+      await svc.call('ketcher', 'set_structure', { artifact_id: 'a', smiles: 'CCO' })
+      expect(requestApproval).toHaveBeenCalledWith({
+        connector: 'ketcher',
+        method: 'set_structure',
+        args: { artifact_id: 'a', smiles: 'CCO' }
+      })
+      expect(call).toHaveBeenCalled()
+    })
+
+    it('errors when the ketcher runtime is not configured', async () => {
+      const svc = new ConnectorService({
+        getConnectors: () => ({ enabledIds: [], autoAllowIds: [] }),
+        resolveApiKey: () => undefined
+      })
+      await expect(svc.call('ketcher', 'open_sketcher', {})).rejects.toThrow(
+        /ketcher runtime not configured/
+      )
+    })
+  })
 })

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -17,6 +17,9 @@ type McpClientManagerLike = {
 type ConnectorServiceDeps = {
   engine?: ParserEngine
   mcpClientManager?: McpClientManagerLike
+  // The interactive Ketcher app is registered like a bundled connector for settings/policy/skill-doc,
+  // but its calls drive a live renderer tile instead of an HTTP parser — so dispatch is diverted here.
+  ketcherService?: { call(method: string, args: Record<string, unknown>): Promise<unknown> }
   getConnectors: () => StoredConnectors | undefined
   resolveApiKey: (ref?: string) => string | undefined
   // Human approval gate for a tool call that isn't pre-approved. Absent (e.g. in tests) means the
@@ -68,6 +71,13 @@ export class ConnectorService {
       throw new Error(`tool blocked by policy: ${connector}/${method}`)
     }
     await this.ensureApproved(connector, method, args)
+
+    // Ketcher runs the same enabled/blocked/approval gate as any bundled connector, then diverts to the
+    // main-process tool host (it drives a renderer tile and cannot go through the fetch-only engine).
+    if (connector === 'ketcher') {
+      if (!this.deps.ketcherService) throw new Error('ketcher runtime not configured')
+      return this.deps.ketcherService.call(method, args)
+    }
 
     return this.engine.call(descriptor, args, this.credentials())
   }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -15,6 +15,7 @@ import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './connectors/
 import { registerFileSaveHandlers } from './file-save'
 import { registerGithubIpcHandlers } from './github-ipc'
 import { KetcherBroker } from './ketcher/broker'
+import { KetcherService, type KetcherRunContext } from './ketcher/service'
 import { registerLogsIpcHandlers } from './logs-ipc'
 import { registerNotebookIpcHandlers } from './notebook/ipc'
 import { NotebookLocalRpcServer } from './notebook/local-rpc-server'
@@ -25,7 +26,7 @@ import { registerSettingsIpcHandlers } from './settings/ipc'
 import { getAppClaudeConfigDir } from './settings/provider-env'
 import { createDefaultSettingsService, type SettingsService } from './settings/service'
 import type { StoredConnectors } from './settings/types'
-import type { KetcherMountNotice, KetcherReply } from '../shared/ketcher'
+import type { KetcherMountNotice, KetcherReply, KetcherSaveRequest } from '../shared/ketcher'
 import { resolveStorageRoot } from './storage-root'
 import { registerUpdateIpcHandlers } from './update/ipc'
 import { startUpdateScheduler } from './update/scheduler'
@@ -106,13 +107,6 @@ const registerIpcHandlers = ({ mainEntryPath }: IpcRegistrationOptions): void =>
       }
     }
   })
-  const connectorService = new ConnectorService({
-    getConnectors: () => connectorsSnapshot,
-    resolveApiKey: (ref) => tryDecryptKey(ref),
-    mcpClientManager,
-    requestApproval: ({ connector, method, args }) =>
-      approvalBroker.request({ connector, method, argsPreview: previewArgs(args) })
-  })
   // Bridges the main-process Ketcher tool host to live sketcher tiles in the renderer(s): it pushes
   // open/command events and resolves each command when the addressed tile replies.
   const ketcherBroker = new KetcherBroker({
@@ -122,6 +116,22 @@ const registerIpcHandlers = ({ mainEntryPath }: IpcRegistrationOptions): void =>
         if (!window.isDestroyed()) window.webContents.send(channel, payload)
       }
     }
+  })
+  // Resolved after the ACP runtime is created below (it owns the active turn's run context). open_sketcher
+  // reads it to attribute its .ket artifact to the current turn's pending run.
+  let resolveKetcherRunContext: () => KetcherRunContext | undefined = () => undefined
+  const ketcherService = new KetcherService({
+    broker: ketcherBroker,
+    repository: artifactRepository,
+    resolveRunContext: () => resolveKetcherRunContext()
+  })
+  const connectorService = new ConnectorService({
+    getConnectors: () => connectorsSnapshot,
+    resolveApiKey: (ref) => tryDecryptKey(ref),
+    mcpClientManager,
+    ketcherService,
+    requestApproval: ({ connector, method, args }) =>
+      approvalBroker.request({ connector, method, argsPreview: previewArgs(args) })
   })
   const notebookRpcServer = new NotebookLocalRpcServer(notebookService, { connectorService })
   // The RPC server needs the runtime service to dispatch to, and the runtime service needs the RPC
@@ -147,6 +157,9 @@ const registerIpcHandlers = ({ mainEntryPath }: IpcRegistrationOptions): void =>
   ipcMain.handle('ketcher:reply', (_event, reply: KetcherReply) => {
     ketcherBroker.reply(reply)
   })
+  ipcMain.handle('ketcher:save', (_event, request: KetcherSaveRequest) =>
+    ketcherService.save(request.artifactId, request.ket)
+  )
 
   void refreshConnectorSkillDocs(
     settingsService,
@@ -170,6 +183,8 @@ const registerIpcHandlers = ({ mainEntryPath }: IpcRegistrationOptions): void =>
     notebookRpcServer,
     settingsService
   })
+  // The Ketcher tool host resolves the active turn's run through the runtime, now that it exists.
+  resolveKetcherRunContext = () => runtime.getActiveArtifactRunContext()
   // Switching the active provider takes effect on the next reconnect. Defer that reconnect until any
   // in-flight prompt finishes so switching never interrupts a running turn; the shared config dir keeps
   // the conversation's context across the switch.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -14,6 +14,7 @@ import { ConnectorService } from './connectors/service'
 import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './connectors/provision'
 import { registerFileSaveHandlers } from './file-save'
 import { registerGithubIpcHandlers } from './github-ipc'
+import { KetcherBroker } from './ketcher/broker'
 import { registerLogsIpcHandlers } from './logs-ipc'
 import { registerNotebookIpcHandlers } from './notebook/ipc'
 import { NotebookLocalRpcServer } from './notebook/local-rpc-server'
@@ -24,6 +25,7 @@ import { registerSettingsIpcHandlers } from './settings/ipc'
 import { getAppClaudeConfigDir } from './settings/provider-env'
 import { createDefaultSettingsService, type SettingsService } from './settings/service'
 import type { StoredConnectors } from './settings/types'
+import type { KetcherMountNotice, KetcherReply } from '../shared/ketcher'
 import { resolveStorageRoot } from './storage-root'
 import { registerUpdateIpcHandlers } from './update/ipc'
 import { startUpdateScheduler } from './update/scheduler'
@@ -111,6 +113,16 @@ const registerIpcHandlers = ({ mainEntryPath }: IpcRegistrationOptions): void =>
     requestApproval: ({ connector, method, args }) =>
       approvalBroker.request({ connector, method, argsPreview: previewArgs(args) })
   })
+  // Bridges the main-process Ketcher tool host to live sketcher tiles in the renderer(s): it pushes
+  // open/command events and resolves each command when the addressed tile replies.
+  const ketcherBroker = new KetcherBroker({
+    generateId: () => randomUUID(),
+    send: (channel, payload) => {
+      for (const window of BrowserWindow.getAllWindows()) {
+        if (!window.isDestroyed()) window.webContents.send(channel, payload)
+      }
+    }
+  })
   const notebookRpcServer = new NotebookLocalRpcServer(notebookService, { connectorService })
   // The RPC server needs the runtime service to dispatch to, and the runtime service needs the RPC
   // server's (lazily-started) connection for host.mcp() env injection — wire the second half here to
@@ -124,6 +136,17 @@ const registerIpcHandlers = ({ mainEntryPath }: IpcRegistrationOptions): void =>
       approvalBroker.respond(request.id, request.decision)
     }
   )
+
+  // Sketcher tiles report their lifecycle and answer commands through the Ketcher broker.
+  ipcMain.handle('ketcher:mounted', (_event, notice: KetcherMountNotice) => {
+    ketcherBroker.mount(notice.artifactId)
+  })
+  ipcMain.handle('ketcher:unmounted', (_event, notice: KetcherMountNotice) => {
+    ketcherBroker.unmount(notice.artifactId)
+  })
+  ipcMain.handle('ketcher:reply', (_event, reply: KetcherReply) => {
+    ketcherBroker.reply(reply)
+  })
 
   void refreshConnectorSkillDocs(
     settingsService,

--- a/src/main/ketcher/broker.test.ts
+++ b/src/main/ketcher/broker.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { KetcherBroker } from './broker'
+
+// Builds a broker with a captured send spy and manual timers so timeouts are deterministic.
+const createBroker = (options?: {
+  timeoutMs?: number
+  mountTimeoutMs?: number
+}): {
+  broker: KetcherBroker
+  send: ReturnType<typeof vi.fn>
+  fireTimers: () => void
+} => {
+  const send = vi.fn()
+  let nextId = 0
+  const timers = new Map<number, () => void>()
+  let timerSeq = 0
+
+  const broker = new KetcherBroker({
+    send,
+    generateId: () => `req-${++nextId}`,
+    timeoutMs: options?.timeoutMs ?? 1000,
+    mountTimeoutMs: options?.mountTimeoutMs ?? 1000,
+    setTimer: (fn) => {
+      const handle = ++timerSeq
+      timers.set(handle, fn)
+      return handle as unknown as ReturnType<typeof setTimeout>
+    },
+    clearTimer: (handle) => {
+      timers.delete(handle as unknown as number)
+    }
+  })
+
+  // Fires every armed timer, simulating the deadline elapsing.
+  const fireTimers = (): void => {
+    for (const [handle, fn] of [...timers.entries()]) {
+      timers.delete(handle)
+      fn()
+    }
+  }
+
+  return { broker, send, fireTimers }
+}
+
+describe('KetcherBroker', () => {
+  it('rejects a command when no tile is mounted', async () => {
+    const { broker, send } = createBroker()
+
+    await expect(broker.dispatch('art-1', 'set', { ket: '{}' })).rejects.toThrow(/not mounted/)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('sends a command to a mounted tile and resolves with its reply', async () => {
+    const { broker, send } = createBroker()
+    broker.mount('art-1')
+
+    const pending = broker.dispatch('art-1', 'get', { format: 'smiles' })
+
+    expect(send).toHaveBeenCalledWith('ketcher:command', {
+      requestId: 'req-1',
+      artifactId: 'art-1',
+      op: 'get',
+      payload: { format: 'smiles' }
+    })
+
+    broker.reply({ requestId: 'req-1', result: 'CCO' })
+    await expect(pending).resolves.toBe('CCO')
+  })
+
+  it('rejects a command whose reply carries an error', async () => {
+    const { broker } = createBroker()
+    broker.mount('art-1')
+
+    const pending = broker.dispatch('art-1', 'set', { ket: 'bad' })
+    broker.reply({ requestId: 'req-1', error: 'parse failed' })
+
+    await expect(pending).rejects.toThrow(/parse failed/)
+  })
+
+  it('rejects a command that is never answered before the timeout', async () => {
+    const { broker, fireTimers } = createBroker()
+    broker.mount('art-1')
+
+    const pending = broker.dispatch('art-1', 'highlight', { atoms: [0] })
+    fireTimers()
+
+    await expect(pending).rejects.toThrow(/timed out/)
+    // A late reply after timeout is ignored (no unhandled rejection).
+    broker.reply({ requestId: 'req-1', result: 'late' })
+  })
+
+  it('isMounted reflects mount/unmount', () => {
+    const { broker } = createBroker()
+    expect(broker.isMounted('art-1')).toBe(false)
+    broker.mount('art-1')
+    expect(broker.isMounted('art-1')).toBe(true)
+    broker.unmount('art-1')
+    expect(broker.isMounted('art-1')).toBe(false)
+  })
+
+  it('waitForMount resolves immediately when already mounted', async () => {
+    const { broker } = createBroker()
+    broker.mount('art-1')
+    await expect(broker.waitForMount('art-1')).resolves.toBeUndefined()
+  })
+
+  it('waitForMount resolves once the tile mounts', async () => {
+    const { broker } = createBroker()
+    const pending = broker.waitForMount('art-1')
+    broker.mount('art-1')
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it('waitForMount rejects when the tile never mounts', async () => {
+    const { broker, fireTimers } = createBroker()
+    const pending = broker.waitForMount('art-1')
+    fireTimers()
+    await expect(pending).rejects.toThrow(/did not mount/)
+  })
+
+  it('openTile pushes a ketcher:open event', () => {
+    const { broker, send } = createBroker()
+    broker.openTile({
+      artifactId: 'art-1',
+      sessionId: 's-1',
+      path: '/tmp/a.ket',
+      name: 'a.ket',
+      content: ''
+    })
+    expect(send).toHaveBeenCalledWith('ketcher:open', {
+      artifactId: 'art-1',
+      sessionId: 's-1',
+      path: '/tmp/a.ket',
+      name: 'a.ket',
+      content: ''
+    })
+  })
+})

--- a/src/main/ketcher/broker.ts
+++ b/src/main/ketcher/broker.ts
@@ -1,0 +1,142 @@
+import type {
+  KetcherCommandOp,
+  KetcherCommandPayload,
+  KetcherOpenTile,
+  KetcherReply
+} from '../../shared/ketcher'
+
+type KetcherBrokerDeps = {
+  // Sends one payload to the renderer(s) that host sketcher tiles (main -> renderer push).
+  send: (channel: string, payload: unknown) => void
+  // Injectable so tests are deterministic; defaults to crypto.randomUUID in the factory below.
+  generateId: () => string
+  // How long a dispatched command waits for the tile's reply before it is rejected.
+  timeoutMs?: number
+  // How long open_sketcher waits for a freshly-opened tile to announce it mounted.
+  mountTimeoutMs?: number
+  // Injectable timers for tests.
+  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void
+}
+
+type PendingCommand = {
+  resolve: (result: unknown) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+type MountWaiter = {
+  resolve: () => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+// Bridges the main-process Ketcher tool host to live renderer tiles, modelled on ApprovalBroker: it
+// tracks which artifacts have a mounted tile, holds a dispatched command open until the tile replies
+// (rejecting on timeout so a tool call never hangs the kernel), and lets open_sketcher wait for a tile
+// to mount before it returns.
+export class KetcherBroker {
+  private readonly pending = new Map<string, PendingCommand>()
+  private readonly mounted = new Set<string>()
+  private readonly mountWaiters = new Map<string, MountWaiter[]>()
+  private readonly timeoutMs: number
+  private readonly mountTimeoutMs: number
+  private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
+
+  constructor(private readonly deps: KetcherBrokerDeps) {
+    this.timeoutMs = deps.timeoutMs ?? 30_000
+    this.mountTimeoutMs = deps.mountTimeoutMs ?? 15_000
+    this.setTimer = deps.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
+    this.clearTimer = deps.clearTimer ?? ((h) => clearTimeout(h))
+  }
+
+  // Records a tile as mounted and releases any open_sketcher call waiting for it.
+  mount(artifactId: string): void {
+    this.mounted.add(artifactId)
+
+    const waiters = this.mountWaiters.get(artifactId)
+    if (!waiters) return
+
+    this.mountWaiters.delete(artifactId)
+    for (const waiter of waiters) {
+      this.clearTimer(waiter.timer)
+      waiter.resolve()
+    }
+  }
+
+  // Forgets a tile that unmounted so later commands fail fast with "tile not mounted".
+  unmount(artifactId: string): void {
+    this.mounted.delete(artifactId)
+  }
+
+  isMounted(artifactId: string): boolean {
+    return this.mounted.has(artifactId)
+  }
+
+  // Asks the renderer to open (or refocus) an editable tile for a freshly written artifact.
+  openTile(payload: KetcherOpenTile): void {
+    this.deps.send('ketcher:open', payload)
+  }
+
+  // Resolves once a tile for the artifact is mounted (immediately if it already is), or rejects on timeout.
+  waitForMount(artifactId: string): Promise<void> {
+    if (this.mounted.has(artifactId)) return Promise.resolve()
+
+    return new Promise<void>((resolve, reject) => {
+      const timer = this.setTimer(() => {
+        this.removeMountWaiter(artifactId, waiter)
+        reject(new Error(`Ketcher tile did not mount: ${artifactId}`))
+      }, this.mountTimeoutMs)
+      const waiter: MountWaiter = { resolve, reject, timer }
+      const waiters = this.mountWaiters.get(artifactId) ?? []
+      waiters.push(waiter)
+      this.mountWaiters.set(artifactId, waiters)
+    })
+  }
+
+  // Sends one imperative command to the mounted tile and resolves with its reply (or rejects on timeout).
+  dispatch(
+    artifactId: string,
+    op: KetcherCommandOp,
+    payload: KetcherCommandPayload
+  ): Promise<unknown> {
+    if (!this.mounted.has(artifactId)) {
+      return Promise.reject(
+        new Error(`Ketcher tile not mounted for artifact ${artifactId}. Open a sketcher first.`)
+      )
+    }
+
+    const requestId = this.deps.generateId()
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = this.setTimer(() => {
+        this.pending.delete(requestId)
+        reject(new Error(`Ketcher command timed out: ${op} on ${artifactId}`))
+      }, this.timeoutMs)
+      this.pending.set(requestId, { resolve, reject, timer })
+      this.deps.send('ketcher:command', { requestId, artifactId, op, payload })
+    })
+  }
+
+  // Called from the IPC handler when a tile answers a command. Unknown ids are ignored (already settled).
+  reply(reply: KetcherReply): void {
+    const entry = this.pending.get(reply.requestId)
+    if (!entry) return
+
+    this.clearTimer(entry.timer)
+    this.pending.delete(reply.requestId)
+
+    if (reply.error) entry.reject(new Error(reply.error))
+    else entry.resolve(reply.result)
+  }
+
+  private removeMountWaiter(artifactId: string, waiter: MountWaiter): void {
+    const waiters = this.mountWaiters.get(artifactId)
+    if (!waiters) return
+
+    const next = waiters.filter((candidate) => candidate !== waiter)
+    if (next.length === 0) this.mountWaiters.delete(artifactId)
+    else this.mountWaiters.set(artifactId, next)
+  }
+}

--- a/src/main/ketcher/service.test.ts
+++ b/src/main/ketcher/service.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import type { ArtifactRepository } from '../artifacts/repository'
+import type { KetcherBroker } from './broker'
+import { KetcherService, type KetcherRunContext } from './service'
+
+// A minimal broker double: records openTile/dispatch calls and lets each test choose mount/reply results.
+const createBroker = (
+  overrides?: Partial<KetcherBroker>
+): {
+  broker: KetcherBroker
+  openTile: ReturnType<typeof vi.fn>
+  dispatch: ReturnType<typeof vi.fn>
+  waitForMount: ReturnType<typeof vi.fn>
+} => {
+  const openTile = vi.fn()
+  const dispatch = vi.fn().mockResolvedValue(undefined)
+  const waitForMount = vi.fn().mockResolvedValue(undefined)
+  const broker = { openTile, dispatch, waitForMount, ...overrides } as unknown as KetcherBroker
+  return { broker, openTile, dispatch, waitForMount }
+}
+
+const runContext: KetcherRunContext = {
+  projectName: 'proj',
+  sessionId: 'session-app',
+  artifactSessionId: 'session-art',
+  runId: 'run-1'
+}
+
+// A repository double that echoes a deterministic ArtifactFile for writePendingFile.
+const createRepository = (
+  writePendingFile = vi.fn()
+): { repository: ArtifactRepository; writePendingFile: ReturnType<typeof vi.fn> } => {
+  writePendingFile.mockImplementation(async (request: { filename: string }) => ({
+    id: `session-art:run-1:${request.filename}`,
+    path: `/artifacts/${request.filename}`,
+    name: request.filename
+  }))
+  return { repository: { writePendingFile } as unknown as ArtifactRepository, writePendingFile }
+}
+
+describe('KetcherService', () => {
+  it('open_sketcher writes a .ket artifact, opens a tile, and returns the id + filename', async () => {
+    const { broker, openTile, waitForMount } = createBroker()
+    const { repository, writePendingFile } = createRepository()
+    const service = new KetcherService({
+      broker,
+      repository,
+      resolveRunContext: () => runContext
+    })
+
+    const out = await service.call('open_sketcher', { smiles: 'CCO', filename: 'aspirin' })
+
+    expect(out).toEqual({ artifact_id: 'session-art:run-1:aspirin.ket', filename: 'aspirin.ket' })
+    expect(writePendingFile).toHaveBeenCalledWith({
+      projectName: 'proj',
+      sessionId: 'session-art',
+      runId: 'run-1',
+      filename: 'aspirin.ket',
+      source: { kind: 'inline', content: 'CCO', encoding: 'utf8' }
+    })
+    expect(openTile).toHaveBeenCalledWith({
+      artifactId: 'session-art:run-1:aspirin.ket',
+      sessionId: 'session-app',
+      path: '/artifacts/aspirin.ket',
+      name: 'aspirin.ket',
+      content: 'CCO'
+    })
+    expect(waitForMount).toHaveBeenCalledWith('session-art:run-1:aspirin.ket')
+  })
+
+  it('open_sketcher errors when no artifact run is active', async () => {
+    const { broker } = createBroker()
+    const { repository } = createRepository()
+    const service = new KetcherService({ broker, repository, resolveRunContext: () => undefined })
+
+    await expect(service.call('open_sketcher', {})).rejects.toThrow(/active agent turn/)
+  })
+
+  it('open_sketcher defaults a blank canvas and a generated filename', async () => {
+    const { broker, openTile } = createBroker()
+    const { repository } = createRepository()
+    const service = new KetcherService({ broker, repository, resolveRunContext: () => runContext })
+
+    const out = (await service.call('open_sketcher', {})) as { filename: string }
+    expect(out.filename).toBe('sketch-1.ket')
+    expect(openTile.mock.calls[0][0].content).toBe('')
+  })
+
+  it('set_structure dispatches to the mounted tile', async () => {
+    const { broker, dispatch } = createBroker()
+    const { repository } = createRepository()
+    const service = new KetcherService({ broker, repository, resolveRunContext: () => runContext })
+
+    const out = await service.call('set_structure', { artifact_id: 'a', smiles: 'c1ccccc1' })
+    expect(out).toEqual({ ok: true })
+    expect(dispatch).toHaveBeenCalledWith('a', 'set', {
+      ket: undefined,
+      molfile: undefined,
+      smiles: 'c1ccccc1'
+    })
+  })
+
+  it('set_structure rejects when no structure is supplied', async () => {
+    const { broker } = createBroker()
+    const { repository } = createRepository()
+    const service = new KetcherService({ broker, repository, resolveRunContext: () => runContext })
+
+    await expect(service.call('set_structure', { artifact_id: 'a' })).rejects.toThrow(
+      /requires one of ket, molfile, or smiles/
+    )
+  })
+
+  it('set_structure requires an artifact_id', async () => {
+    const { broker } = createBroker()
+    const { repository } = createRepository()
+    const service = new KetcherService({ broker, repository, resolveRunContext: () => runContext })
+
+    await expect(service.call('set_structure', { smiles: 'CCO' })).rejects.toThrow(
+      /artifact_id is required/
+    )
+  })
+
+  it('highlight_atoms coerces indices and dispatches highlight', async () => {
+    const { broker, dispatch } = createBroker()
+    const { repository } = createRepository()
+    const service = new KetcherService({ broker, repository, resolveRunContext: () => runContext })
+
+    await service.call('highlight_atoms', { artifact_id: 'a', atoms: [0, 1], color: '#abc' })
+    expect(dispatch).toHaveBeenCalledWith('a', 'highlight', {
+      atoms: [0, 1],
+      bonds: undefined,
+      color: '#abc'
+    })
+  })
+
+  it('highlight_atoms rejects a non-array atoms argument', async () => {
+    const { broker } = createBroker()
+    const { repository } = createRepository()
+    const service = new KetcherService({ broker, repository, resolveRunContext: () => runContext })
+
+    await expect(service.call('highlight_atoms', { artifact_id: 'a', atoms: 3 })).rejects.toThrow(
+      /atoms must be an array/
+    )
+  })
+
+  it('get_structure returns the tile reply in the requested format', async () => {
+    const dispatch = vi.fn().mockResolvedValue('CCO')
+    const { broker } = createBroker({ dispatch } as Partial<KetcherBroker>)
+    const { repository } = createRepository()
+    const service = new KetcherService({ broker, repository, resolveRunContext: () => runContext })
+
+    const out = await service.call('get_structure', { artifact_id: 'a', format: 'smiles' })
+    expect(out).toEqual({ artifact_id: 'a', format: 'smiles', structure: 'CCO' })
+    expect(dispatch).toHaveBeenCalledWith('a', 'get', { format: 'smiles' })
+  })
+
+  it('get_structure defaults to ket and rejects an unknown format', async () => {
+    const dispatch = vi.fn().mockResolvedValue('{}')
+    const { broker } = createBroker({ dispatch } as Partial<KetcherBroker>)
+    const { repository } = createRepository()
+    const service = new KetcherService({ broker, repository, resolveRunContext: () => runContext })
+
+    const out = await service.call('get_structure', { artifact_id: 'a' })
+    expect(out).toEqual({ artifact_id: 'a', format: 'ket', structure: '{}' })
+    await expect(
+      service.call('get_structure', { artifact_id: 'a', format: 'inchi' })
+    ).rejects.toThrow(/format must be one of/)
+  })
+
+  it('rejects an unknown method', async () => {
+    const { broker } = createBroker()
+    const { repository } = createRepository()
+    const service = new KetcherService({ broker, repository, resolveRunContext: () => runContext })
+
+    await expect(service.call('nope', {})).rejects.toThrow(/unknown tool: ketcher\/nope/)
+  })
+
+  it('save writes the current ket back to a tracked artifact path', async () => {
+    const { broker } = createBroker()
+    const { repository } = createRepository()
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+    const service = new KetcherService({
+      broker,
+      repository,
+      resolveRunContext: () => runContext,
+      writeFile
+    })
+
+    const opened = (await service.call('open_sketcher', { filename: 'm.ket' })) as {
+      artifact_id: string
+    }
+    await service.save(opened.artifact_id, '{"root":{}}')
+    expect(writeFile).toHaveBeenCalledWith('/artifacts/m.ket', '{"root":{}}')
+
+    // An unknown artifact id is a no-op (nothing tracked, no throw).
+    await service.save('unknown', 'x')
+    expect(writeFile).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ketcher/service.test.ts
+++ b/src/main/ketcher/service.test.ts
@@ -30,13 +30,22 @@ const runContext: KetcherRunContext = {
 // A repository double that echoes a deterministic ArtifactFile for writePendingFile.
 const createRepository = (
   writePendingFile = vi.fn()
-): { repository: ArtifactRepository; writePendingFile: ReturnType<typeof vi.fn> } => {
+): {
+  repository: ArtifactRepository
+  writePendingFile: ReturnType<typeof vi.fn>
+  resolveManagedFilePath: ReturnType<typeof vi.fn>
+} => {
   writePendingFile.mockImplementation(async (request: { filename: string }) => ({
     id: `session-art:run-1:${request.filename}`,
     path: `/artifacts/${request.filename}`,
     name: request.filename
   }))
-  return { repository: { writePendingFile } as unknown as ArtifactRepository, writePendingFile }
+  const resolveManagedFilePath = vi.fn()
+  return {
+    repository: { writePendingFile, resolveManagedFilePath } as unknown as ArtifactRepository,
+    writePendingFile,
+    resolveManagedFilePath
+  }
 }
 
 describe('KetcherService', () => {
@@ -196,5 +205,30 @@ describe('KetcherService', () => {
     // An unknown artifact id is a no-op (nothing tracked, no throw).
     await service.save('unknown', 'x')
     expect(writeFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('save recovers the finalized path when the pending file has moved', async () => {
+    const { broker } = createBroker()
+    const { repository, resolveManagedFilePath } = createRepository()
+    resolveManagedFilePath.mockResolvedValue('/artifacts/message/m.ket')
+    const enoent = Object.assign(new Error('missing'), { code: 'ENOENT' })
+    const writeFile = vi.fn().mockRejectedValueOnce(enoent).mockResolvedValue(undefined)
+    const service = new KetcherService({
+      broker,
+      repository,
+      resolveRunContext: () => runContext,
+      writeFile
+    })
+
+    const opened = (await service.call('open_sketcher', { filename: 'm.ket' })) as {
+      artifact_id: string
+    }
+    await service.save(opened.artifact_id, '{"root":{}}')
+
+    expect(resolveManagedFilePath).toHaveBeenCalledWith({ path: '/artifacts/m.ket' })
+    expect(writeFile).toHaveBeenLastCalledWith('/artifacts/message/m.ket', '{"root":{}}')
+    // The recovered path is remembered so the next save goes straight there.
+    await service.save(opened.artifact_id, '{"root":{"x":1}}')
+    expect(resolveManagedFilePath).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/ketcher/service.ts
+++ b/src/main/ketcher/service.ts
@@ -1,0 +1,168 @@
+import { writeFile } from 'node:fs/promises'
+
+import type { ArtifactRepository } from '../artifacts/repository'
+import type { KetcherStructureFormat } from '../../shared/ketcher'
+import type { KetcherBroker } from './broker'
+
+// The active turn's artifact run, resolved from the ACP runtime so open_sketcher can write its .ket into
+// the same pending run (host.mcp calls carry no session context of their own).
+export type KetcherRunContext = {
+  projectName: string
+  sessionId: string
+  artifactSessionId: string
+  runId: string
+}
+
+type KetcherServiceDeps = {
+  broker: KetcherBroker
+  repository: ArtifactRepository
+  // Returns the active turn's run context, or undefined between turns (then open_sketcher errors).
+  resolveRunContext: () => KetcherRunContext | undefined
+  // Injectable for tests; defaults to fs.writeFile for the throttled tile-edit persistence path.
+  writeFile?: (path: string, data: string) => Promise<void>
+}
+
+const STRUCTURE_FORMATS: KetcherStructureFormat[] = ['ket', 'molfile', 'smiles']
+
+// Narrows an optional string argument, rejecting a present-but-wrong-typed value.
+const optionalString = (value: unknown, field: string): string | undefined => {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'string') throw new Error(`${field} must be a string`)
+  return value
+}
+
+const requireString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${field} is required`)
+  }
+  return value
+}
+
+// Coerces the atoms/bonds arrays into integer index lists, rejecting non-numeric members.
+const indexList = (value: unknown, field: string): number[] => {
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array of integers`)
+  return value.map((item) => {
+    const n = Number(item)
+    if (!Number.isInteger(n)) throw new Error(`${field} must contain integers`)
+    return n
+  })
+}
+
+// Ensures a display filename is a plain, safe-looking .ket name (the repository does the final check).
+const normalizeFilename = (filename: string | undefined, sequence: number): string => {
+  const base = (filename ?? '').trim() || `sketch-${sequence}.ket`
+  const withExt = base.toLowerCase().endsWith('.ket') ? base : `${base}.ket`
+  // Keep only the last path segment so a stray slash can never widen the artifact write target.
+  return withExt.split(/[\\/]/).pop() ?? `sketch-${sequence}.ket`
+}
+
+// Main-process host for the four interactive Ketcher tools. It writes the .ket artifact, mounts a live
+// sketcher tile via the broker, and forwards set/highlight/get commands to that tile. Registered in the
+// connector registry but dispatched here (not via ParserEngine) — see ConnectorService.callBundled.
+export class KetcherService {
+  // Tracks each open artifact's on-disk path so throttled tile edits can be persisted back to it.
+  private readonly files = new Map<string, { path: string }>()
+  private sequence = 0
+  private readonly writeFileImpl: (path: string, data: string) => Promise<void>
+
+  constructor(private readonly deps: KetcherServiceDeps) {
+    this.writeFileImpl = deps.writeFile ?? ((path, data) => writeFile(path, data, 'utf8'))
+  }
+
+  async call(method: string, args: Record<string, unknown>): Promise<unknown> {
+    switch (method) {
+      case 'open_sketcher':
+        return this.openSketcher(args)
+      case 'set_structure':
+        return this.setStructure(args)
+      case 'highlight_atoms':
+        return this.highlightAtoms(args)
+      case 'get_structure':
+        return this.getStructure(args)
+      default:
+        throw new Error(`unknown tool: ketcher/${method}`)
+    }
+  }
+
+  // Persists a mounted tile's current structure back to its .ket artifact (best-effort, throttled).
+  async save(artifactId: string, ket: string): Promise<void> {
+    const entry = this.files.get(artifactId)
+    if (!entry) return
+    await this.writeFileImpl(entry.path, ket)
+  }
+
+  private async openSketcher(args: Record<string, unknown>): Promise<unknown> {
+    const ket = optionalString(args.ket, 'ket')
+    const molfile = optionalString(args.molfile, 'molfile')
+    const rxn = optionalString(args.rxn, 'rxn')
+    const smiles = optionalString(args.smiles, 'smiles')
+    const seed = ket ?? molfile ?? rxn ?? smiles ?? ''
+
+    const runContext = this.deps.resolveRunContext()
+    if (!runContext) {
+      throw new Error(
+        'open_sketcher must be called during an active agent turn (no artifact run is active).'
+      )
+    }
+
+    this.sequence += 1
+    const filename = normalizeFilename(optionalString(args.filename, 'filename'), this.sequence)
+
+    const artifact = await this.deps.repository.writePendingFile({
+      projectName: runContext.projectName,
+      sessionId: runContext.artifactSessionId,
+      runId: runContext.runId,
+      filename,
+      source: { kind: 'inline', content: seed, encoding: 'utf8' }
+    })
+
+    this.files.set(artifact.id, { path: artifact.path })
+    this.deps.broker.openTile({
+      artifactId: artifact.id,
+      sessionId: runContext.sessionId,
+      path: artifact.path,
+      name: filename,
+      content: seed
+    })
+    // Wait for the tile to mount so a follow-up set/highlight/get finds it; the seed is already on disk,
+    // so a slow mount is not fatal — the tool still returns the artifact id.
+    await this.deps.broker.waitForMount(artifact.id).catch(() => undefined)
+
+    return { artifact_id: artifact.id, filename }
+  }
+
+  private async setStructure(args: Record<string, unknown>): Promise<unknown> {
+    const artifactId = requireString(args.artifact_id, 'artifact_id')
+    const ket = optionalString(args.ket, 'ket')
+    const molfile = optionalString(args.molfile, 'molfile')
+    const smiles = optionalString(args.smiles, 'smiles')
+
+    if (ket === undefined && molfile === undefined && smiles === undefined) {
+      throw new Error('set_structure requires one of ket, molfile, or smiles')
+    }
+
+    await this.deps.broker.dispatch(artifactId, 'set', { ket, molfile, smiles })
+    return { ok: true }
+  }
+
+  private async highlightAtoms(args: Record<string, unknown>): Promise<unknown> {
+    const artifactId = requireString(args.artifact_id, 'artifact_id')
+    const atoms = indexList(args.atoms, 'atoms')
+    const bonds = args.bonds === undefined ? undefined : indexList(args.bonds, 'bonds')
+    const color = optionalString(args.color, 'color')
+
+    await this.deps.broker.dispatch(artifactId, 'highlight', { atoms, bonds, color })
+    return { ok: true }
+  }
+
+  private async getStructure(args: Record<string, unknown>): Promise<unknown> {
+    const artifactId = requireString(args.artifact_id, 'artifact_id')
+    const format = (optionalString(args.format, 'format') ?? 'ket') as KetcherStructureFormat
+    if (!STRUCTURE_FORMATS.includes(format)) {
+      throw new Error(`format must be one of ${STRUCTURE_FORMATS.join(', ')}`)
+    }
+
+    const result = await this.deps.broker.dispatch(artifactId, 'get', { format })
+    return { artifact_id: artifactId, format, structure: String(result ?? '') }
+  }
+}

--- a/src/main/ketcher/service.ts
+++ b/src/main/ketcher/service.ts
@@ -24,6 +24,13 @@ type KetcherServiceDeps = {
 
 const STRUCTURE_FORMATS: KetcherStructureFormat[] = ['ket', 'molfile', 'smiles']
 
+// Treats a missing file as the finalize-move case so save can recover the artifact's new path.
+const isMissingFileError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: unknown }).code === 'ENOENT'
+
 // Narrows an optional string argument, rejecting a present-but-wrong-typed value.
 const optionalString = (value: unknown, field: string): string | undefined => {
   if (value === undefined || value === null) return undefined
@@ -85,10 +92,21 @@ export class KetcherService {
   }
 
   // Persists a mounted tile's current structure back to its .ket artifact (best-effort, throttled).
+  // After a turn ends the pending file is finalized into the message directory, so a stale tracked path
+  // is re-resolved (and remembered) through the repository's pending->message recovery before writing.
   async save(artifactId: string, ket: string): Promise<void> {
     const entry = this.files.get(artifactId)
     if (!entry) return
-    await this.writeFileImpl(entry.path, ket)
+
+    try {
+      await this.writeFileImpl(entry.path, ket)
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+
+      const recovered = await this.deps.repository.resolveManagedFilePath({ path: entry.path })
+      this.files.set(artifactId, { path: recovered })
+      await this.writeFileImpl(recovered, ket)
+    }
   }
 
   private async openSketcher(args: Record<string, unknown>): Promise<unknown> {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -23,6 +23,13 @@ import type {
   ReadArtifactPreviewRequest
 } from '../shared/artifacts'
 import type { SaveBlobFileRequest, SaveBlobFileResult } from '../shared/file-save'
+import type {
+  KetcherCommand,
+  KetcherMountNotice,
+  KetcherOpenTile,
+  KetcherReply,
+  KetcherSaveRequest
+} from '../shared/ketcher'
 import type { OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
 import type {
   AppendNotebookCodeCellRequest,
@@ -254,6 +261,14 @@ interface OpenScienceAPI {
     shutdown(request: NotebookSessionRequest): Promise<{ sessionId: string; status: 'shutdown' }>
     onAvailable(listener: AcpListener<NotebookAvailableEvent>): RemoveListener
     onChanged(listener: AcpListener<NotebookChangedEvent>): RemoveListener
+  }
+  ketcher: {
+    onCommand(listener: AcpListener<KetcherCommand>): RemoveListener
+    onOpen(listener: AcpListener<KetcherOpenTile>): RemoveListener
+    reply(reply: KetcherReply): Promise<void>
+    notifyMounted(notice: KetcherMountNotice): Promise<void>
+    notifyUnmounted(notice: KetcherMountNotice): Promise<void>
+    save(request: KetcherSaveRequest): Promise<void>
   }
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -25,6 +25,13 @@ import type {
   ReadArtifactPreviewRequest
 } from '../shared/artifacts'
 import type { SaveBlobFileRequest, SaveBlobFileResult } from '../shared/file-save'
+import type {
+  KetcherCommand,
+  KetcherMountNotice,
+  KetcherOpenTile,
+  KetcherReply,
+  KetcherSaveRequest
+} from '../shared/ketcher'
 import type { OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
 import type {
   AppendNotebookCodeCellRequest,
@@ -277,6 +284,14 @@ type OpenScienceAPI = {
     onAvailable: (listener: AcpListener<NotebookAvailableEvent>) => RemoveListener
     onChanged: (listener: AcpListener<NotebookChangedEvent>) => RemoveListener
   }
+  ketcher: {
+    onCommand: (listener: AcpListener<KetcherCommand>) => RemoveListener
+    onOpen: (listener: AcpListener<KetcherOpenTile>) => RemoveListener
+    reply: (reply: KetcherReply) => Promise<void>
+    notifyMounted: (notice: KetcherMountNotice) => Promise<void>
+    notifyUnmounted: (notice: KetcherMountNotice) => Promise<void>
+    save: (request: KetcherSaveRequest) => Promise<void>
+  }
 }
 
 // Exposes the small, typed bridge surface available to renderer code.
@@ -501,6 +516,19 @@ const api: OpenScienceAPI = {
       }>,
     onAvailable: (listener) => onIpcMessage('notebook:available', listener),
     onChanged: (listener) => onIpcMessage('notebook:changed', listener)
+  },
+  ketcher: {
+    // Main pushes imperative canvas commands and tile-open requests; the tile pushes back replies and
+    // mount/save notices. Kept behind the preload bridge so renderer code never touches raw IPC.
+    onCommand: (listener: AcpListener<KetcherCommand>) => onIpcMessage('ketcher:command', listener),
+    onOpen: (listener: AcpListener<KetcherOpenTile>) => onIpcMessage('ketcher:open', listener),
+    reply: (reply: KetcherReply) => ipcRenderer.invoke('ketcher:reply', reply) as Promise<void>,
+    notifyMounted: (notice: KetcherMountNotice) =>
+      ipcRenderer.invoke('ketcher:mounted', notice) as Promise<void>,
+    notifyUnmounted: (notice: KetcherMountNotice) =>
+      ipcRenderer.invoke('ketcher:unmounted', notice) as Promise<void>,
+    save: (request: KetcherSaveRequest) =>
+      ipcRenderer.invoke('ketcher:save', request) as Promise<void>
   }
 }
 

--- a/src/renderer/src/lib/node-globals-shim.ts
+++ b/src/renderer/src/lib/node-globals-shim.ts
@@ -1,0 +1,25 @@
+// Ketcher's dependencies (util / assert polyfills, indigo helpers) reference the Node globals
+// `process` and `global`, which don't exist in the sandboxed Electron renderer. Provide a minimal
+// shim so those modules load in the browser context. Imported first in the renderer entry so the
+// globals exist before any lazy Ketcher chunk is fetched.
+const globalScope = globalThis as unknown as Record<string, unknown>
+
+if (typeof globalScope.global === 'undefined') {
+  globalScope.global = globalThis
+}
+
+if (typeof globalScope.process === 'undefined') {
+  globalScope.process = {
+    env: {},
+    argv: [],
+    version: '',
+    versions: {},
+    platform: 'browser',
+    browser: true,
+    nextTick: (callback: (...args: unknown[]) => void, ...args: unknown[]) =>
+      queueMicrotask(() => callback(...args)),
+    cwd: () => '/',
+    stderr: {},
+    stdout: {}
+  }
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,3 +1,5 @@
+// Node-global shim (process/global) must run before any lazy Ketcher chunk loads.
+import './lib/node-globals-shim'
 import './assets/main.css'
 
 import { StrictMode } from 'react'

--- a/src/renderer/src/pages/workspace/KetcherTile.tsx
+++ b/src/renderer/src/pages/workspace/KetcherTile.tsx
@@ -1,0 +1,174 @@
+import { FlaskConical } from 'lucide-react'
+import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react'
+import type { Ketcher } from 'ketcher-core'
+
+import type { PreviewToolItem } from '@/stores/preview-workbench-store'
+
+import { PreviewLoadingContent } from './previews/PreviewFallback'
+import {
+  registerKetcherTile,
+  unregisterKetcherTile,
+  type KetcherTileHandle
+} from './ketcher-tile-bridge'
+import type {
+  KetcherHighlightPayload,
+  KetcherSetPayload,
+  KetcherStructureFormat
+} from '../../../../shared/ketcher'
+
+export type KetcherPreviewItem = PreviewToolItem & {
+  toolKind: 'ketcher'
+  ketcher: NonNullable<PreviewToolItem['ketcher']>
+}
+
+// Throttle window for persisting canvas edits back to the .ket artifact — long enough to coalesce a
+// burst of drawing actions, short enough that a read-back after editing sees the latest structure.
+const SAVE_THROTTLE_MS = 800
+
+// Loads the Ketcher react editor + standalone WASM Indigo backend only when a sketcher tile mounts,
+// mirroring KetcherPreview's lazy import so the heavy bundle never enters the main chunk.
+const KetcherEditor = lazy(async () => {
+  const [{ Editor }, { StandaloneStructServiceProvider }] = await Promise.all([
+    import('ketcher-react'),
+    import('ketcher-standalone')
+  ])
+  await import('ketcher-react/dist/index.css')
+
+  const structServiceProvider = new StandaloneStructServiceProvider()
+
+  const Canvas = ({
+    content,
+    onReady
+  }: {
+    content: string
+    onReady: (ketcher: Ketcher) => void
+  }): React.JSX.Element => (
+    <Editor
+      staticResourcesUrl=""
+      structServiceProvider={structServiceProvider}
+      errorHandler={(message) => console.error('Ketcher tile error', message)}
+      onInit={(ketcher) => {
+        // Seed the canvas from the artifact; Ketcher auto-detects ket/molfile/rxn/SMILES from the text.
+        if (content.trim().length > 0) void ketcher.setMolecule(content)
+        onReady(ketcher)
+      }}
+    />
+  )
+
+  return { default: Canvas }
+})
+
+// The Ketcher public type exposes the micro-editor as an opaque `editor`; these are the loosely-typed
+// internals (canvas render tree, action dispatch, change stream) the tile needs to drive and observe it.
+type MicroEditor = {
+  render: { ctab: unknown }
+  update: (action: unknown) => void
+  subscribe: (event: string, handler: () => void) => unknown
+  unsubscribe: (event: string, handler: unknown) => void
+}
+
+const microEditor = (ketcher: Ketcher): MicroEditor => ketcher.editor as unknown as MicroEditor
+
+// Renders one atom/bond highlight on the mounted canvas via Ketcher's editor action.
+const applyHighlight = async (
+  ketcher: Ketcher,
+  payload: KetcherHighlightPayload
+): Promise<void> => {
+  const { fromHighlightCreate } = await import('ketcher-core')
+  const editor = microEditor(ketcher)
+  const action = fromHighlightCreate(editor.render.ctab as never, [
+    {
+      atoms: payload.atoms ?? [],
+      bonds: payload.bonds ?? [],
+      rgroupAttachmentPoints: [],
+      color: payload.color ?? '#faa'
+    }
+  ])
+  editor.update(action)
+}
+
+// Reads the current structure back from the canvas in the requested serialization.
+const readStructure = (ketcher: Ketcher, format: KetcherStructureFormat): Promise<string> => {
+  if (format === 'molfile') return ketcher.getMolfile()
+  if (format === 'smiles') return ketcher.getSmiles()
+  return ketcher.getKet()
+}
+
+// A live, editable sketcher tile: it registers with the tool-host bridge on mount so open/set/highlight/
+// get commands can target it, and throttles canvas edits back to the artifact so they survive a reload.
+export const KetcherTile = ({ item }: { item: KetcherPreviewItem }): React.JSX.Element => {
+  const { artifactId, content, name } = item.ketcher
+  const ketcherRef = useRef<Ketcher | null>(null)
+  const [ready, setReady] = useState(false)
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Persist the current canvas as ket, coalescing rapid edits into one write per throttle window.
+  const scheduleSave = useCallback(() => {
+    if (saveTimerRef.current) return
+
+    saveTimerRef.current = setTimeout(() => {
+      saveTimerRef.current = null
+      const ketcher = ketcherRef.current
+      if (!ketcher) return
+
+      void ketcher
+        .getKet()
+        .then((ket) => window.api.ketcher.save({ artifactId, ket }))
+        .catch((error: unknown) => console.error('Ketcher tile save failed', error))
+    }, SAVE_THROTTLE_MS)
+  }, [artifactId])
+
+  const handleReady = useCallback((ketcher: Ketcher): void => {
+    ketcherRef.current = ketcher
+    setReady(true)
+  }, [])
+
+  // Register the imperative handle once the editor is live, and mirror edits back to the artifact.
+  useEffect(() => {
+    const ketcher = ketcherRef.current
+    if (!ready || !ketcher) return
+
+    const handle: KetcherTileHandle = {
+      setStructure: async (payload: KetcherSetPayload) => {
+        const structure = payload.ket ?? payload.molfile ?? payload.smiles ?? ''
+        await ketcher.setMolecule(structure)
+        scheduleSave()
+      },
+      highlight: (payload) => applyHighlight(ketcher, payload),
+      getStructure: (format) => readStructure(ketcher, format)
+    }
+
+    registerKetcherTile(artifactId, handle)
+    const editor = microEditor(ketcher)
+    const changeHandler = (): void => scheduleSave()
+    const subscriber = editor.subscribe('change', changeHandler)
+
+    return () => {
+      editor.unsubscribe('change', subscriber)
+      unregisterKetcherTile(artifactId)
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current)
+        saveTimerRef.current = null
+      }
+    }
+  }, [ready, artifactId, scheduleSave])
+
+  return (
+    <div className="flex size-full flex-col overflow-hidden bg-bg-10">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border-300 bg-bg-000 px-3 py-2 text-[12px] text-text-300">
+        <FlaskConical className="size-3.5 shrink-0 text-text-300" aria-hidden="true" />
+        <span className="truncate" title={name}>
+          Ketcher sketcher · {name}
+        </span>
+      </div>
+      <div
+        className="relative min-h-0 flex-1 overflow-hidden bg-bg-000"
+        aria-label={`Molecule sketcher for ${name}`}
+      >
+        <Suspense fallback={<PreviewLoadingContent />}>
+          <KetcherEditor content={content} onReady={handleReady} />
+        </Suspense>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -159,6 +159,10 @@ describe('WorkspacePage draft preservation', () => {
     globalThis.FileReader = MockFileReader as never
 
     window.api = {
+      ketcher: {
+        onCommand: vi.fn(() => vi.fn()),
+        onOpen: vi.fn(() => vi.fn())
+      },
       notebook: {
         onAvailable: vi.fn(() => vi.fn()),
         getReference: vi.fn(() => Promise.resolve(null))

--- a/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
@@ -90,6 +90,10 @@ describe('WorkspacePage notebook entry hydration', () => {
     vi.clearAllMocks()
     getReference = vi.fn(() => Promise.resolve(null))
     window.api = {
+      ketcher: {
+        onCommand: vi.fn(() => vi.fn()),
+        onOpen: vi.fn(() => vi.fn())
+      },
       notebook: {
         onAvailable: vi.fn(() => vi.fn()),
         getReference

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -150,6 +150,10 @@ describe('WorkspacePage preview panel resize sync', () => {
     })
     vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
     window.api = {
+      ketcher: {
+        onCommand: vi.fn(() => vi.fn()),
+        onOpen: vi.fn(() => vi.fn())
+      },
       notebook: {
         onAvailable: vi.fn(() => vi.fn()),
         getReference: vi.fn(() => Promise.resolve(null))

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -14,6 +14,7 @@ import { useNavigationStore } from '@/stores/navigation-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import {
+  createKetcherPreviewItem,
   createNotebookPreviewItem,
   createProjectFilesPreviewItem,
   PROJECT_FILES_PREVIEW_ID,
@@ -33,6 +34,7 @@ import {
 } from './composer/composer-doc'
 import { ConversationPanel } from './ConversationPanel'
 import { DeleteSessionDialog } from './DeleteSessionDialog'
+import { installKetcherCommandBridge } from './ketcher-tile-bridge'
 import { PreviewPanel } from './PreviewPanel'
 import { RenameSessionDialog } from './RenameSessionDialog'
 import { getVisiblePermissionRequests } from './session-permissions'
@@ -324,6 +326,30 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
       removeNotebookAvailableListener()
     }
   }, [upsertPreviewItem])
+
+  // The Ketcher tool host opens editable sketcher tiles and drives them over IPC; install the command
+  // bridge once and open (or refocus) a tile whenever the host writes a new .ket artifact.
+  useEffect(() => {
+    const removeCommandBridge = installKetcherCommandBridge()
+    const removeOpenListener = window.api.ketcher.onOpen((open) => {
+      upsertAndActivatePreviewItem(
+        createKetcherPreviewItem(
+          {
+            artifactId: open.artifactId,
+            path: open.path,
+            name: open.name,
+            content: open.content
+          },
+          open.sessionId
+        )
+      )
+    })
+
+    return () => {
+      removeCommandBridge()
+      removeOpenListener()
+    }
+  }, [upsertAndActivatePreviewItem])
 
   // The availability event only fires while the agent is live, so a session opened after relaunch
   // would lose its notebook entry until the next call. Probe persisted run.json on selection to

--- a/src/renderer/src/pages/workspace/ketcher-tile-bridge.ts
+++ b/src/renderer/src/pages/workspace/ketcher-tile-bridge.ts
@@ -1,0 +1,61 @@
+import type {
+  KetcherCommand,
+  KetcherHighlightPayload,
+  KetcherSetPayload,
+  KetcherStructureFormat
+} from '../../../../shared/ketcher'
+
+// Imperative handle a mounted KetcherTile exposes so the main-process tool host can drive its canvas.
+export type KetcherTileHandle = {
+  setStructure: (payload: KetcherSetPayload) => Promise<void>
+  highlight: (payload: KetcherHighlightPayload) => Promise<void>
+  getStructure: (format: KetcherStructureFormat) => Promise<string>
+}
+
+// Live tiles keyed by artifact id. Only mounted tiles are here, so a missing entry means "not mounted".
+const tiles = new Map<string, KetcherTileHandle>()
+
+// Registers a mounted tile and tells main so post-mount tools (set/highlight/get) can target it.
+export const registerKetcherTile = (artifactId: string, handle: KetcherTileHandle): void => {
+  tiles.set(artifactId, handle)
+  window.api.ketcher.notifyMounted({ artifactId })
+}
+
+// Deregisters an unmounting tile and tells main so later commands fail fast with "tile not mounted".
+export const unregisterKetcherTile = (artifactId: string): void => {
+  tiles.delete(artifactId)
+  window.api.ketcher.notifyUnmounted({ artifactId })
+}
+
+// Applies one command to the addressed tile and returns the value main should reply with (get only).
+const runCommand = async (command: KetcherCommand): Promise<unknown> => {
+  const handle = tiles.get(command.artifactId)
+
+  if (!handle) throw new Error(`Ketcher tile not mounted: ${command.artifactId}`)
+
+  if (command.op === 'set') {
+    await handle.setStructure(command.payload as KetcherSetPayload)
+    return undefined
+  }
+  if (command.op === 'highlight') {
+    await handle.highlight(command.payload as KetcherHighlightPayload)
+    return undefined
+  }
+
+  const format = (command.payload as { format?: KetcherStructureFormat }).format ?? 'ket'
+  return handle.getStructure(format)
+}
+
+// Installs the single main->renderer command listener that dispatches to tiles and replies. Returns an
+// unsubscribe so the owning effect can tear it down.
+export const installKetcherCommandBridge = (): (() => void) =>
+  window.api.ketcher.onCommand((command) => {
+    void runCommand(command)
+      .then((result) => window.api.ketcher.reply({ requestId: command.requestId, result }))
+      .catch((error: unknown) =>
+        window.api.ketcher.reply({
+          requestId: command.requestId,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      )
+  })

--- a/src/renderer/src/pages/workspace/preview-support.ts
+++ b/src/renderer/src/pages/workspace/preview-support.ts
@@ -25,6 +25,12 @@ const PREVIEW_SUPPORTED_EXTENSIONS: Record<string, PreviewFileFormat> = {
   md: 'markdown',
   pdb: 'pdb',
   pdf: 'pdf',
+  ket: 'molecule',
+  mol: 'molecule',
+  sdf: 'molecule',
+  smi: 'molecule',
+  smiles: 'molecule',
+  rxn: 'molecule',
   bash: 'text',
   conf: 'text',
   config: 'text',
@@ -66,6 +72,14 @@ const getPreviewFormatForMimeType = (mimeType: string): PreviewFileFormat => {
     return 'pdb'
   }
   if (normalizedMimeType === 'application/pdf') return 'pdf'
+  if (
+    normalizedMimeType === 'chemical/x-mdl-molfile' ||
+    normalizedMimeType === 'chemical/x-mdl-sdfile' ||
+    normalizedMimeType === 'chemical/x-mdl-rxnfile' ||
+    normalizedMimeType === 'chemical/x-daylight-smiles'
+  ) {
+    return 'molecule'
+  }
   if (normalizedMimeType.startsWith('text/')) return 'text'
 
   return 'unknown'

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
@@ -1,5 +1,7 @@
 import type { PreviewToolItem } from '@/stores/preview-workbench-store'
 
+import { KetcherTile } from '../KetcherTile'
+import type { KetcherPreviewItem } from '../KetcherTile'
 import { NotebookPreview } from '../NotebookPreview'
 import type { NotebookPreviewItem } from '../NotebookPreview'
 import { ProjectFilesView } from '../ProjectFilesView'
@@ -7,12 +9,17 @@ import { ProjectFilesView } from '../ProjectFilesView'
 const isNotebookPreviewItem = (item: PreviewToolItem): item is NotebookPreviewItem =>
   item.toolKind === 'notebook' && Boolean(item.notebook)
 
+const isKetcherPreviewItem = (item: PreviewToolItem): item is KetcherPreviewItem =>
+  item.toolKind === 'ketcher' && Boolean(item.ketcher)
+
 export const PreviewToolContent = ({
   item
 }: {
   item: PreviewToolItem
 }): React.JSX.Element | null => {
   if (item.toolKind === 'files') return <ProjectFilesView />
+
+  if (isKetcherPreviewItem(item)) return <KetcherTile item={item} />
 
   if (!isNotebookPreviewItem(item)) return null
 

--- a/src/renderer/src/pages/workspace/previews/preview-registry.tsx
+++ b/src/renderer/src/pages/workspace/previews/preview-registry.tsx
@@ -4,6 +4,7 @@ import { FastaPreviewRenderer } from './renderers/FastaPreview'
 import { HtmlPreviewRenderer } from './renderers/HtmlPreview'
 import { ImagePreviewRenderer } from './renderers/ImagePreview'
 import { JsonPreviewRenderer } from './renderers/JsonPreview'
+import { KetcherPreviewRenderer } from './renderers/KetcherPreview'
 import { MarkdownPreviewRenderer } from './renderers/MarkdownPreview'
 import { PdbPreviewRenderer } from './renderers/PdbPreview'
 import { PdfPreviewRenderer } from './renderers/PdfPreview'
@@ -28,6 +29,8 @@ export const renderPreviewFile = ({
       return <MarkdownPreviewRenderer item={item} />
     case 'pdb':
       return <PdbPreviewRenderer item={item} />
+    case 'molecule':
+      return <KetcherPreviewRenderer item={item} />
     case 'text':
       return <TextPreviewRenderer item={item} />
     case 'pdf':

--- a/src/renderer/src/pages/workspace/previews/renderers/KetcherPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/KetcherPreview.tsx
@@ -1,0 +1,74 @@
+import { FileWarning, FlaskConical } from 'lucide-react'
+import { Suspense, lazy } from 'react'
+
+import { PreviewFallbackCard, PreviewLoadingContent } from '../PreviewFallback'
+import type { PreviewFileRendererProps } from '../preview-types'
+import { usePreviewFileContent } from '../usePreviewFileContent'
+
+// Ketcher (react editor + standalone WASM Indigo backend) is heavy, so it is loaded only when a
+// molecule preview actually mounts — mirrors how PdbPreview lazy-imports 3Dmol.
+const KetcherCanvas = lazy(async () => {
+  const [{ Editor }, { StandaloneStructServiceProvider }] = await Promise.all([
+    import('ketcher-react'),
+    import('ketcher-standalone')
+  ])
+  await import('ketcher-react/dist/index.css')
+
+  const structServiceProvider = new StandaloneStructServiceProvider()
+
+  const Canvas = ({ content }: { content: string }): React.JSX.Element => (
+    <Editor
+      staticResourcesUrl=""
+      structServiceProvider={structServiceProvider}
+      errorHandler={(message) => console.error('Ketcher preview error', message)}
+      onInit={(ketcher) => {
+        // Ketcher auto-detects the input format (ket JSON, molfile, rxn, SMILES) from the string.
+        void ketcher.setMolecule(content)
+      }}
+    />
+  )
+
+  return { default: Canvas }
+})
+
+const KetcherPreviewViewer = ({
+  content,
+  name
+}: {
+  content: string
+  name: string
+}): React.JSX.Element => (
+  <div className="flex size-full flex-col overflow-hidden bg-bg-10">
+    <div className="flex shrink-0 items-center gap-2 border-b border-border-300 bg-bg-000 px-3 py-2 text-[12px] text-text-300">
+      <FlaskConical className="size-3.5 shrink-0 text-text-300" aria-hidden="true" />
+      <span className="truncate" title={name}>
+        Using Ketcher (Indigo) viewer
+      </span>
+    </div>
+    <div className="relative min-h-0 flex-1 overflow-hidden bg-bg-000" aria-label={`Structure preview of ${name}`}>
+      <Suspense fallback={<PreviewLoadingContent />}>
+        <KetcherCanvas content={content} />
+      </Suspense>
+    </div>
+  </div>
+)
+
+export const KetcherPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JSX.Element => {
+  const state = usePreviewFileContent({ path: item.path, source: item.source })
+
+  if (state.status === 'loading') return <PreviewLoadingContent />
+
+  if (state.status === 'error' || state.preview.encoding !== 'utf8') {
+    return (
+      <PreviewFallbackCard
+        icon={FileWarning}
+        path={item.path}
+        name={item.name}
+        source={item.source}
+        message="Structure file couldn't be read for preview"
+      />
+    )
+  }
+
+  return <KetcherPreviewViewer content={state.preview.content} name={item.name} />
+}

--- a/src/renderer/src/pages/workspace/previews/renderers/KetcherPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/KetcherPreview.tsx
@@ -45,7 +45,10 @@ const KetcherPreviewViewer = ({
         Using Ketcher (Indigo) viewer
       </span>
     </div>
-    <div className="relative min-h-0 flex-1 overflow-hidden bg-bg-000" aria-label={`Structure preview of ${name}`}>
+    <div
+      className="relative min-h-0 flex-1 overflow-hidden bg-bg-000"
+      aria-label={`Structure preview of ${name}`}
+    >
       <Suspense fallback={<PreviewLoadingContent />}>
         <KetcherCanvas content={content} />
       </Suspense>

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -4,7 +4,17 @@ import type { NotebookSessionReference } from '../../../shared/notebook'
 
 export type PreviewPanelState = 'open' | 'collapsed'
 export type PreviewFileFormat =
-  'markdown' | 'text' | 'json' | 'csv' | 'fasta' | 'html' | 'image' | 'pdb' | 'pdf' | 'unknown'
+  | 'markdown'
+  | 'text'
+  | 'json'
+  | 'csv'
+  | 'fasta'
+  | 'html'
+  | 'image'
+  | 'pdb'
+  | 'pdf'
+  | 'molecule'
+  | 'unknown'
 // Distinguishes generated artifacts from user uploads when preview readers and actions differ.
 export type PreviewFileSource = 'artifact' | 'upload'
 export const PROJECT_FILES_PREVIEW_ID = 'tool:project:files'

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -33,11 +33,20 @@ export type PreviewFileItem = PreviewItemBase & {
   name: string
 }
 
+// The live editable sketcher tile mounted for one .ket artifact (driven by the Ketcher tool host).
+export type KetcherTileReference = {
+  artifactId: string
+  path: string
+  name: string
+  content: string
+}
+
 // Tool previews share the workbench chrome with files, but keep their own render path.
 export type PreviewToolItem = PreviewItemBase & {
   type: 'tool'
-  toolKind?: 'notebook' | 'files'
+  toolKind?: 'notebook' | 'files' | 'ketcher'
   notebook?: NotebookSessionReference
+  ketcher?: KetcherTileReference
 }
 
 export type PreviewItem = PreviewFileItem | PreviewToolItem
@@ -145,6 +154,19 @@ const createProjectFilesPreviewItem = (): PreviewToolItem => ({
   type: 'tool',
   toolKind: 'files',
   title: 'Files'
+})
+
+// Builds the editable sketcher tab keyed by artifact id so repeated opens refresh the same tile.
+const createKetcherPreviewItem = (
+  reference: KetcherTileReference,
+  sessionId: string
+): PreviewToolItem => ({
+  id: `tool:ketcher:${reference.artifactId}`,
+  sessionId,
+  type: 'tool',
+  toolKind: 'ketcher',
+  title: reference.name,
+  ketcher: reference
 })
 
 // Chooses a stable fallback tab when the active preview item is removed.
@@ -294,4 +316,4 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
   }
 }))
 
-export { createNotebookPreviewItem, createProjectFilesPreviewItem }
+export { createNotebookPreviewItem, createProjectFilesPreviewItem, createKetcherPreviewItem }

--- a/src/shared/ketcher.ts
+++ b/src/shared/ketcher.ts
@@ -1,0 +1,42 @@
+// Shared IPC contracts for the interactive Ketcher sketcher: the main-process tool host drives a live
+// renderer tile over these payloads, and the tile replies through the same channels.
+
+export type KetcherStructureFormat = 'ket' | 'molfile' | 'smiles'
+
+// One structure fill: exactly one of the three formats is provided by the caller.
+export type KetcherSetPayload = { ket?: string; molfile?: string; smiles?: string }
+
+// Atom (and optional bond) highlight applied to the mounted canvas.
+export type KetcherHighlightPayload = { atoms: number[]; bonds?: number[]; color?: string }
+
+// Structure read-back request; the reply carries the serialized structure string.
+export type KetcherGetPayload = { format?: KetcherStructureFormat }
+
+export type KetcherCommandOp = 'set' | 'highlight' | 'get'
+export type KetcherCommandPayload = KetcherSetPayload | KetcherHighlightPayload | KetcherGetPayload
+
+// main -> renderer: one imperative command addressed to a mounted tile, awaiting a reply.
+export type KetcherCommand = {
+  requestId: string
+  artifactId: string
+  op: KetcherCommandOp
+  payload: KetcherCommandPayload
+}
+
+// renderer -> main: the tile's answer to a command (result for `get`, error on failure).
+export type KetcherReply = { requestId: string; result?: unknown; error?: string }
+
+// main -> renderer: open (or refocus) an editable sketcher tile for a freshly written artifact.
+export type KetcherOpenTile = {
+  artifactId: string
+  sessionId: string
+  path: string
+  name: string
+  content: string
+}
+
+// renderer -> main: a tile announcing that it mounted or unmounted for an artifact.
+export type KetcherMountNotice = { artifactId: string }
+
+// renderer -> main: throttled persistence of a tile's current structure back to its .ket artifact.
+export type KetcherSaveRequest = { artifactId: string; ket: string }


### PR DESCRIPTION
Adds **Ketcher Chemistry** — an interactive 2D molecule sketcher exposed as a Featured connector app, plus a read-only viewer for chemical file artifacts.

## What's included
- **Read-only viewer** for `.ket/.mol/.sdf/.smi/.rxn` artifacts (lazy-loaded Ketcher/Indigo, mirrors the PdbPreview/3Dmol pattern).
- **Interactive sketcher tile** in the preview workbench (`toolKind: 'ketcher'`), modeled on the live NotebookPreview tile — registers an imperative handle on mount, applies commands, throttles edits.
- **4 agent tools** (connector `ketcher`): `open_sketcher` (creates a `.ket` artifact, mounts+activates a tile, returns `artifact_id`), `set_structure`, `highlight_atoms`, `get_structure`.
- **Main↔renderer bridge**: `KetcherBroker` (modeled on `ApprovalBroker`) + `ketcher:command/reply/mounted/unmounted` IPC. Tools are hosted in the main process via `ConnectorService.callBundled`'s special-case (same enabled/blocked/approval gate as every connector; only dispatch is diverted to `KetcherService`).
- **Persistence**: tile edits round-trip back to the `.ket` artifact (throttled), resilient to the pending→message finalize move.
- **Settings**: Ketcher appears as a Featured connector with per-tool permissions + skip-approvals, surfaced automatically through the shared registry/catalog path.

## Dependencies
- Adds `ketcher-react`/`-core`/`-standalone@3.17.0` (React 19-compatible; bundled WASM Indigo, lazy-loaded into separate chunks).

## Testing
- ✅ `npm run typecheck`, `npm run lint`, `npx electron-vite build` (renderer bundles the Ketcher WASM/worker chunks) all pass.
- ✅ Full `npx vitest run` green (1555 passed / 43 skipped), incl. `KetcherBroker`, `KetcherService`, and `ConnectorService` routing unit tests.
- ⚠️ **Needs a `npm run dev` GUI hand-verify before merge**: the live round-trip (open_sketcher → tile mount → set/highlight/get → reply, and Ketcher WASM runtime load) and the highlight rendering path are unit-tested against mocks only. `open_sketcher` resolves the active turn's artifact run, so it's an in-agent-turn tool (not a terminal-cell call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)