### PR TITLE
fix(composer): warn when no model is available instead of an empty toolbar

### DIFF
--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -43,6 +43,41 @@ describe('ComposerModelPicker', () => {
     render()
 
     expect(container.querySelector('[aria-label="Select model"]')).toBeNull()
+    expect(container.querySelector('[aria-label="No model available — open settings"]')).toBeNull()
+  })
+
+  it('warns and opens settings when no model is configured', () => {
+    const openSettings = vi.fn()
+    useSettingsStore.setState({ providers: [], openSettings })
+    render()
+
+    // No picker, but a warning affordance the user can click to fix the missing model.
+    expect(container.querySelector('[aria-label="Select model"]')).toBeNull()
+    const warning = container.querySelector<HTMLButtonElement>(
+      '[aria-label="No model available — open settings"]'
+    )
+    expect(warning).not.toBeNull()
+    expect(warning?.textContent).toContain('No model available')
+
+    act(() => warning?.click())
+    expect(openSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns when the only provider has failed validation', () => {
+    useSettingsStore.setState({
+      providers: [
+        provider({
+          id: 'broken',
+          models: ['m'],
+          lastValidationFailure: { at: 1, category: 'auth', message: 'bad key' }
+        })
+      ]
+    })
+    render()
+
+    expect(
+      container.querySelector('[aria-label="No model available — open settings"]')
+    ).not.toBeNull()
   })
 
   it('shows the active model label when multiple options exist', () => {

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown } from 'lucide-react'
+import { AlertTriangle, Check, ChevronDown } from 'lucide-react'
 
 import {
   DropdownMenu,
@@ -25,18 +25,37 @@ const triggerClassName =
 const optionLabel = (option: ProviderModelOption): string => option.model || option.providerName
 
 // Model/provider switcher shown in the composer toolbar. Reads the settings store directly (the store
-// is global) so the presentational ConversationPanel needn't thread provider state through. Renders
-// nothing unless there's more than one selectable (provider, model) — with a single option there's
-// nothing to switch between.
+// is global) so the presentational ConversationPanel needn't thread provider state through. With no
+// selectable model it shows a warning that opens Settings; with a single option it renders nothing
+// (there's nothing to switch between); otherwise it renders the switcher.
 const ComposerModelPicker = (): React.JSX.Element | null => {
   const providers = useSettingsStore((state) => state.providers)
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
   const activeModel = useSettingsStore((state) => state.activeModel)
   const setActiveProvider = useSettingsStore((state) => state.setActiveProvider)
+  const openSettings = useSettingsStore((state) => state.openSettings)
 
   const options = selectProviderModelOptions(providers)
 
-  if (options.length <= 1) return null
+  // No selectable (provider, model): the user has nothing to send with — either nothing is configured
+  // or every provider failed its last test. Warn instead of hiding so the empty toolbar isn't a
+  // silent dead end; clicking opens Settings to add or fix a provider.
+  if (options.length === 0) {
+    return (
+      <button
+        type="button"
+        onClick={() => openSettings()}
+        className="flex h-8 items-center gap-1.5 rounded-md px-2.5 text-sm text-amber-700 hover:bg-amber-50 transition-colors"
+        aria-label="No model available — open settings"
+      >
+        <AlertTriangle className="size-4 shrink-0" strokeWidth={2} aria-hidden="true" />
+        <span className="truncate">No model available</span>
+      </button>
+    )
+  }
+
+  // A single option leaves nothing to switch between, so the picker stays hidden.
+  if (options.length === 1) return null
 
   // The active option matches by provider and model; an undefined activeModel maps to the empty-model
   // "default" entry.


### PR DESCRIPTION
## Problem

When no model is configured — either nothing has been set up, or every provider failed its last validation — the composer toolbar showed **nothing** where the model picker would be. The user had no way to tell why they couldn't send and no hint about where to fix it.

The root cause: `ComposerModelPicker` hid itself whenever `options.length <= 1`, collapsing two very different states into the same silent nothing:

- **1 option** → nothing to switch between (correct to hide)
- **0 options** → no usable model configured (should be surfaced, not hidden)

## Fix

Split the branch in `ComposerModelPicker`:

- **0 options** → render an amber **"No model available"** warning (with an `AlertTriangle` icon). It's a button that opens Settings so the user can add or fix a provider.
- **1 option** → unchanged (renders nothing).
- **2+ options** → unchanged (the model switcher).

The warning reuses existing conventions already in the codebase (`AlertTriangle` from lucide, the amber palette from `ComposerPermissionProfilePicker`, and the settings store's `openSettings`). All copy is English.

## Tests

Added render tests covering the new branch:

- no providers → warning shown and clicking it calls `openSettings`
- only provider failed validation → warning shown
- single option → still renders nothing

`ComposerModelPicker` 5/5 pass; full workspace suite 357/357 pass; eslint and web typecheck clean.