### PR TITLE
fix(acp): kill agent child on app quit so it cannot outlive the app

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -18,6 +18,7 @@ import type {
 } from '../../shared/acp'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
 import { AcpRuntime } from './runtime'
+import { installAgentShutdownGuard } from './shutdown-guard'
 import type { ArtifactRepository } from '../artifacts/repository'
 import type { ArtifactRunRegistry } from '../artifacts/run-registry'
 import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
@@ -141,6 +142,9 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntime => {
     'acp:revoke-permission-grant',
     (_event, request: AcpRevokePermissionGrantRequest) => runtime.revokePermissionGrant(request)
   )
+
+  // Kill the agent child on quit so it never outlives the app as an orphaned process.
+  installAgentShutdownGuard(app, runtime)
 
   return runtime
 }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -246,6 +246,26 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.actions).toEqual(['mode:bypassPermissions', 'prompt:continue'])
   })
 
+  it('kills the agent process synchronously on shutdown so it cannot outlive the app', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['shutdown-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    expect(process.killed).toBe(false)
+
+    // shutdown() is synchronous (will-quit cannot await): the child must be signalled before it returns.
+    runtime.shutdown()
+    expect(process.killed).toBe(true)
+
+    // Calling it again after the process is gone is a no-op, not a crash.
+    expect(() => runtime.shutdown()).not.toThrow()
+  })
+
   it('reports conservative Auto when the Agent has no native auto mode', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['auto-session'], {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -266,6 +266,25 @@ describe('ACP runtime session management', () => {
     expect(() => runtime.shutdown()).not.toThrow()
   })
 
+  it('kills a child that finishes spawning after shutdown began, so quit-during-connect cannot orphan it', async () => {
+    const process = new FakeAgentProcess()
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      // Model the app quitting mid-spawn: shutdown() lands before this child is handed back to connect.
+      spawnAgent: () => {
+        runtime.shutdown()
+        return asAgentProcess(process)
+      }
+    })
+
+    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(/shutting down/)
+
+    // The child that spawned after killAgentProcess ran must still be terminated, not left as an orphan.
+    expect(process.killed).toBe(true)
+    expect(runtime.getSnapshot().sessionId).toBeUndefined()
+  })
+
   it('reports conservative Auto when the Agent has no native auto mode', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['auto-session'], {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -208,6 +208,9 @@ class AcpRuntime {
   private events: AcpRuntimeEvent[] = []
   private eventSequence = 0
   private agentProcess: ChildProcessWithoutNullStreams | undefined
+  // Latched by shutdown() on app quit. A connect can be mid-spawn (resolveSpawnConfig is async) when
+  // quit fires, so this lets the post-spawn path kill a child that was created after killAgentProcess ran.
+  private shuttingDown = false
   private connection: ClientConnection | undefined
   private connectInFlight: Promise<AcpStateSnapshot> | undefined
   private connectionGeneration = 0
@@ -380,7 +383,17 @@ class AcpRuntime {
     log.info('connecting agent', { cwd: this.cwd, generation })
 
     try {
-      this.agentProcess = await this.spawnAgentProcess()
+      const agentProcess = await this.spawnAgentProcess()
+
+      // spawnAgentProcess resolves the provider config asynchronously, so the app may have begun
+      // quitting during the spawn. If shutdown() already ran, its killAgentProcess() saw no process
+      // yet — kill this freshly-spawned child now and abort, or it would outlive the app as an orphan.
+      if (this.shuttingDown) {
+        agentProcess.kill()
+        throw new Error('ACP runtime is shutting down.')
+      }
+
+      this.agentProcess = agentProcess
       this.attachAgentProcessEvents(this.agentProcess)
 
       const stream = acp.ndJsonStream(
@@ -743,6 +756,7 @@ class AcpRuntime {
   // the app is gone would be an orphaned process still holding its network connection open. The OS
   // reclaims the remaining connection/session state as the process exits.
   shutdown(): void {
+    this.shuttingDown = true
     this.nextConnectionGeneration()
     this.connectInFlight = undefined
     this.connection?.close()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -738,6 +738,18 @@ class AcpRuntime {
     return this.disconnectCurrent(emitClosedStatus)
   }
 
+  // Synchronously terminates the agent child for app shutdown. Electron's `will-quit` cannot await, so
+  // this does only the synchronous work of signalling the child to exit — an agent left running after
+  // the app is gone would be an orphaned process still holding its network connection open. The OS
+  // reclaims the remaining connection/session state as the process exits.
+  shutdown(): void {
+    this.nextConnectionGeneration()
+    this.connectInFlight = undefined
+    this.connection?.close()
+    this.connection = undefined
+    this.killAgentProcess()
+  }
+
   // Applies an active-provider change without interrupting the user. The agent bakes its provider env in
   // at spawn, so a new provider needs a reconnect — but if a prompt is running we defer the reconnect
   // until the session goes idle. Because every provider shares one config dir, the reconnect resumes the
@@ -802,6 +814,18 @@ class AcpRuntime {
     this.connection?.close()
     this.connection = undefined
 
+    this.killAgentProcess()
+
+    if (emitClosedStatus) {
+      this.setStatus('closed')
+    }
+
+    return this.getSnapshot()
+  }
+
+  // Signals the current agent child to exit and marks the exit expected so the stderr/error/exit
+  // handlers stay quiet. Shared by the async disconnect teardown and the synchronous quit shutdown.
+  private killAgentProcess(): void {
     if (this.agentProcess) {
       this.expectedProcessExits.add(this.agentProcess)
 
@@ -811,12 +835,6 @@ class AcpRuntime {
     }
 
     this.agentProcess = undefined
-
-    if (emitClosedStatus) {
-      this.setStatus('closed')
-    }
-
-    return this.getSnapshot()
   }
 
   private nextConnectionGeneration(): number {

--- a/src/main/acp/shutdown-guard.test.ts
+++ b/src/main/acp/shutdown-guard.test.ts
@@ -1,0 +1,45 @@
+import type { App } from 'electron'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpRuntime } from './runtime'
+import { installAgentShutdownGuard } from './shutdown-guard'
+
+// Captures registered app event handlers so the will-quit teardown can be invoked without Electron.
+const createFakeApp = (): {
+  on: App['on']
+  emit: (event: string) => void
+} => {
+  const handlers = new Map<string, () => void>()
+
+  return {
+    on: ((event: string, handler: () => void) => {
+      handlers.set(event, handler)
+    }) as App['on'],
+    emit: (event: string) => handlers.get(event)?.()
+  }
+}
+
+describe('installAgentShutdownGuard', () => {
+  it('shuts the runtime down when the app is quitting', () => {
+    const app = createFakeApp()
+    const shutdown = vi.fn()
+    installAgentShutdownGuard(app, { shutdown } as unknown as Pick<AcpRuntime, 'shutdown'>)
+
+    expect(shutdown).not.toHaveBeenCalled()
+
+    app.emit('will-quit')
+
+    expect(shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not shut the runtime down before quit is committed', () => {
+    const app = createFakeApp()
+    const shutdown = vi.fn()
+    installAgentShutdownGuard(app, { shutdown } as unknown as Pick<AcpRuntime, 'shutdown'>)
+
+    // before-quit can be cancelled (e.g. the migration guard), so it must not trigger the teardown.
+    app.emit('before-quit')
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/acp/shutdown-guard.ts
+++ b/src/main/acp/shutdown-guard.ts
@@ -1,0 +1,17 @@
+import type { App } from 'electron'
+
+import type { AcpRuntime } from './runtime'
+
+// Kills the agent child when the app is actually quitting so no orphaned Claude agent process outlives
+// the window — an orphan would keep its network connection alive after the app is gone. `will-quit`
+// (not `before-quit`) fires only once the quit is committed, so a quit the migration guard cancels —
+// asking the user to keep waiting — does not tear the agent down early. The runtime shutdown is
+// synchronous because Electron does not await quit-event handlers.
+export const installAgentShutdownGuard = (
+  app: Pick<App, 'on'>,
+  runtime: Pick<AcpRuntime, 'shutdown'>
+): void => {
+  app.on('will-quit', () => {
+    runtime.shutdown()
+  })
+}


### PR DESCRIPTION
## Problem

The ACP agent child process is spawned non-detached (`agent-process.ts`) and was killed **only** through `disconnect()` — provider switch, skills reload, resume timeout, or the `acp:disconnect` IPC. No app-lifecycle hook tore it down when the app itself quit.

As a result, on quit the main process exited without killing the child. On Unix a non-detached child is not reaped when its parent exits — it gets reparented to launchd/init and keeps running as an orphan, still holding its network connection open after the app is gone.

## Fix

- Add a synchronous `AcpRuntime.shutdown()`. Electron's `will-quit` cannot await, so it does only the synchronous work of signalling the child to exit.
- Extract the shared child-kill into `killAgentProcess()`, reused by `disconnectCurrent()` and `shutdown()`.
- Add `installAgentShutdownGuard(app, runtime)` and wire it into `registerAcpIpcHandlers`. It uses `will-quit` (not `before-quit`) so a quit that the migration guard cancels — asking the user to keep waiting — does not tear the agent down early.

## Notes

- macOS: closing just the window keeps the app running by convention, so the agent lives until an actual quit (Cmd+Q). This fix triggers on real quit.
- A hard crash / `kill -9` of the main process cannot run JS handlers; covering that would require the child to die with its parent (e.g. `PR_SET_PDEATHSIG`) and is out of scope here.

## Testing

- `npm run typecheck` — clean
- `npx vitest run src/main/acp/runtime.test.ts src/main/acp/shutdown-guard.test.ts` — 39 passed (new: synchronous kill on `shutdown()`, guard fires only on committed quit)
- `npx eslint` on changed files — clean