### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,7 +44,7 @@ The current codebase is an early, working implementation of the first stretch of
 
 **Working today:**
 - ✅ Agent runtime with a full plan/execute/tool-call loop, wrapped over the Agent Client Protocol (ACP)
-- ✅ Multi-provider model configuration with per-model selection — built-in vendors (Claude, DeepSeek, GLM, MiniMax) plus custom gateways and local Claude, all over Anthropic-compatible endpoints, with live catalog refresh and mid-run switching
+- ✅ Multi-provider model configuration with per-model selection — built-in vendors (Claude, DeepSeek, Zhipu AI (GLM), MiniMax, Kimi (Moonshot)) plus custom gateways and local Claude, all over Anthropic-compatible endpoints, with live catalog refresh and mid-run switching
 - ✅ Electron + React + TypeScript desktop shell with a shadcn-based design system
 - ✅ Parallel multi-session workspace with typed tool-activity visualization (diffs, code blocks, web search rows)
 - ✅ Project layer with per-project, per-file session storage, migration from the legacy single-file format, and a home page
@@ -77,7 +77,7 @@ The product is organized into cooperating layers (see [`docs/PRD.md`](docs/PRD.m
 | Layer | Target capability | Current state | Status |
 | --- | --- | --- | --- |
 | **Agent Harness & Shell** | Planning/execution/reflection loop, multi-session UI, skill discovery, async notifications | Single-agent loop via ACP, parallel session mounting, typed tool-activity visualization; no skill discovery or notification bus yet | 🟡 |
-| **Model Layer** | Pluggable gateway across model vendors and locally-hosted models, per-agent routing | Multi-provider config with per-model selection (built-in vendors — Claude, DeepSeek, GLM, MiniMax — plus custom gateways + local Claude), but every provider is reached over an Anthropic-compatible endpoint; no native non-Anthropic protocols or per-agent routing yet | 🟡 |
+| **Model Layer** | Pluggable gateway across model vendors and locally-hosted models, per-agent routing | Multi-provider config with per-model selection (built-in vendors — Claude, DeepSeek, Zhipu AI (GLM), MiniMax, Kimi (Moonshot) — plus custom gateways + local Claude), but every provider is reached over an Anthropic-compatible endpoint; no native non-Anthropic protocols or per-agent routing yet | 🟡 |
 | **Project & Session Organization** | Durable per-project workspaces, session history, fast resume | Project CRUD, per-project/per-file session storage with migration, home page with recents | ✅ |
 | **Multi-Kernel Execution Engine** | Interchangeable Python / R / shell kernels with cross-kernel handoff | One persistent Python kernel with durable run history; no R or REPL control-plane kernel yet | 🟡 |
 | **Environment Management** | Create, switch, snapshot, and register reproducible compute environments | Uses a single managed runtime directory; no environment CRUD or snapshotting | ⬜ |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-science",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-science",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-science",
   "productName": "Open Science",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Open Science — an open-source, model-agnostic AI workbench for scientific discovery.",
   "main": "./out/main/index.js",
   "author": "aipoch",


### PR DESCRIPTION
## Summary

Release bump to **v0.3.1**. Bumps the package version and refreshes ROADMAP maturity language so the docs match what actually ships in this release.

## Changes

- **Version:** `package.json` + `package-lock.json` → `0.3.1`.
- **ROADMAP:** built-in model-vendor list corrected and expanded to `Claude, DeepSeek, Zhipu AI (GLM), MiniMax, Kimi (Moonshot)` (was `Claude, DeepSeek, GLM, MiniMax`), reflecting the new Kimi vendors and the GLM → Zhipu AI identity fix. README is intentionally vendor-agnostic (points at the app's provider picker), so it needs no change.

## Notable work included since v0.3.0

- Managed file downloads from the Files workspace + preview-card refinements and keyboard tab navigation (#158).
- Ceiling-free large-file previews with bounded PDF byte ranges and lazy page rendering (#147).
- New built-in model vendors: Kimi (Moonshot) + Kimi For Coding, and the GLM → Zhipu AI (GLM) identity correction (#156).
- macOS update feed standardized on a single `latest-mac.yml`, fixing a 403 failure class for `latest`-channel builds while keeping v0.3.0 users migrating through the per-arch feeds (#155).
- Platform-aware data-root path guards (reject spaces on unix, Windows MAX_PATH) + return-to-default destination path (#151).
- README refreshed for the released app (#153); GitHub Actions bumped to latest majors (#157).

## Verification

- `npm run lint` clean on tracked source.
- No test is coupled to the version string; docs/version-only change.