### PR TITLE
chore(ci): bump GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (for the manifest script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Tag from the Release event, or the manual input; version is the tag without a leading 'v'.
       - name: Resolve tag and version
@@ -45,7 +45,7 @@ jobs:
         run: gh release download "${{ steps.ref.outputs.tag }}" --repo "${{ github.repository }}" --dir dist-assets
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
Modernize the action versions that were lagging behind the rest of the repo. Checked every `uses:` against each action's latest release:

| action | before | after | latest major |
|--------|--------|-------|--------------|
| actions/checkout | v4 (mirror-to-website) | v7 | v7 |
| actions/setup-node | v4 (mirror), v6 (build, pr-check) | v7 | v7 |
| actions/download-artifact | v8 | — | v8 (already latest) |
| actions/upload-artifact | v7 | — | v7 (already latest) |
| softprops/action-gh-release | v3 | — | v3 (already latest) |
| actions/attest-build-provenance | v4 | — | v4 (already latest) |

Files touched: `mirror-to-website.yml` (checkout v4→v7, setup-node v4→v7), `build.yml` and `pr-check.yml` (setup-node v6→v7). No workflow logic changes; `node-version` / `cache: npm` inputs are unchanged and remain compatible with setup-node v7.

Note: the two `checkout@v4` steps added in #155 are bumped to v7 within that PR, not here.