### PR TITLE
feat: refine settings UI and control interactions

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -127,25 +127,26 @@ The light theme uses a warm off-white page background, white cards, and a deep-g
   --action-panel-toggle: hsl(0 0% 42%);
   --surface-control-hover: hsl(38 20% 90%);
   --message-user-text: hsl(0 0% 12%);
+  --always-black: 0 0% 0%;
 
   /* shadcn semantic tokens */
-  --background: oklch(0.985 0.01 96);
-  --foreground: oklch(0.19 0.025 236);
-  --card: oklch(0.998 0.004 96);
-  --card-foreground: oklch(0.19 0.025 236);
-  --popover: oklch(0.998 0.004 96);
-  --popover-foreground: oklch(0.19 0.025 236);
+  --background: #fafaf8;
+  --foreground: #202321;
+  --card: #ffffff;
+  --card-foreground: #202321;
+  --popover: #ffffff;
+  --popover-foreground: #202321;
   --primary: oklch(0.47 0.105 184);
   --primary-foreground: oklch(0.985 0.008 180);
-  --secondary: oklch(0.94 0.018 93);
-  --secondary-foreground: oklch(0.23 0.03 235);
-  --muted: oklch(0.94 0.018 93);
-  --muted-foreground: oklch(0.48 0.035 235);
+  --secondary: #ececea;
+  --secondary-foreground: #202321;
+  --muted: #ececea;
+  --muted-foreground: #646762;
   --accent: oklch(0.87 0.115 82);
   --accent-foreground: oklch(0.2 0.03 62);
   --destructive: oklch(0.58 0.22 25);
-  --border: oklch(0.87 0.018 92);
-  --input: oklch(0.87 0.018 92);
+  --border: #dededa;
+  --input: #dededa;
   --ring: oklch(0.58 0.11 184);
 }
 ```
@@ -241,18 +242,18 @@ Workspace tokens share the same visual intent as several shadcn tokens. Workspac
 
 Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shared surface colors, see **Workspace ↔ shadcn Equivalence** above.
 
-| Token                               | Tailwind class                     | Light value                                                                   | Usage                                             |
-| ----------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------- |
-| `--bg-400`                          | `bg-bg-400`                        | `hsl(45 10% 88%)`                                                             | Sidebar row action hover                          |
-| `--text-300`                        | `text-text-300`                    | `hsl(43 3% 57%)`                                                              | Footer/action icon default color and loading dots |
-| `--rail-card-bg`                    | `bg-rail-card-bg`                  | `hsl(0 0% 100%)`                                                              | Sidebar rail card                                 |
-| `--danger-000` / `--danger-900`     | `text-danger-000`, `bg-danger-900` | `hsl(0 45% 38%)`, `hsl(0 55% 95%)`                                            | Destructive session menu and dialog actions       |
-| `--action-panel-toggle`             | `text-action-panel-toggle`         | `hsl(0 0% 42%)`                                                               | Collapsed preview toggle                          |
-| `--surface-control-hover`           | `hover:bg-surface-control-hover`   | `hsl(38 20% 90%)`                                                             | Header icon control hover                         |
-| `--message-user-text`               | `text-message-user-text`           | `hsl(0 0% 12%)`                                                               | User message bubble text                          |
-| `--shadow-card`                     | `shadow-card`                      | `0 0 0 1px rgb(10 10 10 / 0.06), 0 4px 24px rgb(10 10 10 / 0.04)`             | Sidebar rail card and composer dock               |
-| `--shadow-card-opaque`              | `shadow-card-opaque`               | `0 0 0 1px rgb(10 10 10 / 0.08), 0 8px 28px rgb(10 10 10 / 0.1)`              | Composer form                                     |
-| `--shadow-menu` / `--shadow-dialog` | `shadow-menu`, `shadow-dialog`     | `0 4px 16px hsl(var(--always-black) / 10%)`, `0 8px 32px rgb(10 10 10 / 12%)` | Session menus and modal dialogs                   |
+| Token                               | Tailwind class                     | Light value                                                       | Usage                                             |
+| ----------------------------------- | ---------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------- |
+| `--bg-400`                          | `bg-bg-400`                        | `hsl(45 10% 88%)`                                                 | Sidebar row action hover                          |
+| `--text-300`                        | `text-text-300`                    | `hsl(43 3% 57%)`                                                  | Footer/action icon default color and loading dots |
+| `--rail-card-bg`                    | `bg-rail-card-bg`                  | `hsl(0 0% 100%)`                                                  | Sidebar rail card                                 |
+| `--danger-000` / `--danger-900`     | `text-danger-000`, `bg-danger-900` | `hsl(0 45% 38%)`, `hsl(0 55% 95%)`                                | Destructive session menu and dialog actions       |
+| `--action-panel-toggle`             | `text-action-panel-toggle`         | `hsl(0 0% 42%)`                                                   | Collapsed preview toggle                          |
+| `--surface-control-hover`           | `hover:bg-surface-control-hover`   | `hsl(38 20% 90%)`                                                 | Header icon control hover                         |
+| `--message-user-text`               | `text-message-user-text`           | `hsl(0 0% 12%)`                                                   | User message bubble text                          |
+| `--shadow-card`                     | `shadow-card`                      | `0 0 0 1px rgb(10 10 10 / 0.06), 0 4px 24px rgb(10 10 10 / 0.04)` | Sidebar rail card and composer dock               |
+| `--shadow-card-opaque`              | `shadow-card-opaque`               | `0 0 0 1px rgb(10 10 10 / 0.08), 0 8px 28px rgb(10 10 10 / 0.1)`  | Composer form                                     |
+| `--shadow-menu` / `--shadow-dialog` | `shadow-menu`, `shadow-dialog`     | `0 2px 8px rgb(0 0 0 / 0.08)`, `0 8px 32px rgb(10 10 10 / 12%)`   | Menus and modal dialogs                           |
 
 ### Border Opacity
 
@@ -268,11 +269,11 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 
 | Semantic role           | Light value             | Dark value            |
 | ----------------------- | ----------------------- | --------------------- |
-| Page background         | `rgb(253 253 252)`      | `rgb(31 31 30)`       |
-| Primary text            | `rgb(18 18 18)`         | `rgb(248 248 246)`    |
+| Page background         | `rgb(250 250 248)`      | `rgb(31 31 30)`       |
+| Primary text            | `rgb(32 35 33)`         | `rgb(248 248 246)`    |
 | Secondary text          | `rgb(55 55 52)`         | `rgb(195 194 183)`    |
-| Weak text / icons       | `rgb(123 121 116)`      | `rgb(148 146 139)`    |
-| Active background       | `rgb(239 238 235)`      | `rgb(18 18 18)`       |
+| Weak text / icons       | `rgb(100 103 98)`       | `rgb(148 146 139)`    |
+| Active background       | `rgb(236 236 234)`      | `rgb(18 18 18)`       |
 | Card / menu background  | `rgb(255 255 255)`      | `rgb(44 44 42)`       |
 | Primary actions / links | `oklch(0.47 0.105 184)` | `oklch(0.68 0.1 184)` |
 | Focus ring              | `oklch(0.58 0.11 184)`  | `oklch(0.7 0.1 184)`  |
@@ -294,9 +295,9 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 
 - Global base: `--radius: 0.5rem`.
 - Small buttons, tabs, and toolbar buttons: `rounded-md`, approximately `6px`.
-- Inputs, menu items, and navigation items: `rounded-lg` or `rounded-md`, approximately `8px`.
+- Inputs, shared menu items, and navigation items: `rounded-lg`, `8px`.
 - Cards / viewer panels: `rounded-lg`; viewer radius is `8px`.
-- Dialog / DropdownMenuContent: `rounded-xl`, `12px`.
+- Dialog: `rounded-xl`, `12px`; shared DropdownMenu / Select content: `rounded-lg`, `8px`.
 - Composer: `rounded-2xl`, `16px`.
 - Pills, drag handles, and status dots: `rounded-full`.
 
@@ -305,7 +306,7 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Page root: `bg-background text-foreground` on Home and generic shells; workspace shell surfaces use `bg-bg-10`.
 - Standard card: `bg-card text-card-foreground border shadow-sm`.
 - Large viewer panel: `bg-card rounded-lg shadow-sm`; a single ring shadow may replace an explicit border.
-- Hover / active: `bg-accent text-accent-foreground`.
+- Shared control hover / open: `bg-muted text-foreground`; content-level active surfaces may use `bg-accent text-accent-foreground` where specified.
 - Weak container: `bg-muted/50`.
 - Inline code / resource reference: `bg-accent/50 text-primary rounded-md px-1.5 py-0.5 font-mono text-sm`.
 - Workspace shell surfaces use `bg-bg-10`; white workspace surfaces use `bg-bg-000`.
@@ -326,13 +327,13 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 
 - All focusable controls use `focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50`.
 - Inputs may add `focus-visible:border-ring/50`; the light focus border target is `rgb(134 182 239)`.
-- Disabled controls use `disabled:pointer-events-none disabled:opacity-50`.
+- Disabled controls use `disabled:pointer-events-none disabled:opacity-50`; shared buttons also use `touch-manipulation`.
 - Sidebar buttons and icon triggers may use `cursor-pointer`; decorative row wrappers provide hover/active styling only and must not imply a click target outside the nested button.
 - Hover, focus, and active states must not change width, height, padding, or border width.
 
 ### Motion
 
-- Standard interaction: `transition-colors duration-150`.
+- Standard interaction: `transition-colors duration-150 motion-reduce:transition-none`.
 - Inline action reveal: `transition-opacity duration-150`, default `opacity-0`, then `opacity-100` on hover or focus-visible.
 - Workspace interactions use `transition-colors duration-200 ease-out`.
 - Session row action reveal uses `transition-[opacity,color,background-color] duration-200 ease-out`.
@@ -355,12 +356,13 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 
 - Primary action: `Button variant="default"` for create, confirm, and save actions.
 - Secondary action: `Button variant="secondary"`.
-- Outline action: `Button variant="outline"`; light borders use `border-border/30`.
+- Outline action: `Button variant="outline"`; default is `border-border bg-card text-foreground`, and hover / `aria-expanded` use `bg-muted` without changing geometry.
 - Lightweight / icon action: `Button variant="ghost" size="icon"`.
 - Destructive action: `Button variant="destructive"` or menu item `text-destructive focus:text-destructive`.
-- Default button: `h-9 px-4 rounded-lg text-sm font-medium`.
-- Compact button: `h-8 px-3 rounded-md text-xs font-medium`; the top create button is `32px` tall.
-- Icon button: usually `size-8 rounded-md`; top bars and viewer toolbar buttons may use `size-7`.
+- Default button: `h-8 px-2.5 rounded-lg text-sm font-medium`.
+- Small button: `h-7 px-2.5 text-[0.8rem]`; large button: `h-9 px-2.5`.
+- Icon button: usually `size-8 rounded-lg`; compact top bars and row actions use `size-7`.
+- Focus is `focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50`; disabled is non-interactive at `opacity-50`. Button feedback uses an explicit transition property list and disables it for reduced motion.
 
 ### External Link
 
@@ -381,8 +383,8 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 
 - Use `Dialog` for regular form dialogs.
 - Use `AlertDialog` for destructive confirmations.
-- Medium `DialogContent`: `sm:max-w-[576px] max-h-[85svh] rounded-xl border bg-background p-0 shadow-lg`; target size is approximately `576px x 612px`.
-- Large settings `DialogContent`: `sm:max-w-[960px] h-[min(688px,calc(100svh-2rem))] rounded-xl bg-card p-0 shadow-md`.
+- Medium `DialogContent`: `sm:max-w-[576px] max-h-[85svh] overscroll-contain rounded-xl border bg-background p-0 shadow-lg`; target size is approximately `576px x 612px`.
+- Large settings `DialogContent`: `sm:max-w-[960px] h-[min(688px,calc(100svh-2rem))] overscroll-contain rounded-xl bg-card p-0 shadow-md`.
 - Compact workspace rename/delete dialogs: `w-[min(420px,calc(100vw-2rem))] rounded-2xl bg-bg-000 p-6 text-text-000 shadow-dialog`, without header/footer dividers.
 - Header: `px-5 py-4`, with `border-b` when needed.
 - Body: `px-5 py-5`; form items use `space-y-4` or `space-y-6`.
@@ -395,16 +397,16 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 ### DropdownMenu / Popover / Select
 
 - Use DropdownMenu for action menus, Popover for lightweight auxiliary layers, and Select for single-value selection.
-- `DropdownMenuContent` / `PopoverContent`: `rounded-xl border bg-popover p-1.5 text-popover-foreground shadow-md`; menu target size is approximately `168px x 101px`.
+- `DropdownMenuContent`: `overscroll-contain rounded-lg border border-border bg-popover p-1.5 text-popover-foreground shadow-menu`; `shadow-menu` is `0 2px 8px rgb(0 0 0 / 0.08)`. Popovers may keep their domain-specific layout.
 - Menu header / label: `px-2 pt-1 pb-0.5 text-xs text-muted-foreground`.
 - Item: `h-8 rounded-lg px-2 py-1.5 text-sm`.
-- Item hover / focus: `focus:bg-accent focus:text-accent-foreground`.
+- Shared item hover / keyboard highlight: `bg-muted text-foreground`; disabled items are non-interactive at `opacity-50`.
 - Session action menu content: `z-modal min-w-[9rem] rounded-xl border-[0.5px] border-border-200 bg-bg-000 p-1.5 shadow-menu`.
 - Session action trigger uses `MoreVertical`, opacity reveal on row hover/focus/menu-open, and an `aria-label` that includes the session title.
 - Session action items: `flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-text-100 data-[highlighted]:bg-bg-200 data-[highlighted]:text-text-000`.
 - Destructive session item: `text-danger-000 data-[highlighted]:bg-danger-900`; the menu includes only `Rename…` and `Delete`.
-- Select trigger: `h-8 rounded-lg bg-card/50 px-2 shadow-sm`; dark mode may use `bg-white/10`.
-- Select option: `min-h-8 rounded-lg px-3 py-1 text-sm`; selected state uses `bg-foreground/5` or the shadcn default active state.
+- Select trigger: `h-8 rounded-lg border border-border bg-card px-2.5`; hover and `data-state=open` use `bg-muted`, and keyboard focus uses the shared 3px ring.
+- Select content uses the same overscroll containment, surface, border, radius, and shadow as DropdownMenu. Options are `min-h-8 rounded-lg`; keyboard highlight uses `bg-muted text-foreground`.
 - Menus do not use a page scrim.
 
 ### Tabs / ToggleGroup
@@ -545,14 +547,17 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 
 ### Settings
 
-- Use a large `Dialog`; the default panel is bordered `rounded-xl border border-border bg-card shadow-dialog`. A maximize control enlarges it to `h-[80vh] w-[80vw]`; the restored size follows content density.
-- Left navigation: `w-52 shrink-0 border-r border-border bg-muted/40 p-3`, organized into labeled groups (for example Capabilities and Workspace). Each group has a `text-xs font-medium text-muted-foreground` heading over its rows.
-- Nav item: `h-8 w-full rounded-lg px-2 text-sm gap-2 hover:bg-accent`, with a `size-4` leading icon (`text-muted-foreground`) and a truncating label.
-- Active: `bg-accent text-accent-foreground font-medium`.
+- Use a large `Dialog`; the restored panel is `h-[min(688px,calc(100vh-2rem))] w-[min(960px,calc(100vw-2rem))] rounded-xl border border-border bg-card shadow-dialog`. Maximize uses `inset-4`, filling the viewport with a stable 16px margin and never shrinking the restored panel.
+- Settings consumes the global semantic palette: background `#FAFAF8`, card/popover `#FFFFFF`, muted/secondary `#ECECEA`, border/input `#DEDEDA`, foreground `#202321`, and muted foreground `#646762`. Do not scope token overrides to the dialog or use `body:has(...)`; Radix portals inherit these root tokens directly.
+- Left navigation: `w-52 shrink-0 border-r border-border bg-background p-3`, organized into labeled groups (for example Capabilities and Workspace). Each group has a `text-xs font-medium text-muted-foreground` heading over its rows.
+- Nav item: `h-8 w-full rounded-lg px-2 text-sm gap-2 hover:bg-muted`, with a `size-4` leading icon (`text-muted-foreground`) and a truncating label.
+- Active: `bg-muted text-foreground font-medium`; the neutral selection keeps deep green reserved for primary actions, focus, links, enabled switches, and success.
 - Content header: `h-12 border-b border-border px-3`, a space-between row. Left cluster: back / forward `size-7` icon buttons (`ArrowLeft` / `ArrowRight`, `disabled:opacity-40`), a `h-4 w-px bg-border` divider, then either a breadcrumb or a plain `h2 text-sm font-semibold` title. Right cluster: a maximize / restore `size-7` toggle (`Maximize2` / `Minimize2`) and a `size-7` close (`X`); both use `hover:bg-muted hover:text-foreground`.
 - Breadcrumb: a clickable root segment (`text-muted-foreground hover:text-foreground`), a muted `/` separator, and the truncated current page label in `text-foreground`, all at `text-sm font-semibold`.
