### PR TITLE
fix(ci): grant contents:write to notarization dry-run so it can start

### DIFF
--- a/.github/workflows/notarize-dryrun.yml
+++ b/.github/workflows/notarize-dryrun.yml
@@ -15,10 +15,12 @@ name: Notarize macOS (dry-run)
 on:
   workflow_dispatch:
 
-# Read-only: this path never writes to a Release or any repo contents. build + notarize only move
-# pipeline artifacts around.
+# Must grant contents: write because the reusable notarize-mac.yml declares it at the workflow level
+# (for its dispatch-only clobber-to-release path) — a called workflow cannot request more permission
+# than its caller grants, so a narrower scope here fails the run at startup. This dry-run's call path
+# never writes to a Release; the grant only satisfies the reusable workflow's declared permissions.
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   # Signed mac-only build (no verify, no publish). Uploads macos-arm64 / macos-x64 run artifacts.


### PR DESCRIPTION
## What

Fixes a `startup_failure` in the just-merged `notarize-dryrun.yml`: the first manual run of *Notarize macOS (dry-run)* failed to initialize (zero jobs, completed in seconds).

## Root cause

`notarize-dryrun.yml` declared `permissions: contents: read`, but it calls the reusable `notarize-mac.yml`, which declares `permissions: contents: write` at the workflow level (used only by its dispatch-only clobber-to-release path). **A called reusable workflow cannot request more permission than its caller grants**, so GitHub rejects the run at startup before any job runs.

## Fix

Grant `contents: write` in the dry-run caller — matching what `release.yml` already grants when it calls the same reusable workflow. The dry-run's call path still writes to **no** Release (the clobber step is dispatch-only inside `notarize-mac.yml`); the grant only satisfies the reusable workflow's declared permissions so it can load.

## Validation

- `actionlint` clean.
- After merge I'll re-trigger the dry-run to confirm it starts and runs the mac build → notarize path.
