### PR TITLE
fix(update): manual download fallback when auto-update errors

### DIFF
--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useUpdateStore } from '@/stores/update-store'
 import { UpdateDialog } from './UpdateDialog'
+import { APP } from '../../../shared/app-config'
 
 // Markdown rendering is covered by AgentMarkdown's own tests; stub it to a plain passthrough so this
 // render test stays deterministic and independent of the streamdown pipeline.
@@ -92,5 +93,17 @@ describe('UpdateDialog', () => {
     act(() => root.render(<UpdateDialog />))
     expect(document.body.textContent).toContain('Open installer')
     expect(document.body.textContent).not.toContain('Restart to update')
+  })
+
+  it('offers a manual download fallback when the update errors', () => {
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: { state: 'error', current: '0.1.0', latest: '0.2.0', error: 'Install failed' }
+    })
+    act(() => root.render(<UpdateDialog />))
+    expect(document.body.textContent).toContain('Install failed')
+    const link = document.body.querySelector(`a[href="${APP.update.downloadPage}"]`)
+    expect(link).not.toBeNull()
+    expect(link?.textContent).toContain('Download manually')
   })
 })

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -76,9 +76,14 @@ const UpdateDialog = (): React.JSX.Element | null => {
           ) : null}
 
           {status.state === 'error' ? (
-            <p className="mt-3 text-xs text-destructive" role="alert">
-              {status.error ?? 'Update failed'}
-            </p>
+            <div className="mt-3" role="alert">
+              <p className="text-xs text-destructive">{status.error ?? 'Update failed'}</p>
+              {/* Fallback when the in-app update fails (e.g. a blocked/failed in-place install): let the
+                  user grab the installer by hand, mirroring the macOS manual-reinstall path. */}
+              <ExternalTextLink href={APP.update.downloadPage} className="mt-1 text-xs">
+                Download manually
+              </ExternalTextLink>
+            </div>
           ) : null}
 
           <div className="mt-4 flex items-center justify-end gap-2">


### PR DESCRIPTION
## Summary

Hardens the win/linux in-place auto-update (electron-updater, #136) with a manual-download fallback. When an update errors — for example a blocked or failed in-place install, which happens *after* the app has already quit and so cannot surface an in-app error — the update dialog's error state now shows a **"Download manually"** link to the public download page, mirroring the existing macOS manual-reinstall path.

Purely additive UI. No change to the success path; applies to every platform's error state.

## Changes

- `UpdateDialog`: error state renders a "Download manually" link to `APP.update.downloadPage`.
- Test: render test asserting the fallback link appears on error.

## Testing

- Unit: `UpdateDialog` render tests (7 pass, incl. the new error-fallback case). Full suite: 1856 passed.
