### PR TITLE
fix(update): show in-app release notes from the CDN manifest on the electron-updater path

### DIFF
--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -23,6 +23,16 @@ class FakeUpdater extends EventEmitter {
   quitAndInstall = vi.fn()
 }
 
+// Fake fetch returning a version.json manifest, so notes hydration never touches the network.
+const manifestFetch = (manifest: object): typeof fetch =>
+  vi.fn(async () => ({ ok: true, json: async () => manifest })) as unknown as typeof fetch
+
+// Fake fetch that always fails, standing in for "no manifest reachable".
+const offlineFetch = (): typeof fetch =>
+  vi.fn(async () => {
+    throw new Error('no network in test')
+  }) as unknown as typeof fetch
+
 describe('ElectronUpdaterStrategy', () => {
   it('disables auto download/install on construction', () => {
     const updater = new FakeUpdater()
@@ -34,7 +44,12 @@ describe('ElectronUpdaterStrategy', () => {
   it('maps check → available with restart applyKind', async () => {
     const broadcast = vi.fn()
     const updater = new FakeUpdater()
-    const strategy = new ElectronUpdaterStrategy({ updater, currentVersion: '0.2.0', broadcast })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast,
+      fetchImpl: offlineFetch()
+    })
     const status = await strategy.check()
     expect(status.state).toBe('available')
     expect(status.latest).toBe('0.3.0')
@@ -48,7 +63,12 @@ describe('ElectronUpdaterStrategy', () => {
   it('maps download → progress then ready', async () => {
     const broadcast = vi.fn()
     const updater = new FakeUpdater()
-    const strategy = new ElectronUpdaterStrategy({ updater, currentVersion: '0.2.0', broadcast })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast,
+      fetchImpl: offlineFetch()
+    })
     await strategy.check()
     const status = await strategy.download()
     expect(broadcast).toHaveBeenCalledWith('update:progress', 42)
@@ -94,5 +114,48 @@ describe('ElectronUpdaterStrategy', () => {
     await strategy.apply()
     expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
     expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true)
+  })
+
+  it('hydrates notes from the CDN manifest when the version matches', async () => {
+    const updater = new FakeUpdater()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: manifestFetch({ version: '0.3.0', downloads: {}, notes: '## Highlights\n- new' })
+    })
+    const status = await strategy.check()
+    expect(status.notes).toBe('## Highlights\n- new')
+  })
+
+  it('keeps the GitHub-link fallback when the manifest version does not match', async () => {
+    const updater = new FakeUpdater()
+    // No releaseNotes in the feed, so without a matching manifest the notes stay empty.
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', { version: '0.3.0' })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: manifestFetch({ version: '0.3.1', downloads: {}, notes: 'stale notes' })
+    })
+    const status = await strategy.check()
+    expect(status.notes).toBe('')
+  })
+
+  it('keeps the fallback when the manifest fetch fails', async () => {
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', { version: '0.3.0' })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    const status = await strategy.check()
+    expect(status.notes).toBe('')
   })
 })

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -1,7 +1,9 @@
 import { app, BrowserWindow } from 'electron'
 import { autoUpdater } from 'electron-updater'
 
+import { APP } from '../../shared/app-config'
 import type { UpdateStatus } from '../../shared/update'
+import { fetchManifest } from './manifest'
 import type { UpdateStrategy } from './strategy'
 
 // Structural subset of electron-updater's autoUpdater we depend on, so tests can inject a fake without
@@ -19,6 +21,10 @@ export type ElectronUpdaterDeps = {
   updater?: MinimalAutoUpdater
   currentVersion?: string
   broadcast?: (channel: string, payload: unknown) => void
+  // CDN manifest the release notes are read from (same version.json the installer flow uses).
+  // Injectable for tests; defaults to the public stable manifest.
+  fetchImpl?: typeof fetch
+  manifestUrl?: string
 }
 
 // Default broadcast pushes to every live window (mirrors service.ts). Never runs in unit tests, which
@@ -50,12 +56,19 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private readonly updater: MinimalAutoUpdater
   private readonly currentVersion: string
   private readonly broadcast: (channel: string, payload: unknown) => void
+  private readonly fetchImpl?: typeof fetch
+  private readonly manifestUrl: string
   private status: UpdateStatus
+  // In-flight manifest notes fetch for the current update, awaited by check() so the returned
+  // status reflects the hydrated notes.
+  private notesHydration?: Promise<void>
 
   constructor(deps: ElectronUpdaterDeps = {}) {
     this.updater = deps.updater ?? (autoUpdater as unknown as MinimalAutoUpdater)
     this.currentVersion = deps.currentVersion ?? app?.getVersion?.() ?? '0.0.0'
     this.broadcast = deps.broadcast ?? defaultBroadcast
+    this.fetchImpl = deps.fetchImpl
+    this.manifestUrl = deps.manifestUrl ?? APP.update.manifestUrl
     this.status = { state: 'idle', current: this.currentVersion, applyKind: 'restart' }
 
     this.updater.autoDownload = false
@@ -72,6 +85,10 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         latest: i.version,
         notes: notesToString(i.releaseNotes)
       })
