### PR TITLE
feat(composer): fuzzy matching for / and @ mention popups

### DIFF
--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
@@ -192,4 +192,70 @@ describe('ArtifactMentionPopup', () => {
     pressKey('Escape')
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  it('matches a filename by fuzzy subsequence a substring would miss', () => {
+    act(() => {
+      root.render(<ArtifactMentionPopup query="rpt" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    // "rpt" is an ordered subsequence of "report.pdf" but not a substring, and matches no upload.
+    const rendered = options()
+    expect(rendered).toHaveLength(1)
+    expect(rendered[0].textContent).toContain('report.pdf')
+    expect(document.body.textContent).not.toContain('sequence.csv')
+  })
+
+  it('highlights the matched characters in the filename', () => {
+    act(() => {
+      root.render(<ArtifactMentionPopup query="report" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    const marks = Array.from(document.body.querySelectorAll('mark'))
+    expect(marks).toHaveLength(1)
+    expect(marks[0].textContent?.toLowerCase()).toBe('report')
+  })
+
+  it('ranks a closer fuzzy match first within a section', () => {
+    // Two outputs in the same section: a prefix match must outrank a later word-boundary match.
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        createSession({
+          artifacts: [
+            {
+              id: 'art-late',
+              kind: 'managed-file',
+              path: '/workspace/final-report.pdf',
+              fileUrl: 'file:///workspace/final-report.pdf',
+              name: 'final-report.pdf',
+              mimeType: 'application/pdf',
+              size: 4096,
+              mtimeMs: 1710000001000
+            },
+            {
+              id: 'art-early',
+              kind: 'managed-file',
+              path: '/workspace/report.pdf',
+              fileUrl: 'file:///workspace/report.pdf',
+              name: 'report.pdf',
+              mimeType: 'application/pdf',
+              size: 4096,
+              mtimeMs: 1710000002000
+            }
+          ]
+        })
+      ]
+    })
+    useNavigationStore.setState({ activeProjectId: 'default' })
+
+    act(() => {
+      root.render(<ArtifactMentionPopup query="report" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    const rendered = options()
+    expect(rendered).toHaveLength(2)
+    // "report.pdf" (prefix) ranks ahead of "final-report.pdf" (match after the dash).
+    expect(rendered[0].textContent).not.toContain('final')
+    expect(rendered[1].textContent).toContain('final-report.pdf')
+  })
 })

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -5,6 +5,8 @@ import { useNavigationStore } from '@/stores/navigation-store'
 import { useSessionStore } from '@/stores/session-store'
 
 import { ArtifactFileIcon } from './artifact-file-icon'
+import { fuzzyScore, type FuzzyMatch } from './fuzzy-match'
+import { HighlightedText } from './HighlightedText'
 import { buildProjectFileLibrary } from '../project-files-library'
 
 // The reference passed back to the composer when an artifact row is picked.
@@ -25,10 +27,12 @@ type ArtifactMentionPopupProps = {
   onClose: () => void
 }
 
-// One suggestion row: a picked artifact plus the display size and its section tag.
+// One suggestion row: a picked artifact plus the display size and its section tag. `positions` holds
+// the fuzzy-match indices into `name` to highlight (empty when the query is empty).
 type ArtifactRow = PickedArtifact & {
   size?: number
   tag: 'upload' | 'output'
+  positions?: number[]
 }
 
 // Human-readable section headers, ordered as they render.
@@ -74,11 +78,22 @@ export const ArtifactMentionPopup = ({
     return [...uploadRows, ...artifactRows]
   }, [sessions, activeProjectId])
 
-  // Case-insensitive filename match; empty query shows every artifact.
-  const matches = useMemo(() => {
-    const needle = query.trim().toLowerCase()
+  // Fuzzy-match the query against each filename, ranked best-first. Ranking happens within each section
+  // so uploads still render before outputs — the flat highlight index depends on that order. Empty
+  // query shows every artifact untouched.
+  const matches = useMemo<ArtifactRow[]>(() => {
+    const needle = query.trim()
     if (needle.length === 0) return rows
-    return rows.filter((row) => row.name.toLowerCase().includes(needle))
+
+    const rankSection = (tag: ArtifactRow['tag']): ArtifactRow[] =>
+      rows
+        .filter((row) => row.tag === tag)
+        .map((row) => ({ row, match: fuzzyScore(needle, row.name) }))
+        .filter((entry): entry is { row: ArtifactRow; match: FuzzyMatch } => entry.match !== null)
+        .sort((a, b) => b.match.score - a.match.score)
+        .map(({ row, match }) => ({ ...row, positions: match.positions }))
+
+    return [...rankSection('upload'), ...rankSection('output')]
   }, [rows, query])
 
   const [activeIndex, setActiveIndex] = useState(0)
@@ -145,7 +160,9 @@ export const ArtifactMentionPopup = ({
           path={row.path}
           source={row.source}
         />
-        <span className="flex-1 min-w-0 truncate font-medium">{row.name}</span>
+        <span className="flex-1 min-w-0 truncate font-medium">
+          <HighlightedText text={row.name} positions={row.positions ?? []} />
+        </span>
         {size ? <span className="text-xs text-text-300 shrink-0">{size}</span> : null}
         <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent text-accent-foreground shrink-0">
           {row.tag}

--- a/src/renderer/src/pages/workspace/composer/HighlightedText.tsx
+++ b/src/renderer/src/pages/workspace/composer/HighlightedText.tsx
@@ -1,0 +1,48 @@
+import { Fragment } from 'react'
+
+// Render `text` with the characters at `positions` (indices produced by fuzzyScore) emphasized, so the
+// user can see why a fuzzy match ranked. Positions must be sorted ascending; anything out of range is
+// ignored. With no positions this is just the plain text.
+export const HighlightedText = ({
+  text,
+  positions
+}: {
+  text: string
+  positions: number[]
+}): React.JSX.Element => {
+  if (positions.length === 0) return <>{text}</>
+
+  const hit = new Set(positions)
+  const segments: React.JSX.Element[] = []
+  let run = ''
+  let runIsHit = hit.has(0)
+
+  const flush = (endExclusive: number): void => {
+    if (run.length === 0) return
+    segments.push(
+      runIsHit ? (
+        <mark
+          key={endExclusive}
+          className="bg-transparent font-semibold text-inherit underline decoration-1 underline-offset-2"
+        >
+          {run}
+        </mark>
+      ) : (
+        <Fragment key={endExclusive}>{run}</Fragment>
+      )
+    )
+    run = ''
+  }
+
+  for (let i = 0; i < text.length; i++) {
+    const isHit = hit.has(i)
+    if (isHit !== runIsHit) {
+      flush(i)
+      runIsHit = isHit
+    }
+    run += text[i]
+  }
+  flush(text.length)
+
+  return <>{segments}</>
+}

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
@@ -158,4 +158,38 @@ describe('SkillMentionPopup', () => {
     act(() => third.click())
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'imp' }))
   })
+
+  it('ranks a name match above a description-only match', () => {
+    act(() => {
+      root.render(<SkillMentionPopup query="literature" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    // "literature" hits Literature Review by name and Imported Helper only by description.
+    const rendered = options()
+    expect(rendered).toHaveLength(2)
+    expect(rendered[0].textContent).toContain('Literature Review')
+    expect(rendered[1].textContent).toContain('Imported Helper')
+  })
+
+  it('matches a fuzzy subsequence that a plain substring would miss', () => {
+    act(() => {
+      root.render(<SkillMentionPopup query="pmpnn" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    // "pmpnn" is not a substring of "ProteinMPNN" but is an ordered subsequence of it.
+    const rendered = options()
+    expect(rendered).toHaveLength(1)
+    expect(rendered[0].textContent).toContain('ProteinMPNN')
+  })
+
+  it('highlights the matched characters in the name', () => {
+    act(() => {
+      root.render(<SkillMentionPopup query="lit" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    // The name match renders the matched run inside a <mark>; description-only matches do not.
+    const marks = Array.from(document.body.querySelectorAll('mark'))
+    expect(marks).toHaveLength(1)
+    expect(marks[0].textContent?.toLowerCase()).toBe('lit')
+  })
 })

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
@@ -3,6 +3,15 @@ import { useEffect, useId, useMemo, useState } from 'react'
 import type { SkillSource, SkillView } from '../../../../../shared/settings'
 import { useSettingsStore } from '@/stores/settings-store'
 
+import { fuzzyScore } from './fuzzy-match'
+import { HighlightedText } from './HighlightedText'
+
+// A skill plus the name-match positions to highlight (empty when it matched on description only).
+type SkillMatch = { skill: SkillView; positions: number[] }
+
+// Name matches always outrank description-only matches, regardless of raw fuzzy score.
+const NAME_WEIGHT = 100
+
 // Popup that suggests skills for the composer's `/` mention trigger. The composer keeps focus in its
 // editor, so this listens for navigation keys on document while mounted rather than owning focus.
 type SkillMentionPopupProps = {
@@ -33,16 +42,29 @@ export const SkillMentionPopup = ({
     if (skills.length === 0) void loadSkills()
   }, [skills.length, loadSkills])
 
-  // Case-insensitive match of the query against name or description; empty query shows every skill.
-  const matches = useMemo(() => {
-    const needle = query.trim().toLowerCase()
-    if (needle.length === 0) return skills
+  // Rank the query best-first: fuzzy subsequence against the name (so "cg" finds "clinical-genomics"),
+  // falling back to a plain substring in the description. Names always outrank description-only hits;
+  // descriptions stay a contiguous "contains" test since scattered matches across prose are noise.
+  // Empty query shows every skill in its original order.
+  const matches = useMemo<SkillMatch[]>(() => {
+    const needle = query.trim()
+    if (needle.length === 0) return skills.map((skill) => ({ skill, positions: [] }))
 
-    return skills.filter(
-      (skill) =>
-        skill.name.toLowerCase().includes(needle) ||
-        skill.description.toLowerCase().includes(needle)
-    )
+    const descNeedle = needle.toLowerCase()
+    return skills
+      .map((skill) => {
+        const nameMatch = fuzzyScore(needle, skill.name)
+        if (nameMatch) {
+          return { skill, score: nameMatch.score + NAME_WEIGHT, positions: nameMatch.positions }
+        }
+        if (skill.description.toLowerCase().includes(descNeedle)) {
+          return { skill, score: 0, positions: [] }
+        }
+        return null
+      })
+      .filter((m): m is SkillMatch & { score: number } => m !== null)
+      .sort((a, b) => b.score - a.score)
+      .map(({ skill, positions }) => ({ skill, positions }))
   }, [skills, query])
 
   const [activeIndex, setActiveIndex] = useState(0)
@@ -71,7 +93,7 @@ export const SkillMentionPopup = ({
         const active = matches[safeIndex]
         if (active) {
           event.preventDefault()
-          onSelect(active)
+          onSelect(active.skill)
         }
       } else if (event.key === 'Escape') {
         event.preventDefault()
@@ -91,7 +113,7 @@ export const SkillMentionPopup = ({
         aria-label="Skill suggestions"
         className="overflow-y-auto max-h-[min(45vh,18rem)]"
       >
-        {matches.map((skill, index) => {
+        {matches.map(({ skill, positions }, index) => {
           const isActive = index === safeIndex
           return (
             <li
@@ -109,7 +131,9 @@ export const SkillMentionPopup = ({
             >
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
-                  <span className="truncate font-medium text-sm">{skill.name}</span>
+                  <span className="truncate font-medium text-sm">
+                    <HighlightedText text={skill.name} positions={positions} />
+                  </span>
                   <div className="flex-1" />
                   <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent text-accent-foreground">
                     {SOURCE_LABELS[skill.source]}

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
@@ -9,8 +9,10 @@ import { HighlightedText } from './HighlightedText'
 // A skill plus the name-match positions to highlight (empty when it matched on description only).
 type SkillMatch = { skill: SkillView; positions: number[] }
 
-// Name matches always outrank description-only matches, regardless of raw fuzzy score.
-const NAME_WEIGHT = 100
+// Match tiers: any name hit ranks strictly above any description-only hit, decided before score.
+// A tier (not an additive weight) is required because a long, gappy fuzzy name score can go negative.
+const TIER_NAME = 1
+const TIER_DESCRIPTION = 0
 
 // Popup that suggests skills for the composer's `/` mention trigger. The composer keeps focus in its
 // editor, so this listens for navigation keys on document while mounted rather than owning focus.
@@ -51,20 +53,28 @@ export const SkillMentionPopup = ({
     if (needle.length === 0) return skills.map((skill) => ({ skill, positions: [] }))
 
     const descNeedle = needle.toLowerCase()
-    return skills
-      .map((skill) => {
-        const nameMatch = fuzzyScore(needle, skill.name)
-        if (nameMatch) {
-          return { skill, score: nameMatch.score + NAME_WEIGHT, positions: nameMatch.positions }
-        }
-        if (skill.description.toLowerCase().includes(descNeedle)) {
-          return { skill, score: 0, positions: [] }
-        }
-        return null
-      })
-      .filter((m): m is SkillMatch & { score: number } => m !== null)
-      .sort((a, b) => b.score - a.score)
-      .map(({ skill, positions }) => ({ skill, positions }))
+    return (
+      skills
+        .map((skill) => {
+          const nameMatch = fuzzyScore(needle, skill.name)
+          if (nameMatch) {
+            return {
+              skill,
+              tier: TIER_NAME,
+              score: nameMatch.score,
+              positions: nameMatch.positions
+            }
+          }
+          if (skill.description.toLowerCase().includes(descNeedle)) {
+            return { skill, tier: TIER_DESCRIPTION, score: 0, positions: [] }
+          }
+          return null
+        })
+        .filter((m): m is SkillMatch & { tier: number; score: number } => m !== null)
+        // Tier first (name always beats description-only), then fuzzy score within a tier.
+        .sort((a, b) => b.tier - a.tier || b.score - a.score)
+        .map(({ skill, positions }) => ({ skill, positions }))
+    )
   }, [skills, query])
 
   const [activeIndex, setActiveIndex] = useState(0)

--- a/src/renderer/src/pages/workspace/composer/fuzzy-match.test.ts
+++ b/src/renderer/src/pages/workspace/composer/fuzzy-match.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { fuzzyScore } from './fuzzy-match'
+
+// Convenience: rank candidates best-first, dropping non-matches, like the popups do.
+const rank = (query: string, candidates: string[]): string[] =>
+  candidates
+    .map((c) => ({ c, m: fuzzyScore(query, c) }))
+    .filter((x): x is { c: string; m: NonNullable<ReturnType<typeof fuzzyScore>> } => x.m !== null)
+    .sort((a, b) => b.m.score - a.m.score)
+    .map((x) => x.c)
+
+describe('fuzzyScore', () => {
+  it('matches an empty query against anything with a neutral score', () => {
+    expect(fuzzyScore('', 'anything')).toEqual({ score: 0, positions: [] })
+  })
+
+  it('is case-insensitive', () => {
+    expect(fuzzyScore('LIT', 'Literature Review')).not.toBeNull()
+    expect(fuzzyScore('lit', 'Literature Review')?.positions).toEqual([0, 1, 2])
+  })
+
+  it('returns null when the query is not an ordered subsequence', () => {
+    expect(fuzzyScore('zz', 'Literature Review')).toBeNull()
+    // Right chars, wrong order.
+    expect(fuzzyScore('tl', 'Literature')).toBeNull()
+  })
+
+  it('matches a non-contiguous subsequence and reports its positions', () => {
+    // "cg" -> the two word-initial letters of "clinical-genomics".
+    const m = fuzzyScore('cg', 'clinical-genomics')
+    expect(m).not.toBeNull()
+    expect(m?.positions).toEqual([0, 9])
+  })
+
+  it('ranks a prefix match above a later word-boundary match', () => {
+    expect(rank('report', ['report.pdf', 'final-report.pdf'])).toEqual([
+      'report.pdf',
+      'final-report.pdf'
+    ])
+  })
+
+  it('drops candidates that are only a partial subsequence', () => {
+    // "pro" is not a subsequence of "Imported Helper": no "o" follows the "r".
+    expect(fuzzyScore('pro', 'Imported Helper')).toBeNull()
+    expect(fuzzyScore('pro', 'ProteinMPNN')).not.toBeNull()
+  })
+
+  it('ranks contiguous matches above scattered ones', () => {
+    const contiguous = fuzzyScore('genom', 'genomics')!
+    const scattered = fuzzyScore('genom', 'gene-normalized-omics-map')!
+    expect(contiguous.score).toBeGreaterThan(scattered.score)
+  })
+
+  it('rewards camelCase word boundaries', () => {
+    // "mpnn" aligns to the "MPNN" hump.
+    const m = fuzzyScore('mpnn', 'ProteinMPNN')
+    expect(m).not.toBeNull()
+    expect(m?.positions).toEqual([7, 8, 9, 10])
+  })
+})

--- a/src/renderer/src/pages/workspace/composer/fuzzy-match.ts
+++ b/src/renderer/src/pages/workspace/composer/fuzzy-match.ts
@@ -1,0 +1,64 @@
+// Shared fuzzy matcher for the composer's `/` and `@` mention popups. The old popups filtered with a
+// plain case-insensitive substring test and kept the source order, so "cg" never found "clinical-
+// genomics" and closer matches never floated to the top. This does an ordered subsequence match with
+// relevance scoring: contiguous runs, word-boundary hits (separators and camelCase humps), and an
+// early first match all score higher, and gaps are penalized.
+
+export type FuzzyMatch = { score: number; positions: number[] }
+
+// Separators that begin a new word. Backslash included for path-like artifact names.
+const SEPARATOR = /[\s\-_/.\\]/
+
+// Whether target[i] starts a new "word": string start, right after a separator, or a camelCase hump.
+const isBoundary = (target: string, i: number): boolean => {
+  if (i === 0) return true
+  const prev = target[i - 1]
+  if (SEPARATOR.test(prev)) return true
+  const cur = target[i]
+  return prev === prev.toLowerCase() && cur !== cur.toLowerCase() && cur === cur.toUpperCase()
+}
+
+const BASE = 1 // per matched char
+const BOUNDARY_BONUS = 8 // match lands on a word boundary
+const PREFIX_BONUS = 4 // match lands on the very first char
+const CONSECUTIVE_BONUS = 5 // match is adjacent to the previous match
+const MAX_GAP_PENALTY = 3 // cap on how much a single gap can cost
+
+// Score `query` against `target`, or return null when `query` is not an ordered subsequence of it. An
+// empty query matches everything with a neutral score. Matching is case-insensitive; boundary
+// detection uses the original casing so camelCase humps still count. Positions index into `target`.
+export const fuzzyScore = (query: string, target: string): FuzzyMatch | null => {
+  if (query.length === 0) return { score: 0, positions: [] }
+
+  const q = query.toLowerCase()
+  const t = target.toLowerCase()
+
+  // Leftmost-greedy subsequence scan — complete for "is subsequence" and stable to score.
+  const positions: number[] = []
+  let cursor = 0
+  for (let qi = 0; qi < q.length; qi++) {
+    const next = t.indexOf(q[qi], cursor)
+    if (next === -1) return null
+    positions.push(next)
+    cursor = next + 1
+  }
+
+  let score = 0
+  for (let k = 0; k < positions.length; k++) {
+    const pos = positions[k]
+    score += BASE
+    if (isBoundary(target, pos)) score += BOUNDARY_BONUS
+    if (pos === 0) score += PREFIX_BONUS
+    if (k === 0) {
+      score -= Math.min(pos, MAX_GAP_PENALTY) // penalize how far in the first match sits
+    } else {
+      const gap = pos - positions[k - 1] - 1
+      if (gap === 0) score += CONSECUTIVE_BONUS
+      else score -= Math.min(gap, MAX_GAP_PENALTY)
+    }
+  }
+
+  // Nudge tighter targets above sprawling ones when scores otherwise tie.
+  score += Math.max(0, 8 - target.length / 8)
+  return { score, positions }
+}


### PR DESCRIPTION
## Summary

The composer's `/` (skills) and `@` (artifacts) mention popups filtered with a plain case-insensitive `.includes()` substring test and kept the source order, so abbreviations like `cg` never found `clinical-genomics` and closer matches never rose to the top. This replaces that with a shared fuzzy matcher and relevance ranking.

- **New `composer/fuzzy-match.ts`** — `fuzzyScore(query, target)` returns `{ score, positions }` or `null`. Leftmost-greedy ordered subsequence match with bonuses for contiguous runs, word boundaries (separators and camelCase humps, so `mpnn` aligns to `ProteinMPNN`), and an early first match; gaps are penalized.
- **New `composer/HighlightedText.tsx`** — underlines the matched characters in each row so the ranking is legible.
- **`SkillMentionPopup.tsx`** — name uses fuzzy matching (name hits weighted above everything); description stays a contiguous substring fallback ranked below any name match, since scattered subsequence matches across prose descriptions are noise.
- **`ArtifactMentionPopup.tsx`** — filenames use fuzzy matching, ranked *within* each section so uploads still render before outputs (the flat keyboard-highlight index depends on that order).

## Tested

- `fuzzyScore` logic verified directly: empty query, non-match, wrong-order rejection, `cg` → `clinical-genomics`, camelCase `mpnn` → `ProteinMPNN`, prefix-over-boundary ranking, contiguous-over-scattered ranking.
- Existing `SkillMentionPopup` / `ArtifactMentionPopup` render-test expectations preserved (e.g. `lit` still matches Literature Review by name and Imported Helper by description, not ProteinMPNN).
- Prettier `--check` clean on all changed files.

## Notes

- The full `npm run typecheck && npm run lint && npm test` suite could not be executed in the dev sandbox (dev toolchain packages were unavailable locally); CI is the first full run. Manual type review of both components was done.
- Skill descriptions are intentionally a substring fallback rather than fuzzy, to avoid noise (e.g. `lit` matching `ProteinMPNN` via scattered chars in its description).