### PR TITLE
fix(skills): parse SKILL.md frontmatter authored with CRLF line endings

### DIFF
--- a/src/main/skills/frontmatter.test.ts
+++ b/src/main/skills/frontmatter.test.ts
@@ -70,20 +70,20 @@ describe('parseFrontmatter', () => {
   it('parses a bundle authored with CRLF line endings', () => {
     const raw = [
       '---',
-      'name: crlf-skill',
+      'name: demo',
       'description: Does a thing.',
       'license: MIT',
       '---',
       '',
-      '# CRLF Skill'
+      '# Demo'
     ].join('\r\n')
     const { fields, body } = parseFrontmatter(raw)
     expect(fields).toMatchObject({
-      name: 'crlf-skill',
+      name: 'demo',
       description: 'Does a thing.',
       license: 'MIT'
     })
-    expect(body.startsWith('# CRLF Skill')).toBe(true)
+    expect(body.startsWith('# Demo')).toBe(true)
   })
 
   it('joins a CRLF folded block scalar (>) into a single spaced line', () => {

--- a/src/main/skills/frontmatter.test.ts
+++ b/src/main/skills/frontmatter.test.ts
@@ -98,7 +98,8 @@ describe('parseFrontmatter', () => {
       '# Demo'
     ].join('\r\n')
     const { fields } = parseFrontmatter(raw)
-    expect(fields.description).toBe('first line second line')
+    // Same value the LF folded test yields: folded to one line, trailing newline kept (YAML clip).
+    expect(fields.description).toBe('first line second line\n')
   })
 
   it('ignores nested (indented) keys after a block scalar, as a flat reader', () => {

--- a/src/main/skills/frontmatter.test.ts
+++ b/src/main/skills/frontmatter.test.ts
@@ -67,6 +67,40 @@ describe('parseFrontmatter', () => {
     expect(fields.name).toBe('demo')
   })
 
+  it('parses a bundle authored with CRLF line endings', () => {
+    const raw = [
+      '---',
+      'name: crlf-skill',
+      'description: Does a thing.',
+      'license: MIT',
+      '---',
+      '',
+      '# CRLF Skill'
+    ].join('\r\n')
+    const { fields, body } = parseFrontmatter(raw)
+    expect(fields).toMatchObject({
+      name: 'crlf-skill',
+      description: 'Does a thing.',
+      license: 'MIT'
+    })
+    expect(body.startsWith('# CRLF Skill')).toBe(true)
+  })
+
+  it('joins a CRLF folded block scalar (>) into a single spaced line', () => {
+    const raw = [
+      '---',
+      'name: demo',
+      'description: >',
+      '  first line',
+      '  second line',
+      '---',
+      '',
+      '# Demo'
+    ].join('\r\n')
+    const { fields } = parseFrontmatter(raw)
+    expect(fields.description).toBe('first line second line')
+  })
+
   it('ignores nested (indented) keys after a block scalar, as a flat reader', () => {
     const raw = [
       '---',

--- a/src/main/skills/frontmatter.ts
+++ b/src/main/skills/frontmatter.ts
@@ -9,14 +9,16 @@ import { load as loadYaml, FAILSAFE_SCHEMA } from 'js-yaml'
 // a comma-separated string and nested maps are dropped. A malformed block is tolerated (empty fields +
 // full body) rather than throwing, so one bad skill can't break the catalog.
 const parseFrontmatter = (raw: string): { fields: Record<string, string>; body: string } => {
-  const match = /^---\n([\s\S]*?)\n---\n?/.exec(raw)
+  // Normalize CRLF/CR to LF so bundles authored on Windows parse the same as Unix ones.
+  const normalized = raw.replace(/\r\n?/g, '\n')
+  const match = /^---\n([\s\S]*?)\n---\n?/.exec(normalized)
 
   if (!match) {
     return { fields: {}, body: raw }
   }
 
   // Drop blank lines left between the closing `---` and the first body line so the body renders clean.
-  const body = raw.slice(match[0].length).replace(/^\n+/, '')
+  const body = normalized.slice(match[0].length).replace(/^\n+/, '')
 
   let parsed: unknown
   try {

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -497,6 +497,22 @@ describe('UserSkillRepository', () => {
     await expect(repo.previewZip(zip)).rejects.toThrow(/needs a name/)
   })
 
+  it('parses a CRLF-authored SKILL.md the same on preview and import', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    // A bundle authored on Windows: every line ends with \r\n.
+    const skill = ['---', 'name: Winreader', 'description: A CRLF bundle.', '---', 'body'].join(
+      '\r\n'
+    )
+    const zip = buildZip([{ path: 'win/SKILL.md', content: Buffer.from(skill) }])
+
+    const [preview] = await repo.previewZip(zip)
+    expect(preview.name).toBe('Winreader')
+    expect(preview.description).toBe('A CRLF bundle.')
+
+    // Import must derive the slug from the name, not fall back to 'imported-skill'.
+    expect(await repo.importFromZip(zip)).toEqual({ status: 'imported', id: 'imported-winreader' })
+  })
+
   // Builds a one-file bundle named "Shared" with a controllable body (so signatures differ).
   const sharedBundle = (body: string): Buffer =>
     buildZip([

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -140,13 +140,6 @@ const findSkillRoots = (entries: { path: string; content: Buffer }[]): SkillRoot
     .sort((a, b) => a.subPath.localeCompare(b.subPath))
 }
 
-// Reads the `name:` value from a SKILL.md frontmatter block, if present.
-const frontmatterName = (text: string): string | undefined => {
-  const match = /^---\n([\s\S]*?)\n---/.exec(text)
-  if (!match) return undefined
-  return /^name:\s*(.*)$/m.exec(match[1])?.[1].trim() || undefined
-}
-
 // Reads and writes user-authored (personal) and imported skills under `<storageRoot>/skills/`.
 class UserSkillRepository {
   constructor(private readonly storageRoot: string) {}
@@ -385,7 +378,7 @@ class UserSkillRepository {
       return { status: 'unchanged', id: `imported-${existingSlug}` }
     }
 
-    const name = frontmatterName(skillMd.content.toString('utf8'))
+    const name = parseFrontmatter(skillMd.content.toString('utf8')).fields.name?.trim()
     const base = toSlug(name ?? 'skill') || 'skill'
     const slug = await this.uniqueSlug('imported', base)
     await this.writeImported(slug, files, '', signature)


### PR DESCRIPTION
## Summary

Importing a skill bundle whose `SKILL.md` was authored on Windows (CRLF line endings) failed in **Settings → Skill import** with:

> The bundle's SKILL.md needs a name in its frontmatter.

…even though `name:` was present. This is a false negative.

## Root cause

`parseFrontmatter` in `src/main/skills/frontmatter.ts` matched the opening/closing block with `/^---\n([\s\S]*?)\n---\n?/` (LF only) and sliced the body from the raw string. A CRLF file starts with `---\r\n`, so `^---\n` never matched → `fields` came back empty → `previewZip` threw. The `name` was there; the parser just couldn't see it past the `\r`.

## Fix

Normalize `\r\n` / lone `\r` to `\n` at the start of `parseFrontmatter`, then match and slice against the normalized text. One change covers the open/close `---` regex, per-line key parsing, and body extraction.

## Tests

Added two `parseFrontmatter` tests (generic `demo` name) covering CRLF frontmatter and a CRLF folded block scalar. Verified the real bundle now yields its name.

- `frontmatter.test.ts` 9/9, `user-skill-repository.test.ts` 27/27
- typecheck + eslint clean