### PR TITLE
fix(acp): replay history preamble on interrupted-session resume

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -942,6 +942,99 @@ describe('resuming an interrupted session on demand', () => {
     expect(session.interrupted).toBeUndefined()
   })
 
+  it('replays a history preamble when an interrupted resume adopts a fresh agent session', async () => {
+    // A completed prior turn that must be replayed once the agent's context is gone.
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Plot the sales data',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'ask'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'Done, saved chart.png'
+    })
+    useSessionStore.getState().finishRun('session-1')
+    // The interrupted turn: a user message the drop left unanswered.
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'now add a trend line',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'ask'
+    })
+    useSessionStore.getState().markDisconnected('session-1')
+
+    const runtime = {
+      state: createSnapshot([]),
+      createSession: vi.fn(),
+      // Step-1 resume adopts a fresh session (contextReset); the shared send path's own re-resume then
+      // hits the already-attached session and reports no reset — mirroring runtime's "already attached"
+      // branch. The interrupted path must still honor its own step-1 signal.
+      resumeSession: vi
+        .fn()
+        .mockResolvedValueOnce({
+          sessionId: 'session-1',
+          cwd: '/workspace/project',
+          contextReset: true
+        })
+        .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+    await flushRuntimeTasks()
+
+    const preamble = runtime.sendPrompt.mock.calls[0]?.[5]
+    expect(preamble).toContain('Plot the sales data')
+    expect(preamble).toContain('Done, saved chart.png')
+    // The re-sent interrupted turn is prior-context only: it is not folded into its own preamble.
+    expect(preamble).not.toContain('now add a trend line')
+  })
+
+  it('does not replay a history preamble when the interrupted resume kept agent context', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Earlier prompt',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'ask'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'Earlier answer'
+    })
+    useSessionStore.getState().finishRun('session-1')
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'keep going',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'ask'
+    })
+    useSessionStore.getState().markDisconnected('session-1')
+
+    const runtime = {
+      state: createSnapshot([]),
+      createSession: vi.fn(),
+      // The agent resumed its own session both times, so there is nothing to replay.
+      resumeSession: vi
+        .fn()
+        .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+    await flushRuntimeTasks()
+
+    expect(runtime.sendPrompt.mock.calls[0]?.[5]).toBeUndefined()
+  })
+
   it('replays a history preamble when a resume resets agent context', async () => {
     // A completed prior turn that should be replayed to the freshly-adopted agent.
     useSessionStore.getState().appendUserMessage({

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -36,6 +36,10 @@ type SendWorkspaceMessageInput = {
   referencedArtifacts?: ArtifactReference[]
   // Structured mention segments of the draft, persisted so the sent bubble renders styled pills.
   parts?: MessagePart[]
+  // Set by the interrupted-resume path when its own resume already reset the agent's context. The
+  // internal re-resume below runs against an already-attached session and can't report the reset
+  // again, so this forces the prior turns to be replayed as a history preamble on the re-sent turn.
+  forceHistoryReplay?: boolean
 }
 
 type SendWorkspaceMessageResult = {
@@ -312,7 +316,8 @@ const sendWorkspaceMessage = async (
     permissionProfile,
     forcedSkillIds,
     referencedArtifacts,
-    parts
+    parts,
+    forceHistoryReplay
   }: SendWorkspaceMessageInput
 ): Promise<SendWorkspaceMessageResult | undefined> => {
   const content = text.trim()
@@ -392,6 +397,7 @@ const sendWorkspaceMessage = async (
     // A resume that lands on a freshly-adopted session (framework switch, or an unresumable restart)
     // lost the agent's context, so replay the prior turns as a preamble on this first prompt.
     let historyPreamble: string | undefined
+    let contextResetFromResume = false
 
     if (resumeCwd) {
       try {
@@ -402,15 +408,19 @@ const sendWorkspaceMessage = async (
           currentSession?.permissionProfile ?? permissionProfile
         )
 
-        if (resumeResult?.contextReset && currentSession) {
-          // currentSession was captured before the new user message was appended, so this is the
-          // prior conversation only — the turn being sent is not duplicated into the preamble.
-          historyPreamble = buildHistoryPreamble(currentSession.messages)
-        }
+        contextResetFromResume = Boolean(resumeResult?.contextReset)
       } catch (error) {
         useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
         return appended
       }
+    }
+
+    // Replay prior turns when this resume reset the agent's context, or the caller already knows a reset
+    // happened (interrupted-resume path — its internal re-resume above hits an already-attached session
+    // and can't report the reset again). currentSession was captured before the new user message was
+    // appended, so this is the prior conversation only — the turn being sent is not duplicated in.
+    if ((contextResetFromResume || forceHistoryReplay) && currentSession) {
+      historyPreamble = buildHistoryPreamble(currentSession.messages)
     }
 
     let promptAttachments = attachments
@@ -525,13 +535,19 @@ const resumeInterruptedWorkspaceSession = async (
     return
   }
 
+  let contextReset = false
+
   try {
-    await runtime.resumeSession(
+    const resumeResult = await runtime.resumeSession(
       sessionId,
       resumeCwd,
       session.projectId,
       session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
     )
+    // Adopting a fresh agent session (framework switch, or an unresumable restart) wipes the agent's
+    // context; capture that so the re-sent turn below replays the transcript. The shared send path's
+    // own re-resume can't observe this — by then the session is already attached.
+    contextReset = Boolean(resumeResult?.contextReset)
     useSessionStore.getState().markResumed(sessionId)
   } catch (error) {
     useSessionStore.getState().failRun(sessionId, getResumeFailureMessage(error))
@@ -553,7 +569,9 @@ const resumeInterruptedWorkspaceSession = async (
     parts: interruptedTurn.parts,
     cwd: resumeCwd,
     projectId: session.projectId,
-    permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
+    permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+    // Replay the prior conversation when this resume adopted a fresh agent session.
+    forceHistoryReplay: contextReset
   })
 }
 


### PR DESCRIPTION
## Summary
`resumeInterruptedWorkspaceSession` discarded the `contextReset` flag returned by its own `resumeSession()` call. When that resume adopted a fresh agent session (unresumable restart / framework switch), the follow-up `sendWorkspaceMessage` re-resumed the now-attached session — which returns no `contextReset` — so no history preamble was built and the interrupted turn was re-sent with **no prior context**.

The interrupted-resume path now captures `contextReset` from its resume and threads it as `forceHistoryReplay` into `sendWorkspaceMessage`, which builds the soft-replay preamble via the existing `buildHistoryPreamble` plumbing. The interrupted turn is still removed before the re-send, so it is not duplicated into its own replayed history.

## Tests
`src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts` — an interrupted resume that adopts a fresh session replays the prior conversation as a preamble (and excludes the re-sent turn); an interrupted resume that keeps agent context replays nothing.

typecheck + lint + `vitest run src/renderer/src/lib/acp` (67 tests) all green.