### PR TITLE
fix(acp): classify agent session resume failures

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -611,11 +611,48 @@ describe('workspace agent message sending', () => {
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
   })
 
-  it('fails the run with a generic message when resume fails for another reason', async () => {
+  it('keeps the underlying cause visible when resume fails for an unexpected reason', async () => {
     const runtime = {
       state: createSnapshot(),
       createSession: vi.fn(),
-      resumeSession: vi.fn().mockRejectedValue(new Error('agent process crashed')),
+      resumeSession: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            "Error invoking remote method 'acp:resume-session': Error: agent process crashed"
+          )
+        ),
+      sendPrompt: vi.fn()
+    }
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Previous prompt',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'Continue restored conversation',
+      cwd: '/workspace/project'
+    })
+
+    // The IPC wrapper is stripped and the real cause is appended rather than swallowed.
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error: 'Agent session resume failed: agent process crashed'
+    })
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+  })
+
+  it('reports a distinct message when the agent build cannot resume sessions', async () => {
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi
+        .fn()
+        .mockRejectedValue(new Error('ACP agent does not support session resume.')),
       sendPrompt: vi.fn()
     }
 
@@ -634,7 +671,35 @@ describe('workspace agent message sending', () => {
 
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       status: 'error',
-      error: 'Agent session resume failed'
+      error: 'This agent build cannot resume sessions; start a new conversation.'
+    })
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+  })
+
+  it('reports a distinct message when the agent connection cannot be re-established', async () => {
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi.fn().mockRejectedValue(new Error('ACP connection failed')),
+      sendPrompt: vi.fn()
+    }
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Previous prompt',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'Continue restored conversation',
+      cwd: '/workspace/project'
+    })
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error: 'Could not reconnect to the agent; check it is installed, then click Resume to retry.'
     })
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
   })
@@ -692,7 +757,7 @@ describe('resuming an interrupted session on demand', () => {
     const runtime = {
       state: createSnapshot(),
       createSession: vi.fn(),
-      resumeSession: vi.fn().mockRejectedValue(new Error('Internal error')),
+      resumeSession: vi.fn().mockRejectedValue(new Error('unexpected agent state')),
       sendPrompt: vi.fn()
     }
     seedDetachedSession()
@@ -701,7 +766,7 @@ describe('resuming an interrupted session on demand', () => {
 
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       status: 'error',
-      error: 'Agent session resume failed'
+      error: 'Agent session resume failed: unexpected agent state'
     })
   })
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -53,8 +53,20 @@ type WorkspaceRuntimeEventProcessor = {
   process: (events: AcpRuntimeEvent[]) => Promise<void>
 }
 
-// The agent process reports a deleted/moved workspace folder as "cwd does not exist"; surface
-// that as the same actionable message already used when a session has no cwd to resume into.
+// Strips the Electron IPC wrapper ("Error invoking remote method '…': Error: <cause>") and any
+// leading "Error:" so the underlying agent message can be shown to the user on its own.
+const unwrapResumeErrorDetail = (message: string): string =>
+  message
+    .replace(/^Error invoking remote method '[^']*':\s*/i, '')
+    .replace(/^Error:\s*/i, '')
+    .trim()
+
+// Turns a resume failure into an actionable message. Each branch matches one distinct cause thrown
+// along the runtime resume path (runtime.ts): a deleted/moved workspace folder ("cwd does not exist"),
+// the bounded handshake timeout, an agent build without the resume capability, or a failure to spawn/
+// reconnect the agent process. Anything else is genuinely unexpected, so the underlying cause is kept
+// visible instead of collapsing to an opaque "resume failed". (The common session-replaced/not-found
+// case never reaches here — the runtime silently adopts a fresh agent session for it.)
 const getResumeFailureMessage = (error: unknown): string => {
   const message = error instanceof Error ? error.message : String(error)
 
@@ -66,7 +78,17 @@ const getResumeFailureMessage = (error: unknown): string => {
     return 'Agent session resume timed out; click Resume to try again.'
   }
 
-  return 'Agent session resume failed'
+  if (/does not support session resume/i.test(message)) {
+    return 'This agent build cannot resume sessions; start a new conversation.'
+  }
+
+  if (/connection (failed|was superseded)|ACP connection/i.test(message)) {
+    return 'Could not reconnect to the agent; check it is installed, then click Resume to retry.'
+  }
+
+  const detail = unwrapResumeErrorDetail(message)
+
+  return detail ? `Agent session resume failed: ${detail}` : 'Agent session resume failed'
 }
 
 // Keeps attachment-finalization failures displayable without assuming Error instances.


### PR DESCRIPTION
## Summary

Resume failures in the workspace were all collapsed into a single opaque `"Agent session resume failed"` message, so users (and logs) couldn't tell what actually went wrong. `getResumeFailureMessage` recognized only two causes and discarded the underlying error for everything else.

This extends the existing substring-classification pattern to cover the remaining distinct causes thrown along the runtime resume path, and stops swallowing the real cause on unexpected failures.

### Distinguished cases

- **Workspace missing** (`cwd does not exist`) — unchanged
- **Timeout** (bounded handshake stalled) — unchanged
- **Agent lacks resume capability** (`ACP agent does not support session resume.`) — new: "This agent build cannot resume sessions; start a new conversation."
- **Connection/spawn failure** (`ACP connection failed` / superseded) — new: "Could not reconnect to the agent; check it is installed, then click Resume to retry."
- **Unexpected** — now appends the underlying cause (stripping the Electron `Error invoking remote method '…':` IPC wrapper) instead of hiding it

Note: the common session-replaced/not-found case (`-32002`/`-32603`) never reaches this function — the runtime already recovers it silently by adopting a fresh agent session, so it is intentionally left out of the classifier.

Renderer-only change; the underlying error strings already propagate through IPC as substrings.

## Testing

- Added 3 tests (agent-cannot-resume, connection-failure, underlying-cause-preserved) and updated 2 existing ones
- `useWorkspaceAgentRuntime.test.ts`: 25 passed
- typecheck + eslint clean