### PR TITLE
fix(update): inject release notes into electron-updater feeds so installed clients show them

### DIFF
--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -133,6 +133,27 @@ jobs:
             ' "$yml"
           done
 
+      # electron-builder never writes releaseNotes into the feeds, so already-installed clients (which
+      # read update notes only from the feed) show an empty "What's new" and only a GitHub link. Inject
+      # the same condensed notes version.json carries into each feed's releaseNotes. inject-feed-notes
+      # parses + re-serializes with js-yaml (never hand-writes YAML) and re-parses its own output, so a
+      # malformed feed fails the job here — before any upload — rather than reaching the installed base.
+      # js-yaml is installed on its own (this job never runs npm ci) with scripts off so no electron
+      # postinstall fires.
+      - name: Inject release notes into update feeds
+        run: |
+          npm install js-yaml@^4 --no-save --no-package-lock --no-audit --no-fund --ignore-scripts
+          shopt -s nullglob
+          feeds=()
+          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml dist-assets/*-mac.yml; do
+            [ -f "$yml" ] && feeds+=("$yml")
+          done
+          if [ ${#feeds[@]} -eq 0 ]; then
+            echo "no update feeds present, skipping notes injection"
+            exit 0
+          fi
+          node scripts/inject-feed-notes.mjs version.json "${feeds[@]}"
+
       # Publish the rewritten feeds to the channel root as mutable, no-cache objects (same policy as
       # version.json), so the updater always sees the latest version immediately.
       - name: Upload update feed to channel root

--- a/scripts/inject-feed-notes.mjs
+++ b/scripts/inject-feed-notes.mjs
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+// Inject the condensed release notes into each electron-updater feed's `releaseNotes` field.
+//
+// Why: already-installed clients (v0.3.0/v0.3.1) read update notes ONLY from the feed's
+// `releaseNotes` — the in-app fix that also reads version.json only helps builds that ship it. So the
+// feed is the sole channel that reaches the existing installed base. electron-builder never writes
+// `releaseNotes` into the feed, hence the empty "What's new" and the GitHub-link fallback.
+//
+// Safety: each feed is parsed with js-yaml, the field is set on the object, and the result is
+// re-serialized by js-yaml — we never hand-write YAML, so malformed output is impossible, and the
+// re-parse guard throws before anything is written/uploaded. Re-running is idempotent (the field is
+// overwritten, not appended). The notes source is the freshly built version.json, so the feed notes
+// stay identical to what the website/manifest shows.
+//
+// CLI: node scripts/inject-feed-notes.mjs <version.json> <feed.yml> [feed.yml...]
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+import yaml from 'js-yaml'
+
+// Set releaseNotes on one feed's YAML text and return the re-serialized text. Throws when the feed
+// isn't a YAML mapping or when the produced YAML fails to re-parse.
+export function injectNotesIntoFeed(feedText, notes) {
+  const doc = yaml.load(feedText)
+  if (!doc || typeof doc !== 'object' || Array.isArray(doc)) {
+    throw new Error('feed is not a YAML mapping')
+  }
+  doc.releaseNotes = notes
+  // lineWidth: -1 disables line wrapping so long scalars (sha512, urls) stay on one line.
+  const out = yaml.dump(doc, { lineWidth: -1 })
+  yaml.load(out) // re-parse guard: fail loudly before any write/upload rather than ship broken YAML
+  return out
+}
+
+// Read the condensed notes from a version.json manifest; '' when absent.
+export function notesFromManifest(manifestText) {
+  return String(JSON.parse(manifestText).notes ?? '').trim()
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [manifestPath, ...feeds] = process.argv.slice(2)
+  if (!manifestPath || feeds.length === 0) {
+    console.error('usage: inject-feed-notes.mjs <version.json> <feed.yml...>')
+    process.exit(1)
+  }
+
+  const notes = notesFromManifest(readFileSync(manifestPath, 'utf8'))
+  if (!notes) {
+    console.log('inject-feed-notes: manifest has no notes, leaving feeds unchanged')
+    process.exit(0)
+  }
+
+  for (const feed of feeds) {
+    writeFileSync(feed, injectNotesIntoFeed(readFileSync(feed, 'utf8'), notes))
+    console.log(`inject-feed-notes: wrote releaseNotes into ${feed}`)
+  }
+}

--- a/scripts/inject-feed-notes.test.ts
+++ b/scripts/inject-feed-notes.test.ts
@@ -1,0 +1,59 @@
+import yaml from 'js-yaml'
+import { describe, expect, it } from 'vitest'
+
+import { injectNotesIntoFeed, notesFromManifest } from './inject-feed-notes.mjs'
+
+// A representative electron-updater mac feed (matches the shape merge-mac-feed.mjs emits).
+const FEED = `version: 0.3.1
+files:
+  - url: releases/0.3.1/open-science-0.3.1-mac-arm64.zip
+    sha512: YTCyMaLpgWFVX/rZz7fDWsEM2EO4glaXmwVHWw3SJi3eUe3vHky28/8pijGLaf+dVXQLBY8daT9hhOIOvTDpqg==
+    size: 176317136
+path: releases/0.3.1/open-science-0.3.1-mac-arm64.zip
+sha512: YTCyMaLpgWFVX/rZz7fDWsEM2EO4glaXmwVHWw3SJi3eUe3vHky28/8pijGLaf+dVXQLBY8daT9hhOIOvTDpqg==
+releaseDate: "2026-07-17T09:15:41.876Z"
+`
+
+const NOTES =
+  '## ✨ Highlights\n\n- **Download your files.** New in this build. (#158)\n- Colons: and `code`, "quotes", trailing spaces   \n'
+
+describe('injectNotesIntoFeed', () => {
+  it('sets releaseNotes while preserving version, files, and integrity fields', () => {
+    const out = injectNotesIntoFeed(FEED, NOTES)
+    const doc = yaml.load(out) as Record<string, unknown>
+    expect(doc.releaseNotes).toBe(NOTES)
+    expect(doc.version).toBe('0.3.1')
+    expect(doc.path).toBe('releases/0.3.1/open-science-0.3.1-mac-arm64.zip')
+    const files = doc.files as Array<{ url: string; sha512: string; size: number }>
+    expect(files).toHaveLength(1)
+    expect(files[0].size).toBe(176317136)
+    expect(files[0].sha512).toBe(
+      'YTCyMaLpgWFVX/rZz7fDWsEM2EO4glaXmwVHWw3SJi3eUe3vHky28/8pijGLaf+dVXQLBY8daT9hhOIOvTDpqg=='
+    )
+  })
+
+  it('always produces valid, re-parseable YAML for notes with special characters', () => {
+    const out = injectNotesIntoFeed(FEED, NOTES)
+    expect(() => yaml.load(out)).not.toThrow()
+  })
+
+  it('is idempotent — re-injecting the same notes yields the same output', () => {
+    const once = injectNotesIntoFeed(FEED, NOTES)
+    const twice = injectNotesIntoFeed(once, NOTES)
+    expect(twice).toBe(once)
+  })
+
+  it('throws on a feed that is not a YAML mapping', () => {
+    expect(() => injectNotesIntoFeed('- just\n- a\n- list\n', NOTES)).toThrow(/mapping/)
+  })
+})
+
+describe('notesFromManifest', () => {
+  it('reads and trims the notes field', () => {
+    expect(notesFromManifest('{"notes":"  hi there  "}')).toBe('hi there')
+  })
+
+  it('returns empty string when notes are absent', () => {
+    expect(notesFromManifest('{"version":"0.3.1"}')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

Already-installed clients (v0.3.0 / v0.3.1) read in-app update notes **only** from the electron-updater `*.yml` feed's `releaseNotes` field, which electron-builder never writes. So the "What's new" section in the update dialog is always empty and only ever shows a "View release notes on GitHub" link. The in-app manifest-notes fix (#162) is client-side and therefore only reaches builds that ship it — the feed is the sole channel that reaches the **existing** installed base.

This writes the condensed release notes (the same ones `version.json` carries) into every feed's `releaseNotes` during the website mirror, so installed clients render the notes in-app.

## Changes

- **`scripts/inject-feed-notes.mjs`** — reads the condensed notes from the freshly built `version.json` and sets `releaseNotes` on each feed. Exposes `injectNotesIntoFeed` / `notesFromManifest` for testing.
- **`.github/workflows/mirror-to-website.yml`** — new "Inject release notes into update feeds" step between the path rewrite and the upload, covering `latest.yml`, `latest-linux.yml`, and every `*-mac.yml`. `js-yaml` is installed standalone with `--ignore-scripts` (this job never runs `npm ci`, and no electron postinstall should fire).
- **`scripts/inject-feed-notes.test.ts`** — 6 tests.

## Why it can't ship a broken feed

The feeds are live objects the entire installed base polls, so a malformed feed would break auto-update. Three safeguards:

1. **Never hand-writes YAML** — it parses the real feed with `js-yaml`, sets the field on the object, and lets `js-yaml.dump` serialize, so escaping/quoting for arbitrary markdown (colons, quotes, trailing spaces, emoji) is the library's job.
2. **Re-parse guard** — it `yaml.load`s its own output before returning; any bad result throws and fails the workflow step **before any `aws s3 cp`**.
3. **Idempotent** — re-running overwrites `releaseNotes` instead of appending, so the manual `v0.3.1` re-mirror can't create a duplicate-key feed.

Integrity fields (`version`, `files[]`, `sha512`, `size`, `path`) are preserved untouched, so re-mirroring `v0.3.1` does not offer an update to clients already on `v0.3.1` (same version → up-to-date); it only backfills notes for the not-yet-updated `v0.3.0` users and every release from here on.

## Tests

- New cases: field set with version/files/integrity preserved; always-valid YAML for notes with special characters; idempotency; throws on a non-mapping feed; `notesFromManifest` trims / handles missing notes.
- `npm run lint`, `npm run typecheck`, and the script suite pass. Live CLI smoke test against a real feed produced a valid `releaseNotes` literal block; the edited workflow YAML validates.

## Rollout

After merge, manually re-run **Mirror to website** with tag `v0.3.1` to backfill notes into the current live feeds.