### PR TITLE
fix(acp): close adopted agent session by its own id on delete

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1530,6 +1530,35 @@ describe('ACP runtime session management', () => {
     ).rejects.toThrow(/not found/)
   })
 
+  it('closes an adopted session on the agent by its own id, not the app-facing id', async () => {
+    const process = new FakeAgentProcess()
+    // Resume rejects (Resource not found), so the runtime adopts a fresh agent session
+    // (adopted-session-1) under the app-facing id (switched-session). The agent only knows the
+    // underlying id, so delete must close/cancel using it, not the app-facing request id.
+    const fakeAgent = startFakeAgent(process, ['adopted-session-1'], { resumeNotFound: true })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const resumed = await runtime.resumeSession({
+      sessionId: 'switched-session',
+      cwd: '/workspace'
+    })
+    expect(resumed.sessionId).toBe('switched-session')
+
+    await runtime.deleteSession({ sessionId: 'switched-session' })
+
+    // The agent received session/close for its own id, not the app-facing one it never knew.
+    expect(fakeAgent.closedSessions).toEqual(['adopted-session-1'])
+    // Local routing state is keyed by the app-facing id and is fully removed.
+    expect(runtime.getSnapshot().sessionIds).toEqual([])
+    await expect(
+      runtime.sendPrompt({ sessionId: 'switched-session', text: 'hello' })
+    ).rejects.toThrow(/not found/)
+  })
+
   it('resumes an existing protocol session so restored conversations can continue', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, [])

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1255,13 +1255,15 @@ class AcpRuntime {
     const session = this.sessions.get(request.sessionId)
 
     if (session) {
+      // Talk to the agent using its own session id: for an adopted session the underlying
+      // agent id (session.sessionId) differs from the app-facing request.sessionId.
       if (this.connection && this.supportsSessionClose) {
         await this.connection.agent.request(acp.methods.agent.session.close, {
-          sessionId: request.sessionId
+          sessionId: session.sessionId
         })
       } else {
         await this.connection?.agent.notify(acp.methods.agent.session.cancel, {
-          sessionId: request.sessionId
+          sessionId: session.sessionId
         })
       }
 


### PR DESCRIPTION
## Summary
`deleteSession` sent the agent-facing `session.close`/`session.cancel` with the **app-facing** `request.sessionId` instead of the underlying `session.sessionId`. For a session adopted onto a fresh agent (unresumable restart / framework switch), the app-facing id differs from the id the agent knows, so a close-capable agent returns "unknown session" and the local cleanup never runs.

The two agent-facing calls now use `session.sessionId` (mirroring `cancelPrompt`, which already did this correctly). Local bookkeeping maps stay keyed by the app-facing `request.sessionId` as before.

## Tests
`src/main/acp/runtime.test.ts` — adopts a session whose underlying id differs from the app-facing id, calls `deleteSession`, and asserts the agent received the close with the **underlying** id (fails on the old code) and that local maps are cleaned up.

typecheck + lint + `vitest run src/main/acp` (128 tests) all green.