### PR TITLE
feat(files): add managed file downloads and preview cards

### DIFF
--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const downloadsPath = join('/Users/example', 'Downloads')
+
+const handlers = new Map<string, (event: unknown, payload?: unknown) => unknown>()
+const showSaveDialog = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/Users/example/Downloads') },
+  BrowserWindow: { fromWebContents: vi.fn(() => null) },
+  dialog: { showSaveDialog },
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown, payload?: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }
+  }
+}))
+
+const { registerFileSaveHandlers } = await import('./file-save')
+
+describe('file save IPC handlers', () => {
+  beforeEach(() => {
+    handlers.clear()
+    showSaveDialog.mockReset()
+  })
+
+  it('registers a managed-file save channel', () => {
+    registerFileSaveHandlers()
+
+    expect(handlers.has('file:save-managed')).toBe(true)
+  })
+
+  it('opens a managed source once and copies that exact file to the selected destination', async () => {
+    const resolveManagedFilePath = vi.fn().mockResolvedValue('/managed/canonical-report.csv')
+    const copyTo = vi.fn().mockResolvedValue(undefined)
+    const close = vi.fn().mockResolvedValue(undefined)
+    const openManagedFile = vi.fn().mockResolvedValue({ copyTo, close })
+    showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: join(downloadsPath, 'report.csv')
+    })
+    registerFileSaveHandlers({
+      resolveManagedFilePath,
+      openManagedFile
+    })
+
+    const result = await handlers.get('file:save-managed')!(
+      { sender: {} },
+      {
+        source: 'upload',
+        path: '/managed/requested-report.csv',
+        suggestedName: '../report.csv'
+      }
+    )
+
+    expect(resolveManagedFilePath).toHaveBeenCalledWith('upload', {
+      path: '/managed/requested-report.csv'
+    })
+    expect(openManagedFile).toHaveBeenCalledWith('/managed/canonical-report.csv')
+    expect(showSaveDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: join(downloadsPath, 'report.csv') })
+    )
+    expect(copyTo).toHaveBeenCalledWith(join(downloadsPath, 'report.csv'))
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      saved: true,
+      filePath: join(downloadsPath, 'report.csv')
+    })
+  })
+
+  it('copies the original pending file identity after it is finalized during Save As', async () => {
+    const resolveManagedFilePath = vi.fn().mockResolvedValue('/managed/.pending/report.csv')
+    const copyTo = vi.fn().mockResolvedValue(undefined)
+    const close = vi.fn().mockResolvedValue(undefined)
+    const openManagedFile = vi.fn().mockResolvedValue({ copyTo, close })
+    showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: join(downloadsPath, 'report.csv')
+    })
+    registerFileSaveHandlers({
+      resolveManagedFilePath,
+      openManagedFile
+    })
+
+    await handlers.get('file:save-managed')!(
+      { sender: {} },
+      { source: 'artifact', path: 'session/report.csv', suggestedName: 'report.csv' }
+    )
+
+    expect(resolveManagedFilePath).toHaveBeenCalledTimes(1)
+    expect(copyTo).toHaveBeenCalledWith(join(downloadsPath, 'report.csv'))
+    expect(openManagedFile).toHaveBeenCalledWith('/managed/.pending/report.csv')
+  })
+
+  it('keeps copying the same real file handle when its source path is renamed', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-'))
+    const pendingPath = join(root, 'pending-report.csv')
+    const finalizedPath = join(root, 'final-report.csv')
+    const destinationPath = join(root, 'downloaded-report.csv')
+    await writeFile(pendingPath, 'stable artifact bytes')
+    const resolveManagedFilePath = vi.fn().mockResolvedValue(pendingPath)
+    showSaveDialog.mockImplementation(async () => {
+      await rename(pendingPath, finalizedPath)
+      return { canceled: false, filePath: destinationPath }
+    })
+    registerFileSaveHandlers({ resolveManagedFilePath })
+
+    try {
+      await handlers.get('file:save-managed')!(
+        { sender: {} },
+        { source: 'artifact', path: pendingPath, suggestedName: 'report.csv' }
+      )
+
+      await expect(readFile(destinationPath, 'utf8')).resolves.toBe('stable artifact bytes')
+      await expect(readFile(finalizedPath, 'utf8')).resolves.toBe('stable artifact bytes')
+      expect(resolveManagedFilePath).toHaveBeenCalledTimes(1)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not truncate a managed file when Save As selects the source itself', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-source-'))
+    const sourcePath = join(root, 'report.csv')
+    await writeFile(sourcePath, 'source must survive')
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: sourcePath })
+    registerFileSaveHandlers({
+      resolveManagedFilePath: vi.fn().mockResolvedValue(sourcePath)
+    })
+
+    try {
+      await expect(
+        handlers.get('file:save-managed')!(
+          { sender: {} },
+          { source: 'artifact', path: sourcePath, suggestedName: 'report.csv' }
+        )
+      ).rejects.toThrow('Cannot save a managed file over its source.')
+      await expect(readFile(sourcePath, 'utf8')).resolves.toBe('source must survive')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps traversal-only suggested names inside Downloads', async () => {
+    const resolveManagedFilePath = vi.fn().mockResolvedValue('/managed/source-report.csv')
+    showSaveDialog.mockResolvedValue({ canceled: true })
+    registerFileSaveHandlers({
+      resolveManagedFilePath,
+      openManagedFile: vi.fn().mockResolvedValue({
+        copyTo: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined)
+      })
+    } as never)
+
+    await handlers.get('file:save-managed')!(
+      { sender: {} },
+      { source: 'upload', path: '/managed/source-report.csv', suggestedName: '..' }
+    )
+
+    expect(showSaveDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultPath: join(downloadsPath, 'source-report.csv')
+      })
+    )
+  })
+
+  it('rejects malformed requests before resolving or prompting', async () => {
+    const resolveManagedFilePath = vi.fn().mockResolvedValue('/managed/report.csv')
+    registerFileSaveHandlers({ resolveManagedFilePath } as never)
+
+    await expect(
+      handlers.get('file:save-managed')!(
+        { sender: {} },
+        {
+          source: 'workspace',
+          path: '/outside/report.csv',
+          suggestedName: 'report.csv'
+        }
+      )
+    ).rejects.toThrow('Invalid managed file save request.')
+
+    expect(resolveManagedFilePath).not.toHaveBeenCalled()
+    expect(showSaveDialog).not.toHaveBeenCalled()
+  })
+
+  it('returns without copying when the save dialog is canceled', async () => {
+    const resolveManagedFilePath = vi.fn().mockResolvedValue('/managed/report.csv')
+    const copyTo = vi.fn().mockResolvedValue(undefined)
+    const close = vi.fn().mockResolvedValue(undefined)
+    const openManagedFile = vi.fn().mockResolvedValue({
+      copyTo,
+      close
+    })
+    showSaveDialog.mockResolvedValue({ canceled: true })
+    registerFileSaveHandlers({ resolveManagedFilePath, openManagedFile } as never)
+
+    const result = await handlers.get('file:save-managed')!(
+      { sender: {} },
+      { source: 'artifact', path: '/managed/report.csv', suggestedName: 'report.csv' }
+    )
+
+    expect(result).toEqual({ saved: false })
+    expect(openManagedFile).toHaveBeenCalledWith('/managed/report.csv')
+    expect(copyTo).not.toHaveBeenCalled()
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the managed file handle when copying fails', async () => {
+    const resolveManagedFilePath = vi.fn().mockResolvedValue('/managed/report.csv')
+    const copyTo = vi.fn().mockRejectedValue(new Error('disk full'))
+    const close = vi.fn().mockResolvedValue(undefined)
+    showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: join(downloadsPath, 'report.csv')
+    })
+    registerFileSaveHandlers({
+      resolveManagedFilePath,
+      openManagedFile: vi.fn().mockResolvedValue({ copyTo, close })
+    } as never)
+
+    await expect(
+      handlers.get('file:save-managed')!(
+        { sender: {} },
+        { source: 'artifact', path: '/managed/report.csv', suggestedName: 'report.csv' }
+      )
+    ).rejects.toThrow('disk full')
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not prompt when managed path validation fails', async () => {
+    const resolveManagedFilePath = vi.fn().mockRejectedValue(new Error('outside artifact storage'))
+    registerFileSaveHandlers({ resolveManagedFilePath } as never)
+
+    await expect(
+      handlers.get('file:save-managed')!(
+        { sender: {} },
+        { source: 'artifact', path: '/outside/report.csv', suggestedName: 'report.csv' }
+      )
+    ).rejects.toThrow('outside artifact storage')
+
+    expect(showSaveDialog).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/file-save.ts
+++ b/src/main/file-save.ts
@@ -1,7 +1,75 @@
-import { BrowserWindow, dialog, ipcMain } from 'electron'
-import { writeFile } from 'fs/promises'
+import { BrowserWindow, app, dialog, ipcMain } from 'electron'
+import { constants } from 'node:fs'
+import { open, writeFile } from 'node:fs/promises'
+import { basename, join } from 'node:path'
+import { pipeline } from 'node:stream/promises'
 
