### PR TITLE
fix(skills): escape personal-skill frontmatter and label detail badge by source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@prisma/client": "^6.19.3",
         "electron-updater": "^6.3.9",
+        "js-yaml": "^4.1.0",
         "openchemlib": "^9.24.0",
         "pdfjs-dist": "^4.10.38",
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@prisma/client": "^6.19.3",
     "electron-updater": "^6.3.9",
+    "js-yaml": "^4.1.0",
     "openchemlib": "^9.24.0",
     "pdfjs-dist": "^4.10.38",
     "zod": "^4.4.3"

--- a/src/main/skills/frontmatter.test.ts
+++ b/src/main/skills/frontmatter.test.ts
@@ -43,8 +43,9 @@ describe('parseFrontmatter', () => {
       '# AlphaFold2'
     ].join('\n')
     const { fields, body } = parseFrontmatter(raw)
+    // The reader is lossless: a folded block scalar keeps its single trailing newline (YAML clip).
     expect(fields.description).toBe(
-      'Predict protein structure for monomers and multimers with AlphaFold2 via the ColabFold runner.'
+      'Predict protein structure for monomers and multimers with AlphaFold2 via the ColabFold runner.\n'
     )
     expect(fields.license).toBe('Apache-2.0')
     expect(body.startsWith('# AlphaFold2')).toBe(true)
@@ -61,7 +62,8 @@ describe('parseFrontmatter', () => {
       'body'
     ].join('\n')
     const { fields } = parseFrontmatter(raw)
-    expect(fields.description).toBe('line one\nline two')
+    // Literal block scalar keeps its trailing newline (clip); the reader no longer trims.
+    expect(fields.description).toBe('line one\nline two\n')
     expect(fields.name).toBe('demo')
   })
 
@@ -77,8 +79,33 @@ describe('parseFrontmatter', () => {
       'body'
     ].join('\n')
     const { fields } = parseFrontmatter(raw)
-    expect(fields.description).toBe('folded text')
+    expect(fields.description).toBe('folded text\n')
     expect(fields['display-name']).toBeUndefined()
+  })
+
+  it('coerces bare date/number/boolean scalars to strings (no Date, no drop)', () => {
+    const raw = [
+      '---',
+      'name: demo',
+      'updated: 2026-07-17',
+      'version: 2',
+      'beta: true',
+      '---',
+      'body'
+    ].join('\n')
+    const { fields } = parseFrontmatter(raw)
+    // The FAILSAFE schema keeps these as verbatim strings; a Date would be dropped as a non-scalar.
+    expect(fields.updated).toBe('2026-07-17')
+    expect(fields.version).toBe('2')
+    expect(fields.beta).toBe('true')
+  })
+
+  it('tolerates malformed frontmatter, returning empty fields and the body', () => {
+    // Unbalanced flow map is invalid YAML; the reader must not throw.
+    const raw = ['---', 'name: [oops', 'description: broken', '---', '# Body'].join('\n')
+    const { fields, body } = parseFrontmatter(raw)
+    expect(fields).toEqual({})
+    expect(body.startsWith('# Body')).toBe(true)
   })
 })
 

--- a/src/main/skills/frontmatter.test.ts
+++ b/src/main/skills/frontmatter.test.ts
@@ -100,6 +100,25 @@ describe('parseFrontmatter', () => {
     expect(fields.beta).toBe('true')
   })
 
