### PR TITLE
feat: pluggable agent framework (Claude Code ↔ OpenCode)

### DIFF
--- a/src/main/acp/agent-process.ts
+++ b/src/main/acp/agent-process.ts
@@ -111,14 +111,17 @@ const spawnClaudeAgentAcp = ({
     baseUrl: env.ANTHROPIC_BASE_URL,
     model: env.ANTHROPIC_MODEL,
     configDir: env.CLAUDE_CONFIG_DIR,
-    // Proxy presence only (never the values): a Finder-launched packaged app inherits no login shell, so
-    // these being false is the usual cause of in-app network failures (curl/WebFetch) while the terminal works.
-    hasHttpProxy: Boolean(env.http_proxy || env.HTTP_PROXY),
-    hasHttpsProxy: Boolean(env.https_proxy || env.HTTPS_PROXY),
-    hasAllProxy: Boolean(env.all_proxy || env.ALL_PROXY),
-    hasNoProxy: Boolean(env.no_proxy || env.NO_PROXY),
-    // PATH is not secret; provider credentials are never logged.
-    path: env.PATH
+    // Proxy presence only (never the values): a Finder-launched packaged app inherits no login shell,
+    // so no proxy being set is the usual cause of in-app network failures while the terminal works.
+    // Collapsed to one flag to keep the line readable; PATH stays out of the routine line.
+    proxied: Boolean(
+      env.http_proxy ||
+      env.HTTP_PROXY ||
+      env.https_proxy ||
+      env.HTTPS_PROXY ||
+      env.all_proxy ||
+      env.ALL_PROXY
+    )
   })
 
   const child = spawn(process.execPath, [entryPath], {

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -66,8 +66,9 @@ const createRuntime = ({
     appVersion: app.getVersion(),
     // Packaged macOS apps often start with cwd at "/" or the app bundle; use home instead.
     defaultCwd: homedir(),
-    // Read the active provider's credentials/model on every connect so provider switches apply.
-    resolveSpawnConfig: () => settingsService.resolveActiveSpawnConfig(),
+    // Resolve the active framework + provider credentials/model on every connect so framework and
+    // provider switches apply on reconnect.
+    resolveBackend: () => settingsService.resolveActiveAgentBackend(),
     // Turn-scoped skill force-load: the runtime uses these to respawn with a picked-but-disabled skill
     // for one prompt and to build the steering nudge naming the picked skills.
     skills: {

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -19,6 +19,7 @@ import type {
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
 import { AcpRuntime } from './runtime'
 import { installAgentShutdownGuard } from './shutdown-guard'
+import { AgentMcpHttpHost } from './mcp-http-host'
 import type { ArtifactRepository } from '../artifacts/repository'
 import type { ArtifactRunRegistry } from '../artifacts/run-registry'
 import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
@@ -69,6 +70,9 @@ const createRuntime = ({
     // Resolve the active framework + provider credentials/model on every connect so framework and
     // provider switches apply on reconnect.
     resolveBackend: () => settingsService.resolveActiveAgentBackend(),
+    // Serves the artifact/notebook MCP over local http for frameworks that reject stdio MCP (opencode);
+    // Claude ignores it and keeps launching them over stdio.
+    mcpHttpHost: new AgentMcpHttpHost(),
     // Turn-scoped skill force-load: the runtime uses these to respawn with a picked-but-disabled skill
     // for one prompt and to build the steering nudge naming the picked skills.
     skills: {

--- a/src/main/acp/mcp-http-host.test.ts
+++ b/src/main/acp/mcp-http-host.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { AgentMcpHttpHost } from './mcp-http-host'
+import { ArtifactRepository } from '../artifacts/repository'
+
+describe('AgentMcpHttpHost', () => {
+  let host: AgentMcpHttpHost | undefined
+  let root: string | undefined
+
+  afterEach(async () => {
+    await host?.close()
+    host = undefined
+
+    if (root) {
+      await rm(root, { recursive: true, force: true })
+      root = undefined
+    }
+  })
+
+  it('serves the artifact MCP tools over http and writes a file for the active run', async () => {
+    root = await mkdtemp(join(tmpdir(), 'mcp-http-host-'))
+    const projectName = 'default-project'
+    const artifactSessionId = 'artifact-session-1'
+    const runId = 'artifact-run-1'
+    // The artifact tool reads the active run id from this main-process-owned handoff file.
+    const currentRunFile = join(root, 'current-run.json')
+    await writeFile(currentRunFile, JSON.stringify({ runId }), 'utf8')
+
+    host = new AgentMcpHttpHost()
+    const { endpoint, token } = await host.ensureStarted()
+    expect(endpoint).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
+
+    host.registerArtifact(artifactSessionId, {
+      storageRoot: root,
+      projectName,
+      sessionId: artifactSessionId,
+      currentRunFile,
+      allowedImportRoots: [root]
+    })
+
+    const client = new Client({ name: 'test-client', version: '0.0.0' })
+    const transport = new StreamableHTTPClientTransport(
+      new URL(host.urlFor('artifact', artifactSessionId)),
+      { requestInit: { headers: { authorization: `Bearer ${token}` } } }
+    )
+    await client.connect(transport)
+
+    const tools = await client.listTools()
+    expect(tools.tools.map((tool) => tool.name)).toContain('write_artifact_file')
+
+    const result = await client.callTool({
+      name: 'write_artifact_file',
+      arguments: {
+        filename: 'note.txt',
+        source: { kind: 'inline', content: 'hello http mcp', encoding: 'utf8' }
+      }
+    })
+    expect(JSON.stringify(result.content)).toContain('note.txt')
+
+    await client.close()
+
+    // The file landed in the pending run through the same repository the stdio path uses.
+    const files = await new ArtifactRepository(root).listPendingRunFiles({
+      projectName,
+      sessionId: artifactSessionId,
+      runId
+    })
+    expect(files.map((file) => file.name)).toContain('note.txt')
+  })
+
+  it('rejects requests without the bearer token', async () => {
+    host = new AgentMcpHttpHost()
+    const { endpoint } = await host.ensureStarted()
+
+    const response = await fetch(`${endpoint}/mcp/artifact/whatever`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}'
+    })
+
+    expect(response.status).toBe(401)
+  })
+})

--- a/src/main/acp/mcp-http-host.ts
+++ b/src/main/acp/mcp-http-host.ts
@@ -127,6 +127,11 @@ class AgentMcpHttpHost {
     this.sessions.delete(routingId)
   }
 
+  // Drops every registered environment (e.g. on runtime disconnect); the server keeps running for reuse.
+  clear(): void {
+    this.sessions.clear()
+  }
+
   // Builds the per-session MCP endpoint URL the agent connects to for one kind.
   urlFor(kind: ServerKind, routingId: string): string {
     if (!this.endpoint) {

--- a/src/main/acp/mcp-http-host.ts
+++ b/src/main/acp/mcp-http-host.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from 'node:crypto'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+
+import type { McpServer as ModelContextProtocolServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+
+import { createArtifactMcpServer, type ArtifactMcpEnvironment } from '../artifacts/mcp-server'
+import { ArtifactRepository } from '../artifacts/repository'
+import { createNotebookMcpServer, type NotebookMcpEnvironment } from '../notebook/mcp-server'
+import { createLogger } from '../logger'
+
+const log = createLogger('mcp-http-host')
+
+type HostConnection = {
+  endpoint: string
+  token: string
+}
+
+// The MCP server kinds this host serves; each maps to a factory + a per-session environment.
+const SERVER_KINDS = ['artifact', 'notebook'] as const
+type ServerKind = (typeof SERVER_KINDS)[number]
+
+const isServerKind = (value: string): value is ServerKind =>
+  (SERVER_KINDS as readonly string[]).includes(value)
+
+// The per-session environment registered for each kind, used to build a fresh MCP server per request.
+type SessionEntry = {
+  artifact?: ArtifactMcpEnvironment
+  notebook?: NotebookMcpEnvironment
+}
+
+// Reads and JSON-parses a POST body so it can be handed to the transport as a pre-parsed payload.
+const readJsonBody = async (request: IncomingMessage): Promise<unknown> => {
+  const chunks: Buffer[] = []
+
+  for await (const chunk of request) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+  }
+
+  if (chunks.length === 0) return undefined
+
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown
+}
+
+const writeJson = (response: ServerResponse, statusCode: number, payload: unknown): void => {
+  response.writeHead(statusCode, { 'content-type': 'application/json' })
+  response.end(`${JSON.stringify(payload)}\n`)
+}
+
+// Hosts the app's artifact + notebook MCP servers over a local, token-authenticated HTTP endpoint, for
+// agent frameworks that only accept http/sse MCP (opencode advertises no stdio). The runtime registers
+// each session's per-kind environment and passes the agent an http McpServer config pointing here;
+// requests are routed by `/mcp/<kind>/<sessionId>`. Stateless: a fresh MCP server + transport is built
+// per request from the registered environment, mirroring the one-server-per-spawn stdio model.
+class AgentMcpHttpHost {
+  private readonly token: string
+  private readonly host: string
+  private server: Server | undefined
+  private startPromise: Promise<HostConnection> | undefined
+  private endpoint: string | undefined
+  private readonly sessions = new Map<string, SessionEntry>()
+
+  constructor(options: { token?: string; host?: string } = {}) {
+    this.token = options.token ?? randomUUID()
+    this.host = options.host ?? '127.0.0.1'
+  }
+
+  // Starts the HTTP server once on an ephemeral port and returns its connection details.
+  async ensureStarted(): Promise<HostConnection> {
+    if (this.startPromise) {
+      return this.startPromise
+    }
+
+    const server = createServer((request, response) => {
+      void this.handleRequest(request, response)
+    })
+    this.server = server
+    this.startPromise = new Promise((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, this.host, () => {
+        const address = server.address()
+
+        if (typeof address !== 'object' || address === null) {
+          reject(new Error('MCP HTTP host did not return a TCP address.'))
+          return
+        }
+
+        this.endpoint = `http://${address.address}:${address.port}`
+        resolve({ endpoint: this.endpoint, token: this.token })
+      })
+    })
+
+    return this.startPromise
+  }
+
+  async close(): Promise<void> {
+    const server = this.server
+
+    this.server = undefined
+    this.startPromise = undefined
+    this.endpoint = undefined
+    this.sessions.clear()
+
+    if (!server) return
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()))
+    })
+  }
+
+  // Registers (or replaces) the artifact environment for one routing id; re-registration on resume
+  // simply overwrites, mirroring the stdio path which respawns with fresh env each connect.
+  registerArtifact(routingId: string, environment: ArtifactMcpEnvironment): void {
+    const entry = this.sessions.get(routingId) ?? {}
+    entry.artifact = environment
+    this.sessions.set(routingId, entry)
+  }
+
+  registerNotebook(routingId: string, environment: NotebookMcpEnvironment): void {
+    const entry = this.sessions.get(routingId) ?? {}
+    entry.notebook = environment
+    this.sessions.set(routingId, entry)
+  }
+
+  // Drops a routing id's registered environments once its session is gone.
+  unregister(routingId: string): void {
+    this.sessions.delete(routingId)
+  }
+
+  // Builds the per-session MCP endpoint URL the agent connects to for one kind.
+  urlFor(kind: ServerKind, routingId: string): string {
+    if (!this.endpoint) {
+      throw new Error('MCP HTTP host is not started.')
+    }
+
+    return `${this.endpoint}/mcp/${kind}/${encodeURIComponent(routingId)}`
+  }
+
+  // Constructs a fresh MCP server for one request from the registered environment, or undefined when
+  // the routing id / kind was never registered.
+  private buildServer(kind: ServerKind, routingId: string): ModelContextProtocolServer | undefined {
+    const entry = this.sessions.get(routingId)
+
+    if (!entry) return undefined
+
+    if (kind === 'artifact') {
+      if (!entry.artifact) return undefined
+
+      return createArtifactMcpServer(
+        new ArtifactRepository(entry.artifact.storageRoot),
+        entry.artifact
+      )
+    }
+
+    if (!entry.notebook) return undefined
+
+    return createNotebookMcpServer(entry.notebook)
+  }
+
+  // Authenticates, routes by path, and serves one MCP request from a fresh stateless server+transport.
+  private async handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+    if (request.headers.authorization !== `Bearer ${this.token}`) {
+      writeJson(response, 401, { error: 'Invalid MCP host token.' })
+      return
+    }
+
+    const url = new URL(request.url ?? '', this.endpoint ?? 'http://127.0.0.1')
+    const match = /^\/mcp\/([^/]+)\/(.+)$/.exec(url.pathname)
+
+    if (!match || !isServerKind(match[1])) {
+      writeJson(response, 404, { error: 'Unknown MCP endpoint.' })
+      return
+    }
+
+    const kind = match[1]
+    const routingId = decodeURIComponent(match[2])
+    const server = this.buildServer(kind, routingId)
+
+    if (!server) {
+      writeJson(response, 404, { error: `No registered ${kind} MCP session: ${routingId}` })
+      return
+    }
+
+    // Stateless: JSON responses, no persisted transport session. One server+transport per request,
+    // torn down when the response closes.
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true
+    })
+    response.on('close', () => {
+      void transport.close()
+      void server.close()
+    })
+
+    try {
+      await server.connect(transport)
+      const body = request.method === 'POST' ? await readJsonBody(request) : undefined
+      await transport.handleRequest(request, response, body)
+    } catch (error) {
+      log.error('MCP host request failed', { kind, error })
+
+      if (!response.headersSent) {
+        writeJson(response, 500, {
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+  }
+}
+
+export { AgentMcpHttpHost }
+export type { HostConnection, ServerKind }

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -334,6 +334,42 @@ describe('ACP permission broker', () => {
     expect(emittedRequests).toHaveLength(1)
   })
 
+  it('classifies an opencode-named MCP tool as MCP, not shell, even when it reports kind execute', async () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+    const mcpServerNames = ['open-science-artifacts', 'open-science-notebook']
+
+    // opencode renames the MCP tool <server>_<tool> and may report kind:execute; without MCP-aware
+    // classification it would be grouped under the shared Bash category and mislabeled as shell.
+    const grant = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'open-science-artifacts_write_artifact_file',
+        kind: 'execute'
+      }),
+      { profile: 'ask', mcpServerNames }
+    )
+    broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
+    await grant
+
+    expect(broker.listGrants('session-1')).toEqual([
+      {
+        categoryKey: 'mcp:open-science-artifacts_write_artifact_file',
+        kind: 'mcp',
+        label: 'open-science-artifacts_write_artifact_file'
+      }
+    ])
+
+    // The same MCP tool is now always-allowed and no longer prompts.
+    void broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'open-science-artifacts_write_artifact_file',
+        kind: 'execute'
+      }),
+      { profile: 'ask', mcpServerNames }
+    )
+    expect(emittedRequests).toHaveLength(1)
+  })
+
   it('does not remember Always across sessions for built-in tools', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
@@ -378,7 +414,7 @@ describe('ACP permission broker', () => {
         { categoryKey: 'tool:Write', kind: 'tool', label: 'Write' },
         { categoryKey: 'bash:python a.py', kind: 'shell', label: 'python a.py' },
         {
-          categoryKey: 'tool:mcp__open-science-notebook__notebook_execute',
+          categoryKey: 'mcp:mcp__open-science-notebook__notebook_execute',
           kind: 'mcp',
           label: 'mcp__open-science-notebook__notebook_execute'
         }
@@ -392,7 +428,7 @@ describe('ACP permission broker', () => {
         .listGrants('session-1')
         .map((grant) => grant.categoryKey)
         .sort()
-    ).toEqual(['bash:python a.py', 'tool:mcp__open-science-notebook__notebook_execute'].sort())
+    ).toEqual(['bash:python a.py', 'mcp:mcp__open-science-notebook__notebook_execute'].sort())
 
     const countBeforeWrite = emittedRequests.length
     broker.requestPermission(

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -7,7 +7,11 @@ import type {
   AcpPermissionResponse
 } from '../../shared/acp'
 import { extractProviderToolName } from './runtime-events'
-import { resolveAutomaticPermission, type PermissionPolicyContext } from './permission-policy'
+import {
+  isMcpToolName,
+  resolveAutomaticPermission,
+  type PermissionPolicyContext
+} from './permission-policy'
 
 type PendingPermission = {
   request: AcpPermissionRequest
@@ -16,10 +20,6 @@ type PendingPermission = {
 }
 
 type EmitPermissionRequest = (request: AcpPermissionRequest) => void
-
-// Claude Code namespaces MCP tools as mcp__<server>__<tool>; notebook and other MCP tool calls carry
-// this prefix as their permission title, so their title alone is a stable per-tool category key.
-const MCP_TOOL_TITLE_PREFIX = 'mcp__'
 
 const ALLOW_ALWAYS_OPTION_KIND = 'allow_always'
 const ALLOW_ONCE_OPTION_KIND = 'allow_once'
@@ -46,17 +46,25 @@ const commandSignature = (command: string): string => {
 }
 
 // Derives a session-scoped "Always" category key from a permission request (first match wins):
-// 1. MCP/notebook tool (title starts with mcp__): keyed by title (the tool name, no args).
+// 1. MCP tool (recognized across frameworks — Claude's mcp__ prefix or an opencode <server>_ name):
+//    keyed by the tool name, no args.
 // 2. Shell/execute tool (provider tool name Bash, or execute kind): keyed by full command signature.
 // 3. Other built-ins (Write/Edit/WebFetch/…): keyed by provider tool name (falls back to title).
-// The mcp__ check runs before the execute branch so a notebook execute-cell is not misrouted to Bash.
-const resolveCategoryKey = (params: RequestPermissionRequest): string => {
+// The MCP check runs before the execute branch so an opencode MCP tool reporting kind:execute (e.g. a
+// notebook execute-cell) is grouped as its own MCP tool, not misrouted to the shared Bash category.
+const resolveCategoryKey = (
+  params: RequestPermissionRequest,
+  mcpServerNames: readonly string[] = []
+): string => {
   const { toolCall } = params
   const title = toolCall.title ?? toolCall.toolCallId
   const providerToolName = extractProviderToolName(toolCall)
 
-  if (title.startsWith(MCP_TOOL_TITLE_PREFIX)) {
-    return `tool:${title}`
+  if (
+    isMcpToolName(toolCall.title, mcpServerNames) ||
+    isMcpToolName(providerToolName, mcpServerNames)
+  ) {
+    return `mcp:${title}`
   }
 
   if (providerToolName === 'Bash' || toolCall.kind === 'execute') {
@@ -72,10 +80,12 @@ const describeGrant = (categoryKey: string): AcpPermissionGrant => {
     return { categoryKey, kind: 'shell', label: categoryKey.slice('bash:'.length) }
   }
 
-  if (categoryKey.startsWith('tool:')) {
-    const label = categoryKey.slice('tool:'.length)
+  if (categoryKey.startsWith('mcp:')) {
+    return { categoryKey, kind: 'mcp', label: categoryKey.slice('mcp:'.length) }
+  }
 
-    return { categoryKey, kind: label.startsWith(MCP_TOOL_TITLE_PREFIX) ? 'mcp' : 'tool', label }
+  if (categoryKey.startsWith('tool:')) {
+    return { categoryKey, kind: 'tool', label: categoryKey.slice('tool:'.length) }
   }
 
   return { categoryKey, kind: 'tool', label: categoryKey }
@@ -137,7 +147,7 @@ class AcpPermissionBroker {
       raw: params
     }
 
-    const categoryKey = resolveCategoryKey(params)
+    const categoryKey = resolveCategoryKey(params, policyContext?.mcpServerNames)
 
     // A model-independent fallback auto-reviews only structured, workspace-contained low-risk tools.
     const automaticOptionId = resolveAutomaticPermission(params, policyContext)

--- a/src/main/acp/permission-policy.test.ts
+++ b/src/main/acp/permission-policy.test.ts
@@ -140,4 +140,32 @@ describe('permission policy', () => {
       })
     ).toBeUndefined()
   })
+
+  it('auto-approves everything under Full access, including shell and network', () => {
+    for (const kind of ['execute', 'fetch', 'read'] as const) {
+      expect(resolveAutomaticPermission(createPermissionRequest(kind), { profile: 'full' })).toBe(
+        'allow'
+      )
+    }
+  })
+
+  it('auto-approves MCP tools under Full access (the user opted in explicitly)', () => {
+    expect(
+      resolveAutomaticPermission(
+        createPermissionRequest('read', undefined, { title: 'mcp__pencil__batch_design' }),
+        { profile: 'full' }
+      )
+    ).toBe('allow')
+  })
+
+  it('falls back to allow_always for Full access only when no one-shot option is offered', () => {
+    const onlyAlways = createPermissionRequest('execute', undefined, {
+      options: [
+        { optionId: 'always', name: 'Allow always', kind: 'allow_always' },
+        { optionId: 'reject', name: 'Reject', kind: 'reject_once' }
+      ]
+    })
+
+    expect(resolveAutomaticPermission(onlyAlways, { profile: 'full' })).toBe('always')
+  })
 })

--- a/src/main/acp/permission-policy.test.ts
+++ b/src/main/acp/permission-policy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   canConservativelyAutoApprove,
+  isMcpToolName,
   isWithinWorkspace,
   resolveAllowOptionId,
   resolveAutomaticPermission
@@ -86,6 +87,58 @@ describe('permission policy', () => {
         '/workspace/project'
       )
     ).toBe(false)
+  })
+
+  it('recognizes MCP tool names across frameworks', () => {
+    const servers = ['open-science-artifacts', 'open-science-notebook']
+
+    // Claude namespaces MCP tools mcp__<server>__<tool> — matched by prefix regardless of server list.
+    expect(isMcpToolName('mcp__pencil__batch_get', [])).toBe(true)
+    // opencode joins them <server>_<tool> — matched only against the session's known server names.
+    expect(isMcpToolName('open-science-artifacts_write_artifact_file', servers)).toBe(true)
+    expect(isMcpToolName('open-science-notebook', servers)).toBe(true)
+    // Built-in framework tools never collide with a server name.
+    expect(isMcpToolName('edit', servers)).toBe(false)
+    expect(isMcpToolName('write_artifact_file', servers)).toBe(false)
+  })
+
+  it('never auto-approves opencode-named MCP tools (<server>_<tool>) reporting a low-risk kind', () => {
+    // The write_artifact_file MCP tool renamed by opencode still performs arbitrary side effects, so a
+    // reported edit/read kind with a workspace location must not slip through the conservative fallback.
+    expect(
+      canConservativelyAutoApprove(
+        createPermissionRequest('edit', [{ path: 'results/output.csv' }], {
+          title: 'open-science-artifacts_write_artifact_file'
+        }),
+        '/workspace/project',
+        ['open-science-artifacts', 'open-science-notebook']
+      )
+    ).toBe(false)
+  })
+
+  it('still auto-approves a genuine built-in edit when MCP server names are provided', () => {
+    expect(
+      canConservativelyAutoApprove(
+        createPermissionRequest('edit', [{ path: 'results/output.csv' }], { title: 'Edit' }),
+        '/workspace/project',
+        ['open-science-artifacts', 'open-science-notebook']
+      )
+    ).toBe(true)
+  })
+
+  it('routes opencode MCP tools to the UI under conservative Auto instead of auto-approving', () => {
+    const request = createPermissionRequest('read', [{ path: 'data/input.csv' }], {
+      title: 'open-science-notebook_notebook_state'
+    })
+
+    expect(
+      resolveAutomaticPermission(request, {
+        profile: 'auto',
+        autoReviewStrategy: 'conservative',
+        cwd: '/workspace/project',
+        mcpServerNames: ['open-science-artifacts', 'open-science-notebook']
+      })
+    ).toBeUndefined()
   })
 
   it('grants a single-use approval only, never escalating to allow_always', () => {

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -60,12 +60,24 @@ const canConservativelyAutoApprove = (
 const resolveAllowOptionId = (params: RequestPermissionRequest): string | undefined =>
   params.options.find((option) => option.kind.toLowerCase() === 'allow_once')?.optionId
 
-// Returns an option only when the application can make a provider-neutral, fail-closed decision.
-// Native auto mode reviews inside the Agent; any request it escalates still belongs in the UI.
+// Full access approves anything the agent asks. Prefer a one-shot allow so the app keeps deciding each
+// call; fall back to allow_always only when the agent offers no one-shot option, so a run never stalls.
+const resolveFullAccessAllowOptionId = (params: RequestPermissionRequest): string | undefined =>
+  resolveAllowOptionId(params) ??
+  params.options.find((option) => option.kind.toLowerCase() === 'allow_always')?.optionId
+
+// Returns an option only when the application can make a provider-neutral decision. Full access is the
+// user's explicit, dialog-confirmed choice, so it auto-approves everything (for frameworks that delegate
+// permissions rather than bypassing natively — a native-bypass agent sends no requests here at all).
+// Otherwise, only native-less 'auto' conservatively approves workspace-contained low-risk operations.
 const resolveAutomaticPermission = (
   params: RequestPermissionRequest,
   context: PermissionPolicyContext | undefined
 ): string | undefined => {
+  if (context?.profile === 'full') {
+    return resolveFullAccessAllowOptionId(params)
+  }
+
   if (
     context?.profile !== 'auto' ||
     context.autoReviewStrategy !== 'conservative' ||

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -11,11 +11,24 @@ type PermissionPolicyContext = {
   profile: PermissionProfileId
   autoReviewStrategy?: PermissionAutoReviewStrategy
   cwd?: string
+  // Agent-visible MCP server names, so MCP tools can be recognized across frameworks (see isMcpToolName).
+  mcpServerNames?: readonly string[]
 }
 
-// Claude Code namespaces MCP tools as mcp__<server>__<tool>; the prefix surfaces in both the
-// permission title and the provider tool name, so either is enough to identify an MCP origin.
+// MCP tool naming differs per framework: Claude Code namespaces them mcp__<server>__<tool>, while
+// opencode joins them <server>_<tool>. The mcp__ prefix identifies Claude's regardless of server;
+// opencode's are recognized against the session's known MCP server names.
 const MCP_TOOL_PREFIX = 'mcp__'
+
+// Recognizes an MCP-originated tool name across frameworks (see MCP_TOOL_PREFIX): Claude's mcp__ prefix,
+// or a known MCP server name used as the tool's own prefix (opencode's <server>_<tool>).
+const isMcpToolName = (
+  name: string | null | undefined,
+  mcpServerNames: readonly string[]
+): boolean =>
+  name != null &&
+  (name.startsWith(MCP_TOOL_PREFIX) ||
+    mcpServerNames.some((server) => name === server || name.startsWith(`${server}_`)))
 
 // Tests whether a tool-reported path stays within the workspace after resolving relative paths.
 const isWithinWorkspace = (path: string, cwd: string): boolean => {
@@ -28,13 +41,15 @@ const isWithinWorkspace = (path: string, cwd: string): boolean => {
 
 // MCP tools can report a benign kind (read/edit) while performing arbitrary side effects, so the
 // conservative fallback treats any MCP-originated call as out of scope regardless of its kind.
-const isMcpTool = (params: RequestPermissionRequest): boolean => {
+const isMcpTool = (
+  params: RequestPermissionRequest,
+  mcpServerNames: readonly string[]
+): boolean => {
   const { toolCall } = params
   const providerToolName = extractProviderToolName(toolCall)
 
   return (
-    toolCall.title?.startsWith(MCP_TOOL_PREFIX) === true ||
-    providerToolName?.startsWith(MCP_TOOL_PREFIX) === true
+    isMcpToolName(toolCall.title, mcpServerNames) || isMcpToolName(providerToolName, mcpServerNames)
   )
 }
 
@@ -43,11 +58,12 @@ const isMcpTool = (params: RequestPermissionRequest): boolean => {
 // read/search/edit operations and side-effect-free thinking can pass without user review.
 const canConservativelyAutoApprove = (
   params: RequestPermissionRequest,
-  cwd: string | undefined
+  cwd: string | undefined,
+  mcpServerNames: readonly string[] = []
 ): boolean => {
   const { kind, locations } = params.toolCall
 
-  if (isMcpTool(params)) return false
+  if (isMcpTool(params, mcpServerNames)) return false
   if (kind === 'think') return true
   if (!cwd || !locations || locations.length === 0) return false
   if (kind !== 'read' && kind !== 'search' && kind !== 'edit') return false
@@ -81,7 +97,7 @@ const resolveAutomaticPermission = (
   if (
     context?.profile !== 'auto' ||
     context.autoReviewStrategy !== 'conservative' ||
-    !canConservativelyAutoApprove(params, context.cwd)
+    !canConservativelyAutoApprove(params, context.cwd, context.mcpServerNames)
   ) {
     return undefined
   }
@@ -91,6 +107,7 @@ const resolveAutomaticPermission = (
 
 export {
   canConservativelyAutoApprove,
+  isMcpToolName,
   isWithinWorkspace,
   resolveAutomaticPermission,
   resolveAllowOptionId

--- a/src/main/acp/permission-profile-controller.test.ts
+++ b/src/main/acp/permission-profile-controller.test.ts
@@ -51,6 +51,29 @@ describe('permission profile controller', () => {
     )
   })
 
+  it('offers broker-enforced Full access when the agent has no native bypass mode', () => {
+    // opencode advertises build/plan, no bypassPermissions; the app owns the decision instead.
+    const modes = createModes(['build', 'plan'])
+
+    const application = resolvePermissionProfileApplication('full', modes, {
+      brokerEnforcesFullAccess: true
+    })
+
+    // No native mode to set, but Full access is available and won't throw — the broker enforces it.
+    expect(application.modeId).toBeUndefined()
+    expect(application.state).toMatchObject({
+      selectedProfile: 'full',
+      effectiveProfile: 'full',
+      fullAccessAvailable: true
+    })
+  })
+
+  it('still rejects Full access when neither native bypass nor broker enforcement is available', () => {
+    expect(() =>
+      resolvePermissionProfileApplication('full', createModes(['build', 'plan']))
+    ).toThrow(PermissionProfileUnavailableError)
+  })
+
   it('keeps conservative Auto selected when the Agent reports default mode', () => {
     const state = resolvePermissionProfileApplication('auto', createModes(['default'])).state
 

--- a/src/main/acp/permission-profile-controller.ts
+++ b/src/main/acp/permission-profile-controller.ts
@@ -30,13 +30,22 @@ const availableModeIds = (modes: SessionModeState | null | undefined): string[] 
 
 // Maps stable application semantics onto the modes advertised by the active Agent. Auto has a
 // conservative application fallback; Full access is offered only when bypass is genuinely available.
+type ResolveOptions = {
+  // Frameworks with no native bypass mode (e.g. opencode) can still offer Full access when the app
+  // owns the permission decision: the agent is configured to delegate every prompt to the client and
+  // the broker auto-approves them. Set this so 'full' is offered and enforced app-side, not natively.
+  brokerEnforcesFullAccess?: boolean
+}
+
 const resolvePermissionProfileApplication = (
   profile: PermissionProfileId,
-  modes: SessionModeState | null | undefined
+  modes: SessionModeState | null | undefined,
+  options: ResolveOptions = {}
 ): PermissionProfileApplication => {
   const modeIds = availableModeIds(modes)
   const hasMode = (modeId: string): boolean => modeIds.includes(modeId)
-  const fullAccessAvailable = hasMode(FULL_ACCESS_MODE_ID)
+  const nativeBypass = hasMode(FULL_ACCESS_MODE_ID)
+  const fullAccessAvailable = nativeBypass || options.brokerEnforcesFullAccess === true
 
   if (profile === 'full' && !fullAccessAvailable) {
     throw new PermissionProfileUnavailableError(profile)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -10,7 +10,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from './runtime'
 import { AgentMcpHttpHost } from './mcp-http-host'
-import { opencodeFramework } from '../agent-framework'
+import { claudeCodeFramework, opencodeFramework } from '../agent-framework'
 import { ArtifactRepository } from '../artifacts/repository'
 import { UploadRepository } from '../uploads/repository'
 import {
@@ -1307,6 +1307,60 @@ describe('ACP runtime session management', () => {
         { sessionId: 'restarted-session', text: 'reply for adopted-session-1' }
       ])
     )
+  })
+
+  it('skips resume entirely for a session that last ran under a different framework', async () => {
+    // A session created under Claude, then continued after switching to opencode: resume can never
+    // succeed (each framework has its own session store), so the runtime must NOT send session/resume
+    // (which would make the agent log a scary internal error) and adopt a fresh session directly.
+    const claudeProcess = new FakeAgentProcess()
+    const claudeAgent = startFakeAgent(claudeProcess, ['claude-session-1'])
+    const opencodeProcess = new FakeAgentProcess()
+    const opencodeAgent = startFakeAgent(opencodeProcess, ['opencode-session-1'])
+
+    let connects = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      // First connect resolves Claude, the second (after the switch) resolves opencode; each framework
+      // spawns its own fake process so their session stores stay distinct.
+      resolveBackend: async () => {
+        connects += 1
+
+        return {
+          framework:
+            connects === 1
+              ? { ...claudeCodeFramework, spawn: () => asAgentProcess(claudeProcess) }
+              : { ...opencodeFramework, spawn: () => asAgentProcess(opencodeProcess) },
+          executablePath: '/bin/agent',
+          env: {},
+          args: []
+        }
+      }
+    })
+
+    const created = await runtime.createSession({ cwd: '/workspace' })
+    expect(created.sessionId).toBe('claude-session-1')
+
+    // Switching frameworks disconnects; the next connect resolves opencode.
+    await runtime.disconnect(false)
+
+    const resumed = await runtime.resumeSession({
+      sessionId: 'claude-session-1',
+      cwd: '/workspace'
+    })
+
+    // Adopted onto opencode under the same app id, with context reset so soft-replay can run.
+    expect(resumed).toEqual({
+      sessionId: 'claude-session-1',
+      cwd: '/workspace',
+      contextReset: true
+    })
+    // The doomed resume was never sent to opencode; it built a fresh session instead.
+    expect(opencodeAgent.resumedSessions).toEqual([])
+    expect(opencodeAgent.newSessions).toHaveLength(1)
+    // And the original Claude agent was never asked to resume either.
+    expect(claudeAgent.resumedSessions).toEqual([])
   })
 
   it('defers a provider reconnect until an in-flight prompt finishes', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1233,6 +1233,8 @@ describe('ACP runtime session management', () => {
       cwd: '/workspace'
     })
     expect(resumed.sessionId).toBe('switched-session')
+    // Signals the caller that agent-side context was lost so it can replay a transcript preamble.
+    expect(resumed.contextReset).toBe(true)
 
     await runtime.sendPrompt({ sessionId: 'switched-session', text: 'keep going' })
 
@@ -1243,6 +1245,37 @@ describe('ACP runtime session management', () => {
         { sessionId: 'switched-session', text: 'reply for adopted-session-1' }
       ])
     )
+  })
+
+  it('prepends a history preamble to the agent content but not the user-facing message', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['adopted-session-1'], { resumeNotFound: true })
+    const messageEvents: Array<{ role?: string; text?: string }> = []
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: {
+        onEvent: (event) => {
+          if (event.kind === 'message' && event.role === 'user') {
+            messageEvents.push({ role: event.role, text: event.text })
+          }
+        }
+      }
+    })
+
+    await runtime.resumeSession({ sessionId: 'switched-session', cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: 'switched-session',
+      text: 'keep going',
+      historyPreamble: 'PRIOR CONTEXT: the user asked to plot data.'
+    })
+
+    // The agent sees the replayed context ahead of the user's text...
+    expect(fakeAgent.prompts[0]?.text).toContain('PRIOR CONTEXT: the user asked to plot data.')
+    expect(fakeAgent.prompts[0]?.text).toContain('keep going')
+    // ...but the conversation bubble records only what the user actually typed.
+    expect(messageEvents).toEqual([{ role: 'user', text: 'keep going' }])
   })
 
   it('adopts a fresh session when the agent returns a generic Internal error on resume', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -9,6 +9,7 @@ import { PassThrough, Readable, Writable } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from './runtime'
+import { opencodeFramework } from '../agent-framework'
 import { ArtifactRepository } from '../artifacts/repository'
 import { UploadRepository } from '../uploads/repository'
 import {
@@ -655,6 +656,35 @@ describe('ACP runtime session management', () => {
       mimeType: 'application/octet-stream',
       uri: expect.stringContaining('data.bin')
     })
+  })
+
+  it('withholds stdio MCP servers and tool guidance for an http-only framework (opencode)', async () => {
+    const root = await createTemporaryRoot()
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['oc-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      // opencode advertises http/sse MCP only (acceptsStdioMcp: false) and carries no Claude _meta.
+      framework: opencodeFramework,
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js'
+      }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'hello opencode' })
+
+    // The stdio artifact server is withheld and no Claude _meta is sent; the artifact tool guidance is
+    // dropped so the agent is never told to use a tool it wasn't given.
+    expect(fakeAgent.newSessions[0].mcpServers).toEqual([])
+    expect(fakeAgent.newSessions[0]._meta).toBeUndefined()
+    expect(fakeAgent.prompts[0].text).toContain('hello opencode')
+    expect(fakeAgent.prompts[0].text).not.toContain('write_artifact_file')
   })
 
   it('allows prompts from different sessions to run concurrently', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -659,7 +659,7 @@ describe('ACP runtime session management', () => {
     })
   })
 
-  it('withholds stdio MCP servers and tool guidance for an http-only framework (opencode)', async () => {
+  it('gives opencode the stdio artifact MCP server + tool guidance (it accepts stdio like Claude)', async () => {
     const root = await createTemporaryRoot()
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['oc-session'])
@@ -667,7 +667,7 @@ describe('ACP runtime session management', () => {
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
-      // opencode advertises http/sse MCP only (acceptsStdioMcp: false) and carries no Claude _meta.
+      // opencode accepts stdio MCP over ACP (verified live), so it gets the same stdio config as Claude.
       framework: opencodeFramework,
       artifacts: {
         configRoot: root,
@@ -680,12 +680,15 @@ describe('ACP runtime session management', () => {
     const session = await runtime.createSession({ cwd: '/workspace' })
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'hello opencode' })
 
-    // The stdio artifact server is withheld and no Claude _meta is sent; the artifact tool guidance is
-    // dropped so the agent is never told to use a tool it wasn't given.
-    expect(fakeAgent.newSessions[0].mcpServers).toEqual([])
+    // The artifact server is delivered over stdio (command/args, not a url) and its tool guidance rides
+    // opencode's prompt prefix. No Claude _meta is sent (that stays framework-specific).
+    const servers = fakeAgent.newSessions[0].mcpServers as Array<{ command?: string; url?: string }>
+    expect(servers).toHaveLength(1)
+    expect(servers[0].command).toBeTruthy()
+    expect(servers[0].url).toBeUndefined()
     expect(fakeAgent.newSessions[0]._meta).toBeUndefined()
     expect(fakeAgent.prompts[0].text).toContain('hello opencode')
-    expect(fakeAgent.prompts[0].text).not.toContain('write_artifact_file')
+    expect(fakeAgent.prompts[0].text).toContain('write_artifact_file')
   })
 
   it('serves artifact/notebook MCP over the http host for an http-only framework', async () => {
@@ -697,7 +700,9 @@ describe('ACP runtime session management', () => {
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
-      framework: opencodeFramework,
+      // A synthetic http-only framework keeps the http-host path covered now that opencode uses stdio;
+      // the AgentMcpHttpHost stays in the runtime for any future framework that rejects stdio MCP.
+      framework: { ...opencodeFramework, acceptsStdioMcp: false },
       mcpHttpHost: httpHost,
       artifacts: {
         configRoot: root,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -9,6 +9,7 @@ import { PassThrough, Readable, Writable } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from './runtime'
+import { AgentMcpHttpHost } from './mcp-http-host'
 import { opencodeFramework } from '../agent-framework'
 import { ArtifactRepository } from '../artifacts/repository'
 import { UploadRepository } from '../uploads/repository'
@@ -685,6 +686,53 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.newSessions[0]._meta).toBeUndefined()
     expect(fakeAgent.prompts[0].text).toContain('hello opencode')
     expect(fakeAgent.prompts[0].text).not.toContain('write_artifact_file')
+  })
+
+  it('serves artifact/notebook MCP over the http host for an http-only framework', async () => {
+    const root = await createTemporaryRoot()
+    const httpHost = new AgentMcpHttpHost()
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['oc-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: opencodeFramework,
+      mcpHttpHost: httpHost,
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js'
+      },
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:1/notebook', token: 'nb' })
+      }
+    })
+
+    try {
+      await runtime.createSession({ cwd: '/workspace' })
+
+      const servers = fakeAgent.newSessions[0].mcpServers as Array<{
+        type?: string
+        name?: string
+        url?: string
+        headers?: Array<{ name: string; value: string }>
+      }>
+
+      // opencode gets http MCP configs (not stdio) pointing at the local host, with bearer auth.
+      expect(servers.map((server) => server.type)).toEqual(['http', 'http'])
+      expect(servers.map((server) => server.name)).toEqual(
+        expect.arrayContaining(['open-science-artifacts', 'open-science-notebook'])
+      )
+      const artifactServer = servers.find((server) => server.name === 'open-science-artifacts')
+      expect(artifactServer?.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp\/artifact\//)
+      expect(artifactServer?.headers?.[0]).toMatchObject({ name: 'authorization' })
+    } finally {
+      await httpHost.close()
+    }
   })
 
   it('allows prompts from different sessions to run concurrently', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -19,6 +19,17 @@ import {
   waitForDataRootWriters
 } from '../storage/migration-state'
 
+// Captures every info-level log so the permission-request audit line can be asserted; real file/console
+// logging is otherwise irrelevant to these tests.
+const { infoLogSpy } = vi.hoisted(() => ({ infoLogSpy: vi.fn() }))
+vi.mock('../logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logger')>()
+  return {
+    ...actual,
+    createLogger: (scope: string) => ({ ...actual.createLogger(scope), info: infoLogSpy })
+  }
+})
+
 // Minimal child-process stand-in that exposes the streams the runtime expects.
 class FakeAgentProcess extends EventEmitter {
   stdin = new PassThrough()
@@ -215,6 +226,79 @@ const getEnvValue = (mcpServer: unknown, name: string): string => {
   }
 
   return entry.value
+}
+
+// Starts a fake agent that fires one permission request per prompt so the runtime's audit line
+// (which carries isMcp) can be asserted black-box. `resume` selects the session/resume behavior:
+// 'ok' resolves resume (reattach), 'notFound' rejects with resourceNotFound so the runtime adopts a
+// fresh session under the same app id. session/new always returns `newSessionId`.
+const startPermissionProbeAgent = (
+  process: FakeAgentProcess,
+  options: {
+    newSessionId: string
+    toolCallId: string
+    toolTitle: string
+    resume?: 'ok' | 'notFound'
+  }
+): void => {
+  acp
+    .agent({ name: 'permission-probe-agent' })
+    .onRequest(acp.methods.agent.initialize, () => ({
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        sessionCapabilities: { close: {}, ...(options.resume ? { resume: {} } : {}) }
+      },
+      authMethods: []
+    }))
+    .onRequest(acp.methods.agent.session.new, () => ({ sessionId: options.newSessionId }))
+    .onRequest(acp.methods.agent.session.resume, (ctx) => {
+      if (options.resume === 'notFound') {
+        throw acp.RequestError.resourceNotFound(ctx.params.sessionId)
+      }
+
+      return {}
+    })
+    .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+      // opencode renames MCP tools <server>_<tool>; classification must come from the session's
+      // recorded MCP server names, so this exercises the sessionMcpServerNames map end to end.
+      await ctx.client.request(acp.methods.client.session.requestPermission, {
+        sessionId: ctx.params.sessionId,
+        toolCall: {
+          toolCallId: options.toolCallId,
+          title: options.toolTitle,
+          kind: 'other',
+          status: 'pending'
+        },
+        options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+      })
+
+      return { stopReason: 'end_turn' }
+    })
+    .onNotification(acp.methods.agent.session.cancel, () => undefined)
+    .onRequest(acp.methods.agent.session.close, () => ({}))
+    .connect(
+      acp.ndJsonStream(
+        Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+        Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+      )
+    )
+}
+
+// White-box view of the per-session MCP name map so cleanup paths (no black-box signal) can be
+// asserted directly.
+const mcpServerNamesMap = (runtime: AcpRuntime): Map<string, string[]> =>
+  (runtime as unknown as { sessionMcpServerNames: Map<string, string[]> }).sessionMcpServerNames
+
+// Finds the isMcp flag the runtime logged for a given permission request (identified by toolCallId).
+const auditedIsMcp = (toolCallId: string): boolean | undefined => {
+  const call = infoLogSpy.mock.calls.find(
+    ([message, data]) =>
+      message === 'permission request received' &&
+      (data as { toolCallId?: string }).toolCallId === toolCallId
+  )
+
+  return (call?.[1] as { isMcp?: boolean } | undefined)?.isMcp
 }
 
 afterEach(async () => {
@@ -1094,6 +1178,273 @@ describe('ACP runtime session management', () => {
     expect(emittedUnknownPermission).toBe(false)
     expect(permissionError).toBeDefined()
     expect(runtime.getSnapshot().pendingPermissions).toEqual([])
+  })
+
+  it('audits each permission request, classifying MCP origin without logging the tool title', async () => {
+    infoLogSpy.mockClear()
+    const process = new FakeAgentProcess()
+
+    acp
+      .agent({ name: 'permission-audit-agent' })
+      .onRequest(acp.methods.agent.initialize, () => ({
+        protocolVersion: acp.PROTOCOL_VERSION,
+        agentCapabilities: {
+          loadSession: false,
+          sessionCapabilities: {
+            close: {}
+          }
+        },
+        authMethods: []
+      }))
+      .onRequest(acp.methods.agent.session.new, () => ({ sessionId: 'remote-session-1' }))
+      .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+        // opencode renames the artifact MCP tool <server>_<tool>; classification must not rely on mcp__.
+        await ctx.client.request(acp.methods.client.session.requestPermission, {
+          sessionId: 'remote-session-1',
+          toolCall: {
+            toolCallId: 'tool-mcp',
+            title: 'open-science-artifacts_write_artifact_file',
+            kind: 'other',
+            status: 'pending'
+          },
+          options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+        })
+        // A WebFetch title is the full URL (user data) and must never reach the audit log.
+        await ctx.client.request(acp.methods.client.session.requestPermission, {
+          sessionId: 'remote-session-1',
+          toolCall: {
+            toolCallId: 'tool-fetch',
+            title: 'https://example.com/secret?token=abc123',
+            kind: 'fetch',
+            status: 'pending'
+          },
+          options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+        })
+
+        return { stopReason: 'end_turn' }
+      })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+
+    // Wire the artifact MCP server so the session records its name (open-science-artifacts); MCP
+    // classification is derived per session from the servers the agent was actually given.
+    const root = await createTemporaryRoot()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: new ArtifactRepository(root)
+      },
+      callbacks: {
+        onPermissionRequest: (request) => {
+          runtime.respondToPermission({ requestId: request.requestId, optionId: 'allow-once' })
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'trigger permission audit' })
+
+    const auditCalls = infoLogSpy.mock.calls.filter(
+      ([message]) => message === 'permission request received'
+    )
+    expect(auditCalls).toHaveLength(2)
+
+    const dataFor = (toolCallId: string): Record<string, unknown> =>
+      auditCalls.find(
+        ([, data]) => (data as { toolCallId?: string }).toolCallId === toolCallId
+      )?.[1] as Record<string, unknown>
+
+    // The opencode-named MCP tool is classified as MCP even though it lacks the mcp__ prefix.
+    expect(dataFor('tool-mcp').isMcp).toBe(true)
+    expect(dataFor('tool-fetch').isMcp).toBe(false)
+
+    // No audit payload may carry the raw tool title (MCP tool name or WebFetch URL are user/sensitive).
+    for (const [, data] of auditCalls) {
+      const serialized = JSON.stringify(data)
+      expect(serialized).not.toContain('example.com')
+      expect(serialized).not.toContain('write_artifact_file')
+    }
+  })
+
+  it('records MCP server names on resume so a resumed session audits its MCP tool calls as MCP', async () => {
+    infoLogSpy.mockClear()
+    const process = new FakeAgentProcess()
+    startPermissionProbeAgent(process, {
+      newSessionId: 'unused-new-session',
+      toolCallId: 'resumed-mcp',
+      toolTitle: 'open-science-artifacts_write_artifact_file',
+      resume: 'ok'
+    })
+    const root = await createTemporaryRoot()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: new ArtifactRepository(root)
+      },
+      callbacks: {
+        onPermissionRequest: (request) => {
+          runtime.respondToPermission({ requestId: request.requestId, optionId: 'allow-once' })
+        }
+      }
+    })
+
+    // Resume (not create) records the artifact MCP server name for this session, so a later MCP tool
+    // call is classified isMcp even though it lacks the mcp__ prefix.
+    await runtime.resumeSession({ sessionId: 'resumed-session', cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: 'resumed-session', text: 'continue resumed session' })
+
+    expect(auditedIsMcp('resumed-mcp')).toBe(true)
+    expect(mcpServerNamesMap(runtime).get('resumed-session')).toEqual(['open-science-artifacts'])
+  })
+
+  it('records MCP server names when adopting a fresh session after an unresumable resume', async () => {
+    infoLogSpy.mockClear()
+    const process = new FakeAgentProcess()
+    // Resume rejects with resourceNotFound, forcing the runtime to adopt a fresh agent session
+    // (adopted-session-1) under the app-facing id (switched-session).
+    startPermissionProbeAgent(process, {
+      newSessionId: 'adopted-session-1',
+      toolCallId: 'adopted-mcp',
+      toolTitle: 'open-science-artifacts_write_artifact_file',
+      resume: 'notFound'
+    })
+    const root = await createTemporaryRoot()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: new ArtifactRepository(root)
+      },
+      callbacks: {
+        onPermissionRequest: (request) => {
+          runtime.respondToPermission({ requestId: request.requestId, optionId: 'allow-once' })
+        }
+      }
+    })
+
+    const resumed = await runtime.resumeSession({
+      sessionId: 'switched-session',
+      cwd: '/workspace'
+    })
+    expect(resumed.contextReset).toBe(true)
+
+    await runtime.sendPrompt({ sessionId: 'switched-session', text: 'keep going' })
+
+    // The adopted session recorded its MCP names under the app-facing id, so the relabeled permission
+    // request audits as MCP.
+    expect(auditedIsMcp('adopted-mcp')).toBe(true)
+    expect(mcpServerNamesMap(runtime).get('switched-session')).toEqual(['open-science-artifacts'])
+  })
+
+  it('registers a reviewer session MCP names for auditing and clears them on dispose', async () => {
+    infoLogSpy.mockClear()
+    const process = new FakeAgentProcess()
+    startPermissionProbeAgent(process, {
+      newSessionId: 'reviewer-session-1',
+      toolCallId: 'reviewer-mcp',
+      toolTitle: 'open-science-reviewer_submit_findings'
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    // The reviewer session records its MCP server name so its (auto-approved) tool calls still audit
+    // with the correct isMcp classification.
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    expect(session.sessionId).toBe('reviewer-session-1')
+    expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(true)
+
+    // Drive a tool-call permission request through the reviewer session (auto-approved by the runtime).
+    await session.prompt([{ type: 'text', text: 'review this turn' }])
+
+    expect(auditedIsMcp('reviewer-mcp')).toBe(true)
+
+    // Disposing the reviewer session unregisters its MCP names.
+    runtime.disposeReviewerSession(session)
+    expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(false)
+  })
+
+  it('clears a session MCP server names when the session is deleted', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['remote-session-1'])
+    const root = await createTemporaryRoot()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: new ArtifactRepository(root)
+      }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    expect(mcpServerNamesMap(runtime).get(session.sessionId)).toEqual(['open-science-artifacts'])
+
+    await runtime.deleteSession({ sessionId: session.sessionId })
+
+    expect(mcpServerNamesMap(runtime).has(session.sessionId)).toBe(false)
+  })
+
+  it('clears all MCP server names on disconnect', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['remote-session-1'])
+    const root = await createTemporaryRoot()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: new ArtifactRepository(root)
+      }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    expect(mcpServerNamesMap(runtime).has(session.sessionId)).toBe(true)
+
+    await runtime.disconnect()
+
+    expect(mcpServerNamesMap(runtime).size).toBe(0)
   })
 
   it('removes a session so later prompts cannot target it', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2033,7 +2033,10 @@ class AcpRuntime {
         this.pushEvent({
           kind: 'system',
           level: 'warning',
-          title: 'claude-agent-acp',
+          // Attribute stderr to the in-flight turn so the renderer can show it in that session's
+          // waiting indicator (best-effort: currentSessionId is the active turn's session).
+          sessionId: this.currentSessionId,
+          title: 'agent',
           text
         })
       }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -948,6 +948,14 @@ class AcpRuntime {
     this.framework = backend.framework
     this.pendingSessionModel = backend.sessionModel
 
+    // Surfaces which backend + model this connect uses, so a fallback to the framework's own default
+    // model (e.g. opencode with no app model to inject) is diagnosable in the log rather than silent.
+    log.info('agent backend resolved', {
+      framework: backend.framework.id,
+      sessionModel: backend.sessionModel ?? '(framework default)',
+      args: backend.args ?? []
+    })
+
     return this.framework.spawn({
       executablePath: backend.executablePath,
       env: backend.env,

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1908,10 +1908,16 @@ class AcpRuntime {
     params: RequestPermissionRequest
   ): Promise<RequestPermissionResponse> {
     // Fork point: a WebFetch/server-side tool that never reaches this line means the "Internal error"
-    // originated elsewhere. Debug level keeps it out of normal runs. Log the tool identity (name/kind),
-    // never the title — a WebFetch title is the full URL with query params (user data).
-    log.debug('permission request received', {
-      tool: extractProviderToolName(params.toolCall) ?? params.toolCall?.kind,
+    // originated elsewhere. Info level so it's a visible audit line (one per prompt): if an MCP call
+    // runs without this appearing, the agent never asked (e.g. an un-gated permission config). Log the
+    // tool identity (name/kind) and whether it looks like MCP — never the title (a WebFetch title is the
+    // full URL with query params, i.e. user data).
+    const toolName = extractProviderToolName(params.toolCall)
+    const isMcp =
+      params.toolCall?.title?.startsWith('mcp__') === true || toolName?.startsWith('mcp__') === true
+    log.info('permission request received', {
+      tool: toolName ?? params.toolCall?.kind,
+      isMcp,
       toolCallId: params.toolCall?.toolCallId,
       sessionId: params.sessionId,
       optionCount: params.options?.length

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -37,8 +37,11 @@ import {
   type PermissionProfileId,
   type SessionPermissionProfileState
 } from '../../shared/permission-profiles'
-import type { SpawnClaudeAgentAcpOptions } from './agent-process'
-import { claudeCodeFramework, type AgentFramework } from '../agent-framework'
+import {
+  claudeCodeFramework,
+  type AgentFramework,
+  type ResolvedAgentBackend
+} from '../agent-framework'
 import { createLogger } from '../logger'
 import {
   extractProviderToolName,
@@ -75,9 +78,10 @@ type AcpRuntimeOptions = {
   defaultCwd: string
   callbacks?: AcpRuntimeCallbacks
   spawnAgent?: () => ChildProcessWithoutNullStreams
-  // Resolves the current active-provider spawn config at connect time so switching providers takes
-  // effect on reconnect. Ignored when an explicit spawnAgent is provided (tests inject that directly).
-  resolveSpawnConfig?: () => Promise<SpawnClaudeAgentAcpOptions> | SpawnClaudeAgentAcpOptions
+  // Resolves the active agent backend (framework + spawn inputs) at connect time so a framework or
+  // provider switch takes effect on reconnect. Ignored when an explicit spawnAgent is provided (tests
+  // inject that directly).
+  resolveBackend?: () => Promise<ResolvedAgentBackend> | ResolvedAgentBackend
   artifacts?: AcpRuntimeArtifactOptions
   uploads?: AcpRuntimeUploadOptions
   notebook?: AcpRuntimeNotebookOptions
@@ -241,7 +245,8 @@ class AcpRuntime {
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
   private readonly skillsHooks: AcpRuntimeSkillsOptions | undefined
-  private readonly framework: AgentFramework
+  // Mutable: refreshed from resolveBackend on each connect so a framework switch applies on reconnect.
+  private framework: AgentFramework
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
@@ -867,33 +872,26 @@ class AcpRuntime {
   }
 
   // Creates the agent process, preferring an injected spawner (tests) and otherwise resolving the
-  // current active-provider spawn config so each reconnect uses up-to-date credentials.
+  // active agent backend so each reconnect uses the current framework + up-to-date credentials.
   private async spawnAgentProcess(): Promise<ChildProcessWithoutNullStreams> {
     if (this.spawnAgent) {
       return this.spawnAgent()
     }
 
-    const config = this.options.resolveSpawnConfig
-      ? await this.options.resolveSpawnConfig()
-      : undefined
+    const backend = this.options.resolveBackend ? await this.options.resolveBackend() : undefined
 
-    if (!config) {
+    if (!backend) {
       throw new Error('ACP agent spawn configuration is not available.')
     }
 
-    if (!config.executablePath) {
-      throw new Error(
-        'Claude executable path is not configured. Complete Claude detection in settings first.'
-      )
-    }
+    // Adopt the framework this reconnect resolved so session meta, permission mapping, and the spawn
+    // itself all agree with the current selection.
+    this.framework = backend.framework
 
-    // The framework owns the actual spawn; the resolved provider env/executable pass through unchanged.
-    // TODO(spike): route provider→model config through framework.prepareModelConfig once opencode
-    // detection + a framework-aware resolveSpawnConfig land (envOverrides is resolved upstream today).
     return this.framework.spawn({
-      executablePath: config.executablePath,
-      env: config.envOverrides ?? {},
-      args: []
+      executablePath: backend.executablePath,
+      env: backend.env,
+      args: backend.args ?? []
     })
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -268,6 +268,9 @@ class AcpRuntime {
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly uploadRepository: UploadRepository | undefined
   private readonly artifactSessionIds = new Map<string, string>()
+  // app session id -> the notebook routing id registered with the http MCP host, so it can be
+  // unregistered on session delete (the artifact routing id is tracked in artifactSessionIds).
+  private readonly notebookRoutingIds = new Map<string, string>()
   private artifactSessionSequence = 0
   private artifactRunSequence = 0
   private notebookSessionSequence = 0
@@ -842,6 +845,8 @@ class AcpRuntime {
     this.sessionProjectNames.clear()
     this.permissionProfiles.clear()
     this.artifactSessionIds.clear()
+    this.notebookRoutingIds.clear()
+    this.mcpHttpHost?.clear()
     this.agentToAppSessionId.clear()
     this.currentSessionId = undefined
     this.supportsSessionClose = false
@@ -1116,11 +1121,14 @@ class AcpRuntime {
 
       session.dispose()
       this.permissionBroker.cancelForSession(request.sessionId)
+      // Drop this session's http MCP host registrations (no-op when no host / stdio framework).
+      this.unregisterHttpMcpSession(request.sessionId)
       this.sessions.delete(request.sessionId)
       this.sessionCwds.delete(request.sessionId)
       this.sessionProjectNames.delete(request.sessionId)
       this.permissionProfiles.delete(request.sessionId)
       this.artifactSessionIds.delete(request.sessionId)
+      this.notebookRoutingIds.delete(request.sessionId)
       this.promptInFlightSessionIds.delete(request.sessionId)
       this.currentSessionId =
         this.currentSessionId === request.sessionId
@@ -1469,7 +1477,12 @@ class AcpRuntime {
 
   // Lets the local notebook RPC layer map pre-start aliases to the final ACP session id.
   private rememberNotebookSession(sessionId: string, notebookSessionId: string): void {
-    if (!this.notebookOptions || !notebookSessionId || notebookSessionId === sessionId) return
+    if (!this.notebookOptions || !notebookSessionId) return
+
+    // Record the routing id the http MCP host was registered under, for later unregister.
+    this.notebookRoutingIds.set(sessionId, notebookSessionId)
+
+    if (notebookSessionId === sessionId) return
 
     this.notebookOptions.registerSessionAlias?.(notebookSessionId, sessionId)
   }
@@ -1572,6 +1585,17 @@ class AcpRuntime {
     })
 
     return servers
+  }
+
+  // Drops one session's artifact/notebook registrations from the http MCP host (no-op without a host).
+  private unregisterHttpMcpSession(appSessionId: string): void {
+    if (!this.mcpHttpHost) return
+
+    const artifactRoutingId = this.artifactSessionIds.get(appSessionId)
+    if (artifactRoutingId) this.mcpHttpHost.unregister(artifactRoutingId)
+
+    const notebookRoutingId = this.notebookRoutingIds.get(appSessionId)
+    if (notebookRoutingId) this.mcpHttpHost.unregister(notebookRoutingId)
   }
 
   // Serves the artifact/notebook MCP over the local http host for frameworks that reject stdio MCP.
@@ -1962,6 +1986,8 @@ class AcpRuntime {
     this.sessionCwds.clear()
     this.sessionProjectNames.clear()
     this.artifactSessionIds.clear()
+    this.notebookRoutingIds.clear()
+    this.mcpHttpHost?.clear()
     this.agentToAppSessionId.clear()
     this.currentSessionId = undefined
     this.supportsSessionClose = false

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2037,12 +2037,14 @@ class AcpRuntime {
       }
 
       if (text) {
+        // Attribute stderr to a session only when exactly one prompt is in flight — then it's
+        // unambiguously that turn's. With zero or multiple concurrent prompts, omit the sessionId
+        // rather than risk pinning it to the wrong conversation's waiting indicator.
+        const inFlight = Array.from(this.promptInFlightSessionIds)
         this.pushEvent({
           kind: 'system',
           level: 'warning',
-          // Attribute stderr to the in-flight turn so the renderer can show it in that session's
-          // waiting indicator (best-effort: currentSessionId is the active turn's session).
-          sessionId: this.currentSessionId,
+          sessionId: inFlight.length === 1 ? inFlight[0] : undefined,
           title: 'agent',
           text
         })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -37,7 +37,8 @@ import {
   type PermissionProfileId,
   type SessionPermissionProfileState
 } from '../../shared/permission-profiles'
-import { spawnClaudeAgentAcp, type SpawnClaudeAgentAcpOptions } from './agent-process'
+import type { SpawnClaudeAgentAcpOptions } from './agent-process'
+import { claudeCodeFramework, type AgentFramework } from '../agent-framework'
 import { createLogger } from '../logger'
 import {
   extractProviderToolName,
@@ -46,10 +47,7 @@ import {
 } from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { AcpPermissionBroker } from './permission-broker'
-import {
-  applyCurrentModeUpdate,
-  resolvePermissionProfileApplication
-} from './permission-profile-controller'
+import { applyCurrentModeUpdate } from './permission-profile-controller'
 import { createArtifactMcpServerConfig } from '../artifacts/mcp-server'
 import { ArtifactRepository, getArtifactCurrentRunFilePath } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
@@ -84,6 +82,9 @@ type AcpRuntimeOptions = {
   uploads?: AcpRuntimeUploadOptions
   notebook?: AcpRuntimeNotebookOptions
   skills?: AcpRuntimeSkillsOptions
+  // The agent backend to drive. Defaults to Claude Code; selecting another (opencode) swaps only the
+  // framework-coupled behavior (spawn, session meta, permission-mode mapping) via AgentFramework.
+  framework?: AgentFramework
   // Bounds the network-bound reconnect+resume so Resume always resolves; the fast attached-session
   // path is never timed. Injectable timer mirrors the approval broker so tests stay deterministic.
   resumeTimeoutMs?: number
@@ -240,6 +241,7 @@ class AcpRuntime {
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
   private readonly skillsHooks: AcpRuntimeSkillsOptions | undefined
+  private readonly framework: AgentFramework
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
@@ -263,6 +265,7 @@ class AcpRuntime {
     this.callbacks = options.callbacks ?? {}
     this.spawnAgent = options.spawnAgent
     this.skillsHooks = options.skills
+    this.framework = options.framework ?? claudeCodeFramework
     this.resumeTimeoutMs = options.resumeTimeoutMs ?? 30_000
     this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
     this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
@@ -332,7 +335,7 @@ class AcpRuntime {
     session: ActiveSession,
     profile: PermissionProfileId
   ): Promise<void> {
-    const application = resolvePermissionProfileApplication(profile, session.modes)
+    const application = this.framework.mapPermissionProfile(profile, session.modes)
 
     if (application.modeId && application.modeId !== session.modes?.currentModeId) {
       if (!this.connection) throw new Error('ACP connection is not available.')
@@ -490,7 +493,7 @@ class AcpRuntime {
           sessionCwd,
           projectName
         }),
-        ...this.createSessionMeta()
+        ...this.buildSessionMetaArg()
       })
       .start()
 
@@ -637,7 +640,7 @@ class AcpRuntime {
           sessionCwd,
           projectName
         }),
-        ...this.createSessionMeta()
+        ...this.buildSessionMetaArg()
       })
     } catch (error) {
       if (!isUnresumableSessionError(error)) throw error
@@ -661,7 +664,7 @@ class AcpRuntime {
             sessionCwd,
             projectName
           }),
-          ...this.createSessionMeta()
+          ...this.buildSessionMetaArg()
         })
         .start()
 
@@ -878,7 +881,20 @@ class AcpRuntime {
       throw new Error('ACP agent spawn configuration is not available.')
     }
 
-    return spawnClaudeAgentAcp(config)
+    if (!config.executablePath) {
+      throw new Error(
+        'Claude executable path is not configured. Complete Claude detection in settings first.'
+      )
+    }
+
+    // The framework owns the actual spawn; the resolved provider env/executable pass through unchanged.
+    // TODO(spike): route provider→model config through framework.prepareModelConfig once opencode
+    // detection + a framework-aware resolveSpawnConfig land (envOverrides is resolved upstream today).
+    return this.framework.spawn({
+      executablePath: config.executablePath,
+      env: config.envOverrides ?? {},
+      args: []
+    })
   }
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
@@ -950,7 +966,14 @@ class AcpRuntime {
         : undefined
       // Prepend a short steering nudge naming the picked skills. It goes only into the content sent to
       // the agent; the user-facing message event keeps the original text (which already shows /Name).
-      const promptText = await this.applySkillNudge(request.text, forced)
+      // Framework-neutral delivery of the system-prompt guidance: Claude carries it in session _meta so
+      // the prefix is empty and the prompt is unchanged; opencode has no preset, so its guidance rides as
+      // a prompt prefix here, ahead of the skill nudge and the user's text.
+      const { promptPrefix } = this.framework.buildSessionSetup({
+        systemPromptAppends: this.getSystemPromptAppends()
+      })
+      const nudgedText = await this.applySkillNudge(request.text, forced)
+      const promptText = promptPrefix ? `${promptPrefix}\n\n${nudgedText}` : nudgedText
       const promptContent = await this.createPromptContent(request.sessionId, {
         ...request,
         text: promptText
@@ -1491,33 +1514,29 @@ class AcpRuntime {
     return servers
   }
 
-  // Builds Claude-specific session metadata: system-prompt guidance for artifact/notebook tooling, plus
-  // a settingSources restriction to the "user" scope (our app-owned CLAUDE_CONFIG_DIR). This is required:
-  // the "project"/"local" scopes are read from the workspace cwd's `.claude`, and when the cwd is under
-  // the home tree that resolves to the user's own ~/.claude — whose `env` block (e.g. a proxy
-  // ANTHROPIC_BASE_URL) would otherwise override the active provider's endpoint. Restricting to "user"
-  // loads only the clean app dir's settings + the app's own skills/plugins/commands.
-  private createSessionMeta(): { _meta: Record<string, unknown> } {
-    const appendSections = [
-      // The skill-privacy guardrail always applies — skills are materialized whenever the app runs.
+  // Collects the system-prompt guidance appended to every session: the skill-privacy guardrail (always
+  // — skills are materialized whenever the app runs), plus artifact/notebook tooling instructions when
+  // those services are wired. The active framework decides how these are delivered (Claude's preset
+  // append vs opencode's prompt prefix).
+  private getSystemPromptAppends(): string[] {
+    return [
       SKILLS_READ_GUARD_SYSTEM_PROMPT_APPEND,
       ...(this.artifactOptions ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
       ...(this.notebookOptions ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : [])
     ]
+  }
 
-    const meta: Record<string, unknown> = {
-      claudeCode: { options: { settingSources: ['user'] } }
-    }
+  // Builds the ACP `_meta` argument for session/new and session/resume, delegating the framework-specific
+  // shape to the active framework. For Claude this is the claudeCode.settingSources restriction (pins the
+  // app-owned config dir so a workspace ~/.claude env block can't override the active provider endpoint)
+  // plus the system-prompt preset carrying the appends; opencode returns no meta and delivers the appends
+  // as a prompt prefix instead.
+  private buildSessionMetaArg(): { _meta?: Record<string, unknown> } {
+    const setup = this.framework.buildSessionSetup({
+      systemPromptAppends: this.getSystemPromptAppends()
+    })
 
-    if (appendSections.length > 0) {
-      meta.systemPrompt = {
-        type: 'preset',
-        preset: 'claude_code',
-        append: appendSections.join('\n\n')
-      }
-    }
-
-    return { _meta: meta }
+    return setup.meta ? { _meta: setup.meta } : {}
   }
 
   // Resolves the artifact/notebook storage project for a session, defaulting to the runtime constant.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -51,12 +51,19 @@ import {
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { AcpPermissionBroker } from './permission-broker'
 import { applyCurrentModeUpdate } from './permission-profile-controller'
-import { createArtifactMcpServerConfig } from '../artifacts/mcp-server'
+import {
+  ARTIFACT_MCP_SERVER_NAME,
+  createArtifactMcpServerConfig,
+  type ArtifactMcpEnvironment
+} from '../artifacts/mcp-server'
+import { AgentMcpHttpHost } from './mcp-http-host'
 import { ArtifactRepository, getArtifactCurrentRunFilePath } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
 import {
+  NOTEBOOK_MCP_SERVER_NAME,
   NOTEBOOK_SYSTEM_PROMPT_APPEND,
   createNotebookMcpServerConfig,
+  type NotebookMcpEnvironment,
   type NotebookRpcConnection
 } from '../notebook/mcp-server'
 import { getNotebookSessionRoot } from '../notebook/repository'
@@ -89,6 +96,9 @@ type AcpRuntimeOptions = {
   // The agent backend to drive. Defaults to Claude Code; selecting another (opencode) swaps only the
   // framework-coupled behavior (spawn, session meta, permission-mode mapping) via AgentFramework.
   framework?: AgentFramework
+  // Local http host for the artifact/notebook MCP servers, used for frameworks that reject stdio MCP
+  // (opencode). Absent ⇒ those frameworks run without artifact/notebook tooling.
+  mcpHttpHost?: AgentMcpHttpHost
   // Bounds the network-bound reconnect+resume so Resume always resolves; the fast attached-session
   // path is never timed. Injectable timer mirrors the approval broker so tests stay deterministic.
   resumeTimeoutMs?: number
@@ -247,6 +257,7 @@ class AcpRuntime {
   private readonly skillsHooks: AcpRuntimeSkillsOptions | undefined
   // Mutable: refreshed from resolveBackend on each connect so a framework switch applies on reconnect.
   private framework: AgentFramework
+  private readonly mcpHttpHost: AgentMcpHttpHost | undefined
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
@@ -271,6 +282,7 @@ class AcpRuntime {
     this.spawnAgent = options.spawnAgent
     this.skillsHooks = options.skills
     this.framework = options.framework ?? claudeCodeFramework
+    this.mcpHttpHost = options.mcpHttpHost
     this.resumeTimeoutMs = options.resumeTimeoutMs ?? 30_000
     this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
     this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
@@ -1396,14 +1408,14 @@ class AcpRuntime {
     this.artifactSessionIds.set(sessionId, artifactSessionId)
   }
 
-  // Provides the agent with exactly one artifact MCP server scoped to this session's storage context.
-  private createArtifactMcpServers(
+  // Builds the artifact MCP environment for one session, shared by the stdio config and the http host.
+  private buildArtifactEnvironment(
     artifactSessionId: string,
     notebookSessionId: string,
     sessionCwd: string,
     projectName: string
-  ): McpServer[] {
-    if (!this.artifactOptions || !artifactSessionId) return []
+  ): ArtifactMcpEnvironment | undefined {
+    if (!this.artifactOptions || !artifactSessionId) return undefined
 
     const allowedImportRoots = [
       sessionCwd,
@@ -1412,15 +1424,36 @@ class AcpRuntime {
         : [])
     ]
 
+    return {
+      storageRoot: this.artifactOptions.dataRoot,
+      projectName,
+      sessionId: artifactSessionId,
+      currentRunFile: this.getArtifactCurrentRunFile(artifactSessionId, projectName),
+      allowedImportRoots
+    }
+  }
+
+  // Provides the agent with exactly one artifact MCP server scoped to this session's storage context.
+  private createArtifactMcpServers(
+    artifactSessionId: string,
+    notebookSessionId: string,
+    sessionCwd: string,
+    projectName: string
+  ): McpServer[] {
+    const environment = this.buildArtifactEnvironment(
+      artifactSessionId,
+      notebookSessionId,
+      sessionCwd,
+      projectName
+    )
+
+    if (!environment || !this.artifactOptions) return []
+
     return [
       createArtifactMcpServerConfig({
         command: this.artifactOptions.mcpCommand ?? process.execPath,
         entryPath: this.artifactOptions.mcpEntryPath,
-        storageRoot: this.artifactOptions.dataRoot,
-        projectName,
-        sessionId: artifactSessionId,
-        currentRunFile: this.getArtifactCurrentRunFile(artifactSessionId, projectName),
-        allowedImportRoots
+        ...environment
       })
     ]
   }
@@ -1441,25 +1474,44 @@ class AcpRuntime {
     this.notebookOptions.registerSessionAlias?.(notebookSessionId, sessionId)
   }
 
+  // Builds the notebook MCP environment for one session, shared by the stdio config and the http host.
+  private async buildNotebookEnvironment(
+    notebookSessionId: string,
+    sessionCwd: string,
+    projectName: string
+  ): Promise<NotebookMcpEnvironment | undefined> {
+    if (!this.notebookOptions || !notebookSessionId) return undefined
+
+    const connection = await this.resolveNotebookRpcConnection()
+
+    return {
+      endpoint: connection.endpoint,
+      token: connection.token,
+      projectName,
+      sessionId: notebookSessionId,
+      workspaceCwd: sessionCwd
+    }
+  }
+
   // Provides the agent with a notebook MCP server scoped to this session's runtime route.
   private async createNotebookMcpServers(
     notebookSessionId: string,
     sessionCwd: string,
     projectName: string
   ): Promise<McpServer[]> {
-    if (!this.notebookOptions || !notebookSessionId) return []
+    const environment = await this.buildNotebookEnvironment(
+      notebookSessionId,
+      sessionCwd,
+      projectName
+    )
 
-    const connection = await this.resolveNotebookRpcConnection()
+    if (!environment || !this.notebookOptions) return []
 
     return [
       createNotebookMcpServerConfig({
         command: this.notebookOptions.mcpCommand ?? process.execPath,
         entryPath: this.notebookOptions.mcpEntryPath,
-        endpoint: connection.endpoint,
-        token: connection.token,
-        projectName,
-        sessionId: notebookSessionId,
-        workspaceCwd: sessionCwd
+        ...environment
       })
     ]
   }
@@ -1489,32 +1541,86 @@ class AcpRuntime {
     sessionCwd: string
     projectName: string
   }): Promise<McpServer[]> {
-    // The artifact/notebook servers are stdio; a framework that only accepts http/sse MCP (opencode)
-    // gets none until they're exposed over http, so a basic turn still runs instead of failing on an
-    // unsupported stdio server config.
-    if (!this.framework.acceptsStdioMcp) {
-      return []
-    }
+    // The artifact/notebook servers are stdio. A framework that only accepts http/sse MCP (opencode)
+    // gets them over the http host when one is wired; without a host it gets none so a basic turn still
+    // runs instead of failing on an unsupported stdio server config.
+    const servers = this.framework.acceptsStdioMcp
+      ? [
+          ...this.createArtifactMcpServers(
+            artifactSessionId,
+            notebookSessionId,
+            sessionCwd,
+            projectName
+          ),
+          ...(await this.createNotebookMcpServers(notebookSessionId, sessionCwd, projectName))
+        ]
+      : await this.createHttpMcpServers(
+          artifactSessionId,
+          notebookSessionId,
+          sessionCwd,
+          projectName
+        )
 
-    const servers = [
-      ...this.createArtifactMcpServers(
-        artifactSessionId,
-        notebookSessionId,
-        sessionCwd,
-        projectName
-      ),
-      ...(await this.createNotebookMcpServers(notebookSessionId, sessionCwd, projectName))
-    ]
-
-    // Log the MCP server launch specs (command + args, no secrets) — a bad command/entry path in a
-    // packaged build can make the agent stall while it waits on an MCP server that never starts.
+    // Log the MCP server launch specs (command/url, no secrets) — a bad command/entry path or an
+    // unstarted host can make the agent stall while it waits on an MCP server that never responds.
     log.info('session MCP servers', {
       count: servers.length,
       servers: servers.map((server) => {
-        const record = server as { name?: string; command?: string; args?: unknown }
-        return { name: record.name, command: record.command, args: record.args }
+        const record = server as { name?: string; command?: string; url?: string; args?: unknown }
+        return { name: record.name, command: record.command, url: record.url, args: record.args }
       })
     })
+
+    return servers
+  }
+
+  // Serves the artifact/notebook MCP over the local http host for frameworks that reject stdio MCP.
+  // Registers each session's environment under its app-owned id and returns http McpServer configs
+  // pointing at the host, authenticated with the host token. No host wired ⇒ no servers (basic turn).
+  private async createHttpMcpServers(
+    artifactSessionId: string,
+    notebookSessionId: string,
+    sessionCwd: string,
+    projectName: string
+  ): Promise<McpServer[]> {
+    if (!this.mcpHttpHost) return []
+
+    const { token } = await this.mcpHttpHost.ensureStarted()
+    const authHeader = { name: 'authorization', value: `Bearer ${token}` }
+    const servers: McpServer[] = []
+
+    const artifactEnvironment = this.buildArtifactEnvironment(
+      artifactSessionId,
+      notebookSessionId,
+      sessionCwd,
+      projectName
+    )
+
+    if (artifactEnvironment) {
+      this.mcpHttpHost.registerArtifact(artifactSessionId, artifactEnvironment)
+      servers.push({
+        type: 'http',
+        name: ARTIFACT_MCP_SERVER_NAME,
+        url: this.mcpHttpHost.urlFor('artifact', artifactSessionId),
+        headers: [authHeader]
+      })
+    }
+
+    const notebookEnvironment = await this.buildNotebookEnvironment(
+      notebookSessionId,
+      sessionCwd,
+      projectName
+    )
+
+    if (notebookEnvironment) {
+      this.mcpHttpHost.registerNotebook(notebookSessionId, notebookEnvironment)
+      servers.push({
+        type: 'http',
+        name: NOTEBOOK_MCP_SERVER_NAME,
+        url: this.mcpHttpHost.urlFor('notebook', notebookSessionId),
+        headers: [authHeader]
+      })
+    }
 
     return servers
   }
@@ -1523,10 +1629,17 @@ class AcpRuntime {
   // — skills are materialized whenever the app runs), plus artifact/notebook tooling instructions when
   // those services are wired. The active framework decides how these are delivered (Claude's preset
   // append vs opencode's prompt prefix).
+  // Whether artifact/notebook MCP tooling reaches the agent this run: either the framework takes stdio
+  // MCP directly (Claude) or an http host is wired to serve it (opencode). Drives both the MCP configs
+  // and whether their system-prompt guidance is sent.
+  private mcpToolingAvailable(): boolean {
+    return this.framework.acceptsStdioMcp || Boolean(this.mcpHttpHost)
+  }
+
   private getSystemPromptAppends(): string[] {
-    // Artifact/notebook guidance names MCP tools that only exist when the framework accepts stdio MCP;
-    // omit it otherwise so the agent isn't told to use tools it wasn't given (see createMcpServers).
-    const toolsAvailable = this.framework.acceptsStdioMcp
+    // Artifact/notebook guidance names MCP tools that only exist when that tooling is actually wired for
+    // this framework; omit it otherwise so the agent isn't told to use tools it wasn't given.
+    const toolsAvailable = this.mcpToolingAvailable()
 
     return [
       SKILLS_READ_GUARD_SYSTEM_PROMPT_APPEND,

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -52,6 +52,7 @@ import {
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { matchSessionModelOption } from './session-config'
 import { AcpPermissionBroker } from './permission-broker'
+import { isMcpToolName } from './permission-policy'
 import { applyCurrentModeUpdate } from './permission-profile-controller'
 import {
   ARTIFACT_MCP_SERVER_NAME,
@@ -238,6 +239,11 @@ class AcpRuntime {
   private supportsSessionResume = false
   private readonly sessions = new Map<string, ActiveSession>()
   private readonly sessionCwds = new Map<string, string>()
+  // Per-session names of the MCP servers the agent was actually given (from createMcpServers), so
+  // MCP-originated tool calls can be recognized across frameworks (Claude's mcp__<server>__<tool> vs
+  // opencode's <server>_<tool>) and never conservatively auto-approved. Derived per session rather
+  // than hardcoded so it can't drift from what createMcpServers wires up.
+  private readonly sessionMcpServerNames = new Map<string, string[]>()
   // Ephemeral background reviewer sessions (built via buildReviewerSession). They are deliberately kept
   // out of `this.sessions` — not tracked in the snapshot, not user-facing — but their tool calls still
   // trigger permission requests over the shared agent connection. This set lets the permission handler
@@ -546,15 +552,16 @@ class AcpRuntime {
     const artifactSessionId = this.createArtifactSessionId()
     const notebookSessionId = this.createNotebookSessionId()
 
+    const mcpServers = await this.createMcpServers({
+      artifactSessionId,
+      notebookSessionId,
+      sessionCwd,
+      projectName
+    })
     const session = await connection.agent
       .buildSession({
         cwd: sessionCwd,
-        mcpServers: await this.createMcpServers({
-          artifactSessionId,
-          notebookSessionId,
-          sessionCwd,
-          projectName
-        }),
+        mcpServers,
         ...this.buildSessionMetaArg()
       })
       .start()
@@ -574,6 +581,7 @@ class AcpRuntime {
 
     this.sessions.set(session.sessionId, session)
     this.sessionCwds.set(session.sessionId, sessionCwd)
+    this.sessionMcpServerNames.set(session.sessionId, this.mcpServerNamesOf(mcpServers))
     this.sessionProjectNames.set(session.sessionId, projectName)
     this.sessionFrameworks.set(session.sessionId, this.framework.id)
     this.rememberArtifactSession(session.sessionId, artifactSessionId)
@@ -599,7 +607,8 @@ class AcpRuntime {
     appSessionId: string,
     session: ActiveSession,
     cwd: string,
-    projectName: string
+    projectName: string,
+    mcpServerNames: string[]
   ): void {
     this.sessions.set(appSessionId, session)
 
@@ -608,6 +617,7 @@ class AcpRuntime {
     }
 
     this.sessionCwds.set(appSessionId, cwd)
+    this.sessionMcpServerNames.set(appSessionId, mcpServerNames)
     this.sessionProjectNames.set(appSessionId, projectName)
     this.sessionFrameworks.set(appSessionId, this.framework.id)
     this.rememberArtifactSession(appSessionId, appSessionId)
@@ -711,17 +721,18 @@ class AcpRuntime {
     }
 
     // Resumed sessions already have stable ids, so the artifact session mirrors the runtime session id.
+    const mcpServers = await this.createMcpServers({
+      artifactSessionId: request.sessionId,
+      notebookSessionId: request.sessionId,
+      sessionCwd,
+      projectName
+    })
     let resumeResponse
     try {
       resumeResponse = await connection.agent.request(acp.methods.agent.session.resume, {
         sessionId: request.sessionId,
         cwd: sessionCwd,
-        mcpServers: await this.createMcpServers({
-          artifactSessionId: request.sessionId,
-          notebookSessionId: request.sessionId,
-          sessionCwd,
-          projectName
-        }),
+        mcpServers,
         ...this.buildSessionMetaArg()
       })
     } catch (error) {
@@ -759,6 +770,7 @@ class AcpRuntime {
 
     this.sessions.set(request.sessionId, session)
     this.sessionCwds.set(request.sessionId, sessionCwd)
+    this.sessionMcpServerNames.set(request.sessionId, this.mcpServerNamesOf(mcpServers))
     this.sessionProjectNames.set(request.sessionId, projectName)
     this.sessionFrameworks.set(request.sessionId, this.framework.id)
     this.rememberArtifactSession(request.sessionId, request.sessionId)
@@ -786,15 +798,16 @@ class AcpRuntime {
     sessionCwd: string,
     projectName: string
   ): Promise<AcpCreateSessionResponse> {
+    const mcpServers = await this.createMcpServers({
+      artifactSessionId: request.sessionId,
+      notebookSessionId: request.sessionId,
+      sessionCwd,
+      projectName
+    })
     const adopted = await connection.agent
       .buildSession({
         cwd: sessionCwd,
-        mcpServers: await this.createMcpServers({
-          artifactSessionId: request.sessionId,
-          notebookSessionId: request.sessionId,
-          sessionCwd,
-          projectName
-        }),
+        mcpServers,
         ...this.buildSessionMetaArg()
       })
       .start()
@@ -811,7 +824,13 @@ class AcpRuntime {
     }
 
     await this.applySessionModel(adopted)
-    this.adoptSession(request.sessionId, adopted, sessionCwd, projectName)
+    this.adoptSession(
+      request.sessionId,
+      adopted,
+      sessionCwd,
+      projectName,
+      this.mcpServerNamesOf(mcpServers)
+    )
     this.emitState()
 
     return { sessionId: request.sessionId, cwd: sessionCwd, contextReset: true }
@@ -919,6 +938,7 @@ class AcpRuntime {
 
     this.sessions.clear()
     this.sessionCwds.clear()
+    this.sessionMcpServerNames.clear()
     this.sessionProjectNames.clear()
     this.permissionProfiles.clear()
     this.artifactSessionIds.clear()
@@ -1216,6 +1236,7 @@ class AcpRuntime {
       this.unregisterHttpMcpSession(request.sessionId)
       this.sessions.delete(request.sessionId)
       this.sessionCwds.delete(request.sessionId)
+      this.sessionMcpServerNames.delete(request.sessionId)
       this.sessionProjectNames.delete(request.sessionId)
       this.sessionFrameworks.delete(request.sessionId)
       this.permissionProfiles.delete(request.sessionId)
@@ -1685,6 +1706,14 @@ class AcpRuntime {
     return servers
   }
 
+  // Extracts the names of the MCP servers handed to a session so MCP-origin tool calls can be
+  // recognized later (see sessionMcpServerNames). Both stdio and http McpServer configs carry a name.
+  private mcpServerNamesOf(servers: McpServer[]): string[] {
+    return servers
+      .map((server) => (server as { name?: unknown }).name)
+      .filter((name): name is string => typeof name === 'string')
+  }
+
   // Drops one session's artifact/notebook registrations from the http MCP host (no-op without a host).
   private unregisterHttpMcpSession(appSessionId: string): void {
     if (!this.mcpHttpHost) return
@@ -1912,9 +1941,12 @@ class AcpRuntime {
     // runs without this appearing, the agent never asked (e.g. an un-gated permission config). Log the
     // tool identity (name/kind) and whether it looks like MCP — never the title (a WebFetch title is the
     // full URL with query params, i.e. user data).
+    const appSessionId = this.agentToAppSessionId.get(params.sessionId) ?? params.sessionId
+    const mcpServerNames = this.sessionMcpServerNames.get(appSessionId) ?? []
     const toolName = extractProviderToolName(params.toolCall)
     const isMcp =
-      params.toolCall?.title?.startsWith('mcp__') === true || toolName?.startsWith('mcp__') === true
+      isMcpToolName(params.toolCall?.title, mcpServerNames) ||
+      isMcpToolName(toolName, mcpServerNames)
     log.info('permission request received', {
       tool: toolName ?? params.toolCall?.kind,
       isMcp,
@@ -1931,8 +1963,6 @@ class AcpRuntime {
         return this.autoApproveReviewerPermission(params)
       }
 
-      const appSessionId = this.agentToAppSessionId.get(params.sessionId) ?? params.sessionId
-
       if (!this.sessions.has(appSessionId)) {
         throw new Error(`Unknown ACP session: ${appSessionId}`)
       }
@@ -1944,7 +1974,8 @@ class AcpRuntime {
         {
           profile: profileState?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE,
           autoReviewStrategy: profileState?.autoReviewStrategy,
-          cwd: this.sessionCwds.get(appSessionId)
+          cwd: this.sessionCwds.get(appSessionId),
+          mcpServerNames
         }
       )
     } catch (error) {
@@ -2093,6 +2124,7 @@ class AcpRuntime {
     this.permissionBroker.cancelAll()
     this.sessions.clear()
     this.sessionCwds.clear()
+    this.sessionMcpServerNames.clear()
     this.sessionProjectNames.clear()
     this.artifactSessionIds.clear()
     this.notebookRoutingIds.clear()
@@ -2186,6 +2218,9 @@ class AcpRuntime {
     // Register so the permission handler recognises this session and auto-approves its tool calls.
     // The orchestrator must call disposeReviewerSession() to unregister and tear it down.
     this.reviewerSessionIds.add(session.sessionId)
+    // Record the reviewer's MCP server names too, so its MCP tool calls are audited as MCP (they are
+    // still auto-approved via reviewerSessionIds, but the isMcp classification must stay accurate).
+    this.sessionMcpServerNames.set(session.sessionId, this.mcpServerNamesOf(request.mcpServers))
 
     return { session, promptPrefix: setup.promptPrefix }
   }
@@ -2194,6 +2229,7 @@ class AcpRuntime {
   // even if the session was never registered (e.g. it failed before start).
   disposeReviewerSession(session: import('@agentclientprotocol/sdk').ActiveSession): void {
     this.reviewerSessionIds.delete(session.sessionId)
+    this.sessionMcpServerNames.delete(session.sessionId)
     session.dispose()
   }
 }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1118,9 +1118,10 @@ class AcpRuntime {
           return message.response
         }
 
-        log.debug('session update', { sessionId: request.sessionId })
         // Route the update under the app-facing id so a session adopted onto a new agent (after a
-        // provider switch) still streams into the same conversation the renderer is watching.
+        // provider switch) still streams into the same conversation the renderer is watching. (No
+        // per-update log line here: it fires once per streamed chunk and floods the console for no
+        // signal — 'prompt start'/'prompt stopped' already bracket the turn.)
         this.handleSessionUpdate(message.notification, request.sessionId)
       }
     } catch (error) {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -71,6 +71,7 @@ import {
 import { getNotebookSessionRoot } from '../notebook/repository'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import { withDataRootWrite } from '../storage/migration-state'
+import { opencodeStorageDir } from '../agent-framework/opencode'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
@@ -1485,10 +1486,16 @@ class AcpRuntime {
     return sessionCwd
   }
 
-  // App-owned directories the agent's Read tool must never read: the CLAUDE_CONFIG_DIR holds the
-  // materialized skill files, whose (bundled/MCP) contents must not be surfaced into the conversation.
+  // App-owned directories the agent's Read tool must never read: both frameworks' config dirs hold the
+  // materialized skill files (+ opencode.json/auth), whose bundled/MCP contents must not be surfaced
+  // into the conversation. Both are guarded regardless of the active framework so a switch leaves no
+  // gap and the cost is a couple of extra prefix checks.
   private protectedReadRoots(): string[] {
-    return this.artifactOptions ? [getAppClaudeConfigDir(this.artifactOptions.configRoot)] : []
+    if (!this.artifactOptions) return []
+
+    const root = this.artifactOptions.configRoot
+
+    return [getAppClaudeConfigDir(root), opencodeStorageDir(root)]
   }
 
   // Creates an app-owned artifact session id so new ACP sessions never decide their storage directory.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2155,26 +2155,23 @@ class AcpRuntime {
     cwd: string
     mcpServers: McpServer[]
     systemPromptAppend?: string
-  }): Promise<import('@agentclientprotocol/sdk').ActiveSession> {
+  }): Promise<{
+    session: import('@agentclientprotocol/sdk').ActiveSession
+    // Framework-neutral rubric delivery: Claude carries the append in session _meta (empty prefix),
+    // opencode has no preset so the rubric rides back as a prompt prefix the caller must prepend.
+    promptPrefix?: string
+  }> {
     const connection = await this.ensureConnected(request.cwd)
 
-    const meta: Record<string, unknown> = {
-      claudeCode: { options: { settingSources: ['user'] } }
-    }
-
-    if (request.systemPromptAppend) {
-      meta.systemPrompt = {
-        type: 'preset',
-        preset: 'claude_code',
-        append: request.systemPromptAppend
-      }
-    }
+    const setup = this.framework.buildSessionSetup({
+      systemPromptAppends: request.systemPromptAppend ? [request.systemPromptAppend] : []
+    })
 
     const session = await connection.agent
       .buildSession({
         cwd: request.cwd,
         mcpServers: request.mcpServers,
-        _meta: meta
+        ...(setup.meta ? { _meta: setup.meta } : {})
       })
       .start()
 
@@ -2182,7 +2179,7 @@ class AcpRuntime {
     // The orchestrator must call disposeReviewerSession() to unregister and tear it down.
     this.reviewerSessionIds.add(session.sessionId)
 
-    return session
+    return { session, promptPrefix: setup.promptPrefix }
   }
 
   // Disposes an ephemeral reviewer session and unregisters it from the auto-approve set. Safe to call

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1489,6 +1489,13 @@ class AcpRuntime {
     sessionCwd: string
     projectName: string
   }): Promise<McpServer[]> {
+    // The artifact/notebook servers are stdio; a framework that only accepts http/sse MCP (opencode)
+    // gets none until they're exposed over http, so a basic turn still runs instead of failing on an
+    // unsupported stdio server config.
+    if (!this.framework.acceptsStdioMcp) {
+      return []
+    }
+
     const servers = [
       ...this.createArtifactMcpServers(
         artifactSessionId,
@@ -1517,10 +1524,14 @@ class AcpRuntime {
   // those services are wired. The active framework decides how these are delivered (Claude's preset
   // append vs opencode's prompt prefix).
   private getSystemPromptAppends(): string[] {
+    // Artifact/notebook guidance names MCP tools that only exist when the framework accepts stdio MCP;
+    // omit it otherwise so the agent isn't told to use tools it wasn't given (see createMcpServers).
+    const toolsAvailable = this.framework.acceptsStdioMcp
+
     return [
       SKILLS_READ_GUARD_SYSTEM_PROMPT_APPEND,
-      ...(this.artifactOptions ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
-      ...(this.notebookOptions ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : [])
+      ...(toolsAvailable && this.artifactOptions ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
+      ...(toolsAvailable && this.notebookOptions ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : [])
     ]
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -7,6 +7,7 @@ import type {
   PromptResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
+  SessionConfigOption,
   SessionModeState,
   SessionNotification
 } from '@agentclientprotocol/sdk'
@@ -49,6 +50,7 @@ import {
   toAcpRuntimeEvent
 } from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
+import { matchSessionModelOption } from './session-config'
 import { AcpPermissionBroker } from './permission-broker'
 import { applyCurrentModeUpdate } from './permission-profile-controller'
 import {
@@ -258,6 +260,9 @@ class AcpRuntime {
   // Mutable: refreshed from resolveBackend on each connect so a framework switch applies on reconnect.
   private framework: AgentFramework
   private readonly mcpHttpHost: AgentMcpHttpHost | undefined
+  // Model to apply per session via the ACP model configOption (opencode); undefined for env-driven
+  // frameworks (Claude). Refreshed from the resolved backend on each connect.
+  private pendingSessionModel: string | undefined
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
@@ -373,6 +378,38 @@ class AcpRuntime {
       effectiveMode: application.state.currentModeId,
       autoReviewStrategy: application.state.autoReviewStrategy
     })
+  }
+
+  // Applies the active model to a freshly built/resumed session via the ACP model configOption, for
+  // frameworks that select the model over the protocol (opencode). No-op for env-driven frameworks
+  // (pendingSessionModel undefined) or when the agent advertises no matching model option — the agent
+  // then keeps its own default. Best-effort: a failure is logged, never fatal to the session.
+  private async applySessionModel(session: ActiveSession): Promise<void> {
+    if (!this.pendingSessionModel || !this.connection) return
+
+    const configOptions = (
+      session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } }
+    ).newSessionResponse?.configOptions
+    const selection = matchSessionModelOption(configOptions, this.pendingSessionModel)
+
+    if (!selection) {
+      log.info('no matching session model option', { desiredModel: this.pendingSessionModel })
+      return
+    }
+
+    try {
+      await this.connection.agent.request(acp.methods.agent.session.setConfigOption, {
+        sessionId: session.sessionId,
+        configId: selection.configId,
+        value: selection.value
+      })
+      log.info('session model applied', { sessionId: session.sessionId, model: selection.value })
+    } catch (error) {
+      log.warn('set session model failed', {
+        sessionId: session.sessionId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
   }
 
   // Starts a fresh agent process connection and initializes protocol capabilities.
@@ -527,6 +564,8 @@ class AcpRuntime {
       session.dispose()
       throw error
     }
+
+    await this.applySessionModel(session)
 
     this.sessions.set(session.sessionId, session)
     this.sessionCwds.set(session.sessionId, sessionCwd)
@@ -699,6 +738,7 @@ class AcpRuntime {
         throw error
       }
 
+      await this.applySessionModel(adopted)
       this.adoptSession(request.sessionId, adopted, sessionCwd, projectName)
       this.emitState()
 
@@ -721,6 +761,8 @@ class AcpRuntime {
       session.dispose()
       throw error
     }
+
+    await this.applySessionModel(session)
 
     this.sessions.set(request.sessionId, session)
     this.sessionCwds.set(request.sessionId, sessionCwd)
@@ -904,6 +946,7 @@ class AcpRuntime {
     // Adopt the framework this reconnect resolved so session meta, permission mapping, and the spawn
     // itself all agree with the current selection.
     this.framework = backend.framework
+    this.pendingSessionModel = backend.sessionModel
 
     return this.framework.spawn({
       executablePath: backend.executablePath,

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -742,7 +742,9 @@ class AcpRuntime {
       this.adoptSession(request.sessionId, adopted, sessionCwd, projectName)
       this.emitState()
 
-      return { sessionId: request.sessionId, cwd: sessionCwd }
+      // Agent-side context did not survive (the session was replaced by a framework/provider switch or
+      // an unresumable restart); tell the caller so it can replay a transcript into the next prompt.
+      return { sessionId: request.sessionId, cwd: sessionCwd, contextReset: true }
     }
     // The SDK exposes public helpers for new sessions only. The runtime keeps this adapter
     // narrow so resume can reuse the same update routing surface as newly-created sessions.
@@ -1039,7 +1041,11 @@ class AcpRuntime {
         systemPromptAppends: this.getSystemPromptAppends()
       })
       const nudgedText = await this.applySkillNudge(request.text, forced)
-      const promptText = promptPrefix ? `${promptPrefix}\n\n${nudgedText}` : nudgedText
+      // A history preamble (transcript replayed after a context reset) leads, then the framework guidance
+      // prefix, then the nudged user text. Absent segments drop out so the normal turn is unchanged.
+      const promptText = [request.historyPreamble, promptPrefix, nudgedText]
+        .filter((segment): segment is string => Boolean(segment))
+        .join('\n\n')
       const promptContent = await this.createPromptContent(request.sessionId, {
         ...request,
         text: promptText

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -247,6 +247,10 @@ class AcpRuntime {
   private readonly agentToAppSessionId = new Map<string, string>()
   // Per-session artifact/notebook storage project; keeps run activation and claims in the same subtree.
   private readonly sessionProjectNames = new Map<string, string>()
+  // The framework each session last ran under. Deliberately NOT cleared on disconnect so a framework
+  // switch (which disconnects) can still tell that an existing session belongs to the other framework
+  // and skip a doomed resume. Cleaned per-session on delete.
+  private readonly sessionFrameworks = new Map<string, string>()
   private readonly promptInFlightSessionIds = new Set<string>()
   private readonly permissionProfiles = new Map<string, SessionPermissionProfileState>()
   // A provider change requested while a prompt was running, applied when the session next goes idle.
@@ -570,6 +574,7 @@ class AcpRuntime {
     this.sessions.set(session.sessionId, session)
     this.sessionCwds.set(session.sessionId, sessionCwd)
     this.sessionProjectNames.set(session.sessionId, projectName)
+    this.sessionFrameworks.set(session.sessionId, this.framework.id)
     this.rememberArtifactSession(session.sessionId, artifactSessionId)
     this.rememberNotebookSession(session.sessionId, notebookSessionId)
     this.currentSessionId = session.sessionId
@@ -603,6 +608,7 @@ class AcpRuntime {
 
     this.sessionCwds.set(appSessionId, cwd)
     this.sessionProjectNames.set(appSessionId, projectName)
+    this.sessionFrameworks.set(appSessionId, this.framework.id)
     this.rememberArtifactSession(appSessionId, appSessionId)
     this.rememberNotebookSession(appSessionId, appSessionId)
     this.currentSessionId = appSessionId
@@ -687,6 +693,22 @@ class AcpRuntime {
       throw new Error('ACP agent does not support session resume.')
     }
 
+    // A session created under a different framework can never be resumed by the current agent — each
+    // framework keeps its own session store, so the request is guaranteed to fail and only makes the
+    // agent log a scary internal error. Skip straight to adopting a fresh session (context still
+    // resets, so the caller replays the transcript) when we know it last ran under another framework.
+    const priorFramework = this.sessionFrameworks.get(request.sessionId)
+
+    if (priorFramework && priorFramework !== this.framework.id) {
+      log.info('skipping cross-framework resume; adopting a fresh session', {
+        sessionId: request.sessionId,
+        from: priorFramework,
+        to: this.framework.id
+      })
+
+      return this.adoptFreshSession(connection, request, sessionCwd, projectName)
+    }
+
     // Resumed sessions already have stable ids, so the artifact session mirrors the runtime session id.
     let resumeResponse
     try {
@@ -704,47 +726,15 @@ class AcpRuntime {
     } catch (error) {
       if (!isUnresumableSessionError(error)) throw error
 
-      // The agent could not resume this session (it was replaced by a provider switch, or an app
-      // restart spawned a fresh agent process that no longer holds it — surfacing as -32002 not-found
-      // or a generic -32603 Internal error). Rather than dead-end the thread, adopt a brand-new agent
-      // session under the SAME app id so the user can keep chatting — earlier turns stay visible; only
-      // agent-side context resets, which is expected after a restart or model switch.
+      // The agent could not resume this session (an app restart spawned a fresh agent process that no
+      // longer holds it — surfacing as -32002 not-found or a generic -32603 Internal error). Rather
+      // than dead-end the thread, adopt a brand-new agent session under the SAME app id.
       log.info('resumed session adopted after unrecoverable resume error', {
         sessionId: request.sessionId,
         reason: error instanceof Error ? error.message : String(error)
       })
 
-      const adopted = await connection.agent
-        .buildSession({
-          cwd: sessionCwd,
-          mcpServers: await this.createMcpServers({
-            artifactSessionId: request.sessionId,
-            notebookSessionId: request.sessionId,
-            sessionCwd,
-            projectName
-          }),
-          ...this.buildSessionMetaArg()
-        })
-        .start()
-
-      try {
-        await this.configurePermissionProfile(
-          request.sessionId,
-          adopted,
-          normalizePermissionProfile(request.permissionProfile)
-        )
-      } catch (error) {
-        adopted.dispose()
-        throw error
-      }
-
-      await this.applySessionModel(adopted)
-      this.adoptSession(request.sessionId, adopted, sessionCwd, projectName)
-      this.emitState()
-
-      // Agent-side context did not survive (the session was replaced by a framework/provider switch or
-      // an unresumable restart); tell the caller so it can replay a transcript into the next prompt.
-      return { sessionId: request.sessionId, cwd: sessionCwd, contextReset: true }
+      return this.adoptFreshSession(connection, request, sessionCwd, projectName)
     }
     // The SDK exposes public helpers for new sessions only. The runtime keeps this adapter
     // narrow so resume can reuse the same update routing surface as newly-created sessions.
@@ -769,6 +759,7 @@ class AcpRuntime {
     this.sessions.set(request.sessionId, session)
     this.sessionCwds.set(request.sessionId, sessionCwd)
     this.sessionProjectNames.set(request.sessionId, projectName)
+    this.sessionFrameworks.set(request.sessionId, this.framework.id)
     this.rememberArtifactSession(request.sessionId, request.sessionId)
     this.currentSessionId = request.sessionId
     this.cwd = sessionCwd
@@ -782,6 +773,47 @@ class AcpRuntime {
     this.emitState()
 
     return { sessionId: request.sessionId, cwd: sessionCwd }
+  }
+
+  // Builds a brand-new agent session under the SAME app id when a resume cannot reattach the original
+  // (a cross-framework switch, or an unresumable restart). Earlier turns stay visible; only agent-side
+  // context is gone, so contextReset is returned to let the caller replay a transcript into the next
+  // prompt. Shared by the cross-framework skip and the unrecoverable-error fallback.
+  private async adoptFreshSession(
+    connection: ClientConnection,
+    request: AcpResumeSessionRequest,
+    sessionCwd: string,
+    projectName: string
+  ): Promise<AcpCreateSessionResponse> {
+    const adopted = await connection.agent
+      .buildSession({
+        cwd: sessionCwd,
+        mcpServers: await this.createMcpServers({
+          artifactSessionId: request.sessionId,
+          notebookSessionId: request.sessionId,
+          sessionCwd,
+          projectName
+        }),
+        ...this.buildSessionMetaArg()
+      })
+      .start()
+
+    try {
+      await this.configurePermissionProfile(
+        request.sessionId,
+        adopted,
+        normalizePermissionProfile(request.permissionProfile)
+      )
+    } catch (error) {
+      adopted.dispose()
+      throw error
+    }
+
+    await this.applySessionModel(adopted)
+    this.adoptSession(request.sessionId, adopted, sessionCwd, projectName)
+    this.emitState()
+
+    return { sessionId: request.sessionId, cwd: sessionCwd, contextReset: true }
   }
 
   // Changes approval behavior only while the conversation is idle. Applying the ACP mode before the
@@ -1183,6 +1215,7 @@ class AcpRuntime {
       this.sessions.delete(request.sessionId)
       this.sessionCwds.delete(request.sessionId)
       this.sessionProjectNames.delete(request.sessionId)
+      this.sessionFrameworks.delete(request.sessionId)
       this.permissionProfiles.delete(request.sessionId)
       this.artifactSessionIds.delete(request.sessionId)
       this.notebookRoutingIds.delete(request.sessionId)

--- a/src/main/acp/session-config.test.ts
+++ b/src/main/acp/session-config.test.ts
@@ -1,0 +1,75 @@
+import type { SessionConfigOption } from '@agentclientprotocol/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { matchSessionModelOption } from './session-config'
+
+// Builds a minimal `model` select option like opencode returns from session/new.
+const modelOption = (
+  values: string[],
+  extra: Partial<SessionConfigOption> = {}
+): SessionConfigOption =>
+  ({
+    type: 'select',
+    id: 'model',
+    name: 'Model',
+    category: 'model',
+    currentValue: values[0],
+    options: values.map((value) => ({ value, name: value })),
+    ...extra
+  }) as SessionConfigOption
+
+describe('matchSessionModelOption', () => {
+  it('matches an opencode provider/model value by its bare-model suffix', () => {
+    const options = [modelOption(['anthropic/claude-sonnet-4-5', 'openai/gpt-5'])]
+
+    expect(matchSessionModelOption(options, 'claude-sonnet-4-5')).toEqual({
+      configId: 'model',
+      value: 'anthropic/claude-sonnet-4-5'
+    })
+  })
+
+  it('prefers an exact value match over a suffix match', () => {
+    const options = [modelOption(['claude-sonnet-4-5', 'anthropic/claude-sonnet-4-5'])]
+
+    expect(matchSessionModelOption(options, 'claude-sonnet-4-5')).toEqual({
+      configId: 'model',
+      value: 'claude-sonnet-4-5'
+    })
+  })
+
+  it('flattens grouped select options', () => {
+    const grouped = {
+      type: 'select',
+      id: 'model',
+      name: 'Model',
+      category: 'model',
+      currentValue: 'anthropic/claude-opus-4-8',
+      options: [
+        { name: 'Anthropic', options: [{ value: 'anthropic/claude-opus-4-8', name: 'Opus' }] }
+      ]
+    } as unknown as SessionConfigOption
+
+    expect(matchSessionModelOption([grouped], 'claude-opus-4-8')).toEqual({
+      configId: 'model',
+      value: 'anthropic/claude-opus-4-8'
+    })
+  })
+
+  it('returns undefined when nothing matches or inputs are empty', () => {
+    const options = [modelOption(['openai/gpt-5'])]
+
+    expect(matchSessionModelOption(options, 'claude-sonnet-4-5')).toBeUndefined()
+    expect(matchSessionModelOption(options, undefined)).toBeUndefined()
+    expect(matchSessionModelOption([], 'claude-sonnet-4-5')).toBeUndefined()
+    expect(matchSessionModelOption(undefined, 'claude-sonnet-4-5')).toBeUndefined()
+  })
+
+  it('identifies the model option by category even when its id differs', () => {
+    const options = [modelOption(['x/y-model'], { id: 'primary_model' })]
+
+    expect(matchSessionModelOption(options, 'y-model')).toEqual({
+      configId: 'primary_model',
+      value: 'x/y-model'
+    })
+  })
+})

--- a/src/main/acp/session-config.ts
+++ b/src/main/acp/session-config.ts
@@ -1,0 +1,59 @@
+import type { SessionConfigOption } from '@agentclientprotocol/sdk'
+
+// The config option id + value to apply via session/set_config_option.
+export type SessionModelSelection = {
+  configId: string
+  value: string
+}
+
+// Flattens a select option's values, tolerating both the flat and grouped option shapes.
+const collectSelectValues = (options: unknown): string[] => {
+  if (!Array.isArray(options)) return []
+
+  const values: string[] = []
+
+  for (const entry of options) {
+    if (!entry || typeof entry !== 'object') continue
+
+    const record = entry as { value?: unknown; options?: unknown }
+
+    if (typeof record.value === 'string') {
+      values.push(record.value)
+    } else if (Array.isArray(record.options)) {
+      for (const sub of record.options) {
+        const value = (sub as { value?: unknown })?.value
+        if (typeof value === 'string') values.push(value)
+      }
+    }
+  }
+
+  return values
+}
+
+// Finds the session's model select option and the value id matching the desired model, so the app can
+// drive an agent's per-session model (opencode surfaces model as a `model` configOption). Matches the
+// desired model against option values exactly, else by the segment after the last '/', since opencode
+// ids are `<provider>/<model>` while the app stores the bare model. Returns undefined when there is no
+// model option or no matching value, so the agent keeps its own default rather than erroring.
+export const matchSessionModelOption = (
+  configOptions: readonly SessionConfigOption[] | null | undefined,
+  desiredModel: string | undefined
+): SessionModelSelection | undefined => {
+  if (!desiredModel) return undefined
+
+  const option = (configOptions ?? []).find(
+    (candidate) =>
+      candidate.type === 'select' && (candidate.category === 'model' || candidate.id === 'model')
+  )
+
+  if (!option || option.type !== 'select') return undefined
+
+  const values = collectSelectValues(option.options)
+  const match =
+    values.find((value) => value === desiredModel) ??
+    values.find((value) => value.split('/').pop() === desiredModel)
+
+  if (!match) return undefined
+
+  return { configId: option.id, value: match }
+}

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -25,6 +25,8 @@ export const claudeCodeFramework: AgentFramework = {
   supportsSkills: true,
   // Claude launches stdio MCP servers directly — the app's artifact/notebook tooling relies on this.
   acceptsStdioMcp: true,
+  // Claude Code speaks only Anthropic /v1/messages.
+  supportedApiTypes: ['anthropic'],
 
   spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams {
     // Still routes through the existing spawner; env carries the resolved provider overrides.

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -23,6 +23,8 @@ export const claudeCodeFramework: AgentFramework = {
   id: 'claude-code',
   displayName: 'Claude Code',
   supportsSkills: true,
+  // Claude launches stdio MCP servers directly — the app's artifact/notebook tooling relies on this.
+  acceptsStdioMcp: true,
 
   spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams {
     // Still routes through the existing spawner; env carries the resolved provider overrides.

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -1,0 +1,69 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import type { SessionModeState } from '@agentclientprotocol/sdk'
+
+import { spawnClaudeAgentAcp } from '../acp/agent-process'
+import {
+  resolvePermissionProfileApplication,
+  type PermissionProfileApplication
+} from '../acp/permission-profile-controller'
+import type { PermissionProfileId } from '../../shared/permission-profiles'
+import { buildProviderEnv, type ResolvedProvider } from '../settings/provider-env'
+import type {
+  AgentFramework,
+  AgentModelConfig,
+  AgentSpawnInput,
+  ModelConfigContext,
+  SessionSetup,
+  SessionSetupContext
+} from './types'
+
+// Claude Code adapter. A faithful extraction of behavior currently inline in AcpRuntime /
+// agent-process / provider-env — moving the runtime onto AgentFramework must not change it.
+export const claudeCodeFramework: AgentFramework = {
+  id: 'claude-code',
+  displayName: 'Claude Code',
+  supportsSkills: true,
+
+  spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams {
+    // Still routes through the existing spawner; env carries the resolved provider overrides.
+    return spawnClaudeAgentAcp({
+      envOverrides: input.env,
+      executablePath: input.executablePath
+    })
+  },
+
+  prepareModelConfig(provider: ResolvedProvider, ctx: ModelConfigContext): AgentModelConfig {
+    // Anthropic-shaped env (ANTHROPIC_* + CLAUDE_CONFIG_DIR/CLAUDE_CODE_EXECUTABLE).
+    return {
+      env: buildProviderEnv(provider, {
+        storageRoot: ctx.storageRoot,
+        claudeExecutablePath: ctx.executablePath
+      })
+    }
+  },
+
+  buildSessionSetup(ctx: SessionSetupContext): SessionSetup {
+    // settingSources:['user'] pins the app-owned config dir so a workspace ~/.claude env can't override
+    // the active provider endpoint. Appends ride the claude_code system-prompt preset.
+    const meta: Record<string, unknown> = {
+      claudeCode: { options: { settingSources: ['user'] } }
+    }
+
+    if (ctx.systemPromptAppends.length > 0) {
+      meta.systemPrompt = {
+        type: 'preset',
+        preset: 'claude_code',
+        append: ctx.systemPromptAppends.join('\n\n')
+      }
+    }
+
+    return { meta }
+  },
+
+  mapPermissionProfile(
+    profile: PermissionProfileId,
+    modes: SessionModeState | null | undefined
+  ): PermissionProfileApplication {
+    return resolvePermissionProfileApplication(profile, modes)
+  }
+}

--- a/src/main/agent-framework/index.ts
+++ b/src/main/agent-framework/index.ts
@@ -1,0 +1,4 @@
+export * from './types'
+export { claudeCodeFramework } from './claude-code'
+export { opencodeFramework } from './opencode'
+export { DEFAULT_AGENT_FRAMEWORK_ID, getAgentFramework, listAgentFrameworks } from './registry'

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildOpencodeConfig } from './opencode'
+
+describe('buildOpencodeConfig', () => {
+  it('registers the model under provider.models and selects it', () => {
+    const config = JSON.parse(
+      buildOpencodeConfig({
+        type: 'custom',
+        baseUrl: 'https://gw.example/v1',
+        model: 'deepseek-v4-pro',
+        key: 'sk-secret'
+      })
+    )
+
+    // A non-catalog model id is both selected and registered, so opencode treats it as a real model
+    // instead of ignoring it and falling back to its own default.
+    expect(config.model).toBe('anthropic/deepseek-v4-pro')
+    expect(config.provider.anthropic.models).toEqual({ 'deepseek-v4-pro': {} })
+    expect(config.provider.anthropic.options).toEqual({
+      baseURL: 'https://gw.example/v1',
+      apiKey: 'sk-secret'
+    })
+  })
+
+  it('merges onto the user config, preserving their providers and mcp', () => {
+    const base = {
+      $schema: 'https://opencode.ai/config.json',
+      mcp: { local: { type: 'local', command: ['x'] } },
+      provider: {
+        'minimax-cn-coding-plan': { options: { apiKey: 'keep-me' } },
+        anthropic: { options: { timeout: 5 }, models: { 'other-model': {} } }
+      }
+    }
+
+    const config = JSON.parse(
+      buildOpencodeConfig(
+        {
+          type: 'custom',
+          baseUrl: 'https://gw.example/v1',
+          model: 'deepseek-v4-pro',
+          key: 'sk-secret'
+        },
+        base
+      )
+    )
+
+    // The user's own provider and mcp block survive untouched.
+    expect(config.mcp).toEqual(base.mcp)
+    expect(config.provider['minimax-cn-coding-plan']).toEqual({ options: { apiKey: 'keep-me' } })
+    // Our additions merge into their anthropic block without dropping their existing keys.
+    expect(config.provider.anthropic.options).toEqual({
+      timeout: 5,
+      baseURL: 'https://gw.example/v1',
+      apiKey: 'sk-secret'
+    })
+    expect(config.provider.anthropic.models).toEqual({ 'other-model': {}, 'deepseek-v4-pro': {} })
+    expect(config.model).toBe('anthropic/deepseek-v4-pro')
+  })
+
+  it('omits model + models registration when the provider has no model', () => {
+    const config = JSON.parse(buildOpencodeConfig({ type: 'claude-default' }))
+
+    expect(config.model).toBeUndefined()
+    expect(config.provider.anthropic.models).toBeUndefined()
+    expect(config.provider.anthropic.options).toEqual({})
+  })
+})

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -1,6 +1,39 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildOpencodeConfig } from './opencode'
+import { buildOpencodeConfig, opencodeFramework } from './opencode'
+
+describe('opencodeFramework.prepareModelConfig', () => {
+  it('writes the connector instructions file and wires it into opencode.json instructions', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      {
+        storageRoot: '/data',
+        executablePath: '/bin/opencode',
+        instructions: '# connectors\nhost.mcp(...)'
+      }
+    )
+
+    const instructionsFile = config.configFiles?.find((file) => file.path.endsWith('connectors.md'))
+    expect(instructionsFile?.content).toContain('host.mcp(')
+
+    const opencodeJson = config.configFiles?.find((file) => file.path.endsWith('opencode.json'))
+    const parsed = JSON.parse(opencodeJson?.content ?? '{}')
+    expect(parsed.instructions).toContain(instructionsFile?.path)
+  })
+
+  it('omits instructions when none are provided', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    expect(config.configFiles?.some((file) => file.path.endsWith('connectors.md'))).toBe(false)
+    const parsed = JSON.parse(
+      config.configFiles?.find((file) => file.path.endsWith('opencode.json'))?.content ?? '{}'
+    )
+    expect(parsed.instructions).toBeUndefined()
+  })
+})
 
 describe('buildOpencodeConfig', () => {
   it('registers the model under provider.models and selects it', () => {

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -56,6 +56,29 @@ describe('buildOpencodeConfig', () => {
     })
   })
 
+  it('forces opencode to delegate edit/bash/webfetch prompts to the client', () => {
+    // Without this, opencode runs everything silently under its permissive default and the app's
+    // Ask/Auto profiles never see a permission request.
+    const config = JSON.parse(
+      buildOpencodeConfig({ type: 'custom', baseUrl: 'https://gw/v1', model: 'm' })
+    )
+
+    expect(config.permission).toEqual({ edit: 'ask', bash: 'ask', webfetch: 'ask' })
+  })
+
+  it('keeps delegation on even if the base config tried to disable it', () => {
+    const config = JSON.parse(
+      buildOpencodeConfig(
+        { type: 'custom', baseUrl: 'https://gw/v1', model: 'm' },
+        { permission: { edit: 'allow', extra: 'allow' } }
+      )
+    )
+
+    // Our ask values win over the base; unrelated base keys are preserved.
+    expect(config.permission).toMatchObject({ edit: 'ask', bash: 'ask', webfetch: 'ask' })
+    expect(config.permission.extra).toBe('allow')
+  })
+
   it('merges onto the user config, preserving their providers and mcp', () => {
     const base = {
       $schema: 'https://opencode.ai/config.json',

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -128,9 +128,22 @@ describe('buildOpencodeConfig', () => {
       })
     )
 
-    // 'both' → OpenAI on opencode, pointed at the OpenAI base (not the /anthropic route).
+    // 'both' → OpenAI on opencode, pointed at the OpenAI base with /v1 (the @ai-sdk/openai-compatible
+    // client appends /chat/completions), not the /anthropic route.
     expect(config.model).toBe('openai-compatible/deepseek-v4-pro')
-    expect(config.provider['openai-compatible'].options.baseURL).toBe('https://api.deepseek.com')
+    expect(config.provider['openai-compatible'].options.baseURL).toBe('https://api.deepseek.com/v1')
+  })
+
+  it('normalizes a custom OpenAI base to end at /v1 (no doubling)', () => {
+    const rooted = JSON.parse(
+      buildOpencodeConfig({ type: 'custom', baseUrl: 'https://gw.example', model: 'm', apiType: 'openai' })
+    )
+    expect(rooted.provider['openai-compatible'].options.baseURL).toBe('https://gw.example/v1')
+
+    const withV1 = JSON.parse(
+      buildOpencodeConfig({ type: 'custom', baseUrl: 'https://gw.example/v1', model: 'm', apiType: 'openai' })
+    )
+    expect(withV1.provider['openai-compatible'].options.baseURL).toBe('https://gw.example/v1')
   })
 
   it('omits model + models registration when the provider has no model', () => {

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -91,6 +91,31 @@ describe('buildOpencodeConfig', () => {
     expect(config.model).toBe('anthropic/deepseek-v4-pro')
   })
 
+  it('maps an openai (or both) provider to an @ai-sdk/openai-compatible provider block', () => {
+    const config = JSON.parse(
+      buildOpencodeConfig({
+        type: 'custom',
+        baseUrl: 'https://gw/v1',
+        model: 'gpt-x',
+        key: 'k',
+        apiType: 'openai'
+      })
+    )
+
+    expect(config.model).toBe('openai-compatible/gpt-x')
+    expect(config.provider['openai-compatible'].npm).toBe('@ai-sdk/openai-compatible')
+    expect(config.provider['openai-compatible'].options).toEqual({
+      baseURL: 'https://gw/v1',
+      apiKey: 'k'
+    })
+    expect(config.provider['openai-compatible'].models).toEqual({ 'gpt-x': {} })
+    // A 'both' provider prefers OpenAI on opencode (which supports both).
+    const both = JSON.parse(
+      buildOpencodeConfig({ type: 'custom', baseUrl: 'https://gw/v1', model: 'm', apiType: 'both' })
+    )
+    expect(both.model).toBe('openai-compatible/m')
+  })
+
   it('omits model + models registration when the provider has no model', () => {
     const config = JSON.parse(buildOpencodeConfig({ type: 'claude-default' }))
 

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -56,26 +56,34 @@ describe('buildOpencodeConfig', () => {
     })
   })
 
-  it('forces opencode to delegate edit/bash/webfetch prompts to the client', () => {
-    // Without this, opencode runs everything silently under its permissive default and the app's
-    // Ask/Auto profiles never see a permission request.
+  it('delegates every side-effecting tool (incl. MCP) via a "*" catch-all, allowing safe reads', () => {
+    // Without the "*" rule, opencode keys permissions by tool name and MCP/websearch/task tools are
+    // unmatched → run silently. The wildcard forces them to prompt; read-only tools stay allow.
     const config = JSON.parse(
       buildOpencodeConfig({ type: 'custom', baseUrl: 'https://gw/v1', model: 'm' })
     )
 
-    expect(config.permission).toEqual({ edit: 'ask', bash: 'ask', webfetch: 'ask' })
+    expect(config.permission['*']).toBe('ask')
+    // Safe read-only tools run without prompting (parity with Claude's Ask mode).
+    for (const tool of ['read', 'glob', 'grep', 'list', 'lsp']) {
+      expect(config.permission[tool]).toBe('allow')
+    }
+    // Mutating/external tools are NOT allowlisted, so they fall through to "*" → ask.
+    expect(config.permission.edit).toBeUndefined()
+    expect(config.permission.bash).toBeUndefined()
   })
 
   it('keeps delegation on even if the base config tried to disable it', () => {
     const config = JSON.parse(
       buildOpencodeConfig(
         { type: 'custom', baseUrl: 'https://gw/v1', model: 'm' },
-        { permission: { edit: 'allow', extra: 'allow' } }
+        { permission: { '*': 'allow', edit: 'allow', extra: 'allow' } }
       )
     )
 
-    // Our ask values win over the base; unrelated base keys are preserved.
-    expect(config.permission).toMatchObject({ edit: 'ask', bash: 'ask', webfetch: 'ask' })
+    // Our catch-all + read allowlist win over the base; unrelated base keys are preserved.
+    expect(config.permission['*']).toBe('ask')
+    expect(config.permission.read).toBe('allow')
     expect(config.permission.extra).toBe('allow')
   })
 

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -116,6 +116,23 @@ describe('buildOpencodeConfig', () => {
     expect(both.model).toBe('openai-compatible/m')
   })
 
+  it('uses the OpenAI base for a dual-endpoint vendor, not its Anthropic base (DeepSeek)', () => {
+    const config = JSON.parse(
+      buildOpencodeConfig({
+        type: 'custom',
+        baseUrl: 'https://api.deepseek.com/anthropic',
+        openaiBaseUrl: 'https://api.deepseek.com',
+        model: 'deepseek-v4-pro',
+        key: 'sk-ds',
+        apiType: 'both'
+      })
+    )
+
+    // 'both' → OpenAI on opencode, pointed at the OpenAI base (not the /anthropic route).
+    expect(config.model).toBe('openai-compatible/deepseek-v4-pro')
+    expect(config.provider['openai-compatible'].options.baseURL).toBe('https://api.deepseek.com')
+  })
+
   it('omits model + models registration when the provider has no model', () => {
     const config = JSON.parse(buildOpencodeConfig({ type: 'claude-default' }))
 

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -136,12 +136,22 @@ describe('buildOpencodeConfig', () => {
 
   it('normalizes a custom OpenAI base to end at /v1 (no doubling)', () => {
     const rooted = JSON.parse(
-      buildOpencodeConfig({ type: 'custom', baseUrl: 'https://gw.example', model: 'm', apiType: 'openai' })
+      buildOpencodeConfig({
+        type: 'custom',
+        baseUrl: 'https://gw.example',
+        model: 'm',
+        apiType: 'openai'
+      })
     )
     expect(rooted.provider['openai-compatible'].options.baseURL).toBe('https://gw.example/v1')
 
     const withV1 = JSON.parse(
-      buildOpencodeConfig({ type: 'custom', baseUrl: 'https://gw.example/v1', model: 'm', apiType: 'openai' })
+      buildOpencodeConfig({
+        type: 'custom',
+        baseUrl: 'https://gw.example/v1',
+        model: 'm',
+        apiType: 'openai'
+      })
     )
     expect(withV1.provider['openai-compatible'].options.baseURL).toBe('https://gw.example/v1')
   })

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -1,0 +1,95 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { join } from 'node:path'
+import type { SessionModeState } from '@agentclientprotocol/sdk'
+
+import {
+  resolvePermissionProfileApplication,
+  type PermissionProfileApplication
+} from '../acp/permission-profile-controller'
+import type { PermissionProfileId } from '../../shared/permission-profiles'
+import { augmentedPathEnv } from '../settings/shell-path'
+import type { ResolvedProvider } from '../settings/provider-env'
+import type {
+  AgentFramework,
+  AgentModelConfig,
+  AgentSpawnInput,
+  ModelConfigContext,
+  SessionSetup,
+  SessionSetupContext
+} from './types'
+
+// SPIKE STUB. opencode speaks ACP over `opencode acp` (stdio JSON-RPC). Only the three shapes that
+// differ from Claude are filled in: model config (opencode.json, not ANTHROPIC_* env), system-prompt
+// delivery (prompt prefix, no preset), and skills (unsupported). Everything else reuses the generic
+// runtime. See docs/internal/pluggable-agent-framework-feasibility.md.
+
+// Env var opencode reads to locate its config file.
+const OPENCODE_CONFIG_ENV = 'OPENCODE_CONFIG'
+
+// Maps the app's Anthropic-compatible custom gateway onto an opencode `anthropic` provider block.
+// TODO(spike): verify the real opencode.json schema + `provider/model` id scheme on a live build;
+// handle official/local providers and opencode-only providers (defer to `opencode auth login`).
+const buildOpencodeConfig = (provider: ResolvedProvider): string => {
+  const model = provider.model ? `anthropic/${provider.model}` : undefined
+
+  return JSON.stringify(
+    {
+      $schema: 'https://opencode.ai/config.json',
+      ...(model ? { model } : {}),
+      provider: {
+        anthropic: {
+          options: {
+            ...(provider.baseUrl ? { baseURL: provider.baseUrl } : {}),
+            ...(provider.key ? { apiKey: provider.key } : {})
+          }
+        }
+      }
+    },
+    null,
+    2
+  )
+}
+
+export const opencodeFramework: AgentFramework = {
+  id: 'opencode',
+  displayName: 'opencode',
+  // opencode has agents/commands, not config-dir skills; hide the skills UI + force-load path.
+  supportsSkills: false,
+
+  spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams {
+    // `opencode acp` starts the ACP subprocess over stdio, matching the app's existing transport.
+    return spawn(input.executablePath, ['acp', ...input.args], {
+      env: { ...augmentedPathEnv(process.env), ...input.env },
+      stdio: 'pipe',
+      windowsHide: true
+    })
+  },
+
+  prepareModelConfig(provider: ResolvedProvider, ctx: ModelConfigContext): AgentModelConfig {
+    // opencode reads a config file, not ANTHROPIC_* env; point OPENCODE_CONFIG at a generated one.
+    const configPath = join(ctx.storageRoot, 'opencode', 'opencode.json')
+
+    return {
+      env: { [OPENCODE_CONFIG_ENV]: configPath },
+      configFiles: [{ path: configPath, content: buildOpencodeConfig(provider) }]
+    }
+  },
+
+  buildSessionSetup(ctx: SessionSetupContext): SessionSetup {
+    // No claude_code preset here; deliver appends as a prompt prefix instead of session meta.
+    // TODO(spike): check whether opencode's ACP exposes any system-prompt customization to use instead.
+    return {
+      promptPrefix:
+        ctx.systemPromptAppends.length > 0 ? ctx.systemPromptAppends.join('\n\n') : undefined
+    }
+  },
+
+  mapPermissionProfile(
+    profile: PermissionProfileId,
+    modes: SessionModeState | null | undefined
+  ): PermissionProfileApplication {
+    // The mapper is already framework-neutral (keys off advertised modes). TODO(spike): confirm the
+    // mode ids opencode advertises match Claude's default/auto/bypassPermissions, else add a remap.
+    return resolvePermissionProfileApplication(profile, modes)
+  }
+}

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -99,11 +99,23 @@ const buildOpencodeConfig = (
     ...baseConfig,
     ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
     ...(instructions.length > 0 ? { instructions } : {}),
-    // Force opencode to ASK the ACP client for every edit/bash/webfetch instead of running silently
-    // under its permissive default. The app then enforces the selected permission profile in its broker
-    // (ask prompts, auto auto-approves workspace edits, full auto-approves all) — a single, mid-session-
-    // switchable decision point. Our keys win over any base config so delegation can't be turned off.
-    permission: { ...basePermission, edit: 'ask', bash: 'ask', webfetch: 'ask' },
+    // Force opencode to ASK the ACP client before every side-effecting tool instead of running
+    // silently under its permissive default. opencode keys permissions by TOOL NAME with a "*"
+    // catch-all, so the wildcard is essential: without it MCP tools (artifact/notebook/connectors),
+    // websearch, task, skill, etc. are unmatched and run without a prompt. Safe read-only tools stay
+    // "allow" so Ask mode doesn't prompt on every file read (parity with Claude). Everything else —
+    // edit, bash, webfetch, websearch, task, skill, and all MCP tools — hits "*" → ask → the ACP
+    // client, where the app enforces the selected profile in its broker (ask prompts, auto approves
+    // workspace edits, full approves all). Our rules win over any base config so it can't be disabled.
+    permission: {
+      ...basePermission,
+      '*': 'ask',
+      read: 'allow',
+      glob: 'allow',
+      grep: 'allow',
+      list: 'allow',
+      lsp: 'allow'
+    },
     provider: {
       ...baseProviders,
       [providerId]: {

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -19,10 +19,11 @@ import type {
   SessionSetupContext
 } from './types'
 
-// SPIKE STUB. opencode speaks ACP over `opencode acp` (stdio JSON-RPC). Only the three shapes that
-// differ from Claude are filled in: model config (opencode.json, not ANTHROPIC_* env), system-prompt
-// delivery (prompt prefix, no preset), and skills (unsupported). Everything else reuses the generic
-// runtime. See docs/internal/pluggable-agent-framework-feasibility.md.
+// opencode speaks ACP over `opencode acp` (stdio JSON-RPC). Only the shapes that differ from Claude
+// are implemented here: model config (a generated opencode.json, not ANTHROPIC_* env), system-prompt
+// delivery (a prompt prefix, since opencode has no preset), and skills (materialized into opencode's
+// config dir, which its native skill tool discovers). Everything else reuses the generic runtime.
+// See docs/internal/pluggable-agent-framework-feasibility.md.
 
 // opencode is isolated the way Claude uses CLAUDE_CONFIG_DIR: it reads config from
 // $XDG_CONFIG_HOME/opencode and auth/data from $XDG_DATA_HOME/opencode. Pointing both at app-owned
@@ -162,7 +163,6 @@ export const opencodeFramework: AgentFramework = {
 
   buildSessionSetup(ctx: SessionSetupContext): SessionSetup {
     // No claude_code preset here; deliver appends as a prompt prefix instead of session meta.
-    // TODO(spike): check whether opencode's ACP exposes any system-prompt customization to use instead.
     return {
       promptPrefix:
         ctx.systemPromptAppends.length > 0 ? ctx.systemPromptAppends.join('\n\n') : undefined
@@ -173,8 +173,9 @@ export const opencodeFramework: AgentFramework = {
     profile: PermissionProfileId,
     modes: SessionModeState | null | undefined
   ): PermissionProfileApplication {
-    // The mapper is already framework-neutral (keys off advertised modes). TODO(spike): confirm the
-    // mode ids opencode advertises match Claude's default/auto/bypassPermissions, else add a remap.
+    // Framework-neutral: the shared resolver keys off the modes the agent advertises (opencode offers
+    // `build`/`plan`, Claude `default`/`acceptEdits`/`bypassPermissions`), degrading gracefully when a
+    // profile has no matching mode.
     return resolvePermissionProfileApplication(profile, modes)
   }
 }

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -7,6 +7,7 @@ import {
   type PermissionProfileApplication
 } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
+import { preferredEndpoint } from '../../shared/settings'
 import { augmentedPathEnv } from '../settings/shell-path'
 import type { ResolvedProvider } from '../settings/provider-env'
 import type {
@@ -37,11 +38,14 @@ const opencodeDataHome = (storageRoot: string): string => join(storageRoot, 'ope
 export const opencodeConfigDir = (storageRoot: string): string =>
   join(opencodeConfigHome(storageRoot), 'opencode')
 
-// The app's providers are Anthropic `/v1/messages`-compatible (custom gateways and official vendors),
-// so they map onto opencode's built-in `anthropic` provider with a `baseURL`/`apiKey` override. An
-// OpenAI-format gateway would instead need a custom provider with `npm: "@ai-sdk/openai-compatible"`;
-// the app does not expose such providers today, so that branch is intentionally not built yet.
-const OPENCODE_PROVIDER_ID = 'anthropic'
+// The opencode provider block used for each endpoint. Anthropic /v1/messages maps to opencode's
+// built-in `anthropic` provider; OpenAI /v1/chat/completions maps to a custom provider backed by the
+// `@ai-sdk/openai-compatible` package. opencode drives both, so the endpoint is chosen from the
+// provider's apiType (preferring OpenAI when it offers both).
+const OPENCODE_ENDPOINT_PROVIDER: Record<'anthropic' | 'openai', { id: string; npm?: string }> = {
+  anthropic: { id: 'anthropic' },
+  openai: { id: 'openai-compatible', npm: '@ai-sdk/openai-compatible' }
+}
 
 const asRecord = (value: unknown): Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -59,8 +63,13 @@ const buildOpencodeConfig = (
   instructionPaths: string[] = []
 ): string => {
   const bareModel = provider.model
+  // opencode drives both endpoints; pick the one for this provider (openai wins when it offers both).
+  const endpoint =
+    preferredEndpoint(provider.apiType ?? 'anthropic', ['anthropic', 'openai']) ?? 'anthropic'
+  const { id: providerId, npm } = OPENCODE_ENDPOINT_PROVIDER[endpoint]
+
   const baseProviders = asRecord(baseConfig.provider)
-  const baseProvider = asRecord(baseProviders[OPENCODE_PROVIDER_ID])
+  const baseProvider = asRecord(baseProviders[providerId])
   const baseOptions = asRecord(baseProvider.options)
   const baseModels = asRecord(baseProvider.models)
   // Preserve any instructions the base config already declared, then append ours (de-duplicated).
@@ -72,12 +81,14 @@ const buildOpencodeConfig = (
   const merged: Record<string, unknown> = {
     $schema: 'https://opencode.ai/config.json',
     ...baseConfig,
-    ...(bareModel ? { model: `${OPENCODE_PROVIDER_ID}/${bareModel}` } : {}),
+    ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
     ...(instructions.length > 0 ? { instructions } : {}),
     provider: {
       ...baseProviders,
-      [OPENCODE_PROVIDER_ID]: {
+      [providerId]: {
         ...baseProvider,
+        // A custom (openai-compatible) provider needs its npm package declared; anthropic is built-in.
+        ...(npm ? { npm } : {}),
         options: {
           ...baseOptions,
           ...(provider.baseUrl ? { baseURL: provider.baseUrl } : {}),

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -44,18 +44,25 @@ const asRecord = (value: unknown): Record<string, unknown> =>
 // back to its own default. Verified against opencode 1.17.13.
 const buildOpencodeConfig = (
   provider: ResolvedProvider,
-  baseConfig: Record<string, unknown> = {}
+  baseConfig: Record<string, unknown> = {},
+  instructionPaths: string[] = []
 ): string => {
   const bareModel = provider.model
   const baseProviders = asRecord(baseConfig.provider)
   const baseProvider = asRecord(baseProviders[OPENCODE_PROVIDER_ID])
   const baseOptions = asRecord(baseProvider.options)
   const baseModels = asRecord(baseProvider.models)
+  // Preserve any instructions the base config already declared, then append ours (de-duplicated).
+  const baseInstructions = Array.isArray(baseConfig.instructions)
+    ? baseConfig.instructions.filter((entry): entry is string => typeof entry === 'string')
+    : []
+  const instructions = [...new Set([...baseInstructions, ...instructionPaths])]
 
   const merged: Record<string, unknown> = {
     $schema: 'https://opencode.ai/config.json',
     ...baseConfig,
     ...(bareModel ? { model: `${OPENCODE_PROVIDER_ID}/${bareModel}` } : {}),
+    ...(instructions.length > 0 ? { instructions } : {}),
     provider: {
       ...baseProviders,
       [OPENCODE_PROVIDER_ID]: {
@@ -97,11 +104,24 @@ export const opencodeFramework: AgentFramework = {
   prepareModelConfig(provider: ResolvedProvider, ctx: ModelConfigContext): AgentModelConfig {
     // opencode reads a config file, not ANTHROPIC_* env; point OPENCODE_CONFIG at an app-owned file
     // that merges the app's provider/model onto the user's existing opencode config.
-    const configPath = join(ctx.storageRoot, 'opencode', 'opencode.json')
+    const configDir = join(ctx.storageRoot, 'opencode')
+    const configPath = join(configDir, 'opencode.json')
+    const configFiles = [{ path: configPath, content: '' }]
+
+    // Connector conventions + tools, wired via opencode's `instructions` config so the agent uses
+    // host.mcp instead of raw HTTP. Absolute path keeps it independent of the session cwd.
+    const instructionPaths: string[] = []
+    if (ctx.instructions) {
+      const instructionsPath = join(configDir, 'instructions', 'connectors.md')
+      instructionPaths.push(instructionsPath)
+      configFiles.push({ path: instructionsPath, content: ctx.instructions })
+    }
+
+    configFiles[0].content = buildOpencodeConfig(provider, ctx.baseConfig, instructionPaths)
 
     return {
       env: { [OPENCODE_CONFIG_ENV]: configPath },
-      configFiles: [{ path: configPath, content: buildOpencodeConfig(provider, ctx.baseConfig) }]
+      configFiles
     }
   },
 

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -78,7 +78,8 @@ const buildOpencodeConfig = (
   // OpenAI base for the openai endpoint; a single-base provider falls back to baseUrl for both. The
   // @ai-sdk/openai-compatible client appends `/chat/completions` to baseURL, so normalize it to end at
   // `/v1` (matching the validator) — a bare root like https://api.deepseek.com would 404 otherwise.
-  const rawBase = endpoint === 'openai' ? (provider.openaiBaseUrl ?? provider.baseUrl) : provider.baseUrl
+  const rawBase =
+    endpoint === 'openai' ? (provider.openaiBaseUrl ?? provider.baseUrl) : provider.baseUrl
   const baseURL =
     endpoint === 'openai' && rawBase ? `${normalizeOpenAiBaseUrl(rawBase)}/v1` : rawBase
 

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -23,8 +23,13 @@ import type {
 // delivery (prompt prefix, no preset), and skills (unsupported). Everything else reuses the generic
 // runtime. See docs/internal/pluggable-agent-framework-feasibility.md.
 
-// Env var opencode reads to locate its config file.
-const OPENCODE_CONFIG_ENV = 'OPENCODE_CONFIG'
+// opencode is isolated the way Claude uses CLAUDE_CONFIG_DIR: it reads config from
+// $XDG_CONFIG_HOME/opencode and auth/data from $XDG_DATA_HOME/opencode. Pointing both at app-owned
+// dirs means the app fully owns opencode's config + auth (the app provider is the only credential)
+// and the user's own ~/.config/opencode + auth.json are never read or written. Verified: with these
+// set, the user's global providers/auth disappear and only the app-injected provider remains.
+const opencodeConfigHome = (storageRoot: string): string => join(storageRoot, 'opencode', 'config')
+const opencodeDataHome = (storageRoot: string): string => join(storageRoot, 'opencode', 'data')
 
 // The app's providers are Anthropic `/v1/messages`-compatible (custom gateways and official vendors),
 // so they map onto opencode's built-in `anthropic` provider with a `baseURL`/`apiKey` override. An
@@ -104,25 +109,28 @@ export const opencodeFramework: AgentFramework = {
   },
 
   prepareModelConfig(provider: ResolvedProvider, ctx: ModelConfigContext): AgentModelConfig {
-    // opencode reads a config file, not ANTHROPIC_* env; point OPENCODE_CONFIG at an app-owned file
-    // that merges the app's provider/model onto the user's existing opencode config.
-    const configDir = join(ctx.storageRoot, 'opencode')
-    const configPath = join(configDir, 'opencode.json')
+    // Isolate opencode via app-owned XDG dirs (mirror of CLAUDE_CONFIG_DIR): opencode reads its config
+    // from $XDG_CONFIG_HOME/opencode and auth/data from $XDG_DATA_HOME/opencode. We own the whole
+    // config here, so the app provider/model is written clean (no merge with the user's global config).
+    const configHome = opencodeConfigHome(ctx.storageRoot)
+    const dataHome = opencodeDataHome(ctx.storageRoot)
+    const opencodeDir = join(configHome, 'opencode')
+    const configPath = join(opencodeDir, 'opencode.json')
     const configFiles = [{ path: configPath, content: '' }]
 
     // Connector conventions + tools, wired via opencode's `instructions` config so the agent uses
     // host.mcp instead of raw HTTP. Absolute path keeps it independent of the session cwd.
     const instructionPaths: string[] = []
     if (ctx.instructions) {
-      const instructionsPath = join(configDir, 'instructions', 'connectors.md')
+      const instructionsPath = join(opencodeDir, 'instructions', 'connectors.md')
       instructionPaths.push(instructionsPath)
       configFiles.push({ path: instructionsPath, content: ctx.instructions })
     }
 
-    configFiles[0].content = buildOpencodeConfig(provider, ctx.baseConfig, instructionPaths)
+    configFiles[0].content = buildOpencodeConfig(provider, {}, instructionPaths)
 
     return {
-      env: { [OPENCODE_CONFIG_ENV]: configPath },
+      env: { XDG_CONFIG_HOME: configHome, XDG_DATA_HOME: dataHome },
       configFiles
     }
   },

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -73,6 +73,10 @@ const buildOpencodeConfig = (
   const endpoint =
     preferredEndpoint(provider.apiType ?? 'anthropic', ['anthropic', 'openai']) ?? 'anthropic'
   const { id: providerId, npm } = OPENCODE_ENDPOINT_PROVIDER[endpoint]
+  // Dual-endpoint vendors (e.g. DeepSeek) serve OpenAI at a different base than Anthropic, so pick the
+  // OpenAI base for the openai endpoint; a single-base provider falls back to baseUrl for both.
+  const baseURL =
+    endpoint === 'openai' ? (provider.openaiBaseUrl ?? provider.baseUrl) : provider.baseUrl
 
   const baseProviders = asRecord(baseConfig.provider)
   const baseProvider = asRecord(baseProviders[providerId])
@@ -97,7 +101,7 @@ const buildOpencodeConfig = (
         ...(npm ? { npm } : {}),
         options: {
           ...baseOptions,
-          ...(provider.baseUrl ? { baseURL: provider.baseUrl } : {}),
+          ...(baseURL ? { baseURL } : {}),
           ...(provider.key ? { apiKey: provider.key } : {})
         },
         // Register the model so opencode treats a non-catalog id as a real, selectable model.

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -8,6 +8,7 @@ import {
 } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import { preferredEndpoint } from '../../shared/settings'
+import { normalizeOpenAiBaseUrl } from '../settings/base-url'
 import { augmentedPathEnv } from '../settings/shell-path'
 import type { ResolvedProvider } from '../settings/provider-env'
 import type {
@@ -74,9 +75,12 @@ const buildOpencodeConfig = (
     preferredEndpoint(provider.apiType ?? 'anthropic', ['anthropic', 'openai']) ?? 'anthropic'
   const { id: providerId, npm } = OPENCODE_ENDPOINT_PROVIDER[endpoint]
   // Dual-endpoint vendors (e.g. DeepSeek) serve OpenAI at a different base than Anthropic, so pick the
-  // OpenAI base for the openai endpoint; a single-base provider falls back to baseUrl for both.
+  // OpenAI base for the openai endpoint; a single-base provider falls back to baseUrl for both. The
+  // @ai-sdk/openai-compatible client appends `/chat/completions` to baseURL, so normalize it to end at
+  // `/v1` (matching the validator) — a bare root like https://api.deepseek.com would 404 otherwise.
+  const rawBase = endpoint === 'openai' ? (provider.openaiBaseUrl ?? provider.baseUrl) : provider.baseUrl
   const baseURL =
-    endpoint === 'openai' ? (provider.openaiBaseUrl ?? provider.baseUrl) : provider.baseUrl
+    endpoint === 'openai' && rawBase ? `${normalizeOpenAiBaseUrl(rawBase)}/v1` : rawBase
 
   const baseProviders = asRecord(baseConfig.provider)
   const baseProvider = asRecord(baseProviders[providerId])
@@ -130,12 +134,22 @@ export const opencodeFramework: AgentFramework = {
   supportedApiTypes: ['anthropic', 'openai'],
 
   spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams {
-    // `opencode acp` starts the ACP subprocess over stdio, matching the app's existing transport.
-    return spawn(input.executablePath, ['acp', ...input.args], {
-      env: { ...augmentedPathEnv(process.env), ...input.env },
-      stdio: 'pipe',
-      windowsHide: true
-    })
+    // `opencode acp` starts the ACP subprocess over stdio, matching the app's existing transport. On
+    // Windows an npm-installed opencode is a `opencode.cmd`/`.bat` shim that Node cannot launch without
+    // a shell (spawn EINVAL, same as Claude's cli.js shim), so those go through the shell with the
+    // path quoted; a native `.exe`/Unix binary spawns directly.
+    const needsShell = process.platform === 'win32' && /\.(cmd|bat)$/i.test(input.executablePath)
+
+    return spawn(
+      needsShell ? `"${input.executablePath}"` : input.executablePath,
+      ['acp', ...input.args],
+      {
+        env: { ...augmentedPathEnv(process.env), ...input.env },
+        stdio: 'pipe',
+        windowsHide: true,
+        shell: needsShell
+      }
+    )
   },
 
   prepareModelConfig(provider: ResolvedProvider, ctx: ModelConfigContext): AgentModelConfig {

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -85,7 +85,7 @@ export { buildOpencodeConfig }
 
 export const opencodeFramework: AgentFramework = {
   id: 'opencode',
-  displayName: 'opencode',
+  displayName: 'OpenCode',
   // opencode has agents/commands, not config-dir skills; hide the skills UI + force-load path.
   supportsSkills: false,
   // Handshake shows opencode advertises mcpCapabilities http+sse only (no stdio). Until the app exposes

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -55,6 +55,9 @@ export const opencodeFramework: AgentFramework = {
   displayName: 'opencode',
   // opencode has agents/commands, not config-dir skills; hide the skills UI + force-load path.
   supportsSkills: false,
+  // Handshake shows opencode advertises mcpCapabilities http+sse only (no stdio). Until the app exposes
+  // its artifact/notebook MCP over http, they're gated off for opencode and only basic turns run.
+  acceptsStdioMcp: false,
 
   spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams {
     // `opencode acp` starts the ACP subprocess over stdio, matching the app's existing transport.

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -111,9 +111,11 @@ export const opencodeFramework: AgentFramework = {
   // opencode discovers skills natively at <configDir>/skills/<name>/SKILL.md (same layout as Claude),
   // loaded on-demand via its skill tool; the app materializes the enabled set into the isolated config.
   supportsSkills: true,
-  // Handshake shows opencode advertises mcpCapabilities http+sse only (no stdio). Until the app exposes
-  // its artifact/notebook MCP over http, they're gated off for opencode and only basic turns run.
-  acceptsStdioMcp: false,
+  // opencode accepts stdio MCP servers over ACP (verified live vs 1.17.13: it launches a stdio server
+  // and sends it the MCP initialize handshake). Its mcpCapabilities advertise only http/sse because
+  // ACP has no stdio flag — stdio is the baseline transport. So opencode uses the SAME stdio artifact/
+  // notebook config as Claude; the http MCP host stays in the runtime but no framework needs it.
+  acceptsStdioMcp: true,
   // opencode speaks both Anthropic /v1/messages and OpenAI /v1/chat/completions.
   supportedApiTypes: ['anthropic', 'openai'],
 

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -31,6 +31,12 @@ import type {
 const opencodeConfigHome = (storageRoot: string): string => join(storageRoot, 'opencode', 'config')
 const opencodeDataHome = (storageRoot: string): string => join(storageRoot, 'opencode', 'data')
 
+// The opencode config directory ($XDG_CONFIG_HOME/opencode) where opencode.json and skills/ live.
+// opencode discovers skills at <configDir>/skills/<name>/SKILL.md — the same layout Claude uses under
+// its config dir — so the app materializes the enabled skill set here for opencode too.
+export const opencodeConfigDir = (storageRoot: string): string =>
+  join(opencodeConfigHome(storageRoot), 'opencode')
+
 // The app's providers are Anthropic `/v1/messages`-compatible (custom gateways and official vendors),
 // so they map onto opencode's built-in `anthropic` provider with a `baseURL`/`apiKey` override. An
 // OpenAI-format gateway would instead need a custom provider with `npm: "@ai-sdk/openai-compatible"`;
@@ -91,8 +97,9 @@ export { buildOpencodeConfig }
 export const opencodeFramework: AgentFramework = {
   id: 'opencode',
   displayName: 'OpenCode',
-  // opencode has agents/commands, not config-dir skills; hide the skills UI + force-load path.
-  supportsSkills: false,
+  // opencode discovers skills natively at <configDir>/skills/<name>/SKILL.md (same layout as Claude),
+  // loaded on-demand via its skill tool; the app materializes the enabled set into the isolated config.
+  supportsSkills: true,
   // Handshake shows opencode advertises mcpCapabilities http+sse only (no stdio). Until the app exposes
   // its artifact/notebook MCP over http, they're gated off for opencode and only basic turns run.
   acceptsStdioMcp: false,

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -87,6 +87,7 @@ const buildOpencodeConfig = (
   const baseProvider = asRecord(baseProviders[providerId])
   const baseOptions = asRecord(baseProvider.options)
   const baseModels = asRecord(baseProvider.models)
+  const basePermission = asRecord(baseConfig.permission)
   // Preserve any instructions the base config already declared, then append ours (de-duplicated).
   const baseInstructions = Array.isArray(baseConfig.instructions)
     ? baseConfig.instructions.filter((entry): entry is string => typeof entry === 'string')
@@ -98,6 +99,11 @@ const buildOpencodeConfig = (
     ...baseConfig,
     ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
     ...(instructions.length > 0 ? { instructions } : {}),
+    // Force opencode to ASK the ACP client for every edit/bash/webfetch instead of running silently
+    // under its permissive default. The app then enforces the selected permission profile in its broker
+    // (ask prompts, auto auto-approves workspace edits, full auto-approves all) — a single, mid-session-
+    // switchable decision point. Our keys win over any base config so delegation can't be turned off.
+    permission: { ...basePermission, edit: 'ask', bash: 'ask', webfetch: 'ask' },
     provider: {
       ...baseProviders,
       [providerId]: {
@@ -192,9 +198,10 @@ export const opencodeFramework: AgentFramework = {
     profile: PermissionProfileId,
     modes: SessionModeState | null | undefined
   ): PermissionProfileApplication {
-    // Framework-neutral: the shared resolver keys off the modes the agent advertises (opencode offers
-    // `build`/`plan`, Claude `default`/`acceptEdits`/`bypassPermissions`), degrading gracefully when a
-    // profile has no matching mode.
-    return resolvePermissionProfileApplication(profile, modes)
+    // opencode advertises `build`/`plan` modes, not Claude's `default`/`bypassPermissions`, so no mode
+    // is set here — the app owns permission decisions instead. prepareModelConfig configures opencode
+    // to delegate every edit/bash/webfetch prompt to the client (see buildOpencodeConfig), so the broker
+    // enforces ask/auto/full app-side. That's why Full access is offered even without a native bypass.
+    return resolvePermissionProfileApplication(profile, modes, { brokerEnforcesFullAccess: true })
   }
 }

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -91,6 +91,8 @@ export const opencodeFramework: AgentFramework = {
   // Handshake shows opencode advertises mcpCapabilities http+sse only (no stdio). Until the app exposes
   // its artifact/notebook MCP over http, they're gated off for opencode and only basic turns run.
   acceptsStdioMcp: false,
+  // opencode speaks both Anthropic /v1/messages and OpenAI /v1/chat/completions.
+  supportedApiTypes: ['anthropic', 'openai'],
 
   spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams {
     // `opencode acp` starts the ACP subprocess over stdio, matching the app's existing transport.

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -26,29 +26,55 @@ import type {
 // Env var opencode reads to locate its config file.
 const OPENCODE_CONFIG_ENV = 'OPENCODE_CONFIG'
 
-// Maps the app's Anthropic-compatible custom gateway onto an opencode `anthropic` provider block.
-// TODO(spike): verify the real opencode.json schema + `provider/model` id scheme on a live build;
-// handle official/local providers and opencode-only providers (defer to `opencode auth login`).
-const buildOpencodeConfig = (provider: ResolvedProvider): string => {
-  const model = provider.model ? `anthropic/${provider.model}` : undefined
+// The app's providers are Anthropic `/v1/messages`-compatible (custom gateways and official vendors),
+// so they map onto opencode's built-in `anthropic` provider with a `baseURL`/`apiKey` override. An
+// OpenAI-format gateway would instead need a custom provider with `npm: "@ai-sdk/openai-compatible"`;
+// the app does not expose such providers today, so that branch is intentionally not built yet.
+const OPENCODE_PROVIDER_ID = 'anthropic'
 
-  return JSON.stringify(
-    {
-      $schema: 'https://opencode.ai/config.json',
-      ...(model ? { model } : {}),
-      provider: {
-        anthropic: {
-          options: {
-            ...(provider.baseUrl ? { baseURL: provider.baseUrl } : {}),
-            ...(provider.key ? { apiKey: provider.key } : {})
-          }
-        }
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+
+// Builds opencode's config by MERGING the app's active provider/model onto the user's existing config
+// so their own providers, mcp servers, and auth are preserved. The model is both selected (top-level
+// `model`) and registered under the provider's `models` map — without the registration opencode does
+// not recognize a non-catalog model id (e.g. a custom gateway's `deepseek-v4-pro`) and silently falls
+// back to its own default. Verified against opencode 1.17.13.
+const buildOpencodeConfig = (
+  provider: ResolvedProvider,
+  baseConfig: Record<string, unknown> = {}
+): string => {
+  const bareModel = provider.model
+  const baseProviders = asRecord(baseConfig.provider)
+  const baseProvider = asRecord(baseProviders[OPENCODE_PROVIDER_ID])
+  const baseOptions = asRecord(baseProvider.options)
+  const baseModels = asRecord(baseProvider.models)
+
+  const merged: Record<string, unknown> = {
+    $schema: 'https://opencode.ai/config.json',
+    ...baseConfig,
+    ...(bareModel ? { model: `${OPENCODE_PROVIDER_ID}/${bareModel}` } : {}),
+    provider: {
+      ...baseProviders,
+      [OPENCODE_PROVIDER_ID]: {
+        ...baseProvider,
+        options: {
+          ...baseOptions,
+          ...(provider.baseUrl ? { baseURL: provider.baseUrl } : {}),
+          ...(provider.key ? { apiKey: provider.key } : {})
+        },
+        // Register the model so opencode treats a non-catalog id as a real, selectable model.
+        ...(bareModel ? { models: { ...baseModels, [bareModel]: {} } } : {})
       }
-    },
-    null,
-    2
-  )
+    }
+  }
+
+  return JSON.stringify(merged, null, 2)
 }
+
+export { buildOpencodeConfig }
 
 export const opencodeFramework: AgentFramework = {
   id: 'opencode',
@@ -69,12 +95,13 @@ export const opencodeFramework: AgentFramework = {
   },
 
   prepareModelConfig(provider: ResolvedProvider, ctx: ModelConfigContext): AgentModelConfig {
-    // opencode reads a config file, not ANTHROPIC_* env; point OPENCODE_CONFIG at a generated one.
+    // opencode reads a config file, not ANTHROPIC_* env; point OPENCODE_CONFIG at an app-owned file
+    // that merges the app's provider/model onto the user's existing opencode config.
     const configPath = join(ctx.storageRoot, 'opencode', 'opencode.json')
 
     return {
       env: { [OPENCODE_CONFIG_ENV]: configPath },
-      configFiles: [{ path: configPath, content: buildOpencodeConfig(provider) }]
+      configFiles: [{ path: configPath, content: buildOpencodeConfig(provider, ctx.baseConfig) }]
     }
   },
 

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -32,6 +32,11 @@ import type {
 const opencodeConfigHome = (storageRoot: string): string => join(storageRoot, 'opencode', 'config')
 const opencodeDataHome = (storageRoot: string): string => join(storageRoot, 'opencode', 'data')
 
+// The root of opencode's app-owned XDG subtree (both config and data live under here): opencode.json,
+// materialized skills, connector instructions, and auth.json. The agent's Read tool must never surface
+// it, so the runtime adds this to its protected-read roots.
+export const opencodeStorageDir = (storageRoot: string): string => join(storageRoot, 'opencode')
+
 // The opencode config directory ($XDG_CONFIG_HOME/opencode) where opencode.json and skills/ live.
 // opencode discovers skills at <configDir>/skills/<name>/SKILL.md — the same layout Claude uses under
 // its config dir — so the app materializes the enabled skill set here for opencode too.

--- a/src/main/agent-framework/registry.ts
+++ b/src/main/agent-framework/registry.ts
@@ -1,0 +1,17 @@
+import { claudeCodeFramework } from './claude-code'
+import { opencodeFramework } from './opencode'
+import type { AgentFramework, AgentFrameworkId } from './types'
+
+const FRAMEWORKS: Record<AgentFrameworkId, AgentFramework> = {
+  'claude-code': claudeCodeFramework,
+  opencode: opencodeFramework
+}
+
+// The default framework until framework selection is wired into settings.
+export const DEFAULT_AGENT_FRAMEWORK_ID: AgentFrameworkId = 'claude-code'
+
+// Resolves a framework by id for the runtime/settings; ids come from a fixed union so this is total.
+export const getAgentFramework = (id: AgentFrameworkId): AgentFramework => FRAMEWORKS[id]
+
+// Lists every registered framework for the (future) settings selector.
+export const listAgentFrameworks = (): AgentFramework[] => Object.values(FRAMEWORKS)

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -33,9 +33,6 @@ export type ModelConfigContext = {
   storageRoot: string
   // Absolute path to the detected framework executable (claude / opencode).
   executablePath: string
-  // The framework's existing user config (e.g. opencode's global opencode.json), read by the settings
-  // layer so the adapter can merge onto it instead of replacing the user's own providers/mcp.
-  baseConfig?: Record<string, unknown>
   // Combined instructions markdown (connector conventions + tools) for frameworks that lack on-demand
   // skill loading; the adapter writes it and wires it into the agent's instruction mechanism so the
   // agent learns host.mcp instead of reimplementing connector calls with raw HTTP. Empty ⇒ omitted.

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -80,3 +80,13 @@ export interface AgentFramework {
   // Config-dir-materialized skills (Claude). Absent ⇒ the app hides the skills UI + force-load path.
   readonly supportsSkills: boolean
 }
+
+// The resolved agent backend for one connect: which framework to drive plus its already-resolved spawn
+// inputs (executable + env + args). Produced by the settings layer at connect time so a framework or
+// provider switch takes effect on reconnect.
+export type ResolvedAgentBackend = {
+  framework: AgentFramework
+  executablePath: string
+  env: Record<string, string>
+  args?: string[]
+}

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -33,6 +33,9 @@ export type ModelConfigContext = {
   storageRoot: string
   // Absolute path to the detected framework executable (claude / opencode).
   executablePath: string
+  // The framework's existing user config (e.g. opencode's global opencode.json), read by the settings
+  // layer so the adapter can merge onto it instead of replacing the user's own providers/mcp.
+  baseConfig?: Record<string, unknown>
 }
 
 // System-prompt guidance the runtime wants appended for a session (artifact routing, notebook, skill

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -3,10 +3,12 @@ import type { SessionModeState } from '@agentclientprotocol/sdk'
 
 import type { PermissionProfileApplication } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
+import type { AgentFrameworkId } from '../../shared/settings'
 import type { ResolvedProvider } from '../settings/provider-env'
 
-// The agent frameworks the app can drive over ACP. Adding one means implementing AgentFramework.
-export type AgentFrameworkId = 'claude-code' | 'opencode'
+// The agent frameworks the app can drive over ACP (id union defined in shared settings so the renderer
+// and persisted settings share it). Adding one means implementing AgentFramework.
+export type { AgentFrameworkId }
 
 // A config file the framework needs on disk before spawn (e.g. a generated opencode.json). The
 // runtime writes these and points the framework at them via env/args.

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -3,7 +3,7 @@ import type { SessionModeState } from '@agentclientprotocol/sdk'
 
 import type { PermissionProfileApplication } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
-import type { AgentFrameworkId } from '../../shared/settings'
+import type { AgentFrameworkId, ChatApiEndpoint } from '../../shared/settings'
 import type { ResolvedProvider } from '../settings/provider-env'
 
 // The agent frameworks the app can drive over ACP (id union defined in shared settings so the renderer
@@ -93,6 +93,10 @@ export interface AgentFramework {
   // http/sse only, so stdio servers must not be handed to it — the app's artifact/notebook tooling
   // (currently stdio) is gated off for such frameworks until it is exposed over http/sse.
   readonly acceptsStdioMcp: boolean
+
+  // Chat endpoints this framework can drive. A provider is only selectable when it shares one:
+  // Claude Code speaks Anthropic /v1/messages; opencode speaks both.
+  readonly supportedApiTypes: readonly ChatApiEndpoint[]
 }
 
 // The resolved agent backend for one connect: which framework to drive plus its already-resolved spawn

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -79,6 +79,11 @@ export interface AgentFramework {
 
   // Config-dir-materialized skills (Claude). Absent ⇒ the app hides the skills UI + force-load path.
   readonly supportsSkills: boolean
+
+  // Whether the framework accepts stdio MCP servers via ACP session mcpServers. opencode advertises
+  // http/sse only, so stdio servers must not be handed to it — the app's artifact/notebook tooling
+  // (currently stdio) is gated off for such frameworks until it is exposed over http/sse.
+  readonly acceptsStdioMcp: boolean
 }
 
 // The resolved agent backend for one connect: which framework to drive plus its already-resolved spawn

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -1,0 +1,82 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import type { SessionModeState } from '@agentclientprotocol/sdk'
+
+import type { PermissionProfileApplication } from '../acp/permission-profile-controller'
+import type { PermissionProfileId } from '../../shared/permission-profiles'
+import type { ResolvedProvider } from '../settings/provider-env'
+
+// The agent frameworks the app can drive over ACP. Adding one means implementing AgentFramework.
+export type AgentFrameworkId = 'claude-code' | 'opencode'
+
+// A config file the framework needs on disk before spawn (e.g. a generated opencode.json). The
+// runtime writes these and points the framework at them via env/args.
+export type AgentConfigFile = {
+  path: string
+  content: string
+}
+
+// How the app's provider maps onto a framework's native model configuration. Claude reads env
+// (ANTHROPIC_*); opencode reads a generated config file referenced by OPENCODE_CONFIG. Fields are
+// merged over the spawn base, so an empty result just spawns with inherited defaults.
+export type AgentModelConfig = {
+  env?: Record<string, string>
+  configFiles?: AgentConfigFile[]
+  args?: string[]
+}
+
+// Inputs for translating a provider; paths differ per framework (Claude wants its executable + config
+// dir root, opencode wants a location to write its generated config into).
+export type ModelConfigContext = {
+  // App storage root; frameworks derive their config dir/location beneath it.
+  storageRoot: string
+  // Absolute path to the detected framework executable (claude / opencode).
+  executablePath: string
+}
+
+// System-prompt guidance the runtime wants appended for a session (artifact routing, notebook, skill
+// privacy). The framework decides HOW it is delivered — see SessionSetup.
+export type SessionSetupContext = {
+  systemPromptAppends: string[]
+}
+
+// Framework-specific session configuration returned to the runtime. `meta` becomes the ACP `_meta`
+// on session/new and session/resume. `promptPrefix` is prepended to prompt content when the framework
+// cannot carry appends in session meta (opencode has no system-prompt preset).
+export type SessionSetup = {
+  meta?: Record<string, unknown>
+  promptPrefix?: string
+}
+
+// Already-resolved spawn inputs: env and args come from prepareModelConfig merged over the base
+// process env; configFiles are written by the runtime before this call.
+export type AgentSpawnInput = {
+  executablePath: string
+  env: Record<string, string>
+  args: string[]
+  debug?: boolean
+}
+
+// One switchable agent backend. The ACP runtime stays generic and delegates only the framework-coupled
+// decisions to this interface. See docs/internal/pluggable-agent-framework-feasibility.md.
+export interface AgentFramework {
+  readonly id: AgentFrameworkId
+  readonly displayName: string
+
+  // Launch the ACP agent subprocess (stdio JSON-RPC), wrapping the per-framework binary + args.
+  spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams
+
+  // Translate the app's provider into the framework's native model config (env / config files / args).
+  prepareModelConfig(provider: ResolvedProvider, ctx: ModelConfigContext): AgentModelConfig
+
+  // Build the session `_meta` and decide how system-prompt appends are delivered for this framework.
+  buildSessionSetup(ctx: SessionSetupContext): SessionSetup
+
+  // Map an app permission profile onto the modes the agent advertised at session build/resume.
+  mapPermissionProfile(
+    profile: PermissionProfileId,
+    modes: SessionModeState | null | undefined
+  ): PermissionProfileApplication
+
+  // Config-dir-materialized skills (Claude). Absent ⇒ the app hides the skills UI + force-load path.
+  readonly supportsSkills: boolean
+}

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -36,6 +36,10 @@ export type ModelConfigContext = {
   // The framework's existing user config (e.g. opencode's global opencode.json), read by the settings
   // layer so the adapter can merge onto it instead of replacing the user's own providers/mcp.
   baseConfig?: Record<string, unknown>
+  // Combined instructions markdown (connector conventions + tools) for frameworks that lack on-demand
+  // skill loading; the adapter writes it and wires it into the agent's instruction mechanism so the
+  // agent learns host.mcp instead of reimplementing connector calls with raw HTTP. Empty ⇒ omitted.
+  instructions?: string
 }
 
 // System-prompt guidance the runtime wants appended for a session (artifact routing, notebook, skill

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -96,4 +96,8 @@ export type ResolvedAgentBackend = {
   executablePath: string
   env: Record<string, string>
   args?: string[]
+  // Model to apply per session via the ACP `model` configOption, for frameworks that select the model
+  // over the protocol rather than via env (opencode). Undefined ⇒ the framework's env/config drives it
+  // (Claude uses ANTHROPIC_MODEL). Applied best-effort: skipped when the agent advertises no match.
+  sessionModel?: string
 }

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -225,6 +225,7 @@ const runArtifactMcpServer = async (
 
 export {
   ARTIFACT_MCP_SERVER_ARG,
+  ARTIFACT_MCP_SERVER_NAME,
   createArtifactMcpEnvironmentFromProcess,
   createArtifactMcpServer,
   createArtifactMcpServerConfig,

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from 'vitest'
-import { renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
+import { renderConnectorInstructions, renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
+
+describe('renderConnectorInstructions', () => {
+  it('emits the host.mcp conventions once and each enabled connector, for opencode', () => {
+    const md = renderConnectorInstructions(['chemistry'])
+
+    expect(md).toContain('host.mcp(')
+    // The "do not reimplement with raw HTTP" rule is what steers opencode away from raw requests.
+    expect(md).toMatch(/urllib|requests|httpx|fetch/)
+    expect(md).toContain('## chemistry')
+    expect(md).toContain('chemistry / pubchem_get_compounds')
+    // Conventions appear once, not per connector.
+    expect(md.match(/Reach this service ONLY via/g)?.length ?? 0).toBe(1)
+  })
+
+  it('returns empty string when no connectors are enabled', () => {
+    expect(renderConnectorInstructions([])).toBe('')
+    expect(renderConnectorInstructions(['nope'])).toBe('')
+  })
+})
 
 describe('renderSkillDoc', () => {
   it('renders frontmatter, conventions, and each tool', () => {

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -92,6 +92,38 @@ export function renderSkillDoc(connectorId: string): string {
   )
 }
 
+// Renders ONE combined instructions doc for agents without on-demand skill loading (opencode): the
+// shared conventions once, then every enabled connector's tools. Delivered via opencode's `instructions`
+// config so the agent reaches connectors through `host.mcp(...)` from the notebook kernel instead of
+// reimplementing the calls with raw HTTP (which bypasses the approval gate, credentials, and limits).
+export function renderConnectorInstructions(connectorIds: string[]): string {
+  const sections = connectorIds
+    .map((connectorId) => {
+      const meta = CONNECTOR_CATALOG.find((c) => c.id === connectorId)
+      if (!meta) return ''
+
+      const methods = getConnectorTools(connectorId)
+        .map(
+          (t) =>
+            `### ${connectorId} / ${t.id}\n\n${t.description}\n\n\`\`\`json\n${JSON.stringify(t.input, null, 2)}\n\`\`\`\n\n` +
+            (t.returns ? `**Returns:** ${t.returns}\n\n` : '') +
+            renderExample(connectorId, t.id, t.input, t.example)
+        )
+        .join('\n')
+
+      return `## ${connectorId}\n\n${meta.useWhen}\n\n${methods}`
+    })
+    .filter(Boolean)
+
+  if (sections.length === 0) return ''
+
+  return (
+    `# Open Science data connectors\n\n` +
+    `These connectors are available for this session. ${CONVENTIONS}\n\n` +
+    `# Available connectors\n\n${sections.join('\n\n')}`
+  )
+}
+
 export type CustomSkillDocServer = { id: string; name: string; description?: string }
 export type CustomSkillDocTool = { name: string; description?: string; inputSchema?: unknown }
 

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -647,13 +647,19 @@ const runScopedReview = async (options: {
     const systemPromptAppend = REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
     const cwd = session.cwd || homedir()
 
-    reviewerSession = await acpRuntime.buildReviewerSession({
+    const built = await acpRuntime.buildReviewerSession({
       cwd,
       mcpServers: [mcpServer.toAcpMcpServerConfig()],
       systemPromptAppend
     })
+    reviewerSession = built.session
 
-    reviewerSession.prompt([{ type: 'text', text: reviewerPrompt }])
+    // opencode has no system-prompt preset, so the rubric rides back as a prompt prefix; Claude gets
+    // it via _meta and returns no prefix. Prepend it so the reviewer rubric reaches either framework.
+    const reviewerPromptText = built.promptPrefix
+      ? `${built.promptPrefix}\n\n${reviewerPrompt}`
+      : reviewerPrompt
+    reviewerSession.prompt([{ type: 'text', text: reviewerPromptText }])
 
     await driveReviewerToStop(
       reviewerSession,
@@ -824,18 +830,23 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
     // Spawn the reviewer ACP session (clean context, reviewer-only tools).
     const cwd = session.cwd || homedir()
 
-    reviewerSession = await acpRuntime.buildReviewerSession({
+    const built = await acpRuntime.buildReviewerSession({
       cwd,
       mcpServers: [mcpServer.toAcpMcpServerConfig()],
       systemPromptAppend
     })
+    reviewerSession = built.session
 
     log.info('reviewer session started', { sessionId: reviewerSession.sessionId })
 
     // Send the prompt and drive the session to completion. A timeout / update cap guards against a
     // hung or fast-looping reviewer that never stops: on expiry this throws, the catch below sets
     // lifecycle='error', and the finally disposes the session + host/MCP servers.
-    reviewerSession.prompt([{ type: 'text', text: reviewerPrompt }])
+    // opencode gets the rubric via a prompt prefix (Claude via _meta, prefix empty).
+    const reviewerPromptText = built.promptPrefix
+      ? `${built.promptPrefix}\n\n${reviewerPrompt}`
+      : reviewerPrompt
+    reviewerSession.prompt([{ type: 'text', text: reviewerPromptText }])
 
     const stopReason = await driveReviewerToStop(
       reviewerSession,

--- a/src/main/settings/base-url.ts
+++ b/src/main/settings/base-url.ts
@@ -7,10 +7,20 @@
 // Matches a trailing `/v1` or `/v1/messages` segment (case-insensitive), with optional trailing slash.
 const REDUNDANT_SUFFIX = /\/v1(\/messages)?\/*$/i
 
+// Same idea for an OpenAI-compatible gateway, whose endpoint is `/v1/chat/completions`.
+const REDUNDANT_OPENAI_SUFFIX = /\/v1(\/chat\/completions)?\/*$/i
+
 const normalizeAnthropicBaseUrl = (baseUrl: string): string => {
   const trimmed = baseUrl.trim().replace(/\/+$/, '')
 
   return trimmed.replace(REDUNDANT_SUFFIX, '')
 }
 
-export { normalizeAnthropicBaseUrl }
+// Strips a trailing `/v1` or `/v1/chat/completions` so appending `/v1/chat/completions` never doubles.
+const normalizeOpenAiBaseUrl = (baseUrl: string): string => {
+  const trimmed = baseUrl.trim().replace(/\/+$/, '')
+
+  return trimmed.replace(REDUNDANT_OPENAI_SUFFIX, '')
+}
+
+export { normalizeAnthropicBaseUrl, normalizeOpenAiBaseUrl }

--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -105,6 +105,32 @@ describe('claude-install: command construction', () => {
   })
 })
 
+describe('claude-install: custom install target (opencode)', () => {
+  const opencodeTarget = {
+    npmPackage: 'opencode-ai',
+    scriptUnix: 'curl -fsSL https://opencode.ai/install | bash'
+  }
+
+  it('installs the target npm package', () => {
+    const spec = getInstallSpawnSpec('npm', 'linux', undefined, opencodeTarget)
+
+    expect(spec.args).toEqual(['i', '-g', 'opencode-ai'])
+  })
+
+  it('pipes the target unix script through bash', () => {
+    const spec = getInstallSpawnSpec('official-script', 'linux', undefined, opencodeTarget)
+
+    expect(spec.command).toBe('bash')
+    expect(spec.args.at(-1)).toContain('curl -fsSL https://opencode.ai/install | bash')
+  })
+
+  it('throws for a script install on Windows when the target has no PowerShell installer', () => {
+    expect(() =>
+      getInstallSpawnSpec('official-script', 'win32', undefined, opencodeTarget)
+    ).toThrow(/No Windows install script/)
+  })
+})
+
 describe('claude-install: region-block detection', () => {
   it('flags piped-HTML region-block output', () => {
     expect(isRegionBlockedOutput('<!DOCTYPE html><html>App unavailable in region</html>')).toBe(

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -29,6 +29,22 @@ type InstallSpawnSpec = {
   shell?: boolean
 }
 
+// The per-tool coordinates the generic runner needs: the npm package to install and the shell/
+// PowerShell one-liners for the official installer. `scriptWindows` is optional — a tool with no
+// Windows PowerShell installer (e.g. opencode) simply omits it, and the script source is not offered
+// on Windows. Defaults to Claude so existing callers keep their exact behavior.
+export type InstallTarget = {
+  npmPackage: string
+  scriptUnix: string
+  scriptWindows?: string
+}
+
+export const CLAUDE_INSTALL_TARGET: InstallTarget = {
+  npmPackage: '@anthropic-ai/claude-code',
+  scriptUnix: 'curl -fsSL https://claude.ai/install.sh | bash',
+  scriptWindows: 'irm https://claude.ai/install.ps1 | iex'
+}
+
 // Builds the exact spawn command/args for a source on a given platform. Windows: npm runs through the
 // shell (npm.cmd), and the official installer is the PowerShell script (install.ps1); other platforms
 // keep npm bare and pipe the shell script through bash. On Unix, npm's global install is redirected to
@@ -40,12 +56,13 @@ type InstallSpawnSpec = {
 const getInstallSpawnSpec = (
   source: ClaudeInstallSource,
   platform: NodeJS.Platform = process.platform,
-  npmPrefixOverride?: string
+  npmPrefixOverride?: string,
+  target: InstallTarget = CLAUDE_INSTALL_TARGET
 ): InstallSpawnSpec => {
   const isWindows = platform === 'win32'
 
   if (source === 'npm') {
-    const baseArgs = ['i', '-g', '@anthropic-ai/claude-code']
+    const baseArgs = ['i', '-g', target.npmPackage]
 
     return {
       command: 'npm',
@@ -56,21 +73,22 @@ const getInstallSpawnSpec = (
     }
   }
 
-  return isWindows
-    ? {
-        command: 'powershell',
-        args: [
-          '-NoProfile',
-          '-ExecutionPolicy',
-          'Bypass',
-          '-Command',
-          'irm https://claude.ai/install.ps1 | iex'
-        ]
-      }
-    : {
-        command: 'bash',
-        args: ['-lc', 'curl -fsSL https://claude.ai/install.sh | bash']
-      }
+  if (isWindows) {
+    // A tool without a Windows PowerShell installer never reaches here (its source list hides the
+    // script on Windows); guard defensively so a mis-routed call fails loudly rather than silently.
+    if (!target.scriptWindows) {
+      throw new Error(
+        'No Windows install script for this tool; use npm or the app-managed download.'
+      )
+    }
+
+    return {
+      command: 'powershell',
+      args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', target.scriptWindows]
+    }
+  }
+
+  return { command: 'bash', args: ['-lc', target.scriptUnix] }
 }
 
 // Default guard so a hung network install cannot block the wizard forever.
@@ -169,6 +187,8 @@ export type RunInstallOptions = {
   // Injectable probe for whether npm's default global prefix is user-writable. When it is NOT (a
   // root-owned system prefix), the npm install is redirected to ~/.local so it never needs sudo.
   npmPrefixWritable?: () => Promise<boolean>
+  // Which tool to install (npm package + script one-liners). Defaults to Claude.
+  installTarget?: InstallTarget
 }
 
 // Options for the region-block-aware install. Extends the run options with an injectable npm probe so
@@ -200,7 +220,8 @@ const runInstall = async ({
   timeoutMs = DEFAULT_INSTALL_TIMEOUT_MS,
   spawnImpl = defaultInstallSpawn,
   platform = process.platform,
-  npmPrefixWritable = () => isNpmGlobalPrefixWritable()
+  npmPrefixWritable = () => isNpmGlobalPrefixWritable(),
+  installTarget
 }: RunInstallOptions): Promise<ClaudeInstallResult> => {
   // Redirect npm's global install to a user-owned prefix only off Windows and only when the default
   // global prefix isn't writable (would otherwise need sudo). Homebrew/nvm/volta users keep a plain
@@ -210,7 +231,7 @@ const runInstall = async ({
       ? join(homedir(), '.local')
       : undefined
 
-  const spec = getInstallSpawnSpec(source, platform, npmPrefixOverride)
+  const spec = getInstallSpawnSpec(source, platform, npmPrefixOverride, installTarget)
 
   onEvent({
     kind: 'log',
@@ -334,7 +355,8 @@ const runInstallWithFallback = async ({
   spawnImpl,
   platform,
   npmProbe,
-  npmPrefixWritable
+  npmPrefixWritable,
+  installTarget
 }: RunInstallWithFallbackOptions): Promise<ClaudeInstallResult> => {
   const result = await runInstall({
     source,
@@ -343,7 +365,8 @@ const runInstallWithFallback = async ({
     timeoutMs,
     spawnImpl,
     platform,
-    npmPrefixWritable
+    npmPrefixWritable,
+    installTarget
   })
 
   if (result.ok || source !== 'official-script' || !result.regionBlocked) return result
@@ -366,7 +389,8 @@ const runInstallWithFallback = async ({
     timeoutMs,
     spawnImpl,
     platform,
-    npmPrefixWritable
+    npmPrefixWritable,
+    installTarget
   })
 }
 

--- a/src/main/settings/environment-check.test.ts
+++ b/src/main/settings/environment-check.test.ts
@@ -26,8 +26,7 @@ describe('runEnvironmentCheck', () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
       agentFrameworkId: 'claude-code' as const,
-      frameworkLabel: 'Claude',
-      runtime:{ found: false },
+      frameworks: [{ id: 'claude-code' as const, label: 'Claude', runtime: { found: false } }],
       encryptionAvailable: true,
       deps: baseDeps()
     })
@@ -45,8 +44,7 @@ describe('runEnvironmentCheck', () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
       agentFrameworkId: 'claude-code' as const,
-      frameworkLabel: 'Claude',
-      runtime:{ found: false },
+      frameworks: [{ id: 'claude-code' as const, label: 'Claude', runtime: { found: false } }],
       encryptionAvailable: true,
       deps: { ...baseDeps(), probeRegistry: vi.fn().mockRejectedValue(new Error('offline')) }
     })
@@ -63,8 +61,7 @@ describe('runEnvironmentCheck', () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/locked',
       agentFrameworkId: 'claude-code' as const,
-      frameworkLabel: 'Claude',
-      runtime:{ found: false },
+      frameworks: [{ id: 'claude-code' as const, label: 'Claude', runtime: { found: false } }],
       encryptionAvailable: true,
       deps: {
         ...baseDeps(),
@@ -84,8 +81,13 @@ describe('runEnvironmentCheck', () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
       agentFrameworkId: 'claude-code' as const,
-      frameworkLabel: 'Claude',
-      runtime:{ found: true, path: '/bin/claude', version: '2.1.0' },
+      frameworks: [
+        {
+          id: 'claude-code' as const,
+          label: 'Claude',
+          runtime: { found: true, path: '/bin/claude', version: '2.1.0' }
+        }
+      ],
       encryptionAvailable: true,
       deps: { ...baseDeps(), probeRegistry }
     })
@@ -104,8 +106,13 @@ describe('runEnvironmentCheck', () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
       agentFrameworkId: 'claude-code' as const,
-      frameworkLabel: 'Claude',
-      runtime:{ found: true, path: '/bin/claude', version: '2.1.0' },
+      frameworks: [
+        {
+          id: 'claude-code' as const,
+          label: 'Claude',
+          runtime: { found: true, path: '/bin/claude', version: '2.1.0' }
+        }
+      ],
       encryptionAvailable: true,
       deps: { ...baseDeps(), findPython: vi.fn().mockResolvedValue(undefined) }
     })
@@ -122,8 +129,13 @@ describe('runEnvironmentCheck', () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
       agentFrameworkId: 'claude-code' as const,
-      frameworkLabel: 'Claude',
-      runtime:{ found: true, path: '/bin/claude' },
+      frameworks: [
+        {
+          id: 'claude-code' as const,
+          label: 'Claude',
+          runtime: { found: true, path: '/bin/claude' }
+        }
+      ],
       encryptionAvailable: false,
       deps: baseDeps()
     })
@@ -136,8 +148,7 @@ describe('runEnvironmentCheck', () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
       agentFrameworkId: 'claude-code' as const,
-      frameworkLabel: 'Claude',
-      runtime:{ found: false },
+      frameworks: [{ id: 'claude-code' as const, label: 'Claude', runtime: { found: false } }],
       encryptionAvailable: true,
       deps: {
         ...baseDeps(),
@@ -160,8 +171,13 @@ describe('runEnvironmentCheck', () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
       agentFrameworkId: 'claude-code' as const,
-      frameworkLabel: 'Claude',
-      runtime:{ found: true, path: '/opt/claude', version: '2.1.0' },
+      frameworks: [
+        {
+          id: 'claude-code' as const,
+          label: 'Claude',
+          runtime: { found: true, path: '/opt/claude', version: '2.1.0' }
+        }
+      ],
       encryptionAvailable: true,
       deps: {
         ...baseDeps(),

--- a/src/main/settings/environment-check.test.ts
+++ b/src/main/settings/environment-check.test.ts
@@ -57,6 +57,57 @@ describe('runEnvironmentCheck', () => {
     })
   })
 
+  it('checks both frameworks but gates only on the selected one', async () => {
+    // Claude installed, OpenCode not — with OpenCode selected, its absence blocks (failed) while the
+    // installed Claude row is informational (passed); the non-selected missing case is a warning.
+    const result = await runEnvironmentCheck({
+      storageRoot: '/data',
+      agentFrameworkId: 'opencode' as const,
+      frameworks: [
+        {
+          id: 'claude-code' as const,
+          label: 'Claude',
+          runtime: { found: true, path: '/bin/claude', version: '2.1.0' }
+        },
+        { id: 'opencode' as const, label: 'OpenCode', runtime: { found: false } }
+      ],
+      encryptionAvailable: true,
+      deps: baseDeps()
+    })
+
+    const rows = result.checks.filter((check) => check.id === 'agent')
+    expect(rows.map((row) => `${row.label}:${row.status}`)).toEqual([
+      'Claude runtime:passed',
+      'OpenCode runtime:failed'
+    ])
+    // Selected (OpenCode) missing → not ready, and it can be auto-installed.
+    expect(result.ready).toBe(false)
+    expect(result.canAutoInstall).toBe(true)
+    expect(result.runtime).toEqual({ found: false })
+  })
+
+  it('is ready when the selected framework is installed even if the other is missing', async () => {
+    const result = await runEnvironmentCheck({
+      storageRoot: '/data',
+      agentFrameworkId: 'claude-code' as const,
+      frameworks: [
+        {
+          id: 'claude-code' as const,
+          label: 'Claude',
+          runtime: { found: true, path: '/bin/claude', version: '2.1.0' }
+        },
+        { id: 'opencode' as const, label: 'OpenCode', runtime: { found: false } }
+      ],
+      encryptionAvailable: true,
+      deps: baseDeps()
+    })
+
+    const opencodeRow = result.checks.find((check) => check.label === 'OpenCode runtime')
+    // The non-selected missing framework is an informational warning, not a blocker.
+    expect(opencodeRow?.status).toBe('warning')
+    expect(result.ready).toBe(true)
+  })
+
   it('blocks automatic setup when the app data directory is not writable', async () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/locked',

--- a/src/main/settings/environment-check.test.ts
+++ b/src/main/settings/environment-check.test.ts
@@ -25,7 +25,9 @@ describe('runEnvironmentCheck', () => {
   it('selects the fastest reachable trusted registry for a missing runtime', async () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
-      claude: { found: false },
+      agentFrameworkId: 'claude-code' as const,
+      frameworkLabel: 'Claude',
+      runtime:{ found: false },
       encryptionAvailable: true,
       deps: baseDeps()
     })
@@ -42,7 +44,9 @@ describe('runEnvironmentCheck', () => {
   it('blocks automatic installation when both trusted registries are unreachable', async () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
-      claude: { found: false },
+      agentFrameworkId: 'claude-code' as const,
+      frameworkLabel: 'Claude',
+      runtime:{ found: false },
       encryptionAvailable: true,
       deps: { ...baseDeps(), probeRegistry: vi.fn().mockRejectedValue(new Error('offline')) }
     })
@@ -58,7 +62,9 @@ describe('runEnvironmentCheck', () => {
   it('blocks automatic setup when the app data directory is not writable', async () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/locked',
-      claude: { found: false },
+      agentFrameworkId: 'claude-code' as const,
+      frameworkLabel: 'Claude',
+      runtime:{ found: false },
       encryptionAvailable: true,
       deps: {
         ...baseDeps(),
@@ -77,7 +83,9 @@ describe('runEnvironmentCheck', () => {
     const probeRegistry = vi.fn()
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
-      claude: { found: true, path: '/bin/claude', version: '2.1.0' },
+      agentFrameworkId: 'claude-code' as const,
+      frameworkLabel: 'Claude',
+      runtime:{ found: true, path: '/bin/claude', version: '2.1.0' },
       encryptionAvailable: true,
       deps: { ...baseDeps(), probeRegistry }
     })
@@ -95,7 +103,9 @@ describe('runEnvironmentCheck', () => {
   it('keeps missing Python non-blocking while explaining the Notebook limitation', async () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
-      claude: { found: true, path: '/bin/claude', version: '2.1.0' },
+      agentFrameworkId: 'claude-code' as const,
+      frameworkLabel: 'Claude',
+      runtime:{ found: true, path: '/bin/claude', version: '2.1.0' },
       encryptionAvailable: true,
       deps: { ...baseDeps(), findPython: vi.fn().mockResolvedValue(undefined) }
     })
@@ -111,7 +121,9 @@ describe('runEnvironmentCheck', () => {
   it('treats unavailable OS key encryption as a non-blocking warning', async () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
-      claude: { found: true, path: '/bin/claude' },
+      agentFrameworkId: 'claude-code' as const,
+      frameworkLabel: 'Claude',
+      runtime:{ found: true, path: '/bin/claude' },
       encryptionAvailable: false,
       deps: baseDeps()
     })
@@ -123,7 +135,9 @@ describe('runEnvironmentCheck', () => {
   it('blocks automatic installation on an unsupported platform when no runtime exists', async () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
-      claude: { found: false },
+      agentFrameworkId: 'claude-code' as const,
+      frameworkLabel: 'Claude',
+      runtime:{ found: false },
       encryptionAvailable: true,
       deps: {
         ...baseDeps(),
@@ -145,7 +159,9 @@ describe('runEnvironmentCheck', () => {
   it('keeps an existing runtime usable when only the managed installer is unsupported', async () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',
-      claude: { found: true, path: '/opt/claude', version: '2.1.0' },
+      agentFrameworkId: 'claude-code' as const,
+      frameworkLabel: 'Claude',
+      runtime:{ found: true, path: '/opt/claude', version: '2.1.0' },
       encryptionAvailable: true,
       deps: {
         ...baseDeps(),

--- a/src/main/settings/environment-check.ts
+++ b/src/main/settings/environment-check.ts
@@ -117,21 +117,24 @@ const inspectRegistry = async (
 
 const runEnvironmentCheck = async ({
   storageRoot,
-  runtime,
   agentFrameworkId,
-  frameworkLabel,
+  frameworks,
   encryptionAvailable,
   deps = {}
 }: {
   storageRoot: string
-  // Detection result for the SELECTED framework's runtime (Claude or OpenCode), in the shared shape.
-  runtime: ClaudeDetectResult
+  // The framework the user selected; only its runtime gates readiness/auto-install.
   agentFrameworkId: AgentFrameworkId
-  // Display name for the runtime check's copy ('Claude' / 'OpenCode').
-  frameworkLabel: string
+  // Every framework's runtime, checked and shown together (in display order). Each carries its label
+  // and detection result in the shared shape.
+  frameworks: { id: AgentFrameworkId; label: string; runtime: ClaudeDetectResult }[]
   encryptionAvailable: boolean
   deps?: EnvironmentCheckDeps
 }): Promise<EnvironmentCheckResult> => {
+  // The selected framework's runtime drives the required gate; the others are shown for context only.
+  const selected = frameworks.find((framework) => framework.id === agentFrameworkId)
+  const selectedRuntime = selected?.runtime ?? { found: false }
+  const selectedLabel = selected?.label ?? 'Agent'
   const platform = deps.platform ?? process.platform
   const architecture = deps.architecture ?? hostArchitecture()
   const verifyStorage = deps.verifyStorage ?? verifyStorageAccess
@@ -158,14 +161,14 @@ const runEnvironmentCheck = async ({
         return {
           id: 'system',
           label: 'System compatibility',
-          status: runtime.found ? 'warning' : 'failed',
-          summary: runtime.found
-            ? `${platformLabel(platform)} ${architecture} can use the detected ${frameworkLabel} runtime.`
+          status: selectedRuntime.found ? 'warning' : 'failed',
+          summary: selectedRuntime.found
+            ? `${platformLabel(platform)} ${architecture} can use the detected ${selectedLabel} runtime.`
             : `${platformLabel(platform)} ${architecture} has no automatic installer package.`,
           detail:
             error instanceof Error
               ? error.message
-              : 'Use the manual setup tab to install a compatible Claude runtime.'
+              : 'Use the manual setup tab to install a compatible agent runtime.'
         }
       }
     }),
@@ -193,12 +196,12 @@ const runEnvironmentCheck = async ({
   let recommendedRegistry: ManagedClaudeRegistry | undefined
   let networkCheck: EnvironmentCheckItem
 
-  if (runtime.found) {
+  if (selectedRuntime.found) {
     networkCheck = {
       id: 'install-network',
       label: 'Installation network',
       status: 'passed',
-      summary: `No download is needed because ${frameworkLabel} is already installed.`
+      summary: `No download is needed because ${selectedLabel} is already installed.`
     }
   } else {
     const registryResults = await Promise.all([
@@ -262,24 +265,34 @@ const runEnvironmentCheck = async ({
         detail: 'Notebook execution will be unavailable until Python 3 is installed.'
       }
 
-  const runtimeCheck: EnvironmentCheckItem = runtime.found
-    ? {
+  // One runtime row per framework, shown together. Only the SELECTED framework's absence is a failure
+  // (it blocks Continue); a non-selected framework that's missing is an informational warning, so the
+  // user isn't forced to install both.
+  const runtimeChecks: EnvironmentCheckItem[] = frameworks.map(({ id, label, runtime }) => {
+    if (runtime.found) {
+      return {
         id: 'agent',
-        label: `${frameworkLabel} runtime`,
+        label: `${label} runtime`,
         status: 'passed',
-        summary: runtime.version
-          ? `${frameworkLabel} ${runtime.version} is ready.`
-          : `${frameworkLabel} is ready.`,
+        summary: runtime.version ? `${label} ${runtime.version} is ready.` : `${label} is ready.`,
         detail: runtime.path
       }
-    : {
-        id: 'agent',
-        label: `${frameworkLabel} runtime`,
-        status: 'failed',
-        summary: `${frameworkLabel} is not installed yet.`,
-        detail:
-          'Automatic setup installs a self-contained runtime without Node.js, npm, or admin access.'
-      }
+    }
+
+    const isSelected = id === agentFrameworkId
+
+    return {
+      id: 'agent',
+      label: `${label} runtime`,
+      status: isSelected ? 'failed' : 'warning',
+      summary: isSelected
+        ? `${label} is not installed yet.`
+        : `${label} is not installed (optional — only needed if you switch to it).`,
+      detail: isSelected
+        ? 'Automatic setup installs a self-contained runtime without Node.js, npm, or admin access.'
+        : undefined
+    }
+  })
 
   const checks = [
     systemCheck,
@@ -287,7 +300,7 @@ const runEnvironmentCheck = async ({
     secureStorageCheck,
     networkCheck,
     pythonCheck,
-    runtimeCheck
+    ...runtimeChecks
   ]
   const passedIds = new Set(
     checks.filter((check) => check.status === 'passed').map((check) => check.id)
@@ -300,13 +313,13 @@ const runEnvironmentCheck = async ({
     checks,
     ready: checks.every((check) => check.status !== 'failed'),
     canAutoInstall:
-      !runtime.found &&
+      !selectedRuntime.found &&
       passedIds.has('system') &&
       passedIds.has('storage') &&
       passedIds.has('install-network'),
     recommendedRegistry,
     agentFrameworkId,
-    runtime
+    runtime: selectedRuntime
   }
 }
 

--- a/src/main/settings/environment-check.ts
+++ b/src/main/settings/environment-check.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../shared/settings'
 import { findPythonCommand, type PythonCommand } from '../notebook/python-command'
 import { getManagedPlatform } from './managed-claude'
+import { resolveOpencodePlatform } from './managed-opencode'
 
 const REGISTRY_URLS: Record<ManagedClaudeRegistry, string> = {
   npmjs: 'https://registry.npmjs.org',
@@ -23,10 +24,14 @@ const REGISTRY_LABELS: Record<ManagedClaudeRegistry, string> = {
   npmmirror: 'China-friendly npmmirror'
 }
 
-const REGISTRY_PROBE_PATH = '/@anthropic-ai%2fclaude-code/latest'
+// The npm package path probed per framework to gauge registry reachability for its managed install.
+const REGISTRY_PROBE_PATHS: Record<AgentFrameworkId, string> = {
+  'claude-code': '/@anthropic-ai%2fclaude-code/latest',
+  opencode: '/opencode-ai/latest'
+}
 const REGISTRY_PROBE_TIMEOUT_MS = 5_000
 
-type RegistryProbe = (registry: ManagedClaudeRegistry) => Promise<number>
+type RegistryProbe = (registry: ManagedClaudeRegistry, packagePath: string) => Promise<number>
 
 export type EnvironmentCheckDeps = {
   platform?: NodeJS.Platform
@@ -65,7 +70,7 @@ const verifyStorageAccess = async (storageRoot: string): Promise<void> => {
 
 // Uses the same direct HTTPS route as the managed downloader and follows a small number of redirects.
 // A HEAD request keeps the required basic source check lightweight on every startup.
-const probeRegistryReachability: RegistryProbe = (registry) => {
+const probeRegistryReachability: RegistryProbe = (registry, packagePath) => {
   const startedAt = Date.now()
 
   return new Promise<number>((resolve, reject) => {
@@ -100,16 +105,17 @@ const probeRegistryReachability: RegistryProbe = (registry) => {
       request.end()
     }
 
-    visit(`${REGISTRY_URLS[registry]}${REGISTRY_PROBE_PATH}`, 3)
+    visit(`${REGISTRY_URLS[registry]}${packagePath}`, 3)
   })
 }
 
 const inspectRegistry = async (
   registry: ManagedClaudeRegistry,
-  probe: RegistryProbe
+  probe: RegistryProbe,
+  packagePath: string
 ): Promise<{ registry: ManagedClaudeRegistry; latencyMs?: number }> => {
   try {
-    return { registry, latencyMs: await probe(registry) }
+    return { registry, latencyMs: await probe(registry, packagePath) }
   } catch {
     return { registry }
   }
@@ -138,7 +144,11 @@ const runEnvironmentCheck = async ({
   const platform = deps.platform ?? process.platform
   const architecture = deps.architecture ?? hostArchitecture()
   const verifyStorage = deps.verifyStorage ?? verifyStorageAccess
-  const resolveManagedPlatform = deps.resolveManagedPlatform ?? (() => getManagedPlatform())
+  // Gauge managed-install availability with the SELECTED framework's own platform map, not always
+  // Claude's, so an arch opencode has no package for isn't reported as auto-installable (and vice versa).
+  const resolveManagedPlatform =
+    deps.resolveManagedPlatform ??
+    (() => (agentFrameworkId === 'opencode' ? resolveOpencodePlatform() : getManagedPlatform()))
   const findPython = deps.findPython ?? findPythonCommand
   const probeRegistry = deps.probeRegistry ?? probeRegistryReachability
   const now = deps.now ?? Date.now
@@ -205,8 +215,8 @@ const runEnvironmentCheck = async ({
     }
   } else {
     const registryResults = await Promise.all([
-      inspectRegistry('npmjs', probeRegistry),
-      inspectRegistry('npmmirror', probeRegistry)
+      inspectRegistry('npmjs', probeRegistry, REGISTRY_PROBE_PATHS[agentFrameworkId]),
+      inspectRegistry('npmmirror', probeRegistry, REGISTRY_PROBE_PATHS[agentFrameworkId])
     ])
     const reachable = registryResults
       .filter(

--- a/src/main/settings/environment-check.ts
+++ b/src/main/settings/environment-check.ts
@@ -4,6 +4,7 @@ import { request as httpsRequest } from 'node:https'
 import { join } from 'node:path'
 
 import type {
+  AgentFrameworkId,
   ClaudeDetectResult,
   EnvironmentCheckItem,
   EnvironmentCheckResult,
@@ -116,12 +117,18 @@ const inspectRegistry = async (
 
 const runEnvironmentCheck = async ({
   storageRoot,
-  claude,
+  runtime,
+  agentFrameworkId,
+  frameworkLabel,
   encryptionAvailable,
   deps = {}
 }: {
   storageRoot: string
-  claude: ClaudeDetectResult
+  // Detection result for the SELECTED framework's runtime (Claude or OpenCode), in the shared shape.
+  runtime: ClaudeDetectResult
+  agentFrameworkId: AgentFrameworkId
+  // Display name for the runtime check's copy ('Claude' / 'OpenCode').
+  frameworkLabel: string
   encryptionAvailable: boolean
   deps?: EnvironmentCheckDeps
 }): Promise<EnvironmentCheckResult> => {
@@ -146,14 +153,14 @@ const runEnvironmentCheck = async ({
             'Automatic setup uses an app-managed runtime and does not require administrator access.'
         }
       } catch (error) {
-        // An already-runnable Claude can still be used even if this architecture has no managed
-        // package. Only a machine that also lacks Claude is blocked from automatic setup.
+        // An already-runnable runtime can still be used even if this architecture has no managed
+        // package. Only a machine that also lacks the runtime is blocked from automatic setup.
         return {
           id: 'system',
           label: 'System compatibility',
-          status: claude.found ? 'warning' : 'failed',
-          summary: claude.found
-            ? `${platformLabel(platform)} ${architecture} can use the detected Claude runtime.`
+          status: runtime.found ? 'warning' : 'failed',
+          summary: runtime.found
+            ? `${platformLabel(platform)} ${architecture} can use the detected ${frameworkLabel} runtime.`
             : `${platformLabel(platform)} ${architecture} has no automatic installer package.`,
           detail:
             error instanceof Error
@@ -186,12 +193,12 @@ const runEnvironmentCheck = async ({
   let recommendedRegistry: ManagedClaudeRegistry | undefined
   let networkCheck: EnvironmentCheckItem
 
-  if (claude.found) {
+  if (runtime.found) {
     networkCheck = {
       id: 'install-network',
       label: 'Installation network',
       status: 'passed',
-      summary: 'No download is needed because Claude is already installed.'
+      summary: `No download is needed because ${frameworkLabel} is already installed.`
     }
   } else {
     const registryResults = await Promise.all([
@@ -255,19 +262,21 @@ const runEnvironmentCheck = async ({
         detail: 'Notebook execution will be unavailable until Python 3 is installed.'
       }
 
-  const claudeCheck: EnvironmentCheckItem = claude.found
+  const runtimeCheck: EnvironmentCheckItem = runtime.found
     ? {
-        id: 'claude',
-        label: 'Claude runtime',
+        id: 'agent',
+        label: `${frameworkLabel} runtime`,
         status: 'passed',
-        summary: claude.version ? `Claude ${claude.version} is ready.` : 'Claude is ready.',
-        detail: claude.path
+        summary: runtime.version
+          ? `${frameworkLabel} ${runtime.version} is ready.`
+          : `${frameworkLabel} is ready.`,
+        detail: runtime.path
       }
     : {
-        id: 'claude',
-        label: 'Claude runtime',
+        id: 'agent',
+        label: `${frameworkLabel} runtime`,
         status: 'failed',
-        summary: 'Claude is not installed yet.',
+        summary: `${frameworkLabel} is not installed yet.`,
         detail:
           'Automatic setup installs a self-contained runtime without Node.js, npm, or admin access.'
       }
@@ -278,7 +287,7 @@ const runEnvironmentCheck = async ({
     secureStorageCheck,
     networkCheck,
     pythonCheck,
-    claudeCheck
+    runtimeCheck
   ]
   const passedIds = new Set(
     checks.filter((check) => check.status === 'passed').map((check) => check.id)
@@ -291,12 +300,13 @@ const runEnvironmentCheck = async ({
     checks,
     ready: checks.every((check) => check.status !== 'failed'),
     canAutoInstall:
-      !claude.found &&
+      !runtime.found &&
       passedIds.has('system') &&
       passedIds.has('storage') &&
       passedIds.has('install-network'),
     recommendedRegistry,
-    claude
+    agentFrameworkId,
+    runtime
   }
 }
 

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -24,7 +24,10 @@ type FakeSettingsService = Record<
   | 'isNpmAvailable'
   | 'checkEnvironment'
   | 'detectClaude'
+  | 'detectOpencode'
   | 'installClaude'
+  | 'installOpencode'
+  | 'setAgentFramework'
   | 'upsertProvider'
   | 'deleteProvider'
   | 'setActiveProvider'
@@ -46,7 +49,14 @@ const createFakeService = (): FakeSettingsService => ({
   isNpmAvailable: vi.fn().mockResolvedValue(true),
   checkEnvironment: vi.fn().mockResolvedValue({ ready: true, checks: [] }),
   detectClaude: vi.fn().mockResolvedValue({ found: false }),
+  detectOpencode: vi
+    .fn()
+    .mockResolvedValue({ claude: {}, providers: [], agentFrameworkId: 'opencode' }),
   installClaude: vi.fn().mockResolvedValue({ installId: 'i', ok: true }),
+  installOpencode: vi.fn().mockResolvedValue({ installId: 'oc', ok: true }),
+  setAgentFramework: vi
+    .fn()
+    .mockResolvedValue({ claude: {}, providers: [], agentFrameworkId: 'opencode' }),
   upsertProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
   deleteProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
   setActiveProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
@@ -215,5 +225,87 @@ describe('settings IPC handlers', () => {
     expect(service.deleteSkill).toHaveBeenCalledWith({ id: 'personal-s' })
 
     expect(onSkillsChanged).toHaveBeenCalledTimes(3)
+  })
+
+  it('registers the OpenCode / framework-switch channels', () => {
+    handlers.clear()
+    registerSettingsIpcHandlers({ service: asService(createFakeService()) })
+
+    for (const channel of [
+      'settings:detect-opencode',
+      'settings:install-opencode',
+      'settings:set-agent-framework'
+    ]) {
+      expect(handlers.has(channel)).toBe(true)
+    }
+  })
+
+  it('routes detect-opencode to the service and forwards its snapshot', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const snapshot = { claude: {}, providers: [], agentFrameworkId: 'opencode' }
+    service.detectOpencode.mockResolvedValue(snapshot)
+    registerSettingsIpcHandlers({ service: asService(service) })
+
+    const result = await invoke('settings:detect-opencode')
+
+    expect(service.detectOpencode).toHaveBeenCalledTimes(1)
+    expect(result).toBe(snapshot)
+  })
+
+  it('routes install-opencode to the service with the requested source and a stream callback', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const outcome = { installId: 'oc', ok: true }
+    service.installOpencode.mockResolvedValue(outcome)
+    registerSettingsIpcHandlers({ service: asService(service) })
+
+    const result = await invoke('settings:install-opencode', { source: 'managed' })
+
+    // The handler forwards the typed request plus the broadcast callback used to stream install logs.
+    expect(service.installOpencode).toHaveBeenCalledWith(
+      { source: 'managed' },
+      expect.any(Function)
+    )
+    expect(result).toBe(outcome)
+  })
+
+  it('routes each install-opencode source to the service unchanged', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    registerSettingsIpcHandlers({ service: asService(service) })
+
+    for (const source of ['managed', 'npm', 'official-script'] as const) {
+      await invoke('settings:install-opencode', { source })
+      expect(service.installOpencode).toHaveBeenCalledWith({ source }, expect.any(Function))
+    }
+  })
+
+  it('persists the selected framework and respawns the agent on set-agent-framework', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const snapshot = { claude: {}, providers: [], agentFrameworkId: 'opencode' }
+    service.setAgentFramework.mockResolvedValue(snapshot)
+    const onActiveProviderChanged = vi.fn()
+    registerSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+
+    const result = await invoke('settings:set-agent-framework', { id: 'opencode' })
+
+    // The handler unwraps the request to the bare framework id the service expects.
+    expect(service.setAgentFramework).toHaveBeenCalledWith('opencode')
+    // Switching frameworks swaps the backend binary, so the live agent must be dropped like a provider switch.
+    expect(onActiveProviderChanged).toHaveBeenCalledOnce()
+    expect(result).toBe(snapshot)
+  })
+
+  it('surfaces a service error thrown by install-opencode', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    service.installOpencode.mockRejectedValue(new Error('download failed'))
+    registerSettingsIpcHandlers({ service: asService(service) })
+
+    await expect(invoke('settings:install-opencode', { source: 'managed' })).rejects.toThrow(
+      'download failed'
+    )
   })
 })

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -9,6 +9,7 @@ import type {
   PreviewSkillZipRequest,
   ScanRepoRequest,
   InstallClaudeRequest,
+  InstallOpencodeRequest,
   ClaudeInstallEvent,
   RefreshProviderModelsRequest,
   SetActiveProviderRequest,
@@ -69,7 +70,9 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:check-environment', () => service.checkEnvironment())
   ipcMain.handle('settings:detect-claude', () => service.detectClaude())
   ipcMain.handle('settings:detect-opencode', () => service.detectOpencode())
-  ipcMain.handle('settings:install-opencode', () => service.installOpencode(broadcastInstallEvent))
+  ipcMain.handle('settings:install-opencode', (_event, request: InstallOpencodeRequest) =>
+    service.installOpencode(request, broadcastInstallEvent)
+  )
 
   ipcMain.handle('settings:install-claude', (_event, request: InstallClaudeRequest) =>
     service.installClaude(request, broadcastInstallEvent)

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -27,6 +27,9 @@ import type {
   ValidateProviderRequest
 } from '../../shared/settings'
 import { createDefaultSettingsService, SettingsService } from './service'
+import { createLogger } from '../logger'
+
+const log = createLogger('settings-ipc')
 
 // IPC channel names for the settings/onboarding surface. Kept together so preload and main agree.
 // Carries both log lines and progress ticks (a `ClaudeInstallEvent` discriminated union).
@@ -100,6 +103,7 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle(
     'settings:set-agent-framework',
     async (_event, request: SetAgentFrameworkRequest) => {
+      log.info('set agent framework requested', { id: request.id })
       const snapshot = await service.setAgentFramework(request.id)
 
       // Switching frameworks needs a fresh agent process, exactly like a provider switch — the live

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -69,6 +69,7 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:check-environment', () => service.checkEnvironment())
   ipcMain.handle('settings:detect-claude', () => service.detectClaude())
   ipcMain.handle('settings:detect-opencode', () => service.detectOpencode())
+  ipcMain.handle('settings:install-opencode', () => service.installOpencode(broadcastInstallEvent))
 
   ipcMain.handle('settings:install-claude', (_event, request: InstallClaudeRequest) =>
     service.installClaude(request, broadcastInstallEvent)

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -12,6 +12,7 @@ import type {
   ClaudeInstallEvent,
   RefreshProviderModelsRequest,
   SetActiveProviderRequest,
+  SetAgentFrameworkRequest,
   AddCustomServerRequest,
   RemoveCustomServerRequest,
   SetCustomServerEnabledRequest,
@@ -90,6 +91,18 @@ const registerSettingsIpcHandlers = ({
       const snapshot = await service.setActiveProvider(request.id, request.model)
 
       // Switching providers requires a fresh agent process so the new credentials take effect.
+      onActiveProviderChanged?.()
+
+      return snapshot
+    }
+  )
+  ipcMain.handle(
+    'settings:set-agent-framework',
+    async (_event, request: SetAgentFrameworkRequest) => {
+      const snapshot = await service.setAgentFramework(request.id)
+
+      // Switching frameworks needs a fresh agent process, exactly like a provider switch — the live
+      // process is a different backend binary, so the choice only takes effect on reconnect.
       onActiveProviderChanged?.()
 
       return snapshot

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -65,6 +65,7 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:npm-available', () => service.isNpmAvailable())
   ipcMain.handle('settings:check-environment', () => service.checkEnvironment())
   ipcMain.handle('settings:detect-claude', () => service.detectClaude())
+  ipcMain.handle('settings:detect-opencode', () => service.detectOpencode())
 
   ipcMain.handle('settings:install-claude', (_event, request: InstallClaudeRequest) =>
     service.installClaude(request, broadcastInstallEvent)

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -555,6 +555,8 @@ const defaultFetchTarball: FetchTarball = async (url) => {
 
 export {
   DEFAULT_REGISTRIES,
+  defaultFetchJson,
+  defaultFetchTarball,
   downloadAndVerify,
   extractFileFromTgz,
   getManagedPlatform,

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -7,7 +7,11 @@ import { gzipSync } from 'node:zlib'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { installManagedOpencode, managedOpencodeDir } from './managed-opencode'
+import {
+  installManagedOpencode,
+  managedOpencodeDir,
+  resolveOpencodePlatform
+} from './managed-opencode'
 
 // One 512-byte ustar header + padded content — synthesizes the npm tarball shape the extractor reads.
 const tarEntry = (name: string, content: Buffer): Buffer => {
@@ -114,5 +118,44 @@ describe('installManagedOpencode', () => {
 
     expect(outcome.result.ok).toBe(false)
     expect(outcome.resolvedPath).toBeUndefined()
+  })
+})
+
+describe('resolveOpencodePlatform', () => {
+  it('resolves the published host keys, including windows-arm64 and musl linux', () => {
+    expect(resolveOpencodePlatform({ platform: 'darwin', arch: 'arm64' })).toEqual({
+      key: 'darwin-arm64',
+      binName: 'opencode'
+    })
+    expect(resolveOpencodePlatform({ platform: 'win32', arch: 'arm64' })).toEqual({
+      key: 'windows-arm64',
+      binName: 'opencode.exe'
+    })
+    expect(
+      resolveOpencodePlatform({ platform: 'linux', arch: 'x64', detectMusl: () => true })
+    ).toEqual({ key: 'linux-x64-musl', binName: 'opencode' })
+  })
+
+  it('promotes Rosetta-translated x64 darwin to the arm64 package', () => {
+    expect(
+      resolveOpencodePlatform({ platform: 'darwin', arch: 'x64', isRosetta: () => true })
+    ).toEqual({ key: 'darwin-arm64', binName: 'opencode' })
+  })
+
+  it('throws for an arch opencode publishes no package for (no false auto-install)', () => {
+    // opencode ships no linux-ia32 / linux-arm (32-bit) native package — resolving must fail rather
+    // than hand back a key that 404s at the registry, so the environment check gates correctly.
+    expect(() => resolveOpencodePlatform({ platform: 'linux', arch: 'ia32' })).toThrow(
+      /Unsupported platform/
+    )
+    expect(() => resolveOpencodePlatform({ platform: 'linux', arch: 'arm' })).toThrow(
+      /Unsupported platform/
+    )
+  })
+
+  it('throws for an unsupported platform', () => {
+    expect(() => resolveOpencodePlatform({ platform: 'aix', arch: 'x64' })).toThrow(
+      /Unsupported platform/
+    )
   })
 })

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'node:crypto'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import { gzipSync } from 'node:zlib'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { installManagedOpencode, managedOpencodeDir } from './managed-opencode'
+
+// One 512-byte ustar header + padded content — synthesizes the npm tarball shape the extractor reads.
+const tarEntry = (name: string, content: Buffer): Buffer => {
+  const header = Buffer.alloc(512)
+  header.write(name, 0, 'ascii')
+  header.write('0000644\0', 100, 'ascii')
+  header.write('0000000\0', 108, 'ascii')
+  header.write('0000000\0', 116, 'ascii')
+  header.write(`${content.length.toString(8).padStart(11, '0')}\0`, 124, 'ascii')
+  header.write('00000000000\0', 136, 'ascii')
+  header.write('        ', 148, 'ascii')
+  header.write('0', 156, 'ascii')
+  header.write('ustar\0', 257, 'ascii')
+  header.write('00', 263, 'ascii')
+  let sum = 0
+  for (const byte of header) sum += byte
+  header.write(`${sum.toString(8).padStart(6, '0')}\0 `, 148, 'ascii')
+
+  const padded = Buffer.alloc(Math.ceil(content.length / 512) * 512)
+  content.copy(padded)
+  return Buffer.concat([header, padded])
+}
+
+const buildTgz = (entries: { name: string; content: Buffer }[]): Buffer =>
+  gzipSync(Buffer.concat([...entries.map((e) => tarEntry(e.name, e.content)), Buffer.alloc(1024)]))
+
+const sha512 = (data: Buffer): string =>
+  `sha512-${createHash('sha512').update(data).digest('base64')}`
+
+describe('installManagedOpencode', () => {
+  let root: string | undefined
+
+  afterEach(async () => {
+    if (root) {
+      await rm(root, { recursive: true, force: true })
+      root = undefined
+    }
+  })
+
+  it('resolves opencode-ai latest, downloads the platform package, extracts package/bin/opencode', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const tgz = buildTgz([
+      { name: 'package/package.json', content: Buffer.from('{"name":"opencode-darwin-arm64"}') },
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho opencode\n') }
+    ])
+    const integrity = sha512(tgz)
+
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/opencode-ai')) return { 'dist-tags': { latest: '1.18.3' } }
+      // Platform package metadata is requested at the resolved version.
+      expect(url).toContain('/opencode-darwin-arm64/1.18.3')
+      return { dist: { tarball: 'https://reg/opencode-darwin-arm64.tgz', integrity } }
+    }
+    const fetchTarball = async (): Promise<{
+      stream: NodeJS.ReadableStream
+      totalBytes?: number
+    }> => ({
+      stream: Readable.from(tgz),
+      totalBytes: tgz.length
+    })
+
+    const outcome = await installManagedOpencode({
+      installId: 'i1',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'darwin-arm64', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      tmpDir: root
+    })
+
+    expect(outcome.result.ok).toBe(true)
+    expect(outcome.version).toBe('1.18.3')
+    expect(outcome.resolvedPath).toBe(join(managedOpencodeDir(root), 'opencode'))
+    expect(await readFile(outcome.resolvedPath!, 'utf8')).toContain('echo opencode')
+  })
+
+  it('reports a structured failure (never throws) when the integrity check fails', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const tgz = buildTgz([{ name: 'package/bin/opencode', content: Buffer.from('x') }])
+
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.endsWith('/opencode-ai')
+        ? { 'dist-tags': { latest: '1.18.3' } }
+        : { dist: { tarball: 'https://reg/x.tgz', integrity: 'sha512-wrong' } }
+    const fetchTarball = async (): Promise<{
+      stream: NodeJS.ReadableStream
+      totalBytes?: number
+    }> => ({
+      stream: Readable.from(tgz)
+    })
+
+    const outcome = await installManagedOpencode({
+      installId: 'i2',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'darwin-arm64', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      tmpDir: root
+    })
+
+    expect(outcome.result.ok).toBe(false)
+    expect(outcome.resolvedPath).toBeUndefined()
+  })
+})

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -28,6 +28,29 @@ const OPENCODE_PLATFORM_PREFIX = 'opencode'
 
 type OpencodePlatform = { key: string; binName: string }
 
+// The non-baseline native packages opencode publishes as `opencode-ai` optionalDependencies. A host key
+// outside this set has no managed package, so resolveOpencodePlatform must throw rather than hand back a
+// key that later 404s at the registry — this is what lets the environment check report an unsupported
+// arch as not auto-installable, mirroring Claude's NATIVE_PLATFORMS allowlist.
+const OPENCODE_NATIVE_KEYS = new Set([
+  'linux-x64',
+  'linux-arm64',
+  'linux-x64-musl',
+  'linux-arm64-musl',
+  'darwin-x64',
+  'darwin-arm64',
+  'windows-x64',
+  'windows-arm64'
+])
+
+// Injectable host probes so key resolution is unit-testable offline (parallel to Claude's deps).
+export type ResolveOpencodePlatformDeps = {
+  platform?: NodeJS.Platform
+  arch?: string
+  detectMusl?: () => boolean
+  isRosetta?: () => boolean
+}
+
 const asRecord = (value: unknown): Record<string, unknown> =>
   value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
 
@@ -54,26 +77,38 @@ const isRosetta = (): boolean => {
 }
 
 // Maps the host to opencode's native-package key. opencode uses `windows` (not Node's `win32`).
-// Resolves the opencode native-package key for this host, throwing on an unsupported arch. Exported so
-// the environment check can gauge opencode auto-installability without the Claude platform map.
-export const resolveOpencodePlatform = (): OpencodePlatform => {
-  const platform = process.platform
-  let cpu = osArch()
+// Resolves the opencode native-package key for this host, throwing on any platform/arch opencode does
+// not publish a package for. Exported so the environment check can gauge opencode auto-installability
+// without the Claude platform map.
+export const resolveOpencodePlatform = (
+  deps: ResolveOpencodePlatformDeps = {}
+): OpencodePlatform => {
+  const platform = deps.platform ?? process.platform
+  let cpu = deps.arch ?? osArch()
+
+  let key: string
+  let binName: string
 
   if (platform === 'linux') {
-    return { key: `linux-${cpu}${detectMusl() ? '-musl' : ''}`, binName: 'opencode' }
+    const musl = deps.detectMusl ? deps.detectMusl() : detectMusl()
+    key = `linux-${cpu}${musl ? '-musl' : ''}`
+    binName = 'opencode'
+  } else if (platform === 'darwin') {
+    if (cpu === 'x64' && (deps.isRosetta ? deps.isRosetta() : isRosetta())) cpu = 'arm64'
+    key = `darwin-${cpu}`
+    binName = 'opencode'
+  } else if (platform === 'win32') {
+    key = `windows-${cpu}`
+    binName = 'opencode.exe'
+  } else {
+    throw new Error(`Unsupported platform for the app-managed OpenCode install: ${platform}-${cpu}`)
   }
 
-  if (platform === 'darwin') {
-    if (cpu === 'x64' && isRosetta()) cpu = 'arm64'
-    return { key: `darwin-${cpu}`, binName: 'opencode' }
+  if (!OPENCODE_NATIVE_KEYS.has(key)) {
+    throw new Error(`Unsupported platform for the app-managed OpenCode install: ${key}`)
   }
 
-  if (platform === 'win32') {
-    return { key: `windows-${cpu}`, binName: 'opencode.exe' }
-  }
-
-  throw new Error(`Unsupported platform for the app-managed OpenCode install: ${platform}-${cpu}`)
+  return { key, binName }
 }
 
 // Stable on-disk location for the managed binary (overwritten on upgrade), parallel to Claude's dir.

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -1,0 +1,201 @@
+import { spawnSync } from 'node:child_process'
+import { chmod, rm } from 'node:fs/promises'
+import { arch as osArch } from 'node:os'
+import { join } from 'node:path'
+
+import type { ClaudeInstallEvent } from '../../shared/settings'
+import {
+  DEFAULT_REGISTRIES,
+  defaultFetchJson,
+  defaultFetchTarball,
+  downloadAndVerify,
+  extractFileFromTgz,
+  type FetchJson,
+  type FetchTarball,
+  type ManagedInstallOutcome
+} from './managed-claude'
+
+// App-managed OpenCode installer. opencode ships per-platform native packages
+// (`opencode-<os>-<arch>[-musl]`) as optionalDependencies of the `opencode-ai` wrapper, with the binary
+// at `package/bin/opencode` — the same native-package model as Claude, so the shared download/verify/
+// extract helpers are reused. Non-AVX2 `-baseline` variants are not selected; modern CPUs get the
+// standard build. Every side-effecting dependency is injectable so the flow is unit-testable offline.
+
+// Wrapper package (its dist-tags.latest gives the version) and the native-package name prefix. Note the
+// native packages are `opencode-<key>`, NOT `opencode-ai-<key>`, so the prefix differs from the wrapper.
+const OPENCODE_WRAPPER = 'opencode-ai'
+const OPENCODE_PLATFORM_PREFIX = 'opencode'
+
+type OpencodePlatform = { key: string; binName: string }
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+
+// musl (Alpine) is inferred from a missing glibcVersionRuntime in Node's process report.
+const detectMusl = (): boolean => {
+  const report =
+    typeof process.report?.getReport === 'function'
+      ? (process.report.getReport() as { header?: { glibcVersionRuntime?: string } })
+      : null
+
+  return report != null && report.header?.glibcVersionRuntime === undefined
+}
+
+// An x64 Node under Rosetta 2 on Apple Silicon should still get the arm64 binary.
+const isRosetta = (): boolean => {
+  try {
+    return (
+      spawnSync('sysctl', ['-n', 'sysctl.proc_translated'], { encoding: 'utf8' }).stdout?.trim() ===
+      '1'
+    )
+  } catch {
+    return false
+  }
+}
+
+// Maps the host to opencode's native-package key. opencode uses `windows` (not Node's `win32`).
+const resolveOpencodePlatform = (): OpencodePlatform => {
+  const platform = process.platform
+  let cpu = osArch()
+
+  if (platform === 'linux') {
+    return { key: `linux-${cpu}${detectMusl() ? '-musl' : ''}`, binName: 'opencode' }
+  }
+
+  if (platform === 'darwin') {
+    if (cpu === 'x64' && isRosetta()) cpu = 'arm64'
+    return { key: `darwin-${cpu}`, binName: 'opencode' }
+  }
+
+  if (platform === 'win32') {
+    return { key: `windows-${cpu}`, binName: 'opencode.exe' }
+  }
+
+  throw new Error(`Unsupported platform for the app-managed OpenCode install: ${platform}-${cpu}`)
+}
+
+// Stable on-disk location for the managed binary (overwritten on upgrade), parallel to Claude's dir.
+export const managedOpencodeDir = (dataRoot: string): string =>
+  join(dataRoot, 'opencode-managed', 'bin')
+
+// Resolves the native package tarball URL + sha512 for one registry: `opencode-ai` latest (unless a
+// version is pinned), then the platform package's dist metadata at that version.
+const resolveNative = async (
+  registry: string,
+  key: string,
+  version: string | undefined,
+  fetchJson: FetchJson
+): Promise<{ version: string; tarball: string; integrity: string }> => {
+  let resolvedVersion = version
+
+  if (!resolvedVersion) {
+    const wrapper = asRecord(await fetchJson(`${registry}/${OPENCODE_WRAPPER}`))
+    const latest = asRecord(wrapper['dist-tags']).latest
+    if (typeof latest !== 'string' || latest.length === 0) {
+      throw new Error('Registry did not report a latest opencode version')
+    }
+    resolvedVersion = latest
+  }
+
+  const meta = asRecord(
+    await fetchJson(`${registry}/${OPENCODE_PLATFORM_PREFIX}-${key}/${resolvedVersion}`)
+  )
+  const dist = asRecord(meta.dist)
+  const tarball = dist.tarball
+  const integrity = dist.integrity
+
+  if (typeof tarball !== 'string' || typeof integrity !== 'string') {
+    throw new Error(`Incomplete registry metadata for ${OPENCODE_PLATFORM_PREFIX}-${key}`)
+  }
+
+  return { version: resolvedVersion, tarball, integrity }
+}
+
+export type InstallManagedOpencodeOptions = {
+  installId: string
+  onEvent: (event: ClaudeInstallEvent) => void
+  dataRoot: string
+  registries?: string[]
+  version?: string
+  platform?: OpencodePlatform
+  fetchJson?: FetchJson
+  fetchTarball?: FetchTarball
+  tmpDir?: string
+}
+
+// Downloads + installs the managed opencode binary, trying each registry in order. Resolves (never
+// rejects) with a structured outcome the service can persist.
+export const installManagedOpencode = async ({
+  installId,
+  onEvent,
+  dataRoot,
+  registries = DEFAULT_REGISTRIES,
+  version,
+  platform = resolveOpencodePlatform(),
+  fetchJson = defaultFetchJson,
+  fetchTarball = defaultFetchTarball,
+  tmpDir
+}: InstallManagedOpencodeOptions): Promise<ManagedInstallOutcome> => {
+  const destPath = join(managedOpencodeDir(dataRoot), platform.binName)
+  const scratch = tmpDir ?? managedOpencodeDir(dataRoot)
+  let lastError = 'no registries configured'
+
+  for (const registry of registries) {
+    const tgzPath = join(scratch, `opencode-download-${Date.now()}.tgz`)
+
+    try {
+      onEvent({ kind: 'progress', installId, phase: 'resolving' })
+      onEvent({
+        kind: 'log',
+        installId,
+        stream: 'system',
+        chunk: `Resolving OpenCode from ${registry} …\n`
+      })
+      const resolution = await resolveNative(registry, platform.key, version, fetchJson)
+
+      await downloadAndVerify({
+        url: resolution.tarball,
+        integrity: resolution.integrity,
+        destPath: tgzPath,
+        installId,
+        onEvent,
+        fetchTarball
+      })
+
+      onEvent({ kind: 'progress', installId, phase: 'extracting' })
+      const found = await extractFileFromTgz({
+        tgzPath,
+        entryName: `package/bin/${platform.binName}`,
+        destPath
+      })
+
+      if (!found) throw new Error(`Native package did not contain bin/${platform.binName}`)
+      if (process.platform !== 'win32') await chmod(destPath, 0o755)
+
+      onEvent({
+        kind: 'log',
+        installId,
+        stream: 'system',
+        chunk: `Installed OpenCode ${resolution.version}.\n`
+      })
+
+      return {
+        result: { installId, ok: true },
+        resolvedPath: destPath,
+        version: resolution.version
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+      onEvent({
+        kind: 'log',
+        installId,
+        stream: 'system',
+        chunk: `${registry} failed: ${lastError}\n`
+      })
+    } finally {
+      await rm(tgzPath, { force: true }).catch(() => undefined)
+    }
+  }
+
+  return { result: { installId, ok: false, error: lastError } }
+}

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -54,7 +54,9 @@ const isRosetta = (): boolean => {
 }
 
 // Maps the host to opencode's native-package key. opencode uses `windows` (not Node's `win32`).
-const resolveOpencodePlatform = (): OpencodePlatform => {
+// Resolves the opencode native-package key for this host, throwing on an unsupported arch. Exported so
+// the environment check can gauge opencode auto-installability without the Claude platform map.
+export const resolveOpencodePlatform = (): OpencodePlatform => {
   const platform = process.platform
   let cpu = osArch()
 

--- a/src/main/settings/opencode-detect.test.ts
+++ b/src/main/settings/opencode-detect.test.ts
@@ -1,0 +1,131 @@
+import { posix, win32 } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  collectCandidateDirs,
+  detectOpencode,
+  parseVersion,
+  type OpencodeDetectDeps
+} from './opencode-detect'
+
+// Builds detect deps around a set of "installed" executables keyed by absolute path.
+const createDeps = (
+  installed: Record<string, string>,
+  overrides: Partial<OpencodeDetectDeps> = {}
+): OpencodeDetectDeps => ({
+  env: { PATH: '/usr/bin:/usr/local/bin' },
+  homePath: '/home/user',
+  // Pinned so probe order is host-independent (tests run on macOS/Linux/Windows CI runners alike).
+  platform: 'linux',
+  isExecutable: (path) => Promise.resolve(path in installed),
+  getVersion: (path) => Promise.resolve(installed[path]),
+  resolveNpmBinDirs: () => Promise.resolve([]),
+  ...overrides
+})
+
+describe('opencode-detect', () => {
+  it('parses a version string out of --version output', () => {
+    expect(parseVersion('1.18.3')).toBe('1.18.3')
+    expect(parseVersion('opencode 1.0.0-beta.2')).toBe('1.0.0-beta.2')
+  })
+
+  it('returns undefined when no candidate is executable', async () => {
+    expect(await detectOpencode(createDeps({}))).toBeUndefined()
+  })
+
+  it('finds opencode on PATH and records its absolute path and version', async () => {
+    const result = await detectOpencode(createDeps({ '/usr/local/bin/opencode': '1.18.0' }))
+
+    expect(result).toEqual({ resolvedPath: '/usr/local/bin/opencode', version: '1.18.0' })
+  })
+
+  it('finds a managed opencode via extraDirs even when it is not on PATH', async () => {
+    const managedDir = '/home/user/.open-science/opencode-managed/bin'
+    const result = await detectOpencode(
+      createDeps({ [posix.join(managedDir, 'opencode')]: '1.19.0' }, { extraDirs: [managedDir] })
+    )
+
+    expect(result).toEqual({ resolvedPath: posix.join(managedDir, 'opencode'), version: '1.19.0' })
+  })
+
+  it('probes the ~/.opencode/bin install-script target', async () => {
+    const result = await detectOpencode(
+      createDeps({ '/home/user/.opencode/bin/opencode': '1.20.0' })
+    )
+
+    expect(result).toEqual({
+      resolvedPath: '/home/user/.opencode/bin/opencode',
+      version: '1.20.0'
+    })
+  })
+
+  it('skips a path that exists but cannot report a version', async () => {
+    const result = await detectOpencode(
+      createDeps(
+        {},
+        { isExecutable: () => Promise.resolve(true), getVersion: () => Promise.resolve(undefined) }
+      )
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it('tolerates a failing npm bin resolution', async () => {
+    const result = await detectOpencode(
+      createDeps(
+        { '/usr/local/bin/opencode': '1.0.0' },
+        { resolveNpmBinDirs: () => Promise.reject(new Error('npm missing')) }
+      )
+    )
+
+    expect(result?.version).toBe('1.0.0')
+  })
+
+  describe('windows', () => {
+    const winDeps = (
+      installed: Record<string, string>,
+      overrides: Partial<OpencodeDetectDeps> = {}
+    ): OpencodeDetectDeps =>
+      createDeps(installed, {
+        platform: 'win32',
+        env: {
+          PATH: 'C:\\Windows;C:\\Users\\me\\bin',
+          APPDATA: 'C:\\Users\\me\\AppData\\Roaming'
+        },
+        homePath: 'C:\\Users\\me',
+        ...overrides
+      })
+
+    it('probes %APPDATA%\\npm and the home install dirs, not the Unix dirs', async () => {
+      const dirs = await collectCandidateDirs(winDeps({}))
+
+      expect(dirs).toContain(win32.join('C:\\Users\\me\\AppData\\Roaming', 'npm'))
+      expect(dirs).toContain(win32.join('C:\\Users\\me', '.opencode', 'bin'))
+      expect(dirs).not.toContain('/opt/homebrew/bin')
+    })
+
+    it('finds opencode.exe from a managed install dir', async () => {
+      const managedDir = win32.join('C:\\Users\\me\\AppData\\Local', 'open-science', 'bin')
+      const result = await detectOpencode(
+        winDeps({ [win32.join(managedDir, 'opencode.exe')]: '1.18.0' }, { extraDirs: [managedDir] })
+      )
+
+      expect(result).toEqual({
+        resolvedPath: win32.join(managedDir, 'opencode.exe'),
+        version: '1.18.0'
+      })
+    })
+
+    it('finds opencode.cmd ahead of the bare name', async () => {
+      const npmDir = win32.join('C:\\Users\\me\\AppData\\Roaming', 'npm')
+      const result = await detectOpencode(
+        winDeps({ [win32.join(npmDir, 'opencode.cmd')]: '1.1.0' })
+      )
+
+      expect(result).toEqual({
+        resolvedPath: win32.join(npmDir, 'opencode.cmd'),
+        version: '1.1.0'
+      })
+    })
+  })
+})

--- a/src/main/settings/opencode-detect.ts
+++ b/src/main/settings/opencode-detect.ts
@@ -1,31 +1,9 @@
 import { execFile } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
 import { promisify } from 'node:util'
 
 import { augmentedPathEnv } from './shell-path'
 
 const execFileAsync = promisify(execFile)
-
-// Resolves opencode's global config path ($XDG_CONFIG_HOME/opencode or ~/.config/opencode).
-const opencodeUserConfigPath = (): string =>
-  join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'opencode', 'opencode.json')
-
-// Reads the user's own opencode config so the app can MERGE its provider/model onto it rather than
-// replacing it. Best-effort: returns undefined when the file is absent or unreadable. opencode's
-// auth.json (from `opencode auth login`) is loaded by opencode itself and is never read or touched.
-export const readOpencodeUserConfig = async (): Promise<Record<string, unknown> | undefined> => {
-  try {
-    const parsed = JSON.parse(await readFile(opencodeUserConfigPath(), 'utf8')) as unknown
-
-    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined
-  } catch {
-    return undefined
-  }
-}
 
 export type OpencodeDetectResult = {
   resolvedPath: string

--- a/src/main/settings/opencode-detect.ts
+++ b/src/main/settings/opencode-detect.ts
@@ -1,9 +1,31 @@
 import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import { promisify } from 'node:util'
 
 import { augmentedPathEnv } from './shell-path'
 
 const execFileAsync = promisify(execFile)
+
+// Resolves opencode's global config path ($XDG_CONFIG_HOME/opencode or ~/.config/opencode).
+const opencodeUserConfigPath = (): string =>
+  join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'opencode', 'opencode.json')
+
+// Reads the user's own opencode config so the app can MERGE its provider/model onto it rather than
+// replacing it. Best-effort: returns undefined when the file is absent or unreadable. opencode's
+// auth.json (from `opencode auth login`) is loaded by opencode itself and is never read or touched.
+export const readOpencodeUserConfig = async (): Promise<Record<string, unknown> | undefined> => {
+  try {
+    const parsed = JSON.parse(await readFile(opencodeUserConfigPath(), 'utf8')) as unknown
+
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
 
 // Best-effort PATH lookup for the opencode binary. Returns the resolved absolute path, or undefined
 // when it isn't installed / not on PATH. Uses the augmented PATH so a Finder-launched packaged app

--- a/src/main/settings/opencode-detect.ts
+++ b/src/main/settings/opencode-detect.ts
@@ -1,3 +1,7 @@
+import { access } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 
@@ -10,44 +14,177 @@ export type OpencodeDetectResult = {
   version?: string
 }
 
-// Reads the opencode binary's reported version (`opencode --version`). Best-effort with a short
-// timeout so a hung binary can't stall detection; undefined when it can't be read.
-const readOpencodeVersion = async (executablePath: string): Promise<string | undefined> => {
-  try {
-    const { stdout } = await execFileAsync(executablePath, ['--version'], {
-      env: augmentedPathEnv(process.env),
-      windowsHide: true,
-      timeout: 5000
-    })
+// Detects a runnable opencode executable across the locations a GUI app might miss because its PATH
+// differs from the user's login shell — including the app-managed install dir, which a bare PATH
+// lookup would never find. Injectable deps (including the host platform) keep the probe order and
+// platform-specific rules unit-testable, mirroring claude-detect.ts.
+export type OpencodeDetectDeps = {
+  env: NodeJS.ProcessEnv
+  homePath: string
+  platform: NodeJS.Platform
+  isExecutable: (path: string) => Promise<boolean>
+  getVersion: (path: string) => Promise<string | undefined>
+  resolveNpmBinDirs: () => Promise<string[]>
+  // Extra fixed directories to probe (e.g. the app-managed install dir), searched after PATH/home.
+  extraDirs?: string[]
+}
 
-    // opencode prints just the version (e.g. "1.18.3"); take the first non-empty token.
-    return stdout.trim().split(/\s+/)[0] || undefined
+// Path semantics follow the injected platform, not the host, so win32 rules can be exercised on posix.
+const pathFor = (platform: NodeJS.Platform): path.PlatformPath =>
+  platform === 'win32' ? path.win32 : path.posix
+
+// Candidate binary filenames for opencode, in probe order. Windows resolves a bare command through
+// PATHEXT, so an npm-installed `opencode.cmd`, a native `opencode.exe`, or a `.bat` shim must each be
+// tried explicitly; the extensionless name is kept last as a catch-all. Unix has only `opencode`.
+const opencodeBinaryNames = (platform: NodeJS.Platform): string[] =>
+  platform === 'win32' ? ['opencode.cmd', 'opencode.exe', 'opencode.bat', 'opencode'] : ['opencode']
+
+// Common non-PATH install locations by platform. Windows: npm's global bin (%APPDATA%\npm). Unix:
+// Homebrew + /usr/local. `~/.local/bin` and `~/.opencode/bin` (install-script targets) are added
+// separately by collectCandidateDirs.
+const wellKnownDirs = (platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string[] => {
+  if (platform === 'win32') {
+    const p = pathFor(platform)
+
+    return env.APPDATA ? [p.join(env.APPDATA, 'npm')] : []
+  }
+
+  return ['/opt/homebrew/bin', '/usr/local/bin']
+}
+
+// Builds the ordered list of directories to search for the opencode binary.
+const collectCandidateDirs = async (deps: OpencodeDetectDeps): Promise<string[]> => {
+  const p = pathFor(deps.platform)
+  const pathDirs = (deps.env.PATH ?? '').split(p.delimiter).filter((dir) => dir.length > 0)
+  const npmBinDirs = await deps.resolveNpmBinDirs().catch(() => [])
+
+  // De-duplicate while preserving first-seen order so the first real hit wins.
+  return Array.from(
+    new Set([
+      ...pathDirs,
+      p.join(deps.homePath, '.local', 'bin'),
+      p.join(deps.homePath, '.opencode', 'bin'),
+      ...(deps.extraDirs ?? []),
+      ...wellKnownDirs(deps.platform, deps.env),
+      ...npmBinDirs
+    ])
+  )
+}
+
+// Probes each candidate directory × filename, returning the first executable whose `--version`
+// succeeds. Returns undefined when opencode is not installed anywhere we look.
+const detectOpencode = async (
+  deps: OpencodeDetectDeps = createDefaultDetectDeps()
+): Promise<OpencodeDetectResult | undefined> => {
+  const p = pathFor(deps.platform)
+  const candidateDirs = await collectCandidateDirs(deps)
+  const binaryNames = opencodeBinaryNames(deps.platform)
+
+  for (const dir of candidateDirs) {
+    for (const name of binaryNames) {
+      const candidate = p.join(dir, name)
+
+      if (!(await deps.isExecutable(candidate))) continue
+
+      const version = await deps.getVersion(candidate)
+
+      // A path that exists but cannot report a version is not a usable opencode; keep searching.
+      if (version === undefined) continue
+
+      return { resolvedPath: candidate, version }
+    }
+  }
+
+  return undefined
+}
+
+// Real filesystem executable check. On Windows the POSIX execute bit is meaningless, so existence
+// plus a known executable extension (encoded in the candidate filenames) is the reliable signal;
+// elsewhere require X_OK.
+const isExecutableFile =
+  (platform: NodeJS.Platform) =>
+  async (path: string): Promise<boolean> => {
+    try {
+      await access(path, platform === 'win32' ? constants.F_OK : constants.X_OK)
+
+      return true
+    } catch {
+      return false
+    }
+  }
+
+// Parses the first version-looking token out of `opencode --version` output (it prints just "1.18.3").
+const parseVersion = (output: string): string | undefined => {
+  const match = output.match(/\d+\.\d+\.[\w.-]+/)
+
+  return match ? match[0] : output.trim() || undefined
+}
+
+// Real `<path> --version` runner. On Windows a `.cmd`/`.bat` shim cannot be launched by execFile
+// directly, so route it through the shell with the path quoted; native `.exe`/Unix binaries run
+// without a shell. Short timeout so a hung binary can't stall detection.
+const runOpencodeVersion =
+  (platform: NodeJS.Platform) =>
+  async (path: string): Promise<string | undefined> => {
+    try {
+      const { stdout } =
+        platform === 'win32'
+          ? await execFileAsync(`"${path}"`, ['--version'], {
+              timeout: 5000,
+              shell: true,
+              windowsHide: true,
+              env: augmentedPathEnv(process.env)
+            })
+          : await execFileAsync(path, ['--version'], {
+              timeout: 5000,
+              windowsHide: true,
+              env: augmentedPathEnv(process.env)
+            })
+
+      return parseVersion(stdout)
+    } catch {
+      return undefined
+    }
+  }
+
+// Resolves the npm global bin directory if npm is present. On Windows npm is a `.cmd` shim (needs a
+// shell) and places global binaries directly in the prefix; Unix nests them under `<prefix>/bin`.
+const resolveNpmBinDirs = (platform: NodeJS.Platform) => async (): Promise<string[]> => {
+  try {
+    const { stdout } =
+      platform === 'win32'
+        ? await execFileAsync('npm', ['prefix', '-g'], {
+            timeout: 10_000,
+            shell: true,
+            windowsHide: true,
+            env: augmentedPathEnv()
+          })
+        : await execFileAsync('npm', ['prefix', '-g'], {
+            timeout: 10_000,
+            env: augmentedPathEnv()
+          })
+    const prefix = stdout.trim()
+
+    if (!prefix) return []
+
+    return platform === 'win32' ? [prefix] : [pathFor(platform).join(prefix, 'bin')]
   } catch {
-    return undefined
+    return []
   }
 }
 
-// Best-effort PATH lookup for the opencode binary + its version. Returns undefined when it isn't
-// installed / not on PATH. Uses the augmented PATH so a Finder-launched packaged app (whose PATH omits
-// Homebrew/user bins) can still find a user-installed opencode.
-export const detectOpencode = async (): Promise<OpencodeDetectResult | undefined> => {
-  const lookup = process.platform === 'win32' ? 'where' : 'which'
+// Production dependency bundle wired to real fs/child_process for the current host platform.
+const createDefaultDetectDeps = (): OpencodeDetectDeps => {
+  const platform = process.platform
 
-  try {
-    const { stdout } = await execFileAsync(lookup, ['opencode'], {
-      env: augmentedPathEnv(process.env),
-      windowsHide: true
-    })
-
-    const resolvedPath = stdout
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean)
-
-    if (!resolvedPath) return undefined
-
-    return { resolvedPath, version: await readOpencodeVersion(resolvedPath) }
-  } catch {
-    return undefined
+  return {
+    env: process.env,
+    homePath: homedir(),
+    platform,
+    isExecutable: isExecutableFile(platform),
+    getVersion: runOpencodeVersion(platform),
+    resolveNpmBinDirs: resolveNpmBinDirs(platform)
   }
 }
+
+export { collectCandidateDirs, createDefaultDetectDeps, detectOpencode, parseVersion }

--- a/src/main/settings/opencode-detect.ts
+++ b/src/main/settings/opencode-detect.ts
@@ -1,0 +1,29 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { augmentedPathEnv } from './shell-path'
+
+const execFileAsync = promisify(execFile)
+
+// Best-effort PATH lookup for the opencode binary. Returns the resolved absolute path, or undefined
+// when it isn't installed / not on PATH. Uses the augmented PATH so a Finder-launched packaged app
+// (whose PATH omits Homebrew/user bins) can still find a user-installed opencode.
+export const detectOpencode = async (): Promise<string | undefined> => {
+  const lookup = process.platform === 'win32' ? 'where' : 'which'
+
+  try {
+    const { stdout } = await execFileAsync(lookup, ['opencode'], {
+      env: augmentedPathEnv(process.env),
+      windowsHide: true
+    })
+
+    return (
+      stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find(Boolean) ?? undefined
+    )
+  } catch {
+    return undefined
+  }
+}

--- a/src/main/settings/opencode-detect.ts
+++ b/src/main/settings/opencode-detect.ts
@@ -27,10 +27,32 @@ export const readOpencodeUserConfig = async (): Promise<Record<string, unknown> 
   }
 }
 
-// Best-effort PATH lookup for the opencode binary. Returns the resolved absolute path, or undefined
-// when it isn't installed / not on PATH. Uses the augmented PATH so a Finder-launched packaged app
-// (whose PATH omits Homebrew/user bins) can still find a user-installed opencode.
-export const detectOpencode = async (): Promise<string | undefined> => {
+export type OpencodeDetectResult = {
+  resolvedPath: string
+  version?: string
+}
+
+// Reads the opencode binary's reported version (`opencode --version`). Best-effort with a short
+// timeout so a hung binary can't stall detection; undefined when it can't be read.
+const readOpencodeVersion = async (executablePath: string): Promise<string | undefined> => {
+  try {
+    const { stdout } = await execFileAsync(executablePath, ['--version'], {
+      env: augmentedPathEnv(process.env),
+      windowsHide: true,
+      timeout: 5000
+    })
+
+    // opencode prints just the version (e.g. "1.18.3"); take the first non-empty token.
+    return stdout.trim().split(/\s+/)[0] || undefined
+  } catch {
+    return undefined
+  }
+}
+
+// Best-effort PATH lookup for the opencode binary + its version. Returns undefined when it isn't
+// installed / not on PATH. Uses the augmented PATH so a Finder-launched packaged app (whose PATH omits
+// Homebrew/user bins) can still find a user-installed opencode.
+export const detectOpencode = async (): Promise<OpencodeDetectResult | undefined> => {
   const lookup = process.platform === 'win32' ? 'where' : 'which'
 
   try {
@@ -39,12 +61,14 @@ export const detectOpencode = async (): Promise<string | undefined> => {
       windowsHide: true
     })
 
-    return (
-      stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .find(Boolean) ?? undefined
-    )
+    const resolvedPath = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean)
+
+    if (!resolvedPath) return undefined
+
+    return { resolvedPath, version: await readOpencodeVersion(resolvedPath) }
   } catch {
     return undefined
   }

--- a/src/main/settings/opencode-install.ts
+++ b/src/main/settings/opencode-install.ts
@@ -1,0 +1,10 @@
+import type { InstallTarget } from './claude-install'
+
+// OpenCode install coordinates for the generic runner in claude-install.ts. The npm wrapper package is
+// `opencode-ai`; the shell installer is served from opencode.ai. There is no official Windows
+// PowerShell installer, so `scriptWindows` is omitted and the script source is hidden on Windows
+// (see getOpencodeInstallSources) — Windows users take the app-managed download or npm.
+export const OPENCODE_INSTALL_TARGET: InstallTarget = {
+  npmPackage: 'opencode-ai',
+  scriptUnix: 'curl -fsSL https://opencode.ai/install | bash'
+}

--- a/src/main/settings/preflight.test.ts
+++ b/src/main/settings/preflight.test.ts
@@ -29,6 +29,7 @@ const run = (overrides: Partial<PreflightInput> = {}): ReturnType<typeof compute
     opencodePathExists: false,
     agentFrameworkId: 'claude-code',
     isProviderKeyUsable: alwaysUsable,
+    activeProviderCompatible: true,
     ...overrides
   })
 
@@ -95,5 +96,11 @@ describe('computePreflight', () => {
 
   it('is not provider-ready when the active provider key is unusable', () => {
     expect(run({ isProviderKeyUsable: () => false }).activeProviderReady).toBe(false)
+  })
+
+  it('is not provider-ready when the active provider is incompatible with the framework', () => {
+    // e.g. OpenCode selected but the active provider is a Local Claude — validated + usable key, yet
+    // unusable by the framework, so the pair must not be marked ready.
+    expect(run({ activeProviderCompatible: false }).activeProviderReady).toBe(false)
   })
 })

--- a/src/main/settings/preflight.test.ts
+++ b/src/main/settings/preflight.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { computePreflight } from './preflight'
+import { computePreflight, type PreflightInput } from './preflight'
 import type { StoredProvider, StoredSettings } from './types'
 
 const customProvider: StoredProvider = {
@@ -21,64 +21,79 @@ const baseSettings = (overrides: Partial<StoredSettings> = {}): StoredSettings =
 
 const alwaysUsable = (): boolean => true
 
+// Fills the injected checks with permissive defaults so each case overrides only what it exercises.
+const run = (overrides: Partial<PreflightInput> = {}): ReturnType<typeof computePreflight> =>
+  computePreflight({
+    settings: baseSettings(),
+    claudePathExists: true,
+    opencodePathExists: false,
+    agentFrameworkId: 'claude-code',
+    isProviderKeyUsable: alwaysUsable,
+    ...overrides
+  })
+
 describe('computePreflight', () => {
   it('is fully ready when claude exists and the active provider validated with a usable key', () => {
-    expect(
-      computePreflight({
-        settings: baseSettings(),
-        claudePathExists: true,
-        isProviderKeyUsable: alwaysUsable
-      })
-    ).toEqual({ claudeReady: true, activeProviderReady: true })
+    expect(run()).toEqual({
+      claudeReady: true,
+      opencodeReady: false,
+      agentFrameworkId: 'claude-code',
+      agentReady: true,
+      activeProviderReady: true
+    })
   })
 
   it('is not claude-ready when the recorded path no longer exists', () => {
-    const result = computePreflight({
-      settings: baseSettings(),
-      claudePathExists: false,
-      isProviderKeyUsable: alwaysUsable
-    })
-
-    expect(result.claudeReady).toBe(false)
+    expect(run({ claudePathExists: false }).claudeReady).toBe(false)
   })
 
   it('is not claude-ready when no path was ever recorded', () => {
-    const result = computePreflight({
-      settings: baseSettings({ claude: {} }),
-      claudePathExists: false,
-      isProviderKeyUsable: alwaysUsable
-    })
+    expect(
+      run({ settings: baseSettings({ claude: {} }), claudePathExists: false }).claudeReady
+    ).toBe(false)
+  })
 
-    expect(result.claudeReady).toBe(false)
+  it('tracks opencode readiness from its own stored path', () => {
+    const settings = baseSettings({ opencodePath: '/bin/opencode' })
+
+    expect(run({ settings, opencodePathExists: true }).opencodeReady).toBe(true)
+    // A binary deleted after onboarding flips opencode back to unready.
+    expect(run({ settings, opencodePathExists: false }).opencodeReady).toBe(false)
+  })
+
+  it('binds agentReady to the selected framework', () => {
+    const settings = baseSettings({ opencodePath: '/bin/opencode' })
+
+    // Selecting opencode makes agentReady follow opencode, even though claude is present.
+    expect(
+      run({
+        settings,
+        agentFrameworkId: 'opencode',
+        claudePathExists: true,
+        opencodePathExists: false
+      })
+    ).toMatchObject({ agentFrameworkId: 'opencode', agentReady: false, claudeReady: true })
+
+    expect(run({ settings, agentFrameworkId: 'opencode', opencodePathExists: true })).toMatchObject(
+      { agentReady: true }
+    )
   })
 
   it('is not provider-ready without an active provider', () => {
-    const result = computePreflight({
-      settings: baseSettings({ activeProviderId: undefined }),
-      claudePathExists: true,
-      isProviderKeyUsable: alwaysUsable
-    })
-
-    expect(result.activeProviderReady).toBe(false)
+    expect(
+      run({ settings: baseSettings({ activeProviderId: undefined }) }).activeProviderReady
+    ).toBe(false)
   })
 
   it('is not provider-ready when the active provider never validated', () => {
-    const result = computePreflight({
-      settings: baseSettings({ providers: [{ ...customProvider, lastValidatedAt: undefined }] }),
-      claudePathExists: true,
-      isProviderKeyUsable: alwaysUsable
+    const settings = baseSettings({
+      providers: [{ ...customProvider, lastValidatedAt: undefined }]
     })
 
-    expect(result.activeProviderReady).toBe(false)
+    expect(run({ settings }).activeProviderReady).toBe(false)
   })
 
   it('is not provider-ready when the active provider key is unusable', () => {
-    const result = computePreflight({
-      settings: baseSettings(),
-      claudePathExists: true,
-      isProviderKeyUsable: () => false
-    })
-
-    expect(result.activeProviderReady).toBe(false)
+    expect(run({ isProviderKeyUsable: () => false }).activeProviderReady).toBe(false)
   })
 })

--- a/src/main/settings/preflight.ts
+++ b/src/main/settings/preflight.ts
@@ -14,6 +14,9 @@ export type PreflightInput = {
   agentFrameworkId: AgentFrameworkId
   // Whether a provider's credentials are usable (claude-default is always true; custom must decrypt).
   isProviderKeyUsable: (provider: StoredProvider) => boolean
+  // Whether the active provider can actually drive the selected framework (endpoint + provider-type
+  // compatibility). Resolved by the caller, which has the vendor registry to derive official apiTypes.
+  activeProviderCompatible: boolean
 }
 
 // Applies the design's gating rules: the selected framework's binary must be present, and an active
@@ -24,7 +27,8 @@ const computePreflight = ({
   claudePathExists,
   opencodePathExists,
   agentFrameworkId,
-  isProviderKeyUsable
+  isProviderKeyUsable,
+  activeProviderCompatible
 }: PreflightInput): Preflight => {
   const claudeReady = Boolean(settings.claude?.resolvedPath) && claudePathExists
   const opencodeReady = Boolean(settings.opencodePath) && opencodePathExists
@@ -34,10 +38,13 @@ const computePreflight = ({
     ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
     : undefined
 
+  // "Ready" also requires the active provider to be able to drive the selected framework, so an
+  // incompatible pair (e.g. OpenCode + a Local Claude provider) is never marked ready.
   const activeProviderReady = Boolean(
     activeProvider &&
     activeProvider.lastValidatedAt !== undefined &&
-    isProviderKeyUsable(activeProvider)
+    isProviderKeyUsable(activeProvider) &&
+    activeProviderCompatible
   )
 
   return { claudeReady, opencodeReady, agentFrameworkId, agentReady, activeProviderReady }

--- a/src/main/settings/preflight.ts
+++ b/src/main/settings/preflight.ts
@@ -1,25 +1,34 @@
-import type { Preflight } from '../../shared/settings'
+import type { AgentFrameworkId, Preflight } from '../../shared/settings'
 import type { StoredProvider, StoredSettings } from './types'
 
-// Pure computation of the two startup gates from stored settings plus a couple of injected checks.
+// Pure computation of the startup gates from stored settings plus a couple of injected checks.
 // Kept free of Electron so the gating matrix is unit-testable in isolation.
 
 export type PreflightInput = {
   settings: StoredSettings
   // Whether the recorded claude executable still exists/executes (light re-check each launch).
   claudePathExists: boolean
+  // Whether the recorded opencode executable still exists (same light re-check).
+  opencodePathExists: boolean
+  // The selected framework, resolved (default applied) by the caller.
+  agentFrameworkId: AgentFrameworkId
   // Whether a provider's credentials are usable (claude-default is always true; custom must decrypt).
   isProviderKeyUsable: (provider: StoredProvider) => boolean
 }
 
-// Applies the design's gating rules: claude must be present, and an active provider must exist,
-// have validated at least once, and have usable credentials.
+// Applies the design's gating rules: the selected framework's binary must be present, and an active
+// provider must exist, have validated at least once, and have usable credentials. Per-framework
+// readiness re-checks the stored path each call, so a binary deleted after onboarding flips to unready.
 const computePreflight = ({
   settings,
   claudePathExists,
+  opencodePathExists,
+  agentFrameworkId,
   isProviderKeyUsable
 }: PreflightInput): Preflight => {
   const claudeReady = Boolean(settings.claude?.resolvedPath) && claudePathExists
+  const opencodeReady = Boolean(settings.opencodePath) && opencodePathExists
+  const agentReady = agentFrameworkId === 'opencode' ? opencodeReady : claudeReady
 
   const activeProvider = settings.activeProviderId
     ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
@@ -27,11 +36,11 @@ const computePreflight = ({
 
   const activeProviderReady = Boolean(
     activeProvider &&
-    activeProvider.lastValidatedAt !== undefined &&
-    isProviderKeyUsable(activeProvider)
+      activeProvider.lastValidatedAt !== undefined &&
+      isProviderKeyUsable(activeProvider)
   )
 
-  return { claudeReady, activeProviderReady }
+  return { claudeReady, opencodeReady, agentFrameworkId, agentReady, activeProviderReady }
 }
 
 export { computePreflight }

--- a/src/main/settings/preflight.ts
+++ b/src/main/settings/preflight.ts
@@ -36,8 +36,8 @@ const computePreflight = ({
 
   const activeProviderReady = Boolean(
     activeProvider &&
-      activeProvider.lastValidatedAt !== undefined &&
-      isProviderKeyUsable(activeProvider)
+    activeProvider.lastValidatedAt !== undefined &&
+    isProviderKeyUsable(activeProvider)
   )
 
   return { claudeReady, opencodeReady, agentFrameworkId, agentReady, activeProviderReady }

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -9,7 +9,11 @@ import { normalizeAnthropicBaseUrl } from './base-url'
 // A provider resolved for spawning: the plaintext key is already decrypted by the caller.
 export type ResolvedProvider = {
   type: ProviderType
+  // Anthropic /v1/messages base (also the sole base for a custom provider). Claude always uses this.
   baseUrl?: string
+  // Distinct OpenAI /v1/chat/completions base for a dual-endpoint vendor (e.g. DeepSeek). Used only
+  // when the chosen endpoint is openai; falls back to baseUrl when absent.
+  openaiBaseUrl?: string
   model?: string
   key?: string
   // Which chat API the endpoint speaks; opencode uses it to pick the anthropic vs openai-compatible

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 
-import type { ProviderType } from '../../shared/settings'
+import type { ProviderApiType, ProviderType } from '../../shared/settings'
 import { normalizeAnthropicBaseUrl } from './base-url'
 
 // Resolves an active provider into the environment overrides that the ACP agent (and the claude
@@ -12,6 +12,9 @@ export type ResolvedProvider = {
   baseUrl?: string
   model?: string
   key?: string
+  // Which chat API the endpoint speaks; opencode uses it to pick the anthropic vs openai-compatible
+  // provider. Absent ⇒ anthropic.
+  apiType?: ProviderApiType
 }
 
 export type ProviderEnvOptions = {

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -60,12 +60,13 @@ describe('settings repository', () => {
     const repository = new SettingsRepository(await createStorageRoot())
 
     await repository.setAgentFramework('opencode')
-    await repository.setOpencodePath('/usr/local/bin/opencode')
+    await repository.setOpencodeInfo('/usr/local/bin/opencode', '1.18.3')
 
     // sanitizeSettings must not strip these fields on read-back, or the selector can never switch.
     const settings = await repository.getSettings()
     expect(settings.agentFrameworkId).toBe('opencode')
     expect(settings.opencodePath).toBe('/usr/local/bin/opencode')
+    expect(settings.opencodeVersion).toBe('1.18.3')
   })
 
   it('replaces a provider in place on upsert by id', async () => {

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -56,6 +56,18 @@ describe('settings repository', () => {
     expect(settings.providers[0]).toMatchObject({ id: 'p1', keyRef: 'enc:abc' })
   })
 
+  it('persists the agent framework + opencode path across a sanitized read', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+
+    await repository.setAgentFramework('opencode')
+    await repository.setOpencodePath('/usr/local/bin/opencode')
+
+    // sanitizeSettings must not strip these fields on read-back, or the selector can never switch.
+    const settings = await repository.getSettings()
+    expect(settings.agentFrameworkId).toBe('opencode')
+    expect(settings.opencodePath).toBe('/usr/local/bin/opencode')
+  })
+
   it('replaces a provider in place on upsert by id', async () => {
     const repository = new SettingsRepository(await createStorageRoot())
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -296,6 +296,19 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
       normalized.length > root.length ? normalized.replace(/[\\/]+$/, '') : normalized
   }
 
+  // Selected agent backend; only the known ids survive so a bad value can't leak through.
+  const agentFrameworkId = asString(value.agentFrameworkId)
+
+  if (agentFrameworkId === 'claude-code' || agentFrameworkId === 'opencode') {
+    settings.agentFrameworkId = agentFrameworkId
+  }
+
+  const opencodePath = asString(value.opencodePath)
+
+  if (opencodePath) {
+    settings.opencodePath = opencodePath
+  }
+
   return settings
 }
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -131,8 +131,14 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
       )
     : undefined
 
+  // Preserve the provider's chat-API type through the read; only known values survive.
+  const apiType = asString(value.apiType)
+
   if (baseUrl) provider.baseUrl = baseUrl
   if (model) provider.model = model
+  if (apiType === 'anthropic' || apiType === 'openai' || apiType === 'both') {
+    provider.apiType = apiType
+  }
   if (vendorId) provider.vendorId = vendorId
   if (region) provider.region = region
   if (fetchedModels && fetchedModels.length > 0) provider.fetchedModels = fetchedModels

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -408,6 +408,20 @@ class SettingsRepository {
     }))
   }
 
+  // Forgets the recorded opencode executable so the status card and gates reflect an uninstall. Called
+  // when a re-detect finds nothing; otherwise a stale path lingers and a spawn against the gone binary
+  // fails with EPIPE.
+  async clearOpencodeInfo(): Promise<StoredSettings> {
+    return this.mutate((settings) => {
+      const { opencodePath, opencodeVersion, ...rest } = settings
+
+      void opencodePath
+      void opencodeVersion
+
+      return rest
+    })
+  }
+
   // Stamps the onboarding-completed time exactly once; later calls leave the first value intact.
   async markOnboardingComplete(timestamp: number): Promise<StoredSettings> {
     return this.mutate((settings) =>

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -313,6 +313,9 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
 
   if (opencodePath) {
     settings.opencodePath = opencodePath
+
+    const opencodeVersion = asString(value.opencodeVersion)
+    if (opencodeVersion) settings.opencodeVersion = opencodeVersion
   }
 
   return settings
@@ -396,9 +399,13 @@ class SettingsRepository {
     return this.mutate((settings) => ({ ...settings, agentFrameworkId: id }))
   }
 
-  // Records the detected opencode executable path for later spawns + the settings status card.
-  async setOpencodePath(path: string): Promise<StoredSettings> {
-    return this.mutate((settings) => ({ ...settings, opencodePath: path }))
+  // Records the detected opencode executable path + version for later spawns + the settings status card.
+  async setOpencodeInfo(resolvedPath: string, version?: string): Promise<StoredSettings> {
+    return this.mutate((settings) => ({
+      ...settings,
+      opencodePath: resolvedPath,
+      opencodeVersion: version
+    }))
   }
 
   // Stamps the onboarding-completed time exactly once; later calls leave the first value intact.

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { isAbsolute, join, normalize, parse } from 'node:path'
 
 import type {
+  AgentFrameworkId,
   ClaudeInfo,
   ProviderType,
   ProviderValidationFailure,
@@ -369,6 +370,11 @@ class SettingsRepository {
   // Records the detected claude executable metadata for later spawns.
   async setClaudeInfo(claude: ClaudeInfo): Promise<StoredSettings> {
     return this.mutate((settings) => ({ ...settings, claude }))
+  }
+
+  // Persists the selected agent backend; applied on the next reconnect.
+  async setAgentFramework(id: AgentFrameworkId): Promise<StoredSettings> {
+    return this.mutate((settings) => ({ ...settings, agentFrameworkId: id }))
   }
 
   // Stamps the onboarding-completed time exactly once; later calls leave the first value intact.

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -377,6 +377,11 @@ class SettingsRepository {
     return this.mutate((settings) => ({ ...settings, agentFrameworkId: id }))
   }
 
+  // Records the detected opencode executable path for later spawns + the settings status card.
+  async setOpencodePath(path: string): Promise<StoredSettings> {
+    return this.mutate((settings) => ({ ...settings, opencodePath: path }))
+  }
+
   // Stamps the onboarding-completed time exactly once; later calls leave the first value intact.
   async markOnboardingComplete(timestamp: number): Promise<StoredSettings> {
     return this.mutate((settings) =>

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1044,4 +1044,57 @@ describe('checkEnvironment', () => {
     expect(result.runtime).toEqual({ found: true, path: found, version: '2.2.0' })
     expect((await repository.getSettings()).claude?.resolvedPath).toBe(found)
   })
+
+  it('checks both framework runtimes together and gates on the selected one (OpenCode)', async () => {
+    await repository.setAgentFramework('opencode')
+    // Claude is detectable (default detectDeps) and OpenCode is declared installed; both rows appear,
+    // but the result's runtime + gating reflect the SELECTED framework (OpenCode).
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.19.0' }
+    })
+
+    const result = await service.checkEnvironment()
+
+    const agentRows = result.checks.filter((check) => check.id === 'agent')
+    expect(agentRows.map((row) => row.label)).toEqual(['Claude Code runtime', 'OpenCode runtime'])
+    expect(agentRows.every((row) => row.status === 'passed')).toBe(true)
+    expect(result.agentFrameworkId).toBe('opencode')
+    expect(result.runtime).toEqual({
+      found: true,
+      path: '/usr/local/bin/opencode',
+      version: '1.19.0'
+    })
+  })
+
+  it('persists a freshly detected OpenCode runtime discovered during the dual probe', async () => {
+    // No recorded opencode; the parallel probe detects one on PATH and must record it so later
+    // gates/cards read the same runtime without re-probing.
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.19.0' }
+    })
+
+    await service.checkEnvironment()
+
+    const settings = await repository.getSettings()
+    expect(settings.opencodePath).toBe('/usr/local/bin/opencode')
+    expect(settings.opencodeVersion).toBe('1.19.0')
+  })
+
+  it('gates on the selected framework: OpenCode selected but missing blocks while Claude passes', async () => {
+    await repository.setAgentFramework('opencode')
+    // Claude is detectable (default detectDeps); OpenCode is declared absent (no opencodeDetected).
+    const service = createService()
+
+    const result = await service.checkEnvironment()
+
+    const agentRows = result.checks.filter((check) => check.id === 'agent')
+    expect(agentRows.map((row) => `${row.label}:${row.status}`)).toEqual([
+      'Claude Code runtime:passed',
+      'OpenCode runtime:failed'
+    ])
+    // Selection drives readiness: the missing selected runtime blocks Continue even though Claude runs.
+    expect(result.agentFrameworkId).toBe('opencode')
+    expect(result.ready).toBe(false)
+    expect(result.runtime).toEqual({ found: false })
+  })
 })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -296,7 +296,13 @@ describe('SettingsService: preflight & spawn config', () => {
     await service.validateProvider({ providerId: created.id })
     await service.setActiveProvider(created.id)
 
-    expect(await service.getPreflight()).toEqual({ claudeReady: true, activeProviderReady: true })
+    expect(await service.getPreflight()).toEqual({
+      claudeReady: true,
+      opencodeReady: false,
+      agentFrameworkId: 'claude-code',
+      agentReady: true,
+      activeProviderReady: true
+    })
   })
 
   it('builds spawn env from the active provider with the decrypted key', async () => {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { execPath } from 'node:process'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -48,6 +48,8 @@ const createService = (
     executeClaudeProbe?: (executablePath: string, env: NodeJS.ProcessEnv) => Promise<void>
     installManagedClaudeImpl?: ManagedInstallImpl
     installManagedOpencodeImpl?: ManagedInstallImpl
+    // When set, opencode detection resolves this path/version; otherwise it finds nothing.
+    opencodeDetected?: { path: string; version: string }
   } = {}
 ): InstanceType<typeof SettingsService> =>
   new SettingsService({
@@ -68,13 +70,17 @@ const createService = (
       getVersion: () => Promise.resolve(detectResult.version),
       resolveNpmBinDirs: () => Promise.resolve([])
     },
-    // Isolated so opencode detection never probes the real host during install tests.
+    // Isolated so opencode detection never probes the real host during tests. Finds nothing unless the
+    // caller declares an installed path (isExecutable/getVersion then answer for exactly that path).
     opencodeDetectDeps: {
-      env: {},
+      env: options.opencodeDetected ? { PATH: dirname(options.opencodeDetected.path) } : {},
       homePath: '/home',
       platform: 'linux',
-      isExecutable: () => Promise.resolve(false),
-      getVersion: () => Promise.resolve(undefined),
+      isExecutable: (path) => Promise.resolve(path === options.opencodeDetected?.path),
+      getVersion: (path) =>
+        Promise.resolve(
+          path === options.opencodeDetected?.path ? options.opencodeDetected.version : undefined
+        ),
       resolveNpmBinDirs: () => Promise.resolve([])
     }
   })
@@ -875,6 +881,33 @@ describe('installOpencode', () => {
 
     expect(result.ok).toBe(false)
     expect((await service.getSettingsView()).opencode).toEqual({})
+  })
+})
+
+describe('detectOpencode', () => {
+  it('clears a stale record when nothing runnable is found (e.g. after an uninstall)', async () => {
+    // Simulate a prior install still recorded in settings.
+    await repository.setOpencodeInfo('/gone/bin/opencode', '1.18.3')
+    const service = createService() // default deps find nothing
+
+    const snapshot = await service.detectOpencode()
+
+    // The stale path/version are forgotten so the card and gates reflect the uninstall.
+    expect(snapshot.opencode).toEqual({})
+    expect((await repository.getSettings()).opencodePath).toBeUndefined()
+  })
+
+  it('records the detected path + version when opencode is present', async () => {
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.19.0' }
+    })
+
+    const snapshot = await service.detectOpencode()
+
+    expect(snapshot.opencode).toEqual({
+      resolvedPath: '/usr/local/bin/opencode',
+      version: '1.19.0'
+    })
   })
 })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -47,6 +47,7 @@ const createService = (
     userClaudeDir?: string
     executeClaudeProbe?: (executablePath: string, env: NodeJS.ProcessEnv) => Promise<void>
     installManagedClaudeImpl?: ManagedInstallImpl
+    installManagedOpencodeImpl?: ManagedInstallImpl
   } = {}
 ): InstanceType<typeof SettingsService> =>
   new SettingsService({
@@ -57,12 +58,23 @@ const createService = (
     executeClaudeProbe: options.executeClaudeProbe,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     installManagedClaudeImpl: options.installManagedClaudeImpl as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installManagedOpencodeImpl: options.installManagedOpencodeImpl as any,
     detectDeps: {
       env: {},
       homePath: '/home',
       platform: 'linux',
       isExecutable: () => Promise.resolve(true),
       getVersion: () => Promise.resolve(detectResult.version),
+      resolveNpmBinDirs: () => Promise.resolve([])
+    },
+    // Isolated so opencode detection never probes the real host during install tests.
+    opencodeDetectDeps: {
+      env: {},
+      homePath: '/home',
+      platform: 'linux',
+      isExecutable: () => Promise.resolve(false),
+      getVersion: () => Promise.resolve(undefined),
       resolveNpmBinDirs: () => Promise.resolve([])
     }
   })
@@ -830,6 +842,39 @@ describe('installClaude (app-managed source)', () => {
       'https://registry.npmmirror.com',
       'https://registry.npmjs.org'
     ])
+  })
+})
+
+describe('installOpencode', () => {
+  it('routes a managed install through the managed installer and persists path + version', async () => {
+    const service = createService(undefined, {
+      installManagedOpencodeImpl: async ({ installId }) => ({
+        result: { installId, ok: true },
+        resolvedPath: '/data/opencode-managed/bin/opencode',
+        version: '1.18.3'
+      })
+    })
+
+    const result = await service.installOpencode({ source: 'managed' }, () => undefined)
+
+    expect(result.ok).toBe(true)
+    expect((await service.getSettingsView()).opencode).toEqual({
+      resolvedPath: '/data/opencode-managed/bin/opencode',
+      version: '1.18.3'
+    })
+  })
+
+  it('does not persist opencode info when the managed install fails', async () => {
+    const service = createService(undefined, {
+      installManagedOpencodeImpl: async ({ installId }) => ({
+        result: { installId, ok: false, error: 'all registries failed' }
+      })
+    })
+
+    const result = await service.installOpencode({ source: 'managed' }, () => undefined)
+
+    expect(result.ok).toBe(false)
+    expect((await service.getSettingsView()).opencode).toEqual({})
   })
 })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -987,8 +987,8 @@ describe('checkEnvironment', () => {
 
     const result = await service.checkEnvironment()
 
-    expect(result.claude).toEqual({ found: true, path: execPath, version: '2.1.0' })
-    expect(result.checks.find((check) => check.id === 'claude')?.status).toBe('passed')
+    expect(result.runtime).toEqual({ found: true, path: execPath, version: '2.1.0' })
+    expect(result.checks.find((check) => check.id === 'agent')?.status).toBe('passed')
   })
 
   it('does not overwrite a healthy recorded executable with a freshly detected PATH entry', async () => {
@@ -1015,7 +1015,7 @@ describe('checkEnvironment', () => {
     const result = await service.checkEnvironment()
 
     // The recorded runtime is retained rather than being replaced by the PATH discovery.
-    expect(result.claude).toEqual({ found: true, path: execPath, version: '2.1.0' })
+    expect(result.runtime).toEqual({ found: true, path: execPath, version: '2.1.0' })
     expect((await repository.getSettings()).claude?.resolvedPath).toBe(execPath)
   })
 
@@ -1041,7 +1041,7 @@ describe('checkEnvironment', () => {
 
     const result = await service.checkEnvironment()
 
-    expect(result.claude).toEqual({ found: true, path: found, version: '2.2.0' })
+    expect(result.runtime).toEqual({ found: true, path: found, version: '2.2.0' })
     expect((await repository.getSettings()).claude?.resolvedPath).toBe(found)
   })
 })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { execPath } from 'node:process'
@@ -907,6 +907,48 @@ describe('detectOpencode', () => {
     expect(snapshot.opencode).toEqual({
       resolvedPath: '/usr/local/bin/opencode',
       version: '1.19.0'
+    })
+  })
+
+  it('keeps a still-present record when the live probe misses (GUI PATH gap, not an uninstall)', async () => {
+    // A real executable the probe fails to see (e.g. narrower GUI PATH). The record must survive.
+    const present = join(storageRoot, 'opencode-present')
+    await writeFile(present, '', 'utf8')
+    await chmod(present, 0o755)
+    await repository.setOpencodeInfo(present, '1.18.3')
+    const service = createService() // default deps find nothing
+
+    const snapshot = await service.detectOpencode()
+
+    expect(snapshot.opencode).toEqual({ resolvedPath: present, version: '1.18.3' })
+  })
+})
+
+describe('detectClaude hardening', () => {
+  it('forgets the recorded claude when its binary is gone from disk (uninstall)', async () => {
+    await repository.setClaudeInfo({ resolvedPath: '/gone/bin/claude', version: '2.1.0' })
+    // found:false + version:undefined makes the injected probe report nothing runnable.
+    const service = createService({ found: false, path: undefined, version: undefined })
+
+    await service.detectClaude()
+
+    // The stale path is forgotten (an empty claude record sanitizes away to undefined on read).
+    expect((await repository.getSettings()).claude?.resolvedPath).toBeUndefined()
+  })
+
+  it('keeps the cached claude on a transient probe miss when its binary still exists', async () => {
+    const present = join(storageRoot, 'claude-present')
+    await writeFile(present, '', 'utf8')
+    await chmod(present, 0o755)
+    await repository.setClaudeInfo({ resolvedPath: present, version: '2.1.0' })
+    const service = createService({ found: false, path: undefined, version: undefined })
+
+    await service.detectClaude()
+
+    // A GUI PATH gap must not wipe a still-installed claude.
+    expect((await repository.getSettings()).claude).toEqual({
+      resolvedPath: present,
+      version: '2.1.0'
     })
   })
 })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -578,8 +578,22 @@ describe('SettingsService: official vendors', () => {
     })
 
     expect(result.ok).toBe(true)
-    // The probe hits the registry base URL (+ the client's /v1/messages suffix).
-    expect(fetchMock.mock.calls[0][0]).toBe('https://api.deepseek.com/anthropic/v1/messages')
+    // DeepSeek is a dual-endpoint vendor (apiType 'both'), so the probe prefers its OpenAI base +
+    // /v1/chat/completions rather than the Anthropic route.
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.deepseek.com/v1/chat/completions')
+  })
+
+  it('validates an anthropic-only official draft against its /v1/messages route', async () => {
+    const service = createService()
+    const fetchMock = vi.fn().mockResolvedValue({ status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // Claude (anthropic-only) keeps the Anthropic Messages probe.
+    await service.validateProvider({
+      draft: { type: 'official', vendorId: 'anthropic', key: 'sk-a' }
+    })
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.anthropic.com/v1/messages')
   })
 })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -323,6 +323,29 @@ describe('SettingsService: preflight & spawn config', () => {
     })
   })
 
+  it('does not report claude ready when the recorded binary exists but fails --version', async () => {
+    // Executable-but-corrupt runtime: execPath is a real file (X_OK passes) yet `--version` fails.
+    // Preflight must validate via --version like the env check, so this must NOT pass as ready.
+    const service = createService({ found: false })
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+
+    const preflight = await service.getPreflight()
+
+    expect(preflight.claudeReady).toBe(false)
+    expect(preflight.agentReady).toBe(false)
+  })
+
+  it('does not report opencode ready when the recorded binary exists but fails --version', async () => {
+    // Same for OpenCode: the recorded path is a real executable, but its --version probe fails
+    // (no opencodeDetected declared, so the injected getVersion returns undefined for it).
+    const service = createService({ found: true, path: '/bin/claude', version: '2.1.0' })
+    await repository.setOpencodeInfo(execPath, '1.18.3')
+
+    const preflight = await service.getPreflight()
+
+    expect(preflight.opencodeReady).toBe(false)
+  })
+
   it('builds spawn env from the active provider with the decrypted key', async () => {
     const service = createService()
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1192,7 +1192,8 @@ class SettingsService {
         type: 'custom',
         baseUrl: resolveVendorBaseUrl(provider.vendorId, provider.region),
         model: modelOverride ?? defaultVendorModel(provider.vendorId),
-        key
+        key,
+        apiType: this.resolveProviderApiType(provider)
       }
     }
 
@@ -1200,7 +1201,8 @@ class SettingsService {
       type: provider.type,
       baseUrl: provider.baseUrl,
       model: modelOverride ?? provider.model,
-      key
+      key,
+      apiType: this.resolveProviderApiType(provider)
     }
   }
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process'
-import { access, readdir } from 'node:fs/promises'
+import { access, mkdir, readdir, writeFile } from 'node:fs/promises'
 import { constants } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { promisify } from 'node:util'
 
@@ -56,7 +56,14 @@ import {
   resolveVendorModelsUrl
 } from '../../shared/provider-registry'
 import { resolveStorageRoot } from '../storage-root'
+import {
+  DEFAULT_AGENT_FRAMEWORK_ID,
+  getAgentFramework,
+  type AgentFrameworkId,
+  type ResolvedAgentBackend
+} from '../agent-framework'
 import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
+import { detectOpencode } from './opencode-detect'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import { detectNpmAvailable, runInstallWithFallback } from './claude-install'
 import { runEnvironmentCheck } from './environment-check'
@@ -949,6 +956,72 @@ class SettingsService {
     }
 
     return { envOverrides, executablePath }
+  }
+
+  // Resolves the active agent backend for one connect: the selected framework plus its spawn inputs.
+  // Claude reuses the existing provider-env path unchanged; other frameworks (opencode) map the active
+  // provider to their own native config (a generated opencode.json) via the framework adapter and get
+  // it written to disk before spawn. The framework can be forced with OPEN_SCIENCE_AGENT_FRAMEWORK for
+  // the spike until the settings selector lands.
+  async resolveActiveAgentBackend(): Promise<ResolvedAgentBackend> {
+    const settings = await this.repository.getSettings()
+    const forced = process.env.OPEN_SCIENCE_AGENT_FRAMEWORK
+    const frameworkId: AgentFrameworkId =
+      forced === 'opencode' || forced === 'claude-code'
+        ? forced
+        : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
+    const framework = getAgentFramework(frameworkId)
+
+    if (framework.id === 'claude-code') {
+      // Unchanged Claude path: skills provisioning + Anthropic-shaped env + local-auth handling.
+      const { envOverrides, executablePath } = await this.resolveActiveSpawnConfig()
+
+      return { framework, executablePath, env: envOverrides }
+    }
+
+    // opencode: no CLAUDE_CONFIG_DIR / skills provisioning; the adapter maps the provider onto its own
+    // config file, which is written before the agent spawns.
+    const activeProvider = settings.activeProviderId
+      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
+      : undefined
+
+    if (!activeProvider) {
+      throw new Error('No active model provider is configured. Configure one in settings.')
+    }
+
+    const executablePath = await this.resolveOpencodeExecutable(settings.opencodePath)
+    const modelConfig = framework.prepareModelConfig(
+      this.resolveProvider(activeProvider, settings.activeModel),
+      { storageRoot: this.storageRoot, executablePath }
+    )
+    await this.writeAgentConfigFiles(modelConfig.configFiles)
+
+    return { framework, executablePath, env: modelConfig.env ?? {}, args: modelConfig.args }
+  }
+
+  // Locates the opencode binary: an explicitly stored path wins, else a best-effort PATH lookup.
+  private async resolveOpencodeExecutable(storedPath: string | undefined): Promise<string> {
+    if (storedPath) return storedPath
+
+    const detected = await detectOpencode()
+
+    if (!detected) {
+      throw new Error(
+        'opencode executable not found. Install opencode or set its path in settings.'
+      )
+    }
+
+    return detected
+  }
+
+  // Writes a framework's generated config files (e.g. opencode.json) to disk ahead of spawn.
+  private async writeAgentConfigFiles(
+    files: { path: string; content: string }[] | undefined
+  ): Promise<void> {
+    for (const file of files ?? []) {
+      await mkdir(dirname(file.path), { recursive: true })
+      await writeFile(file.path, file.content, 'utf8')
+    }
   }
 
   // Maps a stored provider to its masked renderer view, flagging custom keys that no longer decrypt.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -66,8 +66,12 @@ import {
   type ResolvedAgentBackend
 } from '../agent-framework'
 import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
-import { detectOpencode } from './opencode-detect'
-import { installManagedOpencode } from './managed-opencode'
+import {
+  createDefaultDetectDeps as createOpencodeDetectDeps,
+  detectOpencode,
+  type OpencodeDetectDeps
+} from './opencode-detect'
+import { installManagedOpencode, managedOpencodeDir } from './managed-opencode'
 import { opencodeConfigDir } from '../agent-framework/opencode'
 import { ClaudeCodeSkillMaterializer } from '../skills/materializer'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
@@ -142,6 +146,7 @@ export type SettingsServiceOptions = {
   repository?: SettingsRepository
   storageRoot?: string
   detectDeps?: ClaudeDetectDeps
+  opencodeDetectDeps?: OpencodeDetectDeps
   // The machine's own Claude config dir, read to reuse its login for the "local" provider. Injectable
   // so tests don't touch the real ~/.claude.
   userClaudeDir?: string
@@ -164,6 +169,7 @@ class SettingsService {
   private readonly repository: SettingsRepository
   private readonly storageRoot: string
   private readonly detectDeps: ClaudeDetectDeps
+  private readonly opencodeDetectDeps: OpencodeDetectDeps
   private readonly userClaudeDir: string
   private readonly skillRegistry: SkillRegistry
   private readonly userSkills: UserSkillRepository
@@ -185,6 +191,13 @@ class SettingsService {
     this.detectDeps = {
       ...baseDetectDeps,
       extraDirs: [...(baseDetectDeps.extraDirs ?? []), managedClaudeDir(this.storageRoot)]
+    }
+    // Same rationale for opencode: probe the app-managed dir so a managed opencode is re-detected
+    // (its bare `which/where` PATH lookup would otherwise never see the app-owned install dir).
+    const baseOpencodeDetectDeps = options.opencodeDetectDeps ?? createOpencodeDetectDeps()
+    this.opencodeDetectDeps = {
+      ...baseOpencodeDetectDeps,
+      extraDirs: [...(baseOpencodeDetectDeps.extraDirs ?? []), managedOpencodeDir(this.storageRoot)]
     }
     this.userClaudeDir = options.userClaudeDir ?? defaultUserClaudeDir()
     this.skillRegistry = options.skillRegistry ?? new SkillRegistry()
@@ -230,7 +243,7 @@ class SettingsService {
   // Detects the opencode executable and persists its path, mirroring detectClaude. Returns the refreshed
   // snapshot so the settings card reflects the result.
   async detectOpencode(): Promise<SettingsSnapshot> {
-    const detected = await detectOpencode()
+    const detected = await detectOpencode(this.opencodeDetectDeps)
 
     if (detected) {
       await this.repository.setOpencodeInfo(detected.resolvedPath, detected.version)
@@ -1088,7 +1101,7 @@ class SettingsService {
   private async resolveOpencodeExecutable(storedPath: string | undefined): Promise<string> {
     if (storedPath) return storedPath
 
-    const detected = await detectOpencode()
+    const detected = await detectOpencode(this.opencodeDetectDeps)
 
     if (!detected) {
       throw new Error(

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -261,6 +261,10 @@ class SettingsService {
 
     if (detected) {
       await this.repository.setOpencodeInfo(detected.resolvedPath, detected.version)
+    } else {
+      // Nothing runnable found — clear any stale record so the card/gates reflect the uninstall
+      // instead of showing a version for a binary that no longer exists.
+      await this.repository.clearOpencodeInfo()
     }
 
     return this.getSettingsView()
@@ -1140,7 +1144,10 @@ class SettingsService {
 
   // Locates the opencode binary: an explicitly stored path wins, else a best-effort PATH lookup.
   private async resolveOpencodeExecutable(storedPath: string | undefined): Promise<string> {
-    if (storedPath) return storedPath
+    // Trust the stored path only if it still exists. A user who uninstalled opencode leaves a stale
+    // path behind; spawning it launches a ghost that dies immediately (surfacing as write EPIPE), so
+    // fall back to a live detect and, if that also finds nothing, fail with a clear, actionable message.
+    if (storedPath && (await this.pathExists(storedPath))) return storedPath
 
     const detected = await detectOpencode(this.opencodeDetectDeps)
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -474,17 +474,29 @@ class SettingsService {
   async checkEnvironment(): Promise<EnvironmentCheckResult> {
     const settings = await this.repository.getSettings()
     const agentFrameworkId = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
-    const framework = getAgentFramework(agentFrameworkId)
-    const runtime =
-      agentFrameworkId === 'opencode'
-        ? await this.resolveOpencodeRuntime(settings)
-        : await this.resolveClaudeRuntime(settings)
+
+    // Detect every framework's runtime so onboarding can show them side by side; only the selected
+    // one's readiness gates Continue (enforced inside runEnvironmentCheck).
+    const [claudeRuntime, opencodeRuntime] = await Promise.all([
+      this.resolveClaudeRuntime(settings),
+      this.resolveOpencodeRuntime(settings)
+    ])
 
     return runEnvironmentCheck({
       storageRoot: this.storageRoot,
-      runtime,
       agentFrameworkId,
-      frameworkLabel: framework.displayName,
+      frameworks: [
+        {
+          id: 'claude-code',
+          label: getAgentFramework('claude-code').displayName,
+          runtime: claudeRuntime
+        },
+        {
+          id: 'opencode',
+          label: getAgentFramework('opencode').displayName,
+          runtime: opencodeRuntime
+        }
+      ],
       encryptionAvailable: this.isEncryptionAvailable()
     })
   }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -67,6 +67,7 @@ import {
 } from '../agent-framework'
 import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
 import { detectOpencode } from './opencode-detect'
+import { installManagedOpencode } from './managed-opencode'
 import { opencodeConfigDir } from '../agent-framework/opencode'
 import { ClaudeCodeSkillMaterializer } from '../skills/materializer'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
@@ -506,6 +507,22 @@ class SettingsService {
     }
 
     return result
+  }
+
+  // App-managed OpenCode install (first recommendation, like Claude): downloads the native binary and
+  // persists its path + version. Streams progress on the shared install-log channel.
+  async installOpencode(
+    onEvent: (event: ClaudeInstallEvent) => void
+  ): Promise<ClaudeInstallResult> {
+    this.providerSequence += 1
+    const installId = `install-opencode-${Date.now()}-${this.providerSequence}`
+    const outcome = await installManagedOpencode({ installId, onEvent, dataRoot: this.storageRoot })
+
+    if (outcome.result.ok && outcome.resolvedPath) {
+      await this.repository.setOpencodeInfo(outcome.resolvedPath, outcome.version)
+    }
+
+    return outcome.result
   }
 
   // Records that first-run onboarding finished so later launches skip the wizard.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -199,6 +199,7 @@ class SettingsService {
 
     return {
       claude: settings.claude ?? {},
+      opencode: { resolvedPath: settings.opencodePath },
       activeProviderId: settings.activeProviderId,
       activeModel: settings.activeModel,
       providers: settings.providers.map((provider) => this.toProviderView(provider)),
@@ -215,6 +216,18 @@ class SettingsService {
   // Selects the agent backend to drive; the caller reconnects so the choice applies to the next spawn.
   async setAgentFramework(id: AgentFrameworkId): Promise<SettingsSnapshot> {
     await this.repository.setAgentFramework(id)
+
+    return this.getSettingsView()
+  }
+
+  // Detects the opencode executable and persists its path, mirroring detectClaude. Returns the refreshed
+  // snapshot so the settings card reflects the result.
+  async detectOpencode(): Promise<SettingsSnapshot> {
+    const resolvedPath = await detectOpencode()
+
+    if (resolvedPath) {
+      await this.repository.setOpencodePath(resolvedPath)
+    }
 
     return this.getSettingsView()
   }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -50,6 +50,7 @@ import type {
   ValidateProviderRequest,
   ValidateProviderResult
 } from '../../shared/settings'
+import { isProviderUsableByFramework } from '../../shared/settings'
 import {
   defaultVendorModel,
   getOfficialVendor,
@@ -442,12 +443,27 @@ class SettingsService {
       ? await this.pathExists(settings.opencodePath)
       : false
 
+    const agentFrameworkId = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    const framework = getAgentFramework(agentFrameworkId)
+    const activeProvider = settings.activeProviderId
+      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
+      : undefined
+    // Resolve compatibility here where the vendor registry is available (official apiType) and pass the
+    // boolean into the pure preflight computation.
+    const activeProviderCompatible = activeProvider
+      ? isProviderUsableByFramework(
+          { apiType: this.resolveProviderApiType(activeProvider), type: activeProvider.type },
+          framework
+        )
+      : false
+
     return computePreflight({
       settings,
       claudePathExists,
       opencodePathExists,
-      agentFrameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
-      isProviderKeyUsable: (provider) => this.isProviderKeyUsable(provider)
+      agentFrameworkId,
+      isProviderKeyUsable: (provider) => this.isProviderKeyUsable(provider),
+      activeProviderCompatible
     })
   }
 
@@ -1123,6 +1139,28 @@ class SettingsService {
         : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
     const framework = getAgentFramework(frameworkId)
 
+    // Enforce provider↔framework compatibility up front so an incompatible pair fails with a clear
+    // message instead of spawning an agent that can't use the credentials — e.g. OpenCode + a Local
+    // Claude provider (Claude-only login), or Claude + an OpenAI-only gateway.
+    const activeProvider = settings.activeProviderId
+      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
+      : undefined
+
+    if (!activeProvider) {
+      throw new Error('No active model provider is configured. Configure one in settings.')
+    }
+
+    if (
+      !isProviderUsableByFramework(
+        { apiType: this.resolveProviderApiType(activeProvider), type: activeProvider.type },
+        framework
+      )
+    ) {
+      throw new Error(
+        `The active model provider is not compatible with ${framework.displayName}. Pick a compatible model or switch the agent framework in settings.`
+      )
+    }
+
     if (framework.id === 'claude-code') {
       // Unchanged Claude path: skills provisioning + Anthropic-shaped env + local-auth handling.
       const { envOverrides, executablePath } = await this.resolveActiveSpawnConfig()
@@ -1133,14 +1171,6 @@ class SettingsService {
     // opencode maps the provider onto its own isolated config; the adapter writes it before spawn, and
     // the enabled skill set is materialized into opencode's config dir (its native skill tool discovers
     // them on-demand, same SKILL.md layout as Claude).
-    const activeProvider = settings.activeProviderId
-      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
-      : undefined
-
-    if (!activeProvider) {
-      throw new Error('No active model provider is configured. Configure one in settings.')
-    }
-
     await this.materializeOpencodeSkills(settings)
     const executablePath = await this.resolveOpencodeExecutable(settings.opencodePath)
     const provider = this.resolveProvider(activeProvider, settings.activeModel)

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -541,13 +541,21 @@ class SettingsService {
       }
     }
 
-    // detectOpencode persists a hit and clears a stale record, so the card/gates stay accurate.
-    await this.detectOpencode()
+    // Probe once (not twice): detect, then persist a hit or clear a truly-gone record — same rule as
+    // detectOpencode — so the card/gates stay accurate without running the full PATH/version probe again.
     const detected = await detectOpencode(this.opencodeDetectDeps)
 
-    return detected
-      ? { found: true, path: detected.resolvedPath, version: detected.version }
-      : { found: false }
+    if (detected) {
+      await this.repository.setOpencodeInfo(detected.resolvedPath, detected.version)
+
+      return { found: true, path: detected.resolvedPath, version: detected.version }
+    }
+
+    if (cachedPath && !(await this.pathExists(cachedPath))) {
+      await this.repository.clearOpencodeInfo()
+    }
+
+    return { found: false }
   }
 
   // Detects claude and persists the resolved path/version for later spawns.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -64,7 +64,7 @@ import {
   type ResolvedAgentBackend
 } from '../agent-framework'
 import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
-import { detectOpencode } from './opencode-detect'
+import { detectOpencode, readOpencodeUserConfig } from './opencode-detect'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import { detectNpmAvailable, runInstallWithFallback } from './claude-install'
 import { runEnvironmentCheck } from './environment-check'
@@ -1007,7 +1007,10 @@ class SettingsService {
     const provider = this.resolveProvider(activeProvider, settings.activeModel)
     const modelConfig = framework.prepareModelConfig(provider, {
       storageRoot: this.storageRoot,
-      executablePath
+      executablePath,
+      // Merge onto the user's own opencode config so their providers/mcp survive; auth.json is loaded
+      // by opencode separately and is never touched.
+      baseConfig: await readOpencodeUserConfig()
     })
     await this.writeAgentConfigFiles(modelConfig.configFiles)
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -23,6 +23,7 @@ import type {
   InstallClaudeRequest,
   NcbiCredentialsView,
   Preflight,
+  ProviderApiType,
   ProviderDraft,
   ProviderView,
   RefreshProviderModelsRequest,
@@ -52,6 +53,7 @@ import {
   defaultVendorModel,
   getOfficialVendor,
   isOfficialVendorId,
+  resolveVendorApiType,
   resolveVendorBaseUrl,
   resolveVendorModelsUrl
 } from '../../shared/provider-registry'
@@ -208,7 +210,8 @@ class SettingsService {
       agentFrameworks: listAgentFrameworks().map((framework) => ({
         id: framework.id,
         displayName: framework.displayName,
-        supportsSkills: framework.supportsSkills
+        supportsSkills: framework.supportsSkills,
+        supportedApiTypes: [...framework.supportedApiTypes]
       })),
       onboardingCompletedAt: settings.onboardingCompletedAt
     }
@@ -597,6 +600,8 @@ class SettingsService {
 
       provider.baseUrl = baseUrl
       provider.model = model
+      // Which chat API this gateway speaks (drives per-framework availability); defaults to anthropic.
+      provider.apiType = request.apiType ?? existing?.apiType ?? 'anthropic'
       credentialsChanged = Boolean(request.key)
     } else {
       // claude-default: optional model override, no credentials of its own.
@@ -1074,6 +1079,16 @@ class SettingsService {
     }
   }
 
+  // The chat API a provider speaks: official providers come from the registry, custom gateways from
+  // their stored/drafted apiType, everything else defaults to Anthropic /v1/messages.
+  private resolveProviderApiType(provider: StoredProvider): ProviderApiType {
+    if (provider.type === 'official' && provider.vendorId) {
+      return resolveVendorApiType(provider.vendorId)
+    }
+
+    return provider.apiType ?? 'anthropic'
+  }
+
   // Maps a stored provider to its masked renderer view, flagging custom keys that no longer decrypt.
   private toProviderView(provider: StoredProvider): ProviderView {
     const hasKey = Boolean(provider.keyRef)
@@ -1085,6 +1100,7 @@ class SettingsService {
       id: provider.id,
       type: provider.type,
       name: provider.name,
+      apiType: this.resolveProviderApiType(provider),
       baseUrl: provider.baseUrl,
       model: provider.model,
       vendorId: provider.vendorId,

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -468,41 +468,74 @@ class SettingsService {
     })
   }
 
-  // Re-runs the complete host inspection on every app launch. Claude detection is part of the same
-  // pass so a runtime installed outside Open Science between launches is picked up immediately.
+  // Re-runs the complete host inspection on every app launch, for the SELECTED framework's runtime, so
+  // a runtime installed outside Open Science between launches is picked up and onboarding can be
+  // completed with Claude or OpenCode alone.
   async checkEnvironment(): Promise<EnvironmentCheckResult> {
-    // Prefer a previously recorded runtime that still runs over this launch's re-detection. This keeps
-    // a healthy app-managed (or manually chosen) executable from being silently replaced by a PATH
-    // entry discovered later — e.g. an npm `claude.cmd` that only works via a shell — and uses the
-    // `--version` probe (not mere file existence) as the real usability signal, so a stale-but-present
-    // path is never reported as healthy.
-    const cached = (await this.repository.getSettings()).claude
-    let claude: ClaudeDetectResult | undefined
+    const settings = await this.repository.getSettings()
+    const agentFrameworkId = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    const framework = getAgentFramework(agentFrameworkId)
+    const runtime =
+      agentFrameworkId === 'opencode'
+        ? await this.resolveOpencodeRuntime(settings)
+        : await this.resolveClaudeRuntime(settings)
+
+    return runEnvironmentCheck({
+      storageRoot: this.storageRoot,
+      runtime,
+      agentFrameworkId,
+      frameworkLabel: framework.displayName,
+      encryptionAvailable: this.isEncryptionAvailable()
+    })
+  }
+
+  // Resolves the Claude runtime for the environment check. Prefers a previously recorded runtime that
+  // still runs over this launch's re-detection, keeping a healthy app-managed/manual executable from
+  // being replaced by a PATH entry discovered later; the `--version` probe (not mere file existence)
+  // is the usability signal, so a stale-but-present path is never reported healthy.
+  private async resolveClaudeRuntime(settings: StoredSettings): Promise<ClaudeDetectResult> {
+    const cached = settings.claude
 
     if (cached?.resolvedPath) {
       const version = await this.detectDeps.getVersion(cached.resolvedPath)
 
       if (version) {
-        claude = { found: true, path: cached.resolvedPath, version }
-
         // Keep the stored version in sync when an in-place update changed it under the same path.
         if (version !== cached.version) {
           await this.repository.setClaudeInfo({ resolvedPath: cached.resolvedPath, version })
         }
+
+        return { found: true, path: cached.resolvedPath, version }
       }
     }
 
-    // No healthy recorded runtime: fall back to a full detection pass, which persists what it finds so
-    // a runtime installed outside Open Science between launches is picked up.
-    if (!claude) {
-      claude = await this.detectClaude()
+    // No healthy recorded runtime: full detection, which persists what it finds.
+    return this.detectClaude()
+  }
+
+  // Same recorded-runtime-first logic for OpenCode, mapped into the shared detect-result shape.
+  private async resolveOpencodeRuntime(settings: StoredSettings): Promise<ClaudeDetectResult> {
+    const cachedPath = settings.opencodePath
+
+    if (cachedPath) {
+      const version = await this.opencodeDetectDeps.getVersion(cachedPath)
+
+      if (version) {
+        if (version !== settings.opencodeVersion) {
+          await this.repository.setOpencodeInfo(cachedPath, version)
+        }
+
+        return { found: true, path: cachedPath, version }
+      }
     }
 
-    return runEnvironmentCheck({
-      storageRoot: this.storageRoot,
-      claude,
-      encryptionAvailable: this.isEncryptionAvailable()
-    })
+    // detectOpencode persists a hit and clears a stale record, so the card/gates stay accurate.
+    await this.detectOpencode()
+    const detected = await detectOpencode(this.opencodeDetectDeps)
+
+    return detected
+      ? { found: true, path: detected.resolvedPath, version: detected.version }
+      : { found: false }
   }
 
   // Detects claude and persists the resolved path/version for later spawns.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1211,7 +1211,7 @@ class SettingsService {
       )
     ) {
       throw new Error(
-        `The active model provider is not compatible with ${framework.displayName}. Pick a compatible model or switch the agent framework in settings.`
+        `The active model isn't compatible with ${framework.displayName}. Open Settings → Model to pick a compatible model or switch the agent framework.`
       )
     }
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -66,7 +66,7 @@ import {
   type ResolvedAgentBackend
 } from '../agent-framework'
 import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
-import { detectOpencode, readOpencodeUserConfig } from './opencode-detect'
+import { detectOpencode } from './opencode-detect'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import { detectNpmAvailable, runInstallWithFallback } from './claude-install'
 import { runEnvironmentCheck } from './environment-check'
@@ -1034,9 +1034,6 @@ class SettingsService {
     const modelConfig = framework.prepareModelConfig(provider, {
       storageRoot: this.storageRoot,
       executablePath,
-      // Merge onto the user's own opencode config so their providers/mcp survive; auth.json is loaded
-      // by opencode separately and is never touched.
-      baseConfig: await readOpencodeUserConfig(),
       // Connector conventions + tools, so opencode uses host.mcp instead of raw HTTP (it has no skill
       // docs like Claude). Enabled bundled connectors only.
       instructions: renderConnectorInstructions(this.enabledConnectorIds(settings.connectors))

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -84,6 +84,7 @@ import { SettingsRepository } from './repository'
 import { sanitizeCustomMcpServer } from './repository'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import { getConnectorTools } from '../connectors/registry'
+import { renderConnectorInstructions } from '../connectors/skill-doc'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { UserSkillRepository } from '../skills/user-skill-repository'
 import { decodeBoundedBase64 } from '../skills/import-limits'
@@ -731,6 +732,13 @@ class SettingsService {
     return settings.connectors
   }
 
+  // Bundled connectors the user hasn't turned off (default-on), for opencode instruction delivery.
+  private enabledConnectorIds(connectors: StoredConnectors | undefined): string[] {
+    const disabled = new Set(connectors?.disabledConnectorIds ?? [])
+
+    return CONNECTOR_CATALOG.map((meta) => meta.id).filter((id) => !disabled.has(id))
+  }
+
   // Projects the bundled catalog into renderer views, applying the stored opt-out / auto-allow sets.
   private toConnectorViews(connectors: StoredConnectors | undefined): ConnectorView[] {
     const disabled = new Set(connectors?.disabledConnectorIds ?? [])
@@ -1023,7 +1031,10 @@ class SettingsService {
       executablePath,
       // Merge onto the user's own opencode config so their providers/mcp survive; auth.json is loaded
       // by opencode separately and is never touched.
-      baseConfig: await readOpencodeUserConfig()
+      baseConfig: await readOpencodeUserConfig(),
+      // Connector conventions + tools, so opencode uses host.mcp instead of raw HTTP (it has no skill
+      // docs like Claude). Enabled bundled connectors only.
+      instructions: renderConnectorInstructions(this.enabledConnectorIds(settings.connectors))
     })
     await this.writeAgentConfigFiles(modelConfig.configFiles)
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -415,10 +415,15 @@ class SettingsService {
     const claudePathExists = settings.claude?.resolvedPath
       ? await this.pathExists(settings.claude.resolvedPath)
       : false
+    const opencodePathExists = settings.opencodePath
+      ? await this.pathExists(settings.opencodePath)
+      : false
 
     return computePreflight({
       settings,
       claudePathExists,
+      opencodePathExists,
+      agentFrameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
       isProviderKeyUsable: (provider) => this.isProviderKeyUsable(provider)
     })
   }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -59,6 +59,7 @@ import { resolveStorageRoot } from '../storage-root'
 import {
   DEFAULT_AGENT_FRAMEWORK_ID,
   getAgentFramework,
+  listAgentFrameworks,
   type AgentFrameworkId,
   type ResolvedAgentBackend
 } from '../agent-framework'
@@ -201,8 +202,21 @@ class SettingsService {
       activeProviderId: settings.activeProviderId,
       activeModel: settings.activeModel,
       providers: settings.providers.map((provider) => this.toProviderView(provider)),
+      agentFrameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
+      agentFrameworks: listAgentFrameworks().map((framework) => ({
+        id: framework.id,
+        displayName: framework.displayName,
+        supportsSkills: framework.supportsSkills
+      })),
       onboardingCompletedAt: settings.onboardingCompletedAt
     }
+  }
+
+  // Selects the agent backend to drive; the caller reconnects so the choice applies to the next spawn.
+  async setAgentFramework(id: AgentFrameworkId): Promise<SettingsSnapshot> {
+    await this.repository.setAgentFramework(id)
+
+    return this.getSettingsView()
   }
 
   // The full skill catalog across every source: bundled (featured) + imported + personal.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -437,11 +437,14 @@ class SettingsService {
   // Computes the two startup gates, re-checking the claude path each call as the design requires.
   async getPreflight(): Promise<Preflight> {
     const settings = await this.repository.getSettings()
+    // Validate each recorded runtime exactly as the authoritative env check does — by invoking
+    // `--version`, not mere X_OK — so a corrupt-but-executable binary cannot pass preflight and get
+    // auto-selected as "ready" only to be rejected later by the env gate that actually runs it.
     const claudePathExists = settings.claude?.resolvedPath
-      ? await this.pathExists(settings.claude.resolvedPath)
+      ? (await this.detectDeps.getVersion(settings.claude.resolvedPath)) !== undefined
       : false
     const opencodePathExists = settings.opencodePath
-      ? await this.pathExists(settings.opencodePath)
+      ? (await this.opencodeDetectDeps.getVersion(settings.opencodePath)) !== undefined
       : false
 
     const agentFrameworkId = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -21,6 +21,7 @@ import type {
   DeleteSkillRequest,
   EnvironmentCheckResult,
   InstallClaudeRequest,
+  InstallOpencodeRequest,
   NcbiCredentialsView,
   Preflight,
   ProviderApiType,
@@ -71,11 +72,16 @@ import {
   detectOpencode,
   type OpencodeDetectDeps
 } from './opencode-detect'
-import { installManagedOpencode, managedOpencodeDir } from './managed-opencode'
+import {
+  installManagedOpencode,
+  managedOpencodeDir,
+  type InstallManagedOpencodeOptions
+} from './managed-opencode'
 import { opencodeConfigDir } from '../agent-framework/opencode'
 import { ClaudeCodeSkillMaterializer } from '../skills/materializer'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import { detectNpmAvailable, runInstallWithFallback } from './claude-install'
+import { OPENCODE_INSTALL_TARGET } from './opencode-install'
 import { runEnvironmentCheck } from './environment-check'
 import {
   DEFAULT_REGISTRIES,
@@ -160,6 +166,10 @@ export type SettingsServiceOptions = {
   installManagedClaudeImpl?: (
     options: InstallManagedClaudeOptions
   ) => Promise<ManagedInstallOutcome>
+  // Same for the managed OpenCode installer.
+  installManagedOpencodeImpl?: (
+    options: InstallManagedOpencodeOptions
+  ) => Promise<ManagedInstallOutcome>
 }
 
 // Orchestrates the settings units (repository + crypto + detect/install + validate) behind one
@@ -176,6 +186,9 @@ class SettingsService {
   private readonly executeClaudeProbe: ExecuteClaudeProbe
   private readonly installManagedClaudeImpl: (
     options: InstallManagedClaudeOptions
+  ) => Promise<ManagedInstallOutcome>
+  private readonly installManagedOpencodeImpl: (
+    options: InstallManagedOpencodeOptions
   ) => Promise<ManagedInstallOutcome>
   private providerSequence = 0
   // Skills force-loaded for the current turn: subtracted from the stored disabled set at spawn time so
@@ -204,6 +217,7 @@ class SettingsService {
     this.userSkills = options.userSkills ?? new UserSkillRepository(this.storageRoot)
     this.executeClaudeProbe = options.executeClaudeProbe ?? executeClaudeProbe
     this.installManagedClaudeImpl = options.installManagedClaudeImpl ?? installManagedClaude
+    this.installManagedOpencodeImpl = options.installManagedOpencodeImpl ?? installManagedOpencode
   }
 
   // Returns the raw stored settings document (unmasked), for main-process bootstrap needs (e.g. priming
@@ -527,20 +541,42 @@ class SettingsService {
     return result
   }
 
-  // App-managed OpenCode install (first recommendation, like Claude): downloads the native binary and
-  // persists its path + version. Streams progress on the shared install-log channel.
+  // Installs OpenCode from the requested source (app-managed download is the first recommendation, like
+  // Claude). Managed downloads the native binary and persists its path + version; npm/script shell out
+  // and then re-detect. Streams progress on the shared install-log channel.
   async installOpencode(
+    request: InstallOpencodeRequest,
     onEvent: (event: ClaudeInstallEvent) => void
   ): Promise<ClaudeInstallResult> {
     this.providerSequence += 1
     const installId = `install-opencode-${Date.now()}-${this.providerSequence}`
-    const outcome = await installManagedOpencode({ installId, onEvent, dataRoot: this.storageRoot })
 
-    if (outcome.result.ok && outcome.resolvedPath) {
-      await this.repository.setOpencodeInfo(outcome.resolvedPath, outcome.version)
+    if (request.source === 'managed') {
+      const outcome = await this.installManagedOpencodeImpl({
+        installId,
+        onEvent,
+        dataRoot: this.storageRoot
+      })
+
+      if (outcome.result.ok && outcome.resolvedPath) {
+        await this.repository.setOpencodeInfo(outcome.resolvedPath, outcome.version)
+      }
+
+      return outcome.result
     }
 
-    return outcome.result
+    const result = await runInstallWithFallback({
+      source: request.source,
+      installId,
+      onEvent,
+      installTarget: OPENCODE_INSTALL_TARGET
+    })
+
+    if (result.ok) {
+      await this.detectOpencode()
+    }
+
+    return result
   }
 
   // Records that first-run onboarding finished so later launches skip the wizard.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -67,6 +67,8 @@ import {
 } from '../agent-framework'
 import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
 import { detectOpencode } from './opencode-detect'
+import { opencodeConfigDir } from '../agent-framework/opencode'
+import { ClaudeCodeSkillMaterializer } from '../skills/materializer'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import { detectNpmAvailable, runInstallWithFallback } from './claude-install'
 import { runEnvironmentCheck } from './environment-check'
@@ -737,6 +739,18 @@ class SettingsService {
     return settings.connectors
   }
 
+  // Materializes the enabled skill set into opencode's isolated config dir (same skills/<name>/SKILL.md
+  // layout Claude uses), so opencode's native skill tool discovers them. A turn-forced skill overrides
+  // its disabled state, mirroring the Claude provisioning path.
+  private async materializeOpencodeSkills(settings: StoredSettings): Promise<void> {
+    const disabled = new Set(
+      (settings.disabledSkillIds ?? []).filter((id) => !this.turnForcedSkillIds.has(id))
+    )
+    const enabled = (await this.skillCatalog()).filter((skill) => !disabled.has(skill.id))
+
+    await new ClaudeCodeSkillMaterializer().sync(opencodeConfigDir(this.storageRoot), enabled)
+  }
+
   // Bundled connectors the user hasn't turned off (default-on), for opencode instruction delivery.
   private enabledConnectorIds(connectors: StoredConnectors | undefined): string[] {
     const disabled = new Set(connectors?.disabledConnectorIds ?? [])
@@ -1019,8 +1033,9 @@ class SettingsService {
       return { framework, executablePath, env: envOverrides }
     }
 
-    // opencode: no CLAUDE_CONFIG_DIR / skills provisioning; the adapter maps the provider onto its own
-    // config file, which is written before the agent spawns.
+    // opencode maps the provider onto its own isolated config; the adapter writes it before spawn, and
+    // the enabled skill set is materialized into opencode's config dir (its native skill tool discovers
+    // them on-demand, same SKILL.md layout as Claude).
     const activeProvider = settings.activeProviderId
       ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
       : undefined
@@ -1029,6 +1044,7 @@ class SettingsService {
       throw new Error('No active model provider is configured. Configure one in settings.')
     }
 
+    await this.materializeOpencodeSkills(settings)
     const executablePath = await this.resolveOpencodeExecutable(settings.opencodePath)
     const provider = this.resolveProvider(activeProvider, settings.activeModel)
     const modelConfig = framework.prepareModelConfig(provider, {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -262,9 +262,14 @@ class SettingsService {
     if (detected) {
       await this.repository.setOpencodeInfo(detected.resolvedPath, detected.version)
     } else {
-      // Nothing runnable found — clear any stale record so the card/gates reflect the uninstall
-      // instead of showing a version for a binary that no longer exists.
-      await this.repository.clearOpencodeInfo()
+      // Live probe found nothing. Only forget the stored record when its binary is actually gone from
+      // disk (a real uninstall) — a transient probe miss (e.g. a slow --version, a GUI PATH gap) must
+      // not wipe a still-installed opencode.
+      const cached = (await this.repository.getSettings()).opencodePath
+
+      if (cached && !(await this.pathExists(cached))) {
+        await this.repository.clearOpencodeInfo()
+      }
     }
 
     return this.getSettingsView()
@@ -489,6 +494,15 @@ class SettingsService {
 
     if (result.found && result.path) {
       await this.repository.setClaudeInfo({ resolvedPath: result.path, version: result.version })
+    } else {
+      // Live probe missed it. A GUI launch can have a narrower PATH than the installing shell, so only
+      // forget the cached record when the stored binary is actually gone from disk (a real uninstall) —
+      // mirroring checkEnvironment's cached-path resilience so the status surfaces cannot disagree.
+      const cached = (await this.repository.getSettings()).claude
+
+      if (cached?.resolvedPath && !(await this.pathExists(cached.resolvedPath))) {
+        await this.repository.setClaudeInfo({})
+      }
     }
 
     return result
@@ -1039,7 +1053,15 @@ class SettingsService {
   // Builds the spawn env for the active provider, read fresh so switching takes effect on reconnect.
   async resolveActiveSpawnConfig(): Promise<AgentSpawnConfig> {
     const settings = await this.repository.getSettings()
-    const executablePath = settings.claude?.resolvedPath
+    let executablePath = settings.claude?.resolvedPath
+
+    // Trust the stored path only if it still exists. A user who uninstalled Claude leaves a stale path
+    // behind; spawning it launches a ghost that dies immediately (surfacing as write EPIPE), so fall
+    // back to a live detect and, if that also finds nothing, fail with a clear, actionable message.
+    if (!executablePath || !(await this.pathExists(executablePath))) {
+      const detected = await detectClaude(this.detectDeps)
+      executablePath = detected.found ? detected.path : undefined
+    }
 
     if (!executablePath) {
       throw new Error('Claude executable is not configured. Complete onboarding in settings.')

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -202,7 +202,7 @@ class SettingsService {
 
     return {
       claude: settings.claude ?? {},
-      opencode: { resolvedPath: settings.opencodePath },
+      opencode: { resolvedPath: settings.opencodePath, version: settings.opencodeVersion },
       activeProviderId: settings.activeProviderId,
       activeModel: settings.activeModel,
       providers: settings.providers.map((provider) => this.toProviderView(provider)),
@@ -227,10 +227,10 @@ class SettingsService {
   // Detects the opencode executable and persists its path, mirroring detectClaude. Returns the refreshed
   // snapshot so the settings card reflects the result.
   async detectOpencode(): Promise<SettingsSnapshot> {
-    const resolvedPath = await detectOpencode()
+    const detected = await detectOpencode()
 
-    if (resolvedPath) {
-      await this.repository.setOpencodePath(resolvedPath)
+    if (detected) {
+      await this.repository.setOpencodeInfo(detected.resolvedPath, detected.version)
     }
 
     return this.getSettingsView()
@@ -1066,7 +1066,7 @@ class SettingsService {
       )
     }
 
-    return detected
+    return detected.resolvedPath
   }
 
   // Writes a framework's generated config files (e.g. opencode.json) to disk ahead of spawn.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1004,13 +1004,22 @@ class SettingsService {
     }
 
     const executablePath = await this.resolveOpencodeExecutable(settings.opencodePath)
-    const modelConfig = framework.prepareModelConfig(
-      this.resolveProvider(activeProvider, settings.activeModel),
-      { storageRoot: this.storageRoot, executablePath }
-    )
+    const provider = this.resolveProvider(activeProvider, settings.activeModel)
+    const modelConfig = framework.prepareModelConfig(provider, {
+      storageRoot: this.storageRoot,
+      executablePath
+    })
     await this.writeAgentConfigFiles(modelConfig.configFiles)
 
-    return { framework, executablePath, env: modelConfig.env ?? {}, args: modelConfig.args }
+    // opencode picks the model from its own provider config; drive the app's active model over the ACP
+    // session model configOption (applied best-effort per session by the runtime).
+    return {
+      framework,
+      executablePath,
+      env: modelConfig.env ?? {},
+      args: modelConfig.args,
+      sessionModel: provider.model
+    }
   }
 
   // Locates the opencode binary: an explicitly stored path wins, else a best-effort PATH lookup.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -57,7 +57,8 @@ import {
   isOfficialVendorId,
   resolveVendorApiType,
   resolveVendorBaseUrl,
-  resolveVendorModelsUrl
+  resolveVendorModelsUrl,
+  resolveVendorOpenAiBaseUrl
 } from '../../shared/provider-registry'
 import { resolveStorageRoot } from '../storage-root'
 import {
@@ -1304,6 +1305,7 @@ class SettingsService {
       return {
         type: 'custom',
         baseUrl: resolveVendorBaseUrl(provider.vendorId, provider.region),
+        openaiBaseUrl: resolveVendorOpenAiBaseUrl(provider.vendorId, provider.region),
         model: modelOverride ?? defaultVendorModel(provider.vendorId),
         key,
         apiType: this.resolveProviderApiType(provider)
@@ -1326,6 +1328,7 @@ class SettingsService {
       return {
         type: 'custom',
         baseUrl: resolveVendorBaseUrl(draft.vendorId, draft.region),
+        openaiBaseUrl: resolveVendorOpenAiBaseUrl(draft.vendorId, draft.region),
         model: draft.model ?? defaultVendorModel(draft.vendorId),
         key: draft.key,
         // Official vendors declare their own endpoint; a custom draft carries the user's choice.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1297,7 +1297,9 @@ class SettingsService {
         type: 'custom',
         baseUrl: resolveVendorBaseUrl(draft.vendorId, draft.region),
         model: draft.model ?? defaultVendorModel(draft.vendorId),
-        key: draft.key
+        key: draft.key,
+        // Official vendors declare their own endpoint; a custom draft carries the user's choice.
+        apiType: resolveVendorApiType(draft.vendorId)
       }
     }
 
@@ -1305,7 +1307,8 @@ class SettingsService {
       type: draft.type,
       baseUrl: draft.baseUrl,
       model: draft.model,
-      key: draft.key
+      key: draft.key,
+      apiType: draft.apiType ?? 'anthropic'
     }
   }
 

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -1,4 +1,9 @@
-import type { ClaudeInfo, ProviderType, ProviderValidationFailure } from '../../shared/settings'
+import type {
+  ClaudeInfo,
+  ProviderApiType,
+  ProviderType,
+  ProviderValidationFailure
+} from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import type { OfficialVendorId } from '../../shared/provider-registry'
 import type { AgentFrameworkId } from '../agent-framework'
@@ -13,6 +18,9 @@ export type StoredProvider = {
   id: string
   type: ProviderType
   name: string
+  // Which chat API a custom gateway speaks. Official providers derive it from the registry; absent
+  // means 'anthropic' (all pre-existing providers).
+  apiType?: ProviderApiType
   baseUrl?: string
   model?: string
   // Set for official-vendor providers only.

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -1,6 +1,7 @@
 import type { ClaudeInfo, ProviderType, ProviderValidationFailure } from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import type { OfficialVendorId } from '../../shared/provider-registry'
+import type { AgentFrameworkId } from '../agent-framework'
 
 // Main-process-only stored shapes for settings.json. These carry the encrypted key reference and a
 // non-secret masked hint; the plaintext key never lives here (only transiently in service memory).
@@ -70,6 +71,10 @@ export type StoredConnectors = {
 export type StoredSettings = {
   version: typeof SETTINGS_FILE_VERSION
   claude?: ClaudeInfo
+  // Selected agent backend. Absent means the default (Claude Code). Switching needs a reconnect.
+  agentFrameworkId?: AgentFrameworkId
+  // Explicit path to the opencode executable when auto-detection can't find it. Absent = detect on PATH.
+  opencodePath?: string
   activeProviderId?: string
   // Active model within the active provider; backfilled from the provider's own model on load when a
   // pre-v2 settings file (which had no per-model selection) is read.

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -81,8 +81,9 @@ export type StoredSettings = {
   claude?: ClaudeInfo
   // Selected agent backend. Absent means the default (Claude Code). Switching needs a reconnect.
   agentFrameworkId?: AgentFrameworkId
-  // Explicit path to the opencode executable when auto-detection can't find it. Absent = detect on PATH.
+  // Detected opencode executable path + reported version (for the status card). Absent = detect on PATH.
   opencodePath?: string
+  opencodeVersion?: string
   activeProviderId?: string
   // Active model within the active provider; backfilled from the provider's own model on load when a
   // pre-v2 settings file (which had no per-model selection) is read.

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -43,6 +43,34 @@ describe('validate: request construction', () => {
       /invalid base url/i
     )
   })
+
+  it('builds a /v1/chat/completions probe (no anthropic-version) for an OpenAI provider', () => {
+    const request = buildValidationRequest({
+      type: 'custom',
+      baseUrl: 'https://gateway.example.com',
+      model: 'gpt-x',
+      key: 'test-token',
+      apiType: 'openai'
+    })
+
+    expect(request.url).toBe('https://gateway.example.com/v1/chat/completions')
+    expect(request.headers.authorization).toBe('Bearer test-token')
+    expect(request.headers['anthropic-version']).toBeUndefined()
+    expect(JSON.parse(request.body)).toMatchObject({ model: 'gpt-x', max_tokens: 1 })
+  })
+
+  it('uses the OpenAI endpoint for a both-capable provider and never doubles /v1', () => {
+    const request = buildValidationRequest({
+      type: 'custom',
+      baseUrl: 'https://gateway.example.com/v1',
+      model: 'm',
+      key: 'k',
+      apiType: 'both'
+    })
+
+    // preferredEndpoint(both) → openai, so the probe hits chat/completions once.
+    expect(request.url).toBe('https://gateway.example.com/v1/chat/completions')
+  })
 })
 
 describe('validate: classification', () => {

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -68,10 +68,11 @@ const buildAnthropicValidationRequest = (provider: ResolvedProvider): Validation
 const buildOpenAiValidationRequest = (provider: ResolvedProvider): ValidationHttpRequest => {
   let url: string
 
+  // Dual-endpoint vendors serve OpenAI at a different base than Anthropic; probe the OpenAI one.
+  const base = provider.openaiBaseUrl ?? provider.baseUrl ?? ''
+
   try {
-    url = new URL(
-      `${normalizeOpenAiBaseUrl(provider.baseUrl ?? '')}/v1/chat/completions`
-    ).toString()
+    url = new URL(`${normalizeOpenAiBaseUrl(base)}/v1/chat/completions`).toString()
   } catch {
     throw new Error('Invalid base URL.')
   }

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -1,5 +1,6 @@
 import type { ValidateProviderResult, ValidationCategory } from '../../shared/settings'
-import { normalizeAnthropicBaseUrl } from './base-url'
+import { preferredEndpoint } from '../../shared/settings'
+import { normalizeAnthropicBaseUrl, normalizeOpenAiBaseUrl } from './base-url'
 import type { ResolvedProvider } from './provider-env'
 
 // Runs a real connectivity/auth probe for a provider and classifies the outcome into an actionable
@@ -17,21 +18,29 @@ type ValidationHttpRequest = {
   body: string
 }
 
-// Builds the /v1/messages probe request for a custom provider. Throws on an unusable base URL so the
-// caller can classify it as bad-url instead of firing a doomed fetch.
+// Builds the probe request for a custom provider against the endpoint it actually speaks: an
+// OpenAI-compatible gateway gets a `/v1/chat/completions` request, an Anthropic one `/v1/messages`.
+// The endpoint is chosen from the provider's apiType (OpenAI wins when it offers both), matching how
+// the model is driven. Throws on an unusable base URL so the caller can classify it as bad-url.
 const buildValidationRequest = (provider: ResolvedProvider): ValidationHttpRequest => {
   if (!provider.baseUrl) {
     throw new Error('Missing base URL.')
   }
 
+  const endpoint = preferredEndpoint(provider.apiType ?? 'anthropic', ['anthropic', 'openai'])
+
+  return endpoint === 'openai'
+    ? buildOpenAiValidationRequest(provider)
+    : buildAnthropicValidationRequest(provider)
+}
+
+// A minimal /v1/messages probe (Anthropic). The base URL is normalized first so a trailing `/v1`
+// isn't doubled into `.../v1/v1/messages` (a 404).
+const buildAnthropicValidationRequest = (provider: ResolvedProvider): ValidationHttpRequest => {
   let url: string
 
   try {
-    // Mirror how the claude client builds requests: ANTHROPIC_BASE_URL + "/v1/messages". The base URL
-    // is normalized first so a user-supplied trailing `/v1` isn't doubled into `.../v1/v1/messages`
-    // (a 404). Validate it parses as a URL so an unusable base is classified as bad-url instead of
-    // firing a doomed fetch.
-    url = new URL(`${normalizeAnthropicBaseUrl(provider.baseUrl)}/v1/messages`).toString()
+    url = new URL(`${normalizeAnthropicBaseUrl(provider.baseUrl ?? '')}/v1/messages`).toString()
   } catch {
     throw new Error('Invalid base URL.')
   }
@@ -41,7 +50,36 @@ const buildValidationRequest = (provider: ResolvedProvider): ValidationHttpReque
     'anthropic-version': ANTHROPIC_VERSION
   }
 
-  // Custom gateways authenticate with a bearer token.
+  if (provider.key) {
+    headers.authorization = `Bearer ${provider.key}`
+  }
+
+  const body = JSON.stringify({
+    model: provider.model ?? '',
+    max_tokens: 1,
+    messages: [{ role: 'user', content: 'ping' }]
+  })
+
+  return { url, headers, body }
+}
+
+// A minimal /v1/chat/completions probe (OpenAI-compatible). No anthropic-version header; the OpenAI
+// chat body shape is used so a real gateway accepts it.
+const buildOpenAiValidationRequest = (provider: ResolvedProvider): ValidationHttpRequest => {
+  let url: string
+
+  try {
+    url = new URL(
+      `${normalizeOpenAiBaseUrl(provider.baseUrl ?? '')}/v1/chat/completions`
+    ).toString()
+  } catch {
+    throw new Error('Invalid base URL.')
+  }
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/json'
+  }
+
   if (provider.key) {
     headers.authorization = `Bearer ${provider.key}`
   }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -73,6 +73,7 @@ import type {
   DeleteProviderRequest,
   EnvironmentCheckResult,
   InstallClaudeRequest,
+  InstallOpencodeRequest,
   Preflight,
   RefreshProviderModelsRequest,
   RefreshProviderModelsResult,
@@ -170,7 +171,7 @@ interface OpenScienceAPI {
     detectClaude(): Promise<ClaudeDetectResult>
     detectOpencode(): Promise<SettingsSnapshot>
     installClaude(request: InstallClaudeRequest): Promise<ClaudeInstallResult>
-    installOpencode(): Promise<ClaudeInstallResult>
+    installOpencode(request: InstallOpencodeRequest): Promise<ClaudeInstallResult>
     upsertProvider(request: UpsertProviderRequest): Promise<SettingsSnapshot>
     deleteProvider(request: DeleteProviderRequest): Promise<SettingsSnapshot>
     setActiveProvider(request: SetActiveProviderRequest): Promise<SettingsSnapshot>

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -77,6 +77,7 @@ import type {
   RefreshProviderModelsRequest,
   RefreshProviderModelsResult,
   SetActiveProviderRequest,
+  SetAgentFrameworkRequest,
   SetSkillEnabledRequest,
   SettingsSnapshot,
   SkillDetailView,
@@ -171,6 +172,7 @@ interface OpenScienceAPI {
     upsertProvider(request: UpsertProviderRequest): Promise<SettingsSnapshot>
     deleteProvider(request: DeleteProviderRequest): Promise<SettingsSnapshot>
     setActiveProvider(request: SetActiveProviderRequest): Promise<SettingsSnapshot>
+    setAgentFramework(request: SetAgentFrameworkRequest): Promise<SettingsSnapshot>
     validateProvider(request: ValidateProviderRequest): Promise<ValidateProviderResult>
     refreshProviderModels(
       request: RefreshProviderModelsRequest

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -170,6 +170,7 @@ interface OpenScienceAPI {
     detectClaude(): Promise<ClaudeDetectResult>
     detectOpencode(): Promise<SettingsSnapshot>
     installClaude(request: InstallClaudeRequest): Promise<ClaudeInstallResult>
+    installOpencode(): Promise<ClaudeInstallResult>
     upsertProvider(request: UpsertProviderRequest): Promise<SettingsSnapshot>
     deleteProvider(request: DeleteProviderRequest): Promise<SettingsSnapshot>
     setActiveProvider(request: SetActiveProviderRequest): Promise<SettingsSnapshot>

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -168,6 +168,7 @@ interface OpenScienceAPI {
     isNpmAvailable(): Promise<boolean>
     checkEnvironment(): Promise<EnvironmentCheckResult>
     detectClaude(): Promise<ClaudeDetectResult>
+    detectOpencode(): Promise<SettingsSnapshot>
     installClaude(request: InstallClaudeRequest): Promise<ClaudeInstallResult>
     upsertProvider(request: UpsertProviderRequest): Promise<SettingsSnapshot>
     deleteProvider(request: DeleteProviderRequest): Promise<SettingsSnapshot>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -187,6 +187,7 @@ type OpenScienceAPI = {
     detectClaude: () => Promise<ClaudeDetectResult>
     detectOpencode: () => Promise<SettingsSnapshot>
     installClaude: (request: InstallClaudeRequest) => Promise<ClaudeInstallResult>
+    installOpencode: () => Promise<ClaudeInstallResult>
     upsertProvider: (request: UpsertProviderRequest) => Promise<SettingsSnapshot>
     deleteProvider: (request: DeleteProviderRequest) => Promise<SettingsSnapshot>
     setActiveProvider: (request: SetActiveProviderRequest) => Promise<SettingsSnapshot>
@@ -416,6 +417,8 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('settings:detect-opencode') as Promise<SettingsSnapshot>,
     installClaude: (request) =>
       ipcRenderer.invoke('settings:install-claude', request) as Promise<ClaudeInstallResult>,
+    installOpencode: () =>
+      ipcRenderer.invoke('settings:install-opencode') as Promise<ClaudeInstallResult>,
     upsertProvider: (request) =>
       ipcRenderer.invoke('settings:upsert-provider', request) as Promise<SettingsSnapshot>,
     deleteProvider: (request) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -79,6 +79,7 @@ import type {
   RefreshProviderModelsRequest,
   RefreshProviderModelsResult,
   SetActiveProviderRequest,
+  SetAgentFrameworkRequest,
   SetSkillEnabledRequest,
   SettingsSnapshot,
   SkillDetailView,
@@ -188,6 +189,7 @@ type OpenScienceAPI = {
     upsertProvider: (request: UpsertProviderRequest) => Promise<SettingsSnapshot>
     deleteProvider: (request: DeleteProviderRequest) => Promise<SettingsSnapshot>
     setActiveProvider: (request: SetActiveProviderRequest) => Promise<SettingsSnapshot>
+    setAgentFramework: (request: SetAgentFrameworkRequest) => Promise<SettingsSnapshot>
     validateProvider: (request: ValidateProviderRequest) => Promise<ValidateProviderResult>
     refreshProviderModels: (
       request: RefreshProviderModelsRequest
@@ -417,6 +419,8 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('settings:delete-provider', request) as Promise<SettingsSnapshot>,
     setActiveProvider: (request) =>
       ipcRenderer.invoke('settings:set-active-provider', request) as Promise<SettingsSnapshot>,
+    setAgentFramework: (request) =>
+      ipcRenderer.invoke('settings:set-agent-framework', request) as Promise<SettingsSnapshot>,
     validateProvider: (request) =>
       ipcRenderer.invoke('settings:validate-provider', request) as Promise<ValidateProviderResult>,
     refreshProviderModels: (request) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -75,6 +75,7 @@ import type {
   DeleteProviderRequest,
   EnvironmentCheckResult,
   InstallClaudeRequest,
+  InstallOpencodeRequest,
   Preflight,
   RefreshProviderModelsRequest,
   RefreshProviderModelsResult,
@@ -187,7 +188,7 @@ type OpenScienceAPI = {
     detectClaude: () => Promise<ClaudeDetectResult>
     detectOpencode: () => Promise<SettingsSnapshot>
     installClaude: (request: InstallClaudeRequest) => Promise<ClaudeInstallResult>
-    installOpencode: () => Promise<ClaudeInstallResult>
+    installOpencode: (request: InstallOpencodeRequest) => Promise<ClaudeInstallResult>
     upsertProvider: (request: UpsertProviderRequest) => Promise<SettingsSnapshot>
     deleteProvider: (request: DeleteProviderRequest) => Promise<SettingsSnapshot>
     setActiveProvider: (request: SetActiveProviderRequest) => Promise<SettingsSnapshot>
@@ -417,8 +418,8 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('settings:detect-opencode') as Promise<SettingsSnapshot>,
     installClaude: (request) =>
       ipcRenderer.invoke('settings:install-claude', request) as Promise<ClaudeInstallResult>,
-    installOpencode: () =>
-      ipcRenderer.invoke('settings:install-opencode') as Promise<ClaudeInstallResult>,
+    installOpencode: (request) =>
+      ipcRenderer.invoke('settings:install-opencode', request) as Promise<ClaudeInstallResult>,
     upsertProvider: (request) =>
       ipcRenderer.invoke('settings:upsert-provider', request) as Promise<SettingsSnapshot>,
     deleteProvider: (request) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -185,6 +185,7 @@ type OpenScienceAPI = {
     isNpmAvailable: () => Promise<boolean>
     checkEnvironment: () => Promise<EnvironmentCheckResult>
     detectClaude: () => Promise<ClaudeDetectResult>
+    detectOpencode: () => Promise<SettingsSnapshot>
     installClaude: (request: InstallClaudeRequest) => Promise<ClaudeInstallResult>
     upsertProvider: (request: UpsertProviderRequest) => Promise<SettingsSnapshot>
     deleteProvider: (request: DeleteProviderRequest) => Promise<SettingsSnapshot>
@@ -411,6 +412,8 @@ const api: OpenScienceAPI = {
     checkEnvironment: () =>
       ipcRenderer.invoke('settings:check-environment') as Promise<EnvironmentCheckResult>,
     detectClaude: () => ipcRenderer.invoke('settings:detect-claude') as Promise<ClaudeDetectResult>,
+    detectOpencode: () =>
+      ipcRenderer.invoke('settings:detect-opencode') as Promise<SettingsSnapshot>,
     installClaude: (request) =>
       ipcRenderer.invoke('settings:install-claude', request) as Promise<ClaudeInstallResult>,
     upsertProvider: (request) =>

--- a/src/renderer/src/lib/acp/history-preamble.test.ts
+++ b/src/renderer/src/lib/acp/history-preamble.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildHistoryPreamble } from './history-preamble'
+import type { ChatMessage } from '../../stores/session-store'
+
+const message = (
+  partial: Partial<ChatMessage> & Pick<ChatMessage, 'role' | 'content'>
+): ChatMessage =>
+  ({
+    id: Math.random().toString(36).slice(2),
+    status: 'complete',
+    eventIds: [],
+    createdAt: 0,
+    updatedAt: 0,
+    ...partial
+  }) as ChatMessage
+
+describe('buildHistoryPreamble', () => {
+  it('returns undefined when there is nothing meaningful to replay', () => {
+    expect(buildHistoryPreamble([])).toBeUndefined()
+    expect(
+      buildHistoryPreamble([
+        message({ role: 'user', content: '   ' }),
+        message({ role: 'agent', content: '', status: 'error' })
+      ])
+    ).toBeUndefined()
+  })
+
+  it('renders labelled user/assistant turns in order', () => {
+    const preamble = buildHistoryPreamble([
+      message({ role: 'user', content: 'plot the data' }),
+      message({ role: 'agent', content: 'done, see chart.png' })
+    ])
+
+    expect(preamble).toContain('before you joined it')
+    expect(preamble).toContain('**User:** plot the data')
+    expect(preamble).toContain('**Assistant:** done, see chart.png')
+    const userIndex = preamble!.indexOf('**User:**')
+    const agentIndex = preamble!.indexOf('**Assistant:**')
+    expect(userIndex).toBeLessThan(agentIndex)
+  })
+
+  it('skips failed and empty turns', () => {
+    const preamble = buildHistoryPreamble([
+      message({ role: 'user', content: 'first' }),
+      message({ role: 'agent', content: 'half a reply', status: 'error' }),
+      message({ role: 'user', content: 'second' })
+    ])
+
+    expect(preamble).not.toContain('half a reply')
+    expect(preamble).toContain('**User:** first')
+    expect(preamble).toContain('**User:** second')
+  })
+
+  it('keeps the most recent turns within budget and marks omissions', () => {
+    const messages = Array.from({ length: 10 }, (_, index) =>
+      message({
+        role: index % 2 === 0 ? 'user' : 'agent',
+        content: `turn-${index} ${'x'.repeat(50)}`
+      })
+    )
+
+    const preamble = buildHistoryPreamble(messages, 200)
+
+    expect(preamble).toContain('earlier turns omitted')
+    // The newest turn survives; the oldest is dropped.
+    expect(preamble).toContain('turn-9')
+    expect(preamble).not.toContain('turn-0 ')
+  })
+
+  it('never drops below a single most-recent turn even under a tiny budget', () => {
+    const preamble = buildHistoryPreamble([message({ role: 'user', content: 'a'.repeat(500) })], 10)
+
+    expect(preamble).toContain('a'.repeat(500))
+  })
+})

--- a/src/renderer/src/lib/acp/history-preamble.ts
+++ b/src/renderer/src/lib/acp/history-preamble.ts
@@ -1,0 +1,54 @@
+import type { ChatMessage } from '../../stores/session-store'
+
+// Character budget for the replayed transcript. Kept modest so a long conversation cannot blow the new
+// agent's context window on its very first turn; older turns past the budget are summarized as omitted.
+const DEFAULT_PREAMBLE_BUDGET = 12_000
+
+const HEADER =
+  'The conversation below happened earlier in this session, before you joined it. Treat it as prior' +
+  ' context — do not reply to it directly; continue from the user message that follows.'
+
+const OMISSION_NOTE = '[…earlier turns omitted for length…]'
+
+// Renders one message as a labelled transcript line, collapsing trailing whitespace.
+const formatMessage = (message: ChatMessage): string => {
+  const speaker = message.role === 'user' ? 'User' : 'Assistant'
+
+  return `**${speaker}:** ${message.content.trim()}`
+}
+
+// Builds a bounded transcript of prior turns to replay into the next prompt after an agent-side context
+// reset (framework switch or unresumable restart). Only completed text turns are included; tool activity
+// is intentionally omitted because its effects already live on disk. Keeps the most recent turns within a
+// character budget and prepends an omission marker when older turns are dropped. Returns undefined when
+// there is nothing meaningful to replay, so the caller can skip the field entirely.
+export const buildHistoryPreamble = (
+  messages: ChatMessage[],
+  budget: number = DEFAULT_PREAMBLE_BUDGET
+): string | undefined => {
+  const usable = messages.filter(
+    (message) => message.status !== 'error' && message.content.trim().length > 0
+  )
+
+  if (usable.length === 0) return undefined
+
+  // Walk newest-first, accepting turns until the budget is spent, then restore chronological order.
+  const kept: ChatMessage[] = []
+  let used = 0
+
+  for (let index = usable.length - 1; index >= 0; index -= 1) {
+    const line = formatMessage(usable[index])
+    const cost = line.length + 2 // account for the blank line joiner
+
+    if (kept.length > 0 && used + cost > budget) break
+
+    kept.unshift(usable[index])
+    used += cost
+  }
+
+  const omittedSome = kept.length < usable.length
+  const body = kept.map(formatMessage).join('\n\n')
+  const transcript = omittedSome ? `${OMISSION_NOTE}\n\n${body}` : body
+
+  return `${HEADER}\n\n${transcript}`
+}

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -59,7 +59,8 @@ const useAcpRuntime = (): {
     text: string,
     attachments?: AcpPromptRequest['attachments'],
     forcedSkillIds?: string[],
-    referencedArtifacts?: AcpPromptRequest['referencedArtifacts']
+    referencedArtifacts?: AcpPromptRequest['referencedArtifacts'],
+    historyPreamble?: AcpPromptRequest['historyPreamble']
   ) => Promise<AcpStateSnapshot | undefined>
   respondToPermission: (
     requestId: string,
@@ -214,7 +215,8 @@ const useAcpRuntime = (): {
       text: AcpPromptRequest['text'],
       attachments?: AcpPromptRequest['attachments'],
       forcedSkillIds?: string[],
-      referencedArtifacts?: AcpPromptRequest['referencedArtifacts']
+      referencedArtifacts?: AcpPromptRequest['referencedArtifacts'],
+      historyPreamble?: AcpPromptRequest['historyPreamble']
     ) =>
       runSnapshotAction(undefined, () =>
         window.api.acp.sendPrompt({
@@ -224,7 +226,9 @@ const useAcpRuntime = (): {
           // Omit the field entirely when no skills were picked so the request stays minimal.
           ...(forcedSkillIds && forcedSkillIds.length > 0 ? { forcedSkillIds } : {}),
           // Same minimal-request rule for `@`-mentioned artifacts.
-          ...(referencedArtifacts && referencedArtifacts.length > 0 ? { referencedArtifacts } : {})
+          ...(referencedArtifacts && referencedArtifacts.length > 0 ? { referencedArtifacts } : {}),
+          // Only present right after a context reset, when a transcript is replayed for continuity.
+          ...(historyPreamble ? { historyPreamble } : {})
         })
       ),
     [runSnapshotAction]

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -676,6 +676,42 @@ describe('workspace agent message sending', () => {
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
   })
 
+  it('softens the model↔framework incompatibility message instead of an alarming resume failure', async () => {
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            "The active model isn't compatible with Claude Code. Open Settings → Model to pick a compatible model or switch the agent framework."
+          )
+        ),
+      sendPrompt: vi.fn()
+    }
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Previous prompt',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'Continue restored conversation',
+      cwd: '/workspace/project'
+    })
+
+    // No "Agent session resume failed" prefix — the fix lives in settings, which now flags this early.
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error:
+        "The active model isn't compatible with this agent framework. Open Settings → Model to pick a compatible model or switch frameworks."
+    })
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+  })
+
   it('reports a distinct message when the agent connection cannot be re-established', async () => {
     const runtime = {
       state: createSnapshot(),

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -865,6 +865,8 @@ describe('resuming an interrupted session on demand', () => {
       'Continue the analysis',
       [],
       undefined,
+      undefined,
+      // A same-framework interrupted resume does not reset context, so no history preamble is replayed.
       undefined
     )
 
@@ -875,6 +877,86 @@ describe('resuming an interrupted session on demand', () => {
     expect(userMessages).toHaveLength(1)
     expect(userMessages[0].content).toBe('Continue the analysis')
     expect(session.interrupted).toBeUndefined()
+  })
+
+  it('replays a history preamble when a resume resets agent context', async () => {
+    // A completed prior turn that should be replayed to the freshly-adopted agent.
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Plot the sales data',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'Done, saved chart.png'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    const runtime = {
+      // Empty sessionIds forces the resume path for this existing session.
+      state: createSnapshot([]),
+      createSession: vi.fn(),
+      resumeSession: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        cwd: '/workspace/project',
+        contextReset: true
+      }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'now add a trend line',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    await flushRuntimeTasks()
+
+    expect(runtime.resumeSession).toHaveBeenCalledTimes(1)
+    const preamble = runtime.sendPrompt.mock.calls[0]?.[5]
+    expect(preamble).toContain('Plot the sales data')
+    expect(preamble).toContain('Done, saved chart.png')
+    // The preamble carries prior turns only; the turn being sent is not folded into it.
+    expect(preamble).not.toContain('now add a trend line')
+  })
+
+  it('does not replay a history preamble when the resume kept agent context', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Earlier prompt',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'Earlier answer'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    const runtime = {
+      state: createSnapshot([]),
+      createSession: vi.fn(),
+      // No contextReset flag: the agent resumed its own session, so nothing needs replaying.
+      resumeSession: vi
+        .fn()
+        .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'keep going',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    await flushRuntimeTasks()
+
+    expect(runtime.sendPrompt.mock.calls[0]?.[5]).toBeUndefined()
   })
 
   it('reconnects without re-sending when the last turn was already answered', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../stores/preview-workbench-store'
 import {
   createWorkspaceRuntimeEventProcessor,
+  getResumeFailureMessage,
   markRunningSessionsDisconnectedOnDrop,
   processVisibleWorkspaceRuntimeEvents,
   resumeInterruptedWorkspaceSession,
@@ -195,6 +196,32 @@ describe('workspace agent runtime event processing', () => {
       'artifact-event-1',
       'stop-event-1'
     ])
+  })
+})
+
+describe('resume failure classification', () => {
+  it('rewrites a genuine model↔framework incompatibility into the actionable settings message', () => {
+    // Verbatim error thrown by settings/service.ts when the active provider cannot drive the framework.
+    const message = getResumeFailureMessage(
+      new Error(
+        "The active model isn't compatible with Claude Code. Open Settings → Model to pick a compatible model or switch the agent framework."
+      )
+    )
+
+    expect(message).toBe(
+      "The active model isn't compatible with this agent framework. Open Settings → Model to pick a compatible model or switch frameworks."
+    )
+  })
+
+  it('does not mislabel an ACP protocol-version mismatch as a model incompatibility', () => {
+    // Different "not compatible with" phrase from the ACP handshake; must pass through unchanged.
+    const message = getResumeFailureMessage(
+      new Error('ACP protocol version is not compatible with this client')
+    )
+
+    expect(message).toBe(
+      'Agent session resume failed: ACP protocol version is not compatible with this client'
+    )
   })
 })
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -87,6 +87,12 @@ const getResumeFailureMessage = (error: unknown): string => {
     return 'Could not reconnect to the agent; check it is installed, then click Resume to retry.'
   }
 
+  // Model↔framework mismatch is now flagged proactively in Settings → Model, so keep this soft and
+  // actionable rather than an alarming "resume failed" — the fix lives in settings, not here.
+  if (/not compatible with|compatible model/i.test(message)) {
+    return "The active model isn't compatible with this agent framework. Open Settings → Model to pick a compatible model or switch frameworks."
+  }
+
   const detail = unwrapResumeErrorDetail(message)
 
   return detail ? `Agent session resume failed: ${detail}` : 'Agent session resume failed'

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -17,6 +17,7 @@ import type { MessagePart } from '../../../../shared/session-persistence'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { useSessionStore, type ChatMessage } from '../../stores/session-store'
 import { useAcpRuntime } from './useAcpRuntime'
+import { buildHistoryPreamble } from './history-preamble'
 import { applyWorkspaceRuntimeEvent, syncWorkspacePermissionState } from './workspace-events'
 
 type SendWorkspaceMessageInput = {
@@ -379,14 +380,24 @@ const sendWorkspaceMessage = async (
     if (!appended) return undefined
 
     // Persisted sessions are marked running locally before async resume closes duplicate submits.
+    // A resume that lands on a freshly-adopted session (framework switch, or an unresumable restart)
+    // lost the agent's context, so replay the prior turns as a preamble on this first prompt.
+    let historyPreamble: string | undefined
+
     if (resumeCwd) {
       try {
-        await runtime.resumeSession(
+        const resumeResult = await runtime.resumeSession(
           targetSessionId,
           resumeCwd,
           sessionProjectName,
           currentSession?.permissionProfile ?? permissionProfile
         )
+
+        if (resumeResult?.contextReset && currentSession) {
+          // currentSession was captured before the new user message was appended, so this is the
+          // prior conversation only — the turn being sent is not duplicated into the preamble.
+          historyPreamble = buildHistoryPreamble(currentSession.messages)
+        }
       } catch (error) {
         useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
         return appended
@@ -411,7 +422,14 @@ const sendWorkspaceMessage = async (
 
     // The hook returns after local state is updated; event listeners handle the streamed result.
     void runtime
-      .sendPrompt(targetSessionId, content, promptAttachments, forcedSkillIds, referencedArtifacts)
+      .sendPrompt(
+        targetSessionId,
+        content,
+        promptAttachments,
+        forcedSkillIds,
+        referencedArtifacts,
+        historyPreamble
+      )
       .then((snapshot) => {
         if (!snapshot) {
           void failOrMarkDisconnected(targetSessionId, 'Agent run failed')

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -88,8 +88,11 @@ const getResumeFailureMessage = (error: unknown): string => {
   }
 
   // Model↔framework mismatch is now flagged proactively in Settings → Model, so keep this soft and
-  // actionable rather than an alarming "resume failed" — the fix lives in settings, not here.
-  if (/not compatible with|compatible model/i.test(message)) {
+  // actionable rather than an alarming "resume failed" — the fix lives in settings, not here. Anchor
+  // to the specific marker from the thrown error (settings/service.ts: "The active model isn't
+  // compatible with <framework>…") so unrelated "not compatible with" errors — notably an ACP
+  // protocol-version mismatch — fall through to the default message instead of being mislabeled.
+  if (/active model isn'?t compatible with/i.test(message)) {
     return "The active model isn't compatible with this agent framework. Open Settings → Model to pick a compatible model or switch frameworks."
   }
 
@@ -719,6 +722,7 @@ const useWorkspaceAgentRuntime = (): {
 
 export {
   createWorkspaceRuntimeEventProcessor,
+  getResumeFailureMessage,
   markRunningSessionsDisconnectedOnDrop,
   processVisibleWorkspaceRuntimeEvents,
   resumeInterruptedWorkspaceSession,

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -125,6 +125,28 @@ describe('workspace runtime events', () => {
     })
   })
 
+  it('surfaces a session-scoped agent warning as the waiting-indicator status, cleared on stop', async () => {
+    const applied = await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'event-1', kind: 'system', level: 'warning', text: 'retrying request…' })
+    )
+
+    expect(applied).toBe(true)
+    expect(useSessionStore.getState().sessions[0].agentStatus).toBe('retrying request…')
+
+    // The run finishing clears the transient status so it never lingers into the next turn.
+    await applyWorkspaceRuntimeEvent(createEvent({ id: 'event-2', kind: 'stop', text: 'end_turn' }))
+    expect(useSessionStore.getState().sessions[0].agentStatus).toBeUndefined()
+  })
+
+  it('ignores an info-level system event (only warnings become status)', async () => {
+    const applied = await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'event-1', kind: 'system', level: 'info', text: 'Session created' })
+    )
+
+    expect(applied).toBe(false)
+    expect(useSessionStore.getState().sessions[0].agentStatus).toBeUndefined()
+  })
+
   it('syncs permission waiting state from current pending requests', () => {
     syncWorkspacePermissionState([createPermissionRequest()])
 

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -221,6 +221,14 @@ const applyWorkspaceRuntimeEvent = async (
     return true
   }
 
+  // Agent stderr/process warnings arrive as session-scoped system warnings. Surface the latest one in
+  // the waiting indicator so a long silent turn (e.g. the agent retrying a slow request) shows a hint
+  // rather than a blank spinner. setAgentStatus no-ops unless the session is still running.
+  if (event.kind === 'system' && event.level === 'warning' && event.sessionId && event.text) {
+    store.setAgentStatus(event.sessionId, event.text)
+    return true
+  }
+
   if (event.kind === 'tool') {
     // Tool calls do not create preview items; file preview is opened by file-specific actions.
     return false

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -22,7 +22,8 @@ const environment = (checks: EnvironmentCheckResult['checks']): EnvironmentCheck
   checks,
   ready: checks.every((check) => check.status !== 'failed'),
   canAutoInstall: false,
-  claude: { found: true, path: '/bin/claude', version: '2.1.0' }
+  agentFrameworkId: 'claude-code',
+  runtime: { found: true, path: '/bin/claude', version: '2.1.0' }
 })
 
 beforeEach(() => {
@@ -69,7 +70,7 @@ describe('HomePage environment repair notice', () => {
     useSettingsStore.setState({
       environmentCheck: environment([
         {
-          id: 'claude',
+          id: 'agent',
           label: 'Claude runtime',
           status: 'failed',
           summary: 'Claude is missing.'

--- a/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
@@ -187,7 +187,11 @@ const EnvironmentSetupCard = ({
         aria-live="polite"
       >
         {environment
-          ? environment.checks.map((check) => <EnvironmentCheckRow key={check.id} check={check} />)
+          ? // Both agent runtimes share id 'agent', so key by index (+id) to avoid a duplicate-key
+            // collision that could mis-render or skip an update on one of the two runtime rows.
+            environment.checks.map((check, index) => (
+              <EnvironmentCheckRow key={`${check.id}-${index}`} check={check} />
+            ))
           : CHECK_LABELS.map((check) => <PendingCheckRow key={check.id} {...check} />)}
       </ul>
 

--- a/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
@@ -141,7 +141,7 @@ const EnvironmentCheckRow = ({ check }: { check: EnvironmentCheckItem }): React.
 }
 
 // Unframed environment summary rendered inside the onboarding work Card: a re-check control, the
-// per-requirement checklist, and (when Claude is the only gap) a one-click app-managed install with
+// per-requirement checklist, and (when the runtime is the only gap) a one-click app-managed install with
 // progress and a copyable technical log. It intentionally carries no card chrome of its own so the
 // wizard keeps a single visible work surface.
 const EnvironmentSetupCard = ({
@@ -197,7 +197,7 @@ const EnvironmentSetupCard = ({
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="text-sm font-medium text-foreground">
-                  Claude is the only missing item
+                  The agent runtime is the only missing item
                 </p>
                 <p className="mt-0.5 text-xs text-muted-foreground">
                   Install it into Open Science using the {sourceLabel}, with the other trusted
@@ -235,7 +235,7 @@ const EnvironmentSetupCard = ({
         >
           <div className="flex items-center justify-between text-xs">
             <span className="font-medium text-foreground">
-              {structuredProgress?.label ?? 'Installing Claude runtime'}
+              {structuredProgress?.label ?? 'Installing agent runtime'}
             </span>
             <span className="text-muted-foreground">
               {progress !== undefined ? `${progress}%` : 'In progress'}

--- a/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
@@ -38,7 +38,7 @@ const CHECK_LABELS: Array<{ id: EnvironmentCheckId; label: string }> = [
   { id: 'secure-storage', label: 'Secure credential storage' },
   { id: 'install-network', label: 'Installation network' },
   { id: 'python', label: 'Python for Notebook (optional)' },
-  { id: 'claude', label: 'Claude runtime' }
+  { id: 'agent', label: 'Agent runtime' }
 ]
 
 const CHECK_ICONS = {
@@ -47,7 +47,7 @@ const CHECK_ICONS = {
   'secure-storage': KeyRound,
   'install-network': Wifi,
   python: TerminalSquare,
-  claude: TerminalSquare
+  agent: TerminalSquare
 } satisfies Record<EnvironmentCheckId, typeof MonitorCog>
 
 const STATUS_COPY = {

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -446,6 +446,67 @@ describe('OnboardingWizard', () => {
     ).not.toBeNull()
   })
 
+  it('drops a second framework switch while the first is still in flight', async () => {
+    let releaseSwitch: (() => void) | undefined
+    const setAgentFramework = vi
+      .fn()
+      .mockImplementation(() => new Promise<void>((resolve) => (releaseSwitch = resolve)))
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: twoFrameworks,
+      setAgentFramework,
+      checkEnvironment: vi.fn().mockResolvedValue(undefined),
+      preflight: {
+        claudeReady: false,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: false,
+        activeProviderReady: false
+      },
+      environmentCheck: environment(false)
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+
+    const opencodeRadio = (): HTMLButtonElement | undefined =>
+      Array.from(container.querySelectorAll<HTMLButtonElement>('[role="radio"]')).find((button) =>
+        /opencode/i.test(button.textContent ?? '')
+      )
+    // Two rapid clicks before the first switch resolves: the in-flight guard collapses them into one.
+    await act(async () => opencodeRadio()?.click())
+    await act(async () => opencodeRadio()?.click())
+
+    expect(setAgentFramework).toHaveBeenCalledTimes(1)
+
+    await act(async () => releaseSwitch?.())
+  })
+
+  it('disables the framework toggle while a runtime probe is in flight', async () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: twoFrameworks,
+      isDetectingOpencode: true,
+      preflight: {
+        claudeReady: false,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: false,
+        activeProviderReady: false
+      },
+      environmentCheck: environment(false)
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+
+    const radios = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="radio"]'))
+    expect(radios).toHaveLength(2)
+    expect(radios.every((radio) => radio.disabled)).toBe(true)
+  })
+
   it('uses the recommended mirror and surfaces the actual automatic install error', async () => {
     const installClaude = vi
       .fn()

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -293,6 +293,47 @@ describe('OnboardingWizard', () => {
     expect(container.textContent).toContain('OpenCode not detected')
   })
 
+  it("routes the manual OpenCode install button to installOpencode, not installClaude", async () => {
+    const installOpencode = vi.fn().mockResolvedValue({ installId: 'i', ok: true })
+    const installClaude = vi.fn().mockResolvedValue({ installId: 'i', ok: true })
+    useSettingsStore.setState({
+      // Claude is ready (its install card is hidden), so the only "Install with one click" button in
+      // the manual tab belongs to the OpenCode card — even though Claude is the SELECTED framework,
+      // proving the per-card button installs its own runtime.
+      preflight: {
+        claudeReady: true,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: true,
+        activeProviderReady: false
+      },
+      claude: { resolvedPath: '/bin/claude', version: '2.1.0' },
+      environmentCheck: environment(true),
+      installOpencode,
+      installClaude
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+
+    const manualTab = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+    ).find((button) => button.textContent?.includes('Manual setup'))
+    await act(async () => manualTab?.click())
+
+    const installButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button')
+    ).filter((button) => /install with one click/i.test(button.textContent ?? ''))
+    // Exactly one install button (OpenCode's) since Claude is ready.
+    expect(installButtons).toHaveLength(1)
+    await act(async () => installButtons[0].click())
+
+    // Default source is 'managed'; the OpenCode card must route to installOpencode, never installClaude.
+    expect(installOpencode).toHaveBeenCalledWith('managed')
+    expect(installClaude).not.toHaveBeenCalled()
+  })
+
   it('uses the recommended mirror and surfaces the actual automatic install error', async () => {
     const installClaude = vi
       .fn()

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -289,6 +289,8 @@ describe('OnboardingWizard', () => {
     await act(async () => manualTab?.click())
 
     expect(container.querySelector('[role="combobox"][aria-label="Install source"]')).not.toBeNull()
+    // The manual tab shows BOTH runtimes together (Claude status + OpenCode status/install card).
+    expect(container.textContent).toContain('OpenCode not detected')
   })
 
   it('uses the recommended mirror and surfaces the actual automatic install error', async () => {

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -118,7 +118,13 @@ afterEach(() => {
 describe('OnboardingWizard', () => {
   it('keeps first-time users on the environment summary until they explicitly continue', async () => {
     useSettingsStore.setState({
-      preflight: { claudeReady: true, activeProviderReady: false },
+      preflight: {
+        claudeReady: true,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: true,
+        activeProviderReady: false
+      },
       claude: { resolvedPath: '/bin/claude', version: '2.1.0' },
       environmentCheck: environment(true)
     })
@@ -141,7 +147,13 @@ describe('OnboardingWizard', () => {
 
   it('blocks continuation while any required environment check fails', async () => {
     useSettingsStore.setState({
-      preflight: { claudeReady: false, activeProviderReady: false },
+      preflight: {
+        claudeReady: false,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: false,
+        activeProviderReady: false
+      },
       environmentCheck: environment(false)
     })
 
@@ -163,7 +175,13 @@ describe('OnboardingWizard', () => {
 
   it('Back returns from the model step to the Claude step', async () => {
     useSettingsStore.setState({
-      preflight: { claudeReady: true, activeProviderReady: false },
+      preflight: {
+        claudeReady: true,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: true,
+        activeProviderReady: false
+      },
       claude: { resolvedPath: '/bin/claude', version: '2.1.0' },
       environmentCheck: environment(true)
     })
@@ -191,7 +209,13 @@ describe('OnboardingWizard', () => {
 
   it('defaults to automatic detection and keeps the original installer under the manual tab', async () => {
     useSettingsStore.setState({
-      preflight: { claudeReady: false, activeProviderReady: false },
+      preflight: {
+        claudeReady: false,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: false,
+        activeProviderReady: false
+      },
       environmentCheck: environment(false)
     })
 
@@ -217,7 +241,13 @@ describe('OnboardingWizard', () => {
       .fn()
       .mockResolvedValue({ installId: 'i', ok: false, error: 'download integrity failed' })
     useSettingsStore.setState({
-      preflight: { claudeReady: false, activeProviderReady: false },
+      preflight: {
+        claudeReady: false,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: false,
+        activeProviderReady: false
+      },
       environmentCheck: environment(false),
       installClaude
     })
@@ -239,13 +269,25 @@ describe('OnboardingWizard', () => {
     const checkEnvironment = vi.fn().mockImplementation(async () => {
       useSettingsStore.setState({
         environmentCheck: environment(true),
-        preflight: { claudeReady: true, activeProviderReady: false },
+        preflight: {
+          claudeReady: true,
+          opencodeReady: false,
+          agentFrameworkId: 'claude-code',
+          agentReady: true,
+          activeProviderReady: false
+        },
         claude: { resolvedPath: '/managed/claude', version: '2.1.0' }
       })
       return environment(true)
     })
     useSettingsStore.setState({
-      preflight: { claudeReady: false, activeProviderReady: false },
+      preflight: {
+        claudeReady: false,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: false,
+        activeProviderReady: false
+      },
       environmentCheck: environment(false),
       checkEnvironment
     })
@@ -273,7 +315,13 @@ describe('OnboardingWizard', () => {
 
   it('shows structured install progress and a copyable technical log', async () => {
     useSettingsStore.setState({
-      preflight: { claudeReady: false, activeProviderReady: false },
+      preflight: {
+        claudeReady: false,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: false,
+        activeProviderReady: false
+      },
       environmentCheck: environment(false),
       isInstalling: true,
       installLogs: ['Downloading Claude — 5 MB / 10.0 MB']
@@ -292,7 +340,13 @@ describe('OnboardingWizard', () => {
   it('uses a focused repair screen for previously completed onboarding', async () => {
     useSettingsStore.setState({
       onboardingCompletedAt: 1234,
-      preflight: { claudeReady: false, activeProviderReady: true },
+      preflight: {
+        claudeReady: false,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: false,
+        activeProviderReady: true
+      },
       environmentCheck: environment(false)
     })
 
@@ -309,7 +363,13 @@ describe('OnboardingWizard', () => {
     const closeEnvironmentRepair = vi.fn()
     useSettingsStore.setState({
       onboardingCompletedAt: 1234,
-      preflight: { claudeReady: true, activeProviderReady: true },
+      preflight: {
+        claudeReady: true,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: true,
+        activeProviderReady: true
+      },
       environmentCheck: environment(true),
       closeEnvironmentRepair
     })
@@ -329,7 +389,13 @@ describe('OnboardingWizard', () => {
 
   it('defers required-field errors until the first submit attempt', async () => {
     useSettingsStore.setState({
-      preflight: { claudeReady: true, activeProviderReady: false },
+      preflight: {
+        claudeReady: true,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: true,
+        activeProviderReady: false
+      },
       claude: { resolvedPath: '/bin/claude', version: '2.1.0' },
       environmentCheck: environment(true)
     })
@@ -363,7 +429,13 @@ describe('OnboardingWizard', () => {
     // reach the model and, finally, the location step.
     const readyEnvironment = (): void => {
       useSettingsStore.setState({
-        preflight: { claudeReady: true, activeProviderReady: false },
+        preflight: {
+          claudeReady: true,
+          opencodeReady: false,
+          agentFrameworkId: 'claude-code',
+          agentReady: true,
+          activeProviderReady: false
+        },
         claude: { resolvedPath: '/bin/claude', version: '2.1.0' },
         environmentCheck: environment(true)
       })

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -117,6 +117,36 @@ afterEach(() => {
 })
 
 describe('OnboardingWizard', () => {
+  it('offers an agent-framework choice and switches on selection', async () => {
+    const setAgentFramework = vi.fn().mockResolvedValue(undefined)
+    const checkEnvironment = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: [
+        { id: 'claude-code', displayName: 'Claude Code', supportsSkills: true },
+        { id: 'opencode', displayName: 'OpenCode', supportsSkills: true }
+      ],
+      setAgentFramework,
+      checkEnvironment,
+      environmentCheck: environment(true)
+    })
+
+    act(() => {
+      root.render(<OnboardingWizard />)
+    })
+
+    const radios = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="radio"]'))
+    expect(radios.map((r) => r.textContent)).toEqual(['Claude Code', 'OpenCode'])
+    expect(radios[0].getAttribute('aria-checked')).toBe('true')
+
+    await act(async () => {
+      radios[1].click()
+    })
+
+    expect(setAgentFramework).toHaveBeenCalledWith('opencode')
+    expect(checkEnvironment).toHaveBeenCalled()
+  })
+
   it('keeps first-time users on the environment summary until they explicitly continue', async () => {
     useSettingsStore.setState({
       preflight: {

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -289,26 +289,27 @@ describe('OnboardingWizard', () => {
     await act(async () => manualTab?.click())
 
     expect(container.querySelector('[role="combobox"][aria-label="Install source"]')).not.toBeNull()
-    // The manual tab shows BOTH runtimes together (Claude status + OpenCode status/install card).
-    expect(container.textContent).toContain('OpenCode not detected')
+    // The manual tab shows ONLY the selected framework's runtime (default: Claude), not the other.
+    expect(container.textContent).toContain('Claude')
+    expect(container.textContent).not.toContain('OpenCode not detected')
   })
 
-  it("routes the manual OpenCode install button to installOpencode, not installClaude", async () => {
+  it('routes the manual OpenCode install button to installOpencode, not installClaude', async () => {
     const installOpencode = vi.fn().mockResolvedValue({ installId: 'i', ok: true })
     const installClaude = vi.fn().mockResolvedValue({ installId: 'i', ok: true })
     useSettingsStore.setState({
-      // Claude is ready (its install card is hidden), so the only "Install with one click" button in
-      // the manual tab belongs to the OpenCode card — even though Claude is the SELECTED framework,
-      // proving the per-card button installs its own runtime.
+      // OpenCode is the selected framework, so the manual tab shows only its (not-detected) card and
+      // its install button must route to installOpencode, never installClaude.
+      agentFrameworkId: 'opencode',
       preflight: {
         claudeReady: true,
         opencodeReady: false,
-        agentFrameworkId: 'claude-code',
-        agentReady: true,
+        agentFrameworkId: 'opencode',
+        agentReady: false,
         activeProviderReady: false
       },
       claude: { resolvedPath: '/bin/claude', version: '2.1.0' },
-      environmentCheck: environment(true),
+      environmentCheck: environment(false),
       installOpencode,
       installClaude
     })
@@ -322,16 +323,127 @@ describe('OnboardingWizard', () => {
     ).find((button) => button.textContent?.includes('Manual setup'))
     await act(async () => manualTab?.click())
 
+    // Only the selected (OpenCode) runtime shows, so there is exactly one install button — its own.
+    expect(container.textContent).toContain('OpenCode not detected')
     const installButtons = Array.from(
       container.querySelectorAll<HTMLButtonElement>('button')
     ).filter((button) => /install with one click/i.test(button.textContent ?? ''))
-    // Exactly one install button (OpenCode's) since Claude is ready.
     expect(installButtons).toHaveLength(1)
     await act(async () => installButtons[0].click())
 
     // Default source is 'managed'; the OpenCode card must route to installOpencode, never installClaude.
     expect(installOpencode).toHaveBeenCalledWith('managed')
     expect(installClaude).not.toHaveBeenCalled()
+  })
+
+  const twoFrameworks = [
+    { id: 'claude-code' as const, displayName: 'Claude Code', supportsSkills: true },
+    { id: 'opencode' as const, displayName: 'OpenCode', supportsSkills: true }
+  ]
+
+  it('auto-selects OpenCode when Claude is not installed but OpenCode is', async () => {
+    const setAgentFramework = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: twoFrameworks,
+      setAgentFramework,
+      // Claude missing, OpenCode present: the prefer-installed rule switches to OpenCode.
+      preflight: {
+        claudeReady: false,
+        opencodeReady: true,
+        agentFrameworkId: 'claude-code',
+        agentReady: false,
+        activeProviderReady: false
+      },
+      environmentCheck: environment(false)
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+
+    expect(setAgentFramework).toHaveBeenCalledWith('opencode')
+  })
+
+  it('prefers Claude and does not auto-switch when Claude is installed', async () => {
+    const setAgentFramework = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: twoFrameworks,
+      setAgentFramework,
+      // Both installed → keep the Claude default; no auto-switch.
+      preflight: {
+        claudeReady: true,
+        opencodeReady: true,
+        agentFrameworkId: 'claude-code',
+        agentReady: true,
+        activeProviderReady: false
+      },
+      environmentCheck: environment(true)
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+
+    expect(setAgentFramework).not.toHaveBeenCalled()
+  })
+
+  it('does not auto-switch for a returning (recovery) user', async () => {
+    const setAgentFramework = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      onboardingCompletedAt: 1234,
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: twoFrameworks,
+      setAgentFramework,
+      preflight: {
+        claudeReady: false,
+        opencodeReady: true,
+        agentFrameworkId: 'claude-code',
+        agentReady: false,
+        activeProviderReady: false
+      },
+      environmentCheck: environment(false)
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+
+    expect(setAgentFramework).not.toHaveBeenCalled()
+  })
+
+  it('collapses the switcher to a "Change agent" link when the selected agent is ready', async () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: twoFrameworks,
+      claude: { resolvedPath: '/bin/claude', version: '2.1.0' },
+      preflight: {
+        claudeReady: true,
+        opencodeReady: false,
+        agentFrameworkId: 'claude-code',
+        agentReady: true,
+        activeProviderReady: false
+      },
+      environmentCheck: environment(true)
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+
+    // Ready → the toggle is hidden; only a "Change agent" affordance shows.
+    expect(container.querySelector('[role="radiogroup"][aria-label="Agent framework"]')).toBeNull()
+    const changeButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => /change agent/i.test(button.textContent ?? '')
+    )
+    expect(changeButton).not.toBeUndefined()
+
+    // Revealing it exposes the full Claude Code / OpenCode toggle.
+    await act(async () => changeButton?.click())
+    expect(
+      container.querySelector('[role="radiogroup"][aria-label="Agent framework"]')
+    ).not.toBeNull()
   })
 
   it('uses the recommended mirror and surfaces the actual automatic install error', async () => {

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -19,10 +19,11 @@ const environment = (ready: boolean): EnvironmentCheckResult => ({
   ready,
   canAutoInstall: !ready,
   recommendedRegistry: ready ? undefined : 'npmmirror',
-  claude: ready ? { found: true, path: '/bin/claude', version: '2.1.0' } : { found: false },
+  agentFrameworkId: 'claude-code',
+  runtime: ready ? { found: true, path: '/bin/claude', version: '2.1.0' } : { found: false },
   checks: [
     {
-      id: 'claude',
+      id: 'agent',
       label: 'Claude runtime',
       status: ready ? 'passed' : 'failed',
       summary: ready ? 'Claude is ready.' : 'Claude is not installed yet.'

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -147,6 +147,30 @@ describe('OnboardingWizard', () => {
     expect(checkEnvironment).toHaveBeenCalled()
   })
 
+  it('disables Continue when the latest check is for a different framework than selected', async () => {
+    // The env result is a READY Claude check, but OpenCode is now selected — Continue must stay
+    // disabled until a re-check for OpenCode lands (the stale Claude result must not slip through).
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: [
+        { id: 'claude-code', displayName: 'Claude Code', supportsSkills: true },
+        { id: 'opencode', displayName: 'OpenCode', supportsSkills: true }
+      ],
+      setAgentFramework: vi.fn().mockResolvedValue(undefined),
+      checkEnvironment: vi.fn().mockResolvedValue(undefined),
+      environmentCheck: environment(true) // agentFrameworkId: 'claude-code'
+    })
+
+    act(() => {
+      root.render(<OnboardingWizard />)
+    })
+
+    const continueButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Continue'
+    )
+    expect(continueButton?.disabled).toBe(true)
+  })
+
   it('keeps first-time users on the environment summary until they explicitly continue', async () => {
     useSettingsStore.setState({
       preflight: {

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -21,7 +21,8 @@ import type {
   ClaudeInstallSource,
   UpsertProviderRequest
 } from '../../../../shared/settings'
-import { useSettingsStore } from '@/stores/settings-store'
+import { isProviderUsableByFramework } from '../../../../shared/settings'
+import { selectFrameworkApiEndpoints, useSettingsStore } from '@/stores/settings-store'
 import { DataRootWarning } from '@/components/DataRootWarning'
 import { ClaudeInstallCard } from '../settings/ClaudeInstallCard'
 import { ClaudeStatusCard } from '../settings/ClaudeStatusCard'
@@ -116,6 +117,7 @@ const OnboardingWizard = (): React.JSX.Element => {
   const setAgentFramework = useSettingsStore((state) => state.setAgentFramework)
   const isDetectingOpencode = useSettingsStore((state) => state.isDetectingOpencode)
   const installOpencode = useSettingsStore((state) => state.installOpencode)
+  const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
   const preflight = useSettingsStore((state) => state.preflight)
   const isDetectingClaude = useSettingsStore((state) => state.isDetectingClaude)
   const isInstalling = useSettingsStore((state) => state.isInstalling)
@@ -282,6 +284,25 @@ const OnboardingWizard = (): React.JSX.Element => {
       return
     }
 
+    // A provider that validates can still be unusable by the selected framework (e.g. Claude + an
+    // OpenAI-only gateway, or OpenCode + a Local Claude login). Block that before it becomes the active
+    // provider, so onboarding can't finish with a pair the agent can't actually spawn.
+    if (
+      !isProviderUsableByFramework(
+        { apiType: formValue.apiType, type: formValue.type },
+        { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
+      )
+    ) {
+      const label =
+        agentFrameworks.find((framework) => framework.id === agentFrameworkId)?.displayName ??
+        'the selected agent'
+      setValidationOk(false)
+      setValidationMessage(
+        `This provider isn't compatible with ${label}. Pick a provider whose API format ${label} supports, or change the agent framework.`
+      )
+      return
+    }
+
     setIsSaving(true)
     setValidationMessage(undefined)
 
@@ -348,7 +369,13 @@ const OnboardingWizard = (): React.JSX.Element => {
     }
   }
 
-  const environmentReady = environmentCheck?.ready ?? false
+  // Ready only when the latest check is for the CURRENTLY selected framework and no re-check is in
+  // flight — otherwise switching a ready Claude to an uninstalled OpenCode would let Continue fire on
+  // the stale (Claude) result before the re-detect lands.
+  const environmentReady =
+    !isCheckingEnvironment &&
+    environmentCheck?.ready === true &&
+    environmentCheck.agentFrameworkId === agentFrameworkId
 
   if (isRelaunching) {
     return (

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -212,13 +212,17 @@ const OnboardingWizard = (): React.JSX.Element => {
     await checkEnvironment()
   }
 
-  const handleInstall = async (source: ClaudeInstallSource): Promise<void> => {
+  const handleInstall = async (
+    source: ClaudeInstallSource,
+    framework: AgentFrameworkId = agentFrameworkId
+  ): Promise<void> => {
     setAutomaticInstallError(undefined)
 
     try {
-      // Install the framework the user selected for onboarding, not always Claude.
+      // Install the requested framework: the per-card button names its own, the automatic one-click
+      // install targets the selected framework.
       const result =
-        agentFrameworkId === 'opencode'
+        framework === 'opencode'
           ? await installOpencode(source)
           : await installClaude(
               source,
@@ -407,40 +411,6 @@ const OnboardingWizard = (): React.JSX.Element => {
 
                 <CardContent className="flex-1 px-6 py-5">
                   <section aria-label="Prepare environment" className="space-y-5">
-                    {agentFrameworks.length > 1 ? (
-                      <div className="space-y-1.5">
-                        <span className="text-xs font-medium text-text-100">Agent framework</span>
-                        <div
-                          className="grid grid-cols-2 gap-1 rounded-lg bg-bg-10 p-1 ring-1 ring-border-200"
-                          role="radiogroup"
-                          aria-label="Agent framework"
-                        >
-                          {agentFrameworks.map((framework) => (
-                            <button
-                              key={framework.id}
-                              type="button"
-                              role="radio"
-                              aria-checked={agentFrameworkId === framework.id}
-                              onClick={() => void handleSelectFramework(framework.id)}
-                              disabled={isCheckingEnvironment || isInstalling}
-                              className={cn(
-                                'rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60',
-                                agentFrameworkId === framework.id
-                                  ? 'bg-bg-000 text-text-000 shadow-sm ring-1 ring-border-200'
-                                  : 'text-text-100 hover:text-text-000'
-                              )}
-                            >
-                              {framework.displayName}
-                            </button>
-                          ))}
-                        </div>
-                        <p className="text-xs leading-5 text-text-300">
-                          Choose the coding agent Open Science drives. You can change it later in
-                          Settings.
-                        </p>
-                      </div>
-                    ) : null}
-
                     <div
                       className="grid grid-cols-2 gap-1 rounded-lg bg-bg-10 p-1 ring-1 ring-border-200"
                       role="tablist"
@@ -511,45 +481,76 @@ const OnboardingWizard = (): React.JSX.Element => {
                           scripts. Use Re-detect after completing any external permission or
                           installation step.
                         </p>
-                        {agentFrameworkId === 'opencode' ? (
-                          <OpencodeStatusCard
-                            opencode={opencode}
-                            isDetecting={isDetectingOpencode || isCheckingEnvironment}
-                            onDetect={() => void handleEnvironmentCheck()}
+                        {/* Both runtimes are shown together; install each independently. Only the
+                            selected framework (below) is required to continue. */}
+                        <ClaudeStatusCard
+                          claude={claude}
+                          claudeReady={preflight.claudeReady}
+                          isDetecting={isDetectingClaude || isCheckingEnvironment}
+                          onDetect={() => void handleEnvironmentCheck()}
+                          embedded
+                        />
+                        {!preflight.claudeReady ? (
+                          <ClaudeInstallCard
                             isInstalling={isInstalling}
                             installLogs={installLogs}
                             installProgress={installProgress}
                             installError={storeInstallError}
                             npmAvailable={npmAvailable}
-                            onInstall={(source) => void handleInstall(source)}
+                            onInstall={(source) => void handleInstall(source, 'claude-code')}
+                            embedded
                           />
-                        ) : (
-                          <>
-                            <ClaudeStatusCard
-                              claude={claude}
-                              claudeReady={preflight.claudeReady}
-                              isDetecting={isDetectingClaude || isCheckingEnvironment}
-                              onDetect={() => void handleEnvironmentCheck()}
-                              embedded
-                            />
-                            {!preflight.claudeReady ? (
-                              <>
-                                <Separator className="bg-border-200" />
-                                <ClaudeInstallCard
-                                  isInstalling={isInstalling}
-                                  installLogs={installLogs}
-                                  installProgress={installProgress}
-                                  installError={storeInstallError}
-                                  npmAvailable={npmAvailable}
-                                  onInstall={(source) => void handleInstall(source)}
-                                  embedded
-                                />
-                              </>
-                            ) : null}
-                          </>
-                        )}
+                        ) : null}
+                        <Separator className="bg-border-200" />
+                        <OpencodeStatusCard
+                          opencode={opencode}
+                          isDetecting={isDetectingOpencode || isCheckingEnvironment}
+                          onDetect={() => void handleEnvironmentCheck()}
+                          isInstalling={isInstalling}
+                          installLogs={installLogs}
+                          installProgress={installProgress}
+                          installError={storeInstallError}
+                          npmAvailable={npmAvailable}
+                          onInstall={(source) => void handleInstall(source, 'opencode')}
+                        />
                       </div>
                     )}
+
+                    {agentFrameworks.length > 1 ? (
+                      <div className="space-y-1.5 rounded-lg bg-bg-10 p-3 ring-1 ring-border-200">
+                        <span className="text-xs font-medium text-text-100">
+                          Which agent should Open Science use?
+                        </span>
+                        <div
+                          className="grid grid-cols-2 gap-1 rounded-md bg-bg-000 p-1 ring-1 ring-border-200"
+                          role="radiogroup"
+                          aria-label="Agent framework"
+                        >
+                          {agentFrameworks.map((framework) => (
+                            <button
+                              key={framework.id}
+                              type="button"
+                              role="radio"
+                              aria-checked={agentFrameworkId === framework.id}
+                              onClick={() => void handleSelectFramework(framework.id)}
+                              disabled={isCheckingEnvironment || isInstalling}
+                              className={cn(
+                                'rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60',
+                                agentFrameworkId === framework.id
+                                  ? 'bg-bg-10 text-text-000 shadow-sm ring-1 ring-border-200'
+                                  : 'text-text-100 hover:text-text-000'
+                              )}
+                            >
+                              {framework.displayName}
+                            </button>
+                          ))}
+                        </div>
+                        <p className="text-xs leading-5 text-text-300">
+                          Only this agent needs to be installed to continue; you can change it later
+                          in Settings.
+                        </p>
+                      </div>
+                    ) : null}
                   </section>
                 </CardContent>
                 <CardFooter className="mt-auto items-center justify-between gap-4 rounded-b-lg border-border-200 bg-bg-10 px-6 py-3">

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/lib/utils'
 import { APP } from '../../../../shared/app-config'
 import type { StorageInfo } from '../../../../shared/storage'
 import type {
+  AgentFrameworkId,
   ClaudeInstallResult,
   ClaudeInstallSource,
   UpsertProviderRequest
@@ -24,6 +25,7 @@ import { useSettingsStore } from '@/stores/settings-store'
 import { DataRootWarning } from '@/components/DataRootWarning'
 import { ClaudeInstallCard } from '../settings/ClaudeInstallCard'
 import { ClaudeStatusCard } from '../settings/ClaudeStatusCard'
+import { OpencodeStatusCard } from '../settings/OpencodeStatusCard'
 import { EnvironmentSetupCard } from './EnvironmentSetupCard'
 import { ProviderForm } from '../settings/ProviderForm'
 import {
@@ -97,6 +99,8 @@ const toUpsertRequest = (value: ProviderFormValue): UpsertProviderRequest => ({
   model: value.model,
   vendorId: value.vendorId,
   region: value.region,
+  // Persist the chosen API format so an OpenAI-compatible provider is validated + driven correctly.
+  apiType: value.apiType,
   key: value.key || undefined
 })
 
@@ -106,6 +110,12 @@ const toUpsertRequest = (value: ProviderFormValue): UpsertProviderRequest => ({
 // re-open only the environment portion when a required dependency later disappears (recovery mode).
 const OnboardingWizard = (): React.JSX.Element => {
   const claude = useSettingsStore((state) => state.claude)
+  const opencode = useSettingsStore((state) => state.opencode)
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
+  const setAgentFramework = useSettingsStore((state) => state.setAgentFramework)
+  const isDetectingOpencode = useSettingsStore((state) => state.isDetectingOpencode)
+  const installOpencode = useSettingsStore((state) => state.installOpencode)
   const preflight = useSettingsStore((state) => state.preflight)
   const isDetectingClaude = useSettingsStore((state) => state.isDetectingClaude)
   const isInstalling = useSettingsStore((state) => state.isInstalling)
@@ -206,10 +216,14 @@ const OnboardingWizard = (): React.JSX.Element => {
     setAutomaticInstallError(undefined)
 
     try {
-      const result = await installClaude(
-        source,
-        source === 'managed' ? environmentCheck?.recommendedRegistry : undefined
-      )
+      // Install the framework the user selected for onboarding, not always Claude.
+      const result =
+        agentFrameworkId === 'opencode'
+          ? await installOpencode(source)
+          : await installClaude(
+              source,
+              source === 'managed' ? environmentCheck?.recommendedRegistry : undefined
+            )
 
       if (!result.ok) {
         setAutomaticInstallError(describeInstallFailure(result))
@@ -222,6 +236,16 @@ const OnboardingWizard = (): React.JSX.Element => {
         error instanceof Error ? error.message : 'The installer could not be started.'
       )
     }
+  }
+
+  // Switching the framework re-detects it and re-runs the host inspection so the environment card
+  // reflects the chosen runtime immediately.
+  const handleSelectFramework = async (id: AgentFrameworkId): Promise<void> => {
+    if (id === agentFrameworkId) return
+
+    setAutomaticInstallError(undefined)
+    await setAgentFramework(id)
+    await checkEnvironment()
   }
 
   const handleBrowseLocation = async (): Promise<void> => {
@@ -383,6 +407,40 @@ const OnboardingWizard = (): React.JSX.Element => {
 
                 <CardContent className="flex-1 px-6 py-5">
                   <section aria-label="Prepare environment" className="space-y-5">
+                    {agentFrameworks.length > 1 ? (
+                      <div className="space-y-1.5">
+                        <span className="text-xs font-medium text-text-100">Agent framework</span>
+                        <div
+                          className="grid grid-cols-2 gap-1 rounded-lg bg-bg-10 p-1 ring-1 ring-border-200"
+                          role="radiogroup"
+                          aria-label="Agent framework"
+                        >
+                          {agentFrameworks.map((framework) => (
+                            <button
+                              key={framework.id}
+                              type="button"
+                              role="radio"
+                              aria-checked={agentFrameworkId === framework.id}
+                              onClick={() => void handleSelectFramework(framework.id)}
+                              disabled={isCheckingEnvironment || isInstalling}
+                              className={cn(
+                                'rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60',
+                                agentFrameworkId === framework.id
+                                  ? 'bg-bg-000 text-text-000 shadow-sm ring-1 ring-border-200'
+                                  : 'text-text-100 hover:text-text-000'
+                              )}
+                            >
+                              {framework.displayName}
+                            </button>
+                          ))}
+                        </div>
+                        <p className="text-xs leading-5 text-text-300">
+                          Choose the coding agent Open Science drives. You can change it later in
+                          Settings.
+                        </p>
+                      </div>
+                    ) : null}
+
                     <div
                       className="grid grid-cols-2 gap-1 rounded-lg bg-bg-10 p-1 ring-1 ring-border-200"
                       role="tablist"
@@ -453,27 +511,43 @@ const OnboardingWizard = (): React.JSX.Element => {
                           scripts. Use Re-detect after completing any external permission or
                           installation step.
                         </p>
-                        <ClaudeStatusCard
-                          claude={claude}
-                          claudeReady={preflight.claudeReady}
-                          isDetecting={isDetectingClaude || isCheckingEnvironment}
-                          onDetect={() => void handleEnvironmentCheck()}
-                          embedded
-                        />
-                        {!preflight.claudeReady ? (
+                        {agentFrameworkId === 'opencode' ? (
+                          <OpencodeStatusCard
+                            opencode={opencode}
+                            isDetecting={isDetectingOpencode || isCheckingEnvironment}
+                            onDetect={() => void handleEnvironmentCheck()}
+                            isInstalling={isInstalling}
+                            installLogs={installLogs}
+                            installProgress={installProgress}
+                            installError={storeInstallError}
+                            npmAvailable={npmAvailable}
+                            onInstall={(source) => void handleInstall(source)}
+                          />
+                        ) : (
                           <>
-                            <Separator className="bg-border-200" />
-                            <ClaudeInstallCard
-                              isInstalling={isInstalling}
-                              installLogs={installLogs}
-                              installProgress={installProgress}
-                              installError={storeInstallError}
-                              npmAvailable={npmAvailable}
-                              onInstall={(source) => void handleInstall(source)}
+                            <ClaudeStatusCard
+                              claude={claude}
+                              claudeReady={preflight.claudeReady}
+                              isDetecting={isDetectingClaude || isCheckingEnvironment}
+                              onDetect={() => void handleEnvironmentCheck()}
                               embedded
                             />
+                            {!preflight.claudeReady ? (
+                              <>
+                                <Separator className="bg-border-200" />
+                                <ClaudeInstallCard
+                                  isInstalling={isInstalling}
+                                  installLogs={installLogs}
+                                  installProgress={installProgress}
+                                  installError={storeInstallError}
+                                  npmAvailable={npmAvailable}
+                                  onInstall={(source) => void handleInstall(source)}
+                                  embedded
+                                />
+                              </>
+                            ) : null}
                           </>
-                        ) : null}
+                        )}
                       </div>
                     )}
                   </section>

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -142,6 +142,9 @@ const OnboardingWizard = (): React.JSX.Element => {
   // already passed. The user explicitly continues to model configuration after reviewing it.
   const [step, setStep] = useState<WizardStep>('claude')
   const [environmentMode, setEnvironmentMode] = useState<EnvironmentMode>('automatic')
+  // The framework switcher stays collapsed once the selected agent is ready; the user reveals it with
+  // "Change agent" only when they actually want a different runtime.
+  const [showFrameworkSwitcher, setShowFrameworkSwitcher] = useState(false)
   const [automaticInstallError, setAutomaticInstallError] = useState<string | undefined>(undefined)
 
   // Data-root location step. Only `dataRoot` is ever touched here — the config root (settings,
@@ -172,6 +175,9 @@ const OnboardingWizard = (): React.JSX.Element => {
   const [validationMessage, setValidationMessage] = useState<string | undefined>(undefined)
   const [validationOk, setValidationOk] = useState(false)
   const didRequestCheck = useRef(false)
+  // Once the user manually picks an agent, stop auto-selecting; and only auto-select once per mount.
+  const userPickedFramework = useRef(false)
+  const autoSelectAttempted = useRef(false)
   // Guards against handleKeepDefault's completeOnboarding firing spuriously after Restart:
   // AlertDialog.Action fires onOpenChange(false) on click (same as Cancel), and closures inside
   // that handler can't see isRelaunching's update from the same synchronous batch, so a ref is
@@ -253,6 +259,37 @@ const OnboardingWizard = (): React.JSX.Element => {
     await setAgentFramework(id)
     await checkEnvironment()
   }
+
+  // Records an explicit user choice so the prefer-installed auto-selection below never overrides it.
+  const handlePickFramework = (id: AgentFrameworkId): void => {
+    userPickedFramework.current = true
+    void handleSelectFramework(id)
+  }
+
+  // Prefer whatever's installed during first-time onboarding: Claude Code is the default probe, but if
+  // Claude isn't installed while OpenCode is, switch the selection to OpenCode automatically. Runs once
+  // and never overrides an explicit user choice or a returning user's saved framework. Calls the store
+  // actions directly (not handleSelectFramework) so the effect stays free of local setState.
+  useEffect(() => {
+    if (isRecovery || userPickedFramework.current || autoSelectAttempted.current) return
+    if (agentFrameworks.length < 2) return
+
+    if (agentFrameworkId === 'claude-code' && !preflight.claudeReady && preflight.opencodeReady) {
+      autoSelectAttempted.current = true
+      void (async () => {
+        await setAgentFramework('opencode')
+        await checkEnvironment()
+      })()
+    }
+  }, [
+    isRecovery,
+    agentFrameworks.length,
+    agentFrameworkId,
+    preflight.claudeReady,
+    preflight.opencodeReady,
+    setAgentFramework,
+    checkEnvironment
+  ])
 
   const handleBrowseLocation = async (): Promise<void> => {
     const picked = await window.api.storage.pickDirectory()
@@ -508,74 +545,104 @@ const OnboardingWizard = (): React.JSX.Element => {
                           scripts. Use Re-detect after completing any external permission or
                           installation step.
                         </p>
-                        {/* Both runtimes are shown together; install each independently. Only the
-                            selected framework (below) is required to continue. */}
-                        <ClaudeStatusCard
-                          claude={claude}
-                          claudeReady={preflight.claudeReady}
-                          isDetecting={isDetectingClaude || isCheckingEnvironment}
-                          onDetect={() => void handleEnvironmentCheck()}
-                          embedded
-                        />
-                        {!preflight.claudeReady ? (
-                          <ClaudeInstallCard
+                        {/* Only the selected framework's runtime is shown — it is the one that must be
+                            installed to continue. Switch frameworks above to set up the other. */}
+                        {agentFrameworkId === 'opencode' ? (
+                          <OpencodeStatusCard
+                            opencode={opencode}
+                            isDetecting={isDetectingOpencode || isCheckingEnvironment}
+                            onDetect={() => void handleEnvironmentCheck()}
                             isInstalling={isInstalling}
                             installLogs={installLogs}
                             installProgress={installProgress}
                             installError={storeInstallError}
                             npmAvailable={npmAvailable}
-                            onInstall={(source) => void handleInstall(source, 'claude-code')}
-                            embedded
+                            onInstall={(source) => void handleInstall(source, 'opencode')}
                           />
-                        ) : null}
-                        <Separator className="bg-border-200" />
-                        <OpencodeStatusCard
-                          opencode={opencode}
-                          isDetecting={isDetectingOpencode || isCheckingEnvironment}
-                          onDetect={() => void handleEnvironmentCheck()}
-                          isInstalling={isInstalling}
-                          installLogs={installLogs}
-                          installProgress={installProgress}
-                          installError={storeInstallError}
-                          npmAvailable={npmAvailable}
-                          onInstall={(source) => void handleInstall(source, 'opencode')}
-                        />
+                        ) : (
+                          <>
+                            <ClaudeStatusCard
+                              claude={claude}
+                              claudeReady={preflight.claudeReady}
+                              isDetecting={isDetectingClaude || isCheckingEnvironment}
+                              onDetect={() => void handleEnvironmentCheck()}
+                              embedded
+                            />
+                            {!preflight.claudeReady ? (
+                              <ClaudeInstallCard
+                                isInstalling={isInstalling}
+                                installLogs={installLogs}
+                                installProgress={installProgress}
+                                installError={storeInstallError}
+                                npmAvailable={npmAvailable}
+                                onInstall={(source) => void handleInstall(source, 'claude-code')}
+                                embedded
+                              />
+                            ) : null}
+                          </>
+                        )}
                       </div>
                     )}
 
+                    {/* Agent switcher lives below the detection results. Detection auto-picks the
+                        installed runtime, so when the selected agent is ready this collapses to a
+                        "Change agent" link; only a not-ready (or explicitly revealed) state shows the
+                        full Claude Code / OpenCode toggle. */}
                     {agentFrameworks.length > 1 ? (
-                      <div className="space-y-1.5 rounded-lg bg-bg-10 p-3 ring-1 ring-border-200">
-                        <span className="text-xs font-medium text-text-100">
-                          Which agent should Open Science use?
-                        </span>
-                        <div
-                          className="grid grid-cols-2 gap-1 rounded-md bg-bg-000 p-1 ring-1 ring-border-200"
-                          role="radiogroup"
-                          aria-label="Agent framework"
-                        >
-                          {agentFrameworks.map((framework) => (
+                      <div className="rounded-lg bg-bg-10 p-3 ring-1 ring-border-200">
+                        {preflight.agentReady && !showFrameworkSwitcher ? (
+                          <div className="flex items-center justify-between gap-3">
+                            <span className="text-xs leading-5 text-text-300">
+                              Open Science will use{' '}
+                              <span className="font-medium text-text-100">
+                                {agentFrameworks.find((f) => f.id === agentFrameworkId)
+                                  ?.displayName ?? 'the selected agent'}
+                              </span>
+                              . Only this agent needs to be installed to continue.
+                            </span>
                             <button
-                              key={framework.id}
                               type="button"
-                              role="radio"
-                              aria-checked={agentFrameworkId === framework.id}
-                              onClick={() => void handleSelectFramework(framework.id)}
-                              disabled={isCheckingEnvironment || isInstalling}
-                              className={cn(
-                                'rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60',
-                                agentFrameworkId === framework.id
-                                  ? 'bg-bg-10 text-text-000 shadow-sm ring-1 ring-border-200'
-                                  : 'text-text-100 hover:text-text-000'
-                              )}
+                              onClick={() => setShowFrameworkSwitcher(true)}
+                              className="shrink-0 text-xs font-medium text-text-100 underline-offset-2 hover:text-text-000 hover:underline"
                             >
-                              {framework.displayName}
+                              Change agent
                             </button>
-                          ))}
-                        </div>
-                        <p className="text-xs leading-5 text-text-300">
-                          Only this agent needs to be installed to continue; you can change it later
-                          in Settings.
-                        </p>
+                          </div>
+                        ) : (
+                          <div className="space-y-1.5">
+                            <span className="text-xs font-medium text-text-100">
+                              Which agent should Open Science use?
+                            </span>
+                            <div
+                              className="grid grid-cols-2 gap-1 rounded-md bg-bg-000 p-1 ring-1 ring-border-200"
+                              role="radiogroup"
+                              aria-label="Agent framework"
+                            >
+                              {agentFrameworks.map((framework) => (
+                                <button
+                                  key={framework.id}
+                                  type="button"
+                                  role="radio"
+                                  aria-checked={agentFrameworkId === framework.id}
+                                  onClick={() => handlePickFramework(framework.id)}
+                                  disabled={isCheckingEnvironment || isInstalling}
+                                  className={cn(
+                                    'rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60',
+                                    agentFrameworkId === framework.id
+                                      ? 'bg-bg-10 text-text-000 shadow-sm ring-1 ring-border-200'
+                                      : 'text-text-100 hover:text-text-000'
+                                  )}
+                                >
+                                  {framework.displayName}
+                                </button>
+                              ))}
+                            </div>
+                            <p className="text-xs leading-5 text-text-300">
+                              Only this agent needs to be installed to continue; you can change it
+                              later in Settings.
+                            </p>
+                          </div>
+                        )}
                       </div>
                     ) : null}
                   </section>

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -1,6 +1,6 @@
 import { Check } from 'lucide-react'
 import { AlertDialog } from 'radix-ui'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -178,6 +178,10 @@ const OnboardingWizard = (): React.JSX.Element => {
   // Once the user manually picks an agent, stop auto-selecting; and only auto-select once per mount.
   const userPickedFramework = useRef(false)
   const autoSelectAttempted = useRef(false)
+  // Serializes framework switches: detection + preflight run async in the store, so a second switch
+  // started before the first settles could interleave and leave the selection, preflight, and
+  // environment result out of sync. This synchronous guard drops any switch while one is in flight.
+  const switchInFlight = useRef(false)
   // Guards against handleKeepDefault's completeOnboarding firing spuriously after Restart:
   // AlertDialog.Action fires onOpenChange(false) on click (same as Cancel), and closures inside
   // that handler can't see isRelaunching's update from the same synchronous batch, so a ref is
@@ -251,35 +255,40 @@ const OnboardingWizard = (): React.JSX.Element => {
   }
 
   // Switching the framework re-detects it and re-runs the host inspection so the environment card
-  // reflects the chosen runtime immediately.
-  const handleSelectFramework = async (id: AgentFrameworkId): Promise<void> => {
-    if (id === agentFrameworkId) return
+  // reflects the chosen runtime immediately. Serialized by switchInFlight so overlapping switches can't
+  // interleave the store's async detection/preflight; refs (not setState) keep it usable from effects.
+  const runFrameworkSwitch = useCallback(
+    async (id: AgentFrameworkId): Promise<void> => {
+      if (switchInFlight.current || id === agentFrameworkId) return
 
-    setAutomaticInstallError(undefined)
-    await setAgentFramework(id)
-    await checkEnvironment()
-  }
+      switchInFlight.current = true
+      try {
+        await setAgentFramework(id)
+        await checkEnvironment()
+      } finally {
+        switchInFlight.current = false
+      }
+    },
+    [agentFrameworkId, setAgentFramework, checkEnvironment]
+  )
 
   // Records an explicit user choice so the prefer-installed auto-selection below never overrides it.
   const handlePickFramework = (id: AgentFrameworkId): void => {
     userPickedFramework.current = true
-    void handleSelectFramework(id)
+    setAutomaticInstallError(undefined)
+    void runFrameworkSwitch(id)
   }
 
   // Prefer whatever's installed during first-time onboarding: Claude Code is the default probe, but if
   // Claude isn't installed while OpenCode is, switch the selection to OpenCode automatically. Runs once
-  // and never overrides an explicit user choice or a returning user's saved framework. Calls the store
-  // actions directly (not handleSelectFramework) so the effect stays free of local setState.
+  // and never overrides an explicit user choice or a returning user's saved framework.
   useEffect(() => {
     if (isRecovery || userPickedFramework.current || autoSelectAttempted.current) return
     if (agentFrameworks.length < 2) return
 
     if (agentFrameworkId === 'claude-code' && !preflight.claudeReady && preflight.opencodeReady) {
       autoSelectAttempted.current = true
-      void (async () => {
-        await setAgentFramework('opencode')
-        await checkEnvironment()
-      })()
+      void runFrameworkSwitch('opencode')
     }
   }, [
     isRecovery,
@@ -287,8 +296,7 @@ const OnboardingWizard = (): React.JSX.Element => {
     agentFrameworkId,
     preflight.claudeReady,
     preflight.opencodeReady,
-    setAgentFramework,
-    checkEnvironment
+    runFrameworkSwitch
   ])
 
   const handleBrowseLocation = async (): Promise<void> => {
@@ -560,26 +568,30 @@ const OnboardingWizard = (): React.JSX.Element => {
                             onInstall={(source) => void handleInstall(source, 'opencode')}
                           />
                         ) : (
-                          <>
-                            <ClaudeStatusCard
-                              claude={claude}
-                              claudeReady={preflight.claudeReady}
-                              isDetecting={isDetectingClaude || isCheckingEnvironment}
-                              onDetect={() => void handleEnvironmentCheck()}
-                              embedded
-                            />
-                            {!preflight.claudeReady ? (
-                              <ClaudeInstallCard
-                                isInstalling={isInstalling}
-                                installLogs={installLogs}
-                                installProgress={installProgress}
-                                installError={storeInstallError}
-                                npmAvailable={npmAvailable}
-                                onInstall={(source) => void handleInstall(source, 'claude-code')}
+                          // Same boxed shell as OpencodeStatusCard so both frameworks read identically:
+                          // one card holding the runtime status and, when missing, the install picker.
+                          <Card className="gap-0 rounded-lg py-0">
+                            <CardContent className="space-y-3 p-4">
+                              <ClaudeStatusCard
+                                claude={claude}
+                                claudeReady={preflight.claudeReady}
+                                isDetecting={isDetectingClaude || isCheckingEnvironment}
+                                onDetect={() => void handleEnvironmentCheck()}
                                 embedded
                               />
-                            ) : null}
-                          </>
+                              {!preflight.claudeReady ? (
+                                <ClaudeInstallCard
+                                  isInstalling={isInstalling}
+                                  installLogs={installLogs}
+                                  installProgress={installProgress}
+                                  installError={storeInstallError}
+                                  npmAvailable={npmAvailable}
+                                  onInstall={(source) => void handleInstall(source, 'claude-code')}
+                                  embedded
+                                />
+                              ) : null}
+                            </CardContent>
+                          </Card>
                         )}
                       </div>
                     )}
@@ -625,7 +637,12 @@ const OnboardingWizard = (): React.JSX.Element => {
                                   role="radio"
                                   aria-checked={agentFrameworkId === framework.id}
                                   onClick={() => handlePickFramework(framework.id)}
-                                  disabled={isCheckingEnvironment || isInstalling}
+                                  disabled={
+                                    isCheckingEnvironment ||
+                                    isInstalling ||
+                                    isDetectingClaude ||
+                                    isDetectingOpencode
+                                  }
                                   className={cn(
                                     'rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60',
                                     agentFrameworkId === framework.id

--- a/src/renderer/src/pages/settings/ActiveModelSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ActiveModelSelect.render.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentFrameworkView, ProviderView } from '../../../../shared/settings'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { ActiveModelSelect } from './ActiveModelSelect'
+
+// Radix Select calls pointer-capture and scroll APIs jsdom does not implement.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = (): void => undefined
+}
+
+let container: HTMLDivElement
+let root: Root
+
+const FRAMEWORKS: AgentFrameworkView[] = [
+  {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    supportsSkills: true,
+    supportedApiTypes: ['anthropic']
+  },
+  {
+    id: 'opencode',
+    displayName: 'OpenCode',
+    supportsSkills: true,
+    supportedApiTypes: ['anthropic', 'openai']
+  }
+]
+
+const provider = (overrides: Partial<ProviderView>): ProviderView => ({
+  id: 'p',
+  type: 'custom',
+  name: 'Gateway',
+  models: ['m'],
+  hasKey: true,
+  needsKey: false,
+  ...overrides
+})
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  useSettingsStore.setState(createInitialSettingsState())
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+const render = (): void => {
+  act(() => root.render(<ActiveModelSelect />))
+}
+
+// Open the Select trigger and click an option by its visible text (portalled to body).
+const openSelect = (): void => {
+  const trigger = document.body.querySelector<HTMLButtonElement>('[aria-label="Active model"]')
+  act(() => {
+    trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+    trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+const optionByText = (text: string): HTMLElement | undefined =>
+  Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).find((candidate) =>
+    candidate.textContent?.includes(text)
+  )
+
+const clickOption = (text: string): void => {
+  const item = optionByText(text)
+  act(() => {
+    item?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, button: 0 }))
+    item?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+describe('ActiveModelSelect', () => {
+  it('renders nothing when no provider exposes a model', () => {
+    useSettingsStore.setState({ providers: [] })
+    render()
+
+    expect(container.querySelector('[aria-label="Active model"]')).toBeNull()
+    expect(container.textContent).toBe('')
+  })
+
+  it('shows the active model and its source provider in the trigger', () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: FRAMEWORKS,
+      providers: [provider({ id: 'p1', name: 'Gateway', models: ['claude-sonnet-4-5'] })],
+      activeProviderId: 'p1',
+      activeModel: 'claude-sonnet-4-5'
+    })
+    render()
+
+    const trigger = container.querySelector('[aria-label="Active model"]')
+    expect(trigger).not.toBeNull()
+    expect(trigger?.textContent).toContain('claude-sonnet-4-5')
+    expect(trigger?.textContent).toContain('Gateway')
+  })
+
+  it('shows the placeholder when no model is active', () => {
+    useSettingsStore.setState({
+      providers: [provider({ id: 'p1', models: ['m1'] })],
+      activeProviderId: undefined,
+      activeModel: undefined
+    })
+    render()
+
+    expect(container.querySelector('[aria-label="Active model"]')?.textContent).toContain(
+      'Select a model'
+    )
+  })
+
+  it('calls setActiveProvider with the picked provider and model', () => {
+    const setActiveProvider = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: FRAMEWORKS,
+      providers: [provider({ id: 'p1', name: 'Gateway', apiType: 'anthropic', models: ['m1'] })],
+      setActiveProvider
+    })
+    render()
+
+    openSelect()
+    clickOption('m1')
+
+    expect(setActiveProvider).toHaveBeenCalledWith('p1', 'm1')
+  })
+
+  it('marks a provider that cannot drive the current framework as not usable and disables its models', () => {
+    // Claude Code speaks Anthropic only, so an OpenAI-only provider is incompatible.
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: FRAMEWORKS,
+      providers: [
+        provider({ id: 'p1', name: 'DeepSeek', apiType: 'openai', models: ['deepseek-chat'] })
+      ],
+      setActiveProvider: vi.fn().mockResolvedValue(undefined)
+    })
+    render()
+
+    openSelect()
+
+    expect(document.body.textContent).toContain('not usable with this framework')
+    const option = optionByText('deepseek-chat')
+    expect(option).toBeDefined()
+    expect(option?.getAttribute('data-disabled')).not.toBeNull()
+    expect(option?.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('leaves a compatible provider selectable and unlabelled', () => {
+    // OpenCode drives both endpoints, so the OpenAI provider is compatible.
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: FRAMEWORKS,
+      providers: [provider({ id: 'p1', name: 'DeepSeek', apiType: 'openai', models: ['ds-1'] })],
+      setActiveProvider: vi.fn().mockResolvedValue(undefined)
+    })
+    render()
+
+    openSelect()
+
+    expect(document.body.textContent).not.toContain('not usable with this framework')
+    const option = optionByText('ds-1')
+    expect(option?.getAttribute('data-disabled')).toBeNull()
+  })
+
+  it('groups each provider under its own name and lists every catalog model', () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: FRAMEWORKS,
+      providers: [
+        provider({ id: 'p1', name: 'Anthropic', apiType: 'anthropic', models: ['opus', 'sonnet'] }),
+        provider({ id: 'p2', name: 'OpenAI', apiType: 'openai', models: ['gpt'] })
+      ],
+      setActiveProvider: vi.fn().mockResolvedValue(undefined)
+    })
+    render()
+
+    openSelect()
+
+    const options = Array.from(document.body.querySelectorAll('[role="option"]'))
+    expect(options).toHaveLength(3)
+    expect(document.body.textContent).toContain('Anthropic')
+    expect(document.body.textContent).toContain('OpenAI')
+    expect(optionByText('opus')).toBeDefined()
+    expect(optionByText('sonnet')).toBeDefined()
+    expect(optionByText('gpt')).toBeDefined()
+  })
+})

--- a/src/renderer/src/pages/settings/ActiveModelSelect.tsx
+++ b/src/renderer/src/pages/settings/ActiveModelSelect.tsx
@@ -6,7 +6,12 @@ import {
   SelectLabel,
   SelectTrigger
 } from '@/components/ui/select'
-import { selectProviderModelOptions, useSettingsStore } from '@/stores/settings-store'
+import {
+  selectFrameworkApiEndpoints,
+  selectProviderModelOptions,
+  useSettingsStore
+} from '@/stores/settings-store'
+import { isProviderCompatibleWith } from '../../../../shared/settings'
 import { ProviderKindIcon } from './provider-icons'
 import { providerKindKey } from './provider-form-value'
 
@@ -22,10 +27,15 @@ const ActiveModelSelect = (): React.JSX.Element | null => {
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
   const activeModel = useSettingsStore((state) => state.activeModel)
   const setActiveProvider = useSettingsStore((state) => state.setActiveProvider)
+  const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
 
   const options = selectProviderModelOptions(providers)
 
   if (options.length === 0) return null
+
+  // A provider is selectable only when its API format is one the current framework can drive.
+  const isCompatible = (provider: (typeof providers)[number]): boolean =>
+    isProviderCompatibleWith(provider.apiType ?? 'anthropic', frameworkEndpoints)
 
   const activeKeyModel = activeModel ?? ''
   const current = options.find(
@@ -66,25 +76,37 @@ const ActiveModelSelect = (): React.JSX.Element | null => {
         </span>
       </SelectTrigger>
       <SelectContent>
-        {groups.map((group) => (
-          <SelectGroup key={group.provider.id}>
-            <SelectLabel>{group.provider.name}</SelectLabel>
-            {group.options.map((option) => (
-              <SelectItem
-                key={`${option.providerId}${SEP}${option.model}`}
-                value={`${option.providerId}${SEP}${option.model}`}
-                icon={
-                  <ProviderKindIcon
-                    kindKey={providerKindKey(option.providerType, option.vendorId)}
-                    className="size-4"
-                  />
-                }
-              >
-                {option.model || option.providerName}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        ))}
+        {groups.map((group) => {
+          const compatible = isCompatible(group.provider)
+
+          return (
+            <SelectGroup key={group.provider.id}>
+              <SelectLabel>
+                {group.provider.name}
+                {compatible ? null : (
+                  <span className="ml-1 font-normal text-muted-foreground">
+                    · not usable with this framework
+                  </span>
+                )}
+              </SelectLabel>
+              {group.options.map((option) => (
+                <SelectItem
+                  key={`${option.providerId}${SEP}${option.model}`}
+                  value={`${option.providerId}${SEP}${option.model}`}
+                  disabled={!compatible}
+                  icon={
+                    <ProviderKindIcon
+                      kindKey={providerKindKey(option.providerType, option.vendorId)}
+                      className="size-4"
+                    />
+                  }
+                >
+                  {option.model || option.providerName}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          )
+        })}
       </SelectContent>
     </Select>
   )

--- a/src/renderer/src/pages/settings/ActiveModelSelect.tsx
+++ b/src/renderer/src/pages/settings/ActiveModelSelect.tsx
@@ -11,7 +11,7 @@ import {
   selectProviderModelOptions,
   useSettingsStore
 } from '@/stores/settings-store'
-import { isProviderCompatibleWith } from '../../../../shared/settings'
+import { isProviderUsableByFramework } from '../../../../shared/settings'
 import { ProviderKindIcon } from './provider-icons'
 import { providerKindKey } from './provider-form-value'
 
@@ -27,15 +27,20 @@ const ActiveModelSelect = (): React.JSX.Element | null => {
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
   const activeModel = useSettingsStore((state) => state.activeModel)
   const setActiveProvider = useSettingsStore((state) => state.setActiveProvider)
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
 
   const options = selectProviderModelOptions(providers)
 
   if (options.length === 0) return null
 
-  // A provider is selectable only when its API format is one the current framework can drive.
+  // A provider is selectable only when it can actually drive the current framework (endpoint + type;
+  // a Local Claude provider is Claude-only).
   const isCompatible = (provider: (typeof providers)[number]): boolean =>
-    isProviderCompatibleWith(provider.apiType ?? 'anthropic', frameworkEndpoints)
+    isProviderUsableByFramework(
+      { apiType: provider.apiType ?? 'anthropic', type: provider.type },
+      { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
+    )
 
   const activeKeyModel = activeModel ?? ''
   const current = options.find(

--- a/src/renderer/src/pages/settings/AgentFrameworkSection.render.test.tsx
+++ b/src/renderer/src/pages/settings/AgentFrameworkSection.render.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentFrameworkView } from '../../../../shared/settings'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { AgentFrameworkSection } from './AgentFrameworkSection'
+
+// Radix Select/AlertDialog call pointer-capture and scroll APIs jsdom does not implement.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = (): void => undefined
+}
+
+let container: HTMLDivElement
+let root: Root
+
+const FRAMEWORKS: AgentFrameworkView[] = [
+  {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    supportsSkills: true,
+    supportedApiTypes: ['anthropic']
+  },
+  {
+    id: 'opencode',
+    displayName: 'OpenCode',
+    supportsSkills: true,
+    supportedApiTypes: ['anthropic', 'openai']
+  }
+]
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  useSettingsStore.setState(createInitialSettingsState())
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+const render = (): void => {
+  act(() => root.render(<AgentFrameworkSection />))
+}
+
+const openSelect = (): void => {
+  // The SettingsSection wrapper shares this aria-label, so target the trigger button specifically.
+  const trigger = document.body.querySelector<HTMLButtonElement>(
+    'button[aria-label="Agent framework"]'
+  )
+  act(() => {
+    trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+    trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+const clickOption = (text: string): void => {
+  const item = Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).find(
+    (candidate) => candidate.textContent?.includes(text)
+  )
+  act(() => {
+    item?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, button: 0 }))
+    item?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+const clickButtonByText = (text: string): void => {
+  const button = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+    (candidate) => candidate.textContent?.trim() === text
+  )
+  act(() => button?.click())
+}
+
+// Choose a framework in the (deferred) select, which opens the confirmation dialog.
+const chooseFramework = (displayName: string): void => {
+  openSelect()
+  clickOption(displayName)
+}
+
+describe('AgentFrameworkSection', () => {
+  it('shows the selected framework name in the trigger', () => {
+    useSettingsStore.setState({ agentFrameworkId: 'opencode', agentFrameworks: FRAMEWORKS })
+    render()
+
+    expect(container.querySelector('[aria-label="Agent framework"]')?.textContent).toContain(
+      'OpenCode'
+    )
+  })
+
+  it('defaults to Claude Code when no framework is set', () => {
+    useSettingsStore.setState({ agentFrameworkId: undefined, agentFrameworks: [] })
+    render()
+
+    // Falls back to the known list, so both options exist even before a snapshot arrives.
+    expect(container.querySelector('[aria-label="Agent framework"]')?.textContent).toContain(
+      'Claude Code'
+    )
+    openSelect()
+    const options = Array.from(document.body.querySelectorAll('[role="option"]')).map((option) =>
+      option.textContent?.trim()
+    )
+    expect(options).toContain('Claude Code')
+    expect(options).toContain('OpenCode')
+  })
+
+  it('defers the switch behind a confirmation dialog instead of applying it immediately', () => {
+    const setAgentFramework = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: FRAMEWORKS,
+      setAgentFramework
+    })
+    render()
+
+    chooseFramework('OpenCode')
+
+    // The dialog is shown but the store action has not fired yet.
+    expect(document.body.textContent).toContain('Switch to OpenCode?')
+    expect(setAgentFramework).not.toHaveBeenCalled()
+  })
+
+  it('applies the switch only after the user confirms', () => {
+    const setAgentFramework = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: FRAMEWORKS,
+      setAgentFramework
+    })
+    render()
+
+    chooseFramework('OpenCode')
+    clickButtonByText('Switch')
+
+    expect(setAgentFramework).toHaveBeenCalledWith('opencode')
+  })
+
+  it('cancels the switch and leaves the framework unchanged', () => {
+    const setAgentFramework = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: FRAMEWORKS,
+      setAgentFramework
+    })
+    render()
+
+    chooseFramework('OpenCode')
+    clickButtonByText('Cancel')
+
+    expect(setAgentFramework).not.toHaveBeenCalled()
+    expect(document.body.textContent).not.toContain('Switch to OpenCode?')
+  })
+
+  it('warns that skills are unavailable when the selected framework lacks skill support', () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      // The snapshot entry wins over the known fallback, so a skills-less OpenCode is reflected.
+      agentFrameworks: [FRAMEWORKS[0], { ...FRAMEWORKS[1], supportsSkills: false }]
+    })
+    render()
+
+    expect(container.textContent).toContain("Skills aren't available with OpenCode")
+  })
+
+  it('does not warn about skills for a framework that supports them', () => {
+    useSettingsStore.setState({ agentFrameworkId: 'claude-code', agentFrameworks: FRAMEWORKS })
+    render()
+
+    expect(container.textContent).not.toContain("Skills aren't available")
+  })
+})

--- a/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
+++ b/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
@@ -27,7 +27,8 @@ const KNOWN_FRAMEWORKS: AgentFrameworkView[] = [
 
 // Lets the user pick which agent backend drives their sessions. Because a session started on one
 // backend cannot be resumed on another, switching adopts a fresh agent session — so the choice is
-// confirmed first, warning that open conversations lose their prior agent context.
+// confirmed first, noting that open conversations keep their messages and have their transcript
+// replayed to the new backend (soft-replay), though live tool state is not carried over.
 const AgentFrameworkSection = (): React.JSX.Element => {
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
@@ -57,8 +58,8 @@ const AgentFrameworkSection = (): React.JSX.Element => {
       description={
         <>
           Choose which coding-agent backend drives your sessions. Switching starts a fresh agent
-          session — open conversations keep their messages but the new backend won&apos;t have their
-          earlier context.
+          session; open conversations keep their messages, and their earlier transcript is replayed
+          to the new backend so it can continue where you left off.
         </>
       }
       aria-label="Agent framework"
@@ -105,9 +106,10 @@ const AgentFrameworkSection = (): React.JSX.Element => {
               Switch to {pendingName}?
             </AlertDialog.Title>
             <AlertDialog.Description className="mt-2 text-sm leading-relaxed text-muted-foreground">
-              A conversation started on one backend can&apos;t be replayed on another, so switching
-              starts a fresh agent session. Open conversations keep their existing messages, but{' '}
-              {pendingName} won&apos;t have their earlier context. New conversations are unaffected.
+              A conversation can&apos;t be resumed on a different backend, so switching starts a
+              fresh agent session. Open conversations keep their existing messages, and their
+              transcript is replayed to {pendingName} so it can pick up where you left off (tool
+              state is not carried over). New conversations are unaffected.
             </AlertDialog.Description>
             <div className="mt-6 flex justify-end gap-2">
               <AlertDialog.Cancel asChild>

--- a/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
+++ b/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
@@ -1,7 +1,15 @@
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 import { useSettingsStore } from '@/stores/settings-store'
-import type { AgentFrameworkId } from '../../../../shared/settings'
+import type { AgentFrameworkId, AgentFrameworkView } from '../../../../shared/settings'
 import { SettingsRow, SettingsSection } from './SettingsLayout'
+
+// The selectable frameworks, used as a fallback so the dropdown always offers both even before the
+// first snapshot arrives (or if a stale main omits the list). The snapshot's own entries take
+// precedence when present, so live displayName/capability data wins.
+const KNOWN_FRAMEWORKS: AgentFrameworkView[] = [
+  { id: 'claude-code', displayName: 'Claude Code', supportsSkills: true },
+  { id: 'opencode', displayName: 'opencode', supportsSkills: false }
+]
 
 // Lets the user pick which agent backend drives their sessions. Switching persists the choice and
 // reconnects the agent (main drops the connection so the next prompt spawns the selected backend).
@@ -10,12 +18,12 @@ const AgentFrameworkSection = (): React.JSX.Element => {
   const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
   const setAgentFramework = useSettingsStore((state) => state.setAgentFramework)
 
-  // Before the first snapshot loads the list is empty; show the current id so the control is stable.
   const currentId = agentFrameworkId ?? 'claude-code'
-  const frameworks =
-    agentFrameworks && agentFrameworks.length > 0
-      ? agentFrameworks
-      : [{ id: currentId, displayName: currentId, supportsSkills: true }]
+  // Always list both frameworks (so switching is never blocked by an empty/partial list), preferring
+  // the snapshot's entry for each id when it exists.
+  const frameworks = KNOWN_FRAMEWORKS.map(
+    (known) => agentFrameworks?.find((framework) => framework.id === known.id) ?? known
+  )
   const selected = frameworks.find((framework) => framework.id === currentId)
 
   return (

--- a/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
+++ b/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
@@ -1,3 +1,7 @@
+import { AlertDialog } from 'radix-ui'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 import { useSettingsStore } from '@/stores/settings-store'
 import type { AgentFrameworkId, AgentFrameworkView } from '../../../../shared/settings'
@@ -8,15 +12,19 @@ import { SettingsRow, SettingsSection } from './SettingsLayout'
 // precedence when present, so live displayName/capability data wins.
 const KNOWN_FRAMEWORKS: AgentFrameworkView[] = [
   { id: 'claude-code', displayName: 'Claude Code', supportsSkills: true },
-  { id: 'opencode', displayName: 'opencode', supportsSkills: false }
+  { id: 'opencode', displayName: 'OpenCode', supportsSkills: false }
 ]
 
-// Lets the user pick which agent backend drives their sessions. Switching persists the choice and
-// reconnects the agent (main drops the connection so the next prompt spawns the selected backend).
+// Lets the user pick which agent backend drives their sessions. Because a session started on one
+// backend cannot be resumed on another, switching adopts a fresh agent session — so the choice is
+// confirmed first, warning that open conversations lose their prior agent context.
 const AgentFrameworkSection = (): React.JSX.Element => {
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
   const setAgentFramework = useSettingsStore((state) => state.setAgentFramework)
+
+  // The framework the user picked but hasn't confirmed yet; drives the warning dialog.
+  const [pending, setPending] = useState<AgentFrameworkId | undefined>(undefined)
 
   const currentId = agentFrameworkId ?? 'claude-code'
   // Always list both frameworks (so switching is never blocked by an empty/partial list), preferring
@@ -25,14 +33,22 @@ const AgentFrameworkSection = (): React.JSX.Element => {
     (known) => agentFrameworks?.find((framework) => framework.id === known.id) ?? known
   )
   const selected = frameworks.find((framework) => framework.id === currentId)
+  const pendingName =
+    frameworks.find((framework) => framework.id === pending)?.displayName ?? pending
+
+  const confirmSwitch = (): void => {
+    if (pending) void setAgentFramework(pending)
+    setPending(undefined)
+  }
 
   return (
     <SettingsSection
       title="Agent framework"
       description={
         <>
-          Choose which coding-agent backend drives your sessions. Switching reconnects the agent;
-          open conversations continue on the new backend.
+          Choose which coding-agent backend drives your sessions. Switching starts a fresh agent
+          session — open conversations keep their messages but the new backend won&apos;t have their
+          earlier context.
         </>
       }
       aria-label="Agent framework"
@@ -41,7 +57,10 @@ const AgentFrameworkSection = (): React.JSX.Element => {
       <SettingsRow label="Framework" controlClassName="w-auto justify-self-end" className="pt-0">
         <Select
           value={currentId}
-          onValueChange={(id) => void setAgentFramework(id as AgentFrameworkId)}
+          onValueChange={(id) => {
+            // Defer the switch to the confirmation; the controlled value stays until confirmed.
+            if (id !== currentId) setPending(id as AgentFrameworkId)
+          }}
         >
           <SelectTrigger aria-label="Agent framework">
             <span>{selected?.displayName ?? currentId}</span>
@@ -62,6 +81,39 @@ const AgentFrameworkSection = (): React.JSX.Element => {
           workflows.
         </p>
       ) : null}
+
+      <AlertDialog.Root
+        open={Boolean(pending)}
+        onOpenChange={(open) => {
+          if (!open) setPending(undefined)
+        }}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Overlay className="fixed inset-0 z-[60] bg-black/50" />
+          <AlertDialog.Content className="fixed left-1/2 top-1/2 z-[60] w-[min(440px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-popover p-6 text-foreground shadow-menu">
+            <AlertDialog.Title className="text-base font-semibold text-foreground">
+              Switch to {pendingName}?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              A conversation started on one backend can&apos;t be replayed on another, so switching
+              starts a fresh agent session. Open conversations keep their existing messages, but{' '}
+              {pendingName} won&apos;t have their earlier context. New conversations are unaffected.
+            </AlertDialog.Description>
+            <div className="mt-6 flex justify-end gap-2">
+              <AlertDialog.Cancel asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </AlertDialog.Cancel>
+              <AlertDialog.Action asChild>
+                <Button type="button" onClick={confirmSwitch}>
+                  Switch
+                </Button>
+              </AlertDialog.Action>
+            </div>
+          </AlertDialog.Content>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
     </SettingsSection>
   )
 }

--- a/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
+++ b/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
@@ -20,7 +20,7 @@ const KNOWN_FRAMEWORKS: AgentFrameworkView[] = [
   {
     id: 'opencode',
     displayName: 'OpenCode',
-    supportsSkills: false,
+    supportsSkills: true,
     supportedApiTypes: ['anthropic', 'openai']
   }
 ]

--- a/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
+++ b/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
@@ -1,0 +1,61 @@
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
+import { useSettingsStore } from '@/stores/settings-store'
+import type { AgentFrameworkId } from '../../../../shared/settings'
+import { SettingsRow, SettingsSection } from './SettingsLayout'
+
+// Lets the user pick which agent backend drives their sessions. Switching persists the choice and
+// reconnects the agent (main drops the connection so the next prompt spawns the selected backend).
+const AgentFrameworkSection = (): React.JSX.Element => {
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
+  const setAgentFramework = useSettingsStore((state) => state.setAgentFramework)
+
+  // Before the first snapshot loads the list is empty; show the current id so the control is stable.
+  const currentId = agentFrameworkId ?? 'claude-code'
+  const frameworks =
+    agentFrameworks && agentFrameworks.length > 0
+      ? agentFrameworks
+      : [{ id: currentId, displayName: currentId, supportsSkills: true }]
+  const selected = frameworks.find((framework) => framework.id === currentId)
+
+  return (
+    <SettingsSection
+      title="Agent framework"
+      description={
+        <>
+          Choose which coding-agent backend drives your sessions. Switching reconnects the agent;
+          open conversations continue on the new backend.
+        </>
+      }
+      aria-label="Agent framework"
+      separated
+    >
+      <SettingsRow label="Framework" controlClassName="w-auto justify-self-end" className="pt-0">
+        <Select
+          value={currentId}
+          onValueChange={(id) => void setAgentFramework(id as AgentFrameworkId)}
+        >
+          <SelectTrigger aria-label="Agent framework">
+            <span>{selected?.displayName ?? currentId}</span>
+          </SelectTrigger>
+          <SelectContent>
+            {frameworks.map((framework) => (
+              <SelectItem key={framework.id} value={framework.id}>
+                {framework.displayName}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SettingsRow>
+
+      {selected && !selected.supportsSkills ? (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Skills aren&apos;t available with {selected.displayName}; use Claude Code for skill-based
+          workflows.
+        </p>
+      ) : null}
+    </SettingsSection>
+  )
+}
+
+export { AgentFrameworkSection }

--- a/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
+++ b/src/renderer/src/pages/settings/AgentFrameworkSection.tsx
@@ -11,8 +11,18 @@ import { SettingsRow, SettingsSection } from './SettingsLayout'
 // first snapshot arrives (or if a stale main omits the list). The snapshot's own entries take
 // precedence when present, so live displayName/capability data wins.
 const KNOWN_FRAMEWORKS: AgentFrameworkView[] = [
-  { id: 'claude-code', displayName: 'Claude Code', supportsSkills: true },
-  { id: 'opencode', displayName: 'OpenCode', supportsSkills: false }
+  {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    supportsSkills: true,
+    supportedApiTypes: ['anthropic']
+  },
+  {
+    id: 'opencode',
+    displayName: 'OpenCode',
+    supportsSkills: false,
+    supportedApiTypes: ['anthropic', 'openai']
+  }
 ]
 
 // Lets the user pick which agent backend drives their sessions. Because a session started on one

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -4,7 +4,11 @@ import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
-import type { ClaudeInstallProgressEvent, ClaudeInstallSource } from '../../../../shared/settings'
+import type {
+  ClaudeInstallProgressEvent,
+  ClaudeInstallSource,
+  ClaudeInstallSourceInfo
+} from '../../../../shared/settings'
 import { getClaudeInstallSources, getNodeInstallHint } from '../../../../shared/settings'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 import { describeInstallProgress } from './claude-install-progress'
@@ -20,6 +24,9 @@ type ClaudeInstallCardProps = {
   npmAvailable: boolean
   onInstall: (source: ClaudeInstallSource) => void
   embedded?: boolean
+  // The install sources to offer; defaults to Claude's. Pass getOpencodeInstallSources to reuse this
+  // card for OpenCode (same picker, progress bar, log pane, and copyable command).
+  sources?: ClaudeInstallSourceInfo[]
 }
 
 // Source picker + one-click installer with a progress bar and an error-aware, collapsible log pane
@@ -32,14 +39,18 @@ const ClaudeInstallCard = ({
   installError,
   npmAvailable,
   onInstall,
-  embedded = false
+  embedded = false,
+  sources
 }: ClaudeInstallCardProps): React.JSX.Element => {
   // Default to the app-managed download — it needs no Node.js/npm and works behind region blocks.
   const [source, setSource] = useState<ClaudeInstallSource>('managed')
   const [showLog, setShowLog] = useState(false)
   // Sources carry platform-specific copy (e.g. install.ps1 vs install.sh), so resolve them for the
-  // host the app is running on.
-  const installSources = useMemo(() => getClaudeInstallSources(window.api?.platform), [])
+  // host the app is running on. Caller-supplied sources (e.g. OpenCode's) take precedence.
+  const installSources = useMemo(
+    () => sources ?? getClaudeInstallSources(window.api?.platform),
+    [sources]
+  )
   const nodeHint = useMemo(() => getNodeInstallHint(window.api?.platform), [])
   const selectedSource = installSources.find((item) => item.id === source)
   const npmMissing = source === 'npm' && !npmAvailable

--- a/src/renderer/src/pages/settings/GeneralPanel.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.tsx
@@ -5,6 +5,7 @@ import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { GitHubStarBadge } from '@/components/GitHubStarBadge'
 import { Button } from '@/components/ui/button'
 import { APP } from '../../../../shared/app-config'
+import { AgentFrameworkSection } from './AgentFrameworkSection'
 import { AppVersionSection } from './AppVersionSection'
 import { SettingsRow, SettingsSection } from './SettingsLayout'
 
@@ -72,6 +73,8 @@ const GeneralPanel = (): React.JSX.Element => {
   return (
     <div className="space-y-5 p-5">
       <AppVersionSection />
+
+      <AgentFrameworkSection />
 
       <SettingsSection
         title="Diagnostics"

--- a/src/renderer/src/pages/settings/GeneralPanel.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.tsx
@@ -5,7 +5,6 @@ import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { GitHubStarBadge } from '@/components/GitHubStarBadge'
 import { Button } from '@/components/ui/button'
 import { APP } from '../../../../shared/app-config'
-import { AgentFrameworkSection } from './AgentFrameworkSection'
 import { AppVersionSection } from './AppVersionSection'
 import { SettingsRow, SettingsSection } from './SettingsLayout'
 
@@ -73,8 +72,6 @@ const GeneralPanel = (): React.JSX.Element => {
   return (
     <div className="space-y-5 p-5">
       <AppVersionSection />
-
-      <AgentFrameworkSection />
 
       <SettingsSection
         title="Diagnostics"

--- a/src/renderer/src/pages/settings/ModelFrameworkCompatibilityAlert.render.test.tsx
+++ b/src/renderer/src/pages/settings/ModelFrameworkCompatibilityAlert.render.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentFrameworkView, ProviderView } from '../../../../shared/settings'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { ModelFrameworkCompatibilityAlert } from './ModelFrameworkCompatibilityAlert'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  useSettingsStore.setState(createInitialSettingsState())
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+const provider = (overrides: Partial<ProviderView>): ProviderView => ({
+  id: 'p',
+  type: 'custom',
+  name: 'Gateway',
+  models: ['m'],
+  hasKey: true,
+  needsKey: false,
+  ...overrides
+})
+
+const FRAMEWORKS: AgentFrameworkView[] = [
+  {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    supportsSkills: true,
+    supportedApiTypes: ['anthropic']
+  },
+  {
+    id: 'opencode',
+    displayName: 'OpenCode',
+    supportsSkills: true,
+    supportedApiTypes: ['anthropic', 'openai']
+  }
+]
+
+const render = (): void => {
+  act(() => root.render(<ModelFrameworkCompatibilityAlert />))
+}
+
+describe('ModelFrameworkCompatibilityAlert', () => {
+  it('renders nothing when no provider is active', () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: FRAMEWORKS,
+      providers: [provider({ id: 'p1', apiType: 'openai' })],
+      activeProviderId: undefined
+    })
+    render()
+
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('renders nothing when the active provider is compatible with the framework', () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: FRAMEWORKS,
+      providers: [provider({ id: 'p1', apiType: 'anthropic' })],
+      activeProviderId: 'p1'
+    })
+    render()
+
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('warns when the active model is incompatible with the selected framework', () => {
+    // Claude Code (anthropic-only) with an active OpenAI-only provider — the screenshot case.
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: FRAMEWORKS,
+      providers: [provider({ id: 'p1', name: 'DeepSeek', apiType: 'openai' })],
+      activeProviderId: 'p1'
+    })
+    render()
+
+    const alert = container.querySelector('[role="alert"]')
+    expect(alert).not.toBeNull()
+    expect(alert?.textContent).toContain('Claude Code')
+    expect(alert?.textContent).toContain('DeepSeek')
+  })
+
+  it('warns when a Local Claude provider is active under a non-Claude framework', () => {
+    // A claude-default provider is Claude-only regardless of endpoint, so OpenCode can't use it.
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: FRAMEWORKS,
+      providers: [
+        provider({ id: 'p1', name: 'Local Claude', type: 'claude-default', apiType: 'anthropic' })
+      ],
+      activeProviderId: 'p1'
+    })
+    render()
+
+    const alert = container.querySelector('[role="alert"]')
+    expect(alert).not.toBeNull()
+    expect(alert?.textContent).toContain('OpenCode')
+  })
+
+  it('clears the warning after switching to a compatible framework', () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: FRAMEWORKS,
+      providers: [provider({ id: 'p1', apiType: 'openai' })],
+      activeProviderId: 'p1'
+    })
+    render()
+    expect(container.querySelector('[role="alert"]')).not.toBeNull()
+
+    // OpenCode drives the OpenAI endpoint, so the mismatch resolves.
+    act(() => useSettingsStore.setState({ agentFrameworkId: 'opencode' }))
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+})

--- a/src/renderer/src/pages/settings/ModelFrameworkCompatibilityAlert.tsx
+++ b/src/renderer/src/pages/settings/ModelFrameworkCompatibilityAlert.tsx
@@ -1,0 +1,49 @@
+import { AlertTriangle } from 'lucide-react'
+
+import { selectFrameworkApiEndpoints, useSettingsStore } from '@/stores/settings-store'
+import { isProviderUsableByFramework } from '../../../../shared/settings'
+
+// Settings-time compatibility guard for the Model panel. The active provider must be able to drive the
+// selected agent framework (endpoint + provider-type; a Local Claude provider is Claude-only). When the
+// current pair is incompatible, this surfaces the same mismatch the spawn path would otherwise raise
+// only when a conversation fails to start — so the user can fix it here (switch model or framework)
+// instead of discovering it mid-chat. Renders nothing while the pair is compatible or no provider is
+// active.
+const ModelFrameworkCompatibilityAlert = (): React.JSX.Element | null => {
+  const providers = useSettingsStore((state) => state.providers)
+  const activeProviderId = useSettingsStore((state) => state.activeProviderId)
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
+  const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
+
+  const active = providers.find((provider) => provider.id === activeProviderId)
+  if (!active) return null
+
+  const compatible = isProviderUsableByFramework(
+    { apiType: active.apiType ?? 'anthropic', type: active.type },
+    { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
+  )
+  if (compatible) return null
+
+  const frameworkName =
+    agentFrameworks.find((framework) => framework.id === agentFrameworkId)?.displayName ??
+    agentFrameworkId
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-xs text-amber-600 dark:text-amber-400"
+    >
+      <AlertTriangle className="mt-px size-4 shrink-0" aria-hidden="true" />
+      <div className="space-y-0.5">
+        <p className="font-medium">Active model isn&apos;t compatible with {frameworkName}</p>
+        <p className="text-amber-700/90 dark:text-amber-400/80">
+          {active.name} can&apos;t drive {frameworkName}. Pick a compatible model below, or switch
+          the agent framework above — otherwise conversations on this framework won&apos;t start.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export { ModelFrameworkCompatibilityAlert }

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.render.test.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.render.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { OpencodeStatusCard } from './OpencodeStatusCard'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const render = (
+  props: Partial<React.ComponentProps<typeof OpencodeStatusCard>> = {}
+): (() => void) => {
+  const onInstall = props.onInstall ?? vi.fn()
+
+  act(() => {
+    root.render(
+      <OpencodeStatusCard
+        opencode={{}}
+        isDetecting={false}
+        onDetect={vi.fn()}
+        isInstalling={false}
+        installLogs={[]}
+        installProgress={null}
+        installError={undefined}
+        npmAvailable
+        onInstall={onInstall}
+        {...props}
+      />
+    )
+  })
+
+  return onInstall as () => void
+}
+
+describe('OpencodeStatusCard', () => {
+  it('shows the path and version when opencode is detected, and no install picker', () => {
+    render({ opencode: { resolvedPath: '/usr/local/bin/opencode', version: '1.18.3' } })
+
+    expect(container.textContent).toContain('OpenCode is installed')
+    expect(container.textContent).toContain('/usr/local/bin/opencode')
+    expect(container.textContent).toContain('1.18.3')
+    expect(container.querySelector('[aria-label="Install source"]')).toBeNull()
+  })
+
+  it('shows the install-source picker (managed default) when opencode is not detected', () => {
+    render({ opencode: {} })
+
+    expect(container.textContent).toContain('OpenCode not detected')
+    const trigger = container.querySelector('[aria-label="Install source"]')
+    expect(trigger?.tagName).toBe('BUTTON')
+    expect(trigger?.textContent).toContain('App-managed download (recommended)')
+  })
+})

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
@@ -33,7 +33,7 @@ const OpencodeStatusCard = ({
               <XCircle className="size-4 text-muted-foreground" aria-hidden="true" />
             )}
             <span className="text-sm font-medium text-foreground">
-              {found ? 'opencode is installed' : 'opencode not detected'}
+              {found ? 'OpenCode is installed' : 'OpenCode not detected'}
             </span>
           </div>
           <Button
@@ -58,9 +58,9 @@ const OpencodeStatusCard = ({
           </dl>
         ) : (
           <p className="mt-3 text-xs text-muted-foreground">
-            Install opencode (see{' '}
+            Install OpenCode (see{' '}
             <ExternalTextLink href="https://opencode.ai/docs">opencode.ai/docs</ExternalTextLink>),
-            then re-detect. Your opencode providers and login are used as-is.
+            then re-detect.
           </p>
         )}
       </CardContent>

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
@@ -1,24 +1,32 @@
-import { CheckCircle2, RefreshCw, XCircle } from 'lucide-react'
+import { CheckCircle2, Download, RefreshCw, XCircle } from 'lucide-react'
 
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import type { OpencodeInfo } from '../../../../shared/settings'
+import type { ClaudeInstallProgressEvent, OpencodeInfo } from '../../../../shared/settings'
 
 type OpencodeStatusCardProps = {
   opencode: OpencodeInfo
   isDetecting: boolean
   onDetect: () => void
+  // App-managed install (first recommendation, like Claude) shown when opencode isn't detected.
+  isInstalling: boolean
+  installProgress: ClaudeInstallProgressEvent | null
+  installError: string | undefined
+  onInstall: () => void
 }
 
-// Shows whether a runnable opencode executable was found (with its resolved path) plus a re-detect
-// action, mirroring ClaudeStatusCard. opencode is installed by the user (e.g. `brew install opencode`);
-// the app only detects it, so a missing binary links to opencode's install docs rather than offering
-// an in-app install.
+// Shows whether a runnable opencode executable was found (path + version) plus a re-detect action,
+// mirroring ClaudeStatusCard. When not detected it offers an app-managed install (downloads the native
+// binary, first recommendation) with a link to opencode's docs for a manual install.
 const OpencodeStatusCard = ({
   opencode,
   isDetecting,
-  onDetect
+  onDetect,
+  isInstalling,
+  installProgress,
+  installError,
+  onInstall
 }: OpencodeStatusCardProps): React.JSX.Element => {
   const found = Boolean(opencode.resolvedPath)
 
@@ -63,11 +71,29 @@ const OpencodeStatusCard = ({
             ) : null}
           </dl>
         ) : (
-          <p className="mt-3 text-xs text-muted-foreground">
-            Install OpenCode (see{' '}
-            <ExternalTextLink href="https://opencode.ai/docs">opencode.ai/docs</ExternalTextLink>),
-            then re-detect.
-          </p>
+          <div className="mt-3 space-y-3">
+            <p className="text-xs text-muted-foreground">
+              Install OpenCode with one click, or install it manually (see{' '}
+              <ExternalTextLink href="https://opencode.ai/docs">opencode.ai/docs</ExternalTextLink>)
+              and re-detect.
+            </p>
+            <Button type="button" onClick={onInstall} disabled={isInstalling}>
+              <Download className={isInstalling ? 'animate-pulse' : ''} aria-hidden="true" />
+              {isInstalling ? 'Installing…' : 'Install OpenCode'}
+            </Button>
+            {isInstalling && installProgress ? (
+              <p className="text-xs text-muted-foreground" role="status">
+                {installProgress.phase === 'downloading' && installProgress.totalBytes
+                  ? `Downloading… ${Math.round(((installProgress.receivedBytes ?? 0) / installProgress.totalBytes) * 100)}%`
+                  : `${installProgress.phase}…`}
+              </p>
+            ) : null}
+            {installError ? (
+              <p className="text-xs text-destructive" role="alert">
+                {installError}
+              </p>
+            ) : null}
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
@@ -55,6 +55,12 @@ const OpencodeStatusCard = ({
                 {opencode.resolvedPath}
               </dd>
             </div>
+            {opencode.version ? (
+              <div className="flex gap-2">
+                <dt className="shrink-0">Version</dt>
+                <dd className="font-mono text-foreground/80">{opencode.version}</dd>
+              </div>
+            ) : null}
           </dl>
         ) : (
           <p className="mt-3 text-xs text-muted-foreground">

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
@@ -1,0 +1,71 @@
+import { CheckCircle2, RefreshCw, XCircle } from 'lucide-react'
+
+import { ExternalTextLink } from '@/components/ExternalTextLink'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import type { OpencodeInfo } from '../../../../shared/settings'
+
+type OpencodeStatusCardProps = {
+  opencode: OpencodeInfo
+  isDetecting: boolean
+  onDetect: () => void
+}
+
+// Shows whether a runnable opencode executable was found (with its resolved path) plus a re-detect
+// action, mirroring ClaudeStatusCard. opencode is installed by the user (e.g. `brew install opencode`);
+// the app only detects it, so a missing binary links to opencode's install docs rather than offering
+// an in-app install.
+const OpencodeStatusCard = ({
+  opencode,
+  isDetecting,
+  onDetect
+}: OpencodeStatusCardProps): React.JSX.Element => {
+  const found = Boolean(opencode.resolvedPath)
+
+  return (
+    <Card className="gap-0 rounded-lg py-0">
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            {found ? (
+              <CheckCircle2 className="size-4 text-primary" aria-hidden="true" />
+            ) : (
+              <XCircle className="size-4 text-muted-foreground" aria-hidden="true" />
+            )}
+            <span className="text-sm font-medium text-foreground">
+              {found ? 'opencode is installed' : 'opencode not detected'}
+            </span>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onDetect}
+            disabled={isDetecting}
+          >
+            <RefreshCw className={isDetecting ? 'animate-spin' : ''} aria-hidden="true" />
+            {isDetecting ? 'Detecting…' : 'Re-detect'}
+          </Button>
+        </div>
+        {found ? (
+          <dl className="mt-3 space-y-1 text-xs text-muted-foreground">
+            <div className="flex gap-2">
+              <dt className="shrink-0">Path</dt>
+              <dd className="truncate font-mono text-foreground/80" title={opencode.resolvedPath}>
+                {opencode.resolvedPath}
+              </dd>
+            </div>
+          </dl>
+        ) : (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Install opencode (see{' '}
+            <ExternalTextLink href="https://opencode.ai/docs">opencode.ai/docs</ExternalTextLink>),
+            then re-detect. Your opencode providers and login are used as-is.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export { OpencodeStatusCard }

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
@@ -1,19 +1,28 @@
-import { CheckCircle2, Download, RefreshCw, XCircle } from 'lucide-react'
+import { useMemo } from 'react'
+import { CheckCircle2, RefreshCw, XCircle } from 'lucide-react'
 
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import type { ClaudeInstallProgressEvent, OpencodeInfo } from '../../../../shared/settings'
+import type {
+  ClaudeInstallProgressEvent,
+  ClaudeInstallSource,
+  OpencodeInfo
+} from '../../../../shared/settings'
+import { getOpencodeInstallSources } from '../../../../shared/settings'
+import { ClaudeInstallCard } from './ClaudeInstallCard'
 
 type OpencodeStatusCardProps = {
   opencode: OpencodeInfo
   isDetecting: boolean
   onDetect: () => void
-  // App-managed install (first recommendation, like Claude) shown when opencode isn't detected.
+  // Install picker (managed / npm / script, managed first) shown when opencode isn't detected.
   isInstalling: boolean
+  installLogs: string[]
   installProgress: ClaudeInstallProgressEvent | null
   installError: string | undefined
-  onInstall: () => void
+  npmAvailable: boolean
+  onInstall: (source: ClaudeInstallSource) => void
 }
 
 // Shows whether a runnable opencode executable was found (path + version) plus a re-detect action,
@@ -24,11 +33,14 @@ const OpencodeStatusCard = ({
   isDetecting,
   onDetect,
   isInstalling,
+  installLogs,
   installProgress,
   installError,
+  npmAvailable,
   onInstall
 }: OpencodeStatusCardProps): React.JSX.Element => {
   const found = Boolean(opencode.resolvedPath)
+  const installSources = useMemo(() => getOpencodeInstallSources(window.api?.platform), [])
 
   return (
     <Card className="gap-0 rounded-lg py-0">
@@ -73,26 +85,20 @@ const OpencodeStatusCard = ({
         ) : (
           <div className="mt-3 space-y-3">
             <p className="text-xs text-muted-foreground">
-              Install OpenCode with one click, or install it manually (see{' '}
+              OpenCode is required for this framework. Install it below, or install it manually (see{' '}
               <ExternalTextLink href="https://opencode.ai/docs">opencode.ai/docs</ExternalTextLink>)
               and re-detect.
             </p>
-            <Button type="button" onClick={onInstall} disabled={isInstalling}>
-              <Download className={isInstalling ? 'animate-pulse' : ''} aria-hidden="true" />
-              {isInstalling ? 'Installing…' : 'Install OpenCode'}
-            </Button>
-            {isInstalling && installProgress ? (
-              <p className="text-xs text-muted-foreground" role="status">
-                {installProgress.phase === 'downloading' && installProgress.totalBytes
-                  ? `Downloading… ${Math.round(((installProgress.receivedBytes ?? 0) / installProgress.totalBytes) * 100)}%`
-                  : `${installProgress.phase}…`}
-              </p>
-            ) : null}
-            {installError ? (
-              <p className="text-xs text-destructive" role="alert">
-                {installError}
-              </p>
-            ) : null}
+            <ClaudeInstallCard
+              embedded
+              sources={installSources}
+              isInstalling={isInstalling}
+              installLogs={installLogs}
+              installProgress={installProgress}
+              installError={installError}
+              npmAvailable={npmAvailable}
+              onInstall={onInstall}
+            />
           </div>
         )}
       </CardContent>

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -118,30 +118,33 @@ describe('ProviderForm field switching', () => {
     expect(keyInput?.value).toBe('')
   })
 
-  it('moves custom-provider descriptions into three generic field-help tooltips', async () => {
+  it('moves custom-provider descriptions into generic field-help tooltips', async () => {
     render(createEmptyProviderFormValue({ type: 'custom' }))
     const helpButtons = Array.from(
       container.querySelectorAll<HTMLButtonElement>('[data-slot="field-help"]')
     )
 
-    expect(helpButtons).toHaveLength(3)
+    expect(helpButtons).toHaveLength(4)
     expect(
       helpButtons.every((button) => button.getAttribute('aria-label') === 'More information')
     ).toBe(true)
     expect(container.textContent).not.toContain(
-      'Anthropic /v1/messages-compatible base URL, key, and model'
+      'Base URL, key, and model for an Anthropic or OpenAI-compatible endpoint'
     )
-    expect(container.textContent).not.toContain('Only Anthropic')
+    expect(container.textContent).not.toContain('Which chat API this gateway speaks')
 
     await act(async () => helpButtons[0]?.focus())
     expect(document.body.textContent).toContain(
-      'Anthropic /v1/messages-compatible base URL, key, and model'
+      'Base URL, key, and model for an Anthropic or OpenAI-compatible endpoint'
     )
 
     await act(async () => helpButtons[1]?.focus())
-    expect(document.body.textContent).toContain('Only Anthropic /v1/messages–compatible gateways')
+    expect(document.body.textContent).toContain('The gateway root')
 
     await act(async () => helpButtons[2]?.focus())
+    expect(document.body.textContent).toContain('Which chat API this gateway speaks')
+
+    await act(async () => helpButtons[3]?.focus())
     expect(document.body.textContent).toContain('Your key stays private.')
   })
 

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -49,9 +49,23 @@ const fieldErrorClassName = 'text-xs text-destructive'
 // Static field guidance stays close to the form while FieldHelp remains content-agnostic.
 const BASE_URL_HELP_CONTENT = (
   <>
-    Only Anthropic <code>/v1/messages</code>–compatible gateways are supported (an Anthropic-format
-    endpoint, not an OpenAI-compatible one). Give the root — a trailing <code>/v1</code> is added
-    automatically.
+    The gateway root; a trailing <code>/v1</code> is added automatically. Choose the API format
+    below to match the endpoint.
+  </>
+)
+
+// Human labels for the provider API format (which chat endpoint the gateway speaks).
+const API_FORMAT_LABELS: Record<'anthropic' | 'openai' | 'both', string> = {
+  anthropic: 'Anthropic (/v1/messages)',
+  openai: 'OpenAI (/v1/chat/completions)',
+  both: 'Both'
+}
+
+const API_FORMAT_HELP_CONTENT = (
+  <>
+    Which chat API this gateway speaks. Claude Code only works with Anthropic{' '}
+    <code>/v1/messages</code>; OpenCode works with either. A provider is only selectable under an
+    agent framework that supports its format.
   </>
 )
 
@@ -223,6 +237,30 @@ const ProviderForm = ({
                 {errors.baseUrl}
               </p>
             ) : null}
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-1">
+              <span className={fieldLabelClassName}>API format</span>
+              <FieldHelp content={API_FORMAT_HELP_CONTENT} />
+            </div>
+            <Select
+              value={value.apiType}
+              onValueChange={(apiType) =>
+                onChange({ apiType: apiType as ProviderFormValue['apiType'] })
+              }
+            >
+              <SelectTrigger aria-label="API format" disabled={disabled}>
+                <span>{API_FORMAT_LABELS[value.apiType]}</span>
+              </SelectTrigger>
+              <SelectContent>
+                {(['anthropic', 'openai', 'both'] as const).map((apiType) => (
+                  <SelectItem key={apiType} value={apiType}>
+                    {API_FORMAT_LABELS[apiType]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           {keyField}

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -218,4 +218,30 @@ describe('ProviderList', () => {
 
     expect(container.textContent).toContain('No providers yet')
   })
+
+  it('badges the chat endpoint a provider speaks, defaulting to Anthropic when unset', () => {
+    renderList([provider({ apiType: undefined })])
+
+    const badge = container.querySelector(
+      '[aria-label="Speaks the Anthropic /v1/messages endpoint"]'
+    )
+    expect(badge).not.toBeNull()
+    expect(badge?.textContent).toContain('Anthropic')
+  })
+
+  it('badges an OpenAI-compatible provider distinctly', () => {
+    renderList([provider({ apiType: 'openai' })])
+
+    const badge = container.querySelector(
+      '[aria-label="Speaks the OpenAI-compatible /v1/chat/completions endpoint"]'
+    )
+    expect(badge).not.toBeNull()
+    expect(badge?.textContent).toContain('OpenAI')
+  })
+
+  it('badges a dual-endpoint provider with both APIs', () => {
+    renderList([provider({ apiType: 'both' })])
+
+    expect(container.textContent).toContain('Anthropic · OpenAI')
+  })
 })

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -222,9 +222,7 @@ describe('ProviderList', () => {
   it('badges the chat endpoint a provider speaks, defaulting to Anthropic when unset', () => {
     renderList([provider({ apiType: undefined })])
 
-    const badge = container.querySelector(
-      '[aria-label="Speaks the Anthropic /v1/messages endpoint"]'
-    )
+    const badge = container.querySelector('[aria-label="Speaks the /v1/messages endpoint"]')
     expect(badge).not.toBeNull()
     // Shows the raw route path (not a vendor name) plus a route icon, so it can't be read as a provider.
     expect(badge?.textContent).toContain('/v1/messages')
@@ -234,9 +232,7 @@ describe('ProviderList', () => {
   it('badges an OpenAI-compatible provider distinctly', () => {
     renderList([provider({ apiType: 'openai' })])
 
-    const badge = container.querySelector(
-      '[aria-label="Speaks the OpenAI-compatible /v1/chat/completions endpoint"]'
-    )
+    const badge = container.querySelector('[aria-label="Speaks the /v1/chat/completions endpoint"]')
     expect(badge).not.toBeNull()
     expect(badge?.textContent).toContain('/v1/chat/completions')
   })

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -226,7 +226,9 @@ describe('ProviderList', () => {
       '[aria-label="Speaks the Anthropic /v1/messages endpoint"]'
     )
     expect(badge).not.toBeNull()
-    expect(badge?.textContent).toContain('Anthropic')
+    // Shows the raw route path (not a vendor name) plus a route icon, so it can't be read as a provider.
+    expect(badge?.textContent).toContain('/v1/messages')
+    expect(badge?.querySelector('svg')).not.toBeNull()
   })
 
   it('badges an OpenAI-compatible provider distinctly', () => {
@@ -236,12 +238,12 @@ describe('ProviderList', () => {
       '[aria-label="Speaks the OpenAI-compatible /v1/chat/completions endpoint"]'
     )
     expect(badge).not.toBeNull()
-    expect(badge?.textContent).toContain('OpenAI')
+    expect(badge?.textContent).toContain('/v1/chat/completions')
   })
 
-  it('badges a dual-endpoint provider with both APIs', () => {
+  it('badges a dual-endpoint provider with both routes', () => {
     renderList([provider({ apiType: 'both' })])
 
-    expect(container.textContent).toContain('Anthropic · OpenAI')
+    expect(container.textContent).toContain('/v1/messages · /v1/chat/completions')
   })
 })

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -1,6 +1,10 @@
 import { CircleCheck, Pencil, PlugZap, TriangleAlert, Trash2 } from 'lucide-react'
 
-import type { ProviderValidationFailure, ProviderView } from '../../../../shared/settings'
+import type {
+  ProviderApiType,
+  ProviderValidationFailure,
+  ProviderView
+} from '../../../../shared/settings'
 import { providerValidationFailed } from '../../../../shared/settings'
 import { getOfficialVendor } from '../../../../shared/provider-registry'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -36,6 +40,18 @@ const describeValidationFailure = (failure: ProviderValidationFailure): string =
       return 'Test failed: the connection timed out.'
     default:
       return failure.message ? `Test failed: ${failure.message}` : 'Connection test failed.'
+  }
+}
+
+// Short label + full description for the chat endpoint a provider speaks. Surfaced as a badge so the
+// user can see at a glance which agent frameworks a provider can drive: Claude Code needs the Anthropic
+// /v1/messages shape, while OpenCode also accepts the OpenAI /v1/chat/completions shape.
+const ENDPOINT_LABELS: Record<ProviderApiType, { short: string; full: string }> = {
+  anthropic: { short: 'Anthropic', full: 'Anthropic /v1/messages endpoint' },
+  openai: { short: 'OpenAI', full: 'OpenAI-compatible /v1/chat/completions endpoint' },
+  both: {
+    short: 'Anthropic · OpenAI',
+    full: 'both the Anthropic /v1/messages and OpenAI /v1/chat/completions endpoints'
   }
 }
 
@@ -84,6 +100,8 @@ const ProviderList = ({
           // The provider sourcing the selected model (and the last remaining one) can't be deleted:
           // removing it would leave no model to run, so its delete action stays disabled.
           const canDelete = !isActiveSource && providers.length > 1
+          // The chat endpoint(s) this provider speaks; defaults to Anthropic when unset (older/custom).
+          const endpoint = ENDPOINT_LABELS[provider.apiType ?? 'anthropic']
 
           return (
             <li
@@ -104,6 +122,17 @@ const ProviderList = ({
                       />
                       {describeType(provider)}
                     </span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className="inline-flex shrink-0 items-center rounded border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                          aria-label={`Speaks the ${endpoint.full}`}
+                        >
+                          {endpoint.short}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>Speaks the {endpoint.full}</TooltipContent>
+                    </Tooltip>
                     {isBusy ? (
                       <span className="shrink-0 text-[10px] text-muted-foreground">Testing…</span>
                     ) : failure ? (

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -48,11 +48,11 @@ const describeValidationFailure = (failure: ProviderValidationFailure): string =
 // the provider's own name/brand: Claude Code needs the Anthropic /v1/messages route, while OpenCode also
 // accepts the OpenAI /v1/chat/completions route.
 const ENDPOINT_LABELS: Record<ProviderApiType, { path: string; full: string }> = {
-  anthropic: { path: '/v1/messages', full: 'Anthropic /v1/messages endpoint' },
-  openai: { path: '/v1/chat/completions', full: 'OpenAI-compatible /v1/chat/completions endpoint' },
+  anthropic: { path: '/v1/messages', full: '/v1/messages endpoint' },
+  openai: { path: '/v1/chat/completions', full: '/v1/chat/completions endpoint' },
   both: {
     path: '/v1/messages · /v1/chat/completions',
-    full: 'both the Anthropic /v1/messages and OpenAI /v1/chat/completions endpoints'
+    full: '/v1/messages and /v1/chat/completions endpoints'
   }
 }
 

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -1,4 +1,4 @@
-import { CircleCheck, Pencil, PlugZap, TriangleAlert, Trash2 } from 'lucide-react'
+import { CircleCheck, Pencil, PlugZap, Route, TriangleAlert, Trash2 } from 'lucide-react'
 
 import type {
   ProviderApiType,
@@ -43,14 +43,15 @@ const describeValidationFailure = (failure: ProviderValidationFailure): string =
   }
 }
 
-// Short label + full description for the chat endpoint a provider speaks. Surfaced as a badge so the
-// user can see at a glance which agent frameworks a provider can drive: Claude Code needs the Anthropic
-// /v1/messages shape, while OpenCode also accepts the OpenAI /v1/chat/completions shape.
-const ENDPOINT_LABELS: Record<ProviderApiType, { short: string; full: string }> = {
-  anthropic: { short: 'Anthropic', full: 'Anthropic /v1/messages endpoint' },
-  openai: { short: 'OpenAI', full: 'OpenAI-compatible /v1/chat/completions endpoint' },
+// Endpoint route + full description for the chat API a provider speaks. Rendered as a route-icon badge
+// showing the raw /v1 path (not a vendor name) so the user reads it as "which API shape", distinct from
+// the provider's own name/brand: Claude Code needs the Anthropic /v1/messages route, while OpenCode also
+// accepts the OpenAI /v1/chat/completions route.
+const ENDPOINT_LABELS: Record<ProviderApiType, { path: string; full: string }> = {
+  anthropic: { path: '/v1/messages', full: 'Anthropic /v1/messages endpoint' },
+  openai: { path: '/v1/chat/completions', full: 'OpenAI-compatible /v1/chat/completions endpoint' },
   both: {
-    short: 'Anthropic · OpenAI',
+    path: '/v1/messages · /v1/chat/completions',
     full: 'both the Anthropic /v1/messages and OpenAI /v1/chat/completions endpoints'
   }
 }
@@ -125,10 +126,11 @@ const ProviderList = ({
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <span
-                          className="inline-flex shrink-0 items-center rounded border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                          className="inline-flex shrink-0 items-center gap-1 rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
                           aria-label={`Speaks the ${endpoint.full}`}
                         >
-                          {endpoint.short}
+                          <Route className="size-3" strokeWidth={2} aria-hidden="true" />
+                          {endpoint.path}
                         </span>
                       </TooltipTrigger>
                       <TooltipContent>Speaks the {endpoint.full}</TooltipContent>

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -14,7 +14,20 @@ let root: Root
 const installApi = (): void => {
   ;(window as unknown as { api: unknown }).api = {
     settings: {
-      getSettings: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
+      getSettings: vi.fn().mockResolvedValue({
+        claude: {},
+        opencode: {},
+        providers: [],
+        agentFrameworkId: 'claude-code',
+        agentFrameworks: [{ id: 'claude-code', displayName: 'Claude Code', supportsSkills: true }]
+      }),
+      detectOpencode: vi.fn().mockResolvedValue({
+        claude: {},
+        opencode: {},
+        providers: [],
+        agentFrameworkId: 'claude-code',
+        agentFrameworks: [{ id: 'claude-code', displayName: 'Claude Code', supportsSkills: true }]
+      }),
       getPreflight: vi.fn().mockResolvedValue({ claudeReady: true, activeProviderReady: true }),
       isEncryptionAvailable: vi.fn().mockResolvedValue(true),
       isNpmAvailable: vi.fn().mockResolvedValue(true),

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -200,7 +200,8 @@ describe('SettingsPage layout', () => {
       generalTab?.click()
     })
 
-    expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(3)
+    // Agent framework + Diagnostics + Community (AppVersion is not a settings-section).
+    expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(4)
     expect(document.body.querySelector('[data-slot="settings-row"]')).not.toBeNull()
 
     // The Diagnostics panel surfaces the log file path plus Open and Reveal controls.

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -142,7 +142,9 @@ describe('SettingsPage layout', () => {
     // The Model panel content is present (Claude + Providers sections).
     expect(document.body.textContent).toContain('Claude')
     expect(document.body.textContent).toContain('Providers')
-    expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(2)
+    expect(document.body.textContent).toContain('Agent framework')
+    // Agent framework + Claude + Providers.
+    expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(3)
     expect(document.body.querySelector('[data-slot="settings-row"]')).not.toBeNull()
   })
 
@@ -200,8 +202,7 @@ describe('SettingsPage layout', () => {
       generalTab?.click()
     })
 
-    // Agent framework + Diagnostics + Community (AppVersion is not a settings-section).
-    expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(4)
+    expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(3)
     expect(document.body.querySelector('[data-slot="settings-row"]')).not.toBeNull()
 
     // The Diagnostics panel surfaces the log file path plus Open and Reveal controls.

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -19,6 +19,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
 import { AgentFrameworkSection } from './AgentFrameworkSection'
+import { ModelFrameworkCompatibilityAlert } from './ModelFrameworkCompatibilityAlert'
 import { ClaudeInstallCard } from './ClaudeInstallCard'
 import { ClaudeStatusCard } from './ClaudeStatusCard'
 import { OpencodeStatusCard } from './OpencodeStatusCard'
@@ -666,6 +667,8 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                 ) : (
                   <div className="space-y-5 p-5">
                     <AgentFrameworkSection />
+
+                    <ModelFrameworkCompatibilityAlert />
 
                     {agentFrameworkId === 'opencode' ? (
                       <SettingsSection title="OpenCode" aria-label="OpenCode">

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -674,9 +674,11 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                           isDetecting={isDetectingOpencode}
                           onDetect={() => void detectOpencode()}
                           isInstalling={isInstalling}
+                          installLogs={installLogs}
                           installProgress={installProgress}
                           installError={installError}
-                          onInstall={() => void installOpencode()}
+                          npmAvailable={npmAvailable}
+                          onInstall={(source) => void installOpencode(source)}
                         />
                       </SettingsSection>
                     ) : (

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -56,6 +56,7 @@ const toFormValue = (provider: ProviderView): ProviderFormValue =>
     name: provider.name,
     baseUrl: provider.baseUrl ?? '',
     model: provider.model ?? '',
+    apiType: provider.apiType ?? 'anthropic',
     vendorId: provider.vendorId,
     region: provider.region
   })
@@ -69,6 +70,7 @@ const toUpsertRequest = (
   name: value.name,
   baseUrl: value.baseUrl,
   model: value.model,
+  apiType: value.apiType,
   vendorId: value.vendorId,
   region: value.region,
   key: value.key || undefined

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -136,6 +136,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const opencode = useSettingsStore((state) => state.opencode)
   const isDetectingOpencode = useSettingsStore((state) => state.isDetectingOpencode)
   const detectOpencode = useSettingsStore((state) => state.detectOpencode)
+  const installOpencode = useSettingsStore((state) => state.installOpencode)
   const isInstalling = useSettingsStore((state) => state.isInstalling)
   const installLogs = useSettingsStore((state) => state.installLogs)
   const installProgress = useSettingsStore((state) => state.installProgress)
@@ -670,6 +671,10 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                           opencode={opencode}
                           isDetecting={isDetectingOpencode}
                           onDetect={() => void detectOpencode()}
+                          isInstalling={isInstalling}
+                          installProgress={installProgress}
+                          installError={installError}
+                          onInstall={() => void installOpencode()}
                         />
                       </SettingsSection>
                     ) : (

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -21,6 +21,7 @@ import { useSettingsStore } from '@/stores/settings-store'
 import { AgentFrameworkSection } from './AgentFrameworkSection'
 import { ClaudeInstallCard } from './ClaudeInstallCard'
 import { ClaudeStatusCard } from './ClaudeStatusCard'
+import { OpencodeStatusCard } from './OpencodeStatusCard'
 import { GeneralPanel } from './GeneralPanel'
 import { StoragePanel } from './StoragePanel'
 import { SkillsPanel, type SkillsView } from './SkillsPanel'
@@ -131,6 +132,10 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const providers = useSettingsStore((state) => state.providers)
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
   const isDetectingClaude = useSettingsStore((state) => state.isDetectingClaude)
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const opencode = useSettingsStore((state) => state.opencode)
+  const isDetectingOpencode = useSettingsStore((state) => state.isDetectingOpencode)
+  const detectOpencode = useSettingsStore((state) => state.detectOpencode)
   const isInstalling = useSettingsStore((state) => state.isInstalling)
   const installLogs = useSettingsStore((state) => state.installLogs)
   const installProgress = useSettingsStore((state) => state.installProgress)
@@ -195,6 +200,19 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   useEffect(() => {
     if (pendingSkillId !== undefined) consumePendingSkill()
   }, [pendingSkillId, consumePendingSkill])
+
+  // Auto-detect opencode the first time its detection card is shown without a known path, so the card
+  // reflects reality without a manual re-detect. Guarded on path + in-flight to run at most once.
+  useEffect(() => {
+    if (
+      open &&
+      agentFrameworkId === 'opencode' &&
+      !opencode?.resolvedPath &&
+      !isDetectingOpencode
+    ) {
+      void detectOpencode()
+    }
+  }, [open, agentFrameworkId, opencode?.resolvedPath, isDetectingOpencode, detectOpencode])
 
   const currentLocation = history[historyIndex]
   const activePanel = currentLocation.panel
@@ -646,26 +664,36 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                   <div className="space-y-5 p-5">
                     <AgentFrameworkSection />
 
-                    <SettingsSection title="Claude" aria-label="Claude">
-                      <div className="space-y-3">
-                        <ClaudeStatusCard
-                          claude={claude}
-                          claudeReady={preflight.claudeReady}
-                          isDetecting={isDetectingClaude}
-                          onDetect={() => void detectClaude()}
+                    {agentFrameworkId === 'opencode' ? (
+                      <SettingsSection title="opencode" aria-label="opencode">
+                        <OpencodeStatusCard
+                          opencode={opencode}
+                          isDetecting={isDetectingOpencode}
+                          onDetect={() => void detectOpencode()}
                         />
-                        {!preflight.claudeReady ? (
-                          <ClaudeInstallCard
-                            isInstalling={isInstalling}
-                            installLogs={installLogs}
-                            installProgress={installProgress}
-                            installError={installError}
-                            npmAvailable={npmAvailable}
-                            onInstall={(source) => void installClaude(source)}
+                      </SettingsSection>
+                    ) : (
+                      <SettingsSection title="Claude" aria-label="Claude">
+                        <div className="space-y-3">
+                          <ClaudeStatusCard
+                            claude={claude}
+                            claudeReady={preflight.claudeReady}
+                            isDetecting={isDetectingClaude}
+                            onDetect={() => void detectClaude()}
                           />
-                        ) : null}
-                      </div>
-                    </SettingsSection>
+                          {!preflight.claudeReady ? (
+                            <ClaudeInstallCard
+                              isInstalling={isInstalling}
+                              installLogs={installLogs}
+                              installProgress={installProgress}
+                              installError={installError}
+                              npmAvailable={npmAvailable}
+                              onInstall={(source) => void installClaude(source)}
+                            />
+                          ) : null}
+                        </div>
+                      </SettingsSection>
+                    )}
 
                     <SettingsSection
                       title="Providers"

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
+import { AgentFrameworkSection } from './AgentFrameworkSection'
 import { ClaudeInstallCard } from './ClaudeInstallCard'
 import { ClaudeStatusCard } from './ClaudeStatusCard'
 import { GeneralPanel } from './GeneralPanel'
@@ -643,6 +644,8 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                   </div>
                 ) : (
                   <div className="space-y-5 p-5">
+                    <AgentFrameworkSection />
+
                     <SettingsSection title="Claude" aria-label="Claude">
                       <div className="space-y-3">
                         <ClaudeStatusCard

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -440,7 +440,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
           {/* Radix requires a Title/Description for a11y; the visible panel title lives in the header. */}
           <Dialog.Title className="sr-only">Settings</Dialog.Title>
           <Dialog.Description className="sr-only">
-            Manage your Claude installation and model providers.
+            Manage your agent runtime and model providers.
           </Dialog.Description>
 
           {/* Left navigation: grouped settings panels (Capabilities, Workspace). */}

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -665,7 +665,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                     <AgentFrameworkSection />
 
                     {agentFrameworkId === 'opencode' ? (
-                      <SettingsSection title="opencode" aria-label="opencode">
+                      <SettingsSection title="OpenCode" aria-label="OpenCode">
                         <OpencodeStatusCard
                           opencode={opencode}
                           isDetecting={isDetectingOpencode}

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -1,4 +1,4 @@
-import type { ProviderType } from '../../../../shared/settings'
+import type { ProviderApiType, ProviderType } from '../../../../shared/settings'
 import {
   OFFICIAL_VENDORS,
   getOfficialVendor,
@@ -12,6 +12,9 @@ export type ProviderFormValue = {
   name: string
   baseUrl: string
   model: string
+  // Which chat API a custom gateway speaks; drives which agent frameworks can use it. Defaults to
+  // 'anthropic'. Only meaningful for custom providers (official providers take it from the registry).
+  apiType: ProviderApiType
   // Set when type is 'official': the chosen vendor and (for multi-region vendors) the endpoint. Base
   // URL and the model catalog then come from the registry rather than these free-text fields.
   vendorId?: OfficialVendorId
@@ -28,6 +31,7 @@ export const createEmptyProviderFormValue = (
   name: '',
   baseUrl: '',
   model: '',
+  apiType: 'anthropic',
   key: '',
   ...overrides
 })
@@ -87,7 +91,7 @@ export const PROVIDER_KINDS: ProviderKind[] = [
   {
     key: 'custom',
     label: 'Custom Gateway',
-    description: 'Anthropic /v1/messages-compatible base URL, key, and model',
+    description: 'Base URL, key, and model for an Anthropic or OpenAI-compatible endpoint',
     group: 'other'
   },
   {

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -46,6 +46,20 @@ describe('ComposerModelPicker', () => {
     expect(container.querySelector('[aria-label="No model available — open settings"]')).toBeNull()
   })
 
+  it('warns (does not hide) when the only provider is incompatible with the framework', () => {
+    // Claude Code (anthropic-only) + a lone OpenAI-only provider: the picker must not silently vanish.
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      providers: [provider({ id: 'p1', apiType: 'openai', models: ['gpt-x'] })]
+    })
+    render()
+
+    expect(container.querySelector('[aria-label="Select model"]')).toBeNull()
+    const warning = container.querySelector('[aria-label="No compatible model — open settings"]')
+    expect(warning).not.toBeNull()
+    expect(warning?.textContent).toContain('No compatible model')
+  })
+
   it('warns and opens settings when no model is configured', () => {
     const openSettings = vi.fn()
     useSettingsStore.setState({ providers: [], openSettings })

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -8,6 +8,43 @@ import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { incompatibilityReason } from './composer-model-picker-utils'
 
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Radix DropdownMenu/Tooltip mount real portals and run layout/pointer plumbing that jsdom omits.
+// These shims let the genuine components open (and their portaled content mount) under jsdom so the
+// test can drive the real open/hover/click behaviour instead of mocking the menu into the DOM.
+Element.prototype.scrollIntoView = Element.prototype.scrollIntoView ?? ((): void => {})
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => {}
+  Element.prototype.releasePointerCapture = (): void => {}
+}
+if (!(globalThis as { ResizeObserver?: unknown }).ResizeObserver) {
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe(): void {
+      /* no-op shim for Radix layout measurement in jsdom */
+    }
+    unobserve(): void {
+      /* no-op */
+    }
+    disconnect(): void {
+      /* no-op */
+    }
+  }
+}
+if (!globalThis.matchMedia) {
+  ;(globalThis as { matchMedia?: unknown }).matchMedia = (): unknown => ({
+    matches: false,
+    media: '',
+    onchange: null,
+    addEventListener: (): void => {},
+    removeEventListener: (): void => {},
+    addListener: (): void => {},
+    removeListener: (): void => {},
+    dispatchEvent: (): boolean => false
+  })
+}
+
 let container: HTMLDivElement
 let root: Root
 
@@ -38,6 +75,28 @@ const render = (): void => {
   act(() => root.render(<ComposerModelPicker />))
 }
 
+// The repo carries no @testing-library/user-event (no @testing-library at all — every existing
+// interaction test drives the DOM via raw createRoot + act). These helpers dispatch the same real
+// events user-event would, against the real Radix DropdownMenu: keyboard-open the menu, native-click
+// a (portaled) menu item.
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+const openMenu = async (trigger: Element): Promise<void> => {
+  // Radix DropdownMenuTrigger toggles open on Enter/Space keydown; this is the interaction jsdom
+  // supports most reliably and it mounts the portaled content.
+  act(() => {
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+  })
+  await flush()
+}
+
+const menuItems = (): HTMLElement[] =>
+  Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+
 describe('ComposerModelPicker', () => {
   it('renders nothing when there is a single selectable option', () => {
     useSettingsStore.setState({ providers: [provider({ id: 'p1', models: ['only'] })] })
@@ -55,10 +114,114 @@ describe('ComposerModelPicker', () => {
     })
     render()
 
+    // The picker surfaces as a warning trigger (not the plain "Select model") so it stays visible.
     expect(container.querySelector('[aria-label="Select model"]')).toBeNull()
-    const warning = container.querySelector('[aria-label="No compatible model — open settings"]')
-    expect(warning).not.toBeNull()
-    expect(warning?.textContent).toContain('No compatible model')
+    const trigger = container.querySelector('[aria-label="No compatible model"]')
+    expect(trigger).not.toBeNull()
+    expect(trigger?.textContent).toContain('No compatible model')
+  })
+
+  it('exposes each incompatible provider reason as a focusable, non-actionable menu item', async () => {
+    // Claude Code (anthropic-only) + only OpenAI-speaking providers: the menu must state why each
+    // provider is unavailable in an item roving focus can reach (not a label or a disabled item, both
+    // keyboard-unreachable), keep it unselectable, and still offer a way out to Settings.
+    const openSettings = vi.fn()
+    const setActiveProvider = vi.fn()
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: [
+        {
+          id: 'claude-code',
+          displayName: 'Claude Code',
+          supportedApiTypes: ['anthropic'],
+          supportsSkills: true
+        }
+      ],
+      providers: [
+        provider({ id: 'p1', apiType: 'openai', name: 'OpenAI Gateway', models: ['gpt-x'] })
+      ],
+      openSettings,
+      setActiveProvider
+    })
+    render()
+
+    const expectedReason = incompatibilityReason(
+      { apiType: 'openai', type: 'custom', name: 'OpenAI Gateway' },
+      'Claude Code',
+      ['anthropic']
+    )
+    expect(expectedReason).toContain('/v1/messages')
+    expect(expectedReason).toContain('/v1/chat/completions')
+
+    // Surfaces as the warning trigger. Its content is portaled and only mounts once opened.
+    const trigger = container.querySelector('[aria-label="No compatible model"]')
+    expect(trigger).not.toBeNull()
+    expect(document.querySelector('[role="menuitem"]')).toBeNull()
+
+    // 1. Open the dropdown.
+    await openMenu(trigger!)
+
+    // 2. The reason lives in a real menu item (reached by arrow-key roving focus), carries the full
+    // reason as visible text, and is marked unselectable.
+    const reasonItem = menuItems().find((el) => el.textContent?.includes(expectedReason))
+    expect(reasonItem, 'expected a menu item carrying the incompatibility reason').toBeDefined()
+    expect(reasonItem?.textContent).toContain('OpenAI Gateway')
+    expect(reasonItem?.textContent).toContain('Claude Code')
+    expect(reasonItem?.getAttribute('aria-disabled')).toBe('true')
+    // A Radix `disabled` item is skipped by roving focus; the reason item must NOT be disabled so a
+    // keyboard user can land on it — proven by the absence of the data-disabled marker.
+    expect(reasonItem?.hasAttribute('data-disabled')).toBe(false)
+
+    // 2b. Prove keyboard ARROW roving focus can actually land on the reason item — the point of
+    // leaving it aria-disabled rather than Radix-`disabled`. Absence of data-disabled alone only
+    // shows the `disabled` prop was avoided; a Radix-`disabled` item would be dropped from the
+    // roving-focus ring entirely and never reachable by arrow keys. Here we drive the real
+    // ArrowDown/ArrowUp roving focus and assert document.activeElement moves off, then back ONTO,
+    // the reason item via the arrow keys.
+    const content = document.querySelector<HTMLElement>('[role="menu"]')
+    expect(content, 'expected the portaled menu content to be mounted').not.toBeNull()
+    // Radix's RovingFocusGroup defers the focus move to a macrotask (setTimeout), so a microtask
+    // flush isn't enough — drain real timers after each arrow key.
+    const flushTimers = async (): Promise<void> => {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+    }
+    const arrowKey = async (key: 'ArrowDown' | 'ArrowUp'): Promise<void> => {
+      const target = (document.activeElement as Element | null) ?? content!
+      act(() => {
+        target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }))
+      })
+      await flushTimers()
+    }
+    // Keyboard-opening the menu lands roving focus on the first item, which is the reason item.
+    expect(
+      document.activeElement,
+      'keyboard-open should place roving focus on the first (reason) item'
+    ).toBe(reasonItem)
+    // Step off it with ArrowDown (onto the next real item), then back onto it with ArrowUp — proving
+    // arrow-key navigation genuinely traverses to the reason item rather than skipping it.
+    await arrowKey('ArrowDown')
+    expect(
+      document.activeElement,
+      'ArrowDown must move roving focus off the reason item onto the next item'
+    ).not.toBe(reasonItem)
+    expect((document.activeElement as HTMLElement | null)?.textContent).toContain('Open Settings')
+    await arrowKey('ArrowUp')
+    expect(
+      document.activeElement,
+      'ArrowUp must bring roving focus back onto the incompatibility reason item'
+    ).toBe(reasonItem)
+
+    // 3. Activating the reason item must not switch the model (it is informational only).
+    act(() => reasonItem!.click())
+    expect(setActiveProvider).not.toHaveBeenCalled()
+
+    // 4. Open Settings still works as the escape hatch.
+    const openSettingsItem = menuItems().find((el) => el.textContent?.includes('Open Settings'))
+    expect(openSettingsItem, 'expected an "Open Settings" menu item').toBeDefined()
+    act(() => openSettingsItem!.click())
+    expect(openSettings).toHaveBeenCalledTimes(1)
   })
 
   it('warns and opens settings when no model is configured', () => {

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ProviderView } from '../../../../shared/settings'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import { ComposerModelPicker } from './ComposerModelPicker'
+import { incompatibilityReason } from './composer-model-picker-utils'
 
 let container: HTMLDivElement
 let root: Root
@@ -92,6 +93,30 @@ describe('ComposerModelPicker', () => {
     expect(
       container.querySelector('[aria-label="No model available — open settings"]')
     ).not.toBeNull()
+  })
+
+  it('explains an endpoint mismatch by route, not by vendor name', () => {
+    const reason = incompatibilityReason(
+      { apiType: 'openai', type: 'custom', name: 'OpenAI Gateway' },
+      'Claude Code',
+      ['anthropic']
+    )
+
+    expect(reason).toContain('OpenAI Gateway')
+    expect(reason).toContain('Claude Code')
+    expect(reason).toContain('/v1/messages')
+    expect(reason).toContain('/v1/chat/completions')
+  })
+
+  it('explains a local Claude provider is only usable by Claude Code', () => {
+    const reason = incompatibilityReason(
+      { apiType: 'anthropic', type: 'claude-default', name: 'Local Claude' },
+      'OpenCode',
+      ['anthropic', 'openai']
+    )
+
+    expect(reason).toContain('local Claude sign-in')
+    expect(reason).toContain('only Claude Code can run')
   })
 
   it('shows the active model label when multiple options exist', () => {

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -19,6 +19,7 @@ import {
   type ProviderModelOption
 } from '@/stores/settings-store'
 import { isProviderUsableByFramework } from '../../../../shared/settings'
+import { incompatibilityReason } from './composer-model-picker-utils'
 
 const triggerClassName =
   'flex h-8 max-w-[220px] items-center gap-1 rounded-md px-2.5 text-sm text-text-300 hover:bg-bg-200 hover:text-text-100 disabled:cursor-not-allowed disabled:opacity-50 transition-colors'
@@ -38,7 +39,12 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
   const setActiveProvider = useSettingsStore((state) => state.setActiveProvider)
   const openSettings = useSettingsStore((state) => state.openSettings)
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
   const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
+
+  const frameworkName =
+    agentFrameworks.find((framework) => framework.id === agentFrameworkId)?.displayName ??
+    'this framework'
 
   // A provider is selectable only when it can actually drive the current framework (endpoint + type;
   // a Local Claude provider is Claude-only).
@@ -126,7 +132,20 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
               <DropdownMenuLabel>
                 {group.provider.name}
                 {compatible ? null : (
-                  <span className="ml-1 font-normal text-text-300">· unavailable</span>
+                  <span
+                    className="ml-1 cursor-help font-normal text-text-300 underline decoration-dotted underline-offset-2"
+                    title={incompatibilityReason(
+                      {
+                        apiType: group.provider.apiType ?? 'anthropic',
+                        type: group.provider.type,
+                        name: group.provider.name
+                      },
+                      frameworkName,
+                      frameworkEndpoints
+                    )}
+                  >
+                    · unavailable
+                  </span>
                 )}
               </DropdownMenuLabel>
               {group.options.map((option) => {

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -7,9 +7,9 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { ProviderKindIcon } from '../settings/provider-icons'
 import { providerKindKey } from '../settings/provider-form-value'
@@ -60,29 +60,28 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
     providers.filter((provider) => isCompatible(provider)).map((provider) => provider.id)
   )
   const usableOptions = options.filter((option) => compatibleProviderIds.has(option.providerId))
+  const hasUsable = usableOptions.length > 0
 
-  // No option the current framework can actually use: warn instead of hiding so the toolbar isn't a
-  // silent dead end (this also catches the case where the only configured provider is incompatible
-  // with the selected framework). Clicking opens Settings to add/fix a provider or switch frameworks.
-  if (usableOptions.length === 0) {
-    const label = options.length === 0 ? 'No model available' : 'No compatible model'
-
+  // No provider configured at all: nothing to pick or explain, so warn with a button that opens
+  // Settings rather than leaving the toolbar a silent dead end.
+  if (options.length === 0) {
     return (
       <button
         type="button"
         onClick={() => openSettings()}
         className="flex h-8 items-center gap-1.5 rounded-md px-2.5 text-sm text-amber-700 hover:bg-amber-50 transition-colors"
-        aria-label={`${label} — open settings`}
+        aria-label="No model available — open settings"
       >
         <AlertTriangle className="size-4 shrink-0" strokeWidth={2} aria-hidden="true" />
-        <span className="truncate">{label}</span>
+        <span className="truncate">No model available</span>
       </button>
     )
   }
 
-  // A single option (the sole provider, which is usable since usableOptions is non-empty) leaves
-  // nothing to switch between, so the picker stays hidden.
-  if (options.length === 1) return null
+  // A single usable option leaves nothing to switch between, so the picker stays hidden. When the
+  // sole provider is incompatible we instead fall through to the dropdown (hasUsable is false) so its
+  // incompatibility reason stays reachable — an all-incompatible framework must never silently vanish.
+  if (options.length === 1 && hasUsable) return null
 
   // The active option matches by provider and model; an undefined activeModel maps to the empty-model
   // "default" entry.
@@ -102,70 +101,61 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className={triggerClassName} aria-label="Select model">
-          {current ? (
-            <ProviderKindIcon
-              kindKey={providerKindKey(current.providerType, current.vendorId)}
-              className="size-4"
-            />
-          ) : null}
-          <span className="truncate">
-            {current ? (
-              <>
-                <span className="font-medium text-text-100">{optionLabel(current)}</span>
-                {current.model ? (
-                  <span className="ml-1.5 text-text-300">· {current.providerName}</span>
-                ) : null}
-              </>
-            ) : (
-              'Select model'
-            )}
-          </span>
+        <Button
+          variant="ghost"
+          className={cn(triggerClassName, !hasUsable && 'text-amber-700 hover:text-amber-700')}
+          aria-label={hasUsable ? 'Select model' : 'No compatible model'}
+        >
+          {hasUsable ? (
+            <>
+              {current ? (
+                <ProviderKindIcon
+                  kindKey={providerKindKey(current.providerType, current.vendorId)}
+                  className="size-4"
+                />
+              ) : null}
+              <span className="truncate">
+                {current ? (
+                  <>
+                    <span className="font-medium text-text-100">{optionLabel(current)}</span>
+                    {current.model ? (
+                      <span className="ml-1.5 text-text-300">· {current.providerName}</span>
+                    ) : null}
+                  </>
+                ) : (
+                  'Select model'
+                )}
+              </span>
+            </>
+          ) : (
+            <>
+              <AlertTriangle className="size-4 shrink-0" strokeWidth={2} aria-hidden="true" />
+              <span className="truncate">No compatible model</span>
+            </>
+          )}
           <ChevronDown className="size-3.5 shrink-0" aria-hidden="true" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="max-h-[320px] min-w-[15rem] overflow-y-auto">
-        <TooltipProvider delayDuration={150}>
-          {groups.map((group) => {
-            const compatible = isCompatible(group.provider)
+        {groups.map((group) => {
+          const compatible = isCompatible(group.provider)
+          const reason = compatible
+            ? undefined
+            : incompatibilityReason(
+                {
+                  apiType: group.provider.apiType ?? 'anthropic',
+                  type: group.provider.type,
+                  name: group.provider.name
+                },
+                frameworkName,
+                frameworkEndpoints
+              )
 
-            return (
-              <DropdownMenuGroup key={group.provider.id}>
-                <DropdownMenuLabel>
-                  {group.provider.name}
-                  {compatible ? null : (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span
-                          className="ml-1 cursor-help font-normal text-text-300 underline decoration-dotted underline-offset-2"
-                          aria-label={incompatibilityReason(
-                            {
-                              apiType: group.provider.apiType ?? 'anthropic',
-                              type: group.provider.type,
-                              name: group.provider.name
-                            },
-                            frameworkName,
-                            frameworkEndpoints
-                          )}
-                        >
-                          · unavailable
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent side="right" className="max-w-xs">
-                        {incompatibilityReason(
-                          {
-                            apiType: group.provider.apiType ?? 'anthropic',
-                            type: group.provider.type,
-                            name: group.provider.name
-                          },
-                          frameworkName,
-                          frameworkEndpoints
-                        )}
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                </DropdownMenuLabel>
-                {group.options.map((option) => {
+          return (
+            <DropdownMenuGroup key={group.provider.id}>
+              <DropdownMenuLabel>{group.provider.name}</DropdownMenuLabel>
+              {compatible ? (
+                group.options.map((option) => {
                   const isActive =
                     option.providerId === activeProviderId && option.model === activeKeyModel
 
@@ -174,7 +164,6 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
                       key={`${option.providerId}:${option.model}`}
                       role="menuitemradio"
                       aria-checked={isActive}
-                      disabled={!compatible}
                       onSelect={() => void setActiveProvider(option.providerId, option.model)}
                       className={cn('gap-2', isActive && 'font-medium')}
                     >
@@ -192,11 +181,35 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
                       ) : null}
                     </DropdownMenuItem>
                   )
-                })}
-              </DropdownMenuGroup>
-            )
-          })}
-        </TooltipProvider>
+                })
+              ) : (
+                // An incompatible provider gets one focusable, non-actionable item that states WHY it
+                // is unavailable. It stays keyboard-reachable via roving focus (a `disabled` item is
+                // skipped, and a label is not focusable at all), and its visible text is the reason —
+                // so mouse and keyboard/AT users get it without a hover-only tooltip. aria-disabled
+                // marks it unselectable and onSelect is prevented so it never switches the model.
+                <DropdownMenuItem
+                  aria-disabled
+                  onSelect={(event) => event.preventDefault()}
+                  className="items-start gap-2 text-text-300"
+                >
+                  <AlertTriangle
+                    className="mt-0.5 size-4 shrink-0"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  />
+                  <span className="min-w-0 flex-1 whitespace-normal">{reason}</span>
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuGroup>
+          )
+        })}
+        {hasUsable ? null : (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => openSettings()}>Open Settings</DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { ProviderKindIcon } from '../settings/provider-icons'
 import { providerKindKey } from '../settings/provider-form-value'
@@ -124,61 +125,78 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="max-h-[320px] min-w-[15rem] overflow-y-auto">
-        {groups.map((group) => {
-          const compatible = isCompatible(group.provider)
+        <TooltipProvider delayDuration={150}>
+          {groups.map((group) => {
+            const compatible = isCompatible(group.provider)
 
-          return (
-            <DropdownMenuGroup key={group.provider.id}>
-              <DropdownMenuLabel>
-                {group.provider.name}
-                {compatible ? null : (
-                  <span
-                    className="ml-1 cursor-help font-normal text-text-300 underline decoration-dotted underline-offset-2"
-                    title={incompatibilityReason(
-                      {
-                        apiType: group.provider.apiType ?? 'anthropic',
-                        type: group.provider.type,
-                        name: group.provider.name
-                      },
-                      frameworkName,
-                      frameworkEndpoints
-                    )}
-                  >
-                    · unavailable
-                  </span>
-                )}
-              </DropdownMenuLabel>
-              {group.options.map((option) => {
-                const isActive =
-                  option.providerId === activeProviderId && option.model === activeKeyModel
+            return (
+              <DropdownMenuGroup key={group.provider.id}>
+                <DropdownMenuLabel>
+                  {group.provider.name}
+                  {compatible ? null : (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className="ml-1 cursor-help font-normal text-text-300 underline decoration-dotted underline-offset-2"
+                          aria-label={incompatibilityReason(
+                            {
+                              apiType: group.provider.apiType ?? 'anthropic',
+                              type: group.provider.type,
+                              name: group.provider.name
+                            },
+                            frameworkName,
+                            frameworkEndpoints
+                          )}
+                        >
+                          · unavailable
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className="max-w-xs">
+                        {incompatibilityReason(
+                          {
+                            apiType: group.provider.apiType ?? 'anthropic',
+                            type: group.provider.type,
+                            name: group.provider.name
+                          },
+                          frameworkName,
+                          frameworkEndpoints
+                        )}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </DropdownMenuLabel>
+                {group.options.map((option) => {
+                  const isActive =
+                    option.providerId === activeProviderId && option.model === activeKeyModel
 
-                return (
-                  <DropdownMenuItem
-                    key={`${option.providerId}:${option.model}`}
-                    role="menuitemradio"
-                    aria-checked={isActive}
-                    disabled={!compatible}
-                    onSelect={() => void setActiveProvider(option.providerId, option.model)}
-                    className={cn('gap-2', isActive && 'font-medium')}
-                  >
-                    <ProviderKindIcon
-                      kindKey={providerKindKey(option.providerType, option.vendorId)}
-                      className="size-4 shrink-0"
-                    />
-                    <span className="min-w-0 flex-1 truncate">{optionLabel(option)}</span>
-                    {isActive ? (
-                      <Check
-                        className="size-4 shrink-0 text-primary"
-                        strokeWidth={2}
-                        aria-hidden="true"
+                  return (
+                    <DropdownMenuItem
+                      key={`${option.providerId}:${option.model}`}
+                      role="menuitemradio"
+                      aria-checked={isActive}
+                      disabled={!compatible}
+                      onSelect={() => void setActiveProvider(option.providerId, option.model)}
+                      className={cn('gap-2', isActive && 'font-medium')}
+                    >
+                      <ProviderKindIcon
+                        kindKey={providerKindKey(option.providerType, option.vendorId)}
+                        className="size-4 shrink-0"
                       />
-                    ) : null}
-                  </DropdownMenuItem>
-                )
-              })}
-            </DropdownMenuGroup>
-          )
-        })}
+                      <span className="min-w-0 flex-1 truncate">{optionLabel(option)}</span>
+                      {isActive ? (
+                        <Check
+                          className="size-4 shrink-0 text-primary"
+                          strokeWidth={2}
+                          aria-hidden="true"
+                        />
+                      ) : null}
+                    </DropdownMenuItem>
+                  )
+                })}
+              </DropdownMenuGroup>
+            )
+          })}
+        </TooltipProvider>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -13,10 +13,12 @@ import { cn } from '@/lib/utils'
 import { ProviderKindIcon } from '../settings/provider-icons'
 import { providerKindKey } from '../settings/provider-form-value'
 import {
+  selectFrameworkApiEndpoints,
   selectProviderModelOptions,
   useSettingsStore,
   type ProviderModelOption
 } from '@/stores/settings-store'
+import { isProviderCompatibleWith } from '../../../../shared/settings'
 
 const triggerClassName =
   'flex h-8 max-w-[220px] items-center gap-1 rounded-md px-2.5 text-sm text-text-300 hover:bg-bg-200 hover:text-text-100 disabled:cursor-not-allowed disabled:opacity-50 transition-colors'
@@ -35,6 +37,11 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
   const activeModel = useSettingsStore((state) => state.activeModel)
   const setActiveProvider = useSettingsStore((state) => state.setActiveProvider)
   const openSettings = useSettingsStore((state) => state.openSettings)
+  const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
+
+  // A provider is selectable only when its API format is one the current framework can drive.
+  const isCompatible = (provider: (typeof providers)[number]): boolean =>
+    isProviderCompatibleWith(provider.apiType ?? 'anthropic', frameworkEndpoints)
 
   const options = selectProviderModelOptions(providers)
 
@@ -99,38 +106,48 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="max-h-[320px] min-w-[15rem] overflow-y-auto">
-        {groups.map((group) => (
-          <DropdownMenuGroup key={group.provider.id}>
-            <DropdownMenuLabel>{group.provider.name}</DropdownMenuLabel>
-            {group.options.map((option) => {
-              const isActive =
-                option.providerId === activeProviderId && option.model === activeKeyModel
+        {groups.map((group) => {
+          const compatible = isCompatible(group.provider)
 
-              return (
-                <DropdownMenuItem
-                  key={`${option.providerId}:${option.model}`}
-                  role="menuitemradio"
-                  aria-checked={isActive}
-                  onSelect={() => void setActiveProvider(option.providerId, option.model)}
-                  className={cn('gap-2', isActive && 'font-medium')}
-                >
-                  <ProviderKindIcon
-                    kindKey={providerKindKey(option.providerType, option.vendorId)}
-                    className="size-4 shrink-0"
-                  />
-                  <span className="min-w-0 flex-1 truncate">{optionLabel(option)}</span>
-                  {isActive ? (
-                    <Check
-                      className="size-4 shrink-0 text-primary"
-                      strokeWidth={2}
-                      aria-hidden="true"
+          return (
+            <DropdownMenuGroup key={group.provider.id}>
+              <DropdownMenuLabel>
+                {group.provider.name}
+                {compatible ? null : (
+                  <span className="ml-1 font-normal text-text-300">· unavailable</span>
+                )}
+              </DropdownMenuLabel>
+              {group.options.map((option) => {
+                const isActive =
+                  option.providerId === activeProviderId && option.model === activeKeyModel
+
+                return (
+                  <DropdownMenuItem
+                    key={`${option.providerId}:${option.model}`}
+                    role="menuitemradio"
+                    aria-checked={isActive}
+                    disabled={!compatible}
+                    onSelect={() => void setActiveProvider(option.providerId, option.model)}
+                    className={cn('gap-2', isActive && 'font-medium')}
+                  >
+                    <ProviderKindIcon
+                      kindKey={providerKindKey(option.providerType, option.vendorId)}
+                      className="size-4 shrink-0"
                     />
-                  ) : null}
-                </DropdownMenuItem>
-              )
-            })}
-          </DropdownMenuGroup>
-        ))}
+                    <span className="min-w-0 flex-1 truncate">{optionLabel(option)}</span>
+                    {isActive ? (
+                      <Check
+                        className="size-4 shrink-0 text-primary"
+                        strokeWidth={2}
+                        aria-hidden="true"
+                      />
+                    ) : null}
+                  </DropdownMenuItem>
+                )
+              })}
+            </DropdownMenuGroup>
+          )
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -18,7 +18,7 @@ import {
   useSettingsStore,
   type ProviderModelOption
 } from '@/stores/settings-store'
-import { isProviderCompatibleWith } from '../../../../shared/settings'
+import { isProviderUsableByFramework } from '../../../../shared/settings'
 
 const triggerClassName =
   'flex h-8 max-w-[220px] items-center gap-1 rounded-md px-2.5 text-sm text-text-300 hover:bg-bg-200 hover:text-text-100 disabled:cursor-not-allowed disabled:opacity-50 transition-colors'
@@ -37,32 +37,44 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
   const activeModel = useSettingsStore((state) => state.activeModel)
   const setActiveProvider = useSettingsStore((state) => state.setActiveProvider)
   const openSettings = useSettingsStore((state) => state.openSettings)
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
 
-  // A provider is selectable only when its API format is one the current framework can drive.
+  // A provider is selectable only when it can actually drive the current framework (endpoint + type;
+  // a Local Claude provider is Claude-only).
   const isCompatible = (provider: (typeof providers)[number]): boolean =>
-    isProviderCompatibleWith(provider.apiType ?? 'anthropic', frameworkEndpoints)
+    isProviderUsableByFramework(
+      { apiType: provider.apiType ?? 'anthropic', type: provider.type },
+      { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
+    )
 
   const options = selectProviderModelOptions(providers)
+  const compatibleProviderIds = new Set(
+    providers.filter((provider) => isCompatible(provider)).map((provider) => provider.id)
+  )
+  const usableOptions = options.filter((option) => compatibleProviderIds.has(option.providerId))
 
-  // No selectable (provider, model): the user has nothing to send with — either nothing is configured
-  // or every provider failed its last test. Warn instead of hiding so the empty toolbar isn't a
-  // silent dead end; clicking opens Settings to add or fix a provider.
-  if (options.length === 0) {
+  // No option the current framework can actually use: warn instead of hiding so the toolbar isn't a
+  // silent dead end (this also catches the case where the only configured provider is incompatible
+  // with the selected framework). Clicking opens Settings to add/fix a provider or switch frameworks.
+  if (usableOptions.length === 0) {
+    const label = options.length === 0 ? 'No model available' : 'No compatible model'
+
     return (
       <button
         type="button"
         onClick={() => openSettings()}
         className="flex h-8 items-center gap-1.5 rounded-md px-2.5 text-sm text-amber-700 hover:bg-amber-50 transition-colors"
-        aria-label="No model available — open settings"
+        aria-label={`${label} — open settings`}
       >
         <AlertTriangle className="size-4 shrink-0" strokeWidth={2} aria-hidden="true" />
-        <span className="truncate">No model available</span>
+        <span className="truncate">{label}</span>
       </button>
     )
   }
 
-  // A single option leaves nothing to switch between, so the picker stays hidden.
+  // A single option (the sole provider, which is usable since usableOptions is non-empty) leaves
+  // nothing to switch between, so the picker stays hidden.
   if (options.length === 1) return null
 
   // The active option matches by provider and model; an undefined activeModel maps to the empty-model

--- a/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx
@@ -61,6 +61,38 @@ describe('WorkspaceAgentLoadingRow', () => {
     expect(container.textContent).toContain('taking longer than usual')
   })
 
+  it('updates the elapsed time live while the turn runs', () => {
+    seedRunningSession(5000)
+    act(() => root.render(<AgentLoadingIndicator sessionId="s1" />))
+
+    expect(container.textContent).toContain('0:05')
+
+    // The row ticks once a second; advancing the clock should move the label forward.
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    expect(container.textContent).toContain('0:08')
+    expect(container.textContent).not.toContain('0:05')
+  })
+
+  it('crosses into the "taking longer than usual" hint as time passes the threshold', () => {
+    // Start just under the 20s slow-hint threshold: no hint yet.
+    seedRunningSession(18_000)
+    act(() => root.render(<AgentLoadingIndicator sessionId="s1" />))
+
+    expect(container.textContent).toContain('0:18')
+    expect(container.textContent).not.toContain('taking longer than usual')
+
+    // Advance past 20s: the label keeps ticking and the slow hint appears.
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    expect(container.textContent).toContain('0:21')
+    expect(container.textContent).toContain('taking longer than usual')
+  })
+
   it('surfaces the latest agent status line when present', () => {
     seedRunningSession(3000, 'retrying request…')
     act(() => root.render(<AgentLoadingIndicator sessionId="s1" />))

--- a/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChatSession } from '@/stores/session-store'
+import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
+import { AgentLoadingIndicator } from './WorkspaceAgentLoadingRow'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+// A running session whose turn started `startedAgoMs` ago, optionally with a latest agent status line.
+const seedRunningSession = (startedAgoMs: number, agentStatus?: string): void => {
+  const session: ChatSession = {
+    id: 's1',
+    projectId: 'p1',
+    title: 's1',
+    cwd: '/workspace',
+    status: 'running',
+    messages: [],
+    activeRun: { promptMessageId: 'm1', startedAt: Date.now() - startedAgoMs },
+    agentStatus,
+    createdAt: 0,
+    updatedAt: 0
+  }
+  useSessionStore.setState({ sessions: [session], selectedSessionId: 's1' })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-07-18T00:00:00.000Z'))
+  useSessionStore.setState(createInitialSessionState())
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.useRealTimers()
+})
+
+describe('WorkspaceAgentLoadingRow', () => {
+  it('shows the elapsed time for the active turn', () => {
+    seedRunningSession(5000)
+    act(() => root.render(<AgentLoadingIndicator sessionId="s1" />))
+
+    expect(container.textContent).toContain('0:05')
+    expect(container.textContent).not.toContain('taking longer than usual')
+  })
+
+  it('adds a "taking longer than usual" hint past the threshold', () => {
+    seedRunningSession(45_000)
+    act(() => root.render(<AgentLoadingIndicator sessionId="s1" />))
+
+    expect(container.textContent).toContain('0:45')
+    expect(container.textContent).toContain('taking longer than usual')
+  })
+
+  it('surfaces the latest agent status line when present', () => {
+    seedRunningSession(3000, 'retrying request…')
+    act(() => root.render(<AgentLoadingIndicator sessionId="s1" />))
+
+    expect(container.textContent).toContain('retrying request…')
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useState } from 'react'
+
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { cn } from '@/lib/utils'
+import { useSessionStore } from '@/stores/session-store'
 
 type WorkspaceAgentLoadingRowProps = {
   sessionId: string
@@ -8,24 +11,69 @@ type WorkspaceAgentLoadingRowProps = {
 const assistantMessageSurfaceClassName =
   'relative w-full max-w-[56rem] text-sm leading-relaxed text-text-000 md:text-[15px]'
 
-// Shows an accessible interim assistant row before the first streamed text chunk arrives.
-const AgentLoadingIndicator = (): React.JSX.Element => (
-  <div className="flex min-h-5 items-center gap-1.5" role="status" aria-live="polite">
-    <span className="sr-only">Agent is responding</span>
-    <span
-      className="size-1.5 animate-pulse rounded-full bg-text-300 opacity-80"
-      aria-hidden="true"
-    />
-    <span
-      className="size-1.5 animate-pulse rounded-full bg-text-300 opacity-80 [animation-delay:150ms]"
-      aria-hidden="true"
-    />
-    <span
-      className="size-1.5 animate-pulse rounded-full bg-text-300 opacity-80 [animation-delay:300ms]"
-      aria-hidden="true"
-    />
-  </div>
+// Past this, a silent turn is likely waiting on something slow (a retrying/backing-off model request),
+// so we add a gentle hint rather than leaving the user staring at a bare spinner.
+const SLOW_HINT_AFTER_MS = 20_000
+
+// Formats an elapsed millisecond span as M:SS.
+const formatElapsed = (ms: number): string => {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}
+
+const AgentLoadingDots = (): React.JSX.Element => (
+  <span className="flex items-center gap-1.5" aria-hidden="true">
+    <span className="size-1.5 animate-pulse rounded-full bg-text-300 opacity-80" />
+    <span className="size-1.5 animate-pulse rounded-full bg-text-300 opacity-80 [animation-delay:150ms]" />
+    <span className="size-1.5 animate-pulse rounded-full bg-text-300 opacity-80 [animation-delay:300ms]" />
+  </span>
 )
+
+// Interim assistant row shown before the first streamed chunk. Beyond the bare animated dots it shows
+// how long the turn has been running (ticking) and the latest agent status line when one exists, so a
+// long wait reads as "still working" instead of a frozen spinner.
+const AgentLoadingIndicator = ({ sessionId }: WorkspaceAgentLoadingRowProps): React.JSX.Element => {
+  const startedAt = useSessionStore(
+    (state) => state.sessions.find((session) => session.id === sessionId)?.activeRun?.startedAt
+  )
+  const status = useSessionStore(
+    (state) => state.sessions.find((session) => session.id === sessionId)?.agentStatus
+  )
+  const [now, setNow] = useState(() => Date.now())
+
+  // Tick once a second so the elapsed label stays live while the turn runs.
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+
+    return () => clearInterval(timer)
+  }, [])
+
+  const elapsedMs = startedAt ? now - startedAt : 0
+  const slow = elapsedMs >= SLOW_HINT_AFTER_MS
+
+  return (
+    <div className="flex min-h-5 flex-col gap-1" role="status" aria-live="polite">
+      <div className="flex items-center gap-2 text-xs text-text-300">
+        <span className="sr-only">Agent is responding</span>
+        <AgentLoadingDots />
+        {startedAt ? (
+          <span className="tabular-nums" aria-hidden="true">
+            {formatElapsed(elapsedMs)}
+          </span>
+        ) : null}
+        {slow ? <span aria-hidden="true">· taking longer than usual</span> : null}
+      </div>
+      {status ? (
+        <span className="truncate text-[11px] text-text-300/80" title={status}>
+          {status}
+        </span>
+      ) : null}
+    </div>
+  )
+}
 
 // Places the loading indicator in the same transcript geometry as assistant messages.
 const WorkspaceAgentLoadingRow = ({
@@ -38,7 +86,7 @@ const WorkspaceAgentLoadingRow = ({
   >
     <div className="px-4 pb-1 pt-5 md:px-6">
       <div className={cn(assistantMessageSurfaceClassName, 'rounded-2xl bg-bg-200 px-3 py-2')}>
-        <AgentLoadingIndicator />
+        <AgentLoadingIndicator sessionId={sessionId} />
       </div>
     </div>
   </MessageScrollerItem>

--- a/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.tsx
@@ -92,4 +92,6 @@ const WorkspaceAgentLoadingRow = ({
   </MessageScrollerItem>
 )
 
-export { WorkspaceAgentLoadingRow }
+// AgentLoadingIndicator is exported for unit tests (WorkspaceAgentLoadingRow needs a MessageScroller
+// context, whereas the elapsed/status logic under test lives entirely in the indicator).
+export { AgentLoadingIndicator, WorkspaceAgentLoadingRow }

--- a/src/renderer/src/pages/workspace/composer-model-picker-utils.ts
+++ b/src/renderer/src/pages/workspace/composer-model-picker-utils.ts
@@ -1,0 +1,28 @@
+import {
+  providerEndpoints,
+  type ChatApiEndpoint,
+  type ProviderApiType,
+  type ProviderType
+} from '../../../../shared/settings'
+
+// Human-readable route for an endpoint, so a reason reads as a route rather than a vendor name.
+const ENDPOINT_ROUTE: Record<ChatApiEndpoint, string> = {
+  anthropic: '/v1/messages',
+  openai: '/v1/chat/completions'
+}
+
+const routeList = (endpoints: readonly ChatApiEndpoint[]): string =>
+  endpoints.map((endpoint) => ENDPOINT_ROUTE[endpoint]).join(' or ')
+
+// Why a provider can't drive the current framework, shown on hover next to "· unavailable". Two axes:
+// a local Claude sign-in only Claude Code can run, or a chat-endpoint mismatch.
+export const incompatibilityReason = (
+  provider: { apiType: ProviderApiType; type: ProviderType; name: string },
+  frameworkName: string,
+  frameworkEndpoints: readonly ChatApiEndpoint[]
+): string => {
+  if (provider.type === 'claude-default') {
+    return `${provider.name} uses your local Claude sign-in, which only Claude Code can run. Switch to Claude Code or pick another model.`
+  }
+  return `${frameworkName} needs ${routeList(frameworkEndpoints)}, but ${provider.name} speaks ${routeList(providerEndpoints(provider.apiType))}.`
+}

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -67,6 +67,9 @@ export type ChatSession = Omit<
   // Transient: true while a Phase 3 fix loop is active for this session. Disables the send button
   // for the duration of the loop (across reviewer-review and agent-fix sub-phases). Never persisted.
   fixLoopActive?: boolean
+  // Transient: latest agent status/stderr line for the in-flight turn, shown in the waiting indicator
+  // so a long silent wait (e.g. the agent retrying a slow request) isn't a blank spinner. Not persisted.
+  agentStatus?: string
 }
 
 type SessionStoreData = {
@@ -164,6 +167,8 @@ type SessionStore = SessionStoreData & {
   hydrateSessions: (sessions: PersistedChatSession[], manifest?: PersistedSessionManifest) => void
   finishRun: (sessionId: string) => void
   failRun: (sessionId: string, error: string) => void
+  // Sets the transient agent status line shown in the waiting indicator; only applies while running.
+  setAgentStatus: (sessionId: string, text: string) => void
   markResumed: (sessionId: string) => void
   markDisconnected: (sessionId: string) => void
   removeMessage: (sessionId: string, messageId: string) => void
@@ -202,12 +207,20 @@ const stripTransientMessageState = (message: ChatMessage): PersistedChatMessage 
 }
 
 const stripTransientSessionState = (session: ChatSession): PersistedChatSession => {
-  const { activities, isPending, interrupted, fixLoopActive, messages, ...persistedSession } =
-    session
+  const {
+    activities,
+    isPending,
+    interrupted,
+    fixLoopActive,
+    agentStatus,
+    messages,
+    ...persistedSession
+  } = session
 
   void isPending
   void interrupted
   void fixLoopActive
+  void agentStatus
 
   // Persist a bounded projection of tool activities so the transcript survives restarts.
   const persistedActivities = activities
@@ -512,6 +525,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
                 ...session,
                 status: 'running',
                 activeRun,
+                agentStatus: undefined,
                 error: undefined,
                 messages: [...session.messages, userMessage],
                 updatedAt: now
@@ -982,6 +996,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           ...session,
           status: keepArtifactError ? 'error' : 'idle',
           activeRun: undefined,
+          agentStatus: undefined,
           error: keepArtifactError ? session.error : undefined,
           messages: completeStreamingMessages(session.messages),
           activities: completeOpenActivities(session.activities),
@@ -1004,11 +1019,28 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               ...session,
               status: 'error',
               activeRun: undefined,
+              agentStatus: undefined,
               error: message,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
               updatedAt: Date.now()
             }
+          : session
+      )
+    }))
+  },
+
+  // Records the latest agent status/stderr line for the waiting indicator. Ignored unless the session
+  // is running (a stale line must not linger after output starts or the turn ends).
+  setAgentStatus: (sessionId, text) => {
+    const trimmed = text.trim()
+
+    if (!trimmed) return
+
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId && session.status === 'running'
+          ? { ...session, agentStatus: trimmed }
           : session
       )
     }))

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -330,6 +330,190 @@ describe('settings store: environment check', () => {
     await first
   })
 
+  it('re-issues the check when the framework auto-switches mid-flight and does not stick on the stale result', async () => {
+    const claudeResult: EnvironmentCheckResult = {
+      checkedAt: 1,
+      platform: 'darwin',
+      architecture: 'arm64',
+      checks: [],
+      ready: true,
+      canAutoInstall: false,
+      agentFrameworkId: 'claude-code',
+      runtime: { found: false }
+    }
+    const opencodeResult: EnvironmentCheckResult = {
+      ...claudeResult,
+      agentFrameworkId: 'opencode',
+      runtime: { found: true, path: '/bin/opencode' }
+    }
+
+    // Each launch check gets its own controllable promise, resolved in the order the store issued them.
+    const resolvers: Array<(value: EnvironmentCheckResult) => void> = []
+    api.checkEnvironment.mockImplementation(
+      () => new Promise<EnvironmentCheckResult>((resolve) => resolvers.push(resolve))
+    )
+    // After the auto-switch, main reports OpenCode as the persisted framework.
+    api.getSettings.mockResolvedValue({ ...snapshot([]), agentFrameworkId: 'opencode' })
+    api.getPreflight.mockResolvedValue({
+      claudeReady: false,
+      opencodeReady: true,
+      activeProviderReady: true
+    })
+
+    // A: the initial launch check, issued for the default framework (claude-code).
+    const first = useSettingsStore.getState().checkEnvironment()
+    expect(api.checkEnvironment).toHaveBeenCalledTimes(1)
+
+    // The prefer-installed auto-switch selects OpenCode and re-checks while A is still in flight.
+    useSettingsStore.setState({ agentFrameworkId: 'opencode' })
+    const second = useSettingsStore.getState().checkEnvironment()
+    // The second call is NOT swallowed by the in-flight guard: a different framework re-probes.
+    expect(api.checkEnvironment).toHaveBeenCalledTimes(2)
+
+    // A (Claude) resolves first; its result belongs to the previous selection and must be discarded.
+    resolvers[0]?.(claudeResult)
+    await first
+    expect(useSettingsStore.getState().environmentCheck?.agentFrameworkId).not.toBe('claude-code')
+
+    // B (OpenCode) resolves and becomes the visible result.
+    resolvers[1]?.(opencodeResult)
+    await second
+
+    const state = useSettingsStore.getState()
+    expect(state.environmentCheck?.agentFrameworkId).toBe('opencode')
+    expect(state.environmentCheck?.ready).toBe(true)
+    expect(state.isCheckingEnvironment).toBe(false)
+
+    // The wizard's Continue predicate ends up enabled (ready, matching framework, no re-check pending),
+    // instead of being stuck disabled on a Claude result while OpenCode is selected.
+    const environmentReady =
+      !state.isCheckingEnvironment &&
+      state.environmentCheck?.ready === true &&
+      state.environmentCheck.agentFrameworkId === state.agentFrameworkId
+    expect(environmentReady).toBe(true)
+  })
+
+  it('ABA: a late stale same-framework success does not overwrite the newer result', async () => {
+    // A and C are both claude-code (B is the opencode detour), so a framework-only staleness check
+    // would wrongly treat A's late result as current. checkedAt distinguishes the two claude passes.
+    const claudeA: EnvironmentCheckResult = {
+      checkedAt: 10,
+      platform: 'darwin',
+      architecture: 'arm64',
+      checks: [],
+      ready: true,
+      canAutoInstall: false,
+      agentFrameworkId: 'claude-code',
+      runtime: { found: true, path: '/bin/claude' }
+    }
+    const claudeC: EnvironmentCheckResult = { ...claudeA, checkedAt: 30 }
+
+    // Each check gets its own deferred, resolved in the order the test chooses.
+    const deferred: Array<{
+      resolve: (value: EnvironmentCheckResult) => void
+      reject: (error: unknown) => void
+    }> = []
+    api.checkEnvironment.mockImplementation(
+      () =>
+        new Promise<EnvironmentCheckResult>((resolve, reject) => {
+          deferred.push({ resolve, reject })
+        })
+    )
+
+    // A (claude-code), auto-switch to opencode + B, auto-switch back to claude-code + C.
+    const first = useSettingsStore.getState().checkEnvironment()
+    useSettingsStore.setState({ agentFrameworkId: 'opencode' })
+    const second = useSettingsStore.getState().checkEnvironment()
+    useSettingsStore.setState({ agentFrameworkId: 'claude-code' })
+    const third = useSettingsStore.getState().checkEnvironment()
+    expect(api.checkEnvironment).toHaveBeenCalledTimes(3)
+
+    // C resolves and becomes the visible result.
+    deferred[2].resolve(claudeC)
+    await third
+    expect(useSettingsStore.getState().environmentCheck?.checkedAt).toBe(30)
+
+    // A resolves LAST with a success that shares C's framework id; the generation guard discards it.
+    deferred[0].resolve(claudeA)
+    await first
+    // B resolves too; also stale, also discarded.
+    deferred[1].resolve({ ...claudeC, agentFrameworkId: 'opencode' })
+    await second
+
+    const state = useSettingsStore.getState()
+    // C's result stands; A did not overwrite it despite sharing the framework id.
+    expect(state.environmentCheck?.checkedAt).toBe(30)
+    expect(state.environmentCheck?.agentFrameworkId).toBe('claude-code')
+    expect(state.environmentCheckError).toBeUndefined()
+    expect(state.isCheckingEnvironment).toBe(false)
+
+    const environmentReady =
+      !state.isCheckingEnvironment &&
+      state.environmentCheck?.ready === true &&
+      state.environmentCheck.agentFrameworkId === state.agentFrameworkId
+    expect(environmentReady).toBe(true)
+  })
+
+  it('ABA: a stale same-framework failure neither clears the newer loading nor overwrites its success with an error', async () => {
+    const claudeC: EnvironmentCheckResult = {
+      checkedAt: 30,
+      platform: 'darwin',
+      architecture: 'arm64',
+      checks: [],
+      ready: true,
+      canAutoInstall: false,
+      agentFrameworkId: 'claude-code',
+      runtime: { found: true, path: '/bin/claude' }
+    }
+
+    const deferred: Array<{
+      resolve: (value: EnvironmentCheckResult) => void
+      reject: (error: unknown) => void
+    }> = []
+    api.checkEnvironment.mockImplementation(
+      () =>
+        new Promise<EnvironmentCheckResult>((resolve, reject) => {
+          deferred.push({ resolve, reject })
+        })
+    )
+
+    // A (claude-code), opencode + B, back to claude-code + C — all in flight.
+    const first = useSettingsStore.getState().checkEnvironment()
+    useSettingsStore.setState({ agentFrameworkId: 'opencode' })
+    const second = useSettingsStore.getState().checkEnvironment()
+    useSettingsStore.setState({ agentFrameworkId: 'claude-code' })
+    const third = useSettingsStore.getState().checkEnvironment()
+
+    // A (the oldest pass) rejects while C is still running. Its finally must NOT clear C's loading,
+    // and its catch must NOT write environmentCheckError, because a newer generation now owns state.
+    deferred[0].reject(new Error('stale claude A failed'))
+    await first
+
+    let state = useSettingsStore.getState()
+    expect(state.isCheckingEnvironment).toBe(true)
+    expect(state.environmentCheckError).toBeUndefined()
+
+    // C then completes successfully and owns the visible state.
+    deferred[2].resolve(claudeC)
+    await third
+    // B resolves late and is discarded.
+    deferred[1].resolve({ ...claudeC, agentFrameworkId: 'opencode' })
+    await second
+
+    state = useSettingsStore.getState()
+    expect(state.environmentCheck?.checkedAt).toBe(30)
+    expect(state.environmentCheck?.agentFrameworkId).toBe('claude-code')
+    // A's rejection never polluted C's success.
+    expect(state.environmentCheckError).toBeUndefined()
+    expect(state.isCheckingEnvironment).toBe(false)
+
+    const environmentReady =
+      !state.isCheckingEnvironment &&
+      state.environmentCheck?.ready === true &&
+      state.environmentCheck.agentFrameworkId === state.agentFrameworkId
+    expect(environmentReady).toBe(true)
+  })
+
   it('surfaces a failed main-process inspection and always clears loading state', async () => {
     api.checkEnvironment.mockRejectedValue(new Error('environment IPC unavailable'))
 

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -52,7 +52,9 @@ type AcpApi = {
 const snapshot = (providers: SettingsSnapshot['providers']): SettingsSnapshot => ({
   claude: {},
   activeProviderId: undefined,
-  providers
+  providers,
+  agentFrameworkId: 'claude-code',
+  agentFrameworks: [{ id: 'claude-code', displayName: 'Claude Code', supportsSkills: true }]
 })
 
 const providerView = (id: string): SettingsSnapshot['providers'][number] => ({

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -89,7 +89,8 @@ beforeEach(() => {
       checks: [],
       ready: true,
       canAutoInstall: false,
-      claude: { found: true, path: '/bin/claude' }
+      agentFrameworkId: 'claude-code',
+      runtime: { found: true, path: '/bin/claude' }
     }),
     detectClaude: vi.fn().mockResolvedValue({ found: false }),
     detectOpencode: vi.fn().mockImplementation(() => {
@@ -323,7 +324,8 @@ describe('settings store: environment check', () => {
       checks: [],
       ready: true,
       canAutoInstall: false,
-      claude: { found: true, path: '/bin/claude' }
+      agentFrameworkId: 'claude-code',
+      runtime: { found: true, path: '/bin/claude' }
     })
     await first
   })

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -54,7 +54,8 @@ const snapshot = (providers: SettingsSnapshot['providers']): SettingsSnapshot =>
   activeProviderId: undefined,
   providers,
   agentFrameworkId: 'claude-code',
-  agentFrameworks: [{ id: 'claude-code', displayName: 'Claude Code', supportsSkills: true }]
+  agentFrameworks: [{ id: 'claude-code', displayName: 'Claude Code', supportsSkills: true }],
+  opencode: {}
 })
 
 const providerView = (id: string): SettingsSnapshot['providers'][number] => ({

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -20,6 +20,8 @@ type SettingsApi = {
   isNpmAvailable: ReturnType<typeof vi.fn>
   checkEnvironment: ReturnType<typeof vi.fn>
   detectClaude: ReturnType<typeof vi.fn>
+  detectOpencode: ReturnType<typeof vi.fn>
+  setAgentFramework: ReturnType<typeof vi.fn>
   upsertProvider: ReturnType<typeof vi.fn>
   validateProvider: ReturnType<typeof vi.fn>
   refreshProviderModels: ReturnType<typeof vi.fn>
@@ -90,6 +92,14 @@ beforeEach(() => {
       claude: { found: true, path: '/bin/claude' }
     }),
     detectClaude: vi.fn().mockResolvedValue({ found: false }),
+    detectOpencode: vi.fn().mockImplementation(() => {
+      callLog.push('detectOpencode')
+      return Promise.resolve({ ...snapshot([]), agentFrameworkId: 'opencode' })
+    }),
+    setAgentFramework: vi.fn().mockImplementation((request: { id: string }) => {
+      callLog.push(`setFramework:${request.id}`)
+      return Promise.resolve({ ...snapshot([]), agentFrameworkId: request.id })
+    }),
     upsertProvider: vi.fn(),
     validateProvider: vi.fn(),
     refreshProviderModels: vi.fn(),
@@ -704,5 +714,28 @@ describe('settings store: connectors slice', () => {
     await useSettingsStore.getState().respondApproval('req-1', 'allow')
     expect(api.respondConnectorApproval).toHaveBeenCalledWith({ id: 'req-1', decision: 'allow' })
     expect(useSettingsStore.getState().pendingApprovals).toEqual([])
+  })
+})
+
+describe('settings store: setAgentFramework', () => {
+  beforeEach(() => {
+    useSettingsStore.setState(createInitialSettingsState())
+  })
+
+  it('switches, then live-detects the selected framework and refreshes preflight', async () => {
+    await useSettingsStore.getState().setAgentFramework('opencode')
+
+    // The switch persists first, then the newly-selected framework is re-detected so a
+    // just-installed (or just-deleted) binary is reflected before the readiness gate is recomputed.
+    expect(callLog).toEqual(['setFramework:opencode', 'detectOpencode'])
+    expect(api.getPreflight).toHaveBeenCalled()
+    expect(useSettingsStore.getState().agentFrameworkId).toBe('opencode')
+  })
+
+  it('re-detects Claude when switching back to claude-code', async () => {
+    await useSettingsStore.getState().setAgentFramework('claude-code')
+
+    expect(api.detectClaude).toHaveBeenCalled()
+    expect(api.detectOpencode).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -542,6 +542,14 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   setAgentFramework: async (id) => {
     try {
       set(applySnapshot(await window.api.settings.setAgentFramework({ id })))
+      // Live-detect the newly-selected framework so a binary installed (or deleted) since the last
+      // check is reflected right away, then refresh the readiness gate the install prompt keys off.
+      if (id === 'opencode') {
+        await get().detectOpencode()
+      } else {
+        await get().detectClaude()
+      }
+      await get().refreshPreflight()
     } catch (error) {
       console.error('Failed to switch agent framework', error)
     }

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -490,9 +490,15 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     await get().refreshPreflight()
   },
 
-  // Switches the agent backend; main reconnects so the choice applies on the next prompt.
+  // Switches the agent backend; main reconnects so the choice applies on the next prompt. Surfaces
+  // failures (e.g. a stale preload bundle where the IPC is missing after a renderer-only hot reload)
+  // to the console instead of silently reverting the selector.
   setAgentFramework: async (id) => {
-    set(applySnapshot(await window.api.settings.setAgentFramework({ id })))
+    try {
+      set(applySnapshot(await window.api.settings.setAgentFramework({ id })))
+    } catch (error) {
+      console.error('Failed to switch agent framework', error)
+    }
   },
 
   // Detects the opencode executable and refreshes its status card.

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -13,6 +13,7 @@ import type {
   Preflight,
   AgentFrameworkId,
   AgentFrameworkView,
+  OpencodeInfo,
   ProviderType,
   ProviderView,
   RefreshProviderModelsResult,
@@ -54,6 +55,8 @@ type SettingsStoreData = {
   // Selected agent backend and the frameworks available to choose from.
   agentFrameworkId: AgentFrameworkId
   agentFrameworks: AgentFrameworkView[]
+  // Detected opencode executable, for the framework-aware detection card.
+  opencode: OpencodeInfo
   onboardingCompletedAt: number | undefined
   // Bundled skills with their enabled state, loaded lazily when the Skills panel opens.
   skills: SkillView[]
@@ -73,6 +76,7 @@ type SettingsStoreData = {
   // Transient UI state for the wizard/settings page.
   isCheckingEnvironment: boolean
   isDetectingClaude: boolean
+  isDetectingOpencode: boolean
   isInstalling: boolean
   installLogs: string[]
   // Latest progress tick driving the install progress bar; null when no install is active.
@@ -94,6 +98,8 @@ type SettingsStore = SettingsStoreData & {
   refreshPreflight: () => Promise<Preflight>
   checkEnvironment: () => Promise<EnvironmentCheckResult | undefined>
   detectClaude: () => Promise<ClaudeDetectResult>
+  // Detects the opencode executable and refreshes its status card.
+  detectOpencode: () => Promise<void>
   installClaude: (
     source: ClaudeInstallSource,
     managedRegistry?: ManagedClaudeRegistry
@@ -186,6 +192,7 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   providers: [],
   agentFrameworkId: 'claude-code',
   agentFrameworks: [],
+  opencode: {},
   onboardingCompletedAt: undefined,
   skills: [],
   connectors: [],
@@ -199,6 +206,7 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   environmentCheckError: undefined,
   isCheckingEnvironment: false,
   isDetectingClaude: false,
+  isDetectingOpencode: false,
   isInstalling: false,
   installLogs: [],
   installProgress: null,
@@ -216,6 +224,7 @@ const applySnapshot = (snapshot: SettingsSnapshot): Partial<SettingsStoreData> =
   providers: snapshot.providers,
   agentFrameworkId: snapshot.agentFrameworkId,
   agentFrameworks: snapshot.agentFrameworks,
+  opencode: snapshot.opencode,
   onboardingCompletedAt: snapshot.onboardingCompletedAt
 })
 
@@ -484,6 +493,17 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Switches the agent backend; main reconnects so the choice applies on the next prompt.
   setAgentFramework: async (id) => {
     set(applySnapshot(await window.api.settings.setAgentFramework({ id })))
+  },
+
+  // Detects the opencode executable and refreshes its status card.
+  detectOpencode: async () => {
+    set({ isDetectingOpencode: true })
+
+    try {
+      set(applySnapshot(await window.api.settings.detectOpencode()))
+    } finally {
+      set({ isDetectingOpencode: false })
+    }
   },
 
   deleteProvider: async (providerId) => {

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -76,6 +76,15 @@ type SettingsStoreData = {
   environmentCheckError: string | undefined
   // Transient UI state for the wizard/settings page.
   isCheckingEnvironment: boolean
+  // Framework the in-flight environment check was issued for. Used ONLY for the React Strict Mode
+  // de-dup: a same-framework duplicate mount reuses the running pass instead of double-probing.
+  // Staleness/ownership is decided by envCheckGeneration, never by this field.
+  checkingFramework: AgentFrameworkId | undefined
+  // Monotonic token stamped by each checkEnvironment call. The success/catch/finally branches only
+  // mutate shared state when their captured generation is still current, so an older pass (even one
+  // for the same framework, as in a Claude -> OpenCode -> Claude ABA sequence) can never overwrite,
+  // fail, or clear the loading flags of a newer pass.
+  envCheckGeneration: number
   isDetectingClaude: boolean
   isDetectingOpencode: boolean
   isInstalling: boolean
@@ -211,6 +220,8 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   environmentCheck: undefined,
   environmentCheckError: undefined,
   isCheckingEnvironment: false,
+  checkingFramework: undefined,
+  envCheckGeneration: 0,
   isDetectingClaude: false,
   isDetectingOpencode: false,
   isInstalling: false,
@@ -322,11 +333,28 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // their structured, non-secret result. Refresh settings/preflight afterwards because detection may
   // have discovered and persisted a Claude installation that appeared since the previous launch.
   checkEnvironment: async () => {
-    // React Strict Mode intentionally re-runs mount effects in development. The first invocation sets
-    // this flag synchronously, so later callers reuse the in-flight pass instead of probing twice.
-    if (get().isCheckingEnvironment) return get().environmentCheck
+    // React Strict Mode intentionally re-runs mount effects in development. Reuse the in-flight pass
+    // only when it targets the currently-selected framework: an auto-switch (e.g. Claude -> a detected
+    // OpenCode) changes the target mid-flight, and that call must issue its own probe rather than reuse
+    // the previous framework's, or Continue stays disabled on a result that no longer matches.
+    const framework = get().agentFrameworkId
+    if (get().isCheckingEnvironment && get().checkingFramework === framework) {
+      return get().environmentCheck
+    }
 
-    set({ isCheckingEnvironment: true, isDetectingClaude: true, environmentCheckError: undefined })
+    // Stamp a fresh generation; only the branch whose captured token is still current may mutate
+    // shared state. This defeats an ABA sequence (Claude -> OpenCode -> Claude) where an older pass
+    // shares the framework id of the newest one and would otherwise pass a framework-only staleness
+    // check.
+    const generation = get().envCheckGeneration + 1
+
+    set({
+      envCheckGeneration: generation,
+      isCheckingEnvironment: true,
+      checkingFramework: framework,
+      isDetectingClaude: true,
+      environmentCheckError: undefined
+    })
 
     try {
       const environmentCheck = await window.api.settings.checkEnvironment()
@@ -335,6 +363,16 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         window.api.settings.getPreflight(),
         window.api.settings.isNpmAvailable()
       ])
+
+      // Discard a stale result: a newer pass has stamped a later generation and now owns the visible
+      // state, so this older probe must not overwrite it (defensively also require the result to
+      // still match the selected framework).
+      if (
+        get().envCheckGeneration !== generation ||
+        environmentCheck.agentFrameworkId !== get().agentFrameworkId
+      ) {
+        return environmentCheck
+      }
 
       set({
         ...applySnapshot(snapshot),
@@ -345,13 +383,22 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
       return environmentCheck
     } catch (error) {
-      set({
-        environmentCheckError:
-          error instanceof Error ? error.message : 'Environment detection could not be completed.'
-      })
+      // A late failure from a superseded pass must not clobber a newer pass's successful result.
+      if (get().envCheckGeneration === generation) {
+        set({
+          environmentCheckError:
+            error instanceof Error ? error.message : 'Environment detection could not be completed.'
+        })
+      }
       return undefined
     } finally {
-      set({ isCheckingEnvironment: false, isDetectingClaude: false })
+      // Only clear the loading flags when this pass is still the current one; a newer pass may
+      // already be running and now owns them.
+      set((state) =>
+        state.envCheckGeneration === generation
+          ? { isCheckingEnvironment: false, checkingFramework: undefined, isDetectingClaude: false }
+          : {}
+      )
     }
   },
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -184,6 +184,9 @@ type SettingsStore = SettingsStoreData & {
 
 const createInitialPreflight = (): Preflight => ({
   claudeReady: false,
+  opencodeReady: false,
+  agentFrameworkId: 'claude-code',
+  agentReady: false,
   activeProviderReady: false
 })
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -13,6 +13,7 @@ import type {
   Preflight,
   AgentFrameworkId,
   AgentFrameworkView,
+  ChatApiEndpoint,
   OpencodeInfo,
   ProviderType,
   ProviderView,
@@ -229,6 +230,16 @@ const applySnapshot = (snapshot: SettingsSnapshot): Partial<SettingsStoreData> =
   opencode: snapshot.opencode,
   onboardingCompletedAt: snapshot.onboardingCompletedAt
 })
+
+// Stable fallback reference so the selector returns the same array identity across renders
+// (a fresh literal would make useSettingsStore re-render every tick and loop).
+const DEFAULT_FRAMEWORK_API_ENDPOINTS: ChatApiEndpoint[] = ['anthropic']
+
+// The chat endpoints the currently-selected agent framework can drive; a provider is only usable when
+// it shares one. Defaults to Anthropic /v1/messages before the framework list has loaded.
+export const selectFrameworkApiEndpoints = (state: SettingsStoreData): ChatApiEndpoint[] =>
+  state.agentFrameworks.find((framework) => framework.id === state.agentFrameworkId)
+    ?.supportedApiTypes ?? DEFAULT_FRAMEWORK_API_ENDPOINTS
 
 // A single selectable (provider, model) entry for the composer picker. `model` is '' for a provider
 // with no concrete model (a claude-default without an override), meaning "use the provider default".

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -106,7 +106,7 @@ type SettingsStore = SettingsStoreData & {
     managedRegistry?: ManagedClaudeRegistry
   ) => Promise<ClaudeInstallResult>
   // App-managed OpenCode install; shares the install progress/log state with installClaude.
-  installOpencode: () => Promise<ClaudeInstallResult>
+  installOpencode: (source?: ClaudeInstallSource) => Promise<ClaudeInstallResult>
   clearInstallLogs: () => void
   openEnvironmentRepair: () => void
   closeEnvironmentRepair: () => void
@@ -417,7 +417,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   },
 
   // App-managed OpenCode install, mirroring installClaude's shared progress/log handling.
-  installOpencode: async () => {
+  installOpencode: async (source = 'managed') => {
     set({ isInstalling: true, installLogs: [], installProgress: null, installError: undefined })
 
     const unsubscribe = window.api.settings.onInstallLog((event) => {
@@ -429,7 +429,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     })
 
     try {
-      const result = await window.api.settings.installOpencode()
+      const result = await window.api.settings.installOpencode({ source })
 
       // A successful install persisted opencode's path/version in main; reload so the card reflects it.
       set(applySnapshot(await window.api.settings.getSettings()))

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -11,6 +11,8 @@ import type {
   EnvironmentCheckResult,
   ManagedClaudeRegistry,
   Preflight,
+  AgentFrameworkId,
+  AgentFrameworkView,
   ProviderType,
   ProviderView,
   RefreshProviderModelsResult,
@@ -49,6 +51,9 @@ type SettingsStoreData = {
   // Active model within the active provider; undefined means the provider's own default.
   activeModel: string | undefined
   providers: ProviderView[]
+  // Selected agent backend and the frameworks available to choose from.
+  agentFrameworkId: AgentFrameworkId
+  agentFrameworks: AgentFrameworkView[]
   onboardingCompletedAt: number | undefined
   // Bundled skills with their enabled state, loaded lazily when the Skills panel opens.
   skills: SkillView[]
@@ -109,6 +114,8 @@ type SettingsStore = SettingsStoreData & {
   // Activates a provider and, optionally, a specific model within it (composer model switch). An
   // omitted model lets main fall back to the provider's default.
   setActiveProvider: (providerId: string, model?: string) => Promise<void>
+  // Switches the agent backend (main reconnects so the next prompt uses it).
+  setAgentFramework: (id: AgentFrameworkId) => Promise<void>
   deleteProvider: (providerId: string) => Promise<void>
   openSettings: () => void
   closeSettings: () => void
@@ -177,6 +184,8 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   activeProviderId: undefined,
   activeModel: undefined,
   providers: [],
+  agentFrameworkId: 'claude-code',
+  agentFrameworks: [],
   onboardingCompletedAt: undefined,
   skills: [],
   connectors: [],
@@ -205,6 +214,8 @@ const applySnapshot = (snapshot: SettingsSnapshot): Partial<SettingsStoreData> =
   activeProviderId: snapshot.activeProviderId,
   activeModel: snapshot.activeModel,
   providers: snapshot.providers,
+  agentFrameworkId: snapshot.agentFrameworkId,
+  agentFrameworks: snapshot.agentFrameworks,
   onboardingCompletedAt: snapshot.onboardingCompletedAt
 })
 
@@ -468,6 +479,11 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
     set(applySnapshot(snapshot))
     await get().refreshPreflight()
+  },
+
+  // Switches the agent backend; main reconnects so the choice applies on the next prompt.
+  setAgentFramework: async (id) => {
+    set(applySnapshot(await window.api.settings.setAgentFramework({ id })))
   },
 
   deleteProvider: async (providerId) => {

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -104,6 +104,8 @@ type SettingsStore = SettingsStoreData & {
     source: ClaudeInstallSource,
     managedRegistry?: ManagedClaudeRegistry
   ) => Promise<ClaudeInstallResult>
+  // App-managed OpenCode install; shares the install progress/log state with installClaude.
+  installOpencode: () => Promise<ClaudeInstallResult>
   clearInstallLogs: () => void
   openEnvironmentRepair: () => void
   closeEnvironmentRepair: () => void
@@ -388,6 +390,36 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       set(applySnapshot(snapshot))
       await get().refreshPreflight()
 
+      set({ installError: result.ok ? undefined : (result.error ?? 'Install failed.') })
+
+      return result
+    } catch (error) {
+      set({ installError: error instanceof Error ? error.message : 'Install failed.' })
+      throw error
+    } finally {
+      unsubscribe()
+      set({ isInstalling: false, installProgress: null })
+    }
+  },
+
+  // App-managed OpenCode install, mirroring installClaude's shared progress/log handling.
+  installOpencode: async () => {
+    set({ isInstalling: true, installLogs: [], installProgress: null, installError: undefined })
+
+    const unsubscribe = window.api.settings.onInstallLog((event) => {
+      if (event.kind === 'progress') {
+        set({ installProgress: event })
+      } else {
+        set((state) => ({ installLogs: [...state.installLogs, event.chunk] }))
+      }
+    })
+
+    try {
+      const result = await window.api.settings.installOpencode()
+
+      // A successful install persisted opencode's path/version in main; reload so the card reflects it.
+      set(applySnapshot(await window.api.settings.getSettings()))
+      await get().refreshPreflight()
       set({ installError: result.ok ? undefined : (result.error ?? 'Install failed.') })
 
       return result

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -106,6 +106,10 @@ export type AcpCreateSessionRequest = {
 export type AcpCreateSessionResponse = {
   sessionId: string
   cwd?: string
+  // True when a resume could not reattach the agent's own session and a fresh one was adopted under the
+  // same app id (framework switch, or a restart the agent could not resume). Agent-side context is gone,
+  // so the caller may replay a transcript preamble into the next prompt to restore continuity.
+  contextReset?: boolean
 }
 
 export type AcpResumeSessionRequest = {
@@ -128,6 +132,9 @@ export type AcpPromptRequest = {
   forcedSkillIds?: string[]
   // Existing files referenced via composer `@` mentions; appended as prompt content blocks.
   referencedArtifacts?: ArtifactReference[]
+  // Transcript of prior turns injected only into the content sent to the agent (never the user-facing
+  // message), so a freshly-adopted session after a framework switch keeps conversational continuity.
+  historyPreamble?: string
 }
 
 export type AcpCancelPromptRequest = {

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -7,6 +7,8 @@
 // that shifts over time — update the lists here as vendors publish new models. Only vendors with a
 // documented Anthropic-compatible endpoint belong here (e.g. OpenAI's native API does not qualify).
 
+import type { ProviderApiType } from './settings'
+
 export type OfficialVendorId =
   'anthropic' | 'deepseek' | 'zhipu' | 'minimax' | 'kimi' | 'kimiforcode'
 
@@ -27,6 +29,9 @@ export type OfficialVendor = {
   id: OfficialVendorId
   // Human-readable name shown in the provider-type picker and composer group headings.
   label: string
+  // Which chat API this vendor's endpoint speaks; drives per-framework availability. Absent ⇒
+  // 'anthropic' (every shipped vendor today exposes an Anthropic /v1/messages route).
+  apiType?: ProviderApiType
   // Anthropic-compatible model ids offered in the composer once a key is stored. First entry is the
   // default selection when the vendor is first added.
   models: string[]
@@ -199,6 +204,10 @@ export const resolveVendorModelsUrl = (
 // The default model for a freshly added vendor (first catalog entry).
 export const defaultVendorModel = (id: OfficialVendorId): string | undefined =>
   VENDORS_BY_ID.get(id)?.models[0]
+
+// The chat API a vendor speaks, defaulting to Anthropic /v1/messages when unset.
+export const resolveVendorApiType = (id: OfficialVendorId): ProviderApiType =>
+  VENDORS_BY_ID.get(id)?.apiType ?? 'anthropic'
 
 // Whether a vendor needs a region choice (more than one endpoint).
 export const vendorHasRegions = (id: OfficialVendorId): boolean =>

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -19,6 +19,9 @@ export type VendorRegion = {
   id: string
   label: string
   baseUrl: string
+  // The region's OpenAI /v1/chat/completions base, when it differs from the Anthropic `baseUrl` and the
+  // vendor supports both endpoints. Falls back to the region's `baseUrl` when absent.
+  openaiBaseUrl?: string
   // Where the user creates/copies a key for this endpoint; falls back to the vendor-level one.
   apiKeyUrl?: string
   // Full URL of the vendor's model-list endpoint for this region; falls back to the vendor-level one.
@@ -36,7 +39,11 @@ export type OfficialVendor = {
   // default selection when the vendor is first added.
   models: string[]
   // Single-endpoint vendors set `baseUrl`; multi-region vendors set `regions` instead (never both).
+  // `baseUrl` is the Anthropic /v1/messages route; `openaiBaseUrl` is the vendor's separate OpenAI
+  // /v1/chat/completions root (they differ — e.g. DeepSeek serves Anthropic under `/anthropic` and
+  // OpenAI at the bare root). Set both only for a vendor whose apiType is 'both'.
   baseUrl?: string
+  openaiBaseUrl?: string
   regions?: VendorRegion[]
   // Page where the user obtains an API key. For multi-region vendors a per-region url takes priority.
   apiKeyUrl?: string
@@ -64,7 +71,12 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'deepseek',
     label: 'DeepSeek',
+    // DeepSeek exposes both routes: Anthropic /v1/messages under `/anthropic`, and the OpenAI-compatible
+    // /v1/chat/completions at the bare root. The same model ids work on both, so it's safe to prefer
+    // OpenAI where the framework supports it (e.g. OpenCode).
+    apiType: 'both',
     baseUrl: 'https://api.deepseek.com/anthropic',
+    openaiBaseUrl: 'https://api.deepseek.com',
     apiKeyUrl: 'https://platform.deepseek.com/api_keys',
     modelsListUrl: 'https://api.deepseek.com/v1/models',
     models: ['deepseek-v4-pro', 'deepseek-v4-pro[1m]', 'deepseek-v4-flash']
@@ -157,6 +169,23 @@ export const resolveVendorBaseUrl = (
   const region = regions.find((candidate) => candidate.id === regionId) ?? regions[0]
 
   return region?.baseUrl
+}
+
+// Resolves a vendor's OpenAI /v1/chat/completions base, when it publishes one distinct from the
+// Anthropic route (only 'both' vendors do). Undefined otherwise, so callers fall back to `baseUrl`.
+export const resolveVendorOpenAiBaseUrl = (
+  id: OfficialVendorId,
+  regionId?: string
+): string | undefined => {
+  const vendor = VENDORS_BY_ID.get(id)
+
+  if (!vendor) return undefined
+  if (vendor.openaiBaseUrl) return vendor.openaiBaseUrl
+
+  const regions = vendor.regions ?? []
+  const region = regions.find((candidate) => candidate.id === regionId) ?? regions[0]
+
+  return region?.openaiBaseUrl
 }
 
 // Resolves where the user gets an API key for a vendor, preferring the selected region's console and

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { isProviderCompatibleWith, preferredEndpoint, providerEndpoints } from './settings'
+
+describe('provider endpoint compatibility', () => {
+  it('expands a provider apiType into its endpoints', () => {
+    expect(providerEndpoints('anthropic')).toEqual(['anthropic'])
+    expect(providerEndpoints('openai')).toEqual(['openai'])
+    expect(providerEndpoints('both')).toEqual(['anthropic', 'openai'])
+  })
+
+  it('is compatible only when provider and framework share an endpoint', () => {
+    // Claude Code speaks anthropic only.
+    expect(isProviderCompatibleWith('anthropic', ['anthropic'])).toBe(true)
+    expect(isProviderCompatibleWith('openai', ['anthropic'])).toBe(false)
+    expect(isProviderCompatibleWith('both', ['anthropic'])).toBe(true)
+    // OpenCode speaks both.
+    expect(isProviderCompatibleWith('openai', ['anthropic', 'openai'])).toBe(true)
+    expect(isProviderCompatibleWith('anthropic', ['anthropic', 'openai'])).toBe(true)
+  })
+
+  it('prefers the OpenAI endpoint when both sides support it (both + both → openai)', () => {
+    expect(preferredEndpoint('both', ['anthropic', 'openai'])).toBe('openai')
+    // A both-provider on an anthropic-only framework falls back to the shared anthropic endpoint.
+    expect(preferredEndpoint('both', ['anthropic'])).toBe('anthropic')
+    // Single-endpoint providers resolve to that endpoint when shared.
+    expect(preferredEndpoint('openai', ['anthropic', 'openai'])).toBe('openai')
+    expect(preferredEndpoint('anthropic', ['anthropic', 'openai'])).toBe('anthropic')
+    // Incompatible pair → no endpoint.
+    expect(preferredEndpoint('openai', ['anthropic'])).toBeUndefined()
+  })
+})

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { isProviderCompatibleWith, preferredEndpoint, providerEndpoints } from './settings'
+import {
+  getOpencodeInstallSources,
+  isProviderCompatibleWith,
+  preferredEndpoint,
+  providerEndpoints
+} from './settings'
 
 describe('provider endpoint compatibility', () => {
   it('expands a provider apiType into its endpoints', () => {
@@ -28,5 +33,30 @@ describe('provider endpoint compatibility', () => {
     expect(preferredEndpoint('anthropic', ['anthropic', 'openai'])).toBe('anthropic')
     // Incompatible pair → no endpoint.
     expect(preferredEndpoint('openai', ['anthropic'])).toBeUndefined()
+  })
+})
+
+describe('getOpencodeInstallSources', () => {
+  it('leads with the app-managed download and includes npm on every platform', () => {
+    const ids = getOpencodeInstallSources('darwin').map((source) => source.id)
+
+    expect(ids[0]).toBe('managed')
+    expect(ids).toContain('npm')
+    const npm = getOpencodeInstallSources('darwin').find((source) => source.id === 'npm')
+    expect(npm?.displayCommand).toBe('npm i -g opencode-ai')
+  })
+
+  it('offers the shell installer off Windows', () => {
+    const script = getOpencodeInstallSources('linux').find(
+      (source) => source.id === 'official-script'
+    )
+
+    expect(script?.displayCommand).toBe('curl -fsSL https://opencode.ai/install | bash')
+  })
+
+  it('hides the shell installer on Windows (no official PowerShell script)', () => {
+    const ids = getOpencodeInstallSources('win32').map((source) => source.id)
+
+    expect(ids).toEqual(['managed', 'npm'])
   })
 })

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -72,6 +72,18 @@ export const providerValidationFailed = (provider: {
   (provider.lastValidatedAt === undefined ||
     provider.lastValidationFailure.at >= provider.lastValidatedAt)
 
+// The agent backends the app can drive over ACP. Persisted settings and the UI reference these ids;
+// the main-process AgentFramework registry is keyed by the same union.
+export type AgentFrameworkId = 'claude-code' | 'opencode'
+
+// Renderer-facing descriptor for one selectable agent framework (built from the main registry).
+export type AgentFrameworkView = {
+  id: AgentFrameworkId
+  displayName: string
+  // Whether this framework materializes app skills; the renderer hides the skills UI when false.
+  supportsSkills: boolean
+}
+
 // Full renderer snapshot of settings state.
 export type SettingsSnapshot = {
   claude: ClaudeInfo
@@ -80,8 +92,15 @@ export type SettingsSnapshot = {
   // own model; for official providers it's the chosen catalog entry. Undefined until a provider exists.
   activeModel?: string
   providers: ProviderView[]
+  // The selected agent backend, and the frameworks available to choose from.
+  agentFrameworkId: AgentFrameworkId
+  agentFrameworks: AgentFrameworkView[]
   // Timestamp of first-run onboarding completion; undefined until it finishes at least once.
   onboardingCompletedAt?: number
+}
+
+export type SetAgentFrameworkRequest = {
+  id: AgentFrameworkId
 }
 
 // The two hard startup gates. Kept as plain booleans so the wizard can target the first unmet step.

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -311,6 +311,49 @@ export type InstallClaudeRequest = {
   managedRegistry?: ManagedClaudeRegistry
 }
 
+// Install request for OpenCode. Reuses the same three source kinds as Claude; the app-managed download
+// is the recommended default and the only cross-platform-guaranteed path (no user Node/npm needed).
+export type InstallOpencodeRequest = {
+  source: ClaudeInstallSource
+}
+
+// The ordered OpenCode install sources for a host platform, mirroring getClaudeInstallSources. The
+// app-managed native-binary download leads (works on every OS, including native Windows). npm follows
+// (`npm i -g opencode-ai`). The shell installer (`curl … | bash`) is offered only off Windows —
+// OpenCode ships no official Windows PowerShell installer, so Windows users take managed or npm.
+export const getOpencodeInstallSources = (
+  platform: string = 'linux'
+): ClaudeInstallSourceInfo[] => {
+  const isWindows = platform === 'win32'
+
+  const sources: ClaudeInstallSourceInfo[] = [
+    {
+      id: 'managed',
+      label: 'App-managed download (recommended)',
+      displayCommand: '',
+      requiresNpm: false,
+      description: 'Downloads a self-contained OpenCode — no Node.js or npm required.'
+    },
+    {
+      id: 'npm',
+      label: 'npm (global install)',
+      displayCommand: 'npm i -g opencode-ai',
+      requiresNpm: true
+    }
+  ]
+
+  if (!isWindows) {
+    sources.push({
+      id: 'official-script',
+      label: 'Official install script',
+      displayCommand: 'curl -fsSL https://opencode.ai/install | bash',
+      requiresNpm: false
+    })
+  }
+
+  return sources
+}
+
 // One streamed line of installer output. `installId` groups a single install run.
 export type ClaudeInstallLogEvent = {
   kind: 'log'

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -148,9 +148,15 @@ export type SetAgentFrameworkRequest = {
   id: AgentFrameworkId
 }
 
-// The two hard startup gates. Kept as plain booleans so the wizard can target the first unmet step.
+// The hard startup gates. Kept as plain booleans so the wizard can target the first unmet step.
+// Per-framework readiness is exposed alongside `agentReady`, which reflects the currently-selected
+// framework — the gate a session actually depends on.
 export type Preflight = {
   claudeReady: boolean
+  opencodeReady: boolean
+  // Readiness of the selected agent framework (claudeReady or opencodeReady), plus which one it is.
+  agentFrameworkId: AgentFrameworkId
+  agentReady: boolean
   activeProviderReady: boolean
 }
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -51,9 +51,10 @@ export type ClaudeInfo = {
   version?: string
 }
 
-// Detected opencode executable metadata (path only; opencode reports no version over ACP detection).
+// Detected opencode executable metadata (resolved path + reported version), persisted for the card.
 export type OpencodeInfo = {
   resolvedPath?: string
+  version?: string
 }
 
 // Result of probing the machine for a runnable claude executable.

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -20,6 +20,11 @@ export type ClaudeInfo = {
   version?: string
 }
 
+// Detected opencode executable metadata (path only; opencode reports no version over ACP detection).
+export type OpencodeInfo = {
+  resolvedPath?: string
+}
+
 // Result of probing the machine for a runnable claude executable.
 export type ClaudeDetectResult = {
   found: boolean
@@ -87,6 +92,8 @@ export type AgentFrameworkView = {
 // Full renderer snapshot of settings state.
 export type SettingsSnapshot = {
   claude: ClaudeInfo
+  // Detected opencode executable, for the framework-aware detection card.
+  opencode: OpencodeInfo
   activeProviderId?: string
   // The active model within the active provider. For custom/claude-default this mirrors the provider's
   // own model; for official providers it's the chosen catalog entry. Undefined until a provider exists.

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -14,6 +14,37 @@ export const SETTINGS_FILE_VERSION = 2
 // model catalog from the registry), or reuses the local claude auth.
 export type ProviderType = 'custom' | 'claude-default' | 'official'
 
+// The chat API a model endpoint speaks: `anthropic` = /v1/messages, `openai` = /v1/chat/completions.
+// A framework supports a set of these; a provider offers one or `both`.
+export type ChatApiEndpoint = 'anthropic' | 'openai'
+export type ProviderApiType = ChatApiEndpoint | 'both'
+
+// The concrete endpoint(s) a provider offers.
+export const providerEndpoints = (apiType: ProviderApiType): ChatApiEndpoint[] =>
+  apiType === 'both' ? ['anthropic', 'openai'] : [apiType]
+
+// A provider is usable by a framework only when they share at least one endpoint.
+export const isProviderCompatibleWith = (
+  apiType: ProviderApiType,
+  frameworkEndpoints: readonly ChatApiEndpoint[]
+): boolean => providerEndpoints(apiType).some((endpoint) => frameworkEndpoints.includes(endpoint))
+
+// The endpoint to actually use for a (provider, framework) pair. When both sides support OpenAI
+// /v1/chat/completions it wins (per product decision); otherwise the shared Anthropic endpoint; else
+// undefined when the pair is incompatible.
+export const preferredEndpoint = (
+  apiType: ProviderApiType,
+  frameworkEndpoints: readonly ChatApiEndpoint[]
+): ChatApiEndpoint | undefined => {
+  const shared = providerEndpoints(apiType).filter((endpoint) =>
+    frameworkEndpoints.includes(endpoint)
+  )
+
+  if (shared.length === 0) return undefined
+
+  return shared.includes('openai') ? 'openai' : 'anthropic'
+}
+
 // Detected claude executable metadata, persisted so later spawns skip re-detection.
 export type ClaudeInfo = {
   resolvedPath?: string
@@ -46,6 +77,9 @@ export type ProviderView = {
   id: string
   type: ProviderType
   name: string
+  // Which chat API this provider's endpoint speaks; drives per-framework availability. Absent ⇒
+  // treat as 'anthropic' (every existing provider).
+  apiType?: ProviderApiType
   baseUrl?: string
   model?: string
   // Set for official-vendor providers: which vendor and (where applicable) which regional endpoint.
@@ -84,6 +118,9 @@ export type AgentFrameworkId = 'claude-code' | 'opencode'
 // Renderer-facing descriptor for one selectable agent framework (built from the main registry).
 export type AgentFrameworkView = {
   id: AgentFrameworkId
+  // Chat endpoints this framework can drive; a provider is selectable only if it shares one. Absent ⇒
+  // treat as ['anthropic'].
+  supportedApiTypes?: ChatApiEndpoint[]
   displayName: string
   // Whether this framework materializes app skills; the renderer hides the skills UI when false.
   supportsSkills: boolean
@@ -123,6 +160,9 @@ export type ProviderDraft = {
   name?: string
   baseUrl?: string
   model?: string
+  // Which chat API a custom gateway speaks (form selector). Official providers take it from the
+  // registry; omitted defaults to 'anthropic'.
+  apiType?: ProviderApiType
   // Set when type is 'official': the chosen vendor and (where applicable) region. Base URL and model
   // catalog then come from the registry rather than the draft's baseUrl.
   vendorId?: OfficialVendorId

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -23,11 +23,24 @@ export type ProviderApiType = ChatApiEndpoint | 'both'
 export const providerEndpoints = (apiType: ProviderApiType): ChatApiEndpoint[] =>
   apiType === 'both' ? ['anthropic', 'openai'] : [apiType]
 
-// A provider is usable by a framework only when they share at least one endpoint.
+// A provider's endpoint is usable by a framework only when they share at least one endpoint.
 export const isProviderCompatibleWith = (
   apiType: ProviderApiType,
   frameworkEndpoints: readonly ChatApiEndpoint[]
 ): boolean => providerEndpoints(apiType).some((endpoint) => frameworkEndpoints.includes(endpoint))
+
+// Whether a provider can actually drive a given framework. Two axes: endpoint compatibility (above),
+// AND provider-type — a `claude-default` provider reuses the machine's own Claude login (Claude-specific
+// OAuth/config), which no other framework can consume, so it is only usable by Claude Code regardless
+// of endpoint. Enforced both in the renderer gates and main-side (preflight + spawn).
+export const isProviderUsableByFramework = (
+  provider: { apiType: ProviderApiType; type: ProviderType },
+  framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
+): boolean => {
+  if (provider.type === 'claude-default' && framework.id !== 'claude-code') return false
+
+  return isProviderCompatibleWith(provider.apiType, framework.supportedApiTypes)
+}
 
 // The endpoint to actually use for a (provider, framework) pair. When both sides support OpenAI
 // /v1/chat/completions it wins (per product decision); otherwise the shared Anthropic endpoint; else

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -413,7 +413,13 @@ export type NpmAvailability = {
 // Automatic first-run environment inspection. Warnings are intentionally non-blocking (for example,
 // OS keychain encryption may be unavailable while the app can still operate with reduced protection).
 export type EnvironmentCheckId =
-  'system' | 'storage' | 'secure-storage' | 'install-network' | 'python' | 'claude'
+  | 'system'
+  | 'storage'
+  | 'secure-storage'
+  | 'install-network'
+  | 'python'
+  // The selected agent runtime (Claude or OpenCode); label/summary are framework-specific.
+  | 'agent'
 
 export type EnvironmentCheckStatus = 'passed' | 'warning' | 'failed'
 
@@ -436,7 +442,9 @@ export type EnvironmentCheckResult = {
   // data directory. More detailed operational errors are reported by the install log.
   canAutoInstall: boolean
   recommendedRegistry?: ManagedClaudeRegistry
-  claude: ClaudeDetectResult
+  // The framework this check inspected, and its runtime detection result.
+  agentFrameworkId: AgentFrameworkId
+  runtime: ClaudeDetectResult
 }
 
 // A bundled skill's source category: app-bundled, imported from GitHub, or user-authored.


### PR DESCRIPTION
## Summary

Makes the agent runtime pluggable so a user can run the app on **Claude Code** or **OpenCode**, switchable in Settings. The agent was already integrated purely over ACP (`@agentclientprotocol/sdk`), so this introduces an `AgentFramework` provider interface the runtime delegates to (spawn / session setup / model config / permission mapping / skills) and wires OpenCode in behind it. Claude Code behavior is unchanged.

## Highlights

**Framework abstraction**
- `AgentFramework` interface + Claude adapter (faithful extraction of existing behavior) + OpenCode adapter; `AcpRuntime` delegates spawn, session-meta/prompt delivery, model config, and permission mapping to it.
- Framework-aware backend resolution and cross-framework session switch (reuses the provider-switch reconnect path; transcript is soft-replayed into the next prompt since agent-side context resets).

**OpenCode support**
- Detection at Claude parity (managed dir / well-known / npm / `.exe`), version display, and user-initiated install (managed → npm → script).
- XDG isolation (app-owned config/data dirs; the user's `~/.config/opencode` and `auth.json` are never touched), skills materialized like Claude, model injected via generated config + ACP `set_config_option`.
- MCP over stdio (same path as Claude); the HTTP MCP host remains as a fallback for any future http-only framework.

**Providers & permissions**
- Provider↔framework endpoint compatibility (`anthropic` /v1/messages vs `openai` /v1/chat/completions); model picker gates + explains incompatible providers, main-side enforcement, and OpenAI-compatible execution for OpenCode.
- Permission profiles map to native ACP modes for Claude; for OpenCode the generated config delegates every side-effecting tool via a `"*": "ask"` catch-all and the app broker enforces Ask / Auto / Full. MCP tools are recognized across both naming schemes (`mcp__<server>__<tool>` and `<server>_<tool>`) from the session's actual MCP server list.

**Onboarding**
- Framework selection in the environment step, framework-aware checks, and a generation-token env check that survives rapid framework switches.

## Testing

- Full suite green: **2730 passed / 43 skipped**; `typecheck:node` + `typecheck:web` clean; eslint clean.
- New coverage: MCP detection + permission audit + per-session MCP-name lifecycle (create/resume/adopt/delete/disconnect/reviewer), broker classification, env-check ABA race, preflight version gate, resume-error classification, model-picker keyboard roving focus, settings component interactions, and OpenCode settings IPC.

## Not yet verified (manual)

- Live end-to-end OpenCode run requires the OpenCode binary and a full `npm run dev` (main-process changes don't hot-reload). Automated tests drive OpenCode paths via fakes; a manual smoke against a real `opencode acp` is the remaining check before release.
