### PR TITLE
feat(acp): reconnect and continue on abnormal disconnect via Resume

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -980,6 +980,57 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('times out and tears down a reconnect when the agent never answers session/resume', async () => {
+    const process = new FakeAgentProcess()
+    const resumeReceived = createDeferred()
+
+    // A fresh agent that advertises resume support but leaves session/resume pending forever.
+    acp
+      .agent({ name: 'stuck-agent' })
+      .onRequest(acp.methods.agent.initialize, () => ({
+        protocolVersion: acp.PROTOCOL_VERSION,
+        agentCapabilities: {
+          loadSession: false,
+          sessionCapabilities: { close: {}, resume: {} }
+        },
+        authMethods: []
+      }))
+      .onRequest(acp.methods.agent.session.resume, () => {
+        resumeReceived.resolve(undefined)
+        return new Promise<never>(() => {})
+      })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+
+    // Capture the injected timer callback so the test can fire the resume timeout deterministically.
+    let fireResumeTimeout: (() => void) | undefined
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      resumeTimeoutMs: 1000,
+      setTimer: (fn) => {
+        fireResumeTimeout = fn
+        return 0 as unknown as ReturnType<typeof setTimeout>
+      },
+      clearTimer: () => {}
+    })
+
+    const resume = runtime.resumeSession({ sessionId: 'stuck-session', cwd: '/workspace' })
+
+    // Wait until the resume request is genuinely in flight, then trip the injected timeout.
+    await resumeReceived.promise
+    fireResumeTimeout?.()
+
+    await expect(resume).rejects.toThrow(/timed out/i)
+    // The half-open connection is torn down so a retry reconnects cleanly.
+    expect(process.killed).toBe(true)
+  })
+
   it('adopts a fresh session under the same id when a replaced agent no longer holds it', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['adopted-session-1'], { resumeNotFound: true })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -83,6 +83,11 @@ type AcpRuntimeOptions = {
   uploads?: AcpRuntimeUploadOptions
   notebook?: AcpRuntimeNotebookOptions
   skills?: AcpRuntimeSkillsOptions
+  // Bounds the network-bound reconnect+resume so Resume always resolves; the fast attached-session
+  // path is never timed. Injectable timer mirrors the approval broker so tests stay deterministic.
+  resumeTimeoutMs?: number
+  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void
 }
 
 // Turn-scoped skill force-load hooks, wired from the settings service. Optional so tests that construct
