### PR TITLE
fix: exclude .claude worktrees from eslint and vite dev watch

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
         '@renderer': resolve('src/renderer/src')
       }
     },
+    server: {
+      // Don't watch git worktrees under .claude/worktrees — full source copies would trigger
+      // needless rescans/HMR churn during dev.
+      watch: { ignored: ['**/.claude/**'] }
+    },
     plugins: [react(), tailwindcss()]
   }
 })

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,8 @@ export default defineConfig(
       '**/node_modules',
       '**/dist',
       '**/out',
+      // Git worktrees live under .claude/worktrees and hold full source copies; don't lint duplicates.
+      '**/.claude/**',
       // Keep official shadcn registry output unmodified; local adaptations live in wrappers.
       'src/renderer/src/components/ui/message-scroller.tsx'
     ]


### PR DESCRIPTION
## Problem

Git worktrees created under `.claude/worktrees/` are full source-tree copies (3000+ files each). Two dev tools traversed them:

- **eslint** (`npm run lint`) linted **3142** files inside `.claude/` (out of 3630 total) and exited `1` — linting duplicate/stale worktree sources and failing the run.
- **vite dev** (`npm run dev`) watched `.claude/worktrees`, causing needless rescans / HMR churn.

## Fix

- `eslint.config.mjs`: add `'**/.claude/**'` to `ignores`
- `electron.vite.config.ts`: set renderer `server.watch.ignored` for `.claude`

## Not touched

- **vitest** already excludes `.claude/worktrees` (`vitest.config.ts`)
- **prettier** respects `.gitignore` (where `.claude/` is listed)
- **tsc** `include` is scoped to `src/**`

## Verification

`npm run lint` → 488 files, `exit 0` (was 3630 files, `exit 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)