### PR TITLE
fix(notebook): bound agent-facing run output size

### DIFF
--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT,
   NOTEBOOK_RPC_TOOLS,
   NOTEBOOK_SYSTEM_PROMPT_APPEND,
-  createNotebookMcpServerConfig
+  createNotebookMcpServerConfig,
+  truncateNotebookRunResult
 } from './mcp-server'
 
 describe('notebook MCP server config', () => {
@@ -72,5 +74,71 @@ describe('notebook MCP server config', () => {
     expect(toolNames).not.toContain('notebook_append_code_cell')
     expect(toolNames).not.toContain('notebook_finish_code_cell')
     expect(toolNames).not.toContain('notebook_run_cell')
+  })
+})
+
+describe('truncateNotebookRunResult', () => {
+  const runSummary = (text: {
+    stdout?: string
+    stderr?: string
+    traceback?: string
+  }): Record<string, unknown> => ({
+    runId: 'notebook-run-1',
+    status: 'completed',
+    text: { stdout: '', stderr: '', traceback: '', plain: [], ...text },
+    outputs: [],
+    artifacts: [],
+    workingFiles: []
+  })
+
+  it('returns a run summary untouched when every stream is under the limit', () => {
+    const result = runSummary({ stdout: 'small output' })
+
+    const truncated = truncateNotebookRunResult(result)
+
+    expect(truncated).toBe(result)
+    expect(truncated).not.toHaveProperty('truncated')
+  })
+
+  it('clips an oversized stream, marks it truncated, and keeps the JSON parseable', () => {
+    const oversized = 'x'.repeat(NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT + 5_000)
+    const result = runSummary({ stdout: oversized })
+
+    const truncated = truncateNotebookRunResult(result) as {
+      truncated?: boolean
+      text: { stdout: string; stderr: string }
+    }
+
+    expect(truncated.truncated).toBe(true)
+    expect(truncated.text.stdout.length).toBeLessThan(oversized.length)
+    expect(truncated.text.stdout).toContain('truncated 5000 chars')
+    // Streams under the limit are left alone.
+    expect(truncated.text.stderr).toBe('')
+    // The serialized payload the agent receives is still valid JSON.
+    expect(() => JSON.parse(JSON.stringify(truncated))).not.toThrow()
+    // The original object is not mutated.
+    expect((result.text as { stdout: string }).stdout).toBe(oversized)
+  })
+
+  it('clips each oversized stream independently', () => {
+    const oversized = 'y'.repeat(NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT + 1)
+    const result = runSummary({ stdout: oversized, traceback: oversized })
+
+    const truncated = truncateNotebookRunResult(result) as {
+      truncated?: boolean
+      text: { stdout: string; traceback: string }
+    }
+
+    expect(truncated.truncated).toBe(true)
+    expect(truncated.text.stdout).toContain('truncated')
+    expect(truncated.text.traceback).toContain('truncated')
+  })
+
+  it('passes through payloads that are not run summaries', () => {
+    const state = { cells: [], recentRuns: [], kernelStatus: 'idle' }
+
+    expect(truncateNotebookRunResult(state)).toBe(state)
+    expect(truncateNotebookRunResult(null)).toBeNull()
+    expect(truncateNotebookRunResult('plain')).toBe('plain')
   })
 })

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -150,8 +150,53 @@ const callNotebookRpc = async (
   return payload.result
 }
 
-// Serializes notebook RPC results exactly as execution facts for the agent to analyze.
-const toToolText = (value: unknown): string => JSON.stringify(value, null, 2)
+// Per-stream cap for the run summary returned to the agent. The full output is always kept in
+// run.json and the notebook preview; only this agent-facing copy is bounded so a single large
+// result (e.g. a connector call dumping many records to stdout) cannot overflow the tool result.
+const NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT = 8_000
+
+// Clips one output stream to the field limit, appending a marker that points at the full copy.
+const clipStream = (text: string): { text: string; clipped: boolean } => {
+  if (text.length <= NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT) return { text, clipped: false }
+
+  const removed = text.length - NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT
+  return {
+    text: `${text.slice(0, NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT)}\n…[truncated ${removed} chars; full output in notebook preview]`,
+    clipped: true
+  }
+}
+
+// Bounds the agent-facing run summary by clipping oversized stdout/stderr/traceback in place. Only
+// touches values shaped like a run summary (a `text` object with string streams); every other RPC
+// payload (state/restart/shutdown) is returned untouched. Never clips the serialized JSON string,
+// which would produce invalid JSON.
+const truncateNotebookRunResult = (value: unknown): unknown => {
+  if (typeof value !== 'object' || value === null) return value
+  const record = value as Record<string, unknown>
+  const text = record.text
+  if (typeof text !== 'object' || text === null) return value
+
+  const streams = text as Record<string, unknown>
+  let clippedAny = false
+  const nextText: Record<string, unknown> = { ...streams }
+
+  for (const field of ['stdout', 'stderr', 'traceback'] as const) {
+    const stream = streams[field]
+    if (typeof stream !== 'string') continue
+    const { text: clippedText, clipped } = clipStream(stream)
+    nextText[field] = clippedText
+    clippedAny = clippedAny || clipped
+  }
+
+  if (!clippedAny) return value
+
+  return { ...record, text: nextText, truncated: true }
+}
+
+// Serializes notebook RPC results exactly as execution facts for the agent to analyze, bounding the
+// per-stream output size so one large run cannot overflow the tool result.
+const toToolText = (value: unknown): string =>
+  JSON.stringify(truncateNotebookRunResult(value), null, 2)
 
 // Registers one MCP tool that forwards its validated input to a matching notebook RPC method.
 const registerNotebookRpcTool = (
@@ -238,6 +283,7 @@ const runNotebookMcpServer = async (
 }
 
 export {
+  NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT,
   NOTEBOOK_MCP_SERVER_ARG,
   NOTEBOOK_MCP_SERVER_NAME,
   NOTEBOOK_RPC_TOOLS,
@@ -246,6 +292,7 @@ export {
   createNotebookMcpEnvironmentFromProcess,
   createNotebookMcpServer,
   createNotebookMcpServerConfig,
-  runNotebookMcpServer
+  runNotebookMcpServer,
+  truncateNotebookRunResult
 }
 export type { NotebookMcpEnvironment, NotebookMcpServerConfigRequest, NotebookRpcConnection }


### PR DESCRIPTION
## Problem

`notebook_execute` returned the full run summary with **unbounded** `stdout`/`stderr`/`traceback`. A single `host.mcp()` call dumping many records to stdout (e.g. 20 PubMed articles with full abstracts, ~173 KB) blew the tool-result token limit, so the agent could not read its own execution result — even though the run itself completed successfully.

The `NotebookRunRecord.truncated` field was already declared but never set; output bounding had been scaffolded and never implemented.

## Fix

Clip each output stream to a per-field cap (8000 chars) **at the MCP boundary only**, appending a truncation marker and setting `truncated: true`. Persisted `run.json` and the notebook preview keep the full output untouched — only the agent-facing copy is bounded. Clipping is field-aware (inside the parsed object), so the returned JSON stays valid. Non-run-summary payloads (`state`/`restart`/`shutdown`) pass through untouched.

## Verification

- `npm run test` — 8/8 pass (4 new truncation tests)
- `npm run lint` — clean
- `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)