### PR TITLE
fix: install baseline OpenCode on non-AVX2 x64 and isolate home config

### DIFF
--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { buildOpencodeConfig, opencodeFramework } from './opencode'
@@ -79,6 +81,21 @@ describe('opencodeFramework.prepareModelConfig', () => {
     ]) {
       expect(rules[tool]).toBe('ask')
     }
+  })
+
+  it('redirects opencode home to an app-owned dir so the user ~/.opencode cannot inject config', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    // OPENCODE_TEST_HOME overrides opencode's Global.Path.home to an app-owned dir, so its home
+    // `.opencode` config walk finds nothing — set alongside the existing XDG/config isolation env.
+    expect(config.env?.OPENCODE_TEST_HOME).toBe(join('/data', 'opencode', 'home'))
+    expect(config.env?.XDG_CONFIG_HOME).toBe(join('/data', 'opencode', 'config'))
+    expect(config.env?.XDG_DATA_HOME).toBe(join('/data', 'opencode', 'data'))
+    expect(config.env?.OPENCODE_DISABLE_PROJECT_CONFIG).toBe('true')
+    expect(config.env?.OPENCODE_CONFIG_CONTENT).toBeTruthy()
   })
 
   it('disables project config loading so a repo cannot inject opencode.json / .opencode config', () => {

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -39,6 +39,11 @@ const opencodeDataHome = (storageRoot: string): string => join(storageRoot, 'ope
 // it, so the runtime adds this to its protected-read roots.
 export const opencodeStorageDir = (storageRoot: string): string => join(storageRoot, 'opencode')
 
+// An app-owned stand-in for opencode's notion of `$HOME`, passed via OPENCODE_TEST_HOME. It is a stable,
+// empty-by-design directory so opencode's home `.opencode` config walk finds nothing to load.
+const opencodeHomeDir = (storageRoot: string): string =>
+  join(opencodeStorageDir(storageRoot), 'home')
+
 // The opencode config directory ($XDG_CONFIG_HOME/opencode) where opencode.json and skills/ live.
 // opencode discovers skills at <configDir>/skills/<name>/SKILL.md — the same layout Claude uses under
 // its config dir — so the app materializes the enabled skill set here for opencode too.
@@ -253,6 +258,13 @@ export const opencodeFramework: AgentFramework = {
       env: {
         XDG_CONFIG_HOME: configHome,
         XDG_DATA_HOME: dataHome,
+        // Redirect opencode's Global.Path.home (= `OPENCODE_TEST_HOME ?? os.homedir()`) to an app-owned,
+        // empty dir so the user's `~/.opencode` cannot inject config/providers/permissions — the last
+        // non-repo override surface left after OPENCODE_DISABLE_PROJECT_CONFIG closes project config. This
+        // changes ONLY opencode's notion of home; the child's real HOME is untouched, so shell/git tools
+        // behave normally. Tradeoff: opencode also won't read `~/.claude/CLAUDE.md` or home-level skills —
+        // acceptable since the app owns the whole opencode config.
+        OPENCODE_TEST_HOME: opencodeHomeDir(ctx.storageRoot),
         // Refuse to load ANY project config: this stops the session cwd's opencode.json / opencode.jsonc
         // (walked up to the worktree root) and its .opencode/ directory from injecting config at all. A
         // repo therefore cannot flip permission["*"] to "allow", add an exact-id "allow" rule for an MCP

--- a/src/main/settings/environment-check.test.ts
+++ b/src/main/settings/environment-check.test.ts
@@ -108,6 +108,30 @@ describe('runEnvironmentCheck', () => {
     expect(result.ready).toBe(true)
   })
 
+  it('notes the baseline build for a non-AVX2 x64 opencode host while staying auto-installable', async () => {
+    const result = await runEnvironmentCheck({
+      storageRoot: '/data',
+      agentFrameworkId: 'opencode' as const,
+      frameworks: [{ id: 'opencode' as const, label: 'OpenCode', runtime: { found: false } }],
+      encryptionAvailable: true,
+      deps: {
+        ...baseDeps(),
+        platform: 'linux' as const,
+        architecture: 'x64',
+        resolveManagedPlatform: vi.fn().mockReturnValue({ key: 'linux-x64' }),
+        detectAvx2: () => false
+      }
+    })
+
+    const system = result.checks.find((check) => check.id === 'system')
+    // Passed (not a warning) with an informational baseline note — the true capability.
+    expect(system?.status).toBe('passed')
+    expect(system?.summary).toContain('baseline build')
+    expect(system?.detail).toContain('AVX2')
+    // A non-AVX2 x64 host is still fully auto-installable via the baseline package.
+    expect(result.canAutoInstall).toBe(true)
+  })
+
   it('blocks automatic setup when the app data directory is not writable', async () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/locked',

--- a/src/main/settings/environment-check.ts
+++ b/src/main/settings/environment-check.ts
@@ -12,7 +12,7 @@ import type {
 } from '../../shared/settings'
 import { findPythonCommand, type PythonCommand } from '../notebook/python-command'
 import { getManagedPlatform } from './managed-claude'
-import { resolveOpencodePlatform } from './managed-opencode'
+import { detectAvx2, resolveOpencodePlatform } from './managed-opencode'
 
 const REGISTRY_URLS: Record<ManagedClaudeRegistry, string> = {
   npmjs: 'https://registry.npmjs.org',
@@ -40,6 +40,7 @@ export type EnvironmentCheckDeps = {
   resolveManagedPlatform?: () => unknown
   findPython?: () => Promise<PythonCommand | undefined>
   probeRegistry?: RegistryProbe
+  detectAvx2?: () => boolean
   now?: () => number
 }
 
@@ -151,7 +152,13 @@ const runEnvironmentCheck = async ({
     (() => (agentFrameworkId === 'opencode' ? resolveOpencodePlatform() : getManagedPlatform()))
   const findPython = deps.findPython ?? findPythonCommand
   const probeRegistry = deps.probeRegistry ?? probeRegistryReachability
+  const detectAvx2Cap = deps.detectAvx2 ?? detectAvx2
   const now = deps.now ?? Date.now
+
+  // opencode ships a `-baseline` build for a non-AVX2 x64 host, so such a machine is still fully
+  // auto-installable — reflect the true capability with an informational note rather than a warning.
+  const opencodeBaselineNote =
+    agentFrameworkId === 'opencode' && architecture === 'x64' && !detectAvx2Cap()
 
   const [systemCheck, storageCheck, python] = await Promise.all([
     Promise.resolve().then<EnvironmentCheckItem>(() => {
@@ -161,9 +168,12 @@ const runEnvironmentCheck = async ({
           id: 'system',
           label: 'System compatibility',
           status: 'passed',
-          summary: `${platformLabel(platform)} ${architecture} is supported.`,
-          detail:
-            'Automatic setup uses an app-managed runtime and does not require administrator access.'
+          summary: opencodeBaselineNote
+            ? `${platformLabel(platform)} ${architecture} is supported — the baseline build will be installed.`
+            : `${platformLabel(platform)} ${architecture} is supported.`,
+          detail: opencodeBaselineNote
+            ? 'This CPU lacks AVX2, so automatic setup installs the app-managed baseline runtime. No administrator access is required.'
+            : 'Automatic setup uses an app-managed runtime and does not require administrator access.'
         }
       } catch (error) {
         // An already-runnable runtime can still be used even if this architecture has no managed

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   classifyVerifyResult,
   defaultVerifyBinary,
+  detectAvx2,
   installManagedOpencode,
   managedOpencodeDir,
   resolveOpencodePlatform,
@@ -563,6 +564,64 @@ describe('installManagedOpencode', () => {
     // No baseline key was ever requested on arm64.
     expect(requestedKeys.some((url) => url.includes('baseline'))).toBe(false)
     expect(outcome.result.ok).toBe(true)
+  })
+})
+
+describe('detectAvx2', () => {
+  // darwin: sysctl fails via out.error / non-zero status (never throws), so failures must be treated as
+  // "assume present" BEFORE reading stdout — otherwise a capable Intel Mac is mis-flagged as baseline.
+  it('assumes AVX2 present when the darwin sysctl probe errors (ENOENT)', () => {
+    expect(
+      detectAvx2({ platform: 'darwin', runSysctl: () => ({ error: new Error('spawn ENOENT') }) })
+    ).toBe(true)
+  })
+
+  it('assumes AVX2 present when the darwin sysctl probe exits non-zero with empty stdout', () => {
+    expect(detectAvx2({ platform: 'darwin', runSysctl: () => ({ status: 1, stdout: '' }) })).toBe(
+      true
+    )
+  })
+
+  it('detects AVX2 present from the darwin sysctl feature list', () => {
+    expect(
+      detectAvx2({
+        platform: 'darwin',
+        runSysctl: () => ({ status: 0, stdout: 'RDSEED ADX SMAP AVX2 BMI2\n' })
+      })
+    ).toBe(true)
+  })
+
+  it('detects AVX2 absent when the darwin feature list omits it', () => {
+    expect(
+      detectAvx2({
+        platform: 'darwin',
+        runSysctl: () => ({ status: 0, stdout: 'SMEP ERMS INVPCID\n' })
+      })
+    ).toBe(false)
+  })
+
+  it('detects AVX2 present/absent from linux /proc/cpuinfo flags', () => {
+    expect(
+      detectAvx2({ platform: 'linux', readCpuinfo: () => 'flags\t: fpu sse2 avx avx2 bmi2\n' })
+    ).toBe(true)
+    expect(detectAvx2({ platform: 'linux', readCpuinfo: () => 'flags\t: fpu sse2 avx\n' })).toBe(
+      false
+    )
+  })
+
+  it('assumes AVX2 present when reading linux /proc/cpuinfo throws', () => {
+    expect(
+      detectAvx2({
+        platform: 'linux',
+        readCpuinfo: () => {
+          throw new Error('EACCES')
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('assumes AVX2 present on platforms without a cheap probe (win32)', () => {
+    expect(detectAvx2({ platform: 'win32' })).toBe(true)
   })
 })
 

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -245,6 +245,8 @@ describe('installManagedOpencode', () => {
       platform: { key: 'linux-x64', binName: 'opencode' },
       fetchJson,
       fetchTarball,
+      // AVX2 present, so the standard build is tried first — the SIGILL retry is the safety net.
+      detectAvx2: () => true,
       verifyBinary: () => {
         probes += 1
         return probes === 1
@@ -297,6 +299,7 @@ describe('installManagedOpencode', () => {
       platform: { key: 'linux-x64-musl', binName: 'opencode' },
       fetchJson,
       fetchTarball,
+      detectAvx2: () => true,
       verifyBinary: () => {
         probes += 1
         return probes === 1
@@ -350,6 +353,7 @@ describe('installManagedOpencode', () => {
       platform: { key: 'windows-x64', binName: 'opencode.exe' },
       fetchJson,
       fetchTarball,
+      detectAvx2: () => true,
       verifyBinary: () => {
         probes += 1
         return probes === 1
@@ -429,6 +433,7 @@ describe('installManagedOpencode', () => {
       platform: { key: 'linux-x64', binName: 'opencode' },
       fetchJson,
       fetchTarball,
+      detectAvx2: () => true,
       verifyBinary: () => ({ ok: false, reason: 'killed by SIGILL', illegalInstruction: true }),
       tmpDir: root
     })
@@ -438,6 +443,126 @@ describe('installManagedOpencode', () => {
     expect(outcome.result.error).toMatch(/AVX2/)
     // No broken binary left on disk.
     await expect(readFile(join(managedOpencodeDir(root), 'opencode'))).rejects.toThrow()
+  })
+
+  // A non-AVX2 x64 host detected up front installs the -baseline build on the FIRST try: no wasted
+  // standard download + SIGILL. The baseline key is requested first and the standard key is never asked.
+  it('installs the baseline build first when AVX2 is absent on x64 (no standard download)', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const baselineTgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho baseline\n') }
+    ])
+
+    const requestedKeys: string[] = []
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/opencode-ai')) return { 'dist-tags': { latest: '1.18.3' } }
+      if (url.includes('/opencode-linux-x64-baseline/')) {
+        requestedKeys.push('baseline')
+        return { dist: { tarball: 'https://reg/baseline.tgz', integrity: sha512(baselineTgz) } }
+      }
+      requestedKeys.push('standard')
+      return { dist: { tarball: 'https://reg/standard.tgz', integrity: 'sha512-unused' } }
+    }
+    const fetchTarball = async (): Promise<{
+      stream: NodeJS.ReadableStream
+      totalBytes?: number
+    }> => ({ stream: Readable.from(baselineTgz), totalBytes: baselineTgz.length })
+
+    const outcome = await installManagedOpencode({
+      installId: 'i8',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'linux-x64', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      // Positively no AVX2 → prefer the baseline build up front.
+      detectAvx2: () => false,
+      verifyBinary: () => ({ ok: true }),
+      tmpDir: root
+    })
+
+    // The baseline key is requested first, and the standard key is never requested at all.
+    expect(requestedKeys[0]).toBe('baseline')
+    expect(requestedKeys).not.toContain('standard')
+    expect(outcome.result.ok).toBe(true)
+    expect(await readFile(outcome.resolvedPath!, 'utf8')).toContain('echo baseline')
+  })
+
+  // The default path: AVX2 present ⇒ the standard build is requested first (baseline only via retry).
+  it('installs the standard build first when AVX2 is present on x64', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const standardTgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho standard\n') }
+    ])
+
+    const requestedKeys: string[] = []
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/opencode-ai')) return { 'dist-tags': { latest: '1.18.3' } }
+      if (url.includes('-baseline/')) {
+        requestedKeys.push('baseline')
+        return { dist: { tarball: 'https://reg/baseline.tgz', integrity: 'sha512-unused' } }
+      }
+      requestedKeys.push('standard')
+      return { dist: { tarball: 'https://reg/standard.tgz', integrity: sha512(standardTgz) } }
+    }
+    const fetchTarball = async (): Promise<{
+      stream: NodeJS.ReadableStream
+      totalBytes?: number
+    }> => ({ stream: Readable.from(standardTgz), totalBytes: standardTgz.length })
+
+    const outcome = await installManagedOpencode({
+      installId: 'i9',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'linux-x64', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      detectAvx2: () => true,
+      verifyBinary: () => ({ ok: true }),
+      tmpDir: root
+    })
+
+    expect(requestedKeys).toEqual(['standard'])
+    expect(outcome.result.ok).toBe(true)
+    expect(await readFile(outcome.resolvedPath!, 'utf8')).toContain('echo standard')
+  })
+
+  // arm64 has no baseline package, so it must never prefer baseline even when AVX2 detection says absent.
+  it('never prefers baseline on arm64 regardless of AVX2 detection', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const tgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho arm\n') }
+    ])
+
+    const requestedKeys: string[] = []
+    const fetchJson = async (url: string): Promise<unknown> => {
+      if (url.endsWith('/opencode-ai')) return { 'dist-tags': { latest: '1.18.3' } }
+      requestedKeys.push(url)
+      return { dist: { tarball: 'https://reg/arm.tgz', integrity: sha512(tgz) } }
+    }
+    const fetchTarball = async (): Promise<{
+      stream: NodeJS.ReadableStream
+      totalBytes?: number
+    }> => ({ stream: Readable.from(tgz), totalBytes: tgz.length })
+
+    const outcome = await installManagedOpencode({
+      installId: 'i10',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'darwin-arm64', binName: 'opencode' },
+      fetchJson,
+      fetchTarball,
+      detectAvx2: () => false,
+      verifyBinary: () => ({ ok: true }),
+      tmpDir: root
+    })
+
+    // No baseline key was ever requested on arm64.
+    expect(requestedKeys.some((url) => url.includes('baseline'))).toBe(false)
+    expect(outcome.result.ok).toBe(true)
   })
 })
 

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -80,21 +80,39 @@ const isRosetta = (): boolean => {
   }
 }
 
+// Injectable probes for the AVX2 detector so both OS branches are unit-testable cross-platform (parallel
+// to ResolveOpencodePlatformDeps). Real defaults hit /proc/cpuinfo (linux) and sysctl (darwin).
+export type DetectAvx2Deps = {
+  platform?: NodeJS.Platform
+  readCpuinfo?: () => string
+  runSysctl?: () => { error?: Error; status?: number | null; stdout?: string }
+}
+
 // Up-front AVX2 probe so a non-AVX2 x64 host installs the `-baseline` build on the FIRST try instead of
 // downloading the standard build, dying on SIGILL, and retrying. Errs on the side of `true` (standard
 // build) whenever it cannot cheaply/reliably tell — the illegal-instruction→baseline retry is the safety
 // net for those cases. Only meaningful on x64; the caller gates on that.
-export const detectAvx2 = (): boolean => {
-  if (process.platform === 'linux') {
+export const detectAvx2 = (deps: DetectAvx2Deps = {}): boolean => {
+  const platform = deps.platform ?? process.platform
+
+  if (platform === 'linux') {
     try {
-      return /\bavx2\b/i.test(readFileSync('/proc/cpuinfo', 'utf8'))
+      const readCpuinfo = deps.readCpuinfo ?? (() => readFileSync('/proc/cpuinfo', 'utf8'))
+      return /\bavx2\b/i.test(readCpuinfo())
     } catch {
       return true
     }
   }
-  if (process.platform === 'darwin') {
+  if (platform === 'darwin') {
     try {
-      const out = spawnSync('sysctl', ['-n', 'machdep.cpu.leaf7_features'], { encoding: 'utf8' })
+      const runSysctl =
+        deps.runSysctl ??
+        (() => spawnSync('sysctl', ['-n', 'machdep.cpu.leaf7_features'], { encoding: 'utf8' }))
+      const out = runSysctl()
+      // spawnSync signals failure via out.error / a non-zero out.status rather than throwing, leaving
+      // stdout empty — treat any such failure as "assume present" BEFORE testing stdout so a capable
+      // Intel Mac is never mis-flagged as baseline when sysctl is missing or errors.
+      if (out.error || (out.status != null && out.status !== 0)) return true
       return /avx2/i.test(out.stdout ?? '')
     } catch {
       return true

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -1,4 +1,5 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { chmod, rm } from 'node:fs/promises'
 import { arch as osArch } from 'node:os'
 import { join } from 'node:path'
@@ -18,10 +19,11 @@ import {
 // App-managed OpenCode installer. opencode ships per-platform native packages
 // (`opencode-<os>-<arch>[-musl]`) as optionalDependencies of the `opencode-ai` wrapper, with the binary
 // at `package/bin/opencode` — the same native-package model as Claude, so the shared download/verify/
-// extract helpers are reused. Modern CPUs get the standard build; a non-AVX2 x64 host whose post-install
-// smoke check dies on an illegal instruction (SIGILL on POSIX, the NTSTATUS illegal-instruction exit
-// status on Windows) falls back once to the `-baseline` variant opencode publishes for x64 (no fragile
-// pre-detection). Every side-effecting dependency is injectable so the flow is unit-testable offline.
+// extract helpers are reused. Modern CPUs get the standard build; an x64 host detected up front to lack
+// AVX2 installs the `-baseline` variant on the first try, and any x64 host whose post-install smoke check
+// still dies on an illegal instruction (SIGILL on POSIX, the NTSTATUS illegal-instruction exit status on
+// Windows) falls back once to that `-baseline` variant as a safety net. Every side-effecting dependency
+// is injectable so the flow is unit-testable offline.
 
 // Wrapper package (its dist-tags.latest gives the version) and the native-package name prefix. Note the
 // native packages are `opencode-<key>`, NOT `opencode-ai-<key>`, so the prefix differs from the wrapper.
@@ -76,6 +78,30 @@ const isRosetta = (): boolean => {
   } catch {
     return false
   }
+}
+
+// Up-front AVX2 probe so a non-AVX2 x64 host installs the `-baseline` build on the FIRST try instead of
+// downloading the standard build, dying on SIGILL, and retrying. Errs on the side of `true` (standard
+// build) whenever it cannot cheaply/reliably tell — the illegal-instruction→baseline retry is the safety
+// net for those cases. Only meaningful on x64; the caller gates on that.
+export const detectAvx2 = (): boolean => {
+  if (process.platform === 'linux') {
+    try {
+      return /\bavx2\b/i.test(readFileSync('/proc/cpuinfo', 'utf8'))
+    } catch {
+      return true
+    }
+  }
+  if (process.platform === 'darwin') {
+    try {
+      const out = spawnSync('sysctl', ['-n', 'machdep.cpu.leaf7_features'], { encoding: 'utf8' })
+      return /avx2/i.test(out.stdout ?? '')
+    } catch {
+      return true
+    }
+  }
+  // win32 / anything else: no cheap reliable probe — assume standard and rely on the SIGILL retry.
+  return true
 }
 
 // Maps the host to opencode's native-package key. opencode uses `windows` (not Node's `win32`).
@@ -225,6 +251,7 @@ export type InstallManagedOpencodeOptions = {
   fetchJson?: FetchJson
   fetchTarball?: FetchTarball
   verifyBinary?: VerifyBinary
+  detectAvx2?: () => boolean
   tmpDir?: string
 }
 
@@ -247,6 +274,7 @@ export const installManagedOpencode = async ({
   fetchJson = defaultFetchJson,
   fetchTarball = defaultFetchTarball,
   verifyBinary = defaultVerifyBinary,
+  detectAvx2: detectAvx2Dep = detectAvx2,
   tmpDir
 }: InstallManagedOpencodeOptions): Promise<ManagedInstallOutcome> => {
   const destPath = join(managedOpencodeDir(dataRoot), platform.binName)
@@ -318,30 +346,36 @@ export const installManagedOpencode = async ({
   // x64 hosts have a `-baseline` native package variant that drops AVX2; a musl or plain x64 key still
   // contains "x64". arm64 has no baseline, so it is never retried.
   const isX64 = platform.key.includes('x64')
+  // On an x64 host that we can positively tell lacks AVX2, install the baseline build FIRST (no wasted
+  // standard download + SIGILL). When AVX2 is present or undetectable we try the standard build first and
+  // keep the illegal-instruction→baseline retry as the safety net.
+  const preferBaseline = isX64 && !detectAvx2Dep()
+  const firstKey = preferBaseline ? baselinePackageKey(platform.key) : platform.key
 
   for (const registry of registries) {
     try {
-      const standard = await installFromPackage(registry, platform.key, version)
-      if (standard.ok) {
+      const first = await installFromPackage(registry, firstKey, version)
+      if (first.ok) {
         onEvent({
           kind: 'log',
           installId,
           stream: 'system',
-          chunk: `Installed OpenCode ${standard.version}.\n`
+          chunk: `Installed OpenCode ${first.version}${preferBaseline ? ' (baseline)' : ''}.\n`
         })
         return {
           result: { installId, ok: true },
           resolvedPath: destPath,
-          version: standard.version
+          version: first.version
         }
       }
 
-      // The standard build extracted but died on this CPU. On a non-AVX2 x64 host (illegal instruction:
-      // SIGILL on POSIX, the NTSTATUS status on Windows) retry once with the `-baseline` variant so the
-      // onboarding "auto-installable" claim actually holds. If the baseline package is missing (404 at
-      // resolve) or also fails to run, surface the illegal-instruction/AVX2 diagnosis rather than
-      // crashing on an unverifiable package name.
-      if (standard.illegalInstruction && isX64) {
+      // The first build extracted but died on this CPU. If we did NOT already prefer baseline and this is
+      // an x64 host reporting an illegal instruction (SIGILL on POSIX, the NTSTATUS status on Windows),
+      // retry once with the `-baseline` variant so the onboarding "auto-installable" claim holds. Gating
+      // on `!preferBaseline` avoids building a double-`baseline` key when the first attempt already was
+      // baseline. If the baseline package is missing (404 at resolve) or also fails to run, surface the
+      // illegal-instruction/AVX2 diagnosis rather than crashing on an unverifiable package name.
+      if (!preferBaseline && first.illegalInstruction && isX64) {
         onEvent({
           kind: 'log',
           installId,
@@ -352,7 +386,7 @@ export const installManagedOpencode = async ({
           const baseline = await installFromPackage(
             registry,
             baselinePackageKey(platform.key),
-            standard.resolvedVersion
+            first.resolvedVersion
           )
           if (baseline.ok) {
             onEvent({
@@ -372,7 +406,7 @@ export const installManagedOpencode = async ({
         }
       }
 
-      throw new Error(standard.error)
+      throw new Error(first.error)
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error)
       onEvent({


### PR DESCRIPTION
## Summary
Two follow-up hardening items for the managed OpenCode integration (the deferred pieces from the prior reviews).

## AVX2 up-front detection (managed installer)
Previously a non-AVX2 x64 host downloaded the standard native build, died with an illegal instruction, and only then retried the `-baseline` package. Now the installer detects AVX2 up front and picks the baseline build on the **first** try.

- Added an injectable `detectAvx2()` probe: Linux reads `/proc/cpuinfo` for the `avx2` flag; macOS runs `sysctl -n machdep.cpu.leaf7_features`; Windows/unknown assume present (the existing illegal-instruction→baseline retry, incl. the Windows NTSTATUS path, remains the safety net). Any probe error assumes present.
- `installManagedOpencode` computes `preferBaseline = isX64 && !detectAvx2()` and installs `baselinePackageKey(...)` first when set; the illegal-instruction→baseline retry is now gated on `!preferBaseline` so it never builds a double-`baseline` key.
- The environment check surfaces an informational note on the `system` check when an x64 host lacks AVX2 ("the baseline build will be installed"); `canAutoInstall` stays `true` because the host *is* installable via baseline — so the check reflects true capability without a false "unsupported."

## Isolate the user's `~/.opencode`
The round-2 `OPENCODE_DISABLE_PROJECT_CONFIG` closed the repo-controlled config surface, leaving only the user's own home `~/.opencode` able to add an exact-tool permission `allow`. `prepareModelConfig` now sets `OPENCODE_TEST_HOME` in the spawn env to an app-owned directory, redirecting opencode's `Global.Path.home` (`= OPENCODE_TEST_HOME ?? os.homedir()`) so `~/.opencode` no longer loads. This touches only opencode's own home-relative features — **not** the child process's real `HOME`, so shell/git tools are unaffected.

Tradeoff (documented in code): opencode also won't read `~/.claude/CLAUDE.md` or home-level skills — consistent with the app's existing "we own the whole config" model (instructions and skills are app-provided via the config/XDG dirs). `OPENCODE_TEST_HOME` is opencode's only override for its home dir; worth re-verifying on opencode upgrades.

## Tests
- `managed-opencode.test.ts`: `detectAvx2:()=>false` ⇒ baseline requested first (no standard); `()=>true` ⇒ standard first; the illegal-instruction retry still falls back to baseline; arm64 never requests baseline.
- `environment-check.test.ts`: x64 + no-AVX2 surfaces the baseline note with `canAutoInstall:true`.
- `opencode.test.ts`: `prepareModelConfig` sets `OPENCODE_TEST_HOME` to the app-owned home dir alongside the existing XDG / `OPENCODE_DISABLE_PROJECT_CONFIG` / `OPENCODE_CONFIG_CONTENT` entries.

typecheck + lint clean; `vitest run src/main/settings src/main/agent-framework` → 23 files / 320 tests pass.