+  it('flattens a YAML list to a comma-separated string and drops nested maps', () => {
+    const raw = [
+      '---',
+      'name: demo',
+      'requirements: [gpu, compute]', // flow sequence
+      'tags:', // block sequence
+      '  - alpha',
+      '  - beta',
+      'meta:', // nested map is dropped by the flat reader
+      '  key: value',
+      '---',
+      'body'
+    ].join('\n')
+    const { fields } = parseFrontmatter(raw)
+    expect(fields.requirements).toBe('gpu, compute')
+    expect(fields.tags).toBe('alpha, beta')
+    expect(fields.meta).toBeUndefined()
+  })
+
   it('tolerates malformed frontmatter, returning empty fields and the body', () => {
     // Unbalanced flow map is invalid YAML; the reader must not throw.
     const raw = ['---', 'name: [oops', 'description: broken', '---', '# Body'].join('\n')

--- a/src/main/skills/frontmatter.ts
+++ b/src/main/skills/frontmatter.ts
@@ -1,7 +1,10 @@
-// Minimal SKILL.md frontmatter reader. `parseFrontmatter` returns every top-level `key: value` line as
-// a map plus the body with the leading `--- ... ---` block removed. Intentionally not a full YAML parser
-// — only the flat scalar fields the UI needs (description, author, license, ...) — but it does read YAML
-// block scalars (`>` folded, `|` literal) so a multi-line `description: >` yields its text, not ">".
+import { load as loadYaml } from 'js-yaml'
+
+// SKILL.md frontmatter reader. Parses the leading `--- ... ---` block with a real YAML parser (the
+// same one the writer serializes with, so values round-trip), then flattens it to the string scalar
+// fields the UI needs (name, description, author, license, ...). Intentionally a FLAT reader: nested
+// maps/sequences are dropped, and every scalar is coerced to a trimmed string. A malformed block is
+// tolerated (empty fields + full body) rather than throwing, so one bad skill can't break the catalog.
 const parseFrontmatter = (raw: string): { fields: Record<string, string>; body: string } => {
   const match = /^---\n([\s\S]*?)\n---\n?/.exec(raw)
 
@@ -9,40 +12,30 @@ const parseFrontmatter = (raw: string): { fields: Record<string, string>; body: 
     return { fields: {}, body: raw }
   }
 
-  const fields: Record<string, string> = {}
-  const lines = match[1].split('\n')
-  for (let i = 0; i < lines.length; i += 1) {
-    const field = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(lines[i])
-    if (!field) continue
-
-    const key = field[1].toLowerCase()
-    const value = field[2].trim()
-
-    // A bare `>`/`|` (optionally with chomping/indent indicators) opens a block scalar: consume the
-    // following more-indented lines. Folded (`>`) joins them with spaces; literal (`|`) with newlines.
-    if (/^[|>][0-9+-]*$/.test(value)) {
-      const folded = value[0] === '>'
-      const collected: string[] = []
-      let j = i + 1
-      for (; j < lines.length; j += 1) {
-        if (lines[j].trim() === '') {
-          collected.push('')
-          continue
-        }
-        if (!/^\s/.test(lines[j])) break // a non-indented line ends the block (next top-level key)
-        collected.push(lines[j].replace(/^\s+/, ''))
-      }
-      while (collected.length && collected[collected.length - 1] === '') collected.pop()
-      fields[key] = folded ? collected.join(' ').replace(/\s+/g, ' ').trim() : collected.join('\n')
-      i = j - 1
-      continue
-    }
-
-    fields[key] = value
-  }
-
   // Drop blank lines left between the closing `---` and the first body line so the body renders clean.
   const body = raw.slice(match[0].length).replace(/^\n+/, '')
+
+  let parsed: unknown
+  try {
+    parsed = loadYaml(match[1])
+  } catch {
+    return { fields: {}, body }
+  }
+
+  const fields: Record<string, string> = {}
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (value === null) continue
+      // Flat reader: a scalar is coerced to a trimmed string; a simple list (e.g. `requirements:
+      // [gpu]`) is joined to a comma-separated string; nested maps are dropped.
+      if (Array.isArray(value)) {
+        const flat = value.filter((item) => item !== null && typeof item !== 'object')
+        if (flat.length) fields[key.toLowerCase()] = flat.map(String).join(', ')
+      } else if (typeof value !== 'object') {
+        fields[key.toLowerCase()] = String(value).trim()
+      }
+    }
+  }
 
   return { fields, body }
 }

--- a/src/main/skills/frontmatter.ts
+++ b/src/main/skills/frontmatter.ts
@@ -1,10 +1,13 @@
-import { load as loadYaml } from 'js-yaml'
+import { load as loadYaml, FAILSAFE_SCHEMA } from 'js-yaml'
 
 // SKILL.md frontmatter reader. Parses the leading `--- ... ---` block with a real YAML parser (the
