### PR TITLE
fix(settings): verify managed OpenCode binary runs after install

### DIFF
--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -81,6 +81,8 @@ describe('installManagedOpencode', () => {
       platform: { key: 'darwin-arm64', binName: 'opencode' },
       fetchJson,
       fetchTarball,
+      // Injected pass keeps the test offline and host-independent (no real spawn of the extracted file).
+      verifyBinary: () => ({ ok: true }),
       tmpDir: root
     })
 
@@ -118,6 +120,84 @@ describe('installManagedOpencode', () => {
 
     expect(outcome.result.ok).toBe(false)
     expect(outcome.resolvedPath).toBeUndefined()
+  })
+
+  // A downloaded package that extracts cleanly but cannot run on this CPU (e.g. SIGILL on a non-AVX2
+  // x64 host) must fail the install, not persist a broken path.
+  it('fails cleanly and removes the binary when the smoke check reports it cannot run', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const tgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho opencode\n') }
+    ])
+    const integrity = sha512(tgz)
+
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.endsWith('/opencode-ai')
+        ? { 'dist-tags': { latest: '1.18.3' } }
+        : { dist: { tarball: 'https://reg/opencode-darwin-arm64.tgz', integrity } }
+    const fetchTarball = async (): Promise<{
+      stream: NodeJS.ReadableStream
+      totalBytes?: number
+    }> => ({ stream: Readable.from(tgz), totalBytes: tgz.length })
+
+    const outcome = await installManagedOpencode({
+      installId: 'i3',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'darwin-arm64', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      // Simulate a non-AVX2 host: the binary dies with SIGILL when probed.
+      verifyBinary: () => ({ ok: false, reason: 'killed by SIGILL', signal: 'SIGILL' }),
+      tmpDir: root
+    })
+
+    expect(outcome.result.ok).toBe(false)
+    expect(outcome.resolvedPath).toBeUndefined()
+    // Actionable error mentioning the failed probe and the likely AVX2 cause.
+    expect(outcome.result.error).toMatch(/failed to run/)
+    expect(outcome.result.error).toMatch(/AVX2/)
+    // The unusable binary is not left on disk.
+    await expect(readFile(join(managedOpencodeDir(root), 'opencode'))).rejects.toThrow()
+  })
+
+  it('succeeds when the smoke check confirms the binary runs', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const tgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho opencode\n') }
+    ])
+    const integrity = sha512(tgz)
+
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.endsWith('/opencode-ai')
+        ? { 'dist-tags': { latest: '1.18.3' } }
+        : { dist: { tarball: 'https://reg/opencode-darwin-arm64.tgz', integrity } }
+    const fetchTarball = async (): Promise<{
+      stream: NodeJS.ReadableStream
+      totalBytes?: number
+    }> => ({ stream: Readable.from(tgz), totalBytes: tgz.length })
+
+    let verifiedPath: string | undefined
+    const outcome = await installManagedOpencode({
+      installId: 'i4',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'darwin-arm64', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      verifyBinary: (binPath) => {
+        verifiedPath = binPath
+        return { ok: true }
+      },
+      tmpDir: root
+    })
+
+    expect(outcome.result.ok).toBe(true)
+    expect(outcome.resolvedPath).toBe(join(managedOpencodeDir(root), 'opencode'))
+    // The verifier is handed the installed binary path.
+    expect(verifiedPath).toBe(join(managedOpencodeDir(root), 'opencode'))
   })
 })
 

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -148,6 +148,25 @@ const resolveNative = async (
   return { version: resolvedVersion, tarball, integrity }
 }
 
+// Post-install smoke check. A native package can download+extract cleanly yet still be unrunnable on
+// this host (e.g. a non-AVX2 x64 CPU dies with SIGILL at first spawn), so we execute `--version` before
+// treating the install as successful. `ok:false` carries a human reason plus the raw signal so the
+// caller can add an actionable hint.
+export type VerifyBinaryResult =
+  { ok: true } | { ok: false; reason: string; signal?: string | null }
+export type VerifyBinary = (binPath: string) => VerifyBinaryResult
+
+// Default verifier: run the installed binary with `--version` and classify failures. A spawn error, a
+// terminating signal (SIGILL etc.), or a non-zero exit all mean the binary is not usable here.
+const defaultVerifyBinary: VerifyBinary = (binPath) => {
+  const probe = spawnSync(binPath, ['--version'], { encoding: 'utf8', timeout: 15_000 })
+  if (probe.error) return { ok: false, reason: `spawn error: ${probe.error.message}` }
+  if (probe.signal) return { ok: false, reason: `killed by ${probe.signal}`, signal: probe.signal }
+  if (probe.status !== 0)
+    return { ok: false, reason: `\`--version\` exited with code ${probe.status}` }
+  return { ok: true }
+}
+
 export type InstallManagedOpencodeOptions = {
   installId: string
   onEvent: (event: ClaudeInstallEvent) => void
@@ -157,6 +176,7 @@ export type InstallManagedOpencodeOptions = {
   platform?: OpencodePlatform
   fetchJson?: FetchJson
   fetchTarball?: FetchTarball
+  verifyBinary?: VerifyBinary
   tmpDir?: string
 }
 
@@ -171,6 +191,7 @@ export const installManagedOpencode = async ({
   platform = resolveOpencodePlatform(),
   fetchJson = defaultFetchJson,
   fetchTarball = defaultFetchTarball,
+  verifyBinary = defaultVerifyBinary,
   tmpDir
 }: InstallManagedOpencodeOptions): Promise<ManagedInstallOutcome> => {
   const destPath = join(managedOpencodeDir(dataRoot), platform.binName)
@@ -208,6 +229,18 @@ export const installManagedOpencode = async ({
 
       if (!found) throw new Error(`Native package did not contain bin/${platform.binName}`)
       if (process.platform !== 'win32') await chmod(destPath, 0o755)
+
+      // Smoke-check the binary before reporting success — a clean download does not guarantee it runs
+      // on this CPU. Remove the unusable binary and fail loudly so no broken path gets persisted.
+      const verification = verifyBinary(destPath)
+      if (!verification.ok) {
+        await rm(destPath, { force: true }).catch(() => undefined)
+        const hint =
+          verification.signal === 'SIGILL'
+            ? ' Your CPU may not support the required instruction set (AVX2).'
+            : ''
+        throw new Error(`OpenCode installed but failed to run (${verification.reason}).${hint}`)
+      }
 
       onEvent({
         kind: 'log',


### PR DESCRIPTION
## Summary
The app-managed OpenCode installer downloaded, extracted, and chmod'd the native binary, then reported success without ever running it. On an older x64 CPU lacking AVX2 the standard (non-`-baseline`) build installs "successfully" and then dies with SIGILL at first real spawn, surfacing later as a confusing EPIPE.

Adds a post-install smoke check inside `installManagedOpencode` (injectable `verifyBinary`, defaulting to `spawnSync(bin, ['--version'])`). A spawn error, terminating signal, or non-zero exit is treated as an install failure: the broken binary is removed and the structured failure outcome is returned (with an AVX2 hint on SIGILL), so `installOpencode` never persists an unrunnable path.

The `-baseline` fallback was intentionally not added — it depends on registry package naming that can't be verified offline; a loud, clear failure is the priority.

## Tests
`src/main/settings/managed-opencode.test.ts` — install fails cleanly and removes the binary when the verifier reports it can't run; install succeeds and persists the path when the verifier passes.

typecheck + lint + `vitest run src/main/settings` (278 tests) all green.