-- Content area: scrolls independently (`min-h-0 flex-1 overflow-y-auto`); panels pad with `p-5`.
-- Form row: use `Field`; explanatory copy uses `FieldDescription` or `text-muted-foreground`.
+- Right content column uses `bg-card`; its content area scrolls independently (`min-h-0 flex-1 overflow-y-auto`). Panels pad with `p-5`, and maximize mode constrains inner content to `max-w-[880px]`.
+- First-level groups use `SettingsSection`: `text-base font-semibold` title, optional `text-[13px] leading-5 text-muted-foreground` description, and a hairline separator between groups. Do not wrap ordinary sections in cards.
+- Label/control pairs use `SettingsRow`: a two-column grid with the label and optional description on the left and a stable `12rem` to `20rem` control column on the right. Cards remain for repeated objects, install/status surfaces, paths, errors, and drop zones.
+- Form textareas use the shared `Textarea`; binary settings use the shared `Switch`.
 - Select fields use `Select`, with a `32px` trigger height.
 
 #### Skills panel
@@ -561,9 +566,9 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - List toolbar: a single row of `Select` source filter (`w-36`), a flex-1 search `Input` with a leading `Search` icon (`pl-8`, `type="search"`), and a right-aligned "Add skill" control.
 - "Add skill" is a neutral (not primary) `DropdownMenu` trigger: `h-8 rounded-lg border border-border bg-card px-2.5 text-sm font-medium hover:bg-muted`, with a leading `Plus` and a trailing `ChevronDown` (`opacity-70`). Its items — Write from scratch, Upload a skill, Import from GitHub — use `gap-2.5`, a leading icon, and a stacked label + `text-xs text-muted-foreground` hint.
 - Skills group by source (Featured / Imported / Personal). Each group header is a full-width collapse toggle: `text-sm font-semibold` label with a `ChevronDown` that rotates `-rotate-90` when collapsed, over a `text-xs text-muted-foreground` subtitle.
-- Skill row: `flex items-center gap-2 py-2.5`, rows separated by `divide-y divide-border`. The name (`text-sm`) over description (`text-xs text-muted-foreground`) is a flex-1 button opening the detail page; trailing controls are a `size-7` edit button (personal only), a `size-7` delete button (`hover:text-destructive`, non-featured only), and the enable toggle.
-- Enable toggle is an inline `role="switch"` (no shared Switch component): `h-5 w-9 rounded-full`, track `bg-primary` when on / `bg-muted` when off, with a `size-4` white knob that slides `translate-x-4`. The detail page reuses the same markup.
-- Skill detail page: header row pairs a `size-6` scroll icon (`ScrollText`, `text-primary`) + `text-heading font-semibold` name + a rounded source badge (`bg-muted text-xs text-muted-foreground`, e.g. Featured) against the same enable toggle, with a `text-xs text-muted-foreground` "Updated N days ago" line and a `[text-wrap:pretty]` description below. A **Files** section (`border-t border-border pt-4`) renders the `SKILL.md` body via `AgentMarkdown`; a **Details** section lists frontmatter Author / License / Third-party as stacked `text-xs` label + `text-sm` value rows, shown only when present.
+- Skill row: `flex min-h-14 items-center gap-2 py-2.5`, rows separated by `divide-y divide-border`. The name (`text-sm`) over description (`text-xs text-muted-foreground`) is a flex-1 button opening the detail page; trailing controls use `SettingsIconAction` (`Button ghost icon-sm` + Tooltip) for edit and delete, followed by the enable switch.
+- Enable controls use the shared shadcn `Switch`, with `bg-primary` when checked and `bg-input` when unchecked. Skills, Connectors, and their detail pages reuse the same component.
+- Skill detail page: header row pairs a `size-6` scroll icon (`ScrollText`, `text-primary`) + `text-base font-semibold` name + a rounded source badge (`bg-muted text-xs text-muted-foreground`, e.g. Featured) against the same enable switch, with a `text-xs text-muted-foreground` "Updated N days ago" line and a `[text-wrap:pretty]` description below. A **Files** section (`border-t border-border pt-4`) renders the `SKILL.md` body via `AgentMarkdown`; a **Details** section lists frontmatter Author / License / Third-party as stacked `text-xs` label + `text-sm` value rows, shown only when present.
 - Editor (create / edit) is sectioned Identity + Content + References: Content offers a Write / Upload toggle where pasting a `SKILL.md` auto-fills the frontmatter; References is a dropzone writing into the skill's `references/`.
 - Import from GitHub is Preview-first: no standalone import action initially, only a **Preview** button that scans the repo. Scanned candidates list with per-row checkboxes plus a **Select all** checkbox and an **Invert** text button; already-imported skills (matched by exact source URL or by the same folder name) show a muted `Imported` pill and are not pre-selected. The batch action, "Import selected (N)", is a neutral button (`border border-border bg-card hover:bg-muted`), never primary green.
 - Upload is a full-page dropzone (`Drag and drop or click to upload`) accepting a `.md` file or a `.zip` / `.skill` bundle, with a centered "Write from scratch instead" fallback. A dropped file is **parsed first, not imported**: on success it advances to a "Confirm import" page (parsed name, description, and — for a bundle — the file list), with a neutral **Import** button and a **Choose a different file** escape. Nothing is written until Import is confirmed.
@@ -581,7 +586,7 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 | Home              | Row actions                          | `Button ghost icon` + opacity reveal                                                     |
 | Dialog            | Close                                | `DialogClose` or `Button ghost icon`                                                     |
 | Dialog            | Cancel / confirm                     | `DialogFooter` + `Button secondary/default`                                              |
-| Settings          | Left navigation                      | `Button ghost` or `TabsTrigger`; active uses `bg-accent`                                 |
+| Settings          | Left navigation                      | `Button ghost` or `TabsTrigger`; active uses `bg-muted`                                  |
 | Settings          | Back / forward                       | `size-7` icon `button` (`ArrowLeft` / `ArrowRight`), `disabled:opacity-40`               |
 | Settings          | Breadcrumb root                      | Text `button` (`text-muted-foreground hover:text-foreground`)                            |
 | Settings          | Maximize / restore                   | `size-7` icon `button` (`Maximize2` / `Minimize2`)                                       |
@@ -590,8 +595,8 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 | Skills            | Add skill                            | Neutral `DropdownMenu` trigger (`border border-border bg-card`) + `Plus` / `ChevronDown` |
 | Skills            | Group header                         | Full-width collapse `button` + rotating `ChevronDown`                                    |
 | Skills            | Skill row                            | Flex-1 `button` → detail; hover reveals no extra chrome                                  |
-| Skills            | Edit / delete                        | `size-7` icon `button`; delete uses `hover:text-destructive`                             |
-| Skills            | Enable toggle                        | Inline `button role="switch"` (`h-5 w-9`)                                                |
+| Skills            | Edit / delete                        | `SettingsIconAction` (`Button ghost icon-sm` + `Tooltip`)                                |
+| Skills            | Enable toggle                        | Shared shadcn `Switch`                                                                   |
 | Skills            | Import selected                      | Neutral `button` (`border border-border bg-card`), not primary                           |
 | Sidebar           | Back / collapse                      | `Sidebar` + `Button ghost icon`                                                          |
 | Sidebar           | Navigation row                       | `SidebarMenuButton`                                                                      |

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -51,7 +51,7 @@
   --color-rail-card-bg: hsl(var(--rail-card-bg));
   --shadow-card: 0 0 0 1px rgb(10 10 10 / 0.06), 0 4px 24px rgb(10 10 10 / 0.04);
   --shadow-card-opaque: 0 0 0 1px rgb(10 10 10 / 0.08), 0 8px 28px rgb(10 10 10 / 0.1);
-  --shadow-menu: 0 4px 16px hsl(var(--always-black) / 10%);
+  --shadow-menu: 0 2px 8px rgb(0 0 0 / 0.08);
   --shadow-dialog: 0 8px 32px rgb(10 10 10 / 12%);
   --z-index-modal: 50;
   --radius-sm: calc(var(--radius) - 4px);
@@ -89,25 +89,25 @@
   --skill-chip: hsl(214 95% 90%);
   --skill-chip-foreground: hsl(222 63% 47%);
   --always-black: 0 0% 0%;
-  --background: oklch(0.985 0.01 96);
-  --foreground: oklch(0.19 0.025 236);
-  --card: oklch(0.998 0.004 96);
-  --card-foreground: oklch(0.19 0.025 236);
-  --popover: oklch(0.998 0.004 96);
-  --popover-foreground: oklch(0.19 0.025 236);
+  --background: #fafaf8;
+  --foreground: #202321;
+  --card: #ffffff;
+  --card-foreground: #202321;
+  --popover: #ffffff;
+  --popover-foreground: #202321;
   --primary: oklch(0.47 0.105 184);
   --primary-foreground: oklch(0.985 0.008 180);
-  --secondary: oklch(0.94 0.018 93);
-  --secondary-foreground: oklch(0.23 0.03 235);
-  --muted: oklch(0.94 0.018 93);
-  --muted-foreground: oklch(0.48 0.035 235);
+  --secondary: #ececea;
+  --secondary-foreground: #202321;
+  --muted: #ececea;
+  --muted-foreground: #646762;
   --accent: oklch(0.87 0.115 82);
   --accent-foreground: oklch(0.2 0.03 62);
   --destructive: oklch(0.58 0.22 25);
   --session-running: oklch(0.49 0.115 184);
   --session-waiting: oklch(0.62 0.16 68);
-  --border: oklch(0.87 0.018 92);
-  --input: oklch(0.87 0.018 92);
+  --border: #dededa;
+  --input: #dededa;
   --ring: oklch(0.58 0.11 184);
 }
 

--- a/src/renderer/src/components/ui/button.tsx
+++ b/src/renderer/src/components/ui/button.tsx
@@ -5,13 +5,13 @@ import { Slot } from 'radix-ui'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 touch-manipulation items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow,transform] duration-150 outline-none select-none motion-reduce:transition-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px motion-reduce:active:translate-y-0 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/80',
         outline:
-          'border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+          'border-border bg-card text-foreground hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground',
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
         ghost:

--- a/src/renderer/src/components/ui/control-primitives.render.test.tsx
+++ b/src/renderer/src/components/ui/control-primitives.render.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { Button } from './button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from './dropdown-menu'
+import { Select, SelectContent, SelectItem, SelectTrigger } from './select'
+import { Switch } from './switch'
+import { Textarea } from './textarea'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = (): void => undefined
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+describe('shared control interaction styling', () => {
+  it('uses the global neutral outline button states and reduced-motion fallback', () => {
+    act(() => {
+      root.render(
+        <Button variant="outline" aria-expanded="true">
+          Add skill
+        </Button>
+      )
+    })
+
+    const button = document.body.querySelector<HTMLButtonElement>('[data-slot="button"]')
+    expect(button?.className).toContain('border-border')
+    expect(button?.className).toContain('bg-card')
+    expect(button?.className).toContain('hover:bg-muted')
+    expect(button?.className).toContain('aria-expanded:bg-muted')
+    expect(button?.className).toContain('motion-reduce:transition-none')
+    expect(button?.className).toContain('touch-manipulation')
+    expect(button?.className).not.toContain('transition-all')
+    expect(button?.className).not.toContain('bg-background')
+  })
+
+  it('uses semantic menu surfaces and highlighted item states', async () => {
+    await act(async () => {
+      root.render(
+        <DropdownMenu open>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline">Add skill</Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Write from scratch</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )
+    })
+
+    const trigger = document.body.querySelector<HTMLButtonElement>('[data-slot="button"]')
+    const content = document.body.querySelector<HTMLElement>('[data-slot="dropdown-menu-content"]')
+    const item = document.body.querySelector<HTMLElement>('[data-slot="dropdown-menu-item"]')
+
+    expect(trigger?.getAttribute('data-state')).toBe('open')
+    expect(trigger?.className).toContain('aria-expanded:bg-muted')
+    expect(content?.className).toContain('border-border')
+    expect(content?.className).toContain('bg-popover')
+    expect(content?.className).toContain('text-popover-foreground')
+    expect(content?.className).toContain('shadow-menu')
+    expect(content?.className).toContain('overscroll-contain')
+    expect(item?.className).toContain('rounded-lg')
+    expect(item?.className).toContain('data-[highlighted]:bg-muted')
+    expect(item?.className).toContain('motion-reduce:transition-none')
+  })
+
+  it('matches select triggers and options to the same interaction contract', async () => {
+    await act(async () => {
+      root.render(
+        <Select open value="all">
+          <SelectTrigger aria-label="Filter by source">
+            <span>All</span>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+          </SelectContent>
+        </Select>
+      )
+    })
+
+    const trigger = document.body.querySelector<HTMLElement>('[data-slot="select-trigger"]')
+    const content = document.body.querySelector<HTMLElement>('[data-slot="select-content"]')
+    const item = document.body.querySelector<HTMLElement>('[data-slot="select-item"]')
+
+    expect(trigger?.className).toContain('h-8')
+    expect(trigger?.className).toContain('rounded-lg')
+    expect(trigger?.className).toContain('bg-card')
+    expect(trigger?.className).toContain('hover:bg-muted')
+    expect(trigger?.className).toContain('data-[state=open]:bg-muted')
+    expect(trigger?.className).toContain('focus-visible:ring-3')
+    expect(content?.className).toContain('border-border')
+    expect(content?.className).toContain('bg-popover')
+    expect(content?.className).toContain('shadow-menu')
+    expect(content?.className).toContain('overscroll-contain')
+    expect(item?.className).toContain('min-h-8')
+    expect(item?.className).toContain('rounded-lg')
+    expect(item?.className).toContain('data-[highlighted]:bg-muted')
+  })
+
+  it('keeps switch and textarea states accessible without mandatory motion', () => {
+    act(() => {
+      root.render(
+        <>
+          <Switch aria-label="Disabled setting" disabled />
+          <Textarea aria-label="Notes" disabled />
+        </>
+      )
+    })
+
+    const toggle = document.body.querySelector<HTMLButtonElement>('[data-slot="switch"]')
+    const thumb = document.body.querySelector<HTMLElement>('[data-slot="switch-thumb"]')
+    const textarea = document.body.querySelector<HTMLTextAreaElement>('[data-slot="textarea"]')
+
+    expect(toggle?.disabled).toBe(true)
+    expect(toggle?.className).toContain('focus-visible:ring-3')
+    expect(toggle?.className).toContain('motion-reduce:transition-none')
+    expect(toggle?.className).not.toContain('transition-all')
+    expect(thumb?.className).toContain('motion-reduce:transition-none')
+    expect(textarea?.disabled).toBe(true)
+    expect(textarea?.className).toContain('focus-visible:ring-3')
+  })
+})

--- a/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -18,7 +18,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          'z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border-200 bg-bg-10 p-1.5 text-text-000 shadow-card',
+          'z-50 min-w-[8rem] overflow-hidden overscroll-contain rounded-lg border border-border bg-popover p-1.5 text-popover-foreground shadow-menu outline-none',
           className
         )}
         {...props}
