### PR TITLE
fix(storage): harden data-root migration against partial/stale copies

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AcpRuntime } from './runtime'
 import { ArtifactRepository } from '../artifacts/repository'
 import { UploadRepository } from '../uploads/repository'
+import { beginMigration, clearMigrationPending } from '../storage/migration-state'
 
 // Minimal child-process stand-in that exposes the streams the runtime expects.
 class FakeAgentProcess extends EventEmitter {
@@ -215,6 +216,36 @@ afterEach(async () => {
     await rm(temporaryRoot, { recursive: true, force: true })
     temporaryRoot = undefined
   }
+})
+
+describe('ACP runtime migration write-gate', () => {
+  afterEach(() => {
+    // migration-state is a module singleton; clear it so a pending gate can't leak between tests.
+    clearMigrationPending()
+  })
+
+  it('rejects sendPrompt while a data-root migration is pending, then resumes once cleared', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['gated-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+
+    beginMigration()
+    await expect(
+      runtime.sendPrompt({ sessionId: session.sessionId, text: 'blocked' })
+    ).rejects.toThrow(/moving your data/i)
+    // The turn never reached the agent.
+    expect(fakeAgent.prompts).toEqual([])
+
+    clearMigrationPending()
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'allowed' })
+    expect(fakeAgent.prompts).toEqual([{ sessionId: 'gated-session', text: 'allowed' }])
+  })
 })
 
 describe('ACP runtime session management', () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -11,7 +11,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AcpRuntime } from './runtime'
 import { ArtifactRepository } from '../artifacts/repository'
 import { UploadRepository } from '../uploads/repository'
-import { beginMigration, clearMigrationPending } from '../storage/migration-state'
+import {
+  beginMigration,
+  clearMigrationPending,
+  waitForDataRootWriters
+} from '../storage/migration-state'
 
 // Minimal child-process stand-in that exposes the streams the runtime expects.
 class FakeAgentProcess extends EventEmitter {
@@ -245,6 +249,35 @@ describe('ACP runtime migration write-gate', () => {
     clearMigrationPending()
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'allowed' })
     expect(fakeAgent.prompts).toEqual([{ sessionId: 'gated-session', text: 'allowed' }])
+  })
+
+  it('keeps migration drain pending until a prompt that already started finishes', async () => {
+    const process = new FakeAgentProcess()
+    const promptGate = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['drain-session'], {
+      onPrompt: () => promptGate.promise
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+
+    const promptPromise = runtime.sendPrompt({ sessionId: session.sessionId, text: 'running' })
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    beginMigration()
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    promptGate.resolve()
+    await promptPromise
+    await drainPromise
+    expect(drained).toBe(true)
   })
 })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -60,6 +60,7 @@ import {
 } from '../notebook/mcp-server'
 import { getNotebookSessionRoot } from '../notebook/repository'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
