### PR TITLE
feat(lifecycle): add tray residency, single-instance lock, and awaited quit cleanup

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -349,6 +349,70 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().sessionId).toBeUndefined()
   })
 
+  it('shutdownForQuit awaits agent teardown so app.exit cannot race a live child', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['quit-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    expect(process.killed).toBe(false)
+
+    // The awaited quit path must have terminated the agent by the time it resolves.
+    await runtime.shutdownForQuit()
+    expect(process.killed).toBe(true)
+    expect(runtime.getSnapshot().sessionId).toBeUndefined()
+  })
+
+  it('shutdownForQuit waits out an in-flight connect and reaps the mid-spawn child before resolving', async () => {
+    const process = new FakeAgentProcess()
+    let quitPromise: Promise<void> | undefined
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      // Model quit landing mid-spawn on the async path: start the quit teardown, then hand back the
+      // freshly-spawned child. shutdownForQuit must await this in-flight connect so connectFresh reaches
+      // its shutting-down check and tree-kills the child before the teardown resolves — otherwise
+      // app.exit() would run first and orphan it.
+      spawnAgent: () => {
+        quitPromise = runtime.shutdownForQuit()
+        return asAgentProcess(process)
+      }
+    })
+
+    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(/shutting down/)
+    expect(quitPromise).toBeDefined()
+    await quitPromise
+    // The child spawned mid-connect has been reaped by the time the quit teardown resolves.
+    expect(process.killed).toBe(true)
+    expect(runtime.getSnapshot().sessionId).toBeUndefined()
+  })
+
+  it('shutdownForQuit kills an assigned agent instead of waiting on a stalled initialize', async () => {
+    const process = new FakeAgentProcess()
+    // No startFakeAgent: the agent never answers initialize, so connect() assigns the child and then
+    // stalls. shutdownForQuit must kill that assigned child rather than wait out the hung connect.
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const connecting = runtime.createSession({ cwd: '/workspace' }).catch(() => undefined)
+    // Let connectFresh assign this.agentProcess and reach the (unanswered) initialize await.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(process.killed).toBe(false)
+
+    // Must resolve promptly (not hang until shutdownBackends' timeout) with the child reaped.
+    await runtime.shutdownForQuit()
+    expect(process.killed).toBe(true)
+    expect(runtime.getSnapshot().sessionId).toBeUndefined()
+    await connecting
+  })
+
   it('reports conservative Auto when the Agent has no native auto mode', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['auto-session'], {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -39,6 +39,7 @@ import {
 } from '../../shared/permission-profiles'
 import { spawnClaudeAgentAcp, type SpawnClaudeAgentAcpOptions } from './agent-process'
 import { createLogger } from '../logger'
+import { terminateProcessTree } from '../process-tree'
 import {
   extractProviderToolName,
   extractToolFailureText,
@@ -387,10 +388,12 @@ class AcpRuntime {
       const agentProcess = await this.spawnAgentProcess()
 
       // spawnAgentProcess resolves the provider config asynchronously, so the app may have begun
-      // quitting during the spawn. If shutdown() already ran, its killAgentProcess() saw no process
-      // yet — kill this freshly-spawned child now and abort, or it would outlive the app as an orphan.
+      // quitting during the spawn. If a shutdown already latched shuttingDown, its teardown saw no
+      // process yet — tree-kill this freshly-spawned child now and abort, or it would outlive the app as
+      // an orphan. Awaited (not a bare kill) so the quit path, which awaits this in-flight connect, does
+      // not exit before the child's whole tree is reaped on Windows.
       if (this.shuttingDown) {
-        agentProcess.kill()
+        await terminateProcessTree(agentProcess)
         throw new Error('ACP runtime is shutting down.')
       }
 
@@ -765,6 +768,25 @@ class AcpRuntime {
     this.killAgentProcess()
   }
 
+  // Awaitable quit/relaunch teardown. Latches shuttingDown FIRST so a connect that is mid-spawn when
+  // quit lands self-aborts and kills its freshly-spawned child (see connectFresh). Unlike shutdown(),
+  // this can be awaited, so a caller that follows it with app.exit(0) is guaranteed no orphaned agent
+  // remains — assigned, connecting, or mid-spawn.
+  async shutdownForQuit(): Promise<void> {
+    this.shuttingDown = true
+    // Capture the in-flight connect before disconnect() clears it.
+    const inFlight = this.connectInFlight
+    // Kill the currently-assigned agent tree right away. Do NOT wait on the in-flight connect first: it
+    // may be stalled on ACP initialize with the child already assigned, and waiting would let
+    // shutdownBackends time out and app.exit orphan it. disconnect() reaps that child's tree and closes
+    // the connection, which also unblocks (rejects) the stalled connect.
+    await this.disconnect(false)
+    // Cover the child that had not been assigned yet when disconnect ran: a connect still mid-spawn hits
+    // the shutting-down check and tree-kills its freshly-spawned child. Await it (swallowing its
+    // rejection, bounded by shutdownBackends' timeout) so that kill completes before we resolve.
+    if (inFlight) await inFlight.catch(() => undefined)
+  }
+
   // Applies an active-provider change without interrupting the user. The agent bakes its provider env in
   // at spawn, so a new provider needs a reconnect — but if a prompt is running we defer the reconnect
   // until the session goes idle. Because every provider shares one config dir, the reconnect resumes the
@@ -829,7 +851,7 @@ class AcpRuntime {
     this.connection?.close()
     this.connection = undefined
 
-    this.killAgentProcess()
+    await this.killAgentProcessTree()
 
     if (emitClosedStatus) {
       this.setStatus('closed')
@@ -839,7 +861,9 @@ class AcpRuntime {
   }
 
   // Signals the current agent child to exit and marks the exit expected so the stderr/error/exit
-  // handlers stay quiet. Shared by the async disconnect teardown and the synchronous quit shutdown.
+  // handlers stay quiet. Synchronous: used by the will-quit backstop (shutdown()), which Electron
+  // cannot await. It only signals the immediate child — the awaited disconnect path below reaps the
+  // whole tree.
   private killAgentProcess(): void {
     if (this.agentProcess) {
       this.expectedProcessExits.add(this.agentProcess)
@@ -850,6 +874,17 @@ class AcpRuntime {
     }
 
     this.agentProcess = undefined
+  }
+
+  // Awaitable tree teardown for the async disconnect path: marks the exit expected, then hands the
+  // whole process tree to terminateProcessTree so a Windows grandchild (taskkill /T) is reaped before
+  // the caller (before-quit shutdownBackends) proceeds to app.exit.
+  private async killAgentProcessTree(): Promise<void> {
+    const child = this.agentProcess
+    this.agentProcess = undefined
+    if (!child) return
+    this.expectedProcessExits.add(child)
+    await terminateProcessTree(child)
   }
 
   private nextConnectionGeneration(): number {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -393,7 +393,7 @@ class AcpRuntime {
       // an orphan. Awaited (not a bare kill) so the quit path, which awaits this in-flight connect, does
       // not exit before the child's whole tree is reaped on Windows.
       if (this.shuttingDown) {
-        await terminateProcessTree(agentProcess)
+        await terminateProcessTree(agentProcess, undefined, log)
         throw new Error('ACP runtime is shutting down.')
       }
 
@@ -884,7 +884,7 @@ class AcpRuntime {
     this.agentProcess = undefined
     if (!child) return
     this.expectedProcessExits.add(child)
-    await terminateProcessTree(child)
+    await terminateProcessTree(child, undefined, log)
   }
 
   private nextConnectionGeneration(): number {

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { installAppLifecycle, type AppLifecycleDeps, type TrayHandlers } from './app-lifecycle'
+
+type QuitEvent = { preventDefault: () => void; defaultPrevented: boolean }
+type Handler = (event: QuitEvent) => void
+
+type FakeApp = {
+  on: (event: string, handler: Handler) => void
+  exit: ReturnType<typeof vi.fn>
+  // Fires every listener for an event with a fresh preventable event, returning it for assertions.
+  emit: (event: string) => QuitEvent
+}
+
+// Minimal Electron app double: records lifecycle listeners so tests can fire them, and captures exit.
+const makeFakeApp = (): FakeApp => {
+  const handlers = new Map<string, Handler[]>()
+  return {
+    on(event, handler): void {
+      const list = handlers.get(event) ?? []
+      list.push(handler)
+      handlers.set(event, list)
+    },
+    exit: vi.fn(),
+    emit(event): QuitEvent {
+      const evt: QuitEvent = {
+        defaultPrevented: false,
+        preventDefault(): void {
+          evt.defaultPrevented = true
+        }
+      }
+      for (const handler of handlers.get(event) ?? []) handler(evt)
+      return evt
+    }
+  }
+}
+
+type FakeWindow = {
+  destroyed: boolean
+  minimized: boolean
+  visible: boolean
+  focused: boolean
+  isDestroyed: () => boolean
+  isMinimized: () => boolean
+  isVisible: () => boolean
+  restore: () => void
+  show: () => void
+  hide: () => void
+  focus: () => void
+}
+
+// A fake BrowserWindow tracking visibility/focus/destroyed state.
+const makeFakeWindow = (): FakeWindow => ({
+  destroyed: false,
+  minimized: false,
+  visible: true,
+  focused: false,
+  isDestroyed(): boolean {
+    return this.destroyed
+  },
+  isMinimized(): boolean {
+    return this.minimized
+  },
+  isVisible(): boolean {
+    return this.visible
+  },
+  restore(): void {
+    this.minimized = false
+  },
+  show(): void {
+    this.visible = true
+  },
+  hide(): void {
+    this.visible = false
+  },
+  focus(): void {
+    this.focused = true
+  }
+})
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+const asWindow = (w: FakeWindow): import('electron').BrowserWindow =>
+  w as unknown as import('electron').BrowserWindow
+
+type Harness = {
+  app: FakeApp
+  windows: FakeWindow[]
+  tray: { destroy: ReturnType<typeof vi.fn> } | undefined
+  trayHandlers: TrayHandlers | undefined
+  shutdownBackends: () => Promise<void>
+  quit: ReturnType<typeof vi.fn>
+  showMainWindow: () => void
+}
+
+const setup = (
+  overrides: Partial<
+    Pick<AppLifecycleDeps, 'shutdownBackends' | 'isMigrationInProgress' | 'platform'>
+  > & {
+    trayHost?: boolean
+  } = {}
+): Harness => {
+  const app = makeFakeApp()
+  const windows: FakeWindow[] = []
+  const trayHost = overrides.trayHost ?? true
+  const tray = trayHost ? { destroy: vi.fn() } : undefined
+  let trayHandlers: TrayHandlers | undefined
+  const shutdownBackends = overrides.shutdownBackends ?? vi.fn(async () => undefined)
+  const quit = vi.fn()
+
+  const { showMainWindow } = installAppLifecycle({
+    app: app as unknown as AppLifecycleDeps['app'],
+    createMainWindow: () => {
+      const w = makeFakeWindow()
+      windows.push(w)
+      return asWindow(w)
+    },
+    createTray: (handlers) => {
+      trayHandlers = handlers
+      return tray as unknown as import('electron').Tray | undefined
+    },
+    shutdownBackends,
+    isMigrationInProgress: overrides.isMigrationInProgress ?? ((): boolean => false),
+    quit,
+    countWindows: () => windows.filter((w) => !w.destroyed).length,
+    platform: overrides.platform ?? 'linux'
+  })
+
+  return { app, windows, tray, trayHandlers, shutdownBackends, quit, showMainWindow }
+}
+
+describe('installAppLifecycle', () => {
+  it('creates the first window and tray on install', () => {
+    const { windows, trayHandlers } = setup()
+    expect(windows).toHaveLength(1)
+    expect(trayHandlers).toBeDefined()
+  })
+
+  it('runs an awaited backend teardown then exits on a normal quit', async () => {
+    const { app, tray, shutdownBackends } = setup()
+
+    const event = app.emit('before-quit')
+    expect(event.defaultPrevented).toBe(true)
+    expect(app.exit).not.toHaveBeenCalled() // still awaiting shutdown
+
+    await flush()
+    expect(shutdownBackends).toHaveBeenCalledTimes(1)
+    expect(tray?.destroy).toHaveBeenCalledTimes(1)
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('defers to the migration guard when a migration is in progress', async () => {
+    const { app, shutdownBackends } = setup({ isMigrationInProgress: (): boolean => true })
+
+    app.emit('before-quit')
+    await flush()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
+  })
+
+  it('respects a quit an earlier handler already cancelled (defaultPrevented)', async () => {
+    // Mirror index.ts ordering: the migration guard registers a before-quit BEFORE the lifecycle, so
+    // when it prevents the quit our handler must see defaultPrevented and not start a teardown.
+    const app = makeFakeApp()
+    app.on('before-quit', (event) => event.preventDefault())
+
+    const shutdownBackends = vi.fn(async () => undefined)
+    installAppLifecycle({
+      app: app as unknown as AppLifecycleDeps['app'],
+      createMainWindow: () => asWindow(makeFakeWindow()),
+      createTray: () => ({ destroy: vi.fn() }) as unknown as import('electron').Tray,
+      shutdownBackends,
+      isMigrationInProgress: (): boolean => false,
+      quit: vi.fn(),
+      countWindows: (): number => 1,
+      platform: 'linux'
+    })
+
+    app.emit('before-quit')
+    await flush()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
+  })
+
+  it('holds a re-issued quit while cleanup is in flight and only tears down once', async () => {
+    let release: (() => void) | undefined
+    const shutdownBackends = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        })
+    )
+    const { app } = setup({ shutdownBackends })
+
+    app.emit('before-quit') // starts cleanup (pending)
+    const second = app.emit('before-quit') // re-issued while running
+    expect(second.defaultPrevented).toBe(true)
+    expect(shutdownBackends).toHaveBeenCalledTimes(1)
+
+    release?.()
+    await flush()
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('quits on window-all-closed only when non-darwin and no tray host', () => {
+    const noTray = setup({ trayHost: false, platform: 'linux' })
+    noTray.app.emit('window-all-closed')
+    expect(noTray.quit).toHaveBeenCalledTimes(1)
+
+    const withTray = setup({ trayHost: true, platform: 'linux' })
+    withTray.app.emit('window-all-closed')
+    expect(withTray.quit).not.toHaveBeenCalled()
+
+    const darwinNoTray = setup({ trayHost: false, platform: 'darwin' })
+    darwinNoTray.app.emit('window-all-closed')
+    expect(darwinNoTray.quit).not.toHaveBeenCalled()
+  })
+
+  it('recreates the window on show when the last one was closed (macOS)', () => {
+    const { windows, trayHandlers } = setup({ platform: 'darwin' })
+    expect(windows).toHaveLength(1)
+
+    // Model macOS: the window is closed/destroyed but the app stays resident.
+    windows[0].destroyed = true
+
+    trayHandlers?.onShow()
+    expect(windows).toHaveLength(2)
+    expect(windows[1].destroyed).toBe(false)
+  })
+
+  it('restores and focuses an existing hidden/minimized window on show', () => {
+    const { windows, trayHandlers } = setup()
+    windows[0].minimized = true
+    windows[0].visible = false
+
+    trayHandlers?.onShow()
+    expect(windows).toHaveLength(1) // no new window
+    expect(windows[0].minimized).toBe(false)
+    expect(windows[0].visible).toBe(true)
+    expect(windows[0].focused).toBe(true)
+  })
+
+  it('hides the window from the tray Hide item', () => {
+    const { windows, trayHandlers } = setup()
+    expect(windows[0].visible).toBe(true)
+    trayHandlers?.onHide()
+    expect(windows[0].visible).toBe(false)
+  })
+
+  it('quits from the tray Quit item', () => {
+    const { trayHandlers, quit } = setup()
+    trayHandlers?.onQuit()
+    expect(quit).toHaveBeenCalledTimes(1)
+  })
+
+  it('recreates a window on macOS activate when none are open', () => {
+    const { app, windows } = setup({ platform: 'darwin' })
+    windows[0].destroyed = true
+    app.emit('activate')
+    expect(windows).toHaveLength(2)
+  })
+})

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -1,0 +1,113 @@
+import type { App, BrowserWindow, Tray } from 'electron'
+
+// Menu action callbacks the tray is wired to.
+export type TrayHandlers = { onShow: () => void; onHide: () => void; onQuit: () => void }
+
+// Wires the window/tray/quit lifecycle for the UI process. Kept as a dependency-injected unit (no direct
+// electron imports beyond types) so the event ordering, migration-guard interaction, tray-quit cleanup,
+// and window recreation are unit-testable without a real Electron runtime.
+export type AppLifecycleDeps = {
+  // Only the event/exit surface is used; injectable so tests can drive the handlers directly.
+  app: Pick<App, 'on' | 'exit'>
+  // Creates the main window; the lifecycle supplies the close-to-tray predicate it should honor.
+  createMainWindow: (opts: { shouldHideOnClose: () => boolean }) => BrowserWindow
+  // Builds the tray; returns undefined on hosts without a tray (e.g. some Linux desktops).
+  createTray: (handlers: TrayHandlers) => Tray | undefined
+  // Bounded, best-effort backend teardown (agent tree + notebook kernels); never throws.
+  shutdownBackends: () => Promise<void>
+  // True while a data-root migration is copying; a quit during it is owned by the migration guard.
+  isMigrationInProgress: () => boolean
+  // Requests an app quit (app.quit); the before-quit handler below turns it into an awaited teardown.
+  quit: () => void
+  // Number of live BrowserWindows, used to decide whether to recreate on macOS activate.
+  countWindows: () => number
+  // Overridable for tests; defaults to the host platform.
+  platform?: NodeJS.Platform
+}
+
+// Installs the tray, the first window, and the quit/activate/window-all-closed handlers. Returns
+// showMainWindow so the single-instance second-instance hook can surface the window (creating one when
+// none exists — e.g. macOS after the last window was closed but the app stayed resident).
+export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: () => void } => {
+  const platform = deps.platform ?? process.platform
+
+  let mainWindow: BrowserWindow | undefined
+  // Held in a box (not a plain `let`) so the close-to-tray predicate defined below can read it before
+  // it is assigned — the tray, window, and predicate reference each other cyclically.
+  const trayBox: { current: Tray | undefined } = { current: undefined }
+  // Latches make the async quit cleanup idempotent: once started, further quits are held until exit.
+  let shutdownStarted = false
+  let shutdownFinished = false
+
+  // Close-to-tray predicate, evaluated at close time: hide (stay resident) on Windows/Linux while the
+  // tray is active, unless a quit is already underway. macOS keeps its dock convention (real close).
+  const shouldHideOnClose = (): boolean =>
+    platform !== 'darwin' && Boolean(trayBox.current) && !shutdownStarted
+
+  const openWindow = (): BrowserWindow => deps.createMainWindow({ shouldHideOnClose })
+
+  // Surfaces the main window, creating a fresh one when none exists or the last was closed (macOS keeps
+  // the app alive with no window; the tray Show item and a second launch must be able to bring it back).
+  const showMainWindow = (): void => {
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      mainWindow = openWindow()
+      return
+    }
+    if (mainWindow.isMinimized()) mainWindow.restore()
+    if (!mainWindow.isVisible()) mainWindow.show()
+    mainWindow.focus()
+  }
+
+  const hideMainWindow = (): void => {
+    if (mainWindow && !mainWindow.isDestroyed()) mainWindow.hide()
+  }
+
+  trayBox.current = deps.createTray({
+    onShow: showMainWindow,
+    onHide: hideMainWindow,
+    onQuit: () => deps.quit()
+  })
+
+  // Authoritative quit cleanup: stop the agent process tree (awaited, so Windows taskkill /T finishes)
+  // and every notebook kernel before exiting. app.on (not once) plus latches: a re-issued quit while
+  // cleanup runs is held until app.exit(0), which itself skips before-quit/will-quit. Gated on the
+  // migration guard (registered earlier) via defaultPrevented + isMigrationInProgress so a
+  // migration-cancelled quit is respected. #177's will-quit guard remains a synchronous backstop for a
+  // committed quit that never reaches this path.
+  deps.app.on('before-quit', (event) => {
+    if (shutdownFinished) return
+    if (shutdownStarted) {
+      // Cleanup already running; hold the quit until it calls app.exit(0).
+      event.preventDefault()
+      return
+    }
+    if (event.defaultPrevented || deps.isMigrationInProgress()) return
+
+    event.preventDefault()
+    shutdownStarted = true
+    void (async () => {
+      try {
+        await deps.shutdownBackends()
+      } finally {
+        trayBox.current?.destroy()
+        shutdownFinished = true
+        deps.app.exit(0)
+      }
+    })()
+  })
+
+  // macOS: recreate a window when the dock icon is clicked with no windows open.
+  deps.app.on('activate', () => {
+    if (deps.countWindows() === 0) mainWindow = openWindow()
+  })
+
+  // With a tray the app stays resident (windows only hide), so window-all-closed shouldn't quit. Without
+  // a tray, keep the platform convention: quit on Windows/Linux, stay alive on macOS (dock + menu bar).
+  deps.app.on('window-all-closed', () => {
+    if (platform !== 'darwin' && !trayBox.current) deps.quit()
+  })
+
+  mainWindow = openWindow()
+
+  return { showMainWindow }
+}

--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createSecondInstanceRelay, orchestrateAppStartup } from './app-startup'
+
+describe('createSecondInstanceRelay', () => {
+  it('records a signal that arrives before bind and drains it on bind', () => {
+    const relay = createSecondInstanceRelay()
+    const handler = vi.fn()
+
+    relay.signal()
+    expect(handler).not.toHaveBeenCalled()
+
+    relay.bind(handler)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards a signal that arrives after bind directly to the handler', () => {
+    const relay = createSecondInstanceRelay()
+    const handler = vi.fn()
+
+    relay.bind(handler)
+    expect(handler).not.toHaveBeenCalled()
+
+    relay.signal()
+    relay.signal()
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it('drains only once when bound, even if multiple signals arrived first', () => {
+    const relay = createSecondInstanceRelay()
+    const handler = vi.fn()
+
+    relay.signal()
+    relay.signal()
+    relay.bind(handler)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('orchestrateAppStartup', () => {
+  const makeDeps = (
+    overrides: Partial<Parameters<typeof orchestrateAppStartup<{ tag: string }>>[0]> = {}
+  ): Parameters<typeof orchestrateAppStartup<{ tag: string }>>[0] => {
+    const showMainWindow = vi.fn()
+    return {
+      acquireSingleInstanceLock: vi.fn(() => true),
+      quit: vi.fn(),
+      prepare: vi.fn(async () => ({ tag: 'ctx' })),
+      installMigrationQuitGuard: vi.fn(),
+      installAppLifecycle: vi.fn(() => ({ showMainWindow })),
+      ...overrides
+    }
+  }
+
+  it('quits and does no backend work when the lock is already held', async () => {
+    const deps = makeDeps({ acquireSingleInstanceLock: vi.fn(() => false) })
+
+    await orchestrateAppStartup(deps)
+
+    expect(deps.quit).toHaveBeenCalledTimes(1)
+    expect(deps.prepare).not.toHaveBeenCalled()
+    expect(deps.installMigrationQuitGuard).not.toHaveBeenCalled()
+    expect(deps.installAppLifecycle).not.toHaveBeenCalled()
+  })
+
+  it('installs the migration guard before the lifecycle for the primary instance', async () => {
+    const deps = makeDeps()
+
+    await orchestrateAppStartup(deps)
+
+    expect(deps.quit).not.toHaveBeenCalled()
+    expect(deps.prepare).toHaveBeenCalledTimes(1)
+    const guardOrder = vi.mocked(deps.installMigrationQuitGuard).mock.invocationCallOrder[0]
+    const lifecycleOrder = vi.mocked(deps.installAppLifecycle).mock.invocationCallOrder[0]
+    expect(guardOrder).toBeLessThan(lifecycleOrder)
+    // The guard and lifecycle both receive the context produced by prepare.
+    expect(deps.installMigrationQuitGuard).toHaveBeenCalledWith({ tag: 'ctx' })
+    expect(deps.installAppLifecycle).toHaveBeenCalledWith({ tag: 'ctx' })
+  })
+
+  it('surfaces the window for a second instance that arrives during startup', async () => {
+    const showMainWindow = vi.fn()
+    let signalDuringStartup: () => void = () => {}
+    const deps = makeDeps({
+      // Capture the relay signal the lock is wired with, then fire it while prepare() is still running.
+      acquireSingleInstanceLock: vi.fn(({ onSecondInstance }) => {
+        signalDuringStartup = onSecondInstance
+        return true
+      }),
+      prepare: vi.fn(async () => {
+        signalDuringStartup()
+        return { tag: 'ctx' }
+      }),
+      installAppLifecycle: vi.fn(() => ({ showMainWindow }))
+    })
+
+    await orchestrateAppStartup(deps)
+
+    // The handoff arrived before the window existed; it must be drained once the lifecycle is installed.
+    expect(showMainWindow).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes a second instance that arrives after startup straight to the window', async () => {
+    const showMainWindow = vi.fn()
+    let signal: () => void = () => {}
+    const deps = makeDeps({
+      acquireSingleInstanceLock: vi.fn(({ onSecondInstance }) => {
+        signal = onSecondInstance
+        return true
+      }),
+      installAppLifecycle: vi.fn(() => ({ showMainWindow }))
+    })
+
+    await orchestrateAppStartup(deps)
+    expect(showMainWindow).not.toHaveBeenCalled()
+
+    signal()
+    expect(showMainWindow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/app-startup.ts
+++ b/src/main/app-startup.ts
@@ -1,0 +1,69 @@
+// Startup orchestration for the UI process, kept as a dependency-injected unit (no Electron imports) so
+// the single-instance gate, the second-instance-during-startup handoff, and the ordering of the
+// migration quit-guard relative to the lifecycle can be exercised together in a unit test — the real
+// combination, not just each helper in isolation.
+
+// A late-bound relay for OS 'second-instance' events. The lock's handler must be supplied at lock time,
+// but the window that a second launch should surface does not exist until the lifecycle is installed.
+// The relay records a request that arrives in that window and drains it once a target is bound.
+export type SecondInstanceRelay = {
+  // Wired into the single-instance lock as its onSecondInstance handler.
+  signal: () => void
+  // Bind the window surfacer once it exists; immediately drains a request that arrived during startup.
+  bind: (handler: () => void) => void
+}
+
+export const createSecondInstanceRelay = (): SecondInstanceRelay => {
+  let pending = false
+  let handler: (() => void) | undefined
+
+  return {
+    signal: () => {
+      if (handler) handler()
+      else pending = true
+    },
+    bind: (next) => {
+      handler = next
+      if (pending) {
+        pending = false
+        handler()
+      }
+    }
+  }
+}
+
+export type AppStartupDeps<Context> = {
+  // Acquires the OS single-instance lock, wiring the relay's signal as the second-instance handler.
+  // Returns false for a secondary launch (the caller must quit) and true for the primary.
+  acquireSingleInstanceLock: (opts: { onSecondInstance: () => void }) => boolean
+  // Quits this launch when it is a secondary instance.
+  quit: () => void
+  // Heavy post-lock preparation (backend module imports, app.whenReady, logger, IPC registration). Runs
+  // ONLY after the lock is held so a doomed secondary instance never imports the backend or spawns a
+  // duplicate process tree. Returns the context the guard/lifecycle installers need.
+  prepare: () => Promise<Context>
+  // Installs the migration quit-guard. Must run before the lifecycle so its before-quit fires first: a
+  // migration-cancelled quit leaves defaultPrevented set, which the lifecycle's quit cleanup honors.
+  installMigrationQuitGuard: (context: Context) => void
+  // Installs the tray/window/quit lifecycle; returns the window surfacer for second-instance handoff.
+  installAppLifecycle: (context: Context) => { showMainWindow: () => void }
+}
+
+// Runs the ordered startup sequence: gate on the single-instance lock (quitting a secondary launch
+// before any backend work), prepare the backend, install the migration guard, then the lifecycle, and
+// finally bind the second-instance relay to the window — draining any handoff that arrived mid-startup.
+export const orchestrateAppStartup = async <Context>(
+  deps: AppStartupDeps<Context>
+): Promise<void> => {
+  const relay = createSecondInstanceRelay()
+
+  if (!deps.acquireSingleInstanceLock({ onSecondInstance: relay.signal })) {
+    deps.quit()
+    return
+  }
+
+  const context = await deps.prepare()
+  deps.installMigrationQuitGuard(context)
+  const { showMainWindow } = deps.installAppLifecycle(context)
+  relay.bind(showMainWindow)
+}

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -9,9 +9,9 @@ import type {
   ArtifactWriteEncoding,
   ArtifactWriteSource
 } from '../../shared/artifacts'
+import { ARTIFACT_MCP_SERVER_ARG } from '../mcp-server-args'
 import { ArtifactRepository } from './repository'
 
-const ARTIFACT_MCP_SERVER_ARG = '--open-science-artifact-mcp'
 const ARTIFACT_MCP_SERVER_NAME = 'open-science-artifacts'
 
 type ArtifactMcpEnvironment = {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,22 +32,45 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
   const [
     { app, BrowserWindow, nativeImage, protocol },
     { electronApp, optimizer },
-    { default: icon }
+    { default: icon },
+    { acquireSingleInstanceLock }
   ] = await Promise.all([
     import('electron'),
     import('@electron-toolkit/utils'),
-    import('../../resources/icon.png?asset')
+    import('../../resources/icon.png?asset'),
+    import('./single-instance')
   ])
+
+  // Single-instance guard, acquired BEFORE the backend modules are imported (UI path only — the MCP
+  // stdio server modes never reach startElectronApp). A second launch hands off to the primary and
+  // exits, so the app never runs as a duplicate instance with a duplicate backend process tree. The
+  // second-instance hook is late-bound: until the lifecycle is installed it just records the request,
+  // which is drained once the window exists.
+  let pendingSecondInstance = false
+  let onSecondInstance: () => void = () => {
+    pendingSecondInstance = true
+  }
+  if (!acquireSingleInstanceLock({ onSecondInstance: () => onSecondInstance() })) {
+    app.quit()
+    return
+  }
+
   const [
     { registerIpcHandlers },
     { createMainWindow },
     { MANAGED_PREVIEW_SCHEME },
-    { installMigrationQuitGuard }
+    { installMigrationQuitGuard, isMigrationInProgress },
+    { createAppTray },
+    { shutdownBackends },
+    { installAppLifecycle }
   ] = await Promise.all([
     import('./ipc'),
     import('./windows'),
     import('./managed-preview-resources'),
-    import('./storage/migration-state')
+    import('./storage/migration-state'),
+    import('./tray'),
+    import('./lifecycle-shutdown'),
+    import('./app-lifecycle')
   ])
 
   // Dev runs get a "(DEV)" suffix so the app name, macOS menu, and per-app paths (logs, userData)
@@ -97,27 +120,33 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
   })
 
   // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
-  await registerIpcHandlers({ mainEntryPath })
+  const { runtime, notebook } = await registerIpcHandlers({ mainEntryPath })
 
-  // Warn (rather than silently tear down) if the user tries to quit mid data-root migration.
+  // Warn (rather than silently tear down) if the user tries to quit mid data-root migration. Installed
+  // BEFORE the lifecycle so its before-quit runs first: a migration it cancels leaves event.defaultPrevented
+  // set, which the lifecycle's quit cleanup honors.
   installMigrationQuitGuard(app)
 
-  createMainWindow()
-
-  app.on('activate', function () {
-    // On macOS it's common to re-create a window in the app when the
-    // dock icon is clicked and there are no other windows open.
-    if (BrowserWindow.getAllWindows().length === 0) createMainWindow()
+  // Install the tray, first window, and the quit/activate/window-all-closed handlers. shutdownBackends
+  // is bound with the live backend handles; the agent teardown latches shutting-down and awaits the
+  // process tree so a Windows taskkill /T completes before app.exit.
+  const { showMainWindow } = installAppLifecycle({
+    app,
+    createMainWindow,
+    createTray: (handlers) => createAppTray({ iconPath: icon, ...handlers }),
+    shutdownBackends: () => shutdownBackends({ runtime, notebook, log }),
+    isMigrationInProgress,
+    quit: () => app.quit(),
+    countWindows: () => BrowserWindow.getAllWindows().length
   })
 
-  // Quit when all windows are closed, except on macOS. There, it's common
-  // for applications and their menu bar to stay active until the user quits
-  // explicitly with Cmd + Q.
-  app.on('window-all-closed', () => {
-    if (process.platform !== 'darwin') {
-      app.quit()
-    }
-  })
+  // The window now exists: route second-instance handoffs to it, and surface it if one arrived during
+  // startup (before the lifecycle was installed).
+  onSecondInstance = showMainWindow
+  if (pendingSecondInstance) {
+    pendingSecondInstance = false
+    showMainWindow()
+  }
 }
 
 // In this file you can include the rest of your app's specific main process

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,9 @@
 import { fileURLToPath } from 'node:url'
 
-import { ARTIFACT_MCP_SERVER_ARG, runArtifactMcpServer } from './artifacts/mcp-server'
-import { NOTEBOOK_MCP_SERVER_ARG, runNotebookMcpServer } from './notebook/mcp-server'
+// Only the lightweight argv flags are imported statically here. The MCP server modules (and their heavy
+// SDK graph) are imported lazily inside the matching branch, and the Electron backend is imported only
+// after the single-instance lock is held — so no backend module loads before the lock in UI mode.
+import { ARTIFACT_MCP_SERVER_ARG, NOTEBOOK_MCP_SERVER_ARG } from './mcp-server-args'
 
 const APP_NAME = 'Open Science'
 const APP_USER_MODEL_ID = 'com.aipoch.open-science'
@@ -9,17 +11,21 @@ const shouldRunArtifactMcpServer = process.argv.includes(ARTIFACT_MCP_SERVER_ARG
 const shouldRunNotebookMcpServer = process.argv.includes(NOTEBOOK_MCP_SERVER_ARG)
 
 if (shouldRunArtifactMcpServer) {
-  // Reuse the packaged entry point as a Node stdio MCP server before Electron modules are imported.
-  runArtifactMcpServer().catch((error: unknown) => {
-    console.error(error)
-    process.exitCode = 1
-  })
+  // Reuse the packaged entry point as a Node stdio MCP server; import it only in this mode.
+  void import('./artifacts/mcp-server')
+    .then(({ runArtifactMcpServer }) => runArtifactMcpServer())
+    .catch((error: unknown) => {
+      console.error(error)
+      process.exitCode = 1
+    })
 } else if (shouldRunNotebookMcpServer) {
   // Keep notebook MCP mode as a Node stdio process that proxies to the app-owned runtime.
-  runNotebookMcpServer().catch((error: unknown) => {
-    console.error(error)
-    process.exitCode = 1
-  })
+  void import('./notebook/mcp-server')
+    .then(({ runNotebookMcpServer }) => runNotebookMcpServer())
+    .catch((error: unknown) => {
+      console.error(error)
+      process.exitCode = 1
+    })
 } else {
   void startElectronApp(fileURLToPath(import.meta.url)).catch((error: unknown) => {
     console.error(error)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,120 +33,124 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     { app, BrowserWindow, nativeImage, protocol },
     { electronApp, optimizer },
     { default: icon },
-    { acquireSingleInstanceLock }
+    { acquireSingleInstanceLock },
+    { orchestrateAppStartup }
   ] = await Promise.all([
     import('electron'),
     import('@electron-toolkit/utils'),
     import('../../resources/icon.png?asset'),
-    import('./single-instance')
+    import('./single-instance'),
+    import('./app-startup')
   ])
 
-  // Single-instance guard, acquired BEFORE the backend modules are imported (UI path only — the MCP
-  // stdio server modes never reach startElectronApp). A second launch hands off to the primary and
-  // exits, so the app never runs as a duplicate instance with a duplicate backend process tree. The
-  // second-instance hook is late-bound: until the lifecycle is installed it just records the request,
-  // which is drained once the window exists.
-  let pendingSecondInstance = false
-  let onSecondInstance: () => void = () => {
-    pendingSecondInstance = true
-  }
-  if (!acquireSingleInstanceLock({ onSecondInstance: () => onSecondInstance() })) {
-    app.quit()
-    return
-  }
-
-  const [
-    { registerIpcHandlers },
-    { createMainWindow },
-    { MANAGED_PREVIEW_SCHEME },
-    { installMigrationQuitGuard, isMigrationInProgress },
-    { createAppTray },
-    { shutdownBackends },
-    { installAppLifecycle }
-  ] = await Promise.all([
-    import('./ipc'),
-    import('./windows'),
-    import('./managed-preview-resources'),
-    import('./storage/migration-state'),
-    import('./tray'),
-    import('./lifecycle-shutdown'),
-    import('./app-lifecycle')
-  ])
-
-  // Dev runs get a "(DEV)" suffix so the app name, macOS menu, and per-app paths (logs, userData)
-  // are visibly distinct from an installed build — and don't collide with it.
-  app.setName(app.isPackaged ? APP_NAME : `${APP_NAME} (DEV)`)
-
-  protocol.registerSchemesAsPrivileged([MANAGED_PREVIEW_SCHEME])
-
-  await app.whenReady()
-
-  // Initialize file logging as early as possible so startup and agent-spawn issues are captured for
-  // later troubleshooting (especially in packaged builds where console output is not visible).
-  const { createLogger, getLogFilePath, initLogger } = await import('./logger')
-  initLogger({ logDir: app.getPath('logs') })
-  const log = createLogger('main')
-
-  log.info('app starting', {
-    version: app.getVersion(),
-    isPackaged: app.isPackaged,
-    platform: process.platform,
-    electron: process.versions.electron,
-    node: process.versions.node,
-    execPath: process.execPath,
-    logFile: getLogFilePath()
-  })
-
-  // Capture otherwise-silent crashes so a hang or unexpected exit leaves a trail in the log file.
-  process.on('uncaughtException', (error) => log.error('uncaughtException', error))
-  process.on('unhandledRejection', (reason) => log.error('unhandledRejection', reason))
-
-  // Set app user model id for windows
-  electronApp.setAppUserModelId(APP_USER_MODEL_ID)
-
-  // Dev builds use the app icon for the macOS dock.
-  if (process.platform === 'darwin') {
-    const dockIcon = nativeImage.createFromPath(icon)
-    if (!dockIcon.isEmpty()) {
-      app.dock?.setIcon(dockIcon)
-    }
-  }
-
-  // Default open or close DevTools by F12 in development
-  // and ignore CommandOrControl + R in production.
-  // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
-  app.on('browser-window-created', (_, window) => {
-    optimizer.watchWindowShortcuts(window)
-  })
-
-  // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
-  const { runtime, notebook } = await registerIpcHandlers({ mainEntryPath })
-
-  // Warn (rather than silently tear down) if the user tries to quit mid data-root migration. Installed
-  // BEFORE the lifecycle so its before-quit runs first: a migration it cancels leaves event.defaultPrevented
-  // set, which the lifecycle's quit cleanup honors.
-  installMigrationQuitGuard(app)
-
-  // Install the tray, first window, and the quit/activate/window-all-closed handlers. shutdownBackends
-  // is bound with the live backend handles; the agent teardown latches shutting-down and awaits the
-  // process tree so a Windows taskkill /T completes before app.exit.
-  const { showMainWindow } = installAppLifecycle({
-    app,
-    createMainWindow,
-    createTray: (handlers) => createAppTray({ iconPath: icon, ...handlers }),
-    shutdownBackends: () => shutdownBackends({ runtime, notebook, log }),
-    isMigrationInProgress,
+  // Ordered startup: the single-instance lock is acquired FIRST (UI path only — the MCP stdio server
+  // modes never reach startElectronApp), so a secondary launch quits before prepare() imports any
+  // backend module or spawns a duplicate process tree. prepare() then does the heavy post-lock work and
+  // returns the handles the migration guard and lifecycle need; the guard is installed before the
+  // lifecycle so its before-quit runs first. A second launch that arrives mid-startup is recorded by the
+  // relay and surfaced once the window exists.
+  await orchestrateAppStartup({
+    acquireSingleInstanceLock: (opts) => acquireSingleInstanceLock(opts),
     quit: () => app.quit(),
-    countWindows: () => BrowserWindow.getAllWindows().length
-  })
+    prepare: async () => {
+      const [
+        { registerIpcHandlers },
+        { createMainWindow },
+        { MANAGED_PREVIEW_SCHEME },
+        { installMigrationQuitGuard, isMigrationInProgress },
+        { createAppTray },
+        { shutdownBackends },
+        { installAppLifecycle }
+      ] = await Promise.all([
+        import('./ipc'),
+        import('./windows'),
+        import('./managed-preview-resources'),
+        import('./storage/migration-state'),
+        import('./tray'),
+        import('./lifecycle-shutdown'),
+        import('./app-lifecycle')
+      ])
 
-  // The window now exists: route second-instance handoffs to it, and surface it if one arrived during
-  // startup (before the lifecycle was installed).
-  onSecondInstance = showMainWindow
-  if (pendingSecondInstance) {
-    pendingSecondInstance = false
-    showMainWindow()
-  }
+      // Dev runs get a "(DEV)" suffix so the app name, macOS menu, and per-app paths (logs, userData)
+      // are visibly distinct from an installed build — and don't collide with it.
+      app.setName(app.isPackaged ? APP_NAME : `${APP_NAME} (DEV)`)
+
+      protocol.registerSchemesAsPrivileged([MANAGED_PREVIEW_SCHEME])
+
+      await app.whenReady()
+
+      // Initialize file logging as early as possible so startup and agent-spawn issues are captured for
+      // later troubleshooting (especially in packaged builds where console output is not visible).
+      const { createLogger, getLogFilePath, initLogger } = await import('./logger')
+      initLogger({ logDir: app.getPath('logs') })
+      const log = createLogger('main')
+
+      log.info('app starting', {
+        version: app.getVersion(),
+        isPackaged: app.isPackaged,
+        platform: process.platform,
+        electron: process.versions.electron,
+        node: process.versions.node,
+        execPath: process.execPath,
+        logFile: getLogFilePath()
+      })
+
+      // Capture otherwise-silent crashes so a hang or unexpected exit leaves a trail in the log file.
+      process.on('uncaughtException', (error) => log.error('uncaughtException', error))
+      process.on('unhandledRejection', (reason) => log.error('unhandledRejection', reason))
+
+      // Set app user model id for windows
+      electronApp.setAppUserModelId(APP_USER_MODEL_ID)
+
+      // Dev builds use the app icon for the macOS dock.
+      if (process.platform === 'darwin') {
+        const dockIcon = nativeImage.createFromPath(icon)
+        if (!dockIcon.isEmpty()) {
+          app.dock?.setIcon(dockIcon)
+        }
+      }
+
+      // Default open or close DevTools by F12 in development
+      // and ignore CommandOrControl + R in production.
+      // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
+      app.on('browser-window-created', (_, window) => {
+        optimizer.watchWindowShortcuts(window)
+      })
+
+      // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
+      const { runtime, notebook } = await registerIpcHandlers({ mainEntryPath })
+
+      return {
+        installMigrationQuitGuard,
+        isMigrationInProgress,
+        createMainWindow,
+        createAppTray,
+        shutdownBackends,
+        installAppLifecycle,
+        runtime,
+        notebook,
+        log
+      }
+    },
+    // Warn (rather than silently tear down) if the user tries to quit mid data-root migration. Installed
+    // BEFORE the lifecycle so its before-quit runs first: a migration it cancels leaves
+    // event.defaultPrevented set, which the lifecycle's quit cleanup honors.
+    installMigrationQuitGuard: (ctx) => ctx.installMigrationQuitGuard(app),
+    // Install the tray, first window, and the quit/activate/window-all-closed handlers. shutdownBackends
+    // is bound with the live backend handles; the agent teardown latches shutting-down and awaits the
+    // process tree so a Windows taskkill /T completes before app.exit.
+    installAppLifecycle: (ctx) =>
+      ctx.installAppLifecycle({
+        app,
+        createMainWindow: ctx.createMainWindow,
+        createTray: (handlers) => ctx.createAppTray({ iconPath: icon, ...handlers }),
+        shutdownBackends: () =>
+          ctx.shutdownBackends({ runtime: ctx.runtime, notebook: ctx.notebook, log: ctx.log }),
+        isMigrationInProgress: ctx.isMigrationInProgress,
+        quit: () => app.quit(),
+        countWindows: () => BrowserWindow.getAllWindows().length
+      })
+  })
 }
 
 // In this file you can include the rest of your app's specific main process

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -99,7 +99,12 @@ const refreshConnectorSkillDocs = async (
 }
 
 // Registers every main-process IPC surface used by the renderer.
-const registerIpcHandlers = async ({ mainEntryPath }: IpcRegistrationOptions): Promise<void> => {
+const registerIpcHandlers = async ({
+  mainEntryPath
+}: IpcRegistrationOptions): Promise<{
+  runtime: ReturnType<typeof registerAcpIpcHandlers>
+  notebook: ReturnType<typeof createDefaultNotebookRuntimeService>
+}> => {
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
   const settingsService = createDefaultSettingsService()
   const storedSettings = await settingsService.getStoredSettings()
@@ -272,6 +277,10 @@ const registerIpcHandlers = async ({ mainEntryPath }: IpcRegistrationOptions): P
   // real handlers instead of no-ops. Passing the already-constructed AcpRuntime so the reviewer
   // can spawn sessions under the same agent connection.
   registerReviewerIpcHandlers({ acpRuntime: runtime })
+
+  // Return the long-lived backend handles so the app lifecycle (before-quit) can shut them down
+  // cleanly on quit — the agent process tree and every notebook kernel.
+  return { runtime, notebook: notebookService }
 }
 
 export { registerIpcHandlers }

--- a/src/main/lifecycle-shutdown.test.ts
+++ b/src/main/lifecycle-shutdown.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { shutdownBackends, type BackendShutdownDeps } from './lifecycle-shutdown'
+
+// Builds a fresh set of injectable fakes; individual tests override behavior as needed.
+const makeDeps = (overrides: Partial<BackendShutdownDeps> = {}): BackendShutdownDeps => ({
+  runtime: { shutdownForQuit: vi.fn(async () => undefined) },
+  notebook: { shutdownAll: vi.fn(async () => undefined) },
+  log: { error: vi.fn() },
+  ...overrides
+})
+
+describe('shutdownBackends', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shuts down both backends via the quit-safe runtime path', async () => {
+    const deps = makeDeps()
+    await shutdownBackends(deps)
+    expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('still runs notebook shutdown and resolves when runtime teardown rejects', async () => {
+    const err = new Error('runtime boom')
+    const deps = makeDeps({
+      runtime: { shutdownForQuit: vi.fn(async () => Promise.reject(err)) }
+    })
+    await expect(shutdownBackends(deps)).resolves.toBeUndefined()
+    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+    expect(deps.log?.error).toHaveBeenCalledWith(expect.any(String), err)
+  })
+
+  it('resolves and logs even when notebook shutdown rejects', async () => {
+    const err = new Error('notebook boom')
+    const deps = makeDeps({
+      notebook: { shutdownAll: vi.fn(async () => Promise.reject(err)) }
+    })
+    await expect(shutdownBackends(deps)).resolves.toBeUndefined()
+    expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
+    expect(deps.log?.error).toHaveBeenCalledWith(expect.any(String), err)
+  })
+
+  it('resolves via the timeout when a backend never settles', async () => {
+    vi.useFakeTimers()
+    const deps = makeDeps({
+      // A backend that hangs forever; only the timeout can free the caller.
+      runtime: { shutdownForQuit: vi.fn(() => new Promise<never>(() => {})) },
+      timeoutMs: 5000
+    })
+
+    const pending = shutdownBackends(deps)
+    let settled = false
+    void pending.then(() => {
+      settled = true
+    })
+
+    // Before the deadline the promise is still pending.
+    await vi.advanceTimersByTimeAsync(4999)
+    expect(settled).toBe(false)
+
+    // Crossing the timeout resolves the shutdown regardless of the hung backend.
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(pending).resolves.toBeUndefined()
+    expect(settled).toBe(true)
+  })
+})

--- a/src/main/lifecycle-shutdown.ts
+++ b/src/main/lifecycle-shutdown.ts
@@ -1,0 +1,47 @@
+// Coordinates a bounded, best-effort shutdown of the app's backend subsystems (agent runtime and
+// notebook kernels). Kept free of Electron imports so it stays trivially unit-testable: callers inject
+// the runtime/notebook handles. The whole operation is time-bounded so app quit can never hang on a
+// backend that refuses to settle.
+
+export type BackendShutdownDeps = {
+  // shutdownForQuit (not disconnect): it latches the runtime's shutting-down flag before awaiting
+  // teardown, so an agent connect that is mid-spawn when quit lands self-aborts instead of orphaning
+  // its freshly-spawned child. disconnect() alone does not set that latch.
+  runtime: { shutdownForQuit: () => Promise<void> }
+  notebook: { shutdownAll: () => Promise<void> }
+  log?: { error: (msg: string, err?: unknown) => void }
+  // Upper bound for the whole shutdown; defaults to 5000ms.
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 5000
+
+// Shuts down the runtime and notebook backends concurrently, never rejecting and never running longer
+// than `timeoutMs`. A failing backend is logged but does not block the other, and a hung backend is
+// abandoned once the timeout elapses so the caller (app quit) always makes progress.
+export const shutdownBackends = async (deps: BackendShutdownDeps): Promise<void> => {
+  const { runtime, notebook, log, timeoutMs = DEFAULT_TIMEOUT_MS } = deps
+
+  // Run both backends together; allSettled ensures one rejection never short-circuits the other.
+  const settleAll = Promise.allSettled([runtime.shutdownForQuit(), notebook.shutdownAll()]).then(
+    ([runtimeResult, notebookResult]) => {
+      if (runtimeResult.status === 'rejected') {
+        log?.error('runtime.shutdownForQuit failed during shutdown', runtimeResult.reason)
+      }
+      if (notebookResult.status === 'rejected') {
+        log?.error('notebook.shutdownAll failed during shutdown', notebookResult.reason)
+      }
+    }
+  )
+
+  // Race the work against a self-unreffing timer so a stuck backend can't keep the process alive or
+  // hang quit; whichever finishes first resolves the caller.
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs)
+    timer.unref?.()
+  })
+
+  await Promise.race([settleAll, deadline])
+  if (timer) clearTimeout(timer)
+}

--- a/src/main/mcp-server-args.ts
+++ b/src/main/mcp-server-args.ts
@@ -1,0 +1,7 @@
+// Process-argv flags that switch the main entry into a Node stdio MCP server mode instead of the
+// Electron UI. Kept in their own dependency-free module so index.ts can detect the mode from argv
+// WITHOUT statically importing the MCP server modules (and their heavy SDK graph) — those are imported
+// lazily, only once the flag matches, so the UI path acquires the single-instance lock before any
+// backend module loads.
+export const ARTIFACT_MCP_SERVER_ARG = '--open-science-artifact-mcp'
+export const NOTEBOOK_MCP_SERVER_ARG = '--open-science-notebook-mcp'

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -3,7 +3,8 @@ import { McpServer as ModelContextProtocolServer } from '@modelcontextprotocol/s
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
 
-const NOTEBOOK_MCP_SERVER_ARG = '--open-science-notebook-mcp'
+import { NOTEBOOK_MCP_SERVER_ARG } from '../mcp-server-args'
+
 const NOTEBOOK_MCP_SERVER_NAME = 'open-science-notebook'
 
 // Scoped prompt addendum that only applies when the agent is given notebook tools.

--- a/src/main/notebook/python-executor.shutdown.test.ts
+++ b/src/main/notebook/python-executor.shutdown.test.ts
@@ -1,0 +1,77 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// A terminateProcessTree double whose promise we resolve by hand, so the test can prove shutdown()
+// actually awaits an in-flight tree-kill that a hard timeout started (rather than racing app.exit).
+const { terminateMock, resolveTermination } = vi.hoisted(() => {
+  let resolveFn: () => void = () => {}
+  const terminateMock = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveFn = resolve
+      })
+  )
+  return { terminateMock, resolveTermination: (): void => resolveFn() }
+})
+vi.mock('../process-tree', () => ({ terminateProcessTree: terminateMock }))
+
+// A spawn double whose child accepts stdin writes but never answers, forcing execute() to time out.
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return { ...actual, spawn: spawnMock }
+})
+
+const { NotebookPythonExecutor } = await import('./python-executor')
+
+class FakeChild extends EventEmitter {
+  pid = 4321
+  killed = false
+  stdin = { write: vi.fn() }
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+  kill = vi.fn(() => true)
+}
+
+const baseRequest = {
+  cwd: '/tmp/session',
+  notebookSessionRoot: '/tmp/session/notebooks',
+  dataRoot: '/tmp/session/data',
+  runtimeRoot: '/tmp/session/runtime'
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('NotebookPythonExecutor shutdown after a hard timeout', () => {
+  it('awaits the timeout-triggered tree-kill before resolving', async () => {
+    const child = new FakeChild()
+    // Let ensureStarted resolve its 'spawn' wait; the child never emits a bridge response line.
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => child.emit('spawn'))
+      return child
+    })
+
+    const executor = new NotebookPythonExecutor('python3')
+    const result = await executor.execute({ ...baseRequest, code: 'sleep', timeoutMs: 20 })
+
+    // The hard timeout dropped the interpreter from reuse and started a tree-kill we control.
+    expect(result.status).toBe('timeout')
+    expect(terminateMock).toHaveBeenCalledTimes(1)
+
+    let shutdownDone = false
+    const shutdown = executor.shutdown().then(() => {
+      shutdownDone = true
+    })
+
+    // shutdown() must not resolve while the tree-kill is still in flight.
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(shutdownDone).toBe(false)
+
+    resolveTermination()
+    await shutdown
+    expect(shutdownDone).toBe(true)
+  })
+})

--- a/src/main/notebook/python-executor.test.ts
+++ b/src/main/notebook/python-executor.test.ts
@@ -311,6 +311,19 @@ describe('notebook Python executor', () => {
           stdout: ''
         })
         expect(result.stderr).toContain('timed out')
+
+        // Regression: after a hard timeout the interpreter is dropped from reuse, so the next
+        // execution spawns a fresh one and succeeds rather than writing to a process that is being
+        // torn down. On Windows taskkill does not set Node's child.killed, so the executor must clear
+        // this.child itself for this to hold.
+        const next = await executor.execute({
+          code: 'print(1 + 1)',
+          cwd: root,
+          notebookSessionRoot: join(root, 'notebooks', 'default-project', 'session-1'),
+          dataRoot: join(root, 'notebooks', 'default-project', 'session-1', 'data'),
+          runtimeRoot: join(root, 'runtime')
+        })
+        expect(next).toMatchObject({ status: 'completed', stdout: '2\n' })
       } finally {
         await executor.shutdown()
       }

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -266,6 +266,10 @@ class NotebookPythonExecutor implements NotebookExecutor {
   private currentCwd: string | undefined
   private passthroughStdout: string[] = []
   private passthroughStderr: string[] = []
+  // In-flight tree-kills started by a hard timeout, which drops the interpreter from reuse BEFORE
+  // reaping it. shutdown() awaits these so a quit landing right after a timeout cannot app.exit before
+  // the kill (notably Windows taskkill /T) has finished tearing the tree down.
+  private terminations = new Set<Promise<void>>()
 
   // Leading args (e.g. the Windows `py` launcher's `-3`) prepended before the bridge invocation.
   private baseArgs: string[] = []
@@ -300,7 +304,7 @@ class NotebookPythonExecutor implements NotebookExecutor {
             this.readline = undefined
             this.child = undefined
           }
-          void terminateProcessTree(child)
+          this.trackTermination(child)
           reject(
             new NotebookExecutionTimeoutError(
               `Notebook execution timed out after ${request.timeoutMs ?? 120_000}ms.`
@@ -329,6 +333,15 @@ class NotebookPythonExecutor implements NotebookExecutor {
     } catch (error) {
       return errorToExecutionResult(error, request)
     }
+  }
+
+  // Fire-and-forget a tree-kill while keeping its promise so shutdown() can await it. Used on the hard
+  // timeout path, which drops the interpreter from reuse before reaping it.
+  private trackTermination(child: ChildProcessWithoutNullStreams): void {
+    const termination = terminateProcessTree(child).finally(() => {
+      this.terminations.delete(termination)
+    })
+    this.terminations.add(termination)
   }
 
   // Stops the interpreter and rejects any caller waiting for an execution result.
@@ -361,6 +374,15 @@ class NotebookPythonExecutor implements NotebookExecutor {
       // runtime/data file handles are released before a caller deletes those dirs.
       await terminateProcessTree(child)
       await Promise.race([exited, delay(SHUTDOWN_EXIT_GRACE_MS)])
+    }
+
+    // A hard timeout may have already dropped an interpreter and started tree-killing it before this
+    // shutdown ran; await that kill too so quit never exits ahead of an in-flight taskkill /T.
+    if (this.terminations.size > 0) {
+      await Promise.race([
+        Promise.allSettled([...this.terminations]),
+        delay(SHUTDOWN_EXIT_GRACE_MS)
+      ])
     }
 
     this.currentCwd = undefined

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { delimiter } from 'node:path'
 import { createInterface, type Interface } from 'node:readline'
 
+import { terminateProcessTree } from '../process-tree'
 import { resolvePythonCommand } from './python-command'
 import type {
   NotebookExecutionRequest,
@@ -289,7 +290,17 @@ class NotebookPythonExecutor implements NotebookExecutor {
           if (this.pending?.id === id) {
             this.pending = undefined
           }
-          if (!child.killed) child.kill()
+          // Hard timeout: drop the interpreter from reuse BEFORE tree-killing it. On Windows taskkill
+          // does not set Node's child.killed, so ensureStarted()'s `!this.child.killed` check would
+          // otherwise hand the next cell a process that is already being torn down. Clearing
+          // this.child/readline forces the next execute() to spawn a fresh interpreter. tree-kill so a
+          // grandchild the interpreter spawned can't be orphaned.
+          if (this.child === child) {
+            this.readline?.close()
+            this.readline = undefined
+            this.child = undefined
+          }
+          void terminateProcessTree(child)
           reject(
             new NotebookExecutionTimeoutError(
               `Notebook execution timed out after ${request.timeoutMs ?? 120_000}ms.`
@@ -346,7 +357,9 @@ class NotebookPythonExecutor implements NotebookExecutor {
         child.once('close', () => resolve())
       })
 
-      child.kill()
+      // Tree-kill (Windows taskkill /T reaps grandchildren) then wait for the real exit so the cwd/
+      // runtime/data file handles are released before a caller deletes those dirs.
+      await terminateProcessTree(child)
       await Promise.race([exited, delay(SHUTDOWN_EXIT_GRACE_MS)])
     }
 
@@ -404,6 +417,10 @@ class NotebookPythonExecutor implements NotebookExecutor {
     this.readline = createInterface({ input: child.stdout })
     this.readline.on('line', (line) => this.handleLine(line))
     child.stderr.on('data', (data: Buffer) => {
+      // Ignore a superseded child: a hard timeout may have dropped it and spawned a replacement, whose
+      // run must not be failed by the dying interpreter's late stderr.
+      if (this.child !== child) return
+
       const text = data.toString('utf8')
 
       if (!text.trim()) return
@@ -417,6 +434,9 @@ class NotebookPythonExecutor implements NotebookExecutor {
       this.rejectPending(new Error(text.trim()))
     })
     child.on('exit', () => {
+      // Ignore a superseded child's exit: after a hard timeout drops this interpreter and spawns a
+      // replacement, clobbering this.child or rejecting here would kill the new interpreter's run.
+      if (this.child !== child) return
       this.child = undefined
 
       // Unexpected exits are reported to the pending execution instead of being swallowed.

--- a/src/main/process-tree.test.ts
+++ b/src/main/process-tree.test.ts
@@ -1,0 +1,102 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Hoisted taskkill spawn double: records calls and returns an EventEmitter so a test can drive the
+// taskkill process's exit/close/error events.
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(() => new EventEmitter())
+}))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+const { terminateProcessTree } = await import('./process-tree')
+
+// Minimal ChildProcess stand-in exposing only the pid and kill the code under test touches.
+const makeChild = (
+  pid: number | undefined
+): { pid: number | undefined; kill: ReturnType<typeof vi.fn> } => ({
+  pid,
+  kill: vi.fn(() => true)
+})
+
+const originalPlatform = process.platform
+const setPlatform = (value: string): void => {
+  Object.defineProperty(process, 'platform', { value, configurable: true })
+}
+
+afterEach(() => {
+  setPlatform(originalPlatform)
+  vi.clearAllMocks()
+})
+
+describe('terminateProcessTree', () => {
+  it('on win32 kills the whole tree via taskkill and resolves when taskkill exits', async () => {
+    setPlatform('win32')
+    const killer = new EventEmitter()
+    spawnMock.mockReturnValueOnce(killer)
+    const child = makeChild(4321)
+
+    const pending = terminateProcessTree(child as never)
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '4321', '/T', '/F'],
+      expect.objectContaining({ windowsHide: true })
+    )
+    expect(child.kill).not.toHaveBeenCalled()
+
+    // The promise stays pending until taskkill finishes; emitting 'exit' must resolve it.
+    killer.emit('exit', 0, null)
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it('on win32 resolves when taskkill emits an error (no reject, no throw)', async () => {
+    setPlatform('win32')
+    const killer = new EventEmitter()
+    spawnMock.mockReturnValueOnce(killer)
+    const child = makeChild(999)
+
+    const pending = terminateProcessTree(child as never)
+    killer.emit('error', new Error('taskkill not found'))
+
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it('on win32 with an undefined pid does not spawn taskkill and resolves', async () => {
+    setPlatform('win32')
+    const child = makeChild(undefined)
+
+    await expect(terminateProcessTree(child as never)).resolves.toBeUndefined()
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(child.kill).not.toHaveBeenCalled()
+  })
+
+  it('on win32 resolves when spawn itself throws synchronously', async () => {
+    setPlatform('win32')
+    spawnMock.mockImplementationOnce(() => {
+      throw new Error('spawn failed')
+    })
+    const child = makeChild(555)
+
+    await expect(terminateProcessTree(child as never)).resolves.toBeUndefined()
+    expect(child.kill).not.toHaveBeenCalled()
+  })
+
+  it('on non-win32 calls child.kill with the given signal, never invokes taskkill, and resolves', async () => {
+    setPlatform('linux')
+    const child = makeChild(1234)
+
+    await expect(terminateProcessTree(child as never, 'SIGTERM')).resolves.toBeUndefined()
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('on non-win32 calls child.kill with undefined when no signal is provided', async () => {
+    setPlatform('darwin')
+    const child = makeChild(1234)
+
+    await expect(terminateProcessTree(child as never)).resolves.toBeUndefined()
+    expect(child.kill).toHaveBeenCalledWith(undefined)
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/process-tree.test.ts
+++ b/src/main/process-tree.test.ts
@@ -12,9 +12,12 @@ vi.mock('node:child_process', () => ({ spawn: spawnMock }))
 const { terminateProcessTree } = await import('./process-tree')
 
 // Minimal ChildProcess stand-in: an EventEmitter (so waitForExit's once('exit') resolves) exposing the
-// pid/kill/killed/exitCode surface the code under test touches.
+// pid/kill/killed/exitCode surface the code under test touches. kill() flips killed like Node does.
 class FakeChild extends EventEmitter {
-  kill = vi.fn(() => true)
+  kill = vi.fn(() => {
+    this.killed = true
+    return true
+  })
   killed = false
   exitCode: number | null = null
   signalCode: string | null = null
@@ -29,6 +32,8 @@ class FakePs extends EventEmitter {
   kill = vi.fn(() => true)
 }
 
+const esrch = (): NodeJS.ErrnoException => Object.assign(new Error('ESRCH'), { code: 'ESRCH' })
+
 const originalPlatform = process.platform
 const setPlatform = (value: string): void => {
   Object.defineProperty(process, 'platform', { value, configurable: true })
@@ -38,6 +43,7 @@ afterEach(() => {
   setPlatform(originalPlatform)
   vi.restoreAllMocks()
   vi.clearAllMocks()
+  vi.useRealTimers()
 })
 
 describe('terminateProcessTree (win32)', () => {
@@ -61,7 +67,26 @@ describe('terminateProcessTree (win32)', () => {
     expect(child.kill).not.toHaveBeenCalled()
   })
 
-  it('falls back to a direct kill when taskkill exits non-zero', async () => {
+  it('does not fall back spuriously after a clean taskkill even once the grace elapses', async () => {
+    // Regression: the grace timer must be cleared on the success path, or it fires later and produces a
+    // false timeout log plus a stray direct kill while the app keeps running.
+    vi.useFakeTimers()
+    setPlatform('win32')
+    const killer = new EventEmitter()
+    spawnMock.mockReturnValueOnce(killer)
+    const child = new FakeChild(4321)
+    const log = { error: vi.fn() }
+
+    const pending = terminateProcessTree(child as never, undefined, log)
+    killer.emit('exit', 0, null)
+    await pending
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(child.kill).not.toHaveBeenCalled()
+    expect(log.error).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a direct kill and awaits the child when taskkill exits non-zero', async () => {
     setPlatform('win32')
     const killer = new EventEmitter()
     spawnMock.mockReturnValueOnce(killer)
@@ -69,14 +94,20 @@ describe('terminateProcessTree (win32)', () => {
     const log = { error: vi.fn() }
 
     const pending = terminateProcessTree(child as never, undefined, log)
+    // Mirror Node: a settled child process exposes its exit code, which the fallback log reads back.
+    ;(killer as unknown as { exitCode: number }).exitCode = 1
     killer.emit('exit', 1, null)
+    // Let the fallback reach waitForExit (attaching its exit listener) before the child exits.
+    await Promise.resolve()
+    await Promise.resolve()
+    child.emit('exit', 0, null)
 
     await expect(pending).resolves.toBeUndefined()
     expect(child.kill).toHaveBeenCalledTimes(1)
     expect(log.error).toHaveBeenCalled()
   })
 
-  it('falls back to a direct kill when taskkill emits an error', async () => {
+  it('falls back to a direct kill and awaits the child when taskkill emits an error', async () => {
     setPlatform('win32')
     const killer = new EventEmitter()
     spawnMock.mockReturnValueOnce(killer)
@@ -85,10 +116,31 @@ describe('terminateProcessTree (win32)', () => {
 
     const pending = terminateProcessTree(child as never, undefined, log)
     killer.emit('error', new Error('taskkill not found'))
+    await Promise.resolve()
+    await Promise.resolve()
+    child.emit('exit', 0, null)
 
     await expect(pending).resolves.toBeUndefined()
     expect(child.kill).toHaveBeenCalledTimes(1)
     expect(log.error).toHaveBeenCalled()
+  })
+
+  it('falls back and logs when taskkill hangs past the grace, then awaits the child', async () => {
+    vi.useFakeTimers()
+    setPlatform('win32')
+    const killer = new EventEmitter() // never emits exit/error
+    spawnMock.mockReturnValueOnce(killer)
+    const child = new FakeChild(777)
+    const log = { error: vi.fn() }
+
+    const pending = terminateProcessTree(child as never, undefined, log)
+
+    // taskkill grace elapses -> fallback direct kill, then wait for the child's own exit grace.
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(log.error).toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(3_000)
+    await expect(pending).resolves.toBeUndefined()
   })
 
   it('falls back to a direct kill when spawn itself throws synchronously', async () => {
@@ -99,7 +151,10 @@ describe('terminateProcessTree (win32)', () => {
     const child = new FakeChild(555)
     const log = { error: vi.fn() }
 
-    await expect(terminateProcessTree(child as never, undefined, log)).resolves.toBeUndefined()
+    const pending = terminateProcessTree(child as never, undefined, log)
+    child.emit('exit', 0, null)
+
+    await expect(pending).resolves.toBeUndefined()
     expect(child.kill).toHaveBeenCalledTimes(1)
     expect(log.error).toHaveBeenCalled()
   })
@@ -115,82 +170,105 @@ describe('terminateProcessTree (win32)', () => {
 })
 
 describe('terminateProcessTree (posix)', () => {
-  it('reaps descendants discovered via ps, kills the direct child, and awaits its exit', async () => {
+  it('signals descendants and the child, and returns without escalating when everything exits', async () => {
     setPlatform('linux')
     const ps = new FakePs()
     spawnMock.mockReturnValueOnce(ps)
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    // Descendants accept SIGTERM, then the alive-check (signal 0) reports them gone.
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((_pid, sig) => {
+      if (sig === 0) throw esrch()
+      return true
+    })
     const child = new FakeChild(1000)
 
     const pending = terminateProcessTree(child as never, 'SIGTERM')
 
-    expect(spawnMock).toHaveBeenCalledWith(
-      'ps',
-      ['-A', '-o', 'pid=,ppid='],
-      expect.objectContaining({ windowsHide: true })
-    )
-
-    // 1000 -> 1001 -> 1002, plus an unrelated tree that must be ignored.
     ps.stdout.emit('data', Buffer.from('1000 1\n1001 1000\n1002 1001\n2000 1\n'))
     ps.emit('close', 0)
+    await Promise.resolve()
+    await Promise.resolve()
 
-    // Let collectDescendantPids resolve and the kills run.
-    await Promise.resolve()
-    await Promise.resolve()
+    child.emit('exit', 0, null)
+    await expect(pending).resolves.toBeUndefined()
 
     expect(killSpy).toHaveBeenCalledWith(1001, 'SIGTERM')
     expect(killSpy).toHaveBeenCalledWith(1002, 'SIGTERM')
     expect(killSpy).not.toHaveBeenCalledWith(2000, 'SIGTERM')
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    // Nothing survived, so no SIGKILL escalation.
+    expect(killSpy).not.toHaveBeenCalledWith(expect.any(Number), 'SIGKILL')
+  })
 
-    // Still pending until the direct child actually exits.
-    child.emit('exit', 0, null)
+  it('escalates to SIGKILL for survivors and a child that ignores the graceful signal', async () => {
+    vi.useFakeTimers()
+    setPlatform('linux')
+    const ps = new FakePs()
+    spawnMock.mockReturnValueOnce(ps)
+    // Everything stays alive: signal 0 succeeds, so survivors persist and the child never exits.
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const child = new FakeChild(1000)
+
+    const pending = terminateProcessTree(child as never, 'SIGTERM')
+
+    ps.stdout.emit('data', Buffer.from('1000 1\n1001 1000\n'))
+    ps.emit('close', 0)
+
+    // Graceful grace elapses with the child still alive -> escalate.
+    await vi.advanceTimersByTimeAsync(3_000)
+    await vi.advanceTimersByTimeAsync(1_000)
     await expect(pending).resolves.toBeUndefined()
+
+    expect(killSpy).toHaveBeenCalledWith(1001, 'SIGTERM')
+    expect(killSpy).toHaveBeenCalledWith(1001, 'SIGKILL')
+    // The child that ignored SIGTERM is force-killed by pid.
+    expect(killSpy).toHaveBeenCalledWith(1000, 'SIGKILL')
   })
 
   it('still kills the direct child when ps fails to produce a tree', async () => {
     setPlatform('darwin')
     const ps = new FakePs()
     spawnMock.mockReturnValueOnce(ps)
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw esrch()
+    })
     const child = new FakeChild(1234)
 
     const pending = terminateProcessTree(child as never)
     ps.emit('error', new Error('ps missing'))
-
     await Promise.resolve()
     await Promise.resolve()
-
-    expect(killSpy).not.toHaveBeenCalled()
-    expect(child.kill).toHaveBeenCalledWith(undefined)
 
     child.emit('exit', 0, null)
     await expect(pending).resolves.toBeUndefined()
+    expect(killSpy).not.toHaveBeenCalledWith(expect.any(Number), 'SIGTERM')
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
   })
 
-  it('resolves via the grace timer when the child never emits exit', async () => {
+  it('falls back to an empty tree and still terminates when ps hangs past the grace', async () => {
     vi.useFakeTimers()
     setPlatform('linux')
-    const ps = new FakePs()
+    const ps = new FakePs() // never emits data/close/error
     spawnMock.mockReturnValueOnce(ps)
     vi.spyOn(process, 'kill').mockImplementation(() => true)
     const child = new FakeChild(1234)
 
     const pending = terminateProcessTree(child as never)
-    ps.emit('close', 0)
 
-    // Advance past the descendant-wait and the exit grace; the promise must still settle.
+    // ps grace elapses -> empty descendant list; then the child's graceful + SIGKILL grace elapse.
     await vi.advanceTimersByTimeAsync(3_000)
+    expect(ps.kill).toHaveBeenCalledTimes(1)
     await vi.advanceTimersByTimeAsync(3_000)
+    await vi.advanceTimersByTimeAsync(1_000)
     await expect(pending).resolves.toBeUndefined()
-    vi.useRealTimers()
   })
 
   it('resolves immediately when the child has already exited', async () => {
     setPlatform('linux')
     const ps = new FakePs()
     spawnMock.mockReturnValueOnce(ps)
-    vi.spyOn(process, 'kill').mockImplementation(() => true)
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw esrch()
+    })
     const child = new FakeChild(1234)
     child.exitCode = 0
 

--- a/src/main/process-tree.test.ts
+++ b/src/main/process-tree.test.ts
@@ -1,23 +1,33 @@
 import { EventEmitter } from 'node:events'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// Hoisted taskkill spawn double: records calls and returns an EventEmitter so a test can drive the
-// taskkill process's exit/close/error events.
+// Hoisted spawn double: process-tree spawns `taskkill` (win32) or `ps` (posix); each test wires the
+// return value to a controllable EventEmitter so it can drive exit/close/error and ps output.
 const { spawnMock } = vi.hoisted(() => ({
-  spawnMock: vi.fn(() => new EventEmitter())
+  spawnMock: vi.fn()
 }))
 
 vi.mock('node:child_process', () => ({ spawn: spawnMock }))
 
 const { terminateProcessTree } = await import('./process-tree')
 
-// Minimal ChildProcess stand-in exposing only the pid and kill the code under test touches.
-const makeChild = (
-  pid: number | undefined
-): { pid: number | undefined; kill: ReturnType<typeof vi.fn> } => ({
-  pid,
-  kill: vi.fn(() => true)
-})
+// Minimal ChildProcess stand-in: an EventEmitter (so waitForExit's once('exit') resolves) exposing the
+// pid/kill/killed/exitCode surface the code under test touches.
+class FakeChild extends EventEmitter {
+  kill = vi.fn(() => true)
+  killed = false
+  exitCode: number | null = null
+  signalCode: string | null = null
+  constructor(public pid: number | undefined) {
+    super()
+  }
+}
+
+// A ps stand-in: an EventEmitter with its own stdout EventEmitter, matching spawn('ps', ...).
+class FakePs extends EventEmitter {
+  stdout = new EventEmitter()
+  kill = vi.fn(() => true)
+}
 
 const originalPlatform = process.platform
 const setPlatform = (value: string): void => {
@@ -26,15 +36,16 @@ const setPlatform = (value: string): void => {
 
 afterEach(() => {
   setPlatform(originalPlatform)
+  vi.restoreAllMocks()
   vi.clearAllMocks()
 })
 
-describe('terminateProcessTree', () => {
-  it('on win32 kills the whole tree via taskkill and resolves when taskkill exits', async () => {
+describe('terminateProcessTree (win32)', () => {
+  it('kills the whole tree via taskkill and resolves when taskkill exits cleanly', async () => {
     setPlatform('win32')
     const killer = new EventEmitter()
     spawnMock.mockReturnValueOnce(killer)
-    const child = makeChild(4321)
+    const child = new FakeChild(4321)
 
     const pending = terminateProcessTree(child as never)
 
@@ -43,60 +54,149 @@ describe('terminateProcessTree', () => {
       ['/pid', '4321', '/T', '/F'],
       expect.objectContaining({ windowsHide: true })
     )
-    expect(child.kill).not.toHaveBeenCalled()
 
-    // The promise stays pending until taskkill finishes; emitting 'exit' must resolve it.
     killer.emit('exit', 0, null)
     await expect(pending).resolves.toBeUndefined()
+    // A clean taskkill reaps the tree; no direct fallback kill is needed.
+    expect(child.kill).not.toHaveBeenCalled()
   })
 
-  it('on win32 resolves when taskkill emits an error (no reject, no throw)', async () => {
+  it('falls back to a direct kill when taskkill exits non-zero', async () => {
     setPlatform('win32')
     const killer = new EventEmitter()
     spawnMock.mockReturnValueOnce(killer)
-    const child = makeChild(999)
+    const child = new FakeChild(999)
+    const log = { error: vi.fn() }
 
-    const pending = terminateProcessTree(child as never)
+    const pending = terminateProcessTree(child as never, undefined, log)
+    killer.emit('exit', 1, null)
+
+    await expect(pending).resolves.toBeUndefined()
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(log.error).toHaveBeenCalled()
+  })
+
+  it('falls back to a direct kill when taskkill emits an error', async () => {
+    setPlatform('win32')
+    const killer = new EventEmitter()
+    spawnMock.mockReturnValueOnce(killer)
+    const child = new FakeChild(999)
+    const log = { error: vi.fn() }
+
+    const pending = terminateProcessTree(child as never, undefined, log)
     killer.emit('error', new Error('taskkill not found'))
 
     await expect(pending).resolves.toBeUndefined()
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(log.error).toHaveBeenCalled()
   })
 
-  it('on win32 with an undefined pid does not spawn taskkill and resolves', async () => {
-    setPlatform('win32')
-    const child = makeChild(undefined)
-
-    await expect(terminateProcessTree(child as never)).resolves.toBeUndefined()
-    expect(spawnMock).not.toHaveBeenCalled()
-    expect(child.kill).not.toHaveBeenCalled()
-  })
-
-  it('on win32 resolves when spawn itself throws synchronously', async () => {
+  it('falls back to a direct kill when spawn itself throws synchronously', async () => {
     setPlatform('win32')
     spawnMock.mockImplementationOnce(() => {
       throw new Error('spawn failed')
     })
-    const child = makeChild(555)
+    const child = new FakeChild(555)
+    const log = { error: vi.fn() }
+
+    await expect(terminateProcessTree(child as never, undefined, log)).resolves.toBeUndefined()
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(log.error).toHaveBeenCalled()
+  })
+
+  it('with an undefined pid does not spawn taskkill and does not kill', async () => {
+    setPlatform('win32')
+    const child = new FakeChild(undefined)
 
     await expect(terminateProcessTree(child as never)).resolves.toBeUndefined()
+    expect(spawnMock).not.toHaveBeenCalled()
     expect(child.kill).not.toHaveBeenCalled()
   })
+})
 
-  it('on non-win32 calls child.kill with the given signal, never invokes taskkill, and resolves', async () => {
+describe('terminateProcessTree (posix)', () => {
+  it('reaps descendants discovered via ps, kills the direct child, and awaits its exit', async () => {
     setPlatform('linux')
-    const child = makeChild(1234)
+    const ps = new FakePs()
+    spawnMock.mockReturnValueOnce(ps)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const child = new FakeChild(1000)
 
-    await expect(terminateProcessTree(child as never, 'SIGTERM')).resolves.toBeUndefined()
+    const pending = terminateProcessTree(child as never, 'SIGTERM')
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'ps',
+      ['-A', '-o', 'pid=,ppid='],
+      expect.objectContaining({ windowsHide: true })
+    )
+
+    // 1000 -> 1001 -> 1002, plus an unrelated tree that must be ignored.
+    ps.stdout.emit('data', Buffer.from('1000 1\n1001 1000\n1002 1001\n2000 1\n'))
+    ps.emit('close', 0)
+
+    // Let collectDescendantPids resolve and the kills run.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(killSpy).toHaveBeenCalledWith(1001, 'SIGTERM')
+    expect(killSpy).toHaveBeenCalledWith(1002, 'SIGTERM')
+    expect(killSpy).not.toHaveBeenCalledWith(2000, 'SIGTERM')
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
-    expect(spawnMock).not.toHaveBeenCalled()
+
+    // Still pending until the direct child actually exits.
+    child.emit('exit', 0, null)
+    await expect(pending).resolves.toBeUndefined()
   })
 
-  it('on non-win32 calls child.kill with undefined when no signal is provided', async () => {
+  it('still kills the direct child when ps fails to produce a tree', async () => {
     setPlatform('darwin')
-    const child = makeChild(1234)
+    const ps = new FakePs()
+    spawnMock.mockReturnValueOnce(ps)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const child = new FakeChild(1234)
 
-    await expect(terminateProcessTree(child as never)).resolves.toBeUndefined()
+    const pending = terminateProcessTree(child as never)
+    ps.emit('error', new Error('ps missing'))
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(killSpy).not.toHaveBeenCalled()
     expect(child.kill).toHaveBeenCalledWith(undefined)
-    expect(spawnMock).not.toHaveBeenCalled()
+
+    child.emit('exit', 0, null)
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it('resolves via the grace timer when the child never emits exit', async () => {
+    vi.useFakeTimers()
+    setPlatform('linux')
+    const ps = new FakePs()
+    spawnMock.mockReturnValueOnce(ps)
+    vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const child = new FakeChild(1234)
+
+    const pending = terminateProcessTree(child as never)
+    ps.emit('close', 0)
+
+    // Advance past the descendant-wait and the exit grace; the promise must still settle.
+    await vi.advanceTimersByTimeAsync(3_000)
+    await vi.advanceTimersByTimeAsync(3_000)
+    await expect(pending).resolves.toBeUndefined()
+    vi.useRealTimers()
+  })
+
+  it('resolves immediately when the child has already exited', async () => {
+    setPlatform('linux')
+    const ps = new FakePs()
+    spawnMock.mockReturnValueOnce(ps)
+    vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const child = new FakeChild(1234)
+    child.exitCode = 0
+
+    const pending = terminateProcessTree(child as never)
+    ps.emit('close', 0)
+
+    await expect(pending).resolves.toBeUndefined()
   })
 })

--- a/src/main/process-tree.ts
+++ b/src/main/process-tree.ts
@@ -10,7 +10,12 @@ export type ProcessTreeLogger = { error: (message: string, error?: unknown) => v
 // the whole shutdown, this is a second, tighter guard scoped to a single tree.
 const TERMINATE_GRACE_MS = 3_000
 
-// Signals the direct child, tolerating an already-exited process or a handle with no pid.
+// Shorter wait after escalating to SIGKILL: SIGKILL is uncatchable, so a process that survives it is a
+// kernel-level unkillable (uninterruptible sleep) we cannot do anything about — don't wait the full grace.
+const SIGKILL_GRACE_MS = 1_000
+
+// Signals the direct child, tolerating an already-exited process or a handle with no pid. Skips a child
+// already signaled so a first, graceful pass is a no-op on retry; escalation uses forceKillChild instead.
 const killDirectChild = (child: ChildProcess, signal?: NodeJS.Signals): void => {
   try {
     if (!child.killed) child.kill(signal)
@@ -19,25 +24,65 @@ const killDirectChild = (child: ChildProcess, signal?: NodeJS.Signals): void => 
   }
 }
 
-// Resolves once the child actually exits (or the grace elapses), so a caller that follows with
-// app.exit is guaranteed the child is gone — not merely signaled. The timer is unref'd so it never
-// keeps the process alive on its own.
-const waitForExit = (child: ChildProcess, ms: number): Promise<void> =>
-  new Promise<void>((resolve) => {
+// Hard-kills the direct child, bypassing the child.killed guard (a graceful pass already set it). Prefers
+// process.kill(pid) so SIGKILL is delivered even after child.kill() flipped `killed`, falling back to the
+// handle when no pid is exposed.
+const forceKillChild = (child: ChildProcess): void => {
+  try {
+    if (child.pid !== undefined) process.kill(child.pid, 'SIGKILL')
+    else child.kill('SIGKILL')
+  } catch {
+    // Already gone, or we cannot signal it; nothing more to do.
+  }
+}
+
+// True while the pid still exists. Signal 0 performs the permission/existence check without delivering a
+// signal: ESRCH means gone, EPERM means alive but not ours to signal.
+const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+// Sends a signal to each pid, ignoring processes that have already exited or that we cannot signal.
+const signalPids = (pids: number[], signal: NodeJS.Signals): void => {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal)
+    } catch {
+      // Already exited, or no permission; ignore and continue.
+    }
+  }
+}
+
+// Resolves true once the child actually exits, or false once the grace elapses without an exit — so the
+// caller can decide whether to escalate. The timer is cleared on exit (and unref'd) so a settled wait
+// never leaves a live timer to fire spuriously or keep the process alive.
+const waitForExit = (child: ChildProcess, ms: number): Promise<boolean> =>
+  new Promise<boolean>((resolve) => {
     if (child.exitCode !== null || child.signalCode !== null) {
-      resolve()
+      resolve(true)
       return
     }
     let settled = false
-    const done = (): void => {
+    const done = (exited: boolean): void => {
       if (settled) return
       settled = true
-      resolve()
+      resolve(exited)
     }
-    child.once('exit', done)
-    child.once('close', done)
-    const timer = setTimeout(done, ms)
+    const timer = setTimeout(() => done(false), ms)
     timer.unref?.()
+    child.once('exit', () => {
+      clearTimeout(timer)
+      done(true)
+    })
+    child.once('close', () => {
+      clearTimeout(timer)
+      done(true)
+    })
   })
 
 // Best-effort descendant discovery on POSIX. Node's child.kill() signals only the immediate child, so a
@@ -55,11 +100,34 @@ const collectDescendantPids = (rootPid: number): Promise<number[]> =>
     }
 
     let out = ''
+    let settled = false
+    const finish = (pids: number[]): void => {
+      if (settled) return
+      settled = true
+      resolve(pids)
+    }
+
+    // A hung ps must not stall teardown; abandon it after the grace and fall back to the direct kill.
+    // Created before the handlers so they can clear it (avoiding a forward reference from finish()).
+    const timer = setTimeout(() => {
+      try {
+        ps.kill()
+      } catch {
+        // ps may have already exited.
+      }
+      finish([])
+    }, TERMINATE_GRACE_MS)
+    timer.unref?.()
+
     ps.stdout?.on('data', (chunk: Buffer) => {
       out += chunk.toString()
     })
-    ps.on('error', () => resolve([]))
+    ps.on('error', () => {
+      clearTimeout(timer)
+      finish([])
+    })
     ps.on('close', () => {
+      clearTimeout(timer)
       try {
         const childrenByParent = new Map<number, number[]>()
         for (const line of out.split('\n')) {
@@ -82,97 +150,118 @@ const collectDescendantPids = (rootPid: number): Promise<number[]> =>
             stack.push(kid)
           }
         }
-        resolve(descendants)
+        finish(descendants)
       } catch {
-        resolve([])
+        finish([])
       }
     })
-
-    // A hung ps must not stall teardown; abandon it after the grace and fall back to the direct kill.
-    const timer = setTimeout(() => {
-      try {
-        ps.kill()
-      } catch {
-        // ps may have already exited.
-      }
-      resolve([])
-    }, TERMINATE_GRACE_MS)
-    timer.unref?.()
   })
 
-// Terminates a child process and every descendant it spawned, then waits for the direct child to
-// actually exit. On Windows a plain child.kill() only signals the immediate child, orphaning
-// grandchildren, so the whole tree is handed to taskkill /T /F; if taskkill cannot be launched, errors,
-// or exits non-zero we log and still kill the direct child so it never survives. On POSIX child.kill()
-// likewise reaches only the immediate child, so descendants are discovered via `ps` and signaled before
-// the child, and we await the child's real exit. This never rejects: any failure resolves to void so a
-// kill can never surface into the caller (before-quit -> app.exit).
+// Windows tree teardown. taskkill /T /F reaps the whole tree in one shot; child.kill() alone would orphan
+// grandchildren. If taskkill cannot be launched, errors, times out, or exits non-zero, the tree was NOT
+// reaped, so we log and fall back to killing the direct child and awaiting its exit. Descendant cleanup on
+// the fallback path is not possible without taskkill — an accepted platform limitation.
+const terminateWindowsTree = async (
+  child: ChildProcess,
+  signal: NodeJS.Signals | undefined,
+  log: ProcessTreeLogger | undefined
+): Promise<void> => {
+  if (child.pid === undefined) return
+
+  let killer: ChildProcess
+  try {
+    killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { windowsHide: true })
+  } catch (error) {
+    log?.error('taskkill failed to launch; falling back to direct kill', error)
+    killDirectChild(child, signal)
+    await waitForExit(child, TERMINATE_GRACE_MS)
+    return
+  }
+
+  const reaped = await new Promise<boolean>((resolve) => {
+    let settled = false
+    const done = (ok: boolean): void => {
+      if (settled) return
+      settled = true
+      resolve(ok)
+    }
+    // A wedged taskkill must not hang quit; abandon it after the grace and fall back. Cleared by the
+    // exit/error handlers on the settle path so it never fires spuriously while the app keeps running.
+    const timer = setTimeout(() => {
+      log?.error('taskkill did not complete in time; falling back to direct kill')
+      done(false)
+    }, TERMINATE_GRACE_MS)
+    timer.unref?.()
+    // A non-zero exit means taskkill did not reap the tree (e.g. process not found). A null code (killed
+    // by a signal) is treated as success to match prior behavior — it is vanishingly rare on Windows.
+    killer.on('exit', (code) => {
+      clearTimeout(timer)
+      done(code === 0 || code === null)
+    })
+    killer.on('error', (error) => {
+      clearTimeout(timer)
+      log?.error('taskkill errored; falling back to direct kill', error)
+      done(false)
+    })
+  })
+
+  if (!reaped) {
+    if (killer.exitCode !== null && killer.exitCode !== 0) {
+      log?.error(`taskkill exited with code ${killer.exitCode}; falling back to direct kill`)
+    }
+    killDirectChild(child, signal)
+    await waitForExit(child, TERMINATE_GRACE_MS)
+  }
+}
+
+// POSIX tree teardown. child.kill() reaches only the immediate child, so descendants are discovered via
+// `ps` and signaled alongside it. The graceful signal (SIGTERM by default) is given the grace to take
+// effect, then anything still alive — the child that ignored it, or a reparented grandchild — is
+// escalated to SIGKILL and confirmed, so the function does not return leaving the tree running.
+const terminatePosixTree = async (
+  child: ChildProcess,
+  signal: NodeJS.Signals | undefined,
+  log: ProcessTreeLogger | undefined
+): Promise<void> => {
+  const gracefulSignal = signal ?? 'SIGTERM'
+  const descendants = child.pid === undefined ? [] : await collectDescendantPids(child.pid)
+
+  signalPids(descendants, gracefulSignal)
+  killDirectChild(child, gracefulSignal)
+
+  const exited = await waitForExit(child, TERMINATE_GRACE_MS)
+  const survivors = descendants.filter(isProcessAlive)
+
+  if (exited && survivors.length === 0) return
+
+  if (survivors.length > 0) {
+    log?.error(
+      `process tree left ${survivors.length} descendant(s) alive after ${gracefulSignal}; escalating to SIGKILL`
+    )
+    signalPids(survivors, 'SIGKILL')
+  }
+  if (!exited) {
+    log?.error(
+      `process ${child.pid ?? '(no pid)'} did not exit after ${gracefulSignal}; escalating to SIGKILL`
+    )
+    forceKillChild(child)
+    await waitForExit(child, SIGKILL_GRACE_MS)
+  }
+}
+
+// Terminates a child process and every descendant it spawned, then waits for the direct child to actually
+// exit — escalating to SIGKILL anything still alive. On Windows the tree is reaped with taskkill /T /F
+// (with a direct-kill fallback); on POSIX descendants are found via `ps`, signaled, and SIGKILL-escalated.
+// This never rejects: any failure resolves to void so a kill can never surface into the caller
+// (before-quit -> app.exit).
 export const terminateProcessTree = async (
   child: ChildProcess,
   signal?: NodeJS.Signals,
   log?: ProcessTreeLogger
 ): Promise<void> => {
   if (process.platform === 'win32') {
-    if (child.pid === undefined) return
-
-    let killer: ChildProcess
-    try {
-      killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { windowsHide: true })
-    } catch (error) {
-      // spawn itself can throw synchronously (e.g. taskkill missing); fall back to the direct kill.
-      log?.error('taskkill failed to launch; falling back to direct kill', error)
-      killDirectChild(child, signal)
-      return
-    }
-
-    await new Promise<void>((resolve) => {
-      let settled = false
-      const done = (): void => {
-        if (settled) return
-        settled = true
-        resolve()
-      }
-      // Non-zero exit means taskkill did not reap the tree (e.g. process not found); back it up by
-      // signaling the direct child so it never outlives the app.
-      killer.on('exit', (code) => {
-        if (code !== 0 && code !== null) {
-          log?.error(`taskkill exited with code ${code}; falling back to direct kill`)
-          killDirectChild(child, signal)
-        }
-        done()
-      })
-      killer.on('close', done)
-      killer.on('error', (error) => {
-        log?.error('taskkill errored; falling back to direct kill', error)
-        killDirectChild(child, signal)
-        done()
-      })
-      // A wedged taskkill must not hang quit; abandon it after the grace, backing up with a direct kill.
-      const timer = setTimeout(() => {
-        log?.error('taskkill did not complete in time; falling back to direct kill')
-        killDirectChild(child, signal)
-        done()
-      }, TERMINATE_GRACE_MS)
-      timer.unref?.()
-    })
+    await terminateWindowsTree(child, signal, log)
     return
   }
-
-  if (child.pid === undefined) {
-    killDirectChild(child, signal)
-    await waitForExit(child, TERMINATE_GRACE_MS)
-    return
-  }
-
-  const descendants = await collectDescendantPids(child.pid)
-  // Signal descendants first so they can't be re-parented and outlive the tree once the child dies.
-  for (const pid of descendants) {
-    try {
-      process.kill(pid, signal)
-    } catch {
-      // The descendant may have already exited, or we may lack permission; ignore and continue.
-    }
-  }
-  killDirectChild(child, signal)
-  await waitForExit(child, TERMINATE_GRACE_MS)
+  await terminatePosixTree(child, signal, log)
 }

--- a/src/main/process-tree.ts
+++ b/src/main/process-tree.ts
@@ -1,45 +1,178 @@
 import { spawn } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
 
-// Terminates a child process and every descendant it spawned. On Windows a plain child.kill() only
-// signals the immediate child, orphaning grandchildren (e.g. conda / the claude CLI), so we hand the
-// whole tree to taskkill /T /F and await its completion — the caller (before-quit → app.exit) can then
-// be sure the tree is reaped before the app exits. On other platforms Node's own kill propagates well
-// enough and the signal is delivered synchronously. This never rejects: a failed taskkill launch (or
-// its own runtime error) must resolve to void rather than surface into the caller.
-export const terminateProcessTree = (
-  child: ChildProcess,
-  signal?: NodeJS.Signals
-): Promise<void> => {
-  if (process.platform === 'win32') {
-    if (child.pid === undefined) return Promise.resolve()
-    try {
-      const killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
-        windowsHide: true
-      })
-      // Resolve once taskkill finishes, however it finishes: normal exit, stream close, or a runtime
-      // error. Guarded so we resolve exactly once regardless of which event fires first.
-      return new Promise<void>((resolve) => {
-        let settled = false
-        const done = (): void => {
-          if (settled) return
-          settled = true
-          resolve()
-        }
-        killer.on('exit', done)
-        killer.on('close', done)
-        killer.on('error', done)
-      })
-    } catch {
-      // spawn itself can throw synchronously (e.g. taskkill missing); resolve so a kill never fails.
-      return Promise.resolve()
-    }
-  }
+// Optional sink for kill-path diagnostics; callers with a logger pass one, tests and the notebook path
+// omit it. Kept minimal so process-tree stays free of the Electron logger's import graph.
+export type ProcessTreeLogger = { error: (message: string, error?: unknown) => void }
 
+// Upper bound for awaiting a direct child's real exit (POSIX) or taskkill's own completion (Windows).
+// Bounded so a wedged process can never hang app teardown; the caller (before-quit) also time-bounds
+// the whole shutdown, this is a second, tighter guard scoped to a single tree.
+const TERMINATE_GRACE_MS = 3_000
+
+// Signals the direct child, tolerating an already-exited process or a handle with no pid.
+const killDirectChild = (child: ChildProcess, signal?: NodeJS.Signals): void => {
   try {
-    child.kill(signal)
+    if (!child.killed) child.kill(signal)
   } catch {
     // A kill on an already-exited child can throw; treat it as a no-op.
   }
-  return Promise.resolve()
+}
+
+// Resolves once the child actually exits (or the grace elapses), so a caller that follows with
+// app.exit is guaranteed the child is gone — not merely signaled. The timer is unref'd so it never
+// keeps the process alive on its own.
+const waitForExit = (child: ChildProcess, ms: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve()
+      return
+    }
+    let settled = false
+    const done = (): void => {
+      if (settled) return
+      settled = true
+      resolve()
+    }
+    child.once('exit', done)
+    child.once('close', done)
+    const timer = setTimeout(done, ms)
+    timer.unref?.()
+  })
+
+// Best-effort descendant discovery on POSIX. Node's child.kill() signals only the immediate child, so a
+// grandchild (conda, the claude CLI, a package manager) would otherwise be orphaned exactly as it would
+// on Windows without taskkill /T. `ps -A -o pid=,ppid=` is available on both macOS (BSD) and Linux
+// (procps); any failure resolves to an empty list so we still fall back to killing the direct child.
+const collectDescendantPids = (rootPid: number): Promise<number[]> =>
+  new Promise<number[]>((resolve) => {
+    let ps: ChildProcess
+    try {
+      ps = spawn('ps', ['-A', '-o', 'pid=,ppid='], { windowsHide: true })
+    } catch {
+      resolve([])
+      return
+    }
+
+    let out = ''
+    ps.stdout?.on('data', (chunk: Buffer) => {
+      out += chunk.toString()
+    })
+    ps.on('error', () => resolve([]))
+    ps.on('close', () => {
+      try {
+        const childrenByParent = new Map<number, number[]>()
+        for (const line of out.split('\n')) {
+          const [pidText, ppidText] = line.trim().split(/\s+/)
+          const pid = Number(pidText)
+          const ppid = Number(ppidText)
+          if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue
+          const siblings = childrenByParent.get(ppid) ?? []
+          siblings.push(pid)
+          childrenByParent.set(ppid, siblings)
+        }
+
+        // Depth-first walk from the root; the root itself is excluded (the caller kills it via its handle).
+        const descendants: number[] = []
+        const stack = [rootPid]
+        while (stack.length > 0) {
+          const current = stack.pop() as number
+          for (const kid of childrenByParent.get(current) ?? []) {
+            descendants.push(kid)
+            stack.push(kid)
+          }
+        }
+        resolve(descendants)
+      } catch {
+        resolve([])
+      }
+    })
+
+    // A hung ps must not stall teardown; abandon it after the grace and fall back to the direct kill.
+    const timer = setTimeout(() => {
+      try {
+        ps.kill()
+      } catch {
+        // ps may have already exited.
+      }
+      resolve([])
+    }, TERMINATE_GRACE_MS)
+    timer.unref?.()
+  })
+
+// Terminates a child process and every descendant it spawned, then waits for the direct child to
+// actually exit. On Windows a plain child.kill() only signals the immediate child, orphaning
+// grandchildren, so the whole tree is handed to taskkill /T /F; if taskkill cannot be launched, errors,
+// or exits non-zero we log and still kill the direct child so it never survives. On POSIX child.kill()
+// likewise reaches only the immediate child, so descendants are discovered via `ps` and signaled before
+// the child, and we await the child's real exit. This never rejects: any failure resolves to void so a
+// kill can never surface into the caller (before-quit -> app.exit).
+export const terminateProcessTree = async (
+  child: ChildProcess,
+  signal?: NodeJS.Signals,
+  log?: ProcessTreeLogger
+): Promise<void> => {
+  if (process.platform === 'win32') {
+    if (child.pid === undefined) return
+
+    let killer: ChildProcess
+    try {
+      killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { windowsHide: true })
+    } catch (error) {
+      // spawn itself can throw synchronously (e.g. taskkill missing); fall back to the direct kill.
+      log?.error('taskkill failed to launch; falling back to direct kill', error)
+      killDirectChild(child, signal)
+      return
+    }
+
+    await new Promise<void>((resolve) => {
+      let settled = false
+      const done = (): void => {
+        if (settled) return
+        settled = true
+        resolve()
+      }
+      // Non-zero exit means taskkill did not reap the tree (e.g. process not found); back it up by
+      // signaling the direct child so it never outlives the app.
+      killer.on('exit', (code) => {
+        if (code !== 0 && code !== null) {
+          log?.error(`taskkill exited with code ${code}; falling back to direct kill`)
+          killDirectChild(child, signal)
+        }
+        done()
+      })
+      killer.on('close', done)
+      killer.on('error', (error) => {
+        log?.error('taskkill errored; falling back to direct kill', error)
+        killDirectChild(child, signal)
+        done()
+      })
+      // A wedged taskkill must not hang quit; abandon it after the grace, backing up with a direct kill.
+      const timer = setTimeout(() => {
+        log?.error('taskkill did not complete in time; falling back to direct kill')
+        killDirectChild(child, signal)
+        done()
+      }, TERMINATE_GRACE_MS)
+      timer.unref?.()
+    })
+    return
+  }
+
+  if (child.pid === undefined) {
+    killDirectChild(child, signal)
+    await waitForExit(child, TERMINATE_GRACE_MS)
+    return
+  }
+
+  const descendants = await collectDescendantPids(child.pid)
+  // Signal descendants first so they can't be re-parented and outlive the tree once the child dies.
+  for (const pid of descendants) {
+    try {
+      process.kill(pid, signal)
+    } catch {
+      // The descendant may have already exited, or we may lack permission; ignore and continue.
+    }
+  }
+  killDirectChild(child, signal)
+  await waitForExit(child, TERMINATE_GRACE_MS)
 }

--- a/src/main/process-tree.ts
+++ b/src/main/process-tree.ts
@@ -1,0 +1,45 @@
+import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+
+// Terminates a child process and every descendant it spawned. On Windows a plain child.kill() only
+// signals the immediate child, orphaning grandchildren (e.g. conda / the claude CLI), so we hand the
+// whole tree to taskkill /T /F and await its completion — the caller (before-quit → app.exit) can then
+// be sure the tree is reaped before the app exits. On other platforms Node's own kill propagates well
+// enough and the signal is delivered synchronously. This never rejects: a failed taskkill launch (or
+// its own runtime error) must resolve to void rather than surface into the caller.
+export const terminateProcessTree = (
+  child: ChildProcess,
+  signal?: NodeJS.Signals
+): Promise<void> => {
+  if (process.platform === 'win32') {
+    if (child.pid === undefined) return Promise.resolve()
+    try {
+      const killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+        windowsHide: true
+      })
+      // Resolve once taskkill finishes, however it finishes: normal exit, stream close, or a runtime
+      // error. Guarded so we resolve exactly once regardless of which event fires first.
+      return new Promise<void>((resolve) => {
+        let settled = false
+        const done = (): void => {
+          if (settled) return
+          settled = true
+          resolve()
+        }
+        killer.on('exit', done)
+        killer.on('close', done)
+        killer.on('error', done)
+      })
+    } catch {
+      // spawn itself can throw synchronously (e.g. taskkill missing); resolve so a kill never fails.
+      return Promise.resolve()
+    }
+  }
+
+  try {
+    child.kill(signal)
+  } catch {
+    // A kill on an already-exited child can throw; treat it as a no-op.
+  }
+  return Promise.resolve()
+}

--- a/src/main/single-instance.test.ts
+++ b/src/main/single-instance.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Minimal electron app double: a toggleable lock result plus a listener recorder so the test can
+// fire the 'second-instance' event and assert the forwarded argv/cwd.
+const { appMock } = vi.hoisted(() => ({
+  appMock: {
+    requestSingleInstanceLock: vi.fn(),
+    listeners: new Map<string, (event: unknown, argv: string[], cwd: string) => void>(),
+    on: vi.fn((event: string, fn: (event: unknown, argv: string[], cwd: string) => void) => {
+      appMock.listeners.set(event, fn)
+    })
+  }
+}))
+
+vi.mock('electron', () => ({ app: appMock }))
+
+const { acquireSingleInstanceLock } = await import('./single-instance')
+
+afterEach(() => {
+  appMock.listeners.clear()
+  vi.clearAllMocks()
+})
+
+describe('acquireSingleInstanceLock', () => {
+  it('returns false and registers no listener when the lock is not acquired', () => {
+    appMock.requestSingleInstanceLock.mockReturnValue(false)
+    const onSecondInstance = vi.fn()
+
+    const isPrimary = acquireSingleInstanceLock({ onSecondInstance })
+
+    expect(isPrimary).toBe(false)
+    expect(appMock.on).not.toHaveBeenCalled()
+  })
+
+  it('returns true and registers a second-instance listener when the lock is acquired', () => {
+    appMock.requestSingleInstanceLock.mockReturnValue(true)
+    const onSecondInstance = vi.fn()
+
+    const isPrimary = acquireSingleInstanceLock({ onSecondInstance })
+
+    expect(isPrimary).toBe(true)
+    expect(appMock.on).toHaveBeenCalledWith('second-instance', expect.any(Function))
+    expect(appMock.listeners.has('second-instance')).toBe(true)
+  })
+
+  it('forwards argv and workingDirectory to onSecondInstance', () => {
+    appMock.requestSingleInstanceLock.mockReturnValue(true)
+    const onSecondInstance = vi.fn()
+    acquireSingleInstanceLock({ onSecondInstance })
+
+    const argv = ['electron', 'open-science', '--open', 'notebook.ipynb']
+    const cwd = '/Users/tester/projects'
+    appMock.listeners.get('second-instance')?.({}, argv, cwd)
+
+    expect(onSecondInstance).toHaveBeenCalledTimes(1)
+    expect(onSecondInstance).toHaveBeenCalledWith(argv, cwd)
+  })
+})

--- a/src/main/single-instance.ts
+++ b/src/main/single-instance.ts
@@ -1,0 +1,15 @@
+import { app } from 'electron'
+
+// Acquires the OS-level single-instance lock. Returns false when another instance already holds it
+// (this process is a secondary launch and the caller should quit); returns true for the primary
+// instance. On the primary, a 'second-instance' listener forwards the secondary launch's argv and
+// working directory so the caller can focus/route the existing window instead of opening a new one.
+export const acquireSingleInstanceLock = (opts: {
+  onSecondInstance: (argv: string[], cwd: string) => void
+}): boolean => {
+  if (!app.requestSingleInstanceLock()) return false
+  app.on('second-instance', (_event, argv, workingDirectory) => {
+    opts.onSecondInstance(argv, workingDirectory)
+  })
+  return true
+}

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -395,6 +395,13 @@ describe('storage IPC handlers', () => {
     const deps = fakeDeps({ relaunch: undefined })
     registerStorageIpcHandlers(deps)
 
+    // Stage a verified copy first (two-phase flow) so the commit actually switches over and relaunches.
+    // migrate itself interrupts the notebook (shutdownAll), so clear the mocks to isolate the commit's
+    // own cleanup below.
+    await invoke('storage:migrate', { parent: targetParent })
+    vi.mocked(deps.notebook.shutdownAll).mockClear()
+    vi.mocked(deps.runtime.shutdownForQuit).mockClear()
+
     await expect(invoke('storage:commit-and-relaunch', { parent: targetParent })).resolves.toEqual({
       ok: true
     })
@@ -651,7 +658,8 @@ describe('storage IPC handlers', () => {
             new Promise<void>((resolve) => {
               releaseDisconnect = resolve
             })
-        )
+        ),
+        shutdownForQuit: vi.fn().mockResolvedValue(undefined)
       }
     })
     registerStorageIpcHandlers(deps)

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -63,7 +63,10 @@ const tick = (ms = 50): Promise<void> => new Promise((resolve) => setTimeout(res
 type FakeDeps = Parameters<typeof registerStorageIpcHandlers>[0]
 
 const fakeDeps = (overrides: Partial<FakeDeps> = {}): FakeDeps => ({
-  runtime: { disconnect: vi.fn().mockResolvedValue(undefined) },
+  runtime: {
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    shutdownForQuit: vi.fn().mockResolvedValue(undefined)
+  },
   notebook: {
     shutdownAll: vi.fn().mockResolvedValue(undefined),
     getActiveNotebookSessions: vi.fn().mockReturnValue([])
@@ -90,6 +93,8 @@ let target: string
 beforeEach(async () => {
   handlers.clear()
   showOpenDialog.mockReset()
+  appRelaunch.mockClear()
+  appExit.mockClear()
   sentWindows.length = 0
   currentParent = await mkdtemp(join(tmpdir(), 'ds-storage-ipc-current-'))
   dataRoot = dataRootFor(currentParent)
@@ -383,6 +388,42 @@ describe('storage IPC handlers', () => {
     expect(deps.relaunch).not.toHaveBeenCalled()
   })
 
+  it('commit-and-relaunch runs the production cleanup (shutdown backends, then relaunch+exit) with no relaunch override', async () => {
+    initDataRoot(dataRoot)
+    // No injected relaunch: exercise the real cleanRelaunch path (shutdownBackends -> app.relaunch ->
+    // app.exit) instead of the test short-circuit.
+    const deps = fakeDeps({ relaunch: undefined })
+    registerStorageIpcHandlers(deps)
+
+    await expect(invoke('storage:commit-and-relaunch', { parent: targetParent })).resolves.toEqual({
+      ok: true
+    })
+
+    expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+    expect(appRelaunch).toHaveBeenCalledTimes(1)
+    expect(appExit).toHaveBeenCalledWith(0)
+    // Backends are torn down before the relaunch is triggered.
+    expect(vi.mocked(deps.runtime.shutdownForQuit).mock.invocationCallOrder[0]).toBeLessThan(
+      appRelaunch.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('set-data-root-and-relaunch runs the production cleanup before relaunch+exit with no relaunch override', async () => {
+    initDataRoot(dataRoot)
+    const deps = fakeDeps({ relaunch: undefined })
+    registerStorageIpcHandlers(deps)
+
+    await expect(
+      invoke('storage:set-data-root-and-relaunch', { parent: targetParent })
+    ).resolves.toEqual({ ok: true })
+
+    expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+    expect(appRelaunch).toHaveBeenCalledTimes(1)
+    expect(appExit).toHaveBeenCalledWith(0)
+  })
+
   it('commit-and-relaunch returns switchoverFailed and does NOT relaunch when setDataRoot throws', async () => {
     initDataRoot(dataRoot)
     const deps = fakeDeps({
@@ -582,7 +623,8 @@ describe('storage IPC handlers', () => {
             new Promise<void>((resolve) => {
               releaseDisconnect = resolve
             })
-        )
+        ),
+        shutdownForQuit: vi.fn().mockResolvedValue(undefined)
       }
     })
     registerStorageIpcHandlers(deps)
@@ -636,7 +678,8 @@ describe('storage IPC handlers', () => {
             new Promise<void>((resolve) => {
               releaseDisconnect = resolve
             })
-        )
+        ),
+        shutdownForQuit: vi.fn().mockResolvedValue(undefined)
       }
     })
     registerStorageIpcHandlers(deps)

--- a/src/main/storage/ipc.ts
+++ b/src/main/storage/ipc.ts
@@ -14,6 +14,7 @@ import {
 } from '../storage-root'
 import { detectActiveSessions } from './detect-active'
 import { beginMigration, clearMigrationPending, endMigrationCopy } from './migration-state'
+import { shutdownBackends } from '../lifecycle-shutdown'
 import {
   classifyDataRoot,
   commitDataRootSwitch,
@@ -27,7 +28,9 @@ import { availableBytes, computeStorageUsage } from './usage'
 type SessionSource = { projectName: string; sessionId: string }
 
 type StorageIpcDeps = {
-  runtime: { disconnect: () => Promise<unknown> }
+  // disconnect drives the migration session-interrupt; shutdownForQuit is the awaited quit/relaunch
+  // teardown used by cleanRelaunch (via shutdownBackends).
+  runtime: { disconnect: () => Promise<unknown>; shutdownForQuit: () => Promise<void> }
   notebook: { shutdownAll: () => Promise<void>; getActiveNotebookSessions: () => SessionSource[] }
   getActivePromptSessions: () => SessionSource[]
   settingsService: {
@@ -251,6 +254,20 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
     }
   )
 
+  // Shuts the backends down (agent process tree + notebook kernels) before relaunching, so a data-root
+  // switch never leaves an orphaned backend from the old process attached to the app it relaunches into.
+  // The injected deps.relaunch (tests) replaces the whole relaunch+exit, so it short-circuits ahead of
+  // any real shutdown. shutdownBackends is bounded and never throws, so relaunch always makes progress.
+  const cleanRelaunch = async (): Promise<void> => {
+    if (deps.relaunch) {
+      deps.relaunch()
+      return
+    }
+    await shutdownBackends({ runtime: deps.runtime, notebook: deps.notebook })
+    app.relaunch()
+    app.exit(0)
+  }
+
   // Phase 2 (commit): invoked by the modal's "Restart now" once the copy is done. Flips
   // settings.dataRoot to the new root, deletes the old dirs, then relaunches. Ordered so an
   // interruption during the delete only orphans the old root (never data loss); see
@@ -295,12 +312,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         // On success the write-gate stays set through relaunch: the fresh process starts with
         // pending=false, so writes naturally resume against the now-live new root.
         activeStaged = undefined
-        if (deps.relaunch) {
-          deps.relaunch()
-        } else {
-          app.relaunch()
-          app.exit(0)
-        }
+        await cleanRelaunch()
       } else {
         // The commit did not switch over (switchoverFailed, or a no-op refusal: no verified copy /
         // mismatch). The UI's error stage offers no retry, so never leave the app soft-locked: on a
@@ -388,13 +400,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         if (request.markOnboarding) {
           await deps.settingsService.markOnboardingComplete()
         }
-        ;(
-          deps.relaunch ??
-          (() => {
-            app.relaunch()
-            app.exit(0)
-          })
-        )()
+        await cleanRelaunch()
 
         return { ok: true }
       } catch (err) {

--- a/src/main/tray.test.ts
+++ b/src/main/tray.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Menu template item shape captured from Menu.buildFromTemplate.
+type MenuTemplateItem = { label?: string; type?: string; click?: () => void }
+
+// Records what the fake Tray was constructed and configured with so assertions can inspect it.
+type TrayCall = {
+  icon: unknown
+  tooltip?: string
+  contextMenu?: { template: MenuTemplateItem[] }
+  clickHandler?: () => void
+}
+
+let lastTray: TrayCall | undefined
+let lastTemplate: MenuTemplateItem[] | undefined
+// When true the fake Tray constructor throws, simulating a platform without a tray host.
+let trayShouldThrow = false
+
+class FakeTray {
+  constructor(icon: unknown) {
+    if (trayShouldThrow) throw new Error('no tray host')
+
+    lastTray = { icon }
+  }
+
+  setToolTip(tooltip: string): void {
+    if (lastTray) lastTray.tooltip = tooltip
+  }
+
+  setContextMenu(menu: { template: MenuTemplateItem[] }): void {
+    if (lastTray) lastTray.contextMenu = menu
+  }
+
+  on(event: string, handler: () => void): void {
+    if (event === 'click' && lastTray) lastTray.clickHandler = handler
+  }
+}
+
+vi.mock('electron', () => ({
+  Tray: class {
+    constructor(icon: unknown) {
+      return new FakeTray(icon) as unknown as object
+    }
+  },
+  Menu: {
+    buildFromTemplate: (template: MenuTemplateItem[]) => {
+      lastTemplate = template
+      return { template }
+    }
+  },
+  nativeImage: {
+    createFromPath: (path: string) => ({ path, isEmpty: () => false })
+  }
+}))
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined
+  })
+}))
+
+const { createAppTray } = await import('./tray')
+
+const findItem = (label: string): MenuTemplateItem => {
+  const item = lastTemplate?.find((entry) => entry.label === label)
+  expect(item).toBeDefined()
+  return item!
+}
+
+describe('createAppTray', () => {
+  beforeEach(() => {
+    lastTray = undefined
+    lastTemplate = undefined
+    trayShouldThrow = false
+  })
+
+  it('builds a tray with tooltip and a Show/Hide/Quit context menu', () => {
+    const tray = createAppTray({
+      iconPath: '/icons/tray.png',
+      onShow: vi.fn(),
+      onHide: vi.fn(),
+      onQuit: vi.fn()
+    })
+
+    expect(tray).toBeDefined()
+    expect(lastTray?.tooltip).toBe('Open Science')
+    expect(lastTray?.contextMenu?.template).toBe(lastTemplate)
+    expect(lastTemplate?.filter((item) => item.label).map((item) => item.label)).toEqual([
+      'Show',
+      'Hide',
+      'Quit'
+    ])
+  })
+
+  it('wires menu items and left click to the provided callbacks', () => {
+    const onShow = vi.fn()
+    const onHide = vi.fn()
+    const onQuit = vi.fn()
+
+    createAppTray({ iconPath: '/icons/tray.png', onShow, onHide, onQuit })
+
+    findItem('Show').click?.()
+    expect(onShow).toHaveBeenCalledTimes(1)
+
+    findItem('Hide').click?.()
+    expect(onHide).toHaveBeenCalledTimes(1)
+
+    findItem('Quit').click?.()
+    expect(onQuit).toHaveBeenCalledTimes(1)
+
+    lastTray?.clickHandler?.()
+    expect(onShow).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns undefined without throwing when tray construction fails', () => {
+    trayShouldThrow = true
+
+    const args = { iconPath: '/icons/tray.png', onShow: vi.fn(), onHide: vi.fn(), onQuit: vi.fn() }
+    expect(() => createAppTray(args)).not.toThrow()
+    expect(createAppTray(args)).toBe(undefined)
+  })
+})

--- a/src/main/tray.test.ts
+++ b/src/main/tray.test.ts
@@ -1,11 +1,22 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Menu template item shape captured from Menu.buildFromTemplate.
 type MenuTemplateItem = { label?: string; type?: string; click?: () => void }
 
+// A nativeImage stand-in that records template-image flagging so tests can assert the macOS branch.
+type FakeImage = {
+  kind: 'path' | 'bitmap'
+  isTemplate: boolean
+  isEmpty: () => boolean
+  getSize: () => { width: number; height: number }
+  toBitmap: () => Buffer
+  resize: () => FakeImage
+  setTemplateImage: (value: boolean) => void
+}
+
 // Records what the fake Tray was constructed and configured with so assertions can inspect it.
 type TrayCall = {
-  icon: unknown
+  icon: FakeImage
   tooltip?: string
   contextMenu?: { template: MenuTemplateItem[] }
   clickHandler?: () => void
@@ -15,9 +26,30 @@ let lastTray: TrayCall | undefined
 let lastTemplate: MenuTemplateItem[] | undefined
 // When true the fake Tray constructor throws, simulating a platform without a tray host.
 let trayShouldThrow = false
+// Toggles for the nativeImage doubles, driving the macOS template branch and its fallbacks.
+let sourceEmpty = false
+let bitmapThrows = false
+
+const makeImage = (kind: 'path' | 'bitmap'): FakeImage => {
+  const image: FakeImage = {
+    kind,
+    isTemplate: false,
+    isEmpty: () => (kind === 'path' ? sourceEmpty : false),
+    getSize: () => ({ width: 4, height: 4 }),
+    toBitmap: () => {
+      if (bitmapThrows) throw new Error('toBitmap failed')
+      return Buffer.alloc(4 * 4 * 4, 200)
+    },
+    resize: () => image,
+    setTemplateImage: (value: boolean) => {
+      image.isTemplate = value
+    }
+  }
+  return image
+}
 
 class FakeTray {
-  constructor(icon: unknown) {
+  constructor(icon: FakeImage) {
     if (trayShouldThrow) throw new Error('no tray host')
 
     lastTray = { icon }
@@ -38,7 +70,7 @@ class FakeTray {
 
 vi.mock('electron', () => ({
   Tray: class {
-    constructor(icon: unknown) {
+    constructor(icon: FakeImage) {
       return new FakeTray(icon) as unknown as object
     }
   },
@@ -49,7 +81,8 @@ vi.mock('electron', () => ({
     }
   },
   nativeImage: {
-    createFromPath: (path: string) => ({ path, isEmpty: () => false })
+    createFromPath: () => makeImage('path'),
+    createFromBitmap: () => makeImage('bitmap')
   }
 }))
 
@@ -64,6 +97,11 @@ vi.mock('./logger', () => ({
 
 const { createAppTray } = await import('./tray')
 
+const originalPlatform = process.platform
+const setPlatform = (value: string): void => {
+  Object.defineProperty(process, 'platform', { value, configurable: true })
+}
+
 const findItem = (label: string): MenuTemplateItem => {
   const item = lastTemplate?.find((entry) => entry.label === label)
   expect(item).toBeDefined()
@@ -75,6 +113,14 @@ describe('createAppTray', () => {
     lastTray = undefined
     lastTemplate = undefined
     trayShouldThrow = false
+    sourceEmpty = false
+    bitmapThrows = false
+    // Default the shared cases to a non-darwin platform (full-color icon path).
+    setPlatform('linux')
+  })
+
+  afterEach(() => {
+    setPlatform(originalPlatform)
   })
 
   it('builds a tray with tooltip and a Show/Hide/Quit context menu', () => {
@@ -115,11 +161,70 @@ describe('createAppTray', () => {
     expect(onShow).toHaveBeenCalledTimes(2)
   })
 
+  it('uses the full-color icon (not a template) on non-darwin platforms', () => {
+    createAppTray({
+      iconPath: '/icons/tray.png',
+      onShow: vi.fn(),
+      onHide: vi.fn(),
+      onQuit: vi.fn()
+    })
+
+    expect(lastTray?.icon.kind).toBe('path')
+    expect(lastTray?.icon.isTemplate).toBe(false)
+  })
+
   it('returns undefined without throwing when tray construction fails', () => {
     trayShouldThrow = true
 
     const args = { iconPath: '/icons/tray.png', onShow: vi.fn(), onHide: vi.fn(), onQuit: vi.fn() }
     expect(() => createAppTray(args)).not.toThrow()
     expect(createAppTray(args)).toBe(undefined)
+  })
+
+  describe('on macOS', () => {
+    beforeEach(() => {
+      setPlatform('darwin')
+    })
+
+    it('builds a monochrome template image from the app icon', () => {
+      createAppTray({
+        iconPath: '/icons/tray.png',
+        onShow: vi.fn(),
+        onHide: vi.fn(),
+        onQuit: vi.fn()
+      })
+
+      expect(lastTray?.icon.kind).toBe('bitmap')
+      expect(lastTray?.icon.isTemplate).toBe(true)
+    })
+
+    it('falls back to the color icon when the template cannot be built', () => {
+      bitmapThrows = true
+
+      createAppTray({
+        iconPath: '/icons/tray.png',
+        onShow: vi.fn(),
+        onHide: vi.fn(),
+        onQuit: vi.fn()
+      })
+
+      // Template construction failed, so the tray still appears using the plain color icon.
+      expect(lastTray?.icon.kind).toBe('path')
+      expect(lastTray?.icon.isTemplate).toBe(false)
+    })
+
+    it('falls back to the color icon when the source icon is empty', () => {
+      sourceEmpty = true
+
+      createAppTray({
+        iconPath: '/icons/tray.png',
+        onShow: vi.fn(),
+        onHide: vi.fn(),
+        onQuit: vi.fn()
+      })
+
+      expect(lastTray?.icon.kind).toBe('path')
+      expect(lastTray?.icon.isTemplate).toBe(false)
+    })
   })
 })

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,8 +1,47 @@
-import { Menu, Tray, nativeImage } from 'electron'
+import { Menu, Tray, nativeImage, type NativeImage } from 'electron'
 
 import { createLogger } from './logger'
 
 const logger = createLogger('tray')
+
+// macOS menu-bar icons should be monochrome "template" images: black pixels on a transparent background
+// that the system tints to match the light/dark menu bar. The app icon is a light ring-of-dots glyph on
+// a dark rounded-square container, so we keep the dots (mapping their brightness to alpha) and drop the
+// dark container, then paint everything black and flag it as a template. Returns undefined on any
+// failure so the caller can fall back to the full-color icon.
+const TEMPLATE_ICON_SIZE = 18
+const createMacTemplateIcon = (iconPath: string): NativeImage | undefined => {
+  try {
+    const source = nativeImage.createFromPath(iconPath)
+    if (source.isEmpty()) return undefined
+
+    const { width, height } = source.getSize()
+    if (!width || !height) return undefined
+
+    // toBitmap() is BGRA. Map luminance to alpha so the dark container (low luminance) becomes
+    // transparent and the light dots stay opaque with soft anti-aliased edges; paint every pixel black
+    // so setTemplateImage can tint it.
+    const bitmap = source.toBitmap()
+    for (let i = 0; i < bitmap.length; i += 4) {
+      const luminance = 0.299 * bitmap[i + 2] + 0.587 * bitmap[i + 1] + 0.114 * bitmap[i]
+      const alpha = Math.max(0, Math.min(255, Math.round(((luminance - 90) / (232 - 90)) * 255)))
+      bitmap[i] = 0
+      bitmap[i + 1] = 0
+      bitmap[i + 2] = 0
+      bitmap[i + 3] = alpha
+    }
+
+    const template = nativeImage
+      .createFromBitmap(bitmap, { width, height })
+      .resize({ width: TEMPLATE_ICON_SIZE, height: TEMPLATE_ICON_SIZE, quality: 'best' })
+    if (template.isEmpty()) return undefined
+    template.setTemplateImage(true)
+    return template
+  } catch (error) {
+    logger.error('failed to build macOS template tray icon; falling back to the color icon', error)
+    return undefined
+  }
+}
 
 // Builds a system tray icon with a Show/Quit menu. Returns undefined when the platform has no tray
 // host (e.g. Linux without a StatusNotifier/AppIndicator), letting the app fall back to quit-on-close.
@@ -13,8 +52,12 @@ const createAppTray = (opts: {
   onQuit: () => void
 }): Tray | undefined => {
   try {
-    // Load the icon; an empty image is tolerated so the tray still appears with a blank glyph.
-    const icon = nativeImage.createFromPath(opts.iconPath)
+    // macOS gets a monochrome template glyph that follows the menu-bar appearance; other platforms use
+    // the full-color icon. An empty image is tolerated so the tray still appears with a blank glyph.
+    const icon =
+      process.platform === 'darwin'
+        ? (createMacTemplateIcon(opts.iconPath) ?? nativeImage.createFromPath(opts.iconPath))
+        : nativeImage.createFromPath(opts.iconPath)
     const tray = new Tray(icon)
 
     // Right-click (or platform default) menu with the core actions.

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,0 +1,42 @@
+import { Menu, Tray, nativeImage } from 'electron'
+
+import { createLogger } from './logger'
+
+const logger = createLogger('tray')
+
+// Builds a system tray icon with a Show/Quit menu. Returns undefined when the platform has no tray
+// host (e.g. Linux without a StatusNotifier/AppIndicator), letting the app fall back to quit-on-close.
+const createAppTray = (opts: {
+  iconPath: string
+  onShow: () => void
+  onHide: () => void
+  onQuit: () => void
+}): Tray | undefined => {
+  try {
+    // Load the icon; an empty image is tolerated so the tray still appears with a blank glyph.
+    const icon = nativeImage.createFromPath(opts.iconPath)
+    const tray = new Tray(icon)
+
+    // Right-click (or platform default) menu with the core actions.
+    const menu = Menu.buildFromTemplate([
+      { label: 'Show', click: () => opts.onShow() },
+      { label: 'Hide', click: () => opts.onHide() },
+      { type: 'separator' },
+      { label: 'Quit', click: () => opts.onQuit() }
+    ])
+
+    tray.setToolTip('Open Science')
+    tray.setContextMenu(menu)
+
+    // Left click reveals the window on Windows/Linux where it is the expected affordance.
+    tray.on('click', () => opts.onShow())
+
+    return tray
+  } catch (error) {
+    // No tray host available: log and let the caller fall back to normal window/quit behavior.
+    logger.error('failed to create tray', error)
+    return undefined
+  }
+}
+
+export { createAppTray }

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -19,15 +19,24 @@ const { openExternalMock, ipcMainOnMock, ipcMainRemoveListenerMock } = vi.hoiste
 type WindowOpenDetails = { url: string; referrer: { url: string } }
 let windowOpenHandler: ((details: WindowOpenDetails) => unknown) | undefined
 
-// The most recently constructed window and its captured webContents handlers, so tests can drive the
-// before-input-event / did-start-loading listeners the way Electron would.
+// The most recently constructed window and its captured handlers, so tests can drive the
+// before-input-event / lifecycle listeners and the 'close' interceptor the way Electron would.
 type WebContentsHandler = (...args: unknown[]) => void
+// Fake close event mirroring Electron's: preventDefault records that the close was intercepted.
+type CloseEvent = { preventDefault: () => void; defaultPrevented: boolean }
+
+// currentWindow and lastWindow both point at the latest window; two describe blocks, one shared fake.
 let currentWindow: FakeBrowserWindow | undefined
+let lastWindow: FakeBrowserWindow | undefined
 
 class FakeBrowserWindow {
   closeMock = vi.fn()
   sendMock = vi.fn()
   webContentsHandlers = new Map<string, WebContentsHandler>()
+  handlers = new Map<string, Array<(event: CloseEvent) => void>>()
+  hidden = false
+  destroyed = false
+  hideCalls = 0
   webContents = {
     setWindowOpenHandler: (handler: (details: WindowOpenDetails) => unknown): void => {
       windowOpenHandler = handler
@@ -39,12 +48,38 @@ class FakeBrowserWindow {
     getURL: (): string => 'file:///app/index.html'
   }
 
-  on(): this {
+  on(event: string, handler: (event: CloseEvent) => void): this {
+    const list = this.handlers.get(event) ?? []
+    list.push(handler)
+    this.handlers.set(event, list)
     return this
   }
 
+  // Mirror Electron: close() fires the 'close' handlers, so a close-to-tray interceptor that
+  // preventDefault()s keeps the window alive; otherwise the close proceeds to destroy the window.
   close(): void {
     this.closeMock()
+    const event: CloseEvent = {
+      defaultPrevented: false,
+      preventDefault(): void {
+        this.defaultPrevented = true
+      }
+    }
+    for (const handler of this.handlers.get('close') ?? []) handler(event)
+    if (!event.defaultPrevented) this.destroyed = true
+  }
+
+  show(): void {
+    this.hidden = false
+  }
+
+  hide(): void {
+    this.hidden = true
+    this.hideCalls += 1
+  }
+
+  isDestroyed(): boolean {
+    return this.destroyed
   }
 
   loadURL(): Promise<void> {
@@ -57,11 +92,12 @@ class FakeBrowserWindow {
 }
 
 vi.mock('electron', () => ({
-  // isPackaged=true skips the dev title-suffix branch, keeping the fake focused on the open handler.
+  // isPackaged=true skips the dev title-suffix branch, keeping the fake focused on the open + close handlers.
   app: { isPackaged: true },
   BrowserWindow: class {
     constructor() {
       currentWindow = new FakeBrowserWindow()
+      lastWindow = currentWindow
       return currentWindow as unknown as object
     }
   },
@@ -87,6 +123,20 @@ const closeChord = (overrides: Partial<KeyChordInput> = {}): KeyChordInput => ({
   isAutoRepeat: false,
   ...overrides
 })
+
+// Drives the captured 'close' handlers with a fresh event, then mirrors Electron: an un-prevented
+// close proceeds to destroy the window.
+const emitClose = (window: FakeBrowserWindow): CloseEvent => {
+  const event: CloseEvent = {
+    defaultPrevented: false,
+    preventDefault(): void {
+      this.defaultPrevented = true
+    }
+  }
+  for (const handler of window.handlers.get('close') ?? []) handler(event)
+  if (!event.defaultPrevented) window.destroyed = true
+  return event
+}
 
 describe('window navigation policy', () => {
   it('allows only explicit external URL protocols', async () => {
@@ -345,5 +395,76 @@ describe('close chord interception', () => {
     expect(preventDefault).not.toHaveBeenCalled()
     expect(window.sendMock).not.toHaveBeenCalled()
     expect(window.closeMock).not.toHaveBeenCalled()
+  })
+
+  it('routes the Cmd/Ctrl+W direct-close fallback through the close-to-tray interceptor', () => {
+    // Renderer not ready, so the chord falls back to window.close(); with the tray resident that must
+    // hide the window (via the 'close' interceptor) instead of actually closing it.
+    createMainWindow({ shouldHideOnClose: () => true })
+    const window = currentWindow!
+
+    fireInput(window, closeChord())
+
+    expect(window.closeMock).toHaveBeenCalledTimes(1)
+    expect(window.hidden).toBe(true)
+    expect(window.hideCalls).toBe(1)
+    expect(window.isDestroyed()).toBe(false)
+  })
+})
+
+describe('createMainWindow close-to-tray interceptor', () => {
+  beforeEach(() => {
+    lastWindow = undefined
+  })
+
+  it('hides instead of closing when shouldHideOnClose returns true', () => {
+    createMainWindow({ shouldHideOnClose: () => true })
+    const window = lastWindow!
+    expect(window).toBeDefined()
+
+    const event = emitClose(window)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(window.hideCalls).toBe(1)
+    expect(window.hidden).toBe(true)
+    expect(window.isDestroyed()).toBe(false)
+  })
+
+  it('evaluates the predicate at close time so a flipped flag allows a real quit', () => {
+    let quitting = false
+    createMainWindow({ shouldHideOnClose: () => !quitting })
+    const window = lastWindow!
+
+    emitClose(window)
+    expect(window.hideCalls).toBe(1)
+    expect(window.isDestroyed()).toBe(false)
+
+    quitting = true
+    const event = emitClose(window)
+    expect(event.defaultPrevented).toBe(false)
+    expect(window.hideCalls).toBe(1)
+    expect(window.isDestroyed()).toBe(true)
+  })
+
+  it('lets the window close when shouldHideOnClose returns false', () => {
+    createMainWindow({ shouldHideOnClose: () => false })
+    const window = lastWindow!
+
+    const event = emitClose(window)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(window.hideCalls).toBe(0)
+    expect(window.isDestroyed()).toBe(true)
+  })
+
+  it('lets the window close when no options are provided', () => {
+    createMainWindow()
+    const window = lastWindow!
+
+    const event = emitClose(window)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(window.hideCalls).toBe(0)
+    expect(window.isDestroyed()).toBe(true)
   })
 })

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -63,7 +63,7 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
   return window
 }
 
-const createMainWindow = (): BrowserWindow => {
+const createMainWindow = (opts?: { shouldHideOnClose?: () => boolean }): BrowserWindow => {
   const window = createAppWindow({
     width: 1280,
     // The first-run environment summary needs enough vertical space to keep its Continue action
@@ -139,7 +139,19 @@ const createMainWindow = (): BrowserWindow => {
     if (rendererListenerReady && rendererResponsive) {
       window.webContents.send(CLOSE_ACTIVE_PANE_CHANNEL)
     } else {
+      // The chord's window-close fallback still honors close-to-tray: window.close() fires the 'close'
+      // event handled below, which hides (stays resident) instead of closing when the tray is active.
       window.close()
+    }
+  })
+
+  // Close-to-tray: when the tray keeps the app resident, hide the window instead of closing it. The
+  // predicate is evaluated at close time so the caller can flip a quitting flag to allow a real exit.
+  // This also backs the Cmd/Ctrl+W fallback above — its window.close() routes through here.
+  window.on('close', (event) => {
+    if (opts?.shouldHideOnClose?.()) {
+      event.preventDefault()
+      window.hide()
     }
   })
 


### PR DESCRIPTION
## Summary

Keeps the app resident in the system tray on Windows, macOS, and Linux, guarantees that relaunching never spawns a duplicate instance or leaves an orphaned backend process tree (agent + notebook kernels), and layers cleanly on top of the Cmd/Ctrl+W preview-close behavior from #182/#184.

## Motivation

Previously there was no single-instance lock, so a second launch started a whole second app with its own backend process tree. There was also no tray, and no awaited quit-time teardown of notebook kernels — only PR #177's synchronous `will-quit` guard for the ACP agent.

## What changed

New, unit-tested main-process modules:
- **single-instance** — `acquireSingleInstanceLock`; a second launch hands off to the primary and exits.
- **app-startup** — `orchestrateAppStartup` (single-instance gate → prepare → migration-guard → lifecycle, in that order) and `createSecondInstanceRelay` (records a second-instance signal that arrives mid-startup and drains it once the window exists). Extracted from `index.ts` so the startup ordering is unit-tested as a whole.
- **tray** — `createAppTray` (Show / Hide / Quit); returns `undefined` on hosts without a tray (e.g. some Linux desktops) so the app falls back to quit-on-close. On macOS the icon is a monochrome **template** image derived from the app icon, so it follows the light/dark menu bar.
- **lifecycle-shutdown** — `shutdownBackends`, a bounded (5s) best-effort teardown of the agent runtime and every notebook kernel; never throws, never hangs quit.
- **process-tree** — `terminateProcessTree` (async). Windows: `taskkill /pid <pid> /T /F`, with a direct-kill fallback (+ logging) if it fails to launch, errors, times out, or exits non-zero, and the grace timer is cleared on the success path so it never fires spuriously. POSIX: descendants are discovered via `ps`, signaled alongside the child, then anything still alive is confirmed and escalated to SIGKILL. Awaits the child's real exit so nothing outlives `app.exit`.

Lifecycle wiring (`index.ts`):
- Single-instance lock acquired before **any** backend module is imported — only the lightweight argv flags are imported statically (`mcp-server-args.ts`); the MCP stdio server modules and the Electron backend are imported lazily / after the lock, so a secondary launch never loads a duplicate backend.
- Tray with close-to-tray on Windows/Linux; macOS keeps its dock convention. `window-all-closed` quits only when non-darwin **and** no tray host.
- Authoritative async `before-quit` cleanup: `preventDefault` → `await shutdownBackends` → `tray.destroy` → `app.exit(0)`, with `shutdownStarted` / `shutdownFinished` re-entry latches, gated on the migration guard (`isMigrationInProgress` + `event.defaultPrevented`) and installed after it.

Window close behavior (`windows.ts`), merged with #182/#184:
- The Cmd/Ctrl+W interceptor forwards to the renderer to close the active preview pane when it can, otherwise calls `window.close()`.
- Close-to-tray is layered on top: `window.close()` fires the `close` event, which hides the window (stays resident) on Windows/Linux while the tray is active instead of actually closing it.

Hard-kill paths routed through the process tree:
- `acp/runtime`: split `killAgentProcess` into the synchronous backstop and an awaited `killAgentProcessTree` (disconnect path); tree-kills a mid-spawn agent on shutdown.
- `python-executor`: hard-timeout and shutdown kills use `terminateProcessTree`; a kill started by a hard timeout is tracked so `shutdown()` awaits it, so `app.exit` cannot race an in-flight `taskkill /T`.
- `storage/ipc`: `cleanRelaunch` shuts backends down before both relaunch paths (migration commit and the no-move data-root switch).
- `ipc`: `registerIpcHandlers` returns `{ runtime, notebook }` so the lifecycle can shut them down.

## Design notes

The async `before-quit` cleanup is the authoritative exit path — the only one that can *await* Windows `taskkill /T` and `notebook.shutdownAll()` to completion before the process exits. PR #177's `will-quit` + synchronous `runtime.shutdown()` is kept as a lightweight backstop; the authoritative path ends in `app.exit(0)`, which skips `will-quit`, so the backstop only fires for committed quits that never reach the cleanup.

## Testing

- `npm run typecheck` (node + web), `npm run lint`, `npm run build` — all clean.
- `npm test` — 2638 passed / 43 skipped, including #177's `acp/runtime` and `acp/shutdown-guard` suites, plus new coverage for the startup orchestration, the process-tree POSIX/Windows kill + SIGKILL-escalation + timer-fallback paths, the python-executor timeout/shutdown race, and the macOS tray template icon.

## Follow-ups (not blocking)

- Real-device verification per platform (`npm run dev`): confirm the Linux tray icon shows on the target desktops (some need AppIndicator), the macOS menu-bar template glyph reads well at menu-bar size, and that no notebook kernel or ACP agent survives after quit.
