### PR TITLE
fix(skills): harden custom-connector and zip import paths against traversal

### DIFF
--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mkdtemp, readdir, readFile, stat } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { renderCustomSkillDoc } from './skill-doc'
@@ -131,6 +131,23 @@ describe('syncCustomServerSkillDocs', () => {
     // The built-in doc is untouched, and no case-variant directory was created.
     expect(await readFile(builtinDoc, 'utf8')).toBe(before)
     expect((await readdir(dir)).sort()).toEqual(['mcp-chemistry'])
+  })
+
+  it('does not delete the built-in doc when an upgrade left a case-variant directory', async () => {
+    // Real upgrade state: an OLD version wrote mcp-Chemistry (from a custom server named "Chemistry").
+    // On a case-preserving filesystem the built-in sync then writes chemistry's doc into that same
+    // directory; the custom cleanup must recognize it as bundled-owned (case-insensitively) and keep it.
+    const dir = await mkdtemp(join(tmpdir(), 'connector-upgrade-'))
+    await mkdir(join(dir, 'mcp-Chemistry'), { recursive: true })
+    await writeFile(join(dir, 'mcp-Chemistry', 'SKILL.md'), 'stale pre-upgrade content')
+
+    await syncConnectorSkillDocs(dir, ['chemistry'])
+    await syncCustomServerSkillDocs(dir, [], async () => [])
+
+    // The built-in chemistry doc survived (readable case-insensitively) and holds the built-in content.
+    const doc = await readFile(join(dir, 'mcp-chemistry', 'SKILL.md'), 'utf8')
+    expect(doc).toContain('source: connector')
+    expect(doc).toContain('name: mcp-chemistry')
   })
 })
 