-import type { SaveBlobFileRequest, SaveBlobFileResult } from '../shared/file-save'
+import type {
+  SaveBlobFileRequest,
+  SaveBlobFileResult,
+  SaveManagedFileRequest,
+  SaveManagedFileResult
+} from '../shared/file-save'
+
+type RegisterFileSaveHandlersOptions = {
+  resolveManagedFilePath?: (
+    source: SaveManagedFileRequest['source'],
+    request: { path: string }
+  ) => Promise<string>
+  openManagedFile?: (sourcePath: string) => Promise<ManagedFileHandle>
+}
+
+type ManagedFileHandle = {
+  copyTo: (destinationPath: string) => Promise<void>
+  close: () => Promise<void>
+}
+
+// IPC input is renderer-controlled; reject malformed sources and paths before any filesystem work.
+const assertSaveManagedFileRequest = (request: SaveManagedFileRequest): void => {
+  if (
+    typeof request !== 'object' ||
+    request === null ||
+    (request.source !== 'artifact' && request.source !== 'upload') ||
+    typeof request.path !== 'string' ||
+    request.path.trim().length === 0 ||
+    typeof request.suggestedName !== 'string'
+  ) {
+    throw new Error('Invalid managed file save request.')
+  }
+}
+
+// Holds the validated source inode across Save As so a pending artifact rename cannot change identity.
+const openManagedFile = async (sourcePath: string): Promise<ManagedFileHandle> => {
+  const sourceHandle = await open(sourcePath, 'r')
+
+  return {
+    copyTo: async (destinationPath) => {
+      // Open without truncation, then check and write through the same handle to prevent path swaps.
+      const destinationHandle = await open(
+        destinationPath,
+        constants.O_CREAT | constants.O_RDWR,
+        0o666
+      )
+
+      try {
+        const sourceStat = await sourceHandle.stat()
+        const destinationStat = await destinationHandle.stat()
+        if (destinationStat.dev === sourceStat.dev && destinationStat.ino === sourceStat.ino) {
+          throw new Error('Cannot save a managed file over its source.')
+        }
+
+        await destinationHandle.truncate(0)
+        await pipeline(
+          sourceHandle.createReadStream({ autoClose: false, start: 0 }),
+          destinationHandle.createWriteStream({ autoClose: true, start: 0 })
+        )
+      } finally {
+        await destinationHandle.close()
+      }
+    },
+    close: () => sourceHandle.close()
+  }
+}
 
 const extensionForMime = (mimeType: string): string | undefined => {
   switch (mimeType) {
@@ -22,7 +90,7 @@ const extensionForMime = (mimeType: string): string | undefined => {
   }
 }
 
-const registerFileSaveHandlers = (): void => {
+const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {}): void => {
   ipcMain.handle(
     'file:save-blob',
     async (event, request: SaveBlobFileRequest): Promise<SaveBlobFileResult> => {
@@ -46,6 +114,46 @@ const registerFileSaveHandlers = (): void => {
       return { saved: true, filePath }
     }
   )
+
+  // Managed-file export stays in main so large files never pass through renderer memory.
+  ipcMain.handle(
+    'file:save-managed',
+    async (event, request: SaveManagedFileRequest): Promise<SaveManagedFileResult> => {
+      if (!options.resolveManagedFilePath) {
+        throw new Error('Managed file resolver is not configured.')
+      }
+
+      assertSaveManagedFileRequest(request)
+      const sourcePath = await options.resolveManagedFilePath(request.source, {
+        path: request.path
+      })
+      const requestedBaseName = basename(request.suggestedName.trim())
+      const safeName =
+        requestedBaseName && requestedBaseName !== '.' && requestedBaseName !== '..'
+          ? requestedBaseName
+          : basename(sourcePath)
+      const dialogOptions = {
+        defaultPath: join(app.getPath('downloads'), safeName),
+        title: 'Save file'
+      }
+      const managedFile = await (options.openManagedFile ?? openManagedFile)(sourcePath)
+
+      try {
+        const parentWindow = BrowserWindow.fromWebContents(event.sender)
+        const { canceled, filePath } = parentWindow
+          ? await dialog.showSaveDialog(parentWindow, dialogOptions)
+          : await dialog.showSaveDialog(dialogOptions)
+
+        if (canceled || !filePath) return { saved: false }
+
+        await managedFile.copyTo(filePath)
+        return { saved: true, filePath }
+      } finally {
+        await managedFile.close()
+      }
+    }
+  )
 }
 
 export { registerFileSaveHandlers }
+export type { RegisterFileSaveHandlersOptions }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -144,12 +144,17 @@ const registerIpcHandlers = async ({ mainEntryPath }: IpcRegistrationOptions): P
   const artifactRunRegistry = new ArtifactRunRegistry()
   // Share one upload repository so composer staging, prompt finalization, and previews agree.
   const uploadRepository = createDefaultUploadRepository()
+  // One source-neutral resolver keeps previews and user-requested exports on identical trust checks.
+  const resolveManagedFilePath = (
+    source: 'artifact' | 'upload',
+    request: { path: string }
+  ): Promise<string> =>
+    source === 'artifact'
+      ? artifactRepository.resolveManagedFilePath(request)
+      : uploadRepository.resolveManagedUploadPath(request)
   // One registry owns short-lived capability URLs for both managed artifact repositories.
   const previewResources = new ManagedPreviewResources({
-    resolvePath: (source, request) =>
-      source === 'artifact'
-        ? artifactRepository.resolveManagedFilePath(request)
-        : uploadRepository.resolveManagedUploadPath(request)
+    resolvePath: resolveManagedFilePath
   })
   const notebookService = createDefaultNotebookRuntimeService()
 
@@ -212,7 +217,7 @@ const registerIpcHandlers = async ({ mainEntryPath }: IpcRegistrationOptions): P
     }
   )
 
