### PR TITLE
ci(mac): add no-publish notarization dry-run workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,18 @@ on:
           nightly installers get distinct filenames (and in-app version) from stable releases.
         type: boolean
         default: false
+      mac_only:
+        description: >-
+          Build only the two macOS archs (skip Linux + Windows). Used by the notarization dry-run,
+          which only needs a signed mac build; release/nightly leave it false for the full matrix.
+        type: boolean
+        default: false
+      skip_verify:
+        description: >-
+          Skip the lint/typecheck/test job. Used by the notarization dry-run to test signing +
+          notarization in isolation; release/nightly leave it false so builds stay gated on tests.
+        type: boolean
+        default: false
 
 jobs:
   # Gate every packaged build on the quality suite so nightly (push to main) and release (tag) can
@@ -25,6 +37,8 @@ jobs:
   # release/verification environment (see pr-check.yml for why macOS). The build matrix `needs` this.
   verify:
     name: Verify (lint + typecheck + test)
+    # Skipped by the notarization dry-run (skip_verify), which only needs a signed mac build.
+    if: ${{ !inputs.skip_verify }}
     runs-on: macos-14
     steps:
       - name: Checkout
@@ -48,42 +62,49 @@ jobs:
       - name: Test (with coverage)
         run: npm run test:coverage
 
+  # Resolve the platform matrix. mac_only trims it to the two mac archs — used by the notarization
+  # dry-run (notarize-dryrun.yml), which only needs a signed mac build. With mac_only false (the
+  # release.yml / nightly.yml callers) the full matrix is emitted, so their behavior is unchanged.
+  setup:
+    name: Resolve platform matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        shell: bash
+        run: |
+          # Both mac archs build on Apple Silicon (macos-14). x64 is cross-packaged — electron pulls
+          # the x64 runtime and the only per-arch native artifact we ship (the Prisma query engine)
+          # comes from the schema's binaryTargets, pruned per-arch in the build job. This avoids the
+          # scarce Intel macos-13 runner. Windows' engine is query_engine-windows.dll.node (no `lib`
+          # prefix, .dll.node not .so/.dylib). engine_keep = substring of the engine file to keep.
+          mac='[
+            {"name":"macos-arm64","os":"macos-14","platform":"mac","eb_args":"--mac --arm64","engine_keep":"darwin-arm64"},
+            {"name":"macos-x64","os":"macos-14","platform":"mac","eb_args":"--mac --x64","engine_keep":"darwin.dylib"}
+          ]'
+          rest='[
+            {"name":"linux-x64","os":"ubuntu-latest","platform":"linux","eb_args":"--linux","engine_keep":".so.node"},
+            {"name":"windows-x64","os":"windows-latest","platform":"win","eb_args":"--win --x64","engine_keep":"windows.dll"}
+          ]'
+          if [ "${{ inputs.mac_only }}" = "true" ]; then
+            include=$(jq -c '.' <<<"$mac")
+          else
+            include=$(jq -c '. + $rest' --argjson rest "$rest" <<<"$mac")
+          fi
+          echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build ${{ matrix.name }}
-    needs: verify
+    needs: [verify, setup]
+    # Run once the matrix is resolved. Tolerate a skipped verify (skip_verify dry-run) but still
+    # block on a real verify failure — matching the fail-closed behavior when verify runs.
+    if: ${{ always() && needs.setup.result == 'success' && (needs.verify.result == 'success' || needs.verify.result == 'skipped') }}
     runs-on: ${{ matrix.os }}
     strategy:
       # Don't let one platform's failure cancel the others.
       fail-fast: false
-      matrix:
-        include:
-          # Both mac archs build on Apple Silicon (macos-14). x64 is cross-packaged here — electron
-          # downloads the x64 runtime, and the only per-arch native artifact we ship (the Prisma
-          # query engine) is provided by the schema's binaryTargets, then pruned below. This avoids
-          # the scarce Intel `macos-13` runner (long queues). engine_keep = substring of the Prisma
-          # engine filename to keep for this build.
-          - name: macos-arm64
-            os: macos-14
-            platform: mac
-            eb_args: --mac --arm64
-            engine_keep: darwin-arm64
-          - name: macos-x64
-            os: macos-14
-            platform: mac
-            eb_args: --mac --x64
-            engine_keep: darwin.dylib
-          - name: linux-x64
-            os: ubuntu-latest
-            platform: linux
-            eb_args: --linux
-            engine_keep: .so.node
-          - name: windows-x64
-            os: windows-latest
-            platform: win
-            eb_args: --win --x64
-            # Windows' native engine is `query_engine-windows.dll.node` (note: no `lib` prefix, and
-            # `.dll.node` rather than `.so/.dylib`), which the broadened prune glob below matches.
-            engine_keep: windows.dll
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/notarize-dryrun.yml
+++ b/.github/workflows/notarize-dryrun.yml
@@ -1,0 +1,38 @@
+name: Notarize macOS (dry-run)
+
+# Manual, no-publish macOS notarization check.
+#
+# Builds + SIGNS the current ref's mac app (mac only, verify suite skipped for speed), submits it to
+# Apple's notary service, staples the ticket, and re-emits the stapled dmg/zip as run artifacts you
+# can download from the run. It touches NO GitHub Release — unlike notarize-mac.yml's own
+# workflow_dispatch path, which clobbers stapled assets back onto an existing release. Use this to
+# confirm the current build passes notarization before cutting a real release.
+#
+# It reuses the exact release-path jobs (build.yml -> notarize-mac.yml's workflow_call entry) minus
+# the publish step, so a green run means `stapler validate` passed (notarization actually succeeded).
+# Re-runnable with no side effects. No-ops (job succeeds, nothing tested) if APPLE_API_KEY_P8_BASE64
+# is not configured — the gate lives in notarize-mac.yml.
+on:
+  workflow_dispatch:
+
+# Read-only: this path never writes to a Release or any repo contents. build + notarize only move
+# pipeline artifacts around.
+permissions:
+  contents: read
+
+jobs:
+  # Signed mac-only build (no verify, no publish). Uploads macos-arm64 / macos-x64 run artifacts.
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      mac_only: true
+      skip_verify: true
+    secrets: inherit
+
+  # Notarize + staple those artifacts and re-emit the stapled versions (the workflow_call path's
+  # normal behavior — the destructive --clobber-to-release step is dispatch-only, so nothing is
+  # published here). Deliberately no publish job follows.
+  notarize:
+    needs: build
+    uses: ./.github/workflows/notarize-mac.yml
+    secrets: inherit


