### PR TITLE
fix(update): publish a single latest-mac.yml so macOS apps find the update feed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,14 +168,15 @@ jobs:
             # Stable build with a Developer ID cert -> SIGN ONLY (notarize:false). Notarization +
             # stapling happens later in notarize-mac.yml, so this job never waits on Apple.
             #
-            # Per-arch update channel: arm64 and x64 build on separate runners and would both emit
-            # `latest-mac.yml`, colliding at the feed root. Setting the electron-updater channel to the
-            # arch makes each build emit its own `${arch}-mac.yml` and bake `channel: ${arch}` into its
-            # app-update.yml, so each installed arch polls only its own feed. (win/linux keep the
-            # default `latest` channel.)
-            mac_channel="${{ matrix.name }}"; mac_channel="${mac_channel#macos-}"
+            # Update channel stays the default `latest`, so `channel: latest` is baked into
+            # app-update.yml and the mac updater polls the standard `latest-mac.yml`. arm64 and x64
+            # build on separate runners; each emits its own `latest-mac.yml` listing only its arch,
+            # which the publish job merges into a single `latest-mac.yml` carrying both arch zips
+            # (electron-updater's MacUpdater picks the right one by arch at download time). This avoids
+            # the per-arch `${arch}-mac.yml` scheme, which shipped an app-update.yml the mac updater
+            # never matched against the published feed names.
             npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" --publish never \
-              -c.mac.notarize=false -c.publish.channel="$mac_channel"
+              -c.mac.notarize=false
           else
             # No cert, or a nightly build (ad-hoc on purpose): skip electron-builder's own signing.
             # GitHub injects unset secrets as EMPTY strings, and electron-builder mis-reads an empty

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (for the mac-feed merge script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Recompute + upload SHA256SUMS.txt
         env:

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -176,17 +176,20 @@ jobs:
             ditto -c -k --keepParent "$app" "$zip"   # repackage the stapled .app over the zip
           done
 
-      # Stapling repackaged the zip (new bytes), so electron-builder's ${arch}-mac.yml — written at
-      # build time over the PRE-staple zip — now carries a stale sha512/size that would fail the
-      # updater's signature check. Regenerate the feed from the stapled zip: recompute sha512 (base64)
-      # + size and emit a minimal, zip-only feed (no blockmap -> full-zip mac updates for v1). Derived
-      # purely from the stapled zip, so it is correct on both the call and standalone paths.
+      # Stapling repackaged the zip (new bytes), so the build-time feed — written over the PRE-staple
+      # zip — now carries a stale sha512/size that would fail the updater's signature check. The build
+      # runs the default `latest` channel, so it emits `latest-mac.yml` per arch; drop that stale copy
+      # and regenerate a per-arch intermediate `${arch}-mac.yml` from the stapled zip (recompute sha512
+      # base64 + size, minimal zip-only feed, no blockmap -> full-zip mac updates for v1). The publish
+      # job merges the two arch intermediates into the single `latest-mac.yml` the updater polls.
+      # Derived purely from the stapled zip, so it is correct on both the call and standalone paths.
       - name: Regenerate mac update feed
         if: steps.gate.outputs.enabled == 'true'
         env:
           ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
+          rm -f mac/latest-mac.yml
           node -e '
             const fs = require("fs"), crypto = require("crypto"), path = require("path");
             const arch = process.env.ARCH;
@@ -241,13 +244,18 @@ jobs:
             --repo "$GITHUB_REPOSITORY" --clobber
 
   # Standalone path only: after both archs are stapled + clobbered, rebuild SHA256SUMS.txt so it
-  # matches the re-stapled bytes. (In the release.yml path, the publish job regenerates it over the
+  # matches the re-stapled bytes, and merge the per-arch mac feeds into latest-mac.yml (the two
+  # notarize jobs clobbered arm64/x64-mac.yml independently; the combined feed the app polls has to be
+  # rebuilt where both are visible). (In the release.yml path, the publish job does both over the
   # already-stapled artifacts, so no refresh is needed there.)
   refresh-checksums:
     if: ${{ !inputs.from_run }}
     needs: notarize
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout (for the mac-feed merge script)
+        uses: actions/checkout@v4
+
       - name: Recompute + upload SHA256SUMS.txt
         env:
           GH_TOKEN: ${{ github.token }}
@@ -266,3 +274,19 @@ jobs:
           )
           gh release upload "${{ inputs.tag }}" "$dir/SHA256SUMS.txt" \
             --repo "$GITHUB_REPOSITORY" --clobber
