### PR TITLE
fix(acp): surface provider not-found errors with an actionable prompt message

### DIFF
--- a/src/main/acp/prompt-error.test.ts
+++ b/src/main/acp/prompt-error.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { describePromptError } from './prompt-error'
+
+// Builds an ACP RequestError-shaped value: an Error carrying the JSON-RPC code + data the agent attaches.
+const agentError = (
+  message: string,
+  data: Record<string, unknown> = { service: 'session', errorName: 'APIError' },
+  code = -32603
+): Error => Object.assign(new Error(message), { code, data, name: 'RequestError' })
+
+describe('describePromptError', () => {
+  it('rewords a provider JSON resource_not_found into an actionable message with the model name', () => {
+    const error = agentError(
+      'Internal error: Not Found: {"error":{"message":"The requested resource was not found","type":"resource_not_found_error"}}'
+    )
+
+    const text = describePromptError(error, { model: 'deepseek-v4-flash' })
+
+    expect(text).toContain('model "deepseek-v4-flash"')
+    expect(text).toContain('Settings → Model')
+    // Surfaces the provider's own human message, not the raw JSON blob.
+    expect(text).toContain('The requested resource was not found')
+    expect(text).not.toContain('{')
+  })
+
+  it('handles a text-only (non-JSON) provider not-found, including non-English messages', () => {
+    const error = agentError('Internal error: Not Found: 没找到对象')
+
+    const text = describePromptError(error, { model: 'kimi-k3' })
+
+    expect(text).toContain('model "kimi-k3"')
+    expect(text).toContain('没找到对象')
+    // The `Internal error:` RPC wrapper is stripped from the surfaced provider text.
+    expect(text).not.toMatch(/internal error:/i)
+  })
+
+  it('omits the model clause when no model is known', () => {
+    const error = agentError('Internal error: Not Found: model missing')
+
+    const text = describePromptError(error)
+
+    expect(text).toContain('could not find the requested resource.')
+    expect(text).not.toContain('for model')
+  })
+
+  it('passes through an unrelated API error unchanged', () => {
+    const error = agentError('Internal error: Overloaded: service is busy')
+
+    expect(describePromptError(error, { model: 'gpt-5' })).toBe(
+      'Internal error: Overloaded: service is busy'
+    )
+  })
+
+  it('does not treat an ACP protocol not-found (no APIError tag) as a model problem', () => {
+    // A plain session-not-found with no upstream signal must stay verbatim (the resume path owns it).
+    const error = Object.assign(new Error('Resource not found'), { code: -32002 })
+
+    expect(describePromptError(error)).toBe('Resource not found')
+  })
+
+  it('rewords a resource_not_found even without the APIError tag when the type is present', () => {
+    const error = agentError(
+      'Internal error: Not Found: {"error":{"message":"unknown model","type":"resource_not_found_error"}}',
+      {}
+    )
+
+    expect(describePromptError(error)).toContain('could not find the requested resource')
+  })
+
+  it('accepts a plain string error', () => {
+    expect(describePromptError('boom')).toBe('boom')
+  })
+})

