### PR TITLE
feat(skills): batch-import multiple skills from files or a mega-zip

### DIFF
--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -321,14 +321,16 @@ class SettingsService {
   // Imports a skill from an uploaded .zip / .skill bundle, returning the outcome + refreshed list.
   async importSkillZip(request: ImportSkillZipRequest): Promise<ImportSkillResult> {
     const outcome = await this.userSkills.importFromZip(Buffer.from(request.dataBase64, 'base64'), {
+      subPath: request.subPath,
       replaceId: request.replaceId
     })
 
     return { status: outcome.status, id: outcome.id, skills: await this.listSkills() }
   }
 
-  // Parses an uploaded bundle for a confirm-before-import preview, without writing anything.
-  async previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreview> {
+  // Parses an uploaded bundle for a confirm-before-import preview, without writing anything. Returns
+  // one preview per skill root the bundle contains.
+  async previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreview[]> {
     return this.userSkills.previewZip(Buffer.from(request.dataBase64, 'base64'))
   }
 

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -275,6 +275,110 @@ describe('UserSkillRepository', () => {
     const repo = new UserSkillRepository(await makeStorage())
     const zip = buildZip([{ path: 'readme.md', content: Buffer.from('nope') }])
     await expect(repo.importFromZip(zip)).rejects.toThrow(/SKILL\.md/)
+    await expect(repo.previewZip(zip)).rejects.toThrow(/SKILL\.md/)
+  })
+
+  it('discovers one root for a root-level SKILL.md (subPath "")', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const zip = buildZip([
+      { path: 'SKILL.md', content: Buffer.from('---\nname: Root\ndescription: d\n---\nbody') },
+      { path: 'run.py', content: Buffer.from('print(1)') }
+    ])
+
+    const previews = await repo.previewZip(zip)
+    expect(previews).toHaveLength(1)
+    expect(previews[0]).toMatchObject({ name: 'Root', subPath: '' })
+    // Root files stay as-is (SKILL.md already at the root).
+    expect(previews[0].files).toEqual(['SKILL.md', 'run.py'].sort())
+  })
+
+  it('discovers two roots for sibling one-level skill dirs', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const zip = buildZip([
+      { path: 'skill-a/SKILL.md', content: Buffer.from('---\nname: A\ndescription: d\n---\nx') },
+      { path: 'skill-a/run.py', content: Buffer.from('a') },
+      { path: 'skill-b/SKILL.md', content: Buffer.from('---\nname: B\ndescription: d\n---\ny') }
+    ])
+
+    const previews = await repo.previewZip(zip)
+    expect(previews.map((p) => p.subPath)).toEqual(['skill-a', 'skill-b'])
+    // Each root's files are re-based so SKILL.md sits at its root.
+    expect(previews[0].files).toEqual(['SKILL.md', 'run.py'].sort())
+    expect(previews[1].files).toEqual(['SKILL.md'])
+  })
+
+  it('discovers a two-level wrapped skill root (subPath "wrapper/skill-a")', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const zip = buildZip([
+      {
+        path: 'wrapper/skill-a/SKILL.md',
+        content: Buffer.from('---\nname: Wrapped\ndescription: d\n---\nx')
+      },
+      { path: 'wrapper/skill-a/scripts/run.py', content: Buffer.from('a') }
+    ])
+
+    const previews = await repo.previewZip(zip)
+    expect(previews).toHaveLength(1)
+    expect(previews[0]).toMatchObject({ name: 'Wrapped', subPath: 'wrapper/skill-a' })
+    expect(previews[0].files).toEqual(['SKILL.md', 'scripts/run.py'].sort())
+  })
+
+  it('drops a SKILL.md nested under a shallower skill root (counts it once)', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const zip = buildZip([
+      { path: 'a/SKILL.md', content: Buffer.from('---\nname: A\ndescription: d\n---\nx') },
+      { path: 'a/b/SKILL.md', content: Buffer.from('---\nname: B\ndescription: d\n---\ny') }
+    ])
+
+    const previews = await repo.previewZip(zip)
+    expect(previews.map((p) => p.subPath)).toEqual(['a'])
+    // The nested SKILL.md is just a file of skill "a", re-based under it.
+    expect(previews[0].files).toEqual(['SKILL.md', 'b/SKILL.md'].sort())
+  })
+
+  it('imports only the selected sub-skill from a multi-root bundle via subPath', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const zip = buildZip([
+      {
+        path: 'skill-a/SKILL.md',
+        content: Buffer.from('---\nname: Alpha\ndescription: d\n---\nx')
+      },
+      { path: 'skill-a/run.py', content: Buffer.from('alpha') },
+      { path: 'skill-b/SKILL.md', content: Buffer.from('---\nname: Beta\ndescription: d\n---\ny') }
+    ])
+
+    const outcome = await repo.importFromZip(zip, { subPath: 'skill-b' })
+    expect(outcome).toEqual({ status: 'imported', id: 'imported-beta' })
+    // Only Beta was written; Alpha's file must not exist under the imported skill.
+    expect((await repo.list()).map((s) => s.id)).toEqual(['imported-beta'])
+    const body = await readFile(join(storage, 'skills', 'imported', 'beta', 'SKILL.md'), 'utf8')
+    expect(body).toContain('name: Beta')
+  })
+
+  it('throws on a multi-root bundle when no subPath is given', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const zip = buildZip([
+      { path: 'skill-a/SKILL.md', content: Buffer.from('---\nname: A\ndescription: d\n---\nx') },
+      { path: 'skill-b/SKILL.md', content: Buffer.from('---\nname: B\ndescription: d\n---\ny') }
+    ])
+    await expect(repo.importFromZip(zip)).rejects.toThrow(/multiple skills/)
+  })
+
+  it('throws when the requested subPath matches no root', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const zip = buildZip([
+      { path: 'skill-a/SKILL.md', content: Buffer.from('---\nname: A\ndescription: d\n---\nx') }
+    ])
+    await expect(repo.importFromZip(zip, { subPath: 'nope' })).rejects.toThrow(/no skill at/)
+  })
+
+  it('still imports a single-root bundle with no subPath (backward compat)', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const zip = buildZip([
+      { path: 'only/SKILL.md', content: Buffer.from('---\nname: Only\ndescription: d\n---\nx') }
+    ])
+    expect(await repo.importFromZip(zip)).toEqual({ status: 'imported', id: 'imported-only' })
   })
 
   it('previews a bundle without writing it, and flags an identical already-imported bundle', async () => {
@@ -288,18 +392,22 @@ describe('UserSkillRepository', () => {
     ])
 
     const preview = await repo.previewZip(zip)
-    expect(preview).toEqual({
-      name: 'Bundled',
-      description: 'A test bundle.',
-      files: ['SKILL.md', 'scripts/run.py'],
-      alreadyImported: false
-    })
+    expect(preview).toEqual([
+      {
+        name: 'Bundled',
+        description: 'A test bundle.',
+        files: ['SKILL.md', 'scripts/run.py'],
+        alreadyImported: false,
+        replaceableId: undefined,
+        subPath: 'my-bundle'
+      }
+    ])
     // Preview writes nothing.
     expect(await repo.list()).toHaveLength(0)
 
     // After importing, the same bundle previews as already imported.
     await repo.importFromZip(zip)
-    expect((await repo.previewZip(zip)).alreadyImported).toBe(true)
+    expect((await repo.previewZip(zip))[0].alreadyImported).toBe(true)
   })
 
   it('rejects a preview whose SKILL.md has no name', async () => {
@@ -324,12 +432,12 @@ describe('UserSkillRepository', () => {
     await repo.importFromZip(sharedBundle('v1'))
 
     // Same name, different content -> replaceable in place.
-    const preview = await repo.previewZip(sharedBundle('v2'))
+    const [preview] = await repo.previewZip(sharedBundle('v2'))
     expect(preview.alreadyImported).toBe(false)
     expect(preview.replaceableId).toBe('imported-shared')
 
     // The exact same bundle -> a no-op, so no replace is offered.
-    const exact = await repo.previewZip(sharedBundle('v1'))
+    const [exact] = await repo.previewZip(sharedBundle('v1'))
     expect(exact.alreadyImported).toBe(true)
     expect(exact.replaceableId).toBeUndefined()
   })
@@ -339,7 +447,7 @@ describe('UserSkillRepository', () => {
     await repo.importFromZip(sharedBundle('v1'))
     await repo.importFromZip(sharedBundle('v2')) // second "Shared" -> imported-shared-2
 
-    const preview = await repo.previewZip(sharedBundle('v3'))
+    const [preview] = await repo.previewZip(sharedBundle('v3'))
     expect(preview.replaceableId).toBeUndefined()
   })
 

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -93,23 +93,40 @@ const signatureOf = (files: FetchedSkillFile[]): string => {
   return hash.digest('hex')
 }
 
-// Normalizes an extracted zip into skill files with SKILL.md at the root: if the bundle is wrapped in a
-// single top-level directory, that prefix is stripped so `wrapper/SKILL.md` becomes `SKILL.md`.
-const normalizeBundle = (entries: { path: string; content: Buffer }[]): FetchedSkillFile[] => {
-  const hasRootSkill = entries.some((entry) => entry.path.toLowerCase() === 'skill.md')
-  if (hasRootSkill) {
-    return entries.map((entry) => ({ relativePath: entry.path, content: entry.content }))
+// One skill root inside an archive: the directory prefix holding a SKILL.md, plus that skill's files
+// re-based so SKILL.md sits at their root.
+type SkillRoot = { subPath: string; files: FetchedSkillFile[] }
+
+// Discovers every skill root in an extracted archive so a multi-skill bundle can be imported piecewise.
+// A root is any directory directly holding a SKILL.md (case-insensitive) at 1-3 path segments (root,
+// `*/SKILL.md`, or `*/*/SKILL.md`); deeper SKILL.md files are ignored. A root nested under a shallower
+// one is dropped so a single skill is never counted twice. Archive paths always use forward slashes.
+const findSkillRoots = (entries: { path: string; content: Buffer }[]): SkillRoot[] => {
+  const candidates = new Set<string>()
+  for (const entry of entries) {
+    const segments = entry.path.split('/')
+    if (segments[segments.length - 1].toLowerCase() !== 'skill.md') continue
+    if (segments.length > 3) continue
+    candidates.add(segments.slice(0, -1).join('/'))
   }
 
-  const topLevels = new Set(entries.map((entry) => entry.path.split('/')[0]))
-  if (topLevels.size === 1) {
-    const prefix = `${[...topLevels][0]}/`
-    return entries
-      .filter((entry) => entry.path.startsWith(prefix))
-      .map((entry) => ({ relativePath: entry.path.slice(prefix.length), content: entry.content }))
-  }
+  // Keep only the shallowest root on each branch: a candidate under another (or under the archive
+  // root '') is that skill's own file, not a separate skill.
+  const all = [...candidates]
+  const roots = all.filter(
+    (subPath) =>
+      !all.some((other) => other !== subPath && (other === '' || subPath.startsWith(`${other}/`)))
+  )
 
-  return entries.map((entry) => ({ relativePath: entry.path, content: entry.content }))
+  return roots
+    .map((subPath) => {
+      const prefix = subPath === '' ? '' : `${subPath}/`
+      const files = entries
+        .filter((entry) => entry.path.startsWith(prefix))
+        .map((entry) => ({ relativePath: entry.path.slice(prefix.length), content: entry.content }))
+      return { subPath, files }
+    })
+    .sort((a, b) => a.subPath.localeCompare(b.subPath))
 }
 
 // Reads the `name:` value from a SKILL.md frontmatter block, if present.
@@ -269,25 +286,33 @@ class UserSkillRepository {
   // lists the files, flags whether the identical bundle was already imported, and — when its name
   // collides with exactly one existing imported skill of different content — offers that skill's id as
   // a replace target. Writes nothing.
-  async previewZip(zip: Buffer): Promise<SkillBundlePreview> {
-    const files = normalizeBundle(extractZip(zip))
-    const skillMd = files.find((file) => file.relativePath.toLowerCase() === 'skill.md')
-    if (!skillMd) throw new Error('The bundle must contain a SKILL.md.')
+  async previewZip(zip: Buffer): Promise<SkillBundlePreview[]> {
+    const roots = findSkillRoots(extractZip(zip))
+    if (roots.length === 0) throw new Error('The bundle must contain a SKILL.md.')
 
-    const { fields } = parseFrontmatter(skillMd.content.toString('utf8'))
-    const name = fields.name?.trim()
-    if (!name) throw new Error("The bundle's SKILL.md needs a name in its frontmatter.")
+    const previews: SkillBundlePreview[] = []
+    for (const root of roots) {
+      const skillMd = root.files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
+      const { fields } = parseFrontmatter(skillMd.content.toString('utf8'))
+      const name = fields.name?.trim()
+      if (!name) throw new Error("The bundle's SKILL.md needs a name in its frontmatter.")
 
-    const alreadyImported = Boolean(await this.findImportedSlugBySignature(signatureOf(files)))
-    const replaceableId = alreadyImported ? undefined : await this.replaceableImportedId(name)
+      const alreadyImported = Boolean(
+        await this.findImportedSlugBySignature(signatureOf(root.files))
+      )
+      const replaceableId = alreadyImported ? undefined : await this.replaceableImportedId(name)
 
-    return {
-      name,
-      description: fields.description ?? '',
-      files: files.map((file) => file.relativePath).sort(),
-      alreadyImported,
-      replaceableId
+      previews.push({
+        name,
+        description: fields.description ?? '',
+        files: root.files.map((file) => file.relativePath).sort(),
+        alreadyImported,
+        replaceableId,
+        subPath: root.subPath
+      })
     }
+
+    return previews
   }
 
   // The id of the single imported skill sharing this display name, or undefined when there is none or
@@ -301,14 +326,34 @@ class UserSkillRepository {
     return matches.length === 1 ? matches[0].id : undefined
   }
 
-  // Imports a .zip / .skill bundle that contains a SKILL.md. With `replaceId`, the bundle overwrites
-  // that already-imported skill in place. Otherwise it dedups by content signature (re-importing the
-  // same bundle is a no-op) and a bundle whose name is already taken gets a suffixed slug.
-  async importFromZip(zip: Buffer, options: { replaceId?: string } = {}): Promise<ImportOutcome> {
-    const files = normalizeBundle(extractZip(zip))
-    const skillMd = files.find((file) => file.relativePath.toLowerCase() === 'skill.md')
-    if (!skillMd) throw new Error('The bundle must contain a SKILL.md.')
+  // Picks the skill root to import from a multi-root bundle: by explicit subPath when given, else the
+  // sole root — a bundle with several roots requires the caller to disambiguate with a subPath.
+  private selectRoot(roots: SkillRoot[], subPath?: string): SkillRoot {
+    if (subPath !== undefined) {
+      const match = roots.find((root) => root.subPath === subPath)
+      if (!match) throw new Error(`The bundle has no skill at "${subPath}".`)
+      return match
+    }
+    if (roots.length > 1) {
+      throw new Error('The bundle contains multiple skills; specify which one to import.')
+    }
+    return roots[0]
+  }
 
+  // Imports a .zip / .skill bundle that contains a SKILL.md. `subPath` selects one skill from a bundle
+  // holding several. With `replaceId`, the selected skill overwrites that already-imported skill in
+  // place. Otherwise it dedups by content signature (re-importing the same bundle is a no-op) and a
+  // bundle whose name is already taken gets a suffixed slug.
+  async importFromZip(
+    zip: Buffer,
+    options: { subPath?: string; replaceId?: string } = {}
+  ): Promise<ImportOutcome> {
+    const roots = findSkillRoots(extractZip(zip))
+    if (roots.length === 0) throw new Error('The bundle must contain a SKILL.md.')
+
+    const root = this.selectRoot(roots, options.subPath)
+    const files = root.files
+    const skillMd = files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
     const signature = signatureOf(files)
 
     if (options.replaceId !== undefined) {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -184,7 +184,7 @@ interface OpenScienceAPI {
     deleteSkill(request: DeleteSkillRequest): Promise<SkillView[]>
     importSkill(request: ImportSkillRequest): Promise<ImportSkillResult>
     importSkillZip(request: ImportSkillZipRequest): Promise<ImportSkillResult>
-    previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreview>
+    previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreview[]>
     scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult>
     listConnectors(): Promise<ConnectorsSnapshot>
     getConnectorDetail(id: string): Promise<ConnectorDetailView>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -200,7 +200,7 @@ type OpenScienceAPI = {
     deleteSkill: (request: DeleteSkillRequest) => Promise<SkillView[]>
     importSkill: (request: ImportSkillRequest) => Promise<ImportSkillResult>
     importSkillZip: (request: ImportSkillZipRequest) => Promise<ImportSkillResult>
-    previewSkillZip: (request: PreviewSkillZipRequest) => Promise<SkillBundlePreview>
+    previewSkillZip: (request: PreviewSkillZipRequest) => Promise<SkillBundlePreview[]>
     scanRepoSkills: (request: ScanRepoRequest) => Promise<ScanRepoResult>
     listConnectors: () => Promise<ConnectorsSnapshot>
     getConnectorDetail: (id: string) => Promise<ConnectorDetailView>
@@ -435,7 +435,7 @@ const api: OpenScienceAPI = {
     importSkillZip: (request: ImportSkillZipRequest) =>
       ipcRenderer.invoke('settings:import-skill-zip', request) as Promise<ImportSkillResult>,
     previewSkillZip: (request: PreviewSkillZipRequest) =>
-      ipcRenderer.invoke('settings:preview-skill-zip', request) as Promise<SkillBundlePreview>,
+      ipcRenderer.invoke('settings:preview-skill-zip', request) as Promise<SkillBundlePreview[]>,
     scanRepoSkills: (request: ScanRepoRequest) =>
       ipcRenderer.invoke('settings:scan-repo-skills', request) as Promise<ScanRepoResult>,
     listConnectors: () =>

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -244,7 +244,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
         skillsView.kind === 'create'
           ? 'New skill'
           : skillsView.kind === 'upload'
-            ? 'Upload a skill'
+            ? 'Upload skills'
             : skillsView.kind === 'import'
               ? 'Import from GitHub'
               : (() => {

--- a/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SkillUploadView } from './SkillUploadView'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+
+let container: HTMLDivElement
+let root: Root
+
+// Lets FileReader (base64 read) and the awaited store mocks settle before assertions.
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await Promise.resolve()
+  })
+}
+
+// Drops files onto the upload label, matching how the real drag-and-drop hook receives them.
+const dropFiles = async (files: File[]): Promise<void> => {
+  const label = document.body.querySelector('label')
+  const dropEvent = new Event('drop', { bubbles: true })
+  Object.defineProperty(dropEvent, 'dataTransfer', { value: { types: ['Files'], files } })
+  await act(async () => {
+    label?.dispatchEvent(dropEvent)
+  })
+  await flush()
+}
+
+const clickButton = (label: string): void => {
+  const button = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+    (candidate) => candidate.textContent?.trim().includes(label)
+  )
+  act(() => button?.click())
+}
+
+beforeEach(() => {
+  useSettingsStore.setState({
+    ...createInitialSettingsState(),
+    skills: [
+      {
+        id: 'a',
+        name: 'Alpha',
+        description: 'First',
+        source: 'featured' as const,
+        updatedAt: '2026-07-08T00:00:00.000Z',
+        enabled: true
+      }
+    ],
+    createSkill: vi.fn().mockResolvedValue(undefined),
+    importSkillZip: vi
+      .fn()
+      .mockResolvedValue({ status: 'imported', id: 'imported-zip', skills: [] }),
+    previewSkillZip: vi.fn().mockResolvedValue([
+      {
+        subPath: 'skills/one',
+        name: 'One',
+        description: 'First bundled skill',
+        files: ['SKILL.md'],
+        alreadyImported: false
+      },
+      {
+        subPath: 'skills/two',
+        name: 'Two',
+        description: 'Second bundled skill',
+        files: ['SKILL.md'],
+        alreadyImported: false
+      }
+    ])
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+describe('SkillUploadView (batch upload)', () => {
+  it('renders the multi-file upload affordance and returns to create on "Write from scratch instead"', () => {
+    const onWriteInstead = vi.fn()
+    act(() => {
+      root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={onWriteInstead} />)
+    })
+
+    expect(document.body.textContent).toContain('Upload skills')
+    expect(document.body.textContent).toContain('Drag and drop or click to upload')
+    // The file picker accepts multiple files.
+    const input = document.body.querySelector<HTMLInputElement>('[aria-label="Upload skill files"]')
+    expect(input?.multiple).toBe(true)
+
+    clickButton('Write from scratch instead')
+    expect(onWriteInstead).toHaveBeenCalledTimes(1)
+  })
+
+  it('expands a bundle into one unchecked row per skill root; Select all + Import forwards each subPath', async () => {
+    const onUploaded = vi.fn()
+    act(() => {
+      root.render(<SkillUploadView onUploaded={onUploaded} onWriteInstead={vi.fn()} />)
+    })
+
+    const bundle = new File([new Uint8Array([1, 2, 3])], 'pack.zip', { type: 'application/zip' })
+    await dropFiles([bundle])
+
+    // Both skill roots inside the bundle become checklist rows, unchecked by default.
+    expect(useSettingsStore.getState().previewSkillZip).toHaveBeenCalledTimes(1)
+    expect(document.body.textContent).toContain('Found 2 skills')
+    const rowChecks = document.body.querySelectorAll<HTMLInputElement>('[aria-label^="Select "]')
+    // Two row checkboxes + the "Select all" checkbox.
+    const rows = Array.from(rowChecks).filter(
+      (checkbox) => checkbox.getAttribute('aria-label') !== 'Select all'
+    )
+    expect(rows).toHaveLength(2)
+    expect(rows.every((checkbox) => !checkbox.checked)).toBe(true)
+    expect(document.body.textContent).toContain('Import selected (0)')
+
+    // Select all checks every row.
+    const selectAll = document.body.querySelector<HTMLInputElement>('[aria-label="Select all"]')
+    act(() => selectAll?.click())
+    expect(document.body.textContent).toContain('Import selected (2)')
+
+    clickButton('Import selected')
+    await flush()
+
+    const importSkillZip = useSettingsStore.getState().importSkillZip
+    expect(importSkillZip).toHaveBeenCalledTimes(2)
+    expect(importSkillZip).toHaveBeenCalledWith(expect.any(String), {
+      subPath: 'skills/one',
+      replaceId: undefined
+    })
+    expect(importSkillZip).toHaveBeenCalledWith(expect.any(String), {
+      subPath: 'skills/two',
+      replaceId: undefined
+    })
+    expect(onUploaded).toHaveBeenCalled()
+  })
+
+  it('parses a markdown file into a candidate that routes to createSkill', async () => {
+    act(() => {
+      root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
+    })
+
+    const md = new File(['---\nname: Solo\ndescription: A solo skill\n---\n# Body'], 'solo.md', {
+      type: 'text/markdown'
+    })
+    await dropFiles([md])
+
+    // A single markdown candidate appears, unchecked; the bundle preview path is not used.
+    expect(useSettingsStore.getState().previewSkillZip).not.toHaveBeenCalled()
+    expect(document.body.textContent).toContain('Found 1 skill')
+
+    const rowCheck = document.body.querySelector<HTMLInputElement>('[aria-label="Select Solo"]')
+    expect(rowCheck?.checked).toBe(false)
+    act(() => rowCheck?.click())
+
+    clickButton('Import selected')
+    await flush()
+
+    expect(useSettingsStore.getState().createSkill).toHaveBeenCalledWith({
+      name: 'Solo',
+      description: 'A solo skill',
+      body: '# Body'
+    })
+  })
+})

--- a/src/renderer/src/pages/settings/SkillUploadView.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, FileText, Info, Upload } from 'lucide-react'
+import { AlertTriangle, Upload } from 'lucide-react'
 import { useState } from 'react'
 
 import { FileDropOverlay } from '@/components/FileDropOverlay'
@@ -19,20 +19,35 @@ type SkillUploadViewProps = {
   onWriteInstead: () => void
 }
 
-// A parsed upload awaiting confirmation: either a bundle (imported as-is) or a markdown skill (created
-// from its frontmatter). The raw payload is kept so confirming re-uses it without re-reading the file.
-type Pending =
+// One import candidate awaiting confirmation. A bundle candidate maps one skill root inside a .zip /
+// .skill archive (a multi-skill bundle yields several); a markdown candidate maps one uploaded
+// SKILL.md. Each carries a stable `key` for selection tracking, and bundles keep the file's base64 so
+// confirming re-uses it without re-reading the file.
+type Candidate =
   | {
       kind: 'bundle'
+      key: string
       fileName: string
       base64: string
+      subPath: string
       name: string
       description: string
       files: string[]
       alreadyImported: boolean
       replaceableId?: string
     }
-  | { kind: 'markdown'; fileName: string; name: string; description: string; body: string }
+  | {
+      kind: 'markdown'
+      key: string
+      fileName: string
+      name: string
+      description: string
+      body: string
+    }
+
+// The outcome of parsing one picked file: zero-or-more candidates, plus an optional per-file error so
+// one bad file never blocks the others.
+type ParseResult = { candidates: Candidate[]; error?: string }
 
 // Pulls name/description out of a .md frontmatter block, returning the stripped body (mirrors the
 // editor's consumeFrontmatter so an uploaded SKILL.md fills the same fields).
@@ -63,8 +78,9 @@ const fileToBase64 = (file: File): Promise<string> =>
     reader.readAsDataURL(file)
   })
 
-// Full-page upload: drop (or click to browse) a SKILL.md or a .zip / .skill bundle. The file is parsed
-// first and shown as a preview; nothing is written until the user confirms.
+// Full-page batch upload: drop (or click to browse) any mix of SKILL.md files and .zip / .skill
+// bundles, each of which may contain several skills. Everything is parsed into a checklist first;
+// nothing is written until the user picks rows and confirms.
 const SkillUploadView = ({
   onUploaded,
   onWriteInstead
@@ -73,203 +89,274 @@ const SkillUploadView = ({
   const importSkillZip = useSettingsStore((state) => state.importSkillZip)
   const previewSkillZip = useSettingsStore((state) => state.previewSkillZip)
   const skills = useSettingsStore((state) => state.skills)
-  const [pending, setPending] = useState<Pending | null>(null)
-  const [message, setMessage] = useState<string | null>(null)
+  const [candidates, setCandidates] = useState<Candidate[] | null>(null)
+  const [errors, setErrors] = useState<string[]>([])
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [summary, setSummary] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
 
-  // Parses a picked file into a preview without importing it.
-  const handleFile = async (file: File): Promise<void> => {
-    setMessage(null)
+  // Parses one picked file into its candidates, capturing a per-file error instead of throwing.
+  const parseFile = async (file: File): Promise<ParseResult> => {
     const name = file.name.toLowerCase()
 
     if (name.endsWith('.zip') || name.endsWith('.skill')) {
-      setBusy(true)
       try {
         const base64 = await fileToBase64(file)
-        const preview = await previewSkillZip(base64)
-        setPending({ kind: 'bundle', fileName: file.name, base64, ...preview })
+        const previews = await previewSkillZip(base64)
+        if (previews.length === 0) {
+          return { candidates: [], error: `${file.name}: no skills found in the bundle.` }
+        }
+        return {
+          candidates: previews.map((preview) => ({
+            kind: 'bundle',
+            key: `${file.name}::${preview.subPath}`,
+            fileName: file.name,
+            base64,
+            subPath: preview.subPath,
+            name: preview.name,
+            description: preview.description,
+            files: preview.files,
+            alreadyImported: preview.alreadyImported,
+            replaceableId: preview.replaceableId
+          }))
+        }
       } catch (error) {
-        setMessage(error instanceof Error ? error.message : 'Could not read the bundle.')
-      } finally {
-        setBusy(false)
+        const detail = error instanceof Error ? error.message : 'could not read the bundle.'
+        return { candidates: [], error: `${file.name}: ${detail}` }
       }
-      return
     }
 
     if (name.endsWith('.md') || name.endsWith('.markdown')) {
       const parsed = consumeFrontmatter(await file.text())
       if (!parsed.name) {
-        setMessage('The .md file needs a name (and description) in its YAML frontmatter.')
-        return
+        return { candidates: [], error: `${file.name}: needs a name in its YAML frontmatter.` }
       }
-      setPending({
-        kind: 'markdown',
-        fileName: file.name,
-        name: parsed.name,
-        description: parsed.description ?? '',
-        body: parsed.body
-      })
-      return
+      return {
+        candidates: [
+          {
+            kind: 'markdown',
+            key: file.name,
+            fileName: file.name,
+            name: parsed.name,
+            description: parsed.description ?? '',
+            body: parsed.body
+          }
+        ]
+      }
     }
 
-    setMessage('Unsupported file — upload a .md file or a .zip/.skill bundle.')
+    return {
+      candidates: [],
+      error: `${file.name}: unsupported file — upload a .md file or a .zip / .skill bundle.`
+    }
   }
 
-  // Commits the previewed upload: importing a bundle (optionally replacing an existing imported skill
-  // when `replaceId` is given) or creating a skill from the markdown.
-  const confirm = async (replaceId?: string): Promise<void> => {
-    if (!pending || busy) return
+  // Parses every picked file into one flat, unchecked-by-default candidate list.
+  const handleFiles = async (files: File[]): Promise<void> => {
+    if (busy || files.length === 0) return
     setBusy(true)
-    setMessage(null)
+    setSummary(null)
     try {
-      if (pending.kind === 'bundle') {
-        await importSkillZip(pending.base64, replaceId)
-      } else {
-        await createSkill({
-          name: pending.name,
-          description: pending.description,
-          body: pending.body
-        })
-      }
-      onUploaded()
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Import failed.')
+      const results = await Promise.all(files.map(parseFile))
+      setCandidates(results.flatMap((result) => result.candidates))
+      setErrors(results.map((result) => result.error).filter((error): error is string => !!error))
+      // Default selection is empty — the user opts in per row (or via Select all).
+      setSelected(new Set())
     } finally {
       setBusy(false)
     }
   }
 
+  // Imports every checked candidate, tallying successes / skips (no-op re-imports) / failures.
+  const importSelected = async (): Promise<void> => {
+    if (busy || !candidates || selected.size === 0) return
+    setBusy(true)
+    setSummary(null)
+    let imported = 0
+    let skipped = 0
+    let failed = 0
+    for (const candidate of candidates.filter((entry) => selected.has(entry.key))) {
+      try {
+        if (candidate.kind === 'bundle') {
+          const result = await importSkillZip(candidate.base64, {
+            subPath: candidate.subPath,
+            replaceId: candidate.replaceableId
+          })
+          if (result.status === 'unchanged') skipped += 1
+          else imported += 1
+        } else {
+          await createSkill({
+            name: candidate.name,
+            description: candidate.description,
+            body: candidate.body
+          })
+          imported += 1
+        }
+      } catch {
+        failed += 1
+      }
+    }
+    setSummary(`Imported ${imported} · skipped ${skipped} · failed ${failed}`)
+    setBusy(false)
+    if (imported > 0) onUploaded()
+  }
+
+  const toggle = (key: string): void =>
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+
+  const allSelected =
+    candidates !== null && candidates.length > 0 && selected.size === candidates.length
+
+  const toggleAll = (): void =>
+    setSelected(() =>
+      allSelected ? new Set() : new Set((candidates ?? []).map((candidate) => candidate.key))
+    )
+
+  const invertSelection = (): void =>
+    setSelected((prev) => {
+      const next = new Set<string>()
+      for (const candidate of candidates ?? []) {
+        if (!prev.has(candidate.key)) next.add(candidate.key)
+      }
+      return next
+    })
+
   const onInputChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const file = event.target.files?.[0]
-    if (file) void handleFile(file)
+    const files = Array.from(event.target.files ?? [])
+    if (files.length > 0) void handleFiles(files)
     event.target.value = ''
   }
 
   // Drag-and-drop shares the same parse path as the picker; the overlay signals the drop target.
   const { isDragging, dropZoneProps } = useFileDropZone({
     enabled: !busy,
-    onFiles: (files) => void handleFile(files[0])
+    onFiles: (files) => void handleFiles(files)
   })
 
-  // Confirmation page: the parsed skill and its files, then Import / Cancel.
-  if (pending) {
-    // Two duplicate signals: an exact re-upload (bundle content signature already imported), and a
-    // same-name skill already in the catalog (any source) — the latter also covers .md uploads.
-    const exactDuplicate = pending.kind === 'bundle' && pending.alreadyImported
-    const nameTaken = skills.some(
-      (skill) => skill.name.trim().toLowerCase() === pending.name.trim().toLowerCase()
-    )
-    const duplicate = exactDuplicate || nameTaken
-    // The name collides with exactly one existing imported skill (different content): let the user
-    // replace it in place or import a copy, instead of silently creating a suffixed duplicate.
-    const replaceId = pending.kind === 'bundle' ? pending.replaceableId : undefined
+  // Names already in the catalog (any source) — used to flag same-name collisions on the checklist.
+  const existingNames = new Set(skills.map((skill) => skill.name.trim().toLowerCase()))
 
+  // Confirmation page: a checklist of every parsed candidate (nothing checked by default).
+  if (candidates !== null && candidates.length > 0) {
     return (
       <div className="p-5">
         <h2 className="text-base font-semibold text-foreground">Confirm import</h2>
         <p className="mt-0.5 text-[13px] leading-5 text-muted-foreground">
-          Review what will be added from <span className="text-foreground">{pending.fileName}</span>
-          .
+          Pick the skills you want to add. Nothing is written until you import.
         </p>
 
-        <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
-          <div className="flex items-start gap-3">
-            <FileText className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden="true" />
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <span className="truncate text-sm font-semibold text-foreground">
-                  {pending.name}
-                </span>
-                {duplicate ? (
-                  <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                    Already uploaded
-                  </span>
-                ) : null}
-              </div>
-              {pending.description ? (
-                <p className="mt-1 text-xs text-muted-foreground [text-wrap:pretty]">
-                  {pending.description}
-                </p>
-              ) : null}
-            </div>
-          </div>
-
-          {pending.kind === 'bundle' ? (
-            <div className="mt-3 border-t border-border pt-3">
-              <span className="text-xs font-medium text-muted-foreground">
-                Files ({pending.files.length})
-              </span>
-              <ul className="mt-1.5 flex flex-col gap-0.5">
-                {pending.files.map((file) => (
-                  <li key={file} className="truncate font-mono text-xs text-foreground">
-                    {file}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : (
-            <div className="mt-3 border-t border-border pt-3">
-              <span className="text-xs font-medium text-muted-foreground">
-                Creates a personal skill (SKILL.md)
-              </span>
-            </div>
-          )}
-        </div>
-
-        {message ? <ErrorBanner message={message} /> : null}
-
-        <div className="mt-4 flex items-center gap-2">
-          {replaceId ? (
-            <>
+        <div className="mt-5">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <h3 className="text-sm font-semibold text-foreground">
+                Found {candidates.length} skill{candidates.length === 1 ? '' : 's'}
+              </h3>
+              <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <input
+                  type="checkbox"
+                  aria-label="Select all"
+                  checked={allSelected}
+                  onChange={toggleAll}
+                  disabled={busy}
+                  className="size-4 shrink-0"
+                />
+                Select all
+              </label>
               <Button
                 type="button"
-                variant="outline"
-                onClick={() => void confirm(replaceId)}
+                variant="ghost"
+                size="sm"
+                onClick={invertSelection}
                 disabled={busy}
               >
-                {busy ? 'Importing…' : `Replace "${pending.name}"`}
+                Invert
               </Button>
-              <Button type="button" variant="ghost" onClick={() => void confirm()} disabled={busy}>
-                Import as a copy
-              </Button>
-            </>
-          ) : (
-            <Button type="button" variant="outline" onClick={() => void confirm()} disabled={busy}>
-              {busy ? 'Importing…' : 'Import'}
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void importSelected()}
+              disabled={busy || selected.size === 0}
+            >
+              {busy ? 'Importing…' : `Import selected (${selected.size})`}
             </Button>
-          )}
+          </div>
+
+          <ul className="mt-2 flex flex-col divide-y divide-border">
+            {candidates.map((candidate) => {
+              const nameExists = existingNames.has(candidate.name.trim().toLowerCase())
+              const alreadyImported = candidate.kind === 'bundle' && candidate.alreadyImported
+              const secondary =
+                candidate.kind === 'bundle'
+                  ? `${candidate.fileName} · ${candidate.subPath}`
+                  : candidate.fileName
+              return (
+                <li key={candidate.key} className="flex items-center gap-3 py-2.5">
+                  <input
+                    type="checkbox"
+                    aria-label={`Select ${candidate.name}`}
+                    checked={selected.has(candidate.key)}
+                    onChange={() => toggle(candidate.key)}
+                    disabled={busy}
+                    className="size-4 shrink-0"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <span className="block truncate text-sm text-foreground">{candidate.name}</span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {secondary}
+                    </span>
+                  </div>
+                  {alreadyImported ? (
+                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                      Already imported
+                    </span>
+                  ) : nameExists ? (
+                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                      Name exists
+                    </span>
+                  ) : null}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+
+        {errors.map((error) => (
+          <ErrorBanner key={error} message={error} />
+        ))}
+        {summary ? <p className="mt-3 text-xs text-muted-foreground">{summary}</p> : null}
+
+        <div className="mt-4">
           <Button
             type="button"
             variant="ghost"
             onClick={() => {
-              setPending(null)
-              setMessage(null)
+              setCandidates(null)
+              setErrors([])
+              setSelected(new Set())
+              setSummary(null)
             }}
             disabled={busy}
             className="text-muted-foreground"
           >
-            Choose a different file
+            Choose different files
           </Button>
         </div>
-        {duplicate ? (
-          <p className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
-            <Info className="size-3.5 shrink-0" aria-hidden="true" />
-            {exactDuplicate
-              ? 'This exact bundle is already imported — re-importing is a no-op.'
-              : replaceId
-                ? `A skill named "${pending.name}" is already imported — replace it or import a copy.`
-                : `A skill named "${pending.name}" already exists.`}
-          </p>
-        ) : null}
       </div>
     )
   }
 
   return (
     <div className="p-5">
-      <h2 className="text-base font-semibold text-foreground">Upload a skill</h2>
+      <h2 className="text-base font-semibold text-foreground">Upload skills</h2>
       <p className="mt-0.5 text-[13px] leading-5 text-muted-foreground">
-        Add a skill from a SKILL.md file or a .zip / .skill bundle on your computer.
+        Add skills from SKILL.md files or .zip / .skill bundles on your computer. You can select
+        several files at once, and a single archive may contain multiple skills.
       </p>
 
       <label
@@ -279,8 +366,9 @@ const SkillUploadView = ({
         {isDragging ? <FileDropOverlay label="Drop to upload" className="rounded-lg" /> : null}
         <input
           type="file"
-          accept=".md,.zip,.skill"
-          aria-label="Upload a skill file"
+          multiple
+          accept=".md,.markdown,.zip,.skill"
+          aria-label="Upload skill files"
           onChange={onInputChange}
           className="sr-only"
         />
@@ -296,7 +384,10 @@ const SkillUploadView = ({
         </span>
       </label>
 
-      {message ? <ErrorBanner message={message} /> : null}
+      {errors.map((error) => (
+        <ErrorBanner key={error} message={error} />
+      ))}
+      {summary ? <p className="mt-3 text-xs text-muted-foreground">{summary}</p> : null}
 
       <div className="mt-5 text-center">
         <Button type="button" variant="ghost" onClick={onWriteInstead}>

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -49,12 +49,15 @@ beforeEach(() => {
     importSkillZip: vi
       .fn()
       .mockResolvedValue({ status: 'imported', id: 'imported-zip', skills: [] }),
-    previewSkillZip: vi.fn().mockResolvedValue({
-      name: 'Bundled',
-      description: 'From a bundle',
-      files: ['SKILL.md'],
-      alreadyImported: false
-    }),
+    previewSkillZip: vi.fn().mockResolvedValue([
+      {
+        subPath: '',
+        name: 'Bundled',
+        description: 'From a bundle',
+        files: ['SKILL.md'],
+        alreadyImported: false
+      }
+    ]),
     scanRepoSkills: vi.fn().mockResolvedValue({
       skills: [
         {
@@ -293,8 +296,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     // The confirm page shows, with the duplicate reminder (parse-first, not imported yet).
     expect(document.body.textContent).toContain('Confirm import')
-    expect(document.body.textContent).toContain('Already uploaded')
-    expect(document.body.textContent).toContain('A skill named "Alpha" already exists.')
+    expect(document.body.textContent).toContain('Name exists')
     expect(useSettingsStore.getState().createSkill).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -158,8 +158,8 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
             <DropdownMenuItem className="gap-2.5" onSelect={() => onNavigate({ kind: 'upload' })}>
               <FileUp className="size-4 shrink-0" aria-hidden="true" />
               <span className="flex flex-col">
-                <span>Upload a skill</span>
-                <span className="text-xs text-muted-foreground">Pick a SKILL.md file</span>
+                <span>Upload skills</span>
+                <span className="text-xs text-muted-foreground">Pick SKILL.md files</span>
               </span>
             </DropdownMenuItem>
             <DropdownMenuItem className="gap-2.5" onSelect={() => onNavigate({ kind: 'import' })}>

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -28,6 +28,8 @@ type SettingsApi = {
   markOnboardingComplete: ReturnType<typeof vi.fn>
   listSkills: ReturnType<typeof vi.fn>
   setSkillEnabled: ReturnType<typeof vi.fn>
+  importSkillZip: ReturnType<typeof vi.fn>
+  previewSkillZip: ReturnType<typeof vi.fn>
   listConnectors: ReturnType<typeof vi.fn>
   getConnectorDetail: ReturnType<typeof vi.fn>
   setConnectorEnabled: ReturnType<typeof vi.fn>
@@ -98,6 +100,8 @@ beforeEach(() => {
       .mockResolvedValue({ ...snapshot([]), onboardingCompletedAt: 4242 }),
     listSkills: vi.fn().mockResolvedValue([]),
     setSkillEnabled: vi.fn().mockResolvedValue([]),
+    importSkillZip: vi.fn().mockResolvedValue({ status: 'imported', id: 'z', skills: [] }),
+    previewSkillZip: vi.fn().mockResolvedValue([]),
     listConnectors: vi
       .fn()
       .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
@@ -521,6 +525,62 @@ describe('settings store: openSettingsToSkill', () => {
     useSettingsStore.getState().closeSettings()
     expect(useSettingsStore.getState().isSettingsOpen).toBe(false)
     expect(useSettingsStore.getState().pendingSkillId).toBeUndefined()
+  })
+})
+
+describe('settings store: skill bundle upload', () => {
+  it('previewSkillZip returns one preview per skill root the bundle contains', async () => {
+    api.previewSkillZip.mockResolvedValue([
+      {
+        subPath: 'skills/alpha',
+        name: 'Alpha',
+        description: '',
+        files: ['SKILL.md'],
+        alreadyImported: false
+      },
+      {
+        subPath: 'skills/beta',
+        name: 'Beta',
+        description: '',
+        files: ['SKILL.md'],
+        alreadyImported: true
+      }
+    ])
+
+    const previews = await useSettingsStore.getState().previewSkillZip('YmFzZTY0')
+
+    expect(api.previewSkillZip).toHaveBeenCalledWith({ dataBase64: 'YmFzZTY0' })
+    expect(previews).toHaveLength(2)
+    expect(previews.map((preview) => preview.name)).toEqual(['Alpha', 'Beta'])
+  })
+
+  it('importSkillZip forwards the subPath/replaceId opts and reconciles the skill list', async () => {
+    api.importSkillZip.mockResolvedValue({
+      status: 'imported',
+      id: 'imported-alpha',
+      skills: [
+        {
+          id: 'imported-alpha',
+          name: 'Alpha',
+          description: '',
+          source: 'imported',
+          updatedAt: '',
+          enabled: true
+        }
+      ]
+    })
+
+    const result = await useSettingsStore
+      .getState()
+      .importSkillZip('YmFzZTY0', { subPath: 'skills/alpha', replaceId: 'old-alpha' })
+
+    expect(api.importSkillZip).toHaveBeenCalledWith({
+      dataBase64: 'YmFzZTY0',
+      subPath: 'skills/alpha',
+      replaceId: 'old-alpha'
+    })
+    expect(result.status).toBe('imported')
+    expect(useSettingsStore.getState().skills.map((skill) => skill.id)).toEqual(['imported-alpha'])
   })
 })
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -131,9 +131,12 @@ type SettingsStore = SettingsStoreData & {
   // Imports a skill from an uploaded .zip / .skill bundle (base64), returning the outcome.
   // Imports a skill from an uploaded .zip / .skill bundle (base64). With `replaceId`, the bundle
   // overwrites that already-imported skill in place instead of creating a new one.
-  importSkillZip: (dataBase64: string, replaceId?: string) => Promise<ImportSkillResult>
+  importSkillZip: (
+    dataBase64: string,
+    opts?: { subPath?: string; replaceId?: string }
+  ) => Promise<ImportSkillResult>
   // Parses an uploaded bundle without importing it, for a confirm-before-import preview.
-  previewSkillZip: (dataBase64: string) => Promise<SkillBundlePreview>
+  previewSkillZip: (dataBase64: string) => Promise<SkillBundlePreview[]>
   // Scans a GitHub repo for importable skill directories (does not mutate state).
   scanRepoSkills: (repo: string) => Promise<ScanRepoResult>
   // Loads the bundled-connector list (enabled/auto-allow + NCBI credential state) from main.
@@ -518,8 +521,12 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     return result
   },
 
-  importSkillZip: async (dataBase64, replaceId) => {
-    const result = await window.api.settings.importSkillZip({ dataBase64, replaceId })
+  importSkillZip: async (dataBase64, opts) => {
+    const result = await window.api.settings.importSkillZip({
+      dataBase64,
+      subPath: opts?.subPath,
+      replaceId: opts?.replaceId
+    })
     set({ skills: result.skills })
     return result
   },

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -386,6 +386,7 @@ export type ImportSkillZipRequest = {
   dataBase64: string
   filename?: string
   replaceId?: string
+  subPath?: string
 }
 
 // Parse an uploaded .zip / .skill bundle without importing it, for a confirm-before-import preview.
@@ -398,6 +399,7 @@ export type PreviewSkillZipRequest = {
 // exactly one existing imported skill of different content — the id of that skill, offered as a
 // replace target.
 export type SkillBundlePreview = {
+  subPath: string
   name: string
   description: string
   files: string[]


### PR DESCRIPTION
## Summary

The skill upload flow now accepts multiple skills at once instead of a single file.

- Drop or pick several mixed files (`.zip` / `.skill` / `.md`) in one action.
- A single archive may pack many skill folders. The main process detects every skill root at `*/SKILL.md` and `*/*/SKILL.md` (a root `SKILL.md` still counts as one skill), collapsing nested roots so none is double-counted.
- `previewZip` returns one preview per skill root (each with its `subPath`); `importFromZip` takes a `subPath` to import a selected root.
- The upload view aggregates all candidates into one checklist (default unchecked, with select-all / invert) and reports an imported / skipped / failed summary. Per-file parse failures do not block the rest.
- Menu, breadcrumb, and page copy updated to 'Upload skills'.
- The old single-bundle `normalizeBundle` helper is removed (subsumed by the new `findSkillRoots`).

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test` — all pass (added coverage for `findSkillRoots`, subPath import, the multi-file checklist, and store signatures)