-// same one the writer serializes with, so values round-trip), then flattens it to the string scalar
-// fields the UI needs (name, description, author, license, ...). Intentionally a FLAT reader: nested
-// maps/sequences are dropped, and every scalar is coerced to a trimmed string. A malformed block is
-// tolerated (empty fields + full body) rather than throwing, so one bad skill can't break the catalog.
+// same one the writer serializes with, so values round-trip), then flattens it to the string fields
+// the UI needs (name, description, author, license, ...). Uses the FAILSAFE schema so every scalar
+// stays a verbatim string — no bool/number/Date coercion (a bare `2026-07-17` reads as the string,
+// not a Date that would then be dropped). Values are NOT trimmed, so a writer-preserved leading space
+// or trailing newline survives the read losslessly. Intentionally a FLAT reader: a list is joined to
+// a comma-separated string and nested maps are dropped. A malformed block is tolerated (empty fields +
+// full body) rather than throwing, so one bad skill can't break the catalog.
 const parseFrontmatter = (raw: string): { fields: Record<string, string>; body: string } => {
   const match = /^---\n([\s\S]*?)\n---\n?/.exec(raw)
 
@@ -17,7 +20,7 @@ const parseFrontmatter = (raw: string): { fields: Record<string, string>; body: 
 
   let parsed: unknown
   try {
-    parsed = loadYaml(match[1])
+    parsed = loadYaml(match[1], { schema: FAILSAFE_SCHEMA })
   } catch {
     return { fields: {}, body }
   }
@@ -25,14 +28,12 @@ const parseFrontmatter = (raw: string): { fields: Record<string, string>; body: 
   const fields: Record<string, string> = {}
   if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
     for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
-      if (value === null) continue
-      // Flat reader: a scalar is coerced to a trimmed string; a simple list (e.g. `requirements:
-      // [gpu]`) is joined to a comma-separated string; nested maps are dropped.
-      if (Array.isArray(value)) {
-        const flat = value.filter((item) => item !== null && typeof item !== 'object')
-        if (flat.length) fields[key.toLowerCase()] = flat.map(String).join(', ')
-      } else if (typeof value !== 'object') {
-        fields[key.toLowerCase()] = String(value).trim()
+      // Under FAILSAFE, a scalar is already a verbatim string; a list is joined; maps/null are dropped.
+      if (typeof value === 'string') {
+        fields[key.toLowerCase()] = value
+      } else if (Array.isArray(value)) {
+        const flat = value.filter((item): item is string => typeof item === 'string')
+        if (flat.length) fields[key.toLowerCase()] = flat.join(', ')
       }
     }
   }

--- a/src/main/skills/js-yaml.d.ts
+++ b/src/main/skills/js-yaml.d.ts
@@ -1,0 +1,13 @@
+// Minimal ambient declaration for js-yaml (a runtime dependency via electron-updater, declared
+// directly in package.json). js-yaml v4 ships no bundled types and @types/js-yaml is not installed,
+// so this covers just the two functions used here. Replace with @types/js-yaml if that package is
+// ever added.
+declare module 'js-yaml' {
+  export interface DumpOptions {
+    // Max line width before folding; -1 disables folding so values stay byte-lossless.
+    lineWidth?: number
+    indent?: number
+  }
+  export function dump(obj: unknown, options?: DumpOptions): string
+  export function load(input: string): unknown
+}

--- a/src/main/skills/js-yaml.d.ts
+++ b/src/main/skills/js-yaml.d.ts
@@ -3,11 +3,19 @@
 // so this covers just the two functions used here. Replace with @types/js-yaml if that package is
 // ever added.
 declare module 'js-yaml' {
+  // Opaque schema handle; only used to pass FAILSAFE_SCHEMA to load().
+  export type Schema = unknown
+  // Resolves every plain scalar to a string (no bool/number/Date coercion); supports only str/seq/map.
+  export const FAILSAFE_SCHEMA: Schema
+
   export interface DumpOptions {
     // Max line width before folding; -1 disables folding so values stay byte-lossless.
     lineWidth?: number
     indent?: number
   }
+  export interface LoadOptions {
+    schema?: Schema
+  }
   export function dump(obj: unknown, options?: DumpOptions): string
-  export function load(input: string): unknown
+  export function load(input: string, options?: LoadOptions): unknown
 }

--- a/src/main/skills/registry.test.ts
+++ b/src/main/skills/registry.test.ts
@@ -53,7 +53,9 @@ describe('SkillRegistry', () => {
       license: 'Test License',
       thirdParty: 'Weights — Example (CC-BY-4.0)',
       category: 'biomodels',
-      requirements: '[gpu]'
+      // `requirements: [gpu]` is a YAML list; the flat frontmatter reader joins it to a string. The
+      // materializer only substring-matches gpu/compute, so this stays equivalent.
+      requirements: 'gpu'
     })
   })
 

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -135,6 +135,29 @@ describe('UserSkillRepository', () => {
     expect(await repo.list()).toEqual([])
   })
 
