### PR TITLE
fix(ci): route notarize-mac by explicit from_run, not event_name

### DIFF
--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -7,11 +7,17 @@ name: Notarize macOS
 # stapled artifacts. Splitting it out of the build means a slow notarization never ties up the build
 # matrix, and it can be re-run on its own without a rebuild.
 #
-# Two entry points:
-#   - workflow_call — used by release.yml right after build. Operates on the run's signed mac
-#     artifacts and re-uploads the stapled versions (overwrite) so the publish job attaches them.
-#   - workflow_dispatch{ tag } — standalone repair/backfill. Notarizes + staples the mac assets
-#     already attached to an existing Release, clobbers them back, and refreshes SHA256SUMS.txt.
+# Two entry points, selected by the `from_run` input (NOT github.event_name — see below):
+#   - workflow_call (from_run: true) — used by release.yml and notarize-dryrun.yml right after build.
+#     Operates on the run's signed mac artifacts and re-uploads the stapled versions (overwrite) so a
+#     downstream job attaches them.
+#   - workflow_dispatch{ tag } (from_run unset -> false) — standalone repair/backfill. Notarizes +
+#     staples the mac assets already attached to an existing Release, clobbers them back, and
+#     refreshes SHA256SUMS.txt.
+#
+# The mode MUST key off `from_run`, not github.event_name: a workflow_call triggered by a
+# workflow_dispatch run (the notarization dry-run) still reports event_name == 'workflow_dispatch',
+# which would wrongly select the Release path and submit an unrelated published build.
 #
 # Time cap is enforced two ways: each dmg is submitted, then waited on for at most 15m
 # (`notarytool wait --timeout 15m`), and the job as a whole is bounded by `timeout-minutes: 20`.
@@ -27,6 +33,13 @@ on:
         required: false
         type: string
         default: ''
+      from_run:
+        description: >-
+          Operate on THIS run's build artifacts (download by name, re-emit stapled) instead of an
+          existing Release. True for every workflow_call caller (release.yml, notarize-dryrun.yml).
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       tag:
@@ -64,9 +77,9 @@ jobs:
             echo "::notice::APPLE_API_KEY_P8_BASE64 not set — skipping notarization; mac stays as built."
           fi
 
-      # release.yml path: pull this run's signed artifacts for the arch (uploaded by build.yml).
+      # Call path (from_run): pull this run's signed artifacts for the arch (uploaded by build.yml).
       - name: Download signed mac artifact (from this run)
-        if: steps.gate.outputs.enabled == 'true' && github.event_name != 'workflow_dispatch'
+        if: steps.gate.outputs.enabled == 'true' && inputs.from_run
         uses: actions/download-artifact@v8
         with:
           name: macos-${{ matrix.arch }}
@@ -74,7 +87,7 @@ jobs:
 
       # Standalone path: pull the arch's signed assets straight off the existing Release.
       - name: Download signed mac assets (from the release)
-        if: steps.gate.outputs.enabled == 'true' && github.event_name == 'workflow_dispatch'
+        if: steps.gate.outputs.enabled == 'true' && !inputs.from_run
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -163,12 +176,12 @@ jobs:
             ditto -c -k --keepParent "$app" "$zip"   # repackage the stapled .app over the zip
           done
 
-      # release.yml path: replace this run's signed artifact with the stapled one (same name), so the
-      # publish job's merge-multiple download picks up the stapled dmg/zip. overwrite deletes the
-      # prior artifact of this name in the run. The now-stale mac blockmap/latest-mac.yml are dropped
-      # (mac auto-update is disabled), leaving only the two user-facing downloads.
+      # Call path: replace this run's signed artifact with the stapled one (same name), so a
+      # downstream publish job's merge-multiple download picks up the stapled dmg/zip. overwrite
+      # deletes the prior artifact of this name in the run. The now-stale mac blockmap/latest-mac.yml
+      # are dropped (mac auto-update is disabled), leaving only the two user-facing downloads.
       - name: Re-emit stapled artifact (for publish)
-        if: steps.gate.outputs.enabled == 'true' && github.event_name != 'workflow_dispatch'
+        if: steps.gate.outputs.enabled == 'true' && inputs.from_run
         uses: actions/upload-artifact@v7
         with:
           name: macos-${{ matrix.arch }}
@@ -181,7 +194,7 @@ jobs:
 
       # Standalone path: push the stapled dmg/zip back onto the Release, replacing the signed-only ones.
       - name: Clobber stapled assets onto the release
-        if: steps.gate.outputs.enabled == 'true' && github.event_name == 'workflow_dispatch'
+        if: steps.gate.outputs.enabled == 'true' && !inputs.from_run
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -192,7 +205,7 @@ jobs:
   # matches the re-stapled bytes. (In the release.yml path, the publish job regenerates it over the
   # already-stapled artifacts, so no refresh is needed there.)
   refresh-checksums:
-    if: github.event_name == 'workflow_dispatch'
+    if: ${{ !inputs.from_run }}
     needs: notarize
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What

Fixes why the macOS notarization dry-run failed: it submitted an unrelated, ad-hoc-signed **published** build to Apple instead of the run's freshly Developer-ID-signed artifacts.

## Root cause

`notarize-mac.yml` chose between its two modes with `github.event_name`:

- `!= 'workflow_dispatch'` → notarize **this run's** artifacts (release path)
- `== 'workflow_dispatch'` → notarize an **existing Release** (standalone repair)

That assumed a `workflow_call` never originates from a dispatch. But `notarize-dryrun.yml` is triggered by `workflow_dispatch`, and **event_name propagates into the called reusable workflow**. So the dry-run's call took the *Release* branch: `gh release download ""` resolved to the latest release (`v0.2.2`, ad-hoc signed) and submitted it — Apple returned `Invalid` ("not signed with a valid Developer ID certificate / no secure timestamp"). The signing cert and notary API key are both fine; the wrong file was submitted.

## Fix

Select the mode with an explicit **`from_run`** input (declared on `workflow_call` only, default `true`) instead of `event_name`:

- `release.yml` / `notarize-dryrun.yml` (workflow_call) → `from_run` true → **run-artifact path**.
- Standalone `workflow_dispatch { tag }` → `from_run` unset → falsy → **existing-Release path** (unchanged).

All four step conditions and the `refresh-checksums` job condition were switched over. This also hardens a latent bug where a manual `workflow_dispatch` of `release.yml` would have hit the same mis-routing (currently masked only by its tag-ref gate).

## Validation

- `actionlint` clean; no `event_name` left in any condition.
- After merge I'll re-run the dry-run — it should now submit this run's Developer-ID-signed dmg/zip and give a real notarization verdict for the current build.
