### PR TITLE
feat(update): macOS in-place auto-update via electron-updater

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,15 @@ jobs:
           if [ "${{ matrix.platform }}" = "mac" ] && [ "${{ inputs.nightly }}" != "true" ] && [ -n "$CSC_LINK" ]; then
             # Stable build with a Developer ID cert -> SIGN ONLY (notarize:false). Notarization +
             # stapling happens later in notarize-mac.yml, so this job never waits on Apple.
-            npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" --publish never -c.mac.notarize=false
+            #
+            # Per-arch update channel: arm64 and x64 build on separate runners and would both emit
+            # `latest-mac.yml`, colliding at the feed root. Setting the electron-updater channel to the
+            # arch makes each build emit its own `${arch}-mac.yml` and bake `channel: ${arch}` into its
+            # app-update.yml, so each installed arch polls only its own feed. (win/linux keep the
+            # default `latest` channel.)
+            mac_channel="${{ matrix.name }}"; mac_channel="${mac_channel#macos-}"
+            npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" --publish never \
+              -c.mac.notarize=false -c.publish.channel="$mac_channel"
           else
             # No cert, or a nightly build (ad-hoc on purpose): skip electron-builder's own signing.
             # GitHub injects unset secrets as EMPTY strings, and electron-builder mis-reads an empty