### PR DESCRIPTION
## What

Adds a **manual, no-publish macOS notarization dry-run** so we can confirm the current build passes Apple notarization *before* cutting a real release — without touching any GitHub Release.

New workflow **`notarize-dryrun.yml`** (`workflow_dispatch`): builds + signs the selected ref's mac app and runs it through the existing `notarize-mac.yml` call path (submit → wait → staple → `stapler validate`), re-emitting the stapled `dmg`/`zip` as **run artifacts** you can download. There is **no publish job** and **no Release is touched** — unlike `notarize-mac.yml`'s own `workflow_dispatch` path, which clobbers stapled assets back onto an existing Release.

To avoid drift it reuses the exact release-path jobs. `build.yml` gains two optional inputs, both `default: false` (so `release.yml` / `nightly.yml` are unchanged):

- **`mac_only`** — trims the build matrix to the two mac archs.
- **`skip_verify`** — skips the lint/typecheck/test gate.

The previously-static build matrix is now resolved by a small `setup` job so `mac_only` can filter it; the full-matrix output is the same set as before.

## Workflow relationships & per-platform handling

```mermaid
flowchart TD
    subgraph Triggers
      TAG["push tag v* / dispatch"]:::t
      MAIN["push to main"]:::t
      MAN["manual dispatch"]:::t
    end

    REL["release.yml"]:::wf
    NIG["nightly.yml"]:::wf
    DRY["notarize-dryrun.yml (new)"]:::wf

    TAG --> REL
    MAIN --> NIG
    MAN --> DRY

    BUILD["build.yml (reusable)\nverify + matrix build + sign"]:::wf
    NOTAR["notarize-mac.yml (reusable call path)\nsubmit to Apple, wait 15m, staple, validate"]:::wf

    REL -->|"full matrix"| BUILD
    NIG -->|"full matrix, ad-hoc sign"| BUILD
    DRY -->|"mac_only: true\nskip_verify: true"| BUILD

    BUILD --> NOTAR

    REL --> PUB["publish job\n(GitHub Release + checksums + SLSA)"]:::pub
    NOTAR -->|"release path: re-emit stapled artifacts"| PUB
    NIG --> NPUB["nightly prerelease"]:::pub

    NOTAR -.->|"dry-run: re-emit stapled artifacts only\nNO publish, NO Release touched"| ART["run artifacts\n(download & inspect)"]:::art

    classDef t fill:#eef,stroke:#88a;
    classDef wf fill:#efe,stroke:#4a4;
    classDef pub fill:#fee,stroke:#c66;
    classDef art fill:#ffe,stroke:#cc6;
```

Per-platform, by action:

| Platform | Built in | Signed | Notarized + stapled | In dry-run? |
|---|---|---|---|---|
| macOS arm64 | `build.yml` (macos-14) | Developer ID (or ad-hoc) in `build.yml` | `notarize-mac.yml` (Apple notary) | ✅ yes |
| macOS x64 | `build.yml` (cross-packaged on macos-14) | same as arm64 | `notarize-mac.yml` | ✅ yes |
| Linux x64 | `build.yml` (ubuntu-latest) | n/a | n/a | ❌ skipped (`mac_only`) |
| Windows x64 | `build.yml` (windows-latest) | n/a here | n/a here | ❌ skipped (`mac_only`) — extend `mac_only` into a broader filter when Windows signing/notarization lands |

## Notes / caveats

- **No-ops without the Apple secret.** Every step in `notarize-mac.yml` is gated on `APPLE_API_KEY_P8_BASE64` (plus `APPLE_API_KEY_ID` / `APPLE_API_ISSUER`). If unset, the dry-run goes green having tested nothing — confirm the secrets exist before relying on a pass.
- **How to run:** Actions tab → *Notarize macOS (dry-run)* → Run workflow → pick a branch, or `gh workflow run notarize-dryrun.yml --ref <branch>`.
- **Read-only permissions** on the dry-run workflow — it never writes to a Release or repo contents.

## Validation

- `actionlint` clean on both changed workflows.
- Emulated the `setup` job's `jq` logic: the full matrix equals the previous static set; `mac_only` yields just the two mac archs.
