### PR TITLE
fix: recover conversations that outgrow the request size limit (media_unstrippable)

### DIFF
--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -1,0 +1,81 @@
+// Pins the ACP IPC bridge: the channel string and that it forwards verbatim to the runtime method.
+// The runtime behavior is covered in runtime.test.ts; this guards the wiring itself so a channel typo
+// (mismatched against the preload) can't slip through green. resetSessionContext is the overflow-recovery
+// reset the renderer calls before replaying a compacted conversation, distinct from resume-session.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { AcpResumeSessionRequest } from '../../shared/acp'
+
+// Capture every ipcMain.handle registration so a handler can be invoked directly.
+const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown, payload: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }
+  },
+  app: { getVersion: () => '0.0.0-test' },
+  BrowserWindow: { getAllWindows: () => [] }
+}))
+
+// A fake runtime whose methods are spies; registration wires closures over these, so only the invoked
+// handler's method needs meaningful behavior. Hoisted so the (hoisted) vi.mock factory can reference it.
+const { resetSessionContext, resumeSession, AcpRuntimeMock } = vi.hoisted(() => {
+  const resetSessionContext = vi
+    .fn()
+    .mockResolvedValue({ sessionId: 's-1', cwd: '/workspace', contextReset: true })
+  const resumeSession = vi.fn().mockResolvedValue({ sessionId: 's-1', cwd: '/workspace' })
+  const AcpRuntimeMock = vi.fn().mockImplementation(function () {
+    return { resetSessionContext, resumeSession, getSnapshot: vi.fn() }
+  })
+  return { resetSessionContext, resumeSession, AcpRuntimeMock }
+})
+
+vi.mock('./runtime', () => ({ AcpRuntime: AcpRuntimeMock }))
+vi.mock('./shutdown-guard', () => ({ installAgentShutdownGuard: vi.fn() }))
+vi.mock('./mcp-http-host', () => ({ AgentMcpHttpHost: vi.fn() }))
+vi.mock('../storage-root', () => ({
+  resolveConfigRoot: () => '/tmp/config',
+  resolveDataRoot: () => '/tmp/data'
+}))
+
+const { registerAcpIpcHandlers } = await import('./ipc')
+
+// Minimal options — createRuntime just forwards them into the mocked AcpRuntime constructor.
+const registerWithFakes = (): void => {
+  registerAcpIpcHandlers({
+    mcpEntryPath: '/app/out/main/index.js',
+    repository: {} as never,
+    runRegistry: {} as never,
+    uploadRepository: {} as never,
+    notebookRpcServer: {} as never,
+    settingsService: {} as never
+  } as Parameters<typeof registerAcpIpcHandlers>[0])
+}
+
+afterEach(() => {
+  resetSessionContext.mockClear()
+  resumeSession.mockClear()
+})
+
+describe('registerAcpIpcHandlers — reset-session-context bridge', () => {
+  it('registers the acp:reset-session-context channel', () => {
+    registerWithFakes()
+    expect(handlers.has('acp:reset-session-context')).toBe(true)
+  })
+
+  it('forwards the request to runtime.resetSessionContext and returns its result', async () => {
+    registerWithFakes()
+    const request: AcpResumeSessionRequest = { sessionId: 's-1', cwd: '/workspace' }
+
+    const result = await handlers.get('acp:reset-session-context')?.({}, request)
+
+    expect(resetSessionContext).toHaveBeenCalledTimes(1)
+    expect(resetSessionContext).toHaveBeenCalledWith(request)
+    // The distinct resume channel must not be driven by the reset call.
+    expect(resumeSession).not.toHaveBeenCalled()
+    expect(result).toEqual({ sessionId: 's-1', cwd: '/workspace', contextReset: true })
+  })
+})

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -126,6 +126,9 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntime => {
   ipcMain.handle('acp:resume-session', async (_event, request: AcpResumeSessionRequest) =>
     runtime.resumeSession(request)
   )
+  ipcMain.handle('acp:reset-session-context', async (_event, request: AcpResumeSessionRequest) =>
+    runtime.resetSessionContext(request)
+  )
   // Prompt calls wait for the turn to stop, then return the latest snapshot.
   ipcMain.handle('acp:send-prompt', async (_event, request: AcpPromptRequest) => {
     await runtime.sendPrompt(request)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -913,6 +913,76 @@ describe('ACP runtime session management', () => {
     ).resolves.toBeDefined()
   })
 
+  it('does not let a superseded turn finally clear the replay turn in-flight lock', async () => {
+    const root = await createTemporaryRoot()
+    const artifactRepository = new ArtifactRepository(root)
+    // Hold the abandoned turn's finally open (at emitArtifactRunEvent) until the replay turn has claimed
+    // the lock, reproducing production timing where the renderer resends immediately after the reset.
+    const listGate = createDeferred()
+    vi.spyOn(artifactRepository, 'listPendingRunFiles').mockImplementation(async () => {
+      await listGate.promise
+      return []
+    })
+
+    const process = new FakeAgentProcess()
+    // Both prompts stay in-flight so their locks are held; the first is abandoned by the reset.
+    const gateA = createDeferred()
+    const gateB = createDeferred()
+    let firstPrompt = true
+    startFakeAgent(process, ['remote-session-1', 'remote-session-2'], {
+      onPrompt: () => {
+        if (firstPrompt) {
+          firstPrompt = false
+          return gateA.promise
+        }
+        return gateB.promise
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: artifactRepository
+      }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    // The lock is claimed synchronously at turn start, so no polling is needed to observe it.
+    const failedTurn = runtime
+      .sendPrompt({ sessionId: session.sessionId, text: 'oversized turn' })
+      .catch(() => undefined)
+    expect(runtime.getSnapshot().promptInFlightSessionIds).toContain(session.sessionId)
+
+    // Reset abandons the failed turn (its finally now blocks on the gated listPendingRunFiles — before it
+    // reaches its own lock cleanup) and frees the lock so the replay can start.
+    await runtime.resetSessionContext({ sessionId: session.sessionId, cwd: '/workspace' })
+    expect(runtime.getSnapshot().promptInFlightSessionIds).not.toContain(session.sessionId)
+
+    // The replay turn re-claims the lock for the same app session id while the abandoned turn's finally is
+    // still parked in listPendingRunFiles.
+    const replayTurn = runtime
+      .sendPrompt({ sessionId: session.sessionId, text: 'replayed turn' })
+      .catch(() => undefined)
+    expect(runtime.getSnapshot().promptInFlightSessionIds).toContain(session.sessionId)
+
+    // Let the abandoned turn's finally run to completion — its generation token is now stale, so it must
+    // not delete the replay turn's lock. This is the assertion that fails without the guard.
+    listGate.resolve()
+    await failedTurn
+    expect(runtime.getSnapshot().promptInFlightSessionIds).toContain(session.sessionId)
+
+    // Teardown: release both prompt gates so the fake agent can drain (the abandoned turn's server-side
+    // handler is still parked on its gate, which otherwise blocks the replay from completing).
+    gateA.resolve()
+    gateB.resolve()
+    await replayTurn
+  })
+
   it('sends PDFs as extracted text, never as an inlined base64 file', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -12,6 +12,7 @@ import { AcpRuntime } from './runtime'
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { claudeCodeFramework, opencodeFramework } from '../agent-framework'
 import { ArtifactRepository } from '../artifacts/repository'
+import type { UploadedAttachment } from '../../shared/uploads'
 import { UploadRepository } from '../uploads/repository'
 import {
   beginMigration,
@@ -772,6 +773,68 @@ describe('ACP runtime session management', () => {
     await expect(
       readFile(join(root, 'uploads', 'default-project', 'remote-session-1', 'notes.txt'), 'utf8')
     ).resolves.toBe('hello from upload')
+  })
+
+  it('degrades images to file links once a session exceeds its cumulative inline budget', async () => {
+    const root = await createTemporaryRoot()
+    const uploadRepository = new UploadRepository(root)
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+      }
+    })
+    // A tiny budget makes small fixtures cross the cliff: the first image inlines, the next degrades
+    // because the conversation's replayed history already holds the first image's bytes.
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploadRepository },
+      inlineImageBudgetBytes: 15
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+
+    const stageImage = (name: string): Promise<UploadedAttachment[]> =>
+      uploadRepository.stageFiles({
+        files: [
+          { name, mimeType: 'image/png', content: Buffer.from('png-bytes').toString('base64') }
+        ]
+      })
+
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'first image',
+      attachments: await stageImage('first.png')
+    })
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'second image',
+      attachments: await stageImage('second.png')
+    })
+
+    expect(receivedPrompts).toHaveLength(2)
+    // First turn: within budget, so the pixels are inlined as base64.
+    expect(receivedPrompts[0][1]).toMatchObject({
+      type: 'image',
+      mimeType: 'image/png',
+      data: Buffer.from('png-bytes').toString('base64')
+    })
+    // Second turn: the accumulated total would overflow, so the image degrades to a file reference
+    // instead of base64 — keeping the request under the ceiling so compaction stays viable.
+    expect(receivedPrompts[1][1]).toMatchObject({
+      type: 'resource_link',
+      name: 'second.png',
+      title: 'second.png',
+      mimeType: 'image/png',
+      uri: expect.stringContaining('second.png')
+    })
+    // The raw image bytes must not be inlined anywhere in the degraded turn.
+    expect(JSON.stringify(receivedPrompts[1])).not.toContain(
+      Buffer.from('png-bytes').toString('base64')
+    )
   })
 
   it('sends PDFs as extracted text, never as an inlined base64 file', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -837,6 +837,38 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('adopts a fresh agent session under the same app id on a context reset', async () => {
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    // A second agent session id is available for the fresh adoption that the reset performs.
+    startFakeAgent(process, ['remote-session-1', 'remote-session-2'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    const reset = await runtime.resetSessionContext({
+      sessionId: session.sessionId,
+      cwd: '/workspace'
+    })
+
+    // The app-facing id stays attached (a brand-new agent session now backs it), and the caller is told
+    // to replay a transcript because the agent-side context was dropped.
+    expect(reset.contextReset).toBe(true)
+    expect(reset.sessionId).toBe(session.sessionId)
+    expect(runtime.getSnapshot().sessionIds).toContain(session.sessionId)
+
+    // The fresh session still accepts prompts, so the conversation continues after the reset.
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'continue after compaction' })
+    expect(receivedPrompts.at(-1)).toBeDefined()
+  })
+
   it('sends PDFs as extracted text, never as an inlined base64 file', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -869,6 +869,50 @@ describe('ACP runtime session management', () => {
     expect(receivedPrompts.at(-1)).toBeDefined()
   })
 
+  it('releases the in-flight prompt lock on reset so the recovery resend is not rejected', async () => {
+    const process = new FakeAgentProcess()
+    // Only the first prompt is gated so it stays in-flight — the overflow-recovery reset happens while it
+    // is still "running", exactly as in production before the failing prompt's finally clears the lock.
+    // Disposing that session rejects the gated prompt, so its promise is caught up front.
+    const promptGate = createDeferred()
+    let firstPrompt = true
+    startFakeAgent(process, ['remote-session-1', 'remote-session-2'], {
+      onPrompt: () => {
+        if (firstPrompt) {
+          firstPrompt = false
+          return promptGate.promise
+        }
+        return Promise.resolve()
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    const inflight = runtime
+      .sendPrompt({ sessionId: session.sessionId, text: 'oversized turn' })
+      .catch(() => undefined)
+    await vi.waitFor(() =>
+      expect(runtime.getSnapshot().promptInFlightSessionIds).toContain(session.sessionId)
+    )
+
+    await runtime.resetSessionContext({ sessionId: session.sessionId, cwd: '/workspace' })
+
+    // The lock the torn-down turn held is released immediately by the reset.
+    expect(runtime.getSnapshot().promptInFlightSessionIds).not.toContain(session.sessionId)
+
+    // Once the disposed turn has settled, a resend into the same app id succeeds instead of throwing
+    // "An ACP prompt is already running for this session".
+    promptGate.resolve()
+    await inflight
+    await expect(
+      runtime.sendPrompt({ sessionId: session.sessionId, text: 'replayed turn' })
+    ).resolves.toBeDefined()
+  })
+
   it('sends PDFs as extracted text, never as an inlined base64 file', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -78,7 +78,12 @@ import { opencodeStorageDir } from '../agent-framework/opencode'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
-import { buildImageContentData, extractPdfText } from '../uploads/attachment-media'
+import {
+  buildImageContentData,
+  canInlineImageInSession,
+  extractPdfText,
+  MAX_SESSION_INLINE_IMAGE_BYTES
+} from '../uploads/attachment-media'
 
 type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -110,6 +115,9 @@ type AcpRuntimeOptions = {
   resumeTimeoutMs?: number
   setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   clearTimer?: (handle: ReturnType<typeof setTimeout>) => void
+  // Per-session cumulative inlined-image budget in base64 bytes. Defaults to MAX_SESSION_INLINE_IMAGE_BYTES;
+  // injectable so tests can drive the degrade-to-file path with small fixtures.
+  inlineImageBudgetBytes?: number
 }
 
 // Turn-scoped skill force-load hooks, wired from the settings service. Optional so tests that construct
@@ -245,6 +253,11 @@ class AcpRuntime {
   private supportsSessionResume = false
   private readonly sessions = new Map<string, ActiveSession>()
   private readonly sessionCwds = new Map<string, string>()
+  // Running total of base64 image bytes this session has inlined. The agent replays full history each
+  // turn, so this accumulates; once it nears the request ceiling further images degrade to file links
+  // (see canInlineImageInSession) so a long conversation can never overflow the request or break
+  // compaction with `media_unstrippable`. Cleared on session delete and on disconnect.
+  private readonly sessionInlineImageBytes = new Map<string, number>()
   // Per-session names of the MCP servers the agent was actually given (from createMcpServers), so
   // MCP-originated tool calls can be recognized across frameworks (Claude's mcp__<server>__<tool> vs
   // opencode's <server>_<tool>) and never conservatively auto-approved. Derived per session rather
@@ -282,6 +295,7 @@ class AcpRuntime {
   private pendingSessionModel: string | undefined
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
+  private readonly inlineImageBudgetBytes: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private readonly artifactOptions: AcpRuntimeArtifactOptions | undefined
@@ -309,6 +323,7 @@ class AcpRuntime {
     this.framework = options.framework ?? claudeCodeFramework
     this.mcpHttpHost = options.mcpHttpHost
     this.resumeTimeoutMs = options.resumeTimeoutMs ?? 30_000
+    this.inlineImageBudgetBytes = options.inlineImageBudgetBytes ?? MAX_SESSION_INLINE_IMAGE_BYTES
     this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
     this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
     this.artifactOptions = options.artifacts
@@ -998,6 +1013,7 @@ class AcpRuntime {
 
     this.sessions.clear()
     this.sessionCwds.clear()
+    this.sessionInlineImageBytes.clear()
     this.sessionMcpServerNames.clear()
     this.sessionProjectNames.clear()
     this.permissionProfiles.clear()
@@ -1322,6 +1338,7 @@ class AcpRuntime {
     this.unregisterHttpMcpSession(request.sessionId)
     this.sessions.delete(request.sessionId)
     this.sessionCwds.delete(request.sessionId)
+    this.sessionInlineImageBytes.delete(request.sessionId)
     this.sessionMcpServerNames.delete(request.sessionId)
     this.sessionProjectNames.delete(request.sessionId)
     this.sessionFrameworks.delete(request.sessionId)
@@ -1400,13 +1417,13 @@ class AcpRuntime {
 
       // Keep the user's text first, then append files in the same order they were added.
       for (const attachment of finalizedAttachments) {
-        contentBlocks.push(await this.createAttachmentContentBlock(attachment))
+        contentBlocks.push(await this.createAttachmentContentBlock(sessionId, attachment))
       }
     }
 
     // `@`-mentioned artifacts reuse the same per-type block builder as uploads, in mention order.
     for (const reference of referencedArtifacts) {
-      contentBlocks.push(await this.createReferencedArtifactContentBlock(reference))
+      contentBlocks.push(await this.createReferencedArtifactContentBlock(sessionId, reference))
     }
 
     return contentBlocks
@@ -1414,6 +1431,7 @@ class AcpRuntime {
 
   // Converts one managed upload into the richest ACP content block that is safe for its type.
   private async createAttachmentContentBlock(
+    sessionId: string,
     attachment: UploadedAttachment
   ): Promise<ContentBlock> {
     if (!this.uploadRepository) throw new Error('Upload storage is not configured.')
@@ -1421,6 +1439,7 @@ class AcpRuntime {
     const filePath = await this.uploadRepository.resolveManagedUploadPath({ path: attachment.path })
 
     return this.buildFileContentBlock({
+      sessionId,
       absolutePath: filePath,
       uri: pathToFileURL(filePath).href,
       name: attachment.originalName || attachment.name,
@@ -1431,12 +1450,14 @@ class AcpRuntime {
 
   // Converts one `@`-mentioned artifact into the same content block an equivalent upload produces.
   private async createReferencedArtifactContentBlock(
+    sessionId: string,
     reference: ArtifactReference
   ): Promise<ContentBlock> {
     const filePath = await this.resolveReferencedArtifactPath(reference)
     const { size } = await stat(filePath)
 
     return this.buildFileContentBlock({
+      sessionId,
       absolutePath: filePath,
       uri: pathToFileURL(filePath).href,
       name: reference.name,
@@ -1459,13 +1480,14 @@ class AcpRuntime {
   // Builds the richest ACP content block that is safe for a resolved file, shared by uploads and
   // `@`-mentioned artifacts so both reach the agent through identical per-type logic.
   private async buildFileContentBlock(descriptor: {
+    sessionId: string
     absolutePath: string
     uri: string
     name: string
     mimeType?: string
     size: number
   }): Promise<ContentBlock> {
-    const { absolutePath, uri, name, mimeType, size } = descriptor
+    const { sessionId, absolutePath, uri, name, mimeType, size } = descriptor
 
     // Images are embedded as base64 so vision-capable agents receive the actual pixels.
     // Large images are downscaled/re-encoded first so one file cannot overflow the request.
@@ -1475,6 +1497,18 @@ class AcpRuntime {
         mimeType,
         size
       )
+
+      // Inlined images accumulate over a conversation's replayed history. Once this session's running
+      // total nears the request ceiling, degrade further images to a file reference (like large binary
+      // uploads) instead of base64, so the conversation never overflows the request or breaks
+      // compaction with `media_unstrippable`. The file stays reachable to the agent via its uri.
+      const alreadyInlined = this.sessionInlineImageBytes.get(sessionId) ?? 0
+
+      if (!canInlineImageInSession(alreadyInlined, data.length, this.inlineImageBudgetBytes)) {
+        return { type: 'resource_link', uri, name, title: name, mimeType, size }
+      }
+
+      this.sessionInlineImageBytes.set(sessionId, alreadyInlined + data.length)
 
       return { type: 'image', data, mimeType: outMimeType, uri }
     }
@@ -2214,6 +2248,7 @@ class AcpRuntime {
     this.permissionBroker.cancelAll()
     this.sessions.clear()
     this.sessionCwds.clear()
+    this.sessionInlineImageBytes.clear()
     this.sessionMcpServerNames.clear()
     this.sessionProjectNames.clear()
     this.artifactSessionIds.clear()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -715,6 +715,11 @@ class AcpRuntime {
     // The fresh agent session holds no history, so the accumulated media is gone; start its budget clean.
     this.sessionInlineImageBytes.delete(request.sessionId)
 
+    // Release the failed turn's in-flight lock now. Its own `finally` clears it too, but that runs only
+    // after async artifact cleanup, so the recovery resend that follows this reset would otherwise race
+    // it and be rejected with "An ACP prompt is already running for this session".
+    this.promptInFlightSessionIds.delete(request.sessionId)
+
     return this.adoptFreshSession(connection, request, sessionCwd, projectName)
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -279,6 +279,11 @@ class AcpRuntime {
   // and skip a doomed resume. Cleaned per-session on delete.
   private readonly sessionFrameworks = new Map<string, string>()
   private readonly promptInFlightSessionIds = new Set<string>()
+  // Monotonic per-turn token and the token of the turn that currently owns each app session id. When an
+  // overflow-recovery replay reuses a session id, its start bumps the token; the abandoned turn's finally
+  // then sees a newer owner and leaves the replay's shared state (lock, artifact run) untouched.
+  private promptTurnSequence = 0
+  private readonly currentPromptTurnBySession = new Map<string, number>()
   private readonly permissionProfiles = new Map<string, SessionPermissionProfileState>()
   // A provider change requested while a prompt was running, applied when the session next goes idle.
   private pendingProviderReconnect = false
@@ -1047,6 +1052,7 @@ class AcpRuntime {
     this.sessions.clear()
     this.sessionCwds.clear()
     this.sessionInlineImageBytes.clear()
+    this.currentPromptTurnBySession.clear()
     this.sessionMcpServerNames.clear()
     this.sessionProjectNames.clear()
     this.permissionProfiles.clear()
@@ -1194,7 +1200,11 @@ class AcpRuntime {
     }
 
     this.currentSessionId = request.sessionId
+    // Claim ownership of this session's shared turn state so a superseded turn's later finally can tell it
+    // no longer owns the lock/artifact run (see the guarded cleanup in this turn's finally).
+    const promptTurn = ++this.promptTurnSequence
     this.promptInFlightSessionIds.add(request.sessionId)
+    this.currentPromptTurnBySession.set(request.sessionId, promptTurn)
     this.emitState()
     log.info('prompt start', {
       sessionId: request.sessionId,
@@ -1311,8 +1321,18 @@ class AcpRuntime {
           text: errorMessage(error)
         })
       }
-      this.activeArtifactRun = undefined
-      this.promptInFlightSessionIds.delete(request.sessionId)
+      // Only clear shared turn state if a newer turn hasn't taken over this app session id. An
+      // overflow-recovery replay reuses the id: after resetSessionContext releases this (failed) turn's
+      // lock and the renderer starts the replay, this stale finally must not delete the replay's in-flight
+      // lock (which would reopen same-session sends and misreport prompt-in-flight) or clear its active
+      // artifact run. Identity/token comparisons scope each clear to the turn that still owns the state.
+      if (this.activeArtifactRun?.run === artifactRun) {
+        this.activeArtifactRun = undefined
+      }
+      if (this.currentPromptTurnBySession.get(request.sessionId) === promptTurn) {
+        this.currentPromptTurnBySession.delete(request.sessionId)
+        this.promptInFlightSessionIds.delete(request.sessionId)
+      }
       this.emitState()
       // A disabled skill forced for this turn is restored now: clear the force set, then schedule a
       // reconnect so the NEXT prompt respawns with the normal enabled set. Ordering matters — the clear
@@ -1380,6 +1400,7 @@ class AcpRuntime {
     this.sessions.delete(request.sessionId)
     this.sessionCwds.delete(request.sessionId)
     this.sessionInlineImageBytes.delete(request.sessionId)
+    this.currentPromptTurnBySession.delete(request.sessionId)
     this.sessionMcpServerNames.delete(request.sessionId)
     this.sessionProjectNames.delete(request.sessionId)
     this.sessionFrameworks.delete(request.sessionId)
@@ -2290,6 +2311,7 @@ class AcpRuntime {
     this.sessions.clear()
     this.sessionCwds.clear()
     this.sessionInlineImageBytes.clear()
+    this.currentPromptTurnBySession.clear()
     this.sessionMcpServerNames.clear()
     this.sessionProjectNames.clear()
     this.artifactSessionIds.clear()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -690,6 +690,33 @@ class AcpRuntime {
     return this.resumeSessionWithTimeout(request, sessionCwd, projectName)
   }
 
+  // Forcibly drops the agent-side context for a session whose accumulated history can no longer be sent
+  // — chiefly when inlined media pushed the request past the provider's size limit and the backend's own
+  // compaction fails with `media_unstrippable`. Disposes the current agent session and adopts a brand-new
+  // one under the SAME app id, resetting the per-session inline-image budget so a replayed text-only
+  // transcript starts clean. Returns contextReset so the caller replays a bounded transcript into the
+  // next prompt (the app-level equivalent of compaction, which — unlike the backend's — drops all media).
+  async resetSessionContext(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
+    const sessionCwd = resolve(request.cwd || this.cwd || this.options.defaultCwd)
+    const projectName = this.normalizeProjectName(request.projectName)
+    const connection = await this.ensureConnected(sessionCwd)
+
+    // Tear down the currently attached agent session (if any) before adopting a replacement, dropping
+    // its reverse routing so late events from the old agent session can no longer target this app id.
+    const attached = this.sessions.get(request.sessionId)
+
+    if (attached) {
+      attached.dispose()
+      this.agentToAppSessionId.delete(attached.sessionId)
+      this.sessions.delete(request.sessionId)
+    }
+
+    // The fresh agent session holds no history, so the accumulated media is gone; start its budget clean.
+    this.sessionInlineImageBytes.delete(request.sessionId)
+
+    return this.adoptFreshSession(connection, request, sessionCwd, projectName)
+  }
+
   // Races the network-bound resume against a timeout so a stalled agent handshake cannot hang Resume
   // forever. On timeout the half-open connection is torn down so the next Resume reconnects cleanly.
   private async resumeSessionWithTimeout(

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -78,6 +78,7 @@ import { opencodeStorageDir } from '../agent-framework/opencode'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
+import { isMediaOverflowError } from '../../shared/media-overflow'
 import {
   buildImageContentData,
   canInlineImageInSession,
@@ -1265,12 +1266,20 @@ class AcpRuntime {
       }
     } catch (error) {
       log.error('prompt failed', { sessionId: request.sessionId, error })
+      const text = describePromptError(error, { model: this.pendingSessionModel })
+      // Tag a request-size overflow as recoverable so the renderer compacts-and-retries (reset context +
+      // replay a text transcript) instead of dead-ending; the error still throws to drive that recovery.
+      const recoverable =
+        isMediaOverflowError(text) || isMediaOverflowError(errorMessage(error))
+          ? 'context-overflow'
+          : undefined
       this.pushEvent({
         kind: 'error',
         level: 'error',
+        recoverable,
         sessionId: request.sessionId,
         title: 'Prompt failed',
-        text: describePromptError(error, { model: this.pendingSessionModel })
+        text
       })
       throw error
     } finally {
@@ -2305,6 +2314,7 @@ class AcpRuntime {
       timestamp: event.timestamp ?? Date.now(),
       level: event.level ?? 'info',
       kind: event.kind,
+      recoverable: event.recoverable,
       sessionId: event.sessionId,
       messageId: event.messageId,
       role: event.role,

--- a/src/main/uploads/attachment-media.test.ts
+++ b/src/main/uploads/attachment-media.test.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { buildImageContentData, extractPdfText } from './attachment-media'
+import {
+  buildImageContentData,
+  canInlineImageInSession,
+  extractPdfText,
+  MAX_SESSION_INLINE_IMAGE_BYTES
+} from './attachment-media'
 
 // A configurable fake nativeImage so the >2MB compression path is exercised without an Electron runtime.
 type FakeImage = {
@@ -139,5 +144,24 @@ describe('extractPdfText', () => {
 
     expect(result.pageCount).toBe(1)
     expect(result.text).toBe('')
+  })
+})
+
+describe('canInlineImageInSession', () => {
+  it('always inlines the first image of a session even if it is large', () => {
+    expect(canInlineImageInSession(0, MAX_SESSION_INLINE_IMAGE_BYTES * 2, 10)).toBe(true)
+  })
+
+  it('inlines while the running total stays within budget', () => {
+    expect(canInlineImageInSession(4, 6, 10)).toBe(true)
+  })
+
+  it('degrades once the running total would exceed the budget', () => {
+    expect(canInlineImageInSession(6, 5, 10)).toBe(false)
+  })
+
+  it('defaults to the shared session budget when none is passed', () => {
+    expect(canInlineImageInSession(MAX_SESSION_INLINE_IMAGE_BYTES, 1)).toBe(false)
+    expect(canInlineImageInSession(MAX_SESSION_INLINE_IMAGE_BYTES - 1, 1)).toBe(true)
   })
 })

--- a/src/main/uploads/attachment-media.ts
+++ b/src/main/uploads/attachment-media.ts
@@ -13,6 +13,23 @@ const MAX_IMAGE_PAYLOAD_BYTES = 4.5 * 1024 * 1024
 // Anthropic downscales images past 1568px on the long edge anyway, so this is a lossless-of-info cap.
 const MAX_IMAGE_LONG_EDGE = 1568
 
+// A conversation replays its full history every turn, so inlined image payloads accumulate across
+// turns even though each image is individually capped. Once the running base64 total nears the
+// provider's 32MB request ceiling, further images are sent as file references instead of base64.
+// This bounds what one session can contribute so it never drives the request past the limit — which
+// both fails the turn ("Request too large") and breaks compaction with `media_unstrippable`. Base64
+// inflates ~33% and text/tool payloads share the request, so the budget sits well under 32MB.
+export const MAX_SESSION_INLINE_IMAGE_BYTES = 20 * 1024 * 1024
+
+// Whether another image may be inlined given how many base64 bytes this session has already inlined.
+// The first image of a session always inlines (a lone image is per-image capped well under the limit),
+// so a conversation is never left with zero visual content just because one image is large.
+export const canInlineImageInSession = (
+  alreadyInlinedBytes: number,
+  imageBase64Length: number,
+  budget: number = MAX_SESSION_INLINE_IMAGE_BYTES
+): boolean => alreadyInlinedBytes === 0 || alreadyInlinedBytes + imageBase64Length <= budget
+
 // Extracted PDF text is bounded so a huge document can never recreate the oversized-request problem.
 export const MAX_PDF_TEXT_CHARS = 1024 * 1024
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -145,6 +145,7 @@ interface OpenScienceAPI {
     disconnect(): Promise<AcpStateSnapshot>
     createSession(request?: AcpCreateSessionRequest): Promise<AcpCreateSessionResponse>
     resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
+    resetSessionContext(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
     sendPrompt(request: AcpPromptRequest): Promise<AcpStateSnapshot>
     cancel(request: AcpCancelPromptRequest): Promise<AcpStateSnapshot>
     deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot>

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -42,6 +42,10 @@ type PreloadApi = {
     uninstallClaude: () => unknown
     uninstallOpencode: () => unknown
   }
+  acp: {
+    resumeSession: (request: unknown) => unknown
+    resetSessionContext: (request: unknown) => unknown
+  }
 }
 
 let api: PreloadApi
@@ -77,6 +81,7 @@ const sampleDeleteProject = { projectId: 'p-1' }
 const sampleManifest = { projectId: 'p-1', sessionId: 's-1' }
 const sampleInstall = { executablePath: '/usr/local/bin/opencode' }
 const sampleFramework = { framework: 'opencode' }
+const sampleResumeRequest = { sessionId: 's-1', cwd: '/workspace/project' }
 
 const cases: ForwardingCase[] = [
   // sessions block
@@ -140,6 +145,19 @@ const cases: ForwardingCase[] = [
     invoke: (a) => a.settings.uninstallOpencode(),
     channel: 'settings:uninstall-opencode',
     args: []
+  },
+  // ACP session context: resume vs the overflow-recovery reset must hit distinct channels.
+  {
+    name: 'acp.resumeSession → acp:resume-session',
+    invoke: (a) => a.acp.resumeSession(sampleResumeRequest),
+    channel: 'acp:resume-session',
+    args: [sampleResumeRequest]
+  },
+  {
+    name: 'acp.resetSessionContext → acp:reset-session-context',
+    invoke: (a) => a.acp.resetSessionContext(sampleResumeRequest),
+    channel: 'acp:reset-session-context',
+    args: [sampleResumeRequest]
   }
 ]
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -162,6 +162,7 @@ type OpenScienceAPI = {
     disconnect: () => Promise<AcpStateSnapshot>
     createSession: (request?: AcpCreateSessionRequest) => Promise<AcpCreateSessionResponse>
     resumeSession: (request: AcpResumeSessionRequest) => Promise<AcpCreateSessionResponse>
+    resetSessionContext: (request: AcpResumeSessionRequest) => Promise<AcpCreateSessionResponse>
     sendPrompt: (request: AcpPromptRequest) => Promise<AcpStateSnapshot>
     cancel: (request: AcpCancelPromptRequest) => Promise<AcpStateSnapshot>
     deleteSession: (request: AcpDeleteSessionRequest) => Promise<AcpStateSnapshot>
@@ -376,6 +377,8 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('acp:create-session', request) as Promise<AcpCreateSessionResponse>,
     resumeSession: (request) =>
       ipcRenderer.invoke('acp:resume-session', request) as Promise<AcpCreateSessionResponse>,
+    resetSessionContext: (request) =>
+      ipcRenderer.invoke('acp:reset-session-context', request) as Promise<AcpCreateSessionResponse>,
     sendPrompt: (request) =>
       ipcRenderer.invoke('acp:send-prompt', request) as Promise<AcpStateSnapshot>,
     cancel: (request) => ipcRenderer.invoke('acp:cancel', request) as Promise<AcpStateSnapshot>,

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -52,6 +52,12 @@ const useAcpRuntime = (): {
     projectName?: string,
     permissionProfile?: PermissionProfileId
   ) => Promise<AcpCreateSessionResponse>
+  resetSessionContext: (
+    sessionId: AcpResumeSessionRequest['sessionId'],
+    cwd: AcpResumeSessionRequest['cwd'],
+    projectName?: string,
+    permissionProfile?: PermissionProfileId
+  ) => Promise<AcpCreateSessionResponse>
   deleteSession: (sessionId: string) => Promise<AcpStateSnapshot | undefined>
   cancel: (sessionId: string) => Promise<AcpStateSnapshot | undefined>
   sendPrompt: (
@@ -195,6 +201,21 @@ const useAcpRuntime = (): {
     [runValueAction]
   )
 
+  // Drops the agent-side context for a session whose accumulated history outgrew the request limit,
+  // adopting a fresh agent session so the next prompt can replay a bounded text transcript.
+  const resetSessionContext = useCallback(
+    (
+      sessionId: AcpResumeSessionRequest['sessionId'],
+      cwd: AcpResumeSessionRequest['cwd'],
+      projectName?: string,
+      permissionProfile?: PermissionProfileId
+    ) =>
+      runValueAction(setIsConnecting, () =>
+        window.api.acp.resetSessionContext({ sessionId, cwd, projectName, permissionProfile })
+      ),
+    [runValueAction]
+  )
+
   // Deletes a runtime session and returns the updated snapshot if it succeeds.
   const deleteSession = useCallback(
     (sessionId: string) =>
@@ -276,6 +297,7 @@ const useAcpRuntime = (): {
     disconnect,
     createSession,
     resumeSession,
+    resetSessionContext,
     deleteSession,
     cancel,
     sendPrompt,

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1293,6 +1293,30 @@ describe('recovering from a request-size overflow', () => {
     expect(recover).toHaveBeenCalledWith(runtime, 'session-1')
   })
 
+  it('triggers recovery from the recoverable marker even when the message does not match', () => {
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+    const recover = vi.fn().mockResolvedValue(true)
+    const event = createEvent({
+      id: 'overflow-marker',
+      kind: 'error',
+      level: 'error',
+      recoverable: 'context-overflow',
+      sessionId: 'session-1',
+      // An opaque wrapped message the text classifier would miss; the marker still drives recovery.
+      text: 'Internal error: -32603'
+    })
+
+    processContextOverflowRecovery(runtime, [event], new Set(), new Set(), recover)
+
+    expect(recover).toHaveBeenCalledTimes(1)
+  })
+
   it('ignores non-overflow errors, detached sessions, and sessions already recovering', () => {
     const runtime = {
       state: createSnapshot(['session-1']),

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -11,7 +11,9 @@ import {
   createWorkspaceRuntimeEventProcessor,
   getResumeFailureMessage,
   markRunningSessionsDisconnectedOnDrop,
+  processContextOverflowRecovery,
   processVisibleWorkspaceRuntimeEvents,
+  recoverContextOverflowWorkspaceSession,
   resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage
 } from './useWorkspaceAgentRuntime'
@@ -244,6 +246,7 @@ describe('workspace agent message sending', () => {
       state: createSnapshot(),
       createSession: vi.fn(() => createdSession),
       resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
     }
 
@@ -317,6 +320,7 @@ describe('workspace agent message sending', () => {
         cwd: '/workspace/project'
       }),
       resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
     }
 
@@ -388,6 +392,7 @@ describe('workspace agent message sending', () => {
         cwd: '/workspace/project'
       }),
       resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
     }
 
@@ -415,6 +420,7 @@ describe('workspace agent message sending', () => {
         cwd: '/workspace/project'
       }),
       resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
     }
 
@@ -474,6 +480,7 @@ describe('workspace agent message sending', () => {
       state: createSnapshot(['session-1']),
       createSession: vi.fn(),
       resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
@@ -508,6 +515,7 @@ describe('workspace agent message sending', () => {
       state: createSnapshot(['session-1']),
       createSession: vi.fn(),
       resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(undefined)
     }
 
@@ -546,6 +554,7 @@ describe('workspace agent message sending', () => {
       state: createSnapshot(['session-1']),
       createSession: vi.fn(),
       resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(undefined)
     }
 
@@ -576,6 +585,7 @@ describe('workspace agent message sending', () => {
       state: createSnapshot(),
       createSession: vi.fn(),
       resumeSession: vi.fn(() => resumeCanFinish.promise),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
@@ -615,6 +625,7 @@ describe('workspace agent message sending', () => {
         .mockRejectedValue(
           new Error('Invalid params: cwd does not exist on the machine running the agent: /gone')
         ),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn()
     }
 
@@ -649,6 +660,7 @@ describe('workspace agent message sending', () => {
             "Error invoking remote method 'acp:resume-session': Error: agent process crashed"
           )
         ),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn()
     }
 
@@ -680,6 +692,7 @@ describe('workspace agent message sending', () => {
       resumeSession: vi
         .fn()
         .mockRejectedValue(new Error('ACP agent does not support session resume.')),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn()
     }
 
@@ -714,6 +727,7 @@ describe('workspace agent message sending', () => {
             "The active model isn't compatible with Claude Code. Open Settings → Model to pick a compatible model or switch the agent framework."
           )
         ),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn()
     }
 
@@ -744,6 +758,7 @@ describe('workspace agent message sending', () => {
       state: createSnapshot(),
       createSession: vi.fn(),
       resumeSession: vi.fn().mockRejectedValue(new Error('ACP connection failed')),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn()
     }
 
@@ -799,6 +814,7 @@ describe('resuming an interrupted session on demand', () => {
       resumeSession: vi
         .fn()
         .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn()
     }
     seedDetachedSession()
@@ -821,6 +837,7 @@ describe('resuming an interrupted session on demand', () => {
       state: createSnapshot(),
       createSession: vi.fn(),
       resumeSession: vi.fn().mockRejectedValue(new Error('unexpected agent state')),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn()
     }
     seedDetachedSession()
@@ -838,6 +855,7 @@ describe('resuming an interrupted session on demand', () => {
       state: createSnapshot(['session-1']),
       createSession: vi.fn(),
       resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn()
     }
     seedDetachedSession()
@@ -853,6 +871,7 @@ describe('resuming an interrupted session on demand', () => {
       state: { ...createSnapshot(), cwd: '' },
       createSession: vi.fn(),
       resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn()
     }
     seedDetachedSession('')
@@ -915,6 +934,7 @@ describe('resuming an interrupted session on demand', () => {
       resumeSession: vi
         .fn()
         .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
@@ -982,6 +1002,7 @@ describe('resuming an interrupted session on demand', () => {
           contextReset: true
         })
         .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
@@ -1026,6 +1047,7 @@ describe('resuming an interrupted session on demand', () => {
       resumeSession: vi
         .fn()
         .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
@@ -1060,6 +1082,7 @@ describe('resuming an interrupted session on demand', () => {
         cwd: '/workspace/project',
         contextReset: true
       }),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
@@ -1101,6 +1124,7 @@ describe('resuming an interrupted session on demand', () => {
       resumeSession: vi
         .fn()
         .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
@@ -1138,6 +1162,7 @@ describe('resuming an interrupted session on demand', () => {
       resumeSession: vi
         .fn()
         .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      resetSessionContext: vi.fn(),
       sendPrompt: vi.fn()
     }
 
@@ -1147,5 +1172,186 @@ describe('resuming an interrupted session on demand', () => {
     expect(runtime.resumeSession).toHaveBeenCalledTimes(1)
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
     expect(useSessionStore.getState().sessions[0]).toMatchObject({ status: 'idle' })
+  })
+})
+
+describe('recovering from a request-size overflow', () => {
+  beforeEach(() => {
+    useSessionStore.setState(createInitialSessionState())
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const seedOverflowedConversation = (): void => {
+    // A completed prior turn (replayed as text) followed by the unanswered turn that overflowed.
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Analyze the first screenshot',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'ask'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'Here is what it shows'
+    })
+    useSessionStore.getState().finishRun('session-1')
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'now compare with this new screenshot',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'ask'
+    })
+    useSessionStore.getState().failRun('session-1', 'Request too large (max 32MB)')
+  }
+
+  it('resets the agent context, drops the failed turn, and re-sends with a text preamble', async () => {
+    vi.stubGlobal('window', {
+      api: { acp: { getState: vi.fn().mockResolvedValue(createSnapshot(['session-1'])) } }
+    })
+    seedOverflowedConversation()
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        cwd: '/workspace/project',
+        contextReset: true
+      }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    const recovered = await recoverContextOverflowWorkspaceSession(runtime, 'session-1')
+    await flushRuntimeTasks()
+
+    expect(recovered).toBe(true)
+    expect(runtime.resetSessionContext).toHaveBeenCalledWith(
+      'session-1',
+      '/workspace/project',
+      'default-project',
+      'ask'
+    )
+    // The unanswered turn is re-sent (not duplicated) with the prior turn replayed as a text preamble.
+    expect(runtime.sendPrompt.mock.calls[0]?.[1]).toBe('now compare with this new screenshot')
+    const preamble = runtime.sendPrompt.mock.calls[0]?.[5]
+    expect(preamble).toContain('Analyze the first screenshot')
+    expect(preamble).toContain('Here is what it shows')
+    expect(preamble).not.toContain('now compare with this new screenshot')
+  })
+
+  it('keeps the error visible when the context reset itself fails', async () => {
+    seedOverflowedConversation()
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockRejectedValue(new Error('ACP connection failed')),
+      sendPrompt: vi.fn()
+    }
+
+    const recovered = await recoverContextOverflowWorkspaceSession(runtime, 'session-1')
+
+    expect(recovered).toBe(false)
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions[0]?.status).toBe('error')
+  })
+
+  it('triggers recovery once per overflow error event for an attached session', () => {
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+    const recover = vi.fn().mockResolvedValue(true)
+    const handled = new Set<string>()
+    const recovering = new Set<string>()
+    const event = createEvent({
+      id: 'overflow-1',
+      kind: 'error',
+      level: 'error',
+      sessionId: 'session-1',
+      title: 'Prompt failed',
+      text: 'Internal error: Request too large (max 32MB).'
+    })
+
+    processContextOverflowRecovery(runtime, [event], handled, recovering, recover)
+    // A repeated snapshot delivering the same event must not recover twice.
+    processContextOverflowRecovery(runtime, [event], handled, recovering, recover)
+
+    expect(recover).toHaveBeenCalledTimes(1)
+    expect(recover).toHaveBeenCalledWith(runtime, 'session-1')
+  })
+
+  it('ignores non-overflow errors, detached sessions, and sessions already recovering', () => {
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+    const recover = vi.fn().mockResolvedValue(true)
+
+    // An unrelated turn-level error is not a size overflow.
+    processContextOverflowRecovery(
+      runtime,
+      [
+        createEvent({
+          id: 'e1',
+          kind: 'error',
+          level: 'error',
+          sessionId: 'session-1',
+          text: 'gateway 502'
+        })
+      ],
+      new Set(),
+      new Set(),
+      recover
+    )
+    // A detached session goes through the normal Resume path, not auto-recovery.
+    processContextOverflowRecovery(
+      runtime,
+      [
+        createEvent({
+          id: 'e2',
+          kind: 'error',
+          level: 'error',
+          sessionId: 'other-session',
+          text: 'Request too large'
+        })
+      ],
+      new Set(),
+      new Set(),
+      recover
+    )
+    // A session already within its recovery cooldown is skipped.
+    processContextOverflowRecovery(
+      runtime,
+      [
+        createEvent({
+          id: 'e3',
+          kind: 'error',
+          level: 'error',
+          sessionId: 'session-1',
+          text: 'Request too large'
+        })
+      ],
+      new Set(),
+      new Set(['session-1']),
+      recover
+    )
+
+    expect(recover).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -115,6 +115,13 @@ const getErrorMessage = (error: unknown): string =>
 // (connection still up, e.g. a gateway 5xx) surfaces as a normal session error. Reading the status at
 // failure time avoids the race where failRun would flip the session out of 'running' first.
 const failOrMarkDisconnected = async (sessionId: string, message: string): Promise<void> => {
+  // A conversation being auto-compacted after a request-size overflow owns its own outcome (reset +
+  // retry). Don't overwrite the neutral compacting state with a dead-end error from the prompt rejection
+  // the runtime swallowed into undefined.
+  if (useSessionStore.getState().sessions.find((session) => session.id === sessionId)?.compacting) {
+    return
+  }
+
   try {
     const snapshot = await window.api.acp.getState()
 
@@ -605,6 +612,10 @@ const recoverContextOverflowWorkspaceSession = async (
 
   if (!interruptedTurn) return false
 
+  // Flip to the neutral compacting state up front so the UI never shows the raw overflow error while the
+  // reset round-trip is in flight (idempotent with the event-path beginCompaction).
+  useSessionStore.getState().beginCompaction(sessionId)
+
   try {
     await runtime.resetSessionContext(
       sessionId,
@@ -652,7 +663,15 @@ const processContextOverflowRecovery = (
   for (const event of events) {
     if (handledEventIds.has(event.id)) continue
     if (event.kind !== 'error' || !event.sessionId) continue
-    if (!isMediaOverflowError(event.text) && !isMediaOverflowError(event.title)) continue
+
+    // Prefer the runtime's explicit marker; fall back to matching the message so an unmarked overflow
+    // (older event, or a path that didn't tag it) is still recovered.
+    const isOverflow =
+      event.recoverable === 'context-overflow' ||
+      isMediaOverflowError(event.text) ||
+      isMediaOverflowError(event.title)
+
+    if (!isOverflow) continue
 
     handledEventIds.add(event.id)
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -744,13 +744,11 @@ const useWorkspaceAgentRuntime = (): {
   const handledOverflowEventIds = useRef(new Set<string>())
   const recoveringOverflowSessionIds = useRef(new Set<string>())
 
-  // Applies each visible runtime event once and trims ids that fell out of the runtime window.
-  useEffect(() => {
-    void eventProcessor.current.process(runtime.state.events)
-  }, [runtime.state.events])
-
   // Auto-recovers when a conversation outgrows the provider's request-size limit: resets the agent
-  // context and replays a text-only transcript instead of dead-ending on an unrecoverable error.
+  // context and replays a text-only transcript instead of dead-ending on an unrecoverable error. Runs
+  // BEFORE the event processor below so it can flip the session to `compacting` first — the event
+  // processor then shows the neutral note only when a recovery actually started, and surfaces a real
+  // error otherwise (e.g. a repeat overflow inside the cooldown), never a stuck "Compacting…".
   useEffect(() => {
     processContextOverflowRecovery(
       runtime,
@@ -759,6 +757,11 @@ const useWorkspaceAgentRuntime = (): {
       recoveringOverflowSessionIds.current
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps -- runtime is read fresh; fire on new events.
+  }, [runtime.state.events])
+
+  // Applies each visible runtime event once and trims ids that fell out of the runtime window.
+  useEffect(() => {
+    void eventProcessor.current.process(runtime.state.events)
   }, [runtime.state.events])
 
   // Mirrors pending permission requests into per-session store status.

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -16,6 +16,7 @@ import type { ArtifactReference } from '../../../../shared/artifacts'
 import type { MessagePart } from '../../../../shared/session-persistence'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { useSessionStore, type ChatMessage } from '../../stores/session-store'
+import { isMediaOverflowError } from '../../../../shared/media-overflow'
 import { useAcpRuntime } from './useAcpRuntime'
 import { buildHistoryPreamble } from './history-preamble'
 import { applyWorkspaceRuntimeEvent, syncWorkspacePermissionState } from './workspace-events'
@@ -49,7 +50,7 @@ type SendWorkspaceMessageResult = {
 
 type WorkspaceMessageRuntime = Pick<
   ReturnType<typeof useAcpRuntime>,
-  'state' | 'createSession' | 'resumeSession' | 'sendPrompt'
+  'state' | 'createSession' | 'resumeSession' | 'resetSessionContext' | 'sendPrompt'
 >
 
 type RuntimeEventApplier = (event: AcpRuntimeEvent) => Promise<boolean>
@@ -575,6 +576,108 @@ const resumeInterruptedWorkspaceSession = async (
   })
 }
 
+// After an auto-recovery, ignore further overflow events for this session for a short window so a retry
+// that immediately overflows again falls through to a visible error instead of looping. Prevention (the
+// per-session inline-image budget) makes a second overflow unlikely, so this is a backstop, not the norm.
+const CONTEXT_OVERFLOW_RECOVERY_COOLDOWN_MS = 15_000
+
+// Auto-recovers a conversation whose replayed history outgrew the provider's request-size limit
+// (accumulated images/attachments → "Request too large" / the backend's compaction failing with
+// media_unstrippable). This is the app-level compaction the backend cannot do: reset the agent context
+// to a fresh session (no media), then replay a bounded TEXT transcript and re-send the unanswered turn.
+// Mirrors resumeInterruptedWorkspaceSession, differing only in resetting rather than resuming. Returns
+// false when there is nothing to recover or the reset itself fails, so the caller keeps the visible error.
+const recoverContextOverflowWorkspaceSession = async (
+  runtime: WorkspaceMessageRuntime,
+  sessionId: string
+): Promise<boolean> => {
+  const session = useSessionStore.getState().sessions.find((item) => item.id === sessionId)
+
+  if (!session) return false
+
+  const resumeCwd = session.cwd || runtime.state.cwd
+
+  if (!resumeCwd) return false
+
+  // The unanswered user turn is what we re-send; if the last turn already got a reply there is nothing
+  // to retry (a stray late overflow event), so bail before disturbing the agent session.
+  const interruptedTurn = findInterruptedUserTurn(session.messages)
+
+  if (!interruptedTurn) return false
+
+  try {
+    await runtime.resetSessionContext(
+      sessionId,
+      resumeCwd,
+      session.projectId,
+      session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
+    )
+  } catch (error) {
+    useSessionStore.getState().failRun(sessionId, getResumeFailureMessage(error))
+    return false
+  }
+
+  // Drop the unanswered turn so the re-send does not duplicate the bubble; the remaining prior turns are
+  // replayed as a text preamble via forceHistoryReplay (session.messages was captured before removal).
+  useSessionStore.getState().removeMessage(sessionId, interruptedTurn.id)
+
+  await sendWorkspaceMessage(runtime, {
+    sessionId,
+    text: interruptedTurn.content,
+    attachments: interruptedTurn.uploads ?? [],
+    parts: interruptedTurn.parts,
+    cwd: resumeCwd,
+    projectId: session.projectId,
+    permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+    // A fresh agent session lost the prior context, so replay the transcript on this first prompt.
+    forceHistoryReplay: true
+  })
+
+  return true
+}
+
+// Scans runtime error events for the request-size overflow and triggers one auto-recovery per event.
+// handledEventIds dedups across the repeated event snapshots a bounded window re-delivers; the recovery
+// runs only for attached sessions (a detached one uses the normal Resume path) and only once per cooldown.
+const processContextOverflowRecovery = (
+  runtime: WorkspaceMessageRuntime,
+  events: AcpRuntimeEvent[],
+  handledEventIds: Set<string>,
+  recoveringSessionIds: Set<string>,
+  recover: (
+    runtime: WorkspaceMessageRuntime,
+    sessionId: string
+  ) => Promise<boolean> = recoverContextOverflowWorkspaceSession
+): void => {
+  for (const event of events) {
+    if (handledEventIds.has(event.id)) continue
+    if (event.kind !== 'error' || !event.sessionId) continue
+    if (!isMediaOverflowError(event.text) && !isMediaOverflowError(event.title)) continue
+
+    handledEventIds.add(event.id)
+
+    const { sessionId } = event
+
+    if (!runtime.state.sessionIds.includes(sessionId)) continue
+    if (recoveringSessionIds.has(sessionId)) continue
+
+    recoveringSessionIds.add(sessionId)
+    void recover(runtime, sessionId).finally(() => {
+      setTimeout(
+        () => recoveringSessionIds.delete(sessionId),
+        CONTEXT_OVERFLOW_RECOVERY_COOLDOWN_MS
+      )
+    })
+  }
+
+  // Forget ids that fell out of the bounded runtime event window so the set cannot grow unbounded.
+  const visibleIds = new Set(events.map((event) => event.id))
+
+  for (const id of handledEventIds) {
+    if (!visibleIds.has(id)) handledEventIds.delete(id)
+  }
+}
+
 // Flags running sessions as disconnected on a TRANSITION into a dropped connection state. Abnormal
 // drops (agent crash / gateway drop) go through main's handleConnectionClosed → status 'closed';
 // deliberate mid-prompt disconnects use disconnect(false) (no 'closed' emit) and idle provider/skills
@@ -618,10 +721,25 @@ const useWorkspaceAgentRuntime = (): {
   // Tracks the last connection status so the disconnect effect fires only on a transition, not on
   // every unrelated snapshot re-render.
   const previousStatusRef = useRef(runtime.state.status)
+  // Dedup + cooldown state for the request-size overflow auto-recovery, kept across re-renders.
+  const handledOverflowEventIds = useRef(new Set<string>())
+  const recoveringOverflowSessionIds = useRef(new Set<string>())
 
   // Applies each visible runtime event once and trims ids that fell out of the runtime window.
   useEffect(() => {
     void eventProcessor.current.process(runtime.state.events)
+  }, [runtime.state.events])
+
+  // Auto-recovers when a conversation outgrows the provider's request-size limit: resets the agent
+  // context and replays a text-only transcript instead of dead-ending on an unrecoverable error.
+  useEffect(() => {
+    processContextOverflowRecovery(
+      runtime,
+      runtime.state.events,
+      handledOverflowEventIds.current,
+      recoveringOverflowSessionIds.current
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- runtime is read fresh; fire on new events.
   }, [runtime.state.events])
 
   // Mirrors pending permission requests into per-session store status.
@@ -742,7 +860,9 @@ export {
   createWorkspaceRuntimeEventProcessor,
   getResumeFailureMessage,
   markRunningSessionsDisconnectedOnDrop,
+  processContextOverflowRecovery,
   processVisibleWorkspaceRuntimeEvents,
+  recoverContextOverflowWorkspaceSession,
   resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage,
   useWorkspaceAgentRuntime

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -125,29 +125,48 @@ describe('workspace runtime events', () => {
     })
   })
 
-  it('enters the compacting state (not a dead-end error) for a recoverable overflow event', async () => {
+  const overflowEvent = (): AcpRuntimeEvent =>
+    createEvent({
+      id: 'event-overflow',
+      kind: 'error',
+      level: 'error',
+      recoverable: 'context-overflow',
+      title: 'Prompt failed',
+      text: 'Internal error: Request too large (max 32MB).'
+    })
+
+  it('defers to the neutral compacting note while a recovery is already in flight', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',
       content: 'compare these screenshots'
     })
+    // The recovery effect flips the session to compacting before this event is applied.
+    useSessionStore.getState().beginCompaction('transport-session-1')
 
-    const applied = await applyWorkspaceRuntimeEvent(
-      createEvent({
-        id: 'event-overflow',
-        kind: 'error',
-        level: 'error',
-        recoverable: 'context-overflow',
-        title: 'Prompt failed',
-        text: 'Internal error: Request too large (max 32MB).'
-      })
-    )
+    const applied = await applyWorkspaceRuntimeEvent(overflowEvent())
 
     expect(applied).toBe(true)
     const session = useSessionStore.getState().sessions[0]
+    // Stays neutral: no dead-end error surfaced while the recovery runs.
     expect(session.compacting).toBe(true)
     expect(session.status).not.toBe('error')
-    // The raw overflow message is not surfaced as a session error; the UI shows a neutral note instead.
     expect(session.error).toBeUndefined()
+  })
+
+  it('surfaces a real error for a recoverable overflow when no recovery started (e.g. cooldown)', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'compare these screenshots'
+    })
+    // Session is NOT compacting — a repeat overflow inside the cooldown gets no recovery, so it must not
+    // be left in a stuck "Compacting…"; the error becomes visible instead.
+    const applied = await applyWorkspaceRuntimeEvent(overflowEvent())
+
+    expect(applied).toBe(true)
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.status).toBe('error')
+    expect(session.compacting).toBeFalsy()
+    expect(session.error).toContain('Request too large')
   })
 
   it('surfaces a session-scoped agent warning as the waiting-indicator status, cleared on stop', async () => {

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -125,6 +125,31 @@ describe('workspace runtime events', () => {
     })
   })
 
+  it('enters the compacting state (not a dead-end error) for a recoverable overflow event', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'compare these screenshots'
+    })
+
+    const applied = await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'event-overflow',
+        kind: 'error',
+        level: 'error',
+        recoverable: 'context-overflow',
+        title: 'Prompt failed',
+        text: 'Internal error: Request too large (max 32MB).'
+      })
+    )
+
+    expect(applied).toBe(true)
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.compacting).toBe(true)
+    expect(session.status).not.toBe('error')
+    // The raw overflow message is not surfaced as a session error; the UI shows a neutral note instead.
+    expect(session.error).toBeUndefined()
+  })
+
   it('surfaces a session-scoped agent warning as the waiting-indicator status, cleared on stop', async () => {
     const applied = await applyWorkspaceRuntimeEvent(
       createEvent({ id: 'event-1', kind: 'system', level: 'warning', text: 'retrying request…' })

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -4,6 +4,7 @@ import type { ReviewRunRequest } from '../../../../shared/reviewer'
 import { createPreviewFileItem } from '../../pages/workspace/preview-file-item'
 import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
+import { isMediaOverflowError } from '../../../../shared/media-overflow'
 import { useSessionStore } from '../../stores/session-store'
 import { useSettingsStore } from '../../stores/settings-store'
 import { createRuntimeStreamId, isAssistantRuntimeChatMessageEvent } from './chat-events'
@@ -217,10 +218,22 @@ const applyWorkspaceRuntimeEvent = async (
   }
 
   if (event.kind === 'error' && event.sessionId) {
-    // A recoverable request-size overflow is auto-compacted-and-retried by the workspace runtime, so
-    // enter the neutral "compacting" state instead of failing the run with a dead-end error.
-    if (event.recoverable === 'context-overflow') {
-      store.beginCompaction(event.sessionId)
+    // A recoverable request-size overflow shows the neutral "compacting" note ONLY while a recovery is
+    // actually in flight — the workspace runtime flips the session to `compacting` first (its recovery
+    // effect runs before this event is applied). If the session is not compacting, no recovery started
+    // for this overflow (a repeat overflow inside the cooldown, nothing to replay, or a detached
+    // session), so surface a normal error instead of leaving a stuck "Compacting…".
+    const isCompacting = store.sessions.find(
+      (session) => session.id === event.sessionId
+    )?.compacting
+    // Same overflow detection the recovery effect uses (marker first, message as a fallback), so the two
+    // agree on which errors are recoverable.
+    const isOverflow =
+      event.recoverable === 'context-overflow' ||
+      isMediaOverflowError(event.text) ||
+      isMediaOverflowError(event.title)
+
+    if (isOverflow && isCompacting) {
       return true
     }
 

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -217,6 +217,13 @@ const applyWorkspaceRuntimeEvent = async (
   }
 
   if (event.kind === 'error' && event.sessionId) {
+    // A recoverable request-size overflow is auto-compacted-and-retried by the workspace runtime, so
+    // enter the neutral "compacting" state instead of failing the run with a dead-end error.
+    if (event.recoverable === 'context-overflow') {
+      store.beginCompaction(event.sessionId)
+      return true
+    }
+
     store.failRun(event.sessionId, getEventErrorText(event))
     return true
   }

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -428,3 +428,29 @@ describe('ConversationPanel fix loop lock', () => {
     expect(onCancelRun).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('ConversationPanel compacting state', () => {
+  const compactingSession: ChatSession = {
+    id: 'session-compacting',
+    projectId: 'project-a',
+    title: 'Compacting session',
+    cwd: '/workspace',
+    status: 'idle',
+    compacting: true,
+    messages: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now()
+  }
+
+  it('shows a neutral compacting note and hides the overflow error during recovery', () => {
+    // The raw overflow error is still present as a global actionError, but must be suppressed while the
+    // session is compacting so the user sees the recovery affordance, not a dead-end.
+    renderPanel({
+      activeSession: compactingSession,
+      actionError: 'Internal error: Request too large (max 32MB).'
+    })
+
+    expect(container.textContent).toContain('Compacting conversation to fit the context limit')
+    expect(container.textContent).not.toContain('Request too large')
+  })
+})

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -10,6 +10,7 @@ import {
   BookOpen,
   FileText,
   Image as ImageIcon,
+  Loader2,
   PanelRight,
   Plus,
   ScanEye,
@@ -242,6 +243,13 @@ const ConversationPanel = ({
                     isResuming={isResuming}
                     onResume={() => void handleResume()}
                   />
+                ) : activeSession?.compacting ? (
+                  // Auto-recovery after a request-size overflow: a neutral note, not the red error box,
+                  // while the agent context is reset and the conversation is replayed as text.
+                  <div className="mb-2 flex items-center gap-2 rounded-lg border border-border-200 bg-bg-200 px-3 py-2 text-[12px] leading-5 text-text-300">
+                    <Loader2 className="size-3.5 animate-spin" strokeWidth={2} aria-hidden="true" />
+                    Compacting conversation to fit the context limit…
+                  </div>
                 ) : actionError || activeSession?.error ? (
                   <div className="mb-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-700">
                     {actionError ?? activeSession?.error}

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+// Pins that WorkspacePage disables sending while the active session is auto-compacting after a
+// request-size overflow. ConversationPanel only renders the note; the canSendMessage gate is computed
+// here, so without this a manual prompt could race the recovery resend into the same session.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as React from 'react'
+
+import { useNavigationStore } from '@/stores/navigation-store'
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore
+} from '@/stores/preview-workbench-store'
+import { useProjectStore } from '@/stores/project-store'
+import {
+  createInitialSessionState,
+  useSessionStore,
+  type ChatSession
+} from '@/stores/session-store'
+
+import { type ComposerDoc } from './composer/composer-doc'
+
+// Capture the ConversationPanel props the page computes, notably canSendMessage and the draft callback.
+let conversationProps: {
+  draftDoc: ComposerDoc
+  canSendMessage: boolean
+  onDraftDocChange: (doc: ComposerDoc) => void
+}
+
+const runtime = vi.hoisted(() => ({
+  sendMessage: vi.fn(),
+  cancelRun: vi.fn(),
+  deleteRuntimeSession: vi.fn(),
+  respondToPermission: vi.fn()
+}))
+
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: (): React.JSX.Element => <div data-testid="resize-handle" />
+}))
+
+vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
+  useWorkspaceAgentRuntime: () => ({
+    actionError: null,
+    pendingPermissions: [],
+    sendMessage: runtime.sendMessage,
+    cancelRun: runtime.cancelRun,
+    deleteRuntimeSession: runtime.deleteRuntimeSession,
+    respondToPermission: runtime.respondToPermission
+  })
+}))
+
+vi.mock('./WorkspaceSidebar', () => ({
+  WorkspaceSidebar: (): React.JSX.Element => <aside />
+}))
+
+vi.mock('./ConversationPanel', () => ({
+  ConversationPanel: (props: typeof conversationProps): React.JSX.Element => {
+    conversationProps = props
+    return <section data-testid="conversation" />
+  }
+}))
+
+vi.mock('./PreviewPanel', () => ({
+  PreviewPanel: (): React.JSX.Element => <div data-testid="preview-panel" />
+}))
+
+vi.mock('./RenameSessionDialog', () => ({
+  RenameSessionDialog: (): React.JSX.Element => <div />
+}))
+
+vi.mock('./DeleteSessionDialog', () => ({
+  DeleteSessionDialog: (): React.JSX.Element => <div />
+}))
+
+const { WorkspacePage } = await import('./WorkspacePage')
+
+const createSession = (overrides: Partial<ChatSession> = {}): ChatSession => {
+  const now = Date.now()
+
+  return {
+    id: 'sess-a',
+    projectId: 'proj-1',
+    title: 'sess-a',
+    cwd: '/workspace/proj-1',
+    status: 'idle',
+    messages: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides
+  }
+}
+
+const textDoc = (text: string): ComposerDoc => ({ nodes: [{ type: 'text', text }] })
+
+describe('WorkspacePage send gate while compacting', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    useProjectStore.setState({ projects: [] })
+    useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession()],
+      selectedSessionId: 'sess-a'
+    })
+    vi.clearAllMocks()
+
+    window.api = {
+      notebook: {
+        onAvailable: vi.fn(() => vi.fn()),
+        getReference: vi.fn(() => Promise.resolve(null))
+      },
+      preview: {
+        load: vi.fn(() => Promise.resolve(undefined)),
+        save: vi.fn(() => Promise.resolve())
+      },
+      uploads: { deleteUpload: vi.fn(), stageFiles: vi.fn() },
+      reviewer: {
+        onUpdated: vi.fn(() => vi.fn()),
+        onSuppressNextAutoReview: vi.fn(() => vi.fn()),
+        onFixLoopStart: vi.fn(() => vi.fn()),
+        onFixLoopEnd: vi.fn(() => vi.fn()),
+        abortFixLoop: vi.fn(() => Promise.resolve())
+      }
+    } as never
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  const renderPage = async (): Promise<void> => {
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+    })
+  }
+
+  it('disables sending while the active session is compacting, and re-enables after', async () => {
+    await renderPage()
+
+    // A non-empty draft on an idle session is normally sendable — this is the control.
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('retry this'))
+    })
+    expect(conversationProps.canSendMessage).toBe(true)
+
+    // Entering the compacting recovery state must gate the composer even though the status is idle and the
+    // draft is unchanged, so a manual prompt can't race the recovery resend.
+    await act(async () => {
+      useSessionStore.getState().beginCompaction('sess-a')
+    })
+    expect(conversationProps.canSendMessage).toBe(false)
+
+    // Once the replay turn starts (running) and the recovery clears the flag, sending is governed by the
+    // normal status rules again. Finishing the run returns to idle with the draft still sendable.
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+    })
+    expect(conversationProps.canSendMessage).toBe(true)
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -241,7 +241,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     (!docIsEmpty(draftDoc) || attachments.length > 0) &&
     activeSession?.status !== 'running' &&
     activeSession?.status !== 'waiting-permission' &&
-    !activeSession?.fixLoopActive
+    !activeSession?.fixLoopActive &&
+    // Auto-recovery drops the session to idle while it resets context and replays the transcript; block
+    // sends in that window so a manual prompt can't race the recovery resend into the same session.
+    !activeSession?.compacting
   const canChangePermissionProfile =
     isSessionPersistenceReady &&
     activeSession?.status !== 'running' &&

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -67,6 +67,10 @@ export type ChatSession = Omit<
   // Transient: true while a Phase 3 fix loop is active for this session. Disables the send button
   // for the duration of the loop (across reviewer-review and agent-fix sub-phases). Never persisted.
   fixLoopActive?: boolean
+  // Transient: true while the app is auto-recovering a conversation that outgrew the request-size limit
+  // (reset agent context + replay a text transcript). The UI shows a neutral "Compacting…" note instead
+  // of the overflow error, and the promise-path failure is suppressed. Cleared on the next run/settle.
+  compacting?: boolean
   // Transient: latest agent status/stderr line for the in-flight turn, shown in the waiting indicator
   // so a long silent wait (e.g. the agent retrying a slow request) isn't a blank spinner. Not persisted.
   agentStatus?: string
@@ -169,6 +173,9 @@ type SessionStore = SessionStoreData & {
   failRun: (sessionId: string, error: string) => void
   // Sets the transient agent status line shown in the waiting indicator; only applies while running.
   setAgentStatus: (sessionId: string, text: string) => void
+  // Enters the auto-recovery "compacting" state after a request-size overflow: clears the error so the
+  // UI shows a neutral note instead of a dead-end, without blocking the recovery re-send.
+  beginCompaction: (sessionId: string) => void
   markResumed: (sessionId: string) => void
   markDisconnected: (sessionId: string) => void
   removeMessage: (sessionId: string, messageId: string) => void
@@ -212,6 +219,7 @@ const stripTransientSessionState = (session: ChatSession): PersistedChatSession 
     isPending,
     interrupted,
     fixLoopActive,
+    compacting,
     agentStatus,
     messages,
     ...persistedSession
@@ -220,6 +228,7 @@ const stripTransientSessionState = (session: ChatSession): PersistedChatSession 
   void isPending
   void interrupted
   void fixLoopActive
+  void compacting
   void agentStatus
 
   // Persist a bounded projection of tool activities so the transcript survives restarts.
@@ -527,6 +536,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
                 activeRun,
                 agentStatus: undefined,
                 error: undefined,
+                compacting: undefined,
                 messages: [...session.messages, userMessage],
                 updatedAt: now
               }
@@ -997,6 +1007,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           status: keepArtifactError ? 'error' : 'idle',
           activeRun: undefined,
           agentStatus: undefined,
+          compacting: undefined,
           error: keepArtifactError ? session.error : undefined,
           messages: completeStreamingMessages(session.messages),
           activities: completeOpenActivities(session.activities),
@@ -1020,6 +1031,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               status: 'error',
               activeRun: undefined,
               agentStatus: undefined,
+              compacting: undefined,
               error: message,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
@@ -1046,6 +1058,29 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     }))
   },
 
+  // Enters the transient "compacting" state after a request-size overflow. Clears the error and settles
+  // any half-streamed message so nothing hangs, but leaves the status non-running so the recovery re-send
+  // is not blocked by the duplicate-submit guard. The UI shows a neutral note keyed off `compacting`.
+  beginCompaction: (sessionId) => {
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId
+          ? {
+              ...session,
+              status: 'idle',
+              activeRun: undefined,
+              agentStatus: undefined,
+              error: undefined,
+              compacting: true,
+              messages: failStreamingMessages(session.messages),
+              activities: failOpenActivities(session.activities),
+              updatedAt: Date.now()
+            }
+          : session
+      )
+    }))
+  },
+
   // Clears the interrupted/error state after a successful resume so the composer is usable again.
   markResumed: (sessionId) => {
     set((state) => ({
@@ -1056,6 +1091,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               status: 'idle',
               error: undefined,
               interrupted: undefined,
+              compacting: undefined,
               updatedAt: Date.now()
             }
           : session
@@ -1074,6 +1110,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               status: 'error',
               activeRun: undefined,
               interrupted: true,
+              compacting: undefined,
               error: 'Connection lost — Resume to reconnect and continue.',
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -19,11 +19,19 @@ export type AcpRuntimeEventKind =
 
 export type AcpRuntimeEventLevel = 'info' | 'warning' | 'error'
 
+// Marks a prompt failure the app can auto-recover from without user action. 'context-overflow' means
+// the conversation outgrew the provider's request-size limit (accumulated media); the renderer resets
+// the agent context and replays a text-only transcript. Absent on ordinary events.
+export type AcpRecoverableFailure = 'context-overflow'
+
 export type AcpRuntimeEvent = {
   id: string
   timestamp: number
   kind: AcpRuntimeEventKind
   level: AcpRuntimeEventLevel
+  // Set on an error event the app can auto-recover from, so the renderer compacts-and-retries instead
+  // of surfacing a dead-end error.
+  recoverable?: AcpRecoverableFailure
   sessionId?: string
   messageId?: string
   role?: 'assistant' | 'user'

--- a/src/shared/media-overflow.test.ts
+++ b/src/shared/media-overflow.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { isMediaOverflowError } from './media-overflow'
+
+describe('isMediaOverflowError', () => {
+  it('matches the backend compaction failure', () => {
+    expect(isMediaOverflowError('Compacting failed: media_unstrippable')).toBe(true)
+    expect(isMediaOverflowError('media unstrippable')).toBe(true)
+  })
+
+  it('matches the provider request-size rejection', () => {
+    expect(
+      isMediaOverflowError(
+        'Internal error: Request too large (max 32MB). Accumulated images and attachments pushed the request over the limit.'
+      )
+    ).toBe(true)
+  })
+
+  it('does not match unrelated failures', () => {
+    expect(isMediaOverflowError('The requested resource was not found')).toBe(false)
+    expect(isMediaOverflowError('Upload rejected: file is too large (limit 10MB)')).toBe(false)
+    expect(isMediaOverflowError('rate limit exceeded')).toBe(false)
+  })
+
+  it('is safe on empty input', () => {
+    expect(isMediaOverflowError(undefined)).toBe(false)
+    expect(isMediaOverflowError(null)).toBe(false)
+    expect(isMediaOverflowError('')).toBe(false)
+  })
+})

--- a/src/shared/media-overflow.ts
+++ b/src/shared/media-overflow.ts
@@ -1,0 +1,15 @@
+// Recognizes the "conversation grew past the provider's request-size limit" failure so the app can
+// auto-recover (reset the agent context, replay a text-only transcript) instead of dead-ending.
+//
+// Two distinct signatures describe the same underlying condition:
+//   - `media_unstrippable`: the backend's own compaction gave up because accumulated base64 media
+//     blocks cannot be stripped from the history it would summarize.
+//   - `Request too large (max 32MB)`: the provider (Anthropic 413) rejected the turn because the
+//     replayed history plus this turn exceeded the request ceiling.
+// Matching either is enough to trigger recovery; both are specific enough not to catch unrelated
+// "too large" messages (e.g. an oversized upload rejected before it ever reaches the model).
+const MEDIA_OVERFLOW_PATTERN = /media[_\s-]?unstrippable|request too large/i
+
+// Whether a failed-prompt message indicates the request outgrew the provider's size limit.
+export const isMediaOverflowError = (message: string | undefined | null): boolean =>
+  typeof message === 'string' && MEDIA_OVERFLOW_PATTERN.test(message)


### PR DESCRIPTION
Fixes #197.

## Problem
Once a conversation accumulated enough images/attachments, a turn failed with `Request too large (max 32MB)`, and the backend's own compaction failed with `media_unstrippable` (it summarizes text but can't strip base64 media blocks). The only escape was starting a new conversation.

## Approach — prevention + recovery
The app sends only the new turn each prompt; the backend holds and replays history, so the app can't strip old media in place. Its only levers are limiting what it adds and rebuilding context from text.

- **Prevention** — per-session cumulative inlined-image budget (`MAX_SESSION_INLINE_IMAGE_BYTES`, 20MB). Once a session nears the ceiling, further images degrade to `resource_link` file references instead of base64 (like large binaries already do), so a conversation can't be driven past the cliff.
- **Recovery** — when a turn still overflows, the app performs the compaction the backend can't: `resetSessionContext` adopts a fresh agent session, drops the unanswered turn, and re-sends it with a bounded **text-only** transcript replayed for continuity. This drops all accumulated media. Detected from a `recoverable: 'context-overflow'` marker on the failure event; guarded by a per-session cooldown so a repeat overflow surfaces a normal error instead of looping.
- **UX** — during recovery the session shows a neutral "Compacting conversation…" note, not the raw error.

## Testing
Full suite green (2902 passed); typecheck + lint clean. Added coverage for the size classifier, the per-session budget, `resetSessionContext`, the compacting event routing, and the recovery re-send/dedup/cooldown.

## Known limitations
- **Compaction drops media by design.** After a recovery, the agent retains only a ~12k-char text transcript of prior turns — older images/PDFs are no longer visible to the model. This is inherent: the provider rejects the oversized request and the backend cannot strip media from history in place, so rebuilding from text is the only way to keep the conversation alive. Prevention exists precisely to make this recovery rare.
