### PR TITLE
fix(storage): reviewer artifacts on data root + absolute dataRoot

### DIFF
--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ReviewRunRequest } from '../../shared/reviewer'
+import { REVIEWER_IPC } from '../../shared/reviewer'
+import type { AcpRuntime } from '../acp/runtime'
+
+// Distinct roots so a config-vs-data mix-up is unambiguous: artifacts must read from the data root.
+const CONFIG_ROOT = '/tmp/open-science-config-root'
+const DATA_ROOT = '/tmp/open-science-data-root'
+
+// Capture every ipcMain.handle registration so handlers can be invoked directly in the test.
+const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown, payload: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }
+  },
+  BrowserWindow: { getAllWindows: () => [] }
+}))
+
+vi.mock('../storage-root', () => ({
+  resolveStorageRoot: () => CONFIG_ROOT,
+  resolveDataRoot: () => DATA_ROOT
+}))
+
+const runReview = vi.fn().mockResolvedValue(undefined)
+vi.mock('./orchestrator', () => ({
+  runReview: (options: unknown) => runReview(options)
+}))
+
+// The repository/DB/session collaborators are irrelevant to the root split; stub them out.
+vi.mock('./repository', () => ({
+  ReviewRepository: class {
+    getReviewsForSession = vi.fn().mockResolvedValue([])
+  }
+}))
+
+vi.mock('../projects/prisma-client', () => ({
+  getProjectDbClient: vi.fn()
+}))
+
+vi.mock('../session-persistence/repository', () => ({
+  SessionRepository: class {
+    loadAll = vi.fn().mockResolvedValue({ sessions: [] })
+  },
+  // storage-root imports these names from the same module in production; keep them defined.
+  DEV_SESSION_DIR_NAME: 'dev',
+  PROD_SESSION_DIR_NAME: 'prod',
+  getSessionPersistenceDir: () => CONFIG_ROOT
+}))
+
+const { registerReviewerIpcHandlers } = await import('./ipc')
+
+const acpRuntime = {} as AcpRuntime
+
+const createRequest = (): ReviewRunRequest => ({
+  sessionId: 'session-1',
+  turnMessageId: 'message-1',
+  projectId: 'project-1'
+})
+
+describe('reviewer IPC handlers', () => {
+  it('runs reviews with artifacts rooted at the data root, not the config root', async () => {
+    runReview.mockClear()
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    expect(runHandler).toBeDefined()
+
+    runHandler?.({}, createRequest())
+
+    // triggerReview is fire-and-forget; wait for the background session load + runReview call.
+    await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
+
+    const passed = runReview.mock.calls[0][0] as { artifactStorageRoot: string }
+    expect(passed.artifactStorageRoot).toBe(DATA_ROOT)
+    expect(passed.artifactStorageRoot).not.toBe(CONFIG_ROOT)
+  })
+
+  it('lets injected options override the config/data split independently', async () => {
+    runReview.mockClear()
+    registerReviewerIpcHandlers({
+      acpRuntime,
+      storageRoot: '/tmp/injected-config',
+      dataRoot: '/tmp/injected-data'
+    })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    runHandler?.({}, createRequest())
+
+    await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
+
+    const passed = runReview.mock.calls[0][0] as { artifactStorageRoot: string }
+    expect(passed.artifactStorageRoot).toBe('/tmp/injected-data')
+  })
+})

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -10,7 +10,7 @@ import { createLogger } from '../logger'
 import { runReview } from './orchestrator'
 import { ReviewRepository } from './repository'
 import type { AcpRuntime } from '../acp/runtime'
-import { resolveStorageRoot } from '../storage-root'
+import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { SessionRepository } from '../session-persistence/repository'
 