@@ -223,6 +228,10 @@ class AcpRuntime {
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
   private readonly skillsHooks: AcpRuntimeSkillsOptions | undefined
+  // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
+  private readonly resumeTimeoutMs: number
+  private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private readonly artifactOptions: AcpRuntimeArtifactOptions | undefined
   private readonly notebookOptions: AcpRuntimeNotebookOptions | undefined
   private readonly artifactRepository: ArtifactRepository | undefined
@@ -242,6 +251,9 @@ class AcpRuntime {
     this.callbacks = options.callbacks ?? {}
     this.spawnAgent = options.spawnAgent
     this.skillsHooks = options.skills
+    this.resumeTimeoutMs = options.resumeTimeoutMs ?? 30_000
+    this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
+    this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
     this.artifactOptions = options.artifacts
     this.notebookOptions = options.notebook
     this.artifactRepository = options.artifacts
@@ -532,6 +544,51 @@ class AcpRuntime {
       return { sessionId: request.sessionId, cwd: sessionCwd }
     }
 
+    // The reconnect + session/resume handshake spawns a fresh agent and is network-bound, so it is
+    // wrapped in a bounded timeout that tears down the half-open connection if the agent stalls.
+    return this.resumeSessionWithTimeout(request, sessionCwd, projectName)
+  }
+
+  // Races the network-bound resume against a timeout so a stalled agent handshake cannot hang Resume
+  // forever. On timeout the half-open connection is torn down so the next Resume reconnects cleanly.
+  private async resumeSessionWithTimeout(
+    request: AcpResumeSessionRequest,
+    sessionCwd: string,
+    projectName: string
+  ): Promise<AcpCreateSessionResponse> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let timedOut = false
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = this.setTimer(() => {
+        timedOut = true
+        reject(new Error('ACP session resume timed out.'))
+      }, this.resumeTimeoutMs)
+    })
+
+    try {
+      return await Promise.race([
+        this.resumeSessionNetwork(request, sessionCwd, projectName),
+        timeout
+      ])
+    } catch (error) {
+      if (timedOut) {
+        await this.disconnect(false)
+      }
+
+      throw error
+    } finally {
+      if (timer !== undefined) {
+        this.clearTimer(timer)
+      }
+    }
+  }
+
+  // Performs the connect + session/resume handshake for a session the runtime does not yet hold.
+  private async resumeSessionNetwork(
+    request: AcpResumeSessionRequest,
+    sessionCwd: string,
+    projectName: string
+  ): Promise<AcpCreateSessionResponse> {
     const connection = await this.ensureConnected(sessionCwd)
     // Resume is optional in ACP, so fail early when the agent did not advertise it.
     if (!this.supportsSessionResume) {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../stores/preview-workbench-store'
 import {
   createWorkspaceRuntimeEventProcessor,
+  markRunningSessionsDisconnectedOnDrop,
   processVisibleWorkspaceRuntimeEvents,
   resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage
@@ -465,6 +466,83 @@ describe('workspace agent message sending', () => {
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
   })
 
+  it('shows the Resume banner when a prompt fails during a live connection drop', async () => {
+    vi.stubGlobal('window', {
+      api: {
+        acp: {
+          getState: vi
+            .fn()
+            .mockResolvedValue({ ...createSnapshot(['session-1']), status: 'closed' })
+        }
+      }
+    })
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(undefined)
+    }
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'earlier turn',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'hello',
+      cwd: '/workspace/project'
+    })
+    await flushRuntimeTasks()
+    await flushRuntimeTasks()
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      interrupted: true,
+      error: 'Connection lost — Resume to reconnect and continue.'
+    })
+  })
+
+  it('shows a plain error, not the Resume banner, when a prompt fails but the connection is up', async () => {
+    vi.stubGlobal('window', {
+      api: {
+        acp: {
+          getState: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+        }
+      }
+    })
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(undefined)
+    }
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'earlier turn',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'hello',
+      cwd: '/workspace/project'
+    })
+    await flushRuntimeTasks()
+    await flushRuntimeTasks()
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.status).toBe('error')
+    expect(session.interrupted).toBeFalsy()
+    expect(session.error).toBe('Agent run failed')
+  })
+
   it('marks restored sessions running before resume finishes to block duplicate submits', async () => {
     const resumeCanFinish = createDeferred<{ sessionId: string; cwd?: string }>()
     const runtime = {
@@ -658,5 +736,113 @@ describe('resuming an interrupted session on demand', () => {
       status: 'error',
       error: 'Session workspace is missing; start a new conversation.'
     })
+  })
+
+  it('flags a running session as disconnected when the connection drops', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Keep working',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    expect(useSessionStore.getState().sessions[0].status).toBe('running')
+
+    markRunningSessionsDisconnectedOnDrop('connected', 'closed')
+
+    const session = useSessionStore.getState().sessions[0]
+
+    expect(session.status).toBe('error')
+    expect(session.interrupted).toBe(true)
+    expect(session.error).toBe('Connection lost — Resume to reconnect and continue.')
+  })
+
+  it('does not flag an idle session on drop so provider/skills reconnects stay silent', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'All done',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    markRunningSessionsDisconnectedOnDrop('connected', 'closed')
+
+    expect(useSessionStore.getState().sessions[0].interrupted).toBeUndefined()
+    expect(useSessionStore.getState().sessions[0].status).toBe('idle')
+  })
+
+  it('reconnects and re-sends the interrupted user turn exactly once', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Continue the analysis',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'ask'
+    })
+    // A live drop leaves the last user turn unanswered and flags the session for Resume.
+    useSessionStore.getState().markDisconnected('session-1')
+
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi
+        .fn()
+        .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+    await flushRuntimeTasks()
+
+    expect(runtime.resumeSession).toHaveBeenCalled()
+    expect(runtime.sendPrompt).toHaveBeenCalledTimes(1)
+    expect(runtime.sendPrompt).toHaveBeenCalledWith(
+      'session-1',
+      'Continue the analysis',
+      [],
+      undefined,
+      undefined
+    )
+
+    const session = useSessionStore.getState().sessions[0]
+    const userMessages = session.messages.filter((message) => message.role === 'user')
+
+    // The stale turn was removed and re-appended once, so there is no duplicate user bubble.
+    expect(userMessages).toHaveLength(1)
+    expect(userMessages[0].content).toBe('Continue the analysis')
+    expect(session.interrupted).toBeUndefined()
+  })
+
+  it('reconnects without re-sending when the last turn was already answered', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Earlier prompt',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    // A completed assistant reply means the turn was answered before the drop.
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'Here is the answer'
+    })
+    useSessionStore.getState().finishRun('session-1')
+    useSessionStore.getState().markDisconnected('session-1')
+
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi
+        .fn()
+        .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      sendPrompt: vi.fn()
+    }
+
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+    await flushRuntimeTasks()
+
+    expect(runtime.resumeSession).toHaveBeenCalledTimes(1)
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({ status: 'idle' })
   })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react'
 
 import type {
+  AcpConnectionStatus,
   AcpPermissionGrant,
   AcpPermissionRequest,
   AcpRuntimeEvent
@@ -14,7 +15,7 @@ import type { UploadedAttachment } from '../../../../shared/uploads'
 import type { ArtifactReference } from '../../../../shared/artifacts'
 import type { MessagePart } from '../../../../shared/session-persistence'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
-import { useSessionStore } from '../../stores/session-store'
+import { useSessionStore, type ChatMessage } from '../../stores/session-store'
 import { useAcpRuntime } from './useAcpRuntime'
 import { applyWorkspaceRuntimeEvent, syncWorkspacePermissionState } from './workspace-events'
 
@@ -61,12 +62,35 @@ const getResumeFailureMessage = (error: unknown): string => {
     return 'Session workspace is missing; start a new conversation.'
   }
 
+  if (/timed out/i.test(message)) {
+    return 'Agent session resume timed out; click Resume to try again.'
+  }
+
   return 'Agent session resume failed'
 }
 
 // Keeps attachment-finalization failures displayable without assuming Error instances.
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
+
+// Classifies a failed prompt against the live connection status: an abnormal drop (status 'closed'/
+// 'error') shows the Resume banner so the user can reconnect and continue, while a turn-level error
+// (connection still up, e.g. a gateway 5xx) surfaces as a normal session error. Reading the status at
+// failure time avoids the race where failRun would flip the session out of 'running' first.
+const failOrMarkDisconnected = async (sessionId: string, message: string): Promise<void> => {
+  try {
+    const snapshot = await window.api.acp.getState()
+
+    if (snapshot.status === 'closed' || snapshot.status === 'error') {
+      useSessionStore.getState().markDisconnected(sessionId)
+      return
+    }
+  } catch {
+    // Fall back to a plain error if the live status read fails.
+  }
+
+  useSessionStore.getState().failRun(sessionId, message)
+}
 
 // Moves staged uploads into the session directory and updates the already-visible user message.
 const finalizeWorkspaceAttachments = async (
@@ -232,13 +256,13 @@ const startPendingSessionPrompt = (
       .sendPrompt(runtimeSessionId, content, promptAttachments, forcedSkillIds, referencedArtifacts)
       .then((snapshot) => {
         if (!snapshot) {
-          useSessionStore.getState().failRun(runtimeSessionId, 'Agent run failed')
+          void failOrMarkDisconnected(runtimeSessionId, 'Agent run failed')
         }
       })
       .catch((error) => {
-        // A rejected prompt (e.g. an upstream gateway 5xx) must surface as a visible session error
-        // instead of being swallowed as an unhandled rejection.
-        useSessionStore.getState().failRun(runtimeSessionId, getErrorMessage(error))
+        // A rejected prompt surfaces as a Resume banner if the connection dropped, otherwise a
+        // visible session error, instead of being swallowed as an unhandled rejection.
+        void failOrMarkDisconnected(runtimeSessionId, getErrorMessage(error))
       })
   })()
 }
