### PR TITLE
fix(update): stop backend process trees before in-place install

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -470,14 +470,57 @@ describe('ACP runtime session management', () => {
     expect(process.killed).toBe(false)
 
     // The awaited quit path must have terminated the agent by the time it resolves.
-    await runtime.shutdownForQuit()
+    const outcome = await runtime.shutdownForQuit()
+    expect(outcome).toHaveProperty('reaped')
     expect(process.killed).toBe(true)
     expect(runtime.getSnapshot().sessionId).toBeUndefined()
   })
 
+  it('shutdownForQuit latches shutting-down so a later connect is refused', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['quit-latch-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.shutdownForQuit()
+
+    // The latch makes a subsequent connect self-abort rather than spawn a fresh, orphanable agent.
+    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(/shutting down/)
+  })
+
+  it('shutdownForUpdateGate reaps the agent without latching, so the app can reconnect', async () => {
+    const spawns: FakeAgentProcess[] = []
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      // A fresh agent per connect, mirroring a real reconnect after the gate tore the previous one down.
+      spawnAgent: () => {
+        const process = new FakeAgentProcess()
+        startFakeAgent(process, [`gate-session-${spawns.length}`])
+        spawns.push(process)
+        return asAgentProcess(process)
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const outcome = await runtime.shutdownForUpdateGate()
+
+    expect(outcome).toHaveProperty('reaped')
+    expect(spawns[0]?.killed).toBe(true)
+    expect(runtime.getSnapshot().sessionId).toBeUndefined()
+
+    // Non-latching: a fresh session connects instead of throwing "shutting down".
+    await expect(runtime.createSession({ cwd: '/workspace' })).resolves.toBeDefined()
+    expect(spawns).toHaveLength(2)
+  })
+
   it('shutdownForQuit waits out an in-flight connect and reaps the mid-spawn child before resolving', async () => {
     const process = new FakeAgentProcess()
-    let quitPromise: Promise<void> | undefined
+    let quitPromise: Promise<{ reaped: boolean }> | undefined
     const runtime = new AcpRuntime({
       appVersion: '0.2.0',
       defaultCwd: '/workspace',

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -564,6 +564,44 @@ describe('ACP runtime session management', () => {
     await connecting
   })
 
+  it('shutdownForUpdateGate reaps a mid-spawn child, then stays non-latching so the app can reconnect', async () => {
+    const midSpawn = new FakeAgentProcess()
+    let gatePromise: Promise<{ reaped: boolean }> | undefined
+    let spawnCount = 0
+    const reconnectSpawns: FakeAgentProcess[] = []
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => {
+        spawnCount += 1
+        if (spawnCount === 1) {
+          // Model the update gate landing while a connect is inside spawnAgentProcess: start the gate
+          // teardown, then hand back the freshly-spawned child. The gate must latch shutting-down for
+          // its duration so connectFresh's check reaps this child; otherwise it is assigned after the
+          // generation bump and outlives a clean-reported gate, holding the very files the NSIS
+          // installer must delete open.
+          gatePromise = runtime.shutdownForUpdateGate()
+          return asAgentProcess(midSpawn)
+        }
+        const process = new FakeAgentProcess()
+        startFakeAgent(process, [`gate-reconnect-${reconnectSpawns.length}`])
+        reconnectSpawns.push(process)
+        return asAgentProcess(process)
+      }
+    })
+
+    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(/shutting down/)
+    expect(gatePromise).toBeDefined()
+    const outcome = await gatePromise
+    expect(outcome).toHaveProperty('reaped')
+    // The mid-spawn child was reaped, not left orphaned holding the install dir open.
+    expect(midSpawn.killed).toBe(true)
+
+    // Non-latching: once the gate resolves, a fresh connect succeeds (no lasting shutting-down latch).
+    await expect(runtime.createSession({ cwd: '/workspace' })).resolves.toBeDefined()
+    expect(reconnectSpawns).toHaveLength(1)
+  })
+
   it('reports conservative Auto when the Agent has no native auto mode', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['auto-session'], {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -590,7 +590,9 @@ describe('ACP runtime session management', () => {
       }
     })
 
-    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(/shutting down/)
+    // The gate bumped the generation (no shutting-down latch), so the mid-spawn connect self-aborts on
+    // the stale-generation check rather than a shutdown latch.
+    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(/superseded/)
     expect(gatePromise).toBeDefined()
     const outcome = await gatePromise
     expect(outcome).toHaveProperty('reaped')
@@ -600,6 +602,43 @@ describe('ACP runtime session management', () => {
     // Non-latching: once the gate resolves, a fresh connect succeeds (no lasting shutting-down latch).
     await expect(runtime.createSession({ cwd: '/workspace' })).resolves.toBeDefined()
     expect(reconnectSpawns).toHaveLength(1)
+  })
+
+  it('shutdownForUpdateGate never latches shutting-down, so an abandoned (hung) teardown still reconnects', async () => {
+    // Models the P2 timeout shape: the gate's in-flight connect hangs inside spawnAgentProcess, so the
+    // gate's own await never settles and runBounded abandons it once the budget elapses. Because the gate
+    // must NOT set a shutting-down latch (it would never clear on an abandoned teardown), a fresh connect
+    // afterward has to succeed instead of self-aborting forever.
+    const neverResolving = new Promise<never>(() => {})
+    const reconnect = new FakeAgentProcess()
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => {
+        spawnCount += 1
+        if (spawnCount === 1) {
+          // Hang the spawn so the connect (and thus the gate awaiting it) never settles.
+          return neverResolving as unknown as ChildProcessWithoutNullStreams
+        }
+        startFakeAgent(reconnect, ['gate-after-hang'])
+        return asAgentProcess(reconnect)
+      }
+    })
+
+    // Start a connect that wedges mid-spawn; do not await it.
+    const hung = runtime.createSession({ cwd: '/workspace' }).catch(() => undefined)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // Fire the gate but do NOT await it — it hangs on the never-settling in-flight connect, exactly as
+    // runBounded would then abandon at the deadline before any cleanup could clear a latch.
+    void runtime.shutdownForUpdateGate()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // Refused-install contract: the runtime is not wedged, so a fresh connect succeeds.
+    await expect(runtime.createSession({ cwd: '/workspace' })).resolves.toBeDefined()
+    expect(spawnCount).toBe(2)
+    void hung
   })
 
   it('reports conservative Auto when the Agent has no native auto mode', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -463,15 +463,23 @@ class AcpRuntime {
     try {
       const agentProcess = await this.spawnAgentProcess()
 
-      // spawnAgentProcess resolves the provider config asynchronously, so the app may have begun
-      // quitting during the spawn. If a shutdown already latched shuttingDown, its teardown saw no
-      // process yet — tree-kill this freshly-spawned child now and abort, or it would outlive the app as
-      // an orphan. Awaited (not a bare kill) so the quit path, which awaits this in-flight connect, does
-      // not exit before the child's whole tree is reaped on Windows.
-      if (this.shuttingDown) {
+      // spawnAgentProcess resolves the provider config asynchronously, so the connection may have been
+      // torn down or superseded during the spawn: a quit latched shuttingDown, or any teardown/reconnect
+      // bumped the generation past ours (e.g. the pre-update-install gate calls disconnect()). Either way
+      // this freshly-spawned child was never assigned, so the teardown that ran saw no process to reap —
+      // tree-kill it now and abort, or it would outlive that teardown as an orphan holding file handles.
+      // Keying off the generation (not just shuttingDown) lets the NON-LATCHING update gate collect a
+      // late spawn without holding a shuttingDown latch it might never release if it is itself abandoned
+      // on timeout. Awaited (not a bare kill) so a teardown that awaits this in-flight connect does not
+      // resolve before the child's whole tree is reaped on Windows.
+      if (this.shuttingDown || generation !== this.connectionGeneration) {
         const result = await terminateProcessTree(agentProcess, undefined, log)
         this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
-        throw new Error('ACP runtime is shutting down.')
+        throw new Error(
+          this.shuttingDown
+            ? 'ACP runtime is shutting down.'
+            : 'ACP connection superseded during spawn.'
+        )
       }
 
       this.agentProcess = agentProcess
@@ -916,28 +924,23 @@ class AcpRuntime {
   }
 
   // Teardown for the pre-update-install gate. Reaps the current agent tree (so the NSIS installer can
-  // delete files the agent held) but, unlike shutdownForQuit, does NOT leave shuttingDown latched — if
-  // the caller then refuses the install (degraded teardown), the runtime stays usable and the next
-  // prompt lazily reconnects. It DOES latch shuttingDown for the duration of the teardown and awaits the
-  // in-flight connect (like shutdownForQuit), so a connect racing inside spawnAgentProcess self-aborts
-  // and reaps its freshly-spawned child, reflected in the returned reaped signal. Without that window
-  // the mid-spawn child would be assigned after disconnect bumped the generation and outlive a
-  // clean-reported gate, holding open the very files the installer must delete. The latch is released in
-  // finally so a refused install leaves no lasting no-spawn state.
+  // delete files the agent held) but, unlike shutdownForQuit, does NOT latch shuttingDown: a refused
+  // install (degraded or timed-out teardown) must leave the runtime able to lazily reconnect. Crucially
+  // it does not rely on a latch to catch a connect racing inside spawnAgentProcess either — this teardown
+  // can itself be abandoned by its caller (runBounded) once the budget elapses, and a latch set here
+  // would then never clear, wedging every future connect. Instead disconnect() bumps the connection
+  // generation, and connectFresh reaps any freshly-spawned child whose generation is now stale,
+  // independent of shuttingDown. Awaiting the in-flight connect here only sharpens the returned reaped
+  // signal (so a degraded reap makes the caller refuse the install); if that await is abandoned on
+  // timeout the caller refuses on !completed and the stale-generation self-reap still collects the child.
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
     this.lastTreeKillReaped = true
-    this.shuttingDown = true
-    // Capture the in-flight connect before disconnect() clears it, matching shutdownForQuit.
+    // Capture the in-flight connect before disconnect() clears it. disconnect() bumps the generation, so
+    // a connect still mid-spawn will self-reap on the stale-generation check regardless of this await.
     const inFlight = this.connectInFlight
-    try {
-      await this.disconnect(false)
-      // A connect still mid-spawn hits the shutting-down check and tree-kills its child; await it
-      // (swallowing its rejection) so that kill settles before we report the reaped signal.
-      if (inFlight) await inFlight.catch(() => undefined)
-    } finally {
-      // Non-latching: clear the flag so a refused install leaves the runtime able to reconnect.
-      this.shuttingDown = false
-    }
+    await this.disconnect(false)
+    // Await so the mid-spawn child's kill settles before we report the reaped signal.
+    if (inFlight) await inFlight.catch(() => undefined)
     return { reaped: this.lastTreeKillReaped }
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -233,6 +233,10 @@ class AcpRuntime {
   // Latched by shutdown() on app quit. A connect can be mid-spawn (resolveSpawnConfig is async) when
   // quit fires, so this lets the post-spawn path kill a child that was created after killAgentProcess ran.
   private shuttingDown = false
+  // AND-accumulated reaped result of the tree kills performed during the current teardown. Reset to true
+  // at the start of shutdownForQuit/shutdownForUpdateGate, then narrowed by each terminateProcessTree so
+  // those methods can report whether the agent tree was cleanly reaped (vs a degraded taskkill fallback).
+  private lastTreeKillReaped = true
   private connection: ClientConnection | undefined
   private connectInFlight: Promise<AcpStateSnapshot> | undefined
   private connectionGeneration = 0
@@ -465,7 +469,8 @@ class AcpRuntime {
       // an orphan. Awaited (not a bare kill) so the quit path, which awaits this in-flight connect, does
       // not exit before the child's whole tree is reaped on Windows.
       if (this.shuttingDown) {
-        await terminateProcessTree(agentProcess, undefined, log)
+        const result = await terminateProcessTree(agentProcess, undefined, log)
+        this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
         throw new Error('ACP runtime is shutting down.')
       }
 
@@ -891,8 +896,10 @@ class AcpRuntime {
   // Awaitable quit/relaunch teardown. Latches shuttingDown FIRST so a connect that is mid-spawn when
   // quit lands self-aborts and kills its freshly-spawned child (see connectFresh). Unlike shutdown(),
   // this can be awaited, so a caller that follows it with app.exit(0) is guaranteed no orphaned agent
-  // remains — assigned, connecting, or mid-spawn.
-  async shutdownForQuit(): Promise<void> {
+  // remains — assigned, connecting, or mid-spawn. Returns { reaped } so the caller can tell a clean
+  // teardown from a degraded one (taskkill fallback left grandchildren) before committing to app.exit.
+  async shutdownForQuit(): Promise<{ reaped: boolean }> {
+    this.lastTreeKillReaped = true
     this.shuttingDown = true
     // Capture the in-flight connect before disconnect() clears it.
     const inFlight = this.connectInFlight
@@ -905,6 +912,18 @@ class AcpRuntime {
     // the shutting-down check and tree-kills its freshly-spawned child. Await it (swallowing its
     // rejection, bounded by shutdownBackends' timeout) so that kill completes before we resolve.
     if (inFlight) await inFlight.catch(() => undefined)
+    return { reaped: this.lastTreeKillReaped }
+  }
+
+  // Non-latching teardown for the pre-update-install gate. Reaps the current agent tree (so the NSIS
+  // installer can delete files the agent held) WITHOUT latching shuttingDown — so if the caller then
+  // refuses the install (degraded teardown), the runtime stays usable and the next prompt lazily
+  // reconnects. A connect racing mid-spawn is still cleaned up by its own generation-mismatch catch path
+  // (disconnect bumps the generation), just not reflected in the returned reaped signal (best-effort).
+  async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
+    this.lastTreeKillReaped = true
+    await this.disconnect(false)
+    return { reaped: this.lastTreeKillReaped }
   }
 
   // Applies an active-provider change without interrupting the user. The agent bakes its provider env in
@@ -1007,7 +1026,9 @@ class AcpRuntime {
     this.agentProcess = undefined
     if (!child) return
     this.expectedProcessExits.add(child)
-    await terminateProcessTree(child, undefined, log)
+    const result = await terminateProcessTree(child, undefined, log)
+    // Narrow the current teardown's reaped accumulator (reset by shutdownForQuit/shutdownForUpdateGate).
+    this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
   }
 
   private nextConnectionGeneration(): number {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -915,14 +915,29 @@ class AcpRuntime {
     return { reaped: this.lastTreeKillReaped }
   }
 
-  // Non-latching teardown for the pre-update-install gate. Reaps the current agent tree (so the NSIS
-  // installer can delete files the agent held) WITHOUT latching shuttingDown — so if the caller then
-  // refuses the install (degraded teardown), the runtime stays usable and the next prompt lazily
-  // reconnects. A connect racing mid-spawn is still cleaned up by its own generation-mismatch catch path
-  // (disconnect bumps the generation), just not reflected in the returned reaped signal (best-effort).
+  // Teardown for the pre-update-install gate. Reaps the current agent tree (so the NSIS installer can
+  // delete files the agent held) but, unlike shutdownForQuit, does NOT leave shuttingDown latched — if
+  // the caller then refuses the install (degraded teardown), the runtime stays usable and the next
+  // prompt lazily reconnects. It DOES latch shuttingDown for the duration of the teardown and awaits the
+  // in-flight connect (like shutdownForQuit), so a connect racing inside spawnAgentProcess self-aborts
+  // and reaps its freshly-spawned child, reflected in the returned reaped signal. Without that window
+  // the mid-spawn child would be assigned after disconnect bumped the generation and outlive a
+  // clean-reported gate, holding open the very files the installer must delete. The latch is released in
+  // finally so a refused install leaves no lasting no-spawn state.
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
     this.lastTreeKillReaped = true
-    await this.disconnect(false)
+    this.shuttingDown = true
+    // Capture the in-flight connect before disconnect() clears it, matching shutdownForQuit.
+    const inFlight = this.connectInFlight
+    try {
+      await this.disconnect(false)
+      // A connect still mid-spawn hits the shutting-down check and tree-kills its child; await it
+      // (swallowing its rejection) so that kill settles before we report the reaped signal.
+      if (inFlight) await inFlight.catch(() => undefined)
+    } finally {
+      // Non-latching: clear the flag so a refused install leaves the runtime able to reconnect.
+      this.shuttingDown = false
+    }
     return { reaped: this.lastTreeKillReaped }
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,7 +65,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { MANAGED_PREVIEW_SCHEME },
         { installMigrationQuitGuard, isMigrationInProgress },
         { createAppTray },
-        { shutdownBackends },
         { installAppLifecycle }
       ] = await Promise.all([
         import('./ipc'),
@@ -73,7 +72,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./managed-preview-resources'),
         import('./storage/migration-state'),
         import('./tray'),
-        import('./lifecycle-shutdown'),
         import('./app-lifecycle')
       ])
 
@@ -124,17 +122,15 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       })
 
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
-      const { runtime, notebook } = await registerIpcHandlers({ mainEntryPath })
+      const { shutdownCoordinator } = await registerIpcHandlers({ mainEntryPath })
 
       return {
         installMigrationQuitGuard,
         isMigrationInProgress,
         createMainWindow,
         createAppTray,
-        shutdownBackends,
+        shutdownCoordinator,
         installAppLifecycle,
-        runtime,
-        notebook,
         log
       }
     },
@@ -150,8 +146,12 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         app,
         createMainWindow: ctx.createMainWindow,
         createTray: (handlers) => ctx.createAppTray({ iconPath: icon, ...handlers }),
-        shutdownBackends: () =>
-          ctx.shutdownBackends({ runtime: ctx.runtime, notebook: ctx.notebook, log: ctx.log }),
+        // Latching quit teardown via the shared coordinator (the same one the update gate uses). The
+        // coordinator awaits the agent + kernel process trees so a Windows taskkill /T completes before
+        // app.exit; runForQuit bounds it so a stuck backend can't hang quit.
+        shutdownBackends: async () => {
+          await ctx.shutdownCoordinator.runForQuit()
+        },
         isMigrationInProgress: ctx.isMigrationInProgress,
         quit: () => app.quit(),
         countWindows: () => BrowserWindow.getAllWindows().length

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -15,6 +15,7 @@ import { ConnectorService } from './connectors/service'
 import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './connectors/provision'
 import { registerFileSaveHandlers } from './file-save'
 import { registerGithubIpcHandlers } from './github-ipc'
+import { BackendShutdownCoordinator, UPDATE_SHUTDOWN_BUDGET_MS } from './lifecycle-shutdown'
 import { registerLogsIpcHandlers } from './logs-ipc'
 import { registerWindowIpcHandlers } from './window-ipc'
 import { createLogger } from './logger'
@@ -104,6 +105,7 @@ const registerIpcHandlers = async ({
 }: IpcRegistrationOptions): Promise<{
   runtime: ReturnType<typeof registerAcpIpcHandlers>
   notebook: ReturnType<typeof createDefaultNotebookRuntimeService>
+  shutdownCoordinator: BackendShutdownCoordinator
 }> => {
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
   const settingsService = createDefaultSettingsService()
@@ -239,6 +241,20 @@ const registerIpcHandlers = async ({
     settingsService
   })
   runtimeRef.current = runtime
+  // Single shared teardown owner for both the before-quit handler (index.ts) and the pre-update-install
+  // gate. Built here because it needs the runtime, which does not exist when update IPC is registered
+  // above — so the gate is injected via a late-bound closure rather than at strategy construction.
+  const shutdownCoordinator = new BackendShutdownCoordinator({
+    runtime,
+    notebook: notebookService,
+    log: createLogger('shutdown')
+  })
+  // Reap the agent + kernel trees before an in-place install so the NSIS uninstall step never hits files
+  // still locked by a background child. Non-latching, so a refused (degraded) install leaves the app
+  // usable. No-op on the manifest fallback strategy, which does not implement setInstallGate.
+  updateService.setInstallGate?.(() =>
+    shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
+  )
   // Switching the active provider takes effect on the next reconnect. Defer that reconnect until any
   // in-flight prompt finishes so switching never interrupts a running turn; the shared config dir keeps
   // the conversation's context across the switch.
@@ -280,7 +296,7 @@ const registerIpcHandlers = async ({
 
   // Return the long-lived backend handles so the app lifecycle (before-quit) can shut them down
   // cleanly on quit — the agent process tree and every notebook kernel.
-  return { runtime, notebook: notebookService }
+  return { runtime, notebook: notebookService, shutdownCoordinator }
 }
 
 export { registerIpcHandlers }

--- a/src/main/lifecycle-shutdown.test.ts
+++ b/src/main/lifecycle-shutdown.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { shutdownBackends, type BackendShutdownDeps } from './lifecycle-shutdown'
+import {
+  BackendShutdownCoordinator,
+  shutdownBackends,
+  UPDATE_SHUTDOWN_BUDGET_MS,
+  type BackendShutdownDeps
+} from './lifecycle-shutdown'
 
-// Builds a fresh set of injectable fakes; individual tests override behavior as needed.
+// Builds a fresh set of injectable fakes; individual tests override behavior as needed. Both teardowns
+// default to a clean reaped result.
 const makeDeps = (overrides: Partial<BackendShutdownDeps> = {}): BackendShutdownDeps => ({
-  runtime: { shutdownForQuit: vi.fn(async () => undefined) },
-  notebook: { shutdownAll: vi.fn(async () => undefined) },
+  runtime: {
+    shutdownForQuit: vi.fn(async () => ({ reaped: true })),
+    shutdownForUpdateGate: vi.fn(async () => ({ reaped: true }))
+  },
+  notebook: { shutdownAll: vi.fn(async () => ({ reaped: true })) },
   log: { error: vi.fn() },
   ...overrides
 })
@@ -24,7 +33,10 @@ describe('shutdownBackends', () => {
   it('still runs notebook shutdown and resolves when runtime teardown rejects', async () => {
     const err = new Error('runtime boom')
     const deps = makeDeps({
-      runtime: { shutdownForQuit: vi.fn(async () => Promise.reject(err)) }
+      runtime: {
+        shutdownForQuit: vi.fn(async () => Promise.reject(err)),
+        shutdownForUpdateGate: vi.fn(async () => ({ reaped: true }))
+      }
     })
     await expect(shutdownBackends(deps)).resolves.toBeUndefined()
     expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
@@ -45,7 +57,10 @@ describe('shutdownBackends', () => {
     vi.useFakeTimers()
     const deps = makeDeps({
       // A backend that hangs forever; only the timeout can free the caller.
-      runtime: { shutdownForQuit: vi.fn(() => new Promise<never>(() => {})) },
+      runtime: {
+        shutdownForQuit: vi.fn(() => new Promise<never>(() => {})),
+        shutdownForUpdateGate: vi.fn(async () => ({ reaped: true }))
+      },
       timeoutMs: 5000
     })
 
@@ -63,5 +78,63 @@ describe('shutdownBackends', () => {
     await vi.advanceTimersByTimeAsync(1)
     await expect(pending).resolves.toBeUndefined()
     expect(settled).toBe(true)
+  })
+})
+
+describe('BackendShutdownCoordinator', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('runForQuit uses the latching teardown and reports completed + reaped when clean', async () => {
+    const deps = makeDeps()
+    const coordinator = new BackendShutdownCoordinator(deps)
+
+    const outcome = await coordinator.runForQuit()
+
+    expect(outcome).toEqual({ completed: true, reaped: true })
+    expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
+    expect(deps.runtime.shutdownForUpdateGate).not.toHaveBeenCalled()
+    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('runForUpdateGate uses the non-latching teardown', async () => {
+    const deps = makeDeps()
+    const coordinator = new BackendShutdownCoordinator(deps)
+
+    const outcome = await coordinator.runForUpdateGate()
+
+    expect(outcome).toEqual({ completed: true, reaped: true })
+    expect(deps.runtime.shutdownForUpdateGate).toHaveBeenCalledTimes(1)
+    expect(deps.runtime.shutdownForQuit).not.toHaveBeenCalled()
+    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports reaped:false when a tree kill was degraded', async () => {
+    const deps = makeDeps({
+      notebook: { shutdownAll: vi.fn(async () => ({ reaped: false })) }
+    })
+    const coordinator = new BackendShutdownCoordinator(deps)
+
+    const outcome = await coordinator.runForUpdateGate()
+
+    expect(outcome).toEqual({ completed: true, reaped: false })
+  })
+
+  it('reports completed:false (and reaped:false) when the gate teardown exceeds its budget', async () => {
+    vi.useFakeTimers()
+    const deps = makeDeps({
+      runtime: {
+        shutdownForQuit: vi.fn(async () => ({ reaped: true })),
+        // Hangs forever: only the budget deadline can resolve the gate.
+        shutdownForUpdateGate: vi.fn(() => new Promise<never>(() => {}))
+      }
+    })
+    const coordinator = new BackendShutdownCoordinator(deps)
+
+    const pending = coordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
+    await vi.advanceTimersByTimeAsync(UPDATE_SHUTDOWN_BUDGET_MS)
+
+    await expect(pending).resolves.toEqual({ completed: false, reaped: false })
   })
 })

--- a/src/main/lifecycle-shutdown.ts
+++ b/src/main/lifecycle-shutdown.ts
@@ -1,47 +1,133 @@
 // Coordinates a bounded, best-effort shutdown of the app's backend subsystems (agent runtime and
 // notebook kernels). Kept free of Electron imports so it stays trivially unit-testable: callers inject
-// the runtime/notebook handles. The whole operation is time-bounded so app quit can never hang on a
-// backend that refuses to settle.
+// the runtime/notebook handles. Every operation is time-bounded so app quit can never hang on a backend
+// that refuses to settle, and reports { reaped } so the update-install gate can tell a clean teardown
+// (all process trees gone, file handles released) from a degraded one (taskkill fell back to the parent).
 
-export type BackendShutdownDeps = {
-  // shutdownForQuit (not disconnect): it latches the runtime's shutting-down flag before awaiting
-  // teardown, so an agent connect that is mid-spawn when quit lands self-aborts instead of orphaning
-  // its freshly-spawned child. disconnect() alone does not set that latch.
-  runtime: { shutdownForQuit: () => Promise<void> }
-  notebook: { shutdownAll: () => Promise<void> }
-  log?: { error: (msg: string, err?: unknown) => void }
-  // Upper bound for the whole shutdown; defaults to 5000ms.
+export type ShutdownOutcome = {
+  // The two backend teardowns settled within the budget (false = the deadline elapsed first).
+  completed: boolean
+  // Every process tree was cleanly reaped. Only meaningful when completed is true; false otherwise.
+  reaped: boolean
+}
+
+type ShutdownLogger = { error: (msg: string, err?: unknown) => void }
+
+// Deps for the quit/relaunch helper: only the latching teardown is needed. Kept narrow so the migration
+// relaunch path (storage/ipc.ts) does not have to expose the non-latching gate method it never uses.
+export type QuitShutdownDeps = {
+  runtime: {
+    // Latching quit teardown: sets the runtime's shutting-down flag so a mid-spawn connect self-aborts
+    // instead of orphaning its freshly-spawned child. disconnect() alone does not set that latch.
+    shutdownForQuit: () => Promise<{ reaped: boolean }>
+  }
+  notebook: { shutdownAll: () => Promise<{ reaped: boolean }> }
+  log?: ShutdownLogger
+  // Upper bound for the quit-path helpers; defaults to QUIT_SHUTDOWN_BUDGET_MS.
   timeoutMs?: number
 }
 
-const DEFAULT_TIMEOUT_MS = 5000
+// Deps for the coordinator, which drives BOTH paths, so it also needs the non-latching gate teardown.
+export type BackendShutdownDeps = QuitShutdownDeps & {
+  runtime: {
+    // Non-latching pre-update-install teardown: reaps the agent tree but leaves the runtime usable so a
+    // refused install does not wedge the app (the next prompt lazily reconnects).
+    shutdownForUpdateGate: () => Promise<{ reaped: boolean }>
+  }
+}
 
-// Shuts down the runtime and notebook backends concurrently, never rejecting and never running longer
-// than `timeoutMs`. A failing backend is logged but does not block the other, and a hung backend is
-// abandoned once the timeout elapses so the caller (app quit) always makes progress.
-export const shutdownBackends = async (deps: BackendShutdownDeps): Promise<void> => {
-  const { runtime, notebook, log, timeoutMs = DEFAULT_TIMEOUT_MS } = deps
+// Normal quit/relaunch budget: keep it short so a stuck backend can't hang quit.
+export const QUIT_SHUTDOWN_BUDGET_MS = 5000
+// Pre-update-install budget: longer than a single tree's worst-case teardown (a notebook kernel can take
+// up to ~6s for taskkill /T + ~5s waiting for the real exit). The installer's uninstall step deletes the
+// running app's files, so releasing every handle first matters more here than finishing quickly.
+export const UPDATE_SHUTDOWN_BUDGET_MS = 15000
 
-  // Run both backends together; allSettled ensures one rejection never short-circuits the other.
-  const settleAll = Promise.allSettled([runtime.shutdownForQuit(), notebook.shutdownAll()]).then(
+// Runs two backend teardowns concurrently, never rejecting and never running longer than budgetMs. A
+// failing backend is logged but does not block the other, and a hung backend is abandoned once the
+// deadline elapses so the caller always makes progress. Returns whether both settled within budget and
+// whether every process tree was cleanly reaped.
+const runBounded = async (
+  runtimeTeardown: Promise<{ reaped: boolean }>,
+  notebookTeardown: Promise<{ reaped: boolean }>,
+  budgetMs: number,
+  log?: BackendShutdownDeps['log']
+): Promise<ShutdownOutcome> => {
+  let reaped = false
+
+  // allSettled ensures one rejection never short-circuits the other.
+  const settleAll = Promise.allSettled([runtimeTeardown, notebookTeardown]).then(
     ([runtimeResult, notebookResult]) => {
       if (runtimeResult.status === 'rejected') {
-        log?.error('runtime.shutdownForQuit failed during shutdown', runtimeResult.reason)
+        log?.error('runtime shutdown failed during shutdown', runtimeResult.reason)
       }
       if (notebookResult.status === 'rejected') {
-        log?.error('notebook.shutdownAll failed during shutdown', notebookResult.reason)
+        log?.error('notebook shutdownAll failed during shutdown', notebookResult.reason)
       }
+
+      // Optional chaining keeps the never-throw invariant even if a teardown resolves a malformed value.
+      const runtimeReaped =
+        runtimeResult.status === 'fulfilled' && runtimeResult.value?.reaped === true
+      const notebookReaped =
+        notebookResult.status === 'fulfilled' && notebookResult.value?.reaped === true
+      reaped = runtimeReaped && notebookReaped
     }
   )
 
-  // Race the work against a self-unreffing timer so a stuck backend can't keep the process alive or
-  // hang quit; whichever finishes first resolves the caller.
+  // Race the work against a self-unreffing timer so a stuck backend can't keep the process alive or hang
+  // quit; whichever finishes first resolves the caller.
   let timer: ReturnType<typeof setTimeout> | undefined
-  const deadline = new Promise<void>((resolve) => {
-    timer = setTimeout(resolve, timeoutMs)
+  const deadline = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), budgetMs)
     timer.unref?.()
   })
 
-  await Promise.race([settleAll, deadline])
+  const result = await Promise.race([settleAll.then(() => 'done' as const), deadline])
   if (timer) clearTimeout(timer)
+
+  const completed = result === 'done'
+  return { completed, reaped: completed && reaped }
+}
+
+// Quit/relaunch helper (latching teardown). Kept as a standalone function for the data-root migration
+// relaunch path (storage/ipc.ts); the app-quit path goes through BackendShutdownCoordinator instead.
+// Returns void for backward compatibility — that caller only needs the bounded, never-throwing await.
+export const shutdownBackends = async (deps: QuitShutdownDeps): Promise<void> => {
+  await runBounded(
+    deps.runtime.shutdownForQuit(),
+    deps.notebook.shutdownAll(),
+    deps.timeoutMs ?? QUIT_SHUTDOWN_BUDGET_MS,
+    deps.log
+  )
+}
+
+// Single shared owner of backend teardown, used by BOTH the before-quit handler and the pre-update-install
+// gate so the two paths agree on the backend handles. The two entry points differ deliberately:
+//   - runForQuit uses the LATCHING runtime teardown and a short budget (the app is going down regardless).
+//   - runForUpdateGate uses the NON-LATCHING runtime teardown and a longer budget, so a degraded teardown
+//     can be refused without wedging a runtime that must keep serving the still-open app.
+// Idempotency across the two (gate runs, then before-quit) is natural: the gate clears the agent process
+// and notebook sessions, so the subsequent quit teardown finds nothing left to kill and returns fast.
+export class BackendShutdownCoordinator {
+  constructor(private readonly deps: BackendShutdownDeps) {}
+
+  runForQuit(
+    budgetMs: number = this.deps.timeoutMs ?? QUIT_SHUTDOWN_BUDGET_MS
+  ): Promise<ShutdownOutcome> {
+    return runBounded(
+      this.deps.runtime.shutdownForQuit(),
+      this.deps.notebook.shutdownAll(),
+      budgetMs,
+      this.deps.log
+    )
+  }
+
+  runForUpdateGate(budgetMs: number = UPDATE_SHUTDOWN_BUDGET_MS): Promise<ShutdownOutcome> {
+    return runBounded(
+      this.deps.runtime.shutdownForUpdateGate(),
+      this.deps.notebook.shutdownAll(),
+      budgetMs,
+      this.deps.log
+    )
+  }
 }

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -39,7 +39,7 @@ describe('notebook local RPC server', () => {
           outputs: [],
           workingFiles: []
         }),
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
     const server = new NotebookLocalRpcServer(service, { token: 'secret-token' })
@@ -106,7 +106,7 @@ describe('notebook local RPC server', () => {
           outputs: [],
           workingFiles: []
         }),
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
     const server = new NotebookLocalRpcServer(service, { token: 'secret-token' })

--- a/src/main/notebook/python-executor.shutdown.test.ts
+++ b/src/main/notebook/python-executor.shutdown.test.ts
@@ -5,14 +5,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // A terminateProcessTree double whose promise we resolve by hand, so the test can prove shutdown()
 // actually awaits an in-flight tree-kill that a hard timeout started (rather than racing app.exit).
 const { terminateMock, resolveTermination } = vi.hoisted(() => {
-  let resolveFn: () => void = () => {}
+  let resolveFn: (result: { reaped: boolean }) => void = () => {}
   const terminateMock = vi.fn(
     () =>
-      new Promise<void>((resolve) => {
+      new Promise<{ reaped: boolean }>((resolve) => {
         resolveFn = resolve
       })
   )
-  return { terminateMock, resolveTermination: (): void => resolveFn() }
+  return { terminateMock, resolveTermination: (): void => resolveFn({ reaped: true }) }
 })
 vi.mock('../process-tree', () => ({ terminateProcessTree: terminateMock }))
 

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { delimiter } from 'node:path'
 import { createInterface, type Interface } from 'node:readline'
 
-import { terminateProcessTree } from '../process-tree'
+import { terminateProcessTree, type ProcessTreeKillResult } from '../process-tree'
 import { resolvePythonCommand } from './python-command'
 import type {
   NotebookExecutionRequest,
@@ -269,7 +269,7 @@ class NotebookPythonExecutor implements NotebookExecutor {
   // In-flight tree-kills started by a hard timeout, which drops the interpreter from reuse BEFORE
   // reaping it. shutdown() awaits these so a quit landing right after a timeout cannot app.exit before
   // the kill (notably Windows taskkill /T) has finished tearing the tree down.
-  private terminations = new Set<Promise<void>>()
+  private terminations = new Set<Promise<ProcessTreeKillResult>>()
 
   // Leading args (e.g. the Windows `py` launcher's `-3`) prepended before the bridge invocation.
   private baseArgs: string[] = []
@@ -344,8 +344,10 @@ class NotebookPythonExecutor implements NotebookExecutor {
     this.terminations.add(termination)
   }
 
-  // Stops the interpreter and rejects any caller waiting for an execution result.
-  async shutdown(): Promise<void> {
+  // Stops the interpreter and rejects any caller waiting for an execution result. Returns { reaped }:
+  // true only when the interpreter tree was cleanly reaped (and any in-flight timeout kill settled),
+  // so the update-install gate can tell a released-handles teardown from a degraded one.
+  async shutdown(): Promise<ProcessTreeKillResult> {
     if (this.pending) {
       const pending = this.pending
 
@@ -360,6 +362,8 @@ class NotebookPythonExecutor implements NotebookExecutor {
     const child = this.child
     this.child = undefined
 
+    let reaped = true
+
     if (child && !child.killed) {
       // Wait for the OS to actually reap the process before returning. On Windows the file handles
       // the interpreter holds under the cwd/runtime/data dirs are released only once it has fully
@@ -372,22 +376,37 @@ class NotebookPythonExecutor implements NotebookExecutor {
 
       // Tree-kill (Windows taskkill /T reaps grandchildren) then wait for the real exit so the cwd/
       // runtime/data file handles are released before a caller deletes those dirs.
-      await terminateProcessTree(child)
+      const result = await terminateProcessTree(child)
+      reaped = reaped && result.reaped
       await Promise.race([exited, delay(SHUTDOWN_EXIT_GRACE_MS)])
     }
 
     // A hard timeout may have already dropped an interpreter and started tree-killing it before this
-    // shutdown ran; await that kill too so quit never exits ahead of an in-flight taskkill /T.
+    // shutdown ran; await that kill too so quit never exits ahead of an in-flight taskkill /T. A kill
+    // that has not settled within the grace leaves reaped unconfirmed (false).
     if (this.terminations.size > 0) {
-      await Promise.race([
-        Promise.allSettled([...this.terminations]),
-        delay(SHUTDOWN_EXIT_GRACE_MS)
+      const settled = await Promise.race([
+        Promise.allSettled([...this.terminations]).then((results) => ({
+          timedOut: false,
+          results
+        })),
+        delay(SHUTDOWN_EXIT_GRACE_MS).then(() => ({ timedOut: true, results: [] }))
       ])
+
+      if (settled.timedOut) {
+        reaped = false
+      } else {
+        for (const outcome of settled.results) {
+          reaped = reaped && outcome.status === 'fulfilled' && outcome.value.reaped
+        }
+      }
     }
 
     this.currentCwd = undefined
     this.passthroughStdout = []
     this.passthroughStderr = []
+
+    return { reaped }
   }
 
   // Starts the bridge lazily and reuses it until the child exits or is killed.

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -377,7 +377,7 @@ class NotebookPythonExecutor implements NotebookExecutor {
       // Tree-kill (Windows taskkill /T reaps grandchildren) then wait for the real exit so the cwd/
       // runtime/data file handles are released before a caller deletes those dirs.
       const result = await terminateProcessTree(child)
-      reaped = reaped && result.reaped
+      reaped = result.reaped
       await Promise.race([exited, delay(SHUTDOWN_EXIT_GRACE_MS)])
     }
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -76,7 +76,7 @@ describe('notebook runtime service', () => {
             ]
           }
         },
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 
@@ -174,7 +174,7 @@ describe('notebook runtime service', () => {
           cwdAfter: request.cwd,
           outputs: []
         }),
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 
@@ -211,7 +211,7 @@ describe('notebook runtime service', () => {
           cwdAfter: request.cwd,
           outputs: []
         }),
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 
@@ -264,7 +264,7 @@ describe('notebook runtime service', () => {
           cwdAfter: request.cwd,
           outputs: []
         }),
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 
@@ -329,7 +329,7 @@ describe('notebook runtime service', () => {
             outputs: []
           }
         },
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 
@@ -387,7 +387,7 @@ describe('notebook runtime service', () => {
           cwdAfter: request.cwd,
           outputs: []
         }),
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 
@@ -457,7 +457,7 @@ describe('notebook runtime service', () => {
             workingFiles: []
           }
         },
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 
@@ -536,7 +536,7 @@ describe('notebook runtime service', () => {
             workingFiles: []
           }
         },
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 
@@ -581,7 +581,7 @@ describe('notebook runtime service migration write-gate', () => {
         execute: async (): Promise<NotebookExecutionResult> => {
           throw new Error('executor should never run while the gate is up')
         },
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 
@@ -619,7 +619,7 @@ describe('notebook runtime service migration write-gate', () => {
         execute: async (): Promise<NotebookExecutionResult> => {
           throw new Error('executor should not run')
         },
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 
@@ -658,7 +658,7 @@ describe('notebook runtime service migration write-gate', () => {
                 workingFiles: []
               })
           }),
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
     const begin = await service.beginCodeCell({
@@ -730,7 +730,7 @@ describe('notebook runtime service migration write-gate', () => {
           outputs: [],
           workingFiles: []
         }),
-        shutdown: async () => undefined
+        shutdown: async () => ({ reaped: true })
       })
     })
 

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -49,7 +49,8 @@ type NotebookExecutionResult = {
 
 type NotebookExecutor = {
   execute: (request: NotebookExecutionRequest) => Promise<NotebookExecutionResult>
-  shutdown: () => Promise<void>
+  // Returns { reaped } so shutdownAll can report whether every kernel tree was cleanly reaped.
+  shutdown: () => Promise<{ reaped: boolean }>
 }
 
 type NotebookRuntimeServiceCallbacks = {
@@ -510,11 +511,16 @@ class NotebookRuntimeService {
   }
 
   // Shuts down every live interpreter, used by app-level cleanup paths.
-  async shutdownAll(): Promise<void> {
-    await Promise.all(
+  // Shuts down every kernel. Returns { reaped }: true only when every interpreter tree was cleanly
+  // reaped, so the update-install gate can refuse to trigger the NSIS uninstall while a kernel may
+  // still hold file handles under the install dir.
+  async shutdownAll(): Promise<{ reaped: boolean }> {
+    const results = await Promise.all(
       Array.from(this.sessions.values()).map((session) => session.executor.shutdown())
     )
     this.sessions.clear()
+
+    return { reaped: results.every((result) => result.reaped) }
   }
 
   // Lists sessions with a cell mid-execution, for the pre-migration active-session warning.

--- a/src/main/process-tree.test.ts
+++ b/src/main/process-tree.test.ts
@@ -62,7 +62,7 @@ describe('terminateProcessTree (win32)', () => {
     )
 
     killer.emit('exit', 0, null)
-    await expect(pending).resolves.toBeUndefined()
+    await expect(pending).resolves.toEqual({ reaped: true })
     // A clean taskkill reaps the tree; no direct fallback kill is needed.
     expect(child.kill).not.toHaveBeenCalled()
   })
@@ -102,7 +102,8 @@ describe('terminateProcessTree (win32)', () => {
     await Promise.resolve()
     child.emit('exit', 0, null)
 
-    await expect(pending).resolves.toBeUndefined()
+    // Fallback direct kill can't reach grandchildren taskkill would have reaped, so reaped is false.
+    await expect(pending).resolves.toEqual({ reaped: false })
     expect(child.kill).toHaveBeenCalledTimes(1)
     expect(log.error).toHaveBeenCalled()
   })
@@ -120,7 +121,7 @@ describe('terminateProcessTree (win32)', () => {
     await Promise.resolve()
     child.emit('exit', 0, null)
 
-    await expect(pending).resolves.toBeUndefined()
+    await expect(pending).resolves.toEqual({ reaped: false })
     expect(child.kill).toHaveBeenCalledTimes(1)
     expect(log.error).toHaveBeenCalled()
   })
@@ -140,7 +141,7 @@ describe('terminateProcessTree (win32)', () => {
     expect(child.kill).toHaveBeenCalledTimes(1)
     expect(log.error).toHaveBeenCalled()
     await vi.advanceTimersByTimeAsync(3_000)
-    await expect(pending).resolves.toBeUndefined()
+    await expect(pending).resolves.toEqual({ reaped: false })
   })
 
   it('falls back to a direct kill when spawn itself throws synchronously', async () => {
@@ -154,16 +155,17 @@ describe('terminateProcessTree (win32)', () => {
     const pending = terminateProcessTree(child as never, undefined, log)
     child.emit('exit', 0, null)
 
-    await expect(pending).resolves.toBeUndefined()
+    await expect(pending).resolves.toEqual({ reaped: false })
     expect(child.kill).toHaveBeenCalledTimes(1)
     expect(log.error).toHaveBeenCalled()
   })
 
-  it('with an undefined pid does not spawn taskkill and does not kill', async () => {
+  it('with an undefined pid does not spawn taskkill and reports the tree reaped', async () => {
     setPlatform('win32')
     const child = new FakeChild(undefined)
 
-    await expect(terminateProcessTree(child as never)).resolves.toBeUndefined()
+    // No pid means nothing spawned/already gone — nothing left to reap.
+    await expect(terminateProcessTree(child as never)).resolves.toEqual({ reaped: true })
     expect(spawnMock).not.toHaveBeenCalled()
     expect(child.kill).not.toHaveBeenCalled()
   })
@@ -189,7 +191,7 @@ describe('terminateProcessTree (posix)', () => {
     await Promise.resolve()
 
     child.emit('exit', 0, null)
-    await expect(pending).resolves.toBeUndefined()
+    await expect(pending).resolves.toEqual({ reaped: true })
 
     expect(killSpy).toHaveBeenCalledWith(1001, 'SIGTERM')
     expect(killSpy).toHaveBeenCalledWith(1002, 'SIGTERM')
@@ -216,7 +218,8 @@ describe('terminateProcessTree (posix)', () => {
     // Graceful grace elapses with the child still alive -> escalate.
     await vi.advanceTimersByTimeAsync(3_000)
     await vi.advanceTimersByTimeAsync(1_000)
-    await expect(pending).resolves.toBeUndefined()
+    // Survivors stay alive and the child never exits, so the tree was not cleanly reaped.
+    await expect(pending).resolves.toEqual({ reaped: false })
 
     expect(killSpy).toHaveBeenCalledWith(1001, 'SIGTERM')
     expect(killSpy).toHaveBeenCalledWith(1001, 'SIGKILL')
@@ -239,7 +242,8 @@ describe('terminateProcessTree (posix)', () => {
     await Promise.resolve()
 
     child.emit('exit', 0, null)
-    await expect(pending).resolves.toBeUndefined()
+    // No descendants discovered and the child exited, so the (degenerate) tree counts as reaped.
+    await expect(pending).resolves.toEqual({ reaped: true })
     expect(killSpy).not.toHaveBeenCalledWith(expect.any(Number), 'SIGTERM')
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
   })
@@ -259,7 +263,8 @@ describe('terminateProcessTree (posix)', () => {
     expect(ps.kill).toHaveBeenCalledTimes(1)
     await vi.advanceTimersByTimeAsync(3_000)
     await vi.advanceTimersByTimeAsync(1_000)
-    await expect(pending).resolves.toBeUndefined()
+    // The child never exits within its grace, so reaped is false.
+    await expect(pending).resolves.toEqual({ reaped: false })
   })
 
   it('resolves immediately when the child has already exited', async () => {
@@ -275,6 +280,6 @@ describe('terminateProcessTree (posix)', () => {
     const pending = terminateProcessTree(child as never)
     ps.emit('close', 0)
 
-    await expect(pending).resolves.toBeUndefined()
+    await expect(pending).resolves.toEqual({ reaped: true })
   })
 })

--- a/src/main/process-tree.ts
+++ b/src/main/process-tree.ts
@@ -5,6 +5,12 @@ import type { ChildProcess } from 'node:child_process'
 // omit it. Kept minimal so process-tree stays free of the Electron logger's import graph.
 export type ProcessTreeLogger = { error: (message: string, error?: unknown) => void }
 
+// Outcome of a tree teardown. `reaped` is true only when we are confident the WHOLE tree is gone:
+// Windows taskkill /T exited 0, or POSIX left no surviving descendant and the direct child exited.
+// A fallback path (taskkill failed → only the parent was direct-killed) reports reaped:false so a
+// caller that must guarantee released file handles (the update-install gate) can refuse to proceed.
+export type ProcessTreeKillResult = { reaped: boolean }
+
 // Upper bound for awaiting a direct child's real exit (POSIX) or taskkill's own completion (Windows).
 // Bounded so a wedged process can never hang app teardown; the caller (before-quit) also time-bounds
 // the whole shutdown, this is a second, tighter guard scoped to a single tree.
@@ -165,8 +171,9 @@ const terminateWindowsTree = async (
   child: ChildProcess,
   signal: NodeJS.Signals | undefined,
   log: ProcessTreeLogger | undefined
-): Promise<void> => {
-  if (child.pid === undefined) return
+): Promise<ProcessTreeKillResult> => {
+  // No pid means the process never spawned or is already gone — nothing left to reap.
+  if (child.pid === undefined) return { reaped: true }
 
   let killer: ChildProcess
   try {
@@ -175,7 +182,8 @@ const terminateWindowsTree = async (
     log?.error('taskkill failed to launch; falling back to direct kill', error)
     killDirectChild(child, signal)
     await waitForExit(child, TERMINATE_GRACE_MS)
-    return
+    // Direct kill reaches only the parent; grandchildren may survive, so the tree is not cleanly reaped.
+    return { reaped: false }
   }
 
   const reaped = await new Promise<boolean>((resolve) => {
@@ -211,7 +219,11 @@ const terminateWindowsTree = async (
     }
     killDirectChild(child, signal)
     await waitForExit(child, TERMINATE_GRACE_MS)
+    // The fallback direct kill cannot reach grandchildren taskkill would have reaped.
+    return { reaped: false }
   }
+
+  return { reaped: true }
 }
 
 // POSIX tree teardown. child.kill() reaches only the immediate child, so descendants are discovered via
@@ -222,7 +234,7 @@ const terminatePosixTree = async (
   child: ChildProcess,
   signal: NodeJS.Signals | undefined,
   log: ProcessTreeLogger | undefined
-): Promise<void> => {
+): Promise<ProcessTreeKillResult> => {
   const gracefulSignal = signal ?? 'SIGTERM'
   const descendants = child.pid === undefined ? [] : await collectDescendantPids(child.pid)
 
@@ -232,8 +244,9 @@ const terminatePosixTree = async (
   const exited = await waitForExit(child, TERMINATE_GRACE_MS)
   const survivors = descendants.filter(isProcessAlive)
 
-  if (exited && survivors.length === 0) return
+  if (exited && survivors.length === 0) return { reaped: true }
 
+  let childExited = exited
   if (survivors.length > 0) {
     log?.error(
       `process tree left ${survivors.length} descendant(s) alive after ${gracefulSignal}; escalating to SIGKILL`
@@ -245,23 +258,26 @@ const terminatePosixTree = async (
       `process ${child.pid ?? '(no pid)'} did not exit after ${gracefulSignal}; escalating to SIGKILL`
     )
     forceKillChild(child)
-    await waitForExit(child, SIGKILL_GRACE_MS)
+    childExited = await waitForExit(child, SIGKILL_GRACE_MS)
   }
+
+  // Re-check after SIGKILL: reaped only if the direct child exited and no descendant is still alive.
+  return { reaped: childExited && descendants.filter(isProcessAlive).length === 0 }
 }
 
 // Terminates a child process and every descendant it spawned, then waits for the direct child to actually
 // exit — escalating to SIGKILL anything still alive. On Windows the tree is reaped with taskkill /T /F
 // (with a direct-kill fallback); on POSIX descendants are found via `ps`, signaled, and SIGKILL-escalated.
-// This never rejects: any failure resolves to void so a kill can never surface into the caller
-// (before-quit -> app.exit).
+// Returns { reaped } so a caller that must guarantee released handles can tell a clean tree teardown
+// from a degraded fallback. This never rejects: any failure resolves (reaped:false) so a kill can never
+// surface into the caller (before-quit -> app.exit).
 export const terminateProcessTree = async (
   child: ChildProcess,
   signal?: NodeJS.Signals,
   log?: ProcessTreeLogger
-): Promise<void> => {
+): Promise<ProcessTreeKillResult> => {
   if (process.platform === 'win32') {
-    await terminateWindowsTree(child, signal, log)
-    return
+    return terminateWindowsTree(child, signal, log)
   }
-  await terminatePosixTree(child, signal, log)
+  return terminatePosixTree(child, signal, log)
 }

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -65,10 +65,10 @@ type FakeDeps = Parameters<typeof registerStorageIpcHandlers>[0]
 const fakeDeps = (overrides: Partial<FakeDeps> = {}): FakeDeps => ({
   runtime: {
     disconnect: vi.fn().mockResolvedValue(undefined),
-    shutdownForQuit: vi.fn().mockResolvedValue(undefined)
+    shutdownForQuit: vi.fn().mockResolvedValue({ reaped: true })
   },
   notebook: {
-    shutdownAll: vi.fn().mockResolvedValue(undefined),
+    shutdownAll: vi.fn().mockResolvedValue({ reaped: true }),
     getActiveNotebookSessions: vi.fn().mockReturnValue([])
   },
   getActivePromptSessions: vi.fn().mockReturnValue([]),

--- a/src/main/storage/ipc.ts
+++ b/src/main/storage/ipc.ts
@@ -30,8 +30,14 @@ type SessionSource = { projectName: string; sessionId: string }
 type StorageIpcDeps = {
   // disconnect drives the migration session-interrupt; shutdownForQuit is the awaited quit/relaunch
   // teardown used by cleanRelaunch (via shutdownBackends).
-  runtime: { disconnect: () => Promise<unknown>; shutdownForQuit: () => Promise<void> }
-  notebook: { shutdownAll: () => Promise<void>; getActiveNotebookSessions: () => SessionSource[] }
+  runtime: {
+    disconnect: () => Promise<unknown>
+    shutdownForQuit: () => Promise<{ reaped: boolean }>
+  }
+  notebook: {
+    shutdownAll: () => Promise<{ reaped: boolean }>
+    getActiveNotebookSessions: () => SessionSource[]
+  }
   getActivePromptSessions: () => SessionSource[]
   settingsService: {
     setDataRoot: (path: string) => Promise<void>

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -236,7 +236,9 @@ const sameInventory = (left: MigrationInventory, right: MigrationInventory): boo
 type MigrationCopyDeps = {
   currentDataRoot: string
   runtime: { disconnect: () => Promise<unknown> }
-  notebook: { shutdownAll: () => Promise<void> }
+  // Return ignored (awaited only), so kept as Promise<unknown> — mirrors runtime.disconnect above and
+  // stays compatible with both the real service (now returns { reaped }) and void test fakes.
+  notebook: { shutdownAll: () => Promise<unknown> }
   // Injectable for tests; defaults to the real ./data-migration engine function.
   copyAndVerify?: (opts: {
     from: string

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -116,6 +116,54 @@ describe('ElectronUpdaterStrategy', () => {
     expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true)
   })
 
+  it('apply runs the install gate before quitAndInstall when the teardown is clean', async () => {
+    const updater = new FakeUpdater()
+    const gate = vi.fn(async () => ({ completed: true, reaped: true }))
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn()
+    })
+    strategy.setInstallGate(gate)
+
+    await strategy.apply()
+
+    expect(gate).toHaveBeenCalledTimes(1)
+    expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
+  })
+
+  it('apply refuses to install and reports an error when the teardown times out', async () => {
+    const updater = new FakeUpdater()
+    const gate = vi.fn(async () => ({ completed: false, reaped: false }))
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      installGate: gate
+    })
+
+    const status = await strategy.apply()
+
+    expect(updater.quitAndInstall).not.toHaveBeenCalled()
+    expect(status.state).toBe('error')
+  })
+
+  it('apply refuses to install when the teardown completed but a tree was not cleanly reaped', async () => {
+    const updater = new FakeUpdater()
+    const gate = vi.fn(async () => ({ completed: true, reaped: false }))
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      installGate: gate
+    })
+
+    const status = await strategy.apply()
+
+    expect(updater.quitAndInstall).not.toHaveBeenCalled()
+    expect(status.state).toBe('error')
+  })
+
   it('hydrates notes from the CDN manifest when the version matches', async () => {
     const updater = new FakeUpdater()
     const strategy = new ElectronUpdaterStrategy({

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -4,7 +4,10 @@ import { autoUpdater } from 'electron-updater'
 import { APP } from '../../shared/app-config'
 import type { UpdateStatus } from '../../shared/update'
 import { fetchManifest } from './manifest'
-import type { UpdateStrategy } from './strategy'
+import type { InstallGate, UpdateStrategy } from './strategy'
+
+// Minimal logger surface so tests inject a spy without pulling electron-log.
+type UpdaterLogger = { info: (msg: string) => void; error: (msg: string, err?: unknown) => void }
 
 // Structural subset of electron-updater's autoUpdater we depend on, so tests can inject a fake without
 // pulling a real Electron runtime.
@@ -25,6 +28,10 @@ export type ElectronUpdaterDeps = {
   // Injectable for tests; defaults to the public stable manifest.
   fetchImpl?: typeof fetch
   manifestUrl?: string
+  // Pre-install backend-shutdown gate; usually injected later via setInstallGate once the runtime exists.
+  installGate?: InstallGate
+  // Diagnostics sink for the apply path; defaults to a no-op so unit tests stay quiet.
+  log?: UpdaterLogger
 }
 
 // Default broadcast pushes to every live window (mirrors service.ts). Never runs in unit tests, which
@@ -58,10 +65,13 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private readonly broadcast: (channel: string, payload: unknown) => void
   private readonly fetchImpl?: typeof fetch
   private readonly manifestUrl: string
+  private readonly log: UpdaterLogger
   private status: UpdateStatus
   // In-flight manifest notes fetch for the current update, awaited by check() so the returned
   // status reflects the hydrated notes.
   private notesHydration?: Promise<void>
+  // Pre-install backend-shutdown gate, injected once the runtime exists (see ipc.ts).
+  private installGate?: InstallGate
 
   constructor(deps: ElectronUpdaterDeps = {}) {
     this.updater = deps.updater ?? (autoUpdater as unknown as MinimalAutoUpdater)
@@ -69,11 +79,17 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.broadcast = deps.broadcast ?? defaultBroadcast
     this.fetchImpl = deps.fetchImpl
     this.manifestUrl = deps.manifestUrl ?? APP.update.manifestUrl
+    this.log = deps.log ?? { info: () => {}, error: () => {} }
+    this.installGate = deps.installGate
     this.status = { state: 'idle', current: this.currentVersion, applyKind: 'restart' }
 
     this.updater.autoDownload = false
     this.updater.autoInstallOnAppQuit = false
     this.subscribe()
+  }
+
+  setInstallGate(gate: InstallGate): void {
+    this.installGate = gate
   }
 
   private subscribe(): void {
@@ -169,6 +185,25 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   // relaunches into the new version (per-user install = no UAC prompt). On macOS Squirrel.Mac swaps
   // the .app and relaunches; it ignores isSilent, so the same call is correct there too.
   async apply(): Promise<UpdateStatus> {
+    // Stop the agent + notebook process trees BEFORE handing off to the installer. Its uninstall step
+    // deletes the running app's files, and on Windows an executable/DLL still mapped by a background
+    // child (agent CLI, python kernel, conda) is locked — the classic "Failed to uninstall old
+    // application files" error. If the teardown is degraded (budget elapsed, or taskkill fell back and
+    // may have left grandchildren), refuse the install rather than fail mid-uninstall: the gate is
+    // non-latching, so the app stays usable and the user can retry (fewer live processes next time).
+    if (this.installGate) {
+      const readiness = await this.installGate()
+      if (!readiness.completed || !readiness.reaped) {
+        this.log.error('update install gate refused: backend teardown degraded', readiness)
+        this.setStatus({
+          state: 'error',
+          error: 'Could not fully stop background processes before updating. Please try again.'
+        })
+        return this.status
+      }
+      this.log.info('update install gate cleared; proceeding to quitAndInstall')
+    }
+
     this.updater.quitAndInstall(true, true)
     return this.status
   }

--- a/src/main/update/strategy.ts
+++ b/src/main/update/strategy.ts
@@ -1,5 +1,15 @@
 import type { UpdateStatus } from '../../shared/update'
 
+// Readiness reported by the pre-install gate: whether the backend teardown completed within its budget
+// and whether every process tree was cleanly reaped. Structurally matches lifecycle-shutdown's
+// ShutdownOutcome so the coordinator satisfies it without coupling update code to that module.
+export type InstallReadiness = { completed: boolean; reaped: boolean }
+
+// Runs backend teardown before an in-place install and reports whether it is safe to proceed. Injected
+// after the runtime exists; the in-place (NSIS/Squirrel) strategy awaits it before quitAndInstall so it
+// never triggers the installer's uninstall step while a background process still holds app files open.
+export type InstallGate = () => Promise<InstallReadiness>
+
 // The platform-agnostic update contract the IPC layer and scheduler drive. Two implementations exist:
 // ElectronUpdaterStrategy (win/linux, and signed stable macOS — in-place download/restart) and
 // UpdateService (dev/nightly macOS + any other fallback — manifest download + manual reinstall). Both
@@ -10,4 +20,7 @@ export interface UpdateStrategy {
   download(): Promise<UpdateStatus>
   // Applies a ready update: open the installer (mac) or quitAndInstall (win/linux).
   apply(): Promise<UpdateStatus>
+  // Optional: inject the pre-install backend-shutdown gate. Only the in-place strategy uses it; the
+  // manifest fallback (which opens an installer without quitting the running app) leaves it unset.
+  setInstallGate?(gate: InstallGate): void
 }


### PR DESCRIPTION
## Summary

On Windows the electron-updater NSIS installer deletes the running app's files during its uninstall step. Any executable/DLL still mapped by a background child the app spawned (agent CLI, notebook Python kernel, conda) is locked, so the uninstall fails with **"Failed to uninstall old application files"** (exit code 2) and the update aborts mid-flight.

Two gaps caused it:
- the quit teardown was bounded at 5s while a single process tree can need ~11s to reap (`taskkill /T` grace + waiting for the real exit), and
- `quitAndInstall` did not wait for backend teardown at all, so orphaned children routinely outlived the main process and held the install dir open.

## Changes

- **`terminateProcessTree` returns `{ reaped }`** — Windows: `taskkill /T` exited 0; POSIX: child exited and no survivors after escalation. Additive; existing callers that ignore the value are unaffected.
- Propagated through the runtime (`shutdownForQuit`, plus a new **non-latching** `shutdownForUpdateGate`) and the notebook paths (`executor.shutdown` / `shutdownAll`).
- **`BackendShutdownCoordinator`** owns both teardown paths: `runForQuit` (latching, 5s — unchanged quit behavior) and `runForUpdateGate` (non-latching, 15s so a slow `taskkill /T` finishes before the installer runs).
- **`ElectronUpdaterStrategy.apply()`** runs the gate first and *refuses to install* (surfacing an error status) when the teardown was degraded or timed out, instead of triggering the NSIS uninstall against locked files. Because the gate is non-latching, a refused install leaves the app usable and the user can retry.
- Wired via a late-bound `setInstallGate` in `ipc.ts` (the runtime does not exist when update IPC is registered) and `runForQuit` in the before-quit handler (`index.ts`).

Idempotent with before-quit: the gate clears the agent process and notebook sessions, so the subsequent quit teardown finds nothing left to kill.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — 0 errors/warnings
- `npx vitest run src/` — all pass (added coverage: `terminateProcessTree` reaped results across win/posix paths; coordinator dual-budget + timeout; gate refuse/proceed in `ElectronUpdaterStrategy`; `shutdownForUpdateGate` non-latching vs `shutdownForQuit` latching)
- `npm run build` — succeeds

Not verified on a real Windows device — the taskkill/handle-release behavior is exercised via mocks; a manual in-place update on Windows would confirm end-to-end.