### PR TITLE
feat(update): in-place auto-update for windows and linux (electron-updater)

### DIFF
--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -107,3 +107,42 @@ jobs:
           aws s3 cp version.json \
             "s3://$S3_BUCKET/$S3_PREFIX/version.json" \
             --cache-control "no-cache" --content-type "application/json" --only-show-errors
+
+      # electron-updater feed files (win latest.yml, linux latest-linux.yml) must live at the channel
+      # root (a stable url the updater always polls), but the installers + blockmaps they reference live
+      # under releases/<version>/. Rewrite each feed's bare `path:`/`url:` filenames to that versioned
+      # subpath so the updater resolves them against the channel root. Missing feeds (e.g. a mac-only
+      # backfill) are simply skipped.
+      - name: Rewrite update feed paths
+        env:
+          VERSION: ${{ steps.ref.outputs.version }}
+        run: |
+          shopt -s nullglob
+          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml; do
+            [ -f "$yml" ] || continue
+            node -e '
+              const fs = require("fs");
+              const file = process.argv[1];
+              const version = process.env.VERSION;
+              const text = fs.readFileSync(file, "utf8").replace(
+                /^(\s*(?:- )?(?:path|url):\s*)(?!https?:|releases\/)([^\s].*)$/gm,
+                (_m, prefix, name) => `${prefix}releases/${version}/${name}`
+              );
+              fs.writeFileSync(file, text);
+              process.stdout.write(text);
+            ' "$yml"
+          done
+
+      # Publish the rewritten feeds to the channel root as mutable, no-cache objects (same policy as
+      # version.json), so the updater always sees the latest version immediately.
+      - name: Upload update feed to channel root
+        env:
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          S3_PREFIX: ${{ vars.S3_PREFIX }}
+        run: |
+          shopt -s nullglob
+          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml; do
+            [ -f "$yml" ] || continue
+            aws s3 cp "$yml" "s3://$S3_BUCKET/$S3_PREFIX/$(basename "$yml")" \
+              --cache-control "no-cache" --content-type "text/yaml" --only-show-errors
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,10 +71,10 @@ jobs:
             artifacts/*.deb
 
       # Attach user-facing artifacts + checksums: installers (dmg/exe/AppImage/deb) and portable
-      # zips (mac + win). Auto-update metadata (latest*.yml / blockmap) is intentionally NOT published:
-      # the zips here are plain downloads, not update feeds — arm64/x64 build on separate runners and
-      # each emits its own latest-mac.yml (they'd collide), and Squirrel.Mac can't auto-update an
-      # unsigned build anyway. Revisit latest*.yml once a Developer ID cert is configured.
+      # zips (mac + win), plus the win/linux electron-updater feed files (latest.yml, latest-linux.yml)
+      # and blockmaps so the mirror-to-website job can republish them to the CDN feed. macOS latest-mac*
+      # .yml is still excluded: arm64/x64 build on separate runners and each emits its own (they'd
+      # collide), and Squirrel.Mac can't auto-update the unsigned mac build anyway (no Developer ID).
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -88,3 +88,6 @@ jobs:
             artifacts/*.AppImage
             artifacts/*.deb
             artifacts/SHA256SUMS.txt
+            artifacts/latest.yml
+            artifacts/latest-linux.yml
+            artifacts/*.blockmap

--- a/dev-app-update.yml
+++ b/dev-app-update.yml
@@ -1,4 +1,4 @@
-provider: github
-owner: aipoch
-repo: open-science
+provider: generic
+url: https://statics.aipoch.com/open-science/app/stable
+channel: latest
 updaterCacheDirName: open-science-updater

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -101,9 +101,14 @@ linux:
 appImage:
   artifactName: ${name}-${version}-linux-${arch}.${ext}
 npmRebuild: false
+# electron-updater feed. Win/Linux auto-update reads app-update.yml (generated from this block) and
+# fetches <url>/latest.yml. macOS uses the separate version.json manifest flow (no Developer ID yet),
+# so its latest-mac*.yml is intentionally never published (see release.yml). The GitHub Release remains
+# the human-facing download source, populated by release.yml — electron-builder runs with --publish
+# never, so this block only shapes app-update.yml + latest*.yml, it does not upload anything.
 publish:
-  provider: github
-  owner: aipoch
-  repo: open-science
+  provider: generic
+  url: https://statics.aipoch.com/open-science/app/stable
+  channel: latest
 electronDownload:
   mirror: https://npmmirror.com/mirrors/electron/

--- a/src/main/update/create-strategy.test.ts
+++ b/src/main/update/create-strategy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// createUpdateStrategy constructs a concrete strategy per platform. Both strategies touch native
+// modules at construction (UpdateService reads app.getVersion(); ElectronUpdaterStrategy subscribes to
+// autoUpdater), so stub them enough to instantiate without a real Electron runtime.
+vi.mock('electron', () => ({
+  app: { getVersion: () => '0.0.0' },
+  BrowserWindow: { getAllWindows: () => [] }
+}))
+vi.mock('electron-updater', () => ({
+  autoUpdater: { on: () => {}, autoDownload: true, autoInstallOnAppQuit: true }
+}))
+
+import { createUpdateStrategy } from './create-strategy'
+import { ElectronUpdaterStrategy } from './electron-updater-strategy'
+import { UpdateService } from './service'
+
+describe('createUpdateStrategy', () => {
+  it('uses ElectronUpdaterStrategy on win32', () => {
+    expect(createUpdateStrategy('win32')).toBeInstanceOf(ElectronUpdaterStrategy)
+  })
+
+  it('uses ElectronUpdaterStrategy on linux', () => {
+    expect(createUpdateStrategy('linux')).toBeInstanceOf(ElectronUpdaterStrategy)
+  })
+
+  it('uses UpdateService (manifest) on darwin', () => {
+    expect(createUpdateStrategy('darwin')).toBeInstanceOf(UpdateService)
+  })
+})

--- a/src/main/update/create-strategy.ts
+++ b/src/main/update/create-strategy.ts
@@ -1,0 +1,13 @@
+import { ElectronUpdaterStrategy } from './electron-updater-strategy'
+import { UpdateService } from './service'
+import type { UpdateStrategy } from './strategy'
+
+// Picks the update strategy for the host platform. Windows/Linux get true in-place auto-update via
+// electron-updater; macOS (and any other platform) falls back to the manifest installer flow because
+// Squirrel.Mac auto-update needs a Developer ID signature this build doesn't have yet.
+export const createUpdateStrategy = (
+  platform: NodeJS.Platform = process.platform
+): UpdateStrategy => {
+  if (platform === 'win32' || platform === 'linux') return new ElectronUpdaterStrategy()
+  return new UpdateService()
+}

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -1,0 +1,97 @@
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { ElectronUpdaterStrategy } from './electron-updater-strategy'
+
+// The default autoUpdater is never exercised here (every test injects a FakeUpdater); mock the module
+// so importing the strategy doesn't pull a real Electron runtime into the test process.
+vi.mock('electron-updater', () => ({ autoUpdater: {} }))
+
+// Minimal fake of electron-updater's autoUpdater: an EventEmitter plus the methods/flags we drive.
+class FakeUpdater extends EventEmitter {
+  autoDownload = true
+  autoInstallOnAppQuit = true
+  checkForUpdates = vi.fn(async () => {
+    this.emit('checking-for-update')
+    this.emit('update-available', { version: '0.3.0', releaseNotes: 'notes' })
+  })
+  downloadUpdate = vi.fn(async () => {
+    this.emit('download-progress', { percent: 42 })
+    this.emit('update-downloaded', { version: '0.3.0' })
+  })
+  quitAndInstall = vi.fn()
+}
+
+describe('ElectronUpdaterStrategy', () => {
+  it('disables auto download/install on construction', () => {
+    const updater = new FakeUpdater()
+    new ElectronUpdaterStrategy({ updater, currentVersion: '0.2.0', broadcast: vi.fn() })
+    expect(updater.autoDownload).toBe(false)
+    expect(updater.autoInstallOnAppQuit).toBe(false)
+  })
+
+  it('maps check → available with restart applyKind', async () => {
+    const broadcast = vi.fn()
+    const updater = new FakeUpdater()
+    const strategy = new ElectronUpdaterStrategy({ updater, currentVersion: '0.2.0', broadcast })
+    const status = await strategy.check()
+    expect(status.state).toBe('available')
+    expect(status.latest).toBe('0.3.0')
+    expect(status.applyKind).toBe('restart')
+    expect(broadcast).toHaveBeenCalledWith(
+      'update:status',
+      expect.objectContaining({ state: 'available' })
+    )
+  })
+
+  it('maps download → progress then ready', async () => {
+    const broadcast = vi.fn()
+    const updater = new FakeUpdater()
+    const strategy = new ElectronUpdaterStrategy({ updater, currentVersion: '0.2.0', broadcast })
+    await strategy.check()
+    const status = await strategy.download()
+    expect(broadcast).toHaveBeenCalledWith('update:progress', 42)
+    expect(status.state).toBe('ready')
+  })
+
+  it('reports up-to-date when no update is available', async () => {
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-not-available', { version: '0.2.0' })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn()
+    })
+    const status = await strategy.check()
+    expect(status.state).toBe('up-to-date')
+  })
+
+  it('surfaces errors as status error', async () => {
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('error', new Error('boom'))
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn()
+    })
+    const status = await strategy.check()
+    expect(status.state).toBe('error')
+    expect(status.error).toBe('boom')
+  })
+
+  it('apply calls quitAndInstall', async () => {
+    const updater = new FakeUpdater()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn()
+    })
+    await strategy.apply()
+    expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -84,7 +84,7 @@ describe('ElectronUpdaterStrategy', () => {
     expect(status.error).toBe('boom')
   })
 
-  it('apply calls quitAndInstall', async () => {
+  it('apply installs silently and relaunches (quitAndInstall(true, true))', async () => {
     const updater = new FakeUpdater()
     const strategy = new ElectronUpdaterStrategy({
       updater,
@@ -93,5 +93,6 @@ describe('ElectronUpdaterStrategy', () => {
     })
     await strategy.apply()
     expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true)
   })
 })

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -1,0 +1,137 @@
+import { app, BrowserWindow } from 'electron'
+import { autoUpdater } from 'electron-updater'
+
+import type { UpdateStatus } from '../../shared/update'
+import type { UpdateStrategy } from './strategy'
+
+// Structural subset of electron-updater's autoUpdater we depend on, so tests can inject a fake without
+// pulling a real Electron runtime.
+export interface MinimalAutoUpdater {
+  autoDownload: boolean
+  autoInstallOnAppQuit: boolean
+  on(event: string, listener: (...args: unknown[]) => void): unknown
+  checkForUpdates(): Promise<unknown>
+  downloadUpdate(): Promise<unknown>
+  quitAndInstall(): void
+}
+
+export type ElectronUpdaterDeps = {
+  updater?: MinimalAutoUpdater
+  currentVersion?: string
+  broadcast?: (channel: string, payload: unknown) => void
+}
+
+// Default broadcast pushes to every live window (mirrors service.ts). Never runs in unit tests, which
+// inject their own broadcast.
+const defaultBroadcast = (channel: string, payload: unknown): void => {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) window.webContents.send(channel, payload)
+  }
+}
+
+// Coerce electron-updater's releaseNotes (string | {note}[] | null) to a plain string for the dialog.
+const notesToString = (notes: unknown): string => {
+  if (typeof notes === 'string') return notes
+  if (Array.isArray(notes)) {
+    return notes
+      .map((n) =>
+        n && typeof n === 'object' && 'note' in n ? String((n as { note: unknown }).note) : ''
+      )
+      .join('\n')
+  }
+  return ''
+}
+
+// win/linux strategy: wraps electron-updater for true in-place download + restart. Emits the same
+// UpdateStatus shape as UpdateService, always stamped applyKind:'restart'. Opt-in: autoDownload and
+// autoInstallOnAppQuit are disabled so nothing downloads/installs without a user action.
+export class ElectronUpdaterStrategy implements UpdateStrategy {
+  private readonly updater: MinimalAutoUpdater
+  private readonly currentVersion: string
+  private readonly broadcast: (channel: string, payload: unknown) => void
+  private status: UpdateStatus
+
+  constructor(deps: ElectronUpdaterDeps = {}) {
+    this.updater = deps.updater ?? (autoUpdater as unknown as MinimalAutoUpdater)
+    this.currentVersion = deps.currentVersion ?? app?.getVersion?.() ?? '0.0.0'
+    this.broadcast = deps.broadcast ?? defaultBroadcast
+    this.status = { state: 'idle', current: this.currentVersion, applyKind: 'restart' }
+
+    this.updater.autoDownload = false
+    this.updater.autoInstallOnAppQuit = false
+    this.subscribe()
+  }
+
+  private subscribe(): void {
+    this.updater.on('checking-for-update', () => this.setStatus({ state: 'checking' }))
+    this.updater.on('update-available', (info) => {
+      const i = info as { version?: string; releaseNotes?: unknown }
+      this.setStatus({
+        state: 'available',
+        latest: i.version,
+        notes: notesToString(i.releaseNotes)
+      })
+    })
+    this.updater.on('update-not-available', (info) => {
+      const i = info as { version?: string }
+      this.setStatus({ state: 'up-to-date', latest: i.version })
+    })
+    this.updater.on('download-progress', (p) => {
+      const percent = Math.round((p as { percent?: number }).percent ?? 0)
+      this.broadcast('update:progress', percent)
+      this.setStatus({ ...this.status, state: 'downloading', progress: percent })
+    })
+    this.updater.on('update-downloaded', () => {
+      this.setStatus({ ...this.status, state: 'ready', progress: 100 })
+    })
+    this.updater.on('error', (err) => {
+      this.setStatus({ state: 'error', error: err instanceof Error ? err.message : 'Update error' })
+    })
+  }
+
+  // Always re-stamps current + applyKind so every broadcast status is self-consistent regardless of
+  // which event produced it.
+  private setStatus(partial: Partial<UpdateStatus>): void {
+    this.status = {
+      ...partial,
+      state: partial.state ?? this.status.state,
+      current: this.currentVersion,
+      applyKind: 'restart'
+    }
+    this.broadcast('update:status', this.status)
+  }
+
+  getStatus(): UpdateStatus {
+    return this.status
+  }
+
+  async check(): Promise<UpdateStatus> {
+    try {
+      await this.updater.checkForUpdates()
+    } catch (error) {
+      this.setStatus({
+        state: 'error',
+        error: error instanceof Error ? error.message : 'Update check failed'
+      })
+    }
+    return this.status
+  }
+
+  async download(): Promise<UpdateStatus> {
+    this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
+    try {
+      await this.updater.downloadUpdate()
+    } catch (error) {
+      this.setStatus({
+        state: 'error',
+        error: error instanceof Error ? error.message : 'Download failed'
+      })
+    }
+    return this.status
+  }
+
+  async apply(): Promise<UpdateStatus> {
+    this.updater.quitAndInstall()
+    return this.status
+  }
+}

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -12,7 +12,7 @@ export interface MinimalAutoUpdater {
   on(event: string, listener: (...args: unknown[]) => void): unknown
   checkForUpdates(): Promise<unknown>
   downloadUpdate(): Promise<unknown>
-  quitAndInstall(): void
+  quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void
 }
 
 export type ElectronUpdaterDeps = {
@@ -130,8 +130,11 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     return this.status
   }
 
+  // Triggered by the user's "Restart to update" click once the download is ready. Silent install
+  // (isSilent=true) so the assisted NSIS installer never shows its wizard, and isForceRunAfter=true so
+  // the app relaunches into the new version after the in-place swap. per-user install = no UAC prompt.
   async apply(): Promise<UpdateStatus> {
-    this.updater.quitAndInstall()
+    this.updater.quitAndInstall(true, true)
     return this.status
   }
 }

--- a/src/main/update/ipc.ts
+++ b/src/main/update/ipc.ts
@@ -2,12 +2,12 @@ import { ipcMain } from 'electron'
 
 import { APP } from '../../shared/app-config'
 import type { AppInfo, UpdateStatus } from '../../shared/update'
-import { UpdateService } from './service'
+import { createUpdateStrategy } from './create-strategy'
 import type { UpdateStrategy } from './strategy'
 
 // Registers the renderer-callable update commands. Returns the strategy so the scheduler can drive it.
 export const registerUpdateIpcHandlers = (
-  strategy: UpdateStrategy = new UpdateService()
+  strategy: UpdateStrategy = createUpdateStrategy()
 ): UpdateStrategy => {
   ipcMain.handle('update:get-app-info', (): AppInfo => ({
     name: APP.name,

--- a/src/main/update/ipc.ts
+++ b/src/main/update/ipc.ts
@@ -3,19 +3,20 @@ import { ipcMain } from 'electron'
 import { APP } from '../../shared/app-config'
 import type { AppInfo, UpdateStatus } from '../../shared/update'
 import { UpdateService } from './service'
+import type { UpdateStrategy } from './strategy'
 
-// Registers the renderer-callable update commands. Returns the service so the scheduler can drive it.
+// Registers the renderer-callable update commands. Returns the strategy so the scheduler can drive it.
 export const registerUpdateIpcHandlers = (
-  service: UpdateService = new UpdateService()
-): UpdateService => {
+  strategy: UpdateStrategy = new UpdateService()
+): UpdateStrategy => {
   ipcMain.handle('update:get-app-info', (): AppInfo => ({
     name: APP.name,
-    version: service.getStatus().current,
+    version: strategy.getStatus().current,
     copyright: APP.copyright
   }))
-  ipcMain.handle('update:get-status', (): UpdateStatus => service.getStatus())
-  ipcMain.handle('update:check', (): Promise<UpdateStatus> => service.check())
-  ipcMain.handle('update:download', (): Promise<UpdateStatus> => service.download())
-  ipcMain.handle('update:open-installer', (): Promise<UpdateStatus> => service.openInstaller())
-  return service
+  ipcMain.handle('update:get-status', (): UpdateStatus => strategy.getStatus())
+  ipcMain.handle('update:check', (): Promise<UpdateStatus> => strategy.check())
+  ipcMain.handle('update:download', (): Promise<UpdateStatus> => strategy.download())
+  ipcMain.handle('update:apply', (): Promise<UpdateStatus> => strategy.apply())
+  return strategy
 }

--- a/src/main/update/scheduler.ts
+++ b/src/main/update/scheduler.ts
@@ -1,14 +1,14 @@
-import type { UpdateService } from './service'
+import type { UpdateStrategy } from './strategy'
 
 const SIX_HOURS_MS = 6 * 60 * 60 * 1000
 
-// Checks once at startup, then every `intervalMs`. The service swallows its own errors (status:error),
+// Checks once at startup, then every `intervalMs`. The strategy swallows its own errors (status:error),
 // so a failed check never becomes an uncaught rejection or nags the user. Returns a stop function.
 export const startUpdateScheduler = (
-  service: UpdateService,
+  strategy: UpdateStrategy,
   intervalMs: number = SIX_HOURS_MS
 ): (() => void) => {
-  void service.check()
-  const timer = setInterval(() => void service.check(), intervalMs)
+  void strategy.check()
+  const timer = setInterval(() => void strategy.check(), intervalMs)
   return () => clearInterval(timer)
 }

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -66,6 +66,18 @@ describe('UpdateService.check', () => {
     expect(status.state).toBe('error')
     expect(status.error).toBe('offline')
   })
+
+  it('stamps applyKind "installer" on every emitted status', async () => {
+    const service = new UpdateService({
+      fetchImpl: (() => Promise.resolve(jsonResponse(manifest))) as unknown as typeof fetch,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      broadcast: vi.fn()
+    })
+    const status = await service.check()
+    expect(status.applyKind).toBe('installer')
+  })
 })
 
 describe('UpdateService.download', () => {
@@ -177,7 +189,7 @@ describe('UpdateService.download', () => {
   })
 })
 
-describe('UpdateService.openInstaller', () => {
+describe('UpdateService.apply', () => {
   let dir = ''
   afterEach(async () => {
     if (dir) await rm(dir, { recursive: true, force: true })
@@ -227,7 +239,7 @@ describe('UpdateService.openInstaller', () => {
     const openPath = vi.fn(() => Promise.resolve(''))
     const service = await downloadedService(target, { openPath })
 
-    const status = await service.openInstaller()
+    const status = await service.apply()
 
     expect(openPath).toHaveBeenCalledWith(target)
     expect(status.state).toBe('ready')
@@ -239,7 +251,7 @@ describe('UpdateService.openInstaller', () => {
     const openPath = vi.fn(() => Promise.resolve(''))
     const service = await downloadedService(target, { openPath, fileExists: () => false })
 
-    const status = await service.openInstaller()
+    const status = await service.apply()
 
     expect(openPath).not.toHaveBeenCalled()
     expect(status.state).toBe('available')

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -7,6 +7,7 @@ import { APP } from '../../shared/app-config'
 import { isNewer, selectDownload, type UpdateStatus } from '../../shared/update'
 import { downloadInstaller } from './downloader'
 import { fetchManifest } from './manifest'
+import type { UpdateStrategy } from './strategy'
 
 export type UpdateServiceDeps = {
   fetchImpl?: typeof fetch
@@ -18,7 +19,7 @@ export type UpdateServiceDeps = {
   // Resolves where to save the installer, or null if the user cancels. Injected in tests; the
   // default is platform-aware (see resolveSavePath).
   promptSavePath?: (defaultFileName: string) => Promise<string | null>
-  // Filesystem + shell hooks, injected in tests so openInstaller never touches Electron/disk.
+  // Filesystem + shell hooks, injected in tests so apply never touches Electron/disk.
   fileExists?: (path: string) => boolean
   openPath?: (path: string) => Promise<string>
   openExternal?: (url: string) => Promise<void>
@@ -43,7 +44,7 @@ const installerFileName = (url: string): string => {
 
 // Owns the update lifecycle and the single UpdateStatus. Every transition is broadcast so all
 // renderer stores stay in sync. All I/O is injectable for tests; production reads Electron/OS.
-export class UpdateService {
+export class UpdateService implements UpdateStrategy {
   private status: UpdateStatus
   private readonly fetchImpl?: typeof fetch
   private readonly platform: NodeJS.Platform
@@ -67,7 +68,7 @@ export class UpdateService {
     this.fileExists = deps.fileExists ?? existsSync
     this.openPath = deps.openPath ?? ((path) => shell.openPath(path))
     this.openExternal = deps.openExternal ?? ((url) => shell.openExternal(url))
-    this.status = { state: 'idle', current: this.currentVersion }
+    this.status = { state: 'idle', current: this.currentVersion, applyKind: 'installer' }
   }
 
   // Platform-aware save location. Windows/Linux write straight to the Downloads folder (no OS
@@ -90,9 +91,11 @@ export class UpdateService {
     return this.status
   }
 
+  // Manifest flow always applies via an installer, so stamp applyKind here so every broadcast status
+  // carries it (the renderer picks the "Open installer" vs "Restart" action off this field).
   private setStatus(next: UpdateStatus): void {
-    this.status = next
-    this.broadcast('update:status', next)
+    this.status = { ...next, applyKind: 'installer' }
+    this.broadcast('update:status', this.status)
   }
 
   async check(): Promise<UpdateStatus> {
@@ -166,7 +169,7 @@ export class UpdateService {
   // Opens the downloaded installer. If the file is gone (e.g. the user deleted it) or fails to open,
   // drop back to 'available' so the user can re-download in place — the download metadata is still on
   // the status. With no installer for this platform at all, send them to the public download page.
-  async openInstaller(): Promise<UpdateStatus> {
+  async apply(): Promise<UpdateStatus> {
     const { localPath, download } = this.status
     if (localPath && this.fileExists(localPath)) {
       const error = await this.openPath(localPath)

--- a/src/main/update/strategy.ts
+++ b/src/main/update/strategy.ts
@@ -1,0 +1,12 @@
+import type { UpdateStatus } from '../../shared/update'
+
+// The platform-agnostic update contract the IPC layer and scheduler drive. Two implementations exist:
+// UpdateService (macOS + fallback, manifest download + manual reinstall) and ElectronUpdaterStrategy
+// (win/linux, in-place download/restart). Both broadcast the same UpdateStatus.
+export interface UpdateStrategy {
+  getStatus(): UpdateStatus
+  check(): Promise<UpdateStatus>
+  download(): Promise<UpdateStatus>
+  // Applies a ready update: open the installer (mac) or quitAndInstall (win/linux).
+  apply(): Promise<UpdateStatus>
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -195,7 +195,7 @@ interface OpenScienceAPI {
     getStatus(): Promise<UpdateStatus>
     check(): Promise<UpdateStatus>
     download(): Promise<UpdateStatus>
-    openInstaller(): Promise<UpdateStatus>
+    apply(): Promise<UpdateStatus>
     onStatus(listener: (status: UpdateStatus) => void): RemoveListener
     onProgress(listener: (percent: number) => void): RemoveListener
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -210,7 +210,7 @@ type OpenScienceAPI = {
     getStatus: () => Promise<UpdateStatus>
     check: () => Promise<UpdateStatus>
     download: () => Promise<UpdateStatus>
-    openInstaller: () => Promise<UpdateStatus>
+    apply: () => Promise<UpdateStatus>
     onStatus: (listener: (status: UpdateStatus) => void) => RemoveListener
     onProgress: (listener: (percent: number) => void) => RemoveListener
   }
@@ -423,7 +423,7 @@ const api: OpenScienceAPI = {
     getStatus: () => ipcRenderer.invoke('update:get-status') as Promise<UpdateStatus>,
     check: () => ipcRenderer.invoke('update:check') as Promise<UpdateStatus>,
     download: () => ipcRenderer.invoke('update:download') as Promise<UpdateStatus>,
-    openInstaller: () => ipcRenderer.invoke('update:open-installer') as Promise<UpdateStatus>,
+    apply: () => ipcRenderer.invoke('update:apply') as Promise<UpdateStatus>,
     onStatus: (listener) => onIpcMessage('update:status', listener),
     onProgress: (listener) => onIpcMessage('update:progress', listener)
   },

--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -73,4 +73,24 @@ describe('UpdateDialog', () => {
     act(() => button?.click())
     expect(download).toHaveBeenCalled()
   })
+
+  it('shows "Restart to update" when a ready update applies in place (win/linux)', () => {
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: { state: 'ready', current: '0.1.0', latest: '0.2.0', applyKind: 'restart' }
+    })
+    act(() => root.render(<UpdateDialog />))
+    expect(document.body.textContent).toContain('Restart to update')
+    expect(document.body.textContent).not.toContain('Open installer')
+  })
+
+  it('shows "Open installer" when a ready update applies via installer (mac)', () => {
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: { state: 'ready', current: '0.1.0', latest: '0.2.0', applyKind: 'installer' }
+    })
+    act(() => root.render(<UpdateDialog />))
+    expect(document.body.textContent).toContain('Open installer')
+    expect(document.body.textContent).not.toContain('Restart to update')
+  })
 })

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -1,4 +1,4 @@
-import { Download, ExternalLink, X } from 'lucide-react'
+import { Download, ExternalLink, RefreshCw, X } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 
 import { ExternalTextLink } from '@/components/ExternalTextLink'
@@ -14,7 +14,7 @@ const UpdateDialog = (): React.JSX.Element | null => {
   const isOpen = useUpdateStore((state) => state.isDialogOpen)
   const closeDialog = useUpdateStore((state) => state.closeDialog)
   const download = useUpdateStore((state) => state.download)
-  const openInstaller = useUpdateStore((state) => state.openInstaller)
+  const apply = useUpdateStore((state) => state.apply)
 
   if (!isOpen || !status.latest) return null
 
@@ -92,11 +92,20 @@ const UpdateDialog = (): React.JSX.Element | null => {
             {isReady ? (
               <button
                 type="button"
-                onClick={() => void openInstaller()}
+                onClick={() => void apply()}
                 className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
               >
-                <ExternalLink className="size-4" aria-hidden="true" />
-                Open installer
+                {status.applyKind === 'restart' ? (
+                  <>
+                    <RefreshCw className="size-4" aria-hidden="true" />
+                    Restart to update
+                  </>
+                ) : (
+                  <>
+                    <ExternalLink className="size-4" aria-hidden="true" />
+                    Open installer
+                  </>
+                )}
               </button>
             ) : (
               <button

--- a/src/renderer/src/stores/update-store.test.ts
+++ b/src/renderer/src/stores/update-store.test.ts
@@ -32,7 +32,7 @@ describe('useUpdateStore', () => {
         onProgress,
         check: vi.fn(),
         download: vi.fn(),
-        openInstaller: vi.fn()
+        apply: vi.fn()
       }
     }
 
@@ -58,7 +58,7 @@ describe('useUpdateStore', () => {
         onProgress: vi.fn(),
         check: vi.fn(),
         download: vi.fn(),
-        openInstaller: vi.fn()
+        apply: vi.fn()
       }
     }
 

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -12,7 +12,7 @@ type UpdateStore = {
   openDialog: () => void
   closeDialog: () => void
   download: () => Promise<void>
-  openInstaller: () => Promise<void>
+  apply: () => Promise<void>
 }
 
 // Single source of truth for update state in the renderer. The main process broadcasts every
@@ -58,10 +58,10 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
     set({ status: await api.download() })
   },
 
-  openInstaller: async () => {
+  apply: async () => {
     const api = window.api?.update
     if (!api) return
-    const status = await api.openInstaller()
+    const status = await api.apply()
     if (status) set({ status })
   }
 }))

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -22,6 +22,9 @@ export type UpdateStatus = {
   progress?: number // 0-100 while downloading
   localPath?: string // set when state === 'ready'
   error?: string
+  // How the renderer applies a ready update: open the downloaded installer (mac manual reinstall) or
+  // restart into an in-place electron-updater install (win/linux). Set by the active strategy.
+  applyKind?: 'installer' | 'restart'
 }
 
 export type AppInfo = { name: string; version: string; copyright: string }


### PR DESCRIPTION
## Summary

Upgrades the app's update flow from "download full installer + manual reinstall" to true in-place auto-update on **Windows and Linux** via `electron-updater` (background differential download → in-place swap → relaunch). **macOS is intentionally deferred**: Squirrel.Mac in-place update requires a Developer ID signature this build doesn't have yet, so macOS keeps the existing `version.json` manual-reinstall flow.

The renderer/IPC contract is preserved — the main process picks an update strategy by platform behind a single `UpdateStrategy` interface, and the shared `UpdateStatus` gains just one field (`applyKind`).

## What changed

- **`UpdateStrategy` contract + `applyKind`** — new interface (`check`/`download`/`apply`), `UpdateStatus.applyKind: 'installer' | 'restart'`. The old `openInstaller` action is generalized to `apply` across main/preload/renderer.
- **`ManifestInstallerStrategy`** — the existing `UpdateService` (macOS + fallback), unchanged behavior, now stamps `applyKind: 'installer'`.
- **`ElectronUpdaterStrategy`** — new win/linux strategy wrapping `autoUpdater`; `autoDownload`/`autoInstallOnAppQuit` disabled (opt-in), events mapped to the shared `UpdateStatus`, `applyKind: 'restart'`.
- **`createUpdateStrategy(platform)`** — factory: win32/linux → electron-updater, everything else → manifest.
- **Silent Windows install** — `apply()` calls `quitAndInstall(true, true)`: the assisted NSIS installer runs silently (no wizard, per-user = no UAC), then relaunches. Triggered by the user's single click on "Restart to update".
- **Generic feed to CDN** — `electron-builder` `publish` switched to `generic` pointing at `https://statics.aipoch.com/open-science/app/stable`; `release.yml` now attaches `latest.yml`/`latest-linux.yml`/`*.blockmap` to the Release (mac `latest-mac*.yml` still excluded to avoid the arm64/x64 collision); `mirror-to-website.yml` rewrites each feed's `path`/`url` to `releases/<version>/` and uploads the feeds to the channel root.

## Platform behavior (after "Restart to update")

| Platform | Behavior |
|---|---|
| Windows | Silent NSIS install (no wizard, no UAC) → relaunch |
| Linux (AppImage) | In-place file swap → relaunch, no UI |
| macOS | Deferred — opens `.dmg` for manual reinstall (existing flow) |

## Config / secrets

**No new secrets required for win/linux.** The feed rides the existing `mirror-to-website.yml` pipeline and reuses the current S3 credentials/vars:

- Secrets: `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_BUCKET` (already set — `version.json` already ships this way).
- Vars: `S3_REGION`, `CDN_BASE_URL`, `S3_PREFIX`.

The feed base URL is hardcoded in `electron-builder.yml` as `https://statics.aipoch.com/open-science/app/stable`. It must equal `CDN_BASE_URL` + `/` + `S3_PREFIX` (i.e. `CDN_BASE_URL=https://statics.aipoch.com`, `S3_PREFIX=open-science/app/stable`) — the same base as the existing `manifestUrl`. The generic feed is a public CDN read, so the client needs no auth.

macOS auto-update (future) will additionally need Apple Developer ID secrets (`CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`) — `build.yml` already consumes them conditionally.

## Testing

- Unit: `ElectronUpdaterStrategy`, `createUpdateStrategy`, `UpdateService` (applyKind + `apply`), `UpdateDialog` label switch. Full suite: 1855 passed.
- **Packaged verification is required** and cannot run in `npm run dev` (`quitAndInstall` needs `app.isPackaged`). Steps: install an older packaged build, stage a newer `latest.yml` + `releases/<version>/` artifacts on the CDN, launch the old build, confirm capsule → download (differential) → "Restart to update" → silent install → relaunch on the new version. Windows first (unsigned is fine end-to-end), then Linux AppImage.

## Known limitations

- **Bootstrapping**: the first version that ships this feature must still be installed manually; auto-update only activates for updates *from* that version onward.
- **Cross-version**: electron-updater always jumps straight to the latest version (never chains). Differential is best-effort and falls back to a full download across large gaps — the update always succeeds. App-level data migrations must therefore tolerate multi-version jumps (Prisma migrations already do).
