### PR TITLE
docs: restore Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,10 +375,10 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 
 ## Star History
 
-<a href="https://star-history.com/#aipoch/open-science&Date">
+<a href="https://www.star-history.com/?repos=aipoch%2Fopen-science&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=aipoch/open-science&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=aipoch/open-science&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=aipoch/open-science&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=aipoch/open-science&type=date&theme=dark&legend=top-left&sealed_token=SfYmaFKVrSeoWXSFpM9v1yIMgQGuqcSgB3atEXCZ41bGZjk56hO-cJaQrD1sVpdyioihMw-HX-gxMQ3LsNaMPk8hP4sk1CzYoh-AtROEZeFB_5GestwN4xj2dlQSBuqa4nFUWabnN4YTg02U7tipvbF_YkahNnTz5m5W-GEn3xioDebss0lJJL8HrJfl" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=aipoch/open-science&type=date&legend=top-left&sealed_token=SfYmaFKVrSeoWXSFpM9v1yIMgQGuqcSgB3atEXCZ41bGZjk56hO-cJaQrD1sVpdyioihMw-HX-gxMQ3LsNaMPk8hP4sk1CzYoh-AtROEZeFB_5GestwN4xj2dlQSBuqa4nFUWabnN4YTg02U7tipvbF_YkahNnTz5m5W-GEn3xioDebss0lJJL8HrJfl" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=aipoch/open-science&type=date&legend=top-left&sealed_token=SfYmaFKVrSeoWXSFpM9v1yIMgQGuqcSgB3atEXCZ41bGZjk56hO-cJaQrD1sVpdyioihMw-HX-gxMQ3LsNaMPk8hP4sk1CzYoh-AtROEZeFB_5GestwN4xj2dlQSBuqa4nFUWabnN4YTg02U7tipvbF_YkahNnTz5m5W-GEn3xioDebss0lJJL8HrJfl" />
  </picture>
 </a>


### PR DESCRIPTION
## What changed

- Replace the legacy unauthenticated Star History SVG URLs with the newly generated chart URLs using a sealed repository-scoped token.
- Update the chart link to the current Star History URL format.
- Preserve separate light and dark theme images.

## Why

GitHub now restricts access to detailed stargazer data to repository administrators and collaborators. The previous unauthenticated Star History embed can no longer reliably generate the README chart.

## Impact

The Star History chart can render for everyone viewing the repository README without requiring visitors to provide their own GitHub token.

## Validation

- Confirmed both light and dark chart endpoints return HTTP 200 with `image/svg+xml`.
- Ran `git diff --check` successfully.
- Verified the commit contains only the README change.