@@ -35,7 +35,7 @@ function DropdownMenuItem({
     <DropdownMenuPrimitive.Item
       data-slot="dropdown-menu-item"
       className={cn(
-        'relative flex cursor-pointer items-center rounded-md px-2 py-1.5 text-sm outline-none transition-colors select-none hover:bg-bg-200 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[highlighted]:bg-bg-200 data-[highlighted]:text-text-000',
+        'relative flex min-h-8 cursor-pointer items-center rounded-lg px-2 py-1.5 text-sm outline-none transition-colors duration-150 select-none motion-reduce:transition-none hover:bg-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[highlighted]:bg-muted data-[highlighted]:text-foreground',
         className
       )}
       {...props}
@@ -50,7 +50,7 @@ function DropdownMenuLabel({
   return (
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
-      className={cn('px-2 py-1 text-[12px] text-text-300', className)}
+      className={cn('px-2 py-1 text-xs text-muted-foreground', className)}
       {...props}
     />
   )
@@ -63,7 +63,7 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn('-mx-1 my-1 h-px bg-border-300/50', className)}
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
       {...props}
     />
   )

--- a/src/renderer/src/components/ui/input.tsx
+++ b/src/renderer/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>): Re
       type={type}
       data-slot="input"
       className={cn(
-        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors duration-150 outline-none motion-reduce:transition-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className
       )}
       {...props}

--- a/src/renderer/src/components/ui/select.tsx
+++ b/src/renderer/src/components/ui/select.tsx
@@ -20,7 +20,7 @@ function SelectTrigger({
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       className={cn(
-        'flex h-9 w-full items-center justify-between gap-2 rounded-md border border-border bg-transparent px-3 text-sm outline-none transition-colors focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:truncate',
+        'flex h-8 w-full items-center justify-between gap-2 rounded-lg border border-border bg-card px-2.5 text-sm text-foreground outline-none transition-colors duration-150 motion-reduce:transition-none hover:bg-muted data-[state=open]:bg-muted focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:truncate',
         className
       )}
       {...props}
@@ -45,7 +45,7 @@ function SelectContent({
         data-slot="select-content"
         position={position}
         className={cn(
-          'z-50 max-h-72 min-w-[8rem] overflow-hidden rounded-lg border border-border-200 bg-bg-10 text-text-000 shadow-card',
+          'z-50 max-h-72 min-w-[8rem] overflow-hidden overscroll-contain rounded-lg border border-border bg-popover text-popover-foreground shadow-menu outline-none',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1',
           className
@@ -73,7 +73,7 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn('px-2 py-1 text-[11px] font-medium text-text-300', className)}
+      className={cn('px-2 py-1 text-xs font-medium text-muted-foreground', className)}
       {...props}
     />
   )
@@ -91,7 +91,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        'relative flex w-full cursor-pointer items-center gap-2 rounded-md py-1.5 pl-2 pr-8 text-sm outline-none select-none data-[highlighted]:bg-bg-200 data-[highlighted]:text-text-000 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        'relative flex min-h-8 w-full cursor-pointer items-center gap-2 rounded-lg py-1.5 pl-2 pr-8 text-sm outline-none transition-colors duration-150 select-none motion-reduce:transition-none data-[highlighted]:bg-muted data-[highlighted]:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         className
       )}
       {...props}
@@ -114,7 +114,7 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn('-mx-1 my-1 h-px bg-border-300/50', className)}
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
       {...props}
     />
   )

--- a/src/renderer/src/components/ui/switch.tsx
+++ b/src/renderer/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react'
+import { Switch as SwitchPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function Switch({
+  className,
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: 'sm' | 'default'
+}): React.JSX.Element {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-colors duration-150 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 motion-reduce:transition-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[state=checked]:bg-primary data-[state=unchecked]:bg-input data-disabled:cursor-not-allowed data-disabled:opacity-50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:data-[state=unchecked]:bg-input/80',
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform duration-150 motion-reduce:transition-none group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-[state=checked]:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-[state=unchecked]:translate-x-0 group-data-[size=sm]/switch:data-[state=checked]:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/renderer/src/components/ui/textarea.tsx
+++ b/src/renderer/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>): React.JSX.Element {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors duration-150 outline-none motion-reduce:transition-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/renderer/src/pages/settings/AppVersionSection.tsx
+++ b/src/renderer/src/pages/settings/AppVersionSection.tsx
@@ -1,8 +1,10 @@
 import { Download, RefreshCw } from 'lucide-react'
 
 import logoUrl from '@/assets/logo.png'
+import { Button } from '@/components/ui/button'
 import { useUpdateStore } from '@/stores/update-store'
 import { APP } from '../../../../shared/app-config'
+import { SettingsRow, SettingsSection } from './SettingsLayout'
 
 // App identity + update control in Settings→General. Reads the shared update store so it stays in
 // sync with the external capsule; the update button opens the shared dialog (version + notes +
@@ -38,11 +40,9 @@ const AppVersionSection = (): React.JSX.Element => {
   })()
 
   return (
-    <section aria-label="App version">
-      <h3 className="mb-1 text-sm font-semibold text-foreground">About</h3>
-      <div className="rounded-xl border border-border p-4">
-        {/* Identity on the left, update controls on the same row to the right. */}
-        <div className="flex items-start justify-between gap-3">
+    <SettingsSection title="About" aria-label="App version">
+      <SettingsRow
+        label={
           <div className="flex min-w-0 items-center gap-3">
             <img src={logoUrl} alt="" className="size-12 rounded-lg" />
             <div className="min-w-0">
@@ -50,55 +50,52 @@ const AppVersionSection = (): React.JSX.Element => {
                 <span className="text-sm font-semibold text-foreground">{APP.name}</span>
                 <span className="text-xs text-muted-foreground tabular-nums">v{version}</span>
               </p>
-              <p className="mt-0.5 text-xs text-muted-foreground">{APP.copyright}</p>
+              <p className="mt-0.5 text-xs font-normal text-muted-foreground">{APP.copyright}</p>
             </div>
           </div>
-
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-            <button
-              type="button"
-              onClick={() => void check()}
-              disabled={isChecking}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-bg-300 disabled:opacity-50"
-            >
-              <RefreshCw
-                className={isChecking ? 'size-4 animate-spin' : 'size-4'}
-                aria-hidden="true"
-              />
-              {isChecking ? 'Checking…' : 'Check now'}
-            </button>
-
-            {hasUpdate ? (
-              <button
-                type="button"
-                onClick={() => openDialog()}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-              >
-                <Download className="size-4" aria-hidden="true" />
-                {isDownloading
-                  ? `Downloading ${status.progress ?? 0}%`
-                  : status.state === 'ready'
-                    ? 'Update ready'
-                    : `Update to ${status.latest}`}
-              </button>
-            ) : null}
-          </div>
-        </div>
-
-        {statusLine ? (
-          <p
-            className={
-              status.state === 'error'
-                ? 'mt-3 text-xs text-destructive'
-                : 'mt-3 text-xs text-muted-foreground'
-            }
-            role={status.state === 'error' ? 'alert' : undefined}
+        }
+        controlClassName="w-auto justify-self-end"
+      >
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void check()}
+            disabled={isChecking}
           >
-            {statusLine}
-          </p>
-        ) : null}
-      </div>
-    </section>
+            <RefreshCw
+              className={isChecking ? 'size-4 animate-spin' : 'size-4'}
+              aria-hidden="true"
+            />
+            {isChecking ? 'Checking…' : 'Check now'}
+          </Button>
+
+          {hasUpdate ? (
+            <Button type="button" onClick={() => openDialog()}>
+              <Download className="size-4" aria-hidden="true" />
+              {isDownloading
+                ? `Downloading ${status.progress ?? 0}%`
+                : status.state === 'ready'
+                  ? 'Update ready'
+                  : `Update to ${status.latest}`}
+            </Button>
+          ) : null}
+        </div>
+      </SettingsRow>
+
+      {statusLine ? (
+        <p
+          className={
+            status.state === 'error'
+              ? 'mt-2 text-xs text-destructive'
+              : 'mt-2 text-xs text-muted-foreground'
+          }
+          role={status.state === 'error' ? 'alert' : undefined}
+        >
+          {statusLine}
+        </p>
+      ) : null}
+    </SettingsSection>
   )
 }
 

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -61,7 +61,7 @@ const ClaudeInstallCard = ({
     `${item.label}${item.requiresNpm && !npmAvailable ? ' (npm not found)' : ''}`
 
   return (
-    <Card className={cn('gap-0 py-0', embedded && 'rounded-none bg-transparent ring-0')}>
+    <Card className={cn('gap-0 rounded-lg py-0', embedded && 'rounded-none bg-transparent ring-0')}>
       <CardContent className={cn('p-4', embedded && 'px-0 py-0')}>
         <div className="space-y-1.5">
           <label className="text-xs font-medium text-muted-foreground" htmlFor="install-source">

--- a/src/renderer/src/pages/settings/ClaudeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeStatusCard.tsx
@@ -22,7 +22,7 @@ const ClaudeStatusCard = ({
   onDetect,
   embedded = false
 }: ClaudeStatusCardProps): React.JSX.Element => (
-  <Card className={cn('gap-0 py-0', embedded && 'rounded-none bg-transparent ring-0')}>
+  <Card className={cn('gap-0 rounded-lg py-0', embedded && 'rounded-none bg-transparent ring-0')}>
     <CardContent className={cn('p-4', embedded && 'px-0 py-0')}>
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -60,6 +60,9 @@ describe('ConnectorAddForm (local command)', () => {
       root.render(<ConnectorAddForm initialTransport="local" onDone={onDone} onCancel={vi.fn()} />)
     })
 
+    expect(document.body.querySelector('[aria-label="Arguments"]')?.getAttribute('data-slot')).toBe(
+      'textarea'
+    )
     setValue('Name', 'Memory')
     checkTrust()
 

--- a/src/renderer/src/pages/settings/ConnectorAddForm.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.tsx
@@ -6,8 +6,10 @@ import type {
   CustomServerView,
   UpdateCustomServerRequest
 } from '../../../../shared/settings'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { useSettingsStore } from '@/stores/settings-store'
 
 // Which kind of custom connector is being added: a local stdio command or a remote HTTP/SSE server.
@@ -17,8 +19,6 @@ type ConnectorMode = 'local' | 'remote'
 type RemoteTransport = Extract<CustomServerTransport, 'streamable_http' | 'sse'>
 
 const fieldLabelClassName = 'text-xs font-medium text-muted-foreground'
-const textareaClassName =
-  'w-full resize-none rounded-lg border border-input bg-transparent px-2.5 py-2 font-mono text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50'
 
 // Splits an arguments textarea on any whitespace/newlines into a positional arg list, dropping empties.
 const parseArgs = (raw: string): string[] =>
@@ -191,7 +191,7 @@ export function ConnectorAddForm({
   }
 
   const segmentButtonClassName = (active: boolean): string =>
-    `inline-flex h-7 items-center rounded-md px-3 text-sm transition-colors ${
+    `inline-flex h-7 items-center rounded-md px-3 text-sm transition-colors motion-reduce:transition-none ${
       active
         ? 'bg-card font-medium text-foreground shadow-sm'
         : 'text-muted-foreground hover:text-foreground'
@@ -294,13 +294,13 @@ export function ConnectorAddForm({
               <label className={fieldLabelClassName} htmlFor="connector-args">
                 Arguments <span className="text-muted-foreground">(optional)</span>
               </label>
-              <textarea
+              <Textarea
                 id="connector-args"
                 aria-label="Arguments"
                 value={argsText}
                 rows={2}
                 placeholder="-y @modelcontextprotocol/server-memory"
-                className={textareaClassName}
+                className="resize-none font-mono text-[13px]"
                 onChange={(event) => setArgsText(event.target.value)}
               />
               <p className="text-xs text-muted-foreground">Separated by spaces or newlines.</p>
@@ -310,13 +310,13 @@ export function ConnectorAddForm({
               <label className={fieldLabelClassName} htmlFor="connector-env">
                 Environment variables <span className="text-muted-foreground">(optional)</span>
               </label>
-              <textarea
+              <Textarea
                 id="connector-env"
                 aria-label="Environment variables"
                 value={envText}
                 rows={3}
                 placeholder={'KEY=value\nANOTHER_KEY=value'}
-                className={textareaClassName}
+                className="resize-none font-mono text-[13px]"
                 onChange={(event) => setEnvText(event.target.value)}
               />
               <p className="text-xs text-muted-foreground">
@@ -367,13 +367,13 @@ export function ConnectorAddForm({
               <label className={fieldLabelClassName} htmlFor="connector-headers">
                 Headers <span className="text-muted-foreground">(optional)</span>
               </label>
-              <textarea
+              <Textarea
                 id="connector-headers"
                 aria-label="Headers"
                 value={headersText}
                 rows={3}
                 placeholder={'Authorization: Bearer <token>\nX-Api-Key: <key>'}
-                className={textareaClassName}
+                className="resize-none font-mono text-[13px]"
                 onChange={(event) => setHeadersText(event.target.value)}
               />
               <p className="text-xs text-muted-foreground">
@@ -411,19 +411,10 @@ export function ConnectorAddForm({
         ) : null}
 
         <div className="flex items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="inline-flex h-8 items-center rounded-lg px-3 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          >
+          <Button type="button" variant="ghost" onClick={onCancel}>
             Cancel
-          </button>
-          <button
-            type="button"
-            onClick={() => void handleSubmit()}
-            disabled={!canSubmit}
-            className="inline-flex h-8 items-center rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
-          >
+          </Button>
+          <Button type="button" onClick={() => void handleSubmit()} disabled={!canSubmit}>
             {submitting
               ? isEdit
                 ? 'Saving…'
@@ -431,7 +422,7 @@ export function ConnectorAddForm({
               : isEdit
                 ? 'Save changes'
                 : 'Add connector'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
@@ -60,6 +60,13 @@ describe('ConnectorApprovalDialog', () => {
     expect(document.body.textContent).toContain('BioMart')
     expect(document.body.textContent).toContain('get_data')
     expect(document.body.textContent).toContain('{"x":1}')
+    expect(button('Deny')?.getAttribute('data-slot')).toBe('button')
+    expect(button('Deny')?.getAttribute('data-variant')).toBe('destructive')
+    expect(button('Always allow')?.getAttribute('data-variant')).toBe('outline')
+    expect(button('Allow once')?.getAttribute('data-variant')).toBe('default')
+    expect(document.body.querySelector('[role="dialog"]')?.className).toContain(
+      'overscroll-contain'
+    )
   })
 
   it('Allow once responds allow without pre-trusting the connector', () => {

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
@@ -1,6 +1,7 @@
 import { ShieldAlert } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 
+import { Button } from '@/components/ui/button'
 import { useSettingsStore } from '@/stores/settings-store'
 
 // A modal approval card for an un-trusted connector call. A connector tool sends data to an external
@@ -36,7 +37,7 @@ export function ConnectorApprovalDialog(): React.JSX.Element | null {
         <Dialog.Content
           onInteractOutside={(event) => event.preventDefault()}
           onEscapeKeyDown={(event) => event.preventDefault()}
-          className="fixed left-1/2 top-1/2 z-[60] w-[min(440px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-card p-5 text-foreground shadow-dialog"
+          className="fixed left-1/2 top-1/2 z-[60] w-[min(440px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overscroll-contain rounded-xl border border-border bg-card p-5 text-foreground shadow-dialog"
         >
           <div className="flex items-start gap-3">
             <ShieldAlert className="mt-0.5 size-5 shrink-0 text-amber-500" aria-hidden="true" />
@@ -69,27 +70,15 @@ export function ConnectorApprovalDialog(): React.JSX.Element | null {
           </div>
 
           <div className="mt-4 flex justify-end gap-2">
-            <button
-              type="button"
-              onClick={deny}
-              className="rounded-lg border border-border px-3 py-1.5 text-sm text-destructive transition-colors hover:bg-muted"
-            >
+            <Button type="button" variant="destructive" onClick={deny}>
               Deny
-            </button>
-            <button
-              type="button"
-              onClick={allowAlways}
-              className="rounded-lg border border-border px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-muted"
-            >
+            </Button>
+            <Button type="button" variant="outline" onClick={allowAlways}>
               Always allow
-            </button>
-            <button
-              type="button"
-              onClick={allowOnce}
-              className="rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-            >
+            </Button>
+            <Button type="button" onClick={allowOnce}>
               Allow once
-            </button>
+            </Button>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/src/renderer/src/pages/settings/ConnectorDetailView.tsx
+++ b/src/renderer/src/pages/settings/ConnectorDetailView.tsx
@@ -7,7 +7,7 @@ import type {
 } from '../../../../shared/settings'
 import { useSettingsStore } from '@/stores/settings-store'
 import { ConnectorGlyph } from './connector-icons'
-import { SkillToggle } from './SkillsPanel'
+import { SettingsToggle } from './SettingsLayout'
 import { ToolPermissionControl } from './ToolPermissionControl'
 
 type ConnectorDetailViewProps = {
@@ -79,7 +79,7 @@ const ConnectorDetailView = ({ id }: ConnectorDetailViewProps): React.JSX.Elemen
         <div className="flex min-w-0 items-center gap-3">
           <ConnectorGlyph size={28} />
           <div className="flex min-w-0 items-center gap-2">
-            <h1 className="truncate text-heading font-semibold text-foreground">
+            <h1 className="truncate text-base font-semibold text-foreground">
               {detail.displayName}
             </h1>
             <span className="inline-flex shrink-0 items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
@@ -87,9 +87,9 @@ const ConnectorDetailView = ({ id }: ConnectorDetailViewProps): React.JSX.Elemen
             </span>
           </div>
         </div>
-        <SkillToggle
+        <SettingsToggle
           enabled={enabled}
-          label={`Toggle ${detail.displayName}`}
+          aria-label={`Toggle ${detail.displayName}`}
           onToggle={() => void setConnectorEnabled(id, !enabled)}
         />
       </div>
@@ -109,9 +109,9 @@ const ConnectorDetailView = ({ id }: ConnectorDetailViewProps): React.JSX.Elemen
             time.
           </p>
         </div>
-        <SkillToggle
+        <SettingsToggle
           enabled={autoAllow}
-          label={`Skip approvals for ${id}`}
+          aria-label={`Skip approvals for ${id}`}
           onToggle={() => void setConnectorAutoAllow(id, !autoAllow)}
         />
       </div>
@@ -137,7 +137,7 @@ const ConnectorDetailView = ({ id }: ConnectorDetailViewProps): React.JSX.Elemen
                       className="flex min-w-0 flex-1 items-center gap-2 py-2.5 text-left"
                     >
                       <ChevronRight
-                        className={`size-4 shrink-0 text-muted-foreground transition-transform ${
+                        className={`size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none ${
                           isExpanded ? 'rotate-90' : ''
                         }`}
                         aria-hidden="true"

--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -154,6 +154,13 @@ describe('ConnectorsPanel (groups)', () => {
     expect(document.body.textContent).toContain('My MCP')
     // Three featured toggles + one custom toggle.
     expect(document.body.querySelectorAll('[role="switch"]')).toHaveLength(4)
+    expect(document.body.querySelectorAll('[data-slot="settings-list-row"]')).toHaveLength(4)
+    expect(document.body.querySelector('[data-slot="settings-section"]')).not.toBeNull()
+    const addConnector = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button')
+    ).find((button) => button.textContent?.includes('Add connector'))
+    expect(addConnector?.getAttribute('data-slot')).toBe('button')
+    expect(addConnector?.getAttribute('data-variant')).toBe('outline')
   })
 
   it('toggles a featured connector and navigates to its detail on row click', () => {
@@ -180,9 +187,16 @@ describe('ConnectorsPanel (groups)', () => {
     act(() => document.body.querySelector<HTMLButtonElement>('[aria-label="My MCP"]')?.click())
     expect(useSettingsStore.getState().setCustomServerEnabled).toHaveBeenCalledWith('my-mcp', false)
 
-    act(() =>
-      document.body.querySelector<HTMLButtonElement>('[aria-label="Remove My MCP"]')?.click()
-    )
+    const edit = document.body.querySelector<HTMLButtonElement>('[aria-label="Edit My MCP"]')
+    const remove = document.body.querySelector<HTMLButtonElement>('[aria-label="Remove My MCP"]')
+    expect(edit?.getAttribute('data-slot')).toBe('button')
+    expect(remove?.getAttribute('data-slot')).toBe('button')
+    expect(edit?.getAttribute('data-size')).toBe('icon-sm')
+    expect(remove?.getAttribute('data-size')).toBe('icon-sm')
+    expect(edit?.getAttribute('data-state')).toBe('closed')
+    expect(remove?.getAttribute('data-state')).toBe('closed')
+
+    act(() => remove?.click())
     expect(useSettingsStore.getState().removeCustomServer).toHaveBeenCalledWith('my-mcp')
   })
 

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, Globe, Pencil, Plus, Search, Terminal, Trash2 } from 'luci
 import { useEffect, useMemo, useState } from 'react'
 
 import type { ConnectorView, CustomServerView } from '../../../../shared/settings'
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,7 +13,7 @@ import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 import { useSettingsStore } from '@/stores/settings-store'
 import { ConnectorGlyph } from './connector-icons'
-import { SkillToggle } from './SkillsPanel'
+import { SettingsIconAction, SettingsSection, SettingsToggle } from './SettingsLayout'
 
 // The connectors panel sub-view, driven by the settings navigation history. The detail and add pages
 // are separate components owned by SettingsPage; this panel only renders the list + contact-email section.
@@ -124,7 +125,7 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
           <span className="flex items-center gap-1 text-sm font-semibold text-foreground">
             {label}
             <ChevronDown
-              className={`size-4 shrink-0 text-muted-foreground transition-transform ${
+              className={`size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none ${
                 expanded ? '' : '-rotate-90'
               }`}
               aria-hidden="true"
@@ -137,7 +138,11 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
           rows.length > 0 ? (
             <ul className="mt-2 flex flex-col divide-y divide-border">
               {rows.map((connector) => (
-                <li key={connector.id} className="flex items-center gap-3 py-2.5">
+                <li
+                  key={connector.id}
+                  data-slot="settings-list-row"
+                  className="flex min-h-14 items-center gap-3 py-2.5"
+                >
                   <ConnectorGlyph size={24} />
                   <button
                     type="button"
@@ -151,9 +156,9 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
                       {connector.description}
                     </span>
                   </button>
-                  <SkillToggle
+                  <SettingsToggle
                     enabled={connector.enabled}
-                    label={connector.displayName}
+                    aria-label={connector.displayName}
                     onToggle={() => void setConnectorEnabled(connector.id, !connector.enabled)}
                   />
                 </li>
@@ -171,13 +176,16 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
 
   return (
     <div className="p-5">
-      <div className="mb-4 rounded-lg border border-border bg-card p-4">
-        <h3 className="text-sm font-semibold text-foreground">Contact email</h3>
-        <p className="mt-1 text-xs text-muted-foreground">
-          When allowed, shared with research data services that ask for a contact email (such as
-          those run by NCBI, EBI, and OurResearch) on requests made on your behalf.
-        </p>
-
+      <SettingsSection
+        title="Contact email"
+        description={
+          <>
+            When allowed, shared with research data services that ask for a contact email (such as
+            those run by NCBI, EBI, and OurResearch) on requests made on your behalf.
+          </>
+        }
+        className="mb-5"
+      >
         {editing ? (
           <div className="mt-3 flex flex-col gap-3">
             <div className="flex flex-col gap-1">
@@ -202,28 +210,22 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
               </span>
             </div>
             <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => void save()}
-                className="inline-flex h-8 items-center rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-              >
+              <Button type="button" onClick={() => void save()}>
                 Save
-              </button>
-              <button
-                type="button"
-                onClick={() => setEditing(false)}
-                className="inline-flex h-8 items-center rounded-lg border border-border bg-card px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted"
-              >
+              </Button>
+              <Button type="button" variant="outline" onClick={() => setEditing(false)}>
                 Cancel
-              </button>
+              </Button>
               {ncbi.hasApiKey ? (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="sm"
                   onClick={() => void clearKey()}
-                  className="ml-auto text-xs text-muted-foreground transition-colors hover:text-destructive"
+                  className="ml-auto text-muted-foreground hover:text-destructive"
                 >
                   Clear key
-                </button>
+                </Button>
               ) : null}
             </div>
           </div>
@@ -232,16 +234,12 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
             <span className="min-w-0 flex-1 truncate text-sm text-foreground">
               {ncbi.contactEmail ?? 'Not set'}
             </span>
-            <button
-              type="button"
-              onClick={startEditing}
-              className="inline-flex h-8 shrink-0 items-center rounded-lg border border-border bg-card px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted"
-            >
+            <Button type="button" variant="outline" onClick={startEditing}>
               Edit
-            </button>
+            </Button>
           </div>
         )}
-      </div>
+      </SettingsSection>
 
       <div className="mb-4 flex items-center gap-2">
         <Select value={filter} onValueChange={(value) => setFilter(value as GroupFilter)}>
@@ -270,10 +268,12 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
           />
         </div>
         <DropdownMenu>
-          <DropdownMenuTrigger className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted">
-            <Plus className="size-4" aria-hidden="true" />
-            Add connector
-            <ChevronDown className="size-4 opacity-70" aria-hidden="true" />
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" className="shrink-0">
+              <Plus data-icon="inline-start" aria-hidden="true" />
+              Add connector
+              <ChevronDown data-icon="inline-end" className="opacity-70" aria-hidden="true" />
+            </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem
@@ -332,7 +332,7 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
               <span className="flex items-center gap-1 text-sm font-semibold text-foreground">
                 Custom
                 <ChevronDown
-                  className={`size-4 shrink-0 text-muted-foreground transition-transform ${
+                  className={`size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none ${
                     customExpanded ? '' : '-rotate-90'
                   }`}
                   aria-hidden="true"
@@ -345,7 +345,11 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
               visibleCustomServers.length > 0 ? (
                 <ul className="mt-2 flex flex-col divide-y divide-border">
                   {visibleCustomServers.map((server) => (
-                    <li key={server.id} className="flex items-center gap-3 py-2.5">
+                    <li
+                      key={server.id}
+                      data-slot="settings-list-row"
+                      className="flex min-h-14 items-center gap-3 py-2.5"
+                    >
                       <ConnectorGlyph size={24} />
                       <div className="min-w-0 flex-1">
                         <span className="block truncate text-sm text-foreground">
@@ -357,25 +361,20 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
                           </span>
                         ) : null}
                       </div>
-                      <button
-                        type="button"
-                        aria-label={`Edit ${server.name}`}
+                      <SettingsIconAction
+                        label={`Edit ${server.name}`}
+                        icon={Pencil}
                         onClick={() => onNavigate({ kind: 'edit', id: server.id })}
-                        className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                      >
-                        <Pencil className="size-3.5" aria-hidden="true" />
-                      </button>
-                      <button
-                        type="button"
-                        aria-label={`Remove ${server.name}`}
+                      />
+                      <SettingsIconAction
+                        label={`Remove ${server.name}`}
+                        icon={Trash2}
                         onClick={() => void removeCustomServer(server.id)}
-                        className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
-                      >
-                        <Trash2 className="size-3.5" aria-hidden="true" />
-                      </button>
-                      <SkillToggle
+                        danger
+                      />
+                      <SettingsToggle
                         enabled={server.enabled}
-                        label={server.name}
+                        aria-label={server.name}
                         onToggle={() => void setCustomServerEnabled(server.id, !server.enabled)}
                       />
                     </li>

--- a/src/renderer/src/pages/settings/GeneralPanel.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.tsx
@@ -3,13 +3,15 @@ import { useEffect, useState } from 'react'
 
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { GitHubStarBadge } from '@/components/GitHubStarBadge'
+import { Button } from '@/components/ui/button'
 import { APP } from '../../../../shared/app-config'
 import { AppVersionSection } from './AppVersionSection'
+import { SettingsRow, SettingsSection } from './SettingsLayout'
 
 // Community entry links (Discord, X) share the GitHub badge's compact look so the row reads as one
 // set of "connect with the project" actions.
 const socialLinkClassName =
-  'inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium text-text-300 transition-colors duration-150 ease-out hover:bg-bg-300 hover:text-text-000'
+  'inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-card px-2 text-xs font-medium text-muted-foreground transition-colors duration-150 motion-reduce:transition-none hover:bg-muted hover:text-foreground'
 
 // Discord and X are brand marks that lucide-react dropped in v1, so we inline the official SVGs.
 // currentColor lets them inherit the link's text color like the other icons.
@@ -24,11 +26,6 @@ const XMark = ({ className }: { className?: string }): React.JSX.Element => (
     <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
   </svg>
 )
-
-// Standard settings action button (matches the icon buttons in SettingsPage / Connectors / Skills),
-// so the diagnostics actions stay consistent with the rest of Settings.
-const actionButtonClassName =
-  'inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50'
 
 // General app settings. Hosts the Diagnostics (log file) tools and the community/connect links. The log
 // file stays on this device and is never transmitted by the app.
@@ -73,53 +70,55 @@ const GeneralPanel = (): React.JSX.Element => {
   }
 
   return (
-    <div className="space-y-6 p-5">
+    <div className="space-y-5 p-5">
       <AppVersionSection />
-      <section aria-label="Diagnostics">
-        <h3 className="mb-1 text-sm font-semibold text-foreground">Diagnostics</h3>
-        <p className="mb-3 text-xs text-muted-foreground">
-          View this device&apos;s runtime log — it records what the app is doing so problems can be
-          diagnosed.
-        </p>
 
-        <div className="rounded-xl border border-border p-4">
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-xs font-medium text-muted-foreground">Log file</span>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => void handleReveal()}
-                disabled={!logPath}
-                className={actionButtonClassName}
-              >
-                <FolderOpen className="size-4" aria-hidden="true" />
-                Reveal
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleOpenLog()}
-                disabled={isOpening || !logPath}
-                className={actionButtonClassName}
-              >
-                <ExternalLink className="size-4" aria-hidden="true" />
-                {isOpening ? 'Opening…' : 'Open'}
-              </button>
-            </div>
+      <SettingsSection
+        title="Diagnostics"
+        description={
+          <>
+            View this device&apos;s runtime log — it records what the app is doing so problems can
+            be diagnosed.
+          </>
+        }
+        aria-label="Diagnostics"
+        separated
+      >
+        <SettingsRow label="Log file" controlClassName="w-auto justify-self-end" className="pt-0">
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void handleReveal()}
+              disabled={!logPath}
+            >
+              <FolderOpen className="size-4" aria-hidden="true" />
+              Reveal
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void handleOpenLog()}
+              disabled={isOpening || !logPath}
+            >
+              <ExternalLink className="size-4" aria-hidden="true" />
+              {isOpening ? 'Opening…' : 'Open'}
+            </Button>
           </div>
+        </SettingsRow>
 
-          <pre
-            className="mt-2 overflow-x-auto rounded-lg bg-muted px-3 py-2 font-mono text-xs text-foreground"
-            aria-label="Log file path"
-          >
-            {logPath ?? 'Not available yet.'}
-          </pre>
+        <pre
+          className="overflow-x-auto rounded-lg border border-border bg-muted/60 px-3 py-2.5 font-mono text-xs text-foreground"
+          aria-label="Log file path"
+        >
+          {logPath ?? 'Not available yet.'}
+        </pre>
 
-          {message ? (
-            <p className="mt-2 text-xs text-destructive" role="alert">
-              {message}
-            </p>
-          ) : null}
-        </div>
+        {message ? (
+          <p className="mt-2 text-xs text-destructive" role="alert">
+            {message}
+          </p>
+        ) : null}
 
         <p className="mt-3 text-xs text-muted-foreground">
           Something not working?{' '}
@@ -127,14 +126,19 @@ const GeneralPanel = (): React.JSX.Element => {
           and attach the log above. It stays on this device and is never sent automatically; it may
           contain local file paths, so review it before sharing.
         </p>
-      </section>
+      </SettingsSection>
 
-      <section aria-label="Community">
-        <h3 className="mb-1 text-sm font-semibold text-foreground">Enjoying Open Science?</h3>
-        <p className="mb-3 text-xs text-muted-foreground">
-          It&apos;s free and open source. Star it on GitHub to help others find it, and come build
-          in public with us on Discord and X. Thanks for being here.
-        </p>
+      <SettingsSection
+        title="Enjoying Open Science?"
+        description={
+          <>
+            It&apos;s free and open source. Star it on GitHub to help others find it, and come build
+            in public with us on Discord and X. Thanks for being here.
+          </>
+        }
+        aria-label="Community"
+        separated
+      >
         <div className="flex flex-wrap items-center gap-2">
           <GitHubStarBadge className="border border-border" />
           <a
@@ -167,7 +171,7 @@ const GeneralPanel = (): React.JSX.Element => {
             Website
           </a>
         </div>
-      </section>
+      </SettingsSection>
     </div>
   )
 }

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -61,6 +61,7 @@ describe('ProviderList', () => {
   it('shows the masked key and model but never a plaintext key', () => {
     renderList([provider()])
 
+    expect(container.querySelector('[data-slot="settings-list-row"]')).not.toBeNull()
     expect(container.textContent).toContain('sk-a…wxyz')
     expect(container.textContent).toContain('claude-sonnet-4-5')
     // A masked hint is displayed, but there is no way to render a real secret here.

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -1,13 +1,12 @@
 import { CircleCheck, Pencil, PlugZap, TriangleAlert, Trash2 } from 'lucide-react'
-import type { LucideIcon } from 'lucide-react'
 
 import type { ProviderValidationFailure, ProviderView } from '../../../../shared/settings'
 import { providerValidationFailed } from '../../../../shared/settings'
 import { getOfficialVendor } from '../../../../shared/provider-registry'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils'
 import { ProviderKindIcon } from './provider-icons'
 import { providerKindKey } from './provider-form-value'
+import { SettingsIconAction } from './SettingsLayout'
 
 type ProviderListProps = {
   providers: ProviderView[]
@@ -18,15 +17,6 @@ type ProviderListProps = {
   onEdit: (provider: ProviderView) => void
   onDelete: (provider: ProviderView) => void
   onTest: (provider: ProviderView) => void
-}
-
-type IconActionButtonProps = {
-  // Accessible name and hover tooltip text (kept identical so the hover label is also the a11y name).
-  label: string
-  icon: LucideIcon
-  onClick: () => void
-  disabled?: boolean
-  danger?: boolean
 }
 
 // Concise, actionable reason for a failed connection test, shown on the unverified warning.
@@ -59,36 +49,6 @@ const describeType = (provider: ProviderView): string => {
     : 'Official'
 }
 
-// An icon-only row action with a hover tooltip. The label is exposed via aria-label for accessibility
-// and shown on hover via the shared tooltip so the actions row stays compact.
-const IconActionButton = ({
-  label,
-  icon: Icon,
-  onClick,
-  disabled = false,
-  danger = false
-}: IconActionButtonProps): React.JSX.Element => (
-  <Tooltip>
-    <TooltipTrigger asChild>
-      <button
-        type="button"
-        aria-label={label}
-        disabled={disabled}
-        onClick={onClick}
-        className={cn(
-          'inline-flex size-7 items-center justify-center rounded-lg border border-border text-foreground transition-colors hover:bg-muted',
-          danger && 'text-destructive hover:bg-destructive/10 hover:text-destructive',
-          // Disabled actions read as inert gray with no hover affordance (e.g. delete on the selected provider).
-          'disabled:pointer-events-none disabled:border-border disabled:text-muted-foreground disabled:opacity-50'
-        )}
-      >
-        <Icon className="size-3.5" strokeWidth={2} aria-hidden="true" />
-      </button>
-    </TooltipTrigger>
-    <TooltipContent>{label}</TooltipContent>
-  </Tooltip>
-)
-
 // Lists configured providers with their type, masked key, and model. Each row leads with the
 // select/selected control, followed by compact icon actions (test / edit / delete) with hover
 // tooltips. Shared by the settings page (the onboarding wizard uses the form directly).
@@ -102,7 +62,7 @@ const ProviderList = ({
 }: ProviderListProps): React.JSX.Element => {
   if (providers.length === 0) {
     return (
-      <div className="rounded-xl border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+      <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
         No providers yet. Add one to choose your model source.
       </div>
     )
@@ -126,7 +86,11 @@ const ProviderList = ({
           const canDelete = !isActiveSource && providers.length > 1
 
           return (
-            <li key={provider.id} className="rounded-xl border border-border p-3">
+            <li
+              key={provider.id}
+              data-slot="settings-list-row"
+              className="rounded-lg border border-border bg-card p-3"
+            >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
@@ -201,22 +165,29 @@ const ProviderList = ({
                     ) : null}
                   </div>
                 </div>
-              </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2">
-                <IconActionButton
-                  label="Test connection"
-                  icon={PlugZap}
-                  onClick={() => onTest(provider)}
-                  disabled={isBusy}
-                />
-                <IconActionButton label="Edit" icon={Pencil} onClick={() => onEdit(provider)} />
-                <IconActionButton
-                  label="Delete"
-                  icon={Trash2}
-                  onClick={() => onDelete(provider)}
-                  disabled={!canDelete}
-                  danger
-                />
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <SettingsIconAction
+                    label="Test connection"
+                    icon={PlugZap}
+                    onClick={() => onTest(provider)}
+                    disabled={isBusy}
+                    className="border border-border text-foreground"
+                  />
+                  <SettingsIconAction
+                    label="Edit"
+                    icon={Pencil}
+                    onClick={() => onEdit(provider)}
+                    className="border border-border text-foreground"
+                  />
+                  <SettingsIconAction
+                    label="Delete"
+                    icon={Trash2}
+                    onClick={() => onDelete(provider)}
+                    disabled={!canDelete}
+                    className="border border-border"
+                    danger
+                  />
+                </div>
               </div>
             </li>
           )

--- a/src/renderer/src/pages/settings/SettingsLayout.tsx
+++ b/src/renderer/src/pages/settings/SettingsLayout.tsx
@@ -1,0 +1,141 @@
+import type { ComponentProps, ReactNode } from 'react'
+import type { LucideIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+type SettingsSectionProps = ComponentProps<'section'> & {
+  title: string
+  description?: ReactNode
+  action?: ReactNode
+  separated?: boolean
+  contentClassName?: string
+}
+
+// Keeps first-level settings groups aligned without turning every group into a card.
+const SettingsSection = ({
+  title,
+  description,
+  action,
+  separated = false,
+  contentClassName,
+  className,
+  children,
+  ...props
+}: SettingsSectionProps): React.JSX.Element => (
+  <section
+    data-slot="settings-section"
+    className={cn(separated && 'border-t border-border pt-5', className)}
+    {...props}
+  >
+    <div className="flex items-start justify-between gap-4">
+      <div className="min-w-0">
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+        {description ? (
+          <p className="mt-0.5 max-w-2xl text-[13px] leading-5 text-muted-foreground">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+    <div className={cn('mt-3', contentClassName)}>{children}</div>
+  </section>
+)
+
+type SettingsRowProps = ComponentProps<'div'> & {
+  label: ReactNode
+  description?: ReactNode
+  controlClassName?: string
+}
+
+// Aligns descriptive copy and controls to a stable two-column settings grid.
+const SettingsRow = ({
+  label,
+  description,
+  controlClassName,
+  className,
+  children,
+  ...props
+}: SettingsRowProps): React.JSX.Element => (
+  <div
+    data-slot="settings-row"
+    className={cn(
+      'grid min-h-14 grid-cols-[minmax(0,1fr)_minmax(12rem,20rem)] items-center gap-6 py-3',
+      className
+    )}
+    {...props}
+  >
+    <div className="min-w-0">
+      <div className="text-sm font-medium text-foreground">{label}</div>
+      {description ? (
+        <div className="mt-0.5 text-[13px] leading-5 text-muted-foreground">{description}</div>
+      ) : null}
+    </div>
+    <div className={cn('min-w-0 justify-self-stretch', controlClassName)}>{children}</div>
+  </div>
+)
+
+type SettingsToggleProps = Omit<ComponentProps<typeof Switch>, 'checked' | 'onCheckedChange'> & {
+  enabled: boolean
+  onToggle: () => void
+}
+
+// Reserves the Switch hit-area expansion so it cannot overlap adjacent row actions or the scroller.
+const SettingsToggle = ({
+  enabled,
+  onToggle,
+  className,
+  ...props
+}: SettingsToggleProps): React.JSX.Element => (
+  <Switch
+    checked={enabled}
+    onCheckedChange={onToggle}
+    className={cn('ml-1 mr-3', className)}
+    {...props}
+  />
+)
+
+type SettingsIconActionProps = Omit<
+  ComponentProps<typeof Button>,
+  'aria-label' | 'children' | 'size' | 'variant'
+> & {
+  label: string
+  icon: LucideIcon
+  danger?: boolean
+}
+
+// Keeps compact settings actions consistent and gives every icon-only control a visible name.
+const SettingsIconAction = ({
+  label,
+  icon: Icon,
+  danger = false,
+  className,
+  ...props
+}: SettingsIconActionProps): React.JSX.Element => (
+  <TooltipProvider delayDuration={200}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={label}
+          className={cn(
+            'shrink-0 text-muted-foreground',
+            danger && 'hover:bg-destructive/10 hover:text-destructive',
+            className
+          )}
+          {...props}
+        >
+          <Icon className="size-3.5" strokeWidth={2} aria-hidden="true" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+)
+
+export { SettingsIconAction, SettingsRow, SettingsSection, SettingsToggle }

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -84,6 +84,25 @@ afterEach(() => {
 
 describe('SettingsPage layout', () => {
   it('mounts the sidebar + content with grouped nav items and a close control', () => {
+    useSettingsStore.setState({
+      providers: [
+        {
+          id: 'p1',
+          type: 'custom',
+          name: 'Gateway',
+          baseUrl: 'https://gateway.test/v1',
+          model: 'test-model',
+          models: ['test-model'],
+          maskedKey: 'sk-a…wxyz',
+          hasKey: true,
+          needsKey: false,
+          lastValidatedAt: 1
+        }
+      ],
+      activeProviderId: 'p1',
+      activeModel: 'test-model'
+    })
+
     act(() => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
     })
@@ -91,10 +110,14 @@ describe('SettingsPage layout', () => {
     // Dialog content is portaled to the document body.
     const dialog = document.body.querySelector('[role="dialog"]')
     expect(dialog).not.toBeNull()
+    expect(dialog?.getAttribute('data-slot')).toBe('settings-surface')
+    expect(dialog?.className).toContain('overscroll-contain')
 
     // Left navigation grouped as Capabilities (Skills) and Workspace (Model, General).
     const nav = document.body.querySelector('nav[aria-label="Settings"]')
     expect(nav).not.toBeNull()
+    expect(nav?.className).toContain('bg-background')
+    expect(nav?.nextElementSibling?.className).toContain('bg-card')
     expect(nav?.textContent).toContain('Capabilities')
     expect(nav?.textContent).toContain('Workspace')
     const navItems = nav?.querySelectorAll('li') ?? []
@@ -108,10 +131,18 @@ describe('SettingsPage layout', () => {
 
     // The header shows the panel title and a close control.
     expect(document.body.querySelector('[aria-label="Close settings"]')).not.toBeNull()
+    expect(document.body.querySelector('[aria-label="Back"]')?.getAttribute('data-slot')).toBe(
+      'button'
+    )
+    expect(document.body.querySelector('[aria-label="Maximize"]')?.getAttribute('data-slot')).toBe(
+      'button'
+    )
 
     // The Model panel content is present (Claude + Providers sections).
     expect(document.body.textContent).toContain('Claude')
     expect(document.body.textContent).toContain('Providers')
+    expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(2)
+    expect(document.body.querySelector('[data-slot="settings-row"]')).not.toBeNull()
   })
 
   it('opens Add provider as a history-driven sub-page and returns via the back arrow', () => {
@@ -167,6 +198,9 @@ describe('SettingsPage layout', () => {
     await act(async () => {
       generalTab?.click()
     })
+
+    expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(3)
+    expect(document.body.querySelector('[data-slot="settings-row"]')).not.toBeNull()
 
     // The Diagnostics panel surfaces the log file path plus Open and Reveal controls.
     expect(document.body.textContent).toContain('main.log')
@@ -367,5 +401,9 @@ describe('SettingsPage layout', () => {
     // After maximizing, the control flips to Restore.
     expect(document.body.querySelector('[aria-label="Restore"]')).not.toBeNull()
     expect(document.body.querySelector('[aria-label="Maximize"]')).toBeNull()
+    const dialog = document.body.querySelector<HTMLElement>('[data-slot="settings-surface"]')
+    expect(dialog?.className).toContain('inset-4')
+    expect(dialog?.className).not.toContain('h-[80vh]')
+    expect(dialog?.className).not.toContain('w-[80vw]')
   })
 })

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -13,6 +13,9 @@ import { Dialog } from 'radix-ui'
 import { useEffect, useState } from 'react'
 
 import type { ProviderView, UpsertProviderRequest } from '../../../../shared/settings'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
 import { ClaudeInstallCard } from './ClaudeInstallCard'
 import { ClaudeStatusCard } from './ClaudeStatusCard'
@@ -32,6 +35,7 @@ import {
   type ProviderFormValue
 } from './provider-form-value'
 import { ProviderList } from './ProviderList'
+import { SettingsRow, SettingsSection } from './SettingsLayout'
 
 type SettingsPageProps = {
   open: boolean
@@ -392,19 +396,21 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   return (
     <Dialog.Root open={open} onOpenChange={(next) => (next ? undefined : onClose())}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:data-[state=closed]:animate-none motion-reduce:data-[state=open]:animate-none" />
         <Dialog.Content
+          data-slot="settings-surface"
           // Don't let a click/focus outside the dialog dismiss it. A Radix Select inside the panel
           // (provider type, active model, install source) portals its listbox outside the dialog's
           // DOM, so an outside-click meant only to close the open dropdown would otherwise also close
           // the whole panel. The dropdown's own dismiss still closes just the dropdown; the panel is
           // closed intentionally via the ✕ button or Escape.
           onInteractOutside={(event) => event.preventDefault()}
-          className={`fixed left-1/2 top-1/2 z-50 flex -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-border bg-card text-foreground shadow-dialog data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 ${
+          className={cn(
+            'fixed z-50 flex overflow-hidden overscroll-contain rounded-xl border border-border bg-card text-foreground shadow-dialog outline-none data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 motion-reduce:data-[state=closed]:animate-none motion-reduce:data-[state=open]:animate-none',
             isExpanded
-              ? 'h-[80vh] w-[80vw]'
-              : 'h-[min(640px,calc(100vh-2rem))] w-[min(920px,calc(100vw-2rem))]'
-          }`}
+              ? 'inset-4'
+              : 'left-1/2 top-1/2 h-[min(688px,calc(100vh-2rem))] w-[min(960px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2'
+          )}
         >
           {/* Radix requires a Title/Description for a11y; the visible panel title lives in the header. */}
           <Dialog.Title className="sr-only">Settings</Dialog.Title>
@@ -415,7 +421,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
           {/* Left navigation: grouped settings panels (Capabilities, Workspace). */}
           <nav
             aria-label="Settings"
-            className="flex w-52 shrink-0 flex-col gap-3 border-r border-border bg-muted/40 p-3"
+            className="flex w-52 shrink-0 flex-col gap-4 border-r border-border bg-background p-3"
           >
             {SETTINGS_GROUPS.map((group) => (
               <div key={group.label} className="flex flex-col gap-0.5">
@@ -438,10 +444,10 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                               model: { kind: 'list' }
                             })
                           }
-                          className={`flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-sm transition-colors ${
+                          className={`flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-sm transition-colors duration-150 motion-reduce:transition-none ${
                             isActive
                               ? 'bg-muted font-medium text-foreground'
-                              : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+                              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
                           }`}
                         >
                           <Icon
@@ -460,209 +466,228 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
 
           {/* Right column: header bar + scrollable panel content. */}
           <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-card">
-            <div className="flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border px-3">
-              <div className="flex min-w-0 items-center gap-1">
-                {/* Browser-like history controls for the settings navigation. */}
-                <button
-                  type="button"
-                  onClick={goBack}
-                  disabled={!canGoBack}
-                  aria-label="Back"
-                  className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
-                >
-                  <ArrowLeft className="size-4" aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  onClick={goForward}
-                  disabled={!canGoForward}
-                  aria-label="Forward"
-                  className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
-                >
-                  <ArrowRight className="size-4" aria-hidden="true" />
-                </button>
-                <span aria-hidden="true" className="mx-1 h-4 w-px shrink-0 bg-border" />
-                {breadcrumb !== null ? (
-                  <div className="flex min-w-0 items-center gap-1.5 text-sm font-semibold">
-                    <button
-                      type="button"
-                      onClick={() => navigate(breadcrumb.rootTo)}
-                      aria-label={`Back to ${breadcrumb.rootLabel.toLowerCase()}`}
-                      className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-                    >
-                      {breadcrumb.rootLabel}
-                    </button>
-                    <span className="shrink-0 text-muted-foreground" aria-hidden="true">
-                      ›
-                    </span>
-                    <span className="truncate text-foreground">{breadcrumb.leaf}</span>
-                  </div>
-                ) : (
-                  <h2 className="truncate text-sm font-semibold text-foreground">
-                    {SETTINGS_PANELS.find((panel) => panel.id === activePanel)?.label}
-                  </h2>
-                )}
-              </div>
-              <div className="flex shrink-0 items-center gap-1">
-                <button
-                  type="button"
-                  onClick={() => setIsExpanded((value) => !value)}
-                  aria-label={isExpanded ? 'Restore' : 'Maximize'}
-                  className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                >
-                  {isExpanded ? (
-                    <Minimize2 className="size-4" aria-hidden="true" />
-                  ) : (
-                    <Maximize2 className="size-4" aria-hidden="true" />
-                  )}
-                </button>
-                <Dialog.Close
-                  aria-label="Close settings"
-                  className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                >
-                  <X className="size-4" aria-hidden="true" />
-                </Dialog.Close>
-              </div>
-            </div>
-
-            <div className="min-h-0 flex-1 overflow-y-auto">
-              {activePanel === 'skills' ? (
-                <SkillsPanel view={skillsView} onNavigate={navigateSkills} />
-              ) : activePanel === 'connectors' ? (
-                connectorsView.kind === 'detail' ? (
-                  <ConnectorDetailView id={connectorsView.id} />
-                ) : connectorsView.kind === 'add' ? (
-                  <ConnectorAddForm
-                    initialTransport={connectorsView.transport}
-                    onDone={() => navigateConnectors({ kind: 'list' })}
-                    onCancel={() => navigateConnectors({ kind: 'list' })}
-                  />
-                ) : connectorsView.kind === 'edit' ? (
-                  <ConnectorAddForm
-                    editServer={customServers.find((s) => s.id === connectorsView.id)}
-                    onDone={() => navigateConnectors({ kind: 'list' })}
-                    onCancel={() => navigateConnectors({ kind: 'list' })}
-                  />
-                ) : (
-                  <ConnectorsPanel onNavigate={navigateConnectors} />
-                )
-              ) : activePanel === 'general' ? (
-                <GeneralPanel />
-              ) : isProviderFormOpen ? (
-                // Add/edit provider is a secondary page reached via the shared back/forward arrows.
-                <div className="p-5">
-                  {/* Keys are stored with OS encryption; warn (as onboarding does) when the keychain
-                      is unavailable so the reduced-protection fallback is never a silent surprise. */}
-                  {!encryptionAvailable ? (
-                    <p className="mb-4 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-                      Secure key storage is unavailable on this machine. Your key will be stored
-                      with reduced protection.
-                    </p>
-                  ) : null}
-                  <ProviderForm
-                    value={formValue}
-                    onChange={(patch) => setFormValue((current) => ({ ...current, ...patch }))}
-                    hasStoredKey={editingProvider?.hasKey}
-                    maskedKey={editingProvider?.maskedKey}
-                    needsKey={editingProvider?.needsKey}
-                    errors={formErrors}
-                    supportedModels={editingProvider?.models}
-                    onRefreshModels={
-                      editingProvider?.type === 'official' &&
-                      editingProvider.hasKey &&
-                      editingProvider.vendorId &&
-                      resolveVendorModelsUrl(editingProvider.vendorId, editingProvider.region)
-                        ? () => void handleRefreshModels(editingProvider.id)
-                        : undefined
-                    }
-                    isRefreshingModels={isRefreshingModels}
-                    disabled={isSaving}
-                    encryptionAvailable={encryptionAvailable}
-                  />
-                  {statusMessage ? (
-                    <p
-                      className={`mt-3 text-sm ${statusOk ? 'text-primary' : 'text-destructive'}`}
-                      role="alert"
-                    >
-                      {statusMessage}
-                    </p>
-                  ) : null}
-                  <div className="mt-6 flex justify-end gap-2">
-                    <button
-                      type="button"
-                      onClick={closeForm}
-                      disabled={isSaving}
-                      className="rounded-lg border border-border px-3 py-1.5 text-sm transition-colors hover:bg-muted disabled:opacity-50"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => void handleSave()}
-                      disabled={!canSave}
-                      className="rounded-lg border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
-                    >
-                      {isSaving ? 'Saving…' : 'Save'}
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                <div className="space-y-6 p-5">
-                  <section aria-label="Claude">
-                    <h3 className="mb-3 text-sm font-semibold text-foreground">Claude</h3>
-                    <div className="space-y-3">
-                      <ClaudeStatusCard
-                        claude={claude}
-                        claudeReady={preflight.claudeReady}
-                        isDetecting={isDetectingClaude}
-                        onDetect={() => void detectClaude()}
-                      />
-                      {!preflight.claudeReady ? (
-                        <ClaudeInstallCard
-                          isInstalling={isInstalling}
-                          installLogs={installLogs}
-                          installProgress={installProgress}
-                          installError={installError}
-                          npmAvailable={npmAvailable}
-                          onInstall={(source) => void installClaude(source)}
-                        />
-                      ) : null}
-                    </div>
-                  </section>
-
-                  <section aria-label="Providers" className="border-t border-border pt-6">
-                    <div className="mb-3 flex items-center justify-between">
-                      <h3 className="text-sm font-semibold text-foreground">Providers</h3>
+            <TooltipProvider delayDuration={300}>
+              <div className="flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border bg-card px-3">
+                <div className="flex min-w-0 items-center gap-1">
+                  {/* Browser-like history controls for the settings navigation. */}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={goBack}
+                        disabled={!canGoBack}
+                        aria-label="Back"
+                        className="shrink-0 rounded-lg text-muted-foreground disabled:opacity-40"
+                      >
+                        <ArrowLeft className="size-4" aria-hidden="true" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Back</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={goForward}
+                        disabled={!canGoForward}
+                        aria-label="Forward"
+                        className="shrink-0 rounded-lg text-muted-foreground disabled:opacity-40"
+                      >
+                        <ArrowRight className="size-4" aria-hidden="true" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Forward</TooltipContent>
+                  </Tooltip>
+                  <span aria-hidden="true" className="mx-1 h-4 w-px shrink-0 bg-border" />
+                  {breadcrumb !== null ? (
+                    <div className="flex min-w-0 items-center gap-1.5 text-sm font-semibold">
                       <button
                         type="button"
-                        onClick={openCreate}
-                        className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+                        onClick={() => navigate(breadcrumb.rootTo)}
+                        aria-label={`Back to ${breadcrumb.rootLabel.toLowerCase()}`}
+                        className="shrink-0 text-muted-foreground transition-colors motion-reduce:transition-none hover:text-foreground"
                       >
-                        <Plus className="size-4" aria-hidden="true" />
-                        Add provider
+                        {breadcrumb.rootLabel}
                       </button>
+                      <span className="shrink-0 text-muted-foreground" aria-hidden="true">
+                        ›
+                      </span>
+                      <span className="truncate text-foreground">{breadcrumb.leaf}</span>
                     </div>
-
-                    {providers.length > 0 ? (
-                      <div className="mb-4 space-y-1.5">
-                        <span className="text-xs font-medium text-muted-foreground">
-                          Active model
-                        </span>
-                        <ActiveModelSelect />
-                      </div>
-                    ) : null}
-
-                    <ProviderList
-                      providers={providers}
-                      activeProviderId={activeProviderId}
-                      busyProviderId={busyProviderId}
-                      onEdit={openEdit}
-                      onDelete={(provider) => void deleteProvider(provider.id)}
-                      onTest={(provider) => void handleTest(provider)}
-                    />
-                  </section>
+                  ) : (
+                    <h2 className="truncate text-sm font-semibold text-foreground">
+                      {SETTINGS_PANELS.find((panel) => panel.id === activePanel)?.label}
+                    </h2>
+                  )}
                 </div>
-              )}
+                <div className="flex shrink-0 items-center gap-1">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => setIsExpanded((value) => !value)}
+                        aria-label={isExpanded ? 'Restore' : 'Maximize'}
+                        className="rounded-lg text-muted-foreground"
+                      >
+                        {isExpanded ? (
+                          <Minimize2 className="size-4" aria-hidden="true" />
+                        ) : (
+                          <Maximize2 className="size-4" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{isExpanded ? 'Restore' : 'Maximize'}</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <Dialog.Close asChild>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label="Close settings"
+                          className="rounded-lg text-muted-foreground"
+                        >
+                          <X className="size-4" aria-hidden="true" />
+                        </Button>
+                      </TooltipTrigger>
+                    </Dialog.Close>
+                    <TooltipContent>Close settings</TooltipContent>
+                  </Tooltip>
+                </div>
+              </div>
+            </TooltipProvider>
+
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="mx-auto min-h-full w-full max-w-[880px]">
+                {activePanel === 'skills' ? (
+                  <SkillsPanel view={skillsView} onNavigate={navigateSkills} />
+                ) : activePanel === 'connectors' ? (
+                  connectorsView.kind === 'detail' ? (
+                    <ConnectorDetailView id={connectorsView.id} />
+                  ) : connectorsView.kind === 'add' ? (
+                    <ConnectorAddForm
+                      initialTransport={connectorsView.transport}
+                      onDone={() => navigateConnectors({ kind: 'list' })}
+                      onCancel={() => navigateConnectors({ kind: 'list' })}
+                    />
+                  ) : connectorsView.kind === 'edit' ? (
+                    <ConnectorAddForm
+                      editServer={customServers.find((s) => s.id === connectorsView.id)}
+                      onDone={() => navigateConnectors({ kind: 'list' })}
+                      onCancel={() => navigateConnectors({ kind: 'list' })}
+                    />
+                  ) : (
+                    <ConnectorsPanel onNavigate={navigateConnectors} />
+                  )
+                ) : activePanel === 'general' ? (
+                  <GeneralPanel />
+                ) : isProviderFormOpen ? (
+                  // Add/edit provider is a secondary page reached via the shared back/forward arrows.
+                  <div className="p-5">
+                    {/* Keys are stored with OS encryption; warn (as onboarding does) when the keychain
+                      is unavailable so the reduced-protection fallback is never a silent surprise. */}
+                    {!encryptionAvailable ? (
+                      <p className="mb-4 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                        Secure key storage is unavailable on this machine. Your key will be stored
+                        with reduced protection.
+                      </p>
+                    ) : null}
+                    <ProviderForm
+                      value={formValue}
+                      onChange={(patch) => setFormValue((current) => ({ ...current, ...patch }))}
+                      hasStoredKey={editingProvider?.hasKey}
+                      maskedKey={editingProvider?.maskedKey}
+                      needsKey={editingProvider?.needsKey}
+                      errors={formErrors}
+                      supportedModels={editingProvider?.models}
+                      onRefreshModels={
+                        editingProvider?.type === 'official' &&
+                        editingProvider.hasKey &&
+                        editingProvider.vendorId &&
+                        resolveVendorModelsUrl(editingProvider.vendorId, editingProvider.region)
+                          ? () => void handleRefreshModels(editingProvider.id)
+                          : undefined
+                      }
+                      isRefreshingModels={isRefreshingModels}
+                      disabled={isSaving}
+                      encryptionAvailable={encryptionAvailable}
+                    />
+                    {statusMessage ? (
+                      <p
+                        className={`mt-3 text-sm ${statusOk ? 'text-primary' : 'text-destructive'}`}
+                        role="alert"
+                      >
+                        {statusMessage}
+                      </p>
+                    ) : null}
+                    <div className="mt-6 flex justify-end gap-2">
+                      <Button type="button" variant="ghost" onClick={closeForm} disabled={isSaving}>
+                        Cancel
+                      </Button>
+                      <Button type="button" onClick={() => void handleSave()} disabled={!canSave}>
+                        {isSaving ? 'Saving…' : 'Save'}
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="space-y-5 p-5">
+                    <SettingsSection title="Claude" aria-label="Claude">
+                      <div className="space-y-3">
+                        <ClaudeStatusCard
+                          claude={claude}
+                          claudeReady={preflight.claudeReady}
+                          isDetecting={isDetectingClaude}
+                          onDetect={() => void detectClaude()}
+                        />
+                        {!preflight.claudeReady ? (
+                          <ClaudeInstallCard
+                            isInstalling={isInstalling}
+                            installLogs={installLogs}
+                            installProgress={installProgress}
+                            installError={installError}
+                            npmAvailable={npmAvailable}
+                            onInstall={(source) => void installClaude(source)}
+                          />
+                        ) : null}
+                      </div>
+                    </SettingsSection>
+
+                    <SettingsSection
+                      title="Providers"
+                      aria-label="Providers"
+                      separated
+                      action={
+                        <Button type="button" variant="outline" onClick={openCreate}>
+                          <Plus className="size-4" aria-hidden="true" />
+                          Add provider
+                        </Button>
+                      }
+                    >
+                      {providers.length > 0 ? (
+                        <SettingsRow label="Active model" className="border-b border-border pt-0">
+                          <ActiveModelSelect />
+                        </SettingsRow>
+                      ) : null}
+
+                      <ProviderList
+                        providers={providers}
+                        activeProviderId={activeProviderId}
+                        busyProviderId={busyProviderId}
+                        onEdit={openEdit}
+                        onDelete={(provider) => void deleteProvider(provider.id)}
+                        onTest={(provider) => void handleTest(provider)}
+                      />
+                    </SettingsSection>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </Dialog.Content>

--- a/src/renderer/src/pages/settings/SkillDetailView.tsx
+++ b/src/renderer/src/pages/settings/SkillDetailView.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import type { SkillDetailView as SkillDetail } from '../../../../shared/settings'
 import { AgentMarkdown } from '@/components/streamdown/AgentMarkdown'
 import { useSettingsStore } from '@/stores/settings-store'
-import { SkillToggle } from './SkillsPanel'
+import { SettingsToggle } from './SettingsLayout'
 
 type SkillDetailViewProps = {
   skillId: string
@@ -58,15 +58,15 @@ const SkillDetailView = ({ skillId }: SkillDetailViewProps): React.JSX.Element =
         <div className="flex min-w-0 items-center gap-3">
           <ScrollText className="size-6 shrink-0 text-primary" aria-hidden="true" />
           <div className="flex min-w-0 items-center gap-2">
-            <h1 className="truncate text-heading font-semibold text-foreground">{name}</h1>
+            <h1 className="truncate text-base font-semibold text-foreground">{name}</h1>
             <span className="inline-flex shrink-0 items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
               Featured
             </span>
           </div>
         </div>
-        <SkillToggle
+        <SettingsToggle
           enabled={enabled}
-          label={`Toggle ${name}`}
+          aria-label={`Toggle ${name}`}
           onToggle={() => void setSkillEnabled(skillId, !enabled)}
         />
       </div>

--- a/src/renderer/src/pages/settings/SkillEditor.tsx
+++ b/src/renderer/src/pages/settings/SkillEditor.tsx
@@ -3,9 +3,12 @@ import { useEffect, useMemo, useState } from 'react'
 
 import type { SkillReference } from '../../../../shared/settings'
 import { FileDropOverlay } from '@/components/FileDropOverlay'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { useSettingsStore } from '@/stores/settings-store'
+import { SettingsIconAction } from './SettingsLayout'
 
 export type SkillDraft = {
   id?: string
@@ -176,9 +179,9 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="max-w-2xl p-5">
+        <div className="p-5">
           <section>
-            <h3 className="text-base font-semibold text-foreground">Identity</h3>
+            <h2 className="text-base font-semibold text-foreground">Identity</h2>
             <p className="mt-0.5 text-xs text-muted-foreground">
               How this skill appears in the catalog and to the agent.
             </p>
@@ -227,13 +230,13 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
               </label>
               <label className="flex flex-col gap-1.5">
                 <span className="text-sm font-medium text-foreground">Description</span>
-                <textarea
+                <Textarea
                   aria-label="Skill description"
                   value={description}
                   onChange={(event) => setDescription(event.target.value)}
                   rows={2}
                   placeholder="One sentence — what does this skill teach the agent, and when does it apply?"
-                  className="w-full resize-none rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+                  className="resize-none text-sm"
                 />
                 <span className="text-xs text-muted-foreground">
                   This is how the agent decides when to use the skill — be specific.
@@ -247,7 +250,7 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
           <section>
             <div className="flex items-start justify-between gap-3">
               <div>
-                <h3 className="text-base font-semibold text-foreground">Content</h3>
+                <h2 className="text-base font-semibold text-foreground">Content</h2>
                 <p className="mt-0.5 text-xs text-muted-foreground">
                   Markdown shown to the agent when the skill is invoked.
                 </p>
@@ -262,7 +265,7 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
                   role="radio"
                   aria-checked={contentMode === 'write'}
                   onClick={() => setContentMode('write')}
-                  className={`inline-flex h-7 items-center rounded-md px-2.5 text-sm transition-colors ${
+                  className={`inline-flex h-7 items-center rounded-md px-2.5 text-sm transition-colors motion-reduce:transition-none ${
                     contentMode === 'write'
                       ? 'bg-card font-medium text-foreground shadow-sm'
                       : 'text-muted-foreground hover:text-foreground'
@@ -275,7 +278,7 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
                   role="radio"
                   aria-checked={contentMode === 'upload'}
                   onClick={() => setContentMode('upload')}
-                  className={`inline-flex h-7 items-center rounded-md px-2.5 text-sm transition-colors ${
+                  className={`inline-flex h-7 items-center rounded-md px-2.5 text-sm transition-colors motion-reduce:transition-none ${
                     contentMode === 'upload'
                       ? 'bg-card font-medium text-foreground shadow-sm'
                       : 'text-muted-foreground hover:text-foreground'
@@ -288,13 +291,13 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
 
             {contentMode === 'write' ? (
               <>
-                <textarea
+                <Textarea
                   aria-label="Skill body"
                   value={body}
                   onChange={(event) => handleBodyChange(event.target.value)}
                   rows={16}
                   placeholder={'# Instructions\n\nStep-by-step guidance for the agent…'}
-                  className="mt-4 min-h-64 w-full resize-none rounded-lg border border-input bg-transparent px-2.5 py-2 font-mono text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+                  className="mt-4 min-h-64 resize-none font-mono text-[13px]"
                 />
                 <p className="mt-1.5 text-xs text-muted-foreground">
                   Paste a full SKILL.md — if it has a <code className="font-mono">---</code>{' '}
@@ -306,7 +309,7 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
                 type="button"
                 onClick={uploadContent}
                 {...contentDrop.dropZoneProps}
-                className="relative mt-4 flex w-full flex-col items-center gap-2 rounded-lg border border-dashed border-border px-6 py-8 text-center transition-colors hover:bg-muted/50"
+                className="relative mt-4 flex w-full flex-col items-center gap-2 rounded-lg border border-dashed border-border px-6 py-8 text-center transition-colors motion-reduce:transition-none hover:bg-muted/50"
               >
                 {contentDrop.isDragging ? (
                   <FileDropOverlay label="Drop to upload" className="rounded-lg" />
@@ -325,14 +328,14 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
           <div className="my-6 h-px bg-border" />
 
           <section>
-            <h3 className="text-base font-semibold text-foreground">References</h3>
+            <h2 className="text-base font-semibold text-foreground">References</h2>
             <p className="mt-0.5 text-xs text-muted-foreground">
               Supporting files (scripts, templates, data) the skill can read at runtime.
             </p>
 
             <label
               {...referenceDrop.dropZoneProps}
-              className="relative mt-4 flex cursor-pointer flex-col items-center gap-2 rounded-lg border border-dashed border-border px-6 py-6 text-center transition-colors hover:bg-muted/50"
+              className="relative mt-4 flex cursor-pointer flex-col items-center gap-2 rounded-lg border border-dashed border-border px-6 py-6 text-center transition-colors motion-reduce:transition-none hover:bg-muted/50"
             >
               {referenceDrop.isDragging ? (
                 <FileDropOverlay label="Drop reference files" className="rounded-lg" />
@@ -360,16 +363,15 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
                     <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
                       references/{ref.path}
                     </span>
-                    <button
-                      type="button"
-                      aria-label={`Remove ${ref.path}`}
+                    <SettingsIconAction
+                      label={`Remove ${ref.path}`}
+                      icon={X}
                       onClick={() =>
                         setReferences((prev) => prev.filter((item) => item.path !== ref.path))
                       }
-                      className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
-                    >
-                      <X className="size-3.5" aria-hidden="true" />
-                    </button>
+                      className="size-6"
+                      danger
+                    />
                   </li>
                 ))}
               </ul>
@@ -379,21 +381,12 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
       </div>
 
       <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border bg-card px-5 py-3">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="inline-flex h-8 items-center rounded-lg px-3 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
+        <Button type="button" variant="ghost" onClick={onCancel}>
           Cancel
-        </button>
-        <button
-          type="button"
-          onClick={() => void handleSave()}
-          disabled={!canSave}
-          className="inline-flex h-8 items-center rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
-        >
+        </Button>
+        <Button type="button" onClick={() => void handleSave()} disabled={!canSave}>
           {saving ? 'Saving…' : initial.id ? 'Save' : 'Publish'}
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/src/renderer/src/pages/settings/SkillImportView.tsx
+++ b/src/renderer/src/pages/settings/SkillImportView.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import type { ScannedSkillView, SkillView } from '../../../../shared/settings'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useSettingsStore } from '@/stores/settings-store'
 
@@ -87,9 +88,9 @@ const SkillImportView = ({ onImported }: SkillImportViewProps): React.JSX.Elemen
     })
 
   return (
-    <div className="max-w-2xl p-5">
-      <h2 className="text-lg font-semibold text-foreground">Import from GitHub</h2>
-      <p className="mt-0.5 text-sm text-muted-foreground">
+    <div className="p-5">
+      <h2 className="text-base font-semibold text-foreground">Import from GitHub</h2>
+      <p className="mt-0.5 text-[13px] leading-5 text-muted-foreground">
         Preview a repo or skill folder (owner/repo, owner/repo@ref, or a github.com URL), then pick
         the skills you want to import.
       </p>
@@ -104,14 +105,15 @@ const SkillImportView = ({ onImported }: SkillImportViewProps): React.JSX.Elemen
             if (event.key === 'Enter') void runPreview()
           }}
         />
-        <button
+        <Button
           type="button"
+          variant="outline"
           onClick={() => void runPreview()}
           disabled={busy || input.trim().length === 0}
-          className="inline-flex h-8 shrink-0 items-center rounded-lg border border-border px-3 text-sm text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
+          className="shrink-0"
         >
           {busy ? 'Working…' : 'Preview'}
-        </button>
+        </Button>
       </div>
       {message ? <p className="mt-2 text-xs text-muted-foreground">{message}</p> : null}
 
@@ -132,22 +134,18 @@ const SkillImportView = ({ onImported }: SkillImportViewProps): React.JSX.Elemen
                 />
                 Select all
               </label>
-              <button
-                type="button"
-                onClick={invertSelection}
-                className="text-xs text-muted-foreground transition-colors hover:text-foreground"
-              >
+              <Button type="button" variant="ghost" size="sm" onClick={invertSelection}>
                 Invert
-              </button>
+              </Button>
             </div>
-            <button
+            <Button
               type="button"
+              variant="outline"
               onClick={() => void importSelected()}
               disabled={busy || selected.size === 0}
-              className="inline-flex h-8 items-center rounded-lg border border-border bg-card px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
             >
               Import selected ({selected.size})
-            </button>
+            </Button>
           </div>
           <ul className="mt-2 flex flex-col divide-y divide-border">
             {scanned.map((skill) => (

--- a/src/renderer/src/pages/settings/SkillUploadView.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, FileText, Info, Upload } from 'lucide-react'
 import { useState } from 'react'
 
 import { FileDropOverlay } from '@/components/FileDropOverlay'
+import { Button } from '@/components/ui/button'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { useSettingsStore } from '@/stores/settings-store'
 
@@ -164,9 +165,9 @@ const SkillUploadView = ({
     const replaceId = pending.kind === 'bundle' ? pending.replaceableId : undefined
 
     return (
-      <div className="max-w-2xl p-5">
-        <h2 className="text-lg font-semibold text-foreground">Confirm import</h2>
-        <p className="mt-0.5 text-sm text-muted-foreground">
+      <div className="p-5">
+        <h2 className="text-base font-semibold text-foreground">Confirm import</h2>
+        <p className="mt-0.5 text-[13px] leading-5 text-muted-foreground">
           Review what will be added from <span className="text-foreground">{pending.fileName}</span>
           .
         </p>
@@ -220,44 +221,35 @@ const SkillUploadView = ({
         <div className="mt-4 flex items-center gap-2">
           {replaceId ? (
             <>
-              <button
+              <Button
                 type="button"
+                variant="outline"
                 onClick={() => void confirm(replaceId)}
                 disabled={busy}
-                className="inline-flex h-8 items-center rounded-lg border border-border bg-card px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
               >
                 {busy ? 'Importing…' : `Replace "${pending.name}"`}
-              </button>
-              <button
-                type="button"
-                onClick={() => void confirm()}
-                disabled={busy}
-                className="inline-flex h-8 items-center rounded-lg px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
-              >
+              </Button>
+              <Button type="button" variant="ghost" onClick={() => void confirm()} disabled={busy}>
                 Import as a copy
-              </button>
+              </Button>
             </>
           ) : (
-            <button
-              type="button"
-              onClick={() => void confirm()}
-              disabled={busy}
-              className="inline-flex h-8 items-center rounded-lg border border-border bg-card px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
-            >
+            <Button type="button" variant="outline" onClick={() => void confirm()} disabled={busy}>
               {busy ? 'Importing…' : 'Import'}
-            </button>
+            </Button>
           )}
-          <button
+          <Button
             type="button"
+            variant="ghost"
             onClick={() => {
               setPending(null)
               setMessage(null)
             }}
             disabled={busy}
-            className="inline-flex h-8 items-center rounded-lg px-3 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+            className="text-muted-foreground"
           >
             Choose a different file
-          </button>
+          </Button>
         </div>
         {duplicate ? (
           <p className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -274,15 +266,15 @@ const SkillUploadView = ({
   }
 
   return (
-    <div className="max-w-2xl p-5">
-      <h2 className="text-lg font-semibold text-foreground">Upload a skill</h2>
-      <p className="mt-0.5 text-sm text-muted-foreground">
+    <div className="p-5">
+      <h2 className="text-base font-semibold text-foreground">Upload a skill</h2>
+      <p className="mt-0.5 text-[13px] leading-5 text-muted-foreground">
         Add a skill from a SKILL.md file or a .zip / .skill bundle on your computer.
       </p>
 
       <label
         {...dropZoneProps}
-        className="relative mt-4 flex cursor-pointer flex-col items-center gap-3 rounded-lg border border-dashed border-border bg-muted/20 px-6 py-10 text-center transition-colors hover:bg-muted/40"
+        className="relative mt-4 flex cursor-pointer flex-col items-center gap-3 rounded-lg border border-dashed border-border bg-muted/20 px-6 py-10 text-center transition-colors motion-reduce:transition-none hover:bg-muted/40"
       >
         {isDragging ? <FileDropOverlay label="Drop to upload" className="rounded-lg" /> : null}
         <input
@@ -307,13 +299,9 @@ const SkillUploadView = ({
       {message ? <ErrorBanner message={message} /> : null}
 
       <div className="mt-5 text-center">
-        <button
-          type="button"
-          onClick={onWriteInstead}
-          className="rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
+        <Button type="button" variant="ghost" onClick={onWriteInstead}>
           Write from scratch instead
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -103,7 +103,25 @@ describe('SkillsPanel (list view)', () => {
     expect(document.body.textContent).toContain('Alpha')
     expect(document.body.textContent).toContain('Mine')
     expect(document.body.querySelectorAll('[role="switch"]')).toHaveLength(3)
+    expect(document.body.querySelectorAll('[data-slot="switch"]')).toHaveLength(3)
+    const switches = document.body.querySelectorAll<HTMLElement>('[data-slot="switch"]')
+    expect(switches[0]?.getAttribute('data-state')).toBe('checked')
+    expect(switches[0]?.className).toContain('data-[state=checked]:bg-primary')
+    expect(switches[0]?.className).toContain('ml-1')
+    expect(switches[0]?.className).toContain('mr-3')
+    expect(switches[1]?.getAttribute('data-state')).toBe('unchecked')
+    expect(
+      switches[0]?.querySelector<HTMLElement>('[data-slot="switch-thumb"]')?.className
+    ).toContain('data-[state=checked]:translate-x')
+    expect(document.body.querySelectorAll('[data-slot="settings-list-row"]')).toHaveLength(3)
     expect(document.body.textContent).toContain('Add skill')
+    const addSkill = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('Add skill')
+    )
+    expect(addSkill?.getAttribute('data-slot')).toBe('button')
+    expect(addSkill?.getAttribute('data-variant')).toBe('outline')
+    expect(addSkill?.className).toContain('bg-card')
+    expect(switches[0]?.className).toContain('motion-reduce:transition-none')
   })
 
   it('toggles a skill and navigates to its detail on row click', () => {
@@ -137,7 +155,16 @@ describe('SkillsPanel (list view)', () => {
       root.render(<SkillsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
     })
 
-    act(() => document.body.querySelector<HTMLButtonElement>('[aria-label="Delete Mine"]')?.click())
+    const edit = document.body.querySelector<HTMLButtonElement>('[aria-label="Edit Mine"]')
+    const remove = document.body.querySelector<HTMLButtonElement>('[aria-label="Delete Mine"]')
+    expect(edit?.getAttribute('data-slot')).toBe('button')
+    expect(remove?.getAttribute('data-slot')).toBe('button')
+    expect(edit?.getAttribute('data-size')).toBe('icon-sm')
+    expect(remove?.getAttribute('data-size')).toBe('icon-sm')
+    expect(edit?.getAttribute('data-state')).toBe('closed')
+    expect(remove?.getAttribute('data-state')).toBe('closed')
+
+    act(() => remove?.click())
     expect(useSettingsStore.getState().deleteSkill).toHaveBeenCalledWith('personal-mine')
   })
 })
@@ -150,6 +177,12 @@ describe('SkillsPanel (sub-views)', () => {
     })
 
     expect(document.body.textContent).toContain('Identity')
+    expect(
+      document.body.querySelector('[aria-label="Skill description"]')?.getAttribute('data-slot')
+    ).toBe('textarea')
+    expect(
+      document.body.querySelector('[aria-label="Skill body"]')?.getAttribute('data-slot')
+    ).toBe('textarea')
     setValue('Skill name', 'My New Skill')
     setValue('Skill body', '# Body')
 

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, Download, FileUp, Pencil, Plus, Search, Trash2 } from 'luc
 import { useEffect, useMemo, useState } from 'react'
 
 import type { SkillSource } from '../../../../shared/settings'
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,6 +16,7 @@ import { SkillDetailView } from './SkillDetailView'
 import { SkillEditor, SkillEditLoader } from './SkillEditor'
 import { SkillImportView } from './SkillImportView'
 import { SkillUploadView } from './SkillUploadView'
+import { SettingsIconAction, SettingsToggle } from './SettingsLayout'
 
 // The skills panel sub-view, driven by the settings navigation history so each is a breadcrumb page.
 export type SkillsView =
@@ -39,37 +41,6 @@ const SOURCE_GROUPS: ReadonlyArray<{ source: SkillSource; label: string; subtitl
   { source: 'imported', label: 'Imported', subtitle: 'Skills you added from GitHub.' },
   { source: 'personal', label: 'Personal', subtitle: 'Your custom skills.' }
 ]
-
-// A compact on/off toggle. The repo has no shared Switch component, so the control is inlined here and
-// reused by the detail view via the same markup.
-const SkillToggle = ({
-  enabled,
-  label,
-  onToggle
-}: {
-  enabled: boolean
-  label: string
-  onToggle: () => void
-}): React.JSX.Element => (
-  <button
-    type="button"
-    role="switch"
-    aria-checked={enabled}
-    aria-label={label}
-    onClick={onToggle}
-    className={
-      'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ' +
-      (enabled ? 'bg-primary' : 'bg-muted')
-    }
-  >
-    <span
-      className={
-        'inline-block size-4 rounded-full bg-white shadow transition-transform ' +
-        (enabled ? 'translate-x-4' : 'translate-x-0.5')
-      }
-    />
-  </button>
-)
 
 type SkillsPanelProps = {
   view: SkillsView
@@ -169,10 +140,12 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
           />
         </div>
         <DropdownMenu>
-          <DropdownMenuTrigger className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted">
-            <Plus className="size-4" aria-hidden="true" />
-            Add skill
-            <ChevronDown className="size-4 opacity-70" aria-hidden="true" />
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" className="shrink-0">
+              <Plus data-icon="inline-start" aria-hidden="true" />
+              Add skill
+              <ChevronDown data-icon="inline-end" className="opacity-70" aria-hidden="true" />
+            </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem className="gap-2.5" onSelect={() => onNavigate({ kind: 'create' })}>
@@ -218,7 +191,7 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
                 <span className="flex items-center gap-1 text-sm font-semibold text-foreground">
                   {group.label}
                   <ChevronDown
-                    className={`size-4 shrink-0 text-muted-foreground transition-transform ${
+                    className={`size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none ${
                       expanded ? '' : '-rotate-90'
                     }`}
                     aria-hidden="true"
@@ -231,7 +204,11 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
                 rows.length > 0 ? (
                   <ul className="mt-2 flex flex-col divide-y divide-border">
                     {rows.map((skill) => (
-                      <li key={skill.id} className="flex items-center gap-2 py-2.5">
+                      <li
+                        key={skill.id}
+                        data-slot="settings-list-row"
+                        className="flex min-h-14 items-center gap-2 py-2.5"
+                      >
                         <button
                           type="button"
                           onClick={() => onNavigate({ kind: 'detail', id: skill.id })}
@@ -245,28 +222,23 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
                           </span>
                         </button>
                         {skill.source === 'personal' ? (
-                          <button
-                            type="button"
-                            aria-label={`Edit ${skill.name}`}
+                          <SettingsIconAction
+                            label={`Edit ${skill.name}`}
+                            icon={Pencil}
                             onClick={() => onNavigate({ kind: 'edit', id: skill.id })}
-                            className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                          >
-                            <Pencil className="size-3.5" aria-hidden="true" />
-                          </button>
+                          />
                         ) : null}
                         {skill.source !== 'featured' ? (
-                          <button
-                            type="button"
-                            aria-label={`Delete ${skill.name}`}
+                          <SettingsIconAction
+                            label={`Delete ${skill.name}`}
+                            icon={Trash2}
                             onClick={() => void deleteSkill(skill.id)}
-                            className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
-                          >
-                            <Trash2 className="size-3.5" aria-hidden="true" />
-                          </button>
+                            danger
+                          />
                         ) : null}
-                        <SkillToggle
+                        <SettingsToggle
                           enabled={skill.enabled}
-                          label={`Toggle ${skill.name}`}
+                          aria-label={`Toggle ${skill.name}`}
                           onToggle={() => void setSkillEnabled(skill.id, !skill.enabled)}
                         />
                       </li>
@@ -290,4 +262,4 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
   )
 }
 
-export { SkillsPanel, SkillToggle }
+export { SkillsPanel }

--- a/src/renderer/src/pages/settings/ToolPermissionControl.tsx
+++ b/src/renderer/src/pages/settings/ToolPermissionControl.tsx
@@ -17,7 +17,8 @@ export function ToolPermissionControl({
   label
 }: ToolPermissionControlProps): React.JSX.Element {
   const segment = (active: boolean, allow: boolean): string => {
-    const base = 'grid h-6 w-7 place-items-center rounded-md transition-colors'
+    const base =
+      'grid h-6 w-7 place-items-center rounded-md transition-colors motion-reduce:transition-none'
     if (active) {
       return `${base} bg-card shadow-sm ${allow ? 'text-emerald-600' : 'text-foreground'}`
     }

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -64,6 +64,8 @@ describe('ComposerModelPicker', () => {
     const trigger = container.querySelector('[aria-label="Select model"]')
     expect(trigger).not.toBeNull()
     expect(trigger?.textContent).toContain('glm-4.7')
+    expect(trigger?.getAttribute('data-slot')).toBe('button')
+    expect(trigger?.getAttribute('data-variant')).toBe('ghost')
   })
 
   it('offers one trigger across providers and reflects a custom provider label', () => {

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -1,5 +1,6 @@
 import { Check, ChevronDown } from 'lucide-react'
 
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -55,26 +56,28 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className={triggerClassName} aria-label="Select model">
-        {current ? (
-          <ProviderKindIcon
-            kindKey={providerKindKey(current.providerType, current.vendorId)}
-            className="size-4"
-          />
-        ) : null}
-        <span className="truncate">
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className={triggerClassName} aria-label="Select model">
           {current ? (
-            <>
-              <span className="font-medium text-text-100">{optionLabel(current)}</span>
-              {current.model ? (
-                <span className="ml-1.5 text-text-300">· {current.providerName}</span>
-              ) : null}
-            </>
-          ) : (
-            'Select model'
-          )}
-        </span>
-        <ChevronDown className="size-3.5 shrink-0" aria-hidden="true" />
+            <ProviderKindIcon
+              kindKey={providerKindKey(current.providerType, current.vendorId)}
+              className="size-4"
+            />
+          ) : null}
+          <span className="truncate">
+            {current ? (
+              <>
+                <span className="font-medium text-text-100">{optionLabel(current)}</span>
+                {current.model ? (
+                  <span className="ml-1.5 text-text-300">· {current.providerName}</span>
+                ) : null}
+              </>
+            ) : (
+              'Select model'
+            )}
+          </span>
+          <ChevronDown className="size-3.5 shrink-0" aria-hidden="true" />
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="max-h-[320px] min-w-[15rem] overflow-y-auto">
         {groups.map((group) => (

--- a/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.interaction.test.tsx
@@ -71,6 +71,9 @@ describe('ComposerPermissionProfilePicker', () => {
         <ComposerPermissionProfilePicker value="ask" onChange={onChange} disabled={false} />
       )
     })
+    const trigger = container.querySelector('[aria-label="Permission mode: Ask for approval"]')
+    expect(trigger?.getAttribute('data-slot')).toBe('button')
+    expect(trigger?.getAttribute('data-variant')).toBe('ghost')
     act(() =>
       findButton(
         'Auto-approve editsAuto-approve edits to files in the workspace. Still ask before commands, network, and MCP.'
@@ -95,6 +98,9 @@ describe('ComposerPermissionProfilePicker', () => {
 
     expect(onChange).not.toHaveBeenCalled()
     expect(container.textContent).toContain('Enable Full access?')
+    expect(findButton('Cancel').getAttribute('data-slot')).toBe('button')
+    expect(findButton('Cancel').getAttribute('data-variant')).toBe('outline')
+    expect(findButton('Enable').getAttribute('data-slot')).toBe('button')
 
     act(() => findButton('Enable').click())
     expect(onChange).toHaveBeenCalledWith('full')

--- a/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerPermissionProfilePicker.tsx
@@ -7,6 +7,7 @@ import { AlertTriangle, Check, ChevronUp, Shield, ShieldAlert, ShieldCheck, X } 
 import { useState } from 'react'
 import { AlertDialog } from 'radix-ui'
 
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -82,8 +83,9 @@ const ComposerPermissionProfilePicker = ({
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild disabled={disabled}>
-          <button
+          <Button
             type="button"
+            variant="ghost"
             className="flex h-8 min-w-0 items-center gap-1.5 rounded-md px-2 text-[12px] text-text-100 transition-colors duration-200 ease-out hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
             aria-label={`Permission mode: ${selectedProfile.label}`}
           >
@@ -105,7 +107,7 @@ const ComposerPermissionProfilePicker = ({
               strokeWidth={2}
               aria-hidden="true"
             />
-          </button>
+          </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-80 p-1.5">
           {permissionProfiles.map((profile) => {
@@ -202,7 +204,7 @@ const ComposerPermissionProfilePicker = ({
       <AlertDialog.Root open={confirmFullAccess} onOpenChange={setConfirmFullAccess}>
         <AlertDialog.Portal>
           <AlertDialog.Overlay className="fixed inset-0 z-50 bg-black/25 backdrop-blur-[2px]" />
-          <AlertDialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(440px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-bg-000 p-6 text-text-000 shadow-dialog">
+          <AlertDialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(440px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overscroll-contain rounded-2xl bg-bg-000 p-6 text-text-000 shadow-dialog">
             <div className="flex items-start gap-3">
               <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700">
                 <AlertTriangle className="size-5" strokeWidth={2} aria-hidden="true" />
@@ -220,21 +222,22 @@ const ComposerPermissionProfilePicker = ({
             </div>
             <div className="mt-6 flex justify-end gap-2">
               <AlertDialog.Cancel asChild>
-                <button
+                <Button
                   type="button"
-                  className="rounded-lg border border-border-200 px-3 py-2 text-sm hover:bg-bg-200"
+                  variant="outline"
+                  className="border-border-200 bg-bg-000 text-text-000 hover:bg-bg-200 hover:text-text-000"
                 >
                   Cancel
-                </button>
+                </Button>
               </AlertDialog.Cancel>
               <AlertDialog.Action asChild>
-                <button
+                <Button
                   type="button"
-                  className="rounded-lg bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-700"
+                  className="bg-amber-600 text-white hover:bg-amber-700"
                   onClick={() => onChange('full')}
                 >
                   Enable
-                </button>
+                </Button>
               </AlertDialog.Action>
             </div>
           </AlertDialog.Content>

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -248,7 +248,7 @@ describe('ProjectFilesView', () => {
     expect(document.body.textContent).not.toContain('This computer')
   })
 
-  it('uses subtle menu colors and hover feedback for filter items', async () => {
+  it('uses the global semantic menu surface and hover feedback for filter items', async () => {
     await renderView([
       createSession({
         title: 'Session A',
@@ -275,11 +275,21 @@ describe('ProjectFilesView', () => {
       clickDropdownTrigger(filterButton)
     })
 
+    expect(filterButton?.getAttribute('data-slot')).toBe('button')
+    expect(filterButton?.getAttribute('data-variant')).toBe('outline')
+    expect(filterButton?.className).toContain('rounded-lg')
+    expect(filterButton?.className).toContain('border-border')
+    expect(filterButton?.className).toContain('bg-card')
+    expect(filterButton?.className).toContain('hover:bg-muted')
+    expect(filterButton?.className).not.toContain('rounded-md')
+    expect(filterButton?.className).not.toContain('border-border-300')
+    expect(filterButton?.className).not.toContain('shadow-sm')
+    expect(filterButton?.className).not.toContain('hover:bg-bg-100')
     expect(document.body.querySelector('[data-slot="dropdown-menu-content"]')?.className).toContain(
-      'bg-bg-10'
+      'bg-popover'
     )
     expect(document.body.querySelector('[data-filter-id="all"]')?.className).toContain(
-      'hover:bg-bg-200'
+      'data-[highlighted]:bg-muted'
     )
   })
 

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { Button } from '@/components/ui/button'
 import { cn, formatByteSize } from '@/lib/utils'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
@@ -196,7 +197,7 @@ const SectionHeader = ({
   >
     <ChevronDown
       className={cn(
-        'size-3 shrink-0 text-text-300 transition-transform',
+        'size-3 shrink-0 text-text-300 transition-transform motion-reduce:transition-none',
         isCollapsed && '-rotate-90'
       )}
       strokeWidth={2}
@@ -309,9 +310,10 @@ const ProjectFilesFilterMenu = ({
 }): React.JSX.Element => (
   <DropdownMenu>
     <DropdownMenuTrigger asChild>
-      <button
+      <Button
         type="button"
-        className="inline-flex h-8 max-w-[220px] items-center gap-1.5 rounded-md border border-border-300/60 bg-bg-000 px-2.5 text-sm text-text-000 shadow-sm hover:bg-bg-100"
+        variant="outline"
+        className="max-w-[220px] gap-1.5"
         aria-label="Filter project files"
       >
         <File className="size-3.5 shrink-0 text-text-300" strokeWidth={1.8} aria-hidden="true" />
@@ -321,7 +323,7 @@ const ProjectFilesFilterMenu = ({
           strokeWidth={2}
           aria-hidden="true"
         />
-      </button>
+      </Button>
     </DropdownMenuTrigger>
     <DropdownMenuContent align="start" className="w-[320px]">
       <DropdownMenuLabel>Artifacts</DropdownMenuLabel>

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -169,6 +169,19 @@ describe('workspace page component boundaries', () => {
     expect(workspaceSources).not.toContain('text-text-400')
   })
 
+  it('defines the token used by mention popup shadows', () => {
+    const mainCssSource = readFileSync(resolve(__dirname, '../../assets/main.css'), 'utf8')
+    const mentionPopupSources = [
+      resolve(__dirname, 'composer/SkillMentionPopup.tsx'),
+      resolve(__dirname, 'composer/ArtifactMentionPopup.tsx')
+    ]
+      .map((path) => readFileSync(path, 'utf8'))
+      .join('\n')
+
+    expect(mentionPopupSources).toContain('var(--always-black)')
+    expect(mainCssSource).toContain('--always-black:')
+  })
+
   it('uses the shared primary token for every workspace emphasis state', () => {
     const emphasisSources = [
       conversationPanelPath,


### PR DESCRIPTION
## Summary

Refines the Settings experience and establishes consistent global interaction styling for buttons, dropdown menus, and selects.

## Highlights

- Refreshes Settings navigation, content hierarchy, and neutral color treatment while preserving existing copy and workflows.
- Matches Add skill and related menu interactions across default, hover, open, focus, and disabled states.
- Applies the shared control contract to Settings and workspace dropdown entry points, including true full-window Settings expansion.

## Impact

- Affects renderer Settings surfaces and shared Button, DropdownMenu, Select, Switch, Input, and Textarea styling.
- Updates workspace model, permission, and project-file menu triggers to use shared controls.
- Does not change Settings persistence, IPC contracts, provider, skill, or connector data behavior, or onboarding business logic.

## Test Results

- `npm test` - 203 files passed and 1 skipped; 1,869 tests passed and 43 skipped.
- `npm run lint` - passed.
- `npm run build` - passed, including Node and renderer type checks.
- Prettier checks and `git diff --check` - passed.
- Electron visual validation at 1280 x 928 and 1100 x 720 covered default, hover, open menu/select, keyboard focus, maximized Settings, and workspace dropdown cascades.

## Potential Issues

- The build retains the existing third-party `3dmol` warning about `eval`.
- Existing product and accessibility debt outside this change remains: destructive Settings actions lack confirmation or undo, and grant-management actions inside the permission menu are not keyboard reachable.

## Authors

- @roxi3906
