### PR TITLE
fix: harden OpenCode config isolation, session cleanup, and install

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -290,6 +290,9 @@ const startPermissionProbeAgent = (
 const mcpServerNamesMap = (runtime: AcpRuntime): Map<string, string[]> =>
   (runtime as unknown as { sessionMcpServerNames: Map<string, string[]> }).sessionMcpServerNames
 
+const agentToAppSessionMap = (runtime: AcpRuntime): Map<string, string> =>
+  (runtime as unknown as { agentToAppSessionId: Map<string, string> }).agentToAppSessionId
+
 // Finds the isMcp flag the runtime logged for a given permission request (identified by toolCallId).
 const auditedIsMcp = (toolCallId: string): boolean | undefined => {
   const call = infoLogSpy.mock.calls.find(
@@ -1557,6 +1560,28 @@ describe('ACP runtime session management', () => {
     await expect(
       runtime.sendPrompt({ sessionId: 'switched-session', text: 'hello' })
     ).rejects.toThrow(/not found/)
+  })
+
+  it('clears the reverse (agent id -> app id) mapping when an adopted session is deleted', async () => {
+    const process = new FakeAgentProcess()
+    // Resume rejects, so the runtime adopts a fresh agent session (adopted-session-1) under the
+    // app-facing id (switched-session), registering the reverse mapping used to relabel agent events.
+    startFakeAgent(process, ['adopted-session-1'], { resumeNotFound: true })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.resumeSession({ sessionId: 'switched-session', cwd: '/workspace' })
+    // The adoption recorded the underlying id -> app id mapping.
+    expect(agentToAppSessionMap(runtime).get('adopted-session-1')).toBe('switched-session')
+
+    await runtime.deleteSession({ sessionId: 'switched-session' })
+
+    // Delete removes the reverse entry, so a reused agent id or a late agent event carrying the
+    // underlying id no longer resolves to the deleted app session.
+    expect(agentToAppSessionMap(runtime).has('adopted-session-1')).toBe(false)
   })
 
   it('resumes an existing protocol session so restored conversations can continue', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -78,6 +78,9 @@ const startFakeAgent = (
     // When true, the resume handler rejects with a generic "Internal error" (-32603) — what some
     // agents return instead of a clean not-found after their process was replaced by an app restart.
     resumeInternalError?: boolean
+    // When true, the agent does NOT advertise session/close capability, so the runtime must fall back to
+    // the session/cancel notification on delete instead of a close request.
+    supportsClose?: boolean
     onPrompt?: (context: {
       sessionId: string
       text: string
@@ -89,6 +92,7 @@ const startFakeAgent = (
   newSessions: Array<{ cwd: string; mcpServers: unknown[]; _meta?: unknown }>
   resumedSessions: Array<{ sessionId: string; cwd: string; mcpServers: unknown[]; _meta?: unknown }>
   closedSessions: string[]
+  cancelledSessions: string[]
   modeChanges: Array<{ sessionId: string; modeId: string }>
   actions: string[]
 } => {
@@ -101,6 +105,7 @@ const startFakeAgent = (
     _meta?: unknown
   }> = []
   const closedSessions: string[] = []
+  const cancelledSessions: string[] = []
   const modeChanges: Array<{ sessionId: string; modeId: string }> = []
   const actions: string[] = []
   let sessionIndex = 0
@@ -112,7 +117,7 @@ const startFakeAgent = (
       agentCapabilities: {
         loadSession: false,
         sessionCapabilities: {
-          close: {},
+          ...(options.supportsClose === false ? {} : { close: {} }),
           ...(options.supportsResume === false ? {} : { resume: {} })
         }
       },
@@ -177,7 +182,10 @@ const startFakeAgent = (
 
       return { stopReason: 'end_turn' }
     })
-    .onNotification(acp.methods.agent.session.cancel, () => undefined)
+    .onNotification(acp.methods.agent.session.cancel, (ctx) => {
+      cancelledSessions.push(ctx.params.sessionId)
+      return undefined
+    })
     .onRequest(acp.methods.agent.session.close, (ctx) => {
       closedSessions.push(ctx.params.sessionId)
       return {}
@@ -189,7 +197,15 @@ const startFakeAgent = (
       )
     )
 
-  return { prompts, newSessions, resumedSessions, closedSessions, modeChanges, actions }
+  return {
+    prompts,
+    newSessions,
+    resumedSessions,
+    closedSessions,
+    cancelledSessions,
+    modeChanges,
+    actions
+  }
 }
 
 const createModes = (
@@ -1582,6 +1598,30 @@ describe('ACP runtime session management', () => {
     // Delete removes the reverse entry, so a reused agent id or a late agent event carrying the
     // underlying id no longer resolves to the deleted app session.
     expect(agentToAppSessionMap(runtime).has('adopted-session-1')).toBe(false)
+  })
+
+  it('cancels an adopted session by its own id when the agent lacks session/close', async () => {
+    const process = new FakeAgentProcess()
+    // No close capability, so delete must fall back to the session/cancel notification; resume rejects
+    // so the fresh agent session (adopted-session-1) is adopted under the app-facing id.
+    const fakeAgent = startFakeAgent(process, ['adopted-session-1'], {
+      resumeNotFound: true,
+      supportsClose: false
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.resumeSession({ sessionId: 'switched-session', cwd: '/workspace' })
+    await runtime.deleteSession({ sessionId: 'switched-session' })
+
+    // The cancel fallback targets the underlying agent id, not the app-facing one (cancel is a
+    // fire-and-forget notification, so wait for the agent to receive it).
+    await vi.waitFor(() => expect(fakeAgent.cancelledSessions).toEqual(['adopted-session-1']))
+    expect(fakeAgent.closedSessions).toEqual([])
+    expect(runtime.getSnapshot().sessionIds).toEqual([])
   })
 
   it('resumes an existing protocol session so restored conversations can continue', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -309,6 +309,9 @@ const mcpServerNamesMap = (runtime: AcpRuntime): Map<string, string[]> =>
 const agentToAppSessionMap = (runtime: AcpRuntime): Map<string, string> =>
   (runtime as unknown as { agentToAppSessionId: Map<string, string> }).agentToAppSessionId
 
+const sessionFrameworksMap = (runtime: AcpRuntime): Map<string, string> =>
+  (runtime as unknown as { sessionFrameworks: Map<string, string> }).sessionFrameworks
+
 // Finds the isMcp flag the runtime logged for a given permission request (identified by toolCallId).
 const auditedIsMcp = (toolCallId: string): boolean | undefined => {
   const call = infoLogSpy.mock.calls.find(
@@ -1622,6 +1625,33 @@ describe('ACP runtime session management', () => {
     await vi.waitFor(() => expect(fakeAgent.cancelledSessions).toEqual(['adopted-session-1']))
     expect(fakeAgent.closedSessions).toEqual([])
     expect(runtime.getSnapshot().sessionIds).toEqual([])
+  })
+
+  it('cleans up sessionFrameworks when deleting a detached session (post framework-switch)', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['remote-session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    // createSession records the session's framework; a framework switch disconnects (clearing
+    // this.sessions) but deliberately KEEPS sessionFrameworks so a later resume can detect the switch.
+    expect(sessionFrameworksMap(runtime).has(session.sessionId)).toBe(true)
+    await runtime.disconnect()
+    expect(runtime.getSnapshot().sessionIds).toEqual([])
+    // The framework entry survives the disconnect (by design).
+    expect(sessionFrameworksMap(runtime).has(session.sessionId)).toBe(true)
+
+    // Deleting the now-detached session must not throw or talk to a torn-down agent, but must still
+    // drop the leaked framework entry so it cannot later mislead the cross-framework-resume check.
+    await runtime.deleteSession({ sessionId: session.sessionId })
+
+    expect(sessionFrameworksMap(runtime).has(session.sessionId)).toBe(false)
+    expect(fakeAgent.closedSessions).toEqual([])
+    expect(fakeAgent.cancelledSessions).toEqual([])
   })
 
   it('resumes an existing protocol session so restored conversations can continue', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1268,21 +1268,31 @@ class AcpRuntime {
       }
 
       session.dispose()
-      this.permissionBroker.cancelForSession(request.sessionId)
-      // Drop this session's http MCP host registrations (no-op when no host / stdio framework).
-      this.unregisterHttpMcpSession(request.sessionId)
       // Drop the reverse (underlying agent id -> app id) mapping an adopted session registered, so a
       // reused agent id or a late agent event can no longer route to this deleted app session.
       this.agentToAppSessionId.delete(session.sessionId)
-      this.sessions.delete(request.sessionId)
-      this.sessionCwds.delete(request.sessionId)
-      this.sessionMcpServerNames.delete(request.sessionId)
-      this.sessionProjectNames.delete(request.sessionId)
-      this.sessionFrameworks.delete(request.sessionId)
-      this.permissionProfiles.delete(request.sessionId)
-      this.artifactSessionIds.delete(request.sessionId)
-      this.notebookRoutingIds.delete(request.sessionId)
-      this.promptInFlightSessionIds.delete(request.sessionId)
+    }
+
+    // App-session-keyed cleanup runs whether or not a live session is attached. A framework switch
+    // disconnects (clearing this.sessions and most maps) but deliberately KEEPS sessionFrameworks, so
+    // deleting a session that was never re-adopted under the new framework would leak that entry —
+    // later misleading the cross-framework-resume check. These deletes are no-ops when the id is absent.
+    this.permissionBroker.cancelForSession(request.sessionId)
+    // Drop this session's http MCP host registrations (no-op when no host / stdio framework).
+    this.unregisterHttpMcpSession(request.sessionId)
+    this.sessions.delete(request.sessionId)
+    this.sessionCwds.delete(request.sessionId)
+    this.sessionMcpServerNames.delete(request.sessionId)
+    this.sessionProjectNames.delete(request.sessionId)
+    this.sessionFrameworks.delete(request.sessionId)
+    this.permissionProfiles.delete(request.sessionId)
+    this.artifactSessionIds.delete(request.sessionId)
+    this.notebookRoutingIds.delete(request.sessionId)
+    this.promptInFlightSessionIds.delete(request.sessionId)
+
+    // Only announce a deletion and shift the current session when something was actually attached; a
+    // detached cleanup (post-switch) must not emit a spurious event or move currentSessionId.
+    if (session) {
       this.currentSessionId =
         this.currentSessionId === request.sessionId
           ? Array.from(this.sessions.keys())[0]

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1271,6 +1271,9 @@ class AcpRuntime {
       this.permissionBroker.cancelForSession(request.sessionId)
       // Drop this session's http MCP host registrations (no-op when no host / stdio framework).
       this.unregisterHttpMcpSession(request.sessionId)
+      // Drop the reverse (underlying agent id -> app id) mapping an adopted session registered, so a
+      // reused agent id or a late agent event can no longer route to this deleted app session.
+      this.agentToAppSessionId.delete(session.sessionId)
       this.sessions.delete(request.sessionId)
       this.sessionCwds.delete(request.sessionId)
       this.sessionMcpServerNames.delete(request.sessionId)

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -80,6 +80,57 @@ describe('opencodeFramework.prepareModelConfig', () => {
       expect(rules[tool]).toBe('ask')
     }
   })
+
+  it('disables project config loading so a repo cannot inject opencode.json / .opencode config', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    // Truthy per opencode's truthy(): closes the whole project-config surface (both opencode.json/.jsonc
+    // walked up from cwd and the .opencode/ directory), so a repo cannot add an exact-id allow rule or
+    // repoint the provider at all.
+    expect(config.env?.OPENCODE_DISABLE_PROJECT_CONFIG).toBe('true')
+  })
+
+  it('pins the authoritative provider/model/baseURL (not just permission) in OPENCODE_CONFIG_CONTENT', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw.example/v1', model: 'deepseek-v4-pro', key: 'k' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    // The high-priority layer pins model + provider + baseURL so a lower-precedence ~/.opencode cannot
+    // repoint the endpoint or swap the model while inheriting the key ref.
+    expect(content.model).toBe('anthropic/deepseek-v4-pro')
+    expect(content.provider.anthropic.options.baseURL).toBe('https://gw.example/v1')
+    expect(content.provider.anthropic.models).toEqual({ 'deepseek-v4-pro': {} })
+    // Permission policy is still pinned.
+    expect(content.permission['*']).toBe('ask')
+    // The key rides the env as a reference only — never a plaintext literal in the pinned layer.
+    expect(content.provider.anthropic.options.apiKey).toBe('{env:OPENCODE_APP_API_KEY}')
+    expect(config.env?.OPENCODE_CONFIG_CONTENT).not.toContain('"k"')
+  })
+
+  it('mirrors the config file provider/model in the OPENCODE_CONFIG_CONTENT layer (no divergence)', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'gpt-x', key: 'k', apiType: 'openai' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    const fileConfig = JSON.parse(
+      config.configFiles?.find((file) => file.path.endsWith('opencode.json'))?.content ?? '{}'
+    )
+    const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+
+    // The pinned layer and the written file select the same model and provider block, so they cannot
+    // drift out of sync.
+    expect(content.model).toBe(fileConfig.model)
+    expect(content.provider['openai-compatible'].npm).toBe('@ai-sdk/openai-compatible')
+    expect(content.provider['openai-compatible'].options.baseURL).toBe(
+      fileConfig.provider['openai-compatible'].options.baseURL
+    )
+  })
 })
 
 describe('buildOpencodeConfig', () => {

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -62,9 +62,10 @@ const OPENCODE_API_KEY_ENV = 'OPENCODE_APP_API_KEY'
 // The app's permission policy for opencode: every side-effecting/MCP tool must ASK the ACP client (the
 // app's broker then enforces the selected profile); only safe read-only tools run silently (parity with
 // Claude's Ask mode). The `*` catch-all covers unlisted tools (MCP artifact/notebook/connectors, etc.),
-// and the sensitive built-ins are pinned to `ask` explicitly so a workspace config that sets one of
-// those keys to `allow` is overridden rather than winning. Enforced above any project config via the
-// OPENCODE_CONFIG_CONTENT layer (see prepareModelConfig) — the config-file block is only a baseline.
+// and the sensitive built-ins are pinned to `ask` explicitly so a lower-precedence config that sets one
+// of those keys to `allow` is overridden rather than winning. Enforced via the OPENCODE_CONFIG_CONTENT
+// layer (see prepareModelConfig), which also disables project config entirely — the config-file block is
+// only a baseline.
 const OPENCODE_PERMISSION_RULES: Record<string, 'ask' | 'allow' | 'deny'> = {
   '*': 'ask',
   read: 'allow',
@@ -86,16 +87,12 @@ const asRecord = (value: unknown): Record<string, unknown> =>
     ? (value as Record<string, unknown>)
     : {}
 
-// Builds opencode's config by MERGING the app's active provider/model onto the user's existing config
-// so their own providers, mcp servers, and auth are preserved. The model is both selected (top-level
-// `model`) and registered under the provider's `models` map — without the registration opencode does
-// not recognize a non-catalog model id (e.g. a custom gateway's `deepseek-v4-pro`) and silently falls
-// back to its own default. Verified against opencode 1.17.13.
-const buildOpencodeConfig = (
-  provider: ResolvedProvider,
-  baseConfig: Record<string, unknown> = {},
-  instructionPaths: string[] = []
-): string => {
+// Resolves the app provider's opencode endpoint primitives (provider id, npm package, base URL, model).
+// Shared by both the written config file and the OPENCODE_CONFIG_CONTENT layer so the authoritative
+// provider/model they pin can never diverge.
+const resolveOpencodeEndpoint = (
+  provider: ResolvedProvider
+): { bareModel: string | undefined; providerId: string; npm?: string; baseURL?: string } => {
   const bareModel = provider.model
   // opencode drives both endpoints; pick the one for this provider (openai wins when it offers both).
   const endpoint =
@@ -109,6 +106,46 @@ const buildOpencodeConfig = (
     endpoint === 'openai' ? (provider.openaiBaseUrl ?? provider.baseUrl) : provider.baseUrl
   const baseURL =
     endpoint === 'openai' && rawBase ? `${normalizeOpenAiBaseUrl(rawBase)}/v1` : rawBase
+
+  return { bareModel, providerId, npm, baseURL }
+}
+
+// The app-authoritative config layer (model + provider block + permission policy) passed verbatim to
+// opencode via OPENCODE_CONFIG_CONTENT, which opencode deep-merges ABOVE both the app-owned global config
+// and any project config. Pinning the provider/model/baseURL here (not just permission) means a
+// lower-precedence config — e.g. the user's own ~/.opencode — cannot repoint the active provider's
+// baseURL or switch the model to an attacker-defined provider while inheriting the app's key ref, so the
+// real key can only ever go to the app's own endpoint. The key stays an env reference, never plaintext.
+const buildAppConfigContent = (provider: ResolvedProvider): Record<string, unknown> => {
+  const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
+
+  return {
+    ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
+    permission: { ...OPENCODE_PERMISSION_RULES },
+    provider: {
+      [providerId]: {
+        ...(npm ? { npm } : {}),
+        options: {
+          ...(baseURL ? { baseURL } : {}),
+          ...(provider.key ? { apiKey: `{env:${OPENCODE_API_KEY_ENV}}` } : {})
+        },
+        ...(bareModel ? { models: { [bareModel]: {} } } : {})
+      }
+    }
+  }
+}
+
+// Builds opencode's config by MERGING the app's active provider/model onto the user's existing config
+// so their own providers, mcp servers, and auth are preserved. The model is both selected (top-level
+// `model`) and registered under the provider's `models` map — without the registration opencode does
+// not recognize a non-catalog model id (e.g. a custom gateway's `deepseek-v4-pro`) and silently falls
+// back to its own default. Verified against opencode 1.17.13.
+const buildOpencodeConfig = (
+  provider: ResolvedProvider,
+  baseConfig: Record<string, unknown> = {},
+  instructionPaths: string[] = []
+): string => {
+  const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
 
   const baseProviders = asRecord(baseConfig.provider)
   const baseProvider = asRecord(baseProviders[providerId])
@@ -126,12 +163,10 @@ const buildOpencodeConfig = (
     ...baseConfig,
     ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
     ...(instructions.length > 0 ? { instructions } : {}),
-    // Baseline permission policy written into the config file. This alone is NOT sufficient: opencode
-    // loads a project-level opencode.json / .opencode config from the session cwd at HIGHER precedence
-    // than this app-owned (global) config, so a workspace could set `permission["*"]="allow"` here and
-    // disable delegation. The authoritative copy of these rules is passed via the OPENCODE_CONFIG_CONTENT
-    // layer in prepareModelConfig, which opencode merges above project config. See
-    // OPENCODE_PERMISSION_RULES for the policy rationale.
+    // Baseline permission policy written into the app-owned (global) config file. The authoritative
+    // copy of these rules — plus the provider/model pin — is passed via the OPENCODE_CONFIG_CONTENT layer
+    // in prepareModelConfig, which opencode merges at highest precedence AND which disables project
+    // config loading, so a repo can no longer override this. See OPENCODE_PERMISSION_RULES for rationale.
     permission: {
       ...basePermission,
       ...OPENCODE_PERMISSION_RULES
@@ -218,13 +253,19 @@ export const opencodeFramework: AgentFramework = {
       env: {
         XDG_CONFIG_HOME: configHome,
         XDG_DATA_HOME: dataHome,
-        // Enforce the permission policy from the OPENCODE_CONFIG_CONTENT layer, which opencode merges
-        // ABOVE the global XDG config AND above any project-level opencode.json / .opencode config the
-        // repo ships. So a malicious workspace can no longer flip permission["*"] to "allow" and bypass
-        // the app broker; the config-file block above is only a baseline. Residual: a workspace config
-        // that names a specific NON-pinned tool (e.g. an exact MCP tool id) with "allow" still wins for
-        // that one tool, since opencode deep-merges permission keys with no "replace-all" layer here.
-        OPENCODE_CONFIG_CONTENT: JSON.stringify({ permission: OPENCODE_PERMISSION_RULES }),
+        // Refuse to load ANY project config: this stops the session cwd's opencode.json / opencode.jsonc
+        // (walked up to the worktree root) and its .opencode/ directory from injecting config at all. A
+        // repo therefore cannot flip permission["*"] to "allow", add an exact-id "allow" rule for an MCP
+        // tool that would beat "*":"ask", or repoint the provider's baseURL to exfiltrate the app key —
+        // the whole project-config surface is closed at the source, not patched rule-by-rule.
+        OPENCODE_DISABLE_PROJECT_CONFIG: 'true',
+        // Pin the app's authoritative provider/model/baseURL + permission policy as the high-priority
+        // layer opencode merges above the global XDG config (and, since project config is disabled above,
+        // this is the top layer). Pinning provider/model here — not just permission — is defense-in-depth
+        // against the only remaining non-repo surface, the user's own ~/.opencode: it cannot repoint the
+        // active provider's baseURL or swap the model to an attacker provider while inheriting the app's
+        // `{env:...}` key ref. The key itself never rides this layer, only its env reference.
+        OPENCODE_CONFIG_CONTENT: JSON.stringify(buildAppConfigContent(provider)),
         // Pass the decrypted key ONLY via the environment; the config references it as `{env:...}`.
         ...(provider.key ? { [OPENCODE_API_KEY_ENV]: provider.key } : {})
       },

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -222,7 +222,9 @@ describe('installManagedOpencode', () => {
       requestedKeys.push('standard')
       return { dist: { tarball: 'https://reg/standard.tgz', integrity: sha512(standardTgz) } }
     }
-    const fetchTarball = async (url: string): Promise<{
+    const fetchTarball = async (
+      url: string
+    ): Promise<{
       stream: NodeJS.ReadableStream
       totalBytes?: number
     }> => {

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Readable } from 'node:stream'
@@ -8,6 +8,7 @@ import { gzipSync } from 'node:zlib'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import {
+  defaultVerifyBinary,
   installManagedOpencode,
   managedOpencodeDir,
   resolveOpencodePlatform
@@ -221,9 +222,10 @@ describe('installManagedOpencode', () => {
       requestedKeys.push('standard')
       return { dist: { tarball: 'https://reg/standard.tgz', integrity: sha512(standardTgz) } }
     }
-    const fetchTarball = async (
-      url: string
-    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => {
+    const fetchTarball = async (url: string): Promise<{
+      stream: NodeJS.ReadableStream
+      totalBytes?: number
+    }> => {
       const tgz = url.includes('baseline') ? baselineTgz : standardTgz
       return { stream: Readable.from(tgz), totalBytes: tgz.length }
     }
@@ -363,4 +365,42 @@ describe('resolveOpencodePlatform', () => {
       /Unsupported platform/
     )
   })
+})
+
+describe('defaultVerifyBinary', () => {
+  let root: string | undefined
+
+  afterEach(async () => {
+    if (root) {
+      await rm(root, { recursive: true, force: true })
+      root = undefined
+    }
+  })
+
+  it('reports ok for a binary that runs `--version` and exits zero', () => {
+    // node itself answers `--version` with exit 0 — the real spawnSync path, host-independent.
+    expect(defaultVerifyBinary(process.execPath)).toEqual({ ok: true })
+  })
+
+  it('reports a spawn error (unrunnable) when the binary path does not exist', () => {
+    const result = defaultVerifyBinary(join(tmpdir(), 'no-such-opencode-binary-xyz'))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/spawn error/)
+  })
+
+  // A non-zero `--version` exit classifies as unrunnable. Uses a chmod'd shell script, so it is skipped
+  // on Windows (advisory CI leg) where the exec-bit trick does not apply.
+  it.skipIf(process.platform === 'win32')(
+    'reports a non-zero exit (unrunnable) from the real probe',
+    async () => {
+      root = await mkdtemp(join(tmpdir(), 'verify-binary-'))
+      const script = join(root, 'exit3.sh')
+      await writeFile(script, '#!/bin/sh\nexit 3\n')
+      await chmod(script, 0o755)
+
+      const result = defaultVerifyBinary(script)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.reason).toMatch(/exited with code 3/)
+    }
+  )
 })

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -5,13 +6,15 @@ import { join } from 'node:path'
 import { Readable } from 'node:stream'
 import { gzipSync } from 'node:zlib'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  classifyVerifyResult,
   defaultVerifyBinary,
   installManagedOpencode,
   managedOpencodeDir,
-  resolveOpencodePlatform
+  resolveOpencodePlatform,
+  runVersionProbe
 } from './managed-opencode'
 
 // One 512-byte ustar header + padded content — synthesizes the npm tarball shape the extractor reads.
@@ -149,8 +152,8 @@ describe('installManagedOpencode', () => {
       platform: { key: 'darwin-arm64', binName: 'opencode' },
       fetchJson,
       fetchTarball,
-      // Simulate a non-AVX2 host: the binary dies with SIGILL when probed.
-      verifyBinary: () => ({ ok: false, reason: 'killed by SIGILL', signal: 'SIGILL' }),
+      // Simulate a non-AVX2 host: the binary dies on an illegal instruction when probed.
+      verifyBinary: () => ({ ok: false, reason: 'killed by SIGILL', illegalInstruction: true }),
       tmpDir: root
     })
 
@@ -245,7 +248,7 @@ describe('installManagedOpencode', () => {
       verifyBinary: () => {
         probes += 1
         return probes === 1
-          ? { ok: false, reason: 'killed by SIGILL', signal: 'SIGILL' }
+          ? { ok: false, reason: 'killed by SIGILL', illegalInstruction: true }
           : { ok: true }
       },
       tmpDir: root
@@ -255,6 +258,114 @@ describe('installManagedOpencode', () => {
     expect(outcome.result.ok).toBe(true)
     expect(outcome.version).toBe('1.18.3')
     expect(await readFile(outcome.resolvedPath!, 'utf8')).toContain('echo baseline')
+  })
+
+  // A musl x64 host: the baseline package name inserts `baseline` before the `-musl` suffix, so the
+  // retry must request `opencode-linux-x64-baseline-musl` (NOT the non-existent linux-x64-musl-baseline).
+  it('retries the linux-x64-baseline-musl variant for a musl x64 host', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const standardTgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho standard\n') }
+    ])
+    const baselineTgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho baseline\n') }
+    ])
+
+    const requestedKeys: string[] = []
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/opencode-ai')) return { 'dist-tags': { latest: '1.18.3' } }
+      if (url.includes('/opencode-linux-x64-baseline-musl/')) {
+        requestedKeys.push('baseline')
+        return { dist: { tarball: 'https://reg/baseline.tgz', integrity: sha512(baselineTgz) } }
+      }
+      requestedKeys.push('standard')
+      return { dist: { tarball: 'https://reg/standard.tgz', integrity: sha512(standardTgz) } }
+    }
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => {
+      const tgz = url.includes('baseline') ? baselineTgz : standardTgz
+      return { stream: Readable.from(tgz), totalBytes: tgz.length }
+    }
+
+    let probes = 0
+    const outcome = await installManagedOpencode({
+      installId: 'i5b',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'linux-x64-musl', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      verifyBinary: () => {
+        probes += 1
+        return probes === 1
+          ? { ok: false, reason: 'killed by SIGILL', illegalInstruction: true }
+          : { ok: true }
+      },
+      tmpDir: root
+    })
+
+    expect(requestedKeys).toEqual(['standard', 'baseline'])
+    expect(outcome.result.ok).toBe(true)
+    expect(await readFile(outcome.resolvedPath!, 'utf8')).toContain('echo baseline')
+  })
+
+  // On Windows an illegal instruction is an exit STATUS (NTSTATUS), not a signal, so a windows-x64 host
+  // whose standard build reports that status must still retry `opencode-windows-x64-baseline`.
+  it('retries windows-x64-baseline when the standard build reports an illegal-instruction status', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const standardTgz = buildTgz([
+      { name: 'package/bin/opencode.exe', content: Buffer.from('standard\n') }
+    ])
+    const baselineTgz = buildTgz([
+      { name: 'package/bin/opencode.exe', content: Buffer.from('baseline\n') }
+    ])
+
+    const requestedKeys: string[] = []
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/opencode-ai')) return { 'dist-tags': { latest: '1.18.3' } }
+      if (url.includes('/opencode-windows-x64-baseline/')) {
+        requestedKeys.push('baseline')
+        return { dist: { tarball: 'https://reg/baseline.tgz', integrity: sha512(baselineTgz) } }
+      }
+      requestedKeys.push('standard')
+      return { dist: { tarball: 'https://reg/standard.tgz', integrity: sha512(standardTgz) } }
+    }
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => {
+      const tgz = url.includes('baseline') ? baselineTgz : standardTgz
+      return { stream: Readable.from(tgz), totalBytes: tgz.length }
+    }
+
+    // First probe (standard) exits with STATUS_ILLEGAL_INSTRUCTION classified via illegalInstruction;
+    // second probe (baseline) runs.
+    let probes = 0
+    const outcome = await installManagedOpencode({
+      installId: 'i5w',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'windows-x64', binName: 'opencode.exe' },
+      fetchJson,
+      fetchTarball,
+      verifyBinary: () => {
+        probes += 1
+        return probes === 1
+          ? {
+              ok: false,
+              reason: '`--version` exited with code 3221225501',
+              illegalInstruction: true
+            }
+          : { ok: true }
+      },
+      tmpDir: root
+    })
+
+    expect(requestedKeys).toEqual(['standard', 'baseline'])
+    expect(outcome.result.ok).toBe(true)
+    expect(await readFile(outcome.resolvedPath!, 'utf8')).toContain('baseline')
   })
 
   // arm64 has no baseline package, so a SIGILL there must NOT trigger a retry — it fails directly.
@@ -282,7 +393,7 @@ describe('installManagedOpencode', () => {
       platform: { key: 'darwin-arm64', binName: 'opencode' },
       fetchJson,
       fetchTarball,
-      verifyBinary: () => ({ ok: false, reason: 'killed by SIGILL', signal: 'SIGILL' }),
+      verifyBinary: () => ({ ok: false, reason: 'killed by SIGILL', illegalInstruction: true }),
       tmpDir: root
     })
 
@@ -318,7 +429,7 @@ describe('installManagedOpencode', () => {
       platform: { key: 'linux-x64', binName: 'opencode' },
       fetchJson,
       fetchTarball,
-      verifyBinary: () => ({ ok: false, reason: 'killed by SIGILL', signal: 'SIGILL' }),
+      verifyBinary: () => ({ ok: false, reason: 'killed by SIGILL', illegalInstruction: true }),
       tmpDir: root
     })
 
@@ -369,6 +480,86 @@ describe('resolveOpencodePlatform', () => {
   })
 })
 
+describe('runVersionProbe', () => {
+  it('spawns the binary with `--version` and a 15s timeout', () => {
+    const spawn = vi.fn(() => ({ status: 0 }))
+    runVersionProbe('/path/to/opencode', spawn)
+    // Locks the exact probe contract: args and the 15s timeout the classifier depends on.
+    expect(spawn).toHaveBeenCalledWith('/path/to/opencode', ['--version'], {
+      encoding: 'utf8',
+      timeout: 15000
+    })
+  })
+})
+
+describe('classifyVerifyResult', () => {
+  it('reports ok when the probe exits zero', () => {
+    expect(classifyVerifyResult({ status: 0 })).toEqual({ ok: true })
+  })
+
+  it('classifies a non-zero exit (non-win32) as unrunnable, not an illegal instruction', () => {
+    const result = classifyVerifyResult({ status: 3 }, 'linux')
+    expect(result).toEqual({
+      ok: false,
+      reason: '`--version` exited with code 3',
+      illegalInstruction: false
+    })
+  })
+
+  it('classifies a spawn error as unrunnable (not an illegal instruction)', () => {
+    const error = Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' })
+    const result = classifyVerifyResult({ error }, 'linux')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toMatch(/spawn error/)
+      expect(result.illegalInstruction).toBe(false)
+    }
+  })
+
+  it('classifies a timeout-shaped error as unrunnable', () => {
+    const error = Object.assign(new Error('spawnSync ETIMEDOUT'), { code: 'ETIMEDOUT' })
+    const result = classifyVerifyResult({ error }, 'linux')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.illegalInstruction).toBe(false)
+  })
+
+  it('flags SIGILL as an illegal instruction', () => {
+    const result = classifyVerifyResult({ signal: 'SIGILL' }, 'linux')
+    expect(result).toEqual({
+      ok: false,
+      reason: 'killed by SIGILL',
+      illegalInstruction: true
+    })
+  })
+
+  it('classifies a non-SIGILL terminating signal as unrunnable, not an illegal instruction', () => {
+    const result = classifyVerifyResult({ signal: 'SIGTERM' }, 'linux')
+    expect(result).toEqual({
+      ok: false,
+      reason: 'killed by SIGTERM',
+      illegalInstruction: false
+    })
+  })
+
+  it('treats the NTSTATUS illegal-instruction exit status as illegal only on win32', () => {
+    // Unsigned form on Windows → illegal instruction.
+    const win = classifyVerifyResult({ status: 0xc000001d }, 'win32')
+    expect(win.ok).toBe(false)
+    if (!win.ok) expect(win.illegalInstruction).toBe(true)
+
+    // Same status on linux is just a non-zero exit, not an illegal instruction.
+    const linux = classifyVerifyResult({ status: 0xc000001d }, 'linux')
+    expect(linux.ok).toBe(false)
+    if (!linux.ok) expect(linux.illegalInstruction).toBe(false)
+  })
+
+  it('accepts the signed 32-bit form of the NTSTATUS illegal-instruction status on win32', () => {
+    const result = classifyVerifyResult({ status: -1073741795 }, 'win32')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.illegalInstruction).toBe(true)
+  })
+})
+
 describe('defaultVerifyBinary', () => {
   let root: string | undefined
 
@@ -403,6 +594,23 @@ describe('defaultVerifyBinary', () => {
       const result = defaultVerifyBinary(script)
       expect(result.ok).toBe(false)
       if (!result.ok) expect(result.reason).toMatch(/exited with code 3/)
+    }
+  )
+
+  // Genuinely exercises real spawnSync producing a `.signal`: a node child that kills itself with
+  // SIGKILL. POSIX-only, since Windows has no such terminating-signal semantics.
+  it.skipIf(process.platform === 'win32')(
+    'classifies a real terminating signal from spawnSync as unrunnable',
+    () => {
+      const probe = spawnSync(process.execPath, ['-e', 'process.kill(process.pid, "SIGKILL")'], {
+        encoding: 'utf8',
+        timeout: 15000
+      })
+      // Sanity: the real probe actually carried a terminating signal.
+      expect(probe.signal).toBeTruthy()
+      const result = classifyVerifyResult(probe)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.reason).toMatch(/killed by/)
     }
   )
 })

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -199,6 +199,131 @@ describe('installManagedOpencode', () => {
     // The verifier is handed the installed binary path.
     expect(verifiedPath).toBe(join(managedOpencodeDir(root), 'opencode'))
   })
+
+  // A non-AVX2 x64 host: the standard build dies with SIGILL, so the installer retries the -baseline
+  // variant, which runs cleanly. This is what makes the onboarding "auto-installable" claim hold.
+  it('retries the -baseline variant when the standard x64 build reports SIGILL, then succeeds', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const standardTgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho standard\n') }
+    ])
+    const baselineTgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho baseline\n') }
+    ])
+
+    const requestedKeys: string[] = []
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/opencode-ai')) return { 'dist-tags': { latest: '1.18.3' } }
+      if (url.includes('/opencode-linux-x64-baseline/')) {
+        requestedKeys.push('baseline')
+        return { dist: { tarball: 'https://reg/baseline.tgz', integrity: sha512(baselineTgz) } }
+      }
+      requestedKeys.push('standard')
+      return { dist: { tarball: 'https://reg/standard.tgz', integrity: sha512(standardTgz) } }
+    }
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => {
+      const tgz = url.includes('baseline') ? baselineTgz : standardTgz
+      return { stream: Readable.from(tgz), totalBytes: tgz.length }
+    }
+
+    // First probe (standard) dies with SIGILL; second probe (baseline) runs.
+    let probes = 0
+    const outcome = await installManagedOpencode({
+      installId: 'i5',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'linux-x64', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      verifyBinary: () => {
+        probes += 1
+        return probes === 1
+          ? { ok: false, reason: 'killed by SIGILL', signal: 'SIGILL' }
+          : { ok: true }
+      },
+      tmpDir: root
+    })
+
+    expect(requestedKeys).toEqual(['standard', 'baseline'])
+    expect(outcome.result.ok).toBe(true)
+    expect(outcome.version).toBe('1.18.3')
+    expect(await readFile(outcome.resolvedPath!, 'utf8')).toContain('echo baseline')
+  })
+
+  // arm64 has no baseline package, so a SIGILL there must NOT trigger a retry — it fails directly.
+  it('does not retry baseline on arm64 (no baseline package exists)', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const tgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho arm\n') }
+    ])
+    const requestedKeys: string[] = []
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/opencode-ai')) return { 'dist-tags': { latest: '1.18.3' } }
+      requestedKeys.push(url)
+      return { dist: { tarball: 'https://reg/arm.tgz', integrity: sha512(tgz) } }
+    }
+    const fetchTarball = async (): Promise<{
+      stream: NodeJS.ReadableStream
+      totalBytes?: number
+    }> => ({ stream: Readable.from(tgz), totalBytes: tgz.length })
+
+    const outcome = await installManagedOpencode({
+      installId: 'i6',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'darwin-arm64', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      verifyBinary: () => ({ ok: false, reason: 'killed by SIGILL', signal: 'SIGILL' }),
+      tmpDir: root
+    })
+
+    // Never requested a -baseline package for arm64.
+    expect(requestedKeys.some((url) => url.includes('baseline'))).toBe(false)
+    expect(outcome.result.ok).toBe(false)
+    expect(outcome.result.error).toMatch(/AVX2/)
+  })
+
+  // If the -baseline package does not exist (404 at resolve), the SIGILL/AVX2 error is surfaced rather
+  // than crashing on the unverifiable package name.
+  it('surfaces the SIGILL/AVX2 error when no baseline package is available', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const tgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho standard\n') }
+    ])
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/opencode-ai')) return { 'dist-tags': { latest: '1.18.3' } }
+      // The baseline package 404s at the registry.
+      if (url.includes('-baseline/')) throw new Error('404 Not Found')
+      return { dist: { tarball: 'https://reg/standard.tgz', integrity: sha512(tgz) } }
+    }
+    const fetchTarball = async (): Promise<{
+      stream: NodeJS.ReadableStream
+      totalBytes?: number
+    }> => ({ stream: Readable.from(tgz), totalBytes: tgz.length })
+
+    const outcome = await installManagedOpencode({
+      installId: 'i7',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'linux-x64', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      verifyBinary: () => ({ ok: false, reason: 'killed by SIGILL', signal: 'SIGILL' }),
+      tmpDir: root
+    })
+
+    expect(outcome.result.ok).toBe(false)
+    expect(outcome.result.error).toMatch(/failed to run/)
+    expect(outcome.result.error).toMatch(/AVX2/)
+    // No broken binary left on disk.
+    await expect(readFile(join(managedOpencodeDir(root), 'opencode'))).rejects.toThrow()
+  })
 })
 
 describe('resolveOpencodePlatform', () => {

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -281,7 +281,11 @@ export const installManagedOpencode = async ({
           stream: 'system',
           chunk: `Installed OpenCode ${standard.version}.\n`
         })
-        return { result: { installId, ok: true }, resolvedPath: destPath, version: standard.version }
+        return {
+          result: { installId, ok: true },
+          resolvedPath: destPath,
+          version: standard.version
+        }
       }
 
       // The standard build extracted but died on this CPU. On a non-AVX2 x64 host (SIGILL) retry once

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -158,8 +158,9 @@ export type VerifyBinaryResult =
 export type VerifyBinary = (binPath: string) => VerifyBinaryResult
 
 // Default verifier: run the installed binary with `--version` and classify failures. A spawn error, a
-// terminating signal (SIGILL etc.), or a non-zero exit all mean the binary is not usable here.
-const defaultVerifyBinary: VerifyBinary = (binPath) => {
+// terminating signal (SIGILL etc.), or a non-zero exit all mean the binary is not usable here. Exported
+// so the production classification (not just injected fakes) is exercised by tests.
+export const defaultVerifyBinary: VerifyBinary = (binPath) => {
   const probe = spawnSync(binPath, ['--version'], { encoding: 'utf8', timeout: 15_000 })
   if (probe.error) return { ok: false, reason: `spawn error: ${probe.error.message}` }
   if (probe.signal) return { ok: false, reason: `killed by ${probe.signal}`, signal: probe.signal }

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
 import { chmod, rm } from 'node:fs/promises'
 import { arch as osArch } from 'node:os'
 import { join } from 'node:path'
@@ -19,8 +19,9 @@ import {
 // (`opencode-<os>-<arch>[-musl]`) as optionalDependencies of the `opencode-ai` wrapper, with the binary
 // at `package/bin/opencode` — the same native-package model as Claude, so the shared download/verify/
 // extract helpers are reused. Modern CPUs get the standard build; a non-AVX2 x64 host whose post-install
-// smoke check dies with SIGILL falls back once to the `-baseline` variant opencode publishes for x64 (no
-// fragile pre-detection). Every side-effecting dependency is injectable so the flow is unit-testable offline.
+// smoke check dies on an illegal instruction (SIGILL on POSIX, the NTSTATUS illegal-instruction exit
+// status on Windows) falls back once to the `-baseline` variant opencode publishes for x64 (no fragile
+// pre-detection). Every side-effecting dependency is injectable so the flow is unit-testable offline.
 
 // Wrapper package (its dist-tags.latest gives the version) and the native-package name prefix. Note the
 // native packages are `opencode-<key>`, NOT `opencode-ai-<key>`, so the prefix differs from the wrapper.
@@ -150,24 +151,69 @@ const resolveNative = async (
 }
 
 // Post-install smoke check. A native package can download+extract cleanly yet still be unrunnable on
-// this host (e.g. a non-AVX2 x64 CPU dies with SIGILL at first spawn), so we execute `--version` before
-// treating the install as successful. `ok:false` carries a human reason plus the raw signal so the
-// caller can add an actionable hint.
+// this host (e.g. a non-AVX2 x64 CPU dies on an illegal instruction at first spawn), so we execute
+// `--version` before treating the install as successful. `ok:false` carries a human reason plus an
+// `illegalInstruction` flag (the AVX2-baseline signal) so the caller can add an actionable hint.
 export type VerifyBinaryResult =
-  { ok: true } | { ok: false; reason: string; signal?: string | null }
+  { ok: true } | { ok: false; reason: string; illegalInstruction: boolean }
 export type VerifyBinary = (binPath: string) => VerifyBinaryResult
 
-// Default verifier: run the installed binary with `--version` and classify failures. A spawn error, a
-// terminating signal (SIGILL etc.), or a non-zero exit all mean the binary is not usable here. Exported
-// so the production classification (not just injected fakes) is exercised by tests.
-export const defaultVerifyBinary: VerifyBinary = (binPath) => {
-  const probe = spawnSync(binPath, ['--version'], { encoding: 'utf8', timeout: 15_000 })
-  if (probe.error) return { ok: false, reason: `spawn error: ${probe.error.message}` }
-  if (probe.signal) return { ok: false, reason: `killed by ${probe.signal}`, signal: probe.signal }
+// Windows reports an illegal instruction not as a signal but as NTSTATUS STATUS_ILLEGAL_INSTRUCTION in
+// the exit status. Node surfaces it as the unsigned value (3221225501) or its signed 32-bit form
+// (-1073741795), so accept both.
+const ILLEGAL_INSTRUCTION_STATUS = 0xc000001d
+const isIllegalInstructionStatus = (status: number | null | undefined): boolean =>
+  status === ILLEGAL_INSTRUCTION_STATUS || status === (ILLEGAL_INSTRUCTION_STATUS | 0)
+
+// Just the fields of a spawnSync result the classifier reads.
+export type VersionProbe = Partial<Pick<SpawnSyncReturns<string>, 'error' | 'signal' | 'status'>>
+export type VersionProbeSpawn = (
+  command: string,
+  args: readonly string[],
+  options: { encoding: 'utf8'; timeout: number }
+) => VersionProbe
+
+// Runs the installed binary with `--version`. The injectable spawn (defaulting to the real spawnSync)
+// lets tests lock the exact args and timeout without a real process.
+export const runVersionProbe = (
+  binPath: string,
+  spawn: VersionProbeSpawn = spawnSync as unknown as VersionProbeSpawn
+): VersionProbe => spawn(binPath, ['--version'], { encoding: 'utf8', timeout: 15_000 })
+
+// Pure classifier for a version probe. A spawn error, a terminating signal, or a non-zero exit all mean
+// the binary is not usable here; `illegalInstruction` is the AVX2-baseline signal (SIGILL on POSIX, the
+// NTSTATUS illegal-instruction exit status on Windows). The injectable platform makes the Windows
+// status branch testable off-Windows.
+export const classifyVerifyResult = (
+  probe: VersionProbe,
+  platform: NodeJS.Platform = process.platform
+): VerifyBinaryResult => {
+  if (probe.error)
+    return { ok: false, reason: `spawn error: ${probe.error.message}`, illegalInstruction: false }
+  if (probe.signal)
+    return {
+      ok: false,
+      reason: `killed by ${probe.signal}`,
+      illegalInstruction: probe.signal === 'SIGILL'
+    }
   if (probe.status !== 0)
-    return { ok: false, reason: `\`--version\` exited with code ${probe.status}` }
+    return {
+      ok: false,
+      reason: `\`--version\` exited with code ${probe.status}`,
+      illegalInstruction: platform === 'win32' && isIllegalInstructionStatus(probe.status)
+    }
   return { ok: true }
 }
+
+// Default verifier: probe the installed binary, then classify. Exported so the production classification
+// (not just injected fakes) is exercised by tests.
+export const defaultVerifyBinary: VerifyBinary = (binPath) =>
+  classifyVerifyResult(runVersionProbe(binPath))
+
+// The baseline native package inserts `baseline` right after the x64 arch token, BEFORE any `-musl`
+// suffix, matching what opencode publishes: linux-x64 → linux-x64-baseline, linux-x64-musl →
+// linux-x64-baseline-musl. Every x64 key has exactly one `x64` token, so a single replace is correct.
+const baselinePackageKey = (key: string): string => key.replace('x64', 'x64-baseline')
 
 export type InstallManagedOpencodeOptions = {
   installId: string
@@ -187,7 +233,7 @@ export type InstallManagedOpencodeOptions = {
 // errors are thrown instead (registry-level, handled by moving to the next registry).
 type PackageAttempt =
   | { ok: true; version: string }
-  | { ok: false; error: string; sigill: boolean; resolvedVersion: string }
+  | { ok: false; error: string; illegalInstruction: boolean; resolvedVersion: string }
 
 // Downloads + installs the managed opencode binary, trying each registry in order. Resolves (never
 // rejects) with a structured outcome the service can persist.
@@ -251,11 +297,13 @@ export const installManagedOpencode = async ({
       const verification = verifyBinary(destPath)
       if (!verification.ok) {
         await rm(destPath, { force: true }).catch(() => undefined)
-        const sigill = verification.signal === 'SIGILL'
-        const hint = sigill ? ' Your CPU may not support the required instruction set (AVX2).' : ''
+        const illegalInstruction = verification.illegalInstruction
+        const hint = illegalInstruction
+          ? ' Your CPU may not support the required instruction set (AVX2).'
+          : ''
         return {
           ok: false,
-          sigill,
+          illegalInstruction,
           resolvedVersion: resolution.version,
           error: `OpenCode installed but failed to run (${verification.reason}).${hint}`
         }
@@ -288,11 +336,12 @@ export const installManagedOpencode = async ({
         }
       }
 
-      // The standard build extracted but died on this CPU. On a non-AVX2 x64 host (SIGILL) retry once
-      // with the `-baseline` variant so the onboarding "auto-installable" claim actually holds. If the
-      // baseline package is missing (404 at resolve) or also fails to run, surface the SIGILL/AVX2
-      // diagnosis rather than crashing on an unverifiable package name.
-      if (standard.sigill && isX64) {
+      // The standard build extracted but died on this CPU. On a non-AVX2 x64 host (illegal instruction:
+      // SIGILL on POSIX, the NTSTATUS status on Windows) retry once with the `-baseline` variant so the
+      // onboarding "auto-installable" claim actually holds. If the baseline package is missing (404 at
+      // resolve) or also fails to run, surface the illegal-instruction/AVX2 diagnosis rather than
+      // crashing on an unverifiable package name.
+      if (standard.illegalInstruction && isX64) {
         onEvent({
           kind: 'log',
           installId,
@@ -302,7 +351,7 @@ export const installManagedOpencode = async ({
         try {
           const baseline = await installFromPackage(
             registry,
-            `${platform.key}-baseline`,
+            baselinePackageKey(platform.key),
             standard.resolvedVersion
           )
           if (baseline.ok) {
@@ -319,7 +368,7 @@ export const installManagedOpencode = async ({
             }
           }
         } catch {
-          // Baseline unavailable (e.g. 404): fall through to the SIGILL/AVX2 error below.
+          // Baseline unavailable (e.g. 404): fall through to the illegal-instruction/AVX2 error below.
         }
       }
 

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -18,8 +18,9 @@ import {
 // App-managed OpenCode installer. opencode ships per-platform native packages
 // (`opencode-<os>-<arch>[-musl]`) as optionalDependencies of the `opencode-ai` wrapper, with the binary
 // at `package/bin/opencode` — the same native-package model as Claude, so the shared download/verify/
-// extract helpers are reused. Non-AVX2 `-baseline` variants are not selected; modern CPUs get the
-// standard build. Every side-effecting dependency is injectable so the flow is unit-testable offline.
+// extract helpers are reused. Modern CPUs get the standard build; a non-AVX2 x64 host whose post-install
+// smoke check dies with SIGILL falls back once to the `-baseline` variant opencode publishes for x64 (no
+// fragile pre-detection). Every side-effecting dependency is injectable so the flow is unit-testable offline.
 
 // Wrapper package (its dist-tags.latest gives the version) and the native-package name prefix. Note the
 // native packages are `opencode-<key>`, NOT `opencode-ai-<key>`, so the prefix differs from the wrapper.
@@ -180,6 +181,13 @@ export type InstallManagedOpencodeOptions = {
   tmpDir?: string
 }
 
+// Outcome of one package-key install attempt: a runnable binary, or a soft "extracted but won't run"
+// failure (smoke check) the caller may recover from via the baseline retry. Resolve/download/extract
+// errors are thrown instead (registry-level, handled by moving to the next registry).
+type PackageAttempt =
+  | { ok: true; version: string }
+  | { ok: false; error: string; sigill: boolean; resolvedVersion: string }
+
 // Downloads + installs the managed opencode binary, trying each registry in order. Resolves (never
 // rejects) with a structured outcome the service can persist.
 export const installManagedOpencode = async ({
@@ -198,7 +206,14 @@ export const installManagedOpencode = async ({
   const scratch = tmpDir ?? managedOpencodeDir(dataRoot)
   let lastError = 'no registries configured'
 
-  for (const registry of registries) {
+  // Downloads, extracts, and smoke-checks one package key. Throws on registry-level errors (so the
+  // caller can advance to the next registry); returns a soft failure only when the binary extracted
+  // cleanly but does not run on this CPU.
+  const installFromPackage = async (
+    registry: string,
+    packageKey: string,
+    pinnedVersion: string | undefined
+  ): Promise<PackageAttempt> => {
     const tgzPath = join(scratch, `opencode-download-${Date.now()}.tgz`)
 
     try {
@@ -207,9 +222,9 @@ export const installManagedOpencode = async ({
         kind: 'log',
         installId,
         stream: 'system',
-        chunk: `Resolving OpenCode from ${registry} …\n`
+        chunk: `Resolving ${OPENCODE_PLATFORM_PREFIX}-${packageKey} from ${registry} …\n`
       })
-      const resolution = await resolveNative(registry, platform.key, version, fetchJson)
+      const resolution = await resolveNative(registry, packageKey, pinnedVersion, fetchJson)
 
       await downloadAndVerify({
         url: resolution.tarball,
@@ -231,29 +246,79 @@ export const installManagedOpencode = async ({
       if (process.platform !== 'win32') await chmod(destPath, 0o755)
 
       // Smoke-check the binary before reporting success — a clean download does not guarantee it runs
-      // on this CPU. Remove the unusable binary and fail loudly so no broken path gets persisted.
+      // on this CPU. Remove the unusable binary and report a soft failure so no broken path is persisted.
       const verification = verifyBinary(destPath)
       if (!verification.ok) {
         await rm(destPath, { force: true }).catch(() => undefined)
-        const hint =
-          verification.signal === 'SIGILL'
-            ? ' Your CPU may not support the required instruction set (AVX2).'
-            : ''
-        throw new Error(`OpenCode installed but failed to run (${verification.reason}).${hint}`)
+        const sigill = verification.signal === 'SIGILL'
+        const hint = sigill ? ' Your CPU may not support the required instruction set (AVX2).' : ''
+        return {
+          ok: false,
+          sigill,
+          resolvedVersion: resolution.version,
+          error: `OpenCode installed but failed to run (${verification.reason}).${hint}`
+        }
       }
 
-      onEvent({
-        kind: 'log',
-        installId,
-        stream: 'system',
-        chunk: `Installed OpenCode ${resolution.version}.\n`
-      })
+      return { ok: true, version: resolution.version }
+    } finally {
+      await rm(tgzPath, { force: true }).catch(() => undefined)
+    }
+  }
 
-      return {
-        result: { installId, ok: true },
-        resolvedPath: destPath,
-        version: resolution.version
+  // x64 hosts have a `-baseline` native package variant that drops AVX2; a musl or plain x64 key still
+  // contains "x64". arm64 has no baseline, so it is never retried.
+  const isX64 = platform.key.includes('x64')
+
+  for (const registry of registries) {
+    try {
+      const standard = await installFromPackage(registry, platform.key, version)
+      if (standard.ok) {
+        onEvent({
+          kind: 'log',
+          installId,
+          stream: 'system',
+          chunk: `Installed OpenCode ${standard.version}.\n`
+        })
+        return { result: { installId, ok: true }, resolvedPath: destPath, version: standard.version }
       }
+
+      // The standard build extracted but died on this CPU. On a non-AVX2 x64 host (SIGILL) retry once
+      // with the `-baseline` variant so the onboarding "auto-installable" claim actually holds. If the
+      // baseline package is missing (404 at resolve) or also fails to run, surface the SIGILL/AVX2
+      // diagnosis rather than crashing on an unverifiable package name.
+      if (standard.sigill && isX64) {
+        onEvent({
+          kind: 'log',
+          installId,
+          stream: 'system',
+          chunk: 'Standard build is not runnable on this CPU; retrying the -baseline variant …\n'
+        })
+        try {
+          const baseline = await installFromPackage(
+            registry,
+            `${platform.key}-baseline`,
+            standard.resolvedVersion
+          )
+          if (baseline.ok) {
+            onEvent({
+              kind: 'log',
+              installId,
+              stream: 'system',
+              chunk: `Installed OpenCode ${baseline.version} (baseline).\n`
+            })
+            return {
+              result: { installId, ok: true },
+              resolvedPath: destPath,
+              version: baseline.version
+            }
+          }
+        } catch {
+          // Baseline unavailable (e.g. 404): fall through to the SIGILL/AVX2 error below.
+        }
+      }
+
+      throw new Error(standard.error)
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error)
       onEvent({
@@ -262,8 +327,6 @@ export const installManagedOpencode = async ({
         stream: 'system',
         chunk: `${registry} failed: ${lastError}\n`
       })
-    } finally {
-      await rm(tgzPath, { force: true }).catch(() => undefined)
     }
   }
 


### PR DESCRIPTION
## Summary
Second hardening pass on the pluggable agent framework (follow-up review of the #187–#191 fixes). Six fixes across the OpenCode config layer, ACP session lifecycle, and the managed installer. Every config-precedence claim below was verified against opencode's own source.

## OpenCode config isolation (P1)
The previous round enforced permissions via `OPENCODE_CONFIG_CONTENT`, but opencode merges **every** config layer per-key (`mergeDeep`) — including `OPENCODE_PERMISSION` — with no replace-all option. So rule-by-rule pinning could never remove a key a project config *adds*, and two holes remained:
- **P1a:** a project `opencode.json`/`.opencode` could add an exact tool id set to `allow`, which survives the deep-merge and beats `*: ask`, running that tool without asking the app broker.
- **P1b:** a malicious project config could repoint the active provider's `baseURL` (or switch `model` to an attacker-defined provider) while inheriting the `{env:...}` apiKey ref, exfiltrating the real key.

Fix: set **`OPENCODE_DISABLE_PROJECT_CONFIG='true'`** in the spawn env. This disables loading of both the project `opencode.json`/`opencode.jsonc` (cwd→worktree walk-up) **and** the project `.opencode/` directories at the source, so a repo can inject no config at all — closing P1a and P1b together. As defense-in-depth against the only remaining, non-repo surface (the user's own `~/.opencode`), the authoritative `model`/`provider`/`baseURL`/`permission` are now pinned in the `OPENCODE_CONFIG_CONTENT` layer via a shared helper so the written config file and the pinned layer can't diverge. The decrypted key still rides only the spawn env; the config holds only its `{env:...}` reference.

## ACP session lifecycle (P2)
- **Reverse-map leak:** `deleteSession` cleaned the app-session-keyed maps but never removed the `agentToAppSessionId` reverse entry an adopted session registered, leaving stale routing. Now deleted alongside the rest.
- **Framework-switch delete:** `deleteSession` restructured so the agent-side `session.close`/`session.cancel` + `dispose` stay guarded by an attached session, while the app-keyed map cleanup (notably `sessionFrameworks`, which `disconnectCurrent` deliberately preserves across a framework switch) runs unconditionally. This closes a leak where deleting a session that was never re-adopted under the newly-switched framework left a stale `sessionFrameworks` entry that could mislead the cross-framework-resume check. The "Session deleted" event / current-session shift are re-guarded so a detached cleanup stays silent. (There was no mis-routing: a framework switch already disposes the old sessions and kills the old agent.)

## Managed installer (P2)
- A non-AVX2 x64 host was reported as auto-installable in onboarding, then downloaded the standard native package and died with `SIGILL`. The installer now retries once with the `-baseline` package when the post-install `--version` smoke check reports `SIGILL` (x64 only; a missing baseline surfaces the AVX2 error rather than crashing), so the onboarding claim is accurate.

## Tests
New/extended coverage (CONTRIBUTING.md: new behavior comes with tests):
- `opencode.test.ts` — asserts `OPENCODE_DISABLE_PROJECT_CONFIG` is set and the `OPENCODE_CONFIG_CONTENT` layer pins model+provider+baseURL+permission with the key as an env ref (never a plaintext literal).
- `runtime.test.ts` — reverse-map removed on delete; `session.cancel` fallback carries the underlying id when close is unsupported; `sessionFrameworks` cleared on a detached (post-switch) delete with no agent close.
- `managed-opencode.test.ts` — SIGILL→baseline retry succeeds; arm64 never retries; missing baseline surfaces the AVX2 error; and the real `defaultVerifyBinary` classification is covered.

typecheck + lint clean; `vitest run src/main/agent-framework src/main/acp src/main/settings` → 36 files / 434 tests pass.