### PR TITLE
fix(window): Cmd/Ctrl+W closes the active preview tab before the panel

### DIFF
--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
@@ -4,7 +4,11 @@ import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNavigationStore } from '@/stores/navigation-store'
-import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore,
+  type PreviewItem
+} from '@/stores/preview-workbench-store'
 
 import {
   decideCloseActivePaneAction,
@@ -36,24 +40,47 @@ const renderHook = (hook: () => void): { unmount: () => void } => {
   }
 }
 
+// Minimal previewable file tab; only identity fields matter for the close ladder.
+const fileTab = (id: string): PreviewItem => ({
+  id,
+  sessionId: 'session',
+  type: 'file',
+  path: `/tmp/${id}`,
+  format: 'text',
+  name: id,
+  title: id
+})
+
 describe('decideCloseActivePaneAction', () => {
-  it('collapses the pane only when it is open in the workspace', () => {
-    expect(decideCloseActivePaneAction({ view: 'workspace', panelState: 'open' })).toBe(
-      'collapse-pane'
-    )
+  it('closes the active tab when the pane is open in the workspace with a tab', () => {
+    expect(
+      decideCloseActivePaneAction({ view: 'workspace', panelState: 'open', hasActiveTab: true })
+    ).toBe('close-active-tab')
+  })
+
+  it('collapses the pane when it is open in the workspace but has no tab', () => {
+    expect(
+      decideCloseActivePaneAction({ view: 'workspace', panelState: 'open', hasActiveTab: false })
+    ).toBe('collapse-pane')
   })
 
   it('closes the window when the pane is collapsed', () => {
-    expect(decideCloseActivePaneAction({ view: 'workspace', panelState: 'collapsed' })).toBe(
-      'close-window'
-    )
+    expect(
+      decideCloseActivePaneAction({
+        view: 'workspace',
+        panelState: 'collapsed',
+        hasActiveTab: true
+      })
+    ).toBe('close-window')
   })
 
   it('closes the window on the Home screen even if a stale panel state is open', () => {
-    expect(decideCloseActivePaneAction({ view: 'home', panelState: 'open' })).toBe('close-window')
-    expect(decideCloseActivePaneAction({ view: 'home', panelState: 'collapsed' })).toBe(
-      'close-window'
-    )
+    expect(
+      decideCloseActivePaneAction({ view: 'home', panelState: 'open', hasActiveTab: true })
+    ).toBe('close-window')
+    expect(
+      decideCloseActivePaneAction({ view: 'home', panelState: 'collapsed', hasActiveTab: false })
+    ).toBe('close-window')
   })
 })
 
@@ -64,6 +91,7 @@ describe('useCloseActivePaneShortcut', () => {
   beforeEach(() => {
     closeActivePane = undefined
     close.mockClear()
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     ;(window as unknown as { api: unknown }).api = {
       window: {
         close,
@@ -79,10 +107,40 @@ describe('useCloseActivePaneShortcut', () => {
 
   afterEach(() => {
     useNavigationStore.setState({ view: 'home' })
-    usePreviewWorkbenchStore.getState().collapsePanel()
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
   })
 
-  it('collapses the panel when it is open in the workspace', () => {
+  it('closes the active tab and keeps the panel open when other tabs remain', () => {
+    useNavigationStore.setState({ view: 'workspace' })
+    const preview = usePreviewWorkbenchStore.getState()
+    preview.upsertAndActivateItem(fileTab('a'))
+    preview.upsertItem(fileTab('b'))
+
+    const { unmount } = renderHook(() => useCloseActivePaneShortcut())
+    act(() => closeActivePane?.())
+
+    const state = usePreviewWorkbenchStore.getState()
+    expect(state.items.map((item) => item.id)).toEqual(['b'])
+    expect(state.panelState).toBe('open')
+    expect(close).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('collapses the panel in the same keypress when the last tab is closed', () => {
+    useNavigationStore.setState({ view: 'workspace' })
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(fileTab('only'))
+
+    const { unmount } = renderHook(() => useCloseActivePaneShortcut())
+    act(() => closeActivePane?.())
+
+    const state = usePreviewWorkbenchStore.getState()
+    expect(state.items).toHaveLength(0)
+    expect(state.panelState).toBe('collapsed')
+    expect(close).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('collapses the panel when it is open in the workspace but empty', () => {
     useNavigationStore.setState({ view: 'workspace' })
     usePreviewWorkbenchStore.getState().openPanel()
 

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
@@ -3,30 +3,50 @@ import { useEffect } from 'react'
 import { useNavigationStore, type NavigationView } from '@/stores/navigation-store'
 import { usePreviewWorkbenchStore, type PreviewPanelState } from '@/stores/preview-workbench-store'
 
-export type CloseActivePaneAction = 'collapse-pane' | 'close-window'
+export type CloseActivePaneAction = 'close-active-tab' | 'collapse-pane' | 'close-window'
 
-// Cmd+W / Ctrl+W closes the third-column preview panel when it is open in the workspace; otherwise it
-// falls through to closing the window. Gating on the workspace view keeps a stale "open" panel state
-// from swallowing the shortcut on the Home screen, where the panel is not rendered.
+// Cmd+W / Ctrl+W walks a three-level ladder inside the workspace: close the active preview tab, then
+// collapse the (now empty) third-column panel, then fall through to closing the window. Gating on the
+// workspace view keeps a stale "open" panel state from swallowing the shortcut on the Home screen,
+// where the panel is not rendered.
 export const decideCloseActivePaneAction = (input: {
   view: NavigationView
   panelState: PreviewPanelState
-}): CloseActivePaneAction =>
-  input.view === 'workspace' && input.panelState === 'open' ? 'collapse-pane' : 'close-window'
+  hasActiveTab: boolean
+}): CloseActivePaneAction => {
+  if (input.view === 'workspace' && input.panelState === 'open') {
+    return input.hasActiveTab ? 'close-active-tab' : 'collapse-pane'
+  }
 
-// Wires the main-process close chord to the pane-vs-window decision. Store state is read imperatively
-// so the subscription is installed once yet always sees the current view and panel state.
+  return 'close-window'
+}
+
+// Wires the main-process close chord to the tab-vs-pane-vs-window decision. Store state is read
+// imperatively so the subscription is installed once yet always sees the current view and panel state.
 export const useCloseActivePaneShortcut = (): void => {
   useEffect(
     () =>
       window.api.window.onCloseActivePane(() => {
+        const preview = usePreviewWorkbenchStore.getState()
+        const activeItem = preview.items.find((item) => item.id === preview.activeItemId)
+
         const action = decideCloseActivePaneAction({
           view: useNavigationStore.getState().view,
-          panelState: usePreviewWorkbenchStore.getState().panelState
+          panelState: preview.panelState,
+          hasActiveTab: activeItem !== undefined
         })
 
+        if (action === 'close-active-tab' && activeItem) {
+          // Closing the last remaining tab collapses the panel in the same keypress so the shortcut
+          // never leaves the third column open on its empty state. `items` is the pre-removal
+          // snapshot, so length 1 means this was the final tab.
+          preview.removeItem(activeItem.id)
+          if (preview.items.length <= 1) preview.collapsePanel()
+          return
+        }
+
         if (action === 'collapse-pane') {
-          usePreviewWorkbenchStore.getState().collapsePanel()
+          preview.collapsePanel()
           return
         }
 


### PR DESCRIPTION
## Summary

Refines the `Cmd/Ctrl+W` close shortcut shipped in #182. That version collapsed the entire third-column preview panel in one keypress, which was too coarse. This turns it into a three-level ladder (VS Code style), scoped to the workspace view:

1. **Panel open with an active tab** → close that tab.
2. **Panel open but empty** → collapse the panel.
3. **Panel collapsed, or not in the workspace** → fall through to closing the window (unchanged).

Closing the **last** remaining tab collapses the panel in the same keypress, so the shortcut never strands the third column on its empty "No preview content" state. Example: with one tab open, press 1 closes the tab and collapses the panel; press 2 closes the window.

## Scope

- Renderer-only. The main process already just forwards `CLOSE_ACTIVE_PANE_CHANNEL`; the renderer remains the single source of truth for the decision.
- `decideCloseActivePaneAction` gains a `hasActiveTab` input and a `close-active-tab` outcome; the hook reads the preview workbench store imperatively to close the active tab and collapse-on-last.
- Auto-collapse-on-last is intentionally shortcut-only. The per-tab **X** button keeps its current behavior (closing the last tab via X leaves the panel open on the empty state).

## Testing

- `useCloseActivePaneShortcut.test.ts`: 8 tests (pure decision cases + hook cases for close-active-tab, last-tab-collapses, empty-collapse, close-window).
- typecheck, eslint, and the test file all pass locally.