### PR TITLE
fix(win): reject unspawnable claude.cmd in detection and prefer healthy recorded runtime

### DIFF
--- a/src/main/acp/agent-process.ts
+++ b/src/main/acp/agent-process.ts
@@ -75,6 +75,17 @@ const spawnClaudeAgentAcp = ({
   // On Windows, a `claude.cmd` shim can't be spawned by the SDK without a shell (spawn EINVAL); resolve
   // it to the underlying cli.js so the SDK runs it via node. Native/Unix executables pass through.
   const resolvedExecutablePath = resolveClaudeExecutableForSpawn(executablePath)
+
+  // A win32 path still ending in .cmd/.bat here could not be resolved to the cli.js/.exe it wraps, so
+  // the SDK's shell-less spawn below will fail with `spawn EINVAL` (surfacing as an opaque
+  // acp:create-session "internal error"). Warn with the paths (no secrets) so the cause is actionable.
+  if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolvedExecutablePath)) {
+    log.warn('claude executable is an unresolved .cmd/.bat shim; spawn will likely fail (EINVAL)', {
+      executablePath: resolvedExecutablePath,
+      hint: 'Re-run Claude detection, or install the app-managed native binary in settings.'
+    })
+  }
+
   const env = buildAgentSpawnEnv(
     augmentedPathEnv(process.env),
     envOverrides,

--- a/src/main/settings/claude-detect.test.ts
+++ b/src/main/settings/claude-detect.test.ts
@@ -112,15 +112,50 @@ describe('claude-detect', () => {
       expect(dirs).not.toContain('/opt/homebrew/bin')
     })
 
-    it('finds claude.cmd ahead of the bare name', async () => {
+    it('finds claude.cmd ahead of the bare name when it resolves to a spawnable target', async () => {
       const npmDir = win32.join('C:\\Users\\me\\AppData\\Roaming', 'npm')
-      const result = await detectClaude(winDeps({ [win32.join(npmDir, 'claude.cmd')]: '2.3.0' }))
+      const cmd = win32.join(npmDir, 'claude.cmd')
+      const result = await detectClaude(
+        winDeps(
+          { [cmd]: '2.3.0' },
+          // The shim resolves to the cli.js it wraps, so the ACP agent can spawn it via node.
+          { resolveSpawnTarget: (path) => (path === cmd ? win32.join(npmDir, 'cli.js') : path) }
+        )
+      )
+
+      expect(result).toEqual({ found: true, path: cmd, version: '2.3.0' })
+    })
+
+    it('skips a claude.cmd that cannot be spawn-resolved and falls through to claude.exe', async () => {
+      const npmDir = win32.join('C:\\Users\\me\\AppData\\Roaming', 'npm')
+      const result = await detectClaude(
+        winDeps(
+          {
+            [win32.join(npmDir, 'claude.cmd')]: '2.3.0',
+            [win32.join(npmDir, 'claude.exe')]: '2.4.0'
+          },
+          // Identity resolution leaves the shim a .cmd, so it is rejected as unspawnable.
+          { resolveSpawnTarget: (path) => path }
+        )
+      )
 
       expect(result).toEqual({
         found: true,
-        path: win32.join(npmDir, 'claude.cmd'),
-        version: '2.3.0'
+        path: win32.join(npmDir, 'claude.exe'),
+        version: '2.4.0'
       })
+    })
+
+    it('reports not found when the only candidate is an unspawnable .cmd shim', async () => {
+      const npmDir = win32.join('C:\\Users\\me\\AppData\\Roaming', 'npm')
+      const result = await detectClaude(
+        winDeps(
+          { [win32.join(npmDir, 'claude.cmd')]: '2.3.0' },
+          { resolveSpawnTarget: (path) => path }
+        )
+      )
+
+      expect(result).toEqual({ found: false })
     })
 
     it('finds claude.exe when no .cmd shim exists', async () => {

--- a/src/main/settings/claude-detect.ts
+++ b/src/main/settings/claude-detect.ts
@@ -6,6 +6,7 @@ import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 
 import type { ClaudeDetectResult } from '../../shared/settings'
+import { resolveClaudeExecutableForSpawn } from '../acp/claude-executable'
 import { augmentedPathEnv } from './shell-path'
 
 const execFileAsync = promisify(execFile)
@@ -29,6 +30,10 @@ export type ClaudeDetectDeps = {
   resolveNpmBinDirs: () => Promise<string[]>
   // Extra fixed directories to probe (e.g. the app-managed install dir), searched after PATH/home.
   extraDirs?: string[]
+  // Maps a detected path to what the ACP agent will actually spawn (on win32 a `claude.cmd` shim is
+  // resolved to the `cli.js`/`.exe` it wraps). A candidate whose spawn target is still a `.cmd`/`.bat`
+  // cannot be launched without a shell, so detection rejects it. Defaults to identity when omitted.
+  resolveSpawnTarget?: (path: string) => string
 }
 
 // Path semantics follow the injected platform, not the host running the code. Production wires
@@ -79,14 +84,25 @@ const collectCandidateDirs = async (deps: ClaudeDetectDeps): Promise<string[]> =
   )
 }
 
+// Whether a resolved spawn target is still a Windows batch shim. The ACP agent spawns without a shell,
+// so a `.cmd`/`.bat` here would fail with `spawn EINVAL`; such a candidate must be rejected.
+const isUnspawnableShim = (target: string, platform: NodeJS.Platform): boolean => {
+  if (platform !== 'win32') return false
+
+  const lower = target.toLowerCase()
+
+  return lower.endsWith('.cmd') || lower.endsWith('.bat')
+}
+
 // Probes each candidate directory × filename, returning the first executable whose `--version`
-// succeeds.
+// succeeds and that the ACP agent can actually spawn.
 const detectClaude = async (
   deps: ClaudeDetectDeps = createDefaultDetectDeps()
 ): Promise<ClaudeDetectResult> => {
   const p = pathFor(deps.platform)
   const candidateDirs = await collectCandidateDirs(deps)
   const binaryNames = claudeBinaryNames(deps.platform)
+  const resolveSpawnTarget = deps.resolveSpawnTarget ?? ((candidate: string) => candidate)
 
   for (const dir of candidateDirs) {
     for (const name of binaryNames) {
@@ -98,6 +114,11 @@ const detectClaude = async (
 
       // A path that exists but cannot report a version is not a usable claude; keep searching.
       if (version === undefined) continue
+
+      // On win32 the ACP agent spawns the executable without a shell. A `claude.cmd` shim that cannot
+      // be resolved to the `cli.js`/`.exe` it wraps would fail there with `spawn EINVAL` even though
+      // its shell-run `--version` just succeeded, so reject it and keep probing for a spawnable target.
+      if (isUnspawnableShim(resolveSpawnTarget(candidate), deps.platform)) continue
 
       return { found: true, path: candidate, version }
     }
@@ -187,7 +208,8 @@ const createDefaultDetectDeps = (): ClaudeDetectDeps => {
     platform,
     isExecutable: isExecutableFile(platform),
     getVersion: runClaudeVersion(platform),
-    resolveNpmBinDirs: resolveNpmBinDirs(platform)
+    resolveNpmBinDirs: resolveNpmBinDirs(platform),
+    resolveSpawnTarget: (candidate) => resolveClaudeExecutableForSpawn(candidate, platform)
   }
 }
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -828,7 +828,7 @@ describe('installClaude (app-managed source)', () => {
 })
 
 describe('checkEnvironment', () => {
-  it('keeps a cached executable when a GUI PATH cannot rediscover it', async () => {
+  it('keeps a cached executable that still runs when a GUI PATH cannot rediscover it', async () => {
     await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
     const service = new SettingsService({
       repository,
@@ -838,8 +838,9 @@ describe('checkEnvironment', () => {
         env: {},
         homePath: '/home',
         platform: 'linux',
+        // PATH scan finds nothing, but the cached path still reports a version.
         isExecutable: () => Promise.resolve(false),
-        getVersion: () => Promise.resolve(undefined),
+        getVersion: (path) => Promise.resolve(path === execPath ? '2.1.0' : undefined),
         resolveNpmBinDirs: () => Promise.resolve([])
       }
     })
@@ -848,5 +849,56 @@ describe('checkEnvironment', () => {
 
     expect(result.claude).toEqual({ found: true, path: execPath, version: '2.1.0' })
     expect(result.checks.find((check) => check.id === 'claude')?.status).toBe('passed')
+  })
+
+  it('does not overwrite a healthy recorded executable with a freshly detected PATH entry', async () => {
+    const other = join(storageRoot, 'other-bin', 'claude')
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+    const service = new SettingsService({
+      repository,
+      storageRoot,
+      userClaudeDir: join(storageRoot, 'no-user-claude'),
+      detectDeps: {
+        env: { PATH: join(storageRoot, 'other-bin') },
+        homePath: '/home',
+        platform: 'linux',
+        // A different claude is discoverable on PATH, but the cached one is still healthy.
+        isExecutable: (path) => Promise.resolve(path === other),
+        getVersion: (path) =>
+          Promise.resolve(path === execPath ? '2.1.0' : path === other ? '9.9.9' : undefined),
+        resolveNpmBinDirs: () => Promise.resolve([])
+      }
+    })
+
+    const result = await service.checkEnvironment()
+
+    // The recorded runtime is retained rather than being replaced by the PATH discovery.
+    expect(result.claude).toEqual({ found: true, path: execPath, version: '2.1.0' })
+    expect((await repository.getSettings()).claude?.resolvedPath).toBe(execPath)
+  })
+
+  it('re-detects when the recorded executable no longer reports a version', async () => {
+    const stale = join(storageRoot, 'stale', 'claude')
+    const found = join(storageRoot, 'found-bin', 'claude')
+    await repository.setClaudeInfo({ resolvedPath: stale, version: '2.1.0' })
+    const service = new SettingsService({
+      repository,
+      storageRoot,
+      userClaudeDir: join(storageRoot, 'no-user-claude'),
+      detectDeps: {
+        env: { PATH: join(storageRoot, 'found-bin') },
+        homePath: '/home',
+        platform: 'linux',
+        isExecutable: (path) => Promise.resolve(path === found),
+        // The cached path is dead (no version); detection finds a live one on PATH.
+        getVersion: (path) => Promise.resolve(path === found ? '2.2.0' : undefined),
+        resolveNpmBinDirs: () => Promise.resolve([])
+      }
+    })
+
+    const result = await service.checkEnvironment()
+
+    expect(result.claude).toEqual({ found: true, path: found, version: '2.2.0' })
+    expect((await repository.getSettings()).claude?.resolvedPath).toBe(found)
   })
 })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -852,14 +852,16 @@ describe('checkEnvironment', () => {
   })
 
   it('does not overwrite a healthy recorded executable with a freshly detected PATH entry', async () => {
-    const other = join(storageRoot, 'other-bin', 'claude')
+    // Pinned platform is 'linux', so use posix literals; a host join() would splice a win32 drive
+    // letter into PATH and be mis-split on ':' by the posix delimiter.
+    const other = '/other-bin/claude'
     await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
     const service = new SettingsService({
       repository,
       storageRoot,
       userClaudeDir: join(storageRoot, 'no-user-claude'),
       detectDeps: {
-        env: { PATH: join(storageRoot, 'other-bin') },
+        env: { PATH: '/other-bin' },
         homePath: '/home',
         platform: 'linux',
         // A different claude is discoverable on PATH, but the cached one is still healthy.
@@ -878,15 +880,16 @@ describe('checkEnvironment', () => {
   })
 
   it('re-detects when the recorded executable no longer reports a version', async () => {
-    const stale = join(storageRoot, 'stale', 'claude')
-    const found = join(storageRoot, 'found-bin', 'claude')
+    // Pinned platform is 'linux', so use posix literals (see the note above about PATH splitting).
+    const stale = '/stale/claude'
+    const found = '/found-bin/claude'
     await repository.setClaudeInfo({ resolvedPath: stale, version: '2.1.0' })
     const service = new SettingsService({
       repository,
       storageRoot,
       userClaudeDir: join(storageRoot, 'no-user-claude'),
       detectDeps: {
-        env: { PATH: join(storageRoot, 'found-bin') },
+        env: { PATH: '/found-bin' },
         homePath: '/home',
         platform: 'linux',
         isExecutable: (path) => Promise.resolve(path === found),

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -371,21 +371,31 @@ class SettingsService {
   // Re-runs the complete host inspection on every app launch. Claude detection is part of the same
   // pass so a runtime installed outside Open Science between launches is picked up immediately.
   async checkEnvironment(): Promise<EnvironmentCheckResult> {
-    let claude = await this.detectClaude()
+    // Prefer a previously recorded runtime that still runs over this launch's re-detection. This keeps
+    // a healthy app-managed (or manually chosen) executable from being silently replaced by a PATH
+    // entry discovered later — e.g. an npm `claude.cmd` that only works via a shell — and uses the
+    // `--version` probe (not mere file existence) as the real usability signal, so a stale-but-present
+    // path is never reported as healthy.
+    const cached = (await this.repository.getSettings()).claude
+    let claude: ClaudeDetectResult | undefined
 
-    // A GUI launch can have a narrower PATH than the shell that originally installed Claude. Keep a
-    // previously resolved absolute path when it is still executable so automatic and manual status
-    // surfaces cannot disagree about the same healthy runtime.
-    if (!claude.found) {
-      const cached = (await this.repository.getSettings()).claude
+    if (cached?.resolvedPath) {
+      const version = await this.detectDeps.getVersion(cached.resolvedPath)
 
-      if (cached?.resolvedPath && (await this.pathExists(cached.resolvedPath))) {
-        claude = {
-          found: true,
-          path: cached.resolvedPath,
-          version: cached.version
+      if (version) {
+        claude = { found: true, path: cached.resolvedPath, version }
+
+        // Keep the stored version in sync when an in-place update changed it under the same path.
+        if (version !== cached.version) {
+          await this.repository.setClaudeInfo({ resolvedPath: cached.resolvedPath, version })
         }
       }
+    }
+
+    // No healthy recorded runtime: fall back to a full detection pass, which persists what it finds so
+    // a runtime installed outside Open Science between launches is picked up.
+    if (!claude) {
+      claude = await this.detectClaude()
     }
 
     return runEnvironmentCheck({


### PR DESCRIPTION
## Summary

On Windows the ACP agent spawns the Claude executable **without a shell**. A `claude.cmd` shim that cannot be resolved to the `cli.js`/`.exe` it wraps then fails with `spawn EINVAL`, which surfaces as an opaque `acp:create-session … internal error` (and an identical resume failure). This hardens detection and spawn so that path is caught before it reaches the SDK.

Root-cause detail: detection validates a candidate by running `--version` **through a shell** on Windows, so a `claude.cmd` passes the check — but the shell-less spawn later cannot launch it. Detection also re-runs on every launch and searches PATH before the app-managed dir (trying `claude.cmd` before `claude.exe`), so a healthy app-managed `claude.exe` could be silently replaced by an unspawnable PATH shim.

## Changes

- **Detection rejects unspawnable shims** (`claude-detect.ts`): `.cmd`/`.bat` candidates are resolved via `resolveClaudeExecutableForSpawn`; if the spawn target is still a shim it is skipped, so detection keeps probing for a real `claude.exe` or a resolvable shim instead of recording a path that will `EINVAL`. Exposed as an injectable `resolveSpawnTarget` dep for testing.
- **Prefer a healthy recorded runtime** (`service.ts`): `checkEnvironment` now validates the previously recorded `resolvedPath` with `--version` (not mere file existence) and reuses it when it still runs, only falling back to a full re-detection when it does not. This keeps an app-managed `.exe` from being replaced by a later PATH `claude.cmd`, and stops a stale-but-present path being reported as healthy. Manual re-detection is unchanged.
- **Actionable diagnostics** (`agent-process.ts`): logs a warning (paths only — no secrets) before spawning when the resolved path is still a `.cmd`/`.bat`, so the `EINVAL` cause is visible in logs.

## Notes

- Detection still records the original candidate path (e.g. the `.cmd`) and resolves it at spawn time, rather than rewriting it to `cli.js`. Recording a `.js` path would break the shell-based `--version` health check on Windows.
- The warning adds no new sensitive-data category: the existing `spawning ACP agent` log already records `executablePath`/`rawExecutablePath`/`PATH`. No tokens or credentials are logged, and no user-facing error text was changed.
- Out of scope: validating the local provider's `~/.claude` auth (a different failure mode, not `EINVAL`).

## Testing

- `npm run typecheck`, `npm run lint`, `npm test` (2417 passed) all green.
- Unit tests exercise the win32 rules on a POSIX runner via injected platform (no real fs):
  - detection accepts a `.cmd` only when it resolves to a spawnable target; rejects an unresolvable `.cmd` and falls through to `claude.exe`; reports not found when the only candidate is an unspawnable shim.
  - `checkEnvironment` reuses a still-running recorded path, does not overwrite it with a PATH discovery, and re-detects when the recorded path no longer reports a version.
- **Not verified on real Windows hardware.** Needs a device regression for the mixed case: npm-installed `claude.cmd` present alongside an app-managed `claude.exe`.