--- a/src/main/acp/prompt-error.test.ts
+++ b/src/main/acp/prompt-error.test.ts
@@ -31,8 +31,32 @@ describe('describePromptError', () => {
 
     expect(text).toContain('model "kimi-k3"')
     expect(text).toContain('没找到对象')
-    // The `Internal error:` RPC wrapper is stripped from the surfaced provider text.
+    // The `Internal error:` and `Not Found:` wrapper prefixes are stripped from the surfaced text.
     expect(text).not.toMatch(/internal error:/i)
+    expect(text).not.toMatch(/not found:/i)
+  })
+
+  it('extracts the provider message when the JSON payload has trailing text', () => {
+    const error = agentError(
+      'Internal error: Not Found: {"error":{"message":"The requested resource was not found","type":"resource_not_found_error"}} (request id: req-abc-123)'
+    )
+
+    const text = describePromptError(error, { model: 'deepseek-v4-flash' })
+
+    expect(text).toContain('The requested resource was not found')
+    // Neither the raw JSON blob nor the trailing request id leaks into the surfaced text.
+    expect(text).not.toContain('{')
+    expect(text).not.toContain('request id')
+  })
+
+  it('passes through a benign "not found" API error that is not a resource lookup', () => {
+    const error = agentError(
+      'Internal error: Overloaded: rate limit config not found, using default'
+    )
+
+    expect(describePromptError(error, { model: 'gpt-5' })).toBe(
+      'Internal error: Overloaded: rate limit config not found, using default'
+    )
   })
 
   it('omits the model clause when no model is known', () => {

--- a/src/main/acp/prompt-error.test.ts
+++ b/src/main/acp/prompt-error.test.ts
@@ -15,23 +15,24 @@ describe('describePromptError', () => {
       'Internal error: Not Found: {"error":{"message":"The requested resource was not found","type":"resource_not_found_error"}}'
     )
 
-    const text = describePromptError(error, { model: 'deepseek-v4-flash' })
+    const text = describePromptError(error, { model: 'example-model' })
 
-    expect(text).toContain('model "deepseek-v4-flash"')
+    expect(text).toContain('model "example-model"')
     expect(text).toContain('Settings → Model')
     // Surfaces the provider's own human message, not the raw JSON blob.
     expect(text).toContain('The requested resource was not found')
     expect(text).not.toContain('{')
   })
 
-  it('handles a text-only (non-JSON) provider not-found, including non-English messages', () => {
-    const error = agentError('Internal error: Not Found: 没找到对象')
+  it('handles a text-only (non-JSON) provider not-found and strips the wrapper prefixes', () => {
+    const error = agentError('Internal error: Not Found: the requested model is unavailable')
 
-    const text = describePromptError(error, { model: 'kimi-k3' })
+    const text = describePromptError(error, { model: 'example-model' })
 
-    expect(text).toContain('model "kimi-k3"')
-    expect(text).toContain('没找到对象')
-    // The `Internal error:` and `Not Found:` wrapper prefixes are stripped from the surfaced text.
+    expect(text).toContain('model "example-model"')
+    // The provider's own message is surfaced verbatim (in whatever language it sent); only the
+    // `Internal error:` and `Not Found:` wrapper prefixes are stripped from it.
+    expect(text).toContain('the requested model is unavailable')
     expect(text).not.toMatch(/internal error:/i)
     expect(text).not.toMatch(/not found:/i)
   })
@@ -41,7 +42,7 @@ describe('describePromptError', () => {
       'Internal error: Not Found: {"error":{"message":"The requested resource was not found","type":"resource_not_found_error"}} (request id: req-abc-123)'
     )
 
-    const text = describePromptError(error, { model: 'deepseek-v4-flash' })
+    const text = describePromptError(error, { model: 'example-model' })
 
     expect(text).toContain('The requested resource was not found')
     // Neither the raw JSON blob nor the trailing request id leaks into the surfaced text.
@@ -54,7 +55,7 @@ describe('describePromptError', () => {
       'Internal error: Overloaded: rate limit config not found, using default'
     )
 
-    expect(describePromptError(error, { model: 'gpt-5' })).toBe(
+    expect(describePromptError(error, { model: 'example-model' })).toBe(
       'Internal error: Overloaded: rate limit config not found, using default'
     )
   })
@@ -71,7 +72,7 @@ describe('describePromptError', () => {
   it('passes through an unrelated API error unchanged', () => {
     const error = agentError('Internal error: Overloaded: service is busy')
 
-    expect(describePromptError(error, { model: 'gpt-5' })).toBe(
+    expect(describePromptError(error, { model: 'example-model' })).toBe(
       'Internal error: Overloaded: service is busy'
     )
   })
@@ -81,6 +82,15 @@ describe('describePromptError', () => {
     const error = Object.assign(new Error('Resource not found'), { code: -32002 })
 
     expect(describePromptError(error)).toBe('Resource not found')
+  })
+
+  it('does not reword a -32002 protocol not-found even when it carries a JSON body', () => {
+    // A parseable JSON body must not, on its own, promote a protocol not-found into a model problem.
+    const error = Object.assign(new Error('Not Found: {"error":{"message":"session gone"}}'), {
+      code: -32002
+    })
+
+    expect(describePromptError(error)).toBe('Not Found: {"error":{"message":"session gone"}}')
   })
 
   it('rewords a resource_not_found even without the APIError tag when the type is present', () => {

--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -15,17 +15,25 @@ export type PromptErrorContext = {
 // The innermost provider detail pulled from a wrapped error message.
 type UpstreamDetail = { text: string; type?: string }
 
-// Matches the "resource not found" family across the shapes providers actually return: the resource
-// not-found error type, the HTTP status label the wrapper emits (`Not Found:`), the "no such model"
-// phrasing, and the Chinese messages some gateways emit (e.g. Moonshot's 没找到对象). Deliberately does
-// NOT match a bare "not found" substring, so a benign message like "rate limit config not found" isn't
-// mistaken for a model/endpoint problem.
+// The "resource not found" family. The agent renders the provider's HTTP error with an English status
+// label (`Not Found:`) and the provider's structured error type is an ASCII slug (`resource_not_found`),
+// so matching stays language-agnostic without pattern-matching localized message text — the provider's
+// own (possibly non-English) message is still surfaced verbatim as data. Deliberately does NOT match a
+// bare "not found" substring, so a benign message like "rate limit config not found" isn't reworded.
 const NOT_FOUND_PATTERN =
-  /resource[\s_-]?not[\s_-]?found|no such (?:model|resource)|not[\s_-]?found\s*:|没找到|不存在/i
+  /resource[\s_-]?not[\s_-]?found|no such (?:model|resource)|not[\s_-]?found\s*:/i
 
 // Converts an unknown thrown value into its base message string.
 const rawErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
+
+// The JSON-RPC code the agent attached, when present. -32002 is the ACP "resource not found" protocol
+// code (a missing session), which must not be confused with an upstream provider not-found.
+const errorCode = (error: unknown): number | undefined => {
+  const code = (error as { code?: unknown } | null)?.code
+
+  return typeof code === 'number' ? code : undefined
+}
 
 // True when the agent tagged the failure as an upstream provider API error (vs. an ACP protocol
 // error such as a missing session, which the resume path handles separately).
@@ -103,19 +111,26 @@ const extractUpstreamDetail = (message: string): UpstreamDetail | undefined => {
   }
 }
 
-// Whether the failure is an upstream "resource not found" (wrong model id / endpoint), which we reword.
+// Whether the failure is an upstream provider "resource not found" (wrong model id / endpoint), which
+// we reword. Requires a genuine provider signal so an ACP-level protocol not-found (e.g. a -32002
+// missing-session error, even one that carries a JSON body) is never mistaken for a model problem.
 const isProviderNotFound = (
   error: unknown,
   raw: string,
   detail: UpstreamDetail | undefined
 ): boolean => {
-  const matchesNotFound =
-    NOT_FOUND_PATTERN.test(raw) || (detail?.type ? NOT_FOUND_PATTERN.test(detail.type) : false)
+  const hasNotFoundType = detail?.type ? NOT_FOUND_PATTERN.test(detail.type) : false
+  const matchesNotFound = NOT_FOUND_PATTERN.test(raw) || hasNotFoundType
 
   if (!matchesNotFound) return false
 
-  // Require an upstream signal so an ACP-level not-found isn't mistaken for a model problem.
-  return isApiError(error) || /resource_not_found/i.test(raw) || detail !== undefined
+  // The ACP resume path owns protocol not-founds; never reword one unless the agent explicitly tagged
+  // it as an upstream API error.
+  if (errorCode(error) === -32002 && !isApiError(error)) return false
+
+  // Require an upstream signal: the API-error tag, the provider's resource_not_found slug, or a
+  // structured provider error type in the not-found family. A parseable JSON body alone is not enough.
+  return isApiError(error) || /resource_not_found/i.test(raw) || hasNotFoundType
 }
 
 // Produces the session-visible error text for a failed prompt: an actionable message for a provider

--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -1,0 +1,96 @@
+// Turns an agent prompt failure into user-visible text. Agents (opencode) relay an upstream provider
+// HTTP error wrapped as a JSON-RPC failure like
+//   `Internal error: Not Found: {"error":{"message":"The requested resource was not found","type":"resource_not_found_error"}}`
+// which is opaque to a user. When the wrapped error is a provider "resource not found" (a wrong model
+// id or base URL, by far the most common misconfiguration), we surface the provider's own message plus
+// an actionable hint. Any other failure is passed through unchanged so genuinely different problems
+// stay visible. Kept as a pure module so the branch matrix is unit-testable.
+
+export type PromptErrorContext = {
+  // The active model id, when the framework selects it over the protocol (opencode). Named in the hint
+  // so the user knows exactly which value to fix.
+  model?: string
+}
+
+// The innermost provider detail pulled from a wrapped error message.
+type UpstreamDetail = { text: string; type?: string }
+
+// Matches the "resource not found" family across the shapes providers actually return (English JSON
+// `type`, plain English text, and the Chinese messages some gateways emit, e.g. Moonshot's 没找到对象).
+const NOT_FOUND_PATTERN =
+  /not[\s_-]?found|resource_not_found|no such (?:model|resource)|没找到|不存在/i
+
+// Converts an unknown thrown value into its base message string.
+const rawErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+// True when the agent tagged the failure as an upstream provider API error (vs. an ACP protocol
+// error such as a missing session, which the resume path handles separately).
+const isApiError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) return false
+
+  const data = (error as { data?: unknown }).data
+
+  if (typeof data !== 'object' || data === null) return false
+
+  return (data as { errorName?: unknown }).errorName === 'APIError'
+}
+
+// Strips the agent's `Internal error:` wrapper so a text-only provider message reads cleanly.
+const stripInternalWrapper = (message: string): string =>
+  message.replace(/^internal error:\s*/i, '').trim() || message
+
+// Extracts the provider's own `{ error: { message, type } }` payload when the wrapper carries one, so
+// we can show the human message instead of a raw JSON blob. Returns undefined for a text-only wrapper.
+const extractUpstreamDetail = (message: string): UpstreamDetail | undefined => {
+  const braceStart = message.indexOf('{')
+
+  if (braceStart === -1) return undefined
+
+  try {
+    const parsed = JSON.parse(message.slice(braceStart)) as {
+      error?: { message?: unknown; type?: unknown }
+      message?: unknown
+    }
+    const err = parsed.error
+    const text =
+      (typeof err?.message === 'string' && err.message.trim()) ||
+      (typeof parsed.message === 'string' && parsed.message.trim()) ||
+      ''
+
+    if (!text) return undefined
+
+    return { text, type: typeof err?.type === 'string' ? err.type : undefined }
+  } catch {
+    return undefined
+  }
+}
+
+// Whether the failure is an upstream "resource not found" (wrong model id / endpoint), which we reword.
+const isProviderNotFound = (
+  error: unknown,
+  raw: string,
+  detail: UpstreamDetail | undefined
+): boolean => {
+  const matchesNotFound =
+    NOT_FOUND_PATTERN.test(raw) || (detail?.type ? NOT_FOUND_PATTERN.test(detail.type) : false)
+
+  if (!matchesNotFound) return false
+
+  // Require an upstream signal so an ACP-level not-found isn't mistaken for a model problem.
+  return isApiError(error) || /resource_not_found/i.test(raw) || detail !== undefined
+}
+
+// Produces the session-visible error text for a failed prompt: an actionable message for a provider
+// not-found, else the original message untouched.
+export const describePromptError = (error: unknown, ctx: PromptErrorContext = {}): string => {
+  const raw = rawErrorMessage(error)
+  const detail = extractUpstreamDetail(raw)
+
+  if (!isProviderNotFound(error, raw, detail)) return raw
+
+  const providerText = detail?.text ?? stripInternalWrapper(raw)
+  const modelPart = ctx.model ? ` for model "${ctx.model}"` : ''
+
+  return `The model provider could not find the requested resource${modelPart}. The model name or endpoint is likely incorrect — check it in Settings → Model. Provider response: ${providerText}`
+}

--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -15,10 +15,13 @@ export type PromptErrorContext = {
 // The innermost provider detail pulled from a wrapped error message.
 type UpstreamDetail = { text: string; type?: string }
 
-// Matches the "resource not found" family across the shapes providers actually return (English JSON
-// `type`, plain English text, and the Chinese messages some gateways emit, e.g. Moonshot's 没找到对象).
+// Matches the "resource not found" family across the shapes providers actually return: the resource
+// not-found error type, the HTTP status label the wrapper emits (`Not Found:`), the "no such model"
+// phrasing, and the Chinese messages some gateways emit (e.g. Moonshot's 没找到对象). Deliberately does
+// NOT match a bare "not found" substring, so a benign message like "rate limit config not found" isn't
+// mistaken for a model/endpoint problem.
 const NOT_FOUND_PATTERN =
-  /not[\s_-]?found|resource_not_found|no such (?:model|resource)|没找到|不存在/i
+  /resource[\s_-]?not[\s_-]?found|no such (?:model|resource)|not[\s_-]?found\s*:|没找到|不存在/i
 
 // Converts an unknown thrown value into its base message string.
 const rawErrorMessage = (error: unknown): string =>
@@ -36,9 +39,39 @@ const isApiError = (error: unknown): boolean => {
   return (data as { errorName?: unknown }).errorName === 'APIError'
 }
 
-// Strips the agent's `Internal error:` wrapper so a text-only provider message reads cleanly.
-const stripInternalWrapper = (message: string): string =>
-  message.replace(/^internal error:\s*/i, '').trim() || message
+// Strips the agent's `Internal error:` and HTTP `Not Found:` status prefixes so a text-only provider
+// message reads cleanly. Empty result falls back to the original so we never surface a blank string.
+const stripWrapperPrefixes = (message: string): string =>
+  message
+    .replace(/^\s*internal error:\s*/i, '')
+    .replace(/^\s*not[\s_-]?found:\s*/i, '')
+    .trim() || message
+
+// Returns the first balanced `{…}` JSON object starting at `start`, respecting string literals so an
+// escaped or in-string brace doesn't throw off the depth count. Lets us parse a provider payload that
+// is followed by trailing text (e.g. `{…} (request id: abc)`), which `JSON.parse` would otherwise reject.
+const sliceBalancedJson = (message: string, start: number): string | undefined => {
+  let depth = 0
+  let inString = false
+  let escaped = false
+
+  for (let i = start; i < message.length; i++) {
+    const ch = message[i]
+
+    if (inString) {
+      if (escaped) escaped = false
+      else if (ch === '\\') escaped = true
+      else if (ch === '"') inString = false
+      continue
+    }
+
+    if (ch === '"') inString = true
+    else if (ch === '{') depth++
+    else if (ch === '}' && --depth === 0) return message.slice(start, i + 1)
+  }
+
+  return undefined
+}
 
 // Extracts the provider's own `{ error: { message, type } }` payload when the wrapper carries one, so
 // we can show the human message instead of a raw JSON blob. Returns undefined for a text-only wrapper.
@@ -47,8 +80,12 @@ const extractUpstreamDetail = (message: string): UpstreamDetail | undefined => {
 
   if (braceStart === -1) return undefined
 
+  const jsonText = sliceBalancedJson(message, braceStart)
+
+  if (jsonText === undefined) return undefined
+
   try {
-    const parsed = JSON.parse(message.slice(braceStart)) as {
+    const parsed = JSON.parse(jsonText) as {
       error?: { message?: unknown; type?: unknown }
       message?: unknown
     }
@@ -89,7 +126,7 @@ export const describePromptError = (error: unknown, ctx: PromptErrorContext = {}
 
   if (!isProviderNotFound(error, raw, detail)) return raw
 
-  const providerText = detail?.text ?? stripInternalWrapper(raw)
+  const providerText = detail?.text ?? stripWrapperPrefixes(raw)
   const modelPart = ctx.model ? ` for model "${ctx.model}"` : ''
 
   return `The model provider could not find the requested resource${modelPart}. The model name or endpoint is likely incorrect — check it in Settings → Model. Provider response: ${providerText}`

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -52,6 +52,7 @@ import {
 } from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { matchSessionModelOption } from './session-config'
+import { describePromptError } from './prompt-error'
 import { AcpPermissionBroker } from './permission-broker'
 import { isMcpToolName } from './permission-policy'
 import { applyCurrentModeUpdate } from './permission-profile-controller'
@@ -1187,7 +1188,7 @@ class AcpRuntime {
         level: 'error',
         sessionId: request.sessionId,
         title: 'Prompt failed',
-        text: errorMessage(error)
+        text: describePromptError(error, { model: this.pendingSessionModel })
       })
       throw error
     } finally {


### PR DESCRIPTION
## Summary

When an agent (opencode) relays an upstream provider "resource not found" failure, the runtime surfaced the raw JSON-RPC wrapper (`-32603 Internal error: Not Found: {…}`), giving the user no clue the real cause was a wrong model id or base URL. This adds `describePromptError`, which recognizes the not-found family, extracts the provider's own message, and rewords it into an actionable hint naming the active model and pointing at Settings → Model. Unrelated failures and ACP-level protocol not-founds pass through unchanged.

## What changed

- New pure module `src/main/acp/prompt-error.ts` (`describePromptError`) plus unit tests covering the full branch matrix.
- Wired into the prompt-failure path in `runtime.ts`, passing the active `pendingSessionModel`; the error is still re-thrown afterwards so nothing is swallowed.

Detection is intentionally **language-agnostic**: it keys off the agent's English HTTP `Not Found:` status label, the provider's `resource_not_found` error-type slug, and the "no such model/resource" phrasing — the source does not pattern-match localized message text. The provider's own (possibly non-English) message is still surfaced verbatim as data.

Robustness / precision (from review):
- Parse only the first balanced JSON object, so a payload followed by trailing text (e.g. `{…} (request id: …)`) still yields the provider message instead of the raw blob.
- Match only the resource-not-found family, so a benign `config not found, using default` in an APIError isn't reworded as a model/endpoint problem.
- A parseable JSON body is not, by itself, an upstream signal; a `-32002` ACP protocol not-found without the APIError tag passes through verbatim (the resume path owns it).
- Strip the `Not Found:` status prefix from text-only provider messages so they read cleanly.

## Testing

- `npm run test` (prompt-error suite: 10/10 passing)
- `npm run typecheck`
- `npm run lint`

## Reviewer focus

- `NOT_FOUND_PATTERN` scope — tight enough without missing real provider shapes.
- The APIError-tag vs ACP-protocol-not-found separation (the `-32002` cases must stay verbatim).