### PR TITLE
ci(mac): decouple notarization into a capped, re-runnable job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,21 +120,19 @@ jobs:
 
       # Build the renderer + main (incl. typecheck), then package with electron-builder.
       #
-      # macOS signing: electron-builder auto-imports CSC_LINK (base64 .p12) to sign, then notarizes
-      # when APPLE_ID creds are present. With no cert, signing is skipped and the afterPack hook
-      # (build/adhoc-sign.cjs) applies a valid ad-hoc signature so Gatekeeper shows the bypassable
-      # "unidentified developer" prompt instead of "damaged". Linux has no signing concept.
-      # All secrets are optional today — the build works with none set.
+      # macOS signing: this step only SIGNS (Developer ID), it never notarizes. Notarization +
+      # stapling is decoupled into notarize-mac.yml so the build never blocks on Apple's servers
+      # (see that workflow and release.yml). electron-builder auto-imports CSC_LINK (base64 .p12)
+      # to sign a stable build; with no cert — or for any nightly (kept ad-hoc for speed) — signing
+      # is skipped and the afterPack hook (build/adhoc-sign.cjs) applies a valid ad-hoc signature so
+      # Gatekeeper shows the bypassable "unidentified developer" prompt instead of "damaged". Linux
+      # has no signing concept. All secrets are optional — the build works with none set.
       - name: Build & package
         shell: bash
         env:
           # macOS Developer ID (real signing when present, ad-hoc fallback otherwise)
           CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
-          # macOS notarization (notarytool)
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           npm run build
           # Nightly: override the packaged version with `<base>-nightly.<short-sha>` (valid semver
@@ -145,15 +143,17 @@ jobs:
             base=$(node -p "require('./package.json').version")
             eb_ver=(-c.extraMetadata.version="${base}-nightly.${GITHUB_SHA::7}")
           fi
-          if [ "${{ matrix.platform }}" = "mac" ] && [ -n "$CSC_LINK" ]; then
-            # Real Developer ID cert present -> sign + notarize (override the config's notarize:false).
-            npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" --publish never -c.mac.notarize=true
+          if [ "${{ matrix.platform }}" = "mac" ] && [ "${{ inputs.nightly }}" != "true" ] && [ -n "$CSC_LINK" ]; then
+            # Stable build with a Developer ID cert -> SIGN ONLY (notarize:false). Notarization +
+            # stapling happens later in notarize-mac.yml, so this job never waits on Apple.
+            npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" --publish never -c.mac.notarize=false
           else
