### PR TITLE
feat(preview): render .rxn reaction files in the molecule viewer

### DIFF
--- a/src/renderer/src/pages/workspace/preview-support.test.ts
+++ b/src/renderer/src/pages/workspace/preview-support.test.ts
@@ -31,6 +31,11 @@ describe('preview support format detection', () => {
     ['faa', undefined, 'fasta'],
     ['json', undefined, 'json'],
     ['pdb', undefined, 'pdb'],
+    ['mol', undefined, 'molecule'],
+    ['sdf', undefined, 'molecule'],
+    ['smi', undefined, 'molecule'],
+    ['smiles', undefined, 'molecule'],
+    ['rxn', undefined, 'molecule'],
     ['html', undefined, 'html'],
     ['htm', undefined, 'html']
   ])('maps .%s files to %s previews', (extension, mimeType, expectedFormat) => {
@@ -44,6 +49,7 @@ describe('preview support format detection', () => {
     ['image/png', 'image'],
     ['text/markdown', 'markdown'],
     ['chemical/x-pdb', 'pdb'],
+    ['chemical/x-mdl-rxnfile', 'molecule'],
     ['application/xml', 'text'],
     ['application/atom+xml', 'text'],
     ['text/plain', 'text']

--- a/src/renderer/src/pages/workspace/preview-support.ts
+++ b/src/renderer/src/pages/workspace/preview-support.ts
@@ -28,6 +28,7 @@ const PREVIEW_SUPPORTED_EXTENSIONS: Record<string, PreviewFileFormat> = {
   sdf: 'molecule',
   smi: 'molecule',
   smiles: 'molecule',
+  rxn: 'molecule',
   pdf: 'pdf',
   bash: 'text',
   conf: 'text',
@@ -78,6 +79,7 @@ const getPreviewFormatForMimeType = (mimeType: string): PreviewFileFormat => {
   if (
     normalizedMimeType === 'chemical/x-mdl-molfile' ||
     normalizedMimeType === 'chemical/x-mdl-sdfile' ||
+    normalizedMimeType === 'chemical/x-mdl-rxnfile' ||
     normalizedMimeType === 'chemical/x-daylight-smiles'
   ) {
     return 'molecule'

--- a/src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.tsx
@@ -7,6 +7,7 @@ import { getFileExtension } from '../../preview-support'
 import { PreviewFallbackCard, PreviewLoadingContent } from '../PreviewFallback'
 import type { PreviewFileRendererProps } from '../preview-types'
 import { usePreviewFileContent } from '../usePreviewFileContent'
+import { buildReactionMarkup } from './reaction-markup'
 
 type OclModule = typeof import('openchemlib')
 
@@ -14,37 +15,6 @@ type OclModule = typeof import('openchemlib')
 const SMILES_EXTENSIONS = new Set(['smi', 'smiles'])
 // MDL reaction files render as a laid-out row of component depictions instead of one molecule.
 const REACTION_EXTENSIONS = new Set(['rxn'])
-
-// Lays out an MDL reaction as a horizontal row of component depictions separated by "+" and an arrow.
-// OpenChemLib's Reaction has no single toSVG, so each reactant/product molecule is rendered on its own.
-// The markup is built from OpenChemLib-generated SVGs and our own separators — no untrusted HTML.
-const buildReactionMarkup = (
-  ocl: OclModule,
-  content: string,
-  baseId: string,
-  size: { width: number; height: number }
-): string => {
-  const reaction = ocl.Reaction.fromRxn(content)
-  const separator = (symbol: string): string =>
-    `<span style="flex:none;font-size:22px;line-height:1;color:#888;padding:0 4px">${symbol}</span>`
-  const svgFor = (molecule: InstanceType<OclModule['Molecule']>, id: string): string =>
-    molecule.toSVG(size.width, size.height, id, { autoCrop: true, autoCropMargin: 8 })
-
-  const parts: string[] = []
-  const reactantCount = reaction.getReactants()
-  for (let index = 0; index < reactantCount; index += 1) {
-    if (index > 0) parts.push(separator('+'))
-    parts.push(svgFor(reaction.getReactant(index), `${baseId}-r${index}`))
-  }
-  parts.push(separator('→'))
-  const productCount = reaction.getProducts()
-  for (let index = 0; index < productCount; index += 1) {
-    if (index > 0) parts.push(separator('+'))
-    parts.push(svgFor(reaction.getProduct(index), `${baseId}-p${index}`))
-  }
-
-  return `<div style="display:flex;align-items:center;gap:6px;max-width:100%;max-height:100%;overflow:auto">${parts.join('')}</div>`
-}
 
 const MoleculePreviewCanvas = ({
   content,

--- a/src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.tsx
@@ -12,6 +12,39 @@ type OclModule = typeof import('openchemlib')
 
 // SMILES sources parse via fromSmiles; molfile/SDF via fromMolfile (which reads the first record).
 const SMILES_EXTENSIONS = new Set(['smi', 'smiles'])
+// MDL reaction files render as a laid-out row of component depictions instead of one molecule.
+const REACTION_EXTENSIONS = new Set(['rxn'])
+
+// Lays out an MDL reaction as a horizontal row of component depictions separated by "+" and an arrow.
+// OpenChemLib's Reaction has no single toSVG, so each reactant/product molecule is rendered on its own.
+// The markup is built from OpenChemLib-generated SVGs and our own separators — no untrusted HTML.
+const buildReactionMarkup = (
+  ocl: OclModule,
+  content: string,
+  baseId: string,
+  size: { width: number; height: number }
+): string => {
+  const reaction = ocl.Reaction.fromRxn(content)
+  const separator = (symbol: string): string =>
+    `<span style="flex:none;font-size:22px;line-height:1;color:#888;padding:0 4px">${symbol}</span>`
+  const svgFor = (molecule: InstanceType<OclModule['Molecule']>, id: string): string =>
+    molecule.toSVG(size.width, size.height, id, { autoCrop: true, autoCropMargin: 8 })
+
+  const parts: string[] = []
+  const reactantCount = reaction.getReactants()
+  for (let index = 0; index < reactantCount; index += 1) {
+    if (index > 0) parts.push(separator('+'))
+    parts.push(svgFor(reaction.getReactant(index), `${baseId}-r${index}`))
+  }
+  parts.push(separator('→'))
+  const productCount = reaction.getProducts()
+  for (let index = 0; index < productCount; index += 1) {
+    if (index > 0) parts.push(separator('+'))
+    parts.push(svgFor(reaction.getProduct(index), `${baseId}-p${index}`))
+  }
+
+  return `<div style="display:flex;align-items:center;gap:6px;max-width:100%;max-height:100%;overflow:auto">${parts.join('')}</div>`
+}
 
 const MoleculePreviewCanvas = ({
   content,
@@ -37,15 +70,23 @@ const MoleculePreviewCanvas = ({
     if (container.clientWidth <= 0 || container.clientHeight <= 0) return
 
     try {
-      const molecule = SMILES_EXTENSIONS.has(extension)
-        ? ocl.Molecule.fromSmiles(content)
-        : ocl.Molecule.fromMolfile(content)
-      const svg = molecule.toSVG(container.clientWidth, container.clientHeight, svgId, {
-        autoCrop: true,
-        autoCropMargin: 16
-      })
+      if (REACTION_EXTENSIONS.has(extension)) {
+        // Each reaction component is bounded by the tile height so the row fits and scrolls if wide.
+        const componentHeight = Math.max(80, Math.min(container.clientHeight - 24, 260))
+        container.innerHTML = buildReactionMarkup(ocl, content, svgId, {
+          width: Math.round(componentHeight * 1.2),
+          height: componentHeight
+        })
+      } else {
+        const molecule = SMILES_EXTENSIONS.has(extension)
+          ? ocl.Molecule.fromSmiles(content)
+          : ocl.Molecule.fromMolfile(content)
+        container.innerHTML = molecule.toSVG(container.clientWidth, container.clientHeight, svgId, {
+          autoCrop: true,
+          autoCropMargin: 16
+        })
+      }
 
-      container.innerHTML = svg
       setError(undefined)
     } catch (renderError) {
       container.replaceChildren()

--- a/src/renderer/src/pages/workspace/previews/renderers/reaction-markup.test.ts
+++ b/src/renderer/src/pages/workspace/previews/renderers/reaction-markup.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildReactionMarkup } from './reaction-markup'
+
+type BuildReactionArgs = Parameters<typeof buildReactionMarkup>
+
+// A fake OpenChemLib whose Reaction returns stub molecules — lets us assert the layout logic
+// (component count, "+" separators, arrow, unique ids) without depending on real OpenChemLib parsing.
+const fakeOcl = (reactantCount: number, productCount: number): BuildReactionArgs[0] =>
+  ({
+    Reaction: {
+      fromRxn: () => ({
+        getReactants: () => reactantCount,
+        getReactant: (index: number) => ({
+          toSVG: (_w: number, _h: number, id: string) => `<svg id="${id}">reactant-${index}</svg>`
+        }),
+        getProducts: () => productCount,
+        getProduct: (index: number) => ({
+          toSVG: (_w: number, _h: number, id: string) => `<svg id="${id}">product-${index}</svg>`
+        })
+      })
+    }
+  }) as unknown as BuildReactionArgs[0]
+
+const size = { width: 120, height: 90 }
+const countMatches = (html: string, pattern: RegExp): number => (html.match(pattern) ?? []).length
+
+describe('buildReactionMarkup', () => {
+  it('lays out reactants and products separated by "+" and a single arrow', () => {
+    const html = buildReactionMarkup(fakeOcl(2, 1), 'RXN', 'base', size)
+
+    // 2 reactants + 1 product = 3 component depictions.
+    expect(countMatches(html, /<svg/g)).toBe(3)
+    // Exactly one reaction arrow.
+    expect(countMatches(html, /→/g)).toBe(1)
+    // One "+" between the two reactants; the single product needs none.
+    expect(countMatches(html, />\+</g)).toBe(1)
+    // Each component gets a unique svg id derived from the base id.
+    expect(html).toContain('base-r0')
+    expect(html).toContain('base-r1')
+    expect(html).toContain('base-p0')
+  })
+
+  it('adds a "+" between multiple products and none for a lone reactant', () => {
+    const html = buildReactionMarkup(fakeOcl(1, 2), 'RXN', 'b', size)
+
+    expect(countMatches(html, /<svg/g)).toBe(3)
+    // One "+" between the two products; the single reactant needs none.
+    expect(countMatches(html, />\+</g)).toBe(1)
+    expect(countMatches(html, /→/g)).toBe(1)
+  })
+})

--- a/src/renderer/src/pages/workspace/previews/renderers/reaction-markup.ts
+++ b/src/renderer/src/pages/workspace/previews/renderers/reaction-markup.ts
@@ -1,0 +1,32 @@
+type OclModule = typeof import('openchemlib')
+
+// Lays out an MDL reaction as a horizontal row of component depictions separated by "+" and an arrow.
+// OpenChemLib's Reaction has no single toSVG, so each reactant/product molecule is rendered on its own.
+// The markup is built from OpenChemLib-generated SVGs and our own separators — no untrusted HTML.
+export const buildReactionMarkup = (
+  ocl: OclModule,
+  content: string,
+  baseId: string,
+  size: { width: number; height: number }
+): string => {
+  const reaction = ocl.Reaction.fromRxn(content)
+  const separator = (symbol: string): string =>
+    `<span style="flex:none;font-size:22px;line-height:1;color:#888;padding:0 4px">${symbol}</span>`
+  const svgFor = (molecule: InstanceType<OclModule['Molecule']>, id: string): string =>
+    molecule.toSVG(size.width, size.height, id, { autoCrop: true, autoCropMargin: 8 })
+
+  const parts: string[] = []
+  const reactantCount = reaction.getReactants()
+  for (let index = 0; index < reactantCount; index += 1) {
+    if (index > 0) parts.push(separator('+'))
+    parts.push(svgFor(reaction.getReactant(index), `${baseId}-r${index}`))
+  }
+  parts.push(separator('→'))
+  const productCount = reaction.getProducts()
+  for (let index = 0; index < productCount; index += 1) {
+    if (index > 0) parts.push(separator('+'))
+    parts.push(svgFor(reaction.getProduct(index), `${baseId}-p${index}`))
+  }
+
+  return `<div style="display:flex;align-items:center;gap:6px;max-width:100%;max-height:100%;overflow:auto">${parts.join('')}</div>`
+}


### PR DESCRIPTION
## Summary

Adds **`.rxn` (MDL reaction file)** rendering to the OpenChemLib molecule preview — still pure JS, **no Ketcher/Indigo, no WASM, no CSP change**.

- `preview-support`: maps `.rxn` (and `chemical/x-mdl-rxnfile`) to the `'molecule'` preview format.
- `MoleculePreview`: for `.rxn`, parses with `OCL.Reaction.fromRxn` and lays the reaction out as a horizontal row of component depictions — each reactant/product rendered on its own via `getReactant(i)/getProduct(i).toSVG()`, separated by `+` and a `→` arrow (OpenChemLib's `Reaction` has no single `toSVG`). Layout logic extracted to `reaction-markup.ts`.

## Why `.ket` is left out

`.ket` is Ketcher's own JSON format; only **Indigo (WASM)** can parse it — OpenChemLib and RDKit.js cannot. Supporting it would mean re-introducing a WASM dependency for a format the app never generates now that Ketcher is gone. `.rxn`, by contrast, is a standard MDL format that OpenChemLib parses natively.

## Tests

- `reaction-markup.test`: reaction layout with a fake OpenChemLib — component count, `+` separators, single arrow, unique ids.
- `preview-support.test`: molecule extensions (mol/sdf/smi/smiles/rxn) + `chemical/x-mdl-rxnfile` routing.

## Verification

- `npm run typecheck && npm run lint && npm run test` — green (1843 tests).
- Dev: preview a `.rxn` artifact (sample at `/tmp/molecule-samples/esterification.rxn`, 2 reactants → 2 products) — renders the laid-out reaction.
