### PR TITLE
fix(ui): match external-link dialog primary button to settings link color

### DIFF
--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -228,10 +228,10 @@
         }
 
         &.sd-link-safety-primary {
-          @apply border-sd-link-strong bg-sd-link-strong text-white;
+          @apply border-primary bg-primary text-primary-foreground;
 
           &:hover {
-            @apply bg-sd-link;
+            @apply bg-primary/90;
           }
         }
       }


### PR DESCRIPTION
## Summary

The **Open link** button in the link-safety modal ("Open external link?") used the terracotta `sd-link-strong` color, which didn't match the external-link jump links shown in Settings.

This switches it to the teal `primary` token (`bg-primary` / `text-primary-foreground`, hover `bg-primary/90`), so the dialog's primary action matches the color of the jump links elsewhere in the app.

## Testing

- `npm run lint` passes
- Verified via `npm run dev`: renderer builds cleanly, no Tailwind errors