@@ -193,4 +201,5 @@ jobs:
             dist/*.deb
             dist/*.blockmap
             dist/latest*.yml
+            dist/*-mac.yml
           if-no-files-found: error

--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -108,17 +108,17 @@ jobs:
             "s3://$S3_BUCKET/$S3_PREFIX/version.json" \
             --cache-control "no-cache" --content-type "application/json" --only-show-errors
 
-      # electron-updater feed files (win latest.yml, linux latest-linux.yml) must live at the channel
-      # root (a stable url the updater always polls), but the installers + blockmaps they reference live
-      # under releases/<version>/. Rewrite each feed's bare `path:`/`url:` filenames to that versioned
-      # subpath so the updater resolves them against the channel root. Missing feeds (e.g. a mac-only
-      # backfill) are simply skipped.
+      # electron-updater feed files (win latest.yml, linux latest-linux.yml, and the per-arch mac
+      # feeds arm64-mac.yml / x64-mac.yml) must live at the channel root (a stable url the updater
+      # always polls), but the installers + blockmaps they reference live under releases/<version>/.
+      # Rewrite each feed's bare `path:`/`url:` filenames to that versioned subpath so the updater
+      # resolves them against the channel root. Missing feeds (e.g. a mac-only backfill) are skipped.
       - name: Rewrite update feed paths
         env:
           VERSION: ${{ steps.ref.outputs.version }}
         run: |
           shopt -s nullglob
-          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml; do
+          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml dist-assets/*-mac.yml; do
             [ -f "$yml" ] || continue
             node -e '
               const fs = require("fs");
@@ -141,7 +141,7 @@ jobs:
           S3_PREFIX: ${{ vars.S3_PREFIX }}
         run: |
           shopt -s nullglob
-          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml; do
+          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml dist-assets/*-mac.yml; do
             [ -f "$yml" ] || continue
             aws s3 cp "$yml" "s3://$S3_BUCKET/$S3_PREFIX/$(basename "$yml")" \
               --cache-control "no-cache" --content-type "text/yaml" --only-show-errors

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -176,10 +176,47 @@ jobs:
             ditto -c -k --keepParent "$app" "$zip"   # repackage the stapled .app over the zip
           done
 
-      # Call path: replace this run's signed artifact with the stapled one (same name), so a
-      # downstream publish job's merge-multiple download picks up the stapled dmg/zip. overwrite
-      # deletes the prior artifact of this name in the run. The now-stale mac blockmap/latest-mac.yml
-      # are dropped (mac auto-update is disabled), leaving only the two user-facing downloads.
+      # Stapling repackaged the zip (new bytes), so electron-builder's ${arch}-mac.yml — written at
+      # build time over the PRE-staple zip — now carries a stale sha512/size that would fail the
+      # updater's signature check. Regenerate the feed from the stapled zip: recompute sha512 (base64)
+      # + size and emit a minimal, zip-only feed (no blockmap -> full-zip mac updates for v1). Derived
+      # purely from the stapled zip, so it is correct on both the call and standalone paths.
+      - name: Regenerate mac update feed
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          node -e '
+            const fs = require("fs"), crypto = require("crypto"), path = require("path");
+            const arch = process.env.ARCH;
+            const zips = fs.readdirSync("mac").filter((f) => f.endsWith(`-mac-${arch}.zip`));
+            if (zips.length !== 1) {
+              console.error(`::error::expected exactly one mac-${arch} zip, found ${zips.length}`);
+              process.exit(1);
+            }
+            const zip = zips[0];
+            const buf = fs.readFileSync(path.join("mac", zip));
+            const sha512 = crypto.createHash("sha512").update(buf).digest("base64");
+            const m = zip.match(/-(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)-mac-/);
+            const version = m ? m[1] : "0.0.0";
+            const yml =
+              `version: ${version}\n` +
+              `files:\n` +
+              `  - url: ${zip}\n` +
+              `    sha512: ${sha512}\n` +
+              `    size: ${buf.length}\n` +
+              `path: ${zip}\n` +
+              `sha512: ${sha512}\n` +
+              `releaseDate: ${JSON.stringify(new Date().toISOString())}\n`;
+            fs.writeFileSync(path.join("mac", `${arch}-mac.yml`), yml);
+            process.stdout.write(yml);
+          '
+
+      # Call path: replace this run's signed artifacts with the stapled ones (same names) plus the
+      # regenerated ${arch}-mac.yml feed, so the publish job's merge-multiple download picks them up.
+      # overwrite deletes the prior artifacts of this name in the run. The stale mac blockmap is dropped
+      # (v1 does full-zip mac updates), leaving the dmg, zip, and per-arch feed.
       - name: Re-emit stapled artifact (for publish)
         if: steps.gate.outputs.enabled == 'true' && inputs.from_run
         uses: actions/upload-artifact@v7
@@ -190,15 +227,17 @@ jobs:
           path: |
             mac/*-mac-*.dmg
             mac/*-mac-*.zip
+            mac/*-mac.yml
           if-no-files-found: error
 
-      # Standalone path: push the stapled dmg/zip back onto the Release, replacing the signed-only ones.
+      # Standalone path: push the stapled dmg/zip + regenerated feed back onto the Release, replacing
+      # the signed-only ones. (Re-mirror the tag afterward to publish the feed to the CDN.)
       - name: Clobber stapled assets onto the release
         if: steps.gate.outputs.enabled == 'true' && !inputs.from_run
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ inputs.tag }}" mac/*-mac-*.dmg mac/*-mac-*.zip \
+          gh release upload "${{ inputs.tag }}" mac/*-mac-*.dmg mac/*-mac-*.zip mac/*-mac.yml \
             --repo "$GITHUB_REPOSITORY" --clobber
 
   # Standalone path only: after both archs are stapled + clobbered, rebuild SHA256SUMS.txt so it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,10 +83,10 @@ jobs:
             artifacts/*.deb
 
       # Attach user-facing artifacts + checksums: installers (dmg/exe/AppImage/deb) and portable
-      # zips (mac + win), plus the win/linux electron-updater feed files (latest.yml, latest-linux.yml)
-      # and blockmaps so the mirror-to-website job can republish them to the CDN feed. macOS latest-mac*
-      # .yml is still excluded: arm64/x64 build on separate runners and each emits its own (they'd
-      # collide), and Squirrel.Mac can't auto-update the unsigned mac build anyway (no Developer ID).
+      # zips (mac + win), plus the electron-updater feed files so the mirror-to-website job can
+      # republish them to the CDN feed: win/linux latest.yml + latest-linux.yml, and the per-arch mac
+      # feeds arm64-mac.yml + x64-mac.yml (distinct names -> no collision; regenerated post-staple in
+      # notarize-mac.yml). Blockmaps are win/linux only (mac does full-zip updates in v1).
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -102,4 +102,5 @@ jobs:
             artifacts/SHA256SUMS.txt
             artifacts/latest.yml
             artifacts/latest-linux.yml
+            artifacts/*-mac.yml
             artifacts/*.blockmap

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -101,11 +101,14 @@ linux:
 appImage:
   artifactName: ${name}-${version}-linux-${arch}.${ext}
 npmRebuild: false
-# electron-updater feed. Win/Linux auto-update reads app-update.yml (generated from this block) and
-# fetches <url>/latest.yml. macOS uses the separate version.json manifest flow (no Developer ID yet),
-# so its latest-mac*.yml is intentionally never published (see release.yml). The GitHub Release remains
+# electron-updater feed. Win/Linux/macOS auto-update reads app-update.yml (generated from this block)
+# and fetches its feed from <url>. Win/Linux use the default `latest` channel (latest.yml /
+# latest-linux.yml). macOS builds override the channel to the arch at build time (see build.yml), so
+# each arch polls its own `${arch}-mac.yml` — arm64 and x64 build on separate runners and would
+# otherwise collide on one latest-mac.yml. Mac in-place update needs a Developer ID signature (now
+# configured) and the feed is regenerated post-staple in notarize-mac.yml. The GitHub Release remains
 # the human-facing download source, populated by release.yml — electron-builder runs with --publish
-# never, so this block only shapes app-update.yml + latest*.yml, it does not upload anything.
+# never, so this block only shapes app-update.yml + the feed files, it does not upload anything.
 publish:
   provider: generic
   url: https://statics.aipoch.com/open-science/app/stable

--- a/src/main/update/create-strategy.test.ts
+++ b/src/main/update/create-strategy.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 // modules at construction (UpdateService reads app.getVersion(); ElectronUpdaterStrategy subscribes to
 // autoUpdater), so stub them enough to instantiate without a real Electron runtime.
 vi.mock('electron', () => ({
-  app: { getVersion: () => '0.0.0' },
+  app: { getVersion: () => '0.0.0', isPackaged: false },
   BrowserWindow: { getAllWindows: () => [] }
 }))
 vi.mock('electron-updater', () => ({
@@ -24,7 +24,21 @@ describe('createUpdateStrategy', () => {
     expect(createUpdateStrategy('linux')).toBeInstanceOf(ElectronUpdaterStrategy)
   })
 
-  it('uses UpdateService (manifest) on darwin', () => {
-    expect(createUpdateStrategy('darwin')).toBeInstanceOf(UpdateService)
+  it('uses ElectronUpdaterStrategy on darwin for a packaged stable build', () => {
+    expect(createUpdateStrategy('darwin', { isPackaged: true, version: '1.2.3' })).toBeInstanceOf(
+      ElectronUpdaterStrategy
+    )
+  })
+
+  it('falls back to UpdateService on darwin for a nightly (prerelease) build', () => {
+    expect(
+      createUpdateStrategy('darwin', { isPackaged: true, version: '1.2.3-nightly.abc1234' })
+    ).toBeInstanceOf(UpdateService)
+  })
+
+  it('falls back to UpdateService on darwin for an unpackaged (dev) build', () => {
+    expect(createUpdateStrategy('darwin', { isPackaged: false, version: '1.2.3' })).toBeInstanceOf(
+      UpdateService
+    )
   })
 })

--- a/src/main/update/create-strategy.ts
+++ b/src/main/update/create-strategy.ts
@@ -1,13 +1,37 @@
+import { app } from 'electron'
+
 import { ElectronUpdaterStrategy } from './electron-updater-strategy'
 import { UpdateService } from './service'
 import type { UpdateStrategy } from './strategy'
 
-// Picks the update strategy for the host platform. Windows/Linux get true in-place auto-update via
-// electron-updater; macOS (and any other platform) falls back to the manifest installer flow because
-// Squirrel.Mac auto-update needs a Developer ID signature this build doesn't have yet.
+export type CreateStrategyOptions = {
+  // Whether this is a packaged (installed) build. Defaults to app.isPackaged; injectable for tests.
+  isPackaged?: boolean
+  // Running app version. Defaults to app.getVersion(); injectable for tests.
+  version?: string
+}
+
+// macOS in-place auto-update (electron-updater / Squirrel.Mac) only works on a packaged build that is
+// Developer ID signed. CI signs *stable* mac builds; nightly builds are ad-hoc and dev runs are
+// unsigned/unpackaged — both would hit electron-updater's "could not get code signature" error. Gate
+// on packaged + a non-prerelease version (nightly is `x.y.z-nightly.<sha>`) so only signed stable
+// builds get the in-place path; everything else falls back to the manifest installer flow.
+const macCanAutoUpdate = (isPackaged: boolean, version: string): boolean =>
+  isPackaged && !version.includes('-')
+
+// Picks the update strategy for the host platform. Windows/Linux always get true in-place auto-update
+// via electron-updater. macOS gets it too on signed stable builds (see macCanAutoUpdate); otherwise
+// (dev, nightly, or any other platform) it falls back to the manifest installer flow (UpdateService).
 export const createUpdateStrategy = (
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  opts: CreateStrategyOptions = {}
 ): UpdateStrategy => {
   if (platform === 'win32' || platform === 'linux') return new ElectronUpdaterStrategy()
+
+  const isPackaged = opts.isPackaged ?? app?.isPackaged ?? false
+  const version = opts.version ?? app?.getVersion?.() ?? '0.0.0'
+  if (platform === 'darwin' && macCanAutoUpdate(isPackaged, version)) {
+    return new ElectronUpdaterStrategy()
+  }
   return new UpdateService()
 }

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -42,9 +42,10 @@ const notesToString = (notes: unknown): string => {
   return ''
 }
 
-// win/linux strategy: wraps electron-updater for true in-place download + restart. Emits the same
-// UpdateStatus shape as UpdateService, always stamped applyKind:'restart'. Opt-in: autoDownload and
-// autoInstallOnAppQuit are disabled so nothing downloads/installs without a user action.
+// In-place auto-update strategy: wraps electron-updater for true download + restart on win/linux and
+// on signed stable macOS (Squirrel.Mac). Emits the same UpdateStatus shape as UpdateService, always
+// stamped applyKind:'restart'. Opt-in: autoDownload and autoInstallOnAppQuit are disabled so nothing
+// downloads/installs without a user action.
 export class ElectronUpdaterStrategy implements UpdateStrategy {
   private readonly updater: MinimalAutoUpdater
   private readonly currentVersion: string
@@ -130,9 +131,10 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     return this.status
   }
 
-  // Triggered by the user's "Restart to update" click once the download is ready. Silent install
-  // (isSilent=true) so the assisted NSIS installer never shows its wizard, and isForceRunAfter=true so
-  // the app relaunches into the new version after the in-place swap. per-user install = no UAC prompt.
+  // Triggered by the user's "Restart to update" click once the download is ready. On win/linux,
+  // isSilent=true keeps the assisted NSIS installer from showing its wizard and isForceRunAfter=true
+  // relaunches into the new version (per-user install = no UAC prompt). On macOS Squirrel.Mac swaps
+  // the .app and relaunches; it ignores isSilent, so the same call is correct there too.
   async apply(): Promise<UpdateStatus> {
     this.updater.quitAndInstall(true, true)
     return this.status

--- a/src/main/update/strategy.ts
+++ b/src/main/update/strategy.ts
@@ -1,8 +1,9 @@
 import type { UpdateStatus } from '../../shared/update'
 
 // The platform-agnostic update contract the IPC layer and scheduler drive. Two implementations exist:
-// UpdateService (macOS + fallback, manifest download + manual reinstall) and ElectronUpdaterStrategy
-// (win/linux, in-place download/restart). Both broadcast the same UpdateStatus.
+// ElectronUpdaterStrategy (win/linux, and signed stable macOS — in-place download/restart) and
+// UpdateService (dev/nightly macOS + any other fallback — manifest download + manual reinstall). Both
+// broadcast the same UpdateStatus. See create-strategy.ts for how the host is routed.
 export interface UpdateStrategy {
   getStatus(): UpdateStatus
   check(): Promise<UpdateStatus>


### PR DESCRIPTION
## What

Gives **signed stable macOS builds** the same in-place auto-update (electron-updater / Squirrel.Mac) that Windows/Linux already have — download + restart, instead of the manifest download + manual reinstall. Enabled now that mac Developer ID signing + Apple notarization are verified working.

Dev and nightly (ad-hoc, unsigned) builds keep the manifest flow, so this can't regress them.

## Workflow relationships (after this PR)

```mermaid
flowchart TD
    TAG["push tag v*"]:::t --> REL["release.yml"]:::wf
    MAIN["push to main"]:::t --> NIG["nightly.yml"]:::wf
    MAN["manual dispatch"]:::t --> DRY["notarize-dryrun.yml"]:::wf

    REL -->|"full matrix"| BUILD["build.yml (reusable)\nverify + matrix build + SIGN"]:::wf
    NIG -->|"full matrix, ad-hoc"| BUILD
    DRY -->|"mac_only, skip_verify"| BUILD

    BUILD --> NOTAR["notarize-mac.yml (from_run call)\nsubmit → wait → staple →\nREGENERATE ${arch}-mac.yml"]:::wf

    REL --> PUB["publish job\nGitHub Release + checksums + SLSA"]:::pub
    NOTAR -->|"stapled dmg/zip + per-arch feed"| PUB
    DRY -.->|"stapled artifacts only, NO publish"| ART["run artifacts"]:::art

    PUB --> RELEASE["GitHub Release\n(dmg, zip, exe, AppImage, deb,\nlatest.yml, latest-linux.yml,\narm64-mac.yml, x64-mac.yml)"]:::rel
    RELEASE -->|"release: published"| MIRROR["mirror-to-website.yml"]:::wf
    MIRROR --> CDN["CDN feed (statics.aipoch.com/.../app/stable)\nreleases/<version>/ installers +\nchannel-root feeds + version.json"]:::cdn

    classDef t fill:#eef,stroke:#88a;
    classDef wf fill:#efe,stroke:#4a4;
    classDef pub fill:#fee,stroke:#c66;
    classDef art fill:#ffe,stroke:#cc6;
    classDef rel fill:#eef7ff,stroke:#69c;
    classDef cdn fill:#f3e8ff,stroke:#96c;
```

## Per-platform packaging & update path

```mermaid
flowchart LR
    subgraph build["build.yml — build + sign"]
      A1["mac arm64\n(macos-14)\nDevID sign, notarize:false\nchannel=arm64 → arm64-mac.yml"]:::mac
      A2["mac x64\n(cross on macos-14)\nDevID sign, notarize:false\nchannel=x64 → x64-mac.yml"]:::mac
      A3["linux x64\nAppImage + deb\nlatest-linux.yml"]:::lin
      A4["win x64\nNSIS + zip\nlatest.yml + blockmap"]:::win
    end

    A1 --> N["notarize-mac.yml\nnotarize + staple zip →\nregenerate arm64/x64-mac.yml\n(sha512 of STAPLED zip,\nno blockmap = full-zip)"]:::note
    A2 --> N
    A3 --> P["publish + mirror\nfeeds → channel root\ninstallers → releases/<version>/"]:::pub
    A4 --> P
    N --> P

    P --> U1["macOS (signed stable)\nElectronUpdaterStrategy\nfetch ${arch}-mac.yml → full zip →\nquitAndInstall (Squirrel.Mac)"]:::upd
    P --> U2["win / linux\nElectronUpdaterStrategy\nlatest*.yml → differential → restart"]:::upd
    P --> U3["macOS dev / nightly\nUpdateService (unchanged)\nversion.json → manual reinstall"]:::fallback

    classDef mac fill:#eef7ff,stroke:#69c;
    classDef lin fill:#fff3e0,stroke:#e90;
    classDef win fill:#e8f5e9,stroke:#4a4;
    classDef note fill:#fff8e1,stroke:#cc6;
    classDef pub fill:#fee,stroke:#c66;
    classDef upd fill:#e8f7f0,stroke:#3a8;
    classDef fallback fill:#f5f5f5,stroke:#999;
```

## Key decisions

- **Per-arch feeds via electron-updater `channel`, not directory subpaths.** arm64/x64 build on separate runners and would both emit `latest-mac.yml` (collision). Building each with `-c.publish.channel=<arch>` makes electron-builder emit `${arch}-mac.yml` and bake `channel:<arch>` into that build's `app-update.yml`, so each installed arch polls only its own feed — no runtime `setFeedURL`, and it reuses the exact win/linux rewrite-and-publish plumbing.
- **Regenerate the feed after stapling.** electron-builder writes `${arch}-mac.yml` over the *pre-staple* zip; stapling repackages the zip, so the build-time sha512/size is stale and would fail the updater's signature check. `notarize-mac.yml` recomputes sha512 (base64) + size from the stapled zip and rewrites the feed.
- **Full-zip updates (v1), no differential.** Stapling invalidates the blockmap; reproducing electron-builder's blockmap is fragile. Dropped for mac; win/linux differential is unchanged.
- **Gate on `packaged && stable`.** `create-strategy.ts` routes mac → in-place only when `app.isPackaged && !version.includes('-')`. Nightly/dev fall back to `UpdateService`.

## Validation

- 1873 tests pass (3 new darwin routing cases), typecheck + eslint clean, `actionlint` clean.
- Feed regeneration exercised locally: valid YAML, base64 sha512 matches `openssl dgst -sha512 | base64`, correct size, exact per-arch filter.

## Not covered by CI

The **live in-place swap** (`quitAndInstall` replacing the running app) can only be verified on a **real Mac updating from an older installed stable version** — a manual real-device step, same as the win/linux runbook. CI/the dry-run only prove the signed + notarized + stapled zip and a hash-correct feed.
