### PR TITLE
fix(agent-framework): secure OpenCode API key and enforce permission policy

### DIFF
--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -33,6 +33,53 @@ describe('opencodeFramework.prepareModelConfig', () => {
     )
     expect(parsed.instructions).toBeUndefined()
   })
+
+  it('passes the decrypted key via the spawn env and keeps it out of the written config', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'sk-plaintext-secret' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    // The real key rides the env under the referenced var, never touching disk.
+    expect(config.env?.OPENCODE_APP_API_KEY).toBe('sk-plaintext-secret')
+    const opencodeJson = config.configFiles?.find((file) => file.path.endsWith('opencode.json'))
+    expect(opencodeJson?.content).not.toContain('sk-plaintext-secret')
+    expect(JSON.parse(opencodeJson?.content ?? '{}').provider.anthropic.options.apiKey).toBe(
+      '{env:OPENCODE_APP_API_KEY}'
+    )
+  })
+
+  it('does not set the key env var when the provider carries no key', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'claude-default' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+    expect(config.env && 'OPENCODE_APP_API_KEY' in config.env).toBe(false)
+  })
+
+  it('enforces the permission policy via OPENCODE_CONFIG_CONTENT (above any project config)', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    const rules = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}').permission
+    expect(rules['*']).toBe('ask')
+    for (const tool of ['read', 'glob', 'grep', 'list', 'lsp']) {
+      expect(rules[tool]).toBe('allow')
+    }
+    for (const tool of [
+      'edit',
+      'bash',
+      'task',
+      'skill',
+      'webfetch',
+      'websearch',
+      'external_directory'
+    ]) {
+      expect(rules[tool]).toBe('ask')
+    }
+  })
 })
 
 describe('buildOpencodeConfig', () => {
@@ -50,10 +97,54 @@ describe('buildOpencodeConfig', () => {
     // instead of ignoring it and falling back to its own default.
     expect(config.model).toBe('anthropic/deepseek-v4-pro')
     expect(config.provider.anthropic.models).toEqual({ 'deepseek-v4-pro': {} })
+    // The key is referenced via opencode env interpolation, never emitted as a plaintext literal.
     expect(config.provider.anthropic.options).toEqual({
       baseURL: 'https://gw.example/v1',
-      apiKey: 'sk-secret'
+      apiKey: '{env:OPENCODE_APP_API_KEY}'
     })
+  })
+
+  it('never emits the decrypted key as a plaintext literal (only an env reference)', () => {
+    const serialized = buildOpencodeConfig({
+      type: 'custom',
+      baseUrl: 'https://gw.example/v1',
+      model: 'm',
+      key: 'sk-super-secret'
+    })
+
+    expect(serialized).not.toContain('sk-super-secret')
+    expect(JSON.parse(serialized).provider.anthropic.options.apiKey).toBe(
+      '{env:OPENCODE_APP_API_KEY}'
+    )
+  })
+
+  it('omits apiKey entirely when the provider carries no key', () => {
+    const config = JSON.parse(
+      buildOpencodeConfig({ type: 'custom', baseUrl: 'https://gw/v1', model: 'm' })
+    )
+    expect(config.provider.anthropic.options.apiKey).toBeUndefined()
+  })
+
+  it('pins sensitive built-in tools to ask so a workspace config cannot flip them to allow', () => {
+    const config = JSON.parse(
+      buildOpencodeConfig(
+        { type: 'custom', baseUrl: 'https://gw/v1', model: 'm' },
+        { permission: { edit: 'allow', bash: 'allow', task: 'allow' } }
+      )
+    )
+
+    // Our rules override the base for every side-effecting built-in.
+    for (const tool of [
+      'edit',
+      'bash',
+      'task',
+      'skill',
+      'webfetch',
+      'websearch',
+      'external_directory'
+    ]) {
+      expect(config.permission[tool]).toBe('ask')
+    }
   })
 
   it('delegates every side-effecting tool (incl. MCP) via a "*" catch-all, allowing safe reads', () => {
@@ -68,9 +159,9 @@ describe('buildOpencodeConfig', () => {
     for (const tool of ['read', 'glob', 'grep', 'list', 'lsp']) {
       expect(config.permission[tool]).toBe('allow')
     }
-    // Mutating/external tools are NOT allowlisted, so they fall through to "*" → ask.
-    expect(config.permission.edit).toBeUndefined()
-    expect(config.permission.bash).toBeUndefined()
+    // Mutating/external tools are pinned to ask (and unlisted MCP tools fall through to "*" → ask).
+    expect(config.permission.edit).toBe('ask')
+    expect(config.permission.bash).toBe('ask')
   })
 
   it('keeps delegation on even if the base config tried to disable it', () => {
@@ -116,7 +207,7 @@ describe('buildOpencodeConfig', () => {
     expect(config.provider.anthropic.options).toEqual({
       timeout: 5,
       baseURL: 'https://gw.example/v1',
-      apiKey: 'sk-secret'
+      apiKey: '{env:OPENCODE_APP_API_KEY}'
     })
     expect(config.provider.anthropic.models).toEqual({ 'other-model': {}, 'deepseek-v4-pro': {} })
     expect(config.model).toBe('anthropic/deepseek-v4-pro')
@@ -137,7 +228,7 @@ describe('buildOpencodeConfig', () => {
     expect(config.provider['openai-compatible'].npm).toBe('@ai-sdk/openai-compatible')
     expect(config.provider['openai-compatible'].options).toEqual({
       baseURL: 'https://gw/v1',
-      apiKey: 'k'
+      apiKey: '{env:OPENCODE_APP_API_KEY}'
     })
     expect(config.provider['openai-compatible'].models).toEqual({ 'gpt-x': {} })
     // A 'both' provider prefers OpenAI on opencode (which supports both).

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -54,6 +54,33 @@ const OPENCODE_ENDPOINT_PROVIDER: Record<'anthropic' | 'openai', { id: string; n
   openai: { id: 'openai-compatible', npm: '@ai-sdk/openai-compatible' }
 }
 
+// The decrypted provider key is handed to opencode via this spawn-env var and referenced from the
+// generated config as `{env:...}` (opencode substitutes env refs at config-load time). This keeps the
+// plaintext key OFF disk — opencode.json only ever holds the reference, never the secret.
+const OPENCODE_API_KEY_ENV = 'OPENCODE_APP_API_KEY'
+
+// The app's permission policy for opencode: every side-effecting/MCP tool must ASK the ACP client (the
+// app's broker then enforces the selected profile); only safe read-only tools run silently (parity with
+// Claude's Ask mode). The `*` catch-all covers unlisted tools (MCP artifact/notebook/connectors, etc.),
+// and the sensitive built-ins are pinned to `ask` explicitly so a workspace config that sets one of
+// those keys to `allow` is overridden rather than winning. Enforced above any project config via the
+// OPENCODE_CONFIG_CONTENT layer (see prepareModelConfig) — the config-file block is only a baseline.
+const OPENCODE_PERMISSION_RULES: Record<string, 'ask' | 'allow' | 'deny'> = {
+  '*': 'ask',
+  read: 'allow',
+  glob: 'allow',
+  grep: 'allow',
+  list: 'allow',
+  lsp: 'allow',
+  edit: 'ask',
+  bash: 'ask',
+  task: 'ask',
+  skill: 'ask',
+  webfetch: 'ask',
+  websearch: 'ask',
+  external_directory: 'ask'
+}
+
 const asRecord = (value: unknown): Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -99,22 +126,15 @@ const buildOpencodeConfig = (
     ...baseConfig,
     ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
     ...(instructions.length > 0 ? { instructions } : {}),
-    // Force opencode to ASK the ACP client before every side-effecting tool instead of running
-    // silently under its permissive default. opencode keys permissions by TOOL NAME with a "*"
-    // catch-all, so the wildcard is essential: without it MCP tools (artifact/notebook/connectors),
-    // websearch, task, skill, etc. are unmatched and run without a prompt. Safe read-only tools stay
-    // "allow" so Ask mode doesn't prompt on every file read (parity with Claude). Everything else —
-    // edit, bash, webfetch, websearch, task, skill, and all MCP tools — hits "*" → ask → the ACP
-    // client, where the app enforces the selected profile in its broker (ask prompts, auto approves
-    // workspace edits, full approves all). Our rules win over any base config so it can't be disabled.
+    // Baseline permission policy written into the config file. This alone is NOT sufficient: opencode
+    // loads a project-level opencode.json / .opencode config from the session cwd at HIGHER precedence
+    // than this app-owned (global) config, so a workspace could set `permission["*"]="allow"` here and
+    // disable delegation. The authoritative copy of these rules is passed via the OPENCODE_CONFIG_CONTENT
+    // layer in prepareModelConfig, which opencode merges above project config. See
+    // OPENCODE_PERMISSION_RULES for the policy rationale.
     permission: {
       ...basePermission,
-      '*': 'ask',
-      read: 'allow',
-      glob: 'allow',
-      grep: 'allow',
-      list: 'allow',
-      lsp: 'allow'
+      ...OPENCODE_PERMISSION_RULES
     },
     provider: {
       ...baseProviders,
@@ -125,7 +145,9 @@ const buildOpencodeConfig = (
         options: {
           ...baseOptions,
           ...(baseURL ? { baseURL } : {}),
-          ...(provider.key ? { apiKey: provider.key } : {})
+          // Reference the key via env interpolation; the real value is passed in the spawn env only,
+          // so the decrypted key is never persisted to opencode.json (see prepareModelConfig).
+          ...(provider.key ? { apiKey: `{env:${OPENCODE_API_KEY_ENV}}` } : {})
         },
         // Register the model so opencode treats a non-catalog id as a real, selectable model.
         ...(bareModel ? { models: { ...baseModels, [bareModel]: {} } } : {})
@@ -193,7 +215,19 @@ export const opencodeFramework: AgentFramework = {
     configFiles[0].content = buildOpencodeConfig(provider, {}, instructionPaths)
 
     return {
-      env: { XDG_CONFIG_HOME: configHome, XDG_DATA_HOME: dataHome },
+      env: {
+        XDG_CONFIG_HOME: configHome,
+        XDG_DATA_HOME: dataHome,
+        // Enforce the permission policy from the OPENCODE_CONFIG_CONTENT layer, which opencode merges
+        // ABOVE the global XDG config AND above any project-level opencode.json / .opencode config the
+        // repo ships. So a malicious workspace can no longer flip permission["*"] to "allow" and bypass
+        // the app broker; the config-file block above is only a baseline. Residual: a workspace config
+        // that names a specific NON-pinned tool (e.g. an exact MCP tool id) with "allow" still wins for
+        // that one tool, since opencode deep-merges permission keys with no "replace-all" layer here.
+        OPENCODE_CONFIG_CONTENT: JSON.stringify({ permission: OPENCODE_PERMISSION_RULES }),
+        // Pass the decrypted key ONLY via the environment; the config references it as `{env:...}`.
+        ...(provider.key ? { [OPENCODE_API_KEY_ENV]: provider.key } : {})
+      },
       configFiles
     }
   },


### PR DESCRIPTION
## Summary
Two security fixes to the OpenCode agent-framework integration (post-merge review of #185).

- **Decrypted API key no longer written to disk (P1).** `buildOpencodeConfig` previously emitted `apiKey: <decrypted key>` into `opencode.json`, written world-readable by `writeAgentConfigFiles`. The config now emits `apiKey: "{env:OPENCODE_APP_API_KEY}"` and the real key is passed only through the spawn environment. Verified opencode's `{env:...}` interpolation against its source (`config/variable.ts`).
- **Permission rules can no longer be bypassed by a workspace config (P1).** Rules were written only into the app-owned *global* (XDG) config, which opencode ranks lowest — a project `opencode.json`/`.opencode` could flip `permission["*"]` to `allow` and stop opencode from asking the app broker. Rules are now injected via `OPENCODE_CONFIG_CONTENT`, which opencode merges *above* global and project/`.opencode` config (verified in opencode's `config.ts`), and the sensitive built-ins (`edit/bash/task/skill/webfetch/websearch/external_directory`) are pinned to `ask`. Read-only tools stay `allow` (Claude parity).

## Residual limitation (documented in code)
opencode deep-merges the `permission` map per key with no user-space "replace-all" layer (only OS/MDM managed prefs). A workspace config naming a *specific non-pinned tool id* with `"allow"` still wins for that one tool. The `*` catch-all and all pinned built-ins are protected. Fully closing this needs an upstream opencode change or MDM-level config.

## Tests
`src/main/agent-framework/opencode.test.ts` — asserts the key is never emitted as a plaintext literal, the key rides the spawn env only, sensitive built-ins are pinned to `ask`, and the policy lands in the `OPENCODE_CONFIG_CONTENT` (un-overridable) layer.

typecheck + lint + `vitest run src/main/agent-framework` (16 tests) all green.