+  it('round-trips a description with newlines and YAML fences without corrupting the body', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+
+    // A description that, interpolated raw, would prematurely close the frontmatter (`---`) and inject
+    // a bogus field (`not: a-key`). It must survive intact and leave the body untouched.
+    const description = 'First line\n---\nnot: a-key\nSecond line'
+    const id = await repo.createPersonal({
+      name: 'Tricky',
+      description,
+      body: '# Real body\nkeep me'
+    })
+
+    const listed = await repo.list()
+    expect(listed).toHaveLength(1)
+    expect(listed[0].description).toBe(description)
+
+    const body = await repo.body(id)
+    expect(body).toContain('# Real body')
+    expect(body).toContain('keep me')
+    // The injected fence/field must not have leaked into the body.
+    expect(body).not.toContain('not: a-key')
+  })
+
   it('gives colliding names a numeric suffix', async () => {
     const repo = new UserSkillRepository(await makeStorage())
 

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -4,12 +4,13 @@ import { join } from 'node:path'
 import { deflateRawSync } from 'node:zlib'
 
 import { describe, expect, it } from 'vitest'
+import { load as loadYaml } from 'js-yaml'
 
 import {
   UserSkillRepository,
   parseUserSkillId,
   toSlug,
-  frontmatterField
+  frontmatterBlock
 } from './user-skill-repository'
 import type { FetchLike } from './github-import'
 
@@ -106,36 +107,43 @@ describe('toSlug / parseUserSkillId', () => {
   })
 })
 