@@ -68,8 +68,10 @@ const createDefaultReviewRepository = (): ReviewRepository => {
 type ReviewerIpcOptions = {
   // The ACP runtime used to spawn reviewer sessions.
   acpRuntime: AcpRuntime
-  // Optional override for the storage root (for testing).
+  // Optional override for the config root (DB/sessions) (for testing).
   storageRoot?: string
+  // Optional override for the data root (artifacts) (for testing).
+  dataRoot?: string
 }
 
 // Registers the reviewer IPC handlers on the Electron main process. Returns a function that can
@@ -80,6 +82,7 @@ const registerReviewerIpcHandlers = (
   triggerReview: (request: ReviewRunRequest) => void
 } => {
   const storageRoot = options.storageRoot ?? resolveStorageRoot()
+  const dataRoot = options.dataRoot ?? resolveDataRoot()
   const reviewRepository = createDefaultReviewRepository()
   const sessionRepository = new SessionRepository(storageRoot)
 
@@ -135,7 +138,8 @@ const registerReviewerIpcHandlers = (
           getSession: () => session,
           reviewRepository,
           acpRuntime: options.acpRuntime,
-          artifactStorageRoot: storageRoot,
+          // Artifacts live under the relocatable data root; DB/sessions stay on the config root.
+          artifactStorageRoot: dataRoot,
           onReviewUpdate: (review: ReviewWithChecks) => {
             broadcastReviewUpdate({ review })
           },

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -1,9 +1,9 @@
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { isAbsolute, join, normalize, sep } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { SettingsRepository } from './repository'
+import { SettingsRepository, sanitizeSettings } from './repository'
 import type { StoredProvider } from './types'
 
 let storageRoot: string | undefined
@@ -239,8 +239,29 @@ describe('settings repository', () => {
     const second = await repository.setDataRoot('/mnt/data-b')
     expect(second.dataRoot).toBe('/mnt/data-b')
 
+    // getSettings reads through sanitizeSettings, which normalizes the stored path (backslashes on
+    // Windows), so compare against the platform-normalized form rather than the literal.
     const reloaded = await new SettingsRepository(root).getSettings()
-    expect(reloaded.dataRoot).toBe('/mnt/data-b')
+    expect(reloaded.dataRoot).toBe(normalize('/mnt/data-b'))
+  })
+
+  it('sanitizeSettings drops a relative dataRoot and keeps only an absolute, normalized one', () => {
+    // A relative dataRoot (corrupt or hand-edited settings.json) must be dropped so the data tree
+    // never resolves against process.cwd(); initDataRoot then falls back to the default.
+    expect(sanitizeSettings({ dataRoot: 'relative/path' }).dataRoot).toBeUndefined()
+    expect(sanitizeSettings({ dataRoot: './OpenScience' }).dataRoot).toBeUndefined()
+
+    // Whitespace-only is not a path.
+    expect(sanitizeSettings({ dataRoot: '   ' }).dataRoot).toBeUndefined()
+
+    // Build an absolute path with platform-correct roots so isAbsolute holds on POSIX and Windows.
+    const absolute = isAbsolute('/mnt/data') ? '/mnt/data' : `C:${sep}mnt${sep}data`
+    // Surrounding whitespace is trimmed, then the path is kept.
+    expect(sanitizeSettings({ dataRoot: `  ${absolute} ` }).dataRoot).toBe(normalize(absolute))
+
+    // A redundant separator AND a trailing separator collapse to the canonical no-trailing-slash form.
+    const messy = `${absolute}${sep}${sep}x${sep}`
+    expect(sanitizeSettings({ dataRoot: messy }).dataRoot).toBe(normalize(`${absolute}${sep}x`))
   })
 
   it('stamps legacyDataMovePromptDismissedAt once, is idempotent, and survives a reload', async () => {

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -264,6 +264,13 @@ describe('settings repository', () => {
     expect(sanitizeSettings({ dataRoot: messy }).dataRoot).toBe(normalize(`${absolute}${sep}x`))
   })
 
+  it('never strips a trailing separator past a filesystem root', () => {
+    // A drive/filesystem root ("C:\" on Windows, "/" on POSIX) must survive intact: stripping its
+    // trailing separator would turn an absolute path into a drive-relative one.
+    const rootPath = isAbsolute('C:\\') ? 'C:\\' : '/'
+    expect(sanitizeSettings({ dataRoot: rootPath }).dataRoot).toBe(normalize(rootPath))
+  })
+
   it('stamps legacyDataMovePromptDismissedAt once, is idempotent, and survives a reload', async () => {
     const root = await createStorageRoot()
     const repository = new SettingsRepository(root)

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
-import { isAbsolute, join, normalize } from 'node:path'
+import { isAbsolute, join, normalize, parse } from 'node:path'
 
 import type {
   ClaudeInfo,
@@ -287,9 +287,12 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
   if (dataRoot && isAbsolute(dataRoot)) {
     // normalize collapses redundant separators; strip any trailing separator so the stored form
     // matches dataRootForPicked's canonical (no-trailing-slash) output — samePath() compares exact
-    // strings, so a stray trailing slash would wrongly fail the "is default" check.
-    const canonical = normalize(dataRoot).replace(/[\\/]+$/, '')
-    settings.dataRoot = canonical || dataRoot
+    // strings, so a stray trailing slash would wrongly fail the "is default" check. Never strip past a
+    // filesystem root, though: turning "C:\" into "C:" would make an absolute path drive-relative.
+    const normalized = normalize(dataRoot)
+    const { root } = parse(normalized)
+    settings.dataRoot =
+      normalized.length > root.length ? normalized.replace(/[\\/]+$/, '') : normalized
   }
 
   return settings

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { isAbsolute, join, normalize } from 'node:path'
 
 import type {
   ClaudeInfo,
@@ -279,10 +279,17 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
     settings.legacyDataMovePromptDismissedAt = legacyDataMovePromptDismissedAt
   }
 
-  const dataRoot = asString(value.dataRoot)
+  // Only accept an absolute, normalized dataRoot. A relative path (corrupt or hand-edited
+  // settings.json) would make the entire data tree resolve against process.cwd(); drop it so
+  // initDataRoot falls back to the default. Mirrors the OPEN_SCIENCE_STORAGE_ROOT absolute contract.
+  const dataRoot = asString(value.dataRoot)?.trim()
 
-  if (dataRoot) {
-    settings.dataRoot = dataRoot
+  if (dataRoot && isAbsolute(dataRoot)) {
+    // normalize collapses redundant separators; strip any trailing separator so the stored form
+    // matches dataRootForPicked's canonical (no-trailing-slash) output — samePath() compares exact
+    // strings, so a stray trailing slash would wrongly fail the "is default" check.
+    const canonical = normalize(dataRoot).replace(/[\\/]+$/, '')
+    settings.dataRoot = canonical || dataRoot
   }
 
   return settings


### PR DESCRIPTION
## Summary

Two independent follow-ups to the configurable data-root feature (#149): consumers that must track the relocatable data root rather than the fixed config root.

- **Reviewer artifacts**: `reviewer/ipc.ts` passed the config root as `artifactStorageRoot`, but artifacts are written under the data root (`new ArtifactRepository(resolveDataRoot())`). After a relocation, the reviewer's `host.read_artifact()` looked under the config root and hard-failed. It now reads from the data root; the review DB and sessions stay on the config root.
- **dataRoot validation**: `sanitizeSettings` accepted any non-empty string. A relative or hand-edited value would make the entire data tree resolve against `process.cwd()`. It now requires an absolute path and stores the canonical, no-trailing-slash form (matching `dataRootForPicked`), so the exact-equality `samePath` / `isDefault` checks stay correct. Mirrors the existing `OPEN_SCIENCE_STORAGE_ROOT` absolute-path contract.

## Testing

- `npm run lint`, `npm run typecheck` (node + web) — clean.
- `vitest run` for reviewer + settings — 25 passing, including a new reviewer IPC test asserting the config/data-root split and new sanitize cases for relative, whitespace-only, and trailing-separator paths.