+import { isMigrationPending } from '../storage/migration-state'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
@@ -882,6 +883,14 @@ class AcpRuntime {
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
   async sendPrompt(request: AcpPromptRequest): Promise<PromptResponse> {
+    // Write-gate: during the data-root copy→commit window, a prompt would write into the OLD root that
+    // the commit is about to delete. Refuse up front rather than lose the turn's output.
+    if (isMigrationPending()) {
+      throw new Error(
+        'Open Science is moving your data. Wait for the move to finish before running this.'
+      )
+    }
+
     let activeSession = this.sessions.get(request.sessionId)
 
     if (!activeSession) {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -60,7 +60,7 @@ import {
 } from '../notebook/mcp-server'
 import { getNotebookSessionRoot } from '../notebook/repository'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
-import { assertNoMigrationPending } from '../storage/migration-state'
+import { withDataRootWrite } from '../storage/migration-state'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
@@ -883,10 +883,10 @@ class AcpRuntime {
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
   async sendPrompt(request: AcpPromptRequest): Promise<PromptResponse> {
-    // Write-gate: during the data-root copy→commit window, a prompt would write into the OLD root that
-    // the commit is about to delete. Refuse up front rather than lose the turn's output.
-    assertNoMigrationPending()
+    return withDataRootWrite(() => this.sendPromptTurn(request))
+  }
 
+  private async sendPromptTurn(request: AcpPromptRequest): Promise<PromptResponse> {
     let activeSession = this.sessions.get(request.sessionId)
 
     if (!activeSession) {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -60,7 +60,7 @@ import {
 } from '../notebook/mcp-server'
 import { getNotebookSessionRoot } from '../notebook/repository'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
-import { isMigrationPending } from '../storage/migration-state'
+import { assertNoMigrationPending } from '../storage/migration-state'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
@@ -885,11 +885,7 @@ class AcpRuntime {
   async sendPrompt(request: AcpPromptRequest): Promise<PromptResponse> {
     // Write-gate: during the data-root copy→commit window, a prompt would write into the OLD root that
     // the commit is about to delete. Refuse up front rather than lose the turn's output.
-    if (isMigrationPending()) {
-      throw new Error(
-        'Open Science is moving your data. Wait for the move to finish before running this.'
-      )
-    }
+    assertNoMigrationPending()
 
     let activeSession = this.sessions.get(request.sessionId)
 

--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -7,6 +7,11 @@ import type { ArtifactFile, ArtifactWriteSource } from '../../shared/artifacts'
 import { ArtifactRepository } from './repository'
 import { createArtifactHandlers } from './ipc'
 import { ArtifactRunRegistry } from './run-registry'
+import {
+  beginMigration,
+  clearMigrationPending,
+  waitForDataRootWriters
+} from '../storage/migration-state'
 
 let storageRoot: string | undefined
 
@@ -25,6 +30,7 @@ const createInlineSource = (
 })
 
 afterEach(async () => {
+  clearMigrationPending()
   if (storageRoot) {
     await rm(storageRoot, { recursive: true, force: true })
     storageRoot = undefined
@@ -114,6 +120,40 @@ describe('artifact IPC handlers', () => {
       [finalizedArtifact]
     ])
     expect(repository.listMessageFiles).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps migration drain pending until an artifact finalization already in progress finishes', async () => {
+    let releaseFinalize: (() => void) | undefined
+    const repository = {
+      finalizeRunArtifacts: vi.fn(
+        () =>
+          new Promise<ArtifactFile[]>((resolve) => {
+            releaseFinalize = () => resolve([createFinalizedArtifact()])
+          })
+      )
+    } as unknown as ArtifactRepository
+    const registry = new ArtifactRunRegistry()
+    const claimId = registry.register({
+      projectName: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-1'
+    })
+    const handlers = createArtifactHandlers(repository, registry)
+
+    const finalizePromise = handlers.finalizeRunArtifacts({ claimId, messageId: 'message-1' })
+    beginMigration()
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    releaseFinalize?.()
+    await finalizePromise
+    await drainPromise
+    expect(drained).toBe(true)
   })
 
   it('opens only files inside the managed artifact root', async () => {

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -7,6 +7,7 @@ import type {
   ReadArtifactPreviewRequest
 } from '../../shared/artifacts'
 import { resolveDataRoot } from '../storage-root'
+import { assertNoMigrationPending } from '../storage/migration-state'
 import { ArtifactRepository } from './repository'
 import { ArtifactRunRegistry } from './run-registry'
 
@@ -124,9 +125,11 @@ const registerArtifactIpcHandlers = (
 ): void => {
   const handlers = createArtifactHandlers(repository, runRegistry)
 
-  ipcMain.handle('artifacts:finalize-run', (_event, request: FinalizeRunArtifactsRequest) =>
-    handlers.finalizeRunArtifacts(request)
-  )
+  ipcMain.handle('artifacts:finalize-run', (_event, request: FinalizeRunArtifactsRequest) => {
+    // Finalizing moves artifacts under the data root; block it during the migration copy→commit window.
+    assertNoMigrationPending()
+    return handlers.finalizeRunArtifacts(request)
+  })
   ipcMain.handle('artifacts:open-file', (_event, request: OpenArtifactFileRequest) =>
     handlers.openFile(request)
   )

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -7,7 +7,7 @@ import type {
   ReadArtifactPreviewRequest
 } from '../../shared/artifacts'
 import { resolveDataRoot } from '../storage-root'
-import { assertNoMigrationPending } from '../storage/migration-state'
+import { withDataRootWrite } from '../storage/migration-state'
 import { ArtifactRepository } from './repository'
 import { ArtifactRunRegistry } from './run-registry'
 
@@ -62,8 +62,10 @@ const createArtifactHandlers = (
 
   return {
     finalizeRunArtifacts: (request) =>
-      withClaimLock(finalizeLocks, request.claimId, () =>
-        finalizeRunArtifacts(repository, runRegistry, request)
+      withDataRootWrite(() =>
+        withClaimLock(finalizeLocks, request.claimId, () =>
+          finalizeRunArtifacts(repository, runRegistry, request)
+        )
       ),
     openFile: async (request) => {
       // Resolve through the repository first so shell.openPath never sees unmanaged locations.
@@ -125,11 +127,9 @@ const registerArtifactIpcHandlers = (
 ): void => {
   const handlers = createArtifactHandlers(repository, runRegistry)
 
-  ipcMain.handle('artifacts:finalize-run', (_event, request: FinalizeRunArtifactsRequest) => {
-    // Finalizing moves artifacts under the data root; block it during the migration copy→commit window.
-    assertNoMigrationPending()
-    return handlers.finalizeRunArtifacts(request)
-  })
+  ipcMain.handle('artifacts:finalize-run', (_event, request: FinalizeRunArtifactsRequest) =>
+    handlers.finalizeRunArtifacts(request)
+  )
   ipcMain.handle('artifacts:open-file', (_event, request: OpenArtifactFileRequest) =>
     handlers.openFile(request)
   )

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { NotebookExecutionRequest, NotebookExecutionResult } from './runtime-service'
 import { NotebookRuntimeService } from './runtime-service'
 import { NotebookRunRepository } from './repository'
+import { beginMigration, clearMigrationPending } from '../storage/migration-state'
 
 let storageRoot: string | undefined
 
@@ -556,5 +557,50 @@ describe('notebook runtime service', () => {
     releases.get('session-a')?.()
     releases.get('session-b')?.()
     await Promise.all([runA, runB])
+  })
+})
+
+describe('notebook runtime service migration write-gate', () => {
+  afterEach(() => {
+    // migration-state is a module singleton; clear it so a pending gate can't leak between tests.
+    clearMigrationPending()
+  })
+
+  it('rejects runCell while a data-root migration is pending, then resumes once cleared', async () => {
+    const root = await createStorageRoot()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (): Promise<NotebookExecutionResult> => {
+          throw new Error('executor should never run while the gate is up')
+        },
+        shutdown: async () => undefined
+      })
+    })
+
+    beginMigration()
+    await expect(
+      service.runCell({
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        workspaceCwd: '/workspace',
+        cellId: 'cell-1'
+      })
+    ).rejects.toThrow(/moving your data/i)
+
+    // Once the gate is lifted the guard no longer fires: the call proceeds far enough to hit an
+    // ordinary domain error (the cell was never created) instead of the migration message.
+    clearMigrationPending()
+    await expect(
+      service.runCell({
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        workspaceCwd: '/workspace',
+        cellId: 'cell-1'
+      })
+    ).rejects.toThrow(/Notebook cell not found/i)
   })
 })

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6,7 +6,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { NotebookExecutionRequest, NotebookExecutionResult } from './runtime-service'
 import { NotebookRuntimeService } from './runtime-service'
 import { NotebookRunRepository } from './repository'
-import { beginMigration, clearMigrationPending } from '../storage/migration-state'
+import {
+  beginMigration,
+  clearMigrationPending,
+  waitForDataRootWriters
+} from '../storage/migration-state'
 
 let storageRoot: string | undefined
 
@@ -602,5 +606,152 @@ describe('notebook runtime service migration write-gate', () => {
         cellId: 'cell-1'
       })
     ).rejects.toThrow(/Notebook cell not found/i)
+  })
+
+  it('rejects a streamed cell write before creating notebook storage while migration is pending', async () => {
+    const root = await createStorageRoot()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (): Promise<NotebookExecutionResult> => {
+          throw new Error('executor should not run')
+        },
+        shutdown: async () => undefined
+      })
+    })
+
+    beginMigration()
+    await expect(
+      service.beginCodeCell({
+        projectName: 'default-project',
+        sessionId: 'session-stream',
+        workspaceCwd: '/workspace'
+      })
+    ).rejects.toThrow(/moving your data/i)
+    await expect(
+      new NotebookRunRepository(root).findExisting('default-project', 'session-stream')
+    ).resolves.toBeNull()
+  })
+
+  it('keeps migration drain pending until a notebook run already in progress finishes', async () => {
+    const root = await createStorageRoot()
+    let releaseExecution: (() => void) | undefined
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: (request) =>
+          new Promise<NotebookExecutionResult>((resolve) => {
+            releaseExecution = () =>
+              resolve({
+                status: 'completed',
+                stdout: '',
+                stderr: '',
+                traceback: '',
+                cwdAfter: request.cwd,
+                outputs: [],
+                workingFiles: []
+              })
+          }),
+        shutdown: async () => undefined
+      })
+    })
+    const begin = await service.beginCodeCell({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace'
+    })
+    await service.appendCodeCell({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      cellId: begin.cellId,
+      writeId: begin.writeId,
+      delta: '1 + 1'
+    })
+    await service.finishCodeCell({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      cellId: begin.cellId,
+      writeId: begin.writeId
+    })
+
+    const runPromise = service.runCell({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      cellId: begin.cellId
+    })
+    await vi.waitFor(() => expect(releaseExecution).toBeDefined())
+    beginMigration()
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    releaseExecution?.()
+    await runPromise
+    await drainPromise
+    expect(drained).toBe(true)
+  })
+
+  it('holds one write lease across execute setup and execution', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const loadOrCreate = repository.loadOrCreate.bind(repository)
+    let releaseLoad: (() => void) | undefined
+    const loadGate = new Promise<void>((resolve) => {
+      releaseLoad = resolve
+    })
+    vi.spyOn(repository, 'loadOrCreate').mockImplementation(async (request) => {
+      await loadGate
+      return loadOrCreate(request)
+    })
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository,
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: [],
+          workingFiles: []
+        }),
+        shutdown: async () => undefined
+      })
+    })
+
+    const executePromise = service.execute({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      code: '1 + 1'
+    })
+    await vi.waitFor(() => expect(repository.loadOrCreate).toHaveBeenCalled())
+    beginMigration()
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    releaseLoad?.()
+    await expect(executePromise).resolves.toMatchObject({ status: 'completed' })
+    await drainPromise
+    expect(drained).toBe(true)
   })
 })

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -21,6 +21,7 @@ import type {
 import { NotebookPythonExecutor } from './python-executor'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
+import { isMigrationPending } from '../storage/migration-state'
 
 type NotebookExecutionRequest = {
   code: string
@@ -238,6 +239,14 @@ class NotebookRuntimeService {
 
   // Persists a running run, executes the cell, then updates the same history entry with results.
   async runCell(request: RunNotebookCellRequest): Promise<NotebookRunSummary> {
+    // Write-gate: during the data-root copy→commit window, running a cell would write into the OLD
+    // root that the commit is about to delete. Refuse up front rather than lose the run's output.
+    if (isMigrationPending()) {
+      throw new Error(
+        'Open Science is moving your data. Wait for the move to finish before running this.'
+      )
+    }
+
     const session = await this.ensureSession(request)
     const cell = findCell(session, request.cellId)
 

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -21,7 +21,7 @@ import type {
 import { NotebookPythonExecutor } from './python-executor'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
-import { isMigrationPending } from '../storage/migration-state'
+import { assertNoMigrationPending } from '../storage/migration-state'
 
 type NotebookExecutionRequest = {
   code: string
@@ -241,11 +241,7 @@ class NotebookRuntimeService {
   async runCell(request: RunNotebookCellRequest): Promise<NotebookRunSummary> {
     // Write-gate: during the data-root copy→commit window, running a cell would write into the OLD
     // root that the commit is about to delete. Refuse up front rather than lose the run's output.
-    if (isMigrationPending()) {
-      throw new Error(
-        'Open Science is moving your data. Wait for the move to finish before running this.'
-      )
-    }
+    assertNoMigrationPending()
 
     const session = await this.ensureSession(request)
     const cell = findCell(session, request.cellId)
@@ -376,6 +372,9 @@ class NotebookRuntimeService {
 
   // Convenience path used by the terminal and MCP to write a temporary cell and run it.
   async execute(request: ExecuteNotebookCodeRequest): Promise<NotebookRunSummary> {
+    // Write-gate: like runCell, an ad-hoc execute writes under the data root, so refuse while a
+    // data-root migration is pending (copy→commit window).
+    assertNoMigrationPending()
     const begin = await this.beginCodeCell(request)
 
     await this.appendCodeCell({

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -21,7 +21,7 @@ import type {
 import { NotebookPythonExecutor } from './python-executor'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
-import { assertNoMigrationPending } from '../storage/migration-state'
+import { withDataRootWrite } from '../storage/migration-state'
 
 type NotebookExecutionRequest = {
   code: string
@@ -157,6 +157,15 @@ class NotebookRuntimeService {
     writeId: string
     status: NotebookCell['status']
   }> {
+    return withDataRootWrite(() => this.beginCodeCellWrite(request))
+  }
+
+  private async beginCodeCellWrite(request: BeginNotebookCodeCellRequest): Promise<{
+    sessionId: string
+    cellId: string
+    writeId: string
+    status: NotebookCell['status']
+  }> {
     const session = await this.ensureSession(request)
 
     if (session.activeWrite) {
@@ -203,6 +212,15 @@ class NotebookRuntimeService {
     writeId: string
     receivedBytes: number
   }> {
+    return withDataRootWrite(() => this.appendCodeCellWrite(request))
+  }
+
+  private async appendCodeCellWrite(request: AppendNotebookCodeCellRequest): Promise<{
+    sessionId: string
+    cellId: string
+    writeId: string
+    receivedBytes: number
+  }> {
     const session = await this.ensureSession(request)
     const cell = findCell(session, request.cellId)
 
@@ -225,6 +243,15 @@ class NotebookRuntimeService {
     code: string
     status: NotebookCell['status']
   }> {
+    return withDataRootWrite(() => this.finishCodeCellWrite(request))
+  }
+
+  private async finishCodeCellWrite(request: FinishNotebookCodeCellRequest): Promise<{
+    sessionId: string
+    cellId: string
+    code: string
+    status: NotebookCell['status']
+  }> {
     const session = await this.ensureSession(request)
     const cell = findCell(session, request.cellId)
 
@@ -239,10 +266,12 @@ class NotebookRuntimeService {
 
   // Persists a running run, executes the cell, then updates the same history entry with results.
   async runCell(request: RunNotebookCellRequest): Promise<NotebookRunSummary> {
-    // Write-gate: during the data-root copy→commit window, running a cell would write into the OLD
-    // root that the commit is about to delete. Refuse up front rather than lose the run's output.
-    assertNoMigrationPending()
+    return withDataRootWrite(() => this.runCellWithWriteLease(request))
+  }
 
+  private async runCellWithWriteLease(
+    request: RunNotebookCellRequest
+  ): Promise<NotebookRunSummary> {
     const session = await this.ensureSession(request)
     const cell = findCell(session, request.cellId)
 
@@ -372,24 +401,27 @@ class NotebookRuntimeService {
 
   // Convenience path used by the terminal and MCP to write a temporary cell and run it.
   async execute(request: ExecuteNotebookCodeRequest): Promise<NotebookRunSummary> {
-    // Write-gate: like runCell, an ad-hoc execute writes under the data root, so refuse while a
-    // data-root migration is pending (copy→commit window).
-    assertNoMigrationPending()
-    const begin = await this.beginCodeCell(request)
+    return withDataRootWrite(() => this.executeWithWriteLease(request))
+  }
 
-    await this.appendCodeCell({
+  private async executeWithWriteLease(
+    request: ExecuteNotebookCodeRequest
+  ): Promise<NotebookRunSummary> {
+    const begin = await this.beginCodeCellWrite(request)
+
+    await this.appendCodeCellWrite({
       ...request,
       writeId: begin.writeId,
       cellId: begin.cellId,
       delta: request.code
     })
-    await this.finishCodeCell({
+    await this.finishCodeCellWrite({
       ...request,
       writeId: begin.writeId,
       cellId: begin.cellId
     })
 
-    return this.runCell({
+    return this.runCellWithWriteLease({
       ...request,
       cellId: begin.cellId
     })

--- a/src/main/storage-root.test.ts
+++ b/src/main/storage-root.test.ts
@@ -219,7 +219,8 @@ describe('computeDefaultDataRoot', () => {
     // leftover legacy config-root data no longer masks it.
     const configRoot = resolveConfigRoot()
     await mkdir(join(configRoot, 'artifacts'), { recursive: true })
-    await mkdir(join(homeDir, 'OpenScience'), { recursive: true })
+    // A committed data folder holds real data (not just an empty dir), which is what marks it committed.
+    await mkdir(join(homeDir, 'OpenScience', 'artifacts'), { recursive: true })
 
     expect(computeDefaultDataRoot()).toBe(join(homeDir, 'OpenScience'))
 
@@ -259,7 +260,7 @@ describe('computeDefaultDataRoot (dev mode)', () => {
     // pointing at the stale legacy path.
     const configRoot = resolveConfigRoot()
     await mkdir(join(configRoot, 'artifacts'), { recursive: true })
-    await mkdir(join(homeDir, 'OpenScience-DEV'), { recursive: true })
+    await mkdir(join(homeDir, 'OpenScience-DEV', 'artifacts'), { recursive: true })
 
     expect(computeDefaultDataRoot()).toBe(join(homeDir, 'OpenScience-DEV'))
 

--- a/src/main/storage-root.test.ts
+++ b/src/main/storage-root.test.ts
@@ -1,7 +1,9 @@
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, normalize, resolve, sep } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MIGRATION_MARKER_FILENAME } from './storage/migration-marker'
 
 // Unified electron mock: getPath is a vi.fn so main's override tests can assert it isn't called,
 // while our data-root tests point it at a per-test temp home via mockReturnValue.
@@ -191,6 +193,33 @@ describe('computeDefaultDataRoot', () => {
     // config root, or "return to default" would forever point at the old hidden folder.
     const configRoot = resolveConfigRoot()
     await mkdir(join(configRoot, 'runtime'), { recursive: true })
+
+    expect(computeDefaultDataRoot()).toBe(join(homeDir, 'OpenScience'))
+
+    await rm(configRoot, { recursive: true, force: true })
+  })
+
+  it('stays at the legacy config root when <home>/OpenScience exists but carries a migration marker', async () => {
+    // A crashed/in-flight migration left a marker-bearing staging dir at homeDefault. It is NOT the
+    // committed default yet, so a legacy config root with real data must still win — otherwise the
+    // half-copied staging dir would split a legacy user's data across two locations.
+    const configRoot = resolveConfigRoot()
+    await mkdir(join(configRoot, 'artifacts'), { recursive: true })
+    const homeDefault = join(homeDir, 'OpenScience')
+    await mkdir(homeDefault, { recursive: true })
+    await writeFile(join(homeDefault, MIGRATION_MARKER_FILENAME), '{}')
+
+    expect(computeDefaultDataRoot()).toBe(configRoot)
+
+    await rm(configRoot, { recursive: true, force: true })
+  })
+
+  it('prefers a marker-LESS <home>/OpenScience over a legacy config root (committed default wins)', async () => {
+    // Same layout but no marker: homeDefault is a committed data folder, so it is the default and the
+    // leftover legacy config-root data no longer masks it.
+    const configRoot = resolveConfigRoot()
+    await mkdir(join(configRoot, 'artifacts'), { recursive: true })
+    await mkdir(join(homeDir, 'OpenScience'), { recursive: true })
 
     expect(computeDefaultDataRoot()).toBe(join(homeDir, 'OpenScience'))
 

--- a/src/main/storage-root.test.ts
+++ b/src/main/storage-root.test.ts
@@ -146,6 +146,7 @@ describe('computeDefaultDataRoot', () => {
     appMock.isPackaged = true
     homeDir = await mkdtemp(join(tmpdir(), 'ds-storage-root-home-'))
     appMock.getPath.mockReturnValue(homeDir)
+    initDataRoot(undefined)
   })
 
   afterEach(async () => {
@@ -214,15 +215,24 @@ describe('computeDefaultDataRoot', () => {
     await rm(configRoot, { recursive: true, force: true })
   })
 
-  it('prefers a marker-LESS <home>/OpenScience over a legacy config root (committed default wins)', async () => {
-    // Same layout but no marker: homeDefault is a committed data folder, so it is the default and the
-    // leftover legacy config-root data no longer masks it.
+  it('does not treat a markerless partial <home>/OpenScience copy as committed', async () => {
     const configRoot = resolveConfigRoot()
     await mkdir(join(configRoot, 'artifacts'), { recursive: true })
-    // A committed data folder holds real data (not just an empty dir), which is what marks it committed.
     await mkdir(join(homeDir, 'OpenScience', 'artifacts'), { recursive: true })
 
-    expect(computeDefaultDataRoot()).toBe(join(homeDir, 'OpenScience'))
+    expect(computeDefaultDataRoot()).toBe(configRoot)
+
+    await rm(configRoot, { recursive: true, force: true })
+  })
+
+  it('treats an explicitly configured <home>/OpenScience as the committed default', async () => {
+    const configRoot = resolveConfigRoot()
+    const homeDefault = join(homeDir, 'OpenScience')
+    await mkdir(join(configRoot, 'artifacts'), { recursive: true })
+    await mkdir(join(homeDefault, 'artifacts'), { recursive: true })
+    initDataRoot(homeDefault)
+
+    expect(computeDefaultDataRoot()).toBe(homeDefault)
 
     await rm(configRoot, { recursive: true, force: true })
   })
@@ -233,6 +243,7 @@ describe('computeDefaultDataRoot (dev mode)', () => {
     appMock.isPackaged = false
     homeDir = await mkdtemp(join(tmpdir(), 'ds-storage-root-devhome-'))
     appMock.getPath.mockReturnValue(homeDir)
+    initDataRoot(undefined)
   })
 
   afterEach(async () => {
@@ -254,15 +265,17 @@ describe('computeDefaultDataRoot (dev mode)', () => {
     expect(computeDefaultDataRoot()).toBe(join(homeDir, 'OpenScience-DEV'))
   })
 
-  it('prefers <home>/OpenScience-DEV once it exists, even if the config root still has legacy data', async () => {
+  it('prefers an explicitly configured <home>/OpenScience-DEV over legacy data', async () => {
     // A relocated legacy install: leftover markers linger in the config root, but the modern data
     // folder already exists (and is in use). It must win, or isDefault/return-to-default would keep
     // pointing at the stale legacy path.
     const configRoot = resolveConfigRoot()
     await mkdir(join(configRoot, 'artifacts'), { recursive: true })
-    await mkdir(join(homeDir, 'OpenScience-DEV', 'artifacts'), { recursive: true })
+    const homeDefault = join(homeDir, 'OpenScience-DEV')
+    await mkdir(join(homeDefault, 'artifacts'), { recursive: true })
+    initDataRoot(homeDefault)
 
-    expect(computeDefaultDataRoot()).toBe(join(homeDir, 'OpenScience-DEV'))
+    expect(computeDefaultDataRoot()).toBe(homeDefault)
 
     await rm(configRoot, { recursive: true, force: true })
   })

--- a/src/main/storage-root.ts
+++ b/src/main/storage-root.ts
@@ -8,6 +8,7 @@ import {
   PROD_SESSION_DIR_NAME,
   getSessionPersistenceDir
 } from './session-persistence/repository'
+import { hasPendingMigrationMarker } from './storage/migration-marker'
 
 // Fixed, dev-aware config root (DB, sessions, claude, skills, settings live here). Never relocated.
 // A development-only absolute override supports truly isolated onboarding previews without changing
@@ -77,10 +78,14 @@ const LEGACY_DATA_MARKERS = ['artifacts', 'notebooks', 'uploads']
 const computeDefaultDataRoot = (): string => {
   const configRoot = resolveConfigRoot()
   const homeDefault = dataRootForParent(app.getPath('home'))
+  // A marker-bearing homeDefault is a half-copied/uncommitted staging dir, NOT the committed default:
+  // treat it as "not there yet" so a crashed or in-flight migration can't fool the legacy fallback into
+  // thinking the modern data folder already exists (which would split a legacy user's data).
+  const homeDefaultIsCommitted = existsSync(homeDefault) && !hasPendingMigrationMarker(homeDefault)
   const isLegacyInstall =
     LEGACY_DATA_MARKERS.some((dir) => existsSync(join(configRoot, dir))) &&
     !existsSync(join(configRoot, dataFolderName())) &&
-    !existsSync(homeDefault)
+    !homeDefaultIsCommitted
 
   return isLegacyInstall ? configRoot : homeDefault
 }

--- a/src/main/storage-root.ts
+++ b/src/main/storage-root.ts
@@ -70,25 +70,23 @@ const LEGACY_DATA_MARKERS = ['artifacts', 'notebooks', 'uploads']
 // Default data root for a fresh install is `~/OpenScience` (dev `~/OpenScience-DEV`). A legacy
 // install - config root already holds data and never got an OpenScience subdir - keeps its data
 // where it is instead of silently splitting an existing user's data across two locations. But this
-// legacy fallback applies ONLY while no modern data folder exists yet: once `<home>/OpenScience`
-// has been created (by a migration/relocation), it is the canonical default. Without that guard, a
-// leftover legacy dir in the config root (e.g. old artifacts/ never cleaned up) would keep masking
-// the real, in-use data root, so the app would report itself "not on the default" forever and
-// "return to default" would aim at the wrong place.
+// legacy fallback applies ONLY while settings.dataRoot is unset. A migration becomes committed when
+// settings explicitly points at `<home>/OpenScience`; directory existence alone is not evidence,
+// because a failed copy cleanup may leave a markerless partial tree behind.
 const computeDefaultDataRoot = (): string => {
   const configRoot = resolveConfigRoot()
   const homeDefault = dataRootForParent(app.getPath('home'))
   // A marker-bearing homeDefault is a half-copied/uncommitted staging dir, NOT the committed default:
   // treat it as "not there yet" so a crashed or in-flight migration can't fool the legacy fallback into
   // thinking the modern data folder already exists (which would split a legacy user's data).
-  // "Committed" requires real data present, not mere existence: a crash between mkdir and the marker
-  // write, or a rollback that couldn't fully remove the staging dir, can leave an empty/partial
-  // homeDefault with no marker — that must NOT masquerade as the committed default and strand a legacy
-  // user's data in the config root.
+  // The explicit setting is the commit record. A crash between mkdir and marker creation, or a rollback
+  // that couldn't fully remove staging, can leave a markerless partial homeDefault; it must not strand
+  // a legacy user's live data in the config root.
   const homeDefaultIsCommitted =
+    configuredDataRoot !== undefined &&
+    samePath(configuredDataRoot, homeDefault) &&
     existsSync(homeDefault) &&
-    !hasPendingMigrationMarker(homeDefault) &&
-    LEGACY_DATA_MARKERS.some((dir) => existsSync(join(homeDefault, dir)))
+    !hasPendingMigrationMarker(homeDefault)
   const isLegacyInstall =
     LEGACY_DATA_MARKERS.some((dir) => existsSync(join(configRoot, dir))) &&
     !existsSync(join(configRoot, dataFolderName())) &&
@@ -126,10 +124,11 @@ const isPathInsideOrEqual = (parent: string, child: string): boolean => {
 // Relocatable data root. Cached once at startup from settings (a change requires a restart), so this
 // stays a synchronous pure getter for every downstream consumer.
 let cachedDataRoot: string | undefined
+let configuredDataRoot: string | undefined
 
 const initDataRoot = (settingsDataRoot: string | undefined): void => {
-  cachedDataRoot =
-    settingsDataRoot && settingsDataRoot.trim() ? settingsDataRoot : computeDefaultDataRoot()
+  configuredDataRoot = settingsDataRoot && settingsDataRoot.trim() ? settingsDataRoot : undefined
+  cachedDataRoot = configuredDataRoot ?? computeDefaultDataRoot()
 }
 
 // Before initDataRoot has run (early callers, tests), fall back to computeDefaultDataRoot()

--- a/src/main/storage-root.ts
+++ b/src/main/storage-root.ts
@@ -81,7 +81,14 @@ const computeDefaultDataRoot = (): string => {
   // A marker-bearing homeDefault is a half-copied/uncommitted staging dir, NOT the committed default:
   // treat it as "not there yet" so a crashed or in-flight migration can't fool the legacy fallback into
   // thinking the modern data folder already exists (which would split a legacy user's data).
-  const homeDefaultIsCommitted = existsSync(homeDefault) && !hasPendingMigrationMarker(homeDefault)
+  // "Committed" requires real data present, not mere existence: a crash between mkdir and the marker
+  // write, or a rollback that couldn't fully remove the staging dir, can leave an empty/partial
+  // homeDefault with no marker — that must NOT masquerade as the committed default and strand a legacy
+  // user's data in the config root.
+  const homeDefaultIsCommitted =
+    existsSync(homeDefault) &&
+    !hasPendingMigrationMarker(homeDefault) &&
+    LEGACY_DATA_MARKERS.some((dir) => existsSync(join(homeDefault, dir)))
   const isLegacyInstall =
     LEGACY_DATA_MARKERS.some((dir) => existsSync(join(configRoot, dir))) &&
     !existsSync(join(configRoot, dataFolderName())) &&

--- a/src/main/storage/data-migration.test.ts
+++ b/src/main/storage/data-migration.test.ts
@@ -183,6 +183,29 @@ describe('copyAndVerify', () => {
     }
   )
 
+  it.skipIf(process.platform === 'win32')(
+    'refuses to migrate when a top-level migrated dir is itself a symlink',
+    async () => {
+      await mkdir(join(from, 'real-artifacts'), { recursive: true })
+      await writeFile(join(from, 'real-artifacts', 'a.txt'), 'x')
+      await symlink(join(from, 'real-artifacts'), join(from, 'artifacts'))
+
+      const result = await copyAndVerify({
+        from,
+        to,
+        dirs: ['artifacts'],
+        signal: new AbortController().signal,
+        onProgress: () => {}
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error).toMatch(/symbolic link|special file/i)
+      // The source symlink is untouched and nothing was copied to the dest.
+      expect(await exists(join(from, 'artifacts'))).toBe(true)
+      expect(await exists(join(to, 'artifacts'))).toBe(false)
+    }
+  )
+
   it('copies an existing-but-empty source dir instead of dropping it', async () => {
     await seedFixture()
     await mkdir(join(from, 'runtime'), { recursive: true })

--- a/src/main/storage/data-migration.test.ts
+++ b/src/main/storage/data-migration.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, mkdir, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -155,6 +155,33 @@ describe('copyAndVerify', () => {
     expect(await exists(join(to, 'runtime'))).toBe(false)
     expect(await readFile(join(to, 'artifacts', 'a.txt'), 'utf8')).toBe('hello artifacts')
   })
+
+  // Symlink creation needs privilege on Windows, so skip there.
+  it.skipIf(process.platform === 'win32')(
+    'refuses to migrate when a source dir holds a symlink, leaving sources and dest untouched',
+    async () => {
+      await mkdir(join(from, 'artifacts'), { recursive: true })
+      await writeFile(join(from, 'artifacts', 'a.txt'), 'hello artifacts')
+      const linkPath = join(from, 'artifacts', 'link')
+      await symlink(join(from, 'artifacts', 'a.txt'), linkPath)
+
+      const result = await copyAndVerify({
+        from,
+        to,
+        dirs: ['artifacts'],
+        signal: new AbortController().signal,
+        onProgress: () => {}
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error).toMatch(/symbolic link|special file/i)
+      // Source file and the link itself are untouched (caller only deletes on ok).
+      expect(await readFile(join(from, 'artifacts', 'a.txt'), 'utf8')).toBe('hello artifacts')
+      expect(await exists(linkPath)).toBe(true)
+      // No partial dest tree remains.
+      expect(await exists(join(to, 'artifacts'))).toBe(false)
+    }
+  )
 
   it('copies an existing-but-empty source dir instead of dropping it', async () => {
     await seedFixture()

--- a/src/main/storage/data-migration.test.ts
+++ b/src/main/storage/data-migration.test.ts
@@ -227,6 +227,25 @@ describe('copyAndVerify', () => {
     expect(deleteResult.failed).toEqual([])
     expect(await exists(join(from, 'runtime'))).toBe(false)
   })
+
+  it('preserves nested empty directories before the source tree is deleted', async () => {
+    await mkdir(join(from, 'artifacts', 'empty', 'nested'), { recursive: true })
+
+    const result = await copyAndVerify({
+      from,
+      to,
+      dirs: ['artifacts'],
+      signal: new AbortController().signal,
+      onProgress: () => {}
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(await exists(join(to, 'artifacts', 'empty', 'nested'))).toBe(true)
+
+    await deleteSources(from, ['artifacts'])
+    expect(await exists(join(from, 'artifacts', 'empty', 'nested'))).toBe(false)
+    expect(await exists(join(to, 'artifacts', 'empty', 'nested'))).toBe(true)
+  })
 })
 
 describe('deleteSources', () => {

--- a/src/main/storage/data-migration.ts
+++ b/src/main/storage/data-migration.ts
@@ -27,6 +27,15 @@ type MigrateOpts = {
 // Thrown internally to unwind to the single catch site; never escapes copyAndVerify.
 class AbortedError extends Error {}
 
+// Thrown by listFiles when it meets an entry that is neither a regular file nor a directory
+// (symlink, fifo, socket, device). Copying can't represent these safely and a later deleteSources
+// would destroy them, so the migration refuses rather than lose data.
+class NonRegularEntryError extends Error {
+  constructor(public readonly relPath: string) {
+    super(`unsupported entry (symlink or special file): ${relPath}`)
+  }
+}
+
 const exists = async (path: string): Promise<boolean> => {
   try {
     await stat(path)
@@ -45,6 +54,7 @@ const listFiles = async (root: string): Promise<string[]> => {
       const rel = join(dir, entry.name)
       if (entry.isDirectory()) await walk(rel)
       else if (entry.isFile()) out.push(rel)
+      else throw new NonRegularEntryError(rel)
     }
   }
   if (await exists(root)) await walk('.')
@@ -130,9 +140,15 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
     // trace. rmdir only removes it if empty, so any unrelated pre-existing content is left intact.
     await rmdir(to).catch(() => undefined)
     const cancelled = err instanceof AbortedError || signal.aborted
+    const error =
+      err instanceof NonRegularEntryError
+        ? `Can't move your data: "${err.relPath}" is a symbolic link or special file. Remove or replace it with a regular copy, then try again.`
+        : err instanceof Error
+          ? err.message
+          : String(err)
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error,
       ...(cancelled ? { cancelled: true } : {})
     }
   }

--- a/src/main/storage/data-migration.ts
+++ b/src/main/storage/data-migration.ts
@@ -27,7 +27,7 @@ type MigrateOpts = {
 // Thrown internally to unwind to the single catch site; never escapes copyAndVerify.
 class AbortedError extends Error {}
 
-// Thrown by listFiles when it meets an entry that is neither a regular file nor a directory
+// Thrown by listEntries when it meets an entry that is neither a regular file nor a directory
 // (symlink, fifo, socket, device). Copying can't represent these safely and a later deleteSources
 // would destroy them, so the migration refuses rather than lose data.
 class NonRegularEntryError extends Error {
@@ -45,15 +45,21 @@ const exists = async (path: string): Promise<boolean> => {
   }
 }
 
-// Recursively lists files (relative paths) under `root`, or [] if `root` doesn't exist.
-const listFiles = async (root: string): Promise<string[]> => {
-  const out: string[] = []
+// Recursively lists regular files and nested directories under `root`, or empty lists if `root`
+// doesn't exist. Directories are tracked separately so empty nested folders survive the move.
+const listEntries = async (
+  root: string
+): Promise<{ files: string[]; directories: string[]; present: boolean }> => {
+  const files: string[] = []
+  const directories: string[] = []
   const walk = async (dir: string): Promise<void> => {
     const entries = await readdir(join(root, dir), { withFileTypes: true })
     for (const entry of entries) {
       const rel = join(dir, entry.name)
-      if (entry.isDirectory()) await walk(rel)
-      else if (entry.isFile()) out.push(rel)
+      if (entry.isDirectory()) {
+        directories.push(rel)
+        await walk(rel)
+      } else if (entry.isFile()) files.push(rel)
       else throw new NonRegularEntryError(rel)
     }
   }
@@ -63,12 +69,15 @@ const listFiles = async (root: string): Promise<string[]> => {
   let info
   try {
     info = await lstat(root)
-  } catch {
-    return out // missing source dir -> nothing to copy
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { files, directories, present: false }
+    }
+    throw err
   }
   if (!info.isDirectory()) throw new NonRegularEntryError(basename(root))
   await walk('.')
-  return out
+  return { files, directories, present: true }
 }
 
 // Copies a single file, streaming, creating parent dirs as needed.
@@ -94,12 +103,15 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
 
   try {
     checkAbort()
-    const filesByDir = new Map<string, string[]>()
+    const entriesByDir = new Map<
+      string,
+      { files: string[]; directories: string[]; present: boolean }
+    >()
     for (const dir of dirs) {
       const srcDir = join(from, dir)
-      const files = await listFiles(srcDir)
-      filesByDir.set(dir, files)
-      for (const rel of files) {
+      const entries = await listEntries(srcDir)
+      entriesByDir.set(dir, entries)
+      for (const rel of entries.files) {
         totalBytes += (await stat(join(srcDir, rel))).size
       }
     }
@@ -110,14 +122,13 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
     // dir must be mirrored at `to`, not silently dropped.
     for (const dir of dirs) {
       const srcDir = join(from, dir)
-      if (!(await exists(srcDir))) continue
-      const files = filesByDir.get(dir) ?? []
+      const entries = entriesByDir.get(dir) ?? { files: [], directories: [], present: false }
+      if (!entries.present) continue
       const destDir = join(to, dir)
       copiedInto.push(destDir)
-      if (files.length === 0) {
-        await mkdir(destDir, { recursive: true })
-      }
-      for (const rel of files) {
+      await mkdir(destDir, { recursive: true })
+      for (const rel of entries.directories) await mkdir(join(destDir, rel), { recursive: true })
+      for (const rel of entries.files) {
         checkAbort()
         await copyFile(join(srcDir, rel), join(destDir, rel))
         copiedBytes += (await stat(join(destDir, rel))).size
@@ -128,8 +139,13 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
 
     // Verify every copied file exists at `to` with matching size.
     for (const dir of dirs) {
-      const files = filesByDir.get(dir) ?? []
-      for (const rel of files) {
+      const entries = entriesByDir.get(dir) ?? { files: [], directories: [], present: false }
+      for (const rel of entries.directories) {
+        checkAbort()
+        const destStat = await stat(join(to, dir, rel)).catch(() => undefined)
+        if (!destStat?.isDirectory()) throw new Error(`verification failed for ${join(dir, rel)}`)
+      }
+      for (const rel of entries.files) {
         checkAbort()
         const srcSize = (await stat(join(from, dir, rel))).size
         const destStat = await stat(join(to, dir, rel)).catch(() => undefined)
@@ -139,6 +155,7 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
         onProgress({ phase: 'verify', copiedBytes, totalBytes, currentPath: join(dir, rel) })
       }
     }
+    checkAbort()
   } catch (err) {
     // Rollback: remove whatever was written under `to`; `from` was never touched.
     for (const destDir of copiedInto) {

--- a/src/main/storage/data-migration.ts
+++ b/src/main/storage/data-migration.ts
@@ -1,6 +1,6 @@
 import { createReadStream, createWriteStream } from 'node:fs'
-import { mkdir, readdir, rm, rmdir, stat } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { lstat, mkdir, readdir, rm, rmdir, stat } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 
 export type MigrationPhase = 'scan' | 'copy' | 'verify' | 'delete'
@@ -57,7 +57,17 @@ const listFiles = async (root: string): Promise<string[]> => {
       else throw new NonRegularEntryError(rel)
     }
   }
-  if (await exists(root)) await walk('.')
+  // A top-level source dir that is itself a symlink/special node must be rejected up front: exists()
+  // (stat) and readdir would silently follow it, then deleteSources would remove the link and orphan
+  // its target. Inner symlinks/special files are caught inside walk().
+  let info
+  try {
+    info = await lstat(root)
+  } catch {
+    return out // missing source dir -> nothing to copy
+  }
+  if (!info.isDirectory()) throw new NonRegularEntryError(basename(root))
+  await walk('.')
   return out
 }
 

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -475,7 +475,7 @@ describe('storage IPC handlers', () => {
     expect(isMigrationPending()).toBe(false)
   })
 
-  it('commit lifts the write-gate when the switchover fails (app stays usable on the old root)', async () => {
+  it('commit discards the orphan staged copy and lifts the write-gate when the switchover fails', async () => {
     initDataRoot(dataRoot)
     const deps = fakeDeps({
       settingsService: {
@@ -495,7 +495,9 @@ describe('storage IPC handlers', () => {
     }
 
     expect(outcome.switchoverFailed).toBe(true)
+    // The UI can't retry, so the app must not soft-lock: the staged copy is discarded and the gate lifts.
     expect(isMigrationPending()).toBe(false)
+    expect(existsSync(target)).toBe(false)
   })
 
   it('rejects a concurrent migrate call while one is already in flight', async () => {
@@ -549,6 +551,19 @@ describe('storage IPC handlers', () => {
     expect(deps.relaunch).not.toHaveBeenCalled()
     // A cancelled copy leaves the app on the old root, so the write-gate is lifted.
     expect(isMigrationPending()).toBe(false)
+  })
+
+  it('cancel-migrate is a no-op once a copy has completed (only commit/discard may resolve it)', async () => {
+    initDataRoot(dataRoot)
+    registerStorageIpcHandlers(fakeDeps())
+
+    await invoke('storage:migrate', { parent: targetParent }) // copy completes; gate up, staged
+    expect(isMigrationPending()).toBe(true)
+
+    await invoke('storage:cancel-migrate') // late cancel must NOT clear the gate or drop the copy
+
+    expect(isMigrationPending()).toBe(true)
+    expect(existsSync(target)).toBe(true)
   })
 
   it("validate-data-root returns validateNewDataRoot's ok result for a parent with no OpenScience subdir", async () => {

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -31,6 +31,21 @@ vi.mock('electron', () => ({
 
 const { initDataRoot } = await import('../storage-root')
 const { registerStorageIpcHandlers } = await import('./ipc')
+const { clearMigrationPending, isMigrationPending } = await import('./migration-state')
+const { writeMigrationMarker } = await import('./migration-marker')
+
+// Writes the verified staging marker a completed copy phase would leave, so commit/discard gates pass.
+const seedVerifiedMarker = async (targetDir: string, source: string): Promise<void> => {
+  await mkdir(targetDir, { recursive: true })
+  await writeMigrationMarker(targetDir, {
+    version: 1,
+    token: 'tok-ipc',
+    source,
+    target: targetDir,
+    createdAt: Date.now(),
+    status: 'verified'
+  })
+}
 
 const invoke = (channel: string, payload?: unknown): Promise<unknown> =>
   Promise.resolve(handlers.get(channel)!(undefined, payload))
@@ -79,6 +94,8 @@ beforeEach(async () => {
 
 afterEach(async () => {
   initDataRoot(undefined)
+  // migration-state is a module singleton; reset it so a pending write-gate can't leak between tests.
+  clearMigrationPending()
   await rm(currentParent, { recursive: true, force: true })
   await rm(targetParent, { recursive: true, force: true })
 })
@@ -334,6 +351,7 @@ describe('storage IPC handlers', () => {
 
   it('commit-and-relaunch persists the derived target then relaunches', async () => {
     initDataRoot(dataRoot)
+    await seedVerifiedMarker(target, dataRoot)
     const deps = fakeDeps()
     registerStorageIpcHandlers(deps)
 
@@ -344,8 +362,24 @@ describe('storage IPC handlers', () => {
     expect(deps.relaunch).toHaveBeenCalledTimes(1)
   })
 
+  it('commit-and-relaunch returns {ok:false} and does NOT relaunch when no verified copy exists', async () => {
+    initDataRoot(dataRoot)
+    // No marker seeded: the commit gate refuses, nothing is persisted, and the app must not restart.
+    const deps = fakeDeps()
+    registerStorageIpcHandlers(deps)
+
+    const outcome = (await invoke('storage:commit-and-relaunch', { parent: targetParent })) as {
+      ok: boolean
+    }
+
+    expect(outcome.ok).toBe(false)
+    expect(deps.settingsService.setDataRoot).not.toHaveBeenCalled()
+    expect(deps.relaunch).not.toHaveBeenCalled()
+  })
+
   it('commit-and-relaunch returns switchoverFailed and does NOT relaunch when setDataRoot throws', async () => {
     initDataRoot(dataRoot)
+    await seedVerifiedMarker(target, dataRoot)
     const deps = fakeDeps({
       settingsService: {
         setDataRoot: vi.fn().mockRejectedValue(new Error('disk full')),
@@ -368,6 +402,7 @@ describe('storage IPC handlers', () => {
 
   it('commit-and-relaunch invokes settingsService.setDataRoot as a method, preserving its `this`', async () => {
     initDataRoot(dataRoot)
+    await seedVerifiedMarker(target, dataRoot)
     // Regression: the real settings service is a class whose setDataRoot reads `this.repository`.
     // The commit handler must pass it wrapped, not as a bare reference — otherwise the pointer flip
     // throws on undefined `this` and surfaces to the user as switchoverFailed.
@@ -392,9 +427,9 @@ describe('storage IPC handlers', () => {
     expect(deps.relaunch).toHaveBeenCalledTimes(1)
   })
 
-  it('discard-migrated-copy removes the derived target and leaves settings untouched', async () => {
+  it('discard-migrated-copy removes a marker-confirmed staged copy and leaves settings untouched', async () => {
     initDataRoot(dataRoot)
-    await mkdir(target, { recursive: true })
+    await seedVerifiedMarker(target, dataRoot)
     await mkdir(join(target, 'artifacts'), { recursive: true })
     const deps = fakeDeps()
     registerStorageIpcHandlers(deps)
@@ -404,6 +439,63 @@ describe('storage IPC handlers', () => {
     expect(existsSync(target)).toBe(false)
     expect(deps.settingsService.setDataRoot).not.toHaveBeenCalled()
     expect(deps.relaunch).not.toHaveBeenCalled()
+  })
+
+  it('discard-migrated-copy refuses (leaves the folder) when there is no staging marker', async () => {
+    initDataRoot(dataRoot)
+    // A folder that merely shares the name but was never staged by us must not be deleted.
+    await mkdir(join(target, 'artifacts'), { recursive: true })
+    const deps = fakeDeps()
+    registerStorageIpcHandlers(deps)
+
+    await invoke('storage:discard-migrated-copy', { parent: targetParent })
+
+    expect(existsSync(target)).toBe(true)
+  })
+
+  it('leaves the write-gate pending after a successful copy (blocks writes until commit/discard)', async () => {
+    initDataRoot(dataRoot)
+    registerStorageIpcHandlers(fakeDeps())
+
+    expect(isMigrationPending()).toBe(false)
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
+    // The copy succeeded but nothing is committed yet, so the gate stays up.
+    expect(isMigrationPending()).toBe(true)
+  })
+
+  it('discard lifts the write-gate after a staged copy is thrown away', async () => {
+    initDataRoot(dataRoot)
+    registerStorageIpcHandlers(fakeDeps())
+
+    await invoke('storage:migrate', { parent: targetParent }) // stages a verified copy, gate up
+    expect(isMigrationPending()).toBe(true)
+
+    await invoke('storage:discard-migrated-copy', { parent: targetParent })
+
+    expect(isMigrationPending()).toBe(false)
+  })
+
+  it('commit lifts the write-gate when the switchover fails (app stays usable on the old root)', async () => {
+    initDataRoot(dataRoot)
+    const deps = fakeDeps({
+      settingsService: {
+        setDataRoot: vi.fn().mockRejectedValue(new Error('disk full')),
+        markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
+        dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
+        getStoredSettings: vi.fn().mockResolvedValue({})
+      }
+    })
+    registerStorageIpcHandlers(deps)
+
+    await invoke('storage:migrate', { parent: targetParent }) // stages a verified copy, gate up
+    expect(isMigrationPending()).toBe(true)
+
+    const outcome = (await invoke('storage:commit-and-relaunch', { parent: targetParent })) as {
+      switchoverFailed?: boolean
+    }
+
+    expect(outcome.switchoverFailed).toBe(true)
+    expect(isMigrationPending()).toBe(false)
   })
 
   it('rejects a concurrent migrate call while one is already in flight', async () => {
@@ -455,6 +547,8 @@ describe('storage IPC handlers', () => {
 
     await expect(migratePromise).resolves.toMatchObject({ ok: false, cancelled: true })
     expect(deps.relaunch).not.toHaveBeenCalled()
+    // A cancelled copy leaves the app on the old root, so the write-gate is lifted.
+    expect(isMigrationPending()).toBe(false)
   })
 
   it("validate-data-root returns validateNewDataRoot's ok result for a parent with no OpenScience subdir", async () => {

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -43,7 +43,13 @@ const seedVerifiedMarker = async (targetDir: string, source: string): Promise<vo
     source,
     target: targetDir,
     createdAt: Date.now(),
-    status: 'verified'
+    status: 'verified',
+    inventory: {
+      dirs: [],
+      fileCount: 0,
+      totalBytes: 0,
+      digest: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    }
   })
 }
 
@@ -349,17 +355,17 @@ describe('storage IPC handlers', () => {
     expect(deps.relaunch).not.toHaveBeenCalled()
   })
 
-  it('commit-and-relaunch persists the derived target then relaunches', async () => {
+  it('commit-and-relaunch refuses a verified marker not staged by this process', async () => {
     initDataRoot(dataRoot)
     await seedVerifiedMarker(target, dataRoot)
     const deps = fakeDeps()
     registerStorageIpcHandlers(deps)
 
-    await expect(invoke('storage:commit-and-relaunch', { parent: targetParent })).resolves.toEqual({
-      ok: true
-    })
-    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target)
-    expect(deps.relaunch).toHaveBeenCalledTimes(1)
+    await expect(
+      invoke('storage:commit-and-relaunch', { parent: targetParent })
+    ).resolves.toMatchObject({ ok: false })
+    expect(deps.settingsService.setDataRoot).not.toHaveBeenCalled()
+    expect(deps.relaunch).not.toHaveBeenCalled()
   })
 
   it('commit-and-relaunch returns {ok:false} and does NOT relaunch when no verified copy exists', async () => {
@@ -379,7 +385,6 @@ describe('storage IPC handlers', () => {
 
   it('commit-and-relaunch returns switchoverFailed and does NOT relaunch when setDataRoot throws', async () => {
     initDataRoot(dataRoot)
-    await seedVerifiedMarker(target, dataRoot)
     const deps = fakeDeps({
       settingsService: {
         setDataRoot: vi.fn().mockRejectedValue(new Error('disk full')),
@@ -389,6 +394,7 @@ describe('storage IPC handlers', () => {
       }
     })
     registerStorageIpcHandlers(deps)
+    await invoke('storage:migrate', { parent: targetParent })
 
     const outcome = (await invoke('storage:commit-and-relaunch', { parent: targetParent })) as {
       ok: boolean
@@ -402,7 +408,6 @@ describe('storage IPC handlers', () => {
 
   it('commit-and-relaunch invokes settingsService.setDataRoot as a method, preserving its `this`', async () => {
     initDataRoot(dataRoot)
-    await seedVerifiedMarker(target, dataRoot)
     // Regression: the real settings service is a class whose setDataRoot reads `this.repository`.
     // The commit handler must pass it wrapped, not as a bare reference — otherwise the pointer flip
     // throws on undefined `this` and surfaces to the user as switchoverFailed.
@@ -419,6 +424,7 @@ describe('storage IPC handlers', () => {
     }
     const deps = fakeDeps({ settingsService: new FakeSettingsService() })
     registerStorageIpcHandlers(deps)
+    await invoke('storage:migrate', { parent: targetParent })
 
     await expect(invoke('storage:commit-and-relaunch', { parent: targetParent })).resolves.toEqual({
       ok: true
@@ -429,10 +435,10 @@ describe('storage IPC handlers', () => {
 
   it('discard-migrated-copy removes a marker-confirmed staged copy and leaves settings untouched', async () => {
     initDataRoot(dataRoot)
-    await seedVerifiedMarker(target, dataRoot)
-    await mkdir(join(target, 'artifacts'), { recursive: true })
+    await mkdir(join(dataRoot, 'artifacts'), { recursive: true })
     const deps = fakeDeps()
     registerStorageIpcHandlers(deps)
+    await invoke('storage:migrate', { parent: targetParent })
 
     await invoke('storage:discard-migrated-copy', { parent: targetParent })
 
@@ -453,6 +459,55 @@ describe('storage IPC handlers', () => {
     expect(existsSync(target)).toBe(true)
   })
 
+  it('serializes commit and discard so one resolved migration cannot delete both copies', async () => {
+    initDataRoot(dataRoot)
+    await mkdir(join(dataRoot, 'artifacts'), { recursive: true })
+    await writeFile(join(dataRoot, 'artifacts', 'keep.txt'), 'must survive')
+
+    let releaseSetDataRoot: (() => void) | undefined
+    const deps = fakeDeps({
+      settingsService: {
+        setDataRoot: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              releaseSetDataRoot = resolve
+            })
+        ),
+        markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
+        dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
+        getStoredSettings: vi.fn().mockResolvedValue({})
+      }
+    })
+    registerStorageIpcHandlers(deps)
+    await invoke('storage:migrate', { parent: targetParent })
+
+    const commitPromise = invoke('storage:commit-and-relaunch', { parent: targetParent })
+    await tick()
+    await invoke('storage:discard-migrated-copy', { parent: targetParent })
+    releaseSetDataRoot?.()
+    await commitPromise
+
+    expect(existsSync(join(target, 'artifacts', 'keep.txt'))).toBe(true)
+  })
+
+  it('serializes discard and commit when discard wins the resolution race', async () => {
+    initDataRoot(dataRoot)
+    await mkdir(join(dataRoot, 'artifacts'), { recursive: true })
+    await writeFile(join(dataRoot, 'artifacts', 'keep.txt'), 'must survive')
+    const deps = fakeDeps()
+    registerStorageIpcHandlers(deps)
+    await invoke('storage:migrate', { parent: targetParent })
+
+    const discardPromise = invoke('storage:discard-migrated-copy', { parent: targetParent })
+    const commitOutcome = await invoke('storage:commit-and-relaunch', { parent: targetParent })
+    await discardPromise
+
+    expect(commitOutcome).toEqual({ ok: false, error: 'A migration is already being resolved.' })
+    expect(existsSync(join(dataRoot, 'artifacts', 'keep.txt'))).toBe(true)
+    expect(existsSync(target)).toBe(false)
+    expect(deps.settingsService.setDataRoot).not.toHaveBeenCalled()
+  })
+
   it('leaves the write-gate pending after a successful copy (blocks writes until commit/discard)', async () => {
     initDataRoot(dataRoot)
     registerStorageIpcHandlers(fakeDeps())
@@ -461,6 +516,23 @@ describe('storage IPC handlers', () => {
     await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
     // The copy succeeded but nothing is committed yet, so the gate stays up.
     expect(isMigrationPending()).toBe(true)
+  })
+
+  it('rejects a second migrate while a verified copy is waiting for commit or discard', async () => {
+    initDataRoot(dataRoot)
+    registerStorageIpcHandlers(fakeDeps())
+
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
+    const secondOutcome = await invoke('storage:migrate', { parent: currentParent })
+
+    expect(secondOutcome).toEqual({
+      ok: false,
+      error: 'A completed migration is waiting to be committed or discarded.'
+    })
+    expect(isMigrationPending()).toBe(true)
+
+    await invoke('storage:discard-migrated-copy', { parent: targetParent })
+    expect(existsSync(target)).toBe(false)
   })
 
   it('discard lifts the write-gate after a staged copy is thrown away', async () => {
@@ -527,6 +599,33 @@ describe('storage IPC handlers', () => {
     await expect(first).resolves.toEqual({ ok: true })
   })
 
+  it('rejects commit during copying without clearing the write gate', async () => {
+    initDataRoot(dataRoot)
+    let releaseDisconnect: (() => void) | undefined
+    const deps = fakeDeps({
+      runtime: {
+        disconnect: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              releaseDisconnect = resolve
+            })
+        )
+      }
+    })
+    registerStorageIpcHandlers(deps)
+
+    const migratePromise = invoke('storage:migrate', { parent: targetParent })
+    await tick()
+    const commitOutcome = await invoke('storage:commit-and-relaunch', { parent: targetParent })
+    const pendingAfterCommit = isMigrationPending()
+
+    releaseDisconnect?.()
+    await migratePromise
+
+    expect(commitOutcome).toEqual({ ok: false, error: 'A migration copy is still in progress.' })
+    expect(pendingAfterCommit).toBe(true)
+  })
+
   it('cancel-migrate aborts the in-flight migration, surfacing a cancelled result', async () => {
     initDataRoot(dataRoot)
     let releaseDisconnect: (() => void) | undefined
@@ -550,6 +649,29 @@ describe('storage IPC handlers', () => {
     await expect(migratePromise).resolves.toMatchObject({ ok: false, cancelled: true })
     expect(deps.relaunch).not.toHaveBeenCalled()
     // A cancelled copy leaves the app on the old root, so the write-gate is lifted.
+    expect(isMigrationPending()).toBe(false)
+  })
+
+  it('treats cancel during the verify-to-staged transition as a cancelled migration', async () => {
+    initDataRoot(dataRoot)
+    await mkdir(join(dataRoot, 'artifacts'), { recursive: true })
+    await writeFile(join(dataRoot, 'artifacts', 'keep.txt'), 'content')
+    let cancelled = false
+    const deps = fakeDeps({
+      broadcastProgress: (progress) => {
+        if (!cancelled && progress.phase === 'verify') {
+          cancelled = true
+          void invoke('storage:cancel-migrate')
+        }
+      }
+    })
+    registerStorageIpcHandlers(deps)
+
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toMatchObject({
+      ok: false,
+      cancelled: true
+    })
+    expect(existsSync(target)).toBe(false)
     expect(isMigrationPending()).toBe(false)
   })
 

--- a/src/main/storage/ipc.ts
+++ b/src/main/storage/ipc.ts
@@ -14,6 +14,7 @@ import {
 } from '../storage-root'
 import { detectActiveSessions } from './detect-active'
 import { beginMigration, clearMigrationPending, endMigrationCopy } from './migration-state'
+import { readMigrationMarker } from './migration-marker'
 import {
   classifyDataRoot,
   commitDataRootSwitch,
@@ -63,6 +64,9 @@ const defaultBroadcast = (progress: MigrationProgress): void => {
 // in-flight AbortController is held in this closure so cancel can reach it.
 const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
   let activeMigration: AbortController | undefined
+  // The token + target of the copy THIS session staged (set when a copy verifies, cleared when the
+  // migration resolves). commit/discard require it so a stale renderer call can't act on a foreign copy.
+  let activeStaged: { token: string; target: string } | undefined
 
   ipcMain.handle('storage:get-info', async () => {
     const dataRoot = resolveDataRoot()
@@ -171,15 +175,23 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
             onProgress: (progress) => (deps.broadcastProgress ?? defaultBroadcast)(progress)
           }
         )
-        // A failed/cancelled copy leaves the app on the old root, so clear the write-gate now; only a
-        // successful copy keeps `pending` set (writes stay blocked until commit or discard resolves it).
-        if (!result.ok) clearMigrationPending()
+        if (!result.ok) {
+          // A failed/cancelled copy leaves the app on the old root, so clear the write-gate now.
+          clearMigrationPending()
+          activeStaged = undefined
+        } else {
+          // Capture the staged copy's token so commit/discard can prove they act on THIS session's copy.
+          // The write-gate (`pending`) stays set until commit or discard resolves it.
+          const marker = await readMigrationMarker(dataRootForPicked(request.parent))
+          activeStaged = marker ? { token: marker.token, target: marker.target } : undefined
+        }
         return result
       } catch (err) {
         // runDataRootMigration never rejects; guard the IPC boundary anyway so a renderer call
         // never sees a raw thrown error. Nothing was committed, so lift the write-gate.
         console.error('[storage-ipc] migrate failed unexpectedly', err)
         clearMigrationPending()
+        activeStaged = undefined
         return { ok: false, error: err instanceof Error ? err.message : String(err) }
       } finally {
         activeMigration = undefined
@@ -190,9 +202,14 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
   )
 
   ipcMain.handle('storage:cancel-migrate', () => {
+    // Once a copy has completed (activeStaged set), only commit/discard may resolve it: a late cancel
+    // (renderer still showing Cancel during the copy→done transition) must NOT clear the gate/token and
+    // leave a committable-but-unfrozen copy behind.
+    if (activeStaged) return
     activeMigration?.abort()
     // The aborted copy leaves the app on the old root, so writes may resume immediately.
     clearMigrationPending()
+    activeStaged = undefined
   })
 
   // Discards a completed-but-uncommitted copy at `<parent>/OpenScience` when the user picks "Keep
@@ -203,13 +220,19 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
   ipcMain.handle(
     'storage:discard-migrated-copy',
     async (_event, request: { parent: string }): Promise<void> => {
+      if (activeMigration) {
+        // A copy is still running; discarding would race the writer. Ignore the (stale) request.
+        console.error('[storage-ipc] discard-migrated-copy ignored: a copy is in progress')
+        return
+      }
       try {
         const result = await discardStagedCopy(
-          { currentDataRoot: resolveDataRoot() },
+          { currentDataRoot: resolveDataRoot(), expectedToken: activeStaged?.token },
           request.parent
         )
         if (result.ok) {
           clearMigrationPending()
+          activeStaged = undefined
         } else {
           console.error('[storage-ipc] discard-migrated-copy refused', { error: result.error })
         }
@@ -233,7 +256,9 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
           {
             currentDataRoot: resolveDataRoot(),
             // Arrow-wrapped so setDataRoot is called as a method (it reads `this.repository`).
-            setDataRoot: (path) => deps.settingsService.setDataRoot(path)
+            setDataRoot: (path) => deps.settingsService.setDataRoot(path),
+            // Prove the on-disk copy is the one this session staged (guards against a stale marker).
+            expectedToken: activeStaged?.token
           },
           request.parent
         )
@@ -241,12 +266,14 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         console.error('[storage-ipc] commit-and-relaunch failed unexpectedly', err)
         // The commit didn't complete; keep the app usable on the old root by lifting the write-gate.
         clearMigrationPending()
+        activeStaged = undefined
         return { ok: false, error: err instanceof Error ? err.message : String(err) }
       }
 
       if (outcome.ok) {
         // On success the write-gate stays set through relaunch: the fresh process starts with
         // pending=false, so writes naturally resume against the now-live new root.
+        activeStaged = undefined
         if (deps.relaunch) {
           deps.relaunch()
         } else {
@@ -254,9 +281,18 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
           app.exit(0)
         }
       } else {
-        // No switch happened (no verified copy, mismatch, or switchoverFailed): the app stays on the
-        // old root, so lift the write-gate to keep it usable.
+        // The commit did not switch over (switchoverFailed, or a no-op refusal: no verified copy /
+        // mismatch). The UI's error stage offers no retry, so never leave the app soft-locked: on a
+        // switchover failure discard the now-orphan staged copy (best-effort), then lift the write-gate
+        // in every case. The old root is untouched and immediately usable.
+        if ('switchoverFailed' in outcome) {
+          await discardStagedCopy(
+            { currentDataRoot: resolveDataRoot(), expectedToken: activeStaged?.token },
+            request.parent
+          ).catch(() => undefined)
+        }
         clearMigrationPending()
+        activeStaged = undefined
       }
       return outcome
     }

--- a/src/main/storage/ipc.ts
+++ b/src/main/storage/ipc.ts
@@ -1,5 +1,4 @@
 import { existsSync } from 'node:fs'
-import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { app, BrowserWindow, dialog, ipcMain } from 'electron'
@@ -14,10 +13,11 @@ import {
   samePath
 } from '../storage-root'
 import { detectActiveSessions } from './detect-active'
-import { beginMigration, endMigration } from './migration-state'
+import { beginMigration, clearMigrationPending, endMigrationCopy } from './migration-state'
 import {
   classifyDataRoot,
   commitDataRootSwitch,
+  discardStagedCopy,
   runDataRootMigration,
   validateNewDataRoot,
   type ValidateResult
@@ -152,13 +152,14 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
 
       const controller = new AbortController()
       activeMigration = controller
-      // Flag the copy so the before-quit guard (app lifecycle) can warn on Cmd+Q mid-copy.
+      // Flag the copy: sets both the quit guard (Cmd+Q warning) and the write-gate (blocks ACP/notebook
+      // writes to the old root for the whole copy→commit window).
       beginMigration()
       try {
         // Phase 1 only: copy+verify into the new root. Nothing is committed (no setDataRoot, no
         // delete) — the old root and settings.dataRoot stay intact, so this is fully reversible.
         // Commit happens later, on the user's "Restart now" (storage:commit-and-relaunch).
-        return await runDataRootMigration(
+        const result = await runDataRootMigration(
           {
             currentDataRoot: resolveDataRoot(),
             runtime: deps.runtime,
@@ -170,31 +171,48 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
             onProgress: (progress) => (deps.broadcastProgress ?? defaultBroadcast)(progress)
           }
         )
+        // A failed/cancelled copy leaves the app on the old root, so clear the write-gate now; only a
+        // successful copy keeps `pending` set (writes stay blocked until commit or discard resolves it).
+        if (!result.ok) clearMigrationPending()
+        return result
       } catch (err) {
         // runDataRootMigration never rejects; guard the IPC boundary anyway so a renderer call
-        // never sees a raw thrown error.
+        // never sees a raw thrown error. Nothing was committed, so lift the write-gate.
         console.error('[storage-ipc] migrate failed unexpectedly', err)
+        clearMigrationPending()
         return { ok: false, error: err instanceof Error ? err.message : String(err) }
       } finally {
         activeMigration = undefined
-        endMigration()
+        // Relax the quit guard now the copy is done; `pending` (write-gate) persists on success.
+        endMigrationCopy()
       }
     }
   )
 
   ipcMain.handle('storage:cancel-migrate', () => {
     activeMigration?.abort()
+    // The aborted copy leaves the app on the old root, so writes may resume immediately.
+    clearMigrationPending()
   })
 
   // Discards a completed-but-uncommitted copy at `<parent>/OpenScience` when the user picks "Keep
   // current location" on the done stage. Since the copy phase never touched settings.dataRoot or the
-  // old root, this just removes the new copy and leaves the app on its current root. Never throws.
+  // old root, this just removes the new copy and leaves the app on its current root. discardStagedCopy
+  // refuses anything that isn't a marker-confirmed staging copy for the current root, so a misrouted
+  // parent can't delete live data. On a successful discard the write-gate is lifted. Never throws.
   ipcMain.handle(
     'storage:discard-migrated-copy',
     async (_event, request: { parent: string }): Promise<void> => {
-      const target = dataRootForPicked(request.parent)
       try {
-        await rm(target, { recursive: true, force: true })
+        const result = await discardStagedCopy(
+          { currentDataRoot: resolveDataRoot() },
+          request.parent
+        )
+        if (result.ok) {
+          clearMigrationPending()
+        } else {
+          console.error('[storage-ipc] discard-migrated-copy refused', { error: result.error })
+        }
       } catch (err) {
         console.error('[storage-ipc] discard-migrated-copy failed', err)
       }
@@ -221,16 +239,24 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         )
       } catch (err) {
         console.error('[storage-ipc] commit-and-relaunch failed unexpectedly', err)
+        // The commit didn't complete; keep the app usable on the old root by lifting the write-gate.
+        clearMigrationPending()
         return { ok: false, error: err instanceof Error ? err.message : String(err) }
       }
 
       if (outcome.ok) {
+        // On success the write-gate stays set through relaunch: the fresh process starts with
+        // pending=false, so writes naturally resume against the now-live new root.
         if (deps.relaunch) {
           deps.relaunch()
         } else {
           app.relaunch()
           app.exit(0)
         }
+      } else {
+        // No switch happened (no verified copy, mismatch, or switchoverFailed): the app stays on the
+        // old root, so lift the write-gate to keep it usable.
+        clearMigrationPending()
       }
       return outcome
     }

--- a/src/main/storage/ipc.ts
+++ b/src/main/storage/ipc.ts
@@ -14,7 +14,6 @@ import {
 } from '../storage-root'
 import { detectActiveSessions } from './detect-active'
 import { beginMigration, clearMigrationPending, endMigrationCopy } from './migration-state'
-import { readMigrationMarker } from './migration-marker'
 import {
   classifyDataRoot,
   commitDataRootSwitch,
@@ -67,6 +66,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
   // The token + target of the copy THIS session staged (set when a copy verifies, cleared when the
   // migration resolves). commit/discard require it so a stale renderer call can't act on a foreign copy.
   let activeStaged: { token: string; target: string } | undefined
+  let resolutionInProgress = false
 
   ipcMain.handle('storage:get-info', async () => {
     const dataRoot = resolveDataRoot()
@@ -150,6 +150,12 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
   ipcMain.handle(
     'storage:migrate',
     async (_event, request: { parent: string }): Promise<MigrationOutcome> => {
+      if (activeStaged || resolutionInProgress) {
+        return {
+          ok: false,
+          error: 'A completed migration is waiting to be committed or discarded.'
+        }
+      }
       if (activeMigration) {
         return { ok: false, error: 'A migration is already in progress.' }
       }
@@ -172,18 +178,16 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
           request.parent,
           {
             signal: controller.signal,
-            onProgress: (progress) => (deps.broadcastProgress ?? defaultBroadcast)(progress)
+            onProgress: (progress) => (deps.broadcastProgress ?? defaultBroadcast)(progress),
+            onVerified: (staged) => {
+              activeStaged = staged
+            }
           }
         )
         if (!result.ok) {
           // A failed/cancelled copy leaves the app on the old root, so clear the write-gate now.
           clearMigrationPending()
           activeStaged = undefined
-        } else {
-          // Capture the staged copy's token so commit/discard can prove they act on THIS session's copy.
-          // The write-gate (`pending`) stays set until commit or discard resolves it.
-          const marker = await readMigrationMarker(dataRootForPicked(request.parent))
-          activeStaged = marker ? { token: marker.token, target: marker.target } : undefined
         }
         return result
       } catch (err) {
@@ -207,9 +211,6 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
     // leave a committable-but-unfrozen copy behind.
     if (activeStaged) return
     activeMigration?.abort()
-    // The aborted copy leaves the app on the old root, so writes may resume immediately.
-    clearMigrationPending()
-    activeStaged = undefined
   })
 
   // Discards a completed-but-uncommitted copy at `<parent>/OpenScience` when the user picks "Keep
@@ -220,14 +221,20 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
   ipcMain.handle(
     'storage:discard-migrated-copy',
     async (_event, request: { parent: string }): Promise<void> => {
-      if (activeMigration) {
+      if (activeMigration || resolutionInProgress) {
         // A copy is still running; discarding would race the writer. Ignore the (stale) request.
         console.error('[storage-ipc] discard-migrated-copy ignored: a copy is in progress')
         return
       }
+      if (!activeStaged || !samePath(activeStaged.target, dataRootForPicked(request.parent))) {
+        console.error('[storage-ipc] discard-migrated-copy ignored: no matching staged copy')
+        return
+      }
+      const staged = activeStaged
+      resolutionInProgress = true
       try {
         const result = await discardStagedCopy(
-          { currentDataRoot: resolveDataRoot(), expectedToken: activeStaged?.token },
+          { currentDataRoot: resolveDataRoot(), expectedToken: staged.token },
           request.parent
         )
         if (result.ok) {
@@ -238,6 +245,8 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         }
       } catch (err) {
         console.error('[storage-ipc] discard-migrated-copy failed', err)
+      } finally {
+        resolutionInProgress = false
       }
     }
   )
@@ -250,6 +259,17 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
   ipcMain.handle(
     'storage:commit-and-relaunch',
     async (_event, request: { parent: string }): Promise<MigrationOutcome> => {
+      if (activeMigration) {
+        return { ok: false, error: 'A migration copy is still in progress.' }
+      }
+      if (!activeStaged || !samePath(activeStaged.target, dataRootForPicked(request.parent))) {
+        return { ok: false, error: 'No completed migration from this app session was found.' }
+      }
+      if (resolutionInProgress) {
+        return { ok: false, error: 'A migration is already being resolved.' }
+      }
+      const staged = activeStaged
+      resolutionInProgress = true
       let outcome: MigrationOutcome
       try {
         outcome = await commitDataRootSwitch(
@@ -258,7 +278,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
             // Arrow-wrapped so setDataRoot is called as a method (it reads `this.repository`).
             setDataRoot: (path) => deps.settingsService.setDataRoot(path),
             // Prove the on-disk copy is the one this session staged (guards against a stale marker).
-            expectedToken: activeStaged?.token
+            expectedToken: staged.token
           },
           request.parent
         )
@@ -267,6 +287,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         // The commit didn't complete; keep the app usable on the old root by lifting the write-gate.
         clearMigrationPending()
         activeStaged = undefined
+        resolutionInProgress = false
         return { ok: false, error: err instanceof Error ? err.message : String(err) }
       }
 
@@ -287,12 +308,13 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         // in every case. The old root is untouched and immediately usable.
         if ('switchoverFailed' in outcome) {
           await discardStagedCopy(
-            { currentDataRoot: resolveDataRoot(), expectedToken: activeStaged?.token },
+            { currentDataRoot: resolveDataRoot(), expectedToken: staged.token },
             request.parent
           ).catch(() => undefined)
         }
         clearMigrationPending()
         activeStaged = undefined
+        resolutionInProgress = false
       }
       return outcome
     }

--- a/src/main/storage/migration-marker.test.ts
+++ b/src/main/storage/migration-marker.test.ts
@@ -1,0 +1,115 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  MIGRATION_MARKER_FILENAME,
+  hasPendingMigrationMarker,
+  newToken,
+  readMigrationMarker,
+  removeMigrationMarker,
+  scanInventory,
+  writeMigrationMarker,
+  type MigrationMarker
+} from './migration-marker'
+
+let root: string
+
+const sampleMarker = (overrides: Partial<MigrationMarker> = {}): MigrationMarker => ({
+  version: 1,
+  token: 'tok-123',
+  source: '/old/OpenScience',
+  target: '/new/OpenScience',
+  createdAt: 1_700_000_000_000,
+  status: 'copying',
+  ...overrides
+})
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'ds-migration-marker-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('migration-marker read/write/remove', () => {
+  it('round-trips a written marker', async () => {
+    const marker = sampleMarker({
+      status: 'verified',
+      inventory: { dirs: ['artifacts'], fileCount: 2, totalBytes: 10 }
+    })
+    await writeMigrationMarker(root, marker)
+
+    expect(await readMigrationMarker(root)).toEqual(marker)
+  })
+
+  it('hasPendingMigrationMarker reflects the marker file presence', async () => {
+    expect(hasPendingMigrationMarker(root)).toBe(false)
+    await writeMigrationMarker(root, sampleMarker())
+    expect(hasPendingMigrationMarker(root)).toBe(true)
+    await removeMigrationMarker(root)
+    expect(hasPendingMigrationMarker(root)).toBe(false)
+  })
+
+  it('returns null when the marker file is missing', async () => {
+    expect(await readMigrationMarker(root)).toBeNull()
+  })
+
+  it('returns null on corrupt / non-JSON marker content', async () => {
+    await writeFile(join(root, MIGRATION_MARKER_FILENAME), 'not json {')
+    expect(await readMigrationMarker(root)).toBeNull()
+  })
+
+  it('returns null when required fields are missing (short/partial JSON)', async () => {
+    await writeFile(join(root, MIGRATION_MARKER_FILENAME), JSON.stringify({ version: 1 }))
+    expect(await readMigrationMarker(root)).toBeNull()
+  })
+
+  it('removeMigrationMarker is idempotent (no throw when absent)', async () => {
+    await expect(removeMigrationMarker(root)).resolves.toBeUndefined()
+    await writeMigrationMarker(root, sampleMarker())
+    await expect(removeMigrationMarker(root)).resolves.toBeUndefined()
+    await expect(removeMigrationMarker(root)).resolves.toBeUndefined()
+  })
+
+  it('newToken produces distinct values', () => {
+    expect(newToken()).not.toBe(newToken())
+  })
+})
+
+describe('scanInventory', () => {
+  it('counts files and bytes across present dirs, listing only those that exist', async () => {
+    await mkdir(join(root, 'artifacts', 'nested'), { recursive: true })
+    await writeFile(join(root, 'artifacts', 'a.txt'), 'hello') // 5 bytes
+    await writeFile(join(root, 'artifacts', 'nested', 'b.txt'), 'xyz') // 3 bytes
+    await mkdir(join(root, 'notebooks'), { recursive: true })
+    await writeFile(join(root, 'notebooks', 'c.txt'), 'ab') // 2 bytes
+    // uploads is absent on purpose
+
+    const inventory = await scanInventory(root, ['artifacts', 'notebooks', 'uploads'])
+
+    expect(inventory.fileCount).toBe(3)
+    expect(inventory.totalBytes).toBe(10)
+    expect(inventory.dirs.sort()).toEqual(['artifacts', 'notebooks'])
+  })
+
+  it('reports an empty tally when no dirs exist', async () => {
+    expect(await scanInventory(root, ['artifacts', 'uploads'])).toEqual({
+      dirs: [],
+      fileCount: 0,
+      totalBytes: 0
+    })
+  })
+
+  it('counts an existing-but-empty dir as present with zero files', async () => {
+    await mkdir(join(root, 'artifacts'), { recursive: true })
+
+    expect(await scanInventory(root, ['artifacts'])).toEqual({
+      dirs: ['artifacts'],
+      fileCount: 0,
+      totalBytes: 0
+    })
+  })
+})

--- a/src/main/storage/migration-marker.test.ts
+++ b/src/main/storage/migration-marker.test.ts
@@ -38,7 +38,12 @@ describe('migration-marker read/write/remove', () => {
   it('round-trips a written marker', async () => {
     const marker = sampleMarker({
       status: 'verified',
-      inventory: { dirs: ['artifacts'], fileCount: 2, totalBytes: 10 }
+      inventory: {
+        dirs: ['artifacts'],
+        fileCount: 2,
+        totalBytes: 10,
+        digest: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      }
     })
     await writeMigrationMarker(root, marker)
 
@@ -64,6 +69,15 @@ describe('migration-marker read/write/remove', () => {
 
   it('returns null when required fields are missing (short/partial JSON)', async () => {
     await writeFile(join(root, MIGRATION_MARKER_FILENAME), JSON.stringify({ version: 1 }))
+    expect(await readMigrationMarker(root)).toBeNull()
+  })
+
+  it('returns null when a verified marker has a malformed inventory', async () => {
+    await writeFile(
+      join(root, MIGRATION_MARKER_FILENAME),
+      JSON.stringify({ ...sampleMarker({ status: 'verified' }), inventory: { fileCount: -1 } })
+    )
+
     expect(await readMigrationMarker(root)).toBeNull()
   })
 
@@ -93,20 +107,22 @@ describe('scanInventory', () => {
     expect(inventory.fileCount).toBe(3)
     expect(inventory.totalBytes).toBe(10)
     expect(inventory.dirs.sort()).toEqual(['artifacts', 'notebooks'])
+    expect(inventory.digest).toMatch(/^[a-f0-9]{64}$/)
   })
 
   it('reports an empty tally when no dirs exist', async () => {
     expect(await scanInventory(root, ['artifacts', 'uploads'])).toEqual({
       dirs: [],
       fileCount: 0,
-      totalBytes: 0
+      totalBytes: 0,
+      digest: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
     })
   })
 
   it('counts an existing-but-empty dir as present with zero files', async () => {
     await mkdir(join(root, 'artifacts'), { recursive: true })
 
-    expect(await scanInventory(root, ['artifacts'])).toEqual({
+    expect(await scanInventory(root, ['artifacts'])).toMatchObject({
       dirs: ['artifacts'],
       fileCount: 0,
       totalBytes: 0

--- a/src/main/storage/migration-marker.ts
+++ b/src/main/storage/migration-marker.ts
@@ -1,0 +1,104 @@
+import { existsSync, type Dirent } from 'node:fs'
+import { readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { join } from 'node:path'
+
+// Sentinel file dropped INTO a staging data root while a migration copy is in flight. Its presence
+// means "this OpenScience folder is a half-baked/uncommitted staging copy, not the live data root",
+// which both computeDefaultDataRoot (ignore it when picking the default) and the commit/discard gates
+// key off. Kept in a standalone module that imports ONLY node builtins so storage-root's pure getter
+// can call hasPendingMigrationMarker without pulling in electron or migration-service (import cycle).
+export const MIGRATION_MARKER_FILENAME = '.open-science-migration.json'
+
+export type MigrationMarker = {
+  version: 1
+  token: string
+  source: string
+  target: string
+  createdAt: number
+  status: 'copying' | 'verified'
+  inventory?: { dirs: string[]; fileCount: number; totalBytes: number }
+}
+
+// Sync existence check so storage-root's synchronous computeDefaultDataRoot can consult it directly.
+export const hasPendingMigrationMarker = (root: string): boolean =>
+  existsSync(join(root, MIGRATION_MARKER_FILENAME))
+
+// Reads and validates the marker, returning null on a missing, unreadable, corrupt, or structurally
+// incomplete file (missing token/source/target) so callers can treat "no trustworthy marker" uniformly.
+export const readMigrationMarker = async (root: string): Promise<MigrationMarker | null> => {
+  try {
+    const raw = await readFile(join(root, MIGRATION_MARKER_FILENAME), 'utf8')
+    const parsed = JSON.parse(raw) as Partial<MigrationMarker>
+    if (
+      !parsed ||
+      typeof parsed.token !== 'string' ||
+      typeof parsed.source !== 'string' ||
+      typeof parsed.target !== 'string'
+    ) {
+      return null
+    }
+    return parsed as MigrationMarker
+  } catch {
+    return null
+  }
+}
+
+// Writes the marker as pretty-printed JSON (overwrites any prior marker).
+export const writeMigrationMarker = async (
+  root: string,
+  marker: MigrationMarker
+): Promise<void> => {
+  await writeFile(join(root, MIGRATION_MARKER_FILENAME), JSON.stringify(marker, null, 2))
+}
+
+// Removes the marker; idempotent (force:true swallows ENOENT), so committing a marker-free root is fine.
+export const removeMigrationMarker = async (root: string): Promise<void> => {
+  await rm(join(root, MIGRATION_MARKER_FILENAME), { force: true })
+}
+
+// Fresh migration token, used to tie a staged copy to the source/target pair that created it.
+export const newToken = (): string => randomUUID()
+
+// Recursively counts files and bytes under each of `dirs` beneath `root`, returning the subset of dirs
+// that actually exist. Missing dirs and stat failures are skipped rather than thrown, so a partial
+// tree still yields a usable tally. Kept here (node-only) so migration-service can record what it
+// staged without importing the copy engine in data-migration.ts.
+export const scanInventory = async (
+  root: string,
+  dirs: string[]
+): Promise<{ dirs: string[]; fileCount: number; totalBytes: number }> => {
+  const presentDirs: string[] = []
+  let fileCount = 0
+  let totalBytes = 0
+
+  for (const dir of dirs) {
+    let present = false
+    const walk = async (current: string): Promise<void> => {
+      let entries: Dirent[]
+      try {
+        entries = await readdir(current, { withFileTypes: true })
+      } catch {
+        return
+      }
+      present = true
+      for (const entry of entries) {
+        const full = join(current, entry.name)
+        if (entry.isDirectory()) {
+          await walk(full)
+        } else if (entry.isFile()) {
+          fileCount += 1
+          try {
+            totalBytes += (await stat(full)).size
+          } catch {
+            // A file that vanished mid-scan contributes nothing rather than aborting the tally.
+          }
+        }
+      }
+    }
+    await walk(join(root, dir))
+    if (present) presentDirs.push(dir)
+  }
+
+  return { dirs: presentDirs, fileCount, totalBytes }
+}

--- a/src/main/storage/migration-marker.ts
+++ b/src/main/storage/migration-marker.ts
@@ -1,7 +1,7 @@
-import { existsSync, type Dirent } from 'node:fs'
-import { readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
-import { randomUUID } from 'node:crypto'
-import { join } from 'node:path'
+import { createReadStream, existsSync, type Dirent } from 'node:fs'
+import { lstat, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { createHash, randomUUID } from 'node:crypto'
+import { join, relative } from 'node:path'
 
 // Sentinel file dropped INTO a staging data root while a migration copy is in flight. Its presence
 // means "this OpenScience folder is a half-baked/uncommitted staging copy, not the live data root",
@@ -17,7 +17,22 @@ export type MigrationMarker = {
   target: string
   createdAt: number
   status: 'copying' | 'verified'
-  inventory?: { dirs: string[]; fileCount: number; totalBytes: number }
+  inventory?: { dirs: string[]; fileCount: number; totalBytes: number; digest: string }
+}
+
+const isInventory = (value: unknown): value is NonNullable<MigrationMarker['inventory']> => {
+  if (!value || typeof value !== 'object') return false
+  const inventory = value as Record<string, unknown>
+  return (
+    Array.isArray(inventory.dirs) &&
+    inventory.dirs.every((dir) => typeof dir === 'string') &&
+    Number.isSafeInteger(inventory.fileCount) &&
+    (inventory.fileCount as number) >= 0 &&
+    Number.isSafeInteger(inventory.totalBytes) &&
+    (inventory.totalBytes as number) >= 0 &&
+    typeof inventory.digest === 'string' &&
+    /^[a-f0-9]{64}$/.test(inventory.digest)
+  )
 }
 
 // Sync existence check so storage-root's synchronous computeDefaultDataRoot can consult it directly.
@@ -32,9 +47,14 @@ export const readMigrationMarker = async (root: string): Promise<MigrationMarker
     const parsed = JSON.parse(raw) as Partial<MigrationMarker>
     if (
       !parsed ||
+      parsed.version !== 1 ||
       typeof parsed.token !== 'string' ||
       typeof parsed.source !== 'string' ||
-      typeof parsed.target !== 'string'
+      typeof parsed.target !== 'string' ||
+      typeof parsed.createdAt !== 'number' ||
+      !Number.isFinite(parsed.createdAt) ||
+      (parsed.status !== 'copying' && parsed.status !== 'verified') ||
+      (parsed.inventory !== undefined && !isInventory(parsed.inventory))
     ) {
       return null
     }
@@ -61,44 +81,57 @@ export const removeMigrationMarker = async (root: string): Promise<void> => {
 export const newToken = (): string => randomUUID()
 
 // Recursively counts files and bytes under each of `dirs` beneath `root`, returning the subset of dirs
-// that actually exist. Missing dirs and stat failures are skipped rather than thrown, so a partial
-// tree still yields a usable tally. Kept here (node-only) so migration-service can record what it
-// staged without importing the copy engine in data-migration.ts.
+// that actually exist. A missing top-level dir is valid, but errors or unsupported entries inside a
+// present dir abort the scan so commit can never accept a partial tally as proof of equivalence.
 export const scanInventory = async (
   root: string,
   dirs: string[]
-): Promise<{ dirs: string[]; fileCount: number; totalBytes: number }> => {
+): Promise<{ dirs: string[]; fileCount: number; totalBytes: number; digest: string }> => {
   const presentDirs: string[] = []
   let fileCount = 0
   let totalBytes = 0
+  const inventoryHash = createHash('sha256')
 
   for (const dir of dirs) {
-    let present = false
+    const topLevel = join(root, dir)
+    let topLevelInfo
+    try {
+      topLevelInfo = await lstat(topLevel)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue
+      throw err
+    }
+    if (!topLevelInfo.isDirectory()) {
+      throw new Error(`Unsupported inventory entry: ${dir}`)
+    }
+    presentDirs.push(dir)
+    inventoryHash.update(JSON.stringify(['dir', dir]))
+
     const walk = async (current: string): Promise<void> => {
-      let entries: Dirent[]
-      try {
-        entries = await readdir(current, { withFileTypes: true })
-      } catch {
-        return
-      }
-      present = true
+      const entries: Dirent[] = (await readdir(current, { withFileTypes: true })).sort(
+        (left, right) => left.name.localeCompare(right.name)
+      )
       for (const entry of entries) {
         const full = join(current, entry.name)
         if (entry.isDirectory()) {
+          inventoryHash.update(JSON.stringify(['nested-dir', relative(root, full)]))
           await walk(full)
         } else if (entry.isFile()) {
+          const info = await stat(full)
+          const fileHash = createHash('sha256')
+          for await (const chunk of createReadStream(full)) fileHash.update(chunk as Buffer)
           fileCount += 1
-          try {
-            totalBytes += (await stat(full)).size
-          } catch {
-            // A file that vanished mid-scan contributes nothing rather than aborting the tally.
-          }
+          totalBytes += info.size
+          inventoryHash.update(
+            JSON.stringify(['file', relative(root, full), info.size, fileHash.digest('hex')])
+          )
+        } else {
+          throw new Error(`Unsupported inventory entry: ${full}`)
         }
       }
     }
-    await walk(join(root, dir))
-    if (present) presentDirs.push(dir)
+    await walk(topLevel)
   }
 
-  return { dirs: presentDirs, fileCount, totalBytes }
+  return { dirs: presentDirs, fileCount, totalBytes, digest: inventoryHash.digest('hex') }
 }

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -24,9 +24,11 @@ import {
 import {
   MIGRATION_MARKER_FILENAME,
   readMigrationMarker,
+  scanInventory,
   writeMigrationMarker,
   type MigrationMarker
 } from './migration-marker'
+import { withDataRootWrite } from './migration-state'
 
 // Writes a verified staging marker for `<parent>/OpenScience`, as a completed copy phase would have.
 const seedVerifiedMarker = async (
@@ -36,6 +38,7 @@ const seedVerifiedMarker = async (
 ): Promise<string> => {
   const target = dataRootFor(parent)
   await mkdir(target, { recursive: true })
+  const inventory = await scanInventory(source, [...MIGRATED_DIRS])
   await writeMigrationMarker(target, {
     version: 1,
     token: 'tok-test',
@@ -43,6 +46,7 @@ const seedVerifiedMarker = async (
     target,
     createdAt: Date.now(),
     status: 'verified',
+    inventory,
     ...overrides
   })
   return target
@@ -429,6 +433,42 @@ describe('runDataRootMigration (copy phase)', () => {
     expect(deps.setDataRoot).not.toHaveBeenCalled()
   })
 
+  it('waits for data-root writers that were already active before starting the copy', async () => {
+    let releaseWrite: (() => void) | undefined
+    const activeWrite = withDataRootWrite(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseWrite = resolve
+        })
+    )
+    const deps = fakeDeps()
+    let reportCopyStarted: (() => void) | undefined
+    const copyStarted = new Promise<void>((resolve) => {
+      reportCopyStarted = resolve
+    })
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => {
+      reportCopyStarted?.()
+      return { ok: true }
+    })
+
+    const migrationPromise = runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify },
+      emptyParent,
+      runOpts()
+    )
+    const startedBeforeDrain = await Promise.race([
+      copyStarted.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 100))
+    ])
+    expect(startedBeforeDrain).toBe(false)
+    expect(copyAndVerify).not.toHaveBeenCalled()
+
+    releaseWrite?.()
+    await activeWrite
+    await migrationPromise
+    expect(copyAndVerify).toHaveBeenCalledTimes(1)
+  })
+
   it('returns the copy failure untouched', async () => {
     const deps = fakeDeps()
     const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: false, error: 'x' }))
@@ -468,7 +508,12 @@ describe('runDataRootMigration (copy phase)', () => {
       version: 1
     })
     // The verified marker records the staged inventory (empty here since the fake copy wrote nothing).
-    expect(finalMarker?.inventory).toEqual({ dirs: [], fileCount: 0, totalBytes: 0 })
+    expect(finalMarker?.inventory).toEqual({
+      dirs: [],
+      fileCount: 0,
+      totalBytes: 0,
+      digest: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    })
   })
 
   it('removes the marker and cleans up the empty target on copy failure/cancel', async () => {
@@ -544,7 +589,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
     })
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
       emptyParent
     )
 
@@ -564,7 +609,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
       emptyParent
     )
 
@@ -579,7 +624,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
       emptyParent
     )
 
@@ -594,7 +639,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
       emptyParent
     )
 
@@ -614,7 +659,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
       emptyParent
     )
 
@@ -632,7 +677,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
       emptyParent
     )
 
@@ -655,7 +700,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
     }))
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
       emptyParent
     )
 
@@ -673,13 +718,92 @@ describe('commitDataRootSwitch (commit phase)', () => {
     expect(result.ok).toBe(false)
     expect(setDataRoot).not.toHaveBeenCalled()
   })
+
+  it('refuses commit when the current migration session token is missing', async () => {
+    await seedVerifiedMarker(emptyParent, currentDataRoot)
+    const setDataRoot = vi.fn(async () => {})
+
+    const result = await commitDataRootSwitch(
+      {
+        currentDataRoot,
+        setDataRoot,
+        expectedToken: undefined as unknown as string
+      },
+      emptyParent
+    )
+
+    expect(result.ok).toBe(false)
+    expect(setDataRoot).not.toHaveBeenCalled()
+  })
+
+  it('refuses commit when the verified target inventory has changed', async () => {
+    await mkdir(join(currentDataRoot, 'artifacts'), { recursive: true })
+    await writeFile(join(currentDataRoot, 'artifacts', 'keep.txt'), 'hello')
+    const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
+    await mkdir(join(target, 'artifacts'), { recursive: true })
+    await writeFile(join(target, 'artifacts', 'keep.txt'), 'hello')
+    await writeFile(join(target, 'artifacts', 'keep.txt'), 'jello')
+    const setDataRoot = vi.fn(async () => {})
+    const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({
+      deleted: [...MIGRATED_DIRS],
+      failed: []
+    }))
+
+    const result = await commitDataRootSwitch(
+      {
+        currentDataRoot,
+        setDataRoot,
+        deleteSources,
+        expectedToken: 'tok-test'
+      },
+      emptyParent
+    )
+
+    expect(result.ok).toBe(false)
+    expect(setDataRoot).not.toHaveBeenCalled()
+    expect(deleteSources).not.toHaveBeenCalled()
+  })
+
+  it('refuses commit when the source inventory has changed after verification', async () => {
+    await mkdir(join(currentDataRoot, 'artifacts'), { recursive: true })
+    await writeFile(join(currentDataRoot, 'artifacts', 'keep.txt'), 'hello')
+    const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
+    await mkdir(join(target, 'artifacts'), { recursive: true })
+    await writeFile(join(target, 'artifacts', 'keep.txt'), 'hello')
+    await writeFile(join(currentDataRoot, 'artifacts', 'late.txt'), 'late write')
+    const setDataRoot = vi.fn(async () => {})
+    const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({
+      deleted: [...MIGRATED_DIRS],
+      failed: []
+    }))
+
+    const result = await commitDataRootSwitch(
+      {
+        currentDataRoot,
+        setDataRoot,
+        deleteSources,
+        expectedToken: 'tok-test'
+      },
+      emptyParent
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'The staged copy changed after verification. Run the move again.'
+    })
+    expect(setDataRoot).not.toHaveBeenCalled()
+    expect(deleteSources).not.toHaveBeenCalled()
+  })
 })
 
 describe('discardStagedCopy', () => {
   it('deletes a marker-confirmed staged copy for the current root', async () => {
     const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
 
-    const result = await discardStagedCopy({ currentDataRoot }, emptyParent)
+    const result = await discardStagedCopy(
+      { currentDataRoot, expectedToken: 'tok-test' },
+      emptyParent
+    )
 
     expect(result).toEqual({ ok: true })
     expect(existsSync(target)).toBe(false)
@@ -687,7 +811,10 @@ describe('discardStagedCopy', () => {
 
   it('refuses (and deletes nothing) when the derived target is the current data location', async () => {
     // Deriving from currentParent yields currentDataRoot itself.
-    const result = await discardStagedCopy({ currentDataRoot }, currentParent)
+    const result = await discardStagedCopy(
+      { currentDataRoot, expectedToken: 'tok-test' },
+      currentParent
+    )
 
     expect(result).toEqual({ ok: false, error: 'Refused: target is the current data location.' })
     expect(existsSync(currentDataRoot)).toBe(true)
@@ -697,7 +824,10 @@ describe('discardStagedCopy', () => {
     const target = dataRootFor(emptyParent)
     await mkdir(target, { recursive: true })
 
-    const result = await discardStagedCopy({ currentDataRoot }, emptyParent)
+    const result = await discardStagedCopy(
+      { currentDataRoot, expectedToken: 'tok-test' },
+      emptyParent
+    )
 
     expect(result).toEqual({ ok: false, error: 'Refused: not a completed, matching staged copy.' })
     expect(existsSync(target)).toBe(true)
@@ -706,7 +836,10 @@ describe('discardStagedCopy', () => {
   it('refuses when the marker was staged against a different source', async () => {
     const target = await seedVerifiedMarker(emptyParent, '/some/other/OpenScience')
 
-    const result = await discardStagedCopy({ currentDataRoot }, emptyParent)
+    const result = await discardStagedCopy(
+      { currentDataRoot, expectedToken: 'tok-test' },
+      emptyParent
+    )
 
     expect(result).toEqual({ ok: false, error: 'Refused: not a completed, matching staged copy.' })
     expect(existsSync(target)).toBe(true)
@@ -715,7 +848,10 @@ describe('discardStagedCopy', () => {
   it('refuses a mid-copy ("copying") marker so a dir being written is never deleted', async () => {
     const target = await seedVerifiedMarker(emptyParent, currentDataRoot, { status: 'copying' })
 
-    const result = await discardStagedCopy({ currentDataRoot }, emptyParent)
+    const result = await discardStagedCopy(
+      { currentDataRoot, expectedToken: 'tok-test' },
+      emptyParent
+    )
 
     expect(result).toEqual({ ok: false, error: 'Refused: not a completed, matching staged copy.' })
     expect(existsSync(target)).toBe(true)

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -307,6 +307,16 @@ describe('classifyDataRoot', () => {
       error: 'A different folder named OpenScience already exists here. Choose another location.'
     })
   })
+  it('rejects a marker-bearing staging dir as invalid, even when it already holds data', async () => {
+    // A crashed/uncommitted copy carries a marker and may hold a partial data dir; it must never
+    // classify 'adopt' (bypassing the commit gate) — the user must finish or discard the move first.
+    const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
+    await mkdir(join(target, 'artifacts'), { recursive: true })
+
+    const result = await classifyDataRoot(emptyParent, currentDataRoot)
+
+    expect(result.kind).toBe('invalid')
+  })
 })
 
 describe('validateNewDataRoot', () => {
@@ -501,10 +511,9 @@ describe('runDataRootMigration (copy phase)', () => {
     expect(copyAndVerify).not.toHaveBeenCalled()
   })
 
-  it('swallows an interrupt failure and still completes the copy', async () => {
+  it('aborts (and does not copy) when a writer cannot be paused', async () => {
     const deps = fakeDeps()
     deps.runtime.disconnect.mockRejectedValue(new Error('disconnect boom'))
-    deps.notebook.shutdownAll.mockRejectedValue(new Error('shutdown boom'))
     const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
 
     const result = await runDataRootMigration(
@@ -513,8 +522,11 @@ describe('runDataRootMigration (copy phase)', () => {
       runOpts()
     )
 
-    expect(result).toEqual({ ok: true })
-    expect(copyAndVerify).toHaveBeenCalledTimes(1)
+    expect(result.ok).toBe(false)
+    // Copying an unfrozen tree could lose a surviving write on the commit's delete, so we never start.
+    expect(copyAndVerify).not.toHaveBeenCalled()
+    // The staging dir (marker) we created is cleaned up on abort.
+    expect(existsSync(dataRootFor(emptyParent))).toBe(false)
   })
 })
 
@@ -649,6 +661,18 @@ describe('commitDataRootSwitch (commit phase)', () => {
 
     expect(result).toEqual({ ok: true })
   })
+  it('refuses when the marker token does not match the session token', async () => {
+    await seedVerifiedMarker(emptyParent, currentDataRoot) // token 'tok-test'
+    const setDataRoot = vi.fn(async () => {})
+
+    const result = await commitDataRootSwitch(
+      { currentDataRoot, setDataRoot, expectedToken: 'a-different-token' },
+      emptyParent
+    )
+
+    expect(result.ok).toBe(false)
+    expect(setDataRoot).not.toHaveBeenCalled()
+  })
 })
 
 describe('discardStagedCopy', () => {
@@ -675,7 +699,7 @@ describe('discardStagedCopy', () => {
 
     const result = await discardStagedCopy({ currentDataRoot }, emptyParent)
 
-    expect(result).toEqual({ ok: false, error: 'Refused: not a staged migration copy.' })
+    expect(result).toEqual({ ok: false, error: 'Refused: not a completed, matching staged copy.' })
     expect(existsSync(target)).toBe(true)
   })
 
@@ -684,7 +708,28 @@ describe('discardStagedCopy', () => {
 
     const result = await discardStagedCopy({ currentDataRoot }, emptyParent)
 
-    expect(result).toEqual({ ok: false, error: 'Refused: not a staged migration copy.' })
+    expect(result).toEqual({ ok: false, error: 'Refused: not a completed, matching staged copy.' })
+    expect(existsSync(target)).toBe(true)
+  })
+
+  it('refuses a mid-copy ("copying") marker so a dir being written is never deleted', async () => {
+    const target = await seedVerifiedMarker(emptyParent, currentDataRoot, { status: 'copying' })
+
+    const result = await discardStagedCopy({ currentDataRoot }, emptyParent)
+
+    expect(result).toEqual({ ok: false, error: 'Refused: not a completed, matching staged copy.' })
+    expect(existsSync(target)).toBe(true)
+  })
+
+  it('refuses when the staged token does not match the session token', async () => {
+    const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
+
+    const result = await discardStagedCopy(
+      { currentDataRoot, expectedToken: 'other-token' },
+      emptyParent
+    )
+
+    expect(result).toEqual({ ok: false, error: 'Refused: not a completed, matching staged copy.' })
     expect(existsSync(target)).toBe(true)
   })
 })

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -9,15 +9,44 @@ vi.mock('electron', () => ({
   app: { getPath: () => '/home/user', isPackaged: true }
 }))
 
+import { existsSync } from 'node:fs'
+
 import type { MigrationProgress, MigrationResult } from './data-migration'
 import {
   classifyDataRoot,
   commitDataRootSwitch,
   DATA_ROOT_DIRS,
+  discardStagedCopy,
   MIGRATED_DIRS,
   runDataRootMigration,
   validateNewDataRoot
 } from './migration-service'
+import {
+  MIGRATION_MARKER_FILENAME,
+  readMigrationMarker,
+  writeMigrationMarker,
+  type MigrationMarker
+} from './migration-marker'
+
+// Writes a verified staging marker for `<parent>/OpenScience`, as a completed copy phase would have.
+const seedVerifiedMarker = async (
+  parent: string,
+  source: string,
+  overrides: Partial<MigrationMarker> = {}
+): Promise<string> => {
+  const target = dataRootFor(parent)
+  await mkdir(target, { recursive: true })
+  await writeMigrationMarker(target, {
+    version: 1,
+    token: 'tok-test',
+    source,
+    target,
+    createdAt: Date.now(),
+    status: 'verified',
+    ...overrides
+  })
+  return target
+}
 
 // Data folder name mirrors dataFolderName() for a packaged build (see the electron mock above).
 const dataRootFor = (parent: string): string => join(parent, 'OpenScience')
@@ -404,6 +433,54 @@ describe('runDataRootMigration (copy phase)', () => {
     expect(deps.setDataRoot).not.toHaveBeenCalled()
   })
 
+  it("stamps a 'copying' marker before the copy and promotes it to 'verified' on success", async () => {
+    const deps = fakeDeps()
+    const target = dataRootFor(emptyParent)
+    let statusDuringCopy: string | undefined
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => {
+      // The marker must already read 'copying' while bytes are being written.
+      statusDuringCopy = (await readMigrationMarker(target))?.status
+      return { ok: true }
+    })
+
+    await runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify },
+      emptyParent,
+      runOpts()
+    )
+
+    expect(statusDuringCopy).toBe('copying')
+    const finalMarker = await readMigrationMarker(target)
+    expect(finalMarker).toMatchObject({
+      status: 'verified',
+      source: currentDataRoot,
+      target,
+      version: 1
+    })
+    // The verified marker records the staged inventory (empty here since the fake copy wrote nothing).
+    expect(finalMarker?.inventory).toEqual({ dirs: [], fileCount: 0, totalBytes: 0 })
+  })
+
+  it('removes the marker and cleans up the empty target on copy failure/cancel', async () => {
+    const deps = fakeDeps()
+    const target = dataRootFor(emptyParent)
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({
+      ok: false,
+      error: 'x',
+      cancelled: true
+    }))
+
+    await runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify },
+      emptyParent,
+      runOpts()
+    )
+
+    // No marker, and the empty staging shell is gone — a cancelled move leaves no trace.
+    expect(await readMigrationMarker(target)).toBeNull()
+    expect(existsSync(target)).toBe(false)
+  })
+
   it('short-circuits on validation failure without interrupting or copying', async () => {
     const deps = fakeDeps()
     const copyAndVerify = vi.fn()
@@ -442,7 +519,8 @@ describe('runDataRootMigration (copy phase)', () => {
 })
 
 describe('commitDataRootSwitch (commit phase)', () => {
-  it('persists the new root then deletes the old dirs, in that order', async () => {
+  it('persists the new root then deletes the old dirs, in that order, and removes the marker', async () => {
+    const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
     const order: string[] = []
     const deps = fakeDeps()
     deps.setDataRoot.mockImplementation(async () => {
@@ -453,7 +531,6 @@ describe('commitDataRootSwitch (commit phase)', () => {
       return { deleted: [...MIGRATED_DIRS], failed: [] }
     })
 
-    const target = dataRootFor(emptyParent)
     const result = await commitDataRootSwitch(
       { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
       emptyParent
@@ -465,14 +542,83 @@ describe('commitDataRootSwitch (commit phase)', () => {
     expect(order).toEqual(['setDataRoot', 'deleteSources'])
     expect(deps.setDataRoot).toHaveBeenCalledWith(target)
     expect(deleteSources).toHaveBeenCalledWith(currentDataRoot, [...MIGRATED_DIRS])
+    // The committed (now-live) root must carry NO marker.
+    expect(existsSync(join(target, MIGRATION_MARKER_FILENAME))).toBe(false)
   })
 
-  it('returns switchoverFailed and skips delete when setDataRoot fails, leaving both roots intact', async () => {
+  it('refuses to commit when no marker is present (setDataRoot and delete never run)', async () => {
+    await mkdir(dataRootFor(emptyParent), { recursive: true }) // staging dir, but no marker
+    const deps = fakeDeps()
+    const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
+
+    const result = await commitDataRootSwitch(
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      emptyParent
+    )
+
+    expect(result).toEqual({ ok: false, error: 'No completed migration copy was found to commit.' })
+    expect(deps.setDataRoot).not.toHaveBeenCalled()
+    expect(deleteSources).not.toHaveBeenCalled()
+  })
+
+  it("refuses to commit a marker that is only 'copying' (not verified)", async () => {
+    await seedVerifiedMarker(emptyParent, currentDataRoot, { status: 'copying' })
+    const deps = fakeDeps()
+    const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
+
+    const result = await commitDataRootSwitch(
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      emptyParent
+    )
+
+    expect(result).toEqual({ ok: false, error: 'No completed migration copy was found to commit.' })
+    expect(deps.setDataRoot).not.toHaveBeenCalled()
+    expect(deleteSources).not.toHaveBeenCalled()
+  })
+
+  it('refuses to commit a marker staged against a different source (wrong current root)', async () => {
+    await seedVerifiedMarker(emptyParent, '/some/other/OpenScience')
+    const deps = fakeDeps()
+    const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
+
+    const result = await commitDataRootSwitch(
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      emptyParent
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'The staged copy does not match your current data location.'
+    })
+    expect(deps.setDataRoot).not.toHaveBeenCalled()
+    expect(deleteSources).not.toHaveBeenCalled()
+  })
+
+  it('refuses to commit a marker whose recorded target differs from the derived one', async () => {
+    const target = await seedVerifiedMarker(emptyParent, currentDataRoot, {
+      target: '/elsewhere/OpenScience'
+    })
+    const deps = fakeDeps()
+    const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
+
+    const result = await commitDataRootSwitch(
+      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
+      emptyParent
+    )
+
+    expect(result).toEqual({ ok: false, error: 'The staged copy is for a different destination.' })
+    expect(deps.setDataRoot).not.toHaveBeenCalled()
+    expect(deleteSources).not.toHaveBeenCalled()
+    // Marker left intact so the copy stays discardable.
+    expect(existsSync(join(target, MIGRATION_MARKER_FILENAME))).toBe(true)
+  })
+
+  it('returns switchoverFailed, skips delete, and KEEPS the marker when setDataRoot fails', async () => {
+    const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
     const deps = fakeDeps()
     deps.setDataRoot.mockRejectedValue(new Error('disk full'))
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
 
-    const target = dataRootFor(emptyParent)
     const result = await commitDataRootSwitch(
       { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources },
       emptyParent
@@ -484,9 +630,12 @@ describe('commitDataRootSwitch (commit phase)', () => {
       switchoverFailed: true
     })
     expect(deleteSources).not.toHaveBeenCalled()
+    // The copy stays discardable/retryable, so the marker must survive a failed switchover.
+    expect(existsSync(join(target, MIGRATION_MARKER_FILENAME))).toBe(true)
   })
 
   it('still succeeds when deleteSources reports per-dir failures (harmless leftovers)', async () => {
+    await seedVerifiedMarker(emptyParent, currentDataRoot)
     const deps = fakeDeps()
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({
       deleted: ['artifacts'],
@@ -499,5 +648,43 @@ describe('commitDataRootSwitch (commit phase)', () => {
     )
 
     expect(result).toEqual({ ok: true })
+  })
+})
+
+describe('discardStagedCopy', () => {
+  it('deletes a marker-confirmed staged copy for the current root', async () => {
+    const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
+
+    const result = await discardStagedCopy({ currentDataRoot }, emptyParent)
+
+    expect(result).toEqual({ ok: true })
+    expect(existsSync(target)).toBe(false)
+  })
+
+  it('refuses (and deletes nothing) when the derived target is the current data location', async () => {
+    // Deriving from currentParent yields currentDataRoot itself.
+    const result = await discardStagedCopy({ currentDataRoot }, currentParent)
+
+    expect(result).toEqual({ ok: false, error: 'Refused: target is the current data location.' })
+    expect(existsSync(currentDataRoot)).toBe(true)
+  })
+
+  it('refuses when there is no marker at the target', async () => {
+    const target = dataRootFor(emptyParent)
+    await mkdir(target, { recursive: true })
+
+    const result = await discardStagedCopy({ currentDataRoot }, emptyParent)
+
+    expect(result).toEqual({ ok: false, error: 'Refused: not a staged migration copy.' })
+    expect(existsSync(target)).toBe(true)
+  })
+
+  it('refuses when the marker was staged against a different source', async () => {
+    const target = await seedVerifiedMarker(emptyParent, '/some/other/OpenScience')
+
+    const result = await discardStagedCopy({ currentDataRoot }, emptyParent)
+
+    expect(result).toEqual({ ok: false, error: 'Refused: not a staged migration copy.' })
+    expect(existsSync(target)).toBe(true)
   })
 })

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, rm, rmdir, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { type Dirent } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { join, resolve } from 'node:path'
@@ -170,17 +170,24 @@ export const classifyDataRoot = async (
     return { kind: 'invalid', error: 'The selected folder is not usable.' }
   }
 
+  // A marker means this folder is an in-progress/uncommitted staging copy from a migration that never
+  // finished (e.g. a crash). Never adopt it — that would bypass the commit gate and switch to a possibly
+  // incomplete snapshot — and never populate over it; the user must finish or discard that move first.
+  if (entries.some((entry) => entry.name === MIGRATION_MARKER_FILENAME)) {
+    return {
+      kind: 'invalid',
+      error:
+        'This folder holds an unfinished data move. Finish or discard that move before using it here.'
+    }
+  }
+
   const looksLikeOurData = entries.some(
     (entry) => entry.isDirectory() && (MIGRATED_DIRS as readonly string[]).includes(entry.name)
   )
   if (looksLikeOurData) return { kind: 'adopt' }
 
   // runtime/ doesn't count as content: a folder holding only runtime (or nothing) is treated as empty.
-  // The migration marker is likewise ignored — a staging dir that crashed before any data was copied
-  // holds only the marker, and must still classify 'move' (populate it) rather than 'invalid'.
-  const meaningfulEntries = entries.filter(
-    (entry) => entry.name !== 'runtime' && entry.name !== MIGRATION_MARKER_FILENAME
-  )
+  const meaningfulEntries = entries.filter((entry) => entry.name !== 'runtime')
   if (meaningfulEntries.length === 0) return { kind: 'move' }
 
   return {
@@ -234,6 +241,9 @@ type MigrationCopyDeps = {
 type MigrationCommitDeps = {
   currentDataRoot: string
   setDataRoot: (path: string) => Promise<void>
+  // Marker token the IPC layer captured when THIS session's copy completed. Commit refuses unless the
+  // on-disk marker still carries the same token, so a stale/foreign copy can never be committed.
+  expectedToken?: string
   // Injectable for tests; defaults to the real ./data-migration engine function.
   deleteSources?: (
     from: string,
@@ -273,19 +283,19 @@ export const runDataRootMigration = async (
   await mkdir(target, { recursive: true })
   await writeMigrationMarker(target, marker)
 
-  // Interrupt anything that could write mid-copy. Each step is independently wrapped and its failure
-  // logged, not thrown: the write-gate the IPC layer holds for the whole copy→commit window is what
-  // actually makes a swallowed interrupt safe here — no NEW prompt/cell writes can start against the
-  // old root even if a disconnect silently failed, so attempting the copy anyway stays correct.
+  // Freeze in-flight writers before copying. If either interrupt fails we must NOT copy an unfrozen
+  // tree — a surviving write would land outside the snapshot and be lost on the commit's delete — so
+  // clean up the staging dir and abort rather than swallow the failure and press on.
   try {
     await deps.runtime.disconnect()
-  } catch (err) {
-    console.error('[migration-service] runtime.disconnect failed', err)
-  }
-  try {
     await deps.notebook.shutdownAll()
   } catch (err) {
-    console.error('[migration-service] notebook.shutdownAll failed', err)
+    console.error('[migration-service] failed to pause writers; aborting migration', err)
+    await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    return {
+      ok: false,
+      error: 'Could not pause running work to copy your data safely. Please try again in a moment.'
+    }
   }
 
   const doCopyAndVerify = deps.copyAndVerify ?? copyAndVerify
@@ -298,10 +308,12 @@ export const runDataRootMigration = async (
   })
 
   if (!result.ok) {
-    // copyAndVerify's own rollback rmdir(to) no-ops while our marker still sits in `target`, so remove
-    // the marker ourselves and then drop the now-empty staging shell so a cancelled move leaves no trace.
-    await removeMigrationMarker(target)
-    await rmdir(target).catch(() => undefined)
+    // Remove the whole staging dir we created (marker + anything copyAndVerify's rollback missed) so a
+    // half-baked, marker-less folder can never later be mistaken for a committed data root. Safe: a
+    // 'move' target only ever holds our copy plus at most a rebuildable runtime/, never user data.
+    await rm(target, { recursive: true, force: true }).catch((err) =>
+      console.error('[migration-service] failed to clean up staging dir after failed copy', err)
+    )
     return result
   }
 
@@ -338,6 +350,9 @@ export const commitDataRootSwitch = async (
   if (!samePath(marker.target, target)) {
     return { ok: false, error: 'The staged copy is for a different destination.' }
   }
+  if (deps.expectedToken !== undefined && marker.token !== deps.expectedToken) {
+    return { ok: false, error: 'The staged copy is from a different migration attempt.' }
+  }
 
   try {
     await deps.setDataRoot(target)
@@ -352,9 +367,16 @@ export const commitDataRootSwitch = async (
     }
   }
 
-  // The pointer is now committed, so the target is the live root and must carry NO marker — its
-  // presence is the "staging, not yet live" signal computeDefaultDataRoot and this gate both rely on.
-  await removeMigrationMarker(target)
+  // The pointer is now committed, so the target is the live root and should carry NO marker. Removal is
+  // best-effort: the switch already succeeded, so a failure here must NOT fail the commit — that would
+  // leave settings pointing at the new root while this process still used the old one (split brain). A
+  // leftover marker is benign: discardStagedCopy refuses the live root, and computeDefaultDataRoot only
+  // consults it for a legacy fallback the committed settings.dataRoot overrides anyway.
+  try {
+    await removeMigrationMarker(target)
+  } catch (err) {
+    console.error('[migration-service] failed to remove marker after commit (benign leftover)', err)
+  }
 
   const doDeleteSources = deps.deleteSources ?? deleteSources
   const deleteResult = await doDeleteSources(deps.currentDataRoot, [...MIGRATED_DIRS])
@@ -372,7 +394,7 @@ export const commitDataRootSwitch = async (
 // root — never the live data location, and only when a marker confirms this source→target pair — so a
 // misrouted parent can never rm the folder the app is actively using.
 export const discardStagedCopy = async (
-  deps: { currentDataRoot: string },
+  deps: { currentDataRoot: string; expectedToken?: string },
   parent: string
 ): Promise<{ ok: boolean; error?: string }> => {
   const target = dataRootForPicked(parent)
@@ -384,10 +406,14 @@ export const discardStagedCopy = async (
   const marker = await readMigrationMarker(target)
   if (
     !marker ||
+    marker.status !== 'verified' ||
     !samePath(marker.target, target) ||
-    !samePath(marker.source, deps.currentDataRoot)
+    !samePath(marker.source, deps.currentDataRoot) ||
+    (deps.expectedToken !== undefined && marker.token !== deps.expectedToken)
   ) {
-    return { ok: false, error: 'Refused: not a staged migration copy.' }
+    // status must be 'verified' (never delete a dir mid-copy) and the token must match this session's
+    // staged copy — a stale renderer call for another/earlier path is refused rather than obeyed.
+    return { ok: false, error: 'Refused: not a completed, matching staged copy.' }
   }
 
   await rm(target, { recursive: true, force: true })

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -19,6 +19,7 @@ import {
   writeMigrationMarker,
   type MigrationMarker
 } from './migration-marker'
+import { waitForDataRootWriters } from './migration-state'
 
 // All top-level dirs under a data root. Used elsewhere (usage breakdown, legacy detection) to
 // enumerate what a data root actually holds; no longer consulted by classifyDataRoot itself (see
@@ -223,6 +224,15 @@ export const validateNewDataRoot = async (
 export type MigrationOutcome =
   MigrationResult | { ok: false; error: string; switchoverFailed: true }
 
+type MigrationInventory = NonNullable<MigrationMarker['inventory']>
+
+const sameInventory = (left: MigrationInventory, right: MigrationInventory): boolean =>
+  left.fileCount === right.fileCount &&
+  left.totalBytes === right.totalBytes &&
+  left.digest === right.digest &&
+  left.dirs.length === right.dirs.length &&
+  left.dirs.every((dir, index) => dir === right.dirs[index])
+
 type MigrationCopyDeps = {
   currentDataRoot: string
   runtime: { disconnect: () => Promise<unknown> }
@@ -243,7 +253,7 @@ type MigrationCommitDeps = {
   setDataRoot: (path: string) => Promise<void>
   // Marker token the IPC layer captured when THIS session's copy completed. Commit refuses unless the
   // on-disk marker still carries the same token, so a stale/foreign copy can never be committed.
-  expectedToken?: string
+  expectedToken: string
   // Injectable for tests; defaults to the real ./data-migration engine function.
   deleteSources?: (
     from: string,
@@ -261,7 +271,11 @@ type MigrationCommitDeps = {
 export const runDataRootMigration = async (
   deps: MigrationCopyDeps,
   parent: string,
-  runOpts: { signal: AbortSignal; onProgress: (p: MigrationProgress) => void }
+  runOpts: {
+    signal: AbortSignal
+    onProgress: (p: MigrationProgress) => void
+    onVerified?: (staged: { token: string; target: string }) => void
+  }
 ): Promise<MigrationResult> => {
   const validation = await validateNewDataRoot(parent, deps.currentDataRoot)
 
@@ -280,8 +294,14 @@ export const runDataRootMigration = async (
     createdAt: Date.now(),
     status: 'copying'
   }
-  await mkdir(target, { recursive: true })
-  await writeMigrationMarker(target, marker)
+  try {
+    await mkdir(target, { recursive: true })
+    await writeMigrationMarker(target, marker)
+  } catch (err) {
+    console.error('[migration-service] failed to initialize staging dir', err)
+    await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    return { ok: false, error: 'Could not prepare the new data location. Please try again.' }
+  }
 
   // Freeze in-flight writers before copying. If either interrupt fails we must NOT copy an unfrozen
   // tree — a surviving write would land outside the snapshot and be lost on the commit's delete — so
@@ -289,6 +309,7 @@ export const runDataRootMigration = async (
   try {
     await deps.runtime.disconnect()
     await deps.notebook.shutdownAll()
+    await waitForDataRootWriters()
   } catch (err) {
     console.error('[migration-service] failed to pause writers; aborting migration', err)
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
@@ -299,13 +320,20 @@ export const runDataRootMigration = async (
   }
 
   const doCopyAndVerify = deps.copyAndVerify ?? copyAndVerify
-  const result = await doCopyAndVerify({
-    from: deps.currentDataRoot,
-    to: target,
-    dirs: [...MIGRATED_DIRS],
-    signal: runOpts.signal,
-    onProgress: runOpts.onProgress
-  })
+  let result: MigrationResult
+  try {
+    result = await doCopyAndVerify({
+      from: deps.currentDataRoot,
+      to: target,
+      dirs: [...MIGRATED_DIRS],
+      signal: runOpts.signal,
+      onProgress: runOpts.onProgress
+    })
+  } catch (err) {
+    console.error('[migration-service] copy engine failed unexpectedly', err)
+    await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    return { ok: false, error: 'Could not copy your data. Please try again.' }
+  }
 
   if (!result.ok) {
     // Remove the whole staging dir we created (marker + anything copyAndVerify's rollback missed) so a
@@ -317,9 +345,32 @@ export const runDataRootMigration = async (
     return result
   }
 
+  if (runOpts.signal.aborted) {
+    await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    return { ok: false, error: 'migration cancelled', cancelled: true }
+  }
+
   // Record what was staged and promote the marker to 'verified' — the only state the commit gate accepts.
-  const inventory = await scanInventory(target, [...MIGRATED_DIRS])
-  await writeMigrationMarker(target, { ...marker, status: 'verified', inventory })
+  let inventory
+  try {
+    inventory = await scanInventory(target, [...MIGRATED_DIRS])
+  } catch (err) {
+    console.error('[migration-service] failed to inventory staged copy', err)
+    await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    return { ok: false, error: 'Could not verify the copied data. Please run the move again.' }
+  }
+  if (runOpts.signal.aborted) {
+    await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    return { ok: false, error: 'migration cancelled', cancelled: true }
+  }
+  try {
+    await writeMigrationMarker(target, { ...marker, status: 'verified', inventory })
+    runOpts.onVerified?.({ token: marker.token, target })
+  } catch (err) {
+    console.error('[migration-service] failed to finalize staged copy', err)
+    await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    return { ok: false, error: 'Could not finalize the copied data. Please run the move again.' }
+  }
   return result
 }
 
@@ -350,8 +401,29 @@ export const commitDataRootSwitch = async (
   if (!samePath(marker.target, target)) {
     return { ok: false, error: 'The staged copy is for a different destination.' }
   }
-  if (deps.expectedToken !== undefined && marker.token !== deps.expectedToken) {
+  if (!deps.expectedToken || marker.token !== deps.expectedToken) {
     return { ok: false, error: 'The staged copy is from a different migration attempt.' }
+  }
+  if (!marker.inventory) {
+    return { ok: false, error: 'The staged copy has no verified inventory.' }
+  }
+
+  let inventories: [MigrationInventory, MigrationInventory]
+  try {
+    inventories = await Promise.all([
+      scanInventory(deps.currentDataRoot, [...MIGRATED_DIRS]),
+      scanInventory(target, [...MIGRATED_DIRS])
+    ])
+  } catch (err) {
+    console.error('[migration-service] failed to recheck staged copy inventory', err)
+    return { ok: false, error: 'Could not recheck the copied data. Run the move again.' }
+  }
+  const [sourceInventory, targetInventory] = inventories
+  if (
+    !sameInventory(marker.inventory, sourceInventory) ||
+    !sameInventory(marker.inventory, targetInventory)
+  ) {
+    return { ok: false, error: 'The staged copy changed after verification. Run the move again.' }
   }
 
   try {
@@ -394,7 +466,7 @@ export const commitDataRootSwitch = async (
 // root — never the live data location, and only when a marker confirms this source→target pair — so a
 // misrouted parent can never rm the folder the app is actively using.
 export const discardStagedCopy = async (
-  deps: { currentDataRoot: string; expectedToken?: string },
+  deps: { currentDataRoot: string; expectedToken: string },
   parent: string
 ): Promise<{ ok: boolean; error?: string }> => {
   const target = dataRootForPicked(parent)
@@ -409,7 +481,8 @@ export const discardStagedCopy = async (
     marker.status !== 'verified' ||
     !samePath(marker.target, target) ||
     !samePath(marker.source, deps.currentDataRoot) ||
-    (deps.expectedToken !== undefined && marker.token !== deps.expectedToken)
+    !deps.expectedToken ||
+    marker.token !== deps.expectedToken
   ) {
     // status must be 'verified' (never delete a dir mid-copy) and the token must match this session's
     // staged copy — a stale renderer call for another/earlier path is refused rather than obeyed.

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -1,4 +1,4 @@
-import { readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, rm, rmdir, stat, writeFile } from 'node:fs/promises'
 import { type Dirent } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { join, resolve } from 'node:path'
@@ -10,6 +10,15 @@ import {
   type MigrationProgress,
   type MigrationResult
 } from './data-migration'
+import {
+  MIGRATION_MARKER_FILENAME,
+  newToken,
+  readMigrationMarker,
+  removeMigrationMarker,
+  scanInventory,
+  writeMigrationMarker,
+  type MigrationMarker
+} from './migration-marker'
 
 // All top-level dirs under a data root. Used elsewhere (usage breakdown, legacy detection) to
 // enumerate what a data root actually holds; no longer consulted by classifyDataRoot itself (see
@@ -68,11 +77,11 @@ export const classifyDataRoot = async (
   const current = resolve(currentDataRoot)
   const target = dataRootForPicked(parent)
 
-  // Reject only control characters (near-impossible from the OS picker, but the New location field
-  // also accepts typed input). Spaces are intentionally allowed on every platform: Windows profile
-  // paths routinely contain them (C:\Users\John Doe), and blocking spaces there — or on macOS,
-  // where spaced folders are common — is more user-hostile than the rare conda/venv quoting issue
-  // it would guard against. Non-ASCII letters (accented, CJK) are allowed too.
+  // Reject control characters on every platform (near-impossible from the OS picker, but the New
+  // location field also accepts typed input). Spaces are handled per-platform below: allowed on
+  // Windows (profile paths routinely contain them, e.g. C:\Users\John Doe, and it has no shebangs),
+  // but rejected on macOS/Linux where a spaced path breaks conda/venv console scripts. Non-ASCII
+  // letters (accented, CJK) are allowed everywhere.
   // eslint-disable-next-line no-control-regex
   if (/[\u0000-\u001f]/.test(target)) {
     return {
@@ -167,7 +176,11 @@ export const classifyDataRoot = async (
   if (looksLikeOurData) return { kind: 'adopt' }
 
   // runtime/ doesn't count as content: a folder holding only runtime (or nothing) is treated as empty.
-  const meaningfulEntries = entries.filter((entry) => entry.name !== 'runtime')
+  // The migration marker is likewise ignored — a staging dir that crashed before any data was copied
+  // holds only the marker, and must still classify 'move' (populate it) rather than 'invalid'.
+  const meaningfulEntries = entries.filter(
+    (entry) => entry.name !== 'runtime' && entry.name !== MIGRATION_MARKER_FILENAME
+  )
   if (meaningfulEntries.length === 0) return { kind: 'move' }
 
   return {
@@ -246,8 +259,24 @@ export const runDataRootMigration = async (
 
   const target = dataRootForPicked(parent)
 
-  // Interrupt anything that could write mid-copy. Each step is independently wrapped: an interrupt
-  // failure must not abort the copy (it's still safe to attempt), so it is logged and swallowed.
+  // Stamp a 'copying' marker into the staging dir BEFORE any bytes are copied. Its presence makes a
+  // half-copied target unmistakably "not committed": computeDefaultDataRoot skips a marker-bearing
+  // homeDefault, and the commit gate refuses anything that isn't marked 'verified'.
+  const marker: MigrationMarker = {
+    version: 1,
+    token: newToken(),
+    source: deps.currentDataRoot,
+    target,
+    createdAt: Date.now(),
+    status: 'copying'
+  }
+  await mkdir(target, { recursive: true })
+  await writeMigrationMarker(target, marker)
+
+  // Interrupt anything that could write mid-copy. Each step is independently wrapped and its failure
+  // logged, not thrown: the write-gate the IPC layer holds for the whole copy→commit window is what
+  // actually makes a swallowed interrupt safe here — no NEW prompt/cell writes can start against the
+  // old root even if a disconnect silently failed, so attempting the copy anyway stays correct.
   try {
     await deps.runtime.disconnect()
   } catch (err) {
@@ -260,13 +289,26 @@ export const runDataRootMigration = async (
   }
 
   const doCopyAndVerify = deps.copyAndVerify ?? copyAndVerify
-  return doCopyAndVerify({
+  const result = await doCopyAndVerify({
     from: deps.currentDataRoot,
     to: target,
     dirs: [...MIGRATED_DIRS],
     signal: runOpts.signal,
     onProgress: runOpts.onProgress
   })
+
+  if (!result.ok) {
+    // copyAndVerify's own rollback rmdir(to) no-ops while our marker still sits in `target`, so remove
+    // the marker ourselves and then drop the now-empty staging shell so a cancelled move leaves no trace.
+    await removeMigrationMarker(target)
+    await rmdir(target).catch(() => undefined)
+    return result
+  }
+
+  // Record what was staged and promote the marker to 'verified' — the only state the commit gate accepts.
+  const inventory = await scanInventory(target, [...MIGRATED_DIRS])
+  await writeMigrationMarker(target, { ...marker, status: 'verified', inventory })
+  return result
 }
 
 // PHASE 2 (commit): flip settings.dataRoot to the (already-copied, verified) new root, THEN delete
@@ -282,9 +324,26 @@ export const commitDataRootSwitch = async (
 ): Promise<MigrationOutcome> => {
   const target = dataRootForPicked(parent)
 
+  // Commit gate: only ever promote a fully-staged copy whose marker matches THIS exact source→target
+  // pair. This blocks committing a half-copied dir (crash mid-copy), a stale marker from an earlier
+  // aborted move, or a copy staged against a different current root — any of which could delete the
+  // wrong data on the delete step below.
+  const marker = await readMigrationMarker(target)
+  if (!marker || marker.status !== 'verified') {
+    return { ok: false, error: 'No completed migration copy was found to commit.' }
+  }
+  if (!samePath(marker.source, deps.currentDataRoot)) {
+    return { ok: false, error: 'The staged copy does not match your current data location.' }
+  }
+  if (!samePath(marker.target, target)) {
+    return { ok: false, error: 'The staged copy is for a different destination.' }
+  }
+
   try {
     await deps.setDataRoot(target)
   } catch (err) {
+    // Leave the marker in place: the copy stays a discardable staging dir the user can retry or throw
+    // away, exactly as before the failed switch.
     console.error('[migration-service] failed to persist new dataRoot', err)
     return {
       ok: false,
@@ -292,6 +351,10 @@ export const commitDataRootSwitch = async (
       switchoverFailed: true
     }
   }
+
+  // The pointer is now committed, so the target is the live root and must carry NO marker — its
+  // presence is the "staging, not yet live" signal computeDefaultDataRoot and this gate both rely on.
+  await removeMigrationMarker(target)
 
   const doDeleteSources = deps.deleteSources ?? deleteSources
   const deleteResult = await doDeleteSources(deps.currentDataRoot, [...MIGRATED_DIRS])
@@ -301,5 +364,32 @@ export const commitDataRootSwitch = async (
     })
   }
 
+  return { ok: true }
+}
+
+// Throws away an uncommitted staged copy at `<parent>/OpenScience` (the user chose "Keep current
+// location" on the done stage). Refuses unless the target is genuinely a staging copy for the current
+// root — never the live data location, and only when a marker confirms this source→target pair — so a
+// misrouted parent can never rm the folder the app is actively using.
+export const discardStagedCopy = async (
+  deps: { currentDataRoot: string },
+  parent: string
+): Promise<{ ok: boolean; error?: string }> => {
+  const target = dataRootForPicked(parent)
+
+  if (isPathInsideOrEqual(deps.currentDataRoot, target)) {
+    return { ok: false, error: 'Refused: target is the current data location.' }
+  }
+
+  const marker = await readMigrationMarker(target)
+  if (
+    !marker ||
+    !samePath(marker.target, target) ||
+    !samePath(marker.source, deps.currentDataRoot)
+  ) {
+    return { ok: false, error: 'Refused: not a staged migration copy.' }
+  }
+
+  await rm(target, { recursive: true, force: true })
   return { ok: true }
 }

--- a/src/main/storage/migration-state.test.ts
+++ b/src/main/storage/migration-state.test.ts
@@ -2,8 +2,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('electron', () => ({ dialog: { showMessageBoxSync: vi.fn() } }))
 
-const { beginMigration, endMigration, isMigrationInProgress, installMigrationQuitGuard } =
-  await import('./migration-state')
+const {
+  beginMigration,
+  clearMigrationPending,
+  endMigration,
+  endMigrationCopy,
+  installMigrationQuitGuard,
+  isMigrationInProgress,
+  isMigrationPending
+} = await import('./migration-state')
 
 // A minimal app double: records the before-quit listener and whether quit() was called.
 type GuardApp = Parameters<typeof installMigrationQuitGuard>[0]
@@ -35,6 +42,43 @@ describe('migration-state', () => {
     expect(isMigrationInProgress()).toBe(true)
     endMigration()
     expect(isMigrationInProgress()).toBe(false)
+  })
+
+  it('beginMigration sets both the copying (quit) and pending (write-gate) flags', () => {
+    expect(isMigrationInProgress()).toBe(false)
+    expect(isMigrationPending()).toBe(false)
+
+    beginMigration()
+
+    expect(isMigrationInProgress()).toBe(true)
+    expect(isMigrationPending()).toBe(true)
+  })
+
+  it('endMigrationCopy relaxes the quit guard but keeps the write-gate pending', () => {
+    beginMigration()
+    endMigrationCopy()
+
+    // The copy finished, so quit is no longer blocked — but a successful-but-uncommitted copy still
+    // blocks writes until commit or discard resolves it.
+    expect(isMigrationInProgress()).toBe(false)
+    expect(isMigrationPending()).toBe(true)
+  })
+
+  it('clearMigrationPending lifts both flags (copy failed/cancelled/discarded, or switch failed)', () => {
+    beginMigration()
+    endMigrationCopy()
+    clearMigrationPending()
+
+    expect(isMigrationInProgress()).toBe(false)
+    expect(isMigrationPending()).toBe(false)
+  })
+
+  it('endMigration clears both flags (quit-anyway path)', () => {
+    beginMigration()
+    endMigration()
+
+    expect(isMigrationInProgress()).toBe(false)
+    expect(isMigrationPending()).toBe(false)
   })
 
   it('quit guard does not interfere when no migration is running', () => {

--- a/src/main/storage/migration-state.test.ts
+++ b/src/main/storage/migration-state.test.ts
@@ -9,7 +9,9 @@ const {
   endMigrationCopy,
   installMigrationQuitGuard,
   isMigrationInProgress,
-  isMigrationPending
+  isMigrationPending,
+  waitForDataRootWriters,
+  withDataRootWrite
 } = await import('./migration-state')
 
 // A minimal app double: records the before-quit listener and whether quit() was called.
@@ -79,6 +81,33 @@ describe('migration-state', () => {
 
     expect(isMigrationInProgress()).toBe(false)
     expect(isMigrationPending()).toBe(false)
+  })
+
+  it('drains writes that started before migration and rejects new writes after the gate rises', async () => {
+    let releaseWrite: (() => void) | undefined
+    let writeStarted = false
+    const activeWrite = withDataRootWrite(
+      () =>
+        new Promise<void>((resolve) => {
+          writeStarted = true
+          releaseWrite = resolve
+        })
+    )
+    expect(writeStarted).toBe(true)
+
+    beginMigration()
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+    await expect(withDataRootWrite(async () => {})).rejects.toThrow(/moving your data/i)
+
+    releaseWrite?.()
+    await activeWrite
+    await drainPromise
+    expect(drained).toBe(true)
   })
 
   it('quit guard does not interfere when no migration is running', () => {

--- a/src/main/storage/migration-state.ts
+++ b/src/main/storage/migration-state.ts
@@ -41,6 +41,17 @@ export const isMigrationInProgress = (): boolean => copying
 // they can't write into the old root during the copy→commit window.
 export const isMigrationPending = (): boolean => pending
 
+// Throws the standard user-facing error when a migration is pending. Called at every data-root write
+// entry point (ACP prompt, notebook run/execute, uploads) so no new write can land in the old root
+// during the copy→commit window and be lost on the commit's delete.
+export const assertNoMigrationPending = (): void => {
+  if (pending) {
+    throw new Error(
+      'Open Science is moving your data. Wait for the move to finish before running this.'
+    )
+  }
+}
+
 // Native confirm shown when the user tries to quit mid-migration. Returns true iff they chose to
 // quit anyway. Kept as the injectable default so the guard's control flow stays unit-testable
 // without a real Electron dialog.

--- a/src/main/storage/migration-state.ts
+++ b/src/main/storage/migration-state.ts
@@ -9,6 +9,8 @@ import { dialog, type App } from 'electron'
 //     OLD root would be silently discarded by the commit's delete step.
 let copying = false
 let pending = false
+let activeDataRootWriters = 0
+const writerDrainWaiters = new Set<() => void>()
 
 // Marks the start of a migration copy. Sets both flags. Pair with endMigrationCopy() in a finally.
 export const beginMigration = (): void => {
@@ -50,6 +52,25 @@ export const assertNoMigrationPending = (): void => {
       'Open Science is moving your data. Wait for the move to finish before running this.'
     )
   }
+}
+
+export const withDataRootWrite = async <Result>(write: () => Promise<Result>): Promise<Result> => {
+  assertNoMigrationPending()
+  activeDataRootWriters += 1
+  try {
+    return await write()
+  } finally {
+    activeDataRootWriters -= 1
+    if (activeDataRootWriters === 0) {
+      for (const resolve of writerDrainWaiters) resolve()
+      writerDrainWaiters.clear()
+    }
+  }
+}
+
+export const waitForDataRootWriters = (): Promise<void> => {
+  if (activeDataRootWriters === 0) return Promise.resolve()
+  return new Promise((resolve) => writerDrainWaiters.add(resolve))
 }
 
 // Native confirm shown when the user tries to quit mid-migration. Returns true iff they chose to

--- a/src/main/storage/migration-state.ts
+++ b/src/main/storage/migration-state.ts
@@ -1,21 +1,45 @@
 import { dialog, type App } from 'electron'
 
-// Whether a data-root migration is copying/verifying/deleting right now. A module-level flag (not a
-// parameter) because the quit guard in the app lifecycle and the migrate IPC handler live in
-// different modules but must agree on a single truth. Set for the whole duration of runDataRootMigration.
-let migrationInProgress = false
+// Two module-level flags (not parameters) because the quit guard, the migrate IPC handler, and the
+// ACP/notebook write paths live in different modules but must agree on a single truth.
+//   - `copying`  drives the before-quit guard: true only while runDataRootMigration is actively copying.
+//   - `pending`  drives the write-gate: true from the moment the copy starts until the switch is
+//     committed (and the app relaunches) or the copy is cancelled/discarded. It stays true across the
+//     copy→commit window — the exact interval during which a prompt or notebook cell writing to the
+//     OLD root would be silently discarded by the commit's delete step.
+let copying = false
+let pending = false
 
-// Marks the start of a migration. Pair every call with endMigration() in a finally block.
+// Marks the start of a migration copy. Sets both flags. Pair with endMigrationCopy() in a finally.
 export const beginMigration = (): void => {
-  migrationInProgress = true
+  copying = true
+  pending = true
 }
 
-// Marks the end of a migration (success, failure, or cancel).
+// The copy finished (success, failure, or cancel): relax the quit guard, but leave `pending` untouched
+// so a successful-but-uncommitted copy keeps blocking writes until commit or discard resolves it.
+export const endMigrationCopy = (): void => {
+  copying = false
+}
+
+// The migration is fully resolved without committing (copy failed/cancelled, discarded, or a
+// switchover failure left the app on the old root): clear both flags so normal writes resume.
+export const clearMigrationPending = (): void => {
+  pending = false
+  copying = false
+}
+
+// Clears both flags. Used by the quit-guard confirm path (the user is quitting anyway).
 export const endMigration = (): void => {
-  migrationInProgress = false
+  copying = false
+  pending = false
 }
 
-export const isMigrationInProgress = (): boolean => migrationInProgress
+export const isMigrationInProgress = (): boolean => copying
+
+// True whenever a copy is staged-but-not-yet-committed; gates ACP prompts and notebook cell runs so
+// they can't write into the old root during the copy→commit window.
+export const isMigrationPending = (): boolean => pending
 
 // Native confirm shown when the user tries to quit mid-migration. Returns true iff they chose to
 // quit anyway. Kept as the injectable default so the guard's control flow stays unit-testable

--- a/src/main/uploads/ipc.test.ts
+++ b/src/main/uploads/ipc.test.ts
@@ -5,22 +5,37 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const electronState = vi.hoisted(() => ({ homePath: '' }))
+const ipcHandlers = vi.hoisted(
+  () => new Map<string, (event: unknown, request: unknown) => unknown>()
+)
 
 vi.mock('electron', () => ({
   app: {
     getPath: () => electronState.homePath,
     isPackaged: false
   },
-  ipcMain: { handle: vi.fn() }
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (event: unknown, request: unknown) => unknown) =>
+      ipcHandlers.set(channel, handler)
+    )
+  }
 }))
 
 import { dataFolderName } from '../storage-root'
-import { createDefaultUploadRepository } from './ipc'
+import {
+  beginMigration,
+  clearMigrationPending,
+  waitForDataRootWriters
+} from '../storage/migration-state'
+import { createDefaultUploadRepository, registerUploadIpcHandlers } from './ipc'
+import type { UploadRepository } from './repository'
 
 describe('default upload repository', () => {
   let homeRoot: string | undefined
 
   afterEach(async () => {
+    ipcHandlers.clear()
+    clearMigrationPending()
     if (homeRoot) await rm(homeRoot, { recursive: true, force: true })
     homeRoot = undefined
   })
@@ -55,5 +70,33 @@ describe('default upload repository', () => {
     await expect(
       repository.readManagedUploadPreview({ path: attachment.path, encoding: 'utf8' })
     ).resolves.toMatchObject({ content })
+  })
+
+  it('keeps migration drain pending until an upload that already started finishes', async () => {
+    let releaseUpload: (() => void) | undefined
+    const repository = {
+      stageFiles: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseUpload = resolve
+          })
+      )
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const stage = ipcHandlers.get('uploads:stage-files')!
+
+    const uploadPromise = Promise.resolve(stage(undefined, { files: [] }))
+    beginMigration()
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    releaseUpload?.()
+    await uploadPromise
+    await drainPromise
+    expect(drained).toBe(true)
   })
 })

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -7,6 +7,7 @@ import type {
   StageUploadFilesRequest
 } from '../../shared/uploads'
 import { resolveDataRoot } from '../storage-root'
+import { assertNoMigrationPending } from '../storage/migration-state'
 import { UploadRepository } from './repository'
 
 // Uploads are data-class: they follow the configurable data root (defaults to the config root).
@@ -15,15 +16,19 @@ const createDefaultUploadRepository = (): UploadRepository =>
 
 // Registers the small upload IPC surface used by the renderer composer and preview panel.
 const registerUploadIpcHandlers = (repository = createDefaultUploadRepository()): void => {
-  ipcMain.handle('uploads:stage-files', (_event, request: StageUploadFilesRequest) =>
-    repository.stageFiles(request)
-  )
-  ipcMain.handle('uploads:delete', (_event, request: DeleteUploadRequest) =>
-    repository.deleteUpload(request)
-  )
-  ipcMain.handle('uploads:finalize-session', (_event, request: FinalizeUploadSessionRequest) =>
-    repository.finalizePendingSessionUploads(request.sessionId, request.attachments)
-  )
+  // Uploads write/mutate under the data root, so block them during the data-root copy→commit window.
+  ipcMain.handle('uploads:stage-files', (_event, request: StageUploadFilesRequest) => {
+    assertNoMigrationPending()
+    return repository.stageFiles(request)
+  })
+  ipcMain.handle('uploads:delete', (_event, request: DeleteUploadRequest) => {
+    assertNoMigrationPending()
+    return repository.deleteUpload(request)
+  })
+  ipcMain.handle('uploads:finalize-session', (_event, request: FinalizeUploadSessionRequest) => {
+    assertNoMigrationPending()
+    return repository.finalizePendingSessionUploads(request.sessionId, request.attachments)
+  })
   ipcMain.handle('uploads:read-preview', (_event, request: ReadArtifactPreviewRequest) =>
     repository.readManagedUploadPreview(request)
   )

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -7,7 +7,7 @@ import type {
   StageUploadFilesRequest
 } from '../../shared/uploads'
 import { resolveDataRoot } from '../storage-root'
-import { assertNoMigrationPending } from '../storage/migration-state'
+import { withDataRootWrite } from '../storage/migration-state'
 import { UploadRepository } from './repository'
 
 // Uploads are data-class: they follow the configurable data root (defaults to the config root).
@@ -17,18 +17,17 @@ const createDefaultUploadRepository = (): UploadRepository =>
 // Registers the small upload IPC surface used by the renderer composer and preview panel.
 const registerUploadIpcHandlers = (repository = createDefaultUploadRepository()): void => {
   // Uploads write/mutate under the data root, so block them during the data-root copy→commit window.
-  ipcMain.handle('uploads:stage-files', (_event, request: StageUploadFilesRequest) => {
-    assertNoMigrationPending()
-    return repository.stageFiles(request)
-  })
-  ipcMain.handle('uploads:delete', (_event, request: DeleteUploadRequest) => {
-    assertNoMigrationPending()
-    return repository.deleteUpload(request)
-  })
-  ipcMain.handle('uploads:finalize-session', (_event, request: FinalizeUploadSessionRequest) => {
-    assertNoMigrationPending()
-    return repository.finalizePendingSessionUploads(request.sessionId, request.attachments)
-  })
+  ipcMain.handle('uploads:stage-files', (_event, request: StageUploadFilesRequest) =>
+    withDataRootWrite(() => repository.stageFiles(request))
+  )
+  ipcMain.handle('uploads:delete', (_event, request: DeleteUploadRequest) =>
+    withDataRootWrite(() => repository.deleteUpload(request))
+  )
+  ipcMain.handle('uploads:finalize-session', (_event, request: FinalizeUploadSessionRequest) =>
+    withDataRootWrite(() =>
+      repository.finalizePendingSessionUploads(request.sessionId, request.attachments)
+    )
+  )
   ipcMain.handle('uploads:read-preview', (_event, request: ReadArtifactPreviewRequest) =>
     repository.readManagedUploadPreview(request)
   )


### PR DESCRIPTION
## Summary

Follow-up hardening for the configurable data-root migration (#149 / #151). Closes three data-loss / data-corruption paths in the copy → commit → delete flow.

- **Verified-copy marker** (new `src/main/storage/migration-marker.ts`): a `.open-science-migration.json` sentinel (`copying` → `verified`, carrying token + source + target + inventory) is written into the staging copy. `commitDataRootSwitch` now refuses anything but a `verified` marker whose source → target matches the current move, and `discardStagedCopy` refuses any directory that isn't a marker-confirmed staging copy for the current root (never the live root). `computeDefaultDataRoot` ignores a marker-bearing `~/OpenScience`, so a crashed or uncommitted copy can no longer hijack the legacy-install fallback and split a user's data.
- **Write gate**: `migration-state` now tracks two flags — `copying` (drives the quit guard) and `pending` (drives the write gate). `pending` is held across the entire copy → commit window, and `AcpRuntime.sendPrompt` / `NotebookRuntimeService.runCell` refuse while it is set, so a prompt or notebook cell can no longer write into the old root that the commit is about to delete.
- **Symlink / special-file fail-fast**: the copy scanner previously skipped symlinks and special files silently, and `deleteSources` then removed them from the old root — silent data loss. Migration now fails fast with an actionable message instead.
- Corrects a stale comment in `classifyDataRoot` that claimed spaces are allowed on every platform (they are rejected on macOS/Linux, per #151). No runtime change.

## Testing

- `npm run lint`, `npm run typecheck` (node + web), `npm run build` — all clean.
- `vitest run` across storage, storage-root, and acp/notebook runtime — 201 passing, including new tests for the marker, the commit/discard gate, the write-gate lifecycle, and symlink fail-fast.

## Notes / follow-ups

- The write gate covers `sendPrompt` and `runCell` (the primary writers); the direct notebook `execute` path is not gated.
- If the done-stage modal is dismissed without choosing commit or discard, `pending` stays set until relaunch (writes stay blocked). Acceptable per the intent; a future banner or auto-discard could soften it.
