### PR TITLE
fix(window): Cmd/Ctrl+W closes the preview panel before the window

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -16,6 +16,7 @@ import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './connectors/
 import { registerFileSaveHandlers } from './file-save'
 import { registerGithubIpcHandlers } from './github-ipc'
 import { registerLogsIpcHandlers } from './logs-ipc'
+import { registerWindowIpcHandlers } from './window-ipc'
 import { createLogger } from './logger'
 import { registerManagedPreviewIpcHandlers } from './managed-preview-ipc'
 import { registerManagedPreviewProtocol } from './managed-preview-protocol'
@@ -221,6 +222,7 @@ const registerIpcHandlers = async ({ mainEntryPath }: IpcRegistrationOptions): P
   registerFileSaveHandlers({ resolveManagedFilePath })
   registerLogsIpcHandlers()
   registerGithubIpcHandlers()
+  registerWindowIpcHandlers()
   const updateService = registerUpdateIpcHandlers()
   startUpdateScheduler(updateService)
   const runtime = registerAcpIpcHandlers({

--- a/src/main/window-ipc.test.ts
+++ b/src/main/window-ipc.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Capture ipcMain.handle registrations so the handler can be invoked directly.
+const handlers = new Map<string, (event: unknown) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }
+  },
+  BrowserWindow: {}
+}))
+
+const { registerWindowIpcHandlers } = await import('./window-ipc')
+const { WINDOW_CLOSE_CHANNEL } = await import('../shared/window-controls')
+
+const invoke = (sender: unknown): unknown => handlers.get(WINDOW_CLOSE_CHANNEL)!({ sender })
+
+describe('window IPC handler', () => {
+  it('registers the close channel', () => {
+    handlers.clear()
+    registerWindowIpcHandlers()
+    expect(handlers.has(WINDOW_CLOSE_CHANNEL)).toBe(true)
+  })
+
+  it('closes the window that owns the invoking web contents', () => {
+    handlers.clear()
+    const close = vi.fn()
+    const sender = {}
+    const resolveWindow = vi.fn().mockReturnValue({ close })
+    registerWindowIpcHandlers({ resolveWindow })
+
+    invoke(sender)
+
+    expect(resolveWindow).toHaveBeenCalledWith(sender)
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('no-ops when the sender has no owning window', () => {
+    handlers.clear()
+    registerWindowIpcHandlers({ resolveWindow: () => null })
+
+    expect(() => invoke({})).not.toThrow()
+  })
+})

--- a/src/main/window-ipc.ts
+++ b/src/main/window-ipc.ts
@@ -1,0 +1,24 @@
+import { BrowserWindow, ipcMain, type IpcMainInvokeEvent, type WebContents } from 'electron'
+
+import { WINDOW_CLOSE_CHANNEL } from '../shared/window-controls'
+
+// The minimal window surface the close handler needs; keeps the resolver injectable for tests.
+type ClosableWindow = { close: () => void }
+
+type WindowIpcDeps = {
+  // Maps the invoking web contents back to its window. Defaults to Electron's own lookup.
+  resolveWindow?: (sender: WebContents) => ClosableWindow | null
+}
+
+// Renderer fallback for Cmd+W / Ctrl+W: when no preview panel is open, the renderer asks to close the
+// window that owns it. Closing defers to that window's own 'close' handling (e.g. hide-to-tray), so
+// this stays a thin bridge rather than a second place that decides window lifecycle.
+const registerWindowIpcHandlers = (deps: WindowIpcDeps = {}): void => {
+  const resolveWindow = deps.resolveWindow ?? ((sender) => BrowserWindow.fromWebContents(sender))
+
+  ipcMain.handle(WINDOW_CLOSE_CHANNEL, (event: IpcMainInvokeEvent): void => {
+    resolveWindow(event.sender)?.close()
+  })
+}
+
+export { registerWindowIpcHandlers }

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -1,24 +1,49 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Hoisted so the electron mock and the test body share the same shell.openExternal spy.
-const { openExternalMock } = vi.hoisted(() => ({ openExternalMock: vi.fn() }))
+import {
+  CLOSE_ACTIVE_PANE_CHANNEL,
+  CLOSE_ACTIVE_PANE_READY_CHANNEL,
+  type KeyChordInput
+} from '../shared/window-controls'
+
+// Hoisted so the electron mock and the test body share the same spies.
+const { openExternalMock, ipcMainOnMock, ipcMainRemoveListenerMock } = vi.hoisted(() => ({
+  openExternalMock: vi.fn(),
+  ipcMainOnMock: vi.fn(),
+  ipcMainRemoveListenerMock: vi.fn()
+}))
 
 // Captured window-open handler so tests can drive it directly, mirroring how Electron invokes it on a
 // target="_blank" click or window.open() from the main app frame.
 type WindowOpenDetails = { url: string; referrer: { url: string } }
 let windowOpenHandler: ((details: WindowOpenDetails) => unknown) | undefined
 
+// The most recently constructed window and its captured webContents handlers, so tests can drive the
+// before-input-event / did-start-loading listeners the way Electron would.
+type WebContentsHandler = (...args: unknown[]) => void
+let currentWindow: FakeBrowserWindow | undefined
+
 class FakeBrowserWindow {
+  closeMock = vi.fn()
+  sendMock = vi.fn()
+  webContentsHandlers = new Map<string, WebContentsHandler>()
   webContents = {
     setWindowOpenHandler: (handler: (details: WindowOpenDetails) => unknown): void => {
       windowOpenHandler = handler
     },
-    on: vi.fn(),
+    on: (event: string, handler: WebContentsHandler): void => {
+      this.webContentsHandlers.set(event, handler)
+    },
+    send: (...args: unknown[]): void => this.sendMock(...args),
     getURL: (): string => 'file:///app/index.html'
   }
 
   on(): this {
     return this
+  }
+
+  close(): void {
+    this.closeMock()
   }
 
   loadURL(): Promise<void> {
@@ -35,9 +60,11 @@ vi.mock('electron', () => ({
   app: { isPackaged: true },
   BrowserWindow: class {
     constructor() {
-      return new FakeBrowserWindow() as unknown as object
+      currentWindow = new FakeBrowserWindow()
+      return currentWindow as unknown as object
     }
   },
+  ipcMain: { on: ipcMainOnMock, removeListener: ipcMainRemoveListenerMock },
   shell: { openExternal: openExternalMock }
 }))
 
@@ -46,6 +73,19 @@ vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }))
 vi.mock('../../resources/icon.png?asset', () => ({ default: 'icon-path' }))
 
 const { createMainWindow } = await import('./windows')
+
+// A keyDown close chord for the host platform: Cmd+W on macOS, Ctrl+W elsewhere. Built off
+// process.platform so the interception test passes on every CI runner (windows, linux, macOS).
+const closeChord = (overrides: Partial<KeyChordInput> = {}): KeyChordInput => ({
+  type: 'keyDown',
+  key: 'w',
+  control: process.platform !== 'darwin',
+  meta: process.platform === 'darwin',
+  alt: false,
+  shift: false,
+  isAutoRepeat: false,
+  ...overrides
+})
 
 describe('window navigation policy', () => {
   it('allows only explicit external URL protocols', async () => {
@@ -121,5 +161,81 @@ describe('window-open external handler', () => {
     windowOpenHandler!({ url: 'javascript:alert(1)', referrer: { url: '' } })
 
     expect(openExternalMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('close chord interception', () => {
+  beforeEach(() => {
+    currentWindow = undefined
+    ipcMainOnMock.mockReset()
+    ipcMainRemoveListenerMock.mockReset()
+  })
+
+  // Fires the renderer "listener mounted" signal that main registered via ipcMain.on, spoofing the
+  // sender as this window's webContents so the ready flag flips for it.
+  const signalRendererReady = (window: FakeBrowserWindow): void => {
+    const readyHandler = ipcMainOnMock.mock.calls.find(
+      ([channel]) => channel === CLOSE_ACTIVE_PANE_READY_CHANNEL
+    )?.[1] as ((event: { sender: unknown }) => void) | undefined
+    expect(readyHandler).toBeDefined()
+    readyHandler!({ sender: window.webContents })
+  }
+
+  const fireInput = (window: FakeBrowserWindow, input: KeyChordInput): (() => void) => {
+    const preventDefault = vi.fn()
+    const handler = window.webContentsHandlers.get('before-input-event')
+    expect(handler).toBeDefined()
+    handler!({ preventDefault }, input)
+    return preventDefault
+  }
+
+  it('closes the window directly when the chord fires before the renderer is ready', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    const preventDefault = fireInput(window, closeChord())
+
+    // Default Close is suppressed and the window closes directly, so the chord is never a no-op.
+    expect(preventDefault).toHaveBeenCalled()
+    expect(window.closeMock).toHaveBeenCalledTimes(1)
+    expect(window.sendMock).not.toHaveBeenCalled()
+  })
+
+  it('forwards the chord to the renderer once its listener is ready', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    signalRendererReady(window)
+    const preventDefault = fireInput(window, closeChord())
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(window.sendMock).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_CHANNEL)
+    expect(window.closeMock).not.toHaveBeenCalled()
+  })
+
+  it('re-arms the direct-close fallback after a reload clears renderer readiness', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    signalRendererReady(window)
+    // A top-level reload starts loading before the fresh document re-subscribes.
+    window.webContentsHandlers.get('did-start-loading')!()
+
+    fireInput(window, closeChord())
+
+    expect(window.closeMock).toHaveBeenCalledTimes(1)
+    expect(window.sendMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores keys that are not the close chord', () => {
+    createMainWindow()
+    const window = currentWindow!
+    signalRendererReady(window)
+
+    const preventDefault = fireInput(window, closeChord({ key: 'q' }))
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(window.sendMock).not.toHaveBeenCalled()
+    expect(window.closeMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   CLOSE_ACTIVE_PANE_CHANNEL,
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
+  CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
   type KeyChordInput
 } from '../shared/window-controls'
 
@@ -171,14 +172,26 @@ describe('close chord interception', () => {
     ipcMainRemoveListenerMock.mockReset()
   })
 
-  // Fires the renderer "listener mounted" signal that main registered via ipcMain.on, spoofing the
-  // sender as this window's webContents so the ready flag flips for it.
-  const signalRendererReady = (window: FakeBrowserWindow): void => {
-    const readyHandler = ipcMainOnMock.mock.calls.find(
-      ([channel]) => channel === CLOSE_ACTIVE_PANE_READY_CHANNEL
-    )?.[1] as ((event: { sender: unknown }) => void) | undefined
-    expect(readyHandler).toBeDefined()
-    readyHandler!({ sender: window.webContents })
+  // Fires an ipcMain handshake signal that main registered via ipcMain.on, spoofing the sender as this
+  // window's webContents so the readiness flag flips for it.
+  const fireHandshake = (window: FakeBrowserWindow, channel: string): void => {
+    const handler = ipcMainOnMock.mock.calls.find(([registered]) => registered === channel)?.[1] as
+      ((event: { sender: unknown }) => void) | undefined
+    expect(handler).toBeDefined()
+    handler!({ sender: window.webContents })
+  }
+
+  const signalRendererReady = (window: FakeBrowserWindow): void =>
+    fireHandshake(window, CLOSE_ACTIVE_PANE_READY_CHANNEL)
+
+  const signalRendererGone = (window: FakeBrowserWindow): void =>
+    fireHandshake(window, CLOSE_ACTIVE_PANE_UNREADY_CHANNEL)
+
+  // Drives one of the captured webContents lifecycle handlers (render-process-gone, unresponsive, ...).
+  const fireWebContentsEvent = (window: FakeBrowserWindow, event: string): void => {
+    const handler = window.webContentsHandlers.get(event)
+    expect(handler).toBeDefined()
+    handler!()
   }
 
   const fireInput = (window: FakeBrowserWindow, input: KeyChordInput): (() => void) => {
@@ -225,6 +238,53 @@ describe('close chord interception', () => {
 
     expect(window.closeMock).toHaveBeenCalledTimes(1)
     expect(window.sendMock).not.toHaveBeenCalled()
+  })
+
+  it('re-arms the direct-close fallback when the renderer tears its listener down', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    signalRendererReady(window)
+    // The hook unmounted, so its listener is gone even though the document did not reload.
+    signalRendererGone(window)
+
+    fireInput(window, closeChord())
+
+    expect(window.closeMock).toHaveBeenCalledTimes(1)
+    expect(window.sendMock).not.toHaveBeenCalled()
+  })
+
+  it('re-arms the direct-close fallback after the render process is gone', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    signalRendererReady(window)
+    // The renderer crashed; its listener died with the process until a fresh one re-handshakes.
+    fireWebContentsEvent(window, 'render-process-gone')
+
+    fireInput(window, closeChord())
+
+    expect(window.closeMock).toHaveBeenCalledTimes(1)
+    expect(window.sendMock).not.toHaveBeenCalled()
+  })
+
+  it('closes directly while the renderer is unresponsive, then forwards again once responsive', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    signalRendererReady(window)
+    fireWebContentsEvent(window, 'unresponsive')
+
+    // A hung renderer would never process the forwarded chord, so main closes directly instead.
+    fireInput(window, closeChord())
+    expect(window.closeMock).toHaveBeenCalledTimes(1)
+    expect(window.sendMock).not.toHaveBeenCalled()
+
+    // Recovery restores forwarding without requiring the renderer to re-handshake.
+    fireWebContentsEvent(window, 'responsive')
+    fireInput(window, closeChord())
+    expect(window.sendMock).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_CHANNEL)
+    expect(window.closeMock).toHaveBeenCalledTimes(1)
   })
 
   it('ignores keys that are not the close chord', () => {

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -188,11 +188,18 @@ describe('close chord interception', () => {
     fireHandshake(window, CLOSE_ACTIVE_PANE_UNREADY_CHANNEL)
 
   // Drives one of the captured webContents lifecycle handlers (render-process-gone, unresponsive, ...).
-  const fireWebContentsEvent = (window: FakeBrowserWindow, event: string): void => {
+  const fireWebContentsEvent = (
+    window: FakeBrowserWindow,
+    event: string,
+    ...args: unknown[]
+  ): void => {
     const handler = window.webContentsHandlers.get(event)
     expect(handler).toBeDefined()
-    handler!()
+    handler!(...args)
   }
+
+  // A top-level document swap (reload or new URL): main frame, real document change.
+  const mainFrameNavigation = { isMainFrame: true, isSameDocument: false }
 
   const fireInput = (window: FakeBrowserWindow, input: KeyChordInput): (() => void) => {
     const preventDefault = vi.fn()
@@ -226,18 +233,40 @@ describe('close chord interception', () => {
     expect(window.closeMock).not.toHaveBeenCalled()
   })
 
-  it('re-arms the direct-close fallback after a reload clears renderer readiness', () => {
+  it('re-arms the direct-close fallback after a top-level navigation clears renderer readiness', () => {
     createMainWindow()
     const window = currentWindow!
 
     signalRendererReady(window)
-    // A top-level reload starts loading before the fresh document re-subscribes.
-    window.webContentsHandlers.get('did-start-loading')!()
+    // A top-level reload navigates the main frame before the fresh document re-subscribes.
+    fireWebContentsEvent(window, 'did-start-navigation', mainFrameNavigation)
 
     fireInput(window, closeChord())
 
     expect(window.closeMock).toHaveBeenCalledTimes(1)
     expect(window.sendMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps forwarding when a subframe or same-document navigation fires', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    signalRendererReady(window)
+    // A dynamic preview iframe load (subframe) and a hash / pushState change (same document) both
+    // navigate the WebContents without remounting the hook, so readiness must survive them.
+    fireWebContentsEvent(window, 'did-start-navigation', {
+      isMainFrame: false,
+      isSameDocument: false
+    })
+    fireWebContentsEvent(window, 'did-start-navigation', {
+      isMainFrame: true,
+      isSameDocument: true
+    })
+
+    fireInput(window, closeChord())
+
+    expect(window.sendMock).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_CHANNEL)
+    expect(window.closeMock).not.toHaveBeenCalled()
   })
 
   it('re-arms the direct-close fallback when the renderer tears its listener down', () => {
@@ -285,6 +314,25 @@ describe('close chord interception', () => {
     fireInput(window, closeChord())
     expect(window.sendMock).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_CHANNEL)
     expect(window.closeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards again after unresponsive -> crash -> reload -> ready, with no responsive event', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    signalRendererReady(window)
+    // The renderer hangs, then its process dies, then a fresh one loads and re-handshakes. A brand-new
+    // process never emits 'responsive' (that is a same-process recovery signal), so READY alone must
+    // clear the stale unresponsive state or the chord stays a direct close forever.
+    fireWebContentsEvent(window, 'unresponsive')
+    fireWebContentsEvent(window, 'render-process-gone')
+    fireWebContentsEvent(window, 'did-start-navigation', mainFrameNavigation)
+    signalRendererReady(window)
+
+    fireInput(window, closeChord())
+
+    expect(window.sendMock).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_CHANNEL)
+    expect(window.closeMock).not.toHaveBeenCalled()
   })
 
   it('ignores keys that are not the close chord', () => {

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -125,6 +125,13 @@ const createMainWindow = (): BrowserWindow => {
   // Intercept Cmd+W / Ctrl+W before the default menu "Close" role fires. preventDefault here also
   // suppresses the menu accelerator (electron/electron#19279), so the chord never closes the window
   // behind the renderer's back. Forward to the renderer only when it can act on it, otherwise close.
+  //
+  // Accepted residual: send() is fire-and-forget, so a renderer that crashes or hangs in the gap
+  // between this send and its handler running drops this one chord. It is self-correcting — that same
+  // crash/hang revokes readiness, so the next press falls back to the direct close below. A per-chord
+  // ack + timeout would close that gap but risks a worse bug: if a slow-but-healthy renderer collapses
+  // the pane and its ack lands after the timeout, main would then also close the window. We accept one
+  // lost keystroke during a renderer crash over that regression.
   window.webContents.on('before-input-event', (event, input) => {
     if (!isCloseWindowChord(input, process.platform)) return
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -1,8 +1,20 @@
-import { app, BrowserWindow, shell, type BrowserWindowConstructorOptions } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  shell,
+  type BrowserWindowConstructorOptions,
+  type IpcMainEvent
+} from 'electron'
 import { join } from 'path'
 import { is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { isAllowedExternalNavigation, isAllowedFrameNavigation } from './navigation-policy'
+import {
+  CLOSE_ACTIVE_PANE_CHANNEL,
+  CLOSE_ACTIVE_PANE_READY_CHANNEL,
+  isCloseWindowChord
+} from '../shared/window-controls'
 
 const rendererEntry = join(__dirname, '../renderer/index.html')
 const preloadEntry = join(__dirname, '../preload/index.js')
@@ -60,6 +72,37 @@ const createMainWindow = (): BrowserWindow => {
     minWidth: 1100,
     minHeight: 720,
     title: 'Open Science'
+  })
+
+  // The renderer decides pane-vs-window, but only once it has mounted its listener. Track that via the
+  // ready signal so the chord is never forwarded into the void: before the renderer is ready (initial
+  // load, reload, in-flight navigation) the send() below would be dropped and Cmd/Ctrl+W would do
+  // nothing, so main closes the window itself instead. Reset on every top-level load, since a fresh
+  // document has to re-subscribe before it can own the chord again.
+  let rendererListenerReady = false
+  const onListenerReady = (event: IpcMainEvent): void => {
+    if (event.sender === window.webContents) rendererListenerReady = true
+  }
+  ipcMain.on(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)
+  window.webContents.on('did-start-loading', () => {
+    rendererListenerReady = false
+  })
+  window.on('closed', () => {
+    ipcMain.removeListener(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)
+  })
+
+  // Intercept Cmd+W / Ctrl+W before the default menu "Close" role fires. preventDefault here also
+  // suppresses the menu accelerator (electron/electron#19279), so the chord never closes the window
+  // behind the renderer's back. Forward to the renderer when it is ready, otherwise close directly.
+  window.webContents.on('before-input-event', (event, input) => {
+    if (!isCloseWindowChord(input, process.platform)) return
+
+    event.preventDefault()
+    if (rendererListenerReady) {
+      window.webContents.send(CLOSE_ACTIVE_PANE_CHANNEL)
+    } else {
+      window.close()
+    }
   })
 
   // In dev, mirror the "(DEV)" app suffix in the title bar. The renderer's <title> overwrites the

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -13,6 +13,7 @@ import { isAllowedExternalNavigation, isAllowedFrameNavigation } from './navigat
 import {
   CLOSE_ACTIVE_PANE_CHANNEL,
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
+  CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
   isCloseWindowChord
 } from '../shared/window-controls'
 
@@ -74,31 +75,53 @@ const createMainWindow = (): BrowserWindow => {
     title: 'Open Science'
   })
 
-  // The renderer decides pane-vs-window, but only once it has mounted its listener. Track that via the
-  // ready signal so the chord is never forwarded into the void: before the renderer is ready (initial
-  // load, reload, in-flight navigation) the send() below would be dropped and Cmd/Ctrl+W would do
-  // nothing, so main closes the window itself instead. Reset on every top-level load, since a fresh
-  // document has to re-subscribe before it can own the chord again.
+  // The renderer decides pane-vs-window, but only once it has a live, responsive listener. If main
+  // forwards the chord to a renderer that cannot handle it, preventDefault() has already suppressed the
+  // menu Close accelerator, so Cmd/Ctrl+W becomes a silent no-op. Two independent conditions gate the
+  // forward:
+  //   - listener readiness: the renderer mounted its listener (READY) and has not torn it down (UNREADY)
+  //     or been replaced by a fresh document (did-start-loading) or a dead process (render-process-gone).
+  //   - responsiveness: a hung renderer receives the send but never processes it, so treat unresponsive
+  //     as not-forwardable and restore on recovery — tracked separately so a recovered renderer keeps
+  //     its subscription instead of having to re-handshake.
+  // When either fails, main closes the window itself so the chord always does something.
   let rendererListenerReady = false
+  let rendererResponsive = true
   const onListenerReady = (event: IpcMainEvent): void => {
     if (event.sender === window.webContents) rendererListenerReady = true
   }
+  const onListenerGone = (event: IpcMainEvent): void => {
+    if (event.sender === window.webContents) rendererListenerReady = false
+  }
   ipcMain.on(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)
+  ipcMain.on(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL, onListenerGone)
+  // A top-level load swaps in a fresh document that must re-subscribe; a dead render process took its
+  // listener with it. Both revoke readiness until the next READY handshake.
   window.webContents.on('did-start-loading', () => {
     rendererListenerReady = false
   })
+  window.webContents.on('render-process-gone', () => {
+    rendererListenerReady = false
+  })
+  window.webContents.on('unresponsive', () => {
+    rendererResponsive = false
+  })
+  window.webContents.on('responsive', () => {
+    rendererResponsive = true
+  })
   window.on('closed', () => {
     ipcMain.removeListener(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)
+    ipcMain.removeListener(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL, onListenerGone)
   })
 
   // Intercept Cmd+W / Ctrl+W before the default menu "Close" role fires. preventDefault here also
   // suppresses the menu accelerator (electron/electron#19279), so the chord never closes the window
-  // behind the renderer's back. Forward to the renderer when it is ready, otherwise close directly.
+  // behind the renderer's back. Forward to the renderer only when it can act on it, otherwise close.
   window.webContents.on('before-input-event', (event, input) => {
     if (!isCloseWindowChord(input, process.platform)) return
 
     event.preventDefault()
-    if (rendererListenerReady) {
+    if (rendererListenerReady && rendererResponsive) {
       window.webContents.send(CLOSE_ACTIVE_PANE_CHANNEL)
     } else {
       window.close()

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -79,8 +79,8 @@ const createMainWindow = (): BrowserWindow => {
   // forwards the chord to a renderer that cannot handle it, preventDefault() has already suppressed the
   // menu Close accelerator, so Cmd/Ctrl+W becomes a silent no-op. Two independent conditions gate the
   // forward:
-  //   - listener readiness: the renderer mounted its listener (READY) and has not torn it down (UNREADY)
-  //     or been replaced by a fresh document (did-start-loading) or a dead process (render-process-gone).
+  //   - listener readiness: the renderer mounted its listener (READY) and has not torn it down (UNREADY),
+  //     been replaced by a fresh top-level document (did-start-navigation), or died (render-process-gone).
   //   - responsiveness: a hung renderer receives the send but never processes it, so treat unresponsive
   //     as not-forwardable and restore on recovery — tracked separately so a recovered renderer keeps
   //     its subscription instead of having to re-handshake.
@@ -88,17 +88,25 @@ const createMainWindow = (): BrowserWindow => {
   let rendererListenerReady = false
   let rendererResponsive = true
   const onListenerReady = (event: IpcMainEvent): void => {
-    if (event.sender === window.webContents) rendererListenerReady = true
+    if (event.sender !== window.webContents) return
+    rendererListenerReady = true
+    // A renderer that just handshook is by definition running and processing IPC. Clear any stale
+    // unresponsive state here too: after unresponsive -> render-process-gone -> reload, the fresh
+    // process never emits 'responsive' (that only fires as recovery on the *same* process), so READY
+    // is the only signal that the new renderer can act on the chord.
+    rendererResponsive = true
   }
   const onListenerGone = (event: IpcMainEvent): void => {
     if (event.sender === window.webContents) rendererListenerReady = false
   }
   ipcMain.on(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)
   ipcMain.on(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL, onListenerGone)
-  // A top-level load swaps in a fresh document that must re-subscribe; a dead render process took its
-  // listener with it. Both revoke readiness until the next READY handshake.
-  window.webContents.on('did-start-loading', () => {
-    rendererListenerReady = false
+  // A top-level document swap replaces the mounted hook, which must re-subscribe; a dead render process
+  // took its listener with it. Both revoke readiness until the next READY handshake. Gate on the main
+  // frame and a real document change so a dynamic preview iframe loading (or a same-document hash /
+  // pushState navigation) — neither of which remounts the hook — does not falsely disarm the forward.
+  window.webContents.on('did-start-navigation', (details) => {
+    if (details.isMainFrame && !details.isSameDocument) rendererListenerReady = false
   })
   window.webContents.on('render-process-gone', () => {
     rendererListenerReady = false

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -321,6 +321,12 @@ interface OpenScienceAPI {
     // Sends an abort request to stop the running fix loop for a session.
     abortFixLoop(sessionId: string): Promise<void>
   }
+  window: {
+    // Closes the focused window (the Cmd+W / Ctrl+W fallback when no preview panel is open).
+    close(): Promise<void>
+    // Fires when Cmd+W / Ctrl+W is pressed; the renderer decides pane-vs-window.
+    onCloseActivePane(listener: () => void): RemoveListener
+  }
 }
 
 declare global {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -126,6 +126,11 @@ import type {
 } from '../shared/uploads'
 import type { ReviewWithChecks, ReviewRunRequest, ReviewUpdateEvent } from '../shared/reviewer'
 import { REVIEWER_IPC } from '../shared/reviewer'
+import {
+  CLOSE_ACTIVE_PANE_CHANNEL,
+  CLOSE_ACTIVE_PANE_READY_CHANNEL,
+  WINDOW_CLOSE_CHANNEL
+} from '../shared/window-controls'
 
 type RemoveListener = () => void
 type AcpListener<Payload> = (payload: Payload) => void
@@ -338,6 +343,12 @@ type OpenScienceAPI = {
     onFixLoopEnd: (listener: AcpListener<{ sessionId: string }>) => RemoveListener
     // Sends an abort request to stop the running fix loop for a session.
     abortFixLoop: (sessionId: string) => Promise<void>
+  }
+  window: {
+    // Closes the focused window (the Cmd+W / Ctrl+W fallback when no preview panel is open).
+    close: () => Promise<void>
+    // Fires when Cmd+W / Ctrl+W is pressed; the renderer decides pane-vs-window.
+    onCloseActivePane: (listener: () => void) => RemoveListener
   }
 }
 
@@ -616,6 +627,16 @@ const api: OpenScienceAPI = {
     // Sends an abort request to the main process to stop the running fix loop for a session.
     abortFixLoop: (sessionId: string) =>
       ipcRenderer.invoke(REVIEWER_IPC.ABORT_FIX_LOOP, sessionId) as Promise<void>
+  },
+  window: {
+    close: () => ipcRenderer.invoke(WINDOW_CLOSE_CHANNEL) as Promise<void>,
+    onCloseActivePane: (listener) => {
+      const removeListener = onIpcMessage(CLOSE_ACTIVE_PANE_CHANNEL, listener)
+      // Tell main a listener is now mounted so it forwards the chord here instead of closing the
+      // window directly. Sent on subscribe (and again after any reload, which remounts the hook).
+      ipcRenderer.send(CLOSE_ACTIVE_PANE_READY_CHANNEL)
+      return removeListener
+    }
   }
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -126,11 +126,7 @@ import type {
 } from '../shared/uploads'
 import type { ReviewWithChecks, ReviewRunRequest, ReviewUpdateEvent } from '../shared/reviewer'
 import { REVIEWER_IPC } from '../shared/reviewer'
-import {
-  CLOSE_ACTIVE_PANE_CHANNEL,
-  CLOSE_ACTIVE_PANE_READY_CHANNEL,
-  WINDOW_CLOSE_CHANNEL
-} from '../shared/window-controls'
+import { subscribeCloseActivePane, WINDOW_CLOSE_CHANNEL } from '../shared/window-controls'
 
 type RemoveListener = () => void
 type AcpListener<Payload> = (payload: Payload) => void
@@ -630,13 +626,16 @@ const api: OpenScienceAPI = {
   },
   window: {
     close: () => ipcRenderer.invoke(WINDOW_CLOSE_CHANNEL) as Promise<void>,
-    onCloseActivePane: (listener) => {
-      const removeListener = onIpcMessage(CLOSE_ACTIVE_PANE_CHANNEL, listener)
-      // Tell main a listener is now mounted so it forwards the chord here instead of closing the
-      // window directly. Sent on subscribe (and again after any reload, which remounts the hook).
-      ipcRenderer.send(CLOSE_ACTIVE_PANE_READY_CHANNEL)
-      return removeListener
-    }
+    // The shared helper announces READY on subscribe (so main forwards the chord here) and UNREADY on
+    // teardown (so main re-arms its direct close). Reload remounts the hook, re-running the handshake.
+    onCloseActivePane: (listener) =>
+      subscribeCloseActivePane(
+        {
+          on: (channel, paneListener) => onIpcMessage(channel, paneListener),
+          send: (channel) => ipcRenderer.send(channel)
+        },
+        listener
+      )
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import { resolveStartupView } from '@/pages/onboarding/startup-gate'
 import { ConnectorApprovalDialog } from '@/pages/settings/ConnectorApprovalDialog'
 import { SettingsPage } from '@/pages/settings/SettingsPage'
 import { WorkspacePage } from '@/pages/workspace/WorkspacePage'
+import { useCloseActivePaneShortcut } from '@/hooks/useCloseActivePaneShortcut'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -19,6 +20,8 @@ const App = (): React.JSX.Element | null => {
   // Persistence is started once at the top so sessions stay loaded for both Home and Workspace.
   const isSessionPersistenceReady = useSessionPersistence()
   const view = useNavigationStore((state) => state.view)
+  // Cmd+W / Ctrl+W closes the open preview panel before it closes the window.
+  useCloseActivePaneShortcut()
   const loadProjects = useProjectStore((state) => state.loadProjects)
   const isSettingsLoaded = useSettingsStore((state) => state.isLoaded)
   const onboardingCompletedAt = useSettingsStore((state) => state.onboardingCompletedAt)

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useNavigationStore } from '@/stores/navigation-store'
+import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
+
+import {
+  decideCloseActivePaneAction,
+  useCloseActivePaneShortcut
+} from './useCloseActivePaneShortcut'
+
+// React's act() refuses to run unless the environment opts in to act-aware scheduling.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Minimal renderHook harness (the repo does not depend on @testing-library/react).
+const renderHook = (hook: () => void): { unmount: () => void } => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+
+  const HookHarness = (): null => {
+    hook()
+    return null
+  }
+
+  act(() => {
+    root.render(createElement(HookHarness))
+  })
+
+  return {
+    unmount: () =>
+      act(() => {
+        root.unmount()
+      })
+  }
+}
+
+describe('decideCloseActivePaneAction', () => {
+  it('collapses the pane only when it is open in the workspace', () => {
+    expect(decideCloseActivePaneAction({ view: 'workspace', panelState: 'open' })).toBe(
+      'collapse-pane'
+    )
+  })
+
+  it('closes the window when the pane is collapsed', () => {
+    expect(decideCloseActivePaneAction({ view: 'workspace', panelState: 'collapsed' })).toBe(
+      'close-window'
+    )
+  })
+
+  it('closes the window on the Home screen even if a stale panel state is open', () => {
+    expect(decideCloseActivePaneAction({ view: 'home', panelState: 'open' })).toBe('close-window')
+    expect(decideCloseActivePaneAction({ view: 'home', panelState: 'collapsed' })).toBe(
+      'close-window'
+    )
+  })
+})
+
+describe('useCloseActivePaneShortcut', () => {
+  let closeActivePane: (() => void) | undefined
+  const close = vi.fn()
+
+  beforeEach(() => {
+    closeActivePane = undefined
+    close.mockClear()
+    ;(window as unknown as { api: unknown }).api = {
+      window: {
+        close,
+        onCloseActivePane: (listener: () => void) => {
+          closeActivePane = listener
+          return () => {
+            closeActivePane = undefined
+          }
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    useNavigationStore.setState({ view: 'home' })
+    usePreviewWorkbenchStore.getState().collapsePanel()
+  })
+
+  it('collapses the panel when it is open in the workspace', () => {
+    useNavigationStore.setState({ view: 'workspace' })
+    usePreviewWorkbenchStore.getState().openPanel()
+
+    const { unmount } = renderHook(() => useCloseActivePaneShortcut())
+    act(() => closeActivePane?.())
+
+    expect(usePreviewWorkbenchStore.getState().panelState).toBe('collapsed')
+    expect(close).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('closes the window when no panel is open', () => {
+    useNavigationStore.setState({ view: 'workspace' })
+    usePreviewWorkbenchStore.getState().collapsePanel()
+
+    const { unmount } = renderHook(() => useCloseActivePaneShortcut())
+    act(() => closeActivePane?.())
+
+    expect(close).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+})

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+
+import { useNavigationStore, type NavigationView } from '@/stores/navigation-store'
+import { usePreviewWorkbenchStore, type PreviewPanelState } from '@/stores/preview-workbench-store'
+
+export type CloseActivePaneAction = 'collapse-pane' | 'close-window'
+
+// Cmd+W / Ctrl+W closes the third-column preview panel when it is open in the workspace; otherwise it
+// falls through to closing the window. Gating on the workspace view keeps a stale "open" panel state
+// from swallowing the shortcut on the Home screen, where the panel is not rendered.
+export const decideCloseActivePaneAction = (input: {
+  view: NavigationView
+  panelState: PreviewPanelState
+}): CloseActivePaneAction =>
+  input.view === 'workspace' && input.panelState === 'open' ? 'collapse-pane' : 'close-window'
+
+// Wires the main-process close chord to the pane-vs-window decision. Store state is read imperatively
+// so the subscription is installed once yet always sees the current view and panel state.
+export const useCloseActivePaneShortcut = (): void => {
+  useEffect(
+    () =>
+      window.api.window.onCloseActivePane(() => {
+        const action = decideCloseActivePaneAction({
+          view: useNavigationStore.getState().view,
+          panelState: usePreviewWorkbenchStore.getState().panelState
+        })
+
+        if (action === 'collapse-pane') {
+          usePreviewWorkbenchStore.getState().collapsePanel()
+          return
+        }
+
+        void window.api.window.close()
+      }),
+    []
+  )
+}

--- a/src/shared/window-controls.test.ts
+++ b/src/shared/window-controls.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { isCloseWindowChord, type KeyChordInput } from './window-controls'
+
+// Builds a keyDown Input with no modifiers, overridable per case.
+const chord = (overrides: Partial<KeyChordInput> = {}): KeyChordInput => ({
+  type: 'keyDown',
+  key: 'w',
+  control: false,
+  meta: false,
+  alt: false,
+  shift: false,
+  isAutoRepeat: false,
+  ...overrides
+})
+
+describe('isCloseWindowChord', () => {
+  it('matches Cmd+W on macOS', () => {
+    expect(isCloseWindowChord(chord({ meta: true }), 'darwin')).toBe(true)
+  })
+
+  it('matches Ctrl+W on Windows and Linux', () => {
+    expect(isCloseWindowChord(chord({ control: true }), 'win32')).toBe(true)
+    expect(isCloseWindowChord(chord({ control: true }), 'linux')).toBe(true)
+  })
+
+  it('rejects Ctrl+W on macOS and Cmd+W off macOS (wrong primary modifier)', () => {
+    expect(isCloseWindowChord(chord({ control: true }), 'darwin')).toBe(false)
+    expect(isCloseWindowChord(chord({ meta: true }), 'win32')).toBe(false)
+  })
+
+  it('rejects when the other modifier is also held', () => {
+    expect(isCloseWindowChord(chord({ meta: true, control: true }), 'darwin')).toBe(false)
+    expect(isCloseWindowChord(chord({ control: true, meta: true }), 'linux')).toBe(false)
+  })
+
+  it('rejects when Alt or Shift is held', () => {
+    expect(isCloseWindowChord(chord({ meta: true, alt: true }), 'darwin')).toBe(false)
+    expect(isCloseWindowChord(chord({ meta: true, shift: true }), 'darwin')).toBe(false)
+  })
+
+  it('rejects a bare W with no primary modifier', () => {
+    expect(isCloseWindowChord(chord(), 'darwin')).toBe(false)
+  })
+
+  it('rejects other keys', () => {
+    expect(isCloseWindowChord(chord({ meta: true, key: 'q' }), 'darwin')).toBe(false)
+  })
+
+  it('matches by produced character, so it tracks the W key across keyboard layouts', () => {
+    // AZERTY: the character 'w' sits where QWERTY has 'z' (code 'KeyZ'). Matching on the character
+    // keeps the chord aligned with the OS Close accelerator, which also keys off 'w'.
+    expect(isCloseWindowChord(chord({ meta: true, key: 'w' }), 'darwin')).toBe(true)
+    // Uppercase (e.g. Caps Lock) still matches; Shift is rejected separately above.
+    expect(isCloseWindowChord(chord({ control: true, key: 'W' }), 'win32')).toBe(true)
+    // The physical W position producing another character (e.g. AZERTY 'z') must not match.
+    expect(isCloseWindowChord(chord({ meta: true, key: 'z' }), 'darwin')).toBe(false)
+  })
+
+  it('ignores keyUp events', () => {
+    expect(isCloseWindowChord(chord({ meta: true, type: 'keyUp' }), 'darwin')).toBe(false)
+  })
+
+  it('ignores auto-repeat so a held chord cannot close the window after the pane closes', () => {
+    expect(isCloseWindowChord(chord({ meta: true, isAutoRepeat: true }), 'darwin')).toBe(false)
+  })
+})

--- a/src/shared/window-controls.test.ts
+++ b/src/shared/window-controls.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { isCloseWindowChord, type KeyChordInput } from './window-controls'
+import {
+  CLOSE_ACTIVE_PANE_CHANNEL,
+  CLOSE_ACTIVE_PANE_READY_CHANNEL,
+  CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
+  isCloseWindowChord,
+  subscribeCloseActivePane,
+  type KeyChordInput
+} from './window-controls'
 
 // Builds a keyDown Input with no modifiers, overridable per case.
 const chord = (overrides: Partial<KeyChordInput> = {}): KeyChordInput => ({
@@ -63,5 +70,37 @@ describe('isCloseWindowChord', () => {
 
   it('ignores auto-repeat so a held chord cannot close the window after the pane closes', () => {
     expect(isCloseWindowChord(chord({ meta: true, isAutoRepeat: true }), 'darwin')).toBe(false)
+  })
+})
+
+describe('subscribeCloseActivePane', () => {
+  // Verifies the renderer handshake wiring so a wrong channel or a missing signal can't slip through
+  // while main's tests fake the ready state. Main only forwards the chord when it has seen READY, so
+  // subscribing on the wrong channel would silently break the whole feature.
+  it('subscribes to the chord channel and announces readiness on subscribe', () => {
+    const removeListener = vi.fn()
+    const on = vi.fn(() => removeListener)
+    const send = vi.fn()
+    const listener = vi.fn()
+
+    subscribeCloseActivePane({ on, send }, listener)
+
+    expect(on).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_CHANNEL, listener)
+    expect(send).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_READY_CHANNEL)
+  })
+
+  it('removes the listener and announces teardown on unsubscribe', () => {
+    const removeListener = vi.fn()
+    const on = vi.fn(() => removeListener)
+    const send = vi.fn()
+
+    const unsubscribe = subscribeCloseActivePane({ on, send }, vi.fn())
+    send.mockClear()
+    unsubscribe()
+
+    expect(removeListener).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL)
+    // Teardown must not re-announce readiness, which would leave main forwarding into a gone listener.
+    expect(send).not.toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_READY_CHANNEL)
   })
 })

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -15,6 +15,33 @@ export const CLOSE_ACTIVE_PANE_CHANNEL = 'shortcut:close-active-pane'
 // swallow the chord (the forwarded message would be dropped), so it closes the window directly instead.
 export const CLOSE_ACTIVE_PANE_READY_CHANNEL = 'shortcut:close-active-pane-ready'
 
+// Renderer -> main: the close-chord listener has been torn down (hook unmount). Main re-arms its
+// direct-close fallback so a stale "ready" flag never makes it swallow the chord into a gone listener.
+export const CLOSE_ACTIVE_PANE_UNREADY_CHANNEL = 'shortcut:close-active-pane-unready'
+
+// The minimal IPC surface the renderer handshake needs, kept structural so the wiring can be unit-tested
+// without loading preload or importing electron.
+export type CloseActivePaneBridge = {
+  on: (channel: string, listener: () => void) => () => void
+  send: (channel: string) => void
+}
+
+// Wires a renderer close-chord subscription to the main handshake: announce READY on subscribe so main
+// forwards the chord here, and UNREADY on teardown so main re-arms its direct-close fallback. Lives here
+// (not inline in preload) so the exact channels and ordering are covered by shared unit tests.
+export const subscribeCloseActivePane = (
+  bridge: CloseActivePaneBridge,
+  listener: () => void
+): (() => void) => {
+  const removeListener = bridge.on(CLOSE_ACTIVE_PANE_CHANNEL, listener)
+  bridge.send(CLOSE_ACTIVE_PANE_READY_CHANNEL)
+
+  return () => {
+    removeListener()
+    bridge.send(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL)
+  }
+}
+
 // The subset of Electron's before-input-event Input that the chord test needs. Kept structural so the
 // helper stays pure and unit-testable without importing electron.
 export type KeyChordInput = {

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -1,0 +1,43 @@
+// Shared window-control contract between main, preload, and renderer. No main/renderer imports so it
+// can be consumed from any layer.
+//
+// Cmd+W (macOS) / Ctrl+W (Windows, Linux) is repurposed: when the workspace preview panel (the third
+// column) is open it closes that panel instead of the window. The main process intercepts the chord
+// and forwards it to the renderer, which decides whether to collapse the panel or close the window.
+
+// Renderer -> main: close the focused window (the fallback when no pane is open).
+export const WINDOW_CLOSE_CHANNEL = 'window:close'
+
+// Main -> renderer: the close chord was pressed; the renderer decides pane-vs-window.
+export const CLOSE_ACTIVE_PANE_CHANNEL = 'shortcut:close-active-pane'
+
+// Renderer -> main: the renderer's close-chord listener is mounted. Until main sees this it must not
+// swallow the chord (the forwarded message would be dropped), so it closes the window directly instead.
+export const CLOSE_ACTIVE_PANE_READY_CHANNEL = 'shortcut:close-active-pane-ready'
+
+// The subset of Electron's before-input-event Input that the chord test needs. Kept structural so the
+// helper stays pure and unit-testable without importing electron.
+export type KeyChordInput = {
+  type: string
+  key: string
+  control: boolean
+  meta: boolean
+  alt: boolean
+  shift: boolean
+  isAutoRepeat?: boolean
+}
+
+// Matches the platform-correct "close" chord: Cmd+W on macOS, Ctrl+W elsewhere (mirrors Electron's
+// CmdOrCtrl accelerator). Matches the produced character `key` (not the physical `code`) so it tracks
+// whatever key the OS Close accelerator responds to under non-QWERTY layouts — on AZERTY the character
+// 'w' sits on a different physical key, so a `code === 'KeyW'` check would miss it and let the default
+// Close fire uninterrupted. Rejects auto-repeat so a held chord cannot fall through to close the window
+// after the pane is already gone.
+export const isCloseWindowChord = (input: KeyChordInput, platform: string): boolean => {
+  if (input.type !== 'keyDown') return false
+  if (input.isAutoRepeat) return false
+  if (input.key.toLowerCase() !== 'w') return false
+  if (input.alt || input.shift) return false
+
+  return platform === 'darwin' ? input.meta && !input.control : input.control && !input.meta
+}


### PR DESCRIPTION
## Summary

Cmd+W (macOS) / Ctrl+W (Windows, Linux) now closes the third-column preview panel when it is open in the workspace. When no panel is open, the chord falls through to the existing window-close behavior, so keyboard window-close still works.

The main process intercepts the chord via `before-input-event` and `preventDefault` (which also suppresses the default menu Close accelerator, see electron/electron#19279). The renderer stays the single source of truth: it collapses the panel when open, otherwise asks main to close the owning window.

Because `webContents.send` is dropped if no renderer listener is mounted, main only forwards the chord to the renderer when the renderer is both **ready** (its listener is mounted and has not been torn down or replaced) and **responsive**. Otherwise main closes the window directly, so the chord is never silently swallowed. Readiness is negotiated by a small handshake:

- The renderer announces `READY` on subscribe and `UNREADY` on teardown.
- Main revokes readiness on `render-process-gone` and on a top-level document navigation (`did-start-navigation` gated on `isMainFrame && !isSameDocument`), so a dynamic preview iframe load or a same-document hash/pushState navigation does not falsely disarm it.
- Responsiveness is tracked independently via `unresponsive` / `responsive`; a fresh `READY` also clears stale unresponsive state, since a brand-new render process never emits `responsive`.

One accepted residual is documented in `main/windows.ts`: a chord forwarded in the narrow scheduling window before a crashing/hanging renderer runs its handler is dropped, but it is self-correcting (the same crash/hang revokes readiness, so the next press closes directly). A per-chord ack + timeout was deliberately not added — it cannot make the renderer action atomic with main and would risk closing the window after a slow-but-healthy renderer already collapsed the pane.

The close chord matches by produced character (`key === 'w'`), not physical `code`, so it tracks the OS Close accelerator across non-QWERTY layouts (e.g. AZERTY), and rejects auto-repeat so a held chord cannot close the window after the pane is already gone.

## Changes

- `shared/window-controls`: channel constants, pure `isCloseWindowChord` helper, and a shared `subscribeCloseActivePane` handshake helper (so the ready/unready wiring is unit-tested without loading preload)
- `main/windows`: `before-input-event` interception, ready/responsive gating, and lifecycle wiring (`did-start-navigation`, `render-process-gone`, `unresponsive`/`responsive`)
- `main/window-ipc` (+ `main/ipc`): `window:close` IPC bridge
- `preload`: `window.close` / `window.onCloseActivePane` bridge over the shared handshake helper
- `renderer/useCloseActivePaneShortcut`: pane-vs-window decision, mounted in `App`

## Testing

- `npm run lint` — pass
- `npm run typecheck` — pass
- Unit tests — 33 pass across `shared/window-controls`, `main/windows`, `main/window-ipc`, and `renderer/useCloseActivePaneShortcut`, covering: platform chord matching (incl. non-QWERTY layouts and auto-repeat rejection), the ready/unready handshake channels, direct-close fallback before ready, forwarding once ready, re-arming after listener teardown / render-process-gone / top-level navigation, ignoring subframe and same-document navigations, and unresponsive → recovery (including `unresponsive → crash → reload → READY`).
