### PR TITLE
fix(notebook): pin UTF-8 for the Python bridge stdin

### DIFF
--- a/src/main/notebook/python-executor.test.ts
+++ b/src/main/notebook/python-executor.test.ts
@@ -251,6 +251,46 @@ describe('notebook Python executor', () => {
   )
 
   itWithPython(
+    'decodes non-ASCII cell code as UTF-8 even when the parent locale codepage is not',
+    async () => {
+      // Windows repro: Node writes the cell as a UTF-8 JSON line, but Python decodes stdin with the
+      // OS locale codepage (cp936 on a Chinese console), corrupting non-ASCII code into lone
+      // surrogates and making ast.parse raise UnicodeEncodeError. Forcing the parent PYTHONIOENCODING
+      // to a non-UTF-8 codec reproduces that mis-decode portably; the executor must override it to
+      // utf-8 so the child still reads the code correctly.
+      const root = await createStorageRoot()
+      const previous = process.env.PYTHONIOENCODING
+      process.env.PYTHONIOENCODING = 'latin-1'
+      const executor = new NotebookPythonExecutor('python3')
+      const base = {
+        cwd: root,
+        notebookSessionRoot: join(root, 'notebooks', 'default-project', 'session-1'),
+        dataRoot: join(root, 'notebooks', 'default-project', 'session-1', 'data'),
+        runtimeRoot: join(root, 'runtime')
+      }
+
+      // Build the non-ASCII payload from escapes so this source file stays ASCII-only. Covers 2- and
+      // 3-byte UTF-8 sequences (e-acute, em dash, snowman), enough that a codepage mis-decode
+      // corrupts the round-trip.
+      const nonAscii = String.fromCodePoint(0xe9, 0x2014, 0x2603)
+
+      try {
+        const result = await executor.execute({
+          ...base,
+          code: `result = {"term": ${JSON.stringify(nonAscii)}}\nresult`
+        })
+        expect(result).toMatchObject({ status: 'completed' })
+        expect(result.stdout).toBe(`{'term': '${nonAscii}'}\n`)
+      } finally {
+        await executor.shutdown()
+        if (previous === undefined) delete process.env.PYTHONIOENCODING
+        else process.env.PYTHONIOENCODING = previous
+      }
+    },
+    PYTHON_TEST_TIMEOUT_MS
+  )
+
+  itWithPython(
     'returns a timeout execution result when code exceeds timeoutMs',
     async () => {
       const root = await createStorageRoot()

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -378,6 +378,11 @@ class NotebookPythonExecutor implements NotebookExecutor {
         // Force a non-interactive matplotlib backend so plt.show() never opens a GUI window in
         // this headless notebook runtime; respect an explicitly configured backend if present.
         MPLBACKEND: process.env.MPLBACKEND || 'Agg',
+        // Node writes the cell code to stdin as UTF-8, but Python otherwise decodes stdin with the
+        // OS locale codepage (e.g. cp936 on a Chinese Windows console). That mis-decode turns any
+        // non-ASCII in the cell (curly quotes, em-dashes, Chinese comments) into lone surrogates and
+        // makes ast.parse raise UnicodeEncodeError. Pin UTF-8 so both ends agree on the encoding.
+        PYTHONIOENCODING: 'utf-8',
         OPEN_SCIENCE_NOTEBOOK_DIR: request.notebookSessionRoot,
         OPEN_SCIENCE_NOTEBOOK_DATA_DIR: request.dataRoot,
         OPEN_SCIENCE_RUNTIME_DIR: request.runtimeRoot,


### PR DESCRIPTION
## Problem

Running a notebook cell containing non-ASCII characters fails on a non-UTF-8 Windows console (e.g. cp936 on a Chinese locale) with:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\udc80' in position 4: surrogates not allowed
```

The traceback points at `ast.parse` in the Python bridge, but the real cause is upstream: Node writes each cell to the bridge's stdin as a **UTF-8** JSON line, while Python — spawned without a pinned `PYTHONIOENCODING` — decodes stdin using the **OS locale codepage**. On cp936, non-ASCII cell content (curly quotes, em-dashes, Chinese comments) is mis-decoded into lone surrogates, and `ast.parse` then raises `UnicodeEncodeError`.

This never reproduces on macOS/Linux CI because their locale is already UTF-8.

## Fix

Pin `PYTHONIOENCODING=utf-8` in the bridge spawn env so both ends agree on the encoding.

## Test

Added a portable regression test that forces a non-UTF-8 parent codepage (`latin-1`) to reproduce the mis-decode on any platform:

- Without the fix: the cell fails (reproduces the reported error).
- With the fix: non-ASCII cell code round-trips correctly.

Verified locally: `python-executor.test.ts` 10/10 pass, eslint clean, typecheck (node + web) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)