@@ -368,13 +392,13 @@ const sendWorkspaceMessage = async (
       .sendPrompt(targetSessionId, content, promptAttachments, forcedSkillIds, referencedArtifacts)
       .then((snapshot) => {
         if (!snapshot) {
-          useSessionStore.getState().failRun(targetSessionId, 'Agent run failed')
+          void failOrMarkDisconnected(targetSessionId, 'Agent run failed')
         }
       })
       .catch((error) => {
-        // A rejected prompt (e.g. an upstream gateway 5xx) must surface as a visible session error
-        // instead of being swallowed as an unhandled rejection.
-        useSessionStore.getState().failRun(targetSessionId, getErrorMessage(error))
+        // A rejected prompt surfaces as a Resume banner if the connection dropped, otherwise a
+        // visible session error, instead of being swallowed as an unhandled rejection.
+        void failOrMarkDisconnected(targetSessionId, getErrorMessage(error))
       })
 
     return appended
@@ -405,6 +429,26 @@ const sendWorkspaceMessage = async (
   )
 
   return pending
+}
+
+// Finds the interrupted user turn to continue after a reconnect: the most recent user message that
+// has no successful assistant reply after it (a half-streamed reply is failed on disconnect, so it
+// does not count). Returns undefined when the last turn was already answered, so a redundant Resume
+// does not re-send it.
+const findInterruptedUserTurn = (messages: ChatMessage[]): ChatMessage | undefined => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+
+    if (message.role !== 'user') continue
+
+    const hasSuccessfulReply = messages
+      .slice(index + 1)
+      .some((later) => later.role === 'agent' && later.status !== 'error')
+
+    return hasSuccessfulReply ? undefined : message
+  }
+
+  return undefined
 }
 
 // Explicitly re-attaches an interrupted session's ACP runtime so the user can keep chatting. On
