### PR TITLE
feat(reviewer): add specialist auto-review with fix loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ dist-win-artifact/
 
 # SDD scratch (progress ledger, task briefs, reports) — worktree-local, not tracked
 .superpowers/
+.scratch/
+
+.worktreeinclude

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,9 +1,10 @@
 // Prisma schema for the project data layer.
 //
-// Scope (per plan docs/project-session-storage-plan.md): the SQLite DB holds ONLY Project entities.
-// Sessions, messages, and artifacts stay on disk (see src/shared/session-persistence.ts) and are NOT
-// modeled here. At runtime the datasource url is supplied programmatically (see prisma-client.ts) so
-// the DB lives under the app storage root; DATABASE_URL here only serves the Prisma CLI.
+// Scope (per plan docs/project-session-storage-plan.md): the SQLite DB holds project-scoped relational
+// data — Project, its preview state, and reviewer results (Review/Finding). Sessions, messages, and
+// artifacts stay on disk (see src/shared/session-persistence.ts) and are NOT modeled here. At runtime
+// the datasource url is supplied programmatically (see prisma-client.ts) so the DB lives under the app
+// storage root; DATABASE_URL here only serves the Prisma CLI.
 
 generator client {
   provider = "prisma-client-js"
@@ -36,4 +37,46 @@ model ProjectPreviewState {
   activeItemId String?
   items        String   @default("[]")
   updatedAt    DateTime @updatedAt
+}
+
+// One reviewer pass over a single completed turn. See src/main/reviewer/repository.ts. Checks live in
+// a child table (Finding); the review carries the turn scope (JSON), the task lifecycle, and the outcome.
+// Created at runtime via CREATE TABLE IF NOT EXISTS (see src/main/projects/prisma-client.ts), not migrate.
+//
+// v2 (issue 12): removed `summary` and `checks` JSON columns; all checks (pass/warn/fail) now live
+// as rows in the Finding table.
+// v3 (issue 13): replaced `reasoning` (self-authored prose) with `reviewerLog` (captured action stream
+// as JSON array of ReviewerLogEntry). submit_findings no longer accepts `reasoning`.
+model Review {
+  id            String    @id @default(cuid())
+  projectId     String
+  sessionId     String
+  turnMessageId String
+  scope         String    @default("{}")
+  lifecycle     String    @default("running")
+  outcome       String?
+  errorMessage  String?
+  model         String    @default("")
+  reviewerLog   String    @default("[]")
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  findings      Finding[]
+}
+
+// A unified check row — replaces both the old warn/fail-only Finding and the pass-only ReviewCheck
+// JSON blob on Review. status is 'pass'|'warn'|'fail'. locator is optional (pass checks may omit it).
+// resolution is meaningful only for warn/fail checks. Cascade-deleted with its Review.
+// reflagCount (issue 15): number of times this claim was re-flagged in a Phase 3 fix loop; defaults to 0.
+model Finding {
+  id                String  @id @default(cuid())
+  reviewId          String
+  status            String  @default("pass")
+  resolution        String  @default("open")
+  claim             String  @default("")
+  evidence          String  @default("")
+  locator           String  @default("{}")
+  artifactVersionId String?
+  sortIndex         Int     @default(0)
+  reflagCount       Int     @default(0)
+  review            Review  @relation(fields: [reviewId], references: [id], onDelete: Cascade)
 }

--- a/src/main/acp/runtime-events.ts
+++ b/src/main/acp/runtime-events.ts
@@ -209,4 +209,4 @@ const toAcpRuntimeEvent = (
   }
 }
 
-export { extractProviderToolName, extractToolFailureText, toAcpRuntimeEvent }
+export { extractProviderToolName, extractTerminalMeta, extractToolFailureText, toAcpRuntimeEvent }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -216,6 +216,11 @@ class AcpRuntime {
   private supportsSessionResume = false
   private readonly sessions = new Map<string, ActiveSession>()
   private readonly sessionCwds = new Map<string, string>()
+  // Ephemeral background reviewer sessions (built via buildReviewerSession). They are deliberately kept
+  // out of `this.sessions` — not tracked in the snapshot, not user-facing — but their tool calls still
+  // trigger permission requests over the shared agent connection. This set lets the permission handler
+  // recognise them and auto-approve without prompting (design §3: background review, no user interaction).
+  private readonly reviewerSessionIds = new Set<string>()
   // A replaced agent's own session id -> the app-facing id it was adopted under (after a provider
   // switch), so agent-origin events/permissions relabel into the conversation the renderer tracks.
   private readonly agentToAppSessionId = new Map<string, string>()
@@ -1613,6 +1618,13 @@ class AcpRuntime {
     })
 
     try {
+      // Background reviewer sessions run unattended with a restricted toolset: auto-approve their tool
+      // calls instead of routing to the renderer (which never sees these sessions) or throwing "Unknown
+      // ACP session" because they are intentionally not in `this.sessions`. See design §3.
+      if (this.reviewerSessionIds.has(params.sessionId)) {
+        return this.autoApproveReviewerPermission(params)
+      }
+
       const appSessionId = this.agentToAppSessionId.get(params.sessionId) ?? params.sessionId
 
       if (!this.sessions.has(appSessionId)) {
@@ -1638,6 +1650,34 @@ class AcpRuntime {
       })
       throw error
     }
+  }
+
+  // Selects an allow option for an unattended reviewer tool call. Prefers a one-shot allow (the reviewer
+  // session is ephemeral, so remembering an "always" grant is pointless) and falls back to allow_always,
+  // then the first option. A request with no allow option is cancelled rather than left hanging.
+  private autoApproveReviewerPermission(
+    params: RequestPermissionRequest
+  ): RequestPermissionResponse {
+    const allowOption =
+      params.options.find((option) => option.kind === 'allow_once') ??
+      params.options.find((option) => option.kind === 'allow_always') ??
+      params.options[0]
+
+    if (!allowOption) {
+      log.warn('reviewer permission request had no allow option; cancelling', {
+        sessionId: params.sessionId,
+        toolCallId: params.toolCall?.toolCallId
+      })
+      return { outcome: { outcome: 'cancelled' } }
+    }
+
+    log.debug('auto-approving reviewer tool call', {
+      sessionId: params.sessionId,
+      toolCallId: params.toolCall?.toolCallId,
+      optionId: allowOption.optionId
+    })
+
+    return { outcome: { outcome: 'selected', optionId: allowOption.optionId } }
   }
 
   // Normalizes low-level session notifications into runtime/workspace events.
@@ -1800,6 +1840,51 @@ class AcpRuntime {
   // Broadcasts the latest runtime snapshot if a listener is registered.
   private emitState(): void {
     this.callbacks.onStateChanged?.(this.getSnapshot())
+  }
+
+  // Creates an ephemeral reviewer ACP session using the existing agent connection. The reviewer
+  // session is isolated from main agent sessions: it is not tracked in this.sessions, does not
+  // appear in the snapshot, and callers are responsible for disposing it. This allows background
+  // review to run in parallel with the main session without affecting the main state machine.
+  async buildReviewerSession(request: {
+    cwd: string
+    mcpServers: McpServer[]
+    systemPromptAppend?: string
+  }): Promise<import('@agentclientprotocol/sdk').ActiveSession> {
+    const connection = await this.ensureConnected(request.cwd)
+
+    const meta: Record<string, unknown> = {
+      claudeCode: { options: { settingSources: ['user'] } }
+    }
+
+    if (request.systemPromptAppend) {
+      meta.systemPrompt = {
+        type: 'preset',
+        preset: 'claude_code',
+        append: request.systemPromptAppend
+      }
+    }
+
+    const session = await connection.agent
+      .buildSession({
+        cwd: request.cwd,
+        mcpServers: request.mcpServers,
+        _meta: meta
+      })
+      .start()
+
+    // Register so the permission handler recognises this session and auto-approves its tool calls.
+    // The orchestrator must call disposeReviewerSession() to unregister and tear it down.
+    this.reviewerSessionIds.add(session.sessionId)
+
+    return session
+  }
+
+  // Disposes an ephemeral reviewer session and unregisters it from the auto-approve set. Safe to call
+  // even if the session was never registered (e.g. it failed before start).
+  disposeReviewerSession(session: import('@agentclientprotocol/sdk').ActiveSession): void {
+    this.reviewerSessionIds.delete(session.sessionId)
+    session.dispose()
   }
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -27,6 +27,7 @@ import {
   createDefaultProjectRepository,
   registerProjectIpcHandlers
 } from './projects/ipc'
+import { registerReviewerIpcHandlers } from './reviewer/ipc'
 import {
   createDefaultSessionRepository,
   registerSessionPersistenceIpcHandlers
@@ -259,6 +260,11 @@ const registerIpcHandlers = async ({ mainEntryPath }: IpcRegistrationOptions): P
   registerUploadIpcHandlers(uploadRepository)
   registerSessionPersistenceIpcHandlers(sessionRepository)
   registerProjectIpcHandlers(projectRepository, previewStateRepository)
+  // Wire the reviewer backend into the app lifecycle: installs ipcMain.handle('reviewer:run', ...)
+  // and 'reviewer:get-for-session' so the renderer's fire-and-forget reviewer calls resolve to
+  // real handlers instead of no-ops. Passing the already-constructed AcpRuntime so the reviewer
+  // can spawn sessions under the same agent connection.
+  registerReviewerIpcHandlers({ acpRuntime: runtime })
 }
 
 export { registerIpcHandlers }

--- a/src/main/projects/ipc.ts
+++ b/src/main/projects/ipc.ts
@@ -16,6 +16,10 @@ import { resolveStorageRoot } from '../storage-root'
 import { PreviewStateRepository } from './preview-repository'
 import { getProjectDbClient } from './prisma-client'
 import { ProjectRepository } from './repository'
+import { ReviewRepository } from '../reviewer/repository'
+import { createLogger } from '../logger'
+
+const log = createLogger('projects:ipc')
 
 type ProjectHandlers = {
   list: () => Promise<Project[]>
@@ -26,12 +30,25 @@ type ProjectHandlers = {
 }
 
 // Adapts a repository into thin handlers so the IPC surface stays easy to unit test.
-const createProjectHandlers = (repository: ProjectRepository): ProjectHandlers => ({
+const createProjectHandlers = (
+  repository: ProjectRepository,
+  reviewRepository: ReviewRepository
+): ProjectHandlers => ({
   list: () => repository.list(),
   get: (id) => repository.get(id),
   create: (request) => repository.create(request),
   update: (request) => repository.update(request),
-  delete: (id) => repository.delete(id)
+  delete: async (id) => {
+    // Delete cascade: remove reviewer rows first so no orphan reviews/findings remain.
+    // A reviewer-cleanup failure must not block the underlying project delete (fire-and-forget).
+    await reviewRepository.deleteReviewsForProject(id).catch((error: unknown) => {
+      log.warn('deleteReviewsForProject failed (non-fatal)', {
+        projectId: id,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    })
+    await repository.delete(id)
+  }
 })
 
 // Production repositories backed by the SQLite database under the (dev-aware) storage root. The client is
@@ -43,12 +60,16 @@ const createDefaultProjectRepository = (): ProjectRepository =>
 const createDefaultPreviewStateRepository = (): PreviewStateRepository =>
   new PreviewStateRepository(() => getProjectDbClient(resolveStorageRoot()))
 
+const createDefaultReviewRepository = (): ReviewRepository =>
+  new ReviewRepository(() => getProjectDbClient(resolveStorageRoot()))
+
 // Registers the renderer-callable project + per-project preview-state commands.
 const registerProjectIpcHandlers = (
   repository = createDefaultProjectRepository(),
-  previewRepository = createDefaultPreviewStateRepository()
+  previewRepository = createDefaultPreviewStateRepository(),
+  reviewRepository = createDefaultReviewRepository()
 ): void => {
-  const handlers = createProjectHandlers(repository)
+  const handlers = createProjectHandlers(repository, reviewRepository)
 
   ipcMain.handle('projects:list', () => handlers.list())
   ipcMain.handle('projects:get', (_event, id: string) => handlers.get(id))

--- a/src/main/projects/prisma-client.test.ts
+++ b/src/main/projects/prisma-client.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { ProjectRepository } from './repository'
 import { createProjectDbClient, ensureProjectSchema } from './prisma-client'
+import { ReviewRepository } from '../reviewer/repository'
 
 // Proves the runtime CREATE TABLE IF NOT EXISTS DDL is byte-compatible with the generated Prisma client
 // against a real (temp) SQLite database. Requires the query engine, which is present in dev installs.
@@ -58,5 +59,98 @@ describe('project prisma client (integration)', () => {
     await repository.delete(created.id)
     expect(await repository.get(created.id)).toBeNull()
     expect(await repository.list()).toEqual([])
+  })
+
+  // Verifies the runtime FINDING_TABLE_DDL + migration guard are byte-compatible with the Prisma
+  // generated client for the reflagCount column (issue 15).
+  it('Finding.reflagCount DDL column is Prisma-compatible and migration guard is idempotent', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-reflag-parity-'))
+
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+
+    // Fresh install: FINDING_TABLE_DDL already contains reflagCount; client can read/write it.
+    await ensureProjectSchema(client)
+
+    const reviewRepo = new ReviewRepository(() => Promise.resolve(client))
+
+    const review = await reviewRepo.createReview({
+      projectId: 'p1',
+      sessionId: 's1',
+      turnMessageId: 'm1',
+      scope: { turnMessageId: 'm1', blocks: [], artifactVersionIds: [] }
+    })
+
+    await reviewRepo.addChecks(review.id, [
+      { status: 'fail', claim: 'test claim', evidence: 'test evidence', sortIndex: 0 }
+    ])
+
+    const [stored] = await reviewRepo.getReviewsForSession('s1')
+    // New finding defaults to 0.
+    expect(stored.checks[0]!.reflagCount).toBe(0)
+
+    // Increment and verify the Prisma client can read the updated value.
+    await reviewRepo.incrementReflagCount(review.id, 'test claim')
+    const [updated] = await reviewRepo.getReviewsForSession('s1')
+    expect(updated.checks[0]!.reflagCount).toBe(1)
+
+    // Migration guard is idempotent — calling ensureProjectSchema a second time must not throw.
+    await expect(ensureProjectSchema(client)).resolves.toBeUndefined()
+  })
+
+  // Simulates an old DB that has the Finding table without reflagCount; the migration guard must add
+  // the column without error, and existing rows must read back with reflagCount = 0.
+  it('migration guard adds reflagCount to an old DB without the column', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-reflag-migrate-'))
+
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+
+    // Simulate an old DB: create the Finding table WITHOUT reflagCount (pre-issue-15 DDL).
+    await client.$executeRawUnsafe(`CREATE TABLE IF NOT EXISTS "Review" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "projectId" TEXT NOT NULL,
+      "sessionId" TEXT NOT NULL,
+      "turnMessageId" TEXT NOT NULL,
+      "scope" TEXT NOT NULL DEFAULT '{}',
+      "lifecycle" TEXT NOT NULL DEFAULT 'running',
+      "outcome" TEXT,
+      "errorMessage" TEXT,
+      "model" TEXT NOT NULL DEFAULT '',
+      "reviewerLog" TEXT NOT NULL DEFAULT '[]',
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL
+    )`)
+    await client.$executeRawUnsafe(`CREATE TABLE IF NOT EXISTS "Finding" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "reviewId" TEXT NOT NULL,
+      "status" TEXT NOT NULL DEFAULT 'pass',
+      "resolution" TEXT NOT NULL DEFAULT 'open',
+      "claim" TEXT NOT NULL DEFAULT '',
+      "evidence" TEXT NOT NULL DEFAULT '',
+      "locator" TEXT NOT NULL DEFAULT '{}',
+      "artifactVersionId" TEXT,
+      "sortIndex" INTEGER NOT NULL DEFAULT 0,
+      CONSTRAINT "Finding_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    )`)
+
+    // Insert a row into the old schema (no reflagCount column yet).
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Review" ("id","projectId","sessionId","turnMessageId","scope","lifecycle","model","reviewerLog","updatedAt") VALUES ('r1','p1','s1','m1','{}','running','','[]',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Finding" ("id","reviewId","claim","evidence") VALUES ('f1','r1','old claim','old evidence')`
+    )
+
+    // Run ensureProjectSchema — the migration guard must add reflagCount without error.
+    await expect(ensureProjectSchema(client)).resolves.toBeUndefined()
+
+    // Running it again is idempotent (guard catches duplicate-column error).
+    await expect(ensureProjectSchema(client)).resolves.toBeUndefined()
+
+    // The old row reads back with reflagCount = 0 (the column default).
+    const reviewRepo = new ReviewRepository(() => Promise.resolve(client))
+    const [stored] = await reviewRepo.getReviewsForSession('s1')
+    expect(stored.checks[0]!.reflagCount).toBe(0)
   })
 })

--- a/src/main/projects/prisma-client.ts
+++ b/src/main/projects/prisma-client.ts
@@ -26,6 +26,59 @@ const PREVIEW_STATE_TABLE_DDL = `CREATE TABLE IF NOT EXISTS "ProjectPreviewState
     "updatedAt" DATETIME NOT NULL
 );`
 
+// Reviewer results: one Review per audited turn, plus its child checks (stored in Finding table).
+// v2 (issue 12): Review no longer has summary/checks JSON columns; all checks are Finding rows.
+// v3 (issue 13): reasoning replaced by reviewerLog (captured action stream JSON array).
+// Same runtime-DDL approach — applied as CREATE TABLE IF NOT EXISTS so a packaged app stays
+// byte-compatible with the generated client.
+const REVIEW_TABLE_DDL = `CREATE TABLE IF NOT EXISTS "Review" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "turnMessageId" TEXT NOT NULL,
+    "scope" TEXT NOT NULL DEFAULT '{}',
+    "lifecycle" TEXT NOT NULL DEFAULT 'running',
+    "outcome" TEXT,
+    "errorMessage" TEXT,
+    "model" TEXT NOT NULL DEFAULT '',
+    "reviewerLog" TEXT NOT NULL DEFAULT '[]',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);`
+
+// Migration: for existing DBs that still have the old reasoning column, add reviewerLog.
+// The reasoning column is simply ignored by the new Prisma client.
+const REVIEW_ADD_REVIEWER_LOG_DDL = `ALTER TABLE "Review" ADD COLUMN "reviewerLog" TEXT NOT NULL DEFAULT '[]'`
+
+// Migration: add the `status` column to Finding if it doesn't exist yet (for DBs that have the old
+// `severity` column). This is safe to run multiple times (ALTER TABLE ... ADD COLUMN is idempotent
+// when guarded by a catch on the DUPLICATE COLUMN error).
+const FINDING_ADD_STATUS_COLUMN_DDL = `ALTER TABLE "Finding" ADD COLUMN "status" TEXT NOT NULL DEFAULT 'pass'`
+
+// The FOREIGN KEY ... ON DELETE CASCADE matches Prisma's generated DDL; the reviewer repository also
+// deletes findings explicitly (deleteReviewsForSession/Project) so cleanup does not depend on the
+// SQLite foreign-keys pragma being enabled.
+// v2: severity replaced by status ('pass'|'warn'|'fail'); locator is now optional (pass checks omit it).
+// v4 (issue 15): added reflagCount column (Phase 3 fix loop re-flag counter).
+const FINDING_TABLE_DDL = `CREATE TABLE IF NOT EXISTS "Finding" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "reviewId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pass',
+    "resolution" TEXT NOT NULL DEFAULT 'open',
+    "claim" TEXT NOT NULL DEFAULT '',
+    "evidence" TEXT NOT NULL DEFAULT '',
+    "locator" TEXT NOT NULL DEFAULT '{}',
+    "artifactVersionId" TEXT,
+    "sortIndex" INTEGER NOT NULL DEFAULT 0,
+    "reflagCount" INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT "Finding_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);`
+
+// Migration guard: add the `reflagCount` column to Finding if it doesn't exist yet (for DBs that
+// predate issue 15). Idempotent — the catch swallows the duplicate-column error from SQLite (which
+// does not support IF NOT EXISTS on ALTER TABLE ADD COLUMN).
+const FINDING_ADD_REFLAG_COUNT_DDL = `ALTER TABLE "Finding" ADD COLUMN "reflagCount" INTEGER NOT NULL DEFAULT 0`
+
 // Builds a client bound to the SQLite file under the given storage root. Not a singleton, so tests can
 // point separate clients at temp directories. Backslashes are normalized so the file: URL is valid on
 // Windows (Prisma's SQLite connector expects forward slashes).
@@ -39,6 +92,20 @@ const createProjectDbClient = (storageRoot: string): PrismaClient => {
 const ensureProjectSchema = async (client: PrismaClient): Promise<void> => {
   await client.$executeRawUnsafe(PROJECT_TABLE_DDL)
   await client.$executeRawUnsafe(PREVIEW_STATE_TABLE_DDL)
+  await client.$executeRawUnsafe(REVIEW_TABLE_DDL)
+  await client.$executeRawUnsafe(FINDING_TABLE_DDL)
+
+  // Migration guard: if this is an old DB with `severity` but not `status`, add the status column.
+  // Catch ignores the error when the column already exists (no IF NOT EXISTS in SQLite ALTER TABLE).
+  await client.$executeRawUnsafe(FINDING_ADD_STATUS_COLUMN_DDL).catch(() => undefined)
+
+  // Migration guard: if this is an old DB with `reasoning` but not `reviewerLog`, add the new column.
+  // Catch ignores the error when the column already exists (no IF NOT EXISTS in SQLite ALTER TABLE).
+  await client.$executeRawUnsafe(REVIEW_ADD_REVIEWER_LOG_DDL).catch(() => undefined)
+
+  // Migration guard: add reflagCount to Finding for DBs created before issue 15.
+  // Catch ignores the error when the column already exists (no IF NOT EXISTS in SQLite ALTER TABLE).
+  await client.$executeRawUnsafe(FINDING_ADD_REFLAG_COUNT_DDL).catch(() => undefined)
 }
 
 let clientPromise: Promise<PrismaClient> | undefined

--- a/src/main/reviewer/correction.test.ts
+++ b/src/main/reviewer/correction.test.ts
@@ -1,0 +1,682 @@
+// Integration tests for the single-round auditor correction loop.
+// Mirrors the stubbed-ACP-session pattern from orchestrator.test.ts.
+//
+// Tests assert:
+// - [Auditor] message is injected only for warn/fail checks
+// - The injected message format matches the spec (design.md §6)
+// - Resolution transitions happen after the correction turn
+// - Exactly one correction round fires (no re-review loop)
+// - pass reviews inject nothing
+
+import * as acp from '@agentclientprotocol/sdk'
+import type { ContentBlock } from '@agentclientprotocol/sdk'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough, Readable, Writable } from 'node:stream'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { AcpRuntime } from '../acp/runtime'
+import { ReviewRepository } from './repository'
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { runReview } from './orchestrator'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+
+// ---------------------------------------------------------------------------
+// FakeAgentProcess — re-used from orchestrator.test.ts
+// ---------------------------------------------------------------------------
+
+class FakeAgentProcess extends EventEmitter {
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+  killed = false
+
+  kill(): boolean {
+    this.killed = true
+    this.emit('exit', 0, null)
+    return true
+  }
+}
+
+const asAgentProcess = (p: FakeAgentProcess): ChildProcessWithoutNullStreams =>
+  p as unknown as ChildProcessWithoutNullStreams
+
+// ---------------------------------------------------------------------------
+// Minimal session fixture
+// ---------------------------------------------------------------------------
+
+const makeSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Test session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [
+    {
+      id: 'msg-1',
+      role: 'user',
+      content: 'Run the analysis',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1000,
+      updatedAt: 1000
+    },
+    {
+      id: 'msg-2',
+      role: 'agent',
+      content: 'I ran the analysis and found 42 results.',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 2000,
+      updatedAt: 2000
+    }
+  ],
+  createdAt: 900,
+  updatedAt: 2000,
+  ...overrides
+})
+
+// ---------------------------------------------------------------------------
+// MCP helpers — v2 schema: submit_findings accepts checks[] not findings[]
+// ---------------------------------------------------------------------------
+
+const MCP_ACCEPT = 'application/json, text/event-stream'
+
+const parseMcpSseBody = (body: string): { result?: unknown; error?: { message?: string } } => {
+  const dataLine = body.split('\n').find((line) => line.startsWith('data:'))
+  const json = dataLine ? dataLine.slice('data:'.length).trim() : body.trim()
+  return json ? (JSON.parse(json) as { result?: unknown; error?: { message?: string } }) : {}
+}
+
+// v2: submit_findings accepts checks[] with status (pass|warn|fail), not findings[] with severity.
+const callSubmitFindings = async (
+  mcpBaseUrl: string,
+  token: string,
+  checks: Array<{
+    status: 'warn' | 'fail'
+    claim: string
+    evidence: string
+    locator: {
+      blockRef: { messageId?: string; activityId?: string; blockIndex: number }
+      contentHash: string
+    }
+  }>
+): Promise<void> => {
+  const initResponse = await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0' }
+      }
+    })
+  })
+
+  if (!initResponse.ok) throw new Error(`MCP initialize failed: ${initResponse.status}`)
+
+  const initJson = parseMcpSseBody(await initResponse.text())
+  const sessionId = initResponse.headers.get('mcp-session-id')
+  if (!sessionId || !initJson.result) throw new Error('MCP initialize did not return a session id')
+
+  await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`,
+      'mcp-session-id': sessionId
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
+  })
+
+  // v2: use `checks` key, not `findings`
+  const toolResponse = await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`,
+      'mcp-session-id': sessionId
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'submit_findings', arguments: { checks } }
+    })
+  })
+
+  if (!toolResponse.ok) throw new Error(`submit_findings call failed: ${toolResponse.status}`)
+
+  const toolJson = parseMcpSseBody(await toolResponse.text())
+  if (toolJson.error) {
+    throw new Error(`submit_findings returned an error: ${toolJson.error.message ?? 'unknown'}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake agent that handles both the reviewer session and the main-session correction.
+// The main session is registered under 'main-session-1'.
+// ---------------------------------------------------------------------------
+
+type FakeAgentState = {
+  newSessions: Array<{ sessionId: string; cwd: string; mcpServers: unknown[]; _meta?: unknown }>
+  // The text of prompts received per session
+  promptsReceived: Map<string, string[]>
+  // Sessions that were closed
+  closedSessions: string[]
+}
+
+const startFakeAgent = (
+  process: FakeAgentProcess,
+  options: {
+    reviewerSessionId: string
+    mainSessionId: string
+    simulateFindingsViaHttp?: boolean
+    checksToSubmit?: Array<{
+      status: 'warn' | 'fail'
+      claim: string
+      evidence: string
+      locator: {
+        blockRef: { messageId?: string; activityId?: string; blockIndex: number }
+        contentHash: string
+      }
+    }>
+  }
+): FakeAgentState => {
+  const state: FakeAgentState = {
+    newSessions: [],
+    promptsReceived: new Map(),
+    closedSessions: []
+  }
+
+  acp
+    .agent({ name: 'test-agent' })
+    .onRequest(acp.methods.agent.initialize, () => ({
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        sessionCapabilities: { close: {} }
+      },
+      authMethods: []
+    }))
+    .onRequest(acp.methods.agent.session.new, (ctx) => {
+      // Distinguish the reviewer session from the main session by the presence of MCP servers.
+      // The reviewer is always spawned with at least one HTTP MCP server (submit_findings);
+      // the main session (created via createSession()) has no MCP servers configured here.
+      const mcpServers = (ctx.params.mcpServers ?? []) as Array<{ type?: string }>
+      const isReviewer = mcpServers.some((s) => s.type === 'http')
+      const sessionId = isReviewer ? options.reviewerSessionId : options.mainSessionId
+
+      state.newSessions.push({
+        sessionId,
+        cwd: ctx.params.cwd,
+        mcpServers: ctx.params.mcpServers ?? [],
+        ...(ctx.params._meta === undefined ? {} : { _meta: ctx.params._meta })
+      })
+
+      return { sessionId }
+    })
+    .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+      const text = ctx.params.prompt
+        .map((block: ContentBlock) => (block.type === 'text' ? block.text : ''))
+        .join('')
+
+      const existing = state.promptsReceived.get(ctx.params.sessionId) ?? []
+      existing.push(text)
+      state.promptsReceived.set(ctx.params.sessionId, existing)
+
+      // If this is a reviewer session prompt, simulate submit_findings via HTTP.
+      if (ctx.params.sessionId === options.reviewerSessionId && options.simulateFindingsViaHttp) {
+        const latestSession = state.newSessions.find(
+          (s) => s.sessionId === options.reviewerSessionId
+        )
+        const mcpServers = latestSession?.mcpServers ?? []
+        const reviewerMcp = (
+          mcpServers as Array<{
+            type?: string
+            url?: string
+            headers?: Array<{ name: string; value: string }>
+          }>
+        ).find((s) => s.type === 'http')
+
+        if (reviewerMcp?.url) {
+          const token =
+            reviewerMcp.headers
+              ?.find((h) => h.name === 'authorization')
+              ?.value?.replace('Bearer ', '') ?? ''
+          await callSubmitFindings(reviewerMcp.url, token, options.checksToSubmit ?? [])
+        }
+      }
+
+      // Stream a minimal reply chunk.
+      await ctx.client.notify(acp.methods.client.session.update, {
+        sessionId: ctx.params.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          messageId: `reply-${ctx.params.sessionId}`,
+          content: { type: 'text', text: 'Acknowledged. I have fixed the issue.' }
+        }
+      })
+
+      return { stopReason: 'end_turn' }
+    })
+    .onRequest(acp.methods.agent.session.close, (ctx) => {
+      state.closedSessions.push(ctx.params.sessionId)
+      return {}
+    })
+    .connect(
+      acp.ndJsonStream(
+        Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+        Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+      )
+    )
+
+  return state
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let temporaryRoot: string | undefined
+
+beforeEach(async () => {
+  temporaryRoot = await mkdtemp(join(tmpdir(), 'reviewer-correction-test-'))
+})
+
+afterEach(async () => {
+  if (temporaryRoot) {
+    await rm(temporaryRoot, { recursive: true, force: true })
+    temporaryRoot = undefined
+  }
+})
+
+describe('single-round auditor correction', () => {
+  it('injects exactly one [Auditor] message for warn/fail checks', async () => {
+    const process = new FakeAgentProcess()
+    const checksToSubmit = [
+      {
+        status: 'fail' as const,
+        claim: 'Agent claimed 42 results',
+        evidence: 'Tool output shows 0 results in msg-2',
+        locator: { blockRef: { messageId: 'msg-2', blockIndex: 1 }, contentHash: 'abc123' }
+      },
+      {
+        status: 'warn' as const,
+        claim: 'Units inconsistency: mg/L vs mmol/L',
+        evidence: 'Block [0] and block [2] use different units',
+        locator: { blockRef: { messageId: 'msg-2', blockIndex: 0 }, contentHash: 'def456' }
+      }
+    ]
+
+    startFakeAgent(process, {
+      reviewerSessionId: 'reviewer-session-1',
+      mainSessionId: 'main-session-1',
+      simulateFindingsViaHttp: true,
+      checksToSubmit
+    })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    // Pre-register the main session so sendPrompt can find it.
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+    const session = makeSession()
+
+    // Capture prompts sent to the main session via sendCorrectionPrompt.
+    const correctionPrompts: string[] = []
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => session,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1',
+      onCorrectionPrompt: (text) => correctionPrompts.push(text)
+    })
+
+    // Review should be flagged with 2 warn/fail checks.
+    expect(review.outcome).toBe('flagged')
+    // v2: use checks not findings
+    expect(review.checks).toHaveLength(2)
+    expect(review.checks.filter((c) => c.status === 'warn' || c.status === 'fail')).toHaveLength(2)
+
+    // Exactly one [Auditor] message was injected.
+    expect(correctionPrompts).toHaveLength(1)
+    const auditorMsg = correctionPrompts[0]!
+
+    // Message must start with [Auditor] header.
+    expect(auditorMsg).toMatch(/^\[Auditor\]/)
+    expect(auditorMsg).toContain('2 issues')
+
+    // Both checks must appear.
+    expect(auditorMsg).toContain('[fail]')
+    expect(auditorMsg).toContain('Agent claimed 42 results')
+    expect(auditorMsg).toContain('[warn]')
+    expect(auditorMsg).toContain('Units inconsistency')
+
+    // Must end with the instruction line.
+    expect(auditorMsg).toContain('Acknowledge in one line')
+    expect(auditorMsg).toContain("Don't restate or narrate")
+
+    await client.$disconnect()
+  })
+
+  it('does not inject an [Auditor] message for a pass review', async () => {
+    const process = new FakeAgentProcess()
+    // No simulateFindingsViaHttp → reviewer calls submit_findings with empty array (not called → treated as pass)
+    startFakeAgent(process, {
+      reviewerSessionId: 'reviewer-session-1',
+      mainSessionId: 'main-session-1'
+    })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+    const session = makeSession()
+
+    const correctionPrompts: string[] = []
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => session,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1',
+      onCorrectionPrompt: (text) => correctionPrompts.push(text)
+    })
+
+    // Pass review: no injection.
+    expect(review.outcome).toBe('pass')
+    expect(correctionPrompts).toHaveLength(0)
+
+    await client.$disconnect()
+  })
+
+  it('updates check resolutions to unaddressed after the correction turn', async () => {
+    const process = new FakeAgentProcess()
+    const checksToSubmit = [
+      {
+        status: 'fail' as const,
+        claim: 'Fabricated statistic',
+        evidence: 'No supporting tool activity found',
+        locator: { blockRef: { blockIndex: 0 }, contentHash: 'hash1' }
+      }
+    ]
+
+    startFakeAgent(process, {
+      reviewerSessionId: 'reviewer-session-1',
+      mainSessionId: 'main-session-1',
+      simulateFindingsViaHttp: true,
+      checksToSubmit
+    })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+    const session = makeSession()
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => session,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1'
+    })
+
+    // v2: checks not findings
+    expect(review.checks).toHaveLength(1)
+    const check = review.checks[0]!
+    // Phase 1: resolution is updated from 'open' to 'unaddressed' (no re-review to confirm fix).
+    expect(['resolved', 'unaddressed']).toContain(check.resolution)
+    expect(check.resolution).not.toBe('open')
+
+    // Verify the resolution was persisted in DB.
+    const reloaded = await repository.getReviewsForSession('session-1')
+    expect(reloaded[0]?.checks[0]?.resolution).not.toBe('open')
+
+    await client.$disconnect()
+  })
+
+  it('Phase 3 fix loop triggers internal re-review (not via external onRunReviewCalled)', async () => {
+    const process = new FakeAgentProcess()
+    const checksToSubmit = [
+      {
+        status: 'warn' as const,
+        claim: 'Minor label inconsistency',
+        evidence: 'Block [0] and block [2] differ',
+        locator: { blockRef: { blockIndex: 0 }, contentHash: 'hash1' }
+      }
+    ]
+
+    const agentState = startFakeAgent(process, {
+      reviewerSessionId: 'reviewer-session-1',
+      mainSessionId: 'main-session-1',
+      simulateFindingsViaHttp: true,
+      checksToSubmit
+    })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+    const session = makeSession()
+
+    let runReviewCallCount = 0
+    const correctionPrompts: string[] = []
+
+    await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => session,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1',
+      onCorrectionPrompt: (text) => correctionPrompts.push(text),
+      onRunReviewCalled: () => {
+        runReviewCallCount++
+      }
+    })
+
+    // Phase 3: fix loop is driven internally — onRunReviewCalled (external trigger) stays 0.
+    expect(runReviewCallCount).toBe(0)
+
+    // The fix loop attempted at least one correction round.
+    expect(correctionPrompts.length).toBeGreaterThanOrEqual(1)
+
+    // Phase 3: the fix loop spawns more than 1 reviewer session (initial + re-review(s)).
+    // Note: the correction.test.ts fake agent reuses the same MCP server reference for all
+    // reviewer sessions (single-session design); the re-review may fail and terminate early.
+    // The key invariant: re-reviews are driven internally, not via external calls.
+    const reviewerSessions = agentState.newSessions.filter(
+      (s) => s.sessionId === 'reviewer-session-1'
+    )
+    expect(reviewerSessions.length).toBeGreaterThanOrEqual(2)
+
+    await client.$disconnect()
+  })
+
+  it('message format contains numbered list with status and claim', async () => {
+    // Test buildAuditorMessage directly.
+    const { buildAuditorMessage } = await import('./correction')
+
+    const checks = [
+      {
+        id: 'c1',
+        reviewId: 'r1',
+        status: 'fail' as const,
+        resolution: 'open' as const,
+        claim: 'Agent claimed test passed',
+        evidence: 'No test activity found',
+        locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' },
+        sortIndex: 0,
+        reflagCount: 0
+      },
+      {
+        id: 'c2',
+        reviewId: 'r1',
+        status: 'warn' as const,
+        resolution: 'open' as const,
+        claim: 'Unit label inconsistency',
+        evidence: 'Block [0] uses mg/L, block [2] uses mmol/L',
+        locator: { blockRef: { blockIndex: 2 }, contentHash: 'h2' },
+        sortIndex: 1,
+        reflagCount: 0
+      }
+    ]
+
+    const msg = buildAuditorMessage(checks)
+
+    // Header format.
+    expect(msg).toMatch(
+      /^\[Auditor\] A fresh-context reviewer traced your work and found 2 issues:/
+    )
+
+    // Numbered checks with status (not severity).
+    expect(msg).toContain('1. [fail] "Agent claimed test passed"')
+    expect(msg).toContain('No test activity found')
+    expect(msg).toContain('2. [warn] "Unit label inconsistency"')
+    expect(msg).toContain('mg/L')
+
+    // Closing instruction.
+    expect(msg).toContain('Acknowledge in one line and make the fix')
+    expect(msg).toContain("Don't restate or narrate your evaluation.")
+  })
+
+  it('buildAuditorMessage only includes warn/fail checks', async () => {
+    const { buildAuditorMessage } = await import('./correction')
+
+    const checks = [
+      {
+        id: 'c1',
+        reviewId: 'r1',
+        status: 'fail' as const,
+        resolution: 'open' as const,
+        claim: 'Fabricated claim',
+        evidence: 'Evidence',
+        locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' },
+        sortIndex: 0,
+        reflagCount: 0
+      }
+    ]
+
+    const msg = buildAuditorMessage(checks)
+    expect(msg).toContain('1 issue')
+    expect(msg).toContain('[fail]')
+  })
+
+  it('error in correction sendPrompt does not spin into a re-review loop', async () => {
+    const process = new FakeAgentProcess()
+    const checksToSubmit = [
+      {
+        status: 'fail' as const,
+        claim: 'Test claim',
+        evidence: 'Test evidence',
+        locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' }
+      }
+    ]
+
+    startFakeAgent(process, {
+      reviewerSessionId: 'reviewer-session-1',
+      mainSessionId: 'main-session-1',
+      simulateFindingsViaHttp: true,
+      checksToSubmit
+    })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    // Do NOT pre-create a main session — sendPrompt will throw 'session not found'.
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+    const session = makeSession()
+
+    const correctionPrompts: string[] = []
+    let correctionFailedCount = 0
+
+    // Should not throw even if correction fails.
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => session,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1', // session not registered in runtime → sendPrompt throws
+      onCorrectionPrompt: (text) => correctionPrompts.push(text),
+      onCorrectionFailed: () => {
+        correctionFailedCount++
+      }
+    })
+
+    // Review should still be complete even if correction failed.
+    expect(review.lifecycle).toBe('complete')
+    expect(review.outcome).toBe('flagged')
+
+    // The correction prompt was attempted (suppress broadcast in production), but because sendPrompt
+    // threw, onCorrectionFailed fires so the renderer can clear the pending suppression.
+    expect(correctionPrompts).toHaveLength(1)
+    expect(correctionFailedCount).toBe(1)
+
+    await client.$disconnect()
+  })
+})

--- a/src/main/reviewer/correction.ts
+++ b/src/main/reviewer/correction.ts
@@ -1,0 +1,86 @@
+// Auditor correction: after a review with warn/fail findings completes,
+// injects one [Auditor] message into the main session.
+//
+// Phase 3: correction.ts no longer hardcodes unaddressed resolutions.
+// The fix loop in orchestrator.ts drives re-review and sets resolutions from those results.
+
+import type { AcpRuntime } from '../acp/runtime'
+import { createLogger } from '../logger'
+import type { ReviewCheck } from '../../shared/reviewer'
+
+const log = createLogger('reviewer:correction')
+
+// Builds the [Auditor] message body per design.md §6:
+//
+//   [Auditor] A fresh-context reviewer traced your work and found N issues:
+//     1. [fail] "<claim>"  — <evidence>
+//     2. [warn] ...
+//   Acknowledge in one line and make the fix (or rebut in one line if a finding is wrong). Don't restate or narrate your evaluation.
+export const buildAuditorMessage = (checks: ReviewCheck[]): string => {
+  const n = checks.length
+  const issueWord = n === 1 ? 'issue' : 'issues'
+  const header = `[Auditor] A fresh-context reviewer traced your work and found ${n} ${issueWord}:`
+
+  const lines = checks.map((c, i) => {
+    const num = i + 1
+    return `  ${num}. [${c.status}] "${c.claim}"  — ${c.evidence}`
+  })
+
+  const footer =
+    "Acknowledge in one line and make the fix (or rebut in one line if a finding is wrong). Don't restate or narrate your evaluation."
+
+  return [header, ...lines, footer].join('\n')
+}
+
+// Injects the [Auditor] message into the main session and waits for the correction turn to complete.
+// Resolution updates are NOT performed here — Phase 3 orchestrator drives re-review and sets
+// resolutions from the re-review outcome.
+//
+// Errors are isolated: a failed correction is logged but does NOT crash the review lifecycle.
+export const injectAuditorMessage = async (options: {
+  sessionId: string
+  mainSessionId: string
+  findings: ReviewCheck[] // the full checks list; only warn/fail are injected
+  acpRuntime: AcpRuntime
+  // Optional hook for tests to capture the injected message text.
+  onCorrectionPrompt?: (text: string) => void
+  // Called if the correction sendPrompt fails, so the caller can undo pre-emptive suppression.
+  onCorrectionFailed?: () => void
+}): Promise<void> => {
+  const { sessionId, mainSessionId, findings, acpRuntime, onCorrectionPrompt, onCorrectionFailed } =
+    options
+
+  // Only inject for warn/fail checks.
+  const warnFailChecks = findings.filter((c) => c.status === 'warn' || c.status === 'fail')
+  if (warnFailChecks.length === 0) {
+    log.info('no warn/fail checks; skipping auditor injection', { sessionId })
+    return
+  }
+
+  const message = buildAuditorMessage(warnFailChecks)
+
+  log.info('injecting [Auditor] message into main session', {
+    sessionId,
+    mainSessionId,
+    findingCount: warnFailChecks.length
+  })
+
+  // Notify test hooks (if any).
+  onCorrectionPrompt?.(message)
+
+  try {
+    // Inject through the main-session sendPrompt path (design.md cross-cutting requirement).
+    // This is a normal prompt turn that the user sees in the conversation.
+    await acpRuntime.sendPrompt({ sessionId: mainSessionId, text: message })
+    log.info('[Auditor] correction turn complete', { mainSessionId })
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    log.error('[Auditor] correction sendPrompt failed', {
+      mainSessionId,
+      error: errorMsg
+    })
+    // Error handling: a failed correction does NOT spin into a re-review loop.
+    // The correction turn never produced a stop, so undo the pre-emptive auto-review suppression.
+    onCorrectionFailed?.()
+  }
+}

--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -1,0 +1,803 @@
+// Integration tests for the Phase 3 locked re-review fix loop.
+//
+// Asserts the loop/persistence contract (no LLM judgement):
+// - Exactly N [Auditor] injections for N rounds.
+// - Resolution transitions: resolved / open / unaddressed.
+// - reflagCount increment on over-correction (same claim fails again).
+// - Cap termination at 3 rounds (remaining warn/fail set to unaddressed).
+// - All-pass on re-review ends the loop cleanly (resolved).
+// - Each iteration writes a distinct Review row sharing the original turnMessageId.
+// - correction.ts no longer hardcodes unaddressed; resolutions come from re-review.
+//
+// Pattern: stubbed ACP session per orchestrator.test.ts / correction.test.ts (issue 02/05 pattern).
+
+import * as acp from '@agentclientprotocol/sdk'
+import type { ContentBlock } from '@agentclientprotocol/sdk'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough, Readable, Writable } from 'node:stream'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { AcpRuntime } from '../acp/runtime'
+import { ReviewRepository } from './repository'
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { runReview } from './orchestrator'
+import type { PersistedChatSession, PersistedChatMessage } from '../../shared/session-persistence'
+
+// ---------------------------------------------------------------------------
+// FakeAgentProcess
+// ---------------------------------------------------------------------------
+
+class FakeAgentProcess extends EventEmitter {
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+  killed = false
+
+  kill(): boolean {
+    this.killed = true
+    this.emit('exit', 0, null)
+    return true
+  }
+}
+
+const asAgentProcess = (p: FakeAgentProcess): ChildProcessWithoutNullStreams =>
+  p as unknown as ChildProcessWithoutNullStreams
+
+// ---------------------------------------------------------------------------
+// MCP helpers (from orchestrator.test.ts)
+// ---------------------------------------------------------------------------
+
+const MCP_ACCEPT = 'application/json, text/event-stream'
+
+const parseMcpSseBody = (body: string): { result?: unknown; error?: { message?: string } } => {
+  const dataLine = body.split('\n').find((line) => line.startsWith('data:'))
+  const json = dataLine ? dataLine.slice('data:'.length).trim() : body.trim()
+  return json ? (JSON.parse(json) as { result?: unknown; error?: { message?: string } }) : {}
+}
+
+const callSubmitFindings = async (
+  mcpBaseUrl: string,
+  token: string,
+  checks: Array<{
+    status: 'pass' | 'warn' | 'fail'
+    claim: string
+    evidence: string
+    locator?: {
+      blockRef: { messageId?: string; activityId?: string; blockIndex: number }
+      contentHash: string
+    }
+  }>
+): Promise<void> => {
+  const initResponse = await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0' }
+      }
+    })
+  })
+
+  if (!initResponse.ok) throw new Error(`MCP initialize failed: ${initResponse.status}`)
+
+  const initJson = parseMcpSseBody(await initResponse.text())
+  const sessionId = initResponse.headers.get('mcp-session-id')
+  if (!sessionId || !initJson.result) throw new Error('MCP initialize did not return a session id')
+
+  await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`,
+      'mcp-session-id': sessionId
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
+  })
+
+  const toolResponse = await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`,
+      'mcp-session-id': sessionId
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'submit_findings', arguments: { checks } }
+    })
+  })
+
+  if (!toolResponse.ok) throw new Error(`submit_findings call failed: ${toolResponse.status}`)
+  const toolJson = parseMcpSseBody(await toolResponse.text())
+  if (toolJson.error) {
+    throw new Error(`submit_findings returned an error: ${toolJson.error.message ?? 'unknown'}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake ACP agent — handles both reviewer sessions and main-session prompts.
+//
+// The agent maintains a round counter. On the first call it submits the initial
+// warn/fail findings. On each subsequent correction prompt, it records that call.
+// On each re-review session spawned after the correction, the providedReReviewChecks
+// array (indexed by round) supplies what the re-reviewer submits.
+// ---------------------------------------------------------------------------
+
+type ReReviewChecks = Array<{
+  status: 'pass' | 'warn' | 'fail'
+  claim: string
+  evidence: string
+  locator?: {
+    blockRef: { messageId?: string; activityId?: string; blockIndex: number }
+    contentHash: string
+  }
+}>
+
+type FixLoopFakeAgentOptions = {
+  reviewerSessionIdPrefix?: string // defaults to 'reviewer-session'
+  mainSessionId: string
+  // Checks submitted by the initial review
+  initialChecks: Array<{
+    status: 'warn' | 'fail'
+    claim: string
+    evidence: string
+    locator: { blockRef: { blockIndex: number }; contentHash: string }
+  }>
+  // Per-round checks submitted by re-reviewer (index 0 = round 1, index 1 = round 2, ...)
+  // If omitted for a round, the re-reviewer submits no findings (pass).
+  reReviewChecksByRound?: ReReviewChecks[]
+  // Called when a correction prompt arrives at the main session
+  onCorrectionPrompt?: (text: string, round: number) => void
+}
+
+type FixLoopAgentState = {
+  // List of session IDs created (all kinds)
+  sessions: Array<{ sessionId: string; mcpServers: unknown[]; cwd: string }>
+  // Prompts received per session
+  promptsReceived: Map<string, string[]>
+  // Corrected-session message counter (for generating stable IDs in fake sessions)
+  correctionCount: number
+}
+
+// Shared mutable session data — simulates the session JSON being updated when
+// the main agent receives prompts. The test populates this after each correction.
+type SharedSessionData = {
+  getSession: () => PersistedChatSession
+}
+
+const startFixLoopFakeAgent = (
+  process: FakeAgentProcess,
+  options: FixLoopFakeAgentOptions,
+  sessionData: SharedSessionData
+): FixLoopAgentState => {
+  const state: FixLoopAgentState = {
+    sessions: [],
+    promptsReceived: new Map(),
+    correctionCount: 0
+  }
+
+  // Track how many reviewer sessions have been started (to index re-review rounds).
+  let reviewerSessionCount = 0
+
+  acp
+    .agent({ name: 'fix-loop-test-agent' })
+    .onRequest(acp.methods.agent.initialize, () => ({
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        sessionCapabilities: { close: {} }
+      },
+      authMethods: []
+    }))
+    .onRequest(acp.methods.agent.session.new, (ctx) => {
+      const mcpServers = (ctx.params.mcpServers ?? []) as Array<{ type?: string }>
+      const isReviewer = mcpServers.some((s) => s.type === 'http')
+
+      let sessionId: string
+      if (isReviewer) {
+        reviewerSessionCount++
+        sessionId = `${options.reviewerSessionIdPrefix ?? 'reviewer-session'}-${reviewerSessionCount}`
+      } else {
+        sessionId = options.mainSessionId
+      }
+
+      state.sessions.push({
+        sessionId,
+        mcpServers: ctx.params.mcpServers ?? [],
+        cwd: ctx.params.cwd
+      })
+
+      return { sessionId }
+    })
+    .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+      const text = ctx.params.prompt
+        .map((block: ContentBlock) => (block.type === 'text' ? block.text : ''))
+        .join('')
+
+      const existing = state.promptsReceived.get(ctx.params.sessionId) ?? []
+      existing.push(text)
+      state.promptsReceived.set(ctx.params.sessionId, existing)
+
+      // Reviewer sessions have IDs starting with the configured prefix.
+      const prefix = options.reviewerSessionIdPrefix ?? 'reviewer-session'
+      const isReviewerSession = ctx.params.sessionId.startsWith(prefix)
+
+      if (isReviewerSession) {
+        // This is a reviewer session prompt — submit findings based on which review round it is.
+        const roundIndex = reviewerSessionCount - 1 // 0-based index of re-review rounds
+        const sessionRecord = state.sessions[state.sessions.length - 1]
+        const mcpServers = sessionRecord?.mcpServers ?? []
+        const reviewerMcp = (
+          mcpServers as Array<{
+            type?: string
+            url?: string
+            headers?: Array<{ name: string; value: string }>
+          }>
+        ).find((s) => s.type === 'http')
+
+        if (reviewerMcp?.url) {
+          const token =
+            reviewerMcp.headers
+              ?.find((h) => h.name === 'authorization')
+              ?.value?.replace('Bearer ', '') ?? ''
+
+          if (roundIndex === 0) {
+            // Initial review: submit the initial checks
+            await callSubmitFindings(reviewerMcp.url, token, options.initialChecks)
+          } else {
+            // Re-review round (roundIndex >= 1): use re-review checks for this round
+            const reReviewRoundIndex = roundIndex - 1
+            const reReviewChecks = options.reReviewChecksByRound?.[reReviewRoundIndex] ?? []
+            await callSubmitFindings(reviewerMcp.url, token, reReviewChecks)
+          }
+        }
+      } else {
+        // This is a main-session correction prompt
+        state.correctionCount++
+        options.onCorrectionPrompt?.(text, state.correctionCount)
+
+        // Simulate the session JSON being updated with a new agent correction message.
+        // The fix loop needs to reload the session to see new messages after the correction.
+        // In the real app, the session JSON is updated by the ACP runtime's handleSessionUpdate.
+        // In tests, we update the shared session data here.
+        const correctionMsgId = `correction-msg-${state.correctionCount}`
+        const auditorMsgId = `auditor-msg-${state.correctionCount}`
+        const currentMsgs = sessionData.getSession().messages
+        // Add: [Auditor] user message + agent correction response
+        const updatedSession: PersistedChatSession = {
+          ...sessionData.getSession(),
+          messages: [
+            ...currentMsgs,
+            {
+              id: auditorMsgId,
+              role: 'user',
+              content: text,
+              status: 'complete',
+              eventIds: [],
+              createdAt: Date.now(),
+              updatedAt: Date.now()
+            } satisfies PersistedChatMessage,
+            {
+              id: correctionMsgId,
+              role: 'agent',
+              content: 'I have corrected the issue.',
+              status: 'complete',
+              eventIds: [],
+              createdAt: Date.now() + 1,
+              updatedAt: Date.now() + 1
+            } satisfies PersistedChatMessage
+          ]
+        }
+        // Mutate through the shared object so the getSession callback sees updates
+        Object.assign(sessionData, { _session: updatedSession })
+      }
+
+      // Emit a reply chunk and stop.
+      await ctx.client.notify(acp.methods.client.session.update, {
+        sessionId: ctx.params.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          messageId: `reply-${ctx.params.sessionId}-${Date.now()}`,
+          content: { type: 'text', text: 'OK.' }
+        }
+      })
+
+      return { stopReason: 'end_turn' }
+    })
+    .onRequest(acp.methods.agent.session.close, () => ({}))
+    .connect(
+      acp.ndJsonStream(
+        Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+        Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+      )
+    )
+
+  return state
+}
+
+// ---------------------------------------------------------------------------
+// Session fixture helpers
+// ---------------------------------------------------------------------------
+
+const makeSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Test session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [
+    {
+      id: 'msg-1',
+      role: 'user',
+      content: 'Run the analysis',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1000,
+      updatedAt: 1000
+    },
+    {
+      id: 'msg-2',
+      role: 'agent',
+      content: 'I ran the analysis and found 42 results.',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 2000,
+      updatedAt: 2000
+    }
+  ],
+  createdAt: 900,
+  updatedAt: 2000,
+  ...overrides
+})
+
+// Creates a shared session data object whose getSession() returns the latest session state.
+const makeSharedSession = (
+  initial: PersistedChatSession
+): SharedSessionData & { _session: PersistedChatSession } => {
+  const shared = {
+    _session: initial,
+    getSession(): PersistedChatSession {
+      return shared._session
+    }
+  }
+  return shared
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let temporaryRoot: string | undefined
+
+beforeEach(async () => {
+  temporaryRoot = await mkdtemp(join(tmpdir(), 'reviewer-fix-loop-test-'))
+})
+
+afterEach(async () => {
+  if (temporaryRoot) {
+    await rm(temporaryRoot, { recursive: true, force: true })
+    temporaryRoot = undefined
+  }
+})
+
+describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
+  it('resolves all checks when re-review passes; exactly 1 [Auditor] injection for 1 round', async () => {
+    const process = new FakeAgentProcess()
+    const shared = makeSharedSession(makeSession())
+
+    const correctionPrompts: string[] = []
+
+    const agentState = startFixLoopFakeAgent(
+      process,
+      {
+        mainSessionId: 'main-session-1',
+        initialChecks: [
+          {
+            status: 'fail',
+            claim: 'Agent claimed 42 results',
+            evidence: 'Tool output shows 0 results',
+            locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc123' }
+          }
+        ],
+        // Re-review round 1: all pass
+        reReviewChecksByRound: [
+          [
+            {
+              status: 'pass',
+              claim: 'Agent claimed 42 results',
+              evidence: 'Correction confirmed: results now correct'
+            }
+          ]
+        ],
+        onCorrectionPrompt: (text) => {
+          correctionPrompts.push(text)
+        }
+      },
+      shared
+    )
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => shared.getSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1'
+    })
+
+    // Exactly 1 [Auditor] injection for 1 round.
+    expect(correctionPrompts).toHaveLength(1)
+    expect(correctionPrompts[0]).toMatch(/\[Auditor\]/)
+
+    // Exactly 2 reviewer sessions: initial + 1 re-review.
+    const reviewerSessions = agentState.sessions.filter((s) =>
+      s.sessionId.startsWith('reviewer-session')
+    )
+    expect(reviewerSessions).toHaveLength(2)
+
+    // The original review's warn/fail check must now be resolved.
+    const reviews = await repository.getReviewsForSession('session-1')
+    // 2 Review rows: initial + re-review
+    expect(reviews.length).toBeGreaterThanOrEqual(2)
+
+    // The initial review (original turnMessageId = msg-2) should have resolution = resolved.
+    const initialReview = reviews.find((r) =>
+      r.checks.some((c) => c.claim === 'Agent claimed 42 results' && c.resolution === 'resolved')
+    )
+    expect(initialReview).toBeDefined()
+
+    await client.$disconnect()
+  })
+})
+
+describe('fix loop: cap at 3 rounds → unaddressed', () => {
+  it('stops after 3 rounds; remaining warn/fail set to unaddressed; exactly 3 injections', async () => {
+    const process = new FakeAgentProcess()
+    const shared = makeSharedSession(makeSession())
+
+    const correctionPrompts: string[] = []
+
+    const agentState = startFixLoopFakeAgent(
+      process,
+      {
+        mainSessionId: 'main-session-1',
+        initialChecks: [
+          {
+            status: 'fail',
+            claim: 'Persistent issue',
+            evidence: 'Not fixed',
+            locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc' }
+          }
+        ],
+        // All 3 re-review rounds still have warn/fail (never passes)
+        reReviewChecksByRound: [
+          [
+            {
+              status: 'fail',
+              claim: 'Persistent issue',
+              evidence: 'Still not fixed in round 1',
+              locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc' }
+            }
+          ],
+          [
+            {
+              status: 'fail',
+              claim: 'Persistent issue',
+              evidence: 'Still not fixed in round 2',
+              locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc' }
+            }
+          ],
+          [
+            {
+              status: 'fail',
+              claim: 'Persistent issue',
+              evidence: 'Still not fixed in round 3',
+              locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc' }
+            }
+          ]
+        ],
+        onCorrectionPrompt: (text) => {
+          correctionPrompts.push(text)
+        }
+      },
+      shared
+    )
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => shared.getSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1'
+    })
+
+    // Exactly 3 [Auditor] injections.
+    expect(correctionPrompts).toHaveLength(3)
+
+    // 4 reviewer sessions: initial + 3 re-reviews.
+    const reviewerSessions = agentState.sessions.filter((s) =>
+      s.sessionId.startsWith('reviewer-session')
+    )
+    expect(reviewerSessions).toHaveLength(4)
+
+    // The initial review's check must be unaddressed (cap reached).
+    const reviews = await repository.getReviewsForSession('session-1')
+    const hasUnaddressed = reviews.some((r) =>
+      r.checks.some((c) => c.claim === 'Persistent issue' && c.resolution === 'unaddressed')
+    )
+    expect(hasUnaddressed).toBe(true)
+
+    await client.$disconnect()
+  })
+})
+
+describe('fix loop: over-correction increments reflagCount', () => {
+  it('increments reflagCount when the same claim fails again on re-review', async () => {
+    const process = new FakeAgentProcess()
+    const shared = makeSharedSession(makeSession())
+
+    startFixLoopFakeAgent(
+      process,
+      {
+        mainSessionId: 'main-session-1',
+        initialChecks: [
+          {
+            status: 'fail',
+            claim: 'Value should be 42',
+            evidence: 'Tool shows 0',
+            locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc' }
+          }
+        ],
+        // Round 1: over-correction — same claim fails again
+        reReviewChecksByRound: [
+          [
+            {
+              status: 'fail',
+              claim: 'Value should be 42',
+              evidence: 'Now shows 100 — over-corrected',
+              locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc2' }
+            }
+          ],
+          // Round 2: passes
+          [
+            {
+              status: 'pass',
+              claim: 'Value should be 42',
+              evidence: 'Now correct'
+            }
+          ]
+        ]
+      },
+      shared
+    )
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => shared.getSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1'
+    })
+
+    // The original claim's reflagCount should be 1 (re-flagged once).
+    const reviews = await repository.getReviewsForSession('session-1')
+    const allChecks = reviews.flatMap((r) => r.checks)
+    const claimChecks = allChecks.filter((c) => c.claim === 'Value should be 42')
+    const hasReflagged = claimChecks.some((c) => c.reflagCount >= 1)
+    expect(hasReflagged).toBe(true)
+
+    await client.$disconnect()
+  })
+})
+
+describe('fix loop: claim left unchanged stays open', () => {
+  it('keeps claim open (unaddressed at cap) when agent does not address it across all rounds', async () => {
+    const process = new FakeAgentProcess()
+    const shared = makeSharedSession(makeSession())
+
+    const sameWarnCheck = {
+      status: 'warn' as const,
+      claim: 'Ignored warning',
+      evidence: 'No change detected',
+      locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc' }
+    }
+
+    startFixLoopFakeAgent(
+      process,
+      {
+        mainSessionId: 'main-session-1',
+        initialChecks: [
+          {
+            status: 'warn',
+            claim: 'Ignored warning',
+            evidence: 'Agent may not have addressed this',
+            locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc' }
+          }
+        ],
+        // All 3 re-review rounds re-flag the same claim (agent never changes it).
+        reReviewChecksByRound: [[sameWarnCheck], [sameWarnCheck], [sameWarnCheck]]
+      },
+      shared
+    )
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => shared.getSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1'
+    })
+
+    // When the agent never addresses the claim, the loop hits the cap and marks it unaddressed.
+    // The claim should NOT be resolved.
+    const reviews = await repository.getReviewsForSession('session-1')
+    const allChecks = reviews.flatMap((r) => r.checks)
+    const claimChecks = allChecks.filter((c) => c.claim === 'Ignored warning')
+
+    // Must not be resolved (agent left it unchanged → eventually unaddressed at cap).
+    const hasResolved = claimChecks.some((c) => c.resolution === 'resolved')
+    expect(hasResolved).toBe(false)
+
+    // Must be unaddressed (cap reached).
+    const hasUnaddressed = claimChecks.some((c) => c.resolution === 'unaddressed')
+    expect(hasUnaddressed).toBe(true)
+
+    await client.$disconnect()
+  })
+})
+
+describe('fix loop: distinct Review rows per iteration', () => {
+  it('writes a distinct Review row per iteration all sharing the original turnMessageId', async () => {
+    const process = new FakeAgentProcess()
+    const shared = makeSharedSession(makeSession())
+
+    startFixLoopFakeAgent(
+      process,
+      {
+        mainSessionId: 'main-session-1',
+        initialChecks: [
+          {
+            status: 'fail',
+            claim: 'Test claim',
+            evidence: 'Evidence',
+            locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc' }
+          }
+        ],
+        // 2 re-review rounds: first still fails, second passes
+        reReviewChecksByRound: [
+          [
+            {
+              status: 'fail',
+              claim: 'Test claim',
+              evidence: 'Still failing',
+              locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc2' }
+            }
+          ],
+          [
+            {
+              status: 'pass',
+              claim: 'Test claim',
+              evidence: 'Fixed in round 2'
+            }
+          ]
+        ]
+      },
+      shared
+    )
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => shared.getSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1'
+    })
+
+    const reviews = await repository.getReviewsForSession('session-1')
+
+    // 3 Review rows: initial + 2 re-reviews
+    expect(reviews.length).toBeGreaterThanOrEqual(3)
+
+    // All share the same original turnMessageId.
+    const allShareOriginalTurnId = reviews.every((r) => r.turnMessageId === 'msg-2')
+    expect(allShareOriginalTurnId).toBe(true)
+
+    // Each row has a distinct id.
+    const ids = reviews.map((r) => r.id)
+    const uniqueIds = new Set(ids)
+    expect(uniqueIds.size).toBe(ids.length)
+
+    await client.$disconnect()
+  })
+})

--- a/src/main/reviewer/host-sdk-tabular.test.ts
+++ b/src/main/reviewer/host-sdk-tabular.test.ts
@@ -1,0 +1,65 @@
+// Direct unit tests for parseTabular's RFC 4180 handling: quoted fields containing the delimiter,
+// escaped double-quotes, embedded newlines, and duplicate headers. The HTTP-level column tests live
+// in host-sdk.test.ts; these isolate the parser so quoting edge cases are pinned precisely.
+
+import { describe, it, expect } from 'vitest'
+
+import { parseTabular } from './host-sdk'
+
+describe('parseTabular — RFC 4180', () => {
+  it('parses a simple CSV without quotes', () => {
+    const { columns, rowCount } = parseTabular('a,b\n1,2\n3,4\n', ',')
+    expect(rowCount).toBe(2)
+    expect(columns).toEqual({ a: ['1', '3'], b: ['2', '4'] })
+  })
+
+  it('keeps a delimiter inside a quoted field in the same column', () => {
+    const { columns, rowCount } = parseTabular('name,city\n"Smith, John",NYC\n', ',')
+    expect(rowCount).toBe(1)
+    expect(columns).toEqual({ name: ['Smith, John'], city: ['NYC'] })
+  })
+
+  it('unescapes doubled quotes inside a quoted field', () => {
+    const { columns } = parseTabular('quote\n"She said ""hi"""\n', ',')
+    expect(columns.quote).toEqual(['She said "hi"'])
+  })
+
+  it('keeps an embedded newline inside a quoted field as one row', () => {
+    const { columns, rowCount } = parseTabular('a,b\n"line1\nline2",x\n', ',')
+    expect(rowCount).toBe(1)
+    expect(columns.a).toEqual(['line1\nline2'])
+    expect(columns.b).toEqual(['x'])
+  })
+
+  it('does not collapse duplicate headers — later columns are suffixed', () => {
+    const { columns } = parseTabular('id,id,name\n1,2,x\n', ',')
+    expect(columns.id).toEqual(['1'])
+    expect(columns.id_2).toEqual(['2'])
+    expect(columns.name).toEqual(['x'])
+  })
+
+  it('handles quoted fields with the tab delimiter (TSV)', () => {
+    const { columns } = parseTabular('name\tnote\n"a\tb"\thello\n', '\t')
+    expect(columns.name).toEqual(['a\tb'])
+    expect(columns.note).toEqual(['hello'])
+  })
+
+  it('ignores blank lines and a trailing newline', () => {
+    const { columns, rowCount } = parseTabular('a,b\n1,2\n\n', ',')
+    expect(rowCount).toBe(1)
+    expect(columns).toEqual({ a: ['1'], b: ['2'] })
+  })
+
+  it('tolerates CRLF line endings', () => {
+    const { columns, rowCount } = parseTabular('a,b\r\n1,2\r\n', ',')
+    expect(rowCount).toBe(1)
+    expect(columns).toEqual({ a: ['1'], b: ['2'] })
+  })
+
+  it('pads short rows with empty strings', () => {
+    const { columns } = parseTabular('a,b,c\n1,2\n', ',')
+    expect(columns.a).toEqual(['1'])
+    expect(columns.b).toEqual(['2'])
+    expect(columns.c).toEqual([''])
+  })
+})

--- a/src/main/reviewer/host-sdk.test.ts
+++ b/src/main/reviewer/host-sdk.test.ts
@@ -1,0 +1,533 @@
+// Unit tests for ReviewerHostServer: covers host.read_artifact column-parsing for tabular artifacts
+// (CSV/TSV), raw reads, the real managed-storage path layout, missing-file error propagation, and the
+// out-of-scope rejection path.
+//
+// Tests start an actual ReviewerHostServer on a random port and POST to it, mirroring what the
+// Python host bridge does. This exercises the full HTTP RPC layer.
+
+import { writeFile, mkdtemp, mkdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { ReviewerHostServer, buildReviewerHostPythonBootstrap } from './host-sdk'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { TurnScope } from '../../shared/reviewer'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PROJECT = 'project-1'
+// Managed artifacts are addressed by a colon-composite version id: <sessionId>:<messageId>:<filename>.
+const V1 = 'session-1:msg-1:results.csv'
+
+const makeSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: PROJECT,
+  title: 'Test session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [
+    {
+      id: 'msg-1',
+      role: 'user',
+      content: 'Run the analysis',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1000,
+      updatedAt: 1000,
+      artifactIds: [V1]
+    }
+  ],
+  artifacts: [
+    {
+      id: V1,
+      kind: 'managed-file',
+      path: 'results.csv',
+      mimeType: 'text/csv'
+    }
+  ],
+  createdAt: 900,
+  updatedAt: 2000,
+  ...overrides
+})
+
+const makeScope = (artifactVersionIds: string[] = [V1]): TurnScope => ({
+  turnMessageId: 'msg-1',
+  blocks: [
+    {
+      id: 'message:msg-1',
+      kind: 'message',
+      sourceId: 'msg-1',
+      blockIndex: 0,
+      contentHash: 'abc123'
+    }
+  ],
+  artifactVersionIds
+})
+
+// Writes an artifact into the REAL managed layout the app uses:
+// <root>/artifacts/<projectName>/<sessionId>/<messageId>/<filename>, keyed by the colon-composite
+// version id <sessionId>:<messageId>:<filename>.
+const writeArtifact = async (root: string, versionId: string, content: string): Promise<void> => {
+  const firstColon = versionId.indexOf(':')
+  const secondColon = versionId.indexOf(':', firstColon + 1)
+  const sessionId = versionId.slice(0, firstColon)
+  const messageId = versionId.slice(firstColon + 1, secondColon)
+  const filename = versionId.slice(secondColon + 1)
+  const dir = join(root, 'artifacts', PROJECT, sessionId, messageId)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, filename), content)
+}
+
+// Posts a JSON-RPC style request to the host server and returns the parsed body.
+const post = async (
+  endpoint: string,
+  token: string,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<{ result?: unknown; error?: string }> => {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({ method, params })
+  })
+  return response.json() as Promise<{ result?: unknown; error?: string }>
+}
+
+// ---------------------------------------------------------------------------
+// Test lifecycle
+// ---------------------------------------------------------------------------
+
+let tmpDir: string
+let server: ReviewerHostServer
+let endpoint: string
+let token: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'host-sdk-test-'))
+})
+
+afterEach(async () => {
+  await server?.stop().catch(() => undefined)
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// read_artifact: tabular (CSV)
+// ---------------------------------------------------------------------------
+
+describe('host.read_artifact — tabular CSV', () => {
+  it('returns kind=tabular with column-addressable structure for a simple CSV', async () => {
+    await writeArtifact(tmpDir, V1, 'name,value,unit\nalpha,1,mg\nbeta,2,mg\ngamma,3,mg\n')
+
+    server = new ReviewerHostServer(makeSession(), makeScope(), tmpDir)
+    ;({ endpoint, token } = await server.start())
+
+    const body = await post(endpoint, token, 'read_artifact', { id: V1 })
+
+    expect(body.result).toMatchObject({
+      id: V1,
+      kind: 'tabular',
+      rowCount: 3,
+      columns: {
+        name: ['alpha', 'beta', 'gamma'],
+        value: ['1', '2', '3'],
+        unit: ['mg', 'mg', 'mg']
+      }
+    })
+  })
+
+  it('returns kind=tabular for a CSV with more than 5 columns', async () => {
+    const versionId = 'session-1:msg-1:wide.csv'
+    const header = 'a,b,c,d,e,f,g'
+    const row1 = '1,2,3,4,5,6,7'
+    const row2 = '8,9,10,11,12,13,14'
+    await writeArtifact(tmpDir, versionId, `${header}\n${row1}\n${row2}\n`)
+
+    server = new ReviewerHostServer(
+      makeSession({
+        artifacts: [{ id: versionId, kind: 'managed-file', path: 'wide.csv', mimeType: 'text/csv' }]
+      }),
+      makeScope([versionId]),
+      tmpDir
+    )
+    ;({ endpoint, token } = await server.start())
+
+    const body = await post(endpoint, token, 'read_artifact', { id: versionId })
+
+    const result = body.result as {
+      kind: string
+      rowCount: number
+      columns: Record<string, string[]>
+    }
+    expect(result.kind).toBe('tabular')
+    expect(result.rowCount).toBe(2)
+    expect(Object.keys(result.columns)).toHaveLength(7)
+    expect(result.columns['a']).toEqual(['1', '8'])
+    expect(result.columns['g']).toEqual(['7', '14'])
+  })
+
+  it('returns kind=tabular for a TSV artifact', async () => {
+    const versionId = 'session-1:msg-1:data.tsv'
+    await writeArtifact(tmpDir, versionId, 'col1\tcol2\tcol3\nfoo\t10\tbar\nbaz\t20\tqux\n')
+
+    server = new ReviewerHostServer(
+      makeSession({
+        artifacts: [
+          {
+            id: versionId,
+            kind: 'managed-file',
+            path: 'data.tsv',
+            mimeType: 'text/tab-separated-values'
+          }
+        ]
+      }),
+      makeScope([versionId]),
+      tmpDir
+    )
+    ;({ endpoint, token } = await server.start())
+
+    const body = await post(endpoint, token, 'read_artifact', { id: versionId })
+
+    const result = body.result as {
+      kind: string
+      rowCount: number
+      columns: Record<string, string[]>
+    }
+    expect(result.kind).toBe('tabular')
+    expect(result.rowCount).toBe(2)
+    expect(result.columns['col1']).toEqual(['foo', 'baz'])
+    expect(result.columns['col2']).toEqual(['10', '20'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// read_artifact: non-tabular (kind=raw)
+// ---------------------------------------------------------------------------
+
+describe('host.read_artifact — non-tabular', () => {
+  it('returns kind=raw with content for a plain text artifact', async () => {
+    const versionId = 'session-1:msg-1:report.txt'
+    await writeArtifact(tmpDir, versionId, 'Hello from the artifact!')
+
+    server = new ReviewerHostServer(
+      makeSession({
+        artifacts: [
+          { id: versionId, kind: 'managed-file', path: 'report.txt', mimeType: 'text/plain' }
+        ]
+      }),
+      makeScope([versionId]),
+      tmpDir
+    )
+    ;({ endpoint, token } = await server.start())
+
+    const body = await post(endpoint, token, 'read_artifact', { id: versionId })
+
+    expect(body.result).toMatchObject({
+      id: versionId,
+      kind: 'raw',
+      content: 'Hello from the artifact!'
+    })
+  })
+
+  it('returns kind=raw for an artifact with no mimeType (content-sniff fallback)', async () => {
+    const versionId = 'session-1:msg-1:unknown.bin'
+    await writeArtifact(tmpDir, versionId, 'some text content')
+
+    // Session has no mimeType for this artifact — should fall back to raw.
+    server = new ReviewerHostServer(
+      makeSession({
+        artifacts: [{ id: versionId, kind: 'managed-file', path: 'unknown.bin' }]
+      }),
+      makeScope([versionId]),
+      tmpDir
+    )
+    ;({ endpoint, token } = await server.start())
+
+    const body = await post(endpoint, token, 'read_artifact', { id: versionId })
+
+    const result = body.result as { kind: string }
+    expect(result.kind).toBe('raw')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// read_artifact: real content vs. read failure (regression: no silent-swallow)
+// ---------------------------------------------------------------------------
+
+describe('host.read_artifact — read failures are not empty content', () => {
+  it('surfaces an error (not empty content) when the artifact file is missing on disk', async () => {
+    // The version id is in scope, but no file was written to managed storage.
+    server = new ReviewerHostServer(makeSession(), makeScope(), tmpDir)
+    ;({ endpoint, token } = await server.start())
+
+    const body = await post(endpoint, token, 'read_artifact', { id: V1 })
+
+    // A read failure must be an error, NOT a { kind:'raw', content:'' } success — otherwise the
+    // reviewer cannot tell "could not read" from "genuinely empty".
+    expect(body.result).toBeUndefined()
+    expect(body.error).toBeTruthy()
+    expect(body.error).toMatch(/results\.csv|read/i)
+  })
+
+  it('returns empty content WITHOUT error for a genuinely empty (0-byte) readable artifact', async () => {
+    const versionId = 'session-1:msg-1:empty.txt'
+    await writeArtifact(tmpDir, versionId, '')
+
+    server = new ReviewerHostServer(
+      makeSession({
+        artifacts: [
+          { id: versionId, kind: 'managed-file', path: 'empty.txt', mimeType: 'text/plain' }
+        ]
+      }),
+      makeScope([versionId]),
+      tmpDir
+    )
+    ;({ endpoint, token } = await server.start())
+
+    const body = await post(endpoint, token, 'read_artifact', { id: versionId })
+
+    expect(body.error).toBeUndefined()
+    expect(body.result).toMatchObject({ id: versionId, kind: 'raw', content: '' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// read_artifact: scope isolation — out-of-scope id rejected
+// ---------------------------------------------------------------------------
+
+describe('host.read_artifact — scope isolation', () => {
+  it('rejects artifact ids not in the turn scope', async () => {
+    server = new ReviewerHostServer(
+      makeSession(),
+      makeScope([V1]), // only V1 in scope
+      tmpDir
+    )
+    ;({ endpoint, token } = await server.start())
+
+    // A different version id is NOT in scope.
+    const body = await post(endpoint, token, 'read_artifact', {
+      id: 'session-1:msg-1:secret.csv'
+    })
+
+    expect(body.error).toMatch(/secret\.csv/)
+    expect(body.error).toMatch(/not in this turn/)
+  })
+
+  it('rejects requests with an invalid bearer token', async () => {
+    server = new ReviewerHostServer(makeSession(), makeScope(), tmpDir)
+    ;({ endpoint, token } = await server.start())
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer bad-token'
+      },
+      body: JSON.stringify({ method: 'read_artifact', params: { id: V1 } })
+    })
+
+    expect(response.status).toBe(401)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// read_artifact: CSV sniffing by content when no mimeType
+// ---------------------------------------------------------------------------
+
+describe('host.read_artifact — CSV content sniffing', () => {
+  it('detects CSV by comma-delimited content even without a mimeType', async () => {
+    const versionId = 'session-1:msg-1:data.csv'
+    // A clean CSV file but stored without a mimeType in the session artifacts.
+    await writeArtifact(tmpDir, versionId, 'x,y,z\n1,2,3\n4,5,6\n')
+
+    server = new ReviewerHostServer(
+      makeSession({
+        // Artifact stored without mimeType but with .csv extension in path — use extension to sniff.
+        artifacts: [{ id: versionId, kind: 'managed-file', path: 'data.csv' }]
+      }),
+      makeScope([versionId]),
+      tmpDir
+    )
+    ;({ endpoint, token } = await server.start())
+
+    const body = await post(endpoint, token, 'read_artifact', { id: versionId })
+
+    const result = body.result as { kind: string; rowCount: number }
+    expect(result.kind).toBe('tabular')
+    expect(result.rowCount).toBe(2)
+  })
+
+  it('detects TSV by .tsv extension when no mimeType', async () => {
+    const versionId = 'session-1:msg-1:results.tsv'
+    await writeArtifact(tmpDir, versionId, 'a\tb\tc\n1\t2\t3\n')
+
+    server = new ReviewerHostServer(
+      makeSession({
+        artifacts: [{ id: versionId, kind: 'managed-file', path: 'results.tsv' }]
+      }),
+      makeScope([versionId]),
+      tmpDir
+    )
+    ;({ endpoint, token } = await server.start())
+
+    const body = await post(endpoint, token, 'read_artifact', { id: versionId })
+
+    const result = body.result as { kind: string }
+    expect(result.kind).toBe('tabular')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// read_turn / query_execution_log: surface tool I/O from toolContent
+// ---------------------------------------------------------------------------
+
+// A scope whose single block is the tool activity `act-1`.
+const activityScope = (): TurnScope => ({
+  turnMessageId: 'msg-1',
+  blocks: [
+    { id: 'activity:act-1', kind: 'activity', sourceId: 'act-1', blockIndex: 0, contentHash: 'h1' }
+  ],
+  artifactVersionIds: []
+})
+
+describe('host tool I/O — surfaced from toolContent', () => {
+  it('surfaces tool payload text from toolContent when rawInput/rawOutput are absent', async () => {
+    // Mirrors a real MCP notebook_execute activity: no rawInput/rawOutput, payload lives in toolContent.
+    const session = makeSession({
+      messages: [],
+      activities: [
+        {
+          id: 'act-1',
+          kind: 'tool',
+          title: 'mcp__open-science-notebook__notebook_execute',
+          status: 'completed',
+          sortIndex: 0,
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 2,
+          toolContent: [
+            { type: 'content', content: { type: 'text', text: '{"script":"print(6*7)"}' } }
+          ]
+        }
+      ]
+    })
+
+    server = new ReviewerHostServer(session, activityScope(), tmpDir)
+    ;({ endpoint, token } = await server.start())
+
+    // query_execution_log exposes the payload.
+    const log = await post(endpoint, token, 'query_execution_log', { activityId: 'act-1' })
+    const records = log.result as Array<Record<string, unknown>>
+    expect(records).toHaveLength(1)
+    expect(JSON.stringify(records[0])).toContain('print(6*7)')
+
+    // read_turn exposes the same payload on the activity block.
+    const turn = await post(endpoint, token, 'read_turn')
+    const blocks = turn.result as Array<Record<string, unknown>>
+    expect(JSON.stringify(blocks[0])).toContain('print(6*7)')
+  })
+
+  it('preserves existing rawInput/rawOutput/terminalOutput (no regression)', async () => {
+    const session = makeSession({
+      messages: [],
+      activities: [
+        {
+          id: 'act-1',
+          kind: 'tool',
+          title: 'Bash',
+          status: 'completed',
+          sortIndex: 0,
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 2,
+          rawInput: { command: 'ls' },
+          rawOutput: { stdout: 'file.txt' },
+          terminalOutput: 'file.txt'
+        }
+      ]
+    })
+
+    server = new ReviewerHostServer(session, activityScope(), tmpDir)
+    ;({ endpoint, token } = await server.start())
+
+    const log = await post(endpoint, token, 'query_execution_log', { activityId: 'act-1' })
+    const records = log.result as Array<{
+      rawInput?: unknown
+      rawOutput?: unknown
+      terminalOutput?: string
+    }>
+    expect(records[0].rawInput).toEqual({ command: 'ls' })
+    expect(records[0].rawOutput).toEqual({ stdout: 'file.txt' })
+    expect(records[0].terminalOutput).toBe('file.txt')
+  })
+
+  it('tolerates empty / malformed toolContent blocks without throwing', async () => {
+    const session = makeSession({
+      messages: [],
+      activities: [
+        {
+          id: 'act-1',
+          kind: 'tool',
+          title: 'mcp__open-science-notebook__notebook_execute',
+          status: 'completed',
+          sortIndex: 0,
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 2,
+          toolContent: [
+            {},
+            { type: 'content' },
+            { type: 'content', content: { type: 'text', text: 'kept-text' } }
+          ]
+        }
+      ]
+    })
+
+    server = new ReviewerHostServer(session, activityScope(), tmpDir)
+    ;({ endpoint, token } = await server.start())
+
+    const log = await post(endpoint, token, 'query_execution_log', { activityId: 'act-1' })
+    expect(log.error).toBeUndefined()
+    const records = log.result as Array<Record<string, unknown>>
+    expect(JSON.stringify(records[0])).toContain('kept-text')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// host RPC — method surface discoverability
+// ---------------------------------------------------------------------------
+
+describe('host RPC — method surface', () => {
+  it('answers an unknown method with an error naming the supported methods', async () => {
+    server = new ReviewerHostServer(makeSession(), makeScope(), tmpDir)
+    ;({ endpoint, token } = await server.start())
+
+    // The reviewer model tends to guess methods like `list_artifacts`; the error must tell it what
+    // IS available so it stops guessing.
+    const body = await post(endpoint, token, 'list_artifacts')
+
+    expect(body.result).toBeUndefined()
+    expect(body.error).toMatch(/list_artifacts/)
+    expect(body.error).toMatch(/read_turn/)
+    expect(body.error).toMatch(/query_execution_log/)
+    expect(body.error).toMatch(/read_artifact/)
+  })
+})
+
+describe('buildReviewerHostPythonBootstrap — single source of the host client', () => {
+  it('defines all three supported host methods and binds the endpoint/token', () => {
+    const code = buildReviewerHostPythonBootstrap('http://127.0.0.1:9', 'tok-123')
+
+    expect(code).toContain('def read_turn')
+    expect(code).toContain('def query_execution_log')
+    expect(code).toContain('def read_artifact')
+    expect(code).toContain('http://127.0.0.1:9')
+    expect(code).toContain('tok-123')
+  })
+})

--- a/src/main/reviewer/host-sdk.ts
+++ b/src/main/reviewer/host-sdk.ts
@@ -1,0 +1,583 @@
+// Host SDK for the reviewer REPL sandbox. Provides scope-narrowed read functions that the reviewer
+// calls from Python code to access the audited turn's data. All access is validated against the
+// TurnScope produced by resolveTurnScope; out-of-scope ids are rejected.
+//
+// The "host" module is injected into the reviewer Python sandbox via an HTTP RPC endpoint (mirroring
+// how the notebook MCP server's host.mcp() works). The reviewer REPL's Python bridge boots a _Host
+// object; calls to host.read_turn() / host.query_execution_log() / host.read_artifact() POST to this
+// server and get back JSON.
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { extname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+import { getProjectArtifactDir } from '../artifacts/repository'
+import type { PersistedChatSession, PersistedToolActivity } from '../../shared/session-persistence'
+import type { TurnScope, ScopeBlock } from '../../shared/reviewer'
+
+// One readable block as returned by host.read_turn().
+export type OrderedBlock = {
+  blockIndex: number
+  id: string
+  kind: 'message' | 'activity'
+  sourceId: string
+  contentHash: string
+  // Message fields — present when kind='message'
+  role?: string
+  content?: string
+  artifactIds?: string[]
+  // Activity fields — present when kind='activity'
+  title?: string
+  status?: string
+  toolKind?: string
+  rawInput?: unknown
+  rawOutput?: unknown
+  terminalOutput?: string
+  terminalExitCode?: number | null
+}
+
+// Execution record returned by host.query_execution_log().
+export type ExecRecord = {
+  activityId: string
+  title: string
+  status: string
+  rawInput?: unknown
+  rawOutput?: unknown
+  terminalOutput?: string
+  terminalExitCode?: number | null
+}
+
+// Column-addressable structure returned for tabular (CSV/TSV) artifacts so the reviewer can
+// match by column name instead of aligning rows visually.
+export type TabularArtifactContent = {
+  id: string
+  kind: 'tabular'
+  // Each key is a column header; the array contains the string values of that column across all rows.
+  columns: Record<string, string[]>
+  rowCount: number
+}
+
+// Raw content for non-tabular artifacts (text UTF-8 or base64-encoded binary).
+export type RawArtifactContent = {
+  id: string
+  kind: 'raw'
+  content: string
+  encoding: 'utf8' | 'base64'
+}
+
+// Artifact content as returned by host.read_artifact(id): column-addressable for CSV/TSV, raw otherwise.
+export type ArtifactContent = TabularArtifactContent | RawArtifactContent
+
+// The complete set of RPC methods the host exposes. Single-sourced so the unknown-method error can
+// tell a guessing reviewer exactly what IS available (it likes to try e.g. `list_artifacts`).
+export const SUPPORTED_HOST_METHODS = ['read_turn', 'query_execution_log', 'read_artifact'] as const
+
+// The HTTP RPC server that backs the host.* Python functions in the reviewer sandbox.
+// It verifies every requested id against the TurnScope so the reviewer can only see this turn.
+export class ReviewerHostServer {
+  private server: Server
+  readonly token: string
+  private _endpoint: string | undefined
+
+  constructor(
+    private readonly session: PersistedChatSession,
+    private readonly scope: TurnScope,
+    private readonly artifactStorageRoot: string
+  ) {
+    this.token = randomUUID()
+    this.server = createServer((req, res) => {
+      void this.handleRequest(req, res).catch((error) => {
+        res.writeHead(500, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
+      })
+    })
+  }
+
+  // Starts the server on a random port and resolves the endpoint URL.
+  async start(): Promise<{ endpoint: string; token: string }> {
+    await new Promise<void>((resolve, reject) => {
+      this.server.listen(0, '127.0.0.1', () => resolve())
+      this.server.once('error', reject)
+    })
+
+    const addr = this.server.address() as { port: number }
+    this._endpoint = `http://127.0.0.1:${addr.port}`
+
+    return { endpoint: this._endpoint, token: this.token }
+  }
+
+  // Shuts down the server; called after the reviewer session disposes.
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve) => this.server.close(() => resolve()))
+  }
+
+  get endpoint(): string {
+    if (!this._endpoint) throw new Error('ReviewerHostServer not started')
+    return this._endpoint
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // Verify bearer token.
+    const authHeader = req.headers['authorization'] ?? ''
+    const bearer = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : ''
+
+    if (bearer !== this.token) {
+      res.writeHead(401, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Unauthorized' }))
+      return
+    }
+
+    // Read body.
+    const body = await readBody(req)
+    let parsed: { method?: string; params?: Record<string, unknown> }
+
+    try {
+      parsed = JSON.parse(body) as typeof parsed
+    } catch {
+      res.writeHead(400, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Invalid JSON body' }))
+      return
+    }
+
+    const method = parsed.method
+    const params = parsed.params ?? {}
+
+    let result: unknown
+
+    switch (method) {
+      case 'read_turn':
+        result = this.readTurn()
+        break
+      case 'query_execution_log':
+        result = this.queryExecutionLog(params.activityId as string | undefined)
+        break
+      case 'read_artifact':
+        result = await this.readArtifact(params.id as string)
+        break
+      default:
+        res.writeHead(400, { 'content-type': 'application/json' })
+        res.end(
+          JSON.stringify({
+            error:
+              `Unknown method: ${method ?? 'undefined'}. ` +
+              `Supported methods: ${SUPPORTED_HOST_METHODS.join(', ')}.`
+          })
+        )
+        return
+    }
+
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ result }))
+  }
+
+  // Returns the ordered blocks for this turn with their content and metadata.
+  private readTurn(): OrderedBlock[] {
+    const messageMap = new Map(this.session.messages.map((m) => [m.id, m]))
+    const activityMap = new Map((this.session.activities ?? []).map((a) => [a.id, a]))
+
+    return this.scope.blocks.map((block): OrderedBlock => {
+      if (block.kind === 'message') {
+        const msg = messageMap.get(block.sourceId)
+
+        return {
+          blockIndex: block.blockIndex,
+          id: block.id,
+          kind: 'message',
+          sourceId: block.sourceId,
+          contentHash: block.contentHash,
+          role: msg?.role,
+          content: msg?.content,
+          artifactIds: msg?.artifactIds
+        }
+      } else {
+        const activity = activityMap.get(block.sourceId)
+
+        return {
+          blockIndex: block.blockIndex,
+          id: block.id,
+          kind: 'activity',
+          sourceId: block.sourceId,
+          contentHash: block.contentHash,
+          title: activity?.title,
+          status: activity?.status,
+          toolKind: activity?.toolKind,
+          ...(activity ? activityIoFields(activity) : {})
+        }
+      }
+    })
+  }
+
+  // Returns execution records for this turn's activities, optionally filtered to one activity.
+  private queryExecutionLog(activityId?: string): ExecRecord[] {
+    const activityIds = new Set(
+      this.scope.blocks.filter((b) => b.kind === 'activity').map((b) => b.sourceId)
+    )
+    const activities: PersistedToolActivity[] = (this.session.activities ?? []).filter((a) =>
+      activityIds.has(a.id)
+    )
+
+    const target =
+      activityId !== undefined ? activities.filter((a) => a.id === activityId) : activities
+
+    // Out-of-scope id: reject rather than silently returning empty.
+    if (activityId !== undefined && target.length === 0) {
+      throw new Error(
+        `Activity id ${JSON.stringify(activityId)} is not in this turn's scope. ` +
+          `Allowed ids: ${[...activityIds].join(', ')}`
+      )
+    }
+
+    return target.map((a) => ({
+      activityId: a.id,
+      title: a.title,
+      status: a.status,
+      ...activityIoFields(a)
+    }))
+  }
+
+  // Returns artifact content for an artifact id belonging to this turn.
+  // Tabular artifacts (CSV/TSV) are returned as { kind:'tabular'; columns; rowCount } so the
+  // reviewer can address by column name without visual row alignment. Non-tabular artifacts
+  // return { kind:'raw'; content; encoding }.
+  private async readArtifact(id: string): Promise<ArtifactContent> {
+    if (!this.scope.artifactVersionIds.includes(id)) {
+      throw new Error(
+        `Artifact id ${JSON.stringify(id)} is not in this turn's scope. ` +
+          `Allowed ids: ${this.scope.artifactVersionIds.join(', ')}`
+      )
+    }
+
+    // Look up artifact metadata from the session so we can determine the format.
+    const artifactMeta = (this.session.artifacts ?? []).find((a) => a.id === id)
+
+    // Read the artifact from managed storage. A read failure (missing/unreadable file) MUST surface
+    // as an error, not degrade to empty content — otherwise the reviewer cannot distinguish "could
+    // not read" from "the file is genuinely empty", which produces false "empty artifact" findings.
+    const artifactPath = resolveArtifactPath(this.artifactStorageRoot, this.session.projectId, id)
+
+    let bytes: Buffer
+    try {
+      bytes = await readFile(artifactPath)
+    } catch (error) {
+      throw new Error(
+        `Failed to read artifact ${JSON.stringify(id)} at ${artifactPath}: ` +
+          `${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+
+    const isText = isLikelyText(bytes)
+
+    if (isText) {
+      const text = bytes.toString('utf8')
+
+      // Determine if this artifact is a tabular format (CSV/TSV) by mimeType or path extension.
+      if (isTabularArtifact(artifactMeta?.mimeType, artifactMeta?.path)) {
+        const parsed = parseTabular(
+          text,
+          detectDelimiter(artifactMeta?.mimeType, artifactMeta?.path)
+        )
+        return { id, kind: 'tabular', columns: parsed.columns, rowCount: parsed.rowCount }
+      }
+
+      return { id, kind: 'raw', content: text, encoding: 'utf8' }
+    }
+
+    return { id, kind: 'raw', content: bytes.toString('base64'), encoding: 'base64' }
+  }
+}
+
+// Reads the full HTTP request body as a string.
+const readBody = (req: IncomingMessage): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    req.on('error', reject)
+  })
+
+// The I/O fields exposed to the reviewer for one tool activity. Non-MCP tools (e.g. Bash) populate
+// rawInput/rawOutput/terminalOutput directly; MCP tools (notebook_execute, write_artifact_file) leave
+// those empty and record their payload in toolContent instead. To keep the reviewer from being blind
+// to what a tool actually did, we surface the toolContent text under rawOutput when rawOutput is
+// absent — otherwise the reviewer cannot verify a claim against the tool's real output.
+const activityIoFields = (
+  activity: PersistedToolActivity
+): Pick<ExecRecord, 'rawInput' | 'rawOutput' | 'terminalOutput' | 'terminalExitCode'> => {
+  const toolContentText =
+    activity.rawOutput === undefined ? extractToolContentText(activity.toolContent) : undefined
+
+  return {
+    rawInput: activity.rawInput,
+    rawOutput: activity.rawOutput ?? toolContentText,
+    terminalOutput: activity.terminalOutput,
+    terminalExitCode: activity.terminalExitCode
+  }
+}
+
+// Pulls the readable text out of an ACP-style toolContent array. Each block is loosely typed; we
+// tolerate blocks without text (returning undefined when nothing readable is present). Handles both
+// `{ content: { text } }` and flat `{ text }` shapes.
+const extractToolContentText = (toolContent: unknown[] | undefined): string | undefined => {
+  if (!Array.isArray(toolContent)) return undefined
+
+  const texts: string[] = []
+  for (const block of toolContent) {
+    if (typeof block !== 'object' || block === null) continue
+    const record = block as Record<string, unknown>
+
+    const nested =
+      typeof record.content === 'object' && record.content !== null
+        ? (record.content as Record<string, unknown>).text
+        : undefined
+
+    if (typeof nested === 'string') texts.push(nested)
+    else if (typeof record.text === 'string') texts.push(record.text)
+  }
+
+  return texts.length > 0 ? texts.join('\n') : undefined
+}
+
+// Heuristic to distinguish text from binary artifact content.
+const isLikelyText = (bytes: Buffer): boolean => {
+  const sample = bytes.slice(0, 512)
+
+  for (const byte of sample) {
+    if (byte === 0) return false
+  }
+
+  return true
+}
+
+// Resolves an artifact file path from managed storage, reusing the layout owned by ArtifactRepository:
+// <storageRoot>/artifacts/<projectName>/<sessionId>/<messageId>/<filename>. The version id is the
+// colon-composite <sessionId>:<messageId>:<filename> assigned when the artifact is attached to a turn.
+const resolveArtifactPath = (
+  storageRoot: string,
+  projectName: string,
+  versionId: string
+): string => {
+  const firstColon = versionId.indexOf(':')
+  const secondColon = versionId.indexOf(':', firstColon + 1)
+
+  if (firstColon === -1 || secondColon === -1) {
+    throw new Error(`Malformed artifact version id ${JSON.stringify(versionId)}`)
+  }
+
+  const sessionId = versionId.slice(0, firstColon)
+  const messageId = versionId.slice(firstColon + 1, secondColon)
+  const filename = versionId.slice(secondColon + 1)
+
+  return join(getProjectArtifactDir(storageRoot, projectName), sessionId, messageId, filename)
+}
+
+// MIME types and file extensions that indicate a tabular (delimiter-separated) format.
+const TABULAR_MIME_TYPES = new Set([
+  'text/csv',
+  'application/csv',
+  'text/tab-separated-values',
+  'application/tab-separated-values'
+])
+const TABULAR_EXTENSIONS = new Set(['.csv', '.tsv'])
+
+// Returns true when the artifact should be parsed as a tabular structure.
+const isTabularArtifact = (mimeType?: string, path?: string): boolean => {
+  if (mimeType && TABULAR_MIME_TYPES.has(mimeType.toLowerCase().split(';')[0]?.trim() ?? '')) {
+    return true
+  }
+
+  if (path) {
+    const ext = extname(path).toLowerCase()
+    if (TABULAR_EXTENSIONS.has(ext)) return true
+  }
+
+  return false
+}
+
+// Detects the field delimiter for a tabular artifact from its MIME type or path extension.
+// Falls back to comma (CSV) when the format is ambiguous.
+const detectDelimiter = (mimeType?: string, path?: string): ',' | '\t' => {
+  if (mimeType) {
+    const normalized = mimeType.toLowerCase()
+    if (normalized.includes('tab-separated')) return '\t'
+  }
+
+  if (path) {
+    const ext = extname(path).toLowerCase()
+    if (ext === '.tsv') return '\t'
+  }
+
+  return ','
+}
+
+// Splits delimiter-separated text into rows of fields following RFC 4180: fields may be wrapped in
+// double quotes, a quoted field may contain the delimiter, embedded newlines, and escaped quotes
+// (""). CRLF and LF line endings are both accepted. Fully-empty rows (blank lines) are dropped.
+const parseDelimitedRows = (text: string, delimiter: string): string[][] => {
+  const rows: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let inQuotes = false
+  let rowHasContent = false
+
+  const endField = (): void => {
+    row.push(field)
+    field = ''
+  }
+  const endRow = (): void => {
+    endField()
+    // Drop blank lines: a row that is a single empty field with no quoted content.
+    if (rowHasContent || row.length > 1) rows.push(row)
+    row = []
+    rowHasContent = false
+  }
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]!
+
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"'
+          i++
+        } else {
+          inQuotes = false
+        }
+      } else {
+        field += ch
+      }
+      continue
+    }
+
+    if (ch === '"') {
+      inQuotes = true
+      rowHasContent = true
+    } else if (ch === delimiter) {
+      rowHasContent = true
+      endField()
+    } else if (ch === '\r') {
+      // Swallow CR; the following LF (if any) terminates the row.
+    } else if (ch === '\n') {
+      endRow()
+    } else {
+      field += ch
+      rowHasContent = true
+    }
+  }
+
+  // Flush any trailing field/row not terminated by a newline.
+  if (inQuotes || rowHasContent || row.length > 0) endRow()
+
+  return rows
+}
+
+// Parses delimiter-separated text into a column-addressable structure. The first row is treated as
+// the header. Blank lines are ignored; RFC 4180 quoting is honored (see parseDelimitedRows).
+// Duplicate headers are disambiguated by suffixing (`id`, `id_2`, …) so no column is silently lost.
+// Returns columns as Record<header, values[]> plus the row count (excluding the header row).
+export const parseTabular = (
+  text: string,
+  delimiter: ',' | '\t'
+): { columns: Record<string, string[]>; rowCount: number } => {
+  const rows = parseDelimitedRows(text, delimiter)
+
+  if (rows.length === 0) {
+    return { columns: {}, rowCount: 0 }
+  }
+
+  // Disambiguate duplicate headers so each source column survives.
+  const seen = new Map<string, number>()
+  const headers = rows[0]!.map((raw) => {
+    const count = (seen.get(raw) ?? 0) + 1
+    seen.set(raw, count)
+    return count === 1 ? raw : `${raw}_${count}`
+  })
+
+  const columns: Record<string, string[]> = {}
+  for (const header of headers) {
+    columns[header] = []
+  }
+
+  const dataRows = rows.slice(1)
+
+  for (const dataRow of dataRows) {
+    for (let col = 0; col < headers.length; col++) {
+      const header = headers[col]!
+      columns[header]!.push(dataRow[col] ?? '')
+    }
+  }
+
+  return { columns, rowCount: dataRows.length }
+}
+
+// The Python bootstrap code injected into the reviewer sandbox. It defines a `host` module
+// that forwards read_turn / query_execution_log / read_artifact calls to the ReviewerHostServer.
+export const buildReviewerHostPythonBootstrap = (endpoint: string, token: string): string => `
+import json
+import urllib.request
+import urllib.error
+
+class _ReviewerHost:
+    """Scope-narrowed read access to the audited turn. Call these from the reviewer REPL."""
+
+    def __init__(self, endpoint, token):
+        self._endpoint = endpoint
+        self._token = token
+
+    def _call(self, method, params=None):
+        payload = json.dumps({"method": method, "params": params or {}}).encode("utf-8")
+        req = urllib.request.Request(
+            self._endpoint, data=payload, method="POST",
+            headers={
+                "content-type": "application/json",
+                "authorization": "Bearer " + self._token
+            }
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            try:
+                parsed = json.loads(e.read().decode("utf-8"))
+            except Exception:
+                parsed = {}
+            raise RuntimeError(parsed.get("error") or ("host HTTP " + str(e.code)))
+        if body.get("error"):
+            raise RuntimeError("host error: " + str(body["error"]))
+        return body["result"]
+
+    def read_turn(self):
+        """Return the ordered block list for the audited turn."""
+        return self._call("read_turn")
+
+    def query_execution_log(self, activity_id=None):
+        """Return execution records for this turn's activities (optionally filter to one)."""
+        params = {}
+        if activity_id is not None:
+            params["activityId"] = activity_id
+        return self._call("query_execution_log", params)
+
+    def read_artifact(self, artifact_id):
+        """Return artifact content for an artifact belonging to this turn.
+
+        For tabular artifacts (CSV, TSV) returns:
+          {'kind': 'tabular', 'id': ..., 'columns': {'col': [values]}, 'rowCount': N}
+        where each column is addressable by name — no visual row-alignment needed.
+
+        For all other artifacts returns:
+          {'kind': 'raw', 'id': ..., 'content': '...', 'encoding': 'utf8'|'base64'}
+        """
+        return self._call("read_artifact", {"id": artifact_id})
+
+# Inject into sandbox globals under the name host.
+host = _ReviewerHost(${JSON.stringify(endpoint)}, ${JSON.stringify(token)})
+`
+
+// Verifies that a given block id is within the scope. Used by submit_findings to validate locators.
+export const assertBlockInScope = (block: ScopeBlock | undefined, id: string): ScopeBlock => {
+  if (!block) {
+    throw new Error(`Block ${JSON.stringify(id)} is not in the turn scope.`)
+  }
+  return block
+}

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -1,0 +1,179 @@
+// IPC layer for the reviewer feature. Follows the same patterns as src/main/acp/ipc.ts and
+// src/main/artifacts/ipc.ts: ipcMain.handle for renderer-callable commands, BrowserWindow.send
+// for push events from main to renderer.
+
+import { BrowserWindow, ipcMain } from 'electron'
+
+import type { ReviewWithChecks, ReviewRunRequest, ReviewUpdateEvent } from '../../shared/reviewer'
+import { REVIEWER_IPC } from '../../shared/reviewer'
+import { createLogger } from '../logger'
+import { runReview } from './orchestrator'
+import { ReviewRepository } from './repository'
+import type { AcpRuntime } from '../acp/runtime'
+import { resolveStorageRoot } from '../storage-root'
+import { getProjectDbClient } from '../projects/prisma-client'
+import { SessionRepository } from '../session-persistence/repository'
+
+const log = createLogger('reviewer:ipc')
+
+// Sends a review update event to every open renderer window.
+const broadcastReviewUpdate = (event: ReviewUpdateEvent): void => {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(REVIEWER_IPC.UPDATED, event)
+    }
+  }
+}
+
+// Broadcasts the loop-guard event that tells the renderer to skip the next auto-review call for the
+// given session. Called just before the [Auditor] correction prompt is sent so the correction
+// turn's stop does not spawn a second review run (Phase 1 single-round invariant). When clear=true
+// it instead cancels a pending suppression — used when the correction turn failed to send, so the
+// one-shot flag doesn't leak into the session's next real turn.
+const broadcastSuppressNextAutoReview = (sessionId: string, clear = false): void => {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(REVIEWER_IPC.SUPPRESS_NEXT_AUTO_REVIEW, { sessionId, clear })
+    }
+  }
+}
+
+// Broadcasts a fix-loop-start event: the renderer reacts by setting fixLoopActive=true on the
+// session and disabling the composer send button for the duration of the loop.
+const broadcastFixLoopStart = (sessionId: string): void => {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(REVIEWER_IPC.FIX_LOOP_START, { sessionId })
+    }
+  }
+}
+
+// Broadcasts a fix-loop-end event: the renderer reacts by clearing fixLoopActive on the session
+// and re-enabling the composer send button.
+const broadcastFixLoopEnd = (sessionId: string): void => {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(REVIEWER_IPC.FIX_LOOP_END, { sessionId })
+    }
+  }
+}
+
+// Creates the shared ReviewRepository backed by the production SQLite client.
+const createDefaultReviewRepository = (): ReviewRepository => {
+  const storageRoot = resolveStorageRoot()
+
+  return new ReviewRepository(() => getProjectDbClient(storageRoot))
+}
+
+type ReviewerIpcOptions = {
+  // The ACP runtime used to spawn reviewer sessions.
+  acpRuntime: AcpRuntime
+  // Optional override for the storage root (for testing).
+  storageRoot?: string
+}
+
+// Registers the reviewer IPC handlers on the Electron main process. Returns a function that can
+// be called directly to trigger a review (e.g., from the finishRun hook path).
+const registerReviewerIpcHandlers = (
+  options: ReviewerIpcOptions
+): {
+  triggerReview: (request: ReviewRunRequest) => void
+} => {
+  const storageRoot = options.storageRoot ?? resolveStorageRoot()
+  const reviewRepository = createDefaultReviewRepository()
+  const sessionRepository = new SessionRepository(storageRoot)
+
+  // Per-session AbortControllers for active fix loops. Keyed by the main session id (not the
+  // reviewer session id). Entries are created when a fix loop starts and deleted when it ends.
+  const fixLoopAbortControllers = new Map<string, AbortController>()
+
+  // reviewer:run — trigger a review for a completed turn. Fire-and-forget: the renderer does
+  // not await this; it receives reviewer:updated events as the lifecycle progresses.
+  ipcMain.handle(REVIEWER_IPC.RUN, (_event, request: ReviewRunRequest) => {
+    triggerReview(request)
+  })
+
+  // reviewer:get-for-session — load persisted reviews for a session at startup.
+  ipcMain.handle(REVIEWER_IPC.GET_FOR_SESSION, async (_event, sessionId: string) => {
+    return reviewRepository.getReviewsForSession(sessionId)
+  })
+
+  // reviewer:abort-fix-loop — renderer requests that the active fix loop for a session be aborted.
+  // This is triggered when the user presses the cancel button during a fix loop.
+  ipcMain.handle(REVIEWER_IPC.ABORT_FIX_LOOP, (_event, sessionId: string) => {
+    const controller = fixLoopAbortControllers.get(sessionId)
+    if (controller) {
+      log.info('fix loop abort requested', { sessionId })
+      controller.abort()
+    } else {
+      log.warn('abort-fix-loop: no active fix loop found for session', { sessionId })
+    }
+  })
+
+  const triggerReview = (request: ReviewRunRequest): void => {
+    const { sessionId, turnMessageId, projectId, mainSessionId, model } = request
+
+    log.info('review triggered', { sessionId, turnMessageId })
+
+    // Load the session from disk in the background so the orchestrator has the full session JSON.
+    void (async () => {
+      try {
+        const { sessions } = await sessionRepository.loadAll()
+        const session = sessions.find((s) => s.id === sessionId)
+
+        // Create an AbortController for this review's fix loop. The controller is registered
+        // before runReview starts so the abort-fix-loop handler can find it immediately.
+        const abortController = new AbortController()
+        const effectiveMainSessionId = mainSessionId ?? sessionId
+
+        await runReview({
+          sessionId,
+          turnMessageId,
+          projectId,
+          mainSessionId,
+          model: model ?? '',
+          getSession: () => session,
+          reviewRepository,
+          acpRuntime: options.acpRuntime,
+          artifactStorageRoot: storageRoot,
+          onReviewUpdate: (review: ReviewWithChecks) => {
+            broadcastReviewUpdate({ review })
+          },
+          // Before the correction prompt is sent, suppress the next auto-review for the main
+          // session so the [Auditor] correction turn's stop event does not re-trigger a review.
+          onCorrectionPrompt: () => {
+            if (mainSessionId) {
+              broadcastSuppressNextAutoReview(mainSessionId)
+            }
+          },
+          // If the correction turn fails to send, its stop never arrives — clear the suppression so
+          // the session's next real turn still gets auto-reviewed.
+          onCorrectionFailed: () => {
+            if (mainSessionId) {
+              broadcastSuppressNextAutoReview(mainSessionId, true)
+            }
+          },
+          // Broadcast fix-loop lifecycle events and register/deregister the abort controller.
+          onFixLoopStart: () => {
+            fixLoopAbortControllers.set(effectiveMainSessionId, abortController)
+            broadcastFixLoopStart(effectiveMainSessionId)
+          },
+          onFixLoopEnd: () => {
+            fixLoopAbortControllers.delete(effectiveMainSessionId)
+            broadcastFixLoopEnd(effectiveMainSessionId)
+          },
+          fixLoopAbortSignal: abortController.signal
+        })
+      } catch (error) {
+        log.error('runReview threw unexpectedly', {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    })()
+  }
+
+  return { triggerReview }
+}
+
+export { registerReviewerIpcHandlers, createDefaultReviewRepository }

--- a/src/main/reviewer/lifecycle.test.ts
+++ b/src/main/reviewer/lifecycle.test.ts
@@ -1,0 +1,796 @@
+// Integration test for the reviewer app-lifecycle wiring (issue 08).
+//
+// This test mirrors orchestrator.test.ts and correction.test.ts but focuses on:
+// 1. finishRun-style trigger → runReview → persist end-to-end
+// 2. mainSessionId + model flowing from ReviewRunRequest through ipc.ts into runReview
+// 3. Loop guard: [Auditor] correction fires exactly once; its stop does NOT spawn a second runReview
+// 4. Session delete cascades deleteReviewsForSession; project delete cascades deleteReviewsForProject
+//
+// v2 (issue 12): updated to use unified checks[] model (status pass|warn|fail).
+
+import * as acp from '@agentclientprotocol/sdk'
+import type { ContentBlock } from '@agentclientprotocol/sdk'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough, Readable, Writable } from 'node:stream'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { AcpRuntime } from '../acp/runtime'
+import { ReviewRepository } from './repository'
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { runReview } from './orchestrator'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+
+// ---------------------------------------------------------------------------
+// FakeAgentProcess — same pattern as orchestrator.test.ts
+// ---------------------------------------------------------------------------
+
+class FakeAgentProcess extends EventEmitter {
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+  killed = false
+
+  kill(): boolean {
+    this.killed = true
+    this.emit('exit', 0, null)
+    return true
+  }
+}
+
+const asAgentProcess = (p: FakeAgentProcess): ChildProcessWithoutNullStreams =>
+  p as unknown as ChildProcessWithoutNullStreams
+
+// ---------------------------------------------------------------------------
+// Minimal session fixture
+// ---------------------------------------------------------------------------
+
+const makeSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Test session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [
+    {
+      id: 'msg-1',
+      role: 'user',
+      content: 'Run the analysis',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1000,
+      updatedAt: 1000
+    },
+    {
+      id: 'msg-2',
+      role: 'agent',
+      content: 'I ran the analysis and found 42 results.',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 2000,
+      updatedAt: 2000
+    }
+  ],
+  createdAt: 900,
+  updatedAt: 2000,
+  ...overrides
+})
+
+// ---------------------------------------------------------------------------
+// MCP HTTP helpers — v2 schema: submit_findings accepts checks[] not findings[]
+// ---------------------------------------------------------------------------
+
+const MCP_ACCEPT = 'application/json, text/event-stream'
+
+const parseMcpSseBody = (body: string): { result?: unknown; error?: { message?: string } } => {
+  const dataLine = body.split('\n').find((line) => line.startsWith('data:'))
+  const json = dataLine ? dataLine.slice('data:'.length).trim() : body.trim()
+  return json ? (JSON.parse(json) as { result?: unknown; error?: { message?: string } }) : {}
+}
+
+const callSubmitFindings = async (
+  mcpBaseUrl: string,
+  token: string,
+  // v2: checks[] with status (pass|warn|fail)
+  checks: Array<{
+    status: 'pass' | 'warn' | 'fail'
+    claim: string
+    evidence: string
+    locator?: {
+      blockRef: { messageId?: string; activityId?: string; blockIndex: number }
+      contentHash: string
+    }
+  }>
+): Promise<void> => {
+  const initResponse = await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0' }
+      }
+    })
+  })
+
+  if (!initResponse.ok) throw new Error(`MCP initialize failed: ${initResponse.status}`)
+
+  const initJson = parseMcpSseBody(await initResponse.text())
+  const sessionId = initResponse.headers.get('mcp-session-id')
+  if (!sessionId || !initJson.result) throw new Error('MCP initialize did not return a session id')
+
+  await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`,
+      'mcp-session-id': sessionId
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
+  })
+
+  // v2: use `checks` key, not `findings`
+  const toolResponse = await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`,
+      'mcp-session-id': sessionId
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'submit_findings', arguments: { checks } }
+    })
+  })
+
+  if (!toolResponse.ok) throw new Error(`submit_findings call failed: ${toolResponse.status}`)
+
+  const toolJson = parseMcpSseBody(await toolResponse.text())
+  if (toolJson.error) {
+    throw new Error(`submit_findings returned an error: ${toolJson.error.message ?? 'unknown'}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake agent that handles both reviewer session and main-session correction
+// ---------------------------------------------------------------------------
+
+type FakeAgentState = {
+  newSessions: Array<{ sessionId: string; cwd: string; mcpServers: unknown[]; _meta?: unknown }>
+  promptsReceived: Map<string, string[]>
+  closedSessions: string[]
+  // Records the outcome of any permission request the reviewer session raised (regression coverage for
+  // background reviewer auto-approval — an un-tracked reviewer session must not be rejected as unknown).
+  reviewerPermissionOutcomes: string[]
+}
+
+const startFakeAgent = (
+  process: FakeAgentProcess,
+  options: {
+    reviewerSessionId: string
+    mainSessionId: string
+    simulateFindingsViaHttp?: boolean
+    // When set, the reviewer session raises a permission request before submitting findings, so the
+    // test can assert the runtime auto-approves it instead of throwing "Unknown ACP session".
+    requestPermissionFromReviewer?: boolean
+    // v2: checks[] with status (pass|warn|fail)
+    checksToSubmit?: Array<{
+      status: 'pass' | 'warn' | 'fail'
+      claim: string
+      evidence: string
+      locator?: {
+        blockRef: { messageId?: string; activityId?: string; blockIndex: number }
+        contentHash: string
+      }
+    }>
+  }
+): FakeAgentState => {
+  const state: FakeAgentState = {
+    newSessions: [],
+    promptsReceived: new Map(),
+    closedSessions: [],
+    reviewerPermissionOutcomes: []
+  }
+
+  acp
+    .agent({ name: 'test-agent' })
+    .onRequest(acp.methods.agent.initialize, () => ({
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        sessionCapabilities: { close: {} }
+      },
+      authMethods: []
+    }))
+    .onRequest(acp.methods.agent.session.new, (ctx) => {
+      const mcpServers = (ctx.params.mcpServers ?? []) as Array<{ type?: string }>
+      const isReviewer = mcpServers.some((s) => s.type === 'http')
+      const sessionId = isReviewer ? options.reviewerSessionId : options.mainSessionId
+
+      state.newSessions.push({
+        sessionId,
+        cwd: ctx.params.cwd,
+        mcpServers: ctx.params.mcpServers ?? [],
+        ...(ctx.params._meta === undefined ? {} : { _meta: ctx.params._meta })
+      })
+
+      return { sessionId }
+    })
+    .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+      const text = ctx.params.prompt
+        .map((block: ContentBlock) => (block.type === 'text' ? block.text : ''))
+        .join('')
+
+      const existing = state.promptsReceived.get(ctx.params.sessionId) ?? []
+      existing.push(text)
+      state.promptsReceived.set(ctx.params.sessionId, existing)
+
+      // A reviewer session runs unattended: exercise the runtime's auto-approval path by raising a
+      // permission request from it and recording the outcome. Before the fix this threw "Unknown ACP
+      // session" because reviewer sessions are intentionally not tracked in the runtime's session map.
+      if (
+        ctx.params.sessionId === options.reviewerSessionId &&
+        options.requestPermissionFromReviewer
+      ) {
+        const permission = await ctx.client.request(acp.methods.client.session.requestPermission, {
+          sessionId: ctx.params.sessionId,
+          toolCall: {
+            toolCallId: 'reviewer-exec-1',
+            title: 'python read_turn.py',
+            kind: 'execute'
+          },
+          options: [
+            { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+            { optionId: 'allow-always', name: 'Allow always', kind: 'allow_always' },
+            { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+          ]
+        })
+        state.reviewerPermissionOutcomes.push(permission.outcome.outcome)
+      }
+
+      // If this is the reviewer session, simulate submit_findings via HTTP.
+      if (ctx.params.sessionId === options.reviewerSessionId && options.simulateFindingsViaHttp) {
+        const latestSession = state.newSessions.find(
+          (s) => s.sessionId === options.reviewerSessionId
+        )
+        const mcpServers = latestSession?.mcpServers ?? []
+        const reviewerMcp = (
+          mcpServers as Array<{
+            type?: string
+            url?: string
+            headers?: Array<{ name: string; value: string }>
+          }>
+        ).find((s) => s.type === 'http')
+
+        if (reviewerMcp?.url) {
+          const token =
+            reviewerMcp.headers
+              ?.find((h) => h.name === 'authorization')
+              ?.value?.replace('Bearer ', '') ?? ''
+          await callSubmitFindings(reviewerMcp.url, token, options.checksToSubmit ?? [])
+        }
+      }
+
+      // Stream a minimal reply chunk then stop.
+      await ctx.client.notify(acp.methods.client.session.update, {
+        sessionId: ctx.params.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          messageId: `reply-${ctx.params.sessionId}`,
+          content: { type: 'text', text: 'Acknowledged.' }
+        }
+      })
+
+      return { stopReason: 'end_turn' }
+    })
+    .onRequest(acp.methods.agent.session.close, (ctx) => {
+      state.closedSessions.push(ctx.params.sessionId)
+      return {}
+    })
+    .connect(
+      acp.ndJsonStream(
+        Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+        Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+      )
+    )
+
+  return state
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+let temporaryRoot: string | undefined
+
+beforeEach(async () => {
+  temporaryRoot = await mkdtemp(join(tmpdir(), 'reviewer-lifecycle-test-'))
+})
+
+afterEach(async () => {
+  if (temporaryRoot) {
+    await rm(temporaryRoot, { recursive: true, force: true })
+    temporaryRoot = undefined
+  }
+})
+
+describe('reviewer app lifecycle integration', () => {
+  describe('end-to-end: finishRun trigger → runReview → persist', () => {
+    it('creates a review row and checks when submit_findings is called (pass review)', async () => {
+      const process = new FakeAgentProcess()
+      startFakeAgent(process, {
+        reviewerSessionId: 'reviewer-session-1',
+        mainSessionId: 'main-session-1',
+        // No checks submitted → pass
+        simulateFindingsViaHttp: false
+      })
+
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process)
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+
+      const client = createProjectDbClient(temporaryRoot!)
+      await ensureProjectSchema(client)
+      const repository = new ReviewRepository(() => Promise.resolve(client))
+      const session = makeSession()
+
+      const reviewUpdates: import('../../shared/reviewer').ReviewWithChecks[] = []
+
+      const review = await runReview({
+        sessionId: 'session-1',
+        turnMessageId: 'msg-2',
+        projectId: 'project-1',
+        model: 'claude-opus-4-5',
+        getSession: () => session,
+        reviewRepository: repository,
+        acpRuntime: runtime,
+        artifactStorageRoot: temporaryRoot!,
+        onReviewUpdate: (r) => reviewUpdates.push(r)
+      })
+
+      // End-to-end: lifecycle becomes complete, outcome is pass.
+      expect(review.lifecycle).toBe('complete')
+      expect(review.outcome).toBe('pass')
+      expect(review.model).toBe('claude-opus-4-5')
+      // v2: checks (not findings)
+      expect(review.checks).toHaveLength(0)
+
+      // Persisted: reload from DB confirms the review row was written.
+      const stored = await repository.getReviewsForSession('session-1')
+      expect(stored).toHaveLength(1)
+      expect(stored[0]?.lifecycle).toBe('complete')
+      expect(stored[0]?.model).toBe('claude-opus-4-5')
+
+      // onReviewUpdate was called (at least 'running' + 'complete').
+      expect(reviewUpdates.length).toBeGreaterThanOrEqual(2)
+      expect(reviewUpdates.at(-1)?.lifecycle).toBe('complete')
+
+      await client.$disconnect()
+    })
+
+    it('auto-approves the reviewer session tool calls instead of rejecting them as unknown', async () => {
+      const process = new FakeAgentProcess()
+      const state = startFakeAgent(process, {
+        reviewerSessionId: 'reviewer-session-1',
+        mainSessionId: 'main-session-1',
+        // The reviewer raises a permission request (as it would when running Python in its REPL).
+        requestPermissionFromReviewer: true,
+        simulateFindingsViaHttp: false
+      })
+
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process)
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+
+      const client = createProjectDbClient(temporaryRoot!)
+      await ensureProjectSchema(client)
+      const repository = new ReviewRepository(() => Promise.resolve(client))
+      const session = makeSession()
+
+      const review = await runReview({
+        sessionId: 'session-1',
+        turnMessageId: 'msg-2',
+        projectId: 'project-1',
+        getSession: () => session,
+        reviewRepository: repository,
+        acpRuntime: runtime,
+        artifactStorageRoot: temporaryRoot!
+      })
+
+      // The reviewer's permission request was auto-approved (selected), not rejected/thrown.
+      expect(state.reviewerPermissionOutcomes).toEqual(['selected'])
+      // The review still completed end-to-end.
+      expect(review.lifecycle).toBe('complete')
+
+      await client.$disconnect()
+    })
+
+    it('creates check rows when submit_findings reports warn/fail', async () => {
+      const process = new FakeAgentProcess()
+      const checksToSubmit = [
+        {
+          status: 'fail' as const,
+          claim: 'Agent claimed 42 results but tool output shows 0',
+          evidence: 'Terminal output: "Found 0 rows"',
+          locator: { blockRef: { messageId: 'msg-2', blockIndex: 1 }, contentHash: 'abc123' }
+        }
+      ]
+
+      startFakeAgent(process, {
+        reviewerSessionId: 'reviewer-session-1',
+        mainSessionId: 'main-session-1',
+        simulateFindingsViaHttp: true,
+        checksToSubmit
+      })
+
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process)
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+
+      const client = createProjectDbClient(temporaryRoot!)
+      await ensureProjectSchema(client)
+      const repository = new ReviewRepository(() => Promise.resolve(client))
+      const session = makeSession()
+
+      const review = await runReview({
+        sessionId: 'session-1',
+        turnMessageId: 'msg-2',
+        projectId: 'project-1',
+        model: 'claude-opus-4-5',
+        getSession: () => session,
+        reviewRepository: repository,
+        acpRuntime: runtime,
+        artifactStorageRoot: temporaryRoot!
+      })
+
+      expect(review.lifecycle).toBe('complete')
+      expect(review.outcome).toBe('flagged')
+      // v2: checks not findings
+      expect(review.checks).toHaveLength(1)
+      expect(review.checks[0]?.status).toBe('fail')
+      expect(review.checks[0]?.claim).toContain('42 results')
+
+      // Checks are persisted.
+      const stored = await repository.getReviewsForSession('session-1')
+      expect(stored[0]?.checks).toHaveLength(1)
+
+      await client.$disconnect()
+    })
+  })
+
+  describe('mainSessionId + model flow through IPC into runReview', () => {
+    it('threads mainSessionId and model from runReview options into review row and correction', async () => {
+      const process = new FakeAgentProcess()
+      const checksToSubmit = [
+        {
+          status: 'warn' as const,
+          claim: 'Minor inconsistency in label',
+          evidence: 'Block [0] uses mg/L, block [1] uses mmol/L',
+          locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' }
+        }
+      ]
+
+      startFakeAgent(process, {
+        reviewerSessionId: 'reviewer-session-1',
+        mainSessionId: 'main-session-1',
+        simulateFindingsViaHttp: true,
+        checksToSubmit
+      })
+
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process)
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+
+      const client = createProjectDbClient(temporaryRoot!)
+      await ensureProjectSchema(client)
+      const repository = new ReviewRepository(() => Promise.resolve(client))
+      const session = makeSession()
+
+      const correctionPrompts: string[] = []
+
+      const review = await runReview({
+        sessionId: 'session-1',
+        turnMessageId: 'msg-2',
+        projectId: 'project-1',
+        mainSessionId: 'main-session-1',
+        model: 'claude-opus-4-5',
+        getSession: () => session,
+        reviewRepository: repository,
+        acpRuntime: runtime,
+        artifactStorageRoot: temporaryRoot!,
+        onCorrectionPrompt: (text) => correctionPrompts.push(text)
+      })
+
+      // model is recorded on the review row.
+      expect(review.model).toBe('claude-opus-4-5')
+
+      // mainSessionId enabled the correction: exactly one [Auditor] message was sent.
+      expect(correctionPrompts).toHaveLength(1)
+      expect(correctionPrompts[0]).toMatch(/^\[Auditor\]/)
+
+      // Without mainSessionId no correction would fire (pass test in other suite covers this).
+      await client.$disconnect()
+    })
+
+    it('skips correction injection when mainSessionId is omitted', async () => {
+      const process = new FakeAgentProcess()
+      const checksToSubmit = [
+        {
+          status: 'fail' as const,
+          claim: 'Fabricated result',
+          evidence: 'No supporting activity',
+          locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' }
+        }
+      ]
+
+      startFakeAgent(process, {
+        reviewerSessionId: 'reviewer-session-1',
+        mainSessionId: 'main-session-1',
+        simulateFindingsViaHttp: true,
+        checksToSubmit
+      })
+
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process)
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+
+      const client = createProjectDbClient(temporaryRoot!)
+      await ensureProjectSchema(client)
+      const repository = new ReviewRepository(() => Promise.resolve(client))
+      const session = makeSession()
+
+      const correctionPrompts: string[] = []
+
+      const review = await runReview({
+        sessionId: 'session-1',
+        turnMessageId: 'msg-2',
+        projectId: 'project-1',
+        // mainSessionId intentionally omitted
+        getSession: () => session,
+        reviewRepository: repository,
+        acpRuntime: runtime,
+        artifactStorageRoot: temporaryRoot!,
+        onCorrectionPrompt: (text) => correctionPrompts.push(text)
+      })
+
+      expect(review.outcome).toBe('flagged')
+      // No correction without mainSessionId.
+      expect(correctionPrompts).toHaveLength(0)
+
+      await client.$disconnect()
+    })
+  })
+
+  describe('loop guard: correction fires exactly once, guarded turn does not spawn a second runReview', () => {
+    it('the correction turn stop does not re-trigger runReview (onRunReviewCalled count = 0)', async () => {
+      const process = new FakeAgentProcess()
+      const checksToSubmit = [
+        {
+          status: 'warn' as const,
+          claim: 'Units inconsistency',
+          evidence: 'Block [0] and block [2] differ',
+          locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' }
+        }
+      ]
+
+      const agentState = startFakeAgent(process, {
+        reviewerSessionId: 'reviewer-session-1',
+        mainSessionId: 'main-session-1',
+        simulateFindingsViaHttp: true,
+        checksToSubmit
+      })
+
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process)
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+
+      const client = createProjectDbClient(temporaryRoot!)
+      await ensureProjectSchema(client)
+      const repository = new ReviewRepository(() => Promise.resolve(client))
+      const session = makeSession()
+
+      let runReviewCallCount = 0
+      const correctionPrompts: string[] = []
+
+      await runReview({
+        sessionId: 'session-1',
+        turnMessageId: 'msg-2',
+        projectId: 'project-1',
+        mainSessionId: 'main-session-1',
+        getSession: () => session,
+        reviewRepository: repository,
+        acpRuntime: runtime,
+        artifactStorageRoot: temporaryRoot!,
+        onCorrectionPrompt: (text) => correctionPrompts.push(text),
+        onRunReviewCalled: () => {
+          runReviewCallCount++
+        }
+      })
+
+      // Phase 3: fix loop runs internally — the external onRunReviewCalled is NOT invoked.
+      // The fix loop is driven by runFixLoop (internal), not by external runReview re-calls.
+      expect(runReviewCallCount).toBe(0)
+
+      // Phase 3: the fix loop triggers internal re-reviews — multiple reviewer sessions spawn.
+      // The fake agent keeps returning the same findings for each reviewer session, so the loop
+      // runs 3 rounds (cap) and ends with unaddressed. At minimum 4 sessions: initial + 3 re-reviews.
+      const reviewerSessions = agentState.newSessions.filter(
+        (s) => s.sessionId === 'reviewer-session-1'
+      )
+      // The key invariant: re-reviews are driven internally (not via external trigger).
+      expect(reviewerSessions.length).toBeGreaterThan(1)
+
+      await client.$disconnect()
+    })
+  })
+
+  describe('delete cascade', () => {
+    it('deleteReviewsForSession removes all reviews for a session, leaving no orphan findings', async () => {
+      const process = new FakeAgentProcess()
+      startFakeAgent(process, {
+        reviewerSessionId: 'reviewer-session-1',
+        mainSessionId: 'main-session-1',
+        simulateFindingsViaHttp: true,
+        checksToSubmit: [
+          {
+            status: 'fail' as const,
+            claim: 'Bad claim',
+            evidence: 'Evidence',
+            locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' }
+          }
+        ]
+      })
+
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process)
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+
+      const client = createProjectDbClient(temporaryRoot!)
+      await ensureProjectSchema(client)
+      const repository = new ReviewRepository(() => Promise.resolve(client))
+      const session = makeSession()
+
+      await runReview({
+        sessionId: 'session-1',
+        turnMessageId: 'msg-2',
+        projectId: 'project-1',
+        getSession: () => session,
+        reviewRepository: repository,
+        acpRuntime: runtime,
+        artifactStorageRoot: temporaryRoot!
+      })
+
+      // Confirm review and checks exist before delete.
+      const before = await repository.getReviewsForSession('session-1')
+      expect(before).toHaveLength(1)
+      expect(before[0]?.checks).toHaveLength(1)
+
+      // Delete cascade.
+      await repository.deleteReviewsForSession('session-1')
+
+      // No reviews remain.
+      const after = await repository.getReviewsForSession('session-1')
+      expect(after).toHaveLength(0)
+
+      // No orphan check rows remain.
+      const orphanCount = await repository.countFindings()
+      expect(orphanCount).toBe(0)
+
+      await client.$disconnect()
+    })
+
+    it('deleteReviewsForProject removes all reviews across all sessions in a project', async () => {
+      const client = createProjectDbClient(temporaryRoot!)
+      await ensureProjectSchema(client)
+      const repository = new ReviewRepository(() => Promise.resolve(client))
+
+      // Create reviews for two sessions in the same project, plus one in a different project.
+      const scope = { turnMessageId: 'msg-x', blocks: [], artifactVersionIds: [] }
+
+      await repository.createReview({
+        projectId: 'project-A',
+        sessionId: 'session-A1',
+        turnMessageId: 'msg-x',
+        scope,
+        lifecycle: 'complete',
+        outcome: 'pass',
+        model: 'test-model'
+      })
+
+      await repository.createReview({
+        projectId: 'project-A',
+        sessionId: 'session-A2',
+        turnMessageId: 'msg-x',
+        scope,
+        lifecycle: 'complete',
+        outcome: 'pass',
+        model: 'test-model'
+      })
+
+      await repository.createReview({
+        projectId: 'project-B',
+        sessionId: 'session-B1',
+        turnMessageId: 'msg-x',
+        scope,
+        lifecycle: 'complete',
+        outcome: 'pass',
+        model: 'test-model'
+      })
+
+      // Add checks to one of project-A's reviews to check orphan cleanup.
+      const reviewA1 = (await repository.getReviewsForSession('session-A1'))[0]
+      if (reviewA1) {
+        await repository.addChecks(reviewA1.id, [
+          {
+            status: 'warn',
+            claim: 'Minor issue',
+            evidence: 'Evidence',
+            locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' }
+          }
+        ])
+      }
+
+      // Delete project-A reviews.
+      await repository.deleteReviewsForProject('project-A')
+
+      // project-A reviews are gone.
+      const a1After = await repository.getReviewsForSession('session-A1')
+      const a2After = await repository.getReviewsForSession('session-A2')
+      expect(a1After).toHaveLength(0)
+      expect(a2After).toHaveLength(0)
+
+      // project-B review is intact.
+      const b1After = await repository.getReviewsForSession('session-B1')
+      expect(b1After).toHaveLength(1)
+
+      // No orphan checks.
+      const orphanCount = await repository.countFindings()
+      expect(orphanCount).toBe(0)
+
+      await client.$disconnect()
+    })
+  })
+})

--- a/src/main/reviewer/log-capture.test.ts
+++ b/src/main/reviewer/log-capture.test.ts
@@ -1,0 +1,565 @@
+// Tests for reviewer log capture (issue 13, updated for unified tool entry in issue 15).
+// (a) capture: a simulated reviewer update stream produces the expected reviewerLog entries
+//     and survives a repository round-trip.
+// (c) regression: driveReviewerToStop guards still fire on timeout / max-updates.
+// The driveReviewerToStop regression tests live in orchestrator-drive.test.ts; this file focuses on the
+// log-capture behavior layered on top of driveReviewerToStop via the new `onUpdate` callback.
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { ReviewRepository } from './repository'
+import { driveReviewerToStop } from './orchestrator'
+import type { ReviewerLogEntry } from '../../shared/reviewer'
+
+// ---------------------------------------------------------------------------
+// driveReviewerToStop with onUpdate callback — log capture unit tests
+// ---------------------------------------------------------------------------
+
+type FakeUpdate = {
+  kind: string
+  stopReason?: string
+  update?: { sessionUpdate?: string; [key: string]: unknown }
+}
+
+describe('driveReviewerToStop — log capture via onUpdate', () => {
+  it('collects agent_thought_chunk updates into thought entries', async () => {
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'agent_thought_chunk',
+          content: { type: 'text', text: 'Thinking…' }
+        }
+      },
+      {
+        kind: 'session_update',
+        update: { sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: ' More.' } }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    const log: ReviewerLogEntry[] = []
+    await driveReviewerToStop(
+      session,
+      { timeoutMs: 1000, maxUpdates: 100 },
+      { onUpdate: (u) => log.push(u) }
+    )
+
+    // Two thought chunks should be assembled into one thought entry.
+    expect(log.filter((e) => e.kind === 'thought')).toHaveLength(1)
+    const thought = log.find((e) => e.kind === 'thought')
+    expect(thought?.kind).toBe('thought')
+    if (thought?.kind === 'thought') {
+      expect(thought.text).toContain('Thinking…')
+      expect(thought.text).toContain(' More.')
+    }
+  })
+
+  it('collects agent_message_chunk updates into message entries', async () => {
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'Review done.' }
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    const log: ReviewerLogEntry[] = []
+    await driveReviewerToStop(
+      session,
+      { timeoutMs: 1000, maxUpdates: 100 },
+      { onUpdate: (u) => log.push(u) }
+    )
+
+    const messages = log.filter((e) => e.kind === 'message')
+    expect(messages).toHaveLength(1)
+    if (messages[0]?.kind === 'message') {
+      expect(messages[0].text).toBe('Review done.')
+    }
+  })
+
+  it('produces ONE unified tool entry from tool_call + tool_call_update (not split tool_call/tool_result)', async () => {
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-1',
+          // ACP: real tool name is in _meta.claudeCode.toolName, not top-level toolName
+          _meta: { claudeCode: { toolName: 'Bash' } },
+          title: 'python3 -c "host.read_turn()"',
+          rawInput: 'python3 -c "host.read_turn()"'
+        }
+      },
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-1',
+          rawOutput: '[{"kind": "message"}]',
+          status: 'completed'
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    const log: ReviewerLogEntry[] = []
+    await driveReviewerToStop(
+      session,
+      { timeoutMs: 1000, maxUpdates: 100 },
+      { onUpdate: (u) => log.push(u) }
+    )
+
+    // Must produce exactly ONE tool entry (not a tool_call + tool_result pair).
+    const toolEntries = log.filter((e) => e.kind === 'tool')
+    expect(toolEntries).toHaveLength(1)
+    // Verify legacy kinds are absent (cast to string kind for type safety since they no longer exist in the union).
+    expect(log.filter((e) => (e as { kind: string }).kind === 'tool_call')).toHaveLength(0)
+    expect(log.filter((e) => (e as { kind: string }).kind === 'tool_result')).toHaveLength(0)
+
+    // The entry must carry the real tool name from _meta.claudeCode.toolName.
+    const tool = toolEntries[0]
+    expect(tool?.kind).toBe('tool')
+    if (tool?.kind === 'tool') {
+      expect(tool.toolName).toBe('Bash')
+      expect(tool.rawInput).toBe('python3 -c "host.read_turn()"')
+      expect(tool.rawOutput).toBe('[{"kind": "message"}]')
+      expect(tool.status).toBe('ok')
+    }
+  })
+
+  it('fills rawInput from tool_call_update when the initial tool_call seeds an empty input', async () => {
+    // Claude Code emits the initial tool_call with an empty rawInput ({}), then supplies the real
+    // arguments on the following tool_call_update — mirror that so input is not lost.
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-1',
+          _meta: { claudeCode: { toolName: 'Bash' } },
+          title: 'Terminal',
+          rawInput: {}
+        }
+      },
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-1',
+          rawInput: { command: 'python3 -c "import host; host.read_turn()"' },
+          rawOutput: '[block-0]',
+          status: 'completed'
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    const log: ReviewerLogEntry[] = []
+    await driveReviewerToStop(
+      session,
+      { timeoutMs: 1000, maxUpdates: 100 },
+      { onUpdate: (u) => log.push(u) }
+    )
+
+    const tool = log.find((e) => e.kind === 'tool')
+    expect(tool?.kind).toBe('tool')
+    if (tool?.kind === 'tool') {
+      // The real command from the update wins over the empty {} seeded by the initial tool_call.
+      expect(tool.rawInput).toBe(
+        JSON.stringify({ command: 'python3 -c "import host; host.read_turn()"' })
+      )
+      expect(tool.rawInput).not.toBe('{}')
+    }
+  })
+
+  it('serializes an object rawOutput as JSON, not "[object Object]"', async () => {
+    // A non-terminal tool (e.g. submit_findings) returns an object rawOutput with no terminal meta.
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-submit',
+          _meta: { claudeCode: { toolName: 'mcp__open-science-reviewer__submit_findings' } },
+          title: 'submit_findings',
+          rawInput: { checks: [{ status: 'pass' }] }
+        }
+      },
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-submit',
+          rawOutput: { ok: true, received: 4 },
+          status: 'completed'
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    const log: ReviewerLogEntry[] = []
+    await driveReviewerToStop(
+      session,
+      { timeoutMs: 1000, maxUpdates: 100 },
+      { onUpdate: (u) => log.push(u) }
+    )
+
+    const tool = log.find((e) => e.kind === 'tool')
+    expect(tool?.kind).toBe('tool')
+    if (tool?.kind === 'tool') {
+      expect(tool.rawOutput).toBe(JSON.stringify({ ok: true, received: 4 }))
+      expect(tool.rawOutput).not.toContain('[object Object]')
+    }
+  })
+
+  it('merges terminal stdout and exit code from _meta.terminal_output / _meta.terminal_exit', async () => {
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-bash',
+          _meta: { claudeCode: { toolName: 'Bash' } },
+          title: 'wc -l cohort.csv',
+          rawInput: 'wc -l cohort.csv'
+        }
+      },
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-bash',
+          status: 'completed',
+          _meta: {
+            terminal_output: { data: '8904 cohort.csv' },
+            terminal_exit: { exit_code: 0 }
+          }
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    const log: ReviewerLogEntry[] = []
+    await driveReviewerToStop(
+      session,
+      { timeoutMs: 1000, maxUpdates: 100 },
+      { onUpdate: (u) => log.push(u) }
+    )
+
+    const toolEntries = log.filter((e) => e.kind === 'tool')
+    expect(toolEntries).toHaveLength(1)
+    const tool = toolEntries[0]
+    if (tool?.kind === 'tool') {
+      expect(tool.rawOutput).toBe('8904 cohort.csv')
+      expect(tool.exitCode).toBe(0)
+      expect(tool.status).toBe('ok')
+    }
+  })
+
+  it('normalizes ACP "failed" status to "error" and "completed" to "ok"', async () => {
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-err',
+          _meta: { claudeCode: { toolName: 'Bash' } },
+          rawInput: 'python3 bad.py'
+        }
+      },
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-err',
+          status: 'failed',
+          _meta: {
+            terminal_output: { data: 'SyntaxError: bad syntax' },
+            terminal_exit: { exit_code: 1 }
+          }
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    const log: ReviewerLogEntry[] = []
+    await driveReviewerToStop(
+      session,
+      { timeoutMs: 1000, maxUpdates: 100 },
+      { onUpdate: (u) => log.push(u) }
+    )
+
+    const tool = log.find((e) => e.kind === 'tool')
+    expect(tool?.kind).toBe('tool')
+    if (tool?.kind === 'tool') {
+      expect(tool.status).toBe('error')
+      expect(tool.exitCode).toBe(1)
+    }
+  })
+
+  it('does not add chunk updates to the discrete update count (loop guard preserved)', async () => {
+    // 50 streaming chunks followed by a stop — maxUpdates is only 5 discrete updates.
+    const chunkKinds = ['agent_message_chunk', 'agent_thought_chunk']
+    const updates: FakeUpdate[] = [
+      ...Array.from({ length: 50 }, (_, i) => ({
+        kind: 'session_update' as const,
+        update: { sessionUpdate: chunkKinds[i % chunkKinds.length] as string }
+      })),
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    const log: ReviewerLogEntry[] = []
+    // Should not throw even though maxUpdates=5 and there are 50 chunks.
+    await expect(
+      driveReviewerToStop(
+        session,
+        { timeoutMs: 5000, maxUpdates: 5 },
+        { onUpdate: (u) => log.push(u) }
+      )
+    ).resolves.toBe('end_turn')
+  })
+
+  it('works without onUpdate (backward-compatible: no callback = no log)', async () => {
+    const updates: FakeUpdate[] = [
+      { kind: 'session_update', update: { sessionUpdate: 'tool_call' } },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    // Should not throw when no onUpdate is passed.
+    await expect(driveReviewerToStop(session, { timeoutMs: 1000, maxUpdates: 100 })).resolves.toBe(
+      'end_turn'
+    )
+  })
+
+  it('handles orphan tool_call_update with no prior tool_call (defensive)', async () => {
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-orphan',
+          _meta: { claudeCode: { toolName: 'Bash' } },
+          status: 'completed',
+          _meta2: undefined,
+          rawOutput: 'result'
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    const log: ReviewerLogEntry[] = []
+    // Should not crash; should produce a tool entry defensively.
+    await expect(
+      driveReviewerToStop(
+        session,
+        { timeoutMs: 1000, maxUpdates: 100 },
+        { onUpdate: (u) => log.push(u) }
+      )
+    ).resolves.toBe('end_turn')
+
+    const toolEntries = log.filter((e) => e.kind === 'tool')
+    expect(toolEntries).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Repository round-trip for reviewerLog
+// ---------------------------------------------------------------------------
+
+let temporaryRoot: string | undefined
+
+beforeEach(async () => {
+  temporaryRoot = await mkdtemp(join(tmpdir(), 'reviewer-log-capture-test-'))
+})
+
+afterEach(async () => {
+  if (temporaryRoot) {
+    await rm(temporaryRoot, { recursive: true, force: true })
+    temporaryRoot = undefined
+  }
+})
+
+describe('ReviewRepository — reviewerLog round-trip', () => {
+  it('persists a unified-tool reviewerLog and reloads it via getReviewsForSession', async () => {
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const log: ReviewerLogEntry[] = [
+      { kind: 'thought', text: 'Let me read the turn first.' },
+      {
+        kind: 'tool',
+        toolName: 'Bash',
+        title: 'python3 host.read_turn()',
+        rawInput: 'python3 host.read_turn()',
+        rawOutput: '[block-0]',
+        status: 'ok',
+        exitCode: 0
+      },
+      { kind: 'message', text: 'Review complete.' }
+    ]
+
+    await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'msg-1',
+      scope: { turnMessageId: 'msg-1', blocks: [], artifactVersionIds: [] },
+      lifecycle: 'complete',
+      outcome: 'pass',
+      model: 'claude-opus-4-5',
+      reviewerLog: log
+    })
+
+    const reviews = await repository.getReviewsForSession('session-1')
+    expect(reviews).toHaveLength(1)
+    const reloaded = reviews[0]!
+    expect(reloaded.reviewerLog).toHaveLength(3)
+    expect(reloaded.reviewerLog[0]).toEqual({
+      kind: 'thought',
+      text: 'Let me read the turn first.'
+    })
+    expect(reloaded.reviewerLog[1]).toEqual({
+      kind: 'tool',
+      toolName: 'Bash',
+      title: 'python3 host.read_turn()',
+      rawInput: 'python3 host.read_turn()',
+      rawOutput: '[block-0]',
+      status: 'ok',
+      exitCode: 0
+    })
+    expect(reloaded.reviewerLog[2]).toEqual({ kind: 'message', text: 'Review complete.' })
+
+    await client.$disconnect()
+  })
+
+  it('tolerates legacy/unknown entry kinds in the persisted JSON without throwing', async () => {
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    // Simulate a legacy log that still uses the old tool_call/tool_result split (or unknown kind).
+    // The repository parses defensively; unknown kinds should be returned as-is (no crash).
+    const legacyLog = [
+      { kind: 'thought', text: 'old thought' },
+      { kind: 'tool_call', toolName: 'read_turn', title: 'read_turn()' }, // legacy
+      { kind: 'tool_result', status: 'ok', rawOutput: '[...]' }, // legacy
+      { kind: 'unknown_future_kind', data: 'whatever' } // unknown
+    ]
+
+    // Insert as raw JSON bypassing the typed API to simulate legacy data.
+    await client.review.create({
+      data: {
+        projectId: 'project-1',
+        sessionId: 'session-legacy',
+        turnMessageId: 'msg-1',
+        scope: JSON.stringify({ turnMessageId: 'msg-1', blocks: [], artifactVersionIds: [] }),
+        lifecycle: 'complete',
+        outcome: 'pass',
+        model: 'test',
+        reviewerLog: JSON.stringify(legacyLog)
+      }
+    })
+
+    // Must not throw on reload.
+    const reviews = await repository.getReviewsForSession('session-legacy')
+    expect(reviews).toHaveLength(1)
+    // The legacy entries are returned as-is (parseJson just returns the raw array).
+    expect(reviews[0]?.reviewerLog).toHaveLength(4)
+
+    await client.$disconnect()
+  })
+
+  it('returns an empty reviewerLog for reviews created without one', async () => {
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'msg-1',
+      scope: { turnMessageId: 'msg-1', blocks: [], artifactVersionIds: [] },
+      model: 'test'
+    })
+
+    const reviews = await repository.getReviewsForSession('session-1')
+    expect(reviews[0]?.reviewerLog).toEqual([])
+
+    await client.$disconnect()
+  })
+
+  it('persists a reviewerLog via updateReview patch', async () => {
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const created = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'msg-1',
+      scope: { turnMessageId: 'msg-1', blocks: [], artifactVersionIds: [] },
+      model: 'test'
+    })
+
+    const log: ReviewerLogEntry[] = [{ kind: 'thought', text: 'Updated thought.' }]
+
+    await repository.updateReview(created.id, {
+      reviewerLog: log,
+      lifecycle: 'complete',
+      outcome: 'pass'
+    })
+
+    const reviews = await repository.getReviewsForSession('session-1')
+    expect(reviews[0]?.reviewerLog).toHaveLength(1)
+    expect(reviews[0]?.reviewerLog[0]?.kind).toBe('thought')
+
+    await client.$disconnect()
+  })
+
+  it('Review no longer has a reasoning field', async () => {
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'msg-1',
+      scope: { turnMessageId: 'msg-1', blocks: [], artifactVersionIds: [] },
+      model: 'test'
+    })
+
+    // reasoning field should not exist on Review
+    expect('reasoning' in review).toBe(false)
+
+    await client.$disconnect()
+  })
+})

--- a/src/main/reviewer/mcp-server.test.ts
+++ b/src/main/reviewer/mcp-server.test.ts
@@ -1,0 +1,410 @@
+// Tests for the reviewer MCP server's check-to-scope mapping. The key invariant (design.md:114):
+// a check's locator.contentHash is back-filled from the referenced scope block, never trusted
+// from model input, and out-of-scope locators are rejected.
+//
+// v2 (issue 12): submit_findings accepts checks[] (status pass|warn|fail) not findings[]+severity.
+// summary is no longer accepted (strict schema). Pass checks may omit their locator.
+
+import { describe, it, expect } from 'vitest'
+
+import { mapChecksToScope, submitFindingsInputSchema, ReviewerMcpServer } from './mcp-server'
+import type { TurnScope } from '../../shared/reviewer'
+
+const scope: TurnScope = {
+  turnMessageId: 'msg-2',
+  blocks: [
+    {
+      id: 'message:msg-2',
+      kind: 'message',
+      sourceId: 'msg-2',
+      blockIndex: 0,
+      contentHash: 'real-hash-msg-2'
+    },
+    {
+      id: 'activity:act-9',
+      kind: 'activity',
+      sourceId: 'act-9',
+      blockIndex: 1,
+      contentHash: 'real-hash-act-9'
+    }
+  ],
+  artifactVersionIds: ['artifact-csv']
+}
+
+describe('mapChecksToScope', () => {
+  it('back-fills contentHash from the referenced scope block, ignoring the model-supplied value', () => {
+    const mapped = mapChecksToScope(
+      [
+        {
+          status: 'fail',
+          claim: 'wrong count',
+          evidence: 'block 0 says 32',
+          locator: {
+            blockRef: { messageId: 'msg-2', blockIndex: 0 },
+            // Hallucinated/stale hash supplied by the model — must be overwritten.
+            contentHash: 'model-supplied-garbage'
+          }
+        }
+      ],
+      scope
+    )
+
+    expect(mapped).toHaveLength(1)
+    expect(mapped[0]!.locator!.contentHash).toBe('real-hash-msg-2')
+  })
+
+  it('resolves the block by blockIndex for activity references too', () => {
+    const mapped = mapChecksToScope(
+      [
+        {
+          status: 'warn',
+          claim: 'suspicious tool call',
+          evidence: 'act-9',
+          locator: {
+            blockRef: { activityId: 'act-9', blockIndex: 1 },
+            contentHash: 'whatever'
+          }
+        }
+      ],
+      scope
+    )
+
+    expect(mapped[0]!.locator!.contentHash).toBe('real-hash-act-9')
+  })
+
+  it('rejects a locator whose blockIndex is not in scope', () => {
+    expect(() =>
+      mapChecksToScope(
+        [
+          {
+            status: 'fail',
+            claim: 'out of range',
+            evidence: 'x',
+            locator: { blockRef: { blockIndex: 99 }, contentHash: 'x' }
+          }
+        ],
+        scope
+      )
+    ).toThrow(/not in the turn scope/i)
+  })
+
+  it('back-fills the blockRef id from the scope block, overwriting a wrong model-supplied id', () => {
+    const mapped = mapChecksToScope(
+      [
+        {
+          status: 'fail',
+          claim: 'mismatched id',
+          evidence: 'x',
+          // blockIndex 0 is msg-2, but the model claims a different (hallucinated) id.
+          locator: { blockRef: { messageId: 'msg-999', blockIndex: 0 }, contentHash: 'x' }
+        }
+      ],
+      scope
+    )
+
+    // The stored id is corrected to the real block at index 0, not the model's msg-999.
+    expect(mapped[0]!.locator!.blockRef.messageId).toBe('msg-2')
+    expect(mapped[0]!.locator!.blockRef.activityId).toBeUndefined()
+    expect(mapped[0]!.locator!.contentHash).toBe('real-hash-msg-2')
+  })
+
+  it('back-fills activityId (not messageId) for activity blocks', () => {
+    const mapped = mapChecksToScope(
+      [
+        {
+          status: 'warn',
+          claim: 'suspicious tool call',
+          evidence: 'act-9',
+          // Model mislabels an activity block as a message; the id kind is corrected from the block.
+          locator: { blockRef: { messageId: 'act-9', blockIndex: 1 }, contentHash: 'x' }
+        }
+      ],
+      scope
+    )
+
+    expect(mapped[0]!.locator!.blockRef.activityId).toBe('act-9')
+    expect(mapped[0]!.locator!.blockRef.messageId).toBeUndefined()
+  })
+
+  it('preserves sortIndex as submission order', () => {
+    const mapped = mapChecksToScope(
+      [
+        {
+          status: 'warn',
+          claim: 'a',
+          evidence: 'a',
+          locator: { blockRef: { blockIndex: 1 }, contentHash: 'x' }
+        },
+        {
+          status: 'fail',
+          claim: 'b',
+          evidence: 'b',
+          locator: { blockRef: { blockIndex: 0 }, contentHash: 'y' }
+        }
+      ],
+      scope
+    )
+
+    expect(mapped.map((c) => c.sortIndex)).toEqual([0, 1])
+    expect(mapped[0]!.locator!.contentHash).toBe('real-hash-act-9')
+    expect(mapped[1]!.locator!.contentHash).toBe('real-hash-msg-2')
+  })
+
+  it('accepts a pass check without a locator', () => {
+    const mapped = mapChecksToScope(
+      [
+        {
+          status: 'pass',
+          claim: 'row count verified',
+          evidence: 'counted 33 rows from artifact-csv; agent reported 33'
+          // no locator — valid for pass checks
+        }
+      ],
+      scope
+    )
+
+    expect(mapped).toHaveLength(1)
+    expect(mapped[0]!.status).toBe('pass')
+    expect(mapped[0]!.locator).toBeUndefined()
+  })
+})
+
+describe('submitFindingsInputSchema — v3 unified checks[] (no reasoning)', () => {
+  it('accepts checks[] with status pass|warn|fail (no reasoning field)', () => {
+    const parsed = submitFindingsInputSchema.safeParse({
+      checks: [
+        {
+          status: 'pass',
+          claim: 'row count matches',
+          evidence: 'counted 33 rows from artifact; agent reported 33'
+        },
+        {
+          status: 'warn',
+          claim: 'unit label inconsistency',
+          evidence: 'block 0 uses mg/L, block 2 uses mmol/L',
+          locator: { blockRef: { blockIndex: 0 }, contentHash: 'abc' }
+        },
+        {
+          status: 'fail',
+          claim: 'count contradicts tool output',
+          evidence: 'agent said 42 but tool output shows 0',
+          locator: { blockRef: { blockIndex: 1 }, contentHash: 'def' }
+        }
+      ]
+    })
+
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.checks).toHaveLength(3)
+      expect(parsed.data.checks[0]!.status).toBe('pass')
+      expect(parsed.data.checks[1]!.status).toBe('warn')
+      expect(parsed.data.checks[2]!.status).toBe('fail')
+      // v3: no reasoning field
+      expect('reasoning' in parsed.data).toBe(false)
+    }
+  })
+
+  it('rejects a reasoning field (v3: reasoning no longer accepted)', () => {
+    const parsed = submitFindingsInputSchema.safeParse({
+      checks: [],
+      reasoning: 'This should now be rejected'
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('accepts an empty checks array (pure pass)', () => {
+    const parsed = submitFindingsInputSchema.safeParse({ checks: [] })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects unknown status values (inconclusive no longer valid)', () => {
+    const parsed = submitFindingsInputSchema.safeParse({
+      checks: [{ status: 'inconclusive', claim: 'x', evidence: 'y' }]
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects a summary field (v2 no longer accepts summary)', () => {
+    const parsed = submitFindingsInputSchema.safeParse({
+      checks: [],
+      summary: 'No issues found.'
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects the old findings[] field (strict schema)', () => {
+    const parsed = submitFindingsInputSchema.safeParse({
+      findings: [
+        {
+          severity: 'fail',
+          claim: 'x',
+          evidence: 'y',
+          locator: { blockRef: { blockIndex: 0 }, contentHash: 'h' }
+        }
+      ],
+      checks: []
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('accepts pass check without a locator', () => {
+    const parsed = submitFindingsInputSchema.safeParse({
+      checks: [
+        {
+          status: 'pass',
+          claim: 'verified row count',
+          evidence: 'counted 33 rows'
+          // no locator — valid for pass
+        }
+      ]
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it('locator validates a warn check', () => {
+    const parsed = submitFindingsInputSchema.safeParse({
+      checks: [
+        {
+          status: 'warn',
+          claim: 'unit label mismatch',
+          evidence: 'blocks differ',
+          locator: {
+            blockRef: { messageId: 'msg-2', blockIndex: 1 },
+            contentHash: 'deadbeef'
+          }
+        }
+      ]
+    })
+
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      const check = parsed.data.checks[0]!
+      expect(check.status).toBe('warn')
+      expect(check.locator?.blockRef.blockIndex).toBe(1)
+      expect(check.locator?.contentHash).toBe('deadbeef')
+    }
+  })
+})
+
+// The real MCP HTTP client (used by the reviewer ACP session) opens a GET SSE stream after
+// initialize. A prior bug re-created a transport and re-connected the shared McpServer for every
+// GET, throwing "Already connected to a transport" as an unhandledRejection and breaking the tool
+// channel. This exercises the full initialize → GET → tool-call flow against a live server.
+describe('ReviewerMcpServer HTTP transport', () => {
+  const MCP_ACCEPT = 'application/json, text/event-stream'
+
+  const parseSse = (body: string): { result?: unknown; error?: { message?: string } } => {
+    const dataLine = body.split('\n').find((line) => line.startsWith('data:'))
+    const json = dataLine ? dataLine.slice('data:'.length).trim() : body.trim()
+    return json ? JSON.parse(json) : {}
+  }
+
+  it('reuses the session transport for the GET SSE stream and still serves tool calls', async () => {
+    const server = new ReviewerMcpServer(scope, async () => undefined)
+    const { endpoint, token } = await server.start()
+
+    const authHeaders = { authorization: `Bearer ${token}`, accept: MCP_ACCEPT }
+
+    try {
+      // 1. initialize → obtain the session id.
+      const initResponse = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...authHeaders },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0' }
+          }
+        })
+      })
+      expect(initResponse.status).toBe(200)
+      const sessionId = initResponse.headers.get('mcp-session-id')
+      expect(sessionId).toBeTruthy()
+      await initResponse.text()
+
+      await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'mcp-session-id': sessionId!,
+          ...authHeaders
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
+      })
+
+      // 2. GET opens the SSE stream carrying the session id — must reuse the transport, not 4xx/5xx.
+      const controller = new AbortController()
+      const sseResponse = await fetch(endpoint, {
+        method: 'GET',
+        headers: { 'mcp-session-id': sessionId!, ...authHeaders },
+        signal: controller.signal
+      })
+      expect(sseResponse.status).toBe(200)
+      controller.abort()
+      await sseResponse.body?.cancel().catch(() => undefined)
+
+      // 3. A tool call after the GET still works — the channel was not broken by the SSE open.
+      // v2: submit_findings uses checks[] not findings[]
+      const toolResponse = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'mcp-session-id': sessionId!,
+          ...authHeaders
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: { name: 'submit_findings', arguments: { checks: [] } }
+        })
+      })
+      expect(toolResponse.status).toBe(200)
+      const toolJson = parseSse(await toolResponse.text())
+      expect(toolJson.error).toBeUndefined()
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('rejects a request with an unknown mcp-session-id', async () => {
+    const server = new ReviewerMcpServer(scope, async () => undefined)
+    const { endpoint, token } = await server.start()
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          accept: MCP_ACCEPT,
+          authorization: `Bearer ${token}`,
+          'mcp-session-id': 'does-not-exist'
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} })
+      })
+      expect(response.status).toBe(400)
+      await response.text()
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('rejects submit_findings with a summary field (schema-level validation)', async () => {
+    // The MCP SDK may strip unknown fields before passing to the handler, but the schema
+    // itself rejects summary. Verify at the schema level (the HTTP transport test for this
+    // would be inconclusive since the SDK may strip the field in transit).
+    const parsed = submitFindingsInputSchema.safeParse({
+      checks: [],
+      summary: 'This should be rejected'
+    })
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(parsed.error.message).toMatch(/unrecognized_keys|Unrecognized key/i)
+    }
+  })
+})

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -1,0 +1,306 @@
+// In-process HTTP MCP server that exposes `submit_findings` to the reviewer ACP session.
+// Uses the MCP Streamable HTTP transport so the agent connects via URL (McpServerHttp).
+// The server is created per review run and shut down after the reviewer session disposes.
+//
+// v2 (issue 12): submit_findings now accepts a single `checks[]` array with status pass|warn|fail.
+// The old `findings[]` + `summary` + `checks[]` split is gone. `summary` is rejected.
+// A pass check without a locator is accepted; a warn/fail check should have a locator.
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { randomUUID } from 'node:crypto'
+
+import { McpServer as ModelContextProtocolServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { z } from 'zod'
+
+import type { McpServer } from '@agentclientprotocol/sdk'
+
+import type { NewCheck, TurnScope } from '../../shared/reviewer'
+import { assertBlockInScope } from './host-sdk'
+import { createLogger } from '../logger'
+
+const REVIEWER_MCP_SERVER_NAME = 'open-science-reviewer'
+
+const log = createLogger('reviewer:mcp')
+
+// Zod schema for the optional locator on a check submitted by the reviewer.
+const checkLocatorSchema = z.object({
+  blockRef: z
+    .object({
+      messageId: z.string().optional(),
+      activityId: z.string().optional(),
+      blockIndex: z.number().int().min(0)
+    })
+    .describe('Identifies the block within the turn this check points at'),
+  contentHash: z.string().describe('The contentHash of the block this check points at')
+})
+
+// Zod schema for one unified check submitted by the reviewer.
+// status: pass = verified and ok; warn = minor issue; fail = serious issue.
+// locator is optional — pass checks may omit it; warn/fail checks should include it.
+const checkSchema = z.object({
+  status: z
+    .enum(['pass', 'warn', 'fail'])
+    .describe(
+      'pass = verified and ok; warn = minor issue that does not invalidate the result; ' +
+        'fail = serious issue that requires correction. No inconclusive — use warn when uncertain.'
+    ),
+  claim: z.string().min(1).describe('The specific claim or thing being checked'),
+  evidence: z
+    .string()
+    .min(1)
+    .describe(
+      'Supporting evidence from the turn (cite block ids / exec-log entries / artifact content you read). ' +
+        'For pass checks: describe what you verified and why it passed. ' +
+        'For warn/fail: describe the contradiction found.'
+    ),
+  locator: checkLocatorSchema
+    .optional()
+    .describe(
+      'Block-level locator for the claim being checked. Required for warn/fail; optional for pass.'
+    ),
+  artifactVersionId: z
+    .string()
+    .optional()
+    .describe('If this check relates to an artifact, its version id')
+})
+
+// The top-level submit_findings input schema.
+// v2: a single `checks[]` replaces the old findings[]+summary+checks[] split.
+// v3: reasoning removed — the reviewer log is captured from the action stream, not self-authored.
+// summary is explicitly excluded — the panel no longer shows it.
+export const submitFindingsInputSchema = z
+  .object({
+    checks: z
+      .array(checkSchema)
+      .describe(
+        'All checks you ran, each with status pass|warn|fail, claim, evidence, and optional locator. ' +
+          'Pass an empty array if you ran no checks (treat as pass).'
+      )
+  })
+  .strict() // Reject unknown fields including the old `summary`, old `findings`, and old `reasoning`
+
+export type SubmitFindingsInput = z.infer<typeof submitFindingsInputSchema>
+
+// The reviewer-supplied report (v3: no reasoning — captured from action stream instead).
+export type SubmitFindingsReport = Record<string, never>
+
+// Maps model-submitted checks onto the turn scope, enforcing the single-sourcing contract
+// (design.md:114): for checks that carry a locator, the model supplies only blockIndex as the
+// pointer; the block is resolved from scope.blocks, out-of-scope indices are rejected, and the
+// locator's blockRef id (messageId / activityId) AND contentHash are both back-filled from the scope
+// block — never trusted from model input. Pass checks without a locator are accepted as-is.
+export const mapChecksToScope = (
+  checks: SubmitFindingsInput['checks'],
+  scope: TurnScope
+): NewCheck[] =>
+  checks.map((c, i) => {
+    if (!c.locator) {
+      // Pass check without a locator — accept as-is.
+      return {
+        status: c.status,
+        claim: c.claim,
+        evidence: c.evidence,
+        locator: undefined,
+        artifactVersionId: c.artifactVersionId,
+        sortIndex: i
+      }
+    }
+
+    const { blockIndex } = c.locator.blockRef
+    const block = assertBlockInScope(
+      scope.blocks.find((b) => b.blockIndex === blockIndex),
+      String(blockIndex)
+    )
+
+    // Reconstruct the blockRef id from the block itself so a hallucinated/stale id can't be stored.
+    const blockRef =
+      block.kind === 'message'
+        ? { messageId: block.sourceId, blockIndex }
+        : { activityId: block.sourceId, blockIndex }
+
+    return {
+      status: c.status,
+      claim: c.claim,
+      evidence: c.evidence,
+      locator: { blockRef, contentHash: block.contentHash },
+      artifactVersionId: c.artifactVersionId,
+      sortIndex: i
+    }
+  })
+
+/**
+ * @deprecated Use mapChecksToScope
+ */
+export const mapFindingsToScope = mapChecksToScope
+
+// Called by the MCP server when the reviewer calls submit_findings.
+export type SubmitFindingsHandler = (
+  checks: NewCheck[],
+  scope: TurnScope,
+  report: SubmitFindingsReport
+) => Promise<void>
+
+// The per-run reviewer MCP server: exposes submit_findings and starts/stops with the review.
+export class ReviewerMcpServer {
+  private readonly mcpServer: ModelContextProtocolServer
+  private readonly httpServer: ReturnType<typeof createServer>
+  private readonly token: string
+  private _endpoint: string | undefined
+  private readonly transports = new Map<string, StreamableHTTPServerTransport>()
+
+  constructor(
+    private readonly scope: TurnScope,
+    private readonly onSubmitFindings: SubmitFindingsHandler
+  ) {
+    this.token = randomUUID()
+    this.mcpServer = this.buildMcpServer()
+    this.httpServer = createServer((req, res) => {
+      void this.handleHttpRequest(req, res)
+    })
+  }
+
+  // Starts the HTTP MCP server on a random port and returns its URL + auth token.
+  async start(): Promise<{ endpoint: string; token: string }> {
+    await new Promise<void>((resolve, reject) => {
+      this.httpServer.listen(0, '127.0.0.1', () => resolve())
+      this.httpServer.once('error', reject)
+    })
+
+    const addr = this.httpServer.address() as { port: number }
+    this._endpoint = `http://127.0.0.1:${addr.port}/mcp`
+
+    log.info('reviewer MCP server started', { endpoint: this._endpoint })
+
+    return { endpoint: this._endpoint, token: this.token }
+  }
+
+  // Stops the HTTP server; called after the reviewer session is disposed.
+  async stop(): Promise<void> {
+    for (const transport of this.transports.values()) {
+      await transport.close().catch(() => undefined)
+    }
+    this.transports.clear()
+
+    await new Promise<void>((resolve) => this.httpServer.close(() => resolve()))
+
+    log.info('reviewer MCP server stopped')
+  }
+
+  // Returns the ACP McpServer config (HTTP type) to pass to buildSession.
+  toAcpMcpServerConfig(): McpServer {
+    if (!this._endpoint) throw new Error('ReviewerMcpServer not started')
+
+    return {
+      type: 'http' as const,
+      name: REVIEWER_MCP_SERVER_NAME,
+      url: this._endpoint,
+      headers: [{ name: 'authorization', value: `Bearer ${this.token}` }]
+    }
+  }
+
+  private buildMcpServer(): ModelContextProtocolServer {
+    const server = new ModelContextProtocolServer({
+      name: REVIEWER_MCP_SERVER_NAME,
+      version: '1.0.0'
+    })
+
+    server.registerTool(
+      'submit_findings',
+      {
+        title: 'Submit review checks',
+        description:
+          'Submit your structured review checks. Call this exactly once, then stop. ' +
+          'Pass an empty checks array if you ran no checks. ' +
+          'Each check has status (pass/warn/fail), claim, evidence, and optional locator. ' +
+          'Do NOT include a reasoning or summary field — they are no longer accepted.',
+        inputSchema: submitFindingsInputSchema.shape
+      },
+      async (input) => {
+        let parsed: SubmitFindingsInput
+
+        try {
+          parsed = submitFindingsInputSchema.parse(input)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          log.warn('submit_findings validation failed', { error: message })
+          return {
+            content: [{ type: 'text', text: `Validation error: ${message}` }],
+            isError: true
+          }
+        }
+
+        log.info('submit_findings received', { count: parsed.checks.length })
+
+        // Back-fill each locator's contentHash from its scope block and reject out-of-scope
+        // locators (design.md:114 single-sourcing contract). A bad locator is a validation error.
+        let newChecks: NewCheck[]
+        try {
+          newChecks = mapChecksToScope(parsed.checks, this.scope)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          log.warn('submit_findings locator out of scope', { error: message })
+          return {
+            content: [{ type: 'text', text: `Validation error: ${message}` }],
+            isError: true
+          }
+        }
+
+        await this.onSubmitFindings(newChecks, this.scope, {})
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `checks submitted: ${newChecks.length} check(s) recorded`
+            }
+          ]
+        }
+      }
+    )
+
+    return server
+  }
+
+  private async handleHttpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // Verify bearer token.
+    const authHeader = req.headers['authorization'] ?? ''
+    const bearer = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : ''
+
+    if (bearer !== this.token) {
+      res.writeHead(401, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Unauthorized' }))
+      return
+    }
+
+    const sessionId = req.headers['mcp-session-id'] as string | undefined
+
+    let transport: StreamableHTTPServerTransport
+
+    if (sessionId && this.transports.has(sessionId)) {
+      // Established session: every follow-up request (POST messages, GET SSE stream, DELETE) carries
+      // the mcp-session-id, so reuse its transport. Crucially the GET that opens the SSE stream lands
+      // here — connecting a second transport to the shared McpServer would throw "Already connected".
+      transport = this.transports.get(sessionId)!
+    } else if (!sessionId && req.method === 'POST') {
+      // The initialize request is the only one without a session id: create the transport, register it
+      // as soon as the session id is assigned, and connect the McpServer to it exactly once.
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (id) => {
+          this.transports.set(id, transport)
+        }
+      })
+      transport.onclose = () => {
+        if (transport.sessionId) this.transports.delete(transport.sessionId)
+      }
+      await this.mcpServer.connect(transport)
+    } else {
+      res.writeHead(400, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Bad Request: missing or unknown mcp-session-id' }))
+      return
+    }
+
+    await transport.handleRequest(req, res)
+  }
+}

--- a/src/main/reviewer/orchestrator-drive.test.ts
+++ b/src/main/reviewer/orchestrator-drive.test.ts
@@ -1,0 +1,63 @@
+// Focused unit tests for the reviewer drive-loop guard: it must return on stop, time out if the
+// reviewer never stops, and cap the number of updates so a fast-looping reviewer cannot pin the
+// host/MCP servers open forever (finding: no timeout / turn cap on the reviewer session loop).
+
+import { describe, it, expect } from 'vitest'
+
+import { driveReviewerToStop } from './orchestrator'
+
+type FakeUpdate = { kind: string; stopReason?: string; update?: { sessionUpdate?: string } }
+
+describe('driveReviewerToStop', () => {
+  it('returns the stop reason when the reviewer stops', async () => {
+    const updates: FakeUpdate[] = [{ kind: 'chunk' }, { kind: 'stop', stopReason: 'end_turn' }]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    await expect(driveReviewerToStop(session, { timeoutMs: 1000, maxUpdates: 100 })).resolves.toBe(
+      'end_turn'
+    )
+  })
+
+  it('throws a timeout error if the reviewer never stops within the deadline', async () => {
+    // nextUpdate never resolves — simulates a hung reviewer session.
+    const session = { nextUpdate: (): Promise<FakeUpdate> => new Promise<FakeUpdate>(() => {}) }
+
+    await expect(driveReviewerToStop(session, { timeoutMs: 20, maxUpdates: 100 })).rejects.toThrow(
+      /timed out/i
+    )
+  })
+
+  it('throws once the update cap is exceeded (fast-looping reviewer that never stops)', async () => {
+    // Always resolves a non-stop discrete update immediately — would loop forever without the cap.
+    const session = {
+      nextUpdate: async (): Promise<FakeUpdate> => ({
+        kind: 'session_update',
+        update: { sessionUpdate: 'tool_call' }
+      })
+    }
+
+    await expect(driveReviewerToStop(session, { timeoutMs: 5000, maxUpdates: 5 })).rejects.toThrow(
+      /max updates|too many updates/i
+    )
+  })
+
+  it('does not count streaming content chunks toward the update cap', async () => {
+    // A verbose reviewer streams many message/thought chunks before it stops. These are proportional
+    // to output length, not work, so they must not trip the (much smaller) discrete-update cap.
+    const chunkKinds = ['agent_message_chunk', 'agent_thought_chunk', 'agent_message_chunk']
+    const updates: FakeUpdate[] = [
+      ...Array.from({ length: 50 }, (_, i) => ({
+        kind: 'session_update',
+        update: { sessionUpdate: chunkKinds[i % chunkKinds.length] }
+      })),
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    await expect(driveReviewerToStop(session, { timeoutMs: 5000, maxUpdates: 5 })).resolves.toBe(
+      'end_turn'
+    )
+  })
+})

--- a/src/main/reviewer/orchestrator-prompt.test.ts
+++ b/src/main/reviewer/orchestrator-prompt.test.ts
@@ -1,0 +1,41 @@
+// Unit test for buildReviewerPrompt: the host client handed to the reviewer must come from the single
+// source of truth (buildReviewerHostPythonBootstrap), not a second hand-written copy that can drift
+// from the server's actual method set.
+
+import { describe, expect, it } from 'vitest'
+
+import { buildReviewerPrompt } from './orchestrator'
+import { buildReviewerHostPythonBootstrap } from './host-sdk'
+import type { TurnScope } from '../../shared/reviewer'
+
+const scope: TurnScope = {
+  turnMessageId: 'msg-1',
+  blocks: [
+    { id: 'message:msg-1', kind: 'message', sourceId: 'msg-1', blockIndex: 0, contentHash: 'h' }
+  ],
+  artifactVersionIds: []
+}
+
+describe('buildReviewerPrompt — single-source host client', () => {
+  it('embeds the exact bootstrap client (no independent hand-written copy)', () => {
+    const endpoint = 'http://127.0.0.1:5555'
+    const token = 'tok-xyz'
+
+    const prompt = buildReviewerPrompt(scope, endpoint, token)
+
+    // The prompt must contain the bootstrap verbatim — this is what guarantees there is only one
+    // definition of the client and its method set.
+    expect(prompt).toContain(buildReviewerHostPythonBootstrap(endpoint, token))
+    expect(prompt).toContain(endpoint)
+    expect(prompt).toContain(token)
+  })
+
+  it('tells the reviewer to re-run setup per process rather than assuming a pre-loaded host', () => {
+    const prompt = buildReviewerPrompt(scope, 'http://x', 't')
+
+    // The reviewer runs Python via Bash (fresh process each time); the prompt must make that explicit
+    // so the model does not skip setup assuming a persistent pre-injected `host`.
+    expect(prompt).toContain('fresh process')
+    expect(prompt).toContain('no pre-loaded `host`')
+  })
+})

--- a/src/main/reviewer/orchestrator.test.ts
+++ b/src/main/reviewer/orchestrator.test.ts
@@ -1,0 +1,868 @@
+// Integration test for the reviewer orchestrator.
+// Mirrors the patterns from src/main/acp/runtime.test.ts and src/main/notebook/host-mcp.integration.test.ts.
+// The test stubs the ACP session so no real LLM is invoked; it asserts the orchestrator's wiring:
+// - buildSession config (cwd, mcpServers, _meta)
+// - submit_findings validates + persists
+// - lifecycle transitions (running → complete / error)
+// - reviewer session is disposed after submit_findings
+// - recomputation-based findings carry verification output in their evidence field
+// - scope isolation: out-of-scope artifact reads are rejected; no writes to main execution records
+
+import * as acp from '@agentclientprotocol/sdk'
+import type { ContentBlock } from '@agentclientprotocol/sdk'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough, Readable, Writable } from 'node:stream'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { AcpRuntime } from '../acp/runtime'
+import { ReviewRepository } from './repository'
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { runReview } from './orchestrator'
+import { ReviewerHostServer } from './host-sdk'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+
+// Re-use the same FakeAgentProcess pattern from runtime.test.ts.
+class FakeAgentProcess extends EventEmitter {
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+  killed = false
+
+  kill(): boolean {
+    this.killed = true
+    this.emit('exit', 0, null)
+    return true
+  }
+}
+
+const asAgentProcess = (process: FakeAgentProcess): ChildProcessWithoutNullStreams =>
+  process as unknown as ChildProcessWithoutNullStreams
+
+// Minimal session used for turn-scope resolution.
+const makeSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Test session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [
+    {
+      id: 'msg-1',
+      role: 'user',
+      content: 'Run the analysis',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1000,
+      updatedAt: 1000
+    },
+    {
+      id: 'msg-2',
+      role: 'agent',
+      content: 'I ran the analysis and found 42 results.',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 2000,
+      updatedAt: 2000
+    }
+  ],
+  createdAt: 900,
+  updatedAt: 2000,
+  ...overrides
+})
+
+// Builds a fake ACP agent that immediately responds to any session/prompt with a simulated
+// reviewer turn. The reviewer "calls submit_findings" by posting to the HTTP MCP endpoint
+// identified from the mcpServers config.
+const startFakeReviewerAgent = (
+  process: FakeAgentProcess,
+  reviewerSessionId: string,
+  options: {
+    // When set, the agent simulates the reviewer calling submit_findings via the MCP server URL.
+    simulateFindingsViaHttp?: boolean
+    // v3: checks[] only — reasoning removed from submit_findings
+    checksToSubmit?: Array<{
+      status: 'pass' | 'warn' | 'fail'
+      claim: string
+      evidence: string
+      locator?: {
+        blockRef: { messageId?: string; activityId?: string; blockIndex: number }
+        contentHash: string
+      }
+    }>
+  } = {}
+): {
+  newSessions: Array<{ cwd: string; mcpServers: unknown[]; _meta?: unknown }>
+  prompts: Array<{ sessionId: string; text: string }>
+  closedSessions: string[]
+} => {
+  const newSessions: Array<{ cwd: string; mcpServers: unknown[]; _meta?: unknown }> = []
+  const prompts: Array<{ sessionId: string; text: string }> = []
+  const closedSessions: string[] = []
+
+  acp
+    .agent({ name: 'test-reviewer-agent' })
+    .onRequest(acp.methods.agent.initialize, () => ({
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        sessionCapabilities: { close: {} }
+      },
+      authMethods: []
+    }))
+    .onRequest(acp.methods.agent.session.new, (ctx) => {
+      newSessions.push({
+        cwd: ctx.params.cwd,
+        mcpServers: ctx.params.mcpServers ?? [],
+        ...(ctx.params._meta === undefined ? {} : { _meta: ctx.params._meta })
+      })
+
+      return { sessionId: reviewerSessionId }
+    })
+    .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+      const text = ctx.params.prompt
+        .map((block: ContentBlock) => (block.type === 'text' ? block.text : ''))
+        .join('')
+
+      prompts.push({ sessionId: ctx.params.sessionId, text })
+
+      // If requested, simulate the reviewer calling submit_findings via the HTTP MCP server.
+      if (options.simulateFindingsViaHttp && newSessions.length > 0) {
+        const mcpServers = newSessions[newSessions.length - 1]?.mcpServers ?? []
+        const reviewerMcp = (
+          mcpServers as Array<{
+            type?: string
+            url?: string
+            headers?: Array<{ name: string; value: string }>
+          }>
+        ).find((s) => s.type === 'http')
+
+        if (reviewerMcp?.url) {
+          const token =
+            reviewerMcp.headers
+              ?.find((h: { name: string; value: string }) => h.name === 'authorization')
+              ?.value?.replace('Bearer ', '') ?? ''
+          await callSubmitFindings(reviewerMcp.url, token, options.checksToSubmit ?? [])
+        }
+      }
+
+      // Stream a minimal reply chunk.
+      await ctx.client.notify(acp.methods.client.session.update, {
+        sessionId: ctx.params.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          messageId: `reply-${ctx.params.sessionId}`,
+          content: { type: 'text', text: 'Review complete.' }
+        }
+      })
+
+      return { stopReason: 'end_turn' }
+    })
+    .onRequest(acp.methods.agent.session.close, (ctx) => {
+      closedSessions.push(ctx.params.sessionId)
+      return {}
+    })
+    .connect(
+      acp.ndJsonStream(
+        Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+        Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+      )
+    )
+
+  return { newSessions, prompts, closedSessions }
+}
+
+// Calls the submit_findings tool via the reviewer HTTP MCP server.
+// This simulates what the reviewer agent would do after reading the turn.
+//
+// The MCP Streamable HTTP transport requires clients to advertise that they accept both
+// application/json and text/event-stream; responses come back as SSE, so we parse the
+// `data:` line out of the event stream.
+const MCP_ACCEPT = 'application/json, text/event-stream'
+
+const parseMcpSseBody = (body: string): { result?: unknown; error?: { message?: string } } => {
+  // An SSE payload is `event: message\ndata: {json}\n\n`. Fall back to raw JSON.
+  const dataLine = body.split('\n').find((line) => line.startsWith('data:'))
+  const json = dataLine ? dataLine.slice('data:'.length).trim() : body.trim()
+  return json ? (JSON.parse(json) as { result?: unknown; error?: { message?: string } }) : {}
+}
+
+const callSubmitFindings = async (
+  mcpBaseUrl: string,
+  token: string,
+  // v3: checks[] only — reasoning removed from submit_findings (captured from stream instead)
+  checks: Array<{
+    status: 'pass' | 'warn' | 'fail'
+    claim: string
+    evidence: string
+    locator?: {
+      blockRef: { messageId?: string; activityId?: string; blockIndex: number }
+      contentHash: string
+    }
+  }>
+): Promise<void> => {
+  // MCP initialize handshake.
+  const initResponse = await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0' }
+      }
+    })
+  })
+
+  if (!initResponse.ok) {
+    throw new Error(`MCP initialize failed: ${initResponse.status}`)
+  }
+
+  const initJson = parseMcpSseBody(await initResponse.text())
+  const sessionId = initResponse.headers.get('mcp-session-id')
+
+  if (!sessionId || !initJson.result) {
+    throw new Error('MCP initialize did not return a session id')
+  }
+
+  // Send initialized notification.
+  await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`,
+      'mcp-session-id': sessionId
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+      params: {}
+    })
+  })
+
+  // Call submit_findings.
+  const toolResponse = await fetch(mcpBaseUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+      authorization: `Bearer ${token}`,
+      'mcp-session-id': sessionId
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'submit_findings',
+        arguments: { checks }
+      }
+    })
+  })
+
+  if (!toolResponse.ok) {
+    throw new Error(`submit_findings call failed: ${toolResponse.status}`)
+  }
+
+  const toolJson = parseMcpSseBody(await toolResponse.text())
+  if (toolJson.error) {
+    throw new Error(`submit_findings returned an error: ${toolJson.error.message ?? 'unknown'}`)
+  }
+}
+
+let temporaryRoot: string | undefined
+
+beforeEach(async () => {
+  temporaryRoot = await mkdtemp(join(tmpdir(), 'reviewer-orchestrator-test-'))
+})
+
+afterEach(async () => {
+  if (temporaryRoot) {
+    await rm(temporaryRoot, { recursive: true, force: true })
+    temporaryRoot = undefined
+  }
+})
+
+describe('reviewer orchestrator', () => {
+  it('creates a reviewer session with the correct buildSession config', async () => {
+    const process = new FakeAgentProcess()
+    const { newSessions } = startFakeReviewerAgent(process, 'reviewer-session-1')
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const session = makeSession()
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => session,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    // buildSession was called with the correct cwd.
+    expect(newSessions).toHaveLength(1)
+    expect(newSessions[0]?.cwd).toBe('/workspace')
+
+    // The reviewer MCP server (HTTP type) was included.
+    const mcpServers = (newSessions[0]?.mcpServers ?? []) as Array<{ type?: string; name?: string }>
+    expect(mcpServers.some((s) => s.type === 'http' && s.name === 'open-science-reviewer')).toBe(
+      true
+    )
+
+    // _meta includes a systemPrompt with append (rubric).
+    const meta = newSessions[0]?._meta as Record<string, unknown> | undefined
+    const systemPrompt = meta?.systemPrompt as Record<string, unknown> | undefined
+    expect(systemPrompt?.type).toBe('preset')
+    expect(systemPrompt?.preset).toBe('claude_code')
+    expect(typeof systemPrompt?.append).toBe('string')
+    expect((systemPrompt?.append as string).length).toBeGreaterThan(0)
+
+    // Review was persisted.
+    expect(review.sessionId).toBe('session-1')
+    expect(review.turnMessageId).toBe('msg-2')
+
+    await client.$disconnect()
+  })
+
+  it('sets lifecycle=complete and outcome=pass when no findings are submitted', async () => {
+    const process = new FakeAgentProcess()
+    startFakeReviewerAgent(process, 'reviewer-session-1')
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const session = makeSession()
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => session,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    // No submit_findings was called (agent didn't simulate it), so it defaults to pass.
+    expect(review.lifecycle).toBe('complete')
+    expect(review.outcome).toBe('pass')
+    expect(review.checks).toHaveLength(0)
+
+    await client.$disconnect()
+  })
+
+  it('persists checks and sets outcome=flagged when submit_findings is called with warn/fail checks', async () => {
+    const process = new FakeAgentProcess()
+    const checksToSubmit = [
+      {
+        status: 'fail' as const,
+        claim: 'Agent claimed 42 results',
+        evidence: 'Tool output shows 0 results in msg-2',
+        locator: {
+          blockRef: { messageId: 'msg-2', blockIndex: 1 },
+          contentHash: 'abc123'
+        }
+      }
+    ]
+
+    startFakeReviewerAgent(process, 'reviewer-session-1', {
+      simulateFindingsViaHttp: true,
+      checksToSubmit
+    })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const session = makeSession()
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => session,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    expect(review.lifecycle).toBe('complete')
+    expect(review.outcome).toBe('flagged')
+    expect(review.checks).toHaveLength(1)
+    expect(review.checks[0]?.status).toBe('fail')
+    expect(review.checks[0]?.claim).toBe('Agent claimed 42 results')
+
+    // Verify checks are persisted in DB.
+    const reloaded = await repository.getReviewsForSession('session-1')
+    expect(reloaded).toHaveLength(1)
+    expect(reloaded[0]?.checks).toHaveLength(1)
+    expect(reloaded[0]?.checks[0]?.claim).toBe('Agent claimed 42 results')
+
+    await client.$disconnect()
+  })
+
+  it('persists checks and reviewer log (v3: reasoning removed, log captured from stream)', async () => {
+    const process = new FakeAgentProcess()
+
+    startFakeReviewerAgent(process, 'reviewer-session-1', {
+      simulateFindingsViaHttp: true,
+      checksToSubmit: [
+        {
+          status: 'pass',
+          claim: 'row count matches',
+          evidence: 'Loaded artifact and counted 33 rows; agent reported 33'
+        },
+        {
+          status: 'warn',
+          claim: 'external DOI citation unverifiable',
+          evidence: 'Citation is external and not cached in session',
+          locator: { blockRef: { blockIndex: 0 }, contentHash: 'abc' }
+        }
+      ]
+    })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const session = makeSession()
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => session,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    expect(review.lifecycle).toBe('complete')
+    // v2/v3: outcome=flagged because one check has status 'warn'
+    expect(review.outcome).toBe('flagged')
+    // v2/v3: checks includes both pass and warn checks
+    expect(review.checks).toHaveLength(2)
+    expect(review.checks[0]!.status).toBe('pass')
+    expect(review.checks[1]!.status).toBe('warn')
+    // v3: reasoning is gone; reviewerLog captures the stream (the fake agent emits an agent_message_chunk)
+    expect('reasoning' in review).toBe(false)
+    expect(Array.isArray(review.reviewerLog)).toBe(true)
+
+    // Survives a reload from the DB (backs the Session reviewer page across restart).
+    const reloaded = await repository.getReviewsForSession('session-1')
+    expect(reloaded[0]?.checks).toHaveLength(2)
+    expect(Array.isArray(reloaded[0]?.reviewerLog)).toBe(true)
+
+    await client.$disconnect()
+  })
+
+  it('sets lifecycle=error when the session cannot be found', async () => {
+    const process = new FakeAgentProcess()
+    startFakeReviewerAgent(process, 'reviewer-session-1')
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const updateEvents: string[] = []
+
+    const review = await runReview({
+      sessionId: 'missing-session',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => undefined, // session not found
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      onReviewUpdate: (r) => updateEvents.push(r.lifecycle)
+    })
+
+    expect(review.lifecycle).toBe('error')
+    expect(review.errorMessage).toContain('missing-session')
+    // ACP session was never spawned.
+
+    await client.$disconnect()
+  })
+
+  it('calls onReviewUpdate on lifecycle transitions', async () => {
+    const process = new FakeAgentProcess()
+    startFakeReviewerAgent(process, 'reviewer-session-1')
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const lifecycles: string[] = []
+
+    await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => makeSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      onReviewUpdate: (r) => lifecycles.push(r.lifecycle)
+    })
+
+    // First update: 'running' (created), last update: 'complete'.
+    expect(lifecycles[0]).toBe('running')
+    expect(lifecycles[lifecycles.length - 1]).toBe('complete')
+
+    await client.$disconnect()
+  })
+
+  it('submit_findings rejects unknown status values', async () => {
+    // We can test the schema validation directly without a full agent run.
+    const { submitFindingsInputSchema } = await import('./mcp-server')
+
+    const result = submitFindingsInputSchema.safeParse({
+      checks: [
+        {
+          status: 'critical', // invalid — only pass|warn|fail
+          claim: 'test claim',
+          evidence: 'test evidence'
+        }
+      ]
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('submit_findings accepts valid checks (pass, warn, fail)', async () => {
+    const { submitFindingsInputSchema } = await import('./mcp-server')
+
+    const result = submitFindingsInputSchema.safeParse({
+      checks: [
+        {
+          status: 'pass',
+          claim: 'row count verified',
+          evidence: 'counted 33 rows; agent reported 33'
+        },
+        {
+          status: 'warn',
+          claim: 'Minor label inconsistency',
+          evidence: 'Block [2] shows "mg/L" but block [4] uses "mmol/L"',
+          locator: {
+            blockRef: { messageId: 'msg-2', blockIndex: 1 },
+            contentHash: 'deadbeef'
+          }
+        }
+      ]
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('submit_findings rejects summary field (v2: no summary)', async () => {
+    const { submitFindingsInputSchema } = await import('./mcp-server')
+
+    const result = submitFindingsInputSchema.safeParse({
+      checks: [],
+      summary: 'This should be rejected'
+    })
+
+    expect(result.success).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Recomputation-based finding: verification output cited in evidence
+// ---------------------------------------------------------------------------
+//
+// These tests verify that a finding produced from a reviewer's own recomputation
+// (using host.read_artifact to load a tabular artifact and recount rows) correctly
+// cites both the agent's reported value and the reviewer's verification output in
+// its evidence field. They also verify that scope isolation holds: out-of-scope
+// artifact reads are rejected by the host SDK.
+
+describe('reviewer recomputation + scope isolation', () => {
+  it('finding produced from recomputation cites both agent value and reviewer verification output in evidence', async () => {
+    // This test exercises the path where the reviewer reads a tabular artifact via
+    // host.read_artifact (which returns kind=tabular), recomputes a statistic, and submits
+    // a finding whose evidence cites both the agent's claim and the recomputed value.
+    //
+    // We directly exercise ReviewerHostServer + submit_findings schema validation without
+    // spinning up an ACP session, mirroring how the unit tests above isolate the MCP layer.
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'reviewer-recomp-test-'))
+
+    try {
+      // Place a CSV artifact (the "ground truth" table) in managed storage using the real layout:
+      // <root>/artifacts/<projectId>/<sessionId>/<messageId>/<filename>, keyed by the composite id
+      // <sessionId>:<messageId>:<filename>.
+      const artifactVersionId = 'session-1:msg-2:samples.csv'
+      const artifactDir = join(tmpDir, 'artifacts', 'project-1', 'session-1', 'msg-2')
+      await mkdir(artifactDir, { recursive: true })
+      // The table has 33 rows (agent claimed 32 — the off-by-one the reviewer should catch).
+      const rows = Array.from({ length: 33 }, (_, i) => `sample-${i + 1},0.${i + 1}`)
+      const csvContent = `sample_id,value\n${rows.join('\n')}\n`
+      await writeFile(join(artifactDir, 'samples.csv'), csvContent)
+
+      const scope = {
+        turnMessageId: 'msg-2',
+        blocks: [
+          {
+            id: 'message:msg-2',
+            kind: 'message' as const,
+            sourceId: 'msg-2',
+            blockIndex: 0,
+            contentHash: 'hash-msg-2'
+          }
+        ],
+        artifactVersionIds: [artifactVersionId]
+      }
+
+      const session = makeSession({
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'user',
+            content: 'Count the samples',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1000,
+            updatedAt: 1000
+          },
+          {
+            id: 'msg-2',
+            role: 'agent',
+            content: 'I found 32 samples in the dataset.',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 2000,
+            updatedAt: 2000,
+            artifactIds: [artifactVersionId]
+          }
+        ],
+        artifacts: [
+          {
+            id: artifactVersionId,
+            kind: 'managed-file' as const,
+            path: 'samples.csv',
+            mimeType: 'text/csv'
+          }
+        ]
+      })
+
+      // Start the host SDK server.
+      const hostServer = new ReviewerHostServer(session, scope, tmpDir)
+      const { endpoint, token } = await hostServer.start()
+
+      // Simulate the reviewer reading the artifact via host.read_artifact.
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ method: 'read_artifact', params: { id: artifactVersionId } })
+      })
+      const body = (await response.json()) as {
+        result?: { kind: string; rowCount: number; columns: Record<string, string[]> }
+      }
+
+      // The reviewer's recomputed row count from the tabular artifact.
+      const reviewerRowCount = body.result!.rowCount
+
+      // Agent claimed 32, reviewer computed 33 — build the evidence string that cites both.
+      const agentClaimedValue = 32
+      const evidenceText =
+        `Agent claimed ${agentClaimedValue} samples (msg[0]: "I found ${agentClaimedValue} samples"). ` +
+        `Reviewer recomputed rowCount from ${artifactVersionId} (kind=tabular): ${reviewerRowCount} rows.`
+
+      // The finding should cite both the agent's value and the reviewer's verification output.
+      const { submitFindingsInputSchema } = await import('./mcp-server')
+      // v2: use checks[] with status, not findings[] with severity
+      const check = {
+        status: 'fail' as const,
+        claim: `Agent claimed ${agentClaimedValue} samples but the artifact has ${reviewerRowCount}`,
+        evidence: evidenceText,
+        locator: {
+          blockRef: { messageId: 'msg-2', blockIndex: 0 },
+          contentHash: 'hash-msg-2'
+        },
+        artifactVersionId: artifactVersionId
+      }
+
+      const parsed = submitFindingsInputSchema.safeParse({ checks: [check] })
+      expect(parsed.success).toBe(true)
+
+      // Evidence cites the agent's value.
+      expect(check.evidence).toContain('Agent claimed 32')
+      // Evidence cites the reviewer's computed value.
+      expect(check.evidence).toContain('33 rows')
+      // Row count from the tabular artifact matches reality.
+      expect(reviewerRowCount).toBe(33)
+
+      await hostServer.stop()
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('host.read_artifact rejects out-of-scope artifact ids (scope isolation)', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'reviewer-isolation-test-'))
+
+    try {
+      const scope = {
+        turnMessageId: 'msg-1',
+        blocks: [
+          {
+            id: 'message:msg-1',
+            kind: 'message' as const,
+            sourceId: 'msg-1',
+            blockIndex: 0,
+            contentHash: 'hash-msg-1'
+          }
+        ],
+        artifactVersionIds: ['artifact-in-scope'] // only this id is allowed
+      }
+
+      const hostServer = new ReviewerHostServer(makeSession(), scope, tmpDir)
+      const { endpoint, token } = await hostServer.start()
+
+      // Request an artifact that is NOT in this turn's scope.
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          method: 'read_artifact',
+          params: { id: 'artifact-from-different-turn' }
+        })
+      })
+
+      // The server returns 500 with an error message (thrown from readArtifact).
+      const body = (await response.json()) as { error?: string }
+      expect(body.error).toMatch(/artifact-from-different-turn/)
+      expect(body.error).toMatch(/not in this turn/)
+
+      await hostServer.stop()
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('reviewer does not write to main execution records or artifacts during runReview', async () => {
+    // This test verifies sandbox isolation by confirming that runReview completes without
+    // creating any notebook run records (the main execution record store). The reviewer uses
+    // its own host SDK server — it has no access to the main notebook runtime.
+    //
+    // We check this by asserting the review completes (lifecycle=complete) and no notebook
+    // run files were written to the temporary root (which stands in for the main storage).
+    const process = new FakeAgentProcess()
+    const checksToSubmit = [
+      {
+        status: 'fail' as const,
+        claim: 'Agent claimed 42 results but recomputed count = 33',
+        evidence:
+          'Agent stated 42 in msg-2. Reviewer ran host.read_artifact("csv-1") → kind=tabular, rowCount=33.',
+        locator: {
+          blockRef: { messageId: 'msg-2', blockIndex: 1 },
+          contentHash: 'abc123'
+        },
+        artifactVersionId: 'csv-1'
+      }
+    ]
+
+    startFakeReviewerAgent(process, 'reviewer-session-1', {
+      simulateFindingsViaHttp: true,
+      checksToSubmit
+    })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => makeSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    // Review completed successfully.
+    expect(review.lifecycle).toBe('complete')
+    expect(review.outcome).toBe('flagged')
+
+    // v2: use checks not findings
+    const check = review.checks[0]!
+    expect(check.evidence).toContain('Agent stated 42')
+    expect(check.evidence).toContain('rowCount=33')
+    expect(check.artifactVersionId).toBe('csv-1')
+
+    // No notebook run files should have been created in the storage root by the reviewer.
+    // The main notebook runtime was never touched by the reviewer session.
+    const { readdir } = await import('node:fs/promises')
+    const notebookRunsPath = join(temporaryRoot!, 'notebooks')
+    const notebookExists = await readdir(notebookRunsPath).catch(() => null)
+    expect(notebookExists).toBeNull()
+
+    await client.$disconnect()
+  })
+})

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -1,0 +1,1011 @@
+// Orchestrator for the auto-review pipeline. `runReview` is called after each turn completes;
+// it spawns a fresh-context reviewer ACP session, injects the rubric + reviewer MCP + host SDK,
+// drives the reviewer to completion, persists findings, and then disposes the session.
+//
+// Phase 3: after a review with warn/fail, `runFixLoop` drives the bounded re-review loop:
+// inject → correction turn → re-review new blocks → resolve/reflag → repeat (max 3 rounds).
+//
+// Errors are isolated: reviewer failures set lifecycle='error' and do NOT crash the main session.
+
+import { homedir } from 'node:os'
+
+import type { ActiveSession } from '@agentclientprotocol/sdk'
+
+import type { AcpRuntime } from '../acp/runtime'
+import { createLogger } from '../logger'
+import { extractProviderToolName, extractTerminalMeta } from '../acp/runtime-events'
+import type {
+  NewCheck,
+  ReviewCheck,
+  ReviewerLogEntry,
+  ReviewOutcome,
+  ReviewWithChecks,
+  TurnScope
+} from '../../shared/reviewer'
+import type { ReviewRepository } from './repository'
+import { resolveTurnScope } from './scope'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { ReviewerMcpServer } from './mcp-server'
+import { buildReviewerHostPythonBootstrap, ReviewerHostServer } from './host-sdk'
+import { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } from './rubric'
+import { injectAuditorMessage } from './correction'
+
+const log = createLogger('reviewer:orchestrator')
+
+export type RunReviewOptions = {
+  sessionId: string
+  // The turn to review: the agent message id (or user message id) for that turn.
+  turnMessageId: string
+  // The project this session belongs to.
+  projectId: string
+  // Used to resolve the session's persisted data for turn-scope resolution.
+  // For the fix loop, this is called after each correction turn so it must return the LATEST session.
+  getSession: (sessionId: string) => PersistedChatSession | undefined
+  // Repository for persisting review rows + checks.
+  reviewRepository: ReviewRepository
+  // The ACP runtime that owns the agent connection (used to spawn the reviewer session).
+  acpRuntime: AcpRuntime
+  // Storage root for artifact reads (used by the reviewer host SDK).
+  artifactStorageRoot: string
+  // The model/provider tag to record on the Review row.
+  model?: string
+  // Called when the review lifecycle changes, so the IPC layer can broadcast updates.
+  onReviewUpdate?: (review: ReviewWithChecks) => void
+  // The main session id to inject the [Auditor] correction message into (if warn/fail checks).
+  // When omitted, correction injection is skipped.
+  mainSessionId?: string
+  // Optional hook called with the auditor message text before it is sent. Used in tests.
+  onCorrectionPrompt?: (text: string) => void
+  // Optional hook called if the correction sendPrompt fails, so the caller can clear the pre-emptive
+  // auto-review suppression it set before the correction turn (the failed turn emits no stop).
+  onCorrectionFailed?: () => void
+  // Optional hook called when runReview is invoked externally; used in tests to assert no
+  // recursive re-review is triggered by the correction path.
+  onRunReviewCalled?: () => void
+  // Wall-clock budget for the reviewer session drive loop before it is aborted as an error.
+  reviewerTimeoutMs?: number
+  // Hard cap on reviewer session updates before the drive loop aborts (guards a fast-looping agent).
+  reviewerMaxUpdates?: number
+  // Maximum number of fix-loop iterations (whole-loop counter cap). Defaults to 3.
+  fixLoopMaxRounds?: number
+  // Called just before the fix loop starts (after initial review finds warn/fail). Used to lock
+  // the session composer in the renderer.
+  onFixLoopStart?: () => void
+  // Called when the fix loop ends (all pass, cap reached, or aborted). Used to unlock the session
+  // composer in the renderer.
+  onFixLoopEnd?: () => void
+  // AbortSignal to stop the fix loop early (e.g. when the user presses cancel). When aborted,
+  // the loop exits at the next round boundary without further [Auditor] injections.
+  fixLoopAbortSignal?: AbortSignal
+}
+
+// Default drive-loop guards. The wall-clock timeout is the primary backstop against a reviewer that
+// never stops (it is the only guard that catches a reviewer stuck streaming thoughts forever, since
+// those do not count toward the update cap — see below). The update cap is a secondary backstop
+// against a fast-looping reviewer that spins through discrete actions. Reviews do real multi-step
+// verification (several Python cells + reasoning), so the timeout is generous.
+const DEFAULT_REVIEWER_TIMEOUT_MS = 900_000
+const DEFAULT_REVIEWER_MAX_UPDATES = 1000
+
+// Streaming content deltas are emitted one-per-chunk as the reviewer writes its message/thinking, so
+// their count tracks how much it *says*, not how much it *does*. Counting them toward the loop cap
+// made a normally-verbose review trip the guard mid-stream before it could call submit_findings. Only
+// discrete updates (tool calls, plans, tool-call status changes) count toward maxUpdates; a genuine
+// runaway loop shows up there, while a hung/rambling reviewer is caught by the wall-clock timeout.
+const STREAMING_CHUNK_UPDATES = new Set([
+  'agent_message_chunk',
+  'agent_thought_chunk',
+  'user_message_chunk'
+])
+
+// The minimal reviewer-session surface the drive loop needs. `update.sessionUpdate` is the ACP
+// SessionUpdate discriminator, present on session_update messages (absent on the stop message).
+type DrivableSession = {
+  nextUpdate: () => Promise<{
+    kind: string
+    stopReason?: string
+    update?: { sessionUpdate?: string; [key: string]: unknown }
+  }>
+}
+
+// Options for the driveReviewerToStop log-capture callback.
+type DriveOptions = {
+  timeoutMs: number
+  maxUpdates: number
+}
+
+type DriveCallbacks = {
+  // Called for each update that should be captured into the reviewer log.
+  // The caller assembles streaming chunks into whole entries and appends them.
+  onUpdate?: (entry: ReviewerLogEntry) => void
+}
+
+// In-flight accumulator for streaming content (thought/message chunks are assembled into whole entries).
+// Also tracks in-progress tool entries by toolCallId so tool_call_update can merge into the same entry.
+type ChunkAccumulator = {
+  thoughtText: string | null
+  messageText: string | null
+  // Map from toolCallId to the mutable tool log entry (shared reference allows update-in-place).
+  pendingTools: Map<string, ReviewerLogEntry & { kind: 'tool' }>
+}
+
+// Extracts a text chunk from an ACP update's content field (may be a { type:'text', text:string } block).
+const extractTextContent = (update: { content?: unknown }): string => {
+  const c = update.content
+  if (!c) return ''
+  if (typeof c === 'string') return c
+  if (
+    typeof c === 'object' &&
+    c !== null &&
+    'text' in c &&
+    typeof (c as { text: unknown }).text === 'string'
+  ) {
+    return (c as { text: string }).text
+  }
+  return ''
+}
+
+// Serializes an ACP raw tool input/output value to a display string. Strings pass through unchanged;
+// objects are JSON-encoded (never String()'d, which would produce "[object Object]"). Falls back to
+// String() only when the value cannot be serialized (e.g. a circular reference).
+const stringifyRaw = (value: unknown): string => {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+// Flushes any in-flight thought/message accumulator and returns the emitted entry (or null if nothing to flush).
+const flushAccumulator = (
+  acc: ChunkAccumulator,
+  onUpdate: ((entry: ReviewerLogEntry) => void) | undefined
+): void => {
+  if (acc.thoughtText !== null && acc.thoughtText.length > 0) {
+    onUpdate?.({ kind: 'thought', text: acc.thoughtText })
+    acc.thoughtText = null
+  }
+  if (acc.messageText !== null && acc.messageText.length > 0) {
+    onUpdate?.({ kind: 'message', text: acc.messageText })
+    acc.messageText = null
+  }
+}
+
+// Sentinel used to distinguish the timeout branch from a real reviewer update in Promise.race.
+const TIMEOUT = Symbol('reviewer-drive-timeout')
+
+// Consumes reviewer session updates until it stops, returning the stop reason. Throws if the
+// reviewer does not stop within timeoutMs, or if it emits more than maxUpdates discrete updates —
+// either way the caller sets lifecycle='error' and disposes the session + servers. Prevents a hung
+// or runaway reviewer from pinning the host/MCP servers open and leaving the review row 'running'.
+//
+// The optional `onUpdate` callback in `callbacks` is called once per assembled log entry:
+// streaming chunks (agent_thought_chunk, agent_message_chunk) are assembled into whole entries before
+// the callback fires; tool_call and tool_result updates are emitted immediately. The loop-guard
+// behavior is unchanged: streaming chunks still don't count toward maxUpdates.
+export const driveReviewerToStop = async (
+  session: DrivableSession,
+  options: DriveOptions,
+  callbacks?: DriveCallbacks
+): Promise<string | undefined> => {
+  const { timeoutMs, maxUpdates } = options
+  const { onUpdate } = callbacks ?? {}
+  const deadline = Date.now() + timeoutMs
+  let updates = 0
+
+  // In-flight accumulator for streaming text chunks (assembled into whole entries on transition).
+  const acc: ChunkAccumulator = { thoughtText: null, messageText: null, pendingTools: new Map() }
+
+  for (;;) {
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) throw new Error('reviewer session timed out before stopping')
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<typeof TIMEOUT>((resolve) => {
+      timer = setTimeout(() => resolve(TIMEOUT), remaining)
+    })
+
+    try {
+      const result = await Promise.race([session.nextUpdate(), timeout])
+      if (result === TIMEOUT) throw new Error('reviewer session timed out before stopping')
+
+      if (result.kind === 'stop') {
+        // Flush any in-flight streaming chunks before returning.
+        flushAccumulator(acc, onUpdate)
+        return result.stopReason
+      }
+
+      const sessionUpdate = result.update?.sessionUpdate ?? ''
+
+      // Only discrete updates count toward the loop cap; streaming content chunks do not (they scale
+      // with output length, not work, and would trip the guard on a normal verbose review).
+      if (!STREAMING_CHUNK_UPDATES.has(sessionUpdate)) {
+        updates++
+        if (updates >= maxUpdates) {
+          throw new Error(`reviewer session exceeded max updates (${maxUpdates})`)
+        }
+      }
+
+      // --- Log capture: assemble chunks into entries and emit discrete events ---
+      if (onUpdate && result.update) {
+        const u = result.update
+
+        if (sessionUpdate === 'agent_thought_chunk') {
+          // Flush any in-progress message accumulator first (content type switched).
+          if (acc.messageText !== null && acc.messageText.length > 0) {
+            onUpdate({ kind: 'message', text: acc.messageText })
+            acc.messageText = null
+          }
+          // Accumulate into thought buffer.
+          acc.thoughtText = (acc.thoughtText ?? '') + extractTextContent(u as { content?: unknown })
+        } else if (sessionUpdate === 'agent_message_chunk') {
+          // Flush any in-progress thought accumulator first (content type switched).
+          if (acc.thoughtText !== null && acc.thoughtText.length > 0) {
+            onUpdate({ kind: 'thought', text: acc.thoughtText })
+            acc.thoughtText = null
+          }
+          // Accumulate into message buffer.
+          acc.messageText = (acc.messageText ?? '') + extractTextContent(u as { content?: unknown })
+        } else if (sessionUpdate === 'tool_call') {
+          // Flush any in-flight streaming content before a discrete tool call.
+          flushAccumulator(acc, onUpdate)
+          // Extract the real tool name from ACP provider metadata (_meta.claudeCode.toolName etc.).
+          // The top-level `toolName` field is absent in ACP; only the _meta path carries the name.
+          const realToolName =
+            extractProviderToolName(u as { _meta?: unknown }) ??
+            (u.toolName as string | undefined) ??
+            ''
+          const toolCallId = (u.toolCallId as string | undefined) ?? ''
+          const entry: ReviewerLogEntry & { kind: 'tool' } = {
+            kind: 'tool',
+            toolName: realToolName,
+            title: u.title as string | undefined,
+            rawInput: u.rawInput !== undefined ? stringifyRaw(u.rawInput) : undefined
+          }
+          // Remember by toolCallId so tool_call_update can mutate the same object in-place.
+          if (toolCallId) {
+            acc.pendingTools.set(toolCallId, entry)
+          }
+          onUpdate(entry)
+        } else if (sessionUpdate === 'tool_call_update') {
+          // ACP never emits tool_result — updates arrive as tool_call_update carrying rawOutput,
+          // terminal stdout, exit code, and the final status. Mutate the in-flight entry in-place
+          // so the already-appended log entry (shared reference) is updated without re-emit.
+          const toolCallId = (u.toolCallId as string | undefined) ?? ''
+          let entry = toolCallId ? acc.pendingTools.get(toolCallId) : undefined
+          if (!entry) {
+            // Defensive: no prior tool_call seen — create a fresh tool entry now.
+            const realToolName =
+              extractProviderToolName(u as { _meta?: unknown }) ??
+              (u.toolName as string | undefined) ??
+              ''
+            entry = {
+              kind: 'tool',
+              toolName: realToolName,
+              title: u.title as string | undefined
+            }
+            if (toolCallId) acc.pendingTools.set(toolCallId, entry)
+            onUpdate(entry)
+          }
+          // Merge input/output fields into the existing entry. Claude Code seeds the initial
+          // tool_call with an empty {} input and supplies the real arguments here, so a defined
+          // rawInput on the update overrides the seed (mirrors the main-agent `rawInput ?? old` merge).
+          if (u.rawInput !== undefined) {
+            entry.rawInput = stringifyRaw(u.rawInput)
+          }
+          if (u.rawOutput !== undefined) {
+            entry.rawOutput = stringifyRaw(u.rawOutput)
+          }
+          const { terminalOutput, terminalExitCode } = extractTerminalMeta(
+            u as Parameters<typeof extractTerminalMeta>[0]
+          )
+          if (terminalOutput !== undefined) {
+            // Terminal stdout/stderr replaces rawOutput if it arrives via _meta.terminal_output.data
+            entry.rawOutput = terminalOutput
+          }
+          if (terminalExitCode !== undefined) {
+            entry.exitCode = terminalExitCode
+          }
+          // Normalize ACP status to 'ok' | 'error'.
+          const statusRaw = u.status as string | undefined
+          if (statusRaw === 'completed') {
+            entry.status = 'ok'
+          } else if (statusRaw === 'failed' || statusRaw === 'error') {
+            entry.status = 'error'
+          } else if (statusRaw === 'ok' || statusRaw === 'error') {
+            entry.status = statusRaw
+          }
+        }
+      }
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+}
+
+// Options for the Phase 3 fix loop.
+type FixLoopOptions = {
+  sessionId: string
+  // The original turn's message id (shared across all Review rows in this closure).
+  originalTurnMessageId: string
+  // The reviewId whose warn/fail checks are being tracked.
+  originalReviewId: string
+  // The currently-open warn/fail checks to carry forward into each re-review.
+  openChecks: ReviewCheck[]
+  projectId: string
+  mainSessionId: string
+  getSession: (sessionId: string) => PersistedChatSession | undefined
+  reviewRepository: ReviewRepository
+  acpRuntime: AcpRuntime
+  artifactStorageRoot: string
+  model: string
+  onReviewUpdate?: (review: ReviewWithChecks) => void
+  onCorrectionPrompt?: (text: string) => void
+  onCorrectionFailed?: () => void
+  reviewerTimeoutMs: number
+  reviewerMaxUpdates: number
+  maxRounds: number
+  // Optional abort signal: when aborted, the loop exits at the next round boundary.
+  abortSignal?: AbortSignal
+}
+
+// Runs the Phase 3 bounded re-review loop. For each round (up to maxRounds):
+// 1. Injects [Auditor] with the still-open warn/fail checks.
+// 2. The main agent produces a correction turn.
+// 3. Re-reviews the correction turn's new blocks.
+// 4. Updates resolutions on the original review's checks from re-review results:
+//    - claim passes in re-review → resolved
+//    - same claim flagged again → incrementReflagCount on original check; stays open
+//    - claim not mentioned in re-review → stays open
+// 5. If all resolved or cap reached, stops.
+// Cap termination marks remaining open warn/fail checks as 'unaddressed'.
+const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
+  const {
+    sessionId,
+    originalTurnMessageId,
+    originalReviewId,
+    projectId,
+    mainSessionId,
+    getSession,
+    reviewRepository,
+    acpRuntime,
+    artifactStorageRoot,
+    model,
+    onReviewUpdate,
+    onCorrectionPrompt,
+    onCorrectionFailed,
+    reviewerTimeoutMs,
+    reviewerMaxUpdates,
+    maxRounds,
+    abortSignal
+  } = options
+
+  let openChecks = [...options.openChecks]
+
+  for (let round = 0; round < maxRounds; round++) {
+    if (openChecks.length === 0) break
+
+    // Abort check: if the user cancelled during the loop, exit without further [Auditor] injections.
+    if (abortSignal?.aborted) {
+      log.info('fix loop: aborted by user', { sessionId, round, openCount: openChecks.length })
+      return
+    }
+
+    // Step A: record the last known message id before the correction prompt, so we can detect
+    // the correction turn's new agent message after sendPrompt returns.
+    const sessionBefore = getSession(sessionId)
+    const messagesBefore = sessionBefore?.messages ?? []
+    const lastMessageIdBefore =
+      messagesBefore.length > 0 ? messagesBefore[messagesBefore.length - 1]!.id : null
+
+    // Step B: inject [Auditor] with the currently-open warn/fail checks.
+    let correctionFailed = false
+    await injectAuditorMessage({
+      sessionId,
+      mainSessionId,
+      findings: openChecks,
+      acpRuntime,
+      onCorrectionPrompt,
+      onCorrectionFailed: () => {
+        correctionFailed = true
+        onCorrectionFailed?.()
+      }
+    })
+
+    // Error handling: a failed correction counts as a round (prevents infinite loop) but we
+    // cannot re-review (there's no correction turn). Mark remaining as unaddressed and stop.
+    if (correctionFailed) {
+      log.warn('correction failed in fix loop — marking remaining checks unaddressed', {
+        sessionId,
+        round,
+        openCount: openChecks.length
+      })
+      await reviewRepository.updateFindingResolutions(originalReviewId, 'unaddressed')
+      return
+    }
+
+    // Step C: reload the session to see the correction turn's new messages.
+    const sessionAfter = getSession(sessionId)
+    if (!sessionAfter) {
+      log.warn('session not found after correction in fix loop', { sessionId, round })
+      await reviewRepository.updateFindingResolutions(originalReviewId, 'unaddressed')
+      return
+    }
+
+    // Find the first new agent message added after the correction prompt. This is the
+    // correction turn's response — use it as the turnMessageId for the re-review scope.
+    const messagesAfter = sessionAfter.messages ?? []
+    const newMessages = lastMessageIdBefore
+      ? (() => {
+          const cutoffIndex = messagesAfter.findIndex((m) => m.id === lastMessageIdBefore)
+          return cutoffIndex >= 0 ? messagesAfter.slice(cutoffIndex + 1) : messagesAfter
+        })()
+      : messagesAfter
+
+    const correctionAgentMsg = newMessages.find((m) => m.role === 'agent')
+    if (!correctionAgentMsg) {
+      log.warn(
+        'no new agent message after correction in fix loop — using auditor msg as scope marker',
+        {
+          sessionId,
+          round,
+          newMessageCount: newMessages.length
+        }
+      )
+      // Fall back to re-reviewing the whole session's last agent message.
+    }
+
+    const correctionTurnMessageId = correctionAgentMsg?.id ?? originalTurnMessageId
+
+    // Step D: run a re-review scoped to the correction turn's new blocks.
+    // This creates a new Review row sharing the original turnMessageId.
+    log.info('fix loop: running re-review', { sessionId, round, correctionTurnMessageId })
+
+    const reReviewResult = await runScopedReview({
+      sessionId,
+      turnMessageId: correctionTurnMessageId,
+      originalTurnMessageId,
+      projectId,
+      getSession,
+      reviewRepository,
+      acpRuntime,
+      artifactStorageRoot,
+      model,
+      onReviewUpdate,
+      reviewerTimeoutMs,
+      reviewerMaxUpdates
+    })
+
+    // Step E: compute resolution transitions for the original review's open checks.
+    // - If the re-review errored: count as a round but mark remaining unaddressed and stop.
+    // - If the re-review has no warn/fail (all pass or empty): all open checks → resolved.
+    // - If the re-review flags the same claim: incrementReflagCount; stays open.
+    // - If the re-review flags a different claim: original open check stays open.
+
+    if (reReviewResult.lifecycle === 'error') {
+      log.warn('fix loop: re-review errored — marking remaining checks unaddressed', {
+        sessionId,
+        round,
+        openCount: openChecks.length
+      })
+      for (const openCheck of openChecks) {
+        await reviewRepository.updateFindingResolutionForClaim(
+          originalReviewId,
+          openCheck.claim,
+          'unaddressed'
+        )
+      }
+      return
+    }
+
+    const reReviewWarnFail = reReviewResult.checks.filter(
+      (c) => c.status === 'warn' || c.status === 'fail'
+    )
+    const reReviewWarnFailClaims = new Set(reReviewWarnFail.map((c) => c.claim))
+
+    const stillOpenChecks: ReviewCheck[] = []
+
+    for (const openCheck of openChecks) {
+      if (reReviewWarnFailClaims.has(openCheck.claim)) {
+        // Same claim flagged again → over-correction; increment reflagCount and keep open.
+        await reviewRepository.incrementReflagCount(originalReviewId, openCheck.claim)
+        log.info('fix loop: claim re-flagged (over-correction)', {
+          sessionId,
+          round,
+          claim: openCheck.claim
+        })
+        stillOpenChecks.push(openCheck)
+      } else {
+        // Claim not flagged in re-review → resolved.
+        await reviewRepository.updateFindingResolutionForClaim(
+          originalReviewId,
+          openCheck.claim,
+          'resolved'
+        )
+        log.info('fix loop: claim resolved', { sessionId, round, claim: openCheck.claim })
+      }
+    }
+
+    openChecks = stillOpenChecks
+
+    if (openChecks.length === 0) {
+      log.info('fix loop: all checks resolved', { sessionId, rounds: round + 1 })
+      return
+    }
+
+    log.info('fix loop: still-open checks remain', {
+      sessionId,
+      round,
+      stillOpen: openChecks.length
+    })
+  }
+
+  // Cap reached: mark remaining open warn/fail checks as unaddressed.
+  if (openChecks.length > 0) {
+    log.info('fix loop: cap reached — marking remaining checks unaddressed', {
+      sessionId,
+      maxRounds,
+      remaining: openChecks.length
+    })
+    for (const openCheck of openChecks) {
+      await reviewRepository.updateFindingResolutionForClaim(
+        originalReviewId,
+        openCheck.claim,
+        'unaddressed'
+      )
+    }
+  }
+}
+
+// Runs one scoped re-review for a correction turn. Creates a new Review row under the same
+// original turnMessageId so all iterations are grouped. Returns the completed review.
+// Never throws — errors are captured as lifecycle='error'.
+const runScopedReview = async (options: {
+  sessionId: string
+  turnMessageId: string // the correction turn's agent message id
+  originalTurnMessageId: string // shared across all Review rows in this fix-loop closure
+  projectId: string
+  getSession: (sessionId: string) => PersistedChatSession | undefined
+  reviewRepository: ReviewRepository
+  acpRuntime: AcpRuntime
+  artifactStorageRoot: string
+  model: string
+  onReviewUpdate?: (review: ReviewWithChecks) => void
+  reviewerTimeoutMs: number
+  reviewerMaxUpdates: number
+}): Promise<ReviewWithChecks> => {
+  const {
+    sessionId,
+    turnMessageId,
+    originalTurnMessageId,
+    projectId,
+    getSession,
+    reviewRepository,
+    acpRuntime,
+    artifactStorageRoot,
+    model,
+    onReviewUpdate,
+    reviewerTimeoutMs,
+    reviewerMaxUpdates
+  } = options
+
+  const session = getSession(sessionId)
+
+  if (!session) {
+    log.warn('session not found for scoped re-review', { sessionId })
+    const errorReview = await reviewRepository.createReview({
+      projectId,
+      sessionId,
+      turnMessageId: originalTurnMessageId,
+      scope: { turnMessageId: originalTurnMessageId, blocks: [], artifactVersionIds: [] },
+      lifecycle: 'error',
+      errorMessage: `Session ${sessionId} not found during re-review`,
+      model
+    })
+    return { ...errorReview, checks: [] }
+  }
+
+  // Resolve the correction turn's scope.
+  const scope = resolveTurnScope(session, turnMessageId)
+
+  // Create a new Review row sharing the originalTurnMessageId (not the correction turn's id),
+  // so all iterations are grouped under the same original turn.
+  let review = await reviewRepository.createReview({
+    projectId,
+    sessionId,
+    turnMessageId: originalTurnMessageId,
+    scope,
+    lifecycle: 'running',
+    model
+  })
+
+  const initialWithChecks: ReviewWithChecks = { ...review, checks: [] }
+  onReviewUpdate?.(initialWithChecks)
+
+  log.info('scoped re-review created', { reviewId: review.id, blocks: scope.blocks.length })
+
+  // Run the reviewer session (same flow as the initial review).
+  let reviewerSession: ReturnType<typeof Object.create> | undefined
+  let hostServer: ReviewerHostServer | undefined
+  let mcpServer: ReviewerMcpServer | undefined
+  let checksReceived: NewCheck[] = []
+  let checksSubmitted = false
+  const capturedLog: ReviewerLogEntry[] = []
+
+  try {
+    hostServer = new ReviewerHostServer(session, scope, artifactStorageRoot)
+    const { endpoint: hostEndpoint, token: hostToken } = await hostServer.start()
+
+    mcpServer = new ReviewerMcpServer(scope, async (checks: NewCheck[]) => {
+      checksReceived = checks
+      checksSubmitted = true
+    })
+    await mcpServer.start()
+
+    const reviewerPrompt = buildReviewerPrompt(scope, hostEndpoint, hostToken)
+    const systemPromptAppend = REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
+    const cwd = session.cwd || homedir()
+
+    reviewerSession = await acpRuntime.buildReviewerSession({
+      cwd,
+      mcpServers: [mcpServer.toAcpMcpServerConfig()],
+      systemPromptAppend
+    })
+
+    reviewerSession.prompt([{ type: 'text', text: reviewerPrompt }])
+
+    await driveReviewerToStop(
+      reviewerSession,
+      { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates },
+      { onUpdate: (entry) => capturedLog.push(entry) }
+    )
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    log.error('scoped re-review session failed', { reviewId: review.id, error: errorMsg })
+
+    review = await reviewRepository.updateReview(review.id, {
+      lifecycle: 'error',
+      errorMessage: errorMsg
+    })
+    const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
+    onReviewUpdate?.(errorWithChecks)
+    return errorWithChecks
+  } finally {
+    if (reviewerSession) acpRuntime.disposeReviewerSession(reviewerSession)
+    await mcpServer?.stop().catch(() => undefined)
+    await hostServer?.stop().catch(() => undefined)
+  }
+
+  // Persist checks and complete the review.
+  try {
+    if (!checksSubmitted) {
+      log.warn('re-reviewer did not call submit_findings; treating as pass', {
+        reviewId: review.id
+      })
+    }
+
+    await reviewRepository.addChecks(review.id, checksReceived)
+
+    const hasWarnOrFailCheck = checksReceived.some(
+      (c) => c.status === 'warn' || c.status === 'fail'
+    )
+    const outcome: ReviewOutcome = hasWarnOrFailCheck ? 'flagged' : 'pass'
+    review = await reviewRepository.updateReview(review.id, {
+      lifecycle: 'complete',
+      outcome,
+      reviewerLog: capturedLog
+    })
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    log.error('scoped re-review persistence failed', { reviewId: review.id, error: errorMsg })
+    review = await reviewRepository.updateReview(review.id, {
+      lifecycle: 'error',
+      errorMessage: errorMsg
+    })
+    const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
+    onReviewUpdate?.(errorWithChecks)
+    return errorWithChecks
+  }
+
+  // Load the final review with checks.
+  const allReviews = await reviewRepository.getReviewsForSession(sessionId)
+  const finalReview = allReviews.find((r) => r.id === review.id) ?? {
+    ...review,
+    checks: checksReceived.map((c, i): ReviewCheck => ({
+      id: `check-${i}`,
+      reviewId: review.id,
+      status: c.status,
+      resolution: 'open',
+      claim: c.claim,
+      evidence: c.evidence,
+      locator: c.locator,
+      artifactVersionId: c.artifactVersionId,
+      sortIndex: c.sortIndex ?? i,
+      reflagCount: 0
+    }))
+  }
+
+  onReviewUpdate?.(finalReview)
+  return finalReview
+}
+
+// Drives one complete auto-review cycle: scope resolution → DB record → reviewer session →
+// submit_findings → lifecycle update. Returns the final review (with checks) for the caller
+// to broadcast. Never throws — errors are captured as lifecycle='error'.
+export const runReview = async (options: RunReviewOptions): Promise<ReviewWithChecks> => {
+  const {
+    sessionId,
+    turnMessageId,
+    projectId,
+    getSession,
+    reviewRepository,
+    acpRuntime,
+    artifactStorageRoot,
+    model = '',
+    onReviewUpdate,
+    mainSessionId,
+    onCorrectionPrompt,
+    onCorrectionFailed,
+    reviewerTimeoutMs = DEFAULT_REVIEWER_TIMEOUT_MS,
+    reviewerMaxUpdates = DEFAULT_REVIEWER_MAX_UPDATES,
+    fixLoopMaxRounds = 3,
+    onFixLoopStart,
+    onFixLoopEnd,
+    fixLoopAbortSignal
+  } = options
+
+  log.info('runReview started', { sessionId, turnMessageId })
+
+  // Step 1: resolve the turn scope.
+  const session = getSession(sessionId)
+
+  if (!session) {
+    log.warn('session not found for review', { sessionId })
+    const errorReview = await reviewRepository.createReview({
+      projectId,
+      sessionId,
+      turnMessageId,
+      scope: { turnMessageId, blocks: [], artifactVersionIds: [] },
+      lifecycle: 'error',
+      errorMessage: `Session ${sessionId} not found`,
+      model
+    })
+    const withFindings: ReviewWithChecks = { ...errorReview, checks: [] }
+    onReviewUpdate?.(withFindings)
+    return withFindings
+  }
+
+  const scope = resolveTurnScope(session, turnMessageId)
+
+  // Step 2: create the Review row (lifecycle='running') immediately so the renderer shows a spinner.
+  let review = await reviewRepository.createReview({
+    projectId,
+    sessionId,
+    turnMessageId,
+    scope,
+    lifecycle: 'running',
+    model
+  })
+
+  const initialWithFindings: ReviewWithChecks = { ...review, checks: [] }
+  onReviewUpdate?.(initialWithFindings)
+
+  log.info('review created', { reviewId: review.id, blocks: scope.blocks.length })
+
+  // Step 3: run the reviewer session. All failures inside are caught and set lifecycle='error'.
+  let reviewerSession: ActiveSession | undefined
+  let hostServer: ReviewerHostServer | undefined
+  let mcpServer: ReviewerMcpServer | undefined
+  let checksReceived: NewCheck[] = []
+  let checksSubmitted = false
+  const capturedLog: ReviewerLogEntry[] = []
+
+  try {
+    // Start the host SDK server (provides read_turn / query_execution_log / read_artifact).
+    hostServer = new ReviewerHostServer(session, scope, artifactStorageRoot)
+    const { endpoint: hostEndpoint, token: hostToken } = await hostServer.start()
+
+    // Start the submit_findings MCP server.
+    mcpServer = new ReviewerMcpServer(scope, async (checks: NewCheck[]) => {
+      checksReceived = checks
+      checksSubmitted = true
+      log.info('submit_findings received by MCP handler', { count: checks.length })
+    })
+    // The endpoint/token are consumed via mcpServer.toAcpMcpServerConfig() below.
+    await mcpServer.start()
+
+    // Build the reviewer prompt: passes the turn scope metadata and host SDK endpoint.
+    const reviewerPrompt = buildReviewerPrompt(scope, hostEndpoint, hostToken)
+
+    // Combine the rubric with the host SDK Python setup instructions.
+    const systemPromptAppend = REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
+
+    // Spawn the reviewer ACP session (clean context, reviewer-only tools).
+    const cwd = session.cwd || homedir()
+
+    reviewerSession = await acpRuntime.buildReviewerSession({
+      cwd,
+      mcpServers: [mcpServer.toAcpMcpServerConfig()],
+      systemPromptAppend
+    })
+
+    log.info('reviewer session started', { sessionId: reviewerSession.sessionId })
+
+    // Send the prompt and drive the session to completion. A timeout / update cap guards against a
+    // hung or fast-looping reviewer that never stops: on expiry this throws, the catch below sets
+    // lifecycle='error', and the finally disposes the session + host/MCP servers.
+    reviewerSession.prompt([{ type: 'text', text: reviewerPrompt }])
+
+    const stopReason = await driveReviewerToStop(
+      reviewerSession,
+      {
+        timeoutMs: reviewerTimeoutMs,
+        maxUpdates: reviewerMaxUpdates
+      },
+      {
+        onUpdate: (entry) => capturedLog.push(entry)
+      }
+    )
+    log.info('reviewer session stopped', { reviewId: review.id, stopReason })
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    log.error('reviewer session failed', { reviewId: review.id, error: errorMsg })
+
+    review = await reviewRepository.updateReview(review.id, {
+      lifecycle: 'error',
+      errorMessage: errorMsg
+    })
+    const errorWithFindings: ReviewWithChecks = { ...review, checks: [] }
+    onReviewUpdate?.(errorWithFindings)
+
+    return errorWithFindings
+  } finally {
+    // Always dispose the reviewer session and shut down the servers.
+    if (reviewerSession) acpRuntime.disposeReviewerSession(reviewerSession)
+    await mcpServer?.stop().catch(() => undefined)
+    await hostServer?.stop().catch(() => undefined)
+  }
+
+  // Step 4: persist checks and set lifecycle='complete'.
+  // outcome = flagged iff at least one check is warn or fail; otherwise pass.
+  try {
+    if (!checksSubmitted) {
+      log.warn('reviewer did not call submit_findings; treating as pass', { reviewId: review.id })
+    }
+
+    await reviewRepository.addChecks(review.id, checksReceived)
+
+    const hasWarnOrFailCheck = checksReceived.some(
+      (c) => c.status === 'warn' || c.status === 'fail'
+    )
+    const outcome: ReviewOutcome = hasWarnOrFailCheck ? 'flagged' : 'pass'
+    review = await reviewRepository.updateReview(review.id, {
+      lifecycle: 'complete',
+      outcome,
+      reviewerLog: capturedLog
+    })
+
+    log.info('review complete', {
+      reviewId: review.id,
+      outcome,
+      checkCount: checksReceived.length
+    })
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    log.error('review persistence failed', { reviewId: review.id, error: errorMsg })
+
+    review = await reviewRepository.updateReview(review.id, {
+      lifecycle: 'error',
+      errorMessage: errorMsg
+    })
+    const errorWithFindings: ReviewWithChecks = { ...review, checks: [] }
+    onReviewUpdate?.(errorWithFindings)
+    return errorWithFindings
+  }
+
+  // Load the final review + checks to return.
+  const allReviews = await reviewRepository.getReviewsForSession(sessionId)
+  const finalReview = allReviews.find((r) => r.id === review.id) ?? {
+    ...review,
+    checks: checksReceived.map((c, i): ReviewCheck => ({
+      id: `check-${i}`,
+      reviewId: review.id,
+      status: c.status,
+      resolution: 'open',
+      claim: c.claim,
+      evidence: c.evidence,
+      locator: c.locator,
+      artifactVersionId: c.artifactVersionId,
+      sortIndex: c.sortIndex ?? i,
+      reflagCount: 0
+    }))
+  }
+
+  // Step 5: Phase 3 fix loop. If there are warn/fail checks and a main session is provided,
+  // drive the bounded re-review loop: inject → correction → re-review → resolution → repeat.
+  const hasWarnOrFail = finalReview.checks.some((c) => c.status === 'warn' || c.status === 'fail')
+
+  if (mainSessionId && hasWarnOrFail) {
+    onFixLoopStart?.()
+    try {
+      await runFixLoop({
+        sessionId,
+        originalTurnMessageId: turnMessageId,
+        originalReviewId: review.id,
+        openChecks: finalReview.checks.filter((c) => c.status === 'warn' || c.status === 'fail'),
+        projectId,
+        mainSessionId,
+        getSession,
+        reviewRepository,
+        acpRuntime,
+        artifactStorageRoot,
+        model,
+        onReviewUpdate,
+        onCorrectionPrompt,
+        onCorrectionFailed,
+        reviewerTimeoutMs,
+        reviewerMaxUpdates,
+        maxRounds: fixLoopMaxRounds,
+        abortSignal: fixLoopAbortSignal
+      })
+    } finally {
+      onFixLoopEnd?.()
+    }
+
+    // Reload checks after the fix loop so the returned object reflects final resolutions.
+    const reloadedReviews = await reviewRepository.getReviewsForSession(sessionId)
+    const reloadedReview = reloadedReviews.find((r) => r.id === review.id)
+    if (reloadedReview) {
+      onReviewUpdate?.(reloadedReview)
+      return reloadedReview
+    }
+  }
+
+  onReviewUpdate?.(finalReview)
+  return finalReview
+}
+
+// Builds the initial prompt sent to the reviewer session. It passes the turn scope as structured
+// context and provides the host client via the single-sourced bootstrap (see host-sdk.ts) — the
+// reviewer runs Python through Bash, so each fresh process must re-run this setup; there is no
+// pre-loaded `host` object.
+export const buildReviewerPrompt = (
+  scope: TurnScope,
+  hostEndpoint: string,
+  hostToken: string
+): string => {
+  const blockSummary =
+    scope.blocks.length === 0
+      ? 'This turn has no blocks (it may be empty).'
+      : `This turn has ${scope.blocks.length} block(s): ` +
+        scope.blocks
+          .map((b) => `[${b.blockIndex}] ${b.kind}:${b.sourceId}`)
+          .slice(0, 10)
+          .join(', ') +
+        (scope.blocks.length > 10 ? ', ...' : '')
+
+  const artifactSummary =
+    scope.artifactVersionIds.length === 0
+      ? 'No artifacts in this turn.'
+      : `Artifact version ids: ${scope.artifactVersionIds.join(', ')}`
+
+  return [
+    `You are reviewing turn: ${scope.turnMessageId}`,
+    '',
+    blockSummary,
+    artifactSummary,
+    '',
+    'To read the turn data, run Python via Bash. Each invocation is a fresh process, so include this',
+    'host client setup at the top of every snippet — there is no pre-loaded `host`:',
+    '',
+    '```python',
+    buildReviewerHostPythonBootstrap(hostEndpoint, hostToken),
+    '# Then read the turn:',
+    'blocks = host.read_turn()',
+    '```',
+    '',
+    'After reading the turn data, apply the rubric, then call submit_findings once with your findings.',
+    'Call submit_findings with an empty array if you find no issues.'
+  ].join('\n')
+}

--- a/src/main/reviewer/repository.test.ts
+++ b/src/main/reviewer/repository.test.ts
@@ -1,0 +1,464 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { PrismaClient } from '@prisma/client'
+
+import type { NewCheck, ReviewCheck, TurnScope } from '../../shared/reviewer'
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { ReviewRepository } from './repository'
+
+// Integration test against a real (temp) SQLite database, mirroring projects/prisma-client.test.ts:
+// proves the runtime DDL is byte-compatible with the generated client and that round-trip + cascade
+// cleanup behave as the reviewer feature relies on.
+//
+// v2 (issue 12): unified check model — all checks (pass/warn/fail) stored in Finding table.
+// Review no longer has summary/checks JSON columns.
+
+let storageRoot: string | undefined
+let client: PrismaClient | undefined
+
+afterEach(async () => {
+  await client?.$disconnect()
+  client = undefined
+
+  if (storageRoot) {
+    await rm(storageRoot, { recursive: true, force: true })
+    storageRoot = undefined
+  }
+})
+
+const createRepository = async (): Promise<ReviewRepository> => {
+  storageRoot = await mkdtemp(join(tmpdir(), 'open-science-reviewer-'))
+  client = createProjectDbClient(storageRoot)
+  await ensureProjectSchema(client)
+  const boundClient = client
+
+  return new ReviewRepository(() => Promise.resolve(boundClient))
+}
+
+const scope = (turnMessageId: string): TurnScope => ({
+  turnMessageId,
+  blocks: [
+    {
+      id: `message:${turnMessageId}`,
+      kind: 'message',
+      sourceId: turnMessageId,
+      blockIndex: 0,
+      contentHash: 'hash-1'
+    }
+  ],
+  artifactVersionIds: ['art-1']
+})
+
+// v2: checks array uses status (pass|warn|fail) instead of severity.
+const checks = (): NewCheck[] => [
+  {
+    status: 'fail',
+    claim: 'ran 33 rows',
+    evidence: 'tool_result shows 0 rows',
+    locator: { blockRef: { activityId: 'act-1', blockIndex: 1 }, contentHash: 'hash-9' },
+    artifactVersionId: 'art-1',
+    sortIndex: 0
+  },
+  {
+    status: 'warn',
+    claim: 'axis label mismatch',
+    evidence: 'plot title says X, data is Y',
+    locator: { blockRef: { messageId: 'a1', blockIndex: 2 }, contentHash: 'hash-7' },
+    sortIndex: 1
+  },
+  {
+    status: 'pass',
+    claim: 'row count matches reported value',
+    evidence: 'loaded artifact and counted 42 rows; agent reported 42',
+    // pass check: no locator required
+    sortIndex: 2
+  }
+]
+
+describe('review repository (integration)', () => {
+  it('round-trips a review with its unified checks by session', async () => {
+    const repository = await createRepository()
+
+    // v2: createReview no longer accepts summary/checks
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'a1',
+      scope: scope('a1'),
+      model: 'claude-opus-4-8'
+    })
+
+    expect(review.id).toBeTruthy()
+    expect(review.lifecycle).toBe('running')
+    expect(review.outcome).toBeNull()
+    expect(review.createdAt).toBeGreaterThan(0)
+
+    await repository.addChecks(review.id, checks())
+
+    const [stored] = await repository.getReviewsForSession('session-1')
+
+    expect(stored.turnMessageId).toBe('a1')
+    expect(stored.scope).toEqual(scope('a1'))
+    expect(stored.model).toBe('claude-opus-4-8')
+
+    // v2: checks (not findings) include pass+warn+fail
+    expect(stored.checks).toHaveLength(3)
+    expect(stored.checks.map((c) => c.claim)).toEqual([
+      'ran 33 rows',
+      'axis label mismatch',
+      'row count matches reported value'
+    ])
+    // warn/fail check has a locator
+    expect(stored.checks[0]!.locator).toEqual({
+      blockRef: { activityId: 'act-1', blockIndex: 1 },
+      contentHash: 'hash-9'
+    })
+    expect(stored.checks[0]!.status).toBe('fail')
+    expect(stored.checks[0]!.resolution).toBe('open')
+    expect(stored.checks[0]!.artifactVersionId).toBe('art-1')
+    // pass check has no locator
+    expect(stored.checks[2]!.status).toBe('pass')
+    expect(stored.checks[2]!.locator).toBeUndefined()
+  })
+
+  it('updates a review lifecycle and outcome', async () => {
+    const repository = await createRepository()
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    const updated = await repository.updateReview(review.id, {
+      lifecycle: 'complete',
+      outcome: 'flagged',
+      reviewerLog: [{ kind: 'thought', text: 'Recomputed the reported statistic.' }]
+    })
+
+    expect(updated.lifecycle).toBe('complete')
+    expect(updated.outcome).toBe('flagged')
+
+    const [stored] = await repository.getReviewsForSession('session-1')
+    expect(stored.lifecycle).toBe('complete')
+    expect(stored.outcome).toBe('flagged')
+    expect(stored.reviewerLog).toHaveLength(1)
+    expect(stored.reviewerLog[0]?.kind).toBe('thought')
+  })
+
+  it("deletes a session's reviews and their checks, leaving other sessions untouched", async () => {
+    const repository = await createRepository()
+
+    const target = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+    await repository.addChecks(target.id, checks())
+
+    const other = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-2',
+      turnMessageId: 'b1',
+      scope: scope('b1')
+    })
+    await repository.addChecks(other.id, checks())
+
+    await repository.deleteReviewsForSession('session-1')
+
+    expect(await repository.getReviewsForSession('session-1')).toEqual([])
+    // Orphaned checks must not survive their deleted review.
+    expect(await repository.countFindings()).toBe(3)
+
+    const [survivor] = await repository.getReviewsForSession('session-2')
+    expect(survivor.id).toBe(other.id)
+    expect(survivor.checks).toHaveLength(3)
+  })
+
+  it("deletes all of a project's reviews and checks", async () => {
+    const repository = await createRepository()
+
+    const first = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+    await repository.addChecks(first.id, checks())
+    const second = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-2',
+      turnMessageId: 'b1',
+      scope: scope('b1')
+    })
+    await repository.addChecks(second.id, checks())
+
+    // A review in a different project is left alone.
+    const untouched = await repository.createReview({
+      projectId: 'project-2',
+      sessionId: 'session-3',
+      turnMessageId: 'c1',
+      scope: scope('c1')
+    })
+
+    await repository.deleteReviewsForProject('project-1')
+
+    expect(await repository.getReviewsForSession('session-1')).toEqual([])
+    expect(await repository.getReviewsForSession('session-2')).toEqual([])
+    expect(await repository.countFindings()).toBe(0)
+
+    const [survivor] = await repository.getReviewsForSession('session-3')
+    expect(survivor.id).toBe(untouched.id)
+  })
+
+  it('outcome is flagged iff at least one check is warn or fail', async () => {
+    const repository = await createRepository()
+
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-outcome',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    // Add a mix of pass and warn checks.
+    await repository.addChecks(review.id, [
+      { status: 'pass', claim: 'all good', evidence: 'verified', sortIndex: 0 },
+      {
+        status: 'warn',
+        claim: 'minor issue',
+        evidence: 'small inconsistency',
+        locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' },
+        sortIndex: 1
+      }
+    ])
+
+    await repository.updateReview(review.id, {
+      lifecycle: 'complete',
+      outcome: 'flagged' // set by orchestrator based on warn/fail presence
+    })
+
+    const [stored] = await repository.getReviewsForSession('session-outcome')
+    expect(stored.outcome).toBe('flagged')
+    expect(stored.checks.filter((c) => c.status === 'warn')).toHaveLength(1)
+    expect(stored.checks.filter((c) => c.status === 'pass')).toHaveLength(1)
+  })
+
+  it('outcome is pass when all checks have status pass', async () => {
+    const repository = await createRepository()
+
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-allpass',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    await repository.addChecks(review.id, [
+      { status: 'pass', claim: 'row count ok', evidence: 'verified 42 rows', sortIndex: 0 },
+      { status: 'pass', claim: 'artifact headers ok', evidence: 'headers match', sortIndex: 1 }
+    ])
+
+    await repository.updateReview(review.id, {
+      lifecycle: 'complete',
+      outcome: 'pass'
+    })
+
+    const [stored] = await repository.getReviewsForSession('session-allpass')
+    expect(stored.outcome).toBe('pass')
+    expect(stored.checks.every((c) => c.status === 'pass')).toBe(true)
+  })
+
+  it('updateFindingResolutions only touches warn/fail checks, leaving pass checks open', async () => {
+    const repository = await createRepository()
+
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-resolutions',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    await repository.addChecks(review.id, [
+      { status: 'pass', claim: 'row count ok', evidence: 'verified 42 rows', sortIndex: 0 },
+      {
+        status: 'warn',
+        claim: 'axis mismatch',
+        evidence: 'plot title says X, data is Y',
+        locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' },
+        sortIndex: 1
+      },
+      {
+        status: 'fail',
+        claim: 'claimed 33 rows',
+        evidence: 'tool_result shows 0 rows',
+        locator: { blockRef: { blockIndex: 0 }, contentHash: 'h2' },
+        sortIndex: 2
+      }
+    ])
+
+    await repository.updateFindingResolutions(review.id, 'unaddressed')
+
+    const [stored] = await repository.getReviewsForSession('session-resolutions')
+    const byStatus = (s: string): ReviewCheck => stored.checks.find((c) => c.status === s)!
+
+    // warn/fail checks are marked unaddressed after the correction turn
+    expect(byStatus('warn').resolution).toBe('unaddressed')
+    expect(byStatus('fail').resolution).toBe('unaddressed')
+    // pass check keeps its default 'open' resolution — resolution is meaningless for pass
+    expect(byStatus('pass').resolution).toBe('open')
+  })
+
+  it('pass check without locator round-trips correctly', async () => {
+    const repository = await createRepository()
+
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-pass-no-locator',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    await repository.addChecks(review.id, [
+      {
+        status: 'pass',
+        claim: 'verified row count',
+        evidence: 'counted 33 rows from artifact-csv',
+        // intentionally no locator — pass check
+        sortIndex: 0
+      }
+    ])
+
+    const [stored] = await repository.getReviewsForSession('session-pass-no-locator')
+    expect(stored.checks[0]!.status).toBe('pass')
+    expect(stored.checks[0]!.locator).toBeUndefined()
+    expect(stored.checks[0]!.claim).toBe('verified row count')
+  })
+
+  // Phase 3 storage: reflagCount defaults to 0 on every new check and round-trips.
+  it('newly written checks have reflagCount = 0 by default', async () => {
+    const repository = await createRepository()
+
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-reflag-default',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    await repository.addChecks(review.id, [
+      {
+        status: 'fail',
+        claim: 'ran 33 rows',
+        evidence: 'tool_result shows 0 rows',
+        locator: { blockRef: { activityId: 'act-1', blockIndex: 1 }, contentHash: 'hash-9' },
+        sortIndex: 0
+      },
+      {
+        status: 'pass',
+        claim: 'artifact headers ok',
+        evidence: 'headers match',
+        sortIndex: 1
+      }
+    ])
+
+    const [stored] = await repository.getReviewsForSession('session-reflag-default')
+    expect(stored.checks[0]!.reflagCount).toBe(0)
+    expect(stored.checks[1]!.reflagCount).toBe(0)
+  })
+
+  // Phase 3 storage: incrementReflagCount raises by 1 for the matching claim only.
+  it('incrementReflagCount bumps reflagCount by 1 for the matching claim, leaves others untouched', async () => {
+    const repository = await createRepository()
+
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-reflag-increment',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    await repository.addChecks(review.id, [
+      {
+        status: 'fail',
+        claim: 'ran 33 rows',
+        evidence: 'tool_result shows 0 rows',
+        locator: { blockRef: { activityId: 'act-1', blockIndex: 1 }, contentHash: 'hash-9' },
+        sortIndex: 0
+      },
+      {
+        status: 'warn',
+        claim: 'axis label mismatch',
+        evidence: 'plot title says X, data is Y',
+        locator: { blockRef: { messageId: 'a1', blockIndex: 2 }, contentHash: 'hash-7' },
+        sortIndex: 1
+      }
+    ])
+
+    await repository.incrementReflagCount(review.id, 'ran 33 rows')
+
+    const [stored] = await repository.getReviewsForSession('session-reflag-increment')
+    const findClaim = (claim: string): ReviewCheck => stored.checks.find((c) => c.claim === claim)!
+
+    // Only the targeted claim is incremented.
+    expect(findClaim('ran 33 rows').reflagCount).toBe(1)
+    expect(findClaim('axis label mismatch').reflagCount).toBe(0)
+  })
+
+  // Calling incrementReflagCount twice on the same claim accumulates correctly.
+  it('incrementReflagCount is cumulative across multiple calls', async () => {
+    const repository = await createRepository()
+
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-reflag-cumulative',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    await repository.addChecks(review.id, [
+      {
+        status: 'fail',
+        claim: 'value mismatch',
+        evidence: 'expected 42, got 0',
+        locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' },
+        sortIndex: 0
+      }
+    ])
+
+    await repository.incrementReflagCount(review.id, 'value mismatch')
+    await repository.incrementReflagCount(review.id, 'value mismatch')
+
+    const [stored] = await repository.getReviewsForSession('session-reflag-cumulative')
+    expect(stored.checks[0]!.reflagCount).toBe(2)
+  })
+
+  // getReviewsForSession returns reflagCount on every check (including 0).
+  it('getReviewsForSession returns reflagCount on every check', async () => {
+    const repository = await createRepository()
+
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-reflag-all',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    await repository.addChecks(review.id, checks())
+    await repository.incrementReflagCount(review.id, 'ran 33 rows')
+
+    const [stored] = await repository.getReviewsForSession('session-reflag-all')
+
+    // Every check must carry the reflagCount field.
+    expect(stored.checks.every((c) => typeof c.reflagCount === 'number')).toBe(true)
+    // The incremented check has 1; the rest have 0.
+    const flagged = stored.checks.find((c) => c.claim === 'ran 33 rows')!
+    expect(flagged.reflagCount).toBe(1)
+    const others = stored.checks.filter((c) => c.claim !== 'ran 33 rows')
+    expect(others.every((c) => c.reflagCount === 0)).toBe(true)
+  })
+})

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -237,8 +237,9 @@ class ReviewRepository {
   // over-correction. Leaves checks with a different claim untouched.
   async incrementReflagCount(reviewId: string, claim: string): Promise<void> {
     const client = await this.getClient()
-    // Use $executeRawUnsafe because Prisma does not support column += 1 increment in updateMany.
-    // The parameterised query is safe: reviewId and claim are bound as positional parameters.
+    // Use the $executeRaw tagged template because Prisma does not support a column += 1 increment
+    // in updateMany. The query is safe: reviewId and claim are bound as positional parameters by the
+    // tagged template (not string-interpolated), so this is not $executeRawUnsafe.
     await client.$executeRaw`
       UPDATE "Finding"
       SET "reflagCount" = "reflagCount" + 1

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -1,0 +1,277 @@
+import type { Finding as PrismaFinding, PrismaClient, Review as PrismaReview } from '@prisma/client'
+
+import type {
+  CheckStatus,
+  CreateReviewInput,
+  FindingLocator,
+  FindingResolution,
+  NewCheck,
+  Review,
+  ReviewCheck,
+  ReviewerLogEntry,
+  ReviewLifecycle,
+  ReviewOutcome,
+  ReviewWithChecks,
+  TurnScope,
+  UpdateReviewPatch
+} from '../../shared/reviewer'
+
+// Legacy alias for callers still using FindingSeverity (now CheckStatus).
+type FindingSeverity = CheckStatus
+
+// Only the review/finding delegates are needed; typing to this subset keeps the repository unit-testable
+// with a lightweight mock instead of a real (engine-backed) PrismaClient.
+// $executeRaw is also included for the incrementReflagCount atomic update (issue 15).
+type ReviewClient = Pick<PrismaClient, 'review' | 'finding' | '$executeRaw'>
+
+// Resolves the Prisma client on demand so a failed initialization is not held forever (see projects/repository.ts).
+type ReviewClientProvider = () => Promise<ReviewClient>
+
+// JSON columns are parsed defensively: a corrupt value degrades to the given fallback rather than
+// throwing, so one bad row cannot break loading a whole session's reviews.
+const parseJson = <T>(value: string, fallback: T): T => {
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
+const EMPTY_SCOPE = (turnMessageId: string): TurnScope => ({
+  turnMessageId,
+  blocks: [],
+  artifactVersionIds: []
+})
+
+// Narrows the free-text lifecycle column back to the domain union, defaulting unknown values to 'error'
+// so a corrupt row surfaces as a failed review rather than a phantom running one.
+const asLifecycle = (value: string): ReviewLifecycle =>
+  value === 'running' || value === 'complete' ? value : 'error'
+
+const asOutcome = (value: string | null): ReviewOutcome | null =>
+  value === 'pass' || value === 'flagged' ? value : null
+
+// Maps a Prisma review row (JSON strings + DateTime) into the epoch-ms domain shape shared with the renderer.
+// v2: Review no longer has summary/checks columns; those are gone.
+// v3: reasoning replaced by reviewerLog (captured action stream).
+const toReview = (row: PrismaReview): Review => ({
+  id: row.id,
+  projectId: row.projectId,
+  sessionId: row.sessionId,
+  turnMessageId: row.turnMessageId,
+  scope: parseJson<TurnScope>(row.scope, EMPTY_SCOPE(row.turnMessageId)),
+  lifecycle: asLifecycle(row.lifecycle),
+  outcome: asOutcome(row.outcome),
+  errorMessage: row.errorMessage ?? undefined,
+  model: row.model,
+  reviewerLog: parseJson<ReviewerLogEntry[]>(row.reviewerLog, []),
+  createdAt: row.createdAt.getTime(),
+  updatedAt: row.updatedAt.getTime()
+})
+
+// Maps a Prisma Finding row to the unified ReviewCheck domain type.
+// v2: `status` replaces `severity`; locator is optional (pass checks may have empty JSON = {}).
+const asCheckStatus = (value: string): CheckStatus => {
+  if (value === 'fail' || value === 'warn' || value === 'pass') return value
+  // Legacy migration: old 'severity' values were only warn/fail, default to 'warn' if unknown.
+  if (value === 'inconclusive') return 'warn'
+  return 'warn'
+}
+
+const toCheck = (row: PrismaFinding): ReviewCheck => {
+  const locatorRaw = parseJson<FindingLocator | Record<string, never>>(row.locator, {})
+  // A locator is meaningful only when it has a blockRef (pass checks may store '{}').
+  const hasLocator = 'blockRef' in locatorRaw && locatorRaw.blockRef !== undefined
+  return {
+    id: row.id,
+    reviewId: row.reviewId,
+    status: asCheckStatus(row.status),
+    resolution:
+      row.resolution === 'resolved' || row.resolution === 'unaddressed' ? row.resolution : 'open',
+    claim: row.claim,
+    evidence: row.evidence,
+    locator: hasLocator ? (locatorRaw as FindingLocator) : undefined,
+    artifactVersionId: row.artifactVersionId ?? undefined,
+    sortIndex: row.sortIndex,
+    // Default to 0 for rows written before the reflagCount column was added (issue 15 migration guard).
+    reflagCount: row.reflagCount ?? 0
+  }
+}
+
+// Owns Review/check reads/writes. The client is resolved lazily per call so schema-ensure failures can
+// recover (see projects/repository.ts). Reviews live in SQLite while the transcript stays in session JSON;
+// cross-store cleanup is done here by deleting review rows (and their checks) by session/project id.
+class ReviewRepository {
+  constructor(private readonly getClient: ReviewClientProvider) {}
+
+  // Inserts a new review, defaulting a fresh audit to the 'running' lifecycle with no outcome yet.
+  async createReview(input: CreateReviewInput): Promise<Review> {
+    const client = await this.getClient()
+    const row = await client.review.create({
+      data: {
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        turnMessageId: input.turnMessageId,
+        scope: JSON.stringify(input.scope),
+        lifecycle: input.lifecycle ?? 'running',
+        outcome: input.outcome ?? null,
+        errorMessage: input.errorMessage ?? null,
+        model: input.model ?? '',
+        reviewerLog: JSON.stringify(input.reviewerLog ?? [])
+      }
+    })
+
+    return toReview(row)
+  }
+
+  // Patches only the provided fields so a caller can flip lifecycle/outcome without resupplying the rest.
+  async updateReview(id: string, patch: UpdateReviewPatch): Promise<Review> {
+    const data: Record<string, unknown> = {}
+
+    if (patch.scope !== undefined) data.scope = JSON.stringify(patch.scope)
+    if (patch.lifecycle !== undefined) data.lifecycle = patch.lifecycle
+    if (patch.outcome !== undefined) data.outcome = patch.outcome
+    if (patch.errorMessage !== undefined) data.errorMessage = patch.errorMessage
+    if (patch.model !== undefined) data.model = patch.model
+    if (patch.reviewerLog !== undefined) data.reviewerLog = JSON.stringify(patch.reviewerLog)
+
+    const client = await this.getClient()
+    const row = await client.review.update({ where: { id }, data })
+
+    return toReview(row)
+  }
+
+  // Appends checks under a review, defaulting resolution to 'open' and preserving caller sort order.
+  async addChecks(reviewId: string, checks: NewCheck[]): Promise<void> {
+    if (checks.length === 0) return
+
+    const client = await this.getClient()
+
+    await client.finding.createMany({
+      data: checks.map((check, index) => ({
+        reviewId,
+        status: check.status,
+        resolution: check.resolution ?? 'open',
+        claim: check.claim,
+        evidence: check.evidence,
+        locator: JSON.stringify(check.locator ?? {}),
+        artifactVersionId: check.artifactVersionId ?? null,
+        sortIndex: check.sortIndex ?? index
+      }))
+    })
+  }
+
+  /**
+   * @deprecated Use addChecks
+   */
+  async addFindings(reviewId: string, findings: NewCheck[]): Promise<void> {
+    return this.addChecks(reviewId, findings)
+  }
+
+  // Returns a session's reviews (newest first) each with its checks in display order.
+  async getReviewsForSession(sessionId: string): Promise<ReviewWithChecks[]> {
+    const client = await this.getClient()
+    const rows = await client.review.findMany({
+      where: { sessionId },
+      orderBy: { createdAt: 'desc' }
+    })
+
+    return Promise.all(
+      rows.map(async (row) => {
+        const checkRows = await client.finding.findMany({
+          where: { reviewId: row.id },
+          orderBy: { sortIndex: 'asc' }
+        })
+
+        const checks = checkRows.map(toCheck)
+        return {
+          ...toReview(row),
+          checks,
+          // Legacy: expose findings as alias for checks (same data).
+          get findings() {
+            return checks
+          }
+        } as ReviewWithChecks
+      })
+    )
+  }
+
+  // Removes a session's reviews and their checks. Checks are deleted explicitly (not relying on the
+  // SQLite foreign-keys pragma) so cleanup is deterministic across environments.
+  async deleteReviewsForSession(sessionId: string): Promise<void> {
+    await this.deleteReviewsWhere({ sessionId })
+  }
+
+  // Removes every review (and its checks) belonging to a project.
+  async deleteReviewsForProject(projectId: string): Promise<void> {
+    await this.deleteReviewsWhere({ projectId })
+  }
+
+  // Updates warn/fail checks under a review to the given resolution, used after the correction turn.
+  // Phase 1 sets all warn/fail checks to 'unaddressed'; pass checks are left at their default 'open'
+  // since resolution is meaningless for them (see design.md §4.2).
+  async updateFindingResolutions(reviewId: string, resolution: FindingResolution): Promise<void> {
+    const client = await this.getClient()
+    await client.finding.updateMany({
+      where: { reviewId, status: { in: ['warn', 'fail'] } },
+      data: { resolution }
+    })
+  }
+
+  // Updates the resolution for a single claim (by exact match) under a review.
+  // Used by the Phase 3 fix loop to set per-claim resolution from re-review results.
+  async updateFindingResolutionForClaim(
+    reviewId: string,
+    claim: string,
+    resolution: FindingResolution
+  ): Promise<void> {
+    const client = await this.getClient()
+    await client.finding.updateMany({
+      where: { reviewId, claim, status: { in: ['warn', 'fail'] } },
+      data: { resolution }
+    })
+  }
+
+  // Increments reflagCount by 1 for all checks under a review whose claim matches the given string
+  // (exact match, case-sensitive). Used in the Phase 3 fix loop when a claim is re-flagged after an
+  // over-correction. Leaves checks with a different claim untouched.
+  async incrementReflagCount(reviewId: string, claim: string): Promise<void> {
+    const client = await this.getClient()
+    // Use $executeRawUnsafe because Prisma does not support column += 1 increment in updateMany.
+    // The parameterised query is safe: reviewId and claim are bound as positional parameters.
+    await client.$executeRaw`
+      UPDATE "Finding"
+      SET "reflagCount" = "reflagCount" + 1
+      WHERE "reviewId" = ${reviewId} AND "claim" = ${claim}
+    `
+  }
+
+  // Test/diagnostic helper: total check rows, used to assert no orphans survive a cascade delete.
+  async countFindings(): Promise<number> {
+    const client = await this.getClient()
+
+    return client.finding.count()
+  }
+
+  // Shared delete path: gather the matching review ids, drop their checks, then drop the reviews.
+  private async deleteReviewsWhere(where: {
+    sessionId?: string
+    projectId?: string
+  }): Promise<void> {
+    const client = await this.getClient()
+    const reviews = await client.review.findMany({ where, select: { id: true } })
+
+    if (reviews.length === 0) return
+
+    const reviewIds = reviews.map((review) => review.id)
+
+    await client.finding.deleteMany({ where: { reviewId: { in: reviewIds } } })
+    await client.review.deleteMany({ where: { id: { in: reviewIds } } })
+  }
+}
+
+export { ReviewRepository, toCheck, toReview }
+export type { ReviewClient, ReviewClientProvider, FindingSeverity }
+
+// Legacy exports kept for callers that still reference toFinding.
+export const toFinding = toCheck

--- a/src/main/reviewer/rubric.test.ts
+++ b/src/main/reviewer/rubric.test.ts
@@ -1,0 +1,162 @@
+// Tests that assert the rubric string (REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND) was re-grounded
+// on reviewer-agent-profile.yaml (issue 14). These are string-content checks that catch regressions
+// if the rubric drifts back toward the paraphrase or loses load-bearing disciplines.
+
+import { describe, it, expect } from 'vitest'
+import { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } from './rubric'
+
+const rubric = REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
+
+describe('REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND — yaml-grounded disciplines', () => {
+  // -----------------------------------------------------------------------
+  // 1. Tracing framing — REPL / Python must be framed as tracing, NOT recomputation
+  // -----------------------------------------------------------------------
+  describe('tracing-not-recompute discipline', () => {
+    it('contains "trace" or "tracing" framing for REPL/Python use', () => {
+      expect(rubric.toLowerCase()).toMatch(/trace|tracing/)
+    })
+
+    it('does NOT contain recomputation-encouraging wording "re-compute a reported statistic"', () => {
+      expect(rubric).not.toContain('re-compute a reported statistic')
+    })
+
+    it('does NOT frame REPL as rerunning/recomputing analysis', () => {
+      // These are the forbidden recomputation framings
+      expect(rubric).not.toMatch(/re-?run the (whole|entire|full) analysis/)
+      expect(rubric).not.toMatch(/recompute.*statistic/i)
+    })
+
+    it('frames reading saved cell/artifact as tracing not recomputation', () => {
+      // The yaml says: "Reading a saved file's cell is tracing, not recomputation"
+      expect(rubric).toMatch(/tracing.*not.*recomput|reading.*saved.*trac/i)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 2. No-flag-unsourced discipline (yaml:180-190) — top-tier anti-hallucination
+  // -----------------------------------------------------------------------
+  describe('no-flag-unsourced discipline', () => {
+    it('contains explicit "do not flag unsourced values" or equivalent rule', () => {
+      // Must contain the key discipline that not-found is not a finding
+      expect(rubric).toMatch(
+        /do not flag unsourced|not.?found never convicts|unfound.*not.*finding/i
+      )
+    })
+
+    it('states that a value untraceable within the turn is NOT a finding', () => {
+      // The rule: "found-contradiction convicts; not-found never does"
+      expect(rubric).toMatch(
+        /not.found never convicts|cannot trace.*not a finding|untraceable.*not a finding/i
+      )
+    })
+
+    it('states conviction requires a retrieved contradiction, not merely absence', () => {
+      expect(rubric).toMatch(
+        /found.contradiction convicts|retrieved.*contradict|evidence.*contradict/i
+      )
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 3. Fabricated-reference exception (yaml:192-229)
+  // -----------------------------------------------------------------------
+  describe('fabricated-reference exception', () => {
+    it('contains fabricated reference exception as a distinct rule', () => {
+      expect(rubric).toMatch(/fabricated.?reference|citation.*exception|reference.*exception/i)
+    })
+
+    it('specifies the exception covers EXTERNAL works (PMID/DOI/accession)', () => {
+      expect(rubric).toMatch(/external|PMID|DOI|accession/i)
+    })
+
+    it('distinguishes external references from session self-references', () => {
+      // The yaml is explicit: self-references (agent citing its own artifacts) are NOT
+      // covered by this exception — they follow ordinary value rules
+      expect(rubric).toMatch(
+        /self.?reference|session.*self|own.*artifact.*not.*exception|session-self/i
+      )
+    })
+
+    it('states not-found convicts for external references (unique to this exception)', () => {
+      // This is what makes it an exception: not-found still convicts for external refs
+      expect(rubric).toMatch(
+        /not.found.*convicts|resolves to nothing.*finding|traces nowhere.*finding/i
+      )
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 4. Artifact vs prose weighting (yaml:87-94) — restored to yaml fidelity
+  // -----------------------------------------------------------------------
+  describe('artifact-vs-prose weighting', () => {
+    it('describes artifacts as durable deliverables that users cite later', () => {
+      expect(rubric).toMatch(/durable|users.*cite.*later|cite them later/i)
+    })
+
+    it('describes prose as ephemeral/skimmed narration', () => {
+      expect(rubric).toMatch(/prose.*skim|skim.*moment|narration|narrate/i)
+    })
+
+    it('applies strict bar to artifacts and softer bar to prose', () => {
+      expect(rubric).toMatch(/strict|acting on it.*misled/i)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 5. Domain-recall exemption (yaml:261-281)
+  // -----------------------------------------------------------------------
+  describe('domain-recall exemption', () => {
+    it('contains domain recall exemption', () => {
+      expect(rubric).toMatch(/domain.?recall/i)
+    })
+
+    it('states domain recall is exempt from tracing', () => {
+      expect(rubric).toMatch(/domain.?recall.*exempt|exempt.*domain.?recall/i)
+    })
+
+    it('states exemption ends when session contains the source', () => {
+      // Once a source is in the session, domain recall no longer applies
+      expect(rubric).toMatch(/exemption ends|ends.*moment.*session|once.*session.*contains/i)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 6. Output contract — post-issue-12/13 shape
+  // -----------------------------------------------------------------------
+  describe('output contract — post-12/13 shape', () => {
+    it('names submit_findings as the single call', () => {
+      expect(rubric).toContain('submit_findings')
+    })
+
+    it('specifies unified checks[] array', () => {
+      expect(rubric).toMatch(/checks\[\]|checks:.*array|unified.*checks/i)
+    })
+
+    it('explicitly excludes summary field', () => {
+      expect(rubric).toMatch(/no.*summary|summary.*no longer|do not.*summary/i)
+    })
+
+    it('explicitly excludes reasoning field', () => {
+      expect(rubric).toMatch(/no.*reasoning|reasoning.*no longer|do not.*reasoning/i)
+    })
+
+    it('specifies call submit_findings exactly once, no prose', () => {
+      expect(rubric).toMatch(/exactly once|call.*once/i)
+      expect(rubric).toMatch(/no.*prose|do not write.*prose/i)
+    })
+
+    it('states pass is recorded for user / only warn+fail surfaced', () => {
+      // yaml:306-307: "Only fail and warn are surfaced to the agent; pass is recorded for the user"
+      expect(rubric).toMatch(/pass.*recorded|warn.fail.*surfaced|only.*warn.*fail.*surfaced/i)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 7. warn criteria reserve for artifacts (yaml warn arm)
+  // -----------------------------------------------------------------------
+  describe('warn criteria — artifact-reserved', () => {
+    it('mentions warn is reserved for artifacts (labels/legends/units)', () => {
+      expect(rubric).toMatch(/warn.*artifact|label.*legend.*unit|artifact.*warn/i)
+    })
+  })
+})

--- a/src/main/reviewer/rubric.test.ts
+++ b/src/main/reviewer/rubric.test.ts
@@ -128,8 +128,13 @@ describe('REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND — yaml-grounded disciplines', (
       expect(rubric).toContain('submit_findings')
     })
 
-    it('specifies unified checks[] array', () => {
-      expect(rubric).toMatch(/checks\[\]|checks:.*array|unified.*checks/i)
+    it('specifies a checks array as the output', () => {
+      expect(rubric).toMatch(/checks:.*array|array of your findings|• checks/i)
+    })
+
+    it('keeps pass checks visible but consolidated (no one-card-per-value)', () => {
+      expect(rubric).toMatch(/consolidated pass checks|one per area you verified/i)
+      expect(rubric).toMatch(/never one per value|not one card per metric/i)
     })
 
     it('explicitly excludes summary field', () => {

--- a/src/main/reviewer/rubric.ts
+++ b/src/main/reviewer/rubric.ts
@@ -1,0 +1,242 @@
+// The reviewer rubric: the system-prompt guidance appended via _meta.systemPrompt's append field
+// when building a reviewer ACP session. It defines role, criteria, and output contract.
+//
+// Source: docs/draft/reviewer/design-references/reviewer-agent-profile.yaml (system_prompt).
+// This file is a single-hop port of the yaml discipline to this repo's tool framing
+// (host SDK + REPL instead of the yaml's repl/read_file). Keep it here so it evolves
+// independently of the orchestrator and design.md §5 does not drift (design.md §5 mirrors
+// the sections below; any change here should propagate to design.md §5).
+//
+// Adaptation notes (yaml → this repo):
+//   - yaml excludes `python`; here Python IS the host SDK entry point — the portable rule
+//     is "trace, don't recompute", not "no python".
+//   - yaml: query_target_history, compacted-history drift, forged-pointer harness markers —
+//     Phase-1 has none of these mechanisms; omissions are noted with [PHASE-1 OMIT] comments.
+//   - yaml: repl + read_file → here: a `host` Python client (set up from the reviewer prompt) whose
+//     methods POST to the app's host RPC server. It is NOT auto-injected — the reviewer runs Python
+//     through Bash, so each fresh process re-runs the setup snippet from the prompt.
+
+export const REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND = [
+  '<reviewer_instructions>',
+
+  // §5.1 — Role and framework
+  // Adapted from yaml:61-74. Key adaptation: host SDK replaces yaml's repl/read_file.
+  'You are the REVIEWER — an independent reviewer assigned to audit one completed turn of the main agent.',
+  'You work in a CLEAN CONTEXT: no main chat history, no prior work — only the material',
+  "in this turn's scope.",
+  '',
+  'You read the turn through a `host` Python client (set it up from the snippet in the task prompt;',
+  'you run Python via Bash, so re-run the setup in each fresh process). Use it before judging:',
+  '  host.read_turn()                      — ordered block list for this turn (messages + tool activities)',
+  '  host.query_execution_log(activityId?) — rawInput / rawOutput / terminalOutput / terminalExitCode',
+  '  host.read_artifact(id)                — tabular artifacts (CSV/TSV): {kind:"tabular", columns:{col:[values]}, rowCount}',
+  '                                          other artifacts: {kind:"raw", content, encoding}',
+  '                                          Address tabular data by column name, e.g. result["columns"]["gene_id"]',
+  '',
+  // yaml:67-68: "Trace, don't recompute."
+  'TRACE, NOT RECOMPUTE. If the agent claims a number, find the record that produced it and compare —',
+  'a CONTRADICTION is the finding. Reading a saved artifact cell is TRACING, not recomputation.',
+  // yaml:76-81: tabular parsing guidance — adapted to host.read_artifact
+  'For tabular artifacts: never eyeball-align a multi-column CSV row against its header.',
+  'Use host.read_artifact(id) to parse by column name — the response already structures columns for you.',
+  'Reading a saved artifact cell this way is tracing, not recomputation.',
+  '',
+  // yaml:83-85
+  'Call submit_findings ONCE with your findings and stop — do not write any assistant prose',
+  'before or after it. Your structured findings are the only deliverable.',
+  '',
+
+  // §5.2 — One-sentence mandate
+  // yaml:87
+  '## One-sentence mandate',
+  '"Would a reader acting on this turn be misled, or is the work incomplete?"',
+  '',
+
+  // §5.3 — Artifact vs prose weighting
+  // yaml:88-94 — restored to yaml fidelity (not the flattened current wording)
+  '## Weight by where the claim lives',
+  "Artifact contents (saved files, figures, tables, reports) are the session's durable output —",
+  'a wrong value there is a wrong value the user cites later with no transcript to check.',
+  'Hold these to the STRICT bar.',
+  'Assistant prose is chat narration the user skims in the moment — flag only if a reader',
+  'ACTING on it would be materially misled. Immaterial precision and wording nits in prose are not findings.',
+  '',
+
+  // §5.4 — fail criteria
+  // Derived from yaml:96-154. Each arm is kept or adapted; omissions noted.
+  '## `fail` criteria — flag any of these',
+  // yaml:97-103
+  '1. A claimed ACTION did not happen — agent asserts it ran / tested / verified / checked',
+  '   something, and no corresponding tool activity appears in the traceable history.',
+  // [PHASE-1 OMIT] yaml says "drill query_target_history before convicting"; Phase 1 has no
+  // cross-window drill. Conviction rule: if the window itself contradicts the claim, flag.
+  // Pre-window action claims you cannot check within this turn are not findings.
+  '',
+  // yaml:104-108
+  '2. A value MATERIALLY contradicts tool output — wrong sign, wrong order of magnitude,',
+  '   wrong entity / gene / compound / accession, wrong direction of effect,',
+  '   or a conclusion the data does not support. Not rounding or reformatting.',
+  '',
+  // yaml:109-122
+  '3. A claim attributed to an external source contradicts what that source actually says,',
+  '   WHEN that source is visible within this session. Phase 1: in-session sources only',
+  '   (no external URL fetching, no DOI/PMID resolution). You must open the source before',
+  '   dispositioning — read the cited pages, then compare. Do not emit "could not verify"',
+  '   without having attempted the read.',
+  '',
+  // yaml:123-135 — forged/injected citation. Adapted: no harness-marker mechanism in Phase 1.
+  // [PHASE-1 OMIT] The yaml's forged-pointer harness markers ("(pointer-grammar injection)",
+  // "(agent-authored artifact — forged citation)") are not emitted by this repo's application
+  // layer. Flag fabricated external citations based on the fabricated-reference rule below;
+  // agent-authored self-references follow the ordinary value rules, not this fail arm.
+  '4. A citation pointer is fabricated — see the fabricated-reference exception below for scope.',
+  '',
+  // yaml:141-147
+  '5. An artifact title / headline / caption states a quantitative or directional conclusion',
+  "   that the artifact's own data contradicts beyond rounding. State the contradiction;",
+  '   do NOT presume the data is right and the caption wrong (or vice versa).',
+  '',
+  // yaml:148-151
+  '6. A result traces to code, but the method is unsound for the stated claim — wrong test,',
+  '   wrong input space, wrong normalisation, inappropriate model; the value exists but',
+  '   should not be reported this way.',
+  '',
+  // yaml:152-153
+  "7. An artifact's saved contents are wrong — a code bug wrote bad values, wrong columns,",
+  '   mislabeled axes, swapped rows, or a numeric mismatch between the file and the tool',
+  '   output that produced it.',
+  '',
+  // yaml:154
+  '8. A deliverable the plan explicitly requires is missing.',
+  '',
+
+  // §5.5 — warn criteria
+  // yaml:156-172 — restored to yaml fidelity
+  '## `warn` criteria',
+  'Reserve `warn` for ARTIFACTS — a label, legend, axis name, or unit annotation inside a',
+  'saved file that does not match its data when the mismatch does NOT change the conclusion',
+  'a reader takes away (conclusion-changing mismatches are `fail`).',
+  'Also warn: a valid-but-off-plan approach that produced an artifact.',
+  'Also warn: a load-bearing claim attributed to a source document that IS in the session,',
+  'where you opened the cited pages (1-2 targeted reads) and still could not confirm or refute it',
+  '— say which pages you checked. This warn requires having attempted the read.',
+  // yaml:166-167: "agent never opened the source" is not by itself a finding
+  '"Agent never opened the source" alone is not a finding.',
+  'Prose-only process/style issues are not worth a finding.',
+  '',
+
+  // §5.6 — Do NOT flag in prose
+  // yaml:174-178
+  '## Do NOT flag in prose (chat narration)',
+  '  • Rounding, truncation, unit/notation changes, or other format differences',
+  '    from tool output when the conclusion holds.',
+  '  • Paraphrases or summaries of tool output that preserve meaning.',
+  '  • Stylistic, tone, or phrasing choices.',
+  '',
+
+  // §5.7 — Do NOT flag unsourced values (top-tier anti-hallucination rule)
+  // yaml:180-190. Adapted to Phase-1 single-turn scope: no query_target_history available.
+  '## Do NOT flag unsourced values — anywhere, including artifacts',
+  'A value or configuration with no visible in-turn source is NOT evidence of fabrication.',
+  'Most load-bearing values enter a session long before the review window.',
+  'Flag a value ONLY when evidence you actually retrieved CONTRADICTS it:',
+  '  an in-turn tool output that disagrees, or a source document that disagrees (after the',
+  '  required read). Found-contradiction convicts; not-found NEVER convicts.',
+  // [PHASE-1 OMIT] yaml allows a "pass note" via query_target_history when origin matters;
+  // Phase 1 has no cross-window drill — a value untraceable within this turn is simply not a finding.
+  'A value untraceable within this turn is not a finding — do not flag it, not even as warn.',
+  '',
+
+  // §5.8 — Fabricated-reference exception (yaml:192-229)
+  // The one class where not-found still convicts. Boundary carefully preserved.
+  '## EXCEPTION — fabricated references',
+  'External citations and specific identifiers PRESENTED AS RETRIEVED OR ESTABLISHED',
+  '(a PMID, DOI, "Author et al. YEAR", an accession) are checkable claims, not ambient values.',
+  'If the reference traces nowhere — no session source, no in-turn tool output recording it —',
+  'it remains a finding (warn in prose; fail in a saved artifact).',
+  'This is the one class of values where not-found still convicts.',
+  '',
+  // yaml:203-208 — external-vs-self boundary
+  'Checkable scope: this exception covers references to EXTERNAL works — literature,',
+  'databases, accessions. A session SELF-REFERENCE (the agent citing its own earlier',
+  'artifact, version id, or a value it established earlier in this session) is governed by',
+  'the ORDINARY VALUE RULES above — not by this exception.',
+  '',
+  // [PHASE-1 OMIT] yaml:209-228 — truncated/elided spans, carried-identifiers line, compacted
+  // history section — none of these harness constructs exist in Phase 1. The general rule
+  // applies: if you cannot establish the reference exists in this turn, it is a finding.
+  // yaml:224-229 — off-ramp: background-knowledge attribution without specific identifier
+  'Off-ramp: a background-knowledge attribution carrying NO specific checkable identifier',
+  '(no PMID, DOI, accession, or bare "Author et al. YEAR") is domain recall, not this exception.',
+  'The moment a specific identifier is present, this exception governs regardless of framing.',
+  '',
+
+  // §5.9 — Verification discipline (prevents hallucinated findings)
+  // Adapted from yaml and §5.6 of design.md
+  '## Verification discipline (highest priority — prevents hallucinated findings)',
+  'TRACE AGAINST THE RECORD:',
+  '  • A found contradiction convicts. An unfound source NEVER convicts.',
+  '    (Only exception: fabricated external references — see above.)',
+  '  • evidence field: cite ONLY what you READ via host.read_turn / host.query_execution_log /',
+  '    host.read_artifact, or computed yourself in the REPL. Never inject background knowledge.',
+  '',
+  'REPL TARGETED TRACING:',
+  // yaml:76-81 — adapted to host SDK; "tracing, not recomputation" framing preserved
+  '  • Use host.* to pull facts. Use data-analysis packages for targeted spot checks:',
+  '    parse a table cell by column name, cross-check a value against a recorded artifact.',
+  '  • Reading a saved artifact cell is TRACING, not recomputation — do it when it helps.',
+  '  • ONLY target already-recorded outputs / saved artifacts.',
+  '  • REPL is a precision tracing aid, not a default action — use it for targeted spot-checks',
+  '    against recorded evidence, not to redo analysis from scratch.',
+  "  • When your targeted check contradicts the agent's reported value → finding.",
+  "    evidence must cite both the agent's value and your verification output.",
+  '',
+
+  // §5.10 — Domain-recall exemption (yaml:261-281)
+  '## Domain recall — exempt from tracing',
+  "A fact stated from the agent's own background knowledge with NO source document in the session",
+  'is exempt from tracing — there is nothing to check it against. Do not flag it (not even as warn).',
+  'Domain recall covers FACTS, not references: a specific citation or checkable identifier of',
+  'an external work is governed by the fabricated-references exception above, never by this exemption.',
+  'The exemption ends the moment the session contains the source: once a paper, manual, or spec',
+  'the claim refers to is attached to the session, claims about its contents are traceable and',
+  'get the rubric above.',
+  // [PHASE-1 OMIT] yaml:274-281 — TRUNCATED/INCOMPLETE source-document scan void. Phase 1 has
+  // no scan-completeness indicator from the harness. Apply the domain-recall exemption as stated.
+  '',
+
+  // [PHASE-1 OMIT] yaml:282-304 — "Context drift" section (compacted history / summary ids).
+  // Phase 1 does not deliver a "Target's compacted history" section to the reviewer — the
+  // reviewer sees only the current turn's scope. Context-drift checking is deferred to Phase 3.
+
+  // §5.11 — Output contract (v3: unified checks[], no summary, no reasoning)
+  // yaml:83-85, 306-307. Also aligns to the post-issue-12/13 shape.
+  '## Output contract',
+  'Call submit_findings exactly ONCE, then stop.',
+  'Do NOT write any prose before or after the call. Your only output is the submit_findings call.',
+  'Do NOT include a `summary` or `reasoning` field — they are not part of the schema.',
+  'Your full action trace (thinking, tool calls, REPL results) is captured automatically',
+  'from the session stream.',
+  'Only `fail` and `warn` checks are surfaced to the agent; `pass` checks are recorded for the user.',
+  'In that single call provide:',
+  '  • checks: a single unified array of ALL checks you ran, each with:',
+  '      - status:   "pass"  = verified and ok (recorded for user; not injected into agent)',
+  '                  "warn"  = minor issue, result may still be valid',
+  '                  "fail"  = serious issue that requires correction',
+  '                  No "inconclusive" — use "warn" when you attempted verification but could',
+  '                  not confirm or refute.',
+  '      - claim:    What you checked or what the agent claimed (for pass: what you verified;',
+  '                  for warn/fail: the specific claim being flagged).',
+  '      - evidence: What you found. For pass: explain what you verified and why it holds.',
+  '                  For warn/fail: cite the contradiction from the record.',
+  '                  Example (pass): "I loaded artifact csv-1 and counted 33 rows — matching',
+  '                  the 33 the agent reported in msg[2]."',
+  '                  Example (fail): "Agent stated 42 samples (msg[0]). I parsed artifact-csv',
+  '                  with host.read_artifact and found 33 rows."',
+  '      - locator:  Optional block-level pointer { blockRef: { blockIndex: N }, contentHash: "..." }.',
+  '                  Provide for warn/fail checks (points to the claim being flagged).',
+  '                  May be omitted for pass checks.',
+  '      - artifactVersionId: Optional — include when the check relates to a specific artifact.',
+  'If you find no issues, still provide checks describing what you verified (all with status "pass").',
+  '</reviewer_instructions>'
+].join('\n')

--- a/src/main/reviewer/rubric.ts
+++ b/src/main/reviewer/rubric.ts
@@ -209,17 +209,18 @@ export const REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND = [
   // Phase 1 does not deliver a "Target's compacted history" section to the reviewer — the
   // reviewer sees only the current turn's scope. Context-drift checking is deferred to Phase 3.
 
-  // §5.11 — Output contract (v3: unified checks[], no summary, no reasoning)
-  // yaml:83-85, 306-307. Also aligns to the post-issue-12/13 shape.
+  // §5.11 — Output contract
   '## Output contract',
   'Call submit_findings exactly ONCE, then stop.',
-  'Do NOT write any prose before or after the call. Your only output is the submit_findings call.',
+  'Do NOT write any prose before or after the call — your structured findings are the deliverable;',
+  'a prose summary is ignored and wastes tokens.',
   'Do NOT include a `summary` or `reasoning` field — they are not part of the schema.',
   'Your full action trace (thinking, tool calls, REPL results) is captured automatically',
   'from the session stream.',
   'Only `fail` and `warn` checks are surfaced to the agent; `pass` checks are recorded for the user.',
   'In that single call provide:',
-  '  • checks: a single unified array of ALL checks you ran, each with:',
+  '  • checks: an array of your findings (warn/fail) plus a compact record of what you verified (pass),',
+  '    each with:',
   '      - status:   "pass"  = verified and ok (recorded for user; not injected into agent)',
   '                  "warn"  = minor issue, result may still be valid',
   '                  "fail"  = serious issue that requires correction',
@@ -237,6 +238,9 @@ export const REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND = [
   '                  Provide for warn/fail checks (points to the claim being flagged).',
   '                  May be omitted for pass checks.',
   '      - artifactVersionId: Optional — include when the check relates to a specific artifact.',
-  'If you find no issues, still provide checks describing what you verified (all with status "pass").',
+  'Record pass checks CONSOLIDATED: one per area you verified, never one per value traced. A',
+  'system-info report whose fields all match its tool output is ONE pass check ("traced all reported',
+  'metrics to the host output; all match"), not one card per metric.',
+  'If you find no issues, still submit a few consolidated pass checks describing what you verified.',
   '</reviewer_instructions>'
 ].join('\n')

--- a/src/main/reviewer/scope.test.ts
+++ b/src/main/reviewer/scope.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  PersistedChatMessage,
+  PersistedChatSession,
+  PersistedToolActivity
+} from '../../shared/session-persistence'
+import { resolveTurnScope } from './scope'
+
+// Builds a persisted message with sensible defaults; callers override only what a case cares about.
+const message = (
+  id: string,
+  role: 'user' | 'agent',
+  createdAt: number,
+  overrides: Partial<PersistedChatMessage> = {}
+): PersistedChatMessage => ({
+  id,
+  role,
+  content: `${role} ${id}`,
+  status: 'complete',
+  eventIds: [],
+  createdAt,
+  updatedAt: createdAt,
+  ...overrides
+})
+
+// Builds a persisted tool activity with defaults.
+const activity = (
+  id: string,
+  createdAt: number,
+  sortIndex: number,
+  overrides: Partial<PersistedToolActivity> = {}
+): PersistedToolActivity => ({
+  id,
+  kind: 'tool',
+  title: `tool ${id}`,
+  status: 'completed',
+  sortIndex,
+  eventIds: [],
+  createdAt,
+  updatedAt: createdAt,
+  ...overrides
+})
+
+// Two-turn session: turn 1 interleaves u1 → act1 → a1 by createdAt; turn 2 is u2 → a2.
+const buildSession = (): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Session',
+  cwd: '/tmp',
+  status: 'idle',
+  messages: [
+    message('u1', 'user', 1000),
+    message('a1', 'agent', 1002, { artifactIds: ['art-1'] }),
+    message('u2', 'user', 2000),
+    message('a2', 'agent', 2001)
+  ],
+  activities: [activity('act1', 1001, 5, { rawOutput: { rows: 33 } })],
+  createdAt: 1000,
+  updatedAt: 2001
+})
+
+describe('resolveTurnScope', () => {
+  it('returns only the target turn as ordered, interleaved blocks', () => {
+    const scope = resolveTurnScope(buildSession(), 'a1')
+
+    expect(scope.turnMessageId).toBe('a1')
+    expect(
+      scope.blocks.map((block) => ({
+        kind: block.kind,
+        sourceId: block.sourceId,
+        blockIndex: block.blockIndex
+      }))
+    ).toEqual([
+      { kind: 'message', sourceId: 'u1', blockIndex: 0 },
+      { kind: 'activity', sourceId: 'act1', blockIndex: 1 },
+      { kind: 'message', sourceId: 'a1', blockIndex: 2 }
+    ])
+  })
+
+  it('resolves the same turn whether given the user or the agent message id', () => {
+    const fromUser = resolveTurnScope(buildSession(), 'u1')
+    const fromAgent = resolveTurnScope(buildSession(), 'a1')
+
+    expect(fromUser.blocks.map((block) => block.sourceId)).toEqual(['u1', 'act1', 'a1'])
+    expect(fromUser.blocks.map((block) => block.sourceId)).toEqual(
+      fromAgent.blocks.map((block) => block.sourceId)
+    )
+  })
+
+  it('excludes adjacent turns', () => {
+    const scope = resolveTurnScope(buildSession(), 'a2')
+
+    expect(scope.blocks.map((block) => block.sourceId)).toEqual(['u2', 'a2'])
+    // Nothing from turn 1 leaks in.
+    expect(scope.blocks.some((block) => block.sourceId === 'act1')).toBe(false)
+  })
+
+  it('collects artifact version ids produced in the turn', () => {
+    expect(resolveTurnScope(buildSession(), 'a1').artifactVersionIds).toEqual(['art-1'])
+    expect(resolveTurnScope(buildSession(), 'a2').artifactVersionIds).toEqual([])
+  })
+
+  it('produces stable content hashes across repeated calls', () => {
+    const first = resolveTurnScope(buildSession(), 'a1')
+    const second = resolveTurnScope(buildSession(), 'a1')
+
+    expect(first.blocks.map((block) => block.contentHash)).toEqual(
+      second.blocks.map((block) => block.contentHash)
+    )
+    // Every block carries a non-empty hash.
+    expect(first.blocks.every((block) => block.contentHash.length > 0)).toBe(true)
+  })
+
+  it('changes a block hash when that block content changes', () => {
+    const base = resolveTurnScope(buildSession(), 'a1')
+
+    const edited = buildSession()
+    const agentMessage = edited.messages.find((message) => message.id === 'a1')
+    if (agentMessage) agentMessage.content = 'agent a1 (edited)'
+    const editedScope = resolveTurnScope(edited, 'a1')
+
+    const baseAgentHash = base.blocks.find((block) => block.sourceId === 'a1')?.contentHash
+    const editedAgentHash = editedScope.blocks.find((block) => block.sourceId === 'a1')?.contentHash
+    const baseUserHash = base.blocks.find((block) => block.sourceId === 'u1')?.contentHash
+    const editedUserHash = editedScope.blocks.find((block) => block.sourceId === 'u1')?.contentHash
+
+    expect(editedAgentHash).not.toBe(baseAgentHash)
+    // Untouched blocks keep their hash.
+    expect(editedUserHash).toBe(baseUserHash)
+  })
+
+  it('returns an empty scope for an unknown turn message id', () => {
+    const scope = resolveTurnScope(buildSession(), 'does-not-exist')
+
+    expect(scope).toEqual({
+      turnMessageId: 'does-not-exist',
+      blocks: [],
+      artifactVersionIds: []
+    })
+  })
+})

--- a/src/main/reviewer/scope.ts
+++ b/src/main/reviewer/scope.ts
@@ -1,0 +1,141 @@
+import { createHash } from 'node:crypto'
+
+import type {
+  PersistedChatMessage,
+  PersistedChatSession,
+  PersistedToolActivity
+} from '../../shared/session-persistence'
+import type { ScopeBlock, TurnScope } from '../../shared/reviewer'
+
+// One item in the flattened transcript: either a persisted message or a tool activity, tagged so the
+// resolver can order and hash them uniformly. Mirrors the renderer's conversation-item projection.
+type TurnItem =
+  | {
+      kind: 'message'
+      sourceId: string
+      createdAt: number
+      sortIndex: number
+      message: PersistedChatMessage
+    }
+  | {
+      kind: 'activity'
+      sourceId: string
+      createdAt: number
+      sortIndex: number
+      activity: PersistedToolActivity
+    }
+
+// Recursively sorts object keys so equal content always serializes identically, giving stable hashes
+// regardless of the key order the persistence layer happened to write.
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null'
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
+
+  return `{${entries.join(',')}}`
+}
+
+const hashContent = (value: unknown): string =>
+  createHash('sha256').update(stableStringify(value)).digest('hex')
+
+// Hashes only the durable, reviewer-relevant fields of a message so cosmetic/runtime churn does not
+// invalidate a locator, while any change to what the agent actually said or produced does.
+const hashMessage = (message: PersistedChatMessage): string =>
+  hashContent({
+    role: message.role,
+    content: message.content,
+    artifactIds: [...(message.artifactIds ?? [])].sort()
+  })
+
+// Hashes the execution record of a tool activity — the ground truth the reviewer compares claims against.
+const hashActivity = (activity: PersistedToolActivity): string =>
+  hashContent({
+    title: activity.title,
+    status: activity.status,
+    providerToolName: activity.providerToolName,
+    toolKind: activity.toolKind,
+    toolContent: activity.toolContent,
+    toolLocations: activity.toolLocations,
+    rawInput: activity.rawInput,
+    rawOutput: activity.rawOutput,
+    terminalOutput: activity.terminalOutput,
+    terminalExitCode: activity.terminalExitCode
+  })
+
+// Projects messages + activities into one list ordered exactly like the rendered transcript: by
+// timestamp, then sortIndex, then id. Persisted messages carry no sortIndex, so (matching the renderer)
+// they fall back to their array position.
+const buildOrderedItems = (session: PersistedChatSession): TurnItem[] => {
+  const messageItems: TurnItem[] = session.messages.map((message, index) => ({
+    kind: 'message',
+    sourceId: message.id,
+    createdAt: message.createdAt,
+    sortIndex: index,
+    message
+  }))
+  const activityItems: TurnItem[] = (session.activities ?? []).map((activity) => ({
+    kind: 'activity',
+    sourceId: activity.id,
+    createdAt: activity.createdAt,
+    sortIndex: activity.sortIndex,
+    activity
+  }))
+
+  return [...messageItems, ...activityItems].sort((left, right) => {
+    if (left.createdAt !== right.createdAt) return left.createdAt - right.createdAt
+    if (left.sortIndex !== right.sortIndex) return left.sortIndex - right.sortIndex
+    return left.sourceId.localeCompare(right.sourceId)
+  })
+}
+
+const isUserMessage = (item: TurnItem): boolean =>
+  item.kind === 'message' && item.message.role === 'user'
+
+// Resolves the flattened, ordered blocks for the single turn that contains turnMessageId. A turn runs
+// from a user message up to (but excluding) the next user message — the span the reviewer reads. Blocks
+// from other turns are never included. An unknown id yields an empty scope so callers can no-op safely.
+export const resolveTurnScope = (
+  session: PersistedChatSession,
+  turnMessageId: string
+): TurnScope => {
+  const items = buildOrderedItems(session)
+  const targetIndex = items.findIndex((item) => item.sourceId === turnMessageId)
+
+  if (targetIndex === -1) {
+    return { turnMessageId, blocks: [], artifactVersionIds: [] }
+  }
+
+  // Turn start = nearest user message at or before the target; fall back to the list head if the target
+  // precedes any user message (e.g. a leading agent preamble).
+  let startIndex = targetIndex
+  while (startIndex > 0 && !isUserMessage(items[startIndex])) startIndex -= 1
+  if (!isUserMessage(items[startIndex])) startIndex = 0
+
+  // Turn end = the next user message after the start, exclusive; or the end of the transcript.
+  let endIndex = startIndex + 1
+  while (endIndex < items.length && !isUserMessage(items[endIndex])) endIndex += 1
+
+  const turnItems = items.slice(startIndex, endIndex)
+
+  const blocks: ScopeBlock[] = turnItems.map((item, blockIndex) => ({
+    id: `${item.kind}:${item.sourceId}`,
+    kind: item.kind,
+    sourceId: item.sourceId,
+    blockIndex,
+    contentHash: item.kind === 'message' ? hashMessage(item.message) : hashActivity(item.activity)
+  }))
+
+  const artifactVersionIds: string[] = []
+  for (const item of turnItems) {
+    if (item.kind !== 'message') continue
+    for (const artifactId of item.message.artifactIds ?? []) {
+      if (!artifactVersionIds.includes(artifactId)) artifactVersionIds.push(artifactId)
+    }
+  }
+
+  return { turnMessageId, blocks, artifactVersionIds }
+}

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { ReviewRepository } from '../reviewer/repository'
 import { createSessionPersistenceHandlers } from './ipc'
 
 const createSession = (): PersistedChatSession => ({
@@ -14,6 +15,13 @@ const createSession = (): PersistedChatSession => ({
   updatedAt: 1710000000000
 })
 
+// Minimal mock review repository that satisfies the cascade contract.
+const createMockReviewRepository = (): ReviewRepository =>
+  ({
+    deleteReviewsForSession: vi.fn().mockResolvedValue(undefined),
+    deleteReviewsForProject: vi.fn().mockResolvedValue(undefined)
+  }) as unknown as ReviewRepository
+
 describe('session persistence IPC handlers', () => {
   it('routes each command to the repository', async () => {
     const session = createSession()
@@ -25,7 +33,8 @@ describe('session persistence IPC handlers', () => {
       deleteProjectSessions: vi.fn().mockResolvedValue(undefined),
       saveManifest: vi.fn().mockResolvedValue(undefined)
     }
-    const handlers = createSessionPersistenceHandlers(repository)
+    const reviewRepository = createMockReviewRepository()
+    const handlers = createSessionPersistenceHandlers(repository, reviewRepository)
 
     await expect(handlers.loadAll()).resolves.toBe(loadResult)
 
@@ -34,9 +43,13 @@ describe('session persistence IPC handlers', () => {
 
     await handlers.deleteSession({ projectId: 'project-a', sessionId: 'session-1' })
     expect(repository.deleteSession).toHaveBeenCalledWith('project-a', 'session-1')
+    // Cascade: review cleanup is attempted before the session delete.
+    expect(reviewRepository.deleteReviewsForSession).toHaveBeenCalledWith('session-1')
 
     await handlers.deleteProjectSessions({ projectId: 'project-a' })
     expect(repository.deleteProjectSessions).toHaveBeenCalledWith('project-a')
+    // Cascade: review cleanup is attempted for the project.
+    expect(reviewRepository.deleteReviewsForProject).toHaveBeenCalledWith('project-a')
 
     await handlers.saveManifest({ lastProjectId: 'project-a', lastSessionId: 'session-1' })
     expect(repository.saveManifest).toHaveBeenCalledWith({

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -9,6 +9,11 @@ import type {
 } from '../../shared/session-persistence'
 import { resolveStorageRoot } from '../storage-root'
 import { SessionRepository } from './repository'
+import { ReviewRepository } from '../reviewer/repository'
+import { getProjectDbClient } from '../projects/prisma-client'
+import { createLogger } from '../logger'
+
+const log = createLogger('session-persistence:ipc')
 
 type SessionPersistenceRepository = {
   loadAll: () => Promise<LoadAllSessionsResult>
@@ -28,12 +33,34 @@ type SessionPersistenceHandlers = {
 
 // Adapts the repository into small handlers that are easy to unit test.
 const createSessionPersistenceHandlers = (
-  repository: SessionPersistenceRepository
+  repository: SessionPersistenceRepository,
+  reviewRepository: ReviewRepository
 ): SessionPersistenceHandlers => ({
   loadAll: () => repository.loadAll(),
   saveSession: (session) => repository.saveSession(session),
-  deleteSession: (request) => repository.deleteSession(request.projectId, request.sessionId),
-  deleteProjectSessions: (request) => repository.deleteProjectSessions(request.projectId),
+  deleteSession: async (request) => {
+    // Delete cascade: remove reviewer rows first so no orphan reviews/findings remain.
+    // A reviewer-cleanup failure must not block the underlying session delete (fire-and-forget).
+    await reviewRepository.deleteReviewsForSession(request.sessionId).catch((error: unknown) => {
+      log.warn('deleteReviewsForSession failed (non-fatal)', {
+        sessionId: request.sessionId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    })
+    await repository.deleteSession(request.projectId, request.sessionId)
+  },
+  deleteProjectSessions: async (request) => {
+    // Delete cascade: remove reviewer rows first so no orphan reviews/findings remain.
+    // Uses the project-level delete (more efficient than per-session iteration).
+    // A reviewer-cleanup failure must not block the underlying session deletes.
+    await reviewRepository.deleteReviewsForProject(request.projectId).catch((error: unknown) => {
+      log.warn('deleteReviewsForProject failed during deleteProjectSessions (non-fatal)', {
+        projectId: request.projectId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    })
+    await repository.deleteProjectSessions(request.projectId)
+  },
   saveManifest: (request) => repository.saveManifest(request)
 })
 
@@ -41,11 +68,15 @@ const createSessionPersistenceHandlers = (
 const createDefaultSessionRepository = (): SessionRepository =>
   new SessionRepository(resolveStorageRoot())
 
+const createDefaultReviewRepository = (): ReviewRepository =>
+  new ReviewRepository(() => getProjectDbClient(resolveStorageRoot()))
+
 // Registers renderer-callable persistence commands without coupling them to ACP runtime IPC.
 const registerSessionPersistenceIpcHandlers = (
-  repository = createDefaultSessionRepository()
+  repository = createDefaultSessionRepository(),
+  reviewRepository = createDefaultReviewRepository()
 ): void => {
-  const handlers = createSessionPersistenceHandlers(repository)
+  const handlers = createSessionPersistenceHandlers(repository, reviewRepository)
 
   // Keep persistence IPC separate from ACP runtime commands; it owns durable UI state only.
   ipcMain.handle('sessions:load-all', () => handlers.loadAll())

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -117,6 +117,7 @@ import type {
   StageUploadFilesRequest,
   UploadedAttachment
 } from '../shared/uploads'
+import type { ReviewWithChecks, ReviewRunRequest, ReviewUpdateEvent } from '../shared/reviewer'
 
 type RemoveListener = () => void
 type AcpListener<Payload> = (payload: Payload) => void
@@ -295,6 +296,24 @@ interface OpenScienceAPI {
     // Marks the one-time legacy-data-move prompt as answered (declined / keep-here) so it's not shown again.
     dismissLegacyMovePrompt(): Promise<void>
     onProgress(listener: AcpListener<MigrationProgress>): RemoveListener
+  }
+  reviewer: {
+    // Trigger a background review for the given turn. Fire-and-forget; updates come via onUpdated.
+    run(request: ReviewRunRequest): Promise<void>
+    // Load persisted reviews for a session (called at workspace startup).
+    getForSession(sessionId: string): Promise<ReviewWithChecks[]>
+    // Subscribe to review lifecycle/findings updates pushed from the main process.
+    onUpdated(listener: AcpListener<ReviewUpdateEvent>): RemoveListener
+    // Subscribe to loop-guard events: suppress (or, when clear=true, un-suppress) the next
+    // auto-review for the given session.
+    onSuppressNextAutoReview(
+      listener: AcpListener<{ sessionId: string; clear?: boolean }>
+    ): RemoveListener
+    // Fix loop lock: fired when the loop starts (lock composer) / ends or is aborted (unlock).
+    onFixLoopStart(listener: AcpListener<{ sessionId: string }>): RemoveListener
+    onFixLoopEnd(listener: AcpListener<{ sessionId: string }>): RemoveListener
+    // Sends an abort request to stop the running fix loop for a session.
+    abortFixLoop(sessionId: string): Promise<void>
   }
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -119,6 +119,8 @@ import type {
   StageUploadFilesRequest,
   UploadedAttachment
 } from '../shared/uploads'
+import type { ReviewWithChecks, ReviewRunRequest, ReviewUpdateEvent } from '../shared/reviewer'
+import { REVIEWER_IPC } from '../shared/reviewer'
 
 type RemoveListener = () => void
 type AcpListener<Payload> = (payload: Payload) => void
@@ -317,6 +319,19 @@ type OpenScienceAPI = {
     // Mark the one-time legacy-data-move prompt as answered (declined / keep-here) so it's not shown again.
     dismissLegacyMovePrompt: () => Promise<void>
     onProgress: (listener: AcpListener<MigrationProgress>) => RemoveListener
+  }
+  reviewer: {
+    run: (request: ReviewRunRequest) => Promise<void>
+    getForSession: (sessionId: string) => Promise<ReviewWithChecks[]>
+    onUpdated: (listener: AcpListener<ReviewUpdateEvent>) => RemoveListener
+    onSuppressNextAutoReview: (
+      listener: AcpListener<{ sessionId: string; clear?: boolean }>
+    ) => RemoveListener
+    // Fix loop lock events.
+    onFixLoopStart: (listener: AcpListener<{ sessionId: string }>) => RemoveListener
+    onFixLoopEnd: (listener: AcpListener<{ sessionId: string }>) => RemoveListener
+    // Sends an abort request to stop the running fix loop for a session.
+    abortFixLoop: (sessionId: string) => Promise<void>
   }
 }
 
@@ -576,6 +591,23 @@ const api: OpenScienceAPI = {
     dismissLegacyMovePrompt: () =>
       ipcRenderer.invoke('storage:dismiss-legacy-move-prompt') as Promise<void>,
     onProgress: (listener) => onIpcMessage('storage:migrate-progress', listener)
+  },
+  reviewer: {
+    run: (request: ReviewRunRequest) =>
+      ipcRenderer.invoke(REVIEWER_IPC.RUN, request) as Promise<void>,
+    getForSession: (sessionId: string) =>
+      ipcRenderer.invoke(REVIEWER_IPC.GET_FOR_SESSION, sessionId) as Promise<ReviewWithChecks[]>,
+    onUpdated: (listener) => onIpcMessage(REVIEWER_IPC.UPDATED, listener),
+    onSuppressNextAutoReview: (listener: AcpListener<{ sessionId: string; clear?: boolean }>) =>
+      onIpcMessage(REVIEWER_IPC.SUPPRESS_NEXT_AUTO_REVIEW, listener),
+    // Fix loop lock: fired when the loop starts (lock composer) / ends or is aborted (unlock).
+    onFixLoopStart: (listener: AcpListener<{ sessionId: string }>) =>
+      onIpcMessage(REVIEWER_IPC.FIX_LOOP_START, listener),
+    onFixLoopEnd: (listener: AcpListener<{ sessionId: string }>) =>
+      onIpcMessage(REVIEWER_IPC.FIX_LOOP_END, listener),
+    // Sends an abort request to the main process to stop the running fix loop for a session.
+    abortFixLoop: (sessionId: string) =>
+      ipcRenderer.invoke(REVIEWER_IPC.ABORT_FIX_LOOP, sessionId) as Promise<void>
   }
 }
 

--- a/src/renderer/src/components/ReviewerCard.render.test.tsx
+++ b/src/renderer/src/components/ReviewerCard.render.test.tsx
@@ -1,0 +1,886 @@
+// @vitest-environment jsdom
+// Render tests for ReviewerCard covering:
+//   - pass card (no warn/fail checks, collapsed, no expandable section when no checks)
+//   - pass card (with checks) expanding to show per-check cards with green pass badge
+//   - flagged card expanding to show warn/fail check cards
+//   - pass/warn/fail badge rendering
+//   - model pill rendered on each item card
+//   - footer note present for fail/warn expansions, absent for pass
+//   - "Go to transcript" intent fires with the correct locator (warn/fail check intent)
+//   - "Go to transcript" intent fires with reviewId only (pass check intent)
+//
+// v2 (issue 12): unified ReviewCheck model — no separate Finding/ReviewCheck split.
+// header count = warn/fail count. All checks in one unified list.
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ReviewerCard } from './ReviewerCard'
+import type {
+  ReviewWithChecks,
+  ReviewCheck,
+  FindingLocator,
+  GoToTranscriptIntent
+} from '../../../shared/reviewer'
+
+const makeLocator = (blockIndex: number): FindingLocator => ({
+  blockRef: { messageId: `msg-${blockIndex}`, blockIndex },
+  contentHash: `hash-${blockIndex}`
+})
+
+// v2: use ReviewCheck (status, claim, evidence) instead of the old Finding (severity, claim, evidence)
+const makeCheck = (overrides: Partial<ReviewCheck> = {}): ReviewCheck => ({
+  id: 'check-1',
+  reviewId: 'review-1',
+  status: 'fail',
+  resolution: 'open',
+  claim: 'Agent claimed the test passed',
+  evidence: 'No test activity found in execution log',
+  locator: makeLocator(0),
+  sortIndex: 0,
+  reflagCount: 0,
+  ...overrides
+})
+
+// v2: use ReviewWithChecks (checks[], not findings[])
+const makeReview = (overrides: Partial<ReviewWithChecks> = {}): ReviewWithChecks => ({
+  id: 'review-1',
+  projectId: 'proj-1',
+  sessionId: 'session-1',
+  turnMessageId: 'turn-msg-1',
+  scope: { turnMessageId: 'turn-msg-1', blocks: [], artifactVersionIds: [] },
+  lifecycle: 'complete',
+  outcome: 'pass',
+  model: 'claude-opus-4',
+  reviewerLog: [],
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000,
+  checks: [],
+  ...overrides
+})
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+describe('ReviewerCard — pass card', () => {
+  it('renders "No issues found" when complete with no warn/fail checks', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [] })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    expect(container.textContent).toContain('No issues found')
+    expect(container.textContent).toContain('Reviewer')
+  })
+
+  it('renders a collapsed pass card — no expandable section when no checks', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [] })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const header = container.querySelector('[data-testid="reviewer-card"]')
+    expect(header).toBeTruthy()
+
+    // No check rows should appear.
+    expect(container.querySelector('[data-testid="reviewer-finding-row"]')).toBeNull()
+  })
+
+  it('does not show an expand chevron for pass cards with no checks', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [] })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    // The header button should be disabled for pass cards with no checks.
+    const headerBtn = container.querySelector('button')
+    expect(headerBtn?.getAttribute('disabled')).not.toBeNull()
+  })
+
+  it('does not render a misleading "1 check" count when zero checks were recorded', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [] })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    // A zero-check review must not claim a check ran.
+    expect(container.textContent).not.toContain('1 check')
+    expect(container.textContent).toContain('No issues found')
+  })
+
+  it('renders the real check count for a pass card with pass checks', async () => {
+    const review = makeReview({
+      outcome: 'pass',
+      checks: [
+        makeCheck({ id: 'c1', status: 'pass', locator: undefined, sortIndex: 0 }),
+        makeCheck({ id: 'c2', status: 'pass', locator: undefined, sortIndex: 1 })
+      ]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    expect(container.textContent).toContain('2 checks')
+  })
+})
+
+describe('ReviewerCard — findings expansion (warn/fail checks)', () => {
+  it('renders "N findings" summary when the review has warn/fail checks', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck(), makeCheck({ id: 'check-2', sortIndex: 1 })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    expect(container.textContent).toContain('2 findings')
+  })
+
+  it('also shows the total check count for a flagged review', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [
+        makeCheck({ id: 'c1', status: 'fail', sortIndex: 0 }),
+        makeCheck({ id: 'c2', status: 'warn', sortIndex: 1 }),
+        makeCheck({ id: 'c3', status: 'pass', locator: undefined, sortIndex: 2 })
+      ]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    // findings = warn/fail count; total = all checks
+    expect(container.textContent).toContain('2 findings')
+    expect(container.textContent).toContain('3 checks')
+  })
+
+  it('expands to show check claims on chevron click', async () => {
+    const claim = 'Agent claimed the analysis was complete'
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ claim })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    expect(headerBtn).toBeTruthy()
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).toContain(claim)
+  })
+
+  it('shows evidence inline after expanding a flagged review', async () => {
+    const evidence = 'No tool activity found matching the claimed execution'
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ evidence })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).toContain(evidence)
+  })
+})
+
+describe('ReviewerCard — status badges (pass/warn/fail)', () => {
+  it('renders a "fail" badge for fail-status checks', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ status: 'fail' })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).toContain('fail')
+  })
+
+  it('renders a "warn" badge for warn-status checks', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ status: 'warn' })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).toContain('warn')
+  })
+
+  it('applies distinct CSS classes for fail vs warn status badges', async () => {
+    const failReview = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ status: 'fail' })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={failReview} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const badgeSpans = Array.from(container.querySelectorAll('span'))
+    const failBadge = badgeSpans.find((s) => s.textContent?.trim() === 'fail')
+    expect(failBadge?.className).toMatch(/red/)
+
+    // Remount with warn.
+    act(() => root.unmount())
+    root = createRoot(container)
+    const warnReview = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ status: 'warn' })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={warnReview} />)
+    })
+
+    const headerBtnW = container.querySelector('button')
+    await act(async () => {
+      headerBtnW!.click()
+    })
+
+    const badgeSpansW = Array.from(container.querySelectorAll('span'))
+    const warnBadge = badgeSpansW.find((s) => s.textContent?.trim() === 'warn')
+    expect(warnBadge?.className).toMatch(/yellow/)
+  })
+})
+
+describe('ReviewerCard — Go to transcript intent', () => {
+  it('each warn/fail check row has a "Go to transcript" button', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck()]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onGoToTranscript={vi.fn()} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const allButtons = Array.from(container.querySelectorAll('button'))
+    const gotoBtn = allButtons.find((b) => b.textContent?.includes('Go to transcript'))
+    expect(gotoBtn).toBeTruthy()
+  })
+
+  it('fires onGoToTranscript with the correct reviewId, checkId, and locator for warn/fail checks', async () => {
+    const locator = makeLocator(3)
+    const check = makeCheck({ id: 'check-42', locator, status: 'fail' })
+    const review = makeReview({ id: 'review-99', outcome: 'flagged', checks: [check] })
+    const onGoToTranscript = vi.fn()
+
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onGoToTranscript={onGoToTranscript} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const allButtons = Array.from(container.querySelectorAll('button'))
+    const gotoBtn = allButtons.find((b) => b.textContent?.includes('Go to transcript'))
+    expect(gotoBtn).toBeTruthy()
+    await act(async () => {
+      gotoBtn!.click()
+    })
+
+    expect(onGoToTranscript).toHaveBeenCalledOnce()
+    const intent: GoToTranscriptIntent = onGoToTranscript.mock.calls[0][0]
+    expect(intent.reviewId).toBe('review-99')
+    // v2: findingId = checkId for backward compat
+    expect(intent.findingId).toBe('check-42')
+    expect(intent.locator).toEqual(locator)
+  })
+
+  it('fires with the correct locator for each of N warn/fail checks', async () => {
+    const checks = [
+      makeCheck({ id: 'c-0', locator: makeLocator(0), sortIndex: 0, status: 'fail' }),
+      makeCheck({ id: 'c-1', locator: makeLocator(5), sortIndex: 1, status: 'warn' }),
+      makeCheck({ id: 'c-2', locator: makeLocator(9), sortIndex: 2, status: 'fail' })
+    ]
+    const review = makeReview({ id: 'review-multi', outcome: 'flagged', checks })
+    const onGoToTranscript = vi.fn()
+
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onGoToTranscript={onGoToTranscript} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const allButtons = Array.from(container.querySelectorAll('button'))
+    const gotoButtons = allButtons.filter((b) => b.textContent?.includes('Go to transcript'))
+    expect(gotoButtons).toHaveLength(3)
+
+    for (let i = 0; i < gotoButtons.length; i++) {
+      await act(async () => {
+        gotoButtons[i].click()
+      })
+      const call = onGoToTranscript.mock.calls[i]
+      const intent: GoToTranscriptIntent = call[0]
+      expect(intent.findingId).toBe(`c-${i}`)
+      expect(intent.locator).toEqual(makeLocator(i === 0 ? 0 : i === 1 ? 5 : 9))
+    }
+  })
+
+  it('renders "Go to transcript" buttons even when onGoToTranscript is not provided', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck()]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const allButtons = Array.from(container.querySelectorAll('button'))
+    const gotoBtn = allButtons.find((b) => b.textContent?.includes('Go to transcript'))
+    expect(gotoBtn).toBeTruthy()
+
+    await expect(
+      act(async () => {
+        gotoBtn!.click()
+      })
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('ReviewerCard — pass expand (pass check cards)', () => {
+  it('shows a chevron for a pass review that has pass checks', async () => {
+    const review = makeReview({
+      outcome: 'pass',
+      checks: [
+        makeCheck({
+          status: 'pass',
+          claim: 'No tool calls claimed',
+          evidence: 'Verified via exec log.',
+          locator: undefined
+        })
+      ]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    // The header button must NOT be disabled when there are checks to expand.
+    const headerBtn = container.querySelector('button')
+    expect(headerBtn?.getAttribute('disabled')).toBeNull()
+  })
+
+  it('expands a pass review to show one check card per pass check', async () => {
+    const review = makeReview({
+      outcome: 'pass',
+      checks: [
+        makeCheck({
+          id: 'c1',
+          status: 'pass',
+          claim: 'No tool calls claimed',
+          evidence: 'Verified via exec log.',
+          locator: undefined
+        }),
+        makeCheck({
+          id: 'c2',
+          status: 'pass',
+          claim: 'Artifact headers match data',
+          evidence: 'Headers confirmed.',
+          locator: undefined,
+          sortIndex: 1
+        })
+      ]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const checkCards = container.querySelectorAll('[data-testid="reviewer-check-card"]')
+    expect(checkCards).toHaveLength(2)
+  })
+
+  it('renders a green pass badge on pass check cards', async () => {
+    const review = makeReview({
+      outcome: 'pass',
+      checks: [
+        makeCheck({
+          status: 'pass',
+          claim: 'All checks passed',
+          evidence: 'Nothing to flag.',
+          locator: undefined
+        })
+      ]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const badges = Array.from(container.querySelectorAll('[data-testid="reviewer-item-badge"]'))
+    const passBadge = badges.find((b) => b.textContent?.trim() === 'pass')
+    expect(passBadge).toBeTruthy()
+    expect(passBadge?.className).toMatch(/green/)
+  })
+
+  it('renders the check evidence as the card body', async () => {
+    const evidence = 'Verified: no kernel cells ran during this turn.'
+    const review = makeReview({
+      outcome: 'pass',
+      checks: [makeCheck({ status: 'pass', claim: 'No tool calls', evidence, locator: undefined })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).toContain(evidence)
+  })
+
+  it('renders the claim as the check card title', async () => {
+    const claim = 'No tool calls claimed'
+    const review = makeReview({
+      outcome: 'pass',
+      checks: [makeCheck({ status: 'pass', claim, evidence: 'Looks good.', locator: undefined })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).toContain(claim)
+  })
+
+  it('renders a model pill on pass check cards', async () => {
+    const model = 'claude-sonnet-5'
+    const review = makeReview({
+      outcome: 'pass',
+      model,
+      checks: [
+        makeCheck({
+          status: 'pass',
+          claim: 'All good',
+          evidence: 'Nothing flagged.',
+          locator: undefined
+        })
+      ]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const pills = container.querySelectorAll('[data-testid="reviewer-model-pill"]')
+    expect(pills.length).toBeGreaterThan(0)
+    expect(pills[0].textContent).toBe(model)
+  })
+
+  it('does NOT render the self-correct footer note for pass expansions', async () => {
+    const review = makeReview({
+      outcome: 'pass',
+      checks: [
+        makeCheck({ status: 'pass', claim: 'All good', evidence: 'No issues.', locator: undefined })
+      ]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).not.toContain('self-corrects')
+  })
+
+  it('fires a finding-less GoToTranscriptIntent (only reviewId) from a pass check card', async () => {
+    const review = makeReview({
+      id: 'review-pass-42',
+      outcome: 'pass',
+      checks: [
+        makeCheck({ status: 'pass', claim: 'Check one', evidence: 'All good.', locator: undefined })
+      ]
+    })
+    const onGoToTranscript = vi.fn()
+
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onGoToTranscript={onGoToTranscript} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const allButtons = Array.from(container.querySelectorAll('button'))
+    const gotoBtn = allButtons.find((b) => b.textContent?.includes('Go to transcript'))
+    expect(gotoBtn).toBeTruthy()
+    await act(async () => {
+      gotoBtn!.click()
+    })
+
+    expect(onGoToTranscript).toHaveBeenCalledOnce()
+    const intent: GoToTranscriptIntent = onGoToTranscript.mock.calls[0][0]
+    expect(intent.reviewId).toBe('review-pass-42')
+    // A pass check's intent must NOT include findingId or locator.
+    expect(intent.findingId).toBeUndefined()
+    expect(intent.locator).toBeUndefined()
+  })
+})
+
+describe('ReviewerCard — flagged expand (reference-style)', () => {
+  it('renders check evidence inline (no second click required)', async () => {
+    const evidence = 'No tool activity found matching the claimed execution'
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ evidence, status: 'fail' })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).toContain(evidence)
+  })
+
+  it('renders the model pill on flagged check cards', async () => {
+    const model = 'claude-opus-4'
+    const review = makeReview({
+      outcome: 'flagged',
+      model,
+      checks: [makeCheck({ status: 'fail' })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const pills = container.querySelectorAll('[data-testid="reviewer-model-pill"]')
+    expect(pills.length).toBeGreaterThan(0)
+    expect(pills[0].textContent).toBe(model)
+  })
+
+  it('renders the self-correct footer note for warn/fail expansions', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ status: 'warn' })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).toContain('self-corrects')
+  })
+
+  it('fires a check GoToTranscriptIntent with checkId and locator', async () => {
+    const locator = makeLocator(3)
+    const check = makeCheck({ id: 'check-42', locator, status: 'fail' })
+    const review = makeReview({ id: 'review-99', outcome: 'flagged', checks: [check] })
+    const onGoToTranscript = vi.fn()
+
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onGoToTranscript={onGoToTranscript} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const allButtons = Array.from(container.querySelectorAll('button'))
+    const gotoBtn = allButtons.find((b) => b.textContent?.includes('Go to transcript'))
+    expect(gotoBtn).toBeTruthy()
+    await act(async () => {
+      gotoBtn!.click()
+    })
+
+    expect(onGoToTranscript).toHaveBeenCalledOnce()
+    const intent: GoToTranscriptIntent = onGoToTranscript.mock.calls[0][0]
+    expect(intent.reviewId).toBe('review-99')
+    expect(intent.findingId).toBe('check-42')
+    expect(intent.locator).toEqual(locator)
+  })
+})
+
+describe('ReviewerCard — rubric module assertion', () => {
+  it('exports a non-empty rubric string from the dedicated rubric module', async () => {
+    const { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } = await import('../../../main/reviewer/rubric')
+    expect(typeof REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toBe('string')
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND.length).toBeGreaterThan(100)
+  })
+
+  it('rubric contains the one-sentence mandate', async () => {
+    const { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } = await import('../../../main/reviewer/rubric')
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toContain('misled')
+  })
+
+  it('rubric contains all 8 fail criteria', async () => {
+    const { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } = await import('../../../main/reviewer/rubric')
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toMatch(/1\./)
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toMatch(/2\./)
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toMatch(/3\./)
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toMatch(/4\./)
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toMatch(/5\./)
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toMatch(/6\./)
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toMatch(/7\./)
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toMatch(/8\./)
+  })
+
+  it('rubric contains warn criteria including attempted-but-uncertain', async () => {
+    const { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } = await import('../../../main/reviewer/rubric')
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toContain('warn')
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toContain('confirm or refute')
+  })
+
+  it('rubric contains verification discipline including "only report when you have evidence"', async () => {
+    const { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } = await import('../../../main/reviewer/rubric')
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toContain('contradicts')
+  })
+
+  it('rubric contains output contract (submit_findings once)', async () => {
+    const { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } = await import('../../../main/reviewer/rubric')
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toContain('submit_findings')
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toContain('ONCE')
+  })
+
+  it('rubric scopes Phase-1 reference-checking to in-session sources only', async () => {
+    const { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } = await import('../../../main/reviewer/rubric')
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toContain('session')
+  })
+
+  it('rubric output contract uses unified checks[] (no separate findings + summary)', async () => {
+    const { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } = await import('../../../main/reviewer/rubric')
+    // v2: output contract should mention checks[], not findings[] or summary
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).toContain('checks')
+    // v2: summary is removed
+    expect(REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND).not.toContain('summary:')
+  })
+})
+
+describe('ReviewerCard — fix limit reached hint', () => {
+  it('shows "fix limit reached" in header when a capped loop leaves unaddressed checks', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [
+        makeCheck({ id: 'c1', status: 'fail', resolution: 'unaddressed' }),
+        makeCheck({ id: 'c2', status: 'warn', resolution: 'unaddressed', sortIndex: 1 })
+      ]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    expect(container.textContent).toContain('fix limit reached')
+  })
+
+  it('does NOT show "fix limit reached" for a normal (non-capped) flagged card', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ id: 'c1', status: 'fail', resolution: 'open' })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    expect(container.textContent).not.toContain('fix limit reached')
+  })
+
+  it('does NOT show "fix limit reached" for a pass card', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [] })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    expect(container.textContent).not.toContain('fix limit reached')
+  })
+
+  it('does NOT show "fix limit reached" when all warn/fail checks are resolved', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ id: 'c1', status: 'fail', resolution: 'resolved' })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    expect(container.textContent).not.toContain('fix limit reached')
+  })
+})
+
+describe('ReviewerCard — reflag marker', () => {
+  it('shows "re-flagged ×N" marker on a check with reflagCount > 0', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ id: 'c1', status: 'fail', reflagCount: 2 })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).toContain('re-flagged ×2')
+  })
+
+  it('does NOT show a reflag marker when reflagCount is 0', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ id: 'c1', status: 'fail', reflagCount: 0 })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).not.toContain('re-flagged')
+  })
+
+  it('shows a reflag marker with the correct count (×1)', async () => {
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [makeCheck({ id: 'c1', status: 'warn', reflagCount: 1 })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    expect(container.textContent).toContain('re-flagged ×1')
+  })
+})
+
+describe('ReviewerCard — error card', () => {
+  // A verbose multi-line error (e.g. a Prisma failure) must not be dumped inline into the status bar;
+  // it is collapsed behind an expandable detail block.
+  const longError =
+    'Invalid `finding.createMany()` invocation\n\nArgument `severity` is missing.\n' +
+    'at /Users/x/out/main/ipc.js:27097:27'
+
+  it('collapses a long error behind a short summary with an expand affordance', async () => {
+    const review = makeReview({
+      lifecycle: 'error',
+      outcome: null,
+      errorMessage: longError,
+      checks: []
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    // Status bar shows a short label, not the full multi-line error.
+    expect(container.textContent).toContain('Review error')
+    expect(container.textContent).not.toContain('Argument `severity` is missing.')
+
+    // The header is expandable (not a disabled, dead card).
+    const headerBtn = container.querySelector('button')
+    expect(headerBtn?.getAttribute('disabled')).toBeNull()
+  })
+
+  it('reveals the full error message in a detail block after expanding', async () => {
+    const review = makeReview({
+      lifecycle: 'error',
+      outcome: null,
+      errorMessage: longError,
+      checks: []
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    const headerBtn = container.querySelector('button')
+    await act(async () => {
+      headerBtn!.click()
+    })
+
+    const detail = container.querySelector('[data-testid="reviewer-error-detail"]')
+    expect(detail).toBeTruthy()
+    expect(detail?.textContent).toContain('Argument `severity` is missing.')
+  })
+})

--- a/src/renderer/src/components/ReviewerCard.tsx
+++ b/src/renderer/src/components/ReviewerCard.tsx
@@ -1,0 +1,299 @@
+// ReviewerCard: a compact card that appears in the conversation after a turn has been reviewed.
+// Shows "Reviewing..." while running, "No issues found" for a pass, or "N findings" for flagged.
+//
+// v2 (issue 12): unified Checks list — all checks (pass/warn/fail) come from ReviewWithChecks.checks.
+// The header count = number of warn/fail checks. Expansion shows all checks with pass/warn/fail badges.
+//
+// A warn/fail check's "Go to transcript" fires GoToTranscriptIntent with checkId+locator.
+// A pass check's "Go to transcript" fires GoToTranscriptIntent with reviewId only (no checkId/locator),
+// opening the Session reviewer page without an active highlighted check.
+//
+// warn/fail expansions show a self-correct footer note; pass-only expansions do not.
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, ShieldCheck, AlertTriangle, Loader } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+import type { ReviewWithChecks, ReviewCheck, GoToTranscriptIntent } from '../../../shared/reviewer'
+
+type ReviewerCardProps = {
+  review: ReviewWithChecks
+  className?: string
+  // Called when the user clicks "Go to transcript" on any item card.
+  onGoToTranscript?: (intent: GoToTranscriptIntent) => void
+}
+
+// Status badge styles (pass/warn/fail).
+const STATUS_BADGE_STYLES: Record<string, string> = {
+  fail: 'text-red-700 bg-red-50 border border-red-200',
+  warn: 'text-yellow-700 bg-yellow-50 border border-yellow-200',
+  pass: 'text-green-700 bg-green-50 border border-green-200'
+}
+
+// ── Shared item card layout ──────────────────────────────────────────────────
+//
+// All check cards (pass/warn/fail) use this unified layout:
+//   [badge]  [bold title]
+//   [body text]
+//   [model pill]  ...  [Go to transcript button]
+
+type ItemCardProps = {
+  // data-testid for the card root — distinguishes check status types.
+  testId: string
+  // Badge text (e.g. "fail", "warn", "pass") and its CSS classes.
+  badgeText: string
+  badgeClassName: string
+  // Bold title (claim text for all check types).
+  title: string
+  // Body text rendered inline (evidence for all check types).
+  body: string | undefined
+  // Model tag shown at the bottom-left of the card.
+  model: string
+  // Called when the user clicks "Go to transcript".
+  onGoToTranscript: (() => void) | undefined
+  // Number of times this claim was re-flagged in the fix loop (0 means no marker).
+  reflagCount?: number
+}
+
+const ItemCard = ({
+  testId,
+  badgeText,
+  badgeClassName,
+  title,
+  body,
+  model,
+  onGoToTranscript,
+  reflagCount
+}: ItemCardProps): React.JSX.Element => (
+  <div className="rounded-lg border border-border-200 bg-bg-000 p-3" data-testid={testId}>
+    {/* Badge + title row */}
+    <div className="flex items-start gap-2">
+      <span
+        className={cn(
+          'mt-0.5 shrink-0 rounded px-1 py-0.5 text-[11px] font-semibold uppercase tracking-wide',
+          badgeClassName
+        )}
+        data-testid="reviewer-item-badge"
+      >
+        {badgeText}
+      </span>
+      <span className="flex-1 text-xs font-semibold leading-snug text-text-000">{title}</span>
+      {/* Re-flag marker: shown when this claim was re-flagged in the fix loop. */}
+      {reflagCount != null && reflagCount > 0 && (
+        <span
+          className="shrink-0 rounded px-1 py-0.5 text-[11px] text-yellow-600 border border-yellow-200 bg-yellow-50"
+          data-testid="reviewer-reflag-marker"
+        >
+          re-flagged ×{reflagCount}
+        </span>
+      )}
+    </div>
+
+    {/* Body — evidence for all check types */}
+    {body ? <p className="mt-2 text-xs leading-relaxed text-text-300">{body}</p> : null}
+
+    {/* Footer row: model pill (left) + Go to transcript button (right) */}
+    <div className="mt-3 flex items-center justify-between gap-2">
+      <span
+        className="rounded border border-border-200 bg-bg-100 px-1.5 py-0.5 text-[11px] text-text-400"
+        data-testid="reviewer-model-pill"
+      >
+        {model}
+      </span>
+      <button
+        type="button"
+        className="rounded border border-border-200 px-2 py-0.5 text-[11px] text-text-300 hover:border-border-300 hover:text-text-000 transition-colors"
+        onClick={onGoToTranscript}
+      >
+        Go to transcript
+      </button>
+    </div>
+  </div>
+)
+
+// ── Check card ───────────────────────────────────────────────────────────────
+
+type CheckCardProps = {
+  check: ReviewCheck
+  reviewId: string
+  model: string
+  onGoToTranscript?: (intent: GoToTranscriptIntent) => void
+}
+
+const CheckCard = ({
+  check,
+  reviewId,
+  model,
+  onGoToTranscript
+}: CheckCardProps): React.JSX.Element => {
+  const isWarnOrFail = check.status === 'warn' || check.status === 'fail'
+
+  return (
+    <ItemCard
+      testId={isWarnOrFail ? 'reviewer-finding-card' : 'reviewer-check-card'}
+      badgeText={check.status}
+      badgeClassName={STATUS_BADGE_STYLES[check.status] ?? ''}
+      title={check.claim}
+      body={check.evidence}
+      model={model}
+      reflagCount={check.reflagCount}
+      onGoToTranscript={() =>
+        onGoToTranscript?.(
+          isWarnOrFail
+            ? {
+                reviewId,
+                findingId: check.id,
+                checkId: check.id,
+                locator: check.locator
+              }
+            : // Pass check: open panel without highlighting a specific check.
+              { reviewId }
+        )
+      }
+    />
+  )
+}
+
+// ── Main card ────────────────────────────────────────────────────────────────
+
+export const ReviewerCard = ({
+  review,
+  className,
+  onGoToTranscript
+}: ReviewerCardProps): React.JSX.Element => {
+  const [expanded, setExpanded] = useState(false)
+
+  const isRunning = review.lifecycle === 'running'
+  const isError = review.lifecycle === 'error'
+  const isComplete = review.lifecycle === 'complete'
+
+  // v2: header count = warn/fail checks only (pass checks don't count toward "findings").
+  const warnFailCount = review.checks.filter(
+    (c) => c.status === 'warn' || c.status === 'fail'
+  ).length
+  const totalCheckCount = review.checks.length
+  const hasWarnOrFail = warnFailCount > 0
+
+  // Fix loop cap: if any warn/fail check is unaddressed the loop was capped — show the hint.
+  const isCapReached =
+    isComplete &&
+    hasWarnOrFail &&
+    review.checks.some(
+      (c) => (c.status === 'warn' || c.status === 'fail') && c.resolution === 'unaddressed'
+    )
+
+  // A complete review is expandable if it has any checks; an error review is expandable if it carries
+  // a message (kept out of the status bar so a verbose Prisma-style error doesn't overflow the line).
+  const hasErrorDetail = isError && Boolean(review.errorMessage)
+  const canExpand = (isComplete && totalCheckCount > 0) || hasErrorDetail
+  const isFlagged = isComplete && hasWarnOrFail
+
+  // Compact summary line.
+  const summaryText = (): string => {
+    if (isRunning) return 'Reviewing…'
+    if (isError) return 'Review error'
+    if (isComplete && !hasWarnOrFail) return 'No issues found'
+    if (isComplete && hasWarnOrFail)
+      return `${warnFailCount} finding${warnFailCount === 1 ? '' : 's'}`
+    return 'Review pending'
+  }
+
+  // Status icon.
+  const statusIcon = ((): React.JSX.Element => {
+    if (isRunning) return <Loader className="h-3 w-3 animate-spin text-text-400" />
+    if (isError) return <AlertTriangle className="h-3 w-3 text-yellow-500" />
+    if (isComplete && !hasWarnOrFail) return <ShieldCheck className="h-3 w-3 text-green-600" />
+    if (isComplete && hasWarnOrFail) return <AlertTriangle className="h-3 w-3 text-red-500" />
+    return <Loader className="h-3 w-3 text-text-400" />
+  })()
+
+  return (
+    <div
+      className={cn(
+        'mt-2 rounded-lg border border-border-200 bg-bg-100 px-3 py-2 text-xs',
+        className
+      )}
+      data-testid="reviewer-card"
+    >
+      {/* Header row */}
+      <button
+        type="button"
+        className={cn(
+          'flex w-full items-center gap-1.5 text-left',
+          canExpand ? 'cursor-pointer' : 'cursor-default'
+        )}
+        onClick={canExpand ? () => setExpanded((v) => !v) : undefined}
+        disabled={!canExpand}
+        aria-expanded={canExpand ? expanded : undefined}
+      >
+        {statusIcon}
+        <span className="font-medium text-text-200">Reviewer</span>
+        <span className="mx-1 text-text-400">&middot;</span>
+        <span className={cn('text-text-300', isComplete && hasWarnOrFail && 'text-red-600')}>
+          {summaryText()}
+        </span>
+        {/* Total check count — shown for any completed review (pass or flagged), never for zero checks. */}
+        {isComplete && totalCheckCount > 0 && (
+          <>
+            <span className="mx-1 text-text-400">&middot;</span>
+            <span className="text-text-400">
+              {totalCheckCount} {totalCheckCount === 1 ? 'check' : 'checks'}
+            </span>
+          </>
+        )}
+        {/* Fix limit reached — shown when the loop was capped with unaddressed warn/fail checks. */}
+        {isCapReached && (
+          <>
+            <span className="mx-1 text-text-400">&middot;</span>
+            <span className="text-yellow-600">fix limit reached</span>
+          </>
+        )}
+        {canExpand && (
+          <span className="ml-auto">
+            {expanded ? (
+              <ChevronDown className="h-3 w-3 text-text-400" />
+            ) : (
+              <ChevronRight className="h-3 w-3 text-text-400" />
+            )}
+          </span>
+        )}
+      </button>
+
+      {/* Expanded error detail: full message in a scrollable monospace block (kept out of the status bar). */}
+      {hasErrorDetail && expanded && (
+        <div className="mt-2">
+          <div
+            className="max-h-48 overflow-auto rounded-lg border border-border-200 bg-bg-000 p-3"
+            data-testid="reviewer-error-detail"
+          >
+            <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-text-300">
+              {review.errorMessage}
+            </pre>
+          </div>
+        </div>
+      )}
+
+      {/* Expanded item cards: one card per check (pass/warn/fail unified list) */}
+      {canExpand && expanded && (
+        <div className="mt-2 space-y-2">
+          {review.checks.map((check) => (
+            <CheckCard
+              key={check.id}
+              check={check}
+              reviewId={review.id}
+              model={review.model}
+              onGoToTranscript={onGoToTranscript}
+            />
+          ))}
+
+          {/* Self-correct footer note — shown only for warn/fail (flagged) expansions. */}
+          {isFlagged && (
+            <p className="mt-1 text-[11px] italic text-text-400">
+              The agent reads these findings and self-corrects in its next message.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -7,7 +7,13 @@ import {
   usePreviewWorkbenchStore
 } from '../../stores/preview-workbench-store'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
-import { applyWorkspaceRuntimeEvent, syncWorkspacePermissionState } from './workspace-events'
+import {
+  applyWorkspaceRuntimeEvent,
+  assembleReviewRunRequest,
+  syncWorkspacePermissionState,
+  suppressNextAutoReview,
+  clearSuppressNextAutoReview
+} from './workspace-events'
 
 // Creates a runtime event with stable defaults for store adapter tests.
 const createEvent = (overrides: Partial<AcpRuntimeEvent>): AcpRuntimeEvent => ({
@@ -345,6 +351,86 @@ describe('workspace runtime events', () => {
     })
   })
 
+  describe('auto-review gate on stop event', () => {
+    it('triggers a review via window.api.reviewer.run when autoReviewEnabled is true (default)', async () => {
+      const reviewerRun = vi.fn().mockResolvedValue(undefined)
+
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      // Add an agent message so triggerAutoReview finds a turnMessageId.
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+
+      // Give the fire-and-forget promise time to settle.
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(reviewerRun).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'transport-session-1' })
+      )
+
+      vi.unstubAllGlobals()
+    })
+
+    it('does not trigger a review when autoReviewEnabled is false', async () => {
+      const reviewerRun = vi.fn().mockResolvedValue(undefined)
+
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      // Disable auto-review on this session.
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', false)
+
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(reviewerRun).not.toHaveBeenCalled()
+
+      vi.unstubAllGlobals()
+    })
+
+    it('re-enables a review after toggling autoReviewEnabled back to true', async () => {
+      const reviewerRun = vi.fn().mockResolvedValue(undefined)
+
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', false)
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(reviewerRun).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'transport-session-1' })
+      )
+
+      vi.unstubAllGlobals()
+    })
+  })
+
   it('records finalize failures and retries when an artifact event is replayed', async () => {
     const finalizedArtifact = createArtifactFile({
       id: 'transport-session-1:message-1:result.txt',
@@ -385,5 +471,190 @@ describe('workspace runtime events', () => {
     expect(session.messages).toHaveLength(2)
     expect(session.messages[1].artifactIds).toEqual(['transport-session-1:message-1:result.txt'])
     expect(session.error).toBeUndefined()
+  })
+})
+
+describe('loop guard: suppressNextAutoReview', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-04T08:00:00.000Z'))
+    useSessionStore.setState(createInitialSessionState())
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Run the analysis'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'stream-1',
+      eventId: 'event-agent-1',
+      content: 'Analysis complete'
+    })
+  })
+
+  it('suppresses triggerAutoReview for exactly one stop, then resumes normal behavior', async () => {
+    const reviewerRun = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+    // Mark the next stop for suppression (simulates the [Auditor] correction turn).
+    suppressNextAutoReview('transport-session-1')
+
+    // First stop: suppressed (correction turn's stop).
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'stop-correction', kind: 'stop', sessionId: 'transport-session-1' })
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // reviewer.run must NOT have been called for the suppressed stop.
+    expect(reviewerRun).not.toHaveBeenCalled()
+
+    // Append another agent message so the next triggerAutoReview finds a turnMessageId.
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'stream-2',
+      eventId: 'event-agent-2',
+      content: 'Follow-up response'
+    })
+
+    // Second stop: normal turn — must NOT be suppressed.
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'stop-normal', kind: 'stop', sessionId: 'transport-session-1' })
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // reviewer.run called exactly once for the normal turn.
+    expect(reviewerRun).toHaveBeenCalledTimes(1)
+    expect(reviewerRun).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'transport-session-1' })
+    )
+
+    vi.unstubAllGlobals()
+  })
+
+  it('does not suppress a different session', async () => {
+    const reviewerRun = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+    // Suppress only 'other-session'.
+    suppressNextAutoReview('other-session')
+
+    // A stop for 'transport-session-1' should still trigger auto-review.
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'stop-1', kind: 'stop', sessionId: 'transport-session-1' })
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // transport-session-1 is not suppressed, reviewer.run fires.
+    expect(reviewerRun).toHaveBeenCalledTimes(1)
+
+    vi.unstubAllGlobals()
+  })
+
+  it('clearSuppressNextAutoReview cancels a pending suppression (correction turn failed to send)', async () => {
+    const reviewerRun = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+    // A correction was about to fire (suppress set), but its sendPrompt failed — clear the flag so
+    // the user's next real turn is not silently skipped.
+    suppressNextAutoReview('transport-session-1')
+    clearSuppressNextAutoReview('transport-session-1')
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'stop-next', kind: 'stop', sessionId: 'transport-session-1' })
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // The suppression was cleared, so the next turn's review fires normally.
+    expect(reviewerRun).toHaveBeenCalledTimes(1)
+
+    vi.unstubAllGlobals()
+  })
+})
+
+describe('assembleReviewRunRequest — shared turn selection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-17T08:00:00.000Z'))
+    useSessionStore.setState(createInitialSessionState())
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Analyze the data'
+    })
+  })
+
+  it('returns undefined when the session has no completed agent turn', () => {
+    const result = assembleReviewRunRequest('transport-session-1')
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined when the session does not exist', () => {
+    const result = assembleReviewRunRequest('nonexistent-session')
+    expect(result).toBeUndefined()
+  })
+
+  it('selects the last agent message as turnMessageId', () => {
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'stream-1',
+      eventId: 'event-agent-1',
+      content: 'Analysis complete'
+    })
+
+    const result = assembleReviewRunRequest('transport-session-1')
+    const session = useSessionStore.getState().sessions[0]
+    const lastAgent = [...session.messages].reverse().find((m) => m.role === 'agent')
+
+    expect(result).not.toBeUndefined()
+    expect(result!.sessionId).toBe('transport-session-1')
+    expect(result!.turnMessageId).toBe(lastAgent!.id)
+    expect(result!.mainSessionId).toBe('transport-session-1')
+  })
+
+  it('skips autoReviewEnabled — returns a request even when auto-review is off', () => {
+    useSessionStore.getState().setAutoReviewEnabled('transport-session-1', false)
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'stream-1',
+      eventId: 'event-agent-1',
+      content: 'Done'
+    })
+
+    const result = assembleReviewRunRequest('transport-session-1')
+
+    // assembleReviewRunRequest does not check autoReviewEnabled — manual path ignores the toggle.
+    expect(result).not.toBeUndefined()
+  })
+
+  it('picks the most recent of multiple agent turns', () => {
+    // First turn
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'stream-1',
+      eventId: 'event-1',
+      content: 'First response'
+    })
+    // Second user message
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Follow-up'
+    })
+    // Second agent turn
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'stream-2',
+      eventId: 'event-2',
+      content: 'Second response'
+    })
+
+    const result = assembleReviewRunRequest('transport-session-1')
+    const session = useSessionStore.getState().sessions[0]
+    const lastAgent = [...session.messages].reverse().find((m) => m.role === 'agent')
+
+    expect(result!.turnMessageId).toBe(lastAgent!.id)
   })
 })

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -1,13 +1,33 @@
 import type { AcpRuntimeEvent, AcpPermissionRequest } from '../../../../shared/acp'
 import type { ArtifactFile, FinalizeRunArtifactsRequest } from '../../../../shared/artifacts'
+import type { ReviewRunRequest } from '../../../../shared/reviewer'
 import { createPreviewFileItem } from '../../pages/workspace/preview-file-item'
 import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { useSessionStore } from '../../stores/session-store'
+import { useSettingsStore } from '../../stores/settings-store'
 import { createRuntimeStreamId, isAssistantRuntimeChatMessageEvent } from './chat-events'
 
 // Remembers which sessions were marked as waiting during the previous permission sync.
 const pendingPermissionSessionIds = new Set<string>()
+
+// Sessions whose next triggerAutoReview call should be skipped exactly once.
+// Used to suppress the re-review that would otherwise be triggered by the [Auditor] correction turn:
+// the main process broadcasts reviewer:suppress-next-auto-review before sending the correction prompt;
+// the renderer calls suppressNextAutoReview(sessionId) so the correction turn's stop event is ignored.
+const suppressAutoReviewOnceFor = new Set<string>()
+
+// Marks the next triggerAutoReview call for a session as suppressed. Cleared on use (one-shot).
+const suppressNextAutoReview = (sessionId: string): void => {
+  suppressAutoReviewOnceFor.add(sessionId)
+}
+
+// Cancels a pending one-shot suppression. Used when the [Auditor] correction turn fails to send:
+// no stop event will arrive to consume the flag, so it must be cleared to avoid silently skipping
+// the session's next real auto-review.
+const clearSuppressNextAutoReview = (sessionId: string): void => {
+  suppressAutoReviewOnceFor.delete(sessionId)
+}
 
 // Chooses the best user-facing error text from a runtime event.
 const getEventErrorText = (event: AcpRuntimeEvent): string =>
@@ -44,6 +64,62 @@ const openMoleculePreviews = (sessionId: string, artifacts: ArtifactFile[]): voi
         mimeType: artifact.mimeType
       })
     )
+  }
+}
+
+// Assembles a ReviewRunRequest for the last completed agent turn of a session.
+// Returns undefined when no agent turn exists (caller should skip the review).
+// Shared between the auto path (triggerAutoReview) and the manual "Request review" path,
+// so the two can never drift in turn selection or request field construction.
+const assembleReviewRunRequest = (sessionId: string): ReviewRunRequest | undefined => {
+  const sessionState = useSessionStore.getState()
+  const session = sessionState.sessions.find((s) => s.id === sessionId)
+
+  if (!session) return undefined
+
+  // Find the last agent message (the just-completed turn).
+  const lastAgentMessage = [...session.messages].reverse().find((m) => m.role === 'agent')
+
+  if (!lastAgentMessage) return undefined
+
+  return {
+    sessionId,
+    turnMessageId: lastAgentMessage.id,
+    projectId: session.projectId ?? '',
+    mainSessionId: sessionId,
+    model: useSettingsStore.getState().activeModel
+  }
+}
+
+// Triggers a background auto-review for the just-completed turn when autoReviewEnabled is on. The
+// default is on, so a session is auto-reviewed unless the switch was explicitly turned off. Uses the
+// shared assembleReviewRunRequest helper so the auto and manual paths pick the same turn and assemble
+// the same request fields.
+// Fire-and-forget: errors are caught and silently dropped so the main session is never blocked.
+const triggerAutoReview = async (sessionId: string): Promise<void> => {
+  try {
+    // Loop guard: if this session's next review was suppressed (e.g. because the stop comes from
+    // the [Auditor] correction turn), skip exactly this one call and clear the flag.
+    if (suppressAutoReviewOnceFor.has(sessionId)) {
+      suppressAutoReviewOnceFor.delete(sessionId)
+      return
+    }
+
+    const sessionState = useSessionStore.getState()
+    const session = sessionState.sessions.find((s) => s.id === sessionId)
+
+    if (!session) return
+
+    // Auto-review defaults to enabled: skip only when the switch is explicitly off.
+    if (session.autoReviewEnabled === false) return
+
+    const request = assembleReviewRunRequest(sessionId)
+
+    if (!request) return
+
+    await window.api.reviewer.run(request)
+  } catch {
+    // Reviewer errors must never surface to the main session.
   }
 }
 
@@ -87,6 +163,11 @@ const applyWorkspaceRuntimeEvent = async (
 
   if (event.kind === 'stop' && event.sessionId) {
     store.finishRun(event.sessionId)
+
+    // Trigger a background review for the just-completed turn.
+    // We read the session state AFTER finishRun so messages are complete.
+    void triggerAutoReview(event.sessionId)
+
     return true
   }
 
@@ -175,4 +256,10 @@ const syncWorkspacePermissionState = (requests: AcpPermissionRequest[]): void =>
   }
 }
 
-export { applyWorkspaceRuntimeEvent, syncWorkspacePermissionState }
+export {
+  applyWorkspaceRuntimeEvent,
+  assembleReviewRunRequest,
+  syncWorkspacePermissionState,
+  suppressNextAutoReview,
+  clearSuppressNextAutoReview
+}

--- a/src/renderer/src/pages/workspace/ComposerAutoReviewToggle.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAutoReviewToggle.interaction.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ComposerAutoReviewToggle } from './ComposerAutoReviewToggle'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const findToggleButton = (): HTMLButtonElement => {
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) =>
+    candidate.getAttribute('aria-label')?.includes('Auto-review')
+  )
+
+  if (!button) throw new Error('Auto-review toggle button not found')
+
+  return button as HTMLButtonElement
+}
+
+describe('ComposerAutoReviewToggle', () => {
+  it('shows the toggle as enabled (on) when value is true', () => {
+    act(() => {
+      root.render(<ComposerAutoReviewToggle value={true} onChange={vi.fn()} />)
+    })
+
+    const button = findToggleButton()
+
+    expect(button.getAttribute('aria-label')).toContain('Auto-review')
+    expect(button.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('shows the toggle as disabled (off) when value is false', () => {
+    act(() => {
+      root.render(<ComposerAutoReviewToggle value={false} onChange={vi.fn()} />)
+    })
+
+    const button = findToggleButton()
+
+    expect(button.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('calls onChange with true when toggled off → on', () => {
+    const onChange = vi.fn()
+
+    act(() => {
+      root.render(<ComposerAutoReviewToggle value={false} onChange={onChange} />)
+    })
+    act(() => findToggleButton().click())
+
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+
+  it('calls onChange with false when toggled on → off', () => {
+    const onChange = vi.fn()
+
+    act(() => {
+      root.render(<ComposerAutoReviewToggle value={true} onChange={onChange} />)
+    })
+    act(() => findToggleButton().click())
+
+    expect(onChange).toHaveBeenCalledWith(false)
+  })
+
+  it('does not fire onChange when disabled', () => {
+    const onChange = vi.fn()
+
+    act(() => {
+      root.render(<ComposerAutoReviewToggle value={true} onChange={onChange} disabled={true} />)
+    })
+    act(() => findToggleButton().click())
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/pages/workspace/ComposerAutoReviewToggle.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAutoReviewToggle.tsx
@@ -1,0 +1,49 @@
+// Per-session Auto-review toggle for the composer toolbar.
+// Mirrors the shape of ComposerPermissionProfilePicker: a single button that calls onChange
+// with the new boolean value. Default state is on (true); absent (older sessions) also means on.
+// On/off is made legible by color, not just opacity: on = teal shield (--primary) + near-black
+// label; off = greyed shield + muted label. (The earlier off style used text-text-400, an
+// undefined theme token, so off looked almost identical to on.)
+
+import { ShieldCheck } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+type ComposerAutoReviewToggleProps = {
+  value: boolean
+  disabled?: boolean
+  onChange: (enabled: boolean) => void
+}
+
+const ComposerAutoReviewToggle = ({
+  value,
+  disabled = false,
+  onChange
+}: ComposerAutoReviewToggleProps): React.JSX.Element => {
+  const handleClick = (): void => {
+    if (disabled) return
+    onChange(!value)
+  }
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex h-8 min-w-0 items-center gap-1.5 rounded-md px-2 text-[12px] transition-colors duration-200 ease-out hover:bg-bg-200 disabled:cursor-not-allowed disabled:opacity-50',
+        value ? 'font-medium text-text-000' : 'text-text-300 hover:text-text-100'
+      )}
+      aria-label={value ? 'Auto-review on — click to disable' : 'Auto-review off — click to enable'}
+      aria-pressed={value}
+      disabled={disabled}
+      onClick={handleClick}
+    >
+      <ShieldCheck
+        className={cn('size-3.5 shrink-0', value ? 'text-primary' : 'opacity-55')}
+        strokeWidth={2}
+        aria-hidden="true"
+      />
+      <span className="max-w-32 truncate @max-[28rem]/composer:hidden">Auto-review</span>
+    </button>
+  )
+}
+
+export { ComposerAutoReviewToggle }

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -409,4 +409,22 @@ describe('ConversationPanel fix loop lock', () => {
     // The same cancel button is reused; the wiring to abort the loop happens in WorkspacePage
     expect(onCancelRun).toHaveBeenCalledTimes(1)
   })
+
+  it('cancel button is visible during the reviewer-review sub-phase (fix loop active, main agent idle)', () => {
+    const onCancelRun = vi.fn()
+    // Reviewer-review sub-phase: the fix loop is active but the main agent is idle (the reviewer runs in
+    // a separate ACP session, so the main session's status is not 'running'). The cancel affordance
+    // must still be reachable so the user can abort the loop during this window.
+    renderPanel({ activeSession: lockedSession, canSendMessage: false, onCancelRun })
+
+    const cancelButton = container.querySelector('[aria-label="Cancel run"]') as HTMLButtonElement
+    expect(cancelButton).not.toBeNull()
+    // The send button is replaced by cancel while the loop is active — not merely disabled.
+    expect(container.querySelector('[aria-label="Send message"]')).toBeNull()
+
+    act(() => {
+      cancelButton.click()
+    })
+    expect(onCancelRun).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ConversationPanel } from './ConversationPanel'
 import { emptyDoc } from './composer/composer-doc'
 
+import type { ChatSession } from '@/stores/session-store'
+
 // React's act() refuses to run unless the environment opts in to act-aware scheduling.
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -19,8 +21,37 @@ vi.mock('@/lib/utils', () => ({
   cn: (...values: Array<string | false | undefined>) => values.filter(Boolean).join(' ')
 }))
 
+// Radix DropdownMenu calls pointer-capture APIs that jsdom does not implement.
+// Replace with a flat render so items are always visible in the DOM.
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: PropsWithChildren): React.JSX.Element => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: PropsWithChildren): React.JSX.Element => <>{children}</>,
+  DropdownMenuContent: ({ children }: PropsWithChildren): React.JSX.Element => (
+    <div>{children}</div>
+  ),
+  DropdownMenuSeparator: (): React.JSX.Element => <hr />,
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onSelect,
+    ...rest
+  }: PropsWithChildren<{
+    disabled?: boolean
+    onSelect?: () => void
+    'data-testid'?: string
+  }>): React.JSX.Element => (
+    <button type="button" disabled={disabled} onClick={onSelect} {...rest}>
+      {children}
+    </button>
+  )
+}))
+
 vi.mock('./ComposerModelPicker', () => ({
   ComposerModelPicker: (): null => null
+}))
+
+vi.mock('./ComposerAutoReviewToggle', () => ({
+  ComposerAutoReviewToggle: (): null => null
 }))
 
 vi.mock('./WorkspaceMessageScroller', () => ({
@@ -66,6 +97,10 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         onPermissionProfileChange={vi.fn()}
         onRevokePermissionGrant={vi.fn()}
         onClearPermissionGrants={vi.fn()}
+        autoReviewEnabled={true}
+        onAutoReviewToggle={vi.fn()}
+        onRequestReview={vi.fn()}
+        isRequestReviewDisabled={false}
         {...props}
       />
     )
@@ -194,5 +229,184 @@ describe('ConversationPanel composer intake', () => {
     })
 
     expect(onDraftDocChange).toHaveBeenCalledWith({ nodes: [{ type: 'text', text: 'hello' }] })
+  })
+})
+
+describe('ConversationPanel + menu', () => {
+  it('renders both Attach files and Request review items', () => {
+    renderPanel()
+
+    const attachItem = container.querySelector('[data-testid="menu-attach-files"]')
+    const reviewItem = container.querySelector('[data-testid="menu-request-review"]')
+
+    expect(attachItem).not.toBeNull()
+    expect(reviewItem).not.toBeNull()
+  })
+
+  it('Attach files item triggers the hidden file input (onStageAttachmentFiles path)', () => {
+    // We can only confirm the item exists and is not disabled; the picker click is browser-native.
+    renderPanel()
+
+    const attachItem = container.querySelector('[data-testid="menu-attach-files"]')
+    expect(attachItem).not.toBeNull()
+    expect((attachItem as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('Request review calls onRequestReview when enabled', () => {
+    const onRequestReview = vi.fn()
+    renderPanel({ onRequestReview, isRequestReviewDisabled: false })
+
+    const reviewItem = container.querySelector('[data-testid="menu-request-review"]')
+    expect(reviewItem).not.toBeNull()
+    act(() => {
+      ;(reviewItem as HTMLButtonElement).click()
+    })
+
+    expect(onRequestReview).toHaveBeenCalledTimes(1)
+  })
+
+  it('Request review is disabled when isRequestReviewDisabled is true', () => {
+    const onRequestReview = vi.fn()
+    renderPanel({ onRequestReview, isRequestReviewDisabled: true })
+
+    const reviewItem = container.querySelector(
+      '[data-testid="menu-request-review"]'
+    ) as HTMLButtonElement
+    expect(reviewItem.disabled).toBe(true)
+
+    act(() => {
+      reviewItem.click()
+    })
+
+    // disabled button click should not call the handler
+    expect(onRequestReview).not.toHaveBeenCalled()
+  })
+
+  it('Request review is not called when disabled is true (onSelect guard)', () => {
+    const onRequestReview = vi.fn()
+    renderPanel({ onRequestReview, isRequestReviewDisabled: true })
+
+    const reviewItem = container.querySelector(
+      '[data-testid="menu-request-review"]'
+    ) as HTMLButtonElement
+    // Simulate the click directly on the element — disabled buttons suppress click events.
+    act(() => {
+      reviewItem.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onRequestReview).not.toHaveBeenCalled()
+  })
+})
+
+describe('ConversationPanel fix loop lock', () => {
+  const idleSession: ChatSession = {
+    id: 'session-fix-loop',
+    projectId: 'project-a',
+    title: 'Fix loop session',
+    cwd: '/workspace',
+    status: 'idle',
+    messages: [
+      {
+        id: 'msg-1',
+        role: 'agent',
+        content: 'Done',
+        status: 'complete',
+        eventIds: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      }
+    ],
+    createdAt: Date.now(),
+    updatedAt: Date.now()
+  }
+
+  const lockedSession: ChatSession = {
+    ...idleSession,
+    fixLoopActive: true
+  }
+
+  it('send button is disabled when canSendMessage is false (fix loop active)', () => {
+    // canSendMessage is passed from outside (computed by WorkspacePage)
+    renderPanel({ activeSession: idleSession, canSendMessage: false })
+
+    const sendButton = container.querySelector('[aria-label="Send message"]') as HTMLButtonElement
+    expect(sendButton).not.toBeNull()
+    expect(sendButton.disabled).toBe(true)
+  })
+
+  it('send button is enabled when canSendMessage is true (no fix loop)', () => {
+    renderPanel({ activeSession: idleSession, canSendMessage: true })
+
+    const sendButton = container.querySelector('[aria-label="Send message"]') as HTMLButtonElement
+    expect(sendButton).not.toBeNull()
+    expect(sendButton.disabled).toBe(false)
+  })
+
+  it('send button stays disabled when typing does not change canSendMessage (fix loop active)', () => {
+    const onDraftDocChange = vi.fn()
+    renderPanel({
+      activeSession: lockedSession,
+      canSendMessage: false,
+      onDraftDocChange
+    })
+
+    // Simulate typing — the doc change is fired but canSendMessage remains false (external prop)
+    const editor = container.querySelector('[role="textbox"]') as HTMLElement
+    editor.textContent = 'some text'
+    act(() => {
+      editor.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    // Even after typing, the send button remains disabled because canSendMessage=false is external
+    const sendButton = container.querySelector('[aria-label="Send message"]') as HTMLButtonElement
+    if (sendButton) {
+      expect(sendButton.disabled).toBe(true)
+    }
+    // The doc change is still fired (composing is allowed)
+    expect(onDraftDocChange).toHaveBeenCalled()
+  })
+
+  it('cancel button is visible when session is running and calls onCancelRun', () => {
+    const onCancelRun = vi.fn()
+    const runningSession: ChatSession = {
+      ...idleSession,
+      status: 'running',
+      activeRun: { promptMessageId: 'msg-1', startedAt: Date.now() }
+    }
+    renderPanel({ activeSession: runningSession, canSendMessage: false, onCancelRun })
+
+    const cancelButton = container.querySelector('[aria-label="Cancel run"]') as HTMLButtonElement
+    expect(cancelButton).not.toBeNull()
+    act(() => {
+      cancelButton.click()
+    })
+
+    expect(onCancelRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancel button during fix loop calls onCancelRun which unlocks the composer', () => {
+    const onCancelRun = vi.fn()
+    const runningLockedSession: ChatSession = {
+      ...idleSession,
+      status: 'running',
+      activeRun: { promptMessageId: 'msg-1', startedAt: Date.now() },
+      fixLoopActive: true
+    }
+    // When the fix loop is active and session is running, onCancelRun handles both
+    // ACP cancel and fix loop abort (wired in WorkspacePage)
+    renderPanel({
+      activeSession: runningLockedSession,
+      canSendMessage: false,
+      onCancelRun
+    })
+
+    const cancelButton = container.querySelector('[aria-label="Cancel run"]') as HTMLButtonElement
+    expect(cancelButton).not.toBeNull()
+    act(() => {
+      cancelButton.click()
+    })
+
+    // The same cancel button is reused; the wiring to abort the loop happens in WorkspacePage
+    expect(onCancelRun).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -12,6 +12,7 @@ import {
   Image as ImageIcon,
   PanelRight,
   Plus,
+  ScanEye,
   Square,
   X
 } from 'lucide-react'
@@ -19,12 +20,20 @@ import { useRef, useState } from 'react'
 
 import { FileDropOverlay } from '@/components/FileDropOverlay'
 import { ResizablePanel } from '@/components/ui/resizable'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { cn } from '@/lib/utils'
 import type { ChatSession } from '@/stores/session-store'
 
 import { ComposerEditor } from './composer/ComposerEditor'
 import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
+import { ComposerAutoReviewToggle } from './ComposerAutoReviewToggle'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { ComposerPermissionProfilePicker } from './ComposerPermissionProfilePicker'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
@@ -81,6 +90,8 @@ type ConversationPanelProps = {
   permissionProfileState: SessionPermissionProfileState | undefined
   permissionGrants: AcpPermissionGrant[]
   canChangePermissionProfile: boolean
+  // Auto-review toggle: whether the current session has auto-review enabled (default true).
+  autoReviewEnabled: boolean
   onDraftDocChange: (doc: ComposerDoc) => void
   onSendMessage: (forcedSkillIds: string[]) => void
   onStageAttachmentFiles: (files: File[]) => void
@@ -93,6 +104,11 @@ type ConversationPanelProps = {
   onPermissionProfileChange: (profile: PermissionProfileId) => void
   onRevokePermissionGrant: (categoryKey: string) => void
   onClearPermissionGrants: () => void
+  onAutoReviewToggle: (enabled: boolean) => void
+  // Manual review: invoked by the "Request review" + menu item.
+  onRequestReview: () => void
+  // True when "Request review" should be disabled: no completed turn, already reviewed, or currently reviewing.
+  isRequestReviewDisabled: boolean
 }
 
 // Middle chat surface owns the visible conversation and local message composer UI.
@@ -111,6 +127,7 @@ const ConversationPanel = ({
   permissionProfileState,
   permissionGrants,
   canChangePermissionProfile,
+  autoReviewEnabled,
   onDraftDocChange,
   onSendMessage,
   onStageAttachmentFiles,
@@ -122,7 +139,10 @@ const ConversationPanel = ({
   onRespondToPermission,
   onPermissionProfileChange,
   onRevokePermissionGrant,
-  onClearPermissionGrants
+  onClearPermissionGrants,
+  onAutoReviewToggle,
+  onRequestReview,
+  isRequestReviewDisabled
 }: ConversationPanelProps): React.JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   // Local so the interrupted banner can show a spinner and block a double-resume until the request settles.
@@ -320,15 +340,40 @@ const ConversationPanel = ({
                       </div>
 
                       <div className="@container/composer flex items-center gap-1">
-                        <button
-                          type="button"
-                          disabled={!canEditDraft || isUploadingAttachments}
-                          className={composerIconButtonClassName}
-                          aria-label="Add attachment"
-                          onClick={() => fileInputRef.current?.click()}
-                        >
-                          <Plus className="size-4" strokeWidth={2} aria-hidden="true" />
-                        </button>
+                        {/* The + button opens a dropdown for Attach files and Request review actions. */}
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              type="button"
+                              disabled={!canEditDraft || isUploadingAttachments}
+                              className={composerIconButtonClassName}
+                              aria-label="Add attachment or request review"
+                              data-testid="composer-plus-trigger"
+                            >
+                              <Plus className="size-4" strokeWidth={2} aria-hidden="true" />
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent side="top" align="start" className="w-48">
+                            <DropdownMenuItem
+                              data-testid="menu-attach-files"
+                              onSelect={() => fileInputRef.current?.click()}
+                            >
+                              <FileText className="mr-2 size-4 text-text-300" aria-hidden="true" />
+                              Attach files
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              data-testid="menu-request-review"
+                              disabled={isRequestReviewDisabled}
+                              onSelect={() => {
+                                if (!isRequestReviewDisabled) onRequestReview()
+                              }}
+                            >
+                              <ScanEye className="mr-2 size-4 text-text-300" aria-hidden="true" />
+                              Request review
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                         {/* The native picker is hidden because the composer button carries the UI. */}
                         <input
                           ref={fileInputRef}
@@ -347,6 +392,12 @@ const ConversationPanel = ({
                           onChange={onPermissionProfileChange}
                           onRevokeGrant={onRevokePermissionGrant}
                           onClearGrants={onClearPermissionGrants}
+                        />
+
+                        <ComposerAutoReviewToggle
+                          value={autoReviewEnabled}
+                          disabled={!canEditDraft}
+                          onChange={onAutoReviewToggle}
                         />
 
                         <div className="flex-1" />

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -407,8 +407,12 @@ const ConversationPanel = ({
                         <ComposerModelPicker />
 
                         {activeSession?.status === 'running' ||
-                        activeSession?.status === 'waiting-permission' ? (
+                        activeSession?.status === 'waiting-permission' ||
+                        activeSession?.fixLoopActive ? (
                           // Running sessions expose cancel instead of send to prevent overlapping turns.
+                          // During a fix loop the main agent may be idle (the reviewer-review sub-phase runs
+                          // in a separate ACP session), so fixLoopActive keeps the cancel affordance
+                          // reachable across the whole loop, not just the agent-fix running turn.
                           <button
                             type="button"
                             onClick={onCancelRun}

--- a/src/renderer/src/pages/workspace/SessionReviewerPanel.log.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionReviewerPanel.log.render.test.tsx
@@ -1,0 +1,330 @@
+// @vitest-environment jsdom
+// Render tests for the ReviewerLogSection component (issue 13, updated for unified tool entry in issue 15).
+// Verifies:
+// - The "Reviewer log" section is collapsed by default
+// - It renders the log by reusing WorkspaceMessageItem and workspace activity components
+// - An empty/aborted log renders gracefully (collapsed section, no crash)
+// - The old "Full reasoning" prose block is gone
+// - tool entries render as collapsible rows showing real tool name, input, output
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { ReviewWithChecks } from '../../../../shared/reviewer'
+import type { ReviewerLogEntry } from '../../../../shared/reviewer'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// --- fixtures ---
+
+const makeReview = (
+  overrides: Partial<ReviewWithChecks> & { reviewerLog?: ReviewerLogEntry[] } = {}
+): ReviewWithChecks => ({
+  id: 'review-1',
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  turnMessageId: 'msg-1',
+  scope: { turnMessageId: 'msg-1', blocks: [], artifactVersionIds: [] },
+  lifecycle: 'complete',
+  outcome: 'pass',
+  model: 'claude-opus-4-5',
+  reviewerLog: [],
+  checks: [],
+  createdAt: 1000,
+  updatedAt: 1001,
+  ...overrides
+})
+
+const sampleLog: ReviewerLogEntry[] = [
+  { kind: 'thought', text: 'Let me read the turn first.' },
+  {
+    kind: 'tool',
+    toolName: 'Bash',
+    title: 'python3 -c "host.read_turn()"',
+    rawInput: 'python3 -c "import host, json; print(json.dumps(host.read_turn()))"',
+    rawOutput: '[{"kind": "message"}]',
+    status: 'ok',
+    exitCode: 0
+  },
+  { kind: 'message', text: 'Review complete, submitting findings.' }
+]
+
+// --- helpers ---
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+// Lazy-import the component under test.
+const { SessionReviewerPanel } = await import('./SessionReviewerPanel')
+
+describe('SessionReviewerPanel — Reviewer log section (issue 13/15)', () => {
+  it('shows a "Reviewer log" section heading', () => {
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ reviewerLog: sampleLog })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    expect(container.textContent).toContain('Reviewer log')
+  })
+
+  it('is collapsed by default (log content not visible)', () => {
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ reviewerLog: sampleLog })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    // The section title is visible but the log entries are not yet expanded.
+    expect(container.textContent).toContain('Reviewer log')
+    // Log thought text should not be visible until expanded.
+    expect(container.textContent).not.toContain('Let me read the turn first.')
+    // The toggle button exists.
+    const toggle = container.querySelector('[data-testid="reviewer-log-toggle"]')
+    expect(toggle).not.toBeNull()
+  })
+
+  it('expands the log when the toggle is clicked', async () => {
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ reviewerLog: sampleLog })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    const toggle = container.querySelector<HTMLButtonElement>('[data-testid="reviewer-log-toggle"]')
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    // After expansion, log entries are visible.
+    const logBody = container.querySelector('[data-testid="reviewer-log-body"]')
+    expect(logBody).not.toBeNull()
+    expect(container.textContent).toContain('Let me read the turn first.')
+    // The real tool name "Bash" should appear (not just "Terminal").
+    expect(container.textContent).toContain('Bash')
+    expect(container.textContent).toContain('Review complete, submitting findings.')
+  })
+
+  it('renders tool entry as collapsible row with real name visible after log expansion', async () => {
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ reviewerLog: sampleLog })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    // Expand the log section first.
+    const logToggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="reviewer-log-toggle"]'
+    )
+    await act(async () => {
+      logToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    // The tool row toggle should be present and show the real tool name.
+    const toolToggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="tool-log-row-toggle"]'
+    )
+    expect(toolToggle).not.toBeNull()
+    expect(toolToggle?.textContent).toContain('Bash')
+
+    // Tool details should be collapsed by default (no details panel visible).
+    expect(container.querySelector('[data-testid="tool-log-row-details"]')).toBeNull()
+
+    // Expand the tool row.
+    await act(async () => {
+      toolToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    // Now Input and Output should be visible.
+    const details = container.querySelector('[data-testid="tool-log-row-details"]')
+    expect(details).not.toBeNull()
+    expect(details?.textContent).toContain('Input')
+    expect(details?.textContent).toContain('python3 -c "import host')
+    expect(details?.textContent).toContain('Output')
+    expect(details?.textContent).toContain('[{"kind": "message"}]')
+  })
+
+  it('shows ok status dot for tool entry with status=ok', async () => {
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ reviewerLog: sampleLog })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    const logToggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="reviewer-log-toggle"]'
+    )
+    await act(async () => {
+      logToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    // The ok status dot should be in the tool row.
+    const toolToggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="tool-log-row-toggle"]'
+    )
+    expect(toolToggle?.textContent).toContain('● ok')
+  })
+
+  it('shows error status dot for tool entry with status=error', async () => {
+    const errorLog: ReviewerLogEntry[] = [
+      {
+        kind: 'tool',
+        toolName: 'Bash',
+        rawInput: 'python3 bad.py',
+        rawOutput: 'SyntaxError: bad syntax',
+        status: 'error',
+        exitCode: 1
+      }
+    ]
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ reviewerLog: errorLog })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    const logToggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="reviewer-log-toggle"]'
+    )
+    await act(async () => {
+      logToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    const toolToggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="tool-log-row-toggle"]'
+    )
+    expect(toolToggle?.textContent).toContain('● error')
+  })
+
+  it('renders tool entry with no output gracefully (aborted mid-call, no crash)', async () => {
+    const partialLog: ReviewerLogEntry[] = [
+      { kind: 'tool', toolName: 'Bash', rawInput: 'python3 host.read_turn()' }
+    ]
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ reviewerLog: partialLog })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    const logToggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="reviewer-log-toggle"]'
+    )
+    await act(async () => {
+      logToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    // Should render without crashing. Tool name visible.
+    expect(container.textContent).toContain('Bash')
+  })
+
+  it('hides the toggle when the log is empty (graceful empty state)', () => {
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ reviewerLog: [] })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    // With no log entries, either the section is hidden or has no expandable content.
+    // Either way it should not crash.
+    expect(() => {
+      void container.textContent
+    }).not.toThrow()
+    // No log body should be visible.
+    const logBody = container.querySelector('[data-testid="reviewer-log-body"]')
+    expect(logBody).toBeNull()
+  })
+
+  it('does NOT render the old "Full reasoning" prose block', () => {
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ reviewerLog: sampleLog })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    // The old "Full reasoning" toggle should be gone.
+    expect(container.querySelector('[data-testid="reviewer-reasoning-toggle"]')).toBeNull()
+    expect(container.querySelector('[data-testid="reviewer-reasoning-body"]')).toBeNull()
+    // No "Full reasoning" text.
+    expect(container.textContent).not.toContain('Full reasoning')
+  })
+
+  it('does not crash when log has an error-lifecycle review with empty log', () => {
+    const errorReview = makeReview({
+      lifecycle: 'error',
+      outcome: null,
+      errorMessage: 'Reviewer session timed out',
+      reviewerLog: []
+    })
+
+    expect(() => {
+      act(() => {
+        root.render(<SessionReviewerPanel review={errorReview} activeFindingId={undefined} />)
+      })
+    }).not.toThrow()
+  })
+})
+
+describe('SessionReviewerPanel — still shows Checks list (regression)', () => {
+  it('renders the unified checks list unchanged', () => {
+    const check = {
+      id: 'check-1',
+      reviewId: 'review-1',
+      status: 'pass' as const,
+      resolution: 'open' as const,
+      claim: 'Row count verified',
+      evidence: 'Counted 33 rows',
+      sortIndex: 0,
+      reflagCount: 0
+    }
+
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ checks: [check], reviewerLog: sampleLog })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    expect(container.querySelector('[data-testid="reviewer-checks"]')).not.toBeNull()
+    expect(container.textContent).toContain('Row count verified')
+  })
+})

--- a/src/renderer/src/pages/workspace/SessionReviewerPanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionReviewerPanel.render.test.tsx
@@ -1,0 +1,304 @@
+// @vitest-environment jsdom
+// Render tests for the Session reviewer page / panel.
+// v2 (issue 12): unified checks[] model — no separate Summary section.
+// v3 (issue 13): reasoning replaced by reviewerLog; "Full reasoning" section replaced by "Reviewer log".
+// The panel shows a single Checks list with pass/warn/fail badges, claim, evidence,
+// and locator for warn/fail checks. No Summary section. No "Full reasoning" section.
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { ReviewWithChecks, ReviewCheck } from '../../../../shared/reviewer'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// --- fixtures ---
+
+const makeCheck = (overrides: Partial<ReviewCheck>): ReviewCheck => ({
+  id: 'check-1',
+  reviewId: 'review-1',
+  status: 'fail',
+  resolution: 'open',
+  claim: 'Agent claimed to run the test but no tool call exists',
+  evidence: 'msg[2] tool_result shows exit code 127 — command not found',
+  locator: {
+    blockRef: { messageId: 'msg-2', blockIndex: 1 },
+    contentHash: 'abc123'
+  },
+  sortIndex: 0,
+  reflagCount: 0,
+  ...overrides
+})
+
+const makeReview = (overrides: Partial<ReviewWithChecks> = {}): ReviewWithChecks => ({
+  id: 'review-1',
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  turnMessageId: 'msg-1',
+  scope: { turnMessageId: 'msg-1', blocks: [], artifactVersionIds: [] },
+  lifecycle: 'complete',
+  outcome: 'flagged',
+  model: 'claude-3-5-sonnet',
+  reviewerLog: [
+    {
+      kind: 'thought',
+      text: 'Checked msg[2] and found the test runner exited with code 127 (command not found). The agent wrote "All tests passed" with no supporting tool result.'
+    }
+  ],
+  checks: [
+    makeCheck({}),
+    makeCheck({
+      id: 'check-2',
+      status: 'pass',
+      claim: 'Row count verified',
+      evidence: 'Counted 33 rows from artifact-csv; agent reported 33.',
+      locator: undefined,
+      sortIndex: 1
+    })
+  ],
+  createdAt: 1000,
+  updatedAt: 1001,
+  ...overrides
+})
+
+// --- helpers ---
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+// Lazy-import the component under test so vi.mock calls apply first.
+const { SessionReviewerPanel } = await import('./SessionReviewerPanel')
+
+describe('SessionReviewerPanel — unified checks list', () => {
+  it('renders the unified checks list with pass and fail badges', () => {
+    act(() => {
+      root.render(<SessionReviewerPanel review={makeReview()} activeFindingId={undefined} />)
+    })
+
+    // Both checks should appear.
+    expect(container.textContent).toContain('Agent claimed to run the test but no tool call exists')
+    expect(container.textContent).toContain('Row count verified')
+    expect(container.querySelector('[data-testid="reviewer-checks"]')).not.toBeNull()
+    // Status badges.
+    expect(container.textContent).toContain('fail')
+    expect(container.textContent).toContain('pass')
+  })
+
+  it('shows the total check count next to the Checks header', () => {
+    act(() => {
+      // makeReview has 2 checks by default.
+      root.render(<SessionReviewerPanel review={makeReview()} activeFindingId={undefined} />)
+    })
+
+    const header = container.querySelector('[data-testid="reviewer-checks"] h3')
+    expect(header?.textContent).toContain('Checks')
+    expect(header?.textContent).toContain('2')
+  })
+
+  it('omits the count when no checks were recorded', () => {
+    act(() => {
+      root.render(
+        <SessionReviewerPanel review={makeReview({ checks: [] })} activeFindingId={undefined} />
+      )
+    })
+
+    const header = container.querySelector('[data-testid="reviewer-checks"] h3')
+    // A bare "Checks" header with no misleading "· 0".
+    expect(header?.textContent?.trim()).toBe('Checks')
+  })
+
+  it('renders evidence for warn/fail checks', () => {
+    act(() => {
+      root.render(<SessionReviewerPanel review={makeReview()} activeFindingId={undefined} />)
+    })
+
+    expect(container.textContent).toContain(
+      'msg[2] tool_result shows exit code 127 — command not found'
+    )
+  })
+
+  it('renders locator ref for warn/fail checks that have a locator', () => {
+    act(() => {
+      root.render(<SessionReviewerPanel review={makeReview()} activeFindingId={undefined} />)
+    })
+
+    // locator blockRef should be visible (msg-2[1])
+    expect(container.textContent).toContain('msg-2')
+  })
+
+  it('does not show locator for pass checks without locator', () => {
+    const review = makeReview({
+      checks: [
+        makeCheck({
+          status: 'pass',
+          claim: 'Row count ok',
+          evidence: 'Verified 33 rows',
+          locator: undefined
+        })
+      ]
+    })
+
+    act(() => {
+      root.render(<SessionReviewerPanel review={review} activeFindingId={undefined} />)
+    })
+
+    // pass check should show evidence
+    expect(container.textContent).toContain('Verified 33 rows')
+    // but no locator ref since locator is undefined
+    // (The check still renders, just no "Ref:" line)
+  })
+
+  it('does NOT have a Summary section (v2: summary removed)', () => {
+    act(() => {
+      root.render(<SessionReviewerPanel review={makeReview()} activeFindingId={undefined} />)
+    })
+
+    // v2: no separate Summary section
+    expect(container.querySelector('[data-testid="reviewer-summary"]')).toBeNull()
+    // No "Summary" heading
+    const headings = Array.from(container.querySelectorAll('h3'))
+    const summaryHeading = headings.find((h) => h.textContent?.toLowerCase().includes('summary'))
+    expect(summaryHeading).toBeUndefined()
+  })
+
+  it('does NOT show the old "Full reasoning" toggle (v3: reasoning replaced by reviewer log)', () => {
+    act(() => {
+      root.render(<SessionReviewerPanel review={makeReview()} activeFindingId={undefined} />)
+    })
+
+    // v3: no Full reasoning toggle — replaced by Reviewer log section
+    expect(container.querySelector('[data-testid="reviewer-reasoning-toggle"]')).toBeNull()
+    expect(container.querySelector('[data-testid="reviewer-reasoning-body"]')).toBeNull()
+    expect(container.textContent).not.toContain('Full reasoning')
+  })
+
+  it('shows the Reviewer log section instead (collapsed by default)', () => {
+    act(() => {
+      root.render(<SessionReviewerPanel review={makeReview()} activeFindingId={undefined} />)
+    })
+
+    const logToggle = container.querySelector('[data-testid="reviewer-log-toggle"]')
+    expect(logToggle).not.toBeNull()
+    expect(container.querySelector('[data-testid="reviewer-log-body"]')).toBeNull()
+  })
+})
+
+describe('SessionReviewerPanel — pass outcome', () => {
+  it('renders checks and no summary even with no warn/fail checks', () => {
+    const passReview = makeReview({
+      outcome: 'pass',
+      checks: [
+        makeCheck({
+          status: 'pass',
+          claim: 'All verified.',
+          evidence: 'No issues found in this turn.',
+          locator: undefined
+        })
+      ]
+    })
+
+    act(() => {
+      root.render(<SessionReviewerPanel review={passReview} activeFindingId={undefined} />)
+    })
+
+    expect(container.textContent).toContain('No issues found in this turn.')
+    expect(container.querySelector('[data-testid="reviewer-checks"]')).not.toBeNull()
+    // No summary section
+    expect(container.querySelector('[data-testid="reviewer-summary"]')).toBeNull()
+  })
+})
+
+describe('SessionReviewerPanel — GoToTranscript positioning', () => {
+  it('highlights the active check when activeFindingId is set', () => {
+    const review = makeReview({
+      checks: [
+        makeCheck({ id: 'check-1', claim: 'First check' }),
+        makeCheck({ id: 'check-2', claim: 'Second check', sortIndex: 1 })
+      ]
+    })
+
+    act(() => {
+      root.render(<SessionReviewerPanel review={review} activeFindingId="check-2" />)
+    })
+
+    const activeTrace = container.querySelector('[data-finding-id="check-2"]')
+    expect(activeTrace).not.toBeNull()
+    expect(activeTrace?.getAttribute('data-active')).toBe('true')
+  })
+
+  it('does not mark any check active when activeFindingId is undefined', () => {
+    act(() => {
+      root.render(<SessionReviewerPanel review={makeReview()} activeFindingId={undefined} />)
+    })
+
+    const activeTraces = container.querySelectorAll('[data-active="true"]')
+    expect(activeTraces.length).toBe(0)
+  })
+})
+
+describe('SessionReviewerPanel — createSessionReviewerPreviewItem factory', () => {
+  it('creates a stable reviewer preview item with toolKind reviewer', async () => {
+    const { createSessionReviewerPreviewItem } = await import('@/stores/preview-workbench-store')
+
+    const item = createSessionReviewerPreviewItem({
+      sessionId: 'session-1',
+      reviewId: 'review-1',
+      findingId: 'check-2',
+      locator: {
+        blockRef: { messageId: 'msg-2', blockIndex: 1 },
+        contentHash: 'abc123'
+      }
+    })
+
+    expect(item.type).toBe('tool')
+    expect(item.toolKind).toBe('reviewer')
+    expect(item.sessionId).toBe('session-1')
+    expect(item.title).toBe('Session Reviewer')
+    // The same session always returns the same stable id (so the tab is reused).
+    const item2 = createSessionReviewerPreviewItem({
+      sessionId: 'session-1',
+      reviewId: 'review-1',
+      findingId: undefined,
+      locator: undefined
+    })
+    expect(item2.id).toBe(item.id)
+  })
+
+  it('carries the finding reviewId so the panel can select the right review', async () => {
+    const { createSessionReviewerPreviewItem } = await import('@/stores/preview-workbench-store')
+
+    const item = createSessionReviewerPreviewItem({
+      sessionId: 'session-1',
+      reviewId: 'review-42',
+      findingId: 'check-2',
+      locator: undefined
+    })
+
+    expect(item.reviewerReviewId).toBe('review-42')
+    expect(item.reviewerActiveFindingId).toBe('check-2')
+  })
+})
+
+describe('WorkspaceMessageScroller — onGoToTranscript wiring (source check)', () => {
+  it('passes onGoToTranscript to ReviewerCard in the scroller source', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { resolve } = await import('node:path')
+
+    const scrollerSource = readFileSync(resolve(__dirname, 'WorkspaceMessageScroller.tsx'), 'utf8')
+
+    expect(scrollerSource).toContain('onGoToTranscript')
+    expect(scrollerSource).toContain('createSessionReviewerPreviewItem')
+  })
+})

--- a/src/renderer/src/pages/workspace/SessionReviewerPanel.tsx
+++ b/src/renderer/src/pages/workspace/SessionReviewerPanel.tsx
@@ -1,0 +1,307 @@
+// SessionReviewerPanel: the dedicated Session reviewer page rendered inside the PreviewPanel.
+// Opened by clicking "Go to transcript" on any check in the ReviewerCard. Shows:
+//   - A unified Checks list (pass/warn/fail) with status badges, claim, evidence, locator+link
+//   - Expandable "Reviewer log" section (collapsed by default, visually de-emphasized)
+//
+// v2 (issue 12): replaced the old top/middle/bottom three-region layout with a single Checks list.
+// The Summary section is removed (Review no longer has a summary column).
+// v3 (issue 13): replaced the old "Full reasoning" prose block with a "Reviewer log" section that
+// renders the captured reviewer action stream (thinking / tool calls / results / messages), collapsed
+// by default and visually de-emphasized (muted colors, left-rule indent, no colored severity badges).
+//
+// The activeFindingId prop scrolls/highlights the check the user navigated from.
+
+import { useEffect, useRef, useState } from 'react'
+import { CheckCircle, AlertTriangle, XCircle, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+import type { ReviewWithChecks, ReviewCheck, ReviewerLogEntry } from '../../../../shared/reviewer'
+
+type SessionReviewerPanelProps = {
+  review: ReviewWithChecks
+  // Check id to highlight/scroll to (from GoToTranscriptIntent). Undefined = no active check.
+  activeFindingId: string | undefined
+}
+
+// Formats the blockRef into a human-readable reference like "msg-2[1]" or "act-3[0]".
+const formatBlockRef = (check: ReviewCheck): string | null => {
+  if (!check.locator) return null
+  const { blockRef } = check.locator
+  const ref = blockRef.messageId ?? blockRef.activityId ?? 'block'
+  return `${ref}[${blockRef.blockIndex}]`
+}
+
+// Icon component for a check status.
+const StatusIcon = ({ status }: { status: ReviewCheck['status'] }): React.JSX.Element => {
+  if (status === 'fail')
+    return <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-600" aria-hidden />
+  if (status === 'warn')
+    return <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-yellow-500" aria-hidden />
+  return <CheckCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-green-600" aria-hidden />
+}
+
+// One row in the unified checks list.
+const CheckRow = ({
+  check,
+  isActive
+}: {
+  check: ReviewCheck
+  isActive: boolean
+}): React.JSX.Element => {
+  const rowRef = useRef<HTMLDivElement | null>(null)
+
+  // Scroll this row into view when it becomes the active check.
+  useEffect(() => {
+    if (isActive && rowRef.current && typeof rowRef.current.scrollIntoView === 'function') {
+      rowRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }, [isActive])
+
+  const statusStyles: Record<string, string> = {
+    fail: 'text-red-700 bg-red-50 border border-red-200',
+    warn: 'text-yellow-700 bg-yellow-50 border border-yellow-200',
+    pass: 'text-green-700 bg-green-50 border border-green-200'
+  }
+
+  const locatorRef = formatBlockRef(check)
+  const isWarnOrFail = check.status === 'warn' || check.status === 'fail'
+
+  return (
+    <div
+      ref={rowRef}
+      className={cn(
+        'rounded-lg border p-3 transition-colors',
+        isActive ? 'border-primary/40 bg-primary/5' : 'border-border-200 bg-bg-000'
+      )}
+      data-finding-id={check.id}
+      data-active={isActive ? 'true' : 'false'}
+    >
+      {/* Status badge + claim */}
+      <div className="flex items-start gap-2">
+        <StatusIcon status={check.status} />
+        <span
+          className={cn(
+            'mt-0.5 shrink-0 rounded px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+            statusStyles[check.status] ?? ''
+          )}
+        >
+          {check.status}
+        </span>
+        <p className="flex-1 text-xs font-medium leading-snug text-text-000">{check.claim}</p>
+      </div>
+
+      {/* Evidence */}
+      <p className="mt-2 text-xs leading-relaxed text-text-300">{check.evidence}</p>
+
+      {/* Locator reference — only shown for warn/fail checks that have a locator */}
+      {isWarnOrFail && locatorRef && (
+        <div className="mt-2 text-[10px] text-text-400">
+          <span className="font-medium">Ref:</span> {locatorRef}{' '}
+          <span className="text-text-500/60">· hash {check.locator!.contentHash.slice(0, 8)}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Icon for a reviewer log text entry (thought / message). Tool entries render their own
+// chevron-based collapsible header, so they never go through this icon.
+const LogEntryIcon = ({ kind }: { kind: 'thought' | 'message' }): React.JSX.Element => (
+  <span className="text-text-400 select-none" aria-hidden>
+    {kind === 'thought' ? '✦' : '›'}
+  </span>
+)
+
+// One row in the reviewer log. Reuses the same visual vocabulary as the workspace activity rows
+// but de-emphasized: muted colors, no colored severity badges, smaller font.
+const ReviewerLogRow = ({ entry }: { entry: ReviewerLogEntry }): React.JSX.Element => {
+  const [expanded, setExpanded] = useState(false)
+  const rowClassName = 'flex items-start gap-1.5 py-0.5 text-[11px] leading-[1.45]'
+
+  if (entry.kind === 'thought') {
+    return (
+      <div className={rowClassName}>
+        <span className="mt-0.5 w-3.5 shrink-0 text-center">
+          <LogEntryIcon kind="thought" />
+        </span>
+        <span className="text-text-400 italic">{entry.text}</span>
+      </div>
+    )
+  }
+
+  if (entry.kind === 'message') {
+    return (
+      <div className={rowClassName}>
+        <span className="mt-0.5 w-3.5 shrink-0 text-center">
+          <LogEntryIcon kind="message" />
+        </span>
+        <span className="text-text-300">{entry.text}</span>
+      </div>
+    )
+  }
+
+  // tool entry: collapsible row with real tool name + one-line summary + status dot
+  const statusDot =
+    entry.status === 'ok' ? (
+      <span className="shrink-0 text-[10px] text-green-600">● ok</span>
+    ) : entry.status === 'error' ? (
+      <span className="shrink-0 text-[10px] text-red-500">● error</span>
+    ) : null
+
+  // One-line summary: prefer title, fall back to rawInput (first line only)
+  const summary = entry.title ?? (entry.rawInput ? entry.rawInput.split('\n')[0] : undefined)
+
+  const hasDetails = Boolean(entry.rawInput ?? entry.rawOutput)
+
+  return (
+    <div className="py-0.5">
+      <button
+        type="button"
+        className="flex w-full items-center gap-1.5 text-left text-[11px] leading-[1.45] text-text-400 hover:text-text-300 transition-colors"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        data-testid="tool-log-row-toggle"
+        disabled={!hasDetails}
+      >
+        <span className="w-3.5 shrink-0 text-center">
+          <ChevronRight
+            className={cn('h-3 w-3 transition-transform duration-150', expanded ? 'rotate-90' : '')}
+            aria-hidden
+          />
+        </span>
+        <span className="font-semibold text-text-300">{entry.toolName || 'tool'}</span>
+        {summary ? (
+          <code className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-text-400">
+            {summary}
+          </code>
+        ) : null}
+        {statusDot}
+      </button>
+
+      {expanded && hasDetails && (
+        <div className="ml-5 mt-1 space-y-1" data-testid="tool-log-row-details">
+          {entry.rawInput ? (
+            <div>
+              <div className="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-400">
+                Input
+              </div>
+              <pre className="overflow-auto rounded border border-border-200 bg-bg-100 p-1.5 text-[10px] leading-[1.5] text-text-300 whitespace-pre-wrap break-words max-h-36">
+                {entry.rawInput}
+              </pre>
+            </div>
+          ) : null}
+          {entry.rawOutput ? (
+            <div>
+              <div className="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-400">
+                Output
+              </div>
+              <pre className="overflow-auto rounded border border-border-200 bg-bg-100 p-1.5 text-[10px] leading-[1.5] text-text-300 whitespace-pre-wrap break-words max-h-36">
+                {entry.rawOutput}
+                {entry.exitCode !== undefined && entry.exitCode !== null ? (
+                  <span
+                    className={cn(
+                      'block',
+                      entry.exitCode === 0 ? 'text-green-600' : 'text-red-500'
+                    )}
+                  >
+                    {`exit ${entry.exitCode}`}
+                  </span>
+                ) : null}
+              </pre>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// The "Reviewer log" section: collapsed by default, visually de-emphasized with muted left-rule.
+// Reuses WorkspaceMessageItem/activity-style patterns adapted to ReviewerLogEntry (props-driven).
+const ReviewerLogSection = ({ log }: { log: ReviewerLogEntry[] }): React.JSX.Element | null => {
+  const [expanded, setExpanded] = useState(false)
+
+  // If the log is empty, show nothing (graceful empty state per acceptance criterion).
+  if (log.length === 0) return null
+
+  return (
+    <section>
+      <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-text-300">
+        Reviewer log
+      </h3>
+      <button
+        type="button"
+        className="flex items-center gap-1.5 text-[11px] font-medium text-text-400 hover:text-text-300 transition-colors"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        data-testid="reviewer-log-toggle"
+      >
+        <ChevronRight
+          className={cn('h-3 w-3 transition-transform duration-150', expanded ? 'rotate-90' : '')}
+          aria-hidden
+        />
+        {expanded ? 'Collapse Reviewer log' : 'Expand Reviewer log'}
+      </button>
+
+      {expanded && (
+        // De-emphasized container: indented, left-rule, reduced opacity per prototype.
+        <div
+          className="mt-2 border-l-2 border-border-200 pl-2.5 opacity-75 space-y-0.5"
+          data-testid="reviewer-log-body"
+        >
+          {log.map((entry, i) => (
+            <ReviewerLogRow key={i} entry={entry} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+// The Session reviewer panel, rendered inside the right PreviewPanel when toolKind === 'reviewer'.
+const SessionReviewerPanel = ({
+  review,
+  activeFindingId
+}: SessionReviewerPanelProps): React.JSX.Element => {
+  // Sort checks by sortIndex for stable display order.
+  const sortedChecks = [...review.checks].sort((a, b) => a.sortIndex - b.sortIndex)
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header */}
+      <div className="shrink-0 border-b border-border-200 px-4 py-3">
+        <h2 className="text-[13px] font-semibold text-text-000">Session Reviewer</h2>
+        <p className="mt-0.5 text-[11px] text-text-300">
+          {review.model} &middot; {new Date(review.createdAt).toLocaleString()}
+        </p>
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-5">
+        {/* Unified Checks list */}
+        <section data-testid="reviewer-checks">
+          <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-text-300">
+            Checks
+            {sortedChecks.length > 0 && (
+              <span className="font-normal text-text-400"> &middot; {sortedChecks.length}</span>
+            )}
+          </h3>
+          {sortedChecks.length === 0 ? (
+            <p className="text-xs text-text-400">No checks recorded.</p>
+          ) : (
+            <div className="space-y-2">
+              {sortedChecks.map((check) => (
+                <CheckRow key={check.id} check={check} isActive={check.id === activeFindingId} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Reviewer log section — replaces the old "Full reasoning" prose block */}
+        <ReviewerLogSection log={review.reviewerLog ?? []} />
+      </div>
+    </div>
+  )
+}
+
+export { SessionReviewerPanel }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -61,7 +61,31 @@ vi.mock('./WorkspaceToolDiffBlock', () => ({
 vi.mock('@/stores/preview-workbench-store', () => ({
   usePreviewWorkbenchStore: {
     getState: () => ({ upsertAndActivateItem: vi.fn() })
-  }
+  },
+  createSessionReviewerPreviewItem: vi.fn(() => ({
+    id: 'tool:session-1:reviewer',
+    sessionId: 'session-1',
+    type: 'tool',
+    toolKind: 'reviewer',
+    title: 'Session Reviewer'
+  }))
+}))
+
+vi.mock('@/stores/review-store', () => ({
+  useReviewStore: (
+    selector: (state: {
+      getReviewForTurn: () => undefined
+      loadReviewsForSession: () => Promise<void>
+    }) => unknown
+  ) =>
+    selector({
+      getReviewForTurn: () => undefined,
+      loadReviewsForSession: () => Promise.resolve()
+    })
+}))
+
+vi.mock('@/components/ReviewerCard', () => ({
+  ReviewerCard: () => null
 }))
 
 const createMessage = (overrides: Partial<ChatMessage>): ChatMessage => ({

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -5,7 +5,11 @@ import {
   MessageScrollerProvider,
   MessageScrollerViewport
 } from '@/components/ui/message-scroller'
-import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
+import {
+  usePreviewWorkbenchStore,
+  createSessionReviewerPreviewItem
+} from '@/stores/preview-workbench-store'
+import { useReviewStore } from '@/stores/review-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import type { ChatSession } from '@/stores/session-store'
 import { useEffect, useRef, useState } from 'react'
@@ -16,6 +20,7 @@ import {
   createPreviewFileItemFromMention,
   createPreviewFileItemFromUpload
 } from './preview-file-item'
+import { ReviewerCard } from '@/components/ReviewerCard'
 import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
 import { WorkspaceAgentLoadingRow } from './WorkspaceAgentLoadingRow'
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
@@ -23,6 +28,7 @@ import type { ArtifactMentionPart } from './WorkspaceMessageItem'
 import { createConversationItems } from './workspace-conversation-items'
 import { groupConversationItems } from './workspace-tool-activity-groups'
 import type { ActivityExpansionOverrides } from './workspace-tool-activity-groups'
+import type { GoToTranscriptIntent } from '../../../../shared/reviewer'
 
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
@@ -74,11 +80,33 @@ const previewUploadAttachment = (attachment: MessageUploadAttachment, sessionId:
     .upsertAndActivateItem(createPreviewFileItemFromUpload(attachment, sessionId))
 }
 
+// Opens the Session reviewer panel in the preview workbench, positioned at the finding's locator.
+const openSessionReviewer = (sessionId: string, intent: GoToTranscriptIntent): void => {
+  usePreviewWorkbenchStore.getState().upsertAndActivateItem(
+    createSessionReviewerPreviewItem({
+      sessionId,
+      reviewId: intent.reviewId,
+      findingId: intent.findingId,
+      locator: intent.locator
+    })
+  )
+}
+
 // Owns transcript scrolling and session-scoped expansion state for activity groups.
 const WorkspaceMessageScroller = ({
   activeSession
 }: WorkspaceMessageScrollerProps): React.JSX.Element => {
   const currentSessionId = activeSession?.id
+  const getReviewForTurn = useReviewStore((state) => state.getReviewForTurn)
+  const loadReviewsForSession = useReviewStore((state) => state.loadReviewsForSession)
+
+  // Load persisted reviews whenever the active session changes.
+  useEffect(() => {
+    if (currentSessionId) {
+      void loadReviewsForSession(currentSessionId)
+    }
+  }, [currentSessionId, loadReviewsForSession])
+
   // Group expansion is keyed by session so switching conversations never reuses stale UI state.
   const [collapsedActivityGroupState, setCollapsedActivityGroupState] =
     useState<SessionScopedActivityGroupState>(() => ({
@@ -206,6 +234,13 @@ const WorkspaceMessageScroller = ({
     })
   }
 
+  // Opens the Session reviewer panel positioned at the finding the user clicked.
+  // Only the "Go to transcript" button on a finding fires this; clicking the card itself does not.
+  const handleGoToTranscript = (intent: GoToTranscriptIntent): void => {
+    if (!currentSessionId) return
+    openSessionReviewer(currentSessionId, intent)
+  }
+
   return (
     <MessageScrollerProvider
       key={activeSession?.id ?? 'empty-conversation'}
@@ -228,17 +263,31 @@ const WorkspaceMessageScroller = ({
                     activeSession && item.message.role !== 'user'
                       ? getMessageArtifacts(activeSession, item.message)
                       : []
+                  // Look up any review for this agent message (its id is the turnMessageId).
+                  const review =
+                    currentSessionId && item.message.role === 'agent'
+                      ? getReviewForTurn(currentSessionId, item.message.id)
+                      : undefined
 
                   return (
-                    <WorkspaceMessageItem
-                      key={item.id}
-                      message={item.message}
-                      onPreviewArtifact={onPreviewArtifact}
-                      onPreviewUploadAttachment={onPreviewUploadAttachment}
-                      onOpenSkillMention={onOpenSkillMention}
-                      onPreviewMentionArtifact={onPreviewMentionArtifact}
-                      artifacts={artifacts}
-                    />
+                    <div key={item.id}>
+                      <WorkspaceMessageItem
+                        message={item.message}
+                        onPreviewArtifact={onPreviewArtifact}
+                        onPreviewUploadAttachment={onPreviewUploadAttachment}
+                        onOpenSkillMention={onOpenSkillMention}
+                        onPreviewMentionArtifact={onPreviewMentionArtifact}
+                        artifacts={artifacts}
+                      />
+                      {review ? (
+                        <div className="px-4 pb-1 md:px-6">
+                          <div className="mx-auto w-full max-w-[56rem]">
+                            {/* Only "Go to transcript" navigates to the reviewer page; the card itself does not. */}
+                            <ReviewerCard review={review} onGoToTranscript={handleGoToTranscript} />
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
                   )
                 }
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -170,6 +170,13 @@ describe('WorkspacePage draft preservation', () => {
       uploads: {
         deleteUpload,
         stageFiles
+      },
+      reviewer: {
+        onUpdated: vi.fn(() => vi.fn()),
+        onSuppressNextAutoReview: vi.fn(() => vi.fn()),
+        onFixLoopStart: vi.fn(() => vi.fn()),
+        onFixLoopEnd: vi.fn(() => vi.fn()),
+        abortFixLoop: vi.fn(() => Promise.resolve())
       }
     } as never
     container = document.createElement('div')

--- a/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
@@ -97,6 +97,13 @@ describe('WorkspacePage notebook entry hydration', () => {
       preview: {
         load: vi.fn(() => Promise.resolve(undefined)),
         save: vi.fn(() => Promise.resolve())
+      },
+      reviewer: {
+        onUpdated: vi.fn(() => vi.fn()),
+        onSuppressNextAutoReview: vi.fn(() => vi.fn()),
+        onFixLoopStart: vi.fn(() => vi.fn()),
+        onFixLoopEnd: vi.fn(() => vi.fn()),
+        abortFixLoop: vi.fn(() => Promise.resolve())
       }
     } as never
     container = document.createElement('div')

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -153,6 +153,13 @@ describe('WorkspacePage preview panel resize sync', () => {
       notebook: {
         onAvailable: vi.fn(() => vi.fn()),
         getReference: vi.fn(() => Promise.resolve(null))
+      },
+      reviewer: {
+        onUpdated: vi.fn(() => vi.fn()),
+        onSuppressNextAutoReview: vi.fn(() => vi.fn()),
+        onFixLoopStart: vi.fn(() => vi.fn()),
+        onFixLoopEnd: vi.fn(() => vi.fn()),
+        abortFixLoop: vi.fn(() => Promise.resolve())
       }
     } as never
     container = document.createElement('div')

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -21,6 +21,12 @@ import {
 } from '@/stores/preview-workbench-store'
 import type { ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
+import { useReviewStore } from '@/stores/review-store'
+import {
+  assembleReviewRunRequest,
+  suppressNextAutoReview,
+  clearSuppressNextAutoReview
+} from '@/lib/acp/workspace-events'
 import type { StageUploadFile, UploadedAttachment } from '../../../../shared/uploads'
 
 import { planComposerAttachmentIntake } from './composer-attachment-intake'
@@ -117,6 +123,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const selectSession = useSessionStore((state) => state.selectSession)
   const clearSelection = useSessionStore((state) => state.clearSelection)
   const renameSession = useSessionStore((state) => state.renameSession)
+  const setAutoReviewEnabled = useSessionStore((state) => state.setAutoReviewEnabled)
+  const setFixLoopActive = useSessionStore((state) => state.setFixLoopActive)
   // Only sessions belonging to the active project are shown in this workspace.
   const sessions = useMemo(
     () => allSessions.filter((session) => session.projectId === scopedProjectId),
@@ -152,6 +160,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const [draftDoc, setDraftDoc] = useState<ComposerDoc>(emptyDoc)
   const [newConversationPermissionProfile, setNewConversationPermissionProfile] =
     useState<PermissionProfileId>(DEFAULT_PERMISSION_PROFILE)
+  // Draft auto-review state for a not-yet-created conversation. Auto-review defaults on, so a new
+  // conversation starts enabled; the user can toggle it off before sending. On send it is stamped
+  // onto the created session (see sendCurrentMessage).
+  const [newConversationAutoReviewEnabled, setNewConversationAutoReviewEnabled] = useState(true)
   // Unsent composer state (rich doc + staged attachments) is kept per session (and per new conversation)
   // so switching away and back restores it. The active key's state is live; this map holds inactive keys.
   const composerDraftsRef = useRef<
@@ -187,15 +199,49 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     : undefined
   // Always-allow grants only exist for a bound session; new conversations have none yet.
   const activePermissionGrants = activeSession ? (permissionGrants?.[activeSession.id] ?? []) : []
+  // Auto-review defaults on: an existing session is enabled unless explicitly turned off; a new
+  // conversation uses the draft toggle (which also starts on).
+  const activeAutoReviewEnabled = activeSession
+    ? activeSession.autoReviewEnabled !== false
+    : newConversationAutoReviewEnabled
+  // True while any review for the active session is in the 'running' lifecycle.
+  // Using a shallow comparison via reviewsBySession to avoid new array reference on every render.
+  const activeSessionId = activeSession?.id
+  const isReviewing = useReviewStore((state) => {
+    if (!activeSessionId) return false
+    const reviews = state.reviewsBySession[activeSessionId]
+    return reviews ? reviews.some((review) => review.lifecycle === 'running') : false
+  })
+  // "Request review" is disabled when:
+  //   - there is no active session or no completed agent turn yet, OR
+  //   - the last turn already has a review (any lifecycle — no duplicate reviews), OR
+  //   - any review for this session is currently running (no concurrency).
+  const isRequestReviewDisabled = useReviewStore((state) => {
+    if (!activeSessionId) return true
+    if (!activeSession) return true
+    const lastAgentMessage = [...activeSession.messages].reverse().find((m) => m.role === 'agent')
+    if (!lastAgentMessage) return true
+    if (isReviewing) return true
+    const reviews = state.reviewsBySession[activeSessionId]
+    if (reviews) {
+      const hasReviewForLastTurn = reviews.some((r) => r.turnMessageId === lastAgentMessage.id)
+      if (hasReviewForLastTurn) return true
+    }
+    return false
+  })
+  const handleReviewUpdate = useReviewStore((state) => state.handleReviewUpdate)
   // Composer controls follow only the selected session and persistence readiness.
   const canEditDraft = isSessionPersistenceReady
-  // Sending is disabled while the current session is running or awaiting a decision.
+  // Sending is disabled while the current session is running, awaiting a decision, or locked by the
+  // fix loop (fixLoopActive). The fix loop lock persists across both the reviewer-審 sub-phase and
+  // the main agent-改 sub-phase; typing does not override the lock.
   const canSendMessage =
     isSessionPersistenceReady &&
     !isUploadingAttachments &&
     (!docIsEmpty(draftDoc) || attachments.length > 0) &&
     activeSession?.status !== 'running' &&
-    activeSession?.status !== 'waiting-permission'
+    activeSession?.status !== 'waiting-permission' &&
+    !activeSession?.fixLoopActive
   const canChangePermissionProfile =
     isSessionPersistenceReady &&
     activeSession?.status !== 'running' &&
@@ -329,10 +375,54 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     }
   }, [upsertPreviewItem])
 
+  // Subscribe to reviewer lifecycle updates so the card and Reviewing indicator stay live.
+  useEffect(() => {
+    const removeUpdatedListener = window.api.reviewer.onUpdated(handleReviewUpdate)
+
+    return () => {
+      removeUpdatedListener()
+    }
+  }, [handleReviewUpdate])
+
+  // Subscribe to the loop-guard channel: suppress the next auto-review when the [Auditor]
+  // correction prompt is about to fire, so the correction turn's stop does not re-trigger a review.
+  // A clear=true event cancels that suppression if the correction turn failed to send.
+  useEffect(() => {
+    const removeSuppressListener = window.api.reviewer.onSuppressNextAutoReview(
+      ({ sessionId, clear }) => {
+        if (clear) {
+          clearSuppressNextAutoReview(sessionId)
+        } else {
+          suppressNextAutoReview(sessionId)
+        }
+      }
+    )
+
+    return () => {
+      removeSuppressListener()
+    }
+  }, [])
+
+  // Subscribe to fix loop lifecycle events from the main process. When a fix loop starts for a
+  // session, set fixLoopActive=true to disable the send button. When it ends or is aborted, clear
+  // the flag. The lock is per-session: other sessions remain interactive.
+  useEffect(() => {
+    const removeStartListener = window.api.reviewer.onFixLoopStart(({ sessionId }) => {
+      setFixLoopActive(sessionId, true)
+    })
+    const removeEndListener = window.api.reviewer.onFixLoopEnd(({ sessionId }) => {
+      setFixLoopActive(sessionId, false)
+    })
+
+    return () => {
+      removeStartListener()
+      removeEndListener()
+    }
+  }, [setFixLoopActive])
+
   // The availability event only fires while the agent is live, so a session opened after relaunch
   // would lose its notebook entry until the next call. Probe persisted run.json on selection to
   // restore the composer entry immediately for any session that has used the notebook before.
-  const activeSessionId = activeSession?.id
   const activeSessionCwd = activeSession?.cwd
   // Notebooks are stored per project id (notebooks/<projectId>/<sessionId>), so the probe must pass
   // the session's project or it would look under the default project name and never find run.json.
@@ -407,6 +497,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     // The draft effect saves the outgoing doc/attachments and restores the new-conversation state.
     setAttachmentError(null)
     setNewConversationPermissionProfile(DEFAULT_PERMISSION_PROFILE)
+    setNewConversationAutoReviewEnabled(true)
     clearSelection()
   }
 
@@ -468,6 +559,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
 
     const doc = draftDoc
     const attachmentsForSend = attachments
+    // Capture new-conversation intent before send: auto-review defaults on, so only an explicit
+    // "off" needs to be stamped onto the created session (absent = on downstream).
+    const wasNewConversation = !activeSession
+    const draftAutoReviewEnabled = newConversationAutoReviewEnabled
 
     // Optimistically clear composer state; failed sends restore both doc and attachments below. Staged
     // files are consumed (moved into the session dir) by the runtime, so they are not deleted here.
@@ -496,7 +591,15 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
       if (!result) {
         setDraftDoc(doc)
         setAttachments(attachmentsForSend)
+        return
       }
+
+      // Carry the composer's auto-review choice onto the freshly created session. bindPendingSession
+      // preserves the field, so stamping the (pending) session id here survives the durable-id swap.
+      if (wasNewConversation && !draftAutoReviewEnabled) {
+        setAutoReviewEnabled(result.sessionId, false)
+      }
+      setNewConversationAutoReviewEnabled(true)
     })
   }
 
@@ -547,9 +650,22 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     setSessionToDelete(undefined)
   }
 
-  // Cancels the run for the currently visible session when one is selected.
+  // Cancels the run for the currently visible session when one is selected. During an active fix
+  // loop, also sends an abort signal to the main process to stop the loop and unlock the composer.
   const cancelActiveRun = (): void => {
-    if (activeSession) void cancelRun(activeSession.id)
+    if (!activeSession) return
+
+    const sessionId = activeSession.id
+
+    // If a fix loop is running, abort it. The abort handler in the main process will stop the loop;
+    // the renderer reacts to the FIX_LOOP_END event broadcast and clears fixLoopActive.
+    if (activeSession.fixLoopActive) {
+      void window.api.reviewer.abortFixLoop(sessionId).catch((error) => {
+        console.warn('Failed to abort fix loop:', error)
+      })
+    }
+
+    void cancelRun(sessionId)
   }
 
   // Re-attaches the visible interrupted session so the user can keep chatting; awaited by the banner.
@@ -573,6 +689,29 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     }
 
     void setPermissionProfile(activeSession.id, profile)
+  }
+
+  // Persists the auto-review toggle for the active session; for a not-yet-created conversation it
+  // updates the draft state, which sendCurrentMessage stamps onto the new session.
+  const changeAutoReviewEnabled = (enabled: boolean): void => {
+    if (!activeSession) {
+      setNewConversationAutoReviewEnabled(enabled)
+      return
+    }
+
+    setAutoReviewEnabled(activeSession.id, enabled)
+  }
+
+  // Manually triggers a review of the last completed turn, bypassing autoReviewEnabled and the
+  // suppressAutoReviewOnceFor loop guard. Disabled logic is enforced by isRequestReviewDisabled.
+  const requestManualReview = (): void => {
+    if (!activeSession) return
+
+    const request = assembleReviewRunRequest(activeSession.id)
+
+    if (!request) return
+
+    void window.api.reviewer.run(request)
   }
 
   // Revokes one always-allow grant for the visible session; new conversations have no grants.
@@ -648,6 +787,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             permissionProfileState={activePermissionProfileState}
             permissionGrants={activePermissionGrants}
             canChangePermissionProfile={canChangePermissionProfile}
+            autoReviewEnabled={activeAutoReviewEnabled}
             onDraftDocChange={setDraftDoc}
             onSendMessage={sendCurrentMessage}
             onStageAttachmentFiles={stageAttachmentFiles}
@@ -660,6 +800,9 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             onPermissionProfileChange={changePermissionProfile}
             onRevokePermissionGrant={revokeActivePermissionGrant}
             onClearPermissionGrants={clearActivePermissionGrants}
+            onAutoReviewToggle={changeAutoReviewEnabled}
+            onRequestReview={requestManualReview}
+            isRequestReviewDisabled={isRequestReviewDisabled}
           />
 
           <ResizableHandle

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -233,8 +233,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   // Composer controls follow only the selected session and persistence readiness.
   const canEditDraft = isSessionPersistenceReady
   // Sending is disabled while the current session is running, awaiting a decision, or locked by the
-  // fix loop (fixLoopActive). The fix loop lock persists across both the reviewer-審 sub-phase and
-  // the main agent-改 sub-phase; typing does not override the lock.
+  // fix loop (fixLoopActive). The fix loop lock persists across both the reviewer-review sub-phase and
+  // the main agent-fix sub-phase; typing does not override the lock.
   const canSendMessage =
     isSessionPersistenceReady &&
     !isUploadingAttachments &&

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
@@ -1,11 +1,33 @@
+import { useReviewStore } from '@/stores/review-store'
 import type { PreviewToolItem } from '@/stores/preview-workbench-store'
 
 import { NotebookPreview } from '../NotebookPreview'
 import type { NotebookPreviewItem } from '../NotebookPreview'
 import { ProjectFilesView } from '../ProjectFilesView'
+import { SessionReviewerPanel } from '../SessionReviewerPanel'
 
 const isNotebookPreviewItem = (item: PreviewToolItem): item is NotebookPreviewItem =>
   item.toolKind === 'notebook' && Boolean(item.notebook)
+
+// Renders the Session reviewer panel from persisted review data for the tool item's session.
+const SessionReviewerContent = ({ item }: { item: PreviewToolItem }): React.JSX.Element | null => {
+  const sessionId = item.reviewerSessionId ?? ''
+  const getReviewsForSession = useReviewStore((state) => state.getReviewsForSession)
+  // Select the review the finding actually points at; fall back to the newest when the item carries
+  // no reviewId (e.g. a session-level entry point) or that review is gone.
+  const reviews = getReviewsForSession(sessionId)
+  const review = reviews.find((r) => r.id === item.reviewerReviewId) ?? reviews[0]
+
+  if (!review) {
+    return (
+      <div className="flex size-full items-center justify-center text-[12px] text-text-300">
+        No review available for this session.
+      </div>
+    )
+  }
+
+  return <SessionReviewerPanel review={review} activeFindingId={item.reviewerActiveFindingId} />
+}
 
 export const PreviewToolContent = ({
   item
@@ -13,6 +35,8 @@ export const PreviewToolContent = ({
   item: PreviewToolItem
 }): React.JSX.Element | null => {
   if (item.toolKind === 'files') return <ProjectFilesView />
+
+  if (item.toolKind === 'reviewer') return <SessionReviewerContent item={item} />
 
   if (!isNotebookPreviewItem(item)) return null
 

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 
 import type { NotebookSessionReference } from '../../../shared/notebook'
+import type { FindingLocator } from '../../../shared/reviewer'
 import type { UploadedAttachment } from '../../../shared/uploads'
 
 export type PreviewPanelState = 'open' | 'collapsed'
@@ -40,8 +41,13 @@ export type PreviewFileItem = PreviewItemBase & {
 // Tool previews share the workbench chrome with files, but keep their own render path.
 export type PreviewToolItem = PreviewItemBase & {
   type: 'tool'
-  toolKind?: 'notebook' | 'files'
+  toolKind?: 'notebook' | 'files' | 'reviewer'
   notebook?: NotebookSessionReference
+  // Reviewer-specific: which session's reviews to show, which review to select, and the active
+  // finding to scroll to.
+  reviewerSessionId?: string
+  reviewerReviewId?: string
+  reviewerActiveFindingId?: string
 }
 
 export type PreviewItem = PreviewFileItem | PreviewToolItem
@@ -150,6 +156,27 @@ const createProjectFilesPreviewItem = (): PreviewToolItem => ({
   type: 'tool',
   toolKind: 'files',
   title: 'Files'
+})
+
+// Input for opening the Session reviewer panel; findingId/locator determine scroll position.
+export type SessionReviewerPreviewInput = {
+  sessionId: string
+  reviewId: string
+  findingId: string | undefined
+  locator: FindingLocator | undefined
+}
+
+// Builds a stable preview tab for the Session reviewer panel scoped to one session. The id is
+// session-scoped so "Go to transcript" from any card in the same session reuses the same tab.
+const createSessionReviewerPreviewItem = (input: SessionReviewerPreviewInput): PreviewToolItem => ({
+  id: `tool:${input.sessionId}:reviewer`,
+  sessionId: input.sessionId,
+  type: 'tool',
+  toolKind: 'reviewer',
+  title: 'Session Reviewer',
+  reviewerSessionId: input.sessionId,
+  reviewerReviewId: input.reviewId,
+  reviewerActiveFindingId: input.findingId
 })
 
 // Chooses a stable fallback tab when the active preview item is removed.
@@ -349,4 +376,8 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
   }
 }))
 
-export { createNotebookPreviewItem, createProjectFilesPreviewItem }
+export {
+  createNotebookPreviewItem,
+  createProjectFilesPreviewItem,
+  createSessionReviewerPreviewItem
+}

--- a/src/renderer/src/stores/review-store.test.ts
+++ b/src/renderer/src/stores/review-store.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ReviewCheck, ReviewWithChecks, TurnScope } from '../../../shared/reviewer'
+import { createInitialReviewState, useReviewStore } from './review-store'
+
+const emptyScope = (turnMessageId: string): TurnScope => ({
+  turnMessageId,
+  blocks: [],
+  artifactVersionIds: []
+})
+
+// Builds a minimal-but-valid ReviewWithChecks; overrides win so tests can vary id/session/time.
+const makeReview = (overrides: Partial<ReviewWithChecks> = {}): ReviewWithChecks => {
+  const turnMessageId = overrides.turnMessageId ?? 'turn-1'
+  return {
+    id: 'review-1',
+    projectId: 'project-1',
+    sessionId: 'session-1',
+    turnMessageId,
+    scope: emptyScope(turnMessageId),
+    lifecycle: 'complete',
+    outcome: 'pass',
+    model: 'test-model',
+    reviewerLog: [],
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    checks: [],
+    ...overrides
+  }
+}
+
+const makeCheck = (overrides: Partial<ReviewCheck> = {}): ReviewCheck => ({
+  id: 'check-1',
+  reviewId: 'review-1',
+  status: 'fail',
+  claim: 'the table has 33 rows',
+  evidence: 'the artifact shows 12 rows',
+  resolution: 'open',
+  sortIndex: 0,
+  reflagCount: 0,
+  ...overrides
+})
+
+describe('review store', () => {
+  // Reset the store so each assertion starts from an empty reviewsBySession map.
+  beforeEach(() => {
+    useReviewStore.setState(createInitialReviewState())
+  })
+
+  it('starts empty and returns [] for an unknown session', () => {
+    expect(useReviewStore.getState().reviewsBySession).toEqual({})
+    expect(useReviewStore.getState().getReviewsForSession('missing')).toEqual([])
+  })
+
+  it('stores a pushed review under its session id', () => {
+    const review = makeReview({ checks: [makeCheck()] })
+    useReviewStore.getState().handleReviewUpdate({ review })
+
+    const stored = useReviewStore.getState().getReviewsForSession('session-1')
+    expect(stored).toHaveLength(1)
+    expect(stored[0]).toBe(review)
+  })
+
+  it('replaces a review with the same id instead of appending a duplicate', () => {
+    const running = makeReview({ id: 'review-1', lifecycle: 'running', outcome: null })
+    useReviewStore.getState().handleReviewUpdate({ review: running })
+
+    const complete = makeReview({ id: 'review-1', lifecycle: 'complete', outcome: 'flagged' })
+    useReviewStore.getState().handleReviewUpdate({ review: complete })
+
+    const stored = useReviewStore.getState().getReviewsForSession('session-1')
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.lifecycle).toBe('complete')
+    expect(stored[0]?.outcome).toBe('flagged')
+  })
+
+  it('keeps a session list ordered newest-first by createdAt', () => {
+    const older = makeReview({ id: 'review-old', turnMessageId: 'turn-old', createdAt: 1_000 })
+    const newer = makeReview({ id: 'review-new', turnMessageId: 'turn-new', createdAt: 2_000 })
+
+    // Push the older one last to prove ordering is by createdAt, not insertion order.
+    useReviewStore.getState().handleReviewUpdate({ review: newer })
+    useReviewStore.getState().handleReviewUpdate({ review: older })
+
+    const stored = useReviewStore.getState().getReviewsForSession('session-1')
+    expect(stored.map((r) => r.id)).toEqual(['review-new', 'review-old'])
+  })
+
+  it('keeps reviews from different sessions isolated', () => {
+    useReviewStore
+      .getState()
+      .handleReviewUpdate({ review: makeReview({ id: 'a', sessionId: 's1' }) })
+    useReviewStore
+      .getState()
+      .handleReviewUpdate({ review: makeReview({ id: 'b', sessionId: 's2' }) })
+
+    expect(
+      useReviewStore
+        .getState()
+        .getReviewsForSession('s1')
+        .map((r) => r.id)
+    ).toEqual(['a'])
+    expect(
+      useReviewStore
+        .getState()
+        .getReviewsForSession('s2')
+        .map((r) => r.id)
+    ).toEqual(['b'])
+  })
+
+  it('finds the review for a specific turn', () => {
+    useReviewStore
+      .getState()
+      .handleReviewUpdate({ review: makeReview({ id: 'a', turnMessageId: 'turn-a' }) })
+    useReviewStore
+      .getState()
+      .handleReviewUpdate({ review: makeReview({ id: 'b', turnMessageId: 'turn-b' }) })
+
+    expect(useReviewStore.getState().getReviewForTurn('session-1', 'turn-b')?.id).toBe('b')
+    expect(useReviewStore.getState().getReviewForTurn('session-1', 'turn-missing')).toBeUndefined()
+  })
+
+  it('loads persisted reviews for a session from the IPC bridge', async () => {
+    const persisted = [makeReview({ id: 'persisted-1' })]
+    const getForSession = vi.fn().mockResolvedValue(persisted)
+    vi.stubGlobal('window', { api: { reviewer: { getForSession } } })
+
+    await useReviewStore.getState().loadReviewsForSession('session-1')
+
+    expect(getForSession).toHaveBeenCalledWith('session-1')
+    expect(
+      useReviewStore
+        .getState()
+        .getReviewsForSession('session-1')
+        .map((r) => r.id)
+    ).toEqual(['persisted-1'])
+    vi.unstubAllGlobals()
+  })
+
+  it('swallows load errors and leaves the session without reviews', async () => {
+    const getForSession = vi.fn().mockRejectedValue(new Error('db down'))
+    vi.stubGlobal('window', { api: { reviewer: { getForSession } } })
+
+    await expect(
+      useReviewStore.getState().loadReviewsForSession('session-1')
+    ).resolves.toBeUndefined()
+    expect(useReviewStore.getState().getReviewsForSession('session-1')).toEqual([])
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/renderer/src/stores/review-store.ts
+++ b/src/renderer/src/stores/review-store.ts
@@ -1,0 +1,65 @@
+// Renderer-side store for reviewer state. Backed by SQLite (via IPC) and updated by push events
+// from the main process as review lifecycle/checks change.
+
+import { create } from 'zustand'
+
+import type { ReviewWithChecks, ReviewUpdateEvent } from '../../../shared/reviewer'
+
+type ReviewStoreData = {
+  // Map from sessionId to that session's reviews (newest first).
+  reviewsBySession: Record<string, ReviewWithChecks[]>
+}
+
+type ReviewStore = ReviewStoreData & {
+  // Load existing reviews for a session from the DB at startup.
+  loadReviewsForSession: (sessionId: string) => Promise<void>
+  // Handle a push event from the main process (lifecycle/checks updated).
+  handleReviewUpdate: (event: ReviewUpdateEvent) => void
+  // Returns the reviews for a session, newest-first.
+  getReviewsForSession: (sessionId: string) => ReviewWithChecks[]
+  // Returns the most recent review for a given turn (by turnMessageId), if any.
+  getReviewForTurn: (sessionId: string, turnMessageId: string) => ReviewWithChecks | undefined
+}
+
+// Inserts or replaces a review in the list by id, keeping the list in createdAt desc order.
+const upsertReview = (
+  reviews: ReviewWithChecks[],
+  updated: ReviewWithChecks
+): ReviewWithChecks[] => {
+  const without = reviews.filter((r) => r.id !== updated.id)
+  return [updated, ...without].sort((a, b) => b.createdAt - a.createdAt)
+}
+
+export const createInitialReviewState = (): ReviewStoreData => ({
+  reviewsBySession: {}
+})
+
+export const useReviewStore = create<ReviewStore>((set, get) => ({
+  ...createInitialReviewState(),
+
+  loadReviewsForSession: async (sessionId: string) => {
+    try {
+      const reviews = (await window.api.reviewer.getForSession(sessionId)) as ReviewWithChecks[]
+      set((state) => ({
+        reviewsBySession: { ...state.reviewsBySession, [sessionId]: reviews }
+      }))
+    } catch {
+      // Silently ignore load errors — the card will just not appear until next push event.
+    }
+  },
+
+  handleReviewUpdate: (event: ReviewUpdateEvent) => {
+    const { review } = event
+    set((state) => ({
+      reviewsBySession: {
+        ...state.reviewsBySession,
+        [review.sessionId]: upsertReview(state.reviewsBySession[review.sessionId] ?? [], review)
+      }
+    }))
+  },
+
+  getReviewsForSession: (sessionId: string) => get().reviewsBySession[sessionId] ?? [],
+
+  getReviewForTurn: (sessionId: string, turnMessageId: string) =>
+    (get().reviewsBySession[sessionId] ?? []).find((r) => r.turnMessageId === turnMessageId)
+}))

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1172,6 +1172,86 @@ describe('session store', () => {
     expect(persisted).not.toHaveProperty('isPending')
   })
 
+  describe('fix loop active flag', () => {
+    it('setFixLoopActive sets the flag per session', () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-a',
+        content: 'Start'
+      })
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-b',
+        content: 'Other session'
+      })
+
+      useSessionStore.getState().setFixLoopActive('session-a', true)
+
+      const sessions = useSessionStore.getState().sessions
+      const sessionA = sessions.find((s) => s.id === 'session-a')
+      const sessionB = sessions.find((s) => s.id === 'session-b')
+
+      expect(sessionA?.fixLoopActive).toBe(true)
+      expect(sessionB?.fixLoopActive).toBeUndefined()
+    })
+
+    it('setFixLoopActive clears the flag when set to false', () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-a',
+        content: 'Start'
+      })
+      useSessionStore.getState().setFixLoopActive('session-a', true)
+      useSessionStore.getState().setFixLoopActive('session-a', false)
+
+      const session = useSessionStore.getState().sessions.find((s) => s.id === 'session-a')
+      expect(session?.fixLoopActive).toBe(false)
+    })
+
+    it('canSendMessage is blocked while fixLoopActive is true', () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-a',
+        content: 'Start'
+      })
+      useSessionStore.getState().finishRun('session-a')
+      useSessionStore.getState().setFixLoopActive('session-a', true)
+
+      const session = useSessionStore.getState().sessions.find((s) => s.id === 'session-a')
+      // fixLoopActive blocks send; canSendMessage is computed externally but depends on this flag
+      expect(session?.fixLoopActive).toBe(true)
+    })
+
+    it('fixLoopActive is cleared after the loop ends (false)', () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-a',
+        content: 'Start'
+      })
+      useSessionStore.getState().setFixLoopActive('session-a', true)
+      useSessionStore.getState().setFixLoopActive('session-a', false)
+
+      const session = useSessionStore.getState().sessions.find((s) => s.id === 'session-a')
+      expect(session?.fixLoopActive).toBe(false)
+    })
+
+    it('fixLoopActive flag does not affect other sessions', () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-a',
+        content: 'Session A'
+      })
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-b',
+        content: 'Session B'
+      })
+      useSessionStore.getState().finishRun('session-a')
+      useSessionStore.getState().finishRun('session-b')
+
+      useSessionStore.getState().setFixLoopActive('session-a', true)
+
+      const sessionA = useSessionStore.getState().sessions.find((s) => s.id === 'session-a')
+      const sessionB = useSessionStore.getState().sessions.find((s) => s.id === 'session-b')
+
+      expect(sessionA?.fixLoopActive).toBe(true)
+      expect(sessionB?.fixLoopActive).toBeUndefined()
+    })
+  })
+
   describe('interrupted session resume', () => {
     const hydrateInterrupted = (overrides: Partial<PersistedChatSession> = {}): void => {
       useSessionStore.getState().hydrateSessions(

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -64,6 +64,9 @@ export type ChatSession = Omit<
   // Transient: set at hydration when a session was interrupted by an app restart, so the UI can
   // offer an explicit Resume affordance. Never persisted (stripped in stripTransientSessionState).
   interrupted?: boolean
+  // Transient: true while a Phase 3 fix loop is active for this session. Disables the send button
+  // for the duration of the loop (across reviewer-審 and agent-改 sub-phases). Never persisted.
+  fixLoopActive?: boolean
 }
 
 type SessionStoreData = {
@@ -168,6 +171,11 @@ type SessionStore = SessionStoreData & {
   setPermissionPending: (sessionId: string) => void
   clearPermissionPending: (sessionId: string) => void
   setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => void
+  // Persists the per-session auto-review toggle. true = on (default); false = off.
+  setAutoReviewEnabled: (sessionId: string, enabled: boolean) => void
+  // Sets or clears the per-session fix loop active flag. When true, the composer send button is
+  // disabled for this session; when false (loop ended or cancelled), send is re-enabled.
+  setFixLoopActive: (sessionId: string, active: boolean) => void
   renameSession: (sessionId: string, title: string) => void
   deleteSession: (sessionId: string) => void
   removeSessionsForProject: (projectId: string) => void
@@ -194,10 +202,12 @@ const stripTransientMessageState = (message: ChatMessage): PersistedChatMessage 
 }
 
 const stripTransientSessionState = (session: ChatSession): PersistedChatSession => {
-  const { activities, isPending, interrupted, messages, ...persistedSession } = session
+  const { activities, isPending, interrupted, fixLoopActive, messages, ...persistedSession } =
+    session
 
   void isPending
   void interrupted
+  void fixLoopActive
 
   // Persist a bounded projection of tool activities so the transcript survives restarts.
   const persistedActivities = activities
@@ -1097,6 +1107,37 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           ? {
               ...session,
               permissionProfile: profile,
+              updatedAt: Date.now()
+            }
+          : session
+      )
+    }))
+  },
+
+  // Persists the per-session auto-review toggle so finishRun can skip a review when disabled.
+  setAutoReviewEnabled: (sessionId, enabled) => {
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId
+          ? {
+              ...session,
+              autoReviewEnabled: enabled,
+              updatedAt: Date.now()
+            }
+          : session
+      )
+    }))
+  },
+
+  // Sets or clears the per-session fix loop active flag. The flag is transient (never persisted)
+  // and gates canSendMessage in WorkspacePage: true blocks send for the duration of the fix loop.
+  setFixLoopActive: (sessionId, active) => {
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId
+          ? {
+              ...session,
+              fixLoopActive: active,
               updatedAt: Date.now()
             }
           : session

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -65,7 +65,7 @@ export type ChatSession = Omit<
   // offer an explicit Resume affordance. Never persisted (stripped in stripTransientSessionState).
   interrupted?: boolean
   // Transient: true while a Phase 3 fix loop is active for this session. Disables the send button
-  // for the duration of the loop (across reviewer-審 and agent-改 sub-phases). Never persisted.
+  // for the duration of the loop (across reviewer-review and agent-fix sub-phases). Never persisted.
   fixLoopActive?: boolean
 }
 

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -1,0 +1,206 @@
+// Shared reviewer domain types. The reviewer audits one completed turn of the main agent and records
+// structured checks. These types are the contract between the main-process repository/scope resolver
+// and the renderer + IPC layer, so they live in shared with no main/renderer imports.
+//
+// v2 model (issue 12): the old Finding (warn/fail only) + ReviewCheck (pass/inconclusive, JSON blob
+// on Review) are unified into a single ReviewCheck type stored in the Finding table. Every check —
+// pass, warn, or fail — is now a first-class row. The Review row no longer carries a checks JSON
+// column or a summary column; both are removed via migration.
+//
+// v3 model (issue 13): Review.reasoning is replaced by reviewerLog: ReviewerLogEntry[]. The reviewer
+// session's actual action stream (thinking / tool calls / tool results / messages) is captured and
+// stored, replacing the self-authored reasoning prose. submit_findings no longer accepts `reasoning`.
+
+// One entry in the captured reviewer session action log.
+// Streaming chunks (agent_thought_chunk, agent_message_chunk) are assembled into whole entries.
+// tool entries carry the real tool name + input/output from the ACP session update stream.
+// The old split tool_call / tool_result pair is collapsed into ONE unified tool entry per call:
+// tool_call seeds the entry, tool_call_update(s) mutate it in place via shared object reference.
+export type ReviewerLogEntry =
+  | { kind: 'thought'; text: string }
+  | { kind: 'message'; text: string }
+  | {
+      kind: 'tool'
+      toolName: string
+      title?: string
+      rawInput?: string
+      rawOutput?: string
+      status?: 'ok' | 'error'
+      exitCode?: number | null
+    }
+
+// A single flattened block of a turn: one persisted message or one tool activity. blockIndex is the
+// block's position within the turn's ordered window; contentHash pins the block content so downstream
+// out-of-scope/staleness checks can detect edits after the review ran.
+export type ScopeBlock = {
+  id: string
+  kind: 'message' | 'activity'
+  sourceId: string
+  blockIndex: number
+  contentHash: string
+}
+
+// The audited window: the ordered blocks of exactly one turn plus the artifact version ids it produced.
+export type TurnScope = {
+  turnMessageId: string
+  blocks: ScopeBlock[]
+  artifactVersionIds: string[]
+}
+
+// Task state of the review itself (did it run/finish/fail), orthogonal to its outcome.
+export type ReviewLifecycle = 'running' | 'complete' | 'error'
+// Result of a completed review: no warn/fail checks = pass, at least one warn/fail = flagged.
+export type ReviewOutcome = 'pass' | 'flagged'
+
+// The check status: pass = verified and ok; warn = minor issue; fail = serious issue.
+// No 'inconclusive' — use 'warn' with appropriate evidence when verification is uncertain.
+export type CheckStatus = 'pass' | 'warn' | 'fail'
+
+// How far a warn/fail check has been addressed (meaningful only for warn/fail checks).
+export type FindingResolution = 'open' | 'resolved' | 'unaddressed'
+
+// Pins a check's claim to one block of the audited turn.
+export type FindingBlockRef = {
+  messageId?: string
+  activityId?: string
+  blockIndex: number
+}
+
+export type FindingLocator = {
+  blockRef: FindingBlockRef
+  contentHash: string
+}
+
+// The unified check type. All checks (pass/warn/fail) are stored as rows in the Finding table.
+// - pass checks have no locator (they confirm something is correct; no specific block to flag).
+// - warn/fail checks have a locator pinning the claim to a specific turn block.
+// resolution is meaningful only for warn/fail checks.
+// reflagCount (issue 15): number of times this claim was re-flagged in a Phase 3 fix loop; 0 in Phase 1.
+export type ReviewCheck = {
+  id: string
+  reviewId: string
+  status: CheckStatus
+  claim: string
+  evidence: string
+  locator?: FindingLocator // required in practice for warn/fail; optional for pass
+  artifactVersionId?: string
+  resolution: FindingResolution
+  sortIndex: number
+  reflagCount: number
+}
+
+// Legacy alias kept for internal use only; external callers should use ReviewCheck.
+/** @deprecated Use ReviewCheck */
+export type Finding = ReviewCheck
+
+export type Review = {
+  id: string
+  projectId: string
+  sessionId: string
+  turnMessageId: string
+  scope: TurnScope
+  lifecycle: ReviewLifecycle
+  outcome: ReviewOutcome | null
+  errorMessage?: string
+  model: string
+  // Captured reviewer session log: thinking, tool calls, tool results, and messages.
+  // Replaces the old self-authored `reasoning` string (issue 13).
+  reviewerLog: ReviewerLogEntry[]
+  createdAt: number
+  updatedAt: number
+}
+
+// A Review with its checks eagerly loaded, as returned by getReviewsForSession.
+// Note: `checks` is the unified list (replaces both old `findings` and `checks` JSON blob).
+export type ReviewWithChecks = Review & { checks: ReviewCheck[] }
+
+/**
+ * @deprecated Use ReviewWithChecks
+ */
+export type ReviewWithFindings = ReviewWithChecks & { findings: ReviewCheck[] }
+
+// Input to createReview. Only identity + scope are required; lifecycle defaults to 'running'.
+export type CreateReviewInput = {
+  projectId: string
+  sessionId: string
+  turnMessageId: string
+  scope: TurnScope
+  model?: string
+  lifecycle?: ReviewLifecycle
+  outcome?: ReviewOutcome | null
+  reviewerLog?: ReviewerLogEntry[]
+  errorMessage?: string
+}
+
+// Patch applied by updateReview; every field is optional so callers touch only what changed.
+export type UpdateReviewPatch = {
+  scope?: TurnScope
+  lifecycle?: ReviewLifecycle
+  outcome?: ReviewOutcome | null
+  errorMessage?: string | null
+  model?: string
+  reviewerLog?: ReviewerLogEntry[]
+}
+
+// A check to persist under a review; id/reviewId are assigned by the repository.
+export type NewCheck = {
+  status: CheckStatus
+  claim: string
+  evidence: string
+  locator?: FindingLocator // optional — pass checks may omit it
+  artifactVersionId?: string
+  resolution?: FindingResolution
+  sortIndex?: number
+}
+
+/**
+ * @deprecated Use NewCheck
+ */
+export type NewFinding = NewCheck
+
+// IPC: triggers a review run from the renderer (finishRun hook) or manually.
+export type ReviewRunRequest = {
+  sessionId: string
+  turnMessageId: string
+  projectId: string
+  // Main session to inject the [Auditor] correction message into (if warn/fail checks exist).
+  // In production auto-review this is the same as sessionId. Omitting it skips correction injection.
+  mainSessionId?: string
+  // Provider/model tag recorded on the Review row (e.g. 'claude-opus-4-5'). Falls back to ''.
+  model?: string
+}
+
+// IPC: pushed to renderer when a review's lifecycle/outcome/checks change.
+export type ReviewUpdateEvent = {
+  review: ReviewWithChecks
+}
+
+// Navigation intent emitted when the user clicks "Go to transcript" on a warn/fail check.
+// checkId and locator are optional: omitting them opens the Session reviewer page without
+// highlighting a specific check (used when navigating from a pass review).
+export type GoToTranscriptIntent = {
+  reviewId: string
+  findingId?: string // kept for backward compat; same as checkId
+  checkId?: string
+  locator?: ReviewCheck['locator']
+}
+
+// IPC channel names for the reviewer feature.
+export const REVIEWER_IPC = {
+  // Renderer → main: trigger a review run.
+  RUN: 'reviewer:run',
+  // Main → renderer: review updated (lifecycle/outcome/checks changed).
+  UPDATED: 'reviewer:updated',
+  // Renderer → main: load existing reviews for a session.
+  GET_FOR_SESSION: 'reviewer:get-for-session',
+  // Main → renderer: suppress the next triggerAutoReview call for a session (loop guard).
+  // Broadcast just before an [Auditor] correction prompt is sent so the correction turn's
+  // stop event does not spawn a second review run.
+  SUPPRESS_NEXT_AUTO_REVIEW: 'reviewer:suppress-next-auto-review',
+  // Main → renderer: fix loop started for a session (lock composer send button).
+  FIX_LOOP_START: 'reviewer:fix-loop-start',
+  // Main → renderer: fix loop ended or aborted for a session (unlock composer send button).
+  FIX_LOOP_END: 'reviewer:fix-loop-end',
+  // Renderer → main: abort the running fix loop for a session.
+  ABORT_FIX_LOOP: 'reviewer:abort-fix-loop'
+} as const

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -160,4 +160,33 @@ describe('normalizeSessionFile with activities', () => {
     expect(full?.permissionProfile).toBe('full')
     expect(unknown?.permissionProfile).toBe('ask')
   })
+
+  it('round-trips the auto-review toggle and defaults older sessions to enabled', () => {
+    const disabled = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined,
+      autoReviewEnabled: false
+    })
+    const enabled = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined,
+      autoReviewEnabled: true
+    })
+    // A session file written before the reviewer feature has no field at all.
+    const legacy = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined
+    })
+    // A corrupt non-boolean value is treated as the safe default (enabled), not preserved.
+    const corrupt = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined,
+      autoReviewEnabled: 'nope'
+    })
+
+    expect(disabled?.autoReviewEnabled).toBe(false)
+    expect(enabled?.autoReviewEnabled).toBe(true)
+    expect(legacy?.autoReviewEnabled).toBe(true)
+    expect(corrupt?.autoReviewEnabled).toBe(true)
+  })
 })

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -108,6 +108,8 @@ export type PersistedChatSession = {
   status: PersistedSessionStatus
   // Per-conversation approval posture. Older session files omit it and safely restore to Ask.
   permissionProfile?: PermissionProfileId
+  // Per-conversation auto-review toggle. Absent (older files) is treated as enabled.
+  autoReviewEnabled?: boolean
   messages: PersistedChatMessage[]
   activities?: PersistedToolActivity[]
   activeRun?: PersistedActiveRun
@@ -582,6 +584,9 @@ const sanitizeSession = (session: unknown): PersistedChatSession | undefined => 
       session.permissionProfile === undefined
         ? DEFAULT_PERMISSION_PROFILE
         : normalizePermissionProfile(session.permissionProfile),
+    // Auto-review defaults on: a missing or non-boolean value restores as enabled, and only an
+    // explicit false turns it off.
+    autoReviewEnabled: session.autoReviewEnabled === false ? false : true,
     messages: Array.isArray(session.messages)
       ? session.messages.map(sanitizeMessage).filter((item): item is PersistedChatMessage => !!item)
       : [],


### PR DESCRIPTION
Introduce a built-in reviewer that, after each turn, spawns a clean-context, tool-restricted audit session to check the main agent's claims against the real transcript, execution log, and artifacts, then surfaces structured findings.

- Storage: Review/Finding sqlite tables (runtime DDL) + per-session autoReviewEnabled flag
- Scope: flatten a turn into ordered, hashed blocks; a range-narrowed host SDK (read_turn / query_execution_log / read_artifact)
- Reviewer session: reuse buildSession with a rubric system-prompt append plus a reviewer REPL sandbox and the submit_findings MCP contract (zod-validated)
- Correction: inject a single [Auditor] message on warn/fail; Phase 3 locked re-review fix loop (capped at 3 rounds, abortable, reflag tracking)
- UI: composer Auto-review toggle, reviewing indicator, ReviewerCard, and the Session reviewer page reached via Go to transcript
- IPC: reviewer:run / get-for-session plus lifecycle/findings/fix-loop event streams