+
+      # Rebuild the combined latest-mac.yml from the re-stapled per-arch feeds and clobber it onto the
+      # release. No-ops (script exits 0) if the per-arch mac feeds aren't present (non-mac backfill).
+      - name: Merge + upload latest-mac.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          dir=$(mktemp -d)
+          gh release download "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" --dir "$dir" \
+            --pattern 'arm64-mac.yml' --pattern 'x64-mac.yml' || true
+          node scripts/merge-mac-feed.mjs "$dir"
+          if [ -f "$dir/latest-mac.yml" ]; then
+            gh release upload "${{ inputs.tag }}" "$dir/latest-mac.yml" \
+              --repo "$GITHUB_REPOSITORY" --clobber
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       # Checkout first (before downloading artifacts): the mac-feed merge step runs a repo script, and
       # actions/checkout cleans the working dir, which would wipe a pre-downloaded artifacts/.
       - name: Checkout (for the mac-feed merge script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,21 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      # Checkout first (before downloading artifacts): the mac-feed merge step runs a repo script, and
+      # actions/checkout cleans the working dir, which would wipe a pre-downloaded artifacts/.
+      - name: Checkout (for the mac-feed merge script)
+        uses: actions/checkout@v4
+
       - name: Download all build artifacts
         uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true # flatten every platform's files into one directory
+
+      # Merge the two per-arch mac feeds (from notarize-mac) into the single latest-mac.yml the
+      # installed app polls (default `latest` channel). No-ops if the mac feeds are absent.
+      - name: Merge mac update feed
+        run: node scripts/merge-mac-feed.mjs artifacts
 
       # One SHA256SUMS.txt covering all installers so users can verify downloads.
       - name: Generate checksums
@@ -84,9 +94,10 @@ jobs:
 
       # Attach user-facing artifacts + checksums: installers (dmg/exe/AppImage/deb) and portable
       # zips (mac + win), plus the electron-updater feed files so the mirror-to-website job can
-      # republish them to the CDN feed: win/linux latest.yml + latest-linux.yml, and the per-arch mac
-      # feeds arm64-mac.yml + x64-mac.yml (distinct names -> no collision; regenerated post-staple in
-      # notarize-mac.yml). Blockmaps are win/linux only (mac does full-zip updates in v1).
+      # republish them to the CDN feed: win/linux latest.yml + latest-linux.yml, and the mac feeds.
+      # `*-mac.yml` covers the merged latest-mac.yml (the file the app polls) plus the per-arch
+      # arm64/x64-mac.yml intermediates it was built from. Blockmaps are win/linux only (mac does
+      # full-zip updates in v1).
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:

--- a/scripts/merge-mac-feed.mjs
+++ b/scripts/merge-mac-feed.mjs
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+// Merge the two per-arch macOS update feeds (arm64-mac.yml + x64-mac.yml) into a single
+// latest-mac.yml that lists both arch zips. This is the feed the installed app actually polls: its
+// app-update.yml ships the default `latest` channel, so on macOS electron-updater fetches
+// `latest-mac.yml`, then MacUpdater.filterFilesForArch picks the entry whose url contains `arm64`
+// (arm64 + Rosetta) or the other one (Intel x64). Emitting one combined feed avoids the arm64/x64
+// runners colliding on the same filename, without the per-arch `${arch}-mac.yml` channel scheme that
+// left field apps polling a filename the pipeline never published.
+//
+// Usage: node scripts/merge-mac-feed.mjs [dir]   (dir defaults to cwd)
+// No-ops (exit 0) unless BOTH per-arch feeds are present, so a partial/non-mac run is harmless.
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const dir = process.argv[2] ?? '.'
+const archFeeds = ['arm64-mac.yml', 'x64-mac.yml'].map((name) => join(dir, name))
+
+if (!archFeeds.every(existsSync)) {
+  console.log('merge-mac-feed: both per-arch feeds not present, skipping')
+  process.exit(0)
+}
+
+// The per-arch feeds are machine-generated with a fixed shape (see notarize-mac.yml), so a targeted
+// parse is enough and avoids a YAML dependency. Each feed lists exactly one file, so after `files:`
+// the first sha512/size belong to that entry.
+const parse = (file) => {
+  const text = readFileSync(file, 'utf8')
+  const version = text.match(/^version:\s*(.+)$/m)?.[1].trim()
+  const filesBlock = text.slice(text.indexOf('files:'))
+  const url = filesBlock.match(/-\s*url:\s*(.+)/)?.[1].trim()
+  const sha512 = filesBlock.match(/sha512:\s*(.+)/)?.[1].trim()
+  const size = filesBlock.match(/size:\s*(\d+)/)?.[1]
+  const releaseDate = text.match(/^releaseDate:\s*(.+)$/m)?.[1].trim()
+  if (!version || !url || !sha512 || !size) {
+    console.error(`::error::could not parse mac feed ${file}`)
+    process.exit(1)
+  }
+  return { version, url, sha512, size, releaseDate }
+}
+
+const entries = archFeeds.map(parse)
+const version = entries[0].version
+// Newest of the two timestamps, so the combined feed's date reflects the last-stapled arch.
+const releaseDate = entries
+  .map((e) => e.releaseDate?.replace(/^["']|["']$/g, ''))
+  .filter(Boolean)
+  .sort()
+  .pop()
+
+const filesYaml = entries
+  .map((e) => `  - url: ${e.url}\n    sha512: ${e.sha512}\n    size: ${e.size}`)
+  .join('\n')
+
+// Top-level path/sha512 are legacy single-file fields; MacUpdater downloads from files[] after arch
+// filtering, so point them at the first entry for backward-compat.
+const yml =
+  `version: ${version}\n` +
+  `files:\n${filesYaml}\n` +
+  `path: ${entries[0].url}\n` +
+  `sha512: ${entries[0].sha512}\n` +
+  `releaseDate: ${JSON.stringify(releaseDate ?? new Date().toISOString())}\n`
+
+writeFileSync(join(dir, 'latest-mac.yml'), yml)
+process.stdout.write(yml)


### PR DESCRIPTION
## Summary

Standardize the macOS update feed on electron-updater's single `latest-mac.yml` (listing both arch zips) instead of the per-arch `${arch}-mac.yml` channel scheme, while staying fully backward-compatible with already-installed builds.

### Why

Released v0.3.0 mac builds bake a per-arch channel into `app-update.yml` (`channel: arm64` / `channel: x64`), so they poll `arm64-mac.yml` / `x64-mac.yml` — both published, so those users are fine. But the per-arch scheme is non-standard and fragile: **any build on the default `latest` channel** (a local `electron-builder --mac`, an unsigned build that took the else-branch, etc.) polls `latest-mac.yml`, which the pipeline never published, and gets a **403 AccessDenied** (S3 returns 403, not 404, for a missing key). This aligns the feed with what electron-updater fetches by default and removes that failure class.

`MacUpdater.filterFilesForArch` (electron-updater 6.8.9) picks the arm64 or x64 entry from a combined `files[]` list by whether the file url contains `arm64`, so one `latest-mac.yml` correctly serves Apple Silicon, Intel, and Rosetta.

## Changes

- **build.yml** — remove the `-c.publish.channel=<arch>` override for macOS. The default `latest` channel is kept, so `app-update.yml` bakes `channel: latest` and each runner emits `latest-mac.yml`.
- **scripts/merge-mac-feed.mjs** (new) — merge the two per-arch feeds into one `latest-mac.yml` carrying both `files[]` entries. No-ops unless both per-arch feeds are present.
- **release.yml** — run the merge in the publish job (checkout added before artifact download so the repo script is available). The existing `*-mac.yml` glob publishes **both** the per-arch intermediates and the merged feed; `mirror-to-website.yml` needs no change (it already rewrites + uploads `*-mac.yml`).
- **notarize-mac.yml** — drop the stale build-time `latest-mac.yml` before regenerating the per-arch intermediate feeds (still emitted, from the stapled zip); the standalone repair path also rebuilds `latest-mac.yml`.

## Backward-compatible migration

The pipeline keeps publishing the per-arch feeds **and** the merged `latest-mac.yml`, all pointing at the new version. After merging this PR and releasing v0.3.1, the channel root carries:

| feed | points to | polled by |
|------|-----------|-----------|
| `arm64-mac.yml` | v0.3.1 arm64 | existing v0.3.0 users (`channel: arm64`) |
| `x64-mac.yml` | v0.3.1 x64 | existing v0.3.0 users (`channel: x64`) |
| `latest-mac.yml` | v0.3.1 (both archs) | v0.3.1 and later (`channel: latest`) |

Flow:

1. Existing v0.3.0 users have `channel: arm64` / `x64`, so they poll `arm64-mac.yml` / `x64-mac.yml` — now pointing at v0.3.1 — and update in place. No one is stranded.
2. The v0.3.1 they install bakes `channel: latest`, so from then on they poll `latest-mac.yml`.
3. Everyone converges on `latest-mac.yml`; the per-arch feeds become legacy compatibility files and can be dropped in a later release once the old installs have migrated.

No manual S3 action is required: the per-arch feeds keep being produced, so v0.3.0 users reach v0.3.1 through them.

## Verification

- `scripts/merge-mac-feed.mjs` tested against the live v0.3.0 per-arch feeds; output lists both arch zips with correct sha512/size. No-op path confirmed for missing feeds.
- Shipped v0.3.0 `app-update.yml` inspected directly (`channel: arm64`), confirming existing releases are unaffected by the switch.
- eslint + prettier clean on the new script; all three workflow YAMLs parse.