--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -23,15 +23,18 @@ function makeServer(overrides: Partial<StoredCustomMcpServer> = {}): StoredCusto
 }
 
 describe('renderCustomSkillDoc', () => {
-  it('renders frontmatter, a composed "Use when" description, and each tool', () => {
-    const md = renderCustomSkillDoc({ name: 'myserver' }, FAKE_TOOLS)
-    expect(md).toContain('name: mcp-myserver')
+  it('renders frontmatter keyed on the server id, a composed "Use when" description, and each tool', () => {
+    const md = renderCustomSkillDoc({ id: 'srv-1', name: 'myserver' }, FAKE_TOOLS)
+    // The skill name is the immutable id, not the user-facing display name.
+    expect(md).toContain('name: mcp-srv-1')
+    expect(md).not.toContain('name: mcp-myserver')
     expect(md).toContain('source: connector')
     expect(md).toMatch(/description: ".*Use when.*"/)
     expect(md).toContain('## When to Use')
     expect(md).toContain('search')
     expect(md).toContain('fetch')
     expect(md).toContain('"type": "object"')
+    // Runtime routing still uses the display name (the key McpClientManager registers under).
     // No-arg tools render without a third argument (a literal ... would reach the bridge as Ellipsis).
     expect(md).toContain('host.mcp("myserver", "search")')
     expect(md).toContain('host.mcp("myserver", "fetch")')
@@ -39,7 +42,7 @@ describe('renderCustomSkillDoc', () => {
 
   it('uses the server-provided description verbatim when present', () => {
     const md = renderCustomSkillDoc(
-      { name: 'myserver', description: 'Use when the user asks about widgets.' },
+      { id: 'srv-1', name: 'myserver', description: 'Use when the user asks about widgets.' },
       FAKE_TOOLS
     )
     const frontmatter = md.slice(0, md.indexOf('---', 3))
@@ -47,7 +50,7 @@ describe('renderCustomSkillDoc', () => {
   })
 
   it('renders a concrete dict example from a custom tool inputSchema', () => {
-    const md = renderCustomSkillDoc({ name: 'myserver' }, [
+    const md = renderCustomSkillDoc({ id: 'srv-1', name: 'myserver' }, [
       {
         name: 'lookup',
         description: 'Look up a record',
@@ -63,7 +66,7 @@ describe('renderCustomSkillDoc', () => {
 })
 
 describe('syncCustomServerSkillDocs', () => {
-  it('writes mcp-<name>/SKILL.md for an enabled server and removes it once disabled', async () => {
+  it('writes mcp-<id>/SKILL.md for an enabled server and removes it once disabled', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'custom-skills-'))
     const server = makeServer()
     const listTools = async (): Promise<typeof FAKE_TOOLS> => FAKE_TOOLS
@@ -71,15 +74,47 @@ describe('syncCustomServerSkillDocs', () => {
     await syncCustomServerSkillDocs(dir, [server], listTools)
 
     let entries = (await readdir(dir)).sort()
-    expect(entries).toEqual(['mcp-myserver'])
-    expect((await stat(join(dir, 'mcp-myserver'))).isDirectory()).toBe(true)
-    const doc = await readFile(join(dir, 'mcp-myserver', 'SKILL.md'), 'utf8')
-    expect(doc).toContain('name: mcp-myserver')
+    expect(entries).toEqual(['mcp-srv-1'])
+    expect((await stat(join(dir, 'mcp-srv-1'))).isDirectory()).toBe(true)
+    const doc = await readFile(join(dir, 'mcp-srv-1', 'SKILL.md'), 'utf8')
+    expect(doc).toContain('name: mcp-srv-1')
 
     // Server no longer enabled -> its skill dir is removed.
     await syncCustomServerSkillDocs(dir, [], listTools)
     entries = (await readdir(dir)).sort()
     expect(entries).toEqual([])
+  })
+
+  it('never lets a malicious server name escape the skills dir or clobber a bundled connector', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'custom-skills-safe-'))
+    const dir = join(root, 'skills')
+    const listTools = async (): Promise<typeof FAKE_TOOLS> => FAKE_TOOLS
+
+    // A name with path separators and one equal to a bundled connector id: both must be neutralized
+    // because the directory is keyed on the immutable UUID id, not the name.
+    const traversal = makeServer({ id: 'srv-escape', name: '../escape' })
+    const collision = makeServer({ id: 'srv-chem', name: 'chemistry' })
+
+    await syncCustomServerSkillDocs(dir, [traversal, collision], listTools)
+
+    // Nothing was written outside the skills dir.
+    expect((await readdir(root)).sort()).toEqual(['skills'])
+    // Both servers materialized under their id, and no `mcp-chemistry` directory was produced.
+    const entries = (await readdir(dir)).sort()
+    expect(entries).toEqual(['mcp-srv-chem', 'mcp-srv-escape'])
+  })
+
+  it('skips a server whose id is not a safe path segment (tampered settings)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'custom-skills-tampered-'))
+    const listTools = async (): Promise<typeof FAKE_TOOLS> => FAKE_TOOLS
+
+    // A hand-crafted id with separators or equal to a bundled id must be dropped entirely.
+    const badPath = makeServer({ id: '../../evil', name: 'evil' })
+    const bundledId = makeServer({ id: 'chemistry', name: 'evil2' })
+
+    await syncCustomServerSkillDocs(dir, [badPath, bundledId], listTools)
+
+    expect((await readdir(dir)).sort()).toEqual([])
   })
 })
 
@@ -93,22 +128,22 @@ describe('bundled and custom skill-doc sync coexist', () => {
     await syncCustomServerSkillDocs(dir, [server], listTools)
 
     let entries = (await readdir(dir)).sort()
-    expect(entries).toEqual(['mcp-chemistry', 'mcp-myserver'])
+    expect(entries).toEqual(['mcp-chemistry', 'mcp-srv-1'])
 
     // Re-running the bundled sync must not remove the custom server's directory...
     await syncConnectorSkillDocs(dir, ['chemistry'])
     entries = (await readdir(dir)).sort()
-    expect(entries).toEqual(['mcp-chemistry', 'mcp-myserver'])
+    expect(entries).toEqual(['mcp-chemistry', 'mcp-srv-1'])
 
     // ...and re-running the custom sync must not remove the bundled connector's directory.
     await syncCustomServerSkillDocs(dir, [server], listTools)
     entries = (await readdir(dir)).sort()
-    expect(entries).toEqual(['mcp-chemistry', 'mcp-myserver'])
+    expect(entries).toEqual(['mcp-chemistry', 'mcp-srv-1'])
 
     // Disabling the bundled connector only removes the bundled dir, leaving the custom one intact.
     await syncConnectorSkillDocs(dir, [])
     entries = (await readdir(dir)).sort()
-    expect(entries).toEqual(['mcp-myserver'])
+    expect(entries).toEqual(['mcp-srv-1'])
 
     // And disabling the custom server only removes the custom dir.
     await syncConnectorSkillDocs(dir, ['chemistry'])

--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -116,6 +116,22 @@ describe('syncCustomServerSkillDocs', () => {
 
     expect((await readdir(dir)).sort()).toEqual([])
   })
+
+  it('does not overwrite a built-in connector with a case-variant id', async () => {
+    // On a case-insensitive filesystem `mcp-Chemistry` and `mcp-chemistry` are the same directory, so
+    // a tampered mixed-case id must be rejected (the safe id alphabet is lowercase-only).
+    const dir = await mkdtemp(join(tmpdir(), 'connector-case-'))
+    await syncConnectorSkillDocs(dir, ['chemistry'])
+    const builtinDoc = join(dir, 'mcp-chemistry', 'SKILL.md')
+    const before = await readFile(builtinDoc, 'utf8')
+
+    const tampered = makeServer({ id: 'Chemistry', name: 'tampered' })
+    await syncCustomServerSkillDocs(dir, [tampered], async () => [])
+
+    // The built-in doc is untouched, and no case-variant directory was created.
+    expect(await readFile(builtinDoc, 'utf8')).toBe(before)
+    expect((await readdir(dir)).sort()).toEqual(['mcp-chemistry'])
+  })
 })
 
 describe('bundled and custom skill-doc sync coexist', () => {

--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -148,6 +148,13 @@ describe('syncCustomServerSkillDocs', () => {
     const doc = await readFile(join(dir, 'mcp-chemistry', 'SKILL.md'), 'utf8')
     expect(doc).toContain('source: connector')
     expect(doc).toContain('name: mcp-chemistry')
+
+    // Exactly one case-fold-equivalent directory remains: on a case-sensitive filesystem the stale
+    // mcp-Chemistry variant is removed, on a case-insensitive one it never duplicated.
+    const entries = await readdir(dir)
+    const folded = entries.map((entry) => entry.toLowerCase())
+    expect(new Set(folded).size).toBe(entries.length)
+    expect(folded).toEqual(['mcp-chemistry'])
   })
 })
 

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { ALL_CONNECTOR_IDS } from './registry'
 import { renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
@@ -34,10 +34,27 @@ export async function syncConnectorSkillDocs(
   const existing = await readdir(skillsDir).catch(() => [] as string[])
   for (const entry of existing) {
     const m = /^mcp-(.+)$/.exec(entry)
-    // Own (and so may remove) only bundled-connector dirs, matched case-insensitively; remove the
-    // ones whose connector is not currently enabled.
-    if (m && namesBundledConnector(m[1]) && !enabled.has(m[1].toLowerCase())) {
+    if (!m || !namesBundledConnector(m[1])) continue // not a bundled-connector dir; leave it alone
+    const canonicalId = m[1].toLowerCase()
+
+    if (!enabled.has(canonicalId)) {
+      // Disabled connector — remove its dir in whatever case it appears.
       await rm(join(skillsDir, entry), { recursive: true, force: true })
+      continue
+    }
+
+    // Enabled connector: keep exactly one directory, the canonical lowercase `mcp-<id>`. A remaining
+    // case-variant (e.g. mcp-Chemistry left by an old version) is stale and removed — but only when it
+    // is a DISTINCT directory from the canonical one. On a case-insensitive filesystem the variant IS
+    // the canonical dir (same dev+ino, holding the freshly-written built-in doc), so it is kept.
+    if (entry !== `mcp-${canonicalId}`) {
+      const [canonical, variant] = await Promise.all([
+        stat(join(skillsDir, `mcp-${canonicalId}`)).catch(() => null),
+        stat(join(skillsDir, entry)).catch(() => null)
+      ])
+      const distinct =
+        canonical && variant && (canonical.dev !== variant.dev || canonical.ino !== variant.ino)
+      if (distinct) await rm(join(skillsDir, entry), { recursive: true, force: true })
     }
   }
 }

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -39,8 +39,13 @@ export type CustomServerListTools = (server: StoredCustomMcpServer) => Promise<C
 // built-in mcp-chemistry doc. The id is a randomUUID (safe token, never a bundled id); this guard
 // additionally rejects any id that isn't a safe path segment — defense against a tampered
 // settings.json — so a hand-crafted id can't reintroduce traversal or a bundled-id collision.
+//
+// The safe alphabet is LOWERCASE-only: a randomUUID is already lowercase, and this closes a
+// case-folding escape — on a case-insensitive filesystem (default macOS/Windows) an id like
+// `Chemistry` would otherwise pass a case-sensitive reserved-id check yet write to the same
+// `mcp-chemistry` directory as the built-in, and two ids differing only in case would collide.
 const isSafeCustomServerId = (id: string): boolean =>
-  /^[A-Za-z0-9_-]+$/.test(id) && !ALL_CONNECTOR_IDS.includes(id)
+  /^[a-z0-9_-]+$/.test(id) && !ALL_CONNECTOR_IDS.includes(id)
 
 // Writes skills/mcp-<id>/SKILL.md for enabled custom MCP servers, sourced from the server's
 // live listTools() schema rather than a bundled descriptor table (§3.4). Cleanup mirrors

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -33,9 +33,18 @@ export async function syncConnectorSkillDocs(
 
 export type CustomServerListTools = (server: StoredCustomMcpServer) => Promise<CustomSkillDocTool[]>
 
-// Writes skills/mcp-<name>/SKILL.md for enabled custom MCP servers, sourced from the server's
+// A custom server's skill dir is keyed on its immutable UUID id, NEVER its user-facing name. The
+// name is only validated non-empty upstream, so a name like `../evil` would let SKILL.md escape
+// skillsDir, and a name equal to a bundled connector id (e.g. `chemistry`) would clobber the
+// built-in mcp-chemistry doc. The id is a randomUUID (safe token, never a bundled id); this guard
+// additionally rejects any id that isn't a safe path segment — defense against a tampered
+// settings.json — so a hand-crafted id can't reintroduce traversal or a bundled-id collision.
+const isSafeCustomServerId = (id: string): boolean =>
+  /^[A-Za-z0-9_-]+$/.test(id) && !ALL_CONNECTOR_IDS.includes(id)
+
+// Writes skills/mcp-<id>/SKILL.md for enabled custom MCP servers, sourced from the server's
 // live listTools() schema rather than a bundled descriptor table (§3.4). Cleanup mirrors
-// syncConnectorSkillDocs: it only removes names that are NOT known bundled connector ids, so
+// syncConnectorSkillDocs: it only removes ids that are NOT known bundled connector ids, so
 // the two sync passes never delete each other's directories even when run against the same dir.
 export async function syncCustomServerSkillDocs(
   skillsDir: string,
@@ -43,10 +52,11 @@ export async function syncCustomServerSkillDocs(
   listTools: CustomServerListTools
 ): Promise<void> {
   await mkdir(skillsDir, { recursive: true })
-  const enabledNames = new Set(servers.map((s) => s.name))
-  for (const server of servers) {
+  const safeServers = servers.filter((s) => isSafeCustomServerId(s.id))
+  const enabledIds = new Set(safeServers.map((s) => s.id))
+  for (const server of safeServers) {
     const tools = await listTools(server)
-    const dir = join(skillsDir, `mcp-${server.name}`)
+    const dir = join(skillsDir, `mcp-${server.id}`)
     await mkdir(dir, { recursive: true })
     await writeFile(join(dir, 'SKILL.md'), renderCustomSkillDoc(server, tools), 'utf8')
   }
@@ -54,7 +64,7 @@ export async function syncCustomServerSkillDocs(
   for (const entry of existing) {
     const m = /^mcp-(.+)$/.exec(entry)
     if (!m || ALL_CONNECTOR_IDS.includes(m[1])) continue // owned by syncConnectorSkillDocs
-    if (!enabledNames.has(m[1])) {
+    if (!enabledIds.has(m[1])) {
       await rm(join(skillsDir, entry), { recursive: true, force: true })
     }
   }

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -5,6 +5,15 @@ import { renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
 import type { CustomSkillDocTool } from './skill-doc'
 import type { StoredCustomMcpServer } from '../settings/types'
 
+// Whether an `mcp-<x>` directory's suffix names a bundled connector — CASE-INSENSITIVELY. This
+// matters for cleanup ownership: an older version could have left a case-variant dir like
+// `mcp-Chemistry` (from a custom server literally named "Chemistry"), and on a case-preserving
+// filesystem (APFS/NTFS) the built-in sync then writes mcp-chemistry's doc INTO that same directory.
+// A case-sensitive check would treat `mcp-Chemistry` as a stray custom dir and delete the built-in
+// doc with it, so ownership must fold case.
+const namesBundledConnector = (dirId: string): boolean =>
+  ALL_CONNECTOR_IDS.includes(dirId.toLowerCase())
+
 // Writes skills/mcp-<connector>/SKILL.md for enabled connectors; removes the directory for
 // disabled ones. Claude Code discovers skills as `<name>/SKILL.md` directories, not flat files.
 // Custom-server directories (see syncCustomServerSkillDocs below) live in the same skills dir;
@@ -25,7 +34,9 @@ export async function syncConnectorSkillDocs(
   const existing = await readdir(skillsDir).catch(() => [] as string[])
   for (const entry of existing) {
     const m = /^mcp-(.+)$/.exec(entry)
-    if (m && ALL_CONNECTOR_IDS.includes(m[1]) && !enabled.has(m[1])) {
+    // Own (and so may remove) only bundled-connector dirs, matched case-insensitively; remove the
+    // ones whose connector is not currently enabled.
+    if (m && namesBundledConnector(m[1]) && !enabled.has(m[1].toLowerCase())) {
       await rm(join(skillsDir, entry), { recursive: true, force: true })
     }
   }
@@ -68,7 +79,9 @@ export async function syncCustomServerSkillDocs(
   const existing = await readdir(skillsDir).catch(() => [] as string[])
   for (const entry of existing) {
     const m = /^mcp-(.+)$/.exec(entry)
-    if (!m || ALL_CONNECTOR_IDS.includes(m[1])) continue // owned by syncConnectorSkillDocs
+    // A bundled-connector dir (case-insensitive) belongs to syncConnectorSkillDocs — never delete it
+    // here, even a case-variant like mcp-Chemistry that the built-in sync has written its doc into.
+    if (!m || namesBundledConnector(m[1])) continue
     if (!enabledIds.has(m[1])) {
       await rm(join(skillsDir, entry), { recursive: true, force: true })
     }

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -48,7 +48,7 @@ describe('renderSkillDoc', () => {
   it('falls back to a schema-built call example for tools without an authored example', () => {
     // Custom MCP servers ship no `example`, so the doc must still render a concrete, copyable call.
     const md = renderCustomSkillDoc(
-      { name: 'acme', description: 'Use when you need acme tools.' },
+      { id: 'acme-id', name: 'acme', description: 'Use when you need acme tools.' },
       [
         {
           name: 'do_thing',
@@ -65,7 +65,7 @@ describe('renderSkillDoc', () => {
   it('renders a no-arg tool without a third argument (never a literal ...)', () => {
     // A literal `...` as the args positional reaches the bridge as Ellipsis and raises; a no-arg tool
     // must render as host.mcp(server, method) so the example is copy-runnable.
-    const md = renderCustomSkillDoc({ name: 'acme' }, [
+    const md = renderCustomSkillDoc({ id: 'acme-id', name: 'acme' }, [
       { name: 'ping', inputSchema: { type: 'object', properties: {} } }
     ])
     expect(md).toContain('result = host.mcp("acme", "ping")')
@@ -94,7 +94,7 @@ describe('renderSkillDoc', () => {
   it('gives custom MCP servers the same reuse guidance', () => {
     // renderCustomSkillDoc shares the CONVENTIONS block, so the fix must reach custom servers too.
     const md = renderCustomSkillDoc(
-      { name: 'acme', description: 'Use when you need acme tools.' },
+      { id: 'acme-id', name: 'acme', description: 'Use when you need acme tools.' },
       [{ name: 'do_thing', inputSchema: { type: 'object', properties: { q: { type: 'string' } } } }]
     )
     expect(md).toContain('persistent')

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -92,12 +92,16 @@ export function renderSkillDoc(connectorId: string): string {
   )
 }
 
-export type CustomSkillDocServer = { name: string; description?: string }
+export type CustomSkillDocServer = { id: string; name: string; description?: string }
 export type CustomSkillDocTool = { name: string; description?: string; inputSchema?: unknown }
 
 // Same shape as renderSkillDoc, but for a user-added custom MCP server: schema comes from
 // McpClientManager.listTools() at runtime rather than a bundled descriptor table, and the
 // trigger-style description falls back to a composed one when the server has no useWhen text.
+// The skill `name` is keyed on the server's immutable id, never its display name: the name is
+// user-controlled and can contain characters that are unsafe as a filesystem path or that collide
+// with a bundled connector's skill name. The runtime routing key (`host.mcp("<name>", ...)`) still
+// uses the display name, which is what McpClientManager registers the server under.
 export function renderCustomSkillDoc(
   server: CustomSkillDocServer,
   tools: CustomSkillDocTool[]
@@ -105,7 +109,7 @@ export function renderCustomSkillDoc(
   const useWhen =
     server.description ??
     `Use when you need tools from the ${server.name} MCP server — ${tools.map((t) => t.name).join(', ')}.`
-  const header = `---\nname: mcp-${server.name}\ndescription: ${JSON.stringify(useWhen)}\nsource: connector\n---\n`
+  const header = `---\nname: mcp-${server.id}\ndescription: ${JSON.stringify(useWhen)}\nsource: connector\n---\n`
   const methods = tools
     .map(
       (t) =>

--- a/src/main/skills/user-skill-repository.atomic.test.ts
+++ b/src/main/skills/user-skill-repository.atomic.test.ts
@@ -105,8 +105,12 @@ describe('writeImported swap atomicity', () => {
       repo.importFromGitHub(SKILL_URL, fetchSkill('---\nname: Foo\n---\nnew body'))
     ).rejects.toThrow(/preserved at .*backup-.*restored on the next operation/)
 
-    // Restart with a healthy filesystem: a fresh instance recovers the preserved backup on first use.
+    // With a healthy filesystem again, the SAME instance recovers the preserved backup on its next
+    // operation — recovery is not memoized after the first pass, so a backup left later is still fixed.
     vi.mocked(fsp.rename).mockImplementation((from, to) => realRename(from, to))
+    expect(await repo.body(first.id)).toContain('old body')
+
+    // And a fresh instance (a real restart) recovers it just the same.
     const restarted = new UserSkillRepository(root)
     expect(await restarted.body(first.id)).toContain('old body')
   })

--- a/src/main/skills/user-skill-repository.atomic.test.ts
+++ b/src/main/skills/user-skill-repository.atomic.test.ts
@@ -114,4 +114,26 @@ describe('writeImported swap atomicity', () => {
     const restarted = new UserSkillRepository(root)
     expect(await restarted.body(first.id)).toContain('old body')
   })
+
+  it('rejects the operation when a required backup restore fails (no silent proceed)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'atomic-restore-fail-'))
+    const repo = new UserSkillRepository(root)
+    const first = await repo.importFromGitHub(
+      SKILL_URL,
+      fetchSkill('---\nname: Foo\n---\nold body')
+    )
+
+    // Crash state: the live dir survives only as a backup (set up with the real rename).
+    const importedDir = join(root, 'skills', 'imported')
+    await realRename(join(importedDir, 'foo'), join(importedDir, '.foo.backup-crash'))
+
+    // Now make the restore rename fail. Recovery must reject the operation rather than log-and-proceed
+    // (which would let a delete() remove a non-existent live dir and "succeed").
+    vi.mocked(fsp.rename).mockImplementation(async (from, to) => {
+      if (String(from).includes('.backup-')) throw new Error('restore failure')
+      return realRename(from, to)
+    })
+
+    await expect(repo.body(first.id)).rejects.toThrow(/Failed to recover/)
+  })
 })

--- a/src/main/skills/user-skill-repository.atomic.test.ts
+++ b/src/main/skills/user-skill-repository.atomic.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+// Wrap the real fs/promises but make `rename` a spy we can fail on demand. Every other call (mkdir,
+// writeFile, stat, rm) stays real so the test exercises the actual staging/backup dance on disk.
+vi.mock('node:fs/promises', async (importActual) => {
+  const actual = await importActual<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    rename: vi.fn((...args: Parameters<typeof actual.rename>) => actual.rename(...args))
+  }
+})
+
+import * as fsp from 'node:fs/promises'
+import { UserSkillRepository } from './user-skill-repository'
+import type { FetchLike } from './github-import'
+
+const SKILL_URL = 'https://github.com/acme/skills/tree/main/pack/foo'
+
+const fetchSkill =
+  (skillMd: string): FetchLike =>
+  async (url: string) => {
+    if (url.includes('/contents/')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [
+          {
+            type: 'file',
+            name: 'SKILL.md',
+            path: 'pack/foo/SKILL.md',
+            download_url: 'https://raw/s'
+          }
+        ],
+        arrayBuffer: async () => new ArrayBuffer(0)
+      }
+    }
+    const bytes = new TextEncoder().encode(skillMd)
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      arrayBuffer: async () =>
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+    }
+  }
+
+describe('writeImported swap atomicity', () => {
+  it('rolls back to the previous skill when the swap rename fails', async () => {
+    const repo = new UserSkillRepository(await mkdtemp(join(tmpdir(), 'atomic-')))
+
+    const first = await repo.importFromGitHub(
+      SKILL_URL,
+      fetchSkill('---\nname: Foo\n---\nold body')
+    )
+    expect(await repo.body(first.id)).toContain('old body')
+
+    // Fail only the staging -> live-dir rename (its source is the ".import-" staging dir); let the
+    // dir -> backup move and the backup -> dir rollback (sources without ".import-") run for real.
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    vi.mocked(fsp.rename).mockImplementation(async (from, to) => {
+      if (String(from).includes('.import-')) throw new Error('simulated swap failure')
+      return actual.rename(from, to)
+    })
+
+    await expect(
+      repo.importFromGitHub(SKILL_URL, fetchSkill('---\nname: Foo\n---\nnew body'))
+    ).rejects.toThrow(/simulated swap failure/)
+
+    // The failed swap left the previous skill intact — not deleted, not half-written.
+    expect(await repo.body(first.id)).toContain('old body')
+  })
+})

--- a/src/main/skills/user-skill-repository.atomic.test.ts
+++ b/src/main/skills/user-skill-repository.atomic.test.ts
@@ -136,4 +136,23 @@ describe('writeImported swap atomicity', () => {
 
     await expect(repo.body(first.id)).rejects.toThrow(/Failed to recover/)
   })
+
+  it('leaves nothing behind when a fresh import fails its swap rename', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'atomic-fresh-fail-'))
+    const repo = new UserSkillRepository(root)
+
+    // No prior skill, so there is no backup; only the staging -> live rename runs and here it fails.
+    vi.mocked(fsp.rename).mockImplementation(async (from, to) => {
+      if (String(from).includes('.import-')) throw new Error('swap failure')
+      return realRename(from, to)
+    })
+
+    await expect(
+      repo.importFromGitHub(SKILL_URL, fetchSkill('---\nname: Foo\n---\nbody'))
+    ).rejects.toThrow(/swap failure/)
+
+    // Staging was discarded; nothing partial remains.
+    vi.mocked(fsp.rename).mockImplementation((from, to) => realRename(from, to))
+    expect(await repo.list()).toEqual([])
+  })
 })

--- a/src/main/skills/user-skill-repository.atomic.test.ts
+++ b/src/main/skills/user-skill-repository.atomic.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Wrap the real fs/promises but make `rename` a spy we can fail on demand. Every other call (mkdir,
 // writeFile, stat, rm) stays real so the test exercises the actual staging/backup dance on disk.
@@ -19,6 +19,14 @@ import { UserSkillRepository } from './user-skill-repository'
 import type { FetchLike } from './github-import'
 
 const SKILL_URL = 'https://github.com/acme/skills/tree/main/pack/foo'
+
+// The unmocked rename, captured once; each test resets the spy to pass through to it so a prior test's
+// failure injection can't leak into the next test's setup.
+let realRename: typeof import('node:fs/promises').rename
+beforeEach(async () => {
+  realRename = (await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')).rename
+  vi.mocked(fsp.rename).mockImplementation((from, to) => realRename(from, to))
+})
 
 const fetchSkill =
   (skillMd: string): FetchLike =>
@@ -60,10 +68,9 @@ describe('writeImported swap atomicity', () => {
 
     // Fail only the staging -> live-dir rename (its source is the ".import-" staging dir); let the
     // dir -> backup move and the backup -> dir rollback (sources without ".import-") run for real.
-    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
     vi.mocked(fsp.rename).mockImplementation(async (from, to) => {
       if (String(from).includes('.import-')) throw new Error('simulated swap failure')
-      return actual.rename(from, to)
+      return realRename(from, to)
     })
 
     await expect(
@@ -72,5 +79,35 @@ describe('writeImported swap atomicity', () => {
 
     // The failed swap left the previous skill intact — not deleted, not half-written.
     expect(await repo.body(first.id)).toContain('old body')
+  })
+
+  it('preserves the backup and recovers it when the rollback also fails', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'atomic-rollback-'))
+    const repo = new UserSkillRepository(root)
+
+    const first = await repo.importFromGitHub(
+      SKILL_URL,
+      fetchSkill('---\nname: Foo\n---\nold body')
+    )
+    expect(await repo.body(first.id)).toContain('old body')
+
+    // Fail BOTH the swap (staging -> live) and the rollback (backup -> live) — any rename whose source
+    // is a transaction dir. The initial live -> backup move (source is the live dir) still succeeds,
+    // so the backup is left on disk.
+    vi.mocked(fsp.rename).mockImplementation(async (from, to) => {
+      if (String(from).includes('.import-') || String(from).includes('.backup-')) {
+        throw new Error('simulated fs failure')
+      }
+      return realRename(from, to)
+    })
+
+    await expect(
+      repo.importFromGitHub(SKILL_URL, fetchSkill('---\nname: Foo\n---\nnew body'))
+    ).rejects.toThrow(/preserved at .*backup-.*restored on the next operation/)
+
+    // Restart with a healthy filesystem: a fresh instance recovers the preserved backup on first use.
+    vi.mocked(fsp.rename).mockImplementation((from, to) => realRename(from, to))
+    const restarted = new UserSkillRepository(root)
+    expect(await restarted.body(first.id)).toContain('old body')
   })
 })

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { deflateRawSync } from 'node:zlib'
@@ -761,6 +761,38 @@ describe('UserSkillRepository', () => {
       /[Cc]ollision|Conflicting/
     )
     expect(await repo.list()).toEqual([])
+  })
+
+  it('recovers the previous skill after a crash between the two swap renames', async () => {
+    const root = await makeStorage()
+    const repo = new UserSkillRepository(root)
+    const first = await repo.importFromGitHub(SKILL_URL, fakeFetch('---\nname: Foo\n---\nold body'))
+    expect(first.id).toBe('imported-foo')
+
+    // Reproduce the durable on-disk state if the process died after `rename(live, backup)` and before
+    // `rename(staging, live)`: the live dir is gone and only a hidden backup remains.
+    const importedDir = join(root, 'skills', 'imported')
+    await rename(join(importedDir, 'foo'), join(importedDir, '.foo.backup-simulated-crash'))
+
+    // A fresh instance (simulating a restart) must restore the previous skill on its first use.
+    const restarted = new UserSkillRepository(root)
+    expect(await restarted.body(first.id)).toContain('old body')
+    expect((await restarted.list()).map((skill) => skill.id)).toEqual(['imported-foo'])
+  })
+
+  it('ignores a leftover backup dir when the live skill is present (no bogus ids)', async () => {
+    const root = await makeStorage()
+    const repo = new UserSkillRepository(root)
+    await repo.importFromGitHub(SKILL_URL, fakeFetch('---\nname: Foo\n---\nbody'))
+
+    // A stray backup left next to a healthy live dir (e.g. a crash after the swap, before cleanup).
+    const importedDir = join(root, 'skills', 'imported')
+    await mkdir(join(importedDir, '.foo.backup-stale'), { recursive: true })
+    await writeFile(join(importedDir, '.foo.backup-stale', 'SKILL.md'), '---\nname: Foo\n---\nx')
+
+    // list() recovers (removes) the leftover and never surfaces it as a skill id.
+    const listed = await new UserSkillRepository(root).list()
+    expect(listed.map((skill) => skill.id)).toEqual(['imported-foo'])
   })
 
   it('marks scanned candidates already imported by URL or by same name', async () => {

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { deflateRawSync } from 'node:zlib'
@@ -668,6 +668,98 @@ describe('UserSkillRepository', () => {
     }
 
     await expect(repo.importFromGitHub(SKILL_URL, duplicate)).rejects.toThrow(/Duplicate file path/)
+    expect(await repo.list()).toEqual([])
+  })
+
+  it('rejects an import that includes the reserved .source.json manifest path', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+
+    const withManifest: FetchLike = async (url: string) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/s'
+            },
+            {
+              type: 'file',
+              name: '.source.json',
+              path: 'pack/foo/.source.json',
+              download_url: 'https://raw/m'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      const bytes = new TextEncoder().encode('{}')
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        arrayBuffer: async () =>
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      }
+    }
+
+    await expect(repo.importFromGitHub(SKILL_URL, withManifest)).rejects.toThrow(/reserved/)
+    expect(await repo.list()).toEqual([])
+  })
+
+  it('rejects a filesystem-equivalent path collision on case-insensitive volumes', async () => {
+    const storage = await makeStorage()
+
+    // Only meaningful where the filesystem folds case (macOS/Windows default). On a case-sensitive
+    // volume SKILL.md and skill.md are distinct files and coexist, so there is nothing to reject.
+    const probe = join(storage, 'CaseProbe')
+    await writeFile(probe, 'x')
+    const caseInsensitive = await stat(join(storage, 'caseprobe')).then(
+      () => true,
+      () => false
+    )
+    await rm(probe, { force: true })
+    if (!caseInsensitive) return
+
+    const repo = new UserSkillRepository(storage)
+    const collide: FetchLike = async (url: string) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/s'
+            },
+            {
+              type: 'file',
+              name: 'skill.md',
+              path: 'pack/foo/skill.md',
+              download_url: 'https://raw/s2'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      const bytes = new TextEncoder().encode('---\nname: Foo\n---\nbody')
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        arrayBuffer: async () =>
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      }
+    }
+
+    await expect(repo.importFromGitHub(SKILL_URL, collide)).rejects.toThrow(
+      /[Cc]ollision|Conflicting/
+    )
     expect(await repo.list()).toEqual([])
   })
 

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -501,6 +501,98 @@ describe('UserSkillRepository', () => {
     expect((await repo.list())[0].description).toBe('Now updated.')
   })
 
+  it('rejects an import whose file path escapes the skill dir before any file is written', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+
+    // A malicious GitHub response: a second file whose path climbs out of the skill directory once
+    // the root prefix is stripped (`pack/foo/../../../evil` -> `../../../evil`).
+    const escaping: FetchLike = async (url: string) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/s'
+            },
+            {
+              type: 'file',
+              name: 'evil',
+              path: 'pack/foo/../../../evil',
+              download_url: 'https://raw/e'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      const bytes = new TextEncoder().encode('---\nname: Foo\n---\nx')
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        arrayBuffer: async () =>
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      }
+    }
+
+    await expect(repo.importFromGitHub(SKILL_URL, escaping)).rejects.toThrow(
+      /outside its directory/
+    )
+    // The gate runs before any disk write, so no partial skill is left behind.
+    expect(await repo.list()).toEqual([])
+  })
+
+  it('leaves the existing skill intact when a replace import fails the containment gate', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+
+    const good = ['---', 'name: Foo', 'description: original.', '---', 'original body'].join('\n')
+    const first = await repo.importFromGitHub(SKILL_URL, fakeFetch(good))
+    expect(first.status).toBe('imported')
+
+    // Same URL, changed content (so it takes the in-place replace path that deletes first), but now
+    // carrying an escaping file. The destructive rm must not run.
+    const badReplace: FetchLike = async (url: string) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/s2'
+            },
+            {
+              type: 'file',
+              name: 'evil',
+              path: 'pack/foo/../../../evil',
+              download_url: 'https://raw/e2'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      const bytes = new TextEncoder().encode('changed')
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        arrayBuffer: async () =>
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      }
+    }
+
+    await expect(repo.importFromGitHub(SKILL_URL, badReplace)).rejects.toThrow(
+      /outside its directory/
+    )
+    // The original import survived the failed replace.
+    expect(await repo.body(first.id)).toContain('original body')
+  })
+
   it('marks scanned candidates already imported by URL or by same name', async () => {
     const repo = new UserSkillRepository(await makeStorage())
     const skillMd = ['---', 'name: Foo', 'description: An imported skill.', '---', 'body'].join(

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { deflateRawSync } from 'node:zlib'
@@ -793,6 +793,66 @@ describe('UserSkillRepository', () => {
     // list() recovers (removes) the leftover and never surfaces it as a skill id.
     const listed = await new UserSkillRepository(root).list()
     expect(listed.map((skill) => skill.id)).toEqual(['imported-foo'])
+  })
+
+  it('does not resurrect a crashed imported skill after the user deletes it', async () => {
+    const root = await makeStorage()
+    const repo = new UserSkillRepository(root)
+    const first = await repo.importFromGitHub(SKILL_URL, fakeFetch('---\nname: Foo\n---\nold body'))
+
+    // Crash state: live dir gone, only a hidden backup remains.
+    const importedDir = join(root, 'skills', 'imported')
+    await rename(join(importedDir, 'foo'), join(importedDir, '.foo.backup-simulated-crash'))
+
+    // delete() must recover-then-remove, so a later list() can't resurrect the deleted skill.
+    const restarted = new UserSkillRepository(root)
+    await restarted.delete(first.id)
+    expect(await restarted.list()).toEqual([])
+    expect(await new UserSkillRepository(root).list()).toEqual([])
+  })
+
+  it('discards a stale staged (.import-) dir on the next operation', async () => {
+    const root = await makeStorage()
+    const importedDir = join(root, 'skills', 'imported')
+    await mkdir(join(importedDir, '.foo.import-stale'), { recursive: true })
+    await writeFile(join(importedDir, '.foo.import-stale', 'SKILL.md'), '---\nname: Foo\n---\nx')
+
+    const listed = await new UserSkillRepository(root).list()
+    expect(listed).toEqual([])
+    // The uncommitted staging dir was cleaned up, not left lingering.
+    expect(await readdir(importedDir)).toEqual([])
+  })
+
+  it('recovers within the same instance after a rollback leaves a backup (not memoized once)', async () => {
+    const root = await makeStorage()
+    const repo = new UserSkillRepository(root)
+    const first = await repo.importFromGitHub(SKILL_URL, fakeFetch('---\nname: Foo\n---\nold body'))
+    // First op already ran a recovery pass; prove a later crash state is still recovered by the SAME
+    // instance (recovery is not cached after the first call).
+    await repo.list()
+
+    const importedDir = join(root, 'skills', 'imported')
+    await rename(join(importedDir, 'foo'), join(importedDir, '.foo.backup-late-crash'))
+
+    expect(await repo.body(first.id)).toContain('old body')
+  })
+
+  it('runs recovery before previewZip so dedup state is not stale after a crash', async () => {
+    const root = await makeStorage()
+    const repo = new UserSkillRepository(root)
+    const zip = buildZip([
+      { path: 'foo/SKILL.md', content: Buffer.from('---\nname: Foo\n---\nbody') }
+    ])
+    const { id } = await repo.importFromZip(zip)
+    const slug = id.replace(/^imported-/, '')
+
+    // Crash: the imported skill survives only as a hidden backup.
+    const importedDir = join(root, 'skills', 'imported')
+    await rename(join(importedDir, slug), join(importedDir, `.${slug}.backup-crash`))
+
+    // previewZip must recover first, so the same bundle is correctly seen as already imported.
+    const restarted = new UserSkillRepository(root)
+    expect((await restarted.previewZip(zip))[0].alreadyImported).toBe(true)
   })
 
   it('marks scanned candidates already imported by URL or by same name', async () => {

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -925,6 +925,40 @@ describe('UserSkillRepository', () => {
     ])
   })
 
+  it('restores the newest backup when several exist for one slug', async () => {
+    const root = await makeStorage()
+    const importedDir = join(root, 'skills', 'imported')
+    // Two backups for "foo" with different (sortable) generations; the live dir is gone.
+    await mkdir(join(importedDir, '.foo.backup-000000000000001-old'), { recursive: true })
+    await writeFile(
+      join(importedDir, '.foo.backup-000000000000001-old', 'SKILL.md'),
+      '---\nname: Foo\n---\nolder generation'
+    )
+    await mkdir(join(importedDir, '.foo.backup-000000000000002-new'), { recursive: true })
+    await writeFile(
+      join(importedDir, '.foo.backup-000000000000002-new', 'SKILL.md'),
+      '---\nname: Foo\n---\nnewer generation'
+    )
+
+    // Recovery restores the newest generation and discards the older; only the live dir remains.
+    const repo = new UserSkillRepository(root)
+    expect(await repo.body('imported-foo')).toContain('newer generation')
+    expect((await readdir(importedDir)).sort()).toEqual(['foo'])
+  })
+
+  it('recovers a legacy-format transaction dir (no generation timestamp)', async () => {
+    const root = await makeStorage()
+    const importedDir = join(root, 'skills', 'imported')
+    // A backup written before the sortable-generation change (name has no timestamp prefix).
+    await mkdir(join(importedDir, '.foo.backup-legacyuuid'), { recursive: true })
+    await writeFile(
+      join(importedDir, '.foo.backup-legacyuuid', 'SKILL.md'),
+      '---\nname: Foo\n---\nlegacy body'
+    )
+
+    expect(await new UserSkillRepository(root).body('imported-foo')).toContain('legacy body')
+  })
+
   it('recovers within the same instance after a rollback leaves a backup (not memoized once)', async () => {
     const root = await makeStorage()
     const repo = new UserSkillRepository(root)

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -823,6 +823,29 @@ describe('UserSkillRepository', () => {
     expect(await readdir(importedDir)).toEqual([])
   })
 
+  it('serializes concurrent fresh imports so they get distinct slugs (no clobber)', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    // Two different source URLs whose folder name slugifies to the same base ("foo"). Run at once:
+    // slug allocation + swap share one critical section, so the second is suffixed rather than
+    // overwriting the first (which would leave both reporting imported-foo).
+    const [a, b] = await Promise.all([
+      repo.importFromGitHub(
+        'https://github.com/acme/one/tree/main/pack/foo',
+        fakeFetch('---\nname: Foo\n---\nfrom one')
+      ),
+      repo.importFromGitHub(
+        'https://github.com/acme/two/tree/main/pack/foo',
+        fakeFetch('---\nname: Foo\n---\nfrom two')
+      )
+    ])
+
+    expect([a.id, b.id].sort()).toEqual(['imported-foo', 'imported-foo-2'])
+    expect((await repo.list()).map((skill) => skill.id).sort()).toEqual([
+      'imported-foo',
+      'imported-foo-2'
+    ])
+  })
+
   it('recovers within the same instance after a rollback leaves a backup (not memoized once)', async () => {
     const root = await makeStorage()
     const repo = new UserSkillRepository(root)

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -593,6 +593,84 @@ describe('UserSkillRepository', () => {
     expect(await repo.body(first.id)).toContain('original body')
   })
 
+  it('rejects an ancestor/descendant path conflict, leaving the prior skill intact', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+
+    const good = ['---', 'name: Foo', 'description: original.', '---', 'original body'].join('\n')
+    const first = await repo.importFromGitHub(SKILL_URL, fakeFetch(good))
+    expect(first.status).toBe('imported')
+
+    // `a` (a file) and `a/b` (needs `a` to be a directory) can't both exist. Before the staging fix
+    // this failed mid-write and left the old body half-overwritten; now it must be rejected up front.
+    const conflicting: FetchLike = async (url: string) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/s'
+            },
+            { type: 'file', name: 'a', path: 'pack/foo/a', download_url: 'https://raw/a' },
+            { type: 'file', name: 'b', path: 'pack/foo/a/b', download_url: 'https://raw/ab' }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      const bytes = new TextEncoder().encode('changed')
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        arrayBuffer: async () =>
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      }
+    }
+
+    await expect(repo.importFromGitHub(SKILL_URL, conflicting)).rejects.toThrow(
+      /Conflicting file and directory/
+    )
+    expect(await repo.body(first.id)).toContain('original body')
+  })
+
+  it('rejects an import that contains duplicate file paths', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+
+    const duplicate: FetchLike = async (url: string) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/s'
+            },
+            { type: 'file', name: 'dup', path: 'pack/foo/dup.txt', download_url: 'https://raw/d1' },
+            { type: 'file', name: 'dup', path: 'pack/foo/dup.txt', download_url: 'https://raw/d2' }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      const bytes = new TextEncoder().encode('x')
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        arrayBuffer: async () =>
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      }
+    }
+
+    await expect(repo.importFromGitHub(SKILL_URL, duplicate)).rejects.toThrow(/Duplicate file path/)
+    expect(await repo.list()).toEqual([])
+  })
+
   it('marks scanned candidates already imported by URL or by same name', async () => {
     const repo = new UserSkillRepository(await makeStorage())
     const skillMd = ['---', 'name: Foo', 'description: An imported skill.', '---', 'body'].join(

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -34,7 +34,11 @@ const SAFE_SLUG = /^[a-z0-9-]+$/
 // holds the staged new copy, `.<slug>.backup-<id>` the previous copy moved aside during the swap.
 // Both are hidden (leading dot) so they can never be a valid slug, and recoverImportedTransactions()
 // finalizes or rolls them back if a crash left them behind.
-const TRANSACTION_DIR = /^\.([a-z0-9-]+)\.(import|backup)-/
+const TRANSACTION_DIR = /^\.([a-z0-9-]+)\.(import|backup)-(.+)$/
+
+// A sortable transaction generation: a fixed-width millisecond timestamp (lexical order == time order)
+// plus a uuid for uniqueness. Recovery restores the newest backup when more than one exists for a slug.
+const nextGeneration = (): string => `${Date.now().toString().padStart(15, '0')}-${randomUUID()}`
 
 // Reserved id namespaces a user-authored skill may not claim: `os-` is the app's own materialized
 // prefix and `mcp-` is reserved for MCP-provided skills.
@@ -164,14 +168,28 @@ class UserSkillRepository {
     }
   }
 
-  // Finalizes any imported-skill replace that a crash interrupted, so the swap is failure-atomic
-  // across process restarts (a plain two-step rename leaves a window with no live dir). Runs at most
-  // once per instance, before the first read/list/import. For each transaction dir: if a `.backup-`
-  // exists and its live dir is gone, the previous copy is restored (the interrupted replace is rolled
-  // back); a leftover backup whose live dir is present, and any staged `.import-` dir, are discarded.
-  private recovery?: Promise<void>
+  // Serializes transaction recovery and the writeImported swap so neither observes the other's
+  // intermediate on-disk state, and lets every public operation trigger a fresh recovery pass.
+  private lock: Promise<unknown> = Promise.resolve()
+  private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.lock.then(fn, fn)
+    // Chain the next waiter on completion regardless of outcome, so one failure can't wedge the lock.
+    this.lock = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
+  // Finalizes any imported-skill replace that a crash interrupted, so the swap is failure-atomic across
+  // process restarts (a plain two-step rename leaves a window with no live dir). Runs before EVERY
+  // read/list/import/delete — not memoized — so a backup left by a failed rollback, or a transient
+  // recovery error, is retried on the next operation. For each slug: if a `.backup-` exists and the
+  // live dir is gone, the newest backup is restored (the interrupted replace is rolled back) and any
+  // older backups discarded; a backup whose live dir is present, and every staged `.import-` dir, are
+  // discarded. Serialized via runExclusive so it can't race an in-flight swap.
   private recoverImportedTransactions(): Promise<void> {
-    return (this.recovery ??= this.doRecoverImportedTransactions())
+    return this.runExclusive(() => this.doRecoverImportedTransactions())
   }
 
   private async doRecoverImportedTransactions(): Promise<void> {
@@ -183,31 +201,48 @@ class UserSkillRepository {
       return
     }
 
-    // Restore first: move a backup back to its live slug if the live dir is missing.
+    const backupsBySlug = new Map<string, { entry: string; generation: string }[]>()
+    const stagings: string[] = []
     for (const entry of entries) {
       const match = TRANSACTION_DIR.exec(entry)
-      if (!match || match[2] !== 'backup') continue
-      const live = join(dir, match[1])
+      if (!match) continue
+      if (match[2] === 'backup') {
+        const list = backupsBySlug.get(match[1]) ?? []
+        list.push({ entry, generation: match[3] })
+        backupsBySlug.set(match[1], list)
+      } else {
+        stagings.push(entry)
+      }
+    }
+
+    for (const [slug, backups] of backupsBySlug) {
+      const live = join(dir, slug)
       const liveExists = await stat(live).then(
         () => true,
         () => false
       )
-      try {
-        if (liveExists) {
-          await rm(join(dir, entry), { recursive: true, force: true })
-        } else {
-          await rename(join(dir, entry), live)
-          log.warn('recovered interrupted skill import from backup', { slug: match[1] })
+      // Newest generation first, so if we must restore we pick the most recent previous copy.
+      backups.sort((a, b) => b.generation.localeCompare(a.generation))
+      for (let index = 0; index < backups.length; index += 1) {
+        const path = join(dir, backups[index].entry)
+        try {
+          if (index === 0 && !liveExists) {
+            await rename(path, live)
+            log.warn('recovered interrupted skill import from backup', { slug })
+          } else {
+            await rm(path, { recursive: true, force: true })
+          }
+        } catch (error) {
+          log.warn('failed to recover skill transaction backup', {
+            entry: backups[index].entry,
+            error
+          })
         }
-      } catch (error) {
-        log.warn('failed to recover skill transaction backup', { entry, error })
       }
     }
 
-    // Then discard any staged (uncommitted) copies left behind.
-    for (const entry of entries) {
-      const match = TRANSACTION_DIR.exec(entry)
-      if (!match || match[2] !== 'import') continue
+    // Discard any staged (uncommitted) copies left behind.
+    for (const entry of stagings) {
       await rm(join(dir, entry), { recursive: true, force: true }).catch(() => {})
     }
   }
@@ -288,6 +323,9 @@ class UserSkillRepository {
   async delete(id: string): Promise<void> {
     const parsed = parseUserSkillId(id)
     if (!parsed) throw new Error(`Not a user skill id: ${id}`)
+    // Recover first, so a skill left only in a crash backup is restored to its live dir and then
+    // actually removed here — otherwise a later recovery would "resurrect" the deleted skill.
+    await this.recoverImportedTransactions()
 
     await rm(this.skillDir(parsed.source, parsed.slug), { recursive: true, force: true })
   }
@@ -339,6 +377,7 @@ class UserSkillRepository {
   // collides with exactly one existing imported skill of different content — offers that skill's id as
   // a replace target. Writes nothing.
   async previewZip(zip: Buffer): Promise<SkillBundlePreview[]> {
+    await this.recoverImportedTransactions()
     const roots = findSkillRoots(extractZip(zip))
     if (roots.length === 0) throw new Error('The bundle must contain a SKILL.md.')
 
@@ -450,6 +489,7 @@ class UserSkillRepository {
   ): Promise<(ScannedSkill & { alreadyImported: boolean })[]> {
     const repo = parseGitHubRepo(repoInput)
     if (!repo) throw new Error('Not a recognizable GitHub repo (owner/repo or a github.com URL).')
+    await this.recoverImportedTransactions()
 
     const fetcher = fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined)
     if (!fetcher) throw new Error('No fetch implementation available.')
@@ -544,8 +584,9 @@ class UserSkillRepository {
     // and is rolled back, never lost.
     const parent = dirname(dir)
     const stem = basename(dir)
-    const staging = join(parent, `.${stem}.import-${randomUUID()}`)
-    const backup = join(parent, `.${stem}.backup-${randomUUID()}`)
+    const generation = nextGeneration()
+    const staging = join(parent, `.${stem}.import-${generation}`)
+    const backup = join(parent, `.${stem}.backup-${generation}`)
     // Build the whole new copy in staging first; any failure here discards staging and never touches
     // the live skill.
     try {
@@ -572,41 +613,43 @@ class UserSkillRepository {
       throw buildError
     }
 
-    // Swap: move the old copy aside to the backup, move staging into place, then drop the backup. If a
-    // crash lands between the two renames, recoverImportedTransactions() restores the backup on the
-    // next operation, so the previous skill is never lost.
-    const hadExisting = await stat(dir).then(
-      () => true,
-      () => false
-    )
+    // Swap under the lock so it can't race a recovery pass: move the old copy aside to the backup,
+    // move staging into place, then drop the backup. If a crash lands between the two renames,
+    // recoverImportedTransactions() restores the backup on the next operation — the skill is never lost.
     try {
-      if (hadExisting) await rename(dir, backup)
-    } catch (error) {
-      await rm(staging, { recursive: true, force: true }).catch(() => {})
-      throw error // the live dir was never moved; the previous skill is untouched
-    }
+      await this.runExclusive(async () => {
+        const hadExisting = await stat(dir).then(
+          () => true,
+          () => false
+        )
+        if (hadExisting) await rename(dir, backup) // may throw; live dir untouched, staging cleaned below
 
-    try {
-      await rename(staging, dir)
-    } catch (swapError) {
-      await rm(staging, { recursive: true, force: true }).catch(() => {})
-      if (hadExisting) {
         try {
-          await rename(backup, dir)
-        } catch (rollbackError) {
-          // Rollback failed too: keep the backup on disk (recovery will restore it next run) and
-          // surface both errors rather than swallowing them.
-          throw new Error(
-            `Skill replace failed to swap and could not roll back; the previous copy is preserved at ${basename(backup)} and will be restored on the next operation. swap error: ${String(swapError)}; rollback error: ${String(rollbackError)}`
-          )
+          await rename(staging, dir)
+        } catch (swapError) {
+          if (hadExisting) {
+            try {
+              await rename(backup, dir)
+            } catch (rollbackError) {
+              // Rollback failed too: keep the backup on disk (recovery restores it next run) and
+              // surface both errors rather than swallowing them.
+              throw new Error(
+                `Skill replace failed to swap and could not roll back; the previous copy is preserved at ${basename(backup)} and will be restored on the next operation. swap error: ${String(swapError)}; rollback error: ${String(rollbackError)}`
+              )
+            }
+          }
+          throw swapError
         }
-      }
-      throw swapError
-    }
 
-    // New copy is in place; drop the backup last so nothing is deleted until the swap succeeded. A
-    // leftover backup (rm failure) is harmless — recovery removes it once the live dir is present.
-    if (hadExisting) await rm(backup, { recursive: true, force: true }).catch(() => {})
+        // New copy is in place; drop the backup last so nothing is deleted until the swap succeeded. A
+        // leftover backup (rm failure) is harmless — recovery removes it once the live dir is present.
+        if (hadExisting) await rm(backup, { recursive: true, force: true }).catch(() => {})
+      })
+    } catch (error) {
+      // Any swap failure leaves staging behind; discard it (the backup, if any, is intentionally kept).
+      await rm(staging, { recursive: true, force: true }).catch(() => {})
+      throw error
+    }
   }
 
   // Finds a slug not yet taken under the source, appending -2, -3, ... on collision.

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve, sep } from 'node:path'
 
 import type { SkillBundlePreview, SkillReference, SkillSource } from '../../shared/settings'
 import { createLogger } from '../logger'
@@ -463,8 +463,15 @@ class UserSkillRepository {
     const dir = this.skillDir('imported', slug)
     await rm(dir, { recursive: true, force: true })
 
+    // Final containment gate for every import source (zip, GitHub, ...): resolve each target and
+    // confirm it stays inside the skill directory before writing, so a crafted relative path can
+    // never escape even if an upstream path check is bypassed on a given platform.
+    const root = resolve(dir)
     for (const file of files) {
-      const target = join(dir, file.relativePath)
+      const target = resolve(dir, file.relativePath)
+      if (target !== root && !target.startsWith(root + sep)) {
+        throw new Error(`Refusing to write skill file outside its directory: ${file.relativePath}`)
+      }
       await mkdir(dirname(target), { recursive: true })
       await writeFile(target, file.content)
     }

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -464,14 +464,18 @@ class UserSkillRepository {
     const root = resolve(dir)
 
     // Validate the whole file set against the FINAL directory before touching disk. Every target must
-    // stay inside the skill dir, none may BE the dir itself (an empty/`.` path), no two may collide,
-    // and none may be a path-prefix of another (a file `a` and a dir `a/b` can't both exist). A bundle
-    // that fails any of these is rejected outright.
+    // stay inside the skill dir, none may BE the dir itself (an empty/`.` path), none may collide with
+    // the internal source manifest, no two may be exact duplicates, and none may be a path-prefix of
+    // another (a file `a` and a dir `a/b` can't both exist). A bundle failing any of these is rejected.
+    const manifestTarget = resolve(dir, SOURCE_MANIFEST)
     const seen = new Set<string>()
     for (const file of files) {
       const target = resolve(dir, file.relativePath)
       if (target === root || !target.startsWith(root + sep)) {
         throw new Error(`Refusing to write skill file outside its directory: ${file.relativePath}`)
+      }
+      if (target === manifestTarget) {
+        throw new Error(`Skill import may not include the reserved file ${SOURCE_MANIFEST}.`)
       }
       if (seen.has(target)) {
         throw new Error(`Duplicate file path in skill import: ${file.relativePath}`)
@@ -486,30 +490,55 @@ class UserSkillRepository {
       }
     }
 
-    // Build the new copy in a sibling staging dir, then swap it in. Because nothing is written into the
-    // live skill dir until the whole set has been staged successfully, a mid-write failure (e.g. an
-    // ancestor/descendant path conflict surfacing as EISDIR/ENOTDIR) can never leave the existing skill
-    // deleted or partially overwritten. The staging dir is a sibling, so the rename stays on one
-    // filesystem; on any failure it is removed and the original is left untouched.
-    const staging = join(dirname(dir), `.${basename(dir)}.import-${randomUUID()}`)
+    // Stage the new copy in a sibling dir, then swap it in with a backup so the operation is atomic on
+    // failure. Files are written with the `wx` flag so a filesystem-equivalent collision (e.g. SKILL.md
+    // vs skill.md on a case-insensitive volume) fails loudly in staging rather than silently
+    // overwriting. Swap order: move the old dir to a backup, move staging into place, then drop the
+    // backup — so if the final rename throws (or the process dies) the previous skill is still on disk
+    // and is rolled back, never lost.
+    const parent = dirname(dir)
+    const stem = basename(dir)
+    const staging = join(parent, `.${stem}.import-${randomUUID()}`)
+    const backup = join(parent, `.${stem}.backup-${randomUUID()}`)
+    let hadExisting = false
     try {
       await mkdir(staging, { recursive: true })
       for (const file of files) {
         const target = join(staging, file.relativePath)
         await mkdir(dirname(target), { recursive: true })
-        await writeFile(target, file.content)
+        try {
+          await writeFile(target, file.content, { flag: 'wx' })
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+            throw new Error(
+              `Conflicting file paths in skill import (collision at ${file.relativePath}).`
+            )
+          }
+          throw error
+        }
       }
-      await writeFile(
-        join(staging, SOURCE_MANIFEST),
-        JSON.stringify({ url, signature }, null, 2),
-        'utf8'
+      await writeFile(join(staging, SOURCE_MANIFEST), JSON.stringify({ url, signature }, null, 2), {
+        flag: 'wx'
+      })
+
+      hadExisting = await stat(dir).then(
+        () => true,
+        () => false
       )
-      await rm(dir, { recursive: true, force: true })
-      await rename(staging, dir)
+      if (hadExisting) await rename(dir, backup)
+      try {
+        await rename(staging, dir)
+      } catch (swapError) {
+        // Roll the previous skill back so a failed swap never loses it.
+        if (hadExisting) await rename(backup, dir).catch(() => {})
+        throw swapError
+      }
     } catch (error) {
       await rm(staging, { recursive: true, force: true }).catch(() => {})
       throw error
     }
+    // New copy is in place; drop the backup last so nothing is deleted until the swap succeeded.
+    if (hadExisting) await rm(backup, { recursive: true, force: true }).catch(() => {})
   }
 
   // Finds a slug not yet taken under the source, appending -2, -3, ... on collision.

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'node:crypto'
-import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve, sep } from 'node:path'
+import { createHash, randomUUID } from 'node:crypto'
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { basename, dirname, join, resolve, sep } from 'node:path'
 
 import type { SkillBundlePreview, SkillReference, SkillSource } from '../../shared/settings'
 import { createLogger } from '../logger'
@@ -461,27 +461,55 @@ class UserSkillRepository {
     signature: string
   ): Promise<void> {
     const dir = this.skillDir('imported', slug)
-
-    // Containment gate for every import source (zip, GitHub, ...): resolve every target and confirm it
-    // stays inside the skill directory BEFORE touching disk. Validating up front — rather than per
-    // file mid-write — means a crafted relative path can't leave the prior copy deleted or a new copy
-    // half-written; the whole import is rejected before the destructive rm.
     const root = resolve(dir)
-    const targets = files.map((file) => {
+
+    // Validate the whole file set against the FINAL directory before touching disk. Every target must
+    // stay inside the skill dir, none may BE the dir itself (an empty/`.` path), no two may collide,
+    // and none may be a path-prefix of another (a file `a` and a dir `a/b` can't both exist). A bundle
+    // that fails any of these is rejected outright.
+    const seen = new Set<string>()
+    for (const file of files) {
       const target = resolve(dir, file.relativePath)
-      if (target !== root && !target.startsWith(root + sep)) {
+      if (target === root || !target.startsWith(root + sep)) {
         throw new Error(`Refusing to write skill file outside its directory: ${file.relativePath}`)
       }
-      return { target, content: file.content }
-    })
-
-    await rm(dir, { recursive: true, force: true })
-    for (const { target, content } of targets) {
-      await mkdir(dirname(target), { recursive: true })
-      await writeFile(target, content)
+      if (seen.has(target)) {
+        throw new Error(`Duplicate file path in skill import: ${file.relativePath}`)
+      }
+      seen.add(target)
+    }
+    for (const a of seen) {
+      for (const b of seen) {
+        if (a !== b && b.startsWith(a + sep)) {
+          throw new Error('Conflicting file and directory at the same path in skill import.')
+        }
+      }
     }
 
-    await writeFile(join(dir, SOURCE_MANIFEST), JSON.stringify({ url, signature }, null, 2), 'utf8')
+    // Build the new copy in a sibling staging dir, then swap it in. Because nothing is written into the
+    // live skill dir until the whole set has been staged successfully, a mid-write failure (e.g. an
+    // ancestor/descendant path conflict surfacing as EISDIR/ENOTDIR) can never leave the existing skill
+    // deleted or partially overwritten. The staging dir is a sibling, so the rename stays on one
+    // filesystem; on any failure it is removed and the original is left untouched.
+    const staging = join(dirname(dir), `.${basename(dir)}.import-${randomUUID()}`)
+    try {
+      await mkdir(staging, { recursive: true })
+      for (const file of files) {
+        const target = join(staging, file.relativePath)
+        await mkdir(dirname(target), { recursive: true })
+        await writeFile(target, file.content)
+      }
+      await writeFile(
+        join(staging, SOURCE_MANIFEST),
+        JSON.stringify({ url, signature }, null, 2),
+        'utf8'
+      )
+      await rm(dir, { recursive: true, force: true })
+      await rename(staging, dir)
+    } catch (error) {
+      await rm(staging, { recursive: true, force: true }).catch(() => {})
+      throw error
+    }
   }
 
   // Finds a slug not yet taken under the source, appending -2, -3, ... on collision.

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -461,19 +461,24 @@ class UserSkillRepository {
     signature: string
   ): Promise<void> {
     const dir = this.skillDir('imported', slug)
-    await rm(dir, { recursive: true, force: true })
 
-    // Final containment gate for every import source (zip, GitHub, ...): resolve each target and
-    // confirm it stays inside the skill directory before writing, so a crafted relative path can
-    // never escape even if an upstream path check is bypassed on a given platform.
+    // Containment gate for every import source (zip, GitHub, ...): resolve every target and confirm it
+    // stays inside the skill directory BEFORE touching disk. Validating up front — rather than per
+    // file mid-write — means a crafted relative path can't leave the prior copy deleted or a new copy
+    // half-written; the whole import is rejected before the destructive rm.
     const root = resolve(dir)
-    for (const file of files) {
+    const targets = files.map((file) => {
       const target = resolve(dir, file.relativePath)
       if (target !== root && !target.startsWith(root + sep)) {
         throw new Error(`Refusing to write skill file outside its directory: ${file.relativePath}`)
       }
+      return { target, content: file.content }
+    })
+
+    await rm(dir, { recursive: true, force: true })
+    for (const { target, content } of targets) {
       await mkdir(dirname(target), { recursive: true })
-      await writeFile(target, file.content)
+      await writeFile(target, content)
     }
 
     await writeFile(join(dir, SOURCE_MANIFEST), JSON.stringify({ url, signature }, null, 2), 'utf8')

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -30,6 +30,12 @@ const USER_SOURCES: ReadonlyArray<Extract<SkillSource, 'imported' | 'personal'>>
 // Only lowercase slugs so a skill id maps 1:1 to a safe directory name.
 const SAFE_SLUG = /^[a-z0-9-]+$/
 
+// A transaction directory left by an in-progress replace (see writeImported): `.<slug>.import-<id>`
+// holds the staged new copy, `.<slug>.backup-<id>` the previous copy moved aside during the swap.
+// Both are hidden (leading dot) so they can never be a valid slug, and recoverImportedTransactions()
+// finalizes or rolls them back if a crash left them behind.
+const TRANSACTION_DIR = /^\.([a-z0-9-]+)\.(import|backup)-/
+
 // Reserved id namespaces a user-authored skill may not claim: `os-` is the app's own materialized
 // prefix and `mcp-` is reserved for MCP-provided skills.
 const RESERVED_SLUG_PREFIXES = ['os-', 'mcp-'] as const
@@ -148,21 +154,71 @@ class UserSkillRepository {
     return join(this.sourceDir(source), slug)
   }
 
+  // Lists the valid skill slugs under a source, ignoring hidden entries — in particular the
+  // `.import-`/`.backup-` transaction dirs, which must never be surfaced as slugs or skill ids.
+  private async listSlugs(source: (typeof USER_SOURCES)[number]): Promise<string[]> {
+    try {
+      return (await readdir(this.sourceDir(source))).filter((entry) => SAFE_SLUG.test(entry))
+    } catch {
+      return []
+    }
+  }
+
+  // Finalizes any imported-skill replace that a crash interrupted, so the swap is failure-atomic
+  // across process restarts (a plain two-step rename leaves a window with no live dir). Runs at most
+  // once per instance, before the first read/list/import. For each transaction dir: if a `.backup-`
+  // exists and its live dir is gone, the previous copy is restored (the interrupted replace is rolled
+  // back); a leftover backup whose live dir is present, and any staged `.import-` dir, are discarded.
+  private recovery?: Promise<void>
+  private recoverImportedTransactions(): Promise<void> {
+    return (this.recovery ??= this.doRecoverImportedTransactions())
+  }
+
+  private async doRecoverImportedTransactions(): Promise<void> {
+    const dir = this.sourceDir('imported')
+    let entries: string[]
+    try {
+      entries = await readdir(dir)
+    } catch {
+      return
+    }
+
+    // Restore first: move a backup back to its live slug if the live dir is missing.
+    for (const entry of entries) {
+      const match = TRANSACTION_DIR.exec(entry)
+      if (!match || match[2] !== 'backup') continue
+      const live = join(dir, match[1])
+      const liveExists = await stat(live).then(
+        () => true,
+        () => false
+      )
+      try {
+        if (liveExists) {
+          await rm(join(dir, entry), { recursive: true, force: true })
+        } else {
+          await rename(join(dir, entry), live)
+          log.warn('recovered interrupted skill import from backup', { slug: match[1] })
+        }
+      } catch (error) {
+        log.warn('failed to recover skill transaction backup', { entry, error })
+      }
+    }
+
+    // Then discard any staged (uncommitted) copies left behind.
+    for (const entry of entries) {
+      const match = TRANSACTION_DIR.exec(entry)
+      if (!match || match[2] !== 'import') continue
+      await rm(join(dir, entry), { recursive: true, force: true }).catch(() => {})
+    }
+  }
+
   // Lists every personal + imported skill, skipping any dir whose SKILL.md is missing/unreadable.
   async list(): Promise<BundledSkill[]> {
+    await this.recoverImportedTransactions()
     const skills: BundledSkill[] = []
 
     for (const source of USER_SOURCES) {
-      const dir = this.sourceDir(source)
-      let slugs: string[] = []
-      try {
-        slugs = await readdir(dir)
-      } catch {
-        continue
-      }
-
-      for (const slug of slugs) {
-        if (!SAFE_SLUG.test(slug)) continue
+      for (const slug of await this.listSlugs(source)) {
         const skillDir = this.skillDir(source, slug)
 
         try {
@@ -193,6 +249,7 @@ class UserSkillRepository {
   async body(id: string): Promise<string> {
     const parsed = parseUserSkillId(id)
     if (!parsed) throw new Error(`Not a user skill id: ${id}`)
+    await this.recoverImportedTransactions()
 
     return (await readSkillFile(this.skillDir(parsed.source, parsed.slug))).body
   }
@@ -241,6 +298,7 @@ class UserSkillRepository {
   async importFromGitHub(url: string, fetchImpl?: FetchLike): Promise<ImportOutcome> {
     const location = parseGitHubSkillUrl(url)
     if (!location) throw new Error('Not a recognizable GitHub URL.')
+    await this.recoverImportedTransactions()
 
     const fetcher = fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined)
     if (!fetcher) throw new Error('No fetch implementation available.')
@@ -266,16 +324,10 @@ class UserSkillRepository {
     return { status: 'imported', id: `imported-${slug}` }
   }
 
-  // Finds an already-imported skill whose recorded source URL matches, for dedup.
+  // Finds an already-imported skill whose recorded source URL matches, for dedup. Only real slugs are
+  // scanned, so a hidden transaction dir can never be returned as a (bogus) slug.
   private async findImportedSlugByUrl(url: string): Promise<string | undefined> {
-    let slugs: string[] = []
-    try {
-      slugs = await readdir(this.sourceDir('imported'))
-    } catch {
-      return undefined
-    }
-
-    for (const slug of slugs) {
+    for (const slug of await this.listSlugs('imported')) {
       const source = await this.readSource(slug)
       if (source?.url === url) return slug
     }
@@ -348,6 +400,7 @@ class UserSkillRepository {
     zip: Buffer,
     options: { subPath?: string; replaceId?: string } = {}
   ): Promise<ImportOutcome> {
+    await this.recoverImportedTransactions()
     const roots = findSkillRoots(extractZip(zip))
     if (roots.length === 0) throw new Error('The bundle must contain a SKILL.md.')
 
@@ -383,14 +436,7 @@ class UserSkillRepository {
 
   // Finds an imported skill whose recorded content signature matches, for zip dedup.
   private async findImportedSlugBySignature(signature: string): Promise<string | undefined> {
-    let slugs: string[] = []
-    try {
-      slugs = await readdir(this.sourceDir('imported'))
-    } catch {
-      return undefined
-    }
-
-    for (const slug of slugs) {
+    for (const slug of await this.listSlugs('imported')) {
       const source = await this.readSource(slug)
       if (source?.signature === signature) return slug
     }
@@ -500,7 +546,8 @@ class UserSkillRepository {
     const stem = basename(dir)
     const staging = join(parent, `.${stem}.import-${randomUUID()}`)
     const backup = join(parent, `.${stem}.backup-${randomUUID()}`)
-    let hadExisting = false
+    // Build the whole new copy in staging first; any failure here discards staging and never touches
+    // the live skill.
     try {
       await mkdir(staging, { recursive: true })
       for (const file of files) {
@@ -520,36 +567,51 @@ class UserSkillRepository {
       await writeFile(join(staging, SOURCE_MANIFEST), JSON.stringify({ url, signature }, null, 2), {
         flag: 'wx'
       })
+    } catch (buildError) {
+      await rm(staging, { recursive: true, force: true }).catch(() => {})
+      throw buildError
+    }
 
-      hadExisting = await stat(dir).then(
-        () => true,
-        () => false
-      )
+    // Swap: move the old copy aside to the backup, move staging into place, then drop the backup. If a
+    // crash lands between the two renames, recoverImportedTransactions() restores the backup on the
+    // next operation, so the previous skill is never lost.
+    const hadExisting = await stat(dir).then(
+      () => true,
+      () => false
+    )
+    try {
       if (hadExisting) await rename(dir, backup)
-      try {
-        await rename(staging, dir)
-      } catch (swapError) {
-        // Roll the previous skill back so a failed swap never loses it.
-        if (hadExisting) await rename(backup, dir).catch(() => {})
-        throw swapError
-      }
     } catch (error) {
       await rm(staging, { recursive: true, force: true }).catch(() => {})
-      throw error
+      throw error // the live dir was never moved; the previous skill is untouched
     }
-    // New copy is in place; drop the backup last so nothing is deleted until the swap succeeded.
+
+    try {
+      await rename(staging, dir)
+    } catch (swapError) {
+      await rm(staging, { recursive: true, force: true }).catch(() => {})
+      if (hadExisting) {
+        try {
+          await rename(backup, dir)
+        } catch (rollbackError) {
+          // Rollback failed too: keep the backup on disk (recovery will restore it next run) and
+          // surface both errors rather than swallowing them.
+          throw new Error(
+            `Skill replace failed to swap and could not roll back; the previous copy is preserved at ${basename(backup)} and will be restored on the next operation. swap error: ${String(swapError)}; rollback error: ${String(rollbackError)}`
+          )
+        }
+      }
+      throw swapError
+    }
+
+    // New copy is in place; drop the backup last so nothing is deleted until the swap succeeded. A
+    // leftover backup (rm failure) is harmless — recovery removes it once the live dir is present.
     if (hadExisting) await rm(backup, { recursive: true, force: true }).catch(() => {})
   }
 
   // Finds a slug not yet taken under the source, appending -2, -3, ... on collision.
   private async uniqueSlug(source: (typeof USER_SOURCES)[number], base: string): Promise<string> {
-    let slugs: string[] = []
-    try {
-      slugs = await readdir(this.sourceDir(source))
-    } catch {
-      slugs = []
-    }
-    const taken = new Set(slugs)
+    const taken = new Set(await this.listSlugs(source))
 
     if (!taken.has(base)) return base
     for (let index = 2; ; index += 1) {
@@ -560,12 +622,7 @@ class UserSkillRepository {
 
   // Whether a slug's directory already exists under the source.
   private async slugTaken(source: (typeof USER_SOURCES)[number], slug: string): Promise<boolean> {
-    try {
-      const slugs = await readdir(this.sourceDir(source))
-      return slugs.includes(slug)
-    } catch {
-      return false
-    }
+    return (await this.listSlugs(source)).includes(slug)
   }
 
   // Writes a SKILL.md with a minimal frontmatter block (name/description) followed by the body.

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -32,7 +32,7 @@ const SAFE_SLUG = /^[a-z0-9-]+$/
 
 // A transaction directory left by an in-progress replace (see writeImported): `.<slug>.import-<id>`
 // holds the staged new copy, `.<slug>.backup-<id>` the previous copy moved aside during the swap.
-// Both are hidden (leading dot) so they can never be a valid slug, and recoverImportedTransactions()
+// Both are hidden (leading dot) so they can never be a valid slug, and doRecoverImportedTransactions()
 // finalizes or rolls them back if a crash left them behind.
 const TRANSACTION_DIR = /^\.([a-z0-9-]+)\.(import|backup)-(.+)$/
 
@@ -182,16 +182,12 @@ class UserSkillRepository {
   }
 
   // Finalizes any imported-skill replace that a crash interrupted, so the swap is failure-atomic across
-  // process restarts (a plain two-step rename leaves a window with no live dir). Runs before EVERY
-  // read/list/import/delete — not memoized — so a backup left by a failed rollback, or a transient
-  // recovery error, is retried on the next operation. For each slug: if a `.backup-` exists and the
-  // live dir is gone, the newest backup is restored (the interrupted replace is rolled back) and any
-  // older backups discarded; a backup whose live dir is present, and every staged `.import-` dir, are
-  // discarded. Serialized via runExclusive so it can't race an in-flight swap.
-  private recoverImportedTransactions(): Promise<void> {
-    return this.runExclusive(() => this.doRecoverImportedTransactions())
-  }
-
+  // process restarts (a plain two-step rename leaves a window with no live dir). Called at the start of
+  // every public operation, INSIDE that operation's runExclusive critical section — not memoized — so a
+  // backup left by a failed rollback, or a transient recovery error, is retried on the next operation.
+  // For each slug: if a `.backup-` exists and the live dir is gone, the newest backup is restored (the
+  // interrupted replace is rolled back, and a failed restore rejects the operation) and any older
+  // backups discarded; a backup whose live dir is present, and every staged `.import-` dir, are dropped.
   private async doRecoverImportedTransactions(): Promise<void> {
     const dir = this.sourceDir('imported')
     let entries: string[]
@@ -225,18 +221,26 @@ class UserSkillRepository {
       backups.sort((a, b) => b.generation.localeCompare(a.generation))
       for (let index = 0; index < backups.length; index += 1) {
         const path = join(dir, backups[index].entry)
-        try {
-          if (index === 0 && !liveExists) {
+        if (index === 0 && !liveExists) {
+          // The live dir is gone and this backup is the only copy — a failed restore would lose the
+          // skill, so reject the whole operation rather than logging and letting the caller proceed on
+          // a missing skill (which a later recovery could otherwise "resurrect").
+          try {
             await rename(path, live)
-            log.warn('recovered interrupted skill import from backup', { slug })
-          } else {
-            await rm(path, { recursive: true, force: true })
+          } catch (error) {
+            throw new Error(
+              `Failed to recover interrupted skill import for "${slug}" from backup ${backups[index].entry}: ${String(error)}`
+            )
           }
-        } catch (error) {
-          log.warn('failed to recover skill transaction backup', {
-            entry: backups[index].entry,
-            error
-          })
+          log.warn('recovered interrupted skill import from backup', { slug })
+        } else {
+          // Superseded/leftover backup: best-effort cleanup, safe to ignore on failure.
+          await rm(path, { recursive: true, force: true }).catch((error) =>
+            log.warn('failed to remove leftover skill backup', {
+              entry: backups[index].entry,
+              error
+            })
+          )
         }
       }
     }
@@ -247,9 +251,19 @@ class UserSkillRepository {
     }
   }
 
-  // Lists every personal + imported skill, skipping any dir whose SKILL.md is missing/unreadable.
+  // Lists every personal + imported skill, skipping any dir whose SKILL.md is missing/unreadable. The
+  // whole read runs under the lock, after recovery, so it can't observe a live dir mid-swap (a rename
+  // to/from a backup) and drop or duplicate an entry.
   async list(): Promise<BundledSkill[]> {
-    await this.recoverImportedTransactions()
+    return this.runExclusive(async () => {
+      await this.doRecoverImportedTransactions()
+      return this.listSkillsInternal()
+    })
+  }
+
+  // The listing itself, without acquiring the lock or running recovery — call only from within a
+  // critical section that has already recovered (avoids re-entrant locking / deadlock).
+  private async listSkillsInternal(): Promise<BundledSkill[]> {
     const skills: BundledSkill[] = []
 
     for (const source of USER_SOURCES) {
@@ -280,13 +294,16 @@ class UserSkillRepository {
     return skills
   }
 
-  // Returns one user skill's SKILL.md body (frontmatter stripped).
+  // Returns one user skill's SKILL.md body (frontmatter stripped). Recovery + read run under the lock
+  // so a concurrent replace can't rename the live dir out from under the read (transient ENOENT).
   async body(id: string): Promise<string> {
     const parsed = parseUserSkillId(id)
     if (!parsed) throw new Error(`Not a user skill id: ${id}`)
-    await this.recoverImportedTransactions()
 
-    return (await readSkillFile(this.skillDir(parsed.source, parsed.slug))).body
+    return this.runExclusive(async () => {
+      await this.doRecoverImportedTransactions()
+      return (await readSkillFile(this.skillDir(parsed.source, parsed.slug))).body
+    })
   }
 
   // Creates a personal skill, returning its new id. With an explicit `requestedSlug`, that slug is
@@ -323,11 +340,13 @@ class UserSkillRepository {
   async delete(id: string): Promise<void> {
     const parsed = parseUserSkillId(id)
     if (!parsed) throw new Error(`Not a user skill id: ${id}`)
-    // Recover first, so a skill left only in a crash backup is restored to its live dir and then
-    // actually removed here — otherwise a later recovery would "resurrect" the deleted skill.
-    await this.recoverImportedTransactions()
 
-    await rm(this.skillDir(parsed.source, parsed.slug), { recursive: true, force: true })
+    return this.runExclusive(async () => {
+      // Recover first, so a skill left only in a crash backup is restored to its live dir and then
+      // actually removed here — otherwise a later recovery would "resurrect" the deleted skill.
+      await this.doRecoverImportedTransactions()
+      await rm(this.skillDir(parsed.source, parsed.slug), { recursive: true, force: true })
+    })
   }
 
   // Imports a single skill directory from a public GitHub URL, deduplicating against prior imports of
@@ -336,30 +355,36 @@ class UserSkillRepository {
   async importFromGitHub(url: string, fetchImpl?: FetchLike): Promise<ImportOutcome> {
     const location = parseGitHubSkillUrl(url)
     if (!location) throw new Error('Not a recognizable GitHub URL.')
-    await this.recoverImportedTransactions()
 
     const fetcher = fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined)
     if (!fetcher) throw new Error('No fetch implementation available.')
 
+    // Fetch over the network OUTSIDE the lock (it's slow); everything that touches disk — recovery,
+    // dedup, slug allocation, and the swap — runs in one critical section so two concurrent imports
+    // can't both claim the same slug and clobber each other.
     const files = await fetchSkillFiles(location, fetcher)
     const signature = signatureOf(files)
     const base = toSlug(location.path.split('/').filter(Boolean).pop() ?? location.repo) || 'skill'
 
-    // If a prior import from the exact same URL exists, either skip (unchanged) or refresh (changed).
-    const existingSlug = await this.findImportedSlugByUrl(url)
-    if (existingSlug) {
-      const existing = await this.readSource(existingSlug)
-      if (existing?.signature === signature) {
-        return { status: 'unchanged', id: `imported-${existingSlug}` }
-      }
-      await this.writeImported(existingSlug, files, url, signature)
-      return { status: 'updated', id: `imported-${existingSlug}` }
-    }
+    return this.runExclusive(async () => {
+      await this.doRecoverImportedTransactions()
 
-    // A brand-new source; take a free slug (a same-name skill from a different repo gets a suffix).
-    const slug = await this.uniqueSlug('imported', base)
-    await this.writeImported(slug, files, url, signature)
-    return { status: 'imported', id: `imported-${slug}` }
+      // If a prior import from the exact same URL exists, either skip (unchanged) or refresh (changed).
+      const existingSlug = await this.findImportedSlugByUrl(url)
+      if (existingSlug) {
+        const existing = await this.readSource(existingSlug)
+        if (existing?.signature === signature) {
+          return { status: 'unchanged', id: `imported-${existingSlug}` }
+        }
+        await this.writeImported(existingSlug, files, url, signature)
+        return { status: 'updated', id: `imported-${existingSlug}` }
+      }
+
+      // A brand-new source; take a free slug (a same-name skill from a different repo gets a suffix).
+      const slug = await this.uniqueSlug('imported', base)
+      await this.writeImported(slug, files, url, signature)
+      return { status: 'imported', id: `imported-${slug}` }
+    })
   }
 
   // Finds an already-imported skill whose recorded source URL matches, for dedup. Only real slugs are
@@ -377,33 +402,38 @@ class UserSkillRepository {
   // collides with exactly one existing imported skill of different content — offers that skill's id as
   // a replace target. Writes nothing.
   async previewZip(zip: Buffer): Promise<SkillBundlePreview[]> {
-    await this.recoverImportedTransactions()
     const roots = findSkillRoots(extractZip(zip))
     if (roots.length === 0) throw new Error('The bundle must contain a SKILL.md.')
 
-    const previews: SkillBundlePreview[] = []
-    for (const root of roots) {
-      const skillMd = root.files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
-      const { fields } = parseFrontmatter(skillMd.content.toString('utf8'))
-      const name = fields.name?.trim()
-      if (!name) throw new Error("The bundle's SKILL.md needs a name in its frontmatter.")
+    // Recovery + all dedup reads run under the lock so the alreadyImported/replaceable computation
+    // reflects a consistent, fully-recovered view of the imported dir.
+    return this.runExclusive(async () => {
+      await this.doRecoverImportedTransactions()
 
-      const alreadyImported = Boolean(
-        await this.findImportedSlugBySignature(signatureOf(root.files))
-      )
-      const replaceableId = alreadyImported ? undefined : await this.replaceableImportedId(name)
+      const previews: SkillBundlePreview[] = []
+      for (const root of roots) {
+        const skillMd = root.files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
+        const { fields } = parseFrontmatter(skillMd.content.toString('utf8'))
+        const name = fields.name?.trim()
+        if (!name) throw new Error("The bundle's SKILL.md needs a name in its frontmatter.")
 
-      previews.push({
-        name,
-        description: fields.description ?? '',
-        files: root.files.map((file) => file.relativePath).sort(),
-        alreadyImported,
-        replaceableId,
-        subPath: root.subPath
-      })
-    }
+        const alreadyImported = Boolean(
+          await this.findImportedSlugBySignature(signatureOf(root.files))
+        )
+        const replaceableId = alreadyImported ? undefined : await this.replaceableImportedId(name)
 
-    return previews
+        previews.push({
+          name,
+          description: fields.description ?? '',
+          files: root.files.map((file) => file.relativePath).sort(),
+          alreadyImported,
+          replaceableId,
+          subPath: root.subPath
+        })
+      }
+
+      return previews
+    })
   }
 
   // The id of the single imported skill sharing this display name, or undefined when there is none or
@@ -411,7 +441,9 @@ class UserSkillRepository {
   // personal/featured skill that happens to share a name.
   private async replaceableImportedId(name: string): Promise<string | undefined> {
     const target = name.trim().toLowerCase()
-    const matches = (await this.list()).filter(
+    // Non-locking listing: this is only ever called from within a critical section that has already
+    // recovered, so it must not re-acquire the lock (which would deadlock).
+    const matches = (await this.listSkillsInternal()).filter(
       (skill) => skill.source === 'imported' && skill.name.trim().toLowerCase() === target
     )
     return matches.length === 1 ? matches[0].id : undefined
@@ -439,7 +471,6 @@ class UserSkillRepository {
     zip: Buffer,
     options: { subPath?: string; replaceId?: string } = {}
   ): Promise<ImportOutcome> {
-    await this.recoverImportedTransactions()
     const roots = findSkillRoots(extractZip(zip))
     if (roots.length === 0) throw new Error('The bundle must contain a SKILL.md.')
 
@@ -448,29 +479,34 @@ class UserSkillRepository {
     const skillMd = files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
     const signature = signatureOf(files)
 
-    if (options.replaceId !== undefined) {
-      const parsed = parseUserSkillId(options.replaceId)
-      if (
-        !parsed ||
-        parsed.source !== 'imported' ||
-        !(await this.slugTaken('imported', parsed.slug))
-      ) {
-        throw new Error(`Not an imported skill to replace: ${options.replaceId}`)
+    // Recovery, dedup, slug allocation and the swap share one critical section (see importFromGitHub).
+    return this.runExclusive(async () => {
+      await this.doRecoverImportedTransactions()
+
+      if (options.replaceId !== undefined) {
+        const parsed = parseUserSkillId(options.replaceId)
+        if (
+          !parsed ||
+          parsed.source !== 'imported' ||
+          !(await this.slugTaken('imported', parsed.slug))
+        ) {
+          throw new Error(`Not an imported skill to replace: ${options.replaceId}`)
+        }
+        await this.writeImported(parsed.slug, files, '', signature)
+        return { status: 'updated', id: `imported-${parsed.slug}` }
       }
-      await this.writeImported(parsed.slug, files, '', signature)
-      return { status: 'updated', id: `imported-${parsed.slug}` }
-    }
 
-    const existingSlug = await this.findImportedSlugBySignature(signature)
-    if (existingSlug) {
-      return { status: 'unchanged', id: `imported-${existingSlug}` }
-    }
+      const existingSlug = await this.findImportedSlugBySignature(signature)
+      if (existingSlug) {
+        return { status: 'unchanged', id: `imported-${existingSlug}` }
+      }
 
-    const name = frontmatterName(skillMd.content.toString('utf8'))
-    const base = toSlug(name ?? 'skill') || 'skill'
-    const slug = await this.uniqueSlug('imported', base)
-    await this.writeImported(slug, files, '', signature)
-    return { status: 'imported', id: `imported-${slug}` }
+      const name = frontmatterName(skillMd.content.toString('utf8'))
+      const base = toSlug(name ?? 'skill') || 'skill'
+      const slug = await this.uniqueSlug('imported', base)
+      await this.writeImported(slug, files, '', signature)
+      return { status: 'imported', id: `imported-${slug}` }
+    })
   }
 
   // Finds an imported skill whose recorded content signature matches, for zip dedup.
@@ -489,14 +525,17 @@ class UserSkillRepository {
   ): Promise<(ScannedSkill & { alreadyImported: boolean })[]> {
     const repo = parseGitHubRepo(repoInput)
     if (!repo) throw new Error('Not a recognizable GitHub repo (owner/repo or a github.com URL).')
-    await this.recoverImportedTransactions()
 
     const fetcher = fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined)
     if (!fetcher) throw new Error('No fetch implementation available.')
 
+    // Scan over the network outside the lock; build the imported index under the lock, after recovery.
     const [found, index] = await Promise.all([
       scanRepoForSkills(repo, fetcher),
-      this.importedIndex()
+      this.runExclusive(async () => {
+        await this.doRecoverImportedTransactions()
+        return this.importedIndex()
+      })
     ])
 
     // Mark a candidate as already imported when its exact source URL matches, or when its name matches
@@ -512,14 +551,10 @@ class UserSkillRepository {
   private async importedIndex(): Promise<{ urls: Set<string>; slugs: Set<string> }> {
     const urls = new Set<string>()
     const slugs = new Set<string>()
-    let dirs: string[] = []
-    try {
-      dirs = await readdir(this.sourceDir('imported'))
-    } catch {
-      return { urls, slugs }
-    }
 
-    for (const slug of dirs) {
+    // listSlugs ignores hidden entries, so a transaction dir's .source.json is never read as an
+    // already-imported source even if recovery couldn't clean it up.
+    for (const slug of await this.listSlugs('imported')) {
       slugs.add(slug)
       const source = await this.readSource(slug)
       if (source?.url) urls.add(source.url)
@@ -613,38 +648,37 @@ class UserSkillRepository {
       throw buildError
     }
 
-    // Swap under the lock so it can't race a recovery pass: move the old copy aside to the backup,
-    // move staging into place, then drop the backup. If a crash lands between the two renames,
-    // recoverImportedTransactions() restores the backup on the next operation — the skill is never lost.
+    // Swap: move the old copy aside to the backup, move staging into place, then drop the backup. This
+    // runs inside the caller's operation-level critical section (recovery + dedup + slug + swap share
+    // one runExclusive), so it must NOT re-acquire the lock here — that would deadlock. If a crash
+    // lands between the two renames, recovery restores the backup on the next operation.
     try {
-      await this.runExclusive(async () => {
-        const hadExisting = await stat(dir).then(
-          () => true,
-          () => false
-        )
-        if (hadExisting) await rename(dir, backup) // may throw; live dir untouched, staging cleaned below
+      const hadExisting = await stat(dir).then(
+        () => true,
+        () => false
+      )
+      if (hadExisting) await rename(dir, backup) // may throw; live dir untouched, staging cleaned below
 
-        try {
-          await rename(staging, dir)
-        } catch (swapError) {
-          if (hadExisting) {
-            try {
-              await rename(backup, dir)
-            } catch (rollbackError) {
-              // Rollback failed too: keep the backup on disk (recovery restores it next run) and
-              // surface both errors rather than swallowing them.
-              throw new Error(
-                `Skill replace failed to swap and could not roll back; the previous copy is preserved at ${basename(backup)} and will be restored on the next operation. swap error: ${String(swapError)}; rollback error: ${String(rollbackError)}`
-              )
-            }
+      try {
+        await rename(staging, dir)
+      } catch (swapError) {
+        if (hadExisting) {
+          try {
+            await rename(backup, dir)
+          } catch (rollbackError) {
+            // Rollback failed too: keep the backup on disk (recovery restores it next run) and
+            // surface both errors rather than swallowing them.
+            throw new Error(
+              `Skill replace failed to swap and could not roll back; the previous copy is preserved at ${basename(backup)} and will be restored on the next operation. swap error: ${String(swapError)}; rollback error: ${String(rollbackError)}`
+            )
           }
-          throw swapError
         }
+        throw swapError
+      }
 
-        // New copy is in place; drop the backup last so nothing is deleted until the swap succeeded. A
-        // leftover backup (rm failure) is harmless — recovery removes it once the live dir is present.
-        if (hadExisting) await rm(backup, { recursive: true, force: true }).catch(() => {})
-      })
+      // New copy is in place; drop the backup last so nothing is deleted until the swap succeeded. A
+      // leftover backup (rm failure) is harmless — recovery removes it once the live dir is present.
+      if (hadExisting) await rm(backup, { recursive: true, force: true }).catch(() => {})
     } catch (error) {
       // Any swap failure leaves staging behind; discard it (the backup, if any, is intentionally kept).
       await rm(staging, { recursive: true, force: true }).catch(() => {})

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -204,8 +204,11 @@ class UserSkillRepository {
     let entries: string[]
     try {
       entries = await readdir(dir)
-    } catch {
-      return
+    } catch (error) {
+      // A missing dir just means nothing to recover. Any other error (permission, I/O) must block the
+      // operation rather than be swallowed — proceeding could act on an un-recovered/inconsistent state.
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+      throw error
     }
 
     const backupsBySlug = new Map<string, { entry: string; generation: string }[]>()

--- a/src/main/skills/zip-extract.test.ts
+++ b/src/main/skills/zip-extract.test.ts
@@ -114,6 +114,21 @@ describe('extractZip', () => {
     expect(files.map((file) => file.path)).toEqual(['skill/SKILL.md'])
   })
 
+  it('normalizes backslash paths so Windows-style zip-slip is caught and separators unify', () => {
+    const files = extractZip(
+      buildZip([
+        // Backslash traversal: harmless on posix split('/'), a real escape on Windows path.join.
+        { path: '..\\..\\evil.sh', content: Buffer.from('rm -rf', 'utf8'), method: 0 },
+        // A Windows drive-letter absolute path.
+        { path: 'C:\\Windows\\system32\\x', content: Buffer.from('x', 'utf8'), method: 0 },
+        // A legitimate nested file authored with backslashes normalizes to forward slashes.
+        { path: 'skill\\references\\helper.py', content: Buffer.from('ok', 'utf8'), method: 0 }
+      ])
+    )
+
+    expect(files.map((file) => file.path)).toEqual(['skill/references/helper.py'])
+  })
+
   it('throws when the buffer is not a zip', () => {
     expect(() => extractZip(Buffer.from('not a zip at all', 'utf8'))).toThrow()
   })

--- a/src/main/skills/zip-extract.test.ts
+++ b/src/main/skills/zip-extract.test.ts
@@ -114,19 +114,21 @@ describe('extractZip', () => {
     expect(files.map((file) => file.path)).toEqual(['skill/SKILL.md'])
   })
 
-  it('normalizes backslash paths so Windows-style zip-slip is caught and separators unify', () => {
+  it('rejects any entry whose name contains a backslash', () => {
+    // ZIP names must use forward slashes; a backslash is never legitimate and is a Windows zip-slip
+    // vector, so every backslash entry is dropped — even one that looks like a normal nested file
+    // (`a\b` and `a/b` must never collapse onto the same write target).
     const files = extractZip(
       buildZip([
-        // Backslash traversal: harmless on posix split('/'), a real escape on Windows path.join.
         { path: '..\\..\\evil.sh', content: Buffer.from('rm -rf', 'utf8'), method: 0 },
-        // A Windows drive-letter absolute path.
         { path: 'C:\\Windows\\system32\\x', content: Buffer.from('x', 'utf8'), method: 0 },
-        // A legitimate nested file authored with backslashes normalizes to forward slashes.
-        { path: 'skill\\references\\helper.py', content: Buffer.from('ok', 'utf8'), method: 0 }
+        { path: 'skill\\references\\helper.py', content: Buffer.from('ok', 'utf8'), method: 0 },
+        // A genuine forward-slash file alongside them still extracts.
+        { path: 'skill/SKILL.md', content: Buffer.from('ok', 'utf8'), method: 0 }
       ])
     )
 
-    expect(files.map((file) => file.path)).toEqual(['skill/references/helper.py'])
+    expect(files.map((file) => file.path)).toEqual(['skill/SKILL.md'])
   })
 
   it('throws when the buffer is not a zip', () => {

--- a/src/main/skills/zip-extract.ts
+++ b/src/main/skills/zip-extract.ts
@@ -12,7 +12,14 @@ const EOCD_MIN_SIZE = 22
 // An extracted file: its posix-style path within the archive plus its decompressed bytes.
 export type ExtractedZipFile = { path: string; content: Buffer }
 
+// Normalizes an archive path to POSIX form. ZIP entries are meant to use forward slashes, but a
+// hostile archive can use backslashes: on Windows those are real path separators, so `..\..\x`
+// would sail past a slash-only `..` check and then escape when joined with path.join. Collapsing
+// `\` to `/` up front means the safety check and every downstream consumer see one separator.
+const toPosixPath = (path: string): string => path.replace(/\\/g, '/')
+
 // Rejects paths that would escape the extraction root (zip-slip) or aren't real bundle files.
+// Expects an already POSIX-normalized path (see toPosixPath).
 const isUnsafePath = (path: string): boolean => {
   if (path.length === 0) return true
   // Absolute paths (posix or a Windows drive letter) must never be trusted.
@@ -53,7 +60,8 @@ const extractZip = (buffer: Buffer): ExtractedZipFile[] => {
     const extraLength = buffer.readUInt16LE(pointer + 30)
     const commentLength = buffer.readUInt16LE(pointer + 32)
     const localOffset = buffer.readUInt32LE(pointer + 42)
-    const name = buffer.toString('utf8', pointer + 46, pointer + 46 + nameLength)
+    const rawName = buffer.toString('utf8', pointer + 46, pointer + 46 + nameLength)
+    const name = toPosixPath(rawName)
 
     // Advance to the next central-directory record before any skip.
     pointer += 46 + nameLength + extraLength + commentLength

--- a/src/main/skills/zip-extract.ts
+++ b/src/main/skills/zip-extract.ts
@@ -12,16 +12,13 @@ const EOCD_MIN_SIZE = 22
 // An extracted file: its posix-style path within the archive plus its decompressed bytes.
 export type ExtractedZipFile = { path: string; content: Buffer }
 
-// Normalizes an archive path to POSIX form. ZIP entries are meant to use forward slashes, but a
-// hostile archive can use backslashes: on Windows those are real path separators, so `..\..\x`
-// would sail past a slash-only `..` check and then escape when joined with path.join. Collapsing
-// `\` to `/` up front means the safety check and every downstream consumer see one separator.
-const toPosixPath = (path: string): string => path.replace(/\\/g, '/')
-
 // Rejects paths that would escape the extraction root (zip-slip) or aren't real bundle files.
-// Expects an already POSIX-normalized path (see toPosixPath).
 const isUnsafePath = (path: string): boolean => {
   if (path.length === 0) return true
+  // ZIP entry names are required to use forward slashes. A backslash is never legitimate and is a
+  // known zip-slip vector on Windows (where `\` is a real separator), so reject the raw name rather
+  // than normalizing it — normalizing would also silently collapse `a\b` and `a/b` onto one target.
+  if (path.includes('\\')) return true
   // Absolute paths (posix or a Windows drive letter) must never be trusted.
   if (path.startsWith('/') || /^[A-Za-z]:/.test(path)) return true
   // Any `..` segment could climb out of the target directory.
@@ -60,8 +57,7 @@ const extractZip = (buffer: Buffer): ExtractedZipFile[] => {
     const extraLength = buffer.readUInt16LE(pointer + 30)
     const commentLength = buffer.readUInt16LE(pointer + 32)
     const localOffset = buffer.readUInt32LE(pointer + 42)
-    const rawName = buffer.toString('utf8', pointer + 46, pointer + 46 + nameLength)
-    const name = toPosixPath(rawName)
+    const name = buffer.toString('utf8', pointer + 46, pointer + 46 + nameLength)
 
     // Advance to the next central-directory record before any skip.
     pointer += 46 + nameLength + extraLength + commentLength


### PR DESCRIPTION
## Summary

Two path-safety fixes for skill/connector inputs that become files under Claude's skills directory.

**Custom MCP server skill dir keyed on user-controlled name.** `syncCustomServerSkillDocs` built `mcp-${server.name}`, and `name` is only validated non-empty. A name like `../evil` could write `SKILL.md` outside the skills directory, and a name equal to a bundled connector id (e.g. `chemistry`) overwrote the built-in `mcp-chemistry` doc — which cleanup then refused to repair (it skips bundled ids). Now the directory and the SKILL.md frontmatter `name` are keyed on the server's immutable `randomUUID` id, and `provision.ts` rejects any id that isn't a safe path segment or collides with a bundled connector id (defense against a tampered `settings.json`). Runtime `host.mcp("<name>", ...)` routing still uses the display name, which is what `McpClientManager` registers the server under.

**Zip import path check was POSIX-only.** `isUnsafePath` only split on `/`, but `writeImported` writes with `path.join`. On Windows a `..\..\x` entry sailed past the `..` check and escaped once joined. Archive paths are now normalized to POSIX before the safety check and all downstream use, and a resolve-and-contain gate in `writeImported` verifies every target stays inside the skill directory before writing — covering all import sources (zip, GitHub, ...).

## Tests

- New coverage: malicious server name (traversal + bundled-id collision) is neutralized; a server whose id is not a safe path segment is skipped; backslash/drive-letter zip entries are rejected and legitimate backslash paths normalize to forward slashes.
- `connectors` + `skills` suites pass (705 tests), full typecheck and eslint clean.