### PR TITLE
fix(skills): cap resource use for zip and GitHub skill imports

### DIFF
--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -78,6 +78,7 @@ import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import { getConnectorTools } from '../connectors/registry'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { UserSkillRepository } from '../skills/user-skill-repository'
+import { decodeBoundedBase64 } from '../skills/import-limits'
 import { readSkillFile } from '../skills/skill-files'
 import type {
   StoredConnectors,
@@ -320,7 +321,7 @@ class SettingsService {
 
   // Imports a skill from an uploaded .zip / .skill bundle, returning the outcome + refreshed list.
   async importSkillZip(request: ImportSkillZipRequest): Promise<ImportSkillResult> {
-    const outcome = await this.userSkills.importFromZip(Buffer.from(request.dataBase64, 'base64'), {
+    const outcome = await this.userSkills.importFromZip(decodeBoundedBase64(request.dataBase64), {
       subPath: request.subPath,
       replaceId: request.replaceId
     })
@@ -331,7 +332,7 @@ class SettingsService {
   // Parses an uploaded bundle for a confirm-before-import preview, without writing anything. Returns
   // one preview per skill root the bundle contains.
   async previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreview[]> {
-    return this.userSkills.previewZip(Buffer.from(request.dataBase64, 'base64'))
+    return this.userSkills.previewZip(decodeBoundedBase64(request.dataBase64))
   }
 
   // Scans a GitHub repo for importable skill directories (marking already-imported ones).

--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -96,8 +96,9 @@ describe('fetchSkillFiles', () => {
     ).rejects.toThrow(/No SKILL\.md/)
   })
 
-  it('rejects a file larger than the per-file limit', async () => {
-    // A single 17 MiB file exceeds SKILL_IMPORT_LIMITS.maxFileBytes (16 MiB).
+  it('rejects a file larger than the per-file limit (post-download guard)', async () => {
+    // A 6 MiB body with no Content-Length header falls through to the post-download size guard
+    // (SKILL_IMPORT_LIMITS.maxFileBytes is 5 MiB).
     const oversized: FetchLike = async (url) => {
       if (url.includes('/contents/')) {
         return {
@@ -111,20 +112,84 @@ describe('fetchSkillFiles', () => {
               download_url: 'https://raw/big'
             }
           ],
-          arrayBuffer: async () => new ArrayBuffer(17 * 1024 * 1024)
+          arrayBuffer: async () => new ArrayBuffer(0)
         }
       }
       return {
         ok: true,
         status: 200,
         json: async () => ({}),
-        arrayBuffer: async () => new ArrayBuffer(17 * 1024 * 1024)
+        arrayBuffer: async () => new ArrayBuffer(6 * 1024 * 1024)
       }
     }
 
     await expect(
       fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, oversized)
     ).rejects.toThrow(/exceeds the .* limit/)
+  })
+
+  it('rejects an oversized file on Content-Length before buffering the body', async () => {
+    // The download advertises 6 MiB via Content-Length; the guard must fire before arrayBuffer() runs.
+    let bodyRead = false
+    const preCheck: FetchLike = async (url) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/big'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        headers: {
+          get: (name) => (name.toLowerCase() === 'content-length' ? `${6 * 1024 * 1024}` : null)
+        },
+        arrayBuffer: async () => {
+          bodyRead = true
+          return new ArrayBuffer(6 * 1024 * 1024)
+        }
+      }
+    }
+
+    await expect(
+      fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, preCheck)
+    ).rejects.toThrow(/exceeds the .* limit/)
+    expect(bodyRead).toBe(false)
+  })
+
+  it('rejects a wide directory tree that exceeds the request budget', async () => {
+    // The root lists 600 empty subdirectories; walking them all would exceed the 512-request budget
+    // long before any file or byte limit (empty dirs cost nothing against those).
+    const wide: FetchLike = async (url) => {
+      const isRoot = /\/contents\/pack\/foo(\?|$)/.test(url)
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          isRoot
+            ? Array.from({ length: 600 }, (_, i) => ({
+                type: 'dir',
+                name: `d${i}`,
+                path: `pack/foo/d${i}`
+              }))
+            : [],
+        arrayBuffer: async () => new ArrayBuffer(0)
+      }
+    }
+
+    await expect(
+      fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, wide)
+    ).rejects.toThrow(/exceeded .* requests/)
   })
 
   it('rejects a repository nested deeper than the depth limit', async () => {
@@ -147,8 +212,9 @@ describe('fetchSkillFiles', () => {
   })
 
   it('rejects a directory with more files than the count limit', async () => {
+    // 300 files exceeds the structural cap (SKILL_IMPORT_LIMITS.maxFiles is 256).
     const many = Object.fromEntries(
-      Array.from({ length: 2001 }, (_, i) => [`f${i}.txt`, 'x'])
+      Array.from({ length: 300 }, (_, i) => [`f${i}.txt`, 'x'])
     ) as Record<string, string>
     await expect(
       fetchSkillFiles(

--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -337,6 +337,50 @@ describe('fetchSkillFiles', () => {
     ).rejects.toThrow(/per-file limit/)
   })
 
+  it('still reports the size error when cancel() throws synchronously', async () => {
+    // A synchronous throw from cancel() must not mask the size-limit error (it escapes before
+    // Promise.resolve wraps it, so it needs its own guard).
+    const chunk = new Uint8Array(1024 * 1024)
+    const throwingCancel: FetchLike = async (url) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/s'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        body: {
+          getReader: () => ({
+            read: async () => ({ done: false, value: chunk }),
+            cancel: () => {
+              throw new Error('synchronous cancel failure')
+            }
+          })
+        },
+        arrayBuffer: async () => new ArrayBuffer(0)
+      }
+    }
+
+    await expect(
+      fetchSkillFiles(
+        { owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' },
+        throwingCancel
+      )
+    ).rejects.toThrow(/per-file limit/)
+  })
+
   it('reads a streamed body that finishes under the cap and returns its exact bytes', async () => {
     // A finite streamed body (3 MiB in 1 MiB chunks, no Content-Length) under the 5 MiB per-file cap
     // must be accepted and reassembled intact.

--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -295,6 +295,50 @@ describe('fetchSkillFiles', () => {
     expect(cancelled).toBe(true)
   })
 
+  it('reads a streamed body that finishes under the cap and returns its exact bytes', async () => {
+    // A finite streamed body (3 MiB in 1 MiB chunks, no Content-Length) under the 5 MiB per-file cap
+    // must be accepted and reassembled intact.
+    const chunk = new Uint8Array(1024 * 1024).fill(7)
+    const finite: FetchLike = async (url) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/s'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      let served = 0
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        body: {
+          getReader: () => ({
+            read: async () =>
+              served++ < 3 ? { done: false, value: chunk } : { done: true, value: undefined }
+          })
+        },
+        arrayBuffer: async () => new ArrayBuffer(0)
+      }
+    }
+
+    const files = await fetchSkillFiles(
+      { owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' },
+      finite
+    )
+    expect(files).toHaveLength(1)
+    expect(files[0].content.length).toBe(3 * 1024 * 1024)
+    expect(files[0].content.every((b) => b === 7)).toBe(true)
+  })
+
   it('rejects a wide directory tree that exceeds the request budget', async () => {
     // The root lists 600 empty subdirectories; walking them all would exceed the 512-request budget
     // long before any file or byte limit (empty dirs cost nothing against those).

--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -295,6 +295,48 @@ describe('fetchSkillFiles', () => {
     expect(cancelled).toBe(true)
   })
 
+  it('does not hang when the over-limit stream cancel never settles', async () => {
+    // cancel() returns a promise that never resolves; the size error must still reject promptly
+    // (the cancel is fire-and-forget, not awaited).
+    const chunk = new Uint8Array(1024 * 1024)
+    const hangingCancel: FetchLike = async (url) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/s'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        body: {
+          getReader: () => ({
+            read: async () => ({ done: false, value: chunk }),
+            cancel: () => new Promise<void>(() => {}) // never settles
+          })
+        },
+        arrayBuffer: async () => new ArrayBuffer(0)
+      }
+    }
+
+    await expect(
+      fetchSkillFiles(
+        { owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' },
+        hangingCancel
+      )
+    ).rejects.toThrow(/per-file limit/)
+  })
+
   it('reads a streamed body that finishes under the cap and returns its exact bytes', async () => {
     // A finite streamed body (3 MiB in 1 MiB chunks, no Content-Length) under the 5 MiB per-file cap
     // must be accepted and reassembled intact.

--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -204,7 +204,7 @@ describe('fetchSkillFiles', () => {
 
     await expect(
       fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, aggregate)
-    ).rejects.toThrow(/import size limit/)
+    ).rejects.toThrow(/total limit/)
     // First two bodies read (8 MiB), the third rejected before its body was touched.
     expect(bodiesRead).toEqual(['https://raw/a', 'https://raw/b'])
   })
@@ -289,7 +289,7 @@ describe('fetchSkillFiles', () => {
 
     await expect(
       fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, streaming)
-    ).rejects.toThrow(/import size limit/)
+    ).rejects.toThrow(/per-file limit/)
     // Stopped a hair past the 5 MiB cap (6 one-MiB reads), not the whole endless stream, and cancelled.
     expect(chunksServed).toBeLessThanOrEqual(7)
     expect(cancelled).toBe(true)

--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -96,6 +96,68 @@ describe('fetchSkillFiles', () => {
     ).rejects.toThrow(/No SKILL\.md/)
   })
 
+  it('rejects a file larger than the per-file limit', async () => {
+    // A single 17 MiB file exceeds SKILL_IMPORT_LIMITS.maxFileBytes (16 MiB).
+    const oversized: FetchLike = async (url) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/big'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(17 * 1024 * 1024)
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        arrayBuffer: async () => new ArrayBuffer(17 * 1024 * 1024)
+      }
+    }
+
+    await expect(
+      fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, oversized)
+    ).rejects.toThrow(/exceeds the .* limit/)
+  })
+
+  it('rejects a repository nested deeper than the depth limit', async () => {
+    // Every contents request returns a single subdirectory, so the walk recurses without bound
+    // until the depth cap trips.
+    const bottomless: FetchLike = async (url) => {
+      const match = /\/contents\/(.*?)(\?|$)/.exec(url)
+      const path = match ? decodeURIComponent(match[1]) : ''
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [{ type: 'dir', name: 'deeper', path: `${path}/deeper` }],
+        arrayBuffer: async () => new ArrayBuffer(0)
+      }
+    }
+
+    await expect(
+      fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, bottomless)
+    ).rejects.toThrow(/nesting exceeds/)
+  })
+
+  it('rejects a directory with more files than the count limit', async () => {
+    const many = Object.fromEntries(
+      Array.from({ length: 2001 }, (_, i) => [`f${i}.txt`, 'x'])
+    ) as Record<string, string>
+    await expect(
+      fetchSkillFiles(
+        { owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' },
+        fakeFetch(many)
+      )
+    ).rejects.toThrow(/too many files/)
+  })
+
   it('percent-encodes path segments in the contents URL', async () => {
     const urls: string[] = []
     const capturingFetch: FetchLike = async (url) => {

--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -167,6 +167,134 @@ describe('fetchSkillFiles', () => {
     expect(bodyRead).toBe(false)
   })
 
+  it('rejects on the aggregate budget via Content-Length before reading the over-budget body', async () => {
+    // Three files each declaring 4 MiB. The total cap is 10 MiB, so the third pushes the aggregate to
+    // 12 MiB and must be rejected on its Content-Length — before its body is ever read.
+    const bodiesRead: string[] = []
+    const size = 4 * 1024 * 1024
+    const aggregate: FetchLike = async (url) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/a'
+            },
+            { type: 'file', name: 'b.bin', path: 'pack/foo/b.bin', download_url: 'https://raw/b' },
+            { type: 'file', name: 'c.bin', path: 'pack/foo/c.bin', download_url: 'https://raw/c' }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        headers: { get: (name) => (name.toLowerCase() === 'content-length' ? `${size}` : null) },
+        arrayBuffer: async () => {
+          bodiesRead.push(url)
+          return new ArrayBuffer(size)
+        }
+      }
+    }
+
+    await expect(
+      fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, aggregate)
+    ).rejects.toThrow(/import size limit/)
+    // First two bodies read (8 MiB), the third rejected before its body was touched.
+    expect(bodiesRead).toEqual(['https://raw/a', 'https://raw/b'])
+  })
+
+  it('accepts files sitting exactly on the per-file and total limits', async () => {
+    // Two 5 MiB files == the 5 MiB per-file cap each and 10 MiB total exactly. Both must be accepted.
+    const size = 5 * 1024 * 1024
+    const exact: FetchLike = async (url) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/a'
+            },
+            { type: 'file', name: 'b.bin', path: 'pack/foo/b.bin', download_url: 'https://raw/b' }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        headers: { get: (name) => (name.toLowerCase() === 'content-length' ? `${size}` : null) },
+        arrayBuffer: async () => new ArrayBuffer(size)
+      }
+    }
+
+    const files = await fetchSkillFiles(
+      { owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' },
+      exact
+    )
+    expect(files.map((f) => f.relativePath).sort()).toEqual(['SKILL.md', 'b.bin'])
+    expect(files.every((f) => f.content.length === size)).toBe(true)
+  })
+
+  it('bounds a streamed body with no Content-Length, stopping once the cap is passed', async () => {
+    // A body that streams 1 MiB chunks with no Content-Length. Reading must abort once it crosses the
+    // 5 MiB per-file cap instead of draining the whole (here effectively endless) stream.
+    let chunksServed = 0
+    let cancelled = false
+    const chunk = new Uint8Array(1024 * 1024)
+    const streaming: FetchLike = async (url) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/s'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        body: {
+          getReader: () => ({
+            read: async () => {
+              chunksServed += 1
+              return { done: false, value: chunk }
+            },
+            cancel: () => {
+              cancelled = true
+            }
+          })
+        },
+        arrayBuffer: async () => new ArrayBuffer(0)
+      }
+    }
+
+    await expect(
+      fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, streaming)
+    ).rejects.toThrow(/import size limit/)
+    // Stopped a hair past the 5 MiB cap (6 one-MiB reads), not the whole endless stream, and cancelled.
+    expect(chunksServed).toBeLessThanOrEqual(7)
+    expect(cancelled).toBe(true)
+  })
+
   it('rejects a wide directory tree that exceeds the request budget', async () => {
     // The root lists 600 empty subdirectories; walking them all would exceed the 512-request budget
     // long before any file or byte limit (empty dirs cost nothing against those).

--- a/src/main/skills/github-import.ts
+++ b/src/main/skills/github-import.ts
@@ -14,7 +14,9 @@ export type GitHubSkillLocation = {
   path: string
 }
 
-// Injectable fetch so tests don't hit the network.
+// Injectable fetch so tests don't hit the network. `headers.get` is optional: the real fetch Response
+// exposes it (used to read Content-Length before buffering a download), and callers/tests that omit it
+// simply skip the pre-check and fall back to the post-download size guard.
 export type FetchLike = (
   url: string,
   init?: { headers?: Record<string, string> }
@@ -23,6 +25,7 @@ export type FetchLike = (
   status: number
   json: () => Promise<unknown>
   arrayBuffer: () => Promise<ArrayBuffer>
+  headers?: { get: (name: string) => string | null }
 }>
 
 const GITHUB_HEADERS = { 'User-Agent': 'open-science', Accept: 'application/vnd.github+json' }
@@ -64,16 +67,28 @@ const fetchSkillFiles = async (
   const rootPrefix = location.path ? `${location.path}/` : ''
 
   // Bound the recursive download so a huge (or maliciously deep) repository can't freeze or exhaust
-  // the app: cap directory depth, file count, per-file size, and total bytes across the whole skill.
+  // the app: cap directory depth, file count, per-file size, total bytes, AND the number of requests.
+  // The request budget is charged for every fetch — including directory listings — so a wide or
+  // mostly-empty directory tree can't drive an unbounded number of API calls before hitting a byte or
+  // file limit (empty dirs cost nothing against those).
   let fileCount = 0
   let totalBytes = 0
+  let requests = 0
+
+  const request: FetchLike = (url, init) => {
+    requests += 1
+    if (requests > SKILL_IMPORT_LIMITS.maxRequests) {
+      throw new Error(`Skill import exceeded ${SKILL_IMPORT_LIMITS.maxRequests} requests.`)
+    }
+    return fetchImpl(url, init)
+  }
 
   const walk = async (path: string, depth: number): Promise<FetchedSkillFile[]> => {
     if (depth > SKILL_IMPORT_LIMITS.maxDepth) {
       throw new Error(`Skill directory nesting exceeds ${SKILL_IMPORT_LIMITS.maxDepth} levels.`)
     }
 
-    const response = await fetchImpl(contentsUrl(location, path), { headers: GITHUB_HEADERS })
+    const response = await request(contentsUrl(location, path), { headers: GITHUB_HEADERS })
     if (!response.ok) {
       throw new Error(`GitHub API request failed (${response.status}) for ${path || 'repo root'}`)
     }
@@ -89,11 +104,18 @@ const fetchSkillFiles = async (
         if (fileCount >= SKILL_IMPORT_LIMITS.maxFiles) {
           throw new Error(`Skill has too many files (limit ${SKILL_IMPORT_LIMITS.maxFiles}).`)
         }
-        const raw = await fetchImpl(entry.download_url, {
-          headers: { 'User-Agent': 'open-science' }
-        })
+        const raw = await request(entry.download_url, { headers: { 'User-Agent': 'open-science' } })
         if (!raw.ok) {
           throw new Error(`Failed to download ${entry.path} (${raw.status})`)
+        }
+        // Reject on the advertised Content-Length before buffering the body, so an oversized file is
+        // refused without first allocating it in memory. A missing/lying header falls through to the
+        // post-download guard below.
+        const declared = Number(raw.headers?.get('content-length') ?? '')
+        if (Number.isFinite(declared) && declared > SKILL_IMPORT_LIMITS.maxFileBytes) {
+          throw new Error(
+            `File ${entry.path} exceeds the ${SKILL_IMPORT_LIMITS.maxFileBytes}-byte limit.`
+          )
         }
         const content = Buffer.from(await raw.arrayBuffer())
         if (content.length > SKILL_IMPORT_LIMITS.maxFileBytes) {

--- a/src/main/skills/github-import.ts
+++ b/src/main/skills/github-import.ts
@@ -63,9 +63,10 @@ const readBounded = async (
       if (value) {
         read += value.byteLength
         if (read > limit) {
-          // Await cancellation so a rejected cancel() surfaces here instead of as an unhandled
-          // rejection; the read is aborted regardless (works whether cancel is sync or async).
-          await Promise.resolve(reader.cancel?.()).catch(() => {})
+          // Fire-and-forget the cancel: attach a catch so a rejected cancel() can't become an
+          // unhandled rejection, but do NOT await it — a cancel that never settles must not keep the
+          // import hanging. Abort with the size error immediately.
+          void Promise.resolve(reader.cancel?.()).catch(() => {})
           onExceeded()
         }
         chunks.push(Buffer.from(value))

--- a/src/main/skills/github-import.ts
+++ b/src/main/skills/github-import.ts
@@ -63,10 +63,15 @@ const readBounded = async (
       if (value) {
         read += value.byteLength
         if (read > limit) {
-          // Fire-and-forget the cancel: attach a catch so a rejected cancel() can't become an
-          // unhandled rejection, but do NOT await it — a cancel that never settles must not keep the
-          // import hanging. Abort with the size error immediately.
-          void Promise.resolve(reader.cancel?.()).catch(() => {})
+          // Fire-and-forget the cancel: don't await it (a cancel that never settles must not keep the
+          // import hanging) and don't let it mask the size error. The try/catch swallows a SYNCHRONOUS
+          // throw from cancel() — which would otherwise escape before Promise.resolve wraps it — and
+          // the .catch() handles an async rejection. Either way we abort with the size error next.
+          try {
+            void Promise.resolve(reader.cancel?.()).catch(() => {})
+          } catch {
+            /* ignore a synchronous cancel() failure */
+          }
           onExceeded()
         }
         chunks.push(Buffer.from(value))

--- a/src/main/skills/github-import.ts
+++ b/src/main/skills/github-import.ts
@@ -20,7 +20,8 @@ export type GitHubSkillLocation = {
 type ByteStream = {
   getReader: () => {
     read: () => Promise<{ done: boolean; value?: Uint8Array }>
-    cancel?: () => void
+    // The real ReadableStreamDefaultReader.cancel() returns a Promise; keep both shapes for tests.
+    cancel?: () => void | Promise<void>
   }
 }
 
@@ -42,9 +43,11 @@ export type FetchLike = (
 
 const GITHUB_HEADERS = { 'User-Agent': 'open-science', Accept: 'application/vnd.github+json' }
 
-// Reads a download body into a Buffer without ever holding more than `limit` bytes. Prefers the
-// streaming reader (aborting as soon as the running total exceeds the limit); falls back to
-// arrayBuffer() when no stream is exposed, still enforcing the cap on the buffered result.
+// Reads a download body into a Buffer, stopping as soon as the running total crosses `limit` (so an
+// oversized/endless body is never drained). Prefers the streaming reader; falls back to arrayBuffer()
+// when no stream is exposed, still enforcing the cap on the buffered result. Peak memory is bounded by
+// the accumulated chunks (at most `limit` plus one chunk) plus the final Buffer.concat copy — i.e. a
+// small multiple of `limit`, never the whole oversized body.
 const readBounded = async (
   response: { arrayBuffer: () => Promise<ArrayBuffer>; body?: ByteStream | null },
   limit: number,
@@ -60,7 +63,9 @@ const readBounded = async (
       if (value) {
         read += value.byteLength
         if (read > limit) {
-          reader.cancel?.()
+          // Await cancellation so a rejected cancel() surfaces here instead of as an unhandled
+          // rejection; the read is aborted regardless (works whether cancel is sync or async).
+          await Promise.resolve(reader.cancel?.()).catch(() => {})
           onExceeded()
         }
         chunks.push(Buffer.from(value))

--- a/src/main/skills/github-import.ts
+++ b/src/main/skills/github-import.ts
@@ -157,10 +157,14 @@ const fetchSkillFiles = async (
         // a missing or dishonest Content-Length.
         const remainingTotal = SKILL_IMPORT_LIMITS.maxTotalBytes - totalBytes
         const perFileLimit = Math.min(SKILL_IMPORT_LIMITS.maxFileBytes, remainingTotal)
+        // Report which cap actually bound, so the error tells the user whether one file is too big or
+        // the whole skill has outgrown its budget.
         const tooLarge = (): never => {
-          throw new Error(
-            `File ${entry.path} exceeds the import size limit (per-file ${SKILL_IMPORT_LIMITS.maxFileBytes} bytes, ${remainingTotal} left in budget).`
-          )
+          const message =
+            remainingTotal < SKILL_IMPORT_LIMITS.maxFileBytes
+              ? `File ${entry.path} exceeds the ${SKILL_IMPORT_LIMITS.maxTotalBytes}-byte total limit.`
+              : `File ${entry.path} exceeds the ${SKILL_IMPORT_LIMITS.maxFileBytes}-byte per-file limit.`
+          throw new Error(message)
         }
 
         // Reject on the advertised Content-Length before reading a single byte when possible.

--- a/src/main/skills/github-import.ts
+++ b/src/main/skills/github-import.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '../logger'
+import { SKILL_IMPORT_LIMITS } from './import-limits'
 
 const log = createLogger('skills')
 
@@ -62,7 +63,16 @@ const fetchSkillFiles = async (
 ): Promise<FetchedSkillFile[]> => {
   const rootPrefix = location.path ? `${location.path}/` : ''
 
-  const walk = async (path: string): Promise<FetchedSkillFile[]> => {
+  // Bound the recursive download so a huge (or maliciously deep) repository can't freeze or exhaust
+  // the app: cap directory depth, file count, per-file size, and total bytes across the whole skill.
+  let fileCount = 0
+  let totalBytes = 0
+
+  const walk = async (path: string, depth: number): Promise<FetchedSkillFile[]> => {
+    if (depth > SKILL_IMPORT_LIMITS.maxDepth) {
+      throw new Error(`Skill directory nesting exceeds ${SKILL_IMPORT_LIMITS.maxDepth} levels.`)
+    }
+
     const response = await fetchImpl(contentsUrl(location, path), { headers: GITHUB_HEADERS })
     if (!response.ok) {
       throw new Error(`GitHub API request failed (${response.status}) for ${path || 'repo root'}`)
@@ -74,8 +84,11 @@ const fetchSkillFiles = async (
 
     for (const entry of entries) {
       if (entry.type === 'dir') {
-        files.push(...(await walk(entry.path)))
+        files.push(...(await walk(entry.path, depth + 1)))
       } else if (entry.type === 'file' && entry.download_url) {
+        if (fileCount >= SKILL_IMPORT_LIMITS.maxFiles) {
+          throw new Error(`Skill has too many files (limit ${SKILL_IMPORT_LIMITS.maxFiles}).`)
+        }
         const raw = await fetchImpl(entry.download_url, {
           headers: { 'User-Agent': 'open-science' }
         })
@@ -83,6 +96,18 @@ const fetchSkillFiles = async (
           throw new Error(`Failed to download ${entry.path} (${raw.status})`)
         }
         const content = Buffer.from(await raw.arrayBuffer())
+        if (content.length > SKILL_IMPORT_LIMITS.maxFileBytes) {
+          throw new Error(
+            `File ${entry.path} exceeds the ${SKILL_IMPORT_LIMITS.maxFileBytes}-byte limit.`
+          )
+        }
+        totalBytes += content.length
+        if (totalBytes > SKILL_IMPORT_LIMITS.maxTotalBytes) {
+          throw new Error(
+            `Skill exceeds the ${SKILL_IMPORT_LIMITS.maxTotalBytes}-byte total limit.`
+          )
+        }
+        fileCount += 1
         const relativePath = entry.path.startsWith(rootPrefix)
           ? entry.path.slice(rootPrefix.length)
           : entry.name
@@ -93,7 +118,7 @@ const fetchSkillFiles = async (
     return files
   }
 
-  const files = await walk(location.path)
+  const files = await walk(location.path, 0)
 
   if (!files.some((file) => file.relativePath.toLowerCase() === 'skill.md')) {
     throw new Error('No SKILL.md found at the linked location.')

--- a/src/main/skills/github-import.ts
+++ b/src/main/skills/github-import.ts
@@ -14,9 +14,20 @@ export type GitHubSkillLocation = {
   path: string
 }
 
-// Injectable fetch so tests don't hit the network. `headers.get` is optional: the real fetch Response
-// exposes it (used to read Content-Length before buffering a download), and callers/tests that omit it
-// simply skip the pre-check and fall back to the post-download size guard.
+// A minimal view of a byte stream (matches the real fetch Response.body's getReader()). Reading a
+// download through this lets us stop the moment the running total crosses a limit, so a body with a
+// missing or lying Content-Length can never be buffered in full.
+type ByteStream = {
+  getReader: () => {
+    read: () => Promise<{ done: boolean; value?: Uint8Array }>
+    cancel?: () => void
+  }
+}
+
+// Injectable fetch so tests don't hit the network. `headers.get` and `body` are optional: the real
+// fetch Response exposes both. `headers` lets us reject on Content-Length before reading anything;
+// `body` lets us read with a hard byte cap. A response with neither falls back to a bounded
+// arrayBuffer() read plus the post-read size guard.
 export type FetchLike = (
   url: string,
   init?: { headers?: Record<string, string> }
@@ -26,9 +37,41 @@ export type FetchLike = (
   json: () => Promise<unknown>
   arrayBuffer: () => Promise<ArrayBuffer>
   headers?: { get: (name: string) => string | null }
+  body?: ByteStream | null
 }>
 
 const GITHUB_HEADERS = { 'User-Agent': 'open-science', Accept: 'application/vnd.github+json' }
+
+// Reads a download body into a Buffer without ever holding more than `limit` bytes. Prefers the
+// streaming reader (aborting as soon as the running total exceeds the limit); falls back to
+// arrayBuffer() when no stream is exposed, still enforcing the cap on the buffered result.
+const readBounded = async (
+  response: { arrayBuffer: () => Promise<ArrayBuffer>; body?: ByteStream | null },
+  limit: number,
+  onExceeded: () => never
+): Promise<Buffer> => {
+  if (response.body) {
+    const reader = response.body.getReader()
+    const chunks: Buffer[] = []
+    let read = 0
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value) {
+        read += value.byteLength
+        if (read > limit) {
+          reader.cancel?.()
+          onExceeded()
+        }
+        chunks.push(Buffer.from(value))
+      }
+    }
+    return Buffer.concat(chunks)
+  }
+  const buffer = Buffer.from(await response.arrayBuffer())
+  if (buffer.length > limit) onExceeded()
+  return buffer
+}
 
 // Parses a GitHub URL into the repo + skill directory it points at. Accepts tree/blob URLs and trims a
 // trailing SKILL.md so a link to the file resolves to its directory. Returns null when unrecognizable.
@@ -108,27 +151,24 @@ const fetchSkillFiles = async (
         if (!raw.ok) {
           throw new Error(`Failed to download ${entry.path} (${raw.status})`)
         }
-        // Reject on the advertised Content-Length before buffering the body, so an oversized file is
-        // refused without first allocating it in memory. A missing/lying header falls through to the
-        // post-download guard below.
+
+        // The most this file may add: the smaller of the per-file cap and what remains of the total
+        // budget. Reading is bounded by this, so no single body is ever buffered beyond it — even with
+        // a missing or dishonest Content-Length.
+        const remainingTotal = SKILL_IMPORT_LIMITS.maxTotalBytes - totalBytes
+        const perFileLimit = Math.min(SKILL_IMPORT_LIMITS.maxFileBytes, remainingTotal)
+        const tooLarge = (): never => {
+          throw new Error(
+            `File ${entry.path} exceeds the import size limit (per-file ${SKILL_IMPORT_LIMITS.maxFileBytes} bytes, ${remainingTotal} left in budget).`
+          )
+        }
+
+        // Reject on the advertised Content-Length before reading a single byte when possible.
         const declared = Number(raw.headers?.get('content-length') ?? '')
-        if (Number.isFinite(declared) && declared > SKILL_IMPORT_LIMITS.maxFileBytes) {
-          throw new Error(
-            `File ${entry.path} exceeds the ${SKILL_IMPORT_LIMITS.maxFileBytes}-byte limit.`
-          )
-        }
-        const content = Buffer.from(await raw.arrayBuffer())
-        if (content.length > SKILL_IMPORT_LIMITS.maxFileBytes) {
-          throw new Error(
-            `File ${entry.path} exceeds the ${SKILL_IMPORT_LIMITS.maxFileBytes}-byte limit.`
-          )
-        }
+        if (Number.isFinite(declared) && declared > perFileLimit) tooLarge()
+
+        const content = await readBounded(raw, perFileLimit, tooLarge)
         totalBytes += content.length
-        if (totalBytes > SKILL_IMPORT_LIMITS.maxTotalBytes) {
-          throw new Error(
-            `Skill exceeds the ${SKILL_IMPORT_LIMITS.maxTotalBytes}-byte total limit.`
-          )
-        }
         fileCount += 1
         const relativePath = entry.path.startsWith(rootPrefix)
           ? entry.path.slice(rootPrefix.length)

--- a/src/main/skills/import-limits.test.ts
+++ b/src/main/skills/import-limits.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from './import-limits'
+import { decodeBoundedBase64 } from './import-limits'
 
 describe('decodeBoundedBase64', () => {
   it('decodes a bundle within the limit', () => {
@@ -9,11 +9,21 @@ describe('decodeBoundedBase64', () => {
     expect(decoded.equals(bytes)).toBe(true)
   })
 
-  it('rejects an oversized upload from its encoded length, before allocating the buffer', () => {
-    // A base64 string whose decoded size would exceed the total cap. Built from length alone so the
-    // test never actually allocates the decoded payload.
-    const encodedLen = Math.ceil((SKILL_IMPORT_LIMITS.maxTotalBytes + 1) / 3) * 4
-    const oversized = 'A'.repeat(encodedLen)
-    expect(() => decodeBoundedBase64(oversized)).toThrow(/exceeds the .* limit/)
+  it('accounts for padding exactly at the boundary', () => {
+    // "abc" -> "YWJj" (no padding) decodes to exactly 3 bytes: allowed at limit 3, rejected at 2.
+    const three = Buffer.from('abc').toString('base64')
+    expect(decodeBoundedBase64(three, 3).toString()).toBe('abc')
+    expect(() => decodeBoundedBase64(three, 2)).toThrow(/exceeds the .* limit/)
+
+    // "abcd" -> "YWJjZA==" (two pad chars) decodes to 4 bytes; the padding must not be counted as data.
+    const four = Buffer.from('abcd').toString('base64')
+    expect(decodeBoundedBase64(four, 4).toString()).toBe('abcd')
+    expect(() => decodeBoundedBase64(four, 3)).toThrow(/exceeds the .* limit/)
+  })
+
+  it('ignores whitespace in line-wrapped base64 when sizing', () => {
+    const bytes = Buffer.from('abc')
+    const wrapped = `${bytes.toString('base64').slice(0, 2)}\n${bytes.toString('base64').slice(2)}`
+    expect(decodeBoundedBase64(wrapped, 3).equals(bytes)).toBe(true)
   })
 })

--- a/src/main/skills/import-limits.test.ts
+++ b/src/main/skills/import-limits.test.ts
@@ -35,4 +35,20 @@ describe('decodeBoundedBase64', () => {
     const wrapped = `${bytes.toString('base64').slice(0, 2)}\n${bytes.toString('base64').slice(2)}`
     expect(decodeBoundedBase64(wrapped, 3).equals(bytes)).toBe(true)
   })
+
+  it('does not let an unpadded payload under-count past the limit', () => {
+    // 11 bytes with the base64 padding stripped is 15 chars; a floor(len/4)*3 estimate would call it
+    // 9 bytes and wrongly pass a 10-byte cap. The exact size (11) must be rejected.
+    const eleven = Buffer.alloc(11, 0x61)
+    const unpadded = eleven.toString('base64').replace(/=+$/, '')
+    expect(unpadded.length % 4).not.toBe(0) // genuinely unpadded
+    expect(() => decodeBoundedBase64(unpadded, 10)).toThrow(/exceeds the .* limit/)
+    // The same payload is fine under a cap that actually fits it.
+    expect(decodeBoundedBase64(unpadded, 11).length).toBe(11)
+  })
+
+  it('rejects a structurally invalid base64 length', () => {
+    // A trailing group of a single base64 char encodes no bytes and is malformed.
+    expect(() => decodeBoundedBase64('YWJjZ')).toThrow(/not valid base64/)
+  })
 })

--- a/src/main/skills/import-limits.test.ts
+++ b/src/main/skills/import-limits.test.ts
@@ -1,12 +1,21 @@
 import { describe, expect, it } from 'vitest'
 
-import { decodeBoundedBase64 } from './import-limits'
+import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from './import-limits'
 
 describe('decodeBoundedBase64', () => {
   it('decodes a bundle within the limit', () => {
     const bytes = Buffer.from('hello world')
     const decoded = decodeBoundedBase64(bytes.toString('base64'))
     expect(decoded.equals(bytes)).toBe(true)
+  })
+
+  it('accepts an upload exactly at the documented total-byte limit', () => {
+    // A payload whose decoded size equals maxTotalBytes exactly must be allowed (padding-aware sizing).
+    const bytes = Buffer.alloc(SKILL_IMPORT_LIMITS.maxTotalBytes)
+    expect(() => decodeBoundedBase64(bytes.toString('base64'))).not.toThrow()
+    // One byte over the limit is rejected.
+    const over = Buffer.alloc(SKILL_IMPORT_LIMITS.maxTotalBytes + 1)
+    expect(() => decodeBoundedBase64(over.toString('base64'))).toThrow(/exceeds the .* limit/)
   })
 
   it('accounts for padding exactly at the boundary', () => {

--- a/src/main/skills/import-limits.test.ts
+++ b/src/main/skills/import-limits.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from './import-limits'
+
+describe('decodeBoundedBase64', () => {
+  it('decodes a bundle within the limit', () => {
+    const bytes = Buffer.from('hello world')
+    const decoded = decodeBoundedBase64(bytes.toString('base64'))
+    expect(decoded.equals(bytes)).toBe(true)
+  })
+
+  it('rejects an oversized upload from its encoded length, before allocating the buffer', () => {
+    // A base64 string whose decoded size would exceed the total cap. Built from length alone so the
+    // test never actually allocates the decoded payload.
+    const encodedLen = Math.ceil((SKILL_IMPORT_LIMITS.maxTotalBytes + 1) / 3) * 4
+    const oversized = 'A'.repeat(encodedLen)
+    expect(() => decodeBoundedBase64(oversized)).toThrow(/exceeds the .* limit/)
+  })
+})

--- a/src/main/skills/import-limits.test.ts
+++ b/src/main/skills/import-limits.test.ts
@@ -51,4 +51,10 @@ describe('decodeBoundedBase64', () => {
     // A trailing group of a single base64 char encodes no bytes and is malformed.
     expect(() => decodeBoundedBase64('YWJjZ')).toThrow(/not valid base64/)
   })
+
+  it('rejects stray characters and misplaced padding rather than silently dropping them', () => {
+    expect(() => decodeBoundedBase64('YWJj$$$$')).toThrow(/not valid base64/) // non-alphabet chars
+    expect(() => decodeBoundedBase64('YW=j')).toThrow(/not valid base64/) // padding mid-string
+    expect(() => decodeBoundedBase64('YWJjZA=')).toThrow(/not valid base64/) // padded but not a 4-group
+  })
 })

--- a/src/main/skills/import-limits.ts
+++ b/src/main/skills/import-limits.ts
@@ -1,31 +1,22 @@
-// Resource caps that bound a skill import from any source (a .zip/.skill bundle or a recursive
-// GitHub download). Without them a zip bomb or a very large repository could exhaust memory or
-// freeze the app while the user imports a skill from settings. The limits are generous for a real
-// skill (a SKILL.md plus a handful of reference scripts/docs) and only ever trip on abuse.
-export const SKILL_IMPORT_LIMITS = {
-  // Structural cap on the number of files in one import: high enough for a mega-zip carrying several
-  // skills, low enough to reject a pathological archive. Total size is the real limit.
-  maxFiles: 256,
-  // Maximum size of any single file (decompressed, for zip entries).
-  maxFileBytes: 5 * 1024 * 1024,
-  // Maximum total size across all files in one import (decompressed).
-  maxTotalBytes: 10 * 1024 * 1024,
-  // Maximum directory nesting either source is allowed to descend (zip path segments / GitHub dirs).
-  maxDepth: 8,
-  // Maximum GitHub API/download requests one import may issue, so a wide or mostly-empty directory
-  // tree can't trigger an unbounded number of requests even before any file budget is spent.
-  maxRequests: 512
-} as const
+import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 
-// Decodes an uploaded base64 bundle, rejecting an oversized upload from its encoded length BEFORE
-// allocating the decoded buffer. Four base64 chars encode three bytes, so the decoded size is
-// estimated up front; a bundle over the cap never gets decoded into memory.
+// Re-export the shared caps so main-process modules keep importing them from one place; the renderer
+// imports the same constants directly from shared/ to guard the upload picker.
+export { SKILL_IMPORT_LIMITS }
+
+// Decodes an uploaded base64 bundle, rejecting an oversized upload from its EXACT decoded length
+// before allocating the decoded buffer. base64 encodes 3 bytes per 4 chars, minus 1 byte per `=` pad
+// char; whitespace (line-wrapped base64) is ignored. Computing the exact size — not a padding-blind
+// estimate — means a payload sitting right on the limit is neither wrongly rejected nor allowed
+// through by a couple of bytes.
 export const decodeBoundedBase64 = (
   base64: string,
   maxBytes: number = SKILL_IMPORT_LIMITS.maxTotalBytes
 ): Buffer => {
-  const approxBytes = Math.floor(base64.length / 4) * 3
-  if (approxBytes > maxBytes) {
+  const clean = base64.replace(/[^A-Za-z0-9+/=]/g, '')
+  const padding = clean.endsWith('==') ? 2 : clean.endsWith('=') ? 1 : 0
+  const decodedBytes = Math.floor(clean.length / 4) * 3 - padding
+  if (decodedBytes > maxBytes) {
     throw new Error(`Uploaded bundle exceeds the ${maxBytes}-byte limit.`)
   }
   return Buffer.from(base64, 'base64')

--- a/src/main/skills/import-limits.ts
+++ b/src/main/skills/import-limits.ts
@@ -4,24 +4,35 @@ import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 // imports the same constants directly from shared/ to guard the upload picker.
 export { SKILL_IMPORT_LIMITS }
 
+// Matches a well-formed base64 body: alphabet chars followed by at most two `=` pad chars, and
+// nothing else. This enforces that padding appears only at the end (not mid-string) and that no
+// stray non-base64 characters are present.
+const BASE64_BODY = /^[A-Za-z0-9+/]*={0,2}$/
+
 // Decodes an uploaded base64 bundle, rejecting an oversized upload from its EXACT decoded length
-// before allocating the decoded buffer. Whitespace (line-wrapped base64) is ignored. The decoded
-// size is floor(chars * 3 / 4) minus one byte per `=` pad char: using chars*3/4 rather than
-// floor(chars/4)*3 accounts for the final partial group, so an UNPADDED payload whose length isn't a
-// multiple of 4 can't under-count its way past the cap (e.g. 11 unpadded bytes under a 10-byte cap).
+// before allocating the decoded buffer. Only whitespace (line-wrapped base64) is stripped — any other
+// character makes the input invalid rather than being silently dropped. The decoded size is
+// floor(chars * 3 / 4) minus one byte per `=` pad char: using chars*3/4 rather than floor(chars/4)*3
+// accounts for the final partial group, so an UNPADDED payload whose length isn't a multiple of 4
+// can't under-count its way past the cap (e.g. 11 unpadded bytes under a 10-byte cap).
 export const decodeBoundedBase64 = (
   base64: string,
   maxBytes: number = SKILL_IMPORT_LIMITS.maxTotalBytes
 ): Buffer => {
-  const clean = base64.replace(/[^A-Za-z0-9+/=]/g, '')
-  // A group of a single base64 char encodes no bytes and is never valid.
-  if (clean.length % 4 === 1) {
+  const clean = base64.replace(/\s+/g, '')
+  const padding = clean.endsWith('==') ? 2 : clean.endsWith('=') ? 1 : 0
+  // Reject stray characters / misplaced padding, a lone trailing char (encodes no byte), and padded
+  // input that isn't a whole number of 4-char groups.
+  if (
+    !BASE64_BODY.test(clean) ||
+    clean.length % 4 === 1 ||
+    (padding > 0 && clean.length % 4 !== 0)
+  ) {
     throw new Error('Uploaded bundle is not valid base64.')
   }
-  const padding = clean.endsWith('==') ? 2 : clean.endsWith('=') ? 1 : 0
   const decodedBytes = Math.floor((clean.length * 3) / 4) - padding
   if (decodedBytes > maxBytes) {
     throw new Error(`Uploaded bundle exceeds the ${maxBytes}-byte limit.`)
   }
-  return Buffer.from(base64, 'base64')
+  return Buffer.from(clean, 'base64')
 }

--- a/src/main/skills/import-limits.ts
+++ b/src/main/skills/import-limits.ts
@@ -5,17 +5,21 @@ import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 export { SKILL_IMPORT_LIMITS }
 
 // Decodes an uploaded base64 bundle, rejecting an oversized upload from its EXACT decoded length
-// before allocating the decoded buffer. base64 encodes 3 bytes per 4 chars, minus 1 byte per `=` pad
-// char; whitespace (line-wrapped base64) is ignored. Computing the exact size — not a padding-blind
-// estimate — means a payload sitting right on the limit is neither wrongly rejected nor allowed
-// through by a couple of bytes.
+// before allocating the decoded buffer. Whitespace (line-wrapped base64) is ignored. The decoded
+// size is floor(chars * 3 / 4) minus one byte per `=` pad char: using chars*3/4 rather than
+// floor(chars/4)*3 accounts for the final partial group, so an UNPADDED payload whose length isn't a
+// multiple of 4 can't under-count its way past the cap (e.g. 11 unpadded bytes under a 10-byte cap).
 export const decodeBoundedBase64 = (
   base64: string,
   maxBytes: number = SKILL_IMPORT_LIMITS.maxTotalBytes
 ): Buffer => {
   const clean = base64.replace(/[^A-Za-z0-9+/=]/g, '')
+  // A group of a single base64 char encodes no bytes and is never valid.
+  if (clean.length % 4 === 1) {
+    throw new Error('Uploaded bundle is not valid base64.')
+  }
   const padding = clean.endsWith('==') ? 2 : clean.endsWith('=') ? 1 : 0
-  const decodedBytes = Math.floor(clean.length / 4) * 3 - padding
+  const decodedBytes = Math.floor((clean.length * 3) / 4) - padding
   if (decodedBytes > maxBytes) {
     throw new Error(`Uploaded bundle exceeds the ${maxBytes}-byte limit.`)
   }

--- a/src/main/skills/import-limits.ts
+++ b/src/main/skills/import-limits.ts
@@ -3,12 +3,30 @@
 // freeze the app while the user imports a skill from settings. The limits are generous for a real
 // skill (a SKILL.md plus a handful of reference scripts/docs) and only ever trip on abuse.
 export const SKILL_IMPORT_LIMITS = {
-  // Maximum number of files materialized from one import.
-  maxFiles: 2000,
+  // Structural cap on the number of files in one import: high enough for a mega-zip carrying several
+  // skills, low enough to reject a pathological archive. Total size is the real limit.
+  maxFiles: 256,
   // Maximum size of any single file (decompressed, for zip entries).
-  maxFileBytes: 16 * 1024 * 1024,
+  maxFileBytes: 5 * 1024 * 1024,
   // Maximum total size across all files in one import (decompressed).
-  maxTotalBytes: 64 * 1024 * 1024,
-  // Maximum directory nesting a recursive source (GitHub) is allowed to descend.
-  maxDepth: 24
+  maxTotalBytes: 10 * 1024 * 1024,
+  // Maximum directory nesting either source is allowed to descend (zip path segments / GitHub dirs).
+  maxDepth: 8,
+  // Maximum GitHub API/download requests one import may issue, so a wide or mostly-empty directory
+  // tree can't trigger an unbounded number of requests even before any file budget is spent.
+  maxRequests: 512
 } as const
+
+// Decodes an uploaded base64 bundle, rejecting an oversized upload from its encoded length BEFORE
+// allocating the decoded buffer. Four base64 chars encode three bytes, so the decoded size is
+// estimated up front; a bundle over the cap never gets decoded into memory.
+export const decodeBoundedBase64 = (
+  base64: string,
+  maxBytes: number = SKILL_IMPORT_LIMITS.maxTotalBytes
+): Buffer => {
+  const approxBytes = Math.floor(base64.length / 4) * 3
+  if (approxBytes > maxBytes) {
+    throw new Error(`Uploaded bundle exceeds the ${maxBytes}-byte limit.`)
+  }
+  return Buffer.from(base64, 'base64')
+}

--- a/src/main/skills/import-limits.ts
+++ b/src/main/skills/import-limits.ts
@@ -1,0 +1,14 @@
+// Resource caps that bound a skill import from any source (a .zip/.skill bundle or a recursive
+// GitHub download). Without them a zip bomb or a very large repository could exhaust memory or
+// freeze the app while the user imports a skill from settings. The limits are generous for a real
+// skill (a SKILL.md plus a handful of reference scripts/docs) and only ever trip on abuse.
+export const SKILL_IMPORT_LIMITS = {
+  // Maximum number of files materialized from one import.
+  maxFiles: 2000,
+  // Maximum size of any single file (decompressed, for zip entries).
+  maxFileBytes: 16 * 1024 * 1024,
+  // Maximum total size across all files in one import (decompressed).
+  maxTotalBytes: 64 * 1024 * 1024,
+  // Maximum directory nesting a recursive source (GitHub) is allowed to descend.
+  maxDepth: 24
+} as const

--- a/src/main/skills/zip-extract.test.ts
+++ b/src/main/skills/zip-extract.test.ts
@@ -154,11 +154,16 @@ describe('extractZip', () => {
     expect(() => extractZip(buildZip(inputs))).toThrow(/decompressed limit/)
   })
 
-  it('rejects an entry nested deeper than the depth limit', () => {
-    // Nine path segments exceed SKILL_IMPORT_LIMITS.maxDepth (8).
-    const deep = `${Array.from({ length: 9 }, (_, i) => `d${i}`).join('/')}/x.txt`
+  it('counts directory levels for depth, not the filename (off-by-one boundary)', () => {
+    // Depth is the number of directories. A file under exactly 8 directories is at the limit and is
+    // accepted; a 9th directory level exceeds SKILL_IMPORT_LIMITS.maxDepth (8) and is rejected.
+    const atLimit = `${Array.from({ length: 8 }, (_, i) => `d${i}`).join('/')}/x.txt`
+    const files = extractZip(buildZip([{ path: atLimit, content: Buffer.from('x'), method: 0 }]))
+    expect(files.map((f) => f.path)).toEqual([atLimit])
+
+    const tooDeep = `${Array.from({ length: 9 }, (_, i) => `d${i}`).join('/')}/x.txt`
     expect(() =>
-      extractZip(buildZip([{ path: deep, content: Buffer.from('x'), method: 0 }]))
+      extractZip(buildZip([{ path: tooDeep, content: Buffer.from('x'), method: 0 }]))
     ).toThrow(/nested deeper/)
   })
 })

--- a/src/main/skills/zip-extract.test.ts
+++ b/src/main/skills/zip-extract.test.ts
@@ -119,12 +119,46 @@ describe('extractZip', () => {
   })
 
   it('rejects a bundle with more files than the count limit', () => {
-    // 2001 tiny STORE entries exceed SKILL_IMPORT_LIMITS.maxFiles (2000).
-    const inputs: ZipInput[] = Array.from({ length: 2001 }, (_, i) => ({
+    // 300 tiny STORE entries exceed SKILL_IMPORT_LIMITS.maxFiles (256).
+    const inputs: ZipInput[] = Array.from({ length: 300 }, (_, i) => ({
       path: `f${i}.txt`,
       content: Buffer.from('x', 'utf8'),
       method: 0 as const
     }))
     expect(() => extractZip(buildZip(inputs))).toThrow(/too many files/)
+  })
+
+  it('rejects an oversized STORE entry from its known size', () => {
+    // A single STORE file over the 5 MiB per-file cap is rejected without copying it out.
+    const big = Buffer.alloc(5 * 1024 * 1024 + 1, 0x61)
+    expect(() => extractZip(buildZip([{ path: 'big.txt', content: big, method: 0 }]))).toThrow(
+      /exceeds the .* limit/
+    )
+  })
+
+  it('rejects a DEFLATE bomb via the inflate output bound', () => {
+    // 6 MiB of zeros compresses to almost nothing but would inflate past the 5 MiB per-file cap;
+    // inflateRawSync's maxOutputLength makes that throw instead of expanding into memory.
+    const bomb = Buffer.alloc(6 * 1024 * 1024, 0)
+    expect(() => extractZip(buildZip([{ path: 'bomb.bin', content: bomb, method: 8 }]))).toThrow()
+  })
+
+  it('rejects a bundle whose decompressed total exceeds the cap', () => {
+    // Three 4 MiB files are each under the per-file cap but sum to 12 MiB > the 10 MiB total cap.
+    const chunk = Buffer.alloc(4 * 1024 * 1024, 0x62)
+    const inputs: ZipInput[] = [0, 1, 2].map((i) => ({
+      path: `f${i}.txt`,
+      content: chunk,
+      method: 0 as const
+    }))
+    expect(() => extractZip(buildZip(inputs))).toThrow(/decompressed limit/)
+  })
+
+  it('rejects an entry nested deeper than the depth limit', () => {
+    // Nine path segments exceed SKILL_IMPORT_LIMITS.maxDepth (8).
+    const deep = `${Array.from({ length: 9 }, (_, i) => `d${i}`).join('/')}/x.txt`
+    expect(() =>
+      extractZip(buildZip([{ path: deep, content: Buffer.from('x'), method: 0 }]))
+    ).toThrow(/nested deeper/)
   })
 })

--- a/src/main/skills/zip-extract.test.ts
+++ b/src/main/skills/zip-extract.test.ts
@@ -117,4 +117,14 @@ describe('extractZip', () => {
   it('throws when the buffer is not a zip', () => {
     expect(() => extractZip(Buffer.from('not a zip at all', 'utf8'))).toThrow()
   })
+
+  it('rejects a bundle with more files than the count limit', () => {
+    // 2001 tiny STORE entries exceed SKILL_IMPORT_LIMITS.maxFiles (2000).
+    const inputs: ZipInput[] = Array.from({ length: 2001 }, (_, i) => ({
+      path: `f${i}.txt`,
+      content: Buffer.from('x', 'utf8'),
+      method: 0 as const
+    }))
+    expect(() => extractZip(buildZip(inputs))).toThrow(/too many files/)
+  })
 })

--- a/src/main/skills/zip-extract.ts
+++ b/src/main/skills/zip-extract.ts
@@ -67,9 +67,9 @@ const extractZip = (buffer: Buffer): ExtractedZipFile[] => {
     if (isUnsafePath(name)) continue
     if (method !== 0 && method !== 8) continue
 
-    // Bound nesting the same way the GitHub walk does, so a deeply-nested path can't blow past the
-    // depth other consumers assume.
-    if (name.split('/').length > SKILL_IMPORT_LIMITS.maxDepth) {
+    // Bound directory nesting the same way the GitHub walk does. Depth counts directory levels, not
+    // the file itself, so `a/b/.../file` with N leading directories matches GitHub's "N deep".
+    if (name.split('/').length - 1 > SKILL_IMPORT_LIMITS.maxDepth) {
       throw new Error(
         `ZIP entry ${name} is nested deeper than ${SKILL_IMPORT_LIMITS.maxDepth} levels.`
       )

--- a/src/main/skills/zip-extract.ts
+++ b/src/main/skills/zip-extract.ts
@@ -67,6 +67,14 @@ const extractZip = (buffer: Buffer): ExtractedZipFile[] => {
     if (isUnsafePath(name)) continue
     if (method !== 0 && method !== 8) continue
 
+    // Bound nesting the same way the GitHub walk does, so a deeply-nested path can't blow past the
+    // depth other consumers assume.
+    if (name.split('/').length > SKILL_IMPORT_LIMITS.maxDepth) {
+      throw new Error(
+        `ZIP entry ${name} is nested deeper than ${SKILL_IMPORT_LIMITS.maxDepth} levels.`
+      )
+    }
+
     if (files.length >= SKILL_IMPORT_LIMITS.maxFiles) {
       throw new Error(`ZIP bundle has too many files (limit ${SKILL_IMPORT_LIMITS.maxFiles}).`)
     }

--- a/src/main/skills/zip-extract.ts
+++ b/src/main/skills/zip-extract.ts
@@ -1,8 +1,12 @@
 import { inflateRawSync } from 'node:zlib'
 
+import { SKILL_IMPORT_LIMITS } from './import-limits'
+
 // A dependency-free ZIP reader: parses the central directory + each local file header and inflates the
 // entries with node:zlib. Supports the two methods a skill bundle ever uses — STORE (0) and DEFLATE
 // (8); directory entries, other methods, and unsafe paths are skipped rather than throwing.
+// Resource caps (SKILL_IMPORT_LIMITS) bound the file count and per-file/total decompressed size so a
+// zip bomb can't exhaust memory during import.
 
 const EOCD_SIGNATURE = 0x06054b50
 const CENTRAL_SIGNATURE = 0x02014b50
@@ -43,6 +47,7 @@ const extractZip = (buffer: Buffer): ExtractedZipFile[] => {
   const entryCount = buffer.readUInt16LE(eocd + 10)
   let pointer = buffer.readUInt32LE(eocd + 16)
   const files: ExtractedZipFile[] = []
+  let totalBytes = 0
 
   for (let index = 0; index < entryCount; index += 1) {
     if (pointer + 46 > buffer.length || buffer.readUInt32LE(pointer) !== CENTRAL_SIGNATURE) break
@@ -62,6 +67,10 @@ const extractZip = (buffer: Buffer): ExtractedZipFile[] => {
     if (isUnsafePath(name)) continue
     if (method !== 0 && method !== 8) continue
 
+    if (files.length >= SKILL_IMPORT_LIMITS.maxFiles) {
+      throw new Error(`ZIP bundle has too many files (limit ${SKILL_IMPORT_LIMITS.maxFiles}).`)
+    }
+
     // Read the local header to find where the data actually starts: its filename/extra-field lengths
     // can differ from the central directory's, so the offset must be recomputed from it.
     if (buffer.readUInt32LE(localOffset) !== LOCAL_SIGNATURE) continue
@@ -70,7 +79,24 @@ const extractZip = (buffer: Buffer): ExtractedZipFile[] => {
     const dataStart = localOffset + 30 + localNameLength + localExtraLength
     const data = buffer.subarray(dataStart, dataStart + compressedSize)
 
-    const content = method === 0 ? Buffer.from(data) : inflateRawSync(data)
+    // A STORE entry is verbatim, so its size is known up front; a DEFLATE entry is bounded by
+    // maxOutputLength, which makes inflateRawSync throw rather than expand a bomb into memory.
+    if (method === 0 && data.length > SKILL_IMPORT_LIMITS.maxFileBytes) {
+      throw new Error(
+        `ZIP entry ${name} exceeds the ${SKILL_IMPORT_LIMITS.maxFileBytes}-byte limit.`
+      )
+    }
+    const content =
+      method === 0
+        ? Buffer.from(data)
+        : inflateRawSync(data, { maxOutputLength: SKILL_IMPORT_LIMITS.maxFileBytes })
+
+    totalBytes += content.length
+    if (totalBytes > SKILL_IMPORT_LIMITS.maxTotalBytes) {
+      throw new Error(
+        `ZIP bundle exceeds the ${SKILL_IMPORT_LIMITS.maxTotalBytes}-byte decompressed limit.`
+      )
+    }
     files.push({ path: name, content })
   }
 

--- a/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
@@ -139,6 +139,40 @@ describe('SkillUploadView (batch upload)', () => {
     expect(onUploaded).toHaveBeenCalled()
   })
 
+  it('rejects an oversized markdown file on file.size, before reading its contents', async () => {
+    act(() => {
+      root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
+    })
+
+    // 6 MiB exceeds the 5 MiB per-file cap. file.size is checked before file.text() runs.
+    const big = new File(['x'], 'big.md', { type: 'text/markdown' })
+    Object.defineProperty(big, 'size', { value: 6 * 1024 * 1024 })
+    const textSpy = vi.spyOn(big, 'text')
+
+    await dropFiles([big])
+
+    expect(textSpy).not.toHaveBeenCalled()
+    expect(document.body.textContent).toMatch(/too large/)
+    expect(document.body.textContent).not.toContain('Found 1 skill')
+  })
+
+  it('rejects a batch whose total selected size exceeds the cap, before reading any file', async () => {
+    act(() => {
+      root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
+    })
+
+    // Two 6 MiB bundles: each is under the 10 MiB per-bundle cap, but together they exceed the total.
+    const a = new File([new Uint8Array([1])], 'a.zip', { type: 'application/zip' })
+    const b = new File([new Uint8Array([2])], 'b.zip', { type: 'application/zip' })
+    Object.defineProperty(a, 'size', { value: 6 * 1024 * 1024 })
+    Object.defineProperty(b, 'size', { value: 6 * 1024 * 1024 })
+
+    await dropFiles([a, b])
+
+    expect(useSettingsStore.getState().previewSkillZip).not.toHaveBeenCalled()
+    expect(document.body.textContent).toMatch(/too large/)
+  })
+
   it('parses a markdown file into a candidate that routes to createSkill', async () => {
     act(() => {
       root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)

--- a/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
@@ -173,6 +173,22 @@ describe('SkillUploadView (batch upload)', () => {
     expect(document.body.textContent).toMatch(/too large/)
   })
 
+  it('rejects a single oversized bundle on file.size, without previewing it', async () => {
+    act(() => {
+      root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
+    })
+
+    // An 11 MiB bundle exceeds the 10 MiB cap; it must be rejected before previewSkillZip reads it.
+    const big = new File([new Uint8Array([1])], 'huge.zip', { type: 'application/zip' })
+    Object.defineProperty(big, 'size', { value: 11 * 1024 * 1024 })
+
+    await dropFiles([big])
+
+    expect(useSettingsStore.getState().previewSkillZip).not.toHaveBeenCalled()
+    expect(document.body.textContent).toMatch(/too large/)
+    expect(document.body.textContent).not.toContain('Found')
+  })
+
   it('parses a markdown file into a candidate that routes to createSkill', async () => {
     act(() => {
       root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)

--- a/src/renderer/src/pages/settings/SkillUploadView.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.tsx
@@ -5,6 +5,10 @@ import { FileDropOverlay } from '@/components/FileDropOverlay'
 import { Button } from '@/components/ui/button'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { useSettingsStore } from '@/stores/settings-store'
+import { SKILL_IMPORT_LIMITS } from '../../../../shared/skill-import-limits'
+
+// Rounds a byte count to whole MB for a user-facing size-limit message.
+const mb = (bytes: number): string => `${Math.round(bytes / (1024 * 1024))} MB`
 
 // A danger banner for a parse/validation failure (invalid bundle, missing SKILL.md, no name, ...).
 const ErrorBanner = ({ message }: { message: string }): React.JSX.Element => (
@@ -98,8 +102,18 @@ const SkillUploadView = ({
   // Parses one picked file into its candidates, capturing a per-file error instead of throwing.
   const parseFile = async (file: File): Promise<ParseResult> => {
     const name = file.name.toLowerCase()
+    const isBundle = name.endsWith('.zip') || name.endsWith('.skill')
 
-    if (name.endsWith('.zip') || name.endsWith('.skill')) {
+    // Reject on file.size BEFORE reading the file into memory / base64 / IPC. A bundle is bounded by
+    // the total-import cap (it may hold several files); a bare .md by the per-file cap.
+    const sizeLimit = isBundle
+      ? SKILL_IMPORT_LIMITS.maxTotalBytes
+      : SKILL_IMPORT_LIMITS.maxFileBytes
+    if (file.size > sizeLimit) {
+      return { candidates: [], error: `${file.name}: file is too large (limit ${mb(sizeLimit)}).` }
+    }
+
+    if (isBundle) {
       try {
         const base64 = await fileToBase64(file)
         const previews = await previewSkillZip(base64)
@@ -157,6 +171,17 @@ const SkillUploadView = ({
     setBusy(true)
     setSummary(null)
     try {
+      // Cap the whole selection before reading anything, so a batch drop can't allocate an unbounded
+      // amount of memory across all files at once.
+      const totalSize = files.reduce((sum, file) => sum + file.size, 0)
+      if (totalSize > SKILL_IMPORT_LIMITS.maxTotalBytes) {
+        setCandidates([])
+        setErrors([
+          `Selection is too large (${mb(totalSize)}); upload at most ${mb(SKILL_IMPORT_LIMITS.maxTotalBytes)} at a time.`
+        ])
+        setSelected(new Set())
+        return
+      }
       const results = await Promise.all(files.map(parseFile))
       setCandidates(results.flatMap((result) => result.candidates))
       setErrors(results.map((result) => result.error).filter((error): error is string => !!error))

--- a/src/shared/skill-import-limits.ts
+++ b/src/shared/skill-import-limits.ts
@@ -1,0 +1,20 @@
+// Resource caps that bound a skill import from any source (a .zip/.skill bundle or a recursive
+// GitHub download). Without them a zip bomb or a very large repository could exhaust memory or freeze
+// the app while the user imports a skill from settings. Lives in shared/ so the renderer can enforce
+// the same numbers on the upload picker as the main process enforces on extraction/download. The
+// limits are generous for a real skill (a SKILL.md plus a handful of reference files) and only trip on
+// abuse.
+export const SKILL_IMPORT_LIMITS = {
+  // Structural cap on the number of files in one import: high enough for a mega-zip carrying several
+  // skills, low enough to reject a pathological archive. Total size is the real limit.
+  maxFiles: 256,
+  // Maximum size of any single file (decompressed, for zip entries).
+  maxFileBytes: 5 * 1024 * 1024,
+  // Maximum total size across all files in one import (decompressed).
+  maxTotalBytes: 10 * 1024 * 1024,
+  // Maximum directory nesting either source is allowed to descend (zip subdirectories / GitHub dirs).
+  maxDepth: 8,
+  // Maximum GitHub API/download requests one import may issue, so a wide or mostly-empty directory
+  // tree can't trigger an unbounded number of requests even before any file budget is spent.
+  maxRequests: 512
+} as const


### PR DESCRIPTION
## Summary

Skill imports had no resource limits, so a malicious or oversized bundle could exhaust memory or freeze the app during settings import.

- The zip reader inflated every entry unbounded — a classic zip-bomb vector.
- The GitHub importer recursively downloaded every file in a repo with no limit on count, size, or nesting depth.

Adds a shared `SKILL_IMPORT_LIMITS` (`src/main/skills/import-limits.ts`): file count, per-file bytes, total decompressed bytes, and recursion depth. The limits are generous for a real skill (a `SKILL.md` plus a handful of reference files) and only trip on abuse.

- **Zip:** bounds DEFLATE output via `inflateRawSync`'s `maxOutputLength` (throws instead of expanding a bomb into memory), rejects oversized STORE entries, and caps file count and total decompressed bytes.
- **GitHub:** the recursive walk caps directory depth, file count, per-file size, and total bytes.

## Tests

- New coverage: zip bundle exceeding the file-count cap throws; GitHub import rejects an oversized file, a repo nested past the depth limit, and a directory exceeding the file-count cap.
- `skills` import suites pass, full typecheck and eslint clean.

## Note

Touches the same `extractZip` loop as #170; whichever merges second needs a trivial conflict resolution in `zip-extract.ts`.