+      // electron-updater's *.yml feed carries no release notes, so the dialog would only get a
+      // GitHub link. Hydrate the notes from the CDN manifest (the same version.json the installer
+      // flow reads) so the "What's new" section renders in-app.
+      if (i.version) this.notesHydration = this.hydrateNotes(i.version)
     })
     this.updater.on('update-not-available', (info) => {
       const i = info as { version?: string }
@@ -106,6 +123,20 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     return this.status
   }
 
+  // Fetch the CDN manifest and, when it matches the offered update and actually carries notes,
+  // merge them into the current status. Any failure (network, parse, version drift) leaves the
+  // GitHub-link fallback in place — notes are best-effort and never block the update.
+  private async hydrateNotes(version: string): Promise<void> {
+    try {
+      const manifest = await fetchManifest(this.manifestUrl, this.fetchImpl)
+      if (manifest.version === version && manifest.notes && this.status.latest === version) {
+        this.setStatus({ ...this.status, notes: manifest.notes })
+      }
+    } catch {
+      // Keep the fallback that links out to the GitHub release.
+    }
+  }
+
   async check(): Promise<UpdateStatus> {
     try {
       await this.updater.checkForUpdates()
@@ -115,6 +146,8 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         error: error instanceof Error ? error.message : 'Update check failed'
       })
     }
+    // Wait for the notes fetch triggered by update-available so the returned status carries them.
+    await this.notesHydration
     return this.status
   }
 


### PR DESCRIPTION
## Summary

The in-place auto-update path (`ElectronUpdaterStrategy`, used on Windows/Linux and signed stable macOS) sourced its release notes from electron-updater's `*.yml` feed. Those feeds carry **no** `releaseNotes`, so the update dialog's "What's new" section was always empty and only ever showed a "View release notes on GitHub" link — even though the full notes already exist in the CDN manifest (`version.json`).

This wires the notes to where they actually live: on `update-available`, the strategy now fetches the same `version.json` the installer flow (`UpdateService`) reads and uses `manifest.notes`.

## Root cause

- `UpdateDialog` renders notes from `status.notes`; empty notes fall back to the GitHub link.
- On the electron-updater path, `status.notes` came from `notesToString(info.releaseNotes)`, and the `*.yml` feeds never include `releaseNotes`.
- The populated `notes` field lives only in `version.json`, which was consumed exclusively by the fallback `UpdateService` — a path packaged stable builds don't take. So the notes were generated and published, but the active updater never read them.

## Changes

- `electron-updater-strategy.ts`: on `update-available`, fetch the CDN manifest (`APP.update.manifestUrl`) and merge `manifest.notes` into the status when the manifest `version` matches the offered update and actually carries notes. `check()` awaits this hydration so the returned status includes the notes.
- Best-effort by design: any failure (network, parse, version drift) leaves the existing GitHub-link fallback in place and never blocks the update.
- Notes stay single-sourced in `version.json` — nothing is duplicated into the `*.yml` feeds.
- Injectable `fetchImpl` + `manifestUrl` deps, mirroring `UpdateService`, so tests avoid the network.

## Tests

- New cases: notes hydrated when the manifest version matches; GitHub-link fallback kept on version mismatch; fallback kept on fetch failure.
- Existing `update-available`-triggering tests inject an offline fetch so unit tests never hit the network.
- `npm run typecheck`, `npm run lint`, and `vitest` on the update strategy suite all pass.

## Verification

- Unit-tested; behavior intended to be validated in `npm run dev`. Not exercised through a packaged/notarized build.