### PR TITLE
fix(main): open external links regardless of referrer

### DIFF
--- a/src/main/navigation-policy.ts
+++ b/src/main/navigation-policy.ts
@@ -39,12 +39,13 @@ const isAllowedFrameNavigation = (url: string, isMainFrame: boolean, currentUrl 
     ? isAllowedMainFrameNavigation(url, currentUrl)
     : getProtocol(url) === PREVIEW_PROTOCOL
 
-const isAllowedExternalNavigation = (
-  url: string,
-  referrerUrl: string,
-  currentUrl: string
-): boolean =>
-  // Only the trusted top-level app may hand an allowlisted URL to the operating system.
-  isAllowedExternalUrl(url) && isAllowedMainFrameNavigation(referrerUrl, currentUrl)
+// Decides whether a window-open request (target="_blank" / window.open) may be handed to the OS. It
+// gates on the protocol allowlist alone, deliberately NOT on the initiating referrer: app links use
+// rel="noreferrer" and the packaged app runs on a file:// origin (which Chromium strips from
+// cross-origin referrers), so the referrer is reliably empty for legitimate main-frame links. Nothing
+// is lost by dropping it — the only non-app frame is the HTML preview iframe, which is sandboxed with
+// "allow-scripts" but NOT "allow-popups", so it cannot reach setWindowOpenHandler at all. In-frame
+// navigations are confined separately by isAllowedFrameNavigation.
+const isAllowedExternalNavigation = (url: string): boolean => isAllowedExternalUrl(url)
 
 export { isAllowedExternalNavigation, isAllowedExternalUrl, isAllowedFrameNavigation }

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -1,4 +1,51 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Hoisted so the electron mock and the test body share the same shell.openExternal spy.
+const { openExternalMock } = vi.hoisted(() => ({ openExternalMock: vi.fn() }))
+
+// Captured window-open handler so tests can drive it directly, mirroring how Electron invokes it on a
+// target="_blank" click or window.open() from the main app frame.
+type WindowOpenDetails = { url: string; referrer: { url: string } }
+let windowOpenHandler: ((details: WindowOpenDetails) => unknown) | undefined
+
+class FakeBrowserWindow {
+  webContents = {
+    setWindowOpenHandler: (handler: (details: WindowOpenDetails) => unknown): void => {
+      windowOpenHandler = handler
+    },
+    on: vi.fn(),
+    getURL: (): string => 'file:///app/index.html'
+  }
+
+  on(): this {
+    return this
+  }
+
+  loadURL(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  loadFile(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+vi.mock('electron', () => ({
+  // isPackaged=true skips the dev title-suffix branch, keeping the fake focused on the open handler.
+  app: { isPackaged: true },
+  BrowserWindow: class {
+    constructor() {
+      return new FakeBrowserWindow() as unknown as object
+    }
+  },
+  shell: { openExternal: openExternalMock }
+}))
+
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }))
+
+vi.mock('../../resources/icon.png?asset', () => ({ default: 'icon-path' }))
+
+const { createMainWindow } = await import('./windows')
 
 describe('window navigation policy', () => {
   it('allows only explicit external URL protocols', async () => {
@@ -9,20 +56,13 @@ describe('window navigation policy', () => {
     expect(policy?.isAllowedExternalUrl('mailto:researcher@example.com')).toBe(true)
     expect(policy?.isAllowedExternalUrl('file:///Users/example/private.txt')).toBe(false)
     expect(policy?.isAllowedExternalUrl('javascript:alert(1)')).toBe(false)
-    expect(
-      policy?.isAllowedExternalNavigation(
-        'https://example.com/report',
-        'file:///app/index.html',
-        'file:///app/index.html'
-      )
-    ).toBe(true)
-    expect(
-      policy?.isAllowedExternalNavigation(
-        'https://example.com/report',
-        'open-science-preview://resource/report.html',
-        'file:///app/index.html'
-      )
-    ).toBe(false)
+    // External-open is gated on the protocol allowlist alone: the initiating referrer is unreliable
+    // (rel="noreferrer" and file:-origin cross-origin suppression both empty it), and window-open can
+    // only originate from the trusted main frame anyway (see navigation-policy.ts).
+    expect(policy?.isAllowedExternalNavigation('https://example.com/report')).toBe(true)
+    expect(policy?.isAllowedExternalNavigation('mailto:researcher@example.com')).toBe(true)
+    expect(policy?.isAllowedExternalNavigation('javascript:alert(1)')).toBe(false)
+    expect(policy?.isAllowedExternalNavigation('file:///Users/example/private.txt')).toBe(false)
   })
 
   it('keeps subframe navigation inside the managed preview protocol', async () => {
@@ -54,5 +94,32 @@ describe('window navigation policy', () => {
         'file:///app/index.html'
       )
     ).toBe(false)
+  })
+})
+
+describe('window-open external handler', () => {
+  beforeEach(() => {
+    windowOpenHandler = undefined
+    openExternalMock.mockClear()
+  })
+
+  // Regression: app links use rel="noreferrer" and the packaged app runs on a file:// origin, so the
+  // referrer arrives empty. The handler must still open allowlisted URLs.
+  it('opens an allowlisted URL even when the referrer is empty', () => {
+    createMainWindow()
+    const result = windowOpenHandler!({
+      url: 'https://example.com/report',
+      referrer: { url: '' }
+    })
+
+    expect(openExternalMock).toHaveBeenCalledWith('https://example.com/report')
+    expect(result).toEqual({ action: 'deny' })
+  })
+
+  it('refuses to open a dangerous protocol', () => {
+    createMainWindow()
+    windowOpenHandler!({ url: 'javascript:alert(1)', referrer: { url: '' } })
+
+    expect(openExternalMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -36,9 +36,7 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
   })
 
   window.webContents.setWindowOpenHandler((details) => {
-    if (
-      isAllowedExternalNavigation(details.url, details.referrer.url, window.webContents.getURL())
-    ) {
+    if (isAllowedExternalNavigation(details.url)) {
       void shell.openExternal(details.url)
     }
     return { action: 'deny' }


### PR DESCRIPTION
## Summary

External links in Settings (and elsewhere) stopped opening. This is a regression from #147 (large managed-file preview support), which changed the window-open handler from an unconditional `shell.openExternal` to a referrer-gated one:

```ts
isAllowedExternalNavigation(details.url, details.referrer.url, window.webContents.getURL())
```

The gate requires `details.referrer.url` to match the app URL, but it can never be satisfied for legitimate main-frame links:

- Every app link uses `rel="noreferrer"`, which empties the referrer → `new URL('')` throws → denied.
- Even without that, the packaged app runs on a `file://` origin, and Chromium strips cross-origin referrers from `file:` origins → still empty → still denied.

## Fix

Gate window-open on the protocol allowlist (`http` / `https` / `mailto`) alone, dropping the unreliable referrer check.

Nothing is lost security-wise: the only non-app frame is the HTML preview iframe, sandboxed with `allow-scripts` but **not** `allow-popups`, so it can never reach `setWindowOpenHandler`. In-frame navigation stays confined by `isAllowedFrameNavigation` (unchanged).

This restores external links everywhere (Settings, Home, Onboarding, GitHub badge), not just Settings.

## Testing

- Added a regression test that drives the real window-open handler with an empty referrer and asserts `shell.openExternal` still fires (and that dangerous protocols are refused).
- `npm run typecheck`, `eslint`, and the `windows.test.ts` suite all pass.