### PR TITLE
fix(connectors): tier-3 schema/doc polish

### DIFF
--- a/src/main/connectors/descriptors/biorxiv.test.ts
+++ b/src/main/connectors/descriptors/biorxiv.test.ts
@@ -395,7 +395,6 @@ describe('biorxiv / get_content_statistics', () => {
       new_papers: 109,
       new_papers_cumulative: 109,
       revised_papers: 34,
-      preprint_date: null,
       revised_papers_cumulative: 34
     })
   })

--- a/src/main/connectors/descriptors/biorxiv.ts
+++ b/src/main/connectors/descriptors/biorxiv.ts
@@ -358,7 +358,6 @@ const contentStatsResponse = (rows: BiorxivRecord[]): Record<string, unknown> =>
     out.new_papers = toInt(r.new_papers)
     out.new_papers_cumulative = toInt(r.new_papers_cumulative)
     out.revised_papers = toInt(r.revised_papers)
-    out.preprint_date = null
     out.revised_papers_cumulative = toInt(r.revised_papers_cumulative)
     return out
   }),
@@ -614,7 +613,7 @@ export const BIORXIV_TOOLS: ToolDescriptor[] = [
       }
     },
     returns:
-      '`{ "success": bool, "results": [ { "month"|"year", "new_papers", "new_papers_cumulative", "revised_papers", "preprint_date": null, "revised_papers_cumulative" } ], "error": null }`. Monthly rows carry "month" (YYYY-MM); yearly rows carry "year".',
+      '`{ "success": bool, "results": [ { "month"|"year", "new_papers", "new_papers_cumulative", "revised_papers", "revised_papers_cumulative" } ], "error": null }`. Monthly rows carry "month" (YYYY-MM); yearly rows carry "year".',
     example: 'result = host.mcp("biorxiv", "get_content_statistics", {"interval": "yearly"})',
     run: async (ctx, a) => {
       try {

--- a/src/main/connectors/descriptors/cancer-models.ts
+++ b/src/main/connectors/descriptors/cancer-models.ts
@@ -407,7 +407,7 @@ export const CANCER_MODELS_TOOLS: ToolDescriptor[] = [
     input: {
       type: 'object',
       properties: {
-        gene_symbol: { type: 'string' },
+        gene_symbol: { type: 'string', description: 'HUGO gene symbol, e.g. KRAS, IDH1' },
         study_ids: { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 12 }
       },
       required: ['gene_symbol', 'study_ids']
@@ -499,7 +499,7 @@ export const CANCER_MODELS_TOOLS: ToolDescriptor[] = [
     input: {
       type: 'object',
       properties: {
-        gene_symbol: { type: 'string' },
+        gene_symbol: { type: 'string', description: 'HUGO gene symbol, e.g. KRAS, IDH1' },
         study_id: { type: 'string' },
         event_type: {
           type: 'string',

--- a/src/main/connectors/descriptors/drug-regulatory.ts
+++ b/src/main/connectors/descriptors/drug-regulatory.ts
@@ -325,11 +325,31 @@ export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
         dosage_form: { type: 'string' },
         route: { type: 'string' },
         pharm_class: { type: 'string' },
-        pharm_class_type: { type: 'string', enum: ['epc', 'moa', 'cs', 'pe'] },
-        search_type: { type: 'string', enum: ['and', 'or'], default: 'and' },
-        submission_date_from: { type: 'string' },
-        submission_date_to: { type: 'string' },
-        raw_search: { type: 'string' },
+        pharm_class_type: {
+          type: 'string',
+          enum: ['epc', 'moa', 'cs', 'pe'],
+          description:
+            'Which openFDA pharmacologic-class facet `pharm_class` matches: epc (established pharmacologic class), moa (mechanism of action), cs (chemical/structural class), pe (physiologic effect).'
+        },
+        search_type: {
+          type: 'string',
+          enum: ['and', 'or'],
+          default: 'and',
+          description: 'How to combine the mapped filters: "and" (default) or "or".'
+        },
+        submission_date_from: {
+          type: 'string',
+          description: 'Earliest submission date (inclusive), YYYY-MM-DD; ANDed onto the query.'
+        },
+        submission_date_to: {
+          type: 'string',
+          description: 'Latest submission date (inclusive), YYYY-MM-DD; ANDed onto the query.'
+        },
+        raw_search: {
+          type: 'string',
+          description:
+            'Verbatim openFDA Lucene query; when set, overrides every mapped filter above.'
+        },
         max_records: { type: 'integer', default: 50 }
       }
     },
@@ -393,7 +413,11 @@ export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
     input: {
       type: 'object',
       properties: {
-        count_field: { type: 'string' },
+        count_field: {
+          type: 'string',
+          description:
+            'Field to bucket on — a friendly name (sponsor_name, application_number, dosage_form, route, marketing_status, te_code, pharm_class_epc/moa/cs/pe) or a raw openFDA field path.'
+        },
         brand: { type: 'string' },
         generic: { type: 'string' },
         active_ingredient: { type: 'string' },
@@ -402,11 +426,31 @@ export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
         dosage_form: { type: 'string' },
         route: { type: 'string' },
         pharm_class: { type: 'string' },
-        pharm_class_type: { type: 'string', enum: ['epc', 'moa', 'cs', 'pe'] },
-        search_type: { type: 'string', enum: ['and', 'or'], default: 'and' },
-        submission_date_from: { type: 'string' },
-        submission_date_to: { type: 'string' },
-        raw_search: { type: 'string' },
+        pharm_class_type: {
+          type: 'string',
+          enum: ['epc', 'moa', 'cs', 'pe'],
+          description:
+            'Which openFDA pharmacologic-class facet `pharm_class` matches: epc (established pharmacologic class), moa (mechanism of action), cs (chemical/structural class), pe (physiologic effect).'
+        },
+        search_type: {
+          type: 'string',
+          enum: ['and', 'or'],
+          default: 'and',
+          description: 'How to combine the mapped filters: "and" (default) or "or".'
+        },
+        submission_date_from: {
+          type: 'string',
+          description: 'Earliest submission date (inclusive), YYYY-MM-DD; ANDed onto the query.'
+        },
+        submission_date_to: {
+          type: 'string',
+          description: 'Latest submission date (inclusive), YYYY-MM-DD; ANDed onto the query.'
+        },
+        raw_search: {
+          type: 'string',
+          description:
+            'Verbatim openFDA Lucene query; when set, overrides every mapped filter above.'
+        },
         max_buckets: { type: 'integer', default: 100 }
       },
       required: ['count_field']
@@ -466,7 +510,13 @@ export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
     input: {
       type: 'object',
       properties: {
-        class_type: { type: 'string', enum: ['epc', 'moa', 'cs', 'pe'], default: 'epc' },
+        class_type: {
+          type: 'string',
+          enum: ['epc', 'moa', 'cs', 'pe'],
+          default: 'epc',
+          description:
+            'Pharmacologic-class facet to enumerate: epc (established pharmacologic class), moa (mechanism of action), cs (chemical/structural class), pe (physiologic effect).'
+        },
         max_buckets: { type: 'integer', default: 100 }
       }
     },
@@ -575,9 +625,23 @@ export const DRUG_REGULATORY_TOOLS: ToolDescriptor[] = [
           type: 'string',
           enum: ['HUMAN PRESCRIPTION DRUG', 'HUMAN OTC DRUG']
         },
-        exact: { type: 'boolean', default: false },
-        raw_search: { type: 'string' },
-        sections: { type: 'array', items: { type: 'string' } },
+        exact: {
+          type: 'boolean',
+          default: false,
+          description:
+            'Query the non-analyzed `.exact` field variants (exact match instead of tokenized).'
+        },
+        raw_search: {
+          type: 'string',
+          description:
+            'Verbatim openFDA Lucene query; when set, overrides every mapped filter above.'
+        },
+        sections: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'openFDA label section names to extract (e.g. ["boxed_warning", "warnings"]); returns raw section text instead of the default structured record.'
+        },
         max_records: { type: 'integer', default: 25 }
       }
     },

--- a/src/main/connectors/descriptors/genes-ontology.ts
+++ b/src/main/connectors/descriptors/genes-ontology.ts
@@ -400,16 +400,21 @@ export const GENES_ONTOLOGY_TOOLS: ToolDescriptor[] = [
     id: 'get_go_annotations',
     connector: 'genes',
     description:
-      'Retrieve GO annotations for a UniProt gene product from QuickGO (complete, count-verified). Args: uniprot_accession (e.g. "P04637", prefix optional); aspect (None/all or biological_process/molecular_function/cellular_component); evidence (None/all, a preset "experimental_manual"=manually-assigned experimental evidence, "automatic_iea"=electronic/IEA, or an explicit ECO code like "ECO:0000314"; three-letter GO evidence codes like IDA/IEA are NOT accepted — QuickGO silently ignores goEvidence, filter must use ECO codes); taxon_id (optional NCBI taxon, e.g. 9606); include_term_names (hydrate each record with GO term name/aspect/obsolete via one batched ontology lookup); max_records (cap on records; full set still retrieved and summarized; `truncated` flags the cap). Returns {gene_product, total_annotations, n_records, complete, truncated, distinct_go_ids (across ALL annotations), records:[{go_id, go_aspect, qualifier, go_evidence, eco_id, reference, assigned_by, date, ...}]}.',
+      'Retrieve GO annotations for a UniProt gene product from QuickGO (complete, count-verified). Args: uniprot_accession (e.g. "P04637", prefix optional); aspect (omit for all aspects, or one of biological_process/molecular_function/cellular_component); evidence (None/all, a preset "experimental_manual"=manually-assigned experimental evidence, "automatic_iea"=electronic/IEA, or an explicit ECO code like "ECO:0000314"; three-letter GO evidence codes like IDA/IEA are NOT accepted — QuickGO silently ignores goEvidence, filter must use ECO codes); taxon_id (optional NCBI taxon, e.g. 9606); include_term_names (hydrate each record with GO term name/aspect/obsolete via one batched ontology lookup); max_records (cap on records; full set still retrieved and summarized; `truncated` flags the cap). Returns {gene_product, total_annotations, n_records, complete, truncated, distinct_go_ids (across ALL annotations), records:[{go_id, go_aspect, qualifier, go_evidence, eco_id, reference, assigned_by, date, ...}]}.',
     input: {
       type: 'object',
       properties: {
         uniprot_accession: { type: 'string' },
         aspect: {
           type: 'string',
-          enum: ['biological_process', 'molecular_function', 'cellular_component']
+          enum: ['biological_process', 'molecular_function', 'cellular_component'],
+          description: 'Restrict to one GO aspect; omit for all aspects.'
         },
-        evidence: { type: 'string' },
+        evidence: {
+          type: 'string',
+          description:
+            'Evidence filter: a preset ("experimental_manual" = manually-assigned experimental, "automatic_iea" = electronic/IEA) or an explicit ECO code (e.g. "ECO:0000314"); omit for all. Three-letter GO codes (IDA/IEA) are not accepted — filter by ECO code.'
+        },
         taxon_id: { type: 'integer' },
         include_term_names: { type: 'boolean', default: false },
         max_records: { type: 'integer', default: 200 }

--- a/src/main/connectors/descriptors/variants-gnomad.ts
+++ b/src/main/connectors/descriptors/variants-gnomad.ts
@@ -761,7 +761,7 @@ export const VARIANTS_GNOMAD_TOOLS: ToolDescriptor[] = [
     id: 'get_structural_variant',
     connector: 'variants',
     description:
-      'Look up one gnomAD structural variant by its release-specific SV ID (e.g. `DEL_chr17_599b1512` in gnomad_sv_r4). IDs do NOT carry across releases — `dataset` (`gnomad_sv_r4` default, or `gnomad_sv_r2_1`) must match the release the ID came from.',
+      'Look up one gnomAD structural variant by its release-specific SV ID (e.g. `DEL_CHR17_599B1512` in gnomad_sv_r4). IDs do NOT carry across releases — `dataset` (`gnomad_sv_r4` default, or `gnomad_sv_r2_1`) must match the release the ID came from.',
     input: {
       type: 'object',
       properties: {


### PR DESCRIPTION
## Summary

Tier-3 follow-up to #134 — schema/description polish across connectors. Low-risk clarity fixes; the high-value item is describing drug-regulatory's cryptic openFDA params.

- **`drug_regulatory`** — added descriptions to the non-obvious params: `pharm_class_type` / `class_type` (epc / moa / cs / pe), `search_type`, `submission_date_from`/`_to` (explicit `YYYY-MM-DD`), `raw_search` (overrides mapped filters), `count_field`, `exact`, `sections`.
- **`genes-ontology.get_go_annotations`** — `aspect` and `evidence` now carry schema descriptions; fixed the prose that implied passing `None/all` (the enum only allows the three aspect tokens — omit for all).
- **`biorxiv.get_content_statistics`** — dropped the constant, meaningless `preprint_date: null` from the aggregate stat rows (code + `returns` + test).
- **`variants-gnomad.get_structural_variant`** — aligned the SV-id casing in the description with the runnable example (`DEL_CHR17_…`).
- **`cancer-models`** — mirrored the `gene_symbol` description across all gene tools (was only on one).

## Deferred (noted for a later pass)

- CIViC `civic_search_evidence`/`_assertions` filter enum/description emission — needs a `filterInput` refactor plus verifying every CIViC GraphQL enum value; the tool descriptions already document the main enums.
- Catalog `useWhen` "Sourced from…" suffix consistency (cosmetic; the `sources` array already carries it).
- Per-param schema descriptions for `structures-*` / `literature-*` / `rna`, which deliberately document args in prose.

## Verification

- `npm run typecheck && npm run lint && npm run test` — green (1843 tests).