-            # No cert: GitHub injects unset secrets as EMPTY strings, and electron-builder mis-reads an
-            # empty CSC_LINK as a certificate path — it resolves to the cwd and dies with
-            # "<repo path> not a file". Drop the empty vars and disable auto-discovery so electron-builder
-            # skips its own signing entirely; the afterPack hook (build/adhoc-sign.cjs) ad-hoc signs instead.
-            unset CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+            # No cert, or a nightly build (ad-hoc on purpose): skip electron-builder's own signing.
+            # GitHub injects unset secrets as EMPTY strings, and electron-builder mis-reads an empty
+            # CSC_LINK as a certificate path — it resolves to the cwd and dies with
+            # "<repo path> not a file". Drop the empty vars and disable auto-discovery so it skips
+            # signing entirely; the afterPack hook (build/adhoc-sign.cjs) ad-hoc signs instead.
+            unset CSC_LINK CSC_KEY_PASSWORD
             export CSC_IDENTITY_AUTO_DISCOVERY=false
             npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" --publish never
           fi

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -1,0 +1,192 @@
+name: Notarize macOS
+
+# Decoupled macOS notarization + stapling.
+#
+# The build (build.yml) only SIGNS the mac dmg/zip; this workflow submits them to Apple's notary
+# service, waits (with a hard time cap — no custom polling), staples the ticket, and re-emits the
+# stapled artifacts. Splitting it out of the build means a slow notarization never ties up the build
+# matrix, and it can be re-run on its own without a rebuild.
+#
+# Two entry points:
+#   - workflow_call — used by release.yml right after build. Operates on the run's signed mac
+#     artifacts and re-uploads the stapled versions (overwrite) so the publish job attaches them.
+#   - workflow_dispatch{ tag } — standalone repair/backfill. Notarizes + staples the mac assets
+#     already attached to an existing Release, clobbers them back, and refreshes SHA256SUMS.txt.
+#
+# Time cap is enforced two ways: notarytool `--wait --timeout` bounds the Apple wait per file, and
+# job-level `timeout-minutes` bounds the whole job. On timeout/failure the job fails but the Apple
+# submission keeps running, so simply re-running this workflow re-checks and staples — no rebuild.
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Unused by the release path (operates on run artifacts); present for symmetry.'
+        required: false
+        type: string
+        default: ''
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag whose mac assets to notarize + staple (e.g. v0.1.0)'
+        required: true
+
+# gh release upload/download in the dispatch path needs write access to release assets.
+permissions:
+  contents: write
+
+jobs:
+  notarize:
+    name: Notarize + staple ${{ matrix.arch }}
+    runs-on: macos-14
+    # Hard ceiling so a stuck notarization can never run forever (see also notarytool --timeout).
+    timeout-minutes: 45
+    strategy:
+      # One arch's Apple hiccup must not cancel the other.
+      fail-fast: false
+      matrix:
+        arch: [arm64, x64]
+    steps:
+      # Notarization is optional: if the API key secret isn't configured, no-op so a tagged release
+      # still succeeds with the ad-hoc mac build (today's behavior) instead of failing here. Every
+      # real step below is gated on this.
+      - name: Gate on API key presence
+        id: gate
+        env:
+          P8_B64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+        run: |
+          if [ -n "${P8_B64:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::APPLE_API_KEY_P8_BASE64 not set — skipping notarization; mac stays as built."
+          fi
+
+      # release.yml path: pull this run's signed artifacts for the arch (uploaded by build.yml).
+      - name: Download signed mac artifact (from this run)
+        if: steps.gate.outputs.enabled == 'true' && github.event_name != 'workflow_dispatch'
+        uses: actions/download-artifact@v8
+        with:
+          name: macos-${{ matrix.arch }}
+          path: mac
+
+      # Standalone path: pull the arch's signed assets straight off the existing Release.
+      - name: Download signed mac assets (from the release)
+        if: steps.gate.outputs.enabled == 'true' && github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p mac
+          gh release download "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" \
+            --pattern "*-mac-${{ matrix.arch }}.dmg" \
+            --pattern "*-mac-${{ matrix.arch }}.zip" \
+            --dir mac
+
+      # App Store Connect API key (.p8), stored base64-encoded so it survives as a single secret.
+      - name: Write App Store Connect API key
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          P8_B64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+        run: |
+          printf '%s' "$P8_B64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+
+      # Notarize the dmg (Apple ticks every cdhash inside it, including the .app), then staple. The
+      # zip ships the same signed .app, so its ticket already exists from the dmg submission — just
+      # staple that .app and repackage (stapler cannot target a .zip directly). No second submission.
+      - name: Notarize + staple
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          key="$RUNNER_TEMP/AuthKey.p8"
+          nt="$RUNNER_TEMP/notarytool.json"
+          shopt -s nullglob
+
+          if [ -z "${KEY_ID:-}" ] || [ -z "${ISSUER:-}" ]; then
+            echo "::error::APPLE_API_KEY_ID / APPLE_API_ISSUER are not set — cannot notarize"; exit 1
+          fi
+
+          # submit <file>: blocks until Apple settles, capped at 25m; fails (with the log) unless Accepted.
+          submit() {
+            echo "==> notarize: $1"
+            xcrun notarytool submit "$1" \
+              --key "$key" --key-id "$KEY_ID" --issuer "$ISSUER" \
+              --wait --timeout 25m --output-format json | tee "$nt"
+            local id status
+            id=$(grep -o '"id":"[^"]*"' "$nt" | head -1 | cut -d'"' -f4)
+            status=$(grep -o '"status":"[^"]*"' "$nt" | head -1 | cut -d'"' -f4)
+            if [ "$status" != "Accepted" ]; then
+              echo "::error::notarization returned '$status' for $1"
+              xcrun notarytool log "$id" --key "$key" --key-id "$KEY_ID" --issuer "$ISSUER" || true
+              exit 1
+            fi
+          }
+
+          for dmg in mac/*-mac-*.dmg; do
+            submit "$dmg"
+            xcrun stapler staple "$dmg"
+            xcrun stapler validate "$dmg"
+          done
+
+          for zip in mac/*-mac-*.zip; do
+            work=$(mktemp -d)
+            ditto -x -k "$zip" "$work"
+            app=$(find "$work" -maxdepth 1 -name '*.app' -print -quit)
+            if [ -z "$app" ]; then echo "no .app inside $zip — skipping"; continue; fi
+            xcrun stapler staple "$app"      # ticket already issued via the dmg submission above
+            xcrun stapler validate "$app"
+            ditto -c -k --keepParent "$app" "$zip"   # repackage the stapled .app over the zip
+          done
+
+      # release.yml path: replace this run's signed artifact with the stapled one (same name), so the
+      # publish job's merge-multiple download picks up the stapled dmg/zip. overwrite deletes the
+      # prior artifact of this name in the run. The now-stale mac blockmap/latest-mac.yml are dropped
+      # (mac auto-update is disabled), leaving only the two user-facing downloads.
+      - name: Re-emit stapled artifact (for publish)
+        if: steps.gate.outputs.enabled == 'true' && github.event_name != 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-${{ matrix.arch }}
+          overwrite: true
+          retention-days: 1
+          path: |
+            mac/*-mac-*.dmg
+            mac/*-mac-*.zip
+          if-no-files-found: error
+
+      # Standalone path: push the stapled dmg/zip back onto the Release, replacing the signed-only ones.
+      - name: Clobber stapled assets onto the release
+        if: steps.gate.outputs.enabled == 'true' && github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ inputs.tag }}" mac/*-mac-*.dmg mac/*-mac-*.zip \
+            --repo "$GITHUB_REPOSITORY" --clobber
+
+  # Standalone path only: after both archs are stapled + clobbered, rebuild SHA256SUMS.txt so it
+  # matches the re-stapled bytes. (In the release.yml path, the publish job regenerates it over the
+  # already-stapled artifacts, so no refresh is needed there.)
+  refresh-checksums:
+    if: github.event_name == 'workflow_dispatch'
+    needs: notarize
+    runs-on: ubuntu-latest
+    steps:
+      - name: Recompute + upload SHA256SUMS.txt
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          dir=$(mktemp -d)
+          gh release download "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" --dir "$dir" \
+            --pattern '*.dmg' --pattern '*.zip' --pattern '*.exe' \
+            --pattern '*.AppImage' --pattern '*.deb'
+          (
+            cd "$dir"
+            shopt -s nullglob
+            files=(*.dmg *.zip *.exe *.AppImage *.deb)
+            [ ${#files[@]} -gt 0 ] && sha256sum "${files[@]}" > SHA256SUMS.txt
+            cat SHA256SUMS.txt
+          )
+          gh release upload "${{ inputs.tag }}" "$dir/SHA256SUMS.txt" \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -13,9 +13,12 @@ name: Notarize macOS
 #   - workflow_dispatch{ tag } — standalone repair/backfill. Notarizes + staples the mac assets
 #     already attached to an existing Release, clobbers them back, and refreshes SHA256SUMS.txt.
 #
-# Time cap is enforced two ways: notarytool `--wait --timeout` bounds the Apple wait per file, and
-# job-level `timeout-minutes` bounds the whole job. On timeout/failure the job fails but the Apple
-# submission keeps running, so simply re-running this workflow re-checks and staples — no rebuild.
+# Time cap is enforced two ways: each dmg is submitted, then waited on for at most 15m
+# (`notarytool wait --timeout 15m`), and the job as a whole is bounded by `timeout-minutes: 20`.
+# The submission id is captured before waiting, so on a timeout the log still shows it plus the
+# `notarytool info <id>` command to check the real status. A timeout is NOT a rejection — the Apple
+# submission keeps running; publish (which needs this job) is skipped, so nothing bad is published,
+# and re-running this workflow re-checks + staples with no rebuild.
 on:
   workflow_call:
     inputs:
@@ -38,8 +41,8 @@ jobs:
   notarize:
     name: Notarize + staple ${{ matrix.arch }}
     runs-on: macos-14
-    # Hard ceiling so a stuck notarization can never run forever (see also notarytool --timeout).
-    timeout-minutes: 45
+    # Hard ceiling so a stuck notarization can never run forever (see also the wait --timeout below).
+    timeout-minutes: 20
     strategy:
       # One arch's Apple hiccup must not cancel the other.
       fail-fast: false
@@ -107,20 +110,41 @@ jobs:
             echo "::error::APPLE_API_KEY_ID / APPLE_API_ISSUER are not set — cannot notarize"; exit 1
           fi
 
-          # submit <file>: blocks until Apple settles, capped at 25m; fails (with the log) unless Accepted.
+          # submit <file>: submit first (capture the id), then wait up to 15m for a verdict.
+          # Splitting it out guarantees the submission id is known even if the wait times out, so
+          # the log always shows how to check the real status independently (notarytool info).
           submit() {
-            echo "==> notarize: $1"
-            xcrun notarytool submit "$1" \
+            local f="$1" id status
+            echo "==> submit: $f"
+            xcrun notarytool submit "$f" \
               --key "$key" --key-id "$KEY_ID" --issuer "$ISSUER" \
-              --wait --timeout 25m --output-format json | tee "$nt"
-            local id status
+              --no-wait --output-format json > "$nt"
+            cat "$nt"
             id=$(grep -o '"id":"[^"]*"' "$nt" | head -1 | cut -d'"' -f4)
+            if [ -z "$id" ]; then echo "::error::could not read submission id for $f"; exit 1; fi
+
+            echo "==> submission id: $id — waiting up to 15m"
+            xcrun notarytool wait "$id" \
+              --key "$key" --key-id "$KEY_ID" --issuer "$ISSUER" \
+              --timeout 15m --output-format json > "$nt" 2>/dev/null || true
             status=$(grep -o '"status":"[^"]*"' "$nt" | head -1 | cut -d'"' -f4)
-            if [ "$status" != "Accepted" ]; then
-              echo "::error::notarization returned '$status' for $1"
-              xcrun notarytool log "$id" --key "$key" --key-id "$KEY_ID" --issuer "$ISSUER" || true
-              exit 1
-            fi
+            cat "$nt"
+
+            case "$status" in
+              Accepted) return 0 ;;
+              Invalid|Rejected)
+                # Real bad build — will never pass Gatekeeper. Show the per-issue reasons.
+                echo "::error::notarization REJECTED ($status) for $f — fix signing/entitlements:"
+                xcrun notarytool log "$id" --key "$key" --key-id "$KEY_ID" --issuer "$ISSUER" || true
+                exit 1 ;;
+              *)
+                # Timed out / still In Progress — Apple is slow, NOT a rejection. Nothing is published.
+                echo "::error::notarization did NOT finish within 15m for $f (Apple slow, not a rejection)."
+                echo "::error::submission id: $id"
+                echo "Check the real status any time (independent of CI), then re-run this job once Accepted:"
+                echo "  xcrun notarytool info $id --key <AuthKey.p8> --key-id $KEY_ID --issuer $ISSUER"
+                exit 1 ;;
+            esac
           }
 
           for dmg in mac/*-mac-*.dmg; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,27 @@ concurrency:
 
 jobs:
   # Build the platform matrix (macOS arm64/x64 + Linux + Windows x64) via the reusable workflow.
-  # secrets: inherit forwards the optional signing/notarization secrets.
+  # secrets: inherit forwards the optional signing/notarization secrets. macOS is signed but NOT
+  # notarized here — notarization is decoupled into the notarize-mac job below.
   build:
     uses: ./.github/workflows/build.yml
     secrets: inherit
 
-  # Collect every platform's artifacts and publish them to the tag's Release in one shot (a single
-  # publish job avoids the race of multiple build jobs writing the same Release).
-  publish:
+  # Notarize + staple the signed macOS artifacts on their own runner, then re-emit the stapled dmg/zip
+  # (overwriting the build's signed-only ones) so publish always attaches a stapled mac build. Kept out
+  # of the build matrix so a slow Apple notarization never holds up the platform builds; the job is
+  # time-capped and re-runnable (see notarize-mac.yml). No-ops when signing secrets aren't configured.
+  notarize-mac:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/notarize-mac.yml
+    secrets: inherit
+
+  # Collect every platform's artifacts and publish them to the tag's Release in one shot (a single
+  # publish job avoids the race of multiple build jobs writing the same Release). Depends on
+  # notarize-mac so the mac dmg/zip it downloads are the stapled versions.
+  publish:
+    needs: [build, notarize-mac]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     # Job-level permissions fully override the workflow-level block, so contents:write is restated


### PR DESCRIPTION
## Why

macOS notarization currently runs **inline inside every build-matrix job**
(`electron-builder -c.mac.notarize=true`): the runner blocks on Apple's servers,
it cannot be retried without a rebuild, and a slow notarization stalls the whole
release. This moves notarization into its own **time-capped, re-runnable** job so
builds finish fast while every published mac asset is still fully stapled.

Two facts shaped the design:
- A Developer ID build that is signed but **not stapled** is still blocked by
  Gatekeeper — no better for users than the ad-hoc build. So we never publish an
  un-stapled mac asset.
- The web mirror is the real go-live switch: `mirror-to-website.yml` writes
  `version.json` (what the site + in-app updater read) and is manually
  triggerable. Publishing a GitHub Release does not push users — running the
  mirror does.

## What changed

Pipeline becomes **build (sign only) → notarize-mac (capped, re-runnable) → publish (all stapled)**.

- **`build.yml`** — mac stable builds now **sign only** (`-c.mac.notarize=false`).
  Signing is gated on `!nightly` + `CSC_LINK`, so nightlies stay ad-hoc/fast even
  after secrets exist. Inline notarytool env vars removed.
- **`notarize-mac.yml`** (new) — `macos-14`, `timeout-minutes: 45`, matrix
  `arch: [arm64, x64]`. Per arch: `notarytool submit --wait --timeout 25m`
  (bounded wait, no custom polling) → `stapler staple` the dmg → staple the
  `.app` inside the zip (ticket already issued via the dmg submission) → re-emit
  the stapled artifact. Reusable from `release.yml` and standalone via
  `workflow_dispatch { tag }` for re-staple / backfill (clobbers the release
  assets and refreshes `SHA256SUMS.txt`). **No-ops when the API key secret is
  absent**, so releases still succeed ad-hoc.
- **`release.yml`** — run `notarize-mac` between `build` and `publish`
  (`publish: needs [build, notarize-mac]`), so published mac dmg/zip are always
  stapled.

`nightly.yml` and `mirror-to-website.yml` are unchanged.

## Required secrets (Settings → Secrets and variables → Actions)

Signing (build.yml): `MAC_CSC_LINK` (base64 of the Developer ID Application
`.p12`), `MAC_CSC_KEY_PASSWORD`.

Notarization (notarize-mac.yml, App Store Connect API key):
`APPLE_API_KEY_P8_BASE64` (base64 of the `.p8`), `APPLE_API_KEY_ID`,
`APPLE_API_ISSUER`.

Without these, tagged releases still succeed with an ad-hoc mac build.

## Time cap (won't run forever)

Two ceilings: `notarytool --wait --timeout 25m` per file **and** job-level
`timeout-minutes: 45`. On timeout/failure the job fails but the Apple submission
keeps running, so re-running `notarize-mac` re-checks and staples without a
rebuild.

## Verification

- `actionlint 1.7.12` passes on all three workflows (bundled shellcheck included).
- Standalone real test (after secrets are set):
  `gh workflow run notarize-mac.yml -f tag=<existing-tag>` — confirm it submits,
  staples within the cap, `stapler validate` passes, and the release assets are
  clobbered.
- Full path: push a tag, verify build finishes without an Apple wait,
  `notarize-mac` produces stapled dmgs, `publish` attaches stapled mac + win/linux,
  and `spctl --assess` on an up-to-date Mac shows `Notarized Developer ID`.