### PR TITLE
fix(reviewer): default auto-review to off (opt-in)

### DIFF
--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -352,10 +352,13 @@ describe('workspace runtime events', () => {
   })
 
   describe('auto-review gate on stop event', () => {
-    it('triggers a review via window.api.reviewer.run when autoReviewEnabled is true (default)', async () => {
+    it('triggers a review via window.api.reviewer.run when autoReviewEnabled is true', async () => {
       const reviewerRun = vi.fn().mockResolvedValue(undefined)
 
       vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      // Auto-review defaults off, so it must be explicitly enabled for this session.
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
 
       // Add an agent message so triggerAutoReview finds a turnMessageId.
       useSessionStore.getState().appendAgentMessageChunk({
@@ -386,6 +389,29 @@ describe('workspace runtime events', () => {
       // Disable auto-review on this session.
       useSessionStore.getState().setAutoReviewEnabled('transport-session-1', false)
 
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(reviewerRun).not.toHaveBeenCalled()
+
+      vi.unstubAllGlobals()
+    })
+
+    it('does not trigger a review by default when autoReviewEnabled was never set', async () => {
+      const reviewerRun = vi.fn().mockResolvedValue(undefined)
+
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      // No setAutoReviewEnabled call: the session keeps its default (off).
       useSessionStore.getState().appendAgentMessageChunk({
         sessionId: 'transport-session-1',
         streamId: 'stream-1',
@@ -490,6 +516,9 @@ describe('loop guard: suppressNextAutoReview', () => {
       eventId: 'event-agent-1',
       content: 'Analysis complete'
     })
+    // These tests exercise the suppression guard, not the default; auto-review defaults off, so
+    // enable it up front to isolate the loop-guard behavior.
+    useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
   })
 
   it('suppresses triggerAutoReview for exactly one stop, then resumes normal behavior', async () => {

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -92,9 +92,9 @@ const assembleReviewRunRequest = (sessionId: string): ReviewRunRequest | undefin
 }
 
 // Triggers a background auto-review for the just-completed turn when autoReviewEnabled is on. The
-// default is on, so a session is auto-reviewed unless the switch was explicitly turned off. Uses the
-// shared assembleReviewRunRequest helper so the auto and manual paths pick the same turn and assemble
-// the same request fields.
+// default is off, so a session is auto-reviewed only when the switch was explicitly turned on. Uses
+// the shared assembleReviewRunRequest helper so the auto and manual paths pick the same turn and
+// assemble the same request fields.
 // Fire-and-forget: errors are caught and silently dropped so the main session is never blocked.
 const triggerAutoReview = async (sessionId: string): Promise<void> => {
   try {
@@ -110,8 +110,8 @@ const triggerAutoReview = async (sessionId: string): Promise<void> => {
 
     if (!session) return
 
-    // Auto-review defaults to enabled: skip only when the switch is explicitly off.
-    if (session.autoReviewEnabled === false) return
+    // Auto-review defaults to disabled: run only when the switch was explicitly turned on.
+    if (session.autoReviewEnabled !== true) return
 
     const request = assembleReviewRunRequest(sessionId)
 

--- a/src/renderer/src/pages/workspace/ComposerAutoReviewToggle.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAutoReviewToggle.tsx
@@ -1,6 +1,6 @@
 // Per-session Auto-review toggle for the composer toolbar.
 // Mirrors the shape of ComposerPermissionProfilePicker: a single button that calls onChange
-// with the new boolean value. Default state is on (true); absent (older sessions) also means on.
+// with the new boolean value. Default state is off (false); absent (older sessions) also means off.
 // On/off is made legible by color, not just opacity: on = teal shield (--primary) + near-black
 // label; off = greyed shield + muted label. (The earlier off style used text-text-400, an
 // undefined theme token, so off looked almost identical to on.)

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -90,7 +90,7 @@ type ConversationPanelProps = {
   permissionProfileState: SessionPermissionProfileState | undefined
   permissionGrants: AcpPermissionGrant[]
   canChangePermissionProfile: boolean
-  // Auto-review toggle: whether the current session has auto-review enabled (default true).
+  // Auto-review toggle: whether the current session has auto-review enabled (default false).
   autoReviewEnabled: boolean
   onDraftDocChange: (doc: ComposerDoc) => void
   onSendMessage: (forcedSkillIds: string[]) => void

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -160,10 +160,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const [draftDoc, setDraftDoc] = useState<ComposerDoc>(emptyDoc)
   const [newConversationPermissionProfile, setNewConversationPermissionProfile] =
     useState<PermissionProfileId>(DEFAULT_PERMISSION_PROFILE)
-  // Draft auto-review state for a not-yet-created conversation. Auto-review defaults on, so a new
-  // conversation starts enabled; the user can toggle it off before sending. On send it is stamped
+  // Draft auto-review state for a not-yet-created conversation. Auto-review defaults off, so a new
+  // conversation starts disabled; the user can toggle it on before sending. On send it is stamped
   // onto the created session (see sendCurrentMessage).
-  const [newConversationAutoReviewEnabled, setNewConversationAutoReviewEnabled] = useState(true)
+  const [newConversationAutoReviewEnabled, setNewConversationAutoReviewEnabled] = useState(false)
   // Unsent composer state (rich doc + staged attachments) is kept per session (and per new conversation)
   // so switching away and back restores it. The active key's state is live; this map holds inactive keys.
   const composerDraftsRef = useRef<
@@ -199,10 +199,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     : undefined
   // Always-allow grants only exist for a bound session; new conversations have none yet.
   const activePermissionGrants = activeSession ? (permissionGrants?.[activeSession.id] ?? []) : []
-  // Auto-review defaults on: an existing session is enabled unless explicitly turned off; a new
-  // conversation uses the draft toggle (which also starts on).
+  // Auto-review defaults off: an existing session is enabled only when explicitly turned on; a new
+  // conversation uses the draft toggle (which also starts off).
   const activeAutoReviewEnabled = activeSession
-    ? activeSession.autoReviewEnabled !== false
+    ? activeSession.autoReviewEnabled === true
     : newConversationAutoReviewEnabled
   // True while any review for the active session is in the 'running' lifecycle.
   // Using a shallow comparison via reviewsBySession to avoid new array reference on every render.
@@ -497,7 +497,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     // The draft effect saves the outgoing doc/attachments and restores the new-conversation state.
     setAttachmentError(null)
     setNewConversationPermissionProfile(DEFAULT_PERMISSION_PROFILE)
-    setNewConversationAutoReviewEnabled(true)
+    setNewConversationAutoReviewEnabled(false)
     clearSelection()
   }
 
@@ -559,8 +559,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
 
     const doc = draftDoc
     const attachmentsForSend = attachments
-    // Capture new-conversation intent before send: auto-review defaults on, so only an explicit
-    // "off" needs to be stamped onto the created session (absent = on downstream).
+    // Capture new-conversation intent before send: auto-review defaults off, so only an explicit
+    // "on" needs to be stamped onto the created session (absent = off downstream).
     const wasNewConversation = !activeSession
     const draftAutoReviewEnabled = newConversationAutoReviewEnabled
 
@@ -596,10 +596,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
 
       // Carry the composer's auto-review choice onto the freshly created session. bindPendingSession
       // preserves the field, so stamping the (pending) session id here survives the durable-id swap.
-      if (wasNewConversation && !draftAutoReviewEnabled) {
-        setAutoReviewEnabled(result.sessionId, false)
+      if (wasNewConversation && draftAutoReviewEnabled) {
+        setAutoReviewEnabled(result.sessionId, true)
       }
-      setNewConversationAutoReviewEnabled(true)
+      setNewConversationAutoReviewEnabled(false)
     })
   }
 

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -171,7 +171,7 @@ type SessionStore = SessionStoreData & {
   setPermissionPending: (sessionId: string) => void
   clearPermissionPending: (sessionId: string) => void
   setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => void
-  // Persists the per-session auto-review toggle. true = on (default); false = off.
+  // Persists the per-session auto-review toggle. true = on; false = off (default).
   setAutoReviewEnabled: (sessionId: string, enabled: boolean) => void
   // Sets or clears the per-session fix loop active flag. When true, the composer send button is
   // disabled for this session; when false (loop ended or cancelled), send is re-enabled.

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -161,7 +161,7 @@ describe('normalizeSessionFile with activities', () => {
     expect(unknown?.permissionProfile).toBe('ask')
   })
 
-  it('round-trips the auto-review toggle and defaults older sessions to enabled', () => {
+  it('round-trips the auto-review toggle and defaults older sessions to disabled', () => {
     const disabled = normalizeSessionFile({
       ...createSessionWithActivity(undefined),
       activities: undefined,
@@ -177,7 +177,7 @@ describe('normalizeSessionFile with activities', () => {
       ...createSessionWithActivity(undefined),
       activities: undefined
     })
-    // A corrupt non-boolean value is treated as the safe default (enabled), not preserved.
+    // A corrupt non-boolean value is treated as the safe default (disabled), not preserved.
     const corrupt = normalizeSessionFile({
       ...createSessionWithActivity(undefined),
       activities: undefined,
@@ -186,7 +186,7 @@ describe('normalizeSessionFile with activities', () => {
 
     expect(disabled?.autoReviewEnabled).toBe(false)
     expect(enabled?.autoReviewEnabled).toBe(true)
-    expect(legacy?.autoReviewEnabled).toBe(true)
-    expect(corrupt?.autoReviewEnabled).toBe(true)
+    expect(legacy?.autoReviewEnabled).toBe(false)
+    expect(corrupt?.autoReviewEnabled).toBe(false)
   })
 })

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -108,7 +108,8 @@ export type PersistedChatSession = {
   status: PersistedSessionStatus
   // Per-conversation approval posture. Older session files omit it and safely restore to Ask.
   permissionProfile?: PermissionProfileId
-  // Per-conversation auto-review toggle. Absent (older files) is treated as enabled.
+  // Per-conversation auto-review toggle. Absent (older files) or non-true is treated as disabled;
+  // only an explicit true enables it.
   autoReviewEnabled?: boolean
   messages: PersistedChatMessage[]
   activities?: PersistedToolActivity[]

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -584,9 +584,9 @@ const sanitizeSession = (session: unknown): PersistedChatSession | undefined => 
       session.permissionProfile === undefined
         ? DEFAULT_PERMISSION_PROFILE
         : normalizePermissionProfile(session.permissionProfile),
-    // Auto-review defaults on: a missing or non-boolean value restores as enabled, and only an
-    // explicit false turns it off.
-    autoReviewEnabled: session.autoReviewEnabled === false ? false : true,
+    // Auto-review defaults off: a missing or non-boolean value restores as disabled, and only an
+    // explicit true turns it on.
+    autoReviewEnabled: session.autoReviewEnabled === true ? true : false,
     messages: Array.isArray(session.messages)
       ? session.messages.map(sanitizeMessage).filter((item): item is PersistedChatMessage => !!item)
       : [],


### PR DESCRIPTION
## Summary

Flips the composer **Auto-review** toggle from default-on to default-off, so a session is reviewed only when the user explicitly turns it on. The default was baked into several sites, so the semantics are inverted consistently: absent / non-`true` means off, only explicit `true` means on.

## Changes

- `WorkspacePage.tsx` — new-conversation draft starts off; active-session resolution uses `=== true`; reset points and the send-time stamp flip (now stamps `true` only when explicitly enabled).
- `workspace-events.ts` — the auto-review gate skips unless the switch is explicitly on.
- `session-persistence.ts` — hydration restores missing / legacy / corrupt values as disabled.
- `ComposerAutoReviewToggle.tsx` / `ConversationPanel.tsx` / `session-store.ts` — comments updated to match.

## Behavior change

Existing sessions relying on the implicit default now restore as **off**; only sessions with an explicit `true` keep auto-review on.

## Testing

- Updated `session-persistence.test.ts` (legacy/corrupt now default off).
- Updated `workspace-events.test.ts` (explicitly enable where gate/suppression tests assumed default-on) and added a case asserting an untouched session does not trigger a review.
- `npm run typecheck`, `npm run lint`, affected vitest suites (30 tests), and `npm run build` all pass.