@@ -442,6 +486,49 @@ const resumeInterruptedWorkspaceSession = async (
     useSessionStore.getState().markResumed(sessionId)
   } catch (error) {
     useSessionStore.getState().failRun(sessionId, getResumeFailureMessage(error))
+    return
+  }
+
+  // Continue the interrupted turn if it never got a successful reply. Removing the stale user message
+  // first avoids a duplicate bubble, since the shared send path re-appends and re-prompts it once.
+  const interruptedTurn = findInterruptedUserTurn(session.messages)
+
+  if (!interruptedTurn) return
+
+  useSessionStore.getState().removeMessage(sessionId, interruptedTurn.id)
+
+  await sendWorkspaceMessage(runtime, {
+    sessionId,
+    text: interruptedTurn.content,
+    attachments: interruptedTurn.uploads ?? [],
+    parts: interruptedTurn.parts,
+    cwd: resumeCwd,
+    projectId: session.projectId,
+    permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
+  })
+}
+
+// Flags running sessions as disconnected on a TRANSITION into a dropped connection state. Abnormal
+// drops (agent crash / gateway drop) go through main's handleConnectionClosed → status 'closed';
+// deliberate mid-prompt disconnects use disconnect(false) (no 'closed' emit) and idle provider/skills
+// reconnects have no running session, so neither reaches markDisconnected here.
+const markRunningSessionsDisconnectedOnDrop = (
+  previousStatus: AcpConnectionStatus,
+  currentStatus: AcpConnectionStatus
+): void => {
+  const droppedNow =
+    (currentStatus === 'closed' || currentStatus === 'error') &&
+    previousStatus !== 'closed' &&
+    previousStatus !== 'error'
+
+  if (!droppedNow) return
+
+  const { sessions, markDisconnected } = useSessionStore.getState()
+
+  for (const session of sessions) {
+    if (session.status === 'running' || session.status === 'waiting-permission') {
+      markDisconnected(session.id)
+    }
   }
 }
 