-  registerFileSaveHandlers()
+  registerFileSaveHandlers({ resolveManagedFilePath })
   registerLogsIpcHandlers()
   registerGithubIpcHandlers()
   const updateService = registerUpdateIpcHandlers()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -20,7 +20,12 @@ import type {
   OpenArtifactFileRequest,
   ReadArtifactPreviewRequest
 } from '../shared/artifacts'
-import type { SaveBlobFileRequest, SaveBlobFileResult } from '../shared/file-save'
+import type {
+  SaveBlobFileRequest,
+  SaveBlobFileResult,
+  SaveManagedFileRequest,
+  SaveManagedFileResult
+} from '../shared/file-save'
 import type { OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
 import type {
   AppendNotebookCodeCellRequest,
@@ -123,6 +128,7 @@ type AcpListener<Payload> = (payload: Payload) => void
 
 interface OpenScienceAPI {
   saveBlobFile(request: SaveBlobFileRequest): Promise<SaveBlobFileResult>
+  saveManagedFile(request: SaveManagedFileRequest): Promise<SaveManagedFileResult>
   // Host platform (process.platform), e.g. 'win32' | 'darwin' | 'linux'.
   platform: string
   getRuntimeVersions(): {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -22,7 +22,12 @@ import type {
   OpenArtifactFileRequest,
   ReadArtifactPreviewRequest
 } from '../shared/artifacts'
-import type { SaveBlobFileRequest, SaveBlobFileResult } from '../shared/file-save'
+import type {
+  SaveBlobFileRequest,
+  SaveBlobFileResult,
+  SaveManagedFileRequest,
+  SaveManagedFileResult
+} from '../shared/file-save'
 import type { OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
 import type {
   AppendNotebookCodeCellRequest,
@@ -137,6 +142,7 @@ const onIpcMessage = <Payload>(channel: string, listener: AcpListener<Payload>):
 // Custom APIs for renderer
 type OpenScienceAPI = {
   saveBlobFile: (request: SaveBlobFileRequest) => Promise<SaveBlobFileResult>
+  saveManagedFile: (request: SaveManagedFileRequest) => Promise<SaveManagedFileResult>
   // Host platform (process.platform), e.g. 'win32' | 'darwin' | 'linux'. Lets the renderer pick
   // platform-correct copy such as the claude install command shown in the onboarding/settings card.
   platform: string
@@ -324,6 +330,8 @@ type OpenScienceAPI = {
 const api: OpenScienceAPI = {
   saveBlobFile: (request) =>
     ipcRenderer.invoke('file:save-blob', request) as Promise<SaveBlobFileResult>,
+  saveManagedFile: (request) =>
+    ipcRenderer.invoke('file:save-managed', request) as Promise<SaveManagedFileResult>,
   platform: process.platform,
   getRuntimeVersions: () => ({
     electron: process.versions.electron,

--- a/src/renderer/src/pages/workspace/ManagedFileDownloadButton.test.tsx
+++ b/src/renderer/src/pages/workspace/ManagedFileDownloadButton.test.tsx
@@ -1,0 +1,247 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
+
+describe('ManagedFileDownloadButton', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    container.remove()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  const renderButton = async (): Promise<HTMLButtonElement> => {
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <ManagedFileDownloadButton
+          source="artifact"
+          path="/managed/report.csv"
+          suggestedName="report.csv"
+        />
+      )
+    })
+
+    return container.querySelector('button')!
+  }
+
+  it('disables duplicate saves while the first request is pending', async () => {
+    let resolveSave: ((result: { saved: boolean }) => void) | undefined
+    const saveManagedFile = vi.fn(
+      () =>
+        new Promise<{ saved: boolean }>((resolve) => {
+          resolveSave = resolve
+        })
+    )
+    window.api = { saveManagedFile } as unknown as Window['api']
+    const button = await renderButton()
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(saveManagedFile).toHaveBeenCalledTimes(1)
+    expect(button.disabled).toBe(true)
+    expect(button.getAttribute('aria-label')).toBe('Saving report.csv')
+
+    await act(async () => resolveSave?.({ saved: false }))
+  })
+
+  it('uses the same container hover background as the close button', async () => {
+    window.api = {
+      saveManagedFile: vi.fn().mockResolvedValue({ saved: false })
+    } as unknown as Window['api']
+
+    const button = await renderButton()
+    const classNames = button.className.split(/\s+/)
+
+    expect(classNames).toContain('hover:bg-muted')
+    expect(classNames).not.toContain('hover:bg-bg-000')
+  })
+
+  it('does not carry an in-flight result to a different file', async () => {
+    let resolveSave: ((result: { saved: boolean }) => void) | undefined
+    const saveManagedFile = vi.fn(
+      () =>
+        new Promise<{ saved: boolean }>((resolve) => {
+          resolveSave = resolve
+        })
+    )
+    window.api = { saveManagedFile } as unknown as Window['api']
+    const button = await renderButton()
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      root.render(
+        <ManagedFileDownloadButton
+          source="upload"
+          path="/managed/notes.txt"
+          suggestedName="notes.txt"
+        />
+      )
+    })
+
+    const notesButton = container.querySelector<HTMLButtonElement>('button')!
+    expect(notesButton.disabled).toBe(false)
+    expect(notesButton.getAttribute('aria-label')).toBe('Download notes.txt')
+
+    await act(async () => resolveSave?.({ saved: true }))
+
+    expect(container.querySelector('button')?.getAttribute('aria-label')).toBe('Download notes.txt')
+    expect(container.querySelector('[role="status"]')?.textContent).toBe('')
+  })
+
+  it('resets the state when switching away and back to the same file', async () => {
+    vi.useFakeTimers()
+    window.api = {
+      saveManagedFile: vi.fn().mockResolvedValue({ saved: true })
+    } as unknown as Window['api']
+    const button = await renderButton()
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+    expect(button.getAttribute('aria-label')).toBe('Saved report.csv')
+
+    await act(async () => {
+      root.render(
+        <ManagedFileDownloadButton
+          source="upload"
+          path="/managed/notes.txt"
+          suggestedName="notes.txt"
+        />
+      )
+      await Promise.resolve()
+    })
+    await act(async () => {
+      root.render(
+        <ManagedFileDownloadButton
+          source="artifact"
+          path="/managed/report.csv"
+          suggestedName="report.csv"
+        />
+      )
+    })
+
+    const reportButton = container.querySelector<HTMLButtonElement>('button')!
+    expect(reportButton.disabled).toBe(false)
+    expect(reportButton.getAttribute('aria-label')).toBe('Download report.csv')
+  })
+
+  it('keeps unavailable and saving states discoverable through the tooltip trigger', async () => {
+    window.api = {
+      saveManagedFile: vi.fn(() => new Promise<{ saved: boolean }>(() => undefined))
+    } as unknown as Window['api']
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <ManagedFileDownloadButton
+          source="artifact"
+          path="/managed/missing.csv"
+          suggestedName="missing.csv"
+          disabled
+        />
+      )
+    })
+
+    const unavailableButton = container.querySelector('button')
+    expect(unavailableButton?.closest('[data-testid="download-tooltip-trigger"]')).not.toBeNull()
+    expect(
+      unavailableButton
+        ?.closest('[data-testid="download-tooltip-trigger"]')
+        ?.getAttribute('tabindex')
+    ).toBe('0')
+
+    await act(async () => {
+      root.render(
+        <ManagedFileDownloadButton
+          source="artifact"
+          path="/managed/report.csv"
+          suggestedName="report.csv"
+        />
+      )
+    })
+    const downloadButton = container.querySelector<HTMLButtonElement>('button')!
+    await act(async () => {
+      downloadButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(
+      container
+        .querySelector('button')
+        ?.closest('[data-testid="download-tooltip-trigger"]')
+        ?.getAttribute('tabindex')
+    ).toBe('0')
+  })
+
+  it('announces a successful save before restoring the download action', async () => {
+    vi.useFakeTimers()
+    window.api = {
+      saveManagedFile: vi.fn().mockResolvedValue({ saved: true })
+    } as unknown as Window['api']
+    const button = await renderButton()
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(button.getAttribute('aria-label')).toBe('Saved report.csv')
+    expect(container.querySelector('[role="status"]')?.textContent).toBe('Saved report.csv')
+    expect(button.className).toContain('text-emerald-600')
+    expect(button.className).toContain('hover:bg-muted')
+
+    await act(async () => vi.advanceTimersByTime(1600))
+    expect(button.getAttribute('aria-label')).toBe('Download report.csv')
+  })
+
+  it('keeps a failed save visible and allows retrying', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const saveManagedFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('disk full'))
+      .mockResolvedValueOnce({ saved: false })
+    window.api = { saveManagedFile } as unknown as Window['api']
+    const button = await renderButton()
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(button.getAttribute('aria-label')).toBe('Download failed for report.csv')
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(saveManagedFile).toHaveBeenCalledTimes(2)
+    expect(button.getAttribute('aria-label')).toBe('Download report.csv')
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to download managed file: report.csv',
+      expect.any(Error)
+    )
+  })
+})

--- a/src/renderer/src/pages/workspace/ManagedFileDownloadButton.tsx
+++ b/src/renderer/src/pages/workspace/ManagedFileDownloadButton.tsx
@@ -1,0 +1,153 @@
+import { Check, CircleAlert, Download, LoaderCircle } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import type { SaveManagedFileRequest } from '../../../../shared/file-save'
+
+type ManagedFileDownloadButtonProps = SaveManagedFileRequest & {
+  className?: string
+  disabled?: boolean
+  revealOnParentHover?: boolean
+  wrapperClassName?: string
+}
+
+type DownloadStatus = 'idle' | 'saving' | 'saved' | 'error'
+
+// Owns one file identity's transient save state; the wrapper remounts it when that identity changes.
+const ManagedFileDownloadButtonState = ({
+  source,
+  path,
+  suggestedName,
+  className,
+  disabled = false,
+  revealOnParentHover = false,
+  wrapperClassName
+}: ManagedFileDownloadButtonProps): React.JSX.Element => {
+  const [status, setStatus] = useState<DownloadStatus>('idle')
+  const activeSaveRef = useRef<symbol | undefined>(undefined)
+  const resetTimerRef = useRef<number | undefined>(undefined)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (resetTimerRef.current !== undefined) window.clearTimeout(resetTimerRef.current)
+    }
+  }, [])
+
+  const downloadFile = (): void => {
+    if (activeSaveRef.current) return
+
+    const attempt = Symbol('managed-file-save')
+    activeSaveRef.current = attempt
+    if (resetTimerRef.current !== undefined) window.clearTimeout(resetTimerRef.current)
+    setStatus('saving')
+    void window.api
+      .saveManagedFile({ source, path, suggestedName })
+      .then((result) => {
+        if (!mountedRef.current || activeSaveRef.current !== attempt) return
+
+        if (!result.saved) {
+          setStatus('idle')
+          return
+        }
+
+        setStatus('saved')
+        resetTimerRef.current = window.setTimeout(() => {
+          resetTimerRef.current = undefined
+          if (mountedRef.current) setStatus('idle')
+        }, 1600)
+      })
+      .catch((error) => {
+        if (mountedRef.current && activeSaveRef.current === attempt) {
+          console.error(`Failed to download managed file: ${suggestedName}`, error)
+          setStatus('error')
+        }
+      })
+      .finally(() => {
+        if (activeSaveRef.current === attempt) activeSaveRef.current = undefined
+      })
+  }
+
+  const label =
+    status === 'saving'
+      ? `Saving ${suggestedName}`
+      : status === 'saved'
+        ? `Saved ${suggestedName}`
+        : status === 'error'
+          ? `Download failed for ${suggestedName}`
+          : `Download ${suggestedName}`
+  const tooltip =
+    status === 'saving'
+      ? 'Saving'
+      : status === 'saved'
+        ? 'Saved'
+        : status === 'error'
+          ? 'Download failed. Try again'
+          : disabled
+            ? 'File unavailable'
+            : 'Download'
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            data-testid="download-tooltip-trigger"
+            className={cn('group/download inline-flex', wrapperClassName)}
+            tabIndex={disabled || status === 'saving' ? 0 : undefined}
+            aria-label={disabled || status === 'saving' ? tooltip : undefined}
+          >
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className={cn(
+                'bg-bg-000/90 shadow-sm',
+                status === 'saved'
+                  ? 'text-emerald-600 hover:bg-muted hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-400'
+                  : 'text-text-100 hover:bg-muted hover:text-text-000',
+                revealOnParentHover &&
+                  (status === 'idle'
+                    ? 'opacity-0 group-hover:opacity-100 group-focus-visible/download:opacity-100 focus-visible:opacity-100'
+                    : 'opacity-100'),
+                className
+              )}
+              aria-label={label}
+              disabled={disabled || status === 'saving'}
+              onClick={downloadFile}
+            >
+              {status === 'saving' ? (
+                <LoaderCircle
+                  className="animate-spin motion-reduce:animate-none"
+                  aria-hidden="true"
+                />
+              ) : status === 'saved' ? (
+                <Check aria-hidden="true" />
+              ) : status === 'error' ? (
+                <CircleAlert aria-hidden="true" />
+              ) : (
+                <Download aria-hidden="true" />
+              )}
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+      <span className="sr-only" role="status" aria-live="polite">
+        {status === 'idle' ? '' : label}
+      </span>
+    </TooltipProvider>
+  )
+}
+
+// Keeps managed-file export behind one source-neutral renderer control.
+const ManagedFileDownloadButton = (props: ManagedFileDownloadButtonProps): React.JSX.Element => {
+  const requestKey = JSON.stringify([props.source, props.path, props.suggestedName])
+  return <ManagedFileDownloadButtonState key={requestKey} {...props} />
+}
+
+export { ManagedFileDownloadButton }

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -58,6 +58,9 @@ describe('PreviewPanel', () => {
 
   beforeEach(() => {
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    window.api = {
+      saveManagedFile: vi.fn().mockResolvedValue({ saved: true })
+    } as unknown as Window['api']
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -106,9 +109,126 @@ describe('PreviewPanel', () => {
 
     const tabs = container.querySelectorAll('[title]')
     expect(tabs.length).toBe(2)
+    const previewTabs = container.querySelectorAll<HTMLElement>('[role="tab"]')
+    for (const tab of previewTabs) {
+      const panelId = tab.getAttribute('aria-controls')
+      expect(panelId).not.toBeNull()
+      expect(container.querySelector(`#${panelId}`)?.getAttribute('role')).toBe('tabpanel')
+    }
 
     const activeContent = container.querySelector('[data-testid="file-content"]')
     expect(activeContent?.textContent).toBe('file:image:artifact:file-1.png:/workspace/file-1.png')
+  })
+
+  it('wraps an active file in a compact card with middle-ellipsis title and header actions', async () => {
+    const name = 'global_climate_anomaly_analysis_1850-2025.csv'
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(
+      createFileItem({
+        title: name,
+        name,
+        path: `/workspace/${name}`,
+        format: 'csv'
+      })
+    )
+
+    await renderPanel()
+
+    const card = container.querySelector('[data-testid="preview-card"]')
+    const header = card?.querySelector('[data-testid="preview-card-header"]')
+    const titleTail = header?.querySelector('[data-testid="preview-title-tail"]')
+    const tabBar = container.querySelector('[aria-label="Open previews"]')
+
+    expect(card?.className).toContain('rounded-md')
+    expect(card?.className).toContain('shadow-card')
+    expect(card?.className).not.toContain('border-[0.5px]')
+    expect(card?.className).not.toContain('border-border-300/35')
+    expect(card?.parentElement?.className).toContain('pl-2')
+    expect(card?.parentElement?.className).toContain('pr-1')
+    expect(card?.parentElement?.className).not.toContain('px-2')
+    expect(header?.className).toContain('h-8')
+    expect(titleTail?.textContent?.endsWith('.csv')).toBe(true)
+    expect(titleTail?.className).toContain('max-w-')
+    expect(titleTail?.className).toContain('overflow-hidden')
+    expect(header?.querySelector(`[aria-label="Download ${name}"]`)).not.toBeNull()
+    expect(header?.querySelector(`[aria-label="Close preview of ${name}"]`)).not.toBeNull()
+    expect(tabBar?.getAttribute('role')).toBe('tablist')
+    expect(tabBar?.querySelector('[role="tab"][aria-selected="true"]')).not.toBeNull()
+    expect(container.querySelector('[role="tabpanel"]')).not.toBeNull()
+    expect(tabBar?.querySelector(`[aria-label="Close preview of ${name}"]`)).not.toBeNull()
+  })
+
+  it('supports keyboard navigation between preview tabs', async () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+    usePreviewWorkbenchStore.getState().upsertItem(
+      createFileItem({
+        id: 'item-2',
+        title: 'file-2.pdf',
+        format: 'pdf',
+        path: '/workspace/file-2.pdf',
+        name: 'file-2.pdf'
+      })
+    )
+    await renderPanel()
+
+    const firstTab = container.querySelector<HTMLButtonElement>('[role="tab"]')
+    await act(async () => {
+      firstTab?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+    })
+
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-2')
+    expect(container.querySelector('[role="tab"][aria-selected="true"]')?.textContent).toContain(
+      'file-2.pdf'
+    )
+  })
+
+  it('leaves vertical arrows available to the page for a horizontal tab list', async () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+    usePreviewWorkbenchStore.getState().upsertItem(
+      createFileItem({
+        id: 'item-2',
+        title: 'file-2.pdf',
+        format: 'pdf',
+        path: '/workspace/file-2.pdf',
+        name: 'file-2.pdf'
+      })
+    )
+    await renderPanel()
+
+    const firstTab = container.querySelector<HTMLButtonElement>('[role="tab"]')
+    await act(async () => {
+      firstTab?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    })
+
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-1')
+  })
+
+  it('keeps tab close controls out of the tab order and supports Delete on the tab', async () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+    usePreviewWorkbenchStore.getState().upsertItem(
+      createFileItem({
+        id: 'item-2',
+        title: 'file-2.pdf',
+        format: 'pdf',
+        path: '/workspace/file-2.pdf',
+        name: 'file-2.pdf'
+      })
+    )
+    await renderPanel()
+
+    const closeButtons = container.querySelectorAll<HTMLButtonElement>(
+      '[aria-label="Open previews"] [aria-label^="Close preview of "]'
+    )
+    expect(Array.from(closeButtons).every((button) => button.tabIndex === -1)).toBe(true)
+
+    const firstTab = container.querySelector<HTMLButtonElement>('[role="tab"]')!
+    firstTab.focus()
+    await act(async () => {
+      firstTab.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }))
+    })
+
+    expect(usePreviewWorkbenchStore.getState().items.map((item) => item.id)).toEqual(['item-2'])
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-2')
+    expect(document.activeElement?.textContent).toContain('file-2.pdf')
   })
 
   it('passes upload file sources through to the active preview content', async () => {
@@ -127,6 +247,19 @@ describe('PreviewPanel', () => {
     expect(container.querySelector('[data-testid="file-content"]')?.textContent).toBe(
       'file:image:upload:upload.png:/Users/example/.open-science/uploads/default-project/session-1/upload.png'
     )
+
+    const downloadButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Download upload.png"]'
+    )
+    await act(async () => {
+      downloadButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+    expect(window.api.saveManagedFile).toHaveBeenCalledWith({
+      source: 'upload',
+      path: '/Users/example/.open-science/uploads/default-project/session-1/upload.png',
+      suggestedName: 'upload.png'
+    })
   })
 
   it('routes tool preview items to PreviewToolContent', async () => {
@@ -137,6 +270,14 @@ describe('PreviewPanel', () => {
     expect(container.querySelector('[data-testid="tool-content"]')?.textContent).toBe(
       'tool:notebook'
     )
+    expect(container.querySelector('[aria-label^="Download "]')).toBeNull()
+    expect(container.querySelector('[aria-label="Close preview of Tool preview"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="preview-card"]')).toBeNull()
+    expect(container.querySelector('[data-testid="preview-card-header"]')).toBeNull()
+    const toolTab = container.querySelector<HTMLElement>('[role="tab"]')
+    expect(
+      container.querySelector(`#${toolTab?.getAttribute('aria-controls')}`)?.getAttribute('role')
+    ).toBe('tabpanel')
   })
 
   it('renders the Files project tool tab when it is active', async () => {
@@ -152,6 +293,7 @@ describe('PreviewPanel', () => {
 
     expect(container.querySelector('button[title="Files"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="tool-content"]')?.textContent).toBe('tool:files')
+    expect(container.querySelector('[data-testid="preview-card"]')).toBeNull()
   })
 
   it('activates a different tab on click and swaps the rendered content', async () => {
@@ -176,6 +318,33 @@ describe('PreviewPanel', () => {
     expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-2')
     expect(container.querySelector('[data-testid="file-content"]')?.textContent).toBe(
       'file:pdf:artifact:file-2.pdf:/workspace/file-2.pdf'
+    )
+  })
+
+  it('closes an inactive tab without activating or mounting its content', async () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+    usePreviewWorkbenchStore.getState().upsertItem(
+      createFileItem({
+        id: 'item-2',
+        title: 'file-2.pdf',
+        format: 'pdf',
+        path: '/workspace/file-2.pdf',
+        name: 'file-2.pdf'
+      })
+    )
+    await renderPanel()
+
+    const closeInactiveTab = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Open previews"] [aria-label="Close preview of file-2.pdf"]'
+    )
+    await act(async () => {
+      closeInactiveTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-1')
+    expect(usePreviewWorkbenchStore.getState().items.map((item) => item.id)).toEqual(['item-1'])
+    expect(container.querySelector('[data-testid="file-content"]')?.textContent).toContain(
+      'file-1.png'
     )
   })
 

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -1,11 +1,15 @@
 import { X } from 'lucide-react'
+import { useRef } from 'react'
 import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
 
+import { Button } from '@/components/ui/button'
 import { ResizablePanel } from '@/components/ui/resizable'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import type { PreviewItem } from '@/stores/preview-workbench-store'
+import type { PreviewFileItem, PreviewItem } from '@/stores/preview-workbench-store'
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 
+import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
 import { PreviewFileContent } from './previews/PreviewFileContent'
 import { PreviewToolContent } from './previews/PreviewToolContent'
 
@@ -15,8 +19,6 @@ type PreviewPanelProps = {
   minSize: string
   onResize: (panelSize: PanelSize, previousPanelSize: PanelSize | undefined) => void
 }
-
-type PreviewTab = { id: string; title: string }
 
 // Renders the active tab's content, or an empty state when nothing is previewed yet.
 const PreviewActiveContent = ({
@@ -38,47 +40,84 @@ const PreviewActiveContent = ({
 }
 
 const previewTabClassName =
-  'group flex h-8 max-w-[160px] shrink-0 items-center gap-1 rounded-md px-2 text-[12px] transition-colors'
+  'group flex h-8 max-w-[160px] shrink-0 items-center gap-1 rounded-md pl-2 pr-1 text-[12px] transition-colors'
 
-// Renders one open-preview tab and its close affordance.
+// Keeps the identifying tail and extension visible while the flexible prefix owns the ellipsis.
+const MiddleEllipsisFileName = ({ name }: { name: string }): React.JSX.Element => {
+  const extensionIndex = name.lastIndexOf('.')
+  const extensionLength = extensionIndex > 0 ? name.length - extensionIndex : 0
+  const trailingLength = Math.min(name.length, Math.max(extensionLength + 10, 18))
+  const splitIndex = Math.max(1, name.length - trailingLength)
+
+  return (
+    <span className="flex min-w-0 max-w-full flex-1 items-center overflow-hidden whitespace-nowrap">
+      <span className="min-w-0 truncate">{name.slice(0, splitIndex)}</span>
+      <span
+        data-testid="preview-title-tail"
+        className="min-w-0 max-w-[65%] shrink overflow-hidden text-ellipsis [direction:rtl] [unicode-bidi:plaintext]"
+      >
+        {name.slice(splitIndex)}
+      </span>
+    </span>
+  )
+}
+
+const getPreviewTabId = (itemId: string): string => `preview-tab-${encodeURIComponent(itemId)}`
+const getPreviewPanelId = (itemId: string): string => `preview-panel-${encodeURIComponent(itemId)}`
+
+// One tab owns activation/keyboard behavior while its sibling close button preserves quick removal.
 const PreviewTab = ({
   tab,
   isActive,
+  tabRef,
   onActivate,
-  onClose
+  onClose,
+  onKeyDown
 }: {
-  tab: PreviewTab
+  tab: PreviewItem
   isActive: boolean
+  tabRef: (element: HTMLButtonElement | null) => void
   onActivate: (id: string) => void
   onClose: (id: string) => void
+  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void
 }): React.JSX.Element => (
   <div
+    role="presentation"
     className={cn(
       previewTabClassName,
       isActive ? 'bg-bg-300 text-text-000' : 'text-text-300 hover:bg-bg-200 hover:text-text-100'
     )}
   >
     <button
+      ref={tabRef}
       type="button"
-      className="min-w-0 flex-1 truncate text-left"
+      role="tab"
+      id={getPreviewTabId(tab.id)}
+      aria-controls={getPreviewPanelId(tab.id)}
+      aria-selected={isActive}
+      tabIndex={isActive ? 0 : -1}
+      className="flex min-w-0 flex-1 self-stretch items-center text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50"
       onClick={() => onActivate(tab.id)}
+      onKeyDown={onKeyDown}
       title={tab.title}
     >
-      {tab.title}
+      {tab.type === 'file' ? (
+        <MiddleEllipsisFileName name={tab.name} />
+      ) : (
+        <span className="min-w-0 truncate">{tab.title}</span>
+      )}
     </button>
     <button
       type="button"
+      tabIndex={-1}
       className={cn(
-        'shrink-0 rounded-sm p-0.5 hover:bg-bg-000/60',
+        'shrink-0 rounded-sm p-0.5 outline-none hover:bg-bg-000/60 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/50',
         isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
       )}
-      onClick={(event) => {
-        event.stopPropagation()
-        onClose(tab.id)
-      }}
+      onClick={() => onClose(tab.id)}
       aria-label={`Close preview of ${tab.title}`}
     >
-      <X className="size-3.5" aria-hidden />
+      <X className="size-3.5" aria-hidden="true" />
     </button>
   </div>
 )
@@ -90,22 +129,116 @@ const PreviewTabBar = ({
   onActivate,
   onClose
 }: {
-  tabs: PreviewTab[]
+  tabs: PreviewItem[]
   activeItemId: string | undefined
   onActivate: (id: string) => void
   onClose: (id: string) => void
+}): React.JSX.Element => {
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
+
+  const moveToTab = (index: number): void => {
+    const tab = tabs[index]
+    if (!tab) return
+
+    onActivate(tab.id)
+    tabRefs.current[index]?.focus()
+  }
+
+  const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number): void => {
+    const lastIndex = tabs.length - 1
+    let nextIndex: number | undefined
+
+    if (event.key === 'Delete' || event.key === 'Backspace') {
+      const tab = tabs[index]
+      if (!tab) return
+
+      event.preventDefault()
+      const fallbackIndex = index < lastIndex ? index + 1 : index - 1
+      if (fallbackIndex >= 0) moveToTab(fallbackIndex)
+      onClose(tab.id)
+      return
+    }
+
+    if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length
+    if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length
+    if (event.key === 'Home') nextIndex = 0
+    if (event.key === 'End') nextIndex = lastIndex
+    if (nextIndex === undefined) return
+
+    event.preventDefault()
+    moveToTab(nextIndex)
+  }
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Open previews"
+      aria-orientation="horizontal"
+      className="flex shrink-0 items-center gap-1 overflow-x-auto px-2 pb-2"
+    >
+      {tabs.map((tab, index) => (
+        <PreviewTab
+          key={tab.id}
+          tab={tab}
+          isActive={tab.id === activeItemId}
+          tabRef={(element) => {
+            tabRefs.current[index] = element
+          }}
+          onActivate={onActivate}
+          onClose={onClose}
+          onKeyDown={(event) => handleTabKeyDown(event, index)}
+        />
+      ))}
+    </div>
+  )
+}
+
+// The compact card header centralizes the active preview's identity and file-level actions.
+const PreviewCardHeader = ({
+  item,
+  onClose
+}: {
+  item: PreviewFileItem
+  onClose: (id: string) => void
 }): React.JSX.Element => (
-  <div className="flex shrink-0 items-center gap-1 overflow-x-auto px-2 pb-2">
-    {tabs.map((tab) => (
-      <PreviewTab
-        key={tab.id}
-        tab={tab}
-        isActive={tab.id === activeItemId}
-        onActivate={onActivate}
-        onClose={onClose}
-      />
-    ))}
-  </div>
+  <header
+    data-testid="preview-card-header"
+    className="flex h-8 shrink-0 items-center gap-1 border-b border-border-300/50 px-2"
+  >
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="min-w-0 flex-1 text-[12px] font-medium text-text-000">
+            <MiddleEllipsisFileName name={item.name} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{item.title}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+    <ManagedFileDownloadButton
+      source={item.source ?? 'artifact'}
+      path={item.path}
+      suggestedName={item.name}
+      className="bg-transparent shadow-none"
+    />
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="text-text-100 hover:text-text-000"
+            aria-label={`Close preview of ${item.title}`}
+            onClick={() => onClose(item.id)}
+          >
+            <X aria-hidden="true" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Close preview</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  </header>
 )
 
 // Right-side workbench: a tab strip over every previewed file, plus content for the active tab.
@@ -162,10 +295,50 @@ const PreviewPanel = ({
             onClose={removeItem}
           />
         ) : null}
-        <div className="flex-1 overflow-y-auto bg-bg-10">
-          {!activeItem || panelState === 'open' ? (
-            <PreviewActiveContent key={activeContentKey} item={activeItem} />
-          ) : null}
+        <div className={cn('min-h-0 flex-1', activeItem?.type === 'file' && 'pl-2 pr-1')}>
+          {!activeItem ? <PreviewActiveContent key={activeContentKey} item={activeItem} /> : null}
+          {items.map((item) => {
+            const isActivePanel = item.id === activeItemId && panelState === 'open'
+            if (!isActivePanel) {
+              return (
+                <section
+                  key={item.id}
+                  role="tabpanel"
+                  id={getPreviewPanelId(item.id)}
+                  aria-labelledby={getPreviewTabId(item.id)}
+                  hidden
+                />
+              )
+            }
+
+            return item.type === 'file' ? (
+              <section
+                key={item.id}
+                data-testid="preview-card"
+                role="tabpanel"
+                id={getPreviewPanelId(item.id)}
+                aria-labelledby={getPreviewTabId(item.id)}
+                tabIndex={0}
+                className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-md bg-bg-000 shadow-card"
+              >
+                <PreviewCardHeader item={item} onClose={removeItem} />
+                <div className="min-h-0 flex-1 overflow-y-auto bg-bg-000">
+                  <PreviewActiveContent key={activeContentKey} item={item} />
+                </div>
+              </section>
+            ) : (
+              <section
+                key={item.id}
+                role="tabpanel"
+                id={getPreviewPanelId(item.id)}
+                aria-labelledby={getPreviewTabId(item.id)}
+                tabIndex={0}
+                className="h-full min-h-0 w-full overflow-y-auto"
+              >
+                <PreviewActiveContent key={activeContentKey} item={item} />
+              </section>
+            )
+          })}
         </div>
       </aside>
     </ResizablePanel>

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -141,6 +141,7 @@ describe('ProjectFilesView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     window.api = {
+      saveManagedFile: vi.fn().mockResolvedValue({ saved: true }),
       previewResources: {
         acquire: vi.fn(({ path }: { path: string }) =>
           Promise.resolve({
@@ -222,6 +223,72 @@ describe('ProjectFilesView', () => {
     expect(container.textContent).toContain('iso621_bridg...inase.fasta')
     expect(container.querySelector('[title="iso621_bridge_recombinase.fasta"]')).not.toBeNull()
     expect(container.textContent).not.toContain('Hidden session title')
+    expect(
+      container.querySelector('[data-testid="project-file-preview"]')?.parentElement?.parentElement
+        ?.className
+    ).toContain('focus-within:ring')
+  })
+
+  it('downloads an uploaded file without opening its preview', async () => {
+    const upload = createUpload()
+    await renderView([
+      createSession({
+        messages: [createMessage({ uploads: [upload] })]
+      })
+    ])
+
+    const downloadButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Download user upload.png"]'
+    )
+    expect(downloadButton).not.toBeNull()
+    expect(
+      downloadButton?.closest('[data-testid="download-tooltip-trigger"]')?.className
+    ).toContain('absolute')
+
+    await act(async () => {
+      downloadButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(window.api.saveManagedFile).toHaveBeenCalledWith({
+      source: 'upload',
+      path: upload.path,
+      suggestedName: 'user upload.png'
+    })
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBeUndefined()
+  })
+
+  it('downloads a generated file through the artifact source', async () => {
+    await renderView([
+      createSession({
+        artifacts: [
+          {
+            id: 'artifact-download',
+            kind: 'managed-file',
+            path: '/workspace/report.pdf',
+            fileUrl: 'file:///workspace/report.pdf',
+            name: 'report.pdf',
+            mimeType: 'application/pdf',
+            size: 4096,
+            mtimeMs: 1710000002000
+          }
+        ]
+      })
+    ])
+
+    const downloadButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Download report.pdf"]'
+    )
+    await act(async () => {
+      downloadButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(window.api.saveManagedFile).toHaveBeenCalledWith({
+      source: 'artifact',
+      path: '/workspace/report.pdf',
+      suggestedName: 'report.pdf'
+    })
   })
 
   it('opens a filter menu without This computer entries', async () => {

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -29,6 +29,7 @@ import {
   createPreviewFileItemFromUpload
 } from './preview-file-item'
 import type { MessageArtifact } from './preview-file-item'
+import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
 import { getPreviewThumbnailReadEncoding } from './preview-support'
 import { getPreviewFileReader } from './previews/preview-file-reader'
 import { useNearViewport } from './previews/useNearViewport'
@@ -244,52 +245,62 @@ const FileTile = ({
   })
 
   return (
-    <button
-      ref={setTileElement}
-      type="button"
-      className="flex h-[128px] min-w-0 flex-col overflow-hidden rounded-lg border border-border-300/50 bg-bg-000 text-left shadow-sm hover:border-border-200 hover:bg-bg-100"
-      aria-label={previewLabel}
-      title={name}
-      onClick={onPreview}
-    >
-      <span
-        data-testid="project-file-preview"
-        className="relative h-[82px] w-full overflow-hidden bg-bg-200"
+    <div className="group relative h-[128px] min-w-0 overflow-hidden rounded-lg border border-border-300/50 bg-bg-000 shadow-sm hover:border-border-200 hover:bg-bg-100 focus-within:ring-2 focus-within:ring-ring/50 focus-within:ring-inset">
+      <button
+        ref={setTileElement}
+        type="button"
+        className="flex h-[128px] w-full min-w-0 flex-col text-left"
+        aria-label={previewLabel}
+        title={name}
+        onClick={onPreview}
       >
-        <span className={cn('block size-full', missing && 'opacity-40')}>
-          {/* Unmount the reader outside the overscan window so tile previews release local data. */}
-          {isNearViewport ? (
-            <VisibleProjectFilePreview artifact={previewArtifact} target={target} />
-          ) : (
-            <ArtifactPreview artifact={previewArtifact} source={source} isVisible={false} />
-          )}
-        </span>
-        {missing ? (
-          <span className="absolute left-1.5 top-1.5 rounded bg-text-000/75 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-bg-000 shadow-sm">
-            {FILE_MISSING_TAG}
+        <span
+          data-testid="project-file-preview"
+          className="relative h-[82px] w-full overflow-hidden bg-bg-200"
+        >
+          <span className={cn('block size-full', missing && 'opacity-40')}>
+            {/* Unmount the reader outside the overscan window so tile previews release local data. */}
+            {isNearViewport ? (
+              <VisibleProjectFilePreview artifact={previewArtifact} target={target} />
+            ) : (
+              <ArtifactPreview artifact={previewArtifact} source={source} isVisible={false} />
+            )}
           </span>
-        ) : null}
-      </span>
-      <span
-        data-testid="project-file-meta"
-        className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 px-2 py-1.5"
-      >
-        <span className="block min-w-0 truncate text-[11px] leading-5 text-text-000">
-          {displayName}
+          {missing ? (
+            <span className="absolute left-1.5 top-1.5 rounded bg-text-000/75 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-bg-000 shadow-sm">
+              {FILE_MISSING_TAG}
+            </span>
+          ) : null}
         </span>
-        {sizeLabel || relativeTimeLabel ? (
-          <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0 text-[10px] leading-3 text-text-300">
-            {sizeLabel ? <span className="shrink-0">{sizeLabel}</span> : null}
-            {sizeLabel && relativeTimeLabel ? (
-              <span className="shrink-0" aria-hidden="true">
-                ·
-              </span>
-            ) : null}
-            {relativeTimeLabel ? <span className="min-w-0">{relativeTimeLabel}</span> : null}
+        <span
+          data-testid="project-file-meta"
+          className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 px-2 py-1.5"
+        >
+          <span className="block min-w-0 truncate text-[11px] leading-5 text-text-000">
+            {displayName}
           </span>
-        ) : null}
-      </span>
-    </button>
+          {sizeLabel || relativeTimeLabel ? (
+            <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0 text-[10px] leading-3 text-text-300">
+              {sizeLabel ? <span className="shrink-0">{sizeLabel}</span> : null}
+              {sizeLabel && relativeTimeLabel ? (
+                <span className="shrink-0" aria-hidden="true">
+                  ·
+                </span>
+              ) : null}
+              {relativeTimeLabel ? <span className="min-w-0">{relativeTimeLabel}</span> : null}
+            </span>
+          ) : null}
+        </span>
+      </button>
+      <ManagedFileDownloadButton
+        source={source}
+        path={previewArtifact.path}
+        suggestedName={name}
+        disabled={missing}
+        revealOnParentHover
+        wrapperClassName="absolute right-1.5 top-1.5 z-10"
+      />
+    </div>
   )
 }
 

--- a/src/shared/file-save.ts
+++ b/src/shared/file-save.ts
@@ -10,4 +10,17 @@ type SaveBlobFileResult = {
   filePath?: string
 }
 
-export type { SaveBlobFileRequest, SaveBlobFileResult }
+type SaveManagedFileRequest = {
+  source: 'artifact' | 'upload'
+  path: string
+  suggestedName: string
+}
+
+type SaveManagedFileResult = SaveBlobFileResult
+
+export type {
+  SaveBlobFileRequest,
+  SaveBlobFileResult,
+  SaveManagedFileRequest,
+  SaveManagedFileResult
+}


### PR DESCRIPTION
## Summary

Add native managed-file downloads to the Files workspace and file previews, while refining preview presentation and keyboard accessibility.

## Highlights

- Download uploads and generated artifacts from the Files tab through a hover action and native Save As dialog that defaults to Downloads.
- Add a compact file-only preview card header with a full-name tooltip, middle ellipsis that preserves the extension, download action, and close action.
- Keep Files, Notebook, and future tool previews unwrapped while preserving the uploads-first and session-grouped Files layout.
- Support roving tab focus, arrow/Home/End navigation, and Delete/Backspace tab closing with adjacent focus recovery.

## Impact

- Adds a typed managed-file save IPC contract across shared, preload, and main-process layers.
- Reuses canonical artifact and upload resolvers, keeps file bytes out of renderer memory, and holds stable file handles across the native dialog.
- Opens, validates, truncates, and writes the selected destination through one file handle to avoid source overwrite and path-replacement races.
- Does not change persisted data, database schemas, or physical managed-file storage.

## Tests

- `npm test` — 228 test files passed, 1 skipped; 2,135 tests passed, 43 skipped.
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Potential Issues

- Native Save As behavior and destination permissions remain platform-dependent.
- The existing 3Dmol `eval` warning remains present during production builds.

## Author

- Roxi