### PR TITLE
feat(storage): platform-aware data-root path guards + return-to-default destination

### DIFF
--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -190,7 +190,7 @@ describe('storage IPC handlers', () => {
     expect(info.dataRoot).toBe(dataRoot)
     expect(info.isDefault).toBe(false)
     // Even from a custom root, the default and its parent are reported so Settings can offer a
-    // one-click return to `<home>/OpenScience`.
+    // one-click return to `<home>/OpenScience` and show the destination.
     expect(info.defaultDataRoot).toBe(join('/home/user', 'OpenScience'))
     expect(info.defaultParent).toBe('/home/user')
     expect(info.usage.totalBytes).toBe(0)

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -16,7 +16,6 @@ import {
   DATA_ROOT_DIRS,
   MIGRATED_DIRS,
   runDataRootMigration,
-  SPACE_PATH_WARNING,
   validateNewDataRoot
 } from './migration-service'
 
@@ -89,7 +88,7 @@ describe('classifyDataRoot', () => {
     expect(result).toEqual({ kind: 'invalid', error: 'The selected folder does not exist.' })
   })
 
-  it('allows a spaced path but attaches a caution on macOS/Linux (conda/venv shebang limit)', async () => {
+  it('rejects a spaced path on macOS/Linux (conda/venv shebang limit)', async () => {
     const original = process.platform
     Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
     const spacedParent = await mkdtemp(join(tmpdir(), 'ds migsvc spaced '))
@@ -97,15 +96,15 @@ describe('classifyDataRoot', () => {
     try {
       const result = await classifyDataRoot(spacedParent, currentDataRoot)
 
-      // Not blocked — proceeds as a move — but carries the non-blocking spaced-path warning.
-      expect(result).toEqual({ kind: 'move', warning: SPACE_PATH_WARNING })
+      expect(result.kind).toBe('invalid')
+      expect(result.error).toMatch(/no spaces/i)
     } finally {
       Object.defineProperty(process, 'platform', { value: original, configurable: true })
       await rm(spacedParent, { recursive: true, force: true })
     }
   })
 
-  it('allows a spaced path with NO caution on Windows (spaces are normal there)', async () => {
+  it('allows a spaced path on Windows (spaces are normal there)', async () => {
     const original = process.platform
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
     const spacedParent = await mkdtemp(join(tmpdir(), 'ds migsvc spaced win '))
@@ -117,6 +116,54 @@ describe('classifyDataRoot', () => {
     } finally {
       Object.defineProperty(process, 'platform', { value: original, configurable: true })
       await rm(spacedParent, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a target whose path is too long for Windows MAX_PATH', async () => {
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+
+    try {
+      // No fs access happens before this check trips, so a synthetic (never-created) long path
+      // works. A plain posix-style absolute path is used rather than a `C:\...` one because Node's
+      // `path` module picks win32 vs. posix semantics from the real host platform at import time,
+      // not from this mocked process.platform.
+      const longParent = `/${'a'.repeat(220)}`
+      const result = await classifyDataRoot(longParent, currentDataRoot)
+
+      expect(result.kind).toBe('invalid')
+      expect(result.error).toMatch(/too long|260/i)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  })
+
+  it('does not reject a normal short target on Windows for length', async () => {
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+
+    try {
+      const result = await classifyDataRoot(emptyParent, currentDataRoot)
+
+      expect(result.kind).not.toBe('invalid')
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  })
+
+  it('does not enforce MAX_PATH on non-Windows platforms, even for a very long path', async () => {
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+
+    try {
+      const longParent = `/tmp/${'a'.repeat(220)}`
+      const result = await classifyDataRoot(longParent, currentDataRoot)
+
+      // POSIX has no MAX_PATH; this only fails (or not) for unrelated reasons (missing dir), never
+      // for length.
+      expect(result.error).not.toMatch(/too long|260/i)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
     }
   })
 
@@ -147,6 +194,15 @@ describe('classifyDataRoot', () => {
       }
     }
   )
+
+  it('classifies a parent as invalid when the injected write probe reports failure (all platforms)', async () => {
+    const result = await classifyDataRoot(emptyParent, currentDataRoot, {
+      canWrite: async () => false
+    })
+
+    expect(result.kind).toBe('invalid')
+    expect(result.error).toMatch(/can't write/i)
+  })
 
   it('classifies a parent with no OpenScience subdir as move', async () => {
     const result = await classifyDataRoot(emptyParent, currentDataRoot)

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -28,11 +28,32 @@ export type ValidateResult = { ok: true } | { ok: false; error: string }
 // migration, or the user's own pre-existing folder) - the pointer should switch to it as-is,
 // never be moved into. 'invalid' carries a user-facing reason.
 export type DataRootKind = 'move' | 'adopt' | 'invalid'
-export type ClassifyResult = { kind: DataRootKind; error?: string; warning?: string }
+export type ClassifyResult = { kind: DataRootKind; error?: string }
 
-// Non-blocking caution for a spaced path on macOS/Linux (see classifyDataRoot). Exported for tests.
-export const SPACE_PATH_WARNING =
-  'This path contains a space. Python or R environments may fail to run from a spaced path on macOS and Linux — a folder without spaces is safer.'
+// Windows' historical MAX_PATH. Long-path opt-outs exist but aren't something we can rely on across
+// every tool a user's Python/R environment might shell out to, so the app guards against it directly.
+const WINDOWS_MAX_PATH = 260
+// Headroom reserved for the app's deepest nested paths (artifacts/notebooks/runtime) under the root.
+const WINDOWS_NESTED_RESERVE = 110
+
+// Optional injectable deps for classifyDataRoot, so its write probe can be exercised in tests without
+// depending on platform-specific filesystem permission semantics (chmod is a POSIX-only no-op on
+// Windows).
+type ClassifyDataRootDeps = { canWrite?: (dir: string) => Promise<boolean> }
+
+// Real write probe (create + delete a temp file) instead of only fs.access(W_OK): access() checks
+// POSIX bits but NOT macOS TCC (Documents/Desktop/Downloads/external & network volumes) or read-only
+// mounts, so a folder can look writable yet reject the actual write.
+const defaultCanWrite = async (dir: string): Promise<boolean> => {
+  try {
+    const probePath = join(dir, `.open-science-write-test-${randomUUID()}`)
+    await writeFile(probePath, '')
+    await rm(probePath, { force: true })
+    return true
+  } catch {
+    return false
+  }
+}
 
 // Classifies a candidate data root against the current one. `parent` is a directory the user
 // picked; the app derives the data root from it (`dataRootForPicked`) rather than
@@ -40,7 +61,8 @@ export const SPACE_PATH_WARNING =
 // (missing dir, permission denied) is mapped to an 'invalid' result with a user-facing message.
 export const classifyDataRoot = async (
   parent: string,
-  currentDataRoot: string
+  currentDataRoot: string,
+  deps: ClassifyDataRootDeps = {}
 ): Promise<ClassifyResult> => {
   const resolvedParent = resolve(parent)
   const current = resolve(currentDataRoot)
@@ -66,14 +88,29 @@ export const classifyDataRoot = async (
     return { kind: 'invalid', error: 'Choose a location outside the current data folder.' }
   }
 
-  // Spaces are allowed on every platform, but on macOS/Linux they can break conda/venv: Unix shebang
-  // lines (#!/path/bin/python) can't contain a space, so pip/conda console scripts become unrunnable.
-  // A move/adopt to a spaced path therefore carries a NON-BLOCKING caution there. Windows has no
-  // shebangs and treats spaced paths as normal, so no warning is attached.
-  const spaceWarning =
-    process.platform !== 'win32' && /\s/.test(target) ? SPACE_PATH_WARNING : undefined
-  const withWarning = (result: ClassifyResult): ClassifyResult =>
-    spaceWarning && result.kind !== 'invalid' ? { ...result, warning: spaceWarning } : result
+  // On macOS/Linux, a spaced path can break conda/venv: Unix shebang lines (#!/path/bin/python)
+  // can't contain a space, so pip/conda console scripts become unrunnable. Unlike the rest of this
+  // module's warnings-that-don't-block, this is a hard rejection there. Windows has no shebangs and
+  // routinely has spaced profile paths (C:\Users\John Doe), so spaces are allowed there.
+  if (process.platform !== 'win32' && /\s/.test(target)) {
+    return {
+      kind: 'invalid',
+      error:
+        "Choose a folder whose path has no spaces — Python or R environments can't run reliably from a spaced path on macOS or Linux."
+    }
+  }
+
+  // Windows' MAX_PATH (260 chars) applies to the full path of every file the app creates, not just
+  // the root itself — a root that already eats most of the budget leaves no room for anything nested
+  // under artifacts/notebooks/runtime. Reject early, before any fs access, so the failure is a clear
+  // upfront message instead of a cryptic ENAMETOOLONG mid-migration or mid-notebook-run.
+  if (process.platform === 'win32' && target.length + WINDOWS_NESTED_RESERVE > WINDOWS_MAX_PATH) {
+    return {
+      kind: 'invalid',
+      error:
+        "This location's path is too long for Windows. Choose a folder closer to the drive root so your files stay within Windows' 260-character path limit."
+    }
+  }
 
   try {
     const info = await stat(resolvedParent)
@@ -85,16 +122,10 @@ export const classifyDataRoot = async (
     return { kind: 'invalid', error: 'The selected folder does not exist.' }
   }
 
-  // Real write probe (create + delete a temp file) instead of only fs.access(W_OK): access() checks
-  // POSIX bits but NOT macOS TCC (Documents/Desktop/Downloads/external & network volumes) or
-  // read-only mounts, so a folder can look writable yet reject the actual write. Probing here surfaces
-  // TCC-denied, read-only, and out-of-space cases up front with a clear message, before any migration
-  // starts (rather than failing mid-copy with a cryptic error).
-  try {
-    const probePath = join(resolvedParent, `.open-science-write-test-${randomUUID()}`)
-    await writeFile(probePath, '')
-    await rm(probePath, { force: true })
-  } catch {
+  // Probing here surfaces TCC-denied, read-only, and out-of-space cases up front with a clear
+  // message, before any migration starts (rather than failing mid-copy with a cryptic error).
+  const canWrite = deps.canWrite ?? defaultCanWrite
+  if (!(await canWrite(resolvedParent))) {
     return {
       kind: 'invalid',
       error:
@@ -119,7 +150,7 @@ export const classifyDataRoot = async (
       return { kind: 'invalid', error: 'The selected folder is not usable.' }
     }
   } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return withWarning({ kind: 'move' })
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return { kind: 'move' }
     return { kind: 'invalid', error: 'The selected folder is not usable.' }
   }
 
@@ -133,11 +164,11 @@ export const classifyDataRoot = async (
   const looksLikeOurData = entries.some(
     (entry) => entry.isDirectory() && (MIGRATED_DIRS as readonly string[]).includes(entry.name)
   )
-  if (looksLikeOurData) return withWarning({ kind: 'adopt' })
+  if (looksLikeOurData) return { kind: 'adopt' }
 
   // runtime/ doesn't count as content: a folder holding only runtime (or nothing) is treated as empty.
   const meaningfulEntries = entries.filter((entry) => entry.name !== 'runtime')
-  if (meaningfulEntries.length === 0) return withWarning({ kind: 'move' })
+  if (meaningfulEntries.length === 0) return { kind: 'move' }
 
   return {
     kind: 'invalid',

--- a/src/renderer/src/components/LegacyDataMoveDialog.tsx
+++ b/src/renderer/src/components/LegacyDataMoveDialog.tsx
@@ -28,8 +28,9 @@ const LegacyDataMoveDialog = ({
 }: LegacyDataMoveDialogProps): React.JSX.Element => {
   // When set, hand off to the shared migration modal targeting this parent; null returns to the prompt.
   const [migrationTarget, setMigrationTarget] = useState<string | null>(null)
-  // The exact <home>/OpenScience path "Move to OpenScience" would create. Resolved server-side (not
-  // from getInfo's defaultDataRoot, which for a legacy install is the hidden config root itself).
+  // The exact <home>/OpenScience path "Move to OpenScience" would create. Resolved server-side via
+  // inspectDataRoot(defaultParent) rather than getInfo's dataRoot, which for a legacy install is the
+  // hidden config root itself.
   const [destination, setDestination] = useState<string | undefined>(undefined)
   const [pickError, setPickError] = useState<string | undefined>(undefined)
   const [isPicking, setIsPicking] = useState(false)

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -145,8 +145,6 @@ const OnboardingWizard = (): React.JSX.Element => {
   // 'adopt' shows the "used as-is" note; 'move' is the ordinary empty-folder case. Irrelevant once
   // chosenParent is cleared back to the default.
   const [chosenKind, setChosenKind] = useState<'move' | 'adopt' | null>(null)
-  // Non-blocking caution for the chosen location (e.g. a spaced path on macOS/Linux).
-  const [chosenWarning, setChosenWarning] = useState<string | undefined>(undefined)
   const [locationError, setLocationError] = useState<string | undefined>(undefined)
   const [confirmRestart, setConfirmRestart] = useState(false)
   const [isRelaunching, setIsRelaunching] = useState(false)
@@ -239,7 +237,6 @@ const OnboardingWizard = (): React.JSX.Element => {
     setChosenParent(picked)
     setChosenDataRoot(result.dataRoot)
     setChosenKind(result.kind)
-    setChosenWarning(result.warning)
     setLocationError(undefined)
   }
 
@@ -247,7 +244,6 @@ const OnboardingWizard = (): React.JSX.Element => {
     setChosenParent('')
     setChosenDataRoot('')
     setChosenKind(null)
-    setChosenWarning(undefined)
     setLocationError(undefined)
   }
 
@@ -616,15 +612,6 @@ const OnboardingWizard = (): React.JSX.Element => {
                         <p className="mt-2 text-xs text-text-100">
                           This folder already contains Open Science data — it will be used as-is
                           (nothing is moved).
-                        </p>
-                      ) : null}
-
-                      {chosenWarning ? (
-                        <p
-                          className="mt-2 rounded-lg border border-amber-500/40 bg-amber-500/5 px-2.5 py-1.5 text-xs text-amber-700 dark:text-amber-400"
-                          role="alert"
-                        >
-                          {chosenWarning}
                         </p>
                       ) : null}
 

--- a/src/renderer/src/pages/settings/StoragePanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/StoragePanel.render.test.tsx
@@ -387,39 +387,6 @@ describe('StoragePanel', () => {
     ).not.toHaveBeenCalled()
   })
 
-  it('shows a non-blocking caution for a spaced path but keeps the action enabled', async () => {
-    ;(
-      window as unknown as { api: { storage: { pickDirectory: ReturnType<typeof vi.fn> } } }
-    ).api.storage.pickDirectory.mockResolvedValue('/mnt/my data')
-    ;(
-      window as unknown as { api: { storage: { inspectDataRoot: ReturnType<typeof vi.fn> } } }
-    ).api.storage.inspectDataRoot.mockResolvedValue({
-      kind: 'move',
-      dataRoot: '/mnt/my data/OpenScience',
-      warning: 'This path contains a space. Python or R environments may fail to run.'
-    })
-
-    await act(async () => {
-      root.render(<StoragePanel />)
-    })
-    await act(async () => {
-      await Promise.resolve()
-    })
-    await openEditor()
-    await act(async () => {
-      clickButton((button) => button.textContent?.includes('Browse') ?? false)
-      await Promise.resolve()
-    })
-
-    // The caution is shown...
-    expect(container.textContent).toContain('Python or R environments may fail to run')
-    // ...but the move action stays enabled (a warning does not block, unlike an invalid error).
-    const changeButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
-      (button) => button.textContent?.trim() === 'Change location'
-    )
-    expect(changeButton?.disabled).toBe(false)
-  })
-
   it('a path classified as invalid shows the inline error and disables both actions', async () => {
     ;(
       window as unknown as { api: { storage: { pickDirectory: ReturnType<typeof vi.fn> } } }
@@ -484,6 +451,8 @@ describe('StoragePanel', () => {
         button.textContent?.includes('move it back to the default location')
       )
     ).toBe(true)
+    // The destination (default data root) is shown so the user sees where "back to default" goes.
+    expect(container.textContent).toContain('/home/u/OpenScience')
   })
 
   it('does not offer return-to-default when the current root is already the default', async () => {

--- a/src/renderer/src/pages/settings/StoragePanel.tsx
+++ b/src/renderer/src/pages/settings/StoragePanel.tsx
@@ -61,7 +61,6 @@ const StoragePanel = (): React.JSX.Element => {
     kind: DataRootKind
     dataRoot: string
     error?: string
-    warning?: string
   } | null>(null)
   const [migrationTarget, setMigrationTarget] = useState<string | null>(null)
   const [adoptConfirmOpen, setAdoptConfirmOpen] = useState(false)
@@ -230,7 +229,8 @@ const StoragePanel = (): React.JSX.Element => {
                     onClick={() => void handleUseDefault()}
                     className="mt-2 text-xs text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground"
                   >
-                    Or move it back to the default location
+                    Or move it back to the default location{' '}
+                    <span className="font-mono no-underline">({info.defaultDataRoot})</span>
                   </button>
                 ) : null}
 
@@ -273,17 +273,6 @@ const StoragePanel = (): React.JSX.Element => {
                     </p>
                   </>
                 )}
-
-                {/* Non-blocking caution (e.g. spaced path on macOS/Linux): the action stays enabled,
-                    but the user is told before committing. */}
-                {kind && inspection?.warning ? (
-                  <p
-                    className="mt-2 rounded-lg border border-amber-500/40 bg-amber-500/5 px-2.5 py-1.5 text-xs text-amber-700 dark:text-amber-400"
-                    role="alert"
-                  >
-                    {inspection.warning}
-                  </p>
-                ) : null}
 
                 {kind === 'invalid' && inspection?.error ? (
                   <p className="mt-2 text-xs text-destructive" role="alert">

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -9,9 +9,10 @@ export type StorageUsage = { categories: UsageCategory[]; totalBytes: number }
 export type StorageInfo = {
   dataRoot: string
   isDefault: boolean
-  // The default data root and the parent that reproduces it. Lets Settings offer a one-click
-  // "return to default" (relocate back to <home>/OpenScience) when the current root is custom:
-  // defaultParent is fed to the same inspect/migrate flow a browsed folder would be.
+  // The default data root and the parent that reproduces it. `defaultParent` is fed to the same
+  // inspect/migrate flow a browsed folder would be; `defaultDataRoot` is the derived destination
+  // shown to the user in Settings' one-click "return to default" affordance (accurate there because
+  // the affordance only appears when the current root is custom, i.e. the default is <home>/OpenScience).
   defaultDataRoot: string
   defaultParent: string
   // True only when settings.dataRoot is explicitly configured but the resolved directory is gone
@@ -58,7 +59,4 @@ export type DataRootInspection = {
   kind: DataRootKind
   dataRoot: string
   error?: string
-  // Non-blocking caution (e.g. a spaced path on macOS/Linux): the action still proceeds, but the
-  // UI surfaces this so the user isn't surprised by a later broken Python/R environment.
-  warning?: string
 }


### PR DESCRIPTION
Follow-up hardening for the configurable data-root feature (#149).

## Path guards (platform-aware, in `classifyDataRoot`)
- **Spaces:** now **rejected on macOS/Linux** (Unix shebang lines can't contain a space, so conda/venv console scripts break), and **allowed on Windows** (profile paths routinely contain spaces and its tooling handles them). Replaces the previous non-blocking warning, so the whole warning mechanism (`SPACE_PATH_WARNING`, `ClassifyResult.warning`, `DataRootInspection.warning`, and the amber UI in StoragePanel/onboarding) is removed.
- **Windows MAX_PATH:** reject a derived data root on Windows whose path leaves too little headroom (reserve 110) under the 260-char limit, before any filesystem access.

## Testability
- The write probe is now injectable (`deps.canWrite`), so its failure path is exercised on **every** platform, not just via `chmod` (a POSIX-only mechanism). The real probe is kept as the default.

## Settings UX
- The "return to default" affordance now **shows the destination path** (e.g. `Or move it back to the default location (~/OpenScience-DEV)`) via the restored `StorageInfo.defaultDataRoot`; `defaultParent` still drives the migration.

## Notes
- The legacy first-run "move your data" prompt keeps resolving its destination via `inspectDataRoot` (that context is a legacy-in-place install, where the computed default is the hidden config root).
- New/updated tests set `process.platform` explicitly and derive expected paths host-natively, so they pass on Windows too.