@@ -461,6 +548,9 @@ const useWorkspaceAgentRuntime = (): {
 } => {
   const runtime = useAcpRuntime()
   const eventProcessor = useRef(createWorkspaceRuntimeEventProcessor())
+  // Tracks the last connection status so the disconnect effect fires only on a transition, not on
+  // every unrelated snapshot re-render.
+  const previousStatusRef = useRef(runtime.state.status)
 
   // Applies each visible runtime event once and trims ids that fell out of the runtime window.
   useEffect(() => {
@@ -471,6 +561,14 @@ const useWorkspaceAgentRuntime = (): {
   useEffect(() => {
     syncWorkspacePermissionState(runtime.state.pendingPermissions)
   }, [runtime.state.pendingPermissions])
+
+  // An abnormal live drop (agent crash / gateway drop) surfaces as a transition into 'closed'/'error'
+  // while a session is still running. Flag those sessions so the Resume banner appears.
+  useEffect(() => {
+    const previousStatus = previousStatusRef.current
+    previousStatusRef.current = runtime.state.status
+    markRunningSessionsDisconnectedOnDrop(previousStatus, runtime.state.status)
+  }, [runtime.state.status])
 
   // Creates a session if needed, records the user message, then starts the prompt in the background.
   const sendMessage = useCallback(
@@ -575,6 +673,7 @@ const useWorkspaceAgentRuntime = (): {
 
 export {
   createWorkspaceRuntimeEventProcessor,
+  markRunningSessionsDisconnectedOnDrop,
   processVisibleWorkspaceRuntimeEvents,
   resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage,

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -286,7 +286,7 @@ describe('OnboardingWizard', () => {
     expect(container.textContent).not.toContain('Base URL is required.')
 
     const testButton = Array.from(container.querySelectorAll('button')).find((button) =>
-      /test connection/i.test(button.textContent ?? '')
+      /test & continue/i.test(button.textContent ?? '')
     )
     await act(async () => {
       testButton?.click()

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1223,5 +1223,31 @@ describe('session store', () => {
       expect(session.error).toBeUndefined()
       expect(session.status).toBe('idle')
     })
+
+    it('markDisconnected flags a live drop and settles the half-streamed reply, keeping the user turn', () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'transport-session-1',
+        content: 'Read the files',
+        cwd: '/workspace/project'
+      })
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'assistant-message-1',
+        eventId: 'event-1',
+        content: 'I started'
+      })
+
+      useSessionStore.getState().markDisconnected('transport-session-1')
+
+      const session = useSessionStore.getState().sessions[0]
+
+      expect(session.status).toBe('error')
+      expect(session.interrupted).toBe(true)
+      expect(session.error).toBe('Connection lost — Resume to reconnect and continue.')
+      expect(session.activeRun).toBeUndefined()
+      // The user prompt is preserved so Resume can continue it; the streamed reply is failed off.
+      expect(session.messages[0]).toMatchObject({ role: 'user', content: 'Read the files' })
+      expect(session.messages[1]).toMatchObject({ content: 'I started', status: 'error' })
+    })
   })
 })

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -162,6 +162,8 @@ type SessionStore = SessionStoreData & {
   finishRun: (sessionId: string) => void
   failRun: (sessionId: string, error: string) => void
   markResumed: (sessionId: string) => void
+  markDisconnected: (sessionId: string) => void
+  removeMessage: (sessionId: string, messageId: string) => void
   upsertToolActivity: (input: UpsertToolActivityInput) => void
   setPermissionPending: (sessionId: string) => void
   clearPermissionPending: (sessionId: string) => void
@@ -1012,6 +1014,44 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               status: 'idle',
               error: undefined,
               interrupted: undefined,
+              updatedAt: Date.now()
+            }
+          : session
+      )
+    }))
+  },
+
+  // Flags a session dropped by a live connection loss so the Resume banner appears; like failRun it
+  // settles any half-streamed message/open tool so nothing hangs in a perpetually-running state.
+  markDisconnected: (sessionId) => {
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId
+          ? {
+              ...session,
+              status: 'error',
+              activeRun: undefined,
+              interrupted: true,
+              error: 'Connection lost — Resume to reconnect and continue.',
+              messages: failStreamingMessages(session.messages),
+              activities: failOpenActivities(session.activities),
+              updatedAt: Date.now()
+            }
+          : session
+      )
+    }))
+  },
+
+  // Drops a single message by id (used to remove a stale interrupted user turn before it is re-sent).
+  removeMessage: (sessionId, messageId) => {
+    if (!sessionId || !messageId) return
+
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId
+          ? {
+              ...session,
+              messages: session.messages.filter((message) => message.id !== messageId),
               updatedAt: Date.now()
             }
           : session


### PR DESCRIPTION
## Problem

When the live ACP agent connection drops abnormally mid-session (agent process crash, gateway drop, network blip — the app stays open), there was no reconnect affordance. The in-flight prompt failed into a generic red error box, and the only "Resume" in the app appeared solely at app-restart hydration. So an abnormal drop dead-ended the conversation.

## Change

An abnormal drop now surfaces the neutral **Resume** banner (distinct from the red error box used for turn-level errors), and Resume actually reconnects and continues:

- **Classify the failure at failure time** against the live connection status (`acp getState`): a dropped connection (`closed`/`error`) marks the session disconnected → Resume banner; a turn-level error (connection still up, e.g. a gateway 5xx) keeps the plain error box. Reading the status at the moment of failure avoids the race where `failRun` flips the session out of `running` before a status-transition effect can flag it.
- **Resume reconnects, resumes, and continues** the interrupted turn: after a successful `session/resume`, the stale unanswered user message is removed and re-sent through the shared send path, so the turn continues without a duplicate bubble. A redundant Resume on an already-answered turn just reconnects.
- **Bounded resume handshake**: the reconnect + `session/resume` path is wrapped in an injectable timeout, so Resume always resolves (success or a clear retryable error) and tears down a half-open connection on timeout rather than spinning forever.

The existing app-restart interrupted path and its banner are unchanged; this reuses the same `interrupted` flag and `SessionInterruptedBanner`.

## Testing

- `npm run typecheck` — passes (node + web).
- `npx vitest run` over `src/main/acp`, workspace, store, and `lib/acp` renderer suites — 528 passing, including new cases: a live drop shows the Resume banner (not the red box), a connection-up failure keeps the red box, and the resume handshake times out and tears down.
- `npx eslint --cache .` — clean.
- Manually verified in `npm run dev`: with a prompt in flight, killing the agent process shows the Resume banner; clicking Resume reconnects and re-sends the interrupted turn.
