### PR TITLE
ci: fix windows runtime bundle tar paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,9 @@ jobs:
           echo "fetching offline bundle: $url"
           if curl -fsSL "$url" -o "$RUNNER_TEMP/default-envs.tar.gz"; then
             mkdir -p resources/default-envs
-            tar -xzf "$RUNNER_TEMP/default-envs.tar.gz" -C resources/default-envs
+            tar_args=()
+            [ "$RUNNER_OS" = "Windows" ] && tar_args+=(--force-local)
+            tar "${tar_args[@]}" -xzf "$RUNNER_TEMP/default-envs.tar.gz" -C resources/default-envs
             echo "staged offline bundle ($(ls resources/default-envs/pkgs | wc -l) tarballs) for ${{ matrix.subdir }}"
           else
             echo "::warning::no offline bundle at $url (run stage-runtime-bundle.yml first) — app will provision on first run"

--- a/.github/workflows/stage-runtime-bundle.yml
+++ b/.github/workflows/stage-runtime-bundle.yml
@@ -68,7 +68,7 @@ jobs:
       # One tarball per platform keeps the CDN upload + build-time download to a single object.
       - name: Pack bundle
         shell: bash
-        run: tar -czf "$RUNNER_TEMP/default-envs.tar.gz" -C resources/default-envs .
+        run: tar --force-local -czf "$RUNNER_TEMP/default-envs.tar.gz" -C resources/default-envs .
 
       # Read DEFAULT_ENV_VERSION straight from its source of truth so the CDN path always matches what
       # the app fetches at runtime (bundle-fetch.ts uses the same version segment).

--- a/.github/workflows/stage-runtime-bundle.yml
+++ b/.github/workflows/stage-runtime-bundle.yml
@@ -68,7 +68,10 @@ jobs:
       # One tarball per platform keeps the CDN upload + build-time download to a single object.
       - name: Pack bundle
         shell: bash
-        run: tar --force-local -czf "$RUNNER_TEMP/default-envs.tar.gz" -C resources/default-envs .
+        run: |
+          tar_args=()
+          [ "$RUNNER_OS" = "Windows" ] && tar_args+=(--force-local)
+          tar "${tar_args[@]}" -czf "$RUNNER_TEMP/default-envs.tar.gz" -C resources/default-envs .
 
       # Read DEFAULT_ENV_VERSION straight from its source of truth so the CDN path always matches what
       # the app fetches at runtime (bundle-fetch.ts uses the same version segment).


### PR DESCRIPTION
Fixes the Windows Git Bash tar path handling for runtime bundle staging and consumption.\n\nValidation:\n- Runtime bundle staging passed for win-64 after applying --force-local conditionally.\n- Release workflow run 29627960615 passed for build / Build windows-x64 and uploaded artifact windows-x64.\n\nThis updates PR #160 with the workflow fix needed to package the notebook runtime bundle on Windows.