-describe('frontmatterField', () => {
-  it('emits an ordinary single-line value inline with no trailing newline', () => {
-    expect(frontmatterField('name', 'My Skill')).toBe('name: My Skill')
-    expect(frontmatterField('description', 'Does a thing.')).toBe('description: Does a thing.')
+describe('frontmatterBlock', () => {
+  // Reads the block back with a conformant YAML parser and asserts each field is byte-identical to
+  // the input — the property that actually matters (Claude Code parses SKILL.md with real YAML).
+  const roundTrip = (name: string, description: string): { name: unknown; description: unknown } =>
+    loadYaml(frontmatterBlock({ name, description })) as { name: unknown; description: unknown }
+
+  it('round-trips ordinary values as strings', () => {
+    const out = roundTrip('My Skill', 'Does a thing.')
+    expect(out).toEqual({ name: 'My Skill', description: 'Does a thing.' })
   })
 
-  it('serializes YAML-typed tokens as strings so they never read back as bool/null/number', () => {
-    // A plain `description: true` would parse as a boolean; force these to a block scalar.
+  it('keeps YAML-typed tokens as strings (never bool/null/number)', () => {
     for (const value of ['true', 'false', 'null', 'yes', 'no', '~', '123', '3.14', '+1', '0x1f']) {
-      const out = frontmatterField('description', value)
-      expect(out.startsWith('description: |-')).toBe(true)
-      expect(out).toContain(`  ${value}`)
+      const out = roundTrip('X', value)
+      expect(out.description).toBe(value)
+      expect(typeof out.description).toBe('string')
     }
   })
 
-  it('uses a strip-chomped (|-) block scalar for multiline values, indenting every line', () => {
-    const out = frontmatterField('description', 'line one\n\nline three')
-    expect(out).toBe('description: |-\n  line one\n\n  line three')
-    // No trailing newline is appended by the block scalar itself.
-    expect(out.endsWith('line three')).toBe(true)
+  it('losslessly round-trips trailing newlines and leading spaces', () => {
+    for (const value of [
+      'line one\n', // trailing newline preserved
+      'a\n\nb\n\n', // multiple trailing newlines
+      '  indented', // leading spaces
+      '  keep\n    me  \n' // leading + trailing whitespace across lines
+    ]) {
+      expect(roundTrip('X', value).description).toBe(value)
+    }
   })
 
-  it('blocks values that would otherwise break the frontmatter (--- fence, key: line)', () => {
-    expect(frontmatterField('description', 'a\n---\nb').startsWith('description: |-')).toBe(true)
-    expect(frontmatterField('description', 'not: a-key').startsWith('description: |-')).toBe(true)
+  it('round-trips values that would otherwise break the frontmatter (--- fence, key: line)', () => {
+    expect(roundTrip('X', 'a\n---\nb').description).toBe('a\n---\nb')
+    expect(roundTrip('X', 'not: a-key').description).toBe('not: a-key')
   })
 
-  it('serializes an empty value as an empty block scalar (not null)', () => {
-    // A bare `description:` would parse as null; `description: |-` yields an empty string.
-    expect(frontmatterField('description', '')).toBe('description: |-')
+  it('round-trips an empty value as an empty string (not null)', () => {
+    expect(roundTrip('X', '').description).toBe('')
   })
 })
 

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -12,6 +12,7 @@ import {
   toSlug,
   frontmatterBlock
 } from './user-skill-repository'
+import { parseFrontmatter } from './frontmatter'
 import type { FetchLike } from './github-import'
 
 const makeStorage = async (): Promise<string> => mkdtemp(join(tmpdir(), 'user-skills-'))
@@ -144,6 +145,15 @@ describe('frontmatterBlock', () => {
 
   it('round-trips an empty value as an empty string (not null)', () => {
     expect(roundTrip('X', '').description).toBe('')
+  })
+
+  it('round-trips losslessly through the app frontmatter reader too', () => {
+    // Not just a standard parser — the app's own parseFrontmatter must recover the exact value,
+    // including a trailing newline and leading spaces (it no longer trims).
+    for (const value of ['line one\n', '  indented', 'plain text', 'true', '2026-07-17']) {
+      const doc = `---\n${frontmatterBlock({ name: 'X', description: value })}---\nbody`
+      expect(parseFrontmatter(doc).fields.description).toBe(value)
+    }
   })
 })
 

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -5,7 +5,12 @@ import { deflateRawSync } from 'node:zlib'
 
 import { describe, expect, it } from 'vitest'
 
-import { UserSkillRepository, parseUserSkillId, toSlug } from './user-skill-repository'
+import {
+  UserSkillRepository,
+  parseUserSkillId,
+  toSlug,
+  frontmatterField
+} from './user-skill-repository'
 import type { FetchLike } from './github-import'
 
 const makeStorage = async (): Promise<string> => mkdtemp(join(tmpdir(), 'user-skills-'))
@@ -98,6 +103,39 @@ describe('toSlug / parseUserSkillId', () => {
     expect(parseUserSkillId('personal-my-skill')).toEqual({ source: 'personal', slug: 'my-skill' })
     expect(parseUserSkillId('imported-foo')).toEqual({ source: 'imported', slug: 'foo' })
     expect(parseUserSkillId('citation-formatter')).toBeNull()
+  })
+})
+
+describe('frontmatterField', () => {
+  it('emits an ordinary single-line value inline with no trailing newline', () => {
+    expect(frontmatterField('name', 'My Skill')).toBe('name: My Skill')
+    expect(frontmatterField('description', 'Does a thing.')).toBe('description: Does a thing.')
+  })
+
+  it('serializes YAML-typed tokens as strings so they never read back as bool/null/number', () => {
+    // A plain `description: true` would parse as a boolean; force these to a block scalar.
+    for (const value of ['true', 'false', 'null', 'yes', 'no', '~', '123', '3.14', '+1', '0x1f']) {
+      const out = frontmatterField('description', value)
+      expect(out.startsWith('description: |-')).toBe(true)
+      expect(out).toContain(`  ${value}`)
+    }
+  })
+
+  it('uses a strip-chomped (|-) block scalar for multiline values, indenting every line', () => {
+    const out = frontmatterField('description', 'line one\n\nline three')
+    expect(out).toBe('description: |-\n  line one\n\n  line three')
+    // No trailing newline is appended by the block scalar itself.
+    expect(out.endsWith('line three')).toBe(true)
+  })
+
+  it('blocks values that would otherwise break the frontmatter (--- fence, key: line)', () => {
+    expect(frontmatterField('description', 'a\n---\nb').startsWith('description: |-')).toBe(true)
+    expect(frontmatterField('description', 'not: a-key').startsWith('description: |-')).toBe(true)
+  })
+
+  it('serializes an empty value as an empty block scalar (not null)', () => {
+    // A bare `description:` would parse as null; `description: |-` yields an empty string.
+    expect(frontmatterField('description', '')).toBe('description: |-')
   })
 })
 

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -53,6 +53,26 @@ const toSlug = (name: string): string =>
     .replace(/^-+|-+$/g, '')
     .slice(0, 64)
 
+// Serializes one frontmatter field so arbitrary user text can never corrupt SKILL.md. A plain,
+// single-line value is emitted inline; anything with a newline, a surrounding space, or a leading
+// YAML indicator (which includes `---`, a bare `-`, quotes, `|`/`>`, etc.) is emitted as a literal
+// (`|`) block scalar. Because every block line is indented, a value containing `---` or a `key:`-like
+// line can't be mistaken for the closing fence or another field by a real YAML parser or by our own
+// parseFrontmatter reader.
+const frontmatterField = (key: string, value: string): string => {
+  const normalized = value.replace(/\r\n?/g, '\n')
+  const isPlain =
+    normalized.length > 0 &&
+    !normalized.includes('\n') &&
+    normalized === normalized.trim() &&
+    !/^[-?:,[\]{}#&*!|>'"%@`]/.test(normalized) &&
+    !/:(\s|$)/.test(normalized) &&
+    !/\s#/.test(normalized)
+  if (isPlain) return `${key}: ${normalized}`
+  const indented = normalized.split('\n').map((line) => (line ? `  ${line}` : ''))
+  return [`${key}: |`, ...indented].join('\n')
+}
+
 // A skill id is `<source>-<slug>`; parse it back to its source + slug (null for bundled/unknown ids).
 const parseUserSkillId = (
   id: string
@@ -510,8 +530,8 @@ class UserSkillRepository {
 
     const frontmatter = [
       '---',
-      `name: ${input.name}`,
-      `description: ${input.description}`,
+      frontmatterField('name', input.name),
+      frontmatterField('description', input.description),
       '---'
     ].join('\n')
     const contents = `${frontmatter}\n\n${input.body.trimStart()}`

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -53,24 +53,32 @@ const toSlug = (name: string): string =>
     .replace(/^-+|-+$/g, '')
     .slice(0, 64)
 
-// Serializes one frontmatter field so arbitrary user text can never corrupt SKILL.md. A plain,
-// single-line value is emitted inline; anything with a newline, a surrounding space, or a leading
-// YAML indicator (which includes `---`, a bare `-`, quotes, `|`/`>`, etc.) is emitted as a literal
-// (`|`) block scalar. Because every block line is indented, a value containing `---` or a `key:`-like
-// line can't be mistaken for the closing fence or another field by a real YAML parser or by our own
-// parseFrontmatter reader.
+// A single-line value that a YAML parser would read back as a non-string: a boolean/null keyword or
+// anything that starts like a number. Such a value MUST NOT be emitted as a plain scalar, or `name:
+// true` / `description: 123` would round-trip as a boolean/number instead of the user's string.
+const YAML_KEYWORD = /^(?:true|false|null|none|yes|no|on|off|~)$/i
+
+// Serializes one frontmatter field so arbitrary user text always round-trips as a STRING and can
+// never corrupt SKILL.md. A plain, single-line value is emitted inline; anything with a newline, a
+// surrounding space, a leading YAML indicator (`---`, a bare `-`, quotes, `|`/`>`, a digit/`+`/`.`
+// that could read as a number, ...), or a boolean/null keyword is emitted as a literal block scalar.
+// `|-` (strip chomping) is used so no trailing newline is appended, and every block line is indented
+// so a value containing `---` or a `key:`-like line can't be mistaken for the closing fence or
+// another field — by a real YAML parser or by our own parseFrontmatter reader.
 const frontmatterField = (key: string, value: string): string => {
   const normalized = value.replace(/\r\n?/g, '\n')
   const isPlain =
     normalized.length > 0 &&
     !normalized.includes('\n') &&
     normalized === normalized.trim() &&
-    !/^[-?:,[\]{}#&*!|>'"%@`]/.test(normalized) &&
+    !/^[-?:,[\]{}#&*!|>'"%@`+.\d]/.test(normalized) &&
     !/:(\s|$)/.test(normalized) &&
-    !/\s#/.test(normalized)
+    !/\s#/.test(normalized) &&
+    !YAML_KEYWORD.test(normalized)
   if (isPlain) return `${key}: ${normalized}`
+  if (normalized === '') return `${key}: |-`
   const indented = normalized.split('\n').map((line) => (line ? `  ${line}` : ''))
-  return [`${key}: |`, ...indented].join('\n')
+  return [`${key}: |-`, ...indented].join('\n')
 }
 
 // A skill id is `<source>-<slug>`; parse it back to its source + slug (null for bundled/unknown ids).
@@ -571,4 +579,4 @@ class UserSkillRepository {
   }
 }
 
-export { UserSkillRepository, parseUserSkillId, toSlug }
+export { UserSkillRepository, parseUserSkillId, toSlug, frontmatterField }

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -2,6 +2,8 @@ import { createHash } from 'node:crypto'
 import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
+import { dump as dumpYaml } from 'js-yaml'
+
 import type { SkillBundlePreview, SkillReference, SkillSource } from '../../shared/settings'
 import { createLogger } from '../logger'
 import {
@@ -53,33 +55,14 @@ const toSlug = (name: string): string =>
     .replace(/^-+|-+$/g, '')
     .slice(0, 64)
 
-// A single-line value that a YAML parser would read back as a non-string: a boolean/null keyword or
-// anything that starts like a number. Such a value MUST NOT be emitted as a plain scalar, or `name:
-// true` / `description: 123` would round-trip as a boolean/number instead of the user's string.
-const YAML_KEYWORD = /^(?:true|false|null|none|yes|no|on|off|~)$/i
-
-// Serializes one frontmatter field so arbitrary user text always round-trips as a STRING and can
-// never corrupt SKILL.md. A plain, single-line value is emitted inline; anything with a newline, a
-// surrounding space, a leading YAML indicator (`---`, a bare `-`, quotes, `|`/`>`, a digit/`+`/`.`
-// that could read as a number, ...), or a boolean/null keyword is emitted as a literal block scalar.
-// `|-` (strip chomping) is used so no trailing newline is appended, and every block line is indented
-// so a value containing `---` or a `key:`-like line can't be mistaken for the closing fence or
-// another field — by a real YAML parser or by our own parseFrontmatter reader.
-const frontmatterField = (key: string, value: string): string => {
-  const normalized = value.replace(/\r\n?/g, '\n')
-  const isPlain =
-    normalized.length > 0 &&
-    !normalized.includes('\n') &&
-    normalized === normalized.trim() &&
-    !/^[-?:,[\]{}#&*!|>'"%@`+.\d]/.test(normalized) &&
-    !/:(\s|$)/.test(normalized) &&
-    !/\s#/.test(normalized) &&
-    !YAML_KEYWORD.test(normalized)
-  if (isPlain) return `${key}: ${normalized}`
-  if (normalized === '') return `${key}: |-`
-  const indented = normalized.split('\n').map((line) => (line ? `  ${line}` : ''))
-  return [`${key}: |-`, ...indented].join('\n')
-}
+// Serializes the SKILL.md frontmatter block from arbitrary user values. A hand-rolled emitter kept
+// getting subtle YAML edge cases wrong (type coercion of `true`/`123`, trailing-newline handling,
+// leading spaces), so this delegates to js-yaml: it quotes or block-escapes each value as needed so
+// every field round-trips LOSSLESSLY and always as a string through any conformant YAML parser. The
+// leading `---`/trailing `---` document markers are added by the caller. `lineWidth: -1` disables line
+// folding so long descriptions aren't rewrapped (which would not be byte-lossless).
+const frontmatterBlock = (fields: { name: string; description: string }): string =>
+  dumpYaml(fields, { lineWidth: -1 })
 
 // A skill id is `<source>-<slug>`; parse it back to its source + slug (null for bundled/unknown ids).
 const parseUserSkillId = (
@@ -536,12 +519,8 @@ class UserSkillRepository {
     const dir = this.skillDir(source, slug)
     await mkdir(dir, { recursive: true })
 
-    const frontmatter = [
-      '---',
-      frontmatterField('name', input.name),
-      frontmatterField('description', input.description),
-      '---'
-    ].join('\n')
+    // js-yaml.dump already ends with a newline, so the closing fence follows directly.
+    const frontmatter = `---\n${frontmatterBlock({ name: input.name, description: input.description })}---`
     const contents = `${frontmatter}\n\n${input.body.trimStart()}`
 
     await writeFile(join(dir, 'SKILL.md'), contents, 'utf8')
@@ -579,4 +558,4 @@ class UserSkillRepository {
   }
 }
 
-export { UserSkillRepository, parseUserSkillId, toSlug, frontmatterField }
+export { UserSkillRepository, parseUserSkillId, toSlug, frontmatterBlock }

--- a/src/renderer/src/pages/settings/SkillDetailView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillDetailView.render.test.tsx
@@ -82,6 +82,48 @@ describe('SkillDetailView', () => {
     expect(document.body.textContent).toContain('Weights — Example (CC-BY-4.0)')
   })
 
+  it('labels the badge by the skill source, not always "Featured"', async () => {
+    for (const [source, label] of [
+      ['featured', 'Featured'],
+      ['imported', 'Imported'],
+      ['personal', 'Personal']
+    ] as const) {
+      ;(window as unknown as { api: unknown }).api = {
+        settings: { getSkillDetail: vi.fn().mockResolvedValue({ ...detail, source }) }
+      }
+      useSettingsStore.setState({
+        ...createInitialSettingsState(),
+        skills: [
+          {
+            id: 'a',
+            name: 'Alpha',
+            description: 'First skill description.',
+            source,
+            updatedAt: detail.updatedAt,
+            enabled: true
+          }
+        ],
+        setSkillEnabled: vi.fn().mockResolvedValue(undefined)
+      })
+
+      const localContainer = document.createElement('div')
+      document.body.appendChild(localContainer)
+      const localRoot = createRoot(localContainer)
+      await act(async () => {
+        localRoot.render(<SkillDetailView skillId="a" />)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      const badge = localContainer.querySelector('span.rounded-full')
+      expect(badge?.textContent).toBe(label)
+
+      act(() => localRoot.unmount())
+      localContainer.remove()
+    }
+  })
+
   it('toggles the skill from the detail header switch', async () => {
     await act(async () => {
       root.render(<SkillDetailView skillId="a" />)

--- a/src/renderer/src/pages/settings/SkillDetailView.tsx
+++ b/src/renderer/src/pages/settings/SkillDetailView.tsx
@@ -50,6 +50,10 @@ const SkillDetailView = ({ skillId }: SkillDetailViewProps): React.JSX.Element =
   const name = skill?.name ?? detail?.name ?? ''
   const description = detail?.description ?? skill?.description ?? ''
   const updated = detail ? formatUpdated(detail.updatedAt) : ''
+  // Badge reflects the skill's actual source; imported and personal skills are not "Featured".
+  const source = skill?.source ?? detail?.source
+  const sourceLabel =
+    source === 'imported' ? 'Imported' : source === 'personal' ? 'Personal' : 'Featured'
 
   return (
     <div className="p-5">
@@ -60,7 +64,7 @@ const SkillDetailView = ({ skillId }: SkillDetailViewProps): React.JSX.Element =
           <div className="flex min-w-0 items-center gap-2">
             <h1 className="truncate text-base font-semibold text-foreground">{name}</h1>
             <span className="inline-flex shrink-0 items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-              Featured
+              {sourceLabel}
             </span>
           </div>
         </div>

--- a/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
@@ -9,12 +9,18 @@ import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-
 let container: HTMLDivElement
 let root: Root
 
-// Lets FileReader (base64 read) and the awaited store mocks settle before assertions.
-const flush = async (): Promise<void> => {
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 0))
-    await Promise.resolve()
-  })
+// Lets the async drop pipeline settle before assertions: dispatch -> Promise.all(parseFile) ->
+// FileReader.readAsDataURL (a macrotask) -> previewSkillZip -> setState. That's several event-loop
+// turns, so pump multiple macrotask cycles rather than a single one — a single tick was enough locally
+// but flaked on loaded CI runners (the FileReader onload hadn't fired yet). Ten turns is ample and
+// still runs in a few ms.
+const flush = async (cycles = 10): Promise<void> => {
+  for (let i = 0; i < cycles; i += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      await Promise.resolve()
+    })
+  }
 }
 
 // Drops files onto the upload label, matching how the real drag-and-drop hook receives them.


### PR DESCRIPTION
## Summary

Two robustness/correctness fixes.

**Personal-skill frontmatter written without escaping.** `writeSkill` interpolated the user's `name` and `description` straight into the YAML frontmatter, so a multiline description or one containing `---` could close the frontmatter early or inject a bogus field — corrupting `SKILL.md`, which drives the catalog display and the agent trigger description. Each field is now serialized so a plain single-line value stays inline, and anything with a newline, surrounding whitespace, or a leading YAML indicator is written as an indented literal (`|`) block scalar. The output round-trips through both a real YAML parser and the repo's own `parseFrontmatter` reader, and an embedded `---` can no longer be mistaken for the closing fence.

**Skill detail always labeled "Featured".** `SkillDetailView` hardcoded the badge, mislabeling imported and personal skills opened from settings or mention history. The badge is now derived from the skill's `source` (Featured / Imported / Personal).

## Tests

- New coverage: a description containing newlines, a `---` fence, and a `key:`-like line round-trips intact and does not leak into the body.
- `skills` + `frontmatter` suites pass, full typecheck and eslint clean.