### PR TITLE
feat(skills): make nested-bundle skill import resilient

### DIFF
--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -40,7 +40,8 @@ type FakeSettingsService = Record<
   | 'setSkillEnabled'
   | 'createSkill'
   | 'updateSkill'
-  | 'deleteSkill',
+  | 'deleteSkill'
+  | 'importSkillZipBatch',
   ReturnType<typeof vi.fn>
 >
 
@@ -83,7 +84,8 @@ const createFakeService = (): FakeSettingsService => ({
   setSkillEnabled: vi.fn().mockResolvedValue([]),
   createSkill: vi.fn().mockResolvedValue([]),
   updateSkill: vi.fn().mockResolvedValue([]),
-  deleteSkill: vi.fn().mockResolvedValue([])
+  deleteSkill: vi.fn().mockResolvedValue([]),
+  importSkillZipBatch: vi.fn().mockResolvedValue({ results: [], skills: [] })
 })
 
 // Adapts the spy bag into the SettingsService shape the registration function expects.
@@ -266,6 +268,27 @@ describe('settings IPC handlers', () => {
     expect(service.deleteSkill).toHaveBeenCalledWith({ id: 'personal-s' })
 
     expect(onSkillsChanged).toHaveBeenCalledTimes(3)
+  })
+
+  it('routes import-skill-zip-batch to the service, forwards its result, and fires onSkillsChanged', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const onSkillsChanged = vi.fn()
+    const result = {
+      results: [{ subPath: 'a', status: 'imported' as const, id: 'imported-a' }],
+      skills: []
+    }
+    service.importSkillZipBatch.mockResolvedValue(result)
+    registerSettingsIpcHandlers({ service: asService(service), onSkillsChanged })
+
+    expect(handlers.has('settings:import-skill-zip-batch')).toBe(true)
+
+    const request = { dataBase64: 'YmFzZTY0', items: [{ subPath: 'a' }] }
+    const forwarded = await invoke('settings:import-skill-zip-batch', request)
+
+    expect(service.importSkillZipBatch).toHaveBeenCalledWith(request)
+    expect(forwarded).toBe(result)
+    expect(onSkillsChanged).toHaveBeenCalledTimes(1)
   })
 
   it('registers the OpenCode / framework-switch channels', () => {

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -6,6 +6,7 @@ import type {
   DeleteSkillRequest,
   ImportSkillRequest,
   ImportSkillZipRequest,
+  ImportSkillZipBatchRequest,
   PreviewSkillZipRequest,
   ScanRepoRequest,
   InstallClaudeRequest,
@@ -181,6 +182,14 @@ const registerSettingsIpcHandlers = ({
     onSkillsChanged?.()
     return result
   })
+  ipcMain.handle(
+    'settings:import-skill-zip-batch',
+    async (_event, request: ImportSkillZipBatchRequest) => {
+      const result = await service.importSkillZipBatch(request)
+      onSkillsChanged?.()
+      return result
+    }
+  )
   ipcMain.handle('settings:preview-skill-zip', (_event, request: PreviewSkillZipRequest) =>
     service.previewSkillZip(request)
   )

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -438,11 +438,12 @@ class SettingsService {
   ): Promise<ImportSkillZipBatchResult> {
     const zip = decodeBoundedBase64(request.dataBase64, SKILL_IMPORT_LIMITS.maxBundleBytes)
     const outcomes = await this.userSkills.importFromZipBatch(zip, request.items)
-    // On failure the renderer keys off `error`; `status` is a required-field placeholder ignored then.
-    const results = outcomes.map((entry) =>
+    // Success and failure are mutually exclusive: a succeeded item carries status+id, a failed one
+    // carries only error (never a placeholder status).
+    const results: ImportSkillZipBatchResult['results'] = outcomes.map((entry) =>
       entry.outcome
         ? { subPath: entry.subPath, status: entry.outcome.status, id: entry.outcome.id }
-        : { subPath: entry.subPath, status: 'imported' as const, error: entry.error }
+        : { subPath: entry.subPath, error: entry.error ?? 'Import failed.' }
     )
     return { results, skills: await this.listSkills() }
   }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -41,8 +41,10 @@ import type {
   ImportSkillRequest,
   ImportSkillResult,
   ImportSkillZipRequest,
+  ImportSkillZipBatchRequest,
+  ImportSkillZipBatchResult,
   PreviewSkillZipRequest,
-  SkillBundlePreview,
+  SkillBundlePreviewResult,
   ScanRepoRequest,
   ScanRepoResult,
   UpdateSkillRequest,
@@ -108,7 +110,7 @@ import { getConnectorTools } from '../connectors/registry'
 import { renderConnectorInstructions } from '../connectors/skill-doc'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { UserSkillRepository } from '../skills/user-skill-repository'
-import { decodeBoundedBase64 } from '../skills/import-limits'
+import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limits'
 import { readSkillFile } from '../skills/skill-files'
 import type {
   StoredConnectors,
@@ -416,9 +418,11 @@ class SettingsService {
     return { status: outcome.status, id: outcome.id, skills: await this.listSkills() }
   }
 
-  // Imports a skill from an uploaded .zip / .skill bundle, returning the outcome + refreshed list.
+  // Imports a skill from an uploaded .zip / .skill bundle, returning the outcome + refreshed list. The
+  // decode is bounded by the (larger) whole-bundle cap since one upload may carry many skills.
   async importSkillZip(request: ImportSkillZipRequest): Promise<ImportSkillResult> {
-    const outcome = await this.userSkills.importFromZip(decodeBoundedBase64(request.dataBase64), {
+    const zip = decodeBoundedBase64(request.dataBase64, SKILL_IMPORT_LIMITS.maxBundleBytes)
+    const outcome = await this.userSkills.importFromZip(zip, {
       subPath: request.subPath,
       replaceId: request.replaceId
     })
@@ -426,10 +430,29 @@ class SettingsService {
     return { status: outcome.status, id: outcome.id, skills: await this.listSkills() }
   }
 
+  // Imports several skills from ONE uploaded bundle in a single call (the bundle is decoded and
+  // unpacked once). Per-item failures are reported without aborting the rest; the refreshed list is
+  // returned once at the end.
+  async importSkillZipBatch(
+    request: ImportSkillZipBatchRequest
+  ): Promise<ImportSkillZipBatchResult> {
+    const zip = decodeBoundedBase64(request.dataBase64, SKILL_IMPORT_LIMITS.maxBundleBytes)
+    const outcomes = await this.userSkills.importFromZipBatch(zip, request.items)
+    // On failure the renderer keys off `error`; `status` is a required-field placeholder ignored then.
+    const results = outcomes.map((entry) =>
+      entry.outcome
+        ? { subPath: entry.subPath, status: entry.outcome.status, id: entry.outcome.id }
+        : { subPath: entry.subPath, status: 'imported' as const, error: entry.error }
+    )
+    return { results, skills: await this.listSkills() }
+  }
+
   // Parses an uploaded bundle for a confirm-before-import preview, without writing anything. Returns
-  // one preview per skill root the bundle contains.
-  async previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreview[]> {
-    return this.userSkills.previewZip(decodeBoundedBase64(request.dataBase64))
+  // the importable skills plus any the bundle contained that were skipped (too large, no SKILL.md, ...).
+  async previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreviewResult> {
+    return this.userSkills.previewZip(
+      decodeBoundedBase64(request.dataBase64, SKILL_IMPORT_LIMITS.maxBundleBytes)
+    )
   }
 
   // Scans a GitHub repo for importable skill directories (marking already-imported ones).

--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { SKILL_IMPORT_LIMITS } from './import-limits'
 import {
   parseGitHubSkillUrl,
   parseGitHubRepo,
@@ -7,6 +8,11 @@ import {
   scanRepoForSkills,
   type FetchLike
 } from './github-import'
+
+// Per-file / total caps the download guards enforce; tests derive sizes from these so they track the
+// configured limits instead of hard-coded numbers.
+const OVER_FILE = SKILL_IMPORT_LIMITS.maxFileBytes + 1
+const AT_FILE = SKILL_IMPORT_LIMITS.maxFileBytes
 
 describe('parseGitHubSkillUrl', () => {
   it('parses tree URLs into owner/repo/ref/path', () => {
@@ -97,8 +103,8 @@ describe('fetchSkillFiles', () => {
   })
 
   it('rejects a file larger than the per-file limit (post-download guard)', async () => {
-    // A 6 MiB body with no Content-Length header falls through to the post-download size guard
-    // (SKILL_IMPORT_LIMITS.maxFileBytes is 5 MiB).
+    // A body one byte over the per-file cap with no Content-Length header falls through to the
+    // post-download size guard.
     const oversized: FetchLike = async (url) => {
       if (url.includes('/contents/')) {
         return {
@@ -119,7 +125,7 @@ describe('fetchSkillFiles', () => {
         ok: true,
         status: 200,
         json: async () => ({}),
-        arrayBuffer: async () => new ArrayBuffer(6 * 1024 * 1024)
+        arrayBuffer: async () => new ArrayBuffer(OVER_FILE)
       }
     }
 
@@ -129,7 +135,8 @@ describe('fetchSkillFiles', () => {
   })
 
   it('rejects an oversized file on Content-Length before buffering the body', async () => {
-    // The download advertises 6 MiB via Content-Length; the guard must fire before arrayBuffer() runs.
+    // The download advertises an over-cap size via Content-Length; the guard must fire before
+    // arrayBuffer() runs.
     let bodyRead = false
     const preCheck: FetchLike = async (url) => {
       if (url.includes('/contents/')) {
@@ -152,11 +159,11 @@ describe('fetchSkillFiles', () => {
         status: 200,
         json: async () => ({}),
         headers: {
-          get: (name) => (name.toLowerCase() === 'content-length' ? `${6 * 1024 * 1024}` : null)
+          get: (name) => (name.toLowerCase() === 'content-length' ? `${OVER_FILE}` : null)
         },
         arrayBuffer: async () => {
           bodyRead = true
-          return new ArrayBuffer(6 * 1024 * 1024)
+          return new ArrayBuffer(0)
         }
       }
     }
@@ -168,10 +175,10 @@ describe('fetchSkillFiles', () => {
   })
 
   it('rejects on the aggregate budget via Content-Length before reading the over-budget body', async () => {
-    // Three files each declaring 4 MiB. The total cap is 10 MiB, so the third pushes the aggregate to
-    // 12 MiB and must be rejected on its Content-Length — before its body is ever read.
+    // Three files each declaring one per-file cap's worth. Two fit the total cap; the third pushes the
+    // aggregate over it and must be rejected on its Content-Length — before its body is ever read.
     const bodiesRead: string[] = []
-    const size = 4 * 1024 * 1024
+    const size = AT_FILE
     const aggregate: FetchLike = async (url) => {
       if (url.includes('/contents/')) {
         return {
@@ -205,13 +212,14 @@ describe('fetchSkillFiles', () => {
     await expect(
       fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, aggregate)
     ).rejects.toThrow(/total limit/)
-    // First two bodies read (8 MiB), the third rejected before its body was touched.
+    // First two bodies read, the third rejected before its body was touched.
     expect(bodiesRead).toEqual(['https://raw/a', 'https://raw/b'])
   })
 
-  it('accepts files sitting exactly on the per-file and total limits', async () => {
-    // Two 5 MiB files == the 5 MiB per-file cap each and 10 MiB total exactly. Both must be accepted.
-    const size = 5 * 1024 * 1024
+  it('accepts files sitting exactly on the per-file cap', async () => {
+    // Two files each exactly at the per-file cap (and within the total cap). Both must be accepted —
+    // a file at the cap is allowed, only one over it is rejected.
+    const size = AT_FILE
     const exact: FetchLike = async (url) => {
       if (url.includes('/contents/')) {
         return {
@@ -248,7 +256,8 @@ describe('fetchSkillFiles', () => {
 
   it('bounds a streamed body with no Content-Length, stopping once the cap is passed', async () => {
     // A body that streams 1 MiB chunks with no Content-Length. Reading must abort once it crosses the
-    // 5 MiB per-file cap instead of draining the whole (here effectively endless) stream.
+    // per-file cap instead of draining the whole (here effectively endless) stream.
+    const capMiB = Math.ceil(SKILL_IMPORT_LIMITS.maxFileBytes / (1024 * 1024))
     let chunksServed = 0
     let cancelled = false
     const chunk = new Uint8Array(1024 * 1024)
@@ -290,8 +299,8 @@ describe('fetchSkillFiles', () => {
     await expect(
       fetchSkillFiles({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, streaming)
     ).rejects.toThrow(/per-file limit/)
-    // Stopped a hair past the 5 MiB cap (6 one-MiB reads), not the whole endless stream, and cancelled.
-    expect(chunksServed).toBeLessThanOrEqual(7)
+    // Stopped a hair past the cap, not the whole endless stream, and cancelled.
+    expect(chunksServed).toBeLessThanOrEqual(capMiB + 2)
     expect(cancelled).toBe(true)
   })
 
@@ -382,8 +391,8 @@ describe('fetchSkillFiles', () => {
   })
 
   it('reads a streamed body that finishes under the cap and returns its exact bytes', async () => {
-    // A finite streamed body (3 MiB in 1 MiB chunks, no Content-Length) under the 5 MiB per-file cap
-    // must be accepted and reassembled intact.
+    // A finite streamed body (3 MiB in 1 MiB chunks, no Content-Length) under the per-file cap must be
+    // accepted and reassembled intact.
     const chunk = new Uint8Array(1024 * 1024).fill(7)
     const finite: FetchLike = async (url) => {
       if (url.includes('/contents/')) {

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -523,7 +523,7 @@ describe('UserSkillRepository', () => {
     expect(skipped).toEqual([])
     expect(previews.map((p) => p.name)).toEqual(['Alpha', 'Beta'])
     // Each inner root's subPath is namespaced by the archive base name (+ inner dir).
-    expect(previews.map((p) => p.subPath)).toEqual(['alpha-111/alpha', 'beta-222/beta'])
+    expect(previews.map((p) => p.subPath)).toEqual(['alpha-111.zip/alpha', 'beta-222.zip/beta'])
   })
 
   it('namespaces a root-level SKILL.md inside a nested archive by the archive name alone', async () => {
@@ -534,7 +534,7 @@ describe('UserSkillRepository', () => {
     const outer = buildZip([{ path: 'gamma-333.zip', content: inner }])
 
     const { previews } = await repo.previewZip(outer)
-    expect(previews).toEqual([expect.objectContaining({ name: 'Gamma', subPath: 'gamma-333' })])
+    expect(previews).toEqual([expect.objectContaining({ name: 'Gamma', subPath: 'gamma-333.zip' })])
   })
 
   it('keeps the good nested skills and skips a nested archive with no SKILL.md', async () => {
@@ -585,12 +585,59 @@ describe('UserSkillRepository', () => {
     const outer = buildZip([{ path: 'alpha-111.zip', content: innerBundle('Alpha') }])
 
     const results = await repo.importFromZipBatch(outer, [
-      { subPath: 'alpha-111/alpha' },
+      { subPath: 'alpha-111.zip/alpha' },
       { subPath: 'does/not/exist' }
     ])
     expect(results[0].outcome?.status).toBe('imported')
     expect(results[1].error).toMatch(/no skill at/)
     expect((await repo.list()).map((s) => s.name)).toEqual(['Alpha'])
+  })
+
+  it('skips a loose single-skill root whose file exceeds the per-skill cap', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    // 6 MiB file: within the bundle-wide walk cap but over the 5 MiB per-skill file cap.
+    const zip = buildZip([
+      { path: 'SKILL.md', content: Buffer.from('---\nname: Big\ndescription: d\n---\nx') },
+      { path: 'blob.bin', content: Buffer.alloc(6 * 1024 * 1024, 7) }
+    ])
+
+    const { previews, skipped } = await repo.previewZip(zip)
+    expect(previews).toHaveLength(0)
+    expect(skipped[0].reason).toMatch(/over 5 MB/)
+  })
+
+  it('skips a loose root whose oversized file the lenient walk dropped (no partial import)', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    // 9 MiB file exceeds the nested-archive/entry cap, so the outer walk drops it; the root that owns
+    // it must be skipped rather than imported without it.
+    const zip = buildZip([
+      { path: 'pack/SKILL.md', content: Buffer.from('---\nname: Pack\ndescription: d\n---\nx') },
+      { path: 'pack/huge.bin', content: Buffer.alloc(9 * 1024 * 1024, 7) }
+    ])
+
+    const { previews, skipped } = await repo.previewZip(zip)
+    expect(previews).toHaveLength(0)
+    expect(skipped.some((s) => s.source === 'pack' && /too large/.test(s.reason))).toBe(true)
+  })
+
+  it('does not alias a loose dir and a nested archive that share a stem', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const nested = buildZip([
+      { path: 'SKILL.md', content: Buffer.from('---\nname: FromArchive\ndescription: d\n---\ny') }
+    ])
+    const outer = buildZip([
+      {
+        path: 'alpha/SKILL.md',
+        content: Buffer.from('---\nname: FromDir\ndescription: d\n---\nx')
+      },
+      { path: 'alpha.zip', content: nested }
+    ])
+
+    const { previews } = await repo.previewZip(outer)
+    // Both skills survive under distinct subPaths — selecting one can't import the other.
+    expect(previews.map((p) => p.subPath)).toEqual(['alpha', 'alpha.zip'])
+    expect(previews.map((p) => p.name).sort()).toEqual(['FromArchive', 'FromDir'])
+    expect(new Set(previews.map((p) => p.subPath)).size).toBe(2)
   })
 
   it('parses a CRLF-authored SKILL.md the same on preview and import', async () => {

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -13,6 +13,7 @@ import {
   frontmatterBlock
 } from './user-skill-repository'
 import { parseFrontmatter } from './frontmatter'
+import { SKILL_IMPORT_LIMITS } from './import-limits'
 import type { FetchLike } from './github-import'
 
 const makeStorage = async (): Promise<string> => mkdtemp(join(tmpdir(), 'user-skills-'))
@@ -593,31 +594,39 @@ describe('UserSkillRepository', () => {
     expect((await repo.list()).map((s) => s.name)).toEqual(['Alpha'])
   })
 
-  it('skips a loose single-skill root whose file exceeds the per-skill cap', async () => {
+  it('skips a loose single-skill root that exceeds the per-skill file-count cap', async () => {
     const repo = new UserSkillRepository(await makeStorage())
-    // 6 MiB file: within the bundle-wide walk cap but over the 5 MiB per-skill file cap.
+    // A SKILL.md plus more loose files than the per-skill cap allows — within the bundle-wide walk
+    // caps, but over the per-skill file count, so the root is rejected rather than imported.
+    const extras = Array.from({ length: SKILL_IMPORT_LIMITS.maxFiles + 1 }, (_, i) => ({
+      path: `f${i}.txt`,
+      content: Buffer.from('x')
+    }))
     const zip = buildZip([
       { path: 'SKILL.md', content: Buffer.from('---\nname: Big\ndescription: d\n---\nx') },
-      { path: 'blob.bin', content: Buffer.alloc(6 * 1024 * 1024, 7) }
+      ...extras
     ])
 
     const { previews, skipped } = await repo.previewZip(zip)
     expect(previews).toHaveLength(0)
-    expect(skipped[0].reason).toMatch(/over 5 MB/)
+    expect(skipped[0].reason).toMatch(/more than \d+ files/)
   })
 
-  it('skips a loose root whose oversized file the lenient walk dropped (no partial import)', async () => {
+  it('skips a loose root whose file the lenient walk dropped (no partial import)', async () => {
     const repo = new UserSkillRepository(await makeStorage())
-    // 9 MiB file exceeds the nested-archive/entry cap, so the outer walk drops it; the root that owns
-    // it must be skipped rather than imported without it.
+    // A file nested past the depth cap is dropped by the outer walk; the root that owns it must be
+    // skipped rather than imported without it. (Depth is a cheap stand-in for any dropped-file cause.)
+    const tooDeep = `pack/${Array.from({ length: SKILL_IMPORT_LIMITS.maxDepth }, (_, i) => `d${i}`).join('/')}/x.txt`
     const zip = buildZip([
       { path: 'pack/SKILL.md', content: Buffer.from('---\nname: Pack\ndescription: d\n---\nx') },
-      { path: 'pack/huge.bin', content: Buffer.alloc(9 * 1024 * 1024, 7) }
+      { path: tooDeep, content: Buffer.from('deep') }
     ])
 
     const { previews, skipped } = await repo.previewZip(zip)
     expect(previews).toHaveLength(0)
-    expect(skipped.some((s) => s.source === 'pack' && /too large/.test(s.reason))).toBe(true)
+    expect(skipped.some((s) => s.source === 'pack' && /couldn't be imported/.test(s.reason))).toBe(
+      true
+    )
   })
 
   it('does not alias a loose dir and a nested archive that share a stem', async () => {

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -354,7 +354,8 @@ describe('UserSkillRepository', () => {
     const repo = new UserSkillRepository(await makeStorage())
     const zip = buildZip([{ path: 'readme.md', content: Buffer.from('nope') }])
     await expect(repo.importFromZip(zip)).rejects.toThrow(/SKILL\.md/)
-    await expect(repo.previewZip(zip)).rejects.toThrow(/SKILL\.md/)
+    // Preview no longer throws: it returns nothing importable so the UI can say "no skills found".
+    expect(await repo.previewZip(zip)).toEqual({ previews: [], skipped: [] })
   })
 
   it('discovers one root for a root-level SKILL.md (subPath "")', async () => {
@@ -364,7 +365,7 @@ describe('UserSkillRepository', () => {
       { path: 'run.py', content: Buffer.from('print(1)') }
     ])
 
-    const previews = await repo.previewZip(zip)
+    const { previews } = await repo.previewZip(zip)
     expect(previews).toHaveLength(1)
     expect(previews[0]).toMatchObject({ name: 'Root', subPath: '' })
     // Root files stay as-is (SKILL.md already at the root).
@@ -379,7 +380,7 @@ describe('UserSkillRepository', () => {
       { path: 'skill-b/SKILL.md', content: Buffer.from('---\nname: B\ndescription: d\n---\ny') }
     ])
 
-    const previews = await repo.previewZip(zip)
+    const { previews } = await repo.previewZip(zip)
     expect(previews.map((p) => p.subPath)).toEqual(['skill-a', 'skill-b'])
     // Each root's files are re-based so SKILL.md sits at its root.
     expect(previews[0].files).toEqual(['SKILL.md', 'run.py'].sort())
@@ -396,7 +397,7 @@ describe('UserSkillRepository', () => {
       { path: 'wrapper/skill-a/scripts/run.py', content: Buffer.from('a') }
     ])
 
-    const previews = await repo.previewZip(zip)
+    const { previews } = await repo.previewZip(zip)
     expect(previews).toHaveLength(1)
     expect(previews[0]).toMatchObject({ name: 'Wrapped', subPath: 'wrapper/skill-a' })
     expect(previews[0].files).toEqual(['SKILL.md', 'scripts/run.py'].sort())
@@ -409,7 +410,7 @@ describe('UserSkillRepository', () => {
       { path: 'a/b/SKILL.md', content: Buffer.from('---\nname: B\ndescription: d\n---\ny') }
     ])
 
-    const previews = await repo.previewZip(zip)
+    const { previews } = await repo.previewZip(zip)
     expect(previews.map((p) => p.subPath)).toEqual(['a'])
     // The nested SKILL.md is just a file of skill "a", re-based under it.
     expect(previews[0].files).toEqual(['SKILL.md', 'b/SKILL.md'].sort())
@@ -471,30 +472,125 @@ describe('UserSkillRepository', () => {
     ])
 
     const preview = await repo.previewZip(zip)
-    expect(preview).toEqual([
-      {
-        name: 'Bundled',
-        description: 'A test bundle.',
-        files: ['SKILL.md', 'scripts/run.py'],
-        alreadyImported: false,
-        replaceableId: undefined,
-        subPath: 'my-bundle'
-      }
-    ])
+    expect(preview).toEqual({
+      previews: [
+        {
+          name: 'Bundled',
+          description: 'A test bundle.',
+          files: ['SKILL.md', 'scripts/run.py'],
+          alreadyImported: false,
+          replaceableId: undefined,
+          subPath: 'my-bundle'
+        }
+      ],
+      skipped: []
+    })
     // Preview writes nothing.
     expect(await repo.list()).toHaveLength(0)
 
     // After importing, the same bundle previews as already imported.
     await repo.importFromZip(zip)
-    expect((await repo.previewZip(zip))[0].alreadyImported).toBe(true)
+    expect((await repo.previewZip(zip)).previews[0].alreadyImported).toBe(true)
   })
 
-  it('rejects a preview whose SKILL.md has no name', async () => {
+  it('skips a preview whose SKILL.md has no name (instead of failing the bundle)', async () => {
     const repo = new UserSkillRepository(await makeStorage())
     const zip = buildZip([
       { path: 'thing/SKILL.md', content: Buffer.from('---\ndescription: no name here\n---\nbody') }
     ])
-    await expect(repo.previewZip(zip)).rejects.toThrow(/needs a name/)
+    const { previews, skipped } = await repo.previewZip(zip)
+    expect(previews).toHaveLength(0)
+    expect(skipped).toEqual([{ source: 'thing', reason: 'SKILL.md has no name' }])
+  })
+
+  // A bundle of nested .zip bundles (one archive per skill) — the "export all my skills" shape.
+  const innerBundle = (name: string, dir = name.toLowerCase()): Buffer =>
+    buildZip([
+      {
+        path: `${dir}/SKILL.md`,
+        content: Buffer.from(`---\nname: ${name}\ndescription: d\n---\nbody`)
+      }
+    ])
+
+  it('discovers a skill in each nested .zip of a zip-of-zips, namespaced by archive name', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const outer = buildZip([
+      { path: 'alpha-111.zip', content: innerBundle('Alpha') },
+      { path: 'beta-222.zip', content: innerBundle('Beta') }
+    ])
+
+    const { previews, skipped } = await repo.previewZip(outer)
+    expect(skipped).toEqual([])
+    expect(previews.map((p) => p.name)).toEqual(['Alpha', 'Beta'])
+    // Each inner root's subPath is namespaced by the archive base name (+ inner dir).
+    expect(previews.map((p) => p.subPath)).toEqual(['alpha-111/alpha', 'beta-222/beta'])
+  })
+
+  it('namespaces a root-level SKILL.md inside a nested archive by the archive name alone', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const inner = buildZip([
+      { path: 'SKILL.md', content: Buffer.from('---\nname: Gamma\ndescription: d\n---\nx') }
+    ])
+    const outer = buildZip([{ path: 'gamma-333.zip', content: inner }])
+
+    const { previews } = await repo.previewZip(outer)
+    expect(previews).toEqual([expect.objectContaining({ name: 'Gamma', subPath: 'gamma-333' })])
+  })
+
+  it('keeps the good nested skills and skips a nested archive with no SKILL.md', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const junk = buildZip([{ path: 'readme.md', content: Buffer.from('nope') }])
+    const outer = buildZip([
+      { path: 'good.zip', content: innerBundle('Alpha') },
+      { path: 'bad.zip', content: junk }
+    ])
+
+    const { previews, skipped } = await repo.previewZip(outer)
+    expect(previews.map((p) => p.name)).toEqual(['Alpha'])
+    expect(skipped).toEqual([{ source: 'bad.zip', reason: 'no SKILL.md found' }])
+  })
+
+  it('skips a nested entry that is not a valid ZIP, importing the rest', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const outer = buildZip([
+      { path: 'good.zip', content: innerBundle('Alpha') },
+      { path: 'corrupt.zip', content: Buffer.from('not a zip at all') }
+    ])
+
+    const { previews, skipped } = await repo.previewZip(outer)
+    expect(previews.map((p) => p.name)).toEqual(['Alpha'])
+    expect(skipped.map((s) => s.source)).toEqual(['corrupt.zip'])
+    expect(skipped[0].reason).toMatch(/valid ZIP/i)
+  })
+
+  it('batch-imports every selected nested skill in one pass', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const outer = buildZip([
+      { path: 'alpha-111.zip', content: innerBundle('Alpha') },
+      { path: 'beta-222.zip', content: innerBundle('Beta') }
+    ])
+
+    const { previews } = await repo.previewZip(outer)
+    const results = await repo.importFromZipBatch(
+      outer,
+      previews.map((p) => ({ subPath: p.subPath }))
+    )
+    expect(results.map((r) => r.outcome?.status)).toEqual(['imported', 'imported'])
+    expect((await repo.list()).map((s) => s.name).sort()).toEqual(['Alpha', 'Beta'])
+  })
+
+  it('reports a per-item error in a batch without aborting the other items', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const outer = buildZip([{ path: 'alpha-111.zip', content: innerBundle('Alpha') }])
+
+    const results = await repo.importFromZipBatch(outer, [
+      { subPath: 'alpha-111/alpha' },
+      { subPath: 'does/not/exist' }
+    ])
+    expect(results[0].outcome?.status).toBe('imported')
+    expect(results[1].error).toMatch(/no skill at/)
+    expect((await repo.list()).map((s) => s.name)).toEqual(['Alpha'])
   })
 
   it('parses a CRLF-authored SKILL.md the same on preview and import', async () => {
@@ -505,7 +601,7 @@ describe('UserSkillRepository', () => {
     )
     const zip = buildZip([{ path: 'win/SKILL.md', content: Buffer.from(skill) }])
 
-    const [preview] = await repo.previewZip(zip)
+    const [preview] = (await repo.previewZip(zip)).previews
     expect(preview.name).toBe('Winreader')
     expect(preview.description).toBe('A CRLF bundle.')
 
@@ -527,12 +623,12 @@ describe('UserSkillRepository', () => {
     await repo.importFromZip(sharedBundle('v1'))
 
     // Same name, different content -> replaceable in place.
-    const [preview] = await repo.previewZip(sharedBundle('v2'))
+    const [preview] = (await repo.previewZip(sharedBundle('v2'))).previews
     expect(preview.alreadyImported).toBe(false)
     expect(preview.replaceableId).toBe('imported-shared')
 
     // The exact same bundle -> a no-op, so no replace is offered.
-    const [exact] = await repo.previewZip(sharedBundle('v1'))
+    const [exact] = (await repo.previewZip(sharedBundle('v1'))).previews
     expect(exact.alreadyImported).toBe(true)
     expect(exact.replaceableId).toBeUndefined()
   })
@@ -542,7 +638,7 @@ describe('UserSkillRepository', () => {
     await repo.importFromZip(sharedBundle('v1'))
     await repo.importFromZip(sharedBundle('v2')) // second "Shared" -> imported-shared-2
 
-    const [preview] = await repo.previewZip(sharedBundle('v3'))
+    const [preview] = (await repo.previewZip(sharedBundle('v3'))).previews
     expect(preview.replaceableId).toBeUndefined()
   })
 
@@ -1004,7 +1100,7 @@ describe('UserSkillRepository', () => {
 
     // previewZip must recover first, so the same bundle is correctly seen as already imported.
     const restarted = new UserSkillRepository(root)
-    expect((await restarted.previewZip(zip))[0].alreadyImported).toBe(true)
+    expect((await restarted.previewZip(zip)).previews[0].alreadyImported).toBe(true)
   })
 
   it('marks scanned candidates already imported by URL or by same name', async () => {

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -640,6 +640,38 @@ describe('UserSkillRepository', () => {
     expect(new Set(previews.map((p) => p.subPath)).size).toBe(2)
   })
 
+  it('folds a .zip living under a loose skill root into that skill, not a separate one', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const zip = buildZip([
+      { path: 'tool/SKILL.md', content: Buffer.from('---\nname: Tool\ndescription: d\n---\nx') },
+      { path: 'tool/references/data.zip', content: Buffer.from('opaque archive bytes') }
+    ])
+
+    const { previews, skipped } = await repo.previewZip(zip)
+    // One skill (Tool) that keeps its bundled archive as a resource — no spurious separate skill and
+    // no "no SKILL.md" skip for the inner archive.
+    expect(previews).toHaveLength(1)
+    expect(previews[0].name).toBe('Tool')
+    expect(previews[0].files).toContain('references/data.zip')
+    expect(skipped).toEqual([])
+  })
+
+  it('imports the bundled-archive resource to disk as part of the skill', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const zip = buildZip([
+      { path: 'tool/SKILL.md', content: Buffer.from('---\nname: Tool\ndescription: d\n---\nx') },
+      { path: 'tool/references/data.zip', content: Buffer.from('opaque archive bytes') }
+    ])
+
+    expect((await repo.importFromZip(zip)).status).toBe('imported')
+    const written = await readFile(
+      join(storage, 'skills', 'imported', 'tool', 'references', 'data.zip'),
+      'utf8'
+    )
+    expect(written).toBe('opaque archive bytes')
+  })
+
   it('parses a CRLF-authored SKILL.md the same on preview and import', async () => {
     const repo = new UserSkillRepository(await makeStorage())
     // A bundle authored on Windows: every line ends with \r\n.

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -629,6 +629,18 @@ describe('UserSkillRepository', () => {
     )
   })
 
+  it('skips a loose root whose unsafe path was dropped (no partial import)', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const zip = buildZip([
+      { path: 'tool/SKILL.md', content: Buffer.from('---\nname: Tool\ndescription: d\n---\nx') },
+      { path: 'tool/../evil.txt', content: Buffer.from('nope') }
+    ])
+
+    const { previews, skipped } = await repo.previewZip(zip)
+    expect(previews).toHaveLength(0)
+    expect(skipped.some((s) => s.source === 'tool' && /unsafe path/.test(s.reason))).toBe(true)
+  })
+
   it('does not alias a loose dir and a nested archive that share a stem', async () => {
     const repo = new UserSkillRepository(await makeStorage())
     const nested = buildZip([

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -218,13 +218,35 @@ const discoverSkillRoots = (zip: Buffer): SkillDiscovery => {
     roots.push({ subPath: unique, files: rootFiles })
   }
 
-  // Loose (non-archive) top-level files form ordinary roots — but they must still satisfy the per-skill
-  // caps, and a root whose content the lenient walk had to drop is rejected (importing it would produce
-  // a silently-partial skill).
-  const looseSkips = outerSkips.filter((entry) => !isNestedArchive(entry.path)).map((e) => e.path)
-  for (const root of findSkillRoots(files.filter((file) => !isNestedArchive(file.path)))) {
-    const prefix = root.subPath === '' ? '' : `${root.subPath}/`
-    if (looseSkips.some((path) => path === root.subPath || path.startsWith(prefix))) {
+  // Loose (non-archive) top-level files form ordinary roots. A SKILL.md is never an archive, so roots
+  // are discovered from the non-archive files.
+  const looseRoots = findSkillRoots(files.filter((file) => !isNestedArchive(file.path)))
+  const rootPrefixes = looseRoots.map((root) => ({
+    root,
+    prefix: root.subPath === '' ? '' : `${root.subPath}/`
+  }))
+
+  // A .zip/.skill that lives UNDER a discovered loose root is that skill's own resource (e.g.
+  // `tool/references/data.zip`), not a separate skill: fold it back in (re-based) so the root imports
+  // complete, and it counts toward that skill's per-skill caps. Every other archive is standalone.
+  const standaloneArchives: typeof files = []
+  for (const archive of files.filter((file) => isNestedArchive(file.path))) {
+    const owner = rootPrefixes.find(({ prefix }) => archive.path.startsWith(prefix))
+    if (owner) {
+      owner.root.files.push({
+        relativePath: archive.path.slice(owner.prefix.length),
+        content: archive.content
+      })
+    } else {
+      standaloneArchives.push(archive)
+    }
+  }
+
+  // Each loose root must satisfy the per-skill caps (the outer walk used bundle-wide caps), and a root
+  // any of whose files the lenient walk had to drop is rejected — importing it would produce a
+  // silently-partial skill.
+  for (const { root, prefix } of rootPrefixes) {
+    if (outerSkips.some((e) => e.path === root.subPath || e.path.startsWith(prefix))) {
       skipped.push({
         source: root.subPath || 'skill',
         reason: 'contains a file too large to import'
@@ -239,9 +261,9 @@ const discoverSkillRoots = (zip: Buffer): SkillDiscovery => {
     addRoot(root.subPath, root.files)
   }
 
-  // Each nested archive is its own bundle: unpack it under the strict per-skill caps (extractZip throws
-  // on any cap violation, so the whole inner skill is skipped, never partially imported).
-  for (const archive of files.filter((file) => isNestedArchive(file.path))) {
+  // Each standalone archive is its own bundle: unpack it under the strict per-skill caps (extractZip
+  // throws on any cap violation, so the whole inner skill is skipped, never partially imported).
+  for (const archive of standaloneArchives) {
     let innerRoots: SkillRoot[]
     try {
       innerRoots = findSkillRoots(extractZip(archive.content))

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -4,7 +4,14 @@ import { basename, dirname, join, resolve, sep } from 'node:path'
 
 import { dump as dumpYaml } from 'js-yaml'
 
-import type { SkillBundlePreview, SkillReference, SkillSource } from '../../shared/settings'
+import type {
+  SkillBundlePreview,
+  SkillBundlePreviewResult,
+  SkillReference,
+  SkillSource,
+  SkippedSkill
+} from '../../shared/settings'
+import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 import { createLogger } from '../logger'
 import {
   fetchSkillFiles,
@@ -18,7 +25,7 @@ import {
 import { parseFrontmatter } from './frontmatter'
 import type { BundledSkill } from './registry'
 import { readSkillFile } from './skill-files'
-import { extractZip } from './zip-extract'
+import { extractZip, extractZipLenient } from './zip-extract'
 
 const log = createLogger('skills')
 
@@ -148,6 +155,74 @@ const findSkillRoots = (entries: { path: string; content: Buffer }[]): SkillRoot
       return { subPath, files }
     })
     .sort((a, b) => a.subPath.localeCompare(b.subPath))
+}
+
+// True for an archive entry that is itself a skill bundle (a .zip / .skill nested inside the upload).
+const isNestedArchive = (path: string): boolean => /\.(zip|skill)$/i.test(path)
+
+// Strips the electron/main wrapper off an error so only the human-readable tail is shown as a reason.
+const reasonFromError = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.replace(/^(Error invoking remote method '[^']*': )?(Error: )?/, '') || 'unreadable'
+}
+
+// The outcome of scanning a bundle: the skill roots we can import, plus the ones we skipped and why.
+type SkillDiscovery = { roots: SkillRoot[]; skipped: SkippedSkill[] }
+
+// Discovers every importable skill in an uploaded bundle, resilient to individual failures. Direct
+// SKILL.md roots (a plain skill dir, or a bundle of sibling skill dirs) are found as before; any entry
+// that is itself a .zip/.skill is unpacked ONE level deeper and its root(s) surfaced under a
+// namespaced subPath (the archive's base name). An entry that's too large, unreadable, or holds no
+// SKILL.md is recorded as skipped rather than failing the whole bundle. Nesting beyond one archive
+// level is not followed (a nested archive's own nested archives are ignored), which also bounds
+// recursion. The outer walk is lenient so one bad entry never sinks the rest.
+const discoverSkillRoots = (zip: Buffer): SkillDiscovery => {
+  const skipped: SkippedSkill[] = []
+  const { files, skipped: outerSkips } = extractZipLenient(zip, {
+    maxFiles: SKILL_IMPORT_LIMITS.maxBundleEntries,
+    maxFileBytes: SKILL_IMPORT_LIMITS.maxSkillArchiveBytes,
+    maxTotalBytes: SKILL_IMPORT_LIMITS.maxBundleBytes,
+    maxDepth: SKILL_IMPORT_LIMITS.maxDepth
+  })
+  for (const entry of outerSkips) skipped.push({ source: entry.path, reason: entry.reason })
+
+  // Loose files at the outer level (everything that isn't a nested archive) form ordinary roots.
+  const roots = findSkillRoots(files.filter((file) => !isNestedArchive(file.path)))
+
+  // Each nested archive is its own bundle: unpack it under the strict per-skill caps and namespace its
+  // roots by the archive's base name, so preview and import derive the same stable subPath.
+  for (const archive of files.filter((file) => isNestedArchive(file.path))) {
+    let innerRoots: SkillRoot[]
+    try {
+      innerRoots = findSkillRoots(extractZip(archive.content))
+    } catch (error) {
+      skipped.push({ source: archive.path, reason: reasonFromError(error) })
+      continue
+    }
+    if (innerRoots.length === 0) {
+      skipped.push({ source: archive.path, reason: 'no SKILL.md found' })
+      continue
+    }
+    const prefix = archive.path.replace(/\.(zip|skill)$/i, '')
+    for (const root of innerRoots) {
+      roots.push({
+        subPath: root.subPath === '' ? prefix : `${prefix}/${root.subPath}`,
+        files: root.files
+      })
+    }
+  }
+
+  // Bound the candidate count so a pathological archive of tiny skills can't flood the checklist.
+  if (roots.length > SKILL_IMPORT_LIMITS.maxSkillsPerBundle) {
+    for (const dropped of roots.splice(SKILL_IMPORT_LIMITS.maxSkillsPerBundle)) {
+      skipped.push({
+        source: dropped.subPath || 'skill',
+        reason: `bundle has more than ${SKILL_IMPORT_LIMITS.maxSkillsPerBundle} skills`
+      })
+    }
+  }
+
+  return { roots: roots.sort((a, b) => a.subPath.localeCompare(b.subPath)), skipped }
 }
 
 // Reads and writes user-authored (personal) and imported skills under `<storageRoot>/skills/`.
@@ -408,9 +483,8 @@ class UserSkillRepository {
   // lists the files, flags whether the identical bundle was already imported, and — when its name
   // collides with exactly one existing imported skill of different content — offers that skill's id as
   // a replace target. Writes nothing.
-  async previewZip(zip: Buffer): Promise<SkillBundlePreview[]> {
-    const roots = findSkillRoots(extractZip(zip))
-    if (roots.length === 0) throw new Error('The bundle must contain a SKILL.md.')
+  async previewZip(zip: Buffer): Promise<SkillBundlePreviewResult> {
+    const { roots, skipped } = discoverSkillRoots(zip)
 
     // Recovery + all dedup reads run under the lock so the alreadyImported/replaceable computation
     // reflects a consistent, fully-recovered view of the imported dir.
@@ -418,28 +492,37 @@ class UserSkillRepository {
       await this.doRecoverImportedTransactions()
 
       const previews: SkillBundlePreview[] = []
+      // A root that can't be parsed into a valid preview (no name, bad frontmatter) is skipped with a
+      // reason instead of failing the whole bundle — so the importable skills still come through.
       for (const root of roots) {
-        const skillMd = root.files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
-        const { fields } = parseFrontmatter(skillMd.content.toString('utf8'))
-        const name = fields.name?.trim()
-        if (!name) throw new Error("The bundle's SKILL.md needs a name in its frontmatter.")
+        try {
+          const skillMd = root.files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
+          const { fields } = parseFrontmatter(skillMd.content.toString('utf8'))
+          const name = fields.name?.trim()
+          if (!name) {
+            skipped.push({ source: root.subPath || 'skill', reason: 'SKILL.md has no name' })
+            continue
+          }
 
-        const alreadyImported = Boolean(
-          await this.findImportedSlugBySignature(signatureOf(root.files))
-        )
-        const replaceableId = alreadyImported ? undefined : await this.replaceableImportedId(name)
+          const alreadyImported = Boolean(
+            await this.findImportedSlugBySignature(signatureOf(root.files))
+          )
+          const replaceableId = alreadyImported ? undefined : await this.replaceableImportedId(name)
 
-        previews.push({
-          name,
-          description: fields.description ?? '',
-          files: root.files.map((file) => file.relativePath).sort(),
-          alreadyImported,
-          replaceableId,
-          subPath: root.subPath
-        })
+          previews.push({
+            name,
+            description: fields.description ?? '',
+            files: root.files.map((file) => file.relativePath).sort(),
+            alreadyImported,
+            replaceableId,
+            subPath: root.subPath
+          })
+        } catch (error) {
+          skipped.push({ source: root.subPath || 'skill', reason: reasonFromError(error) })
+        }
       }
 
-      return previews
+      return { previews, skipped }
     })
   }
 
@@ -478,43 +561,87 @@ class UserSkillRepository {
     zip: Buffer,
     options: { subPath?: string; replaceId?: string } = {}
   ): Promise<ImportOutcome> {
-    const roots = findSkillRoots(extractZip(zip))
+    const { roots } = discoverSkillRoots(zip)
     if (roots.length === 0) throw new Error('The bundle must contain a SKILL.md.')
 
     const root = this.selectRoot(roots, options.subPath)
-    const files = root.files
-    const skillMd = files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
-    const signature = signatureOf(files)
 
     // Recovery, dedup, slug allocation and the swap share one critical section (see importFromGitHub).
     return this.runExclusive(async () => {
       await this.doRecoverImportedTransactions()
-
-      if (options.replaceId !== undefined) {
-        const parsed = parseUserSkillId(options.replaceId)
-        if (
-          !parsed ||
-          parsed.source !== 'imported' ||
-          !(await this.slugTaken('imported', parsed.slug))
-        ) {
-          throw new Error(`Not an imported skill to replace: ${options.replaceId}`)
-        }
-        await this.writeImported(parsed.slug, files, '', signature)
-        return { status: 'updated', id: `imported-${parsed.slug}` }
-      }
-
-      const existingSlug = await this.findImportedSlugBySignature(signature)
-      if (existingSlug) {
-        return { status: 'unchanged', id: `imported-${existingSlug}` }
-      }
-
-      // CRLF-aware name extraction (from #181) inside #170's operation-level critical section.
-      const name = parseFrontmatter(skillMd.content.toString('utf8')).fields.name?.trim()
-      const base = toSlug(name ?? 'skill') || 'skill'
-      const slug = await this.uniqueSlug('imported', base)
-      await this.writeImported(slug, files, '', signature)
-      return { status: 'imported', id: `imported-${slug}` }
+      return this.writeRootLocked(root, options.replaceId)
     })
+  }
+
+  // Imports several skills from ONE bundle in a single pass: the bundle is discovered once and the
+  // whole batch runs under one critical section (one recovery, no per-skill re-extraction of a large
+  // upload). Each requested subPath is imported independently — a failure on one is captured as an
+  // error for that item and does not abort the rest. Returns one result per requested item.
+  async importFromZipBatch(
+    zip: Buffer,
+    items: { subPath: string; replaceId?: string }[]
+  ): Promise<{ subPath: string; outcome?: ImportOutcome; error?: string }[]> {
+    const { roots } = discoverSkillRoots(zip)
+    const bySubPath = new Map(roots.map((root) => [root.subPath, root]))
+
+    return this.runExclusive(async () => {
+      await this.doRecoverImportedTransactions()
+
+      const results: { subPath: string; outcome?: ImportOutcome; error?: string }[] = []
+      for (const item of items) {
+        const root = bySubPath.get(item.subPath)
+        if (!root) {
+          results.push({
+            subPath: item.subPath,
+            error: `The bundle has no skill at "${item.subPath}".`
+          })
+          continue
+        }
+        try {
+          results.push({
+            subPath: item.subPath,
+            outcome: await this.writeRootLocked(root, item.replaceId)
+          })
+        } catch (error) {
+          results.push({ subPath: item.subPath, error: reasonFromError(error) })
+        }
+      }
+      return results
+    })
+  }
+
+  // Writes one discovered skill root: replaces `replaceId` in place when given, else dedups by content
+  // signature (a re-import of the same bytes is a no-op) and allocates a fresh (possibly suffixed) slug.
+  // MUST be called from within a runExclusive critical section that has already recovered.
+  private async writeRootLocked(root: SkillRoot, replaceId?: string): Promise<ImportOutcome> {
+    const files = root.files
+    const skillMd = files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
+    const signature = signatureOf(files)
+
+    if (replaceId !== undefined) {
+      const parsed = parseUserSkillId(replaceId)
+      if (
+        !parsed ||
+        parsed.source !== 'imported' ||
+        !(await this.slugTaken('imported', parsed.slug))
+      ) {
+        throw new Error(`Not an imported skill to replace: ${replaceId}`)
+      }
+      await this.writeImported(parsed.slug, files, '', signature)
+      return { status: 'updated', id: `imported-${parsed.slug}` }
+    }
+
+    const existingSlug = await this.findImportedSlugBySignature(signature)
+    if (existingSlug) {
+      return { status: 'unchanged', id: `imported-${existingSlug}` }
+    }
+
+    // CRLF-aware name extraction (from #181) inside #170's operation-level critical section.
+    const name = parseFrontmatter(skillMd.content.toString('utf8')).fields.name?.trim()
+    const base = toSlug(name ?? 'skill') || 'skill'
+    const slug = await this.uniqueSlug('imported', base)
+    await this.writeImported(slug, files, '', signature)
+    return { status: 'imported', id: `imported-${slug}` }
   }
 
   // Finds an imported skill whose recorded content signature matches, for zip dedup.

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -166,16 +166,38 @@ const reasonFromError = (error: unknown): string => {
   return message.replace(/^(Error invoking remote method '[^']*': )?(Error: )?/, '') || 'unreadable'
 }
 
+// Rounds a byte count to whole MB for a user-facing size-limit reason.
+const mb = (bytes: number): string => `${Math.round(bytes / (1024 * 1024))} MB`
+
+// Checks one skill's files against the PER-SKILL caps, returning a plain-English reason if it violates
+// them (else null). The outer bundle walk uses generous bundle-wide caps, so a loose (directly-visible)
+// skill root — which never goes through the strict extractZip path a nested archive does — must be
+// re-validated here, otherwise a single-skill upload could sneak in an oversized file or total.
+const perSkillCapReason = (files: FetchedSkillFile[]): string | null => {
+  if (files.length > SKILL_IMPORT_LIMITS.maxFiles) {
+    return `skill has more than ${SKILL_IMPORT_LIMITS.maxFiles} files`
+  }
+  if (files.some((file) => file.content.length > SKILL_IMPORT_LIMITS.maxFileBytes)) {
+    return `contains a file over ${mb(SKILL_IMPORT_LIMITS.maxFileBytes)}`
+  }
+  const total = files.reduce((sum, file) => sum + file.content.length, 0)
+  if (total > SKILL_IMPORT_LIMITS.maxTotalBytes) {
+    return `skill exceeds ${mb(SKILL_IMPORT_LIMITS.maxTotalBytes)}`
+  }
+  return null
+}
+
 // The outcome of scanning a bundle: the skill roots we can import, plus the ones we skipped and why.
 type SkillDiscovery = { roots: SkillRoot[]; skipped: SkippedSkill[] }
 
 // Discovers every importable skill in an uploaded bundle, resilient to individual failures. Direct
 // SKILL.md roots (a plain skill dir, or a bundle of sibling skill dirs) are found as before; any entry
-// that is itself a .zip/.skill is unpacked ONE level deeper and its root(s) surfaced under a
-// namespaced subPath (the archive's base name). An entry that's too large, unreadable, or holds no
-// SKILL.md is recorded as skipped rather than failing the whole bundle. Nesting beyond one archive
-// level is not followed (a nested archive's own nested archives are ignored), which also bounds
-// recursion. The outer walk is lenient so one bad entry never sinks the rest.
+// that is itself a .zip/.skill is unpacked ONE level deeper and its root(s) surfaced under a subPath
+// namespaced by the FULL archive path (so a nested `alpha.zip` can't collide with a loose `alpha/`
+// dir). An entry that's too large, unreadable, holds no SKILL.md, or (for a loose root) violates the
+// per-skill caps is recorded as skipped rather than failing the whole bundle. Nesting beyond one
+// archive level is not followed, which bounds recursion. subPaths are made unique so preview rows,
+// renderer keys, and batch-import selection never alias two different skills onto one key.
 const discoverSkillRoots = (zip: Buffer): SkillDiscovery => {
   const skipped: SkippedSkill[] = []
   const { files, skipped: outerSkips } = extractZipLenient(zip, {
@@ -186,11 +208,39 @@ const discoverSkillRoots = (zip: Buffer): SkillDiscovery => {
   })
   for (const entry of outerSkips) skipped.push({ source: entry.path, reason: entry.reason })
 
-  // Loose files at the outer level (everything that isn't a nested archive) form ordinary roots.
-  const roots = findSkillRoots(files.filter((file) => !isNestedArchive(file.path)))
+  const roots: SkillRoot[] = []
+  const used = new Set<string>()
+  // Claims a unique subPath (suffixing on the rare clash) so no two roots ever share one key.
+  const addRoot = (subPath: string, rootFiles: FetchedSkillFile[]): void => {
+    let unique = subPath
+    for (let n = 2; used.has(unique); n += 1) unique = `${subPath}#${n}`
+    used.add(unique)
+    roots.push({ subPath: unique, files: rootFiles })
+  }
 
-  // Each nested archive is its own bundle: unpack it under the strict per-skill caps and namespace its
-  // roots by the archive's base name, so preview and import derive the same stable subPath.
+  // Loose (non-archive) top-level files form ordinary roots — but they must still satisfy the per-skill
+  // caps, and a root whose content the lenient walk had to drop is rejected (importing it would produce
+  // a silently-partial skill).
+  const looseSkips = outerSkips.filter((entry) => !isNestedArchive(entry.path)).map((e) => e.path)
+  for (const root of findSkillRoots(files.filter((file) => !isNestedArchive(file.path)))) {
+    const prefix = root.subPath === '' ? '' : `${root.subPath}/`
+    if (looseSkips.some((path) => path === root.subPath || path.startsWith(prefix))) {
+      skipped.push({
+        source: root.subPath || 'skill',
+        reason: 'contains a file too large to import'
+      })
+      continue
+    }
+    const violation = perSkillCapReason(root.files)
+    if (violation) {
+      skipped.push({ source: root.subPath || 'skill', reason: violation })
+      continue
+    }
+    addRoot(root.subPath, root.files)
+  }
+
+  // Each nested archive is its own bundle: unpack it under the strict per-skill caps (extractZip throws
+  // on any cap violation, so the whole inner skill is skipped, never partially imported).
   for (const archive of files.filter((file) => isNestedArchive(file.path))) {
     let innerRoots: SkillRoot[]
     try {
@@ -203,12 +253,8 @@ const discoverSkillRoots = (zip: Buffer): SkillDiscovery => {
       skipped.push({ source: archive.path, reason: 'no SKILL.md found' })
       continue
     }
-    const prefix = archive.path.replace(/\.(zip|skill)$/i, '')
     for (const root of innerRoots) {
-      roots.push({
-        subPath: root.subPath === '' ? prefix : `${prefix}/${root.subPath}`,
-        files: root.files
-      })
+      addRoot(root.subPath === '' ? archive.path : `${archive.path}/${root.subPath}`, root.files)
     }
   }
 

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -246,10 +246,11 @@ const discoverSkillRoots = (zip: Buffer): SkillDiscovery => {
   // any of whose files the lenient walk had to drop is rejected — importing it would produce a
   // silently-partial skill.
   for (const { root, prefix } of rootPrefixes) {
-    if (outerSkips.some((e) => e.path === root.subPath || e.path.startsWith(prefix))) {
+    const droppedFile = outerSkips.find((e) => e.path === root.subPath || e.path.startsWith(prefix))
+    if (droppedFile) {
       skipped.push({
         source: root.subPath || 'skill',
-        reason: 'contains a file too large to import'
+        reason: `contains a file that couldn't be imported (${droppedFile.reason})`
       })
       continue
     }

--- a/src/main/skills/zip-extract.test.ts
+++ b/src/main/skills/zip-extract.test.ts
@@ -2,6 +2,7 @@ import { deflateRawSync } from 'node:zlib'
 
 import { describe, expect, it } from 'vitest'
 
+import { SKILL_IMPORT_LIMITS } from './import-limits'
 import { extractZip, extractZipLenient } from './zip-extract'
 
 // CRC-32 (used only to build genuinely valid local/central headers in the test archives).
@@ -146,24 +147,26 @@ describe('extractZip', () => {
   })
 
   it('rejects an oversized STORE entry from its known size', () => {
-    // A single STORE file over the 5 MiB per-file cap is rejected without copying it out.
-    const big = Buffer.alloc(5 * 1024 * 1024 + 1, 0x61)
+    // A single STORE file over the per-file cap is rejected without copying it out.
+    const big = Buffer.alloc(SKILL_IMPORT_LIMITS.maxFileBytes + 1, 0x61)
     expect(() => extractZip(buildZip([{ path: 'big.txt', content: big, method: 0 }]))).toThrow(
       /exceeds the .* limit/
     )
   })
 
   it('rejects a DEFLATE bomb via the inflate output bound', () => {
-    // 6 MiB of zeros compresses to almost nothing but would inflate past the 5 MiB per-file cap;
-    // inflateRawSync's maxOutputLength makes that throw instead of expanding into memory.
-    const bomb = Buffer.alloc(6 * 1024 * 1024, 0)
+    // Zeros compress to almost nothing but would inflate past the per-file cap; inflateRawSync's
+    // maxOutputLength makes that throw instead of expanding into memory.
+    const bomb = Buffer.alloc(SKILL_IMPORT_LIMITS.maxFileBytes + 1024, 0)
     expect(() => extractZip(buildZip([{ path: 'bomb.bin', content: bomb, method: 8 }]))).toThrow()
   })
 
   it('rejects a bundle whose decompressed total exceeds the cap', () => {
-    // Three 4 MiB files are each under the per-file cap but sum to 12 MiB > the 10 MiB total cap.
-    const chunk = Buffer.alloc(4 * 1024 * 1024, 0x62)
-    const inputs: ZipInput[] = [0, 1, 2].map((i) => ({
+    // Files each at the per-file cap, enough of them to overflow the per-skill total cap.
+    const chunk = Buffer.alloc(SKILL_IMPORT_LIMITS.maxFileBytes, 0x62)
+    const count =
+      Math.floor(SKILL_IMPORT_LIMITS.maxTotalBytes / SKILL_IMPORT_LIMITS.maxFileBytes) + 1
+    const inputs: ZipInput[] = Array.from({ length: count }, (_, i) => ({
       path: `f${i}.txt`,
       content: chunk,
       method: 0 as const

--- a/src/main/skills/zip-extract.test.ts
+++ b/src/main/skills/zip-extract.test.ts
@@ -2,7 +2,7 @@ import { deflateRawSync } from 'node:zlib'
 
 import { describe, expect, it } from 'vitest'
 
-import { extractZip } from './zip-extract'
+import { extractZip, extractZipLenient } from './zip-extract'
 
 // CRC-32 (used only to build genuinely valid local/central headers in the test archives).
 const crcTable = ((): Uint32Array => {
@@ -182,5 +182,45 @@ describe('extractZip', () => {
     expect(() =>
       extractZip(buildZip([{ path: tooDeep, content: Buffer.from('x'), method: 0 }]))
     ).toThrow(/nested deeper/)
+  })
+})
+
+describe('extractZipLenient', () => {
+  const limits = { maxFiles: 100, maxFileBytes: 1024, maxTotalBytes: 4096, maxDepth: 8 }
+
+  it('keeps valid entries and skips an oversized one with a reason (never throws)', () => {
+    const zip = buildZip([
+      { path: 'ok.txt', content: Buffer.from('small'), method: 0 },
+      { path: 'huge.bin', content: Buffer.alloc(limits.maxFileBytes + 1, 1), method: 0 }
+    ])
+    const { files, skipped } = extractZipLenient(zip, limits)
+    expect(files.map((f) => f.path)).toEqual(['ok.txt'])
+    expect(skipped).toEqual([{ path: 'huge.bin', reason: expect.stringMatching(/too large/) }])
+  })
+
+  it('skips entries past the file-count cap instead of failing the whole archive', () => {
+    const inputs = Array.from({ length: 5 }, (_, i) => ({
+      path: `f${i}.txt`,
+      content: Buffer.from('x'),
+      method: 0 as const
+    }))
+    const { files, skipped } = extractZipLenient(buildZip(inputs), { ...limits, maxFiles: 3 })
+    expect(files).toHaveLength(3)
+    expect(skipped).toHaveLength(2)
+    expect(skipped[0].reason).toMatch(/too many entries/)
+  })
+
+  it('skips an entry that would push the archive past the total-size cap', () => {
+    const zip = buildZip([
+      { path: 'a.bin', content: Buffer.alloc(900, 1), method: 0 },
+      { path: 'b.bin', content: Buffer.alloc(900, 1), method: 0 }
+    ])
+    const { files, skipped } = extractZipLenient(zip, { ...limits, maxTotalBytes: 1000 })
+    expect(files.map((f) => f.path)).toEqual(['a.bin'])
+    expect(skipped[0].reason).toMatch(/exceeds/)
+  })
+
+  it('still throws on a structurally invalid archive', () => {
+    expect(() => extractZipLenient(Buffer.from('not a zip'), limits)).toThrow(/valid ZIP/)
   })
 })

--- a/src/main/skills/zip-extract.test.ts
+++ b/src/main/skills/zip-extract.test.ts
@@ -223,7 +223,47 @@ describe('extractZipLenient', () => {
     expect(skipped[0].reason).toMatch(/exceeds/)
   })
 
+  it('records unsafe paths as skipped so their owning root can be rejected', () => {
+    const zip = buildZip([
+      { path: 'tool/SKILL.md', content: Buffer.from('ok'), method: 0 },
+      { path: 'tool/../evil.txt', content: Buffer.from('nope'), method: 0 }
+    ])
+
+    const { files, skipped } = extractZipLenient(zip, limits)
+    expect(files.map((f) => f.path)).toEqual(['tool/SKILL.md'])
+    expect(skipped).toEqual([{ path: 'tool/../evil.txt', reason: 'unsafe path' }])
+  })
+
   it('still throws on a structurally invalid archive', () => {
     expect(() => extractZipLenient(Buffer.from('not a zip'), limits)).toThrow(/valid ZIP/)
+  })
+
+  it('records an out-of-range local-header offset as skipped, never throwing', () => {
+    const zip = buildZip([
+      { path: 'good.txt', content: Buffer.from('ok'), method: 0 },
+      { path: 'bad.txt', content: Buffer.from('nope'), method: 0 }
+    ])
+    // Point bad.txt's central record at an out-of-range local-header offset. Central records follow
+    // entry order, so bad.txt's is the second (after good.txt's 46 + name-length bytes).
+    const centralStart = zip.readUInt32LE(zip.length - 22 + 16)
+    const badCentral = centralStart + 46 + 'good.txt'.length
+    zip.writeUInt32LE(0x7fffffff, badCentral + 42)
+
+    const { files, skipped } = extractZipLenient(zip, limits)
+    expect(files.map((f) => f.path)).toEqual(['good.txt'])
+    expect(skipped).toEqual([{ path: 'bad.txt', reason: expect.stringMatching(/local header/) }])
+  })
+
+  it('records a corrupt local signature as skipped, keeping the other entries', () => {
+    const zip = buildZip([
+      { path: 'bad.txt', content: Buffer.from('nope'), method: 0 },
+      { path: 'good.txt', content: Buffer.from('ok'), method: 0 }
+    ])
+    // bad.txt is the first entry, so its local header sits at offset 0; wipe its signature.
+    zip.writeUInt32LE(0, 0)
+
+    const { files, skipped } = extractZipLenient(zip, limits)
+    expect(files.map((f) => f.path)).toEqual(['good.txt'])
+    expect(skipped).toEqual([{ path: 'bad.txt', reason: 'malformed local header' }])
   })
 })

--- a/src/main/skills/zip-extract.ts
+++ b/src/main/skills/zip-extract.ts
@@ -16,6 +16,25 @@ const EOCD_MIN_SIZE = 22
 // An extracted file: its posix-style path within the archive plus its decompressed bytes.
 export type ExtractedZipFile = { path: string; content: Buffer }
 
+// One entry the lenient extractor declined to unpack, with a plain-English reason (for surfacing to
+// the user as a skipped item rather than failing the whole import).
+export type SkippedZipEntry = { path: string; reason: string }
+
+// The lenient extractor's outcome: the entries it did unpack, plus the ones it skipped and why.
+export type LenientExtractOutcome = { files: ExtractedZipFile[]; skipped: SkippedZipEntry[] }
+
+// Caps the lenient extractor enforces per call. Split out so the OUTER bundle walk can allow larger
+// single entries (nested skill archives) than the per-file cap used for a single skill's own files.
+export type LenientExtractLimits = {
+  maxFiles: number
+  maxFileBytes: number
+  maxTotalBytes: number
+  maxDepth: number
+}
+
+// Rounds a byte count to whole MB for a user-facing size-limit reason.
+const mb = (bytes: number): string => `${Math.round(bytes / (1024 * 1024))} MB`
+
 // Rejects paths that would escape the extraction root (zip-slip) or aren't real bundle files.
 const isUnsafePath = (path: string): boolean => {
   if (path.length === 0) return true
@@ -115,4 +134,84 @@ const extractZip = (buffer: Buffer): ExtractedZipFile[] => {
   return files
 }
 
-export { extractZip }
+// Lenient sibling of extractZip: instead of throwing when a single entry violates a cap, it SKIPS that
+// entry (recording a plain-English reason) and keeps going, so one oversized/unsupported/too-deep
+// entry can't sink an otherwise-importable bundle. Only a structurally invalid archive (no central
+// directory) still throws. Used for the OUTER walk of a multi-skill bundle, where each entry is
+// either a nested skill archive or a loose skill file and failures should be reported, not fatal.
+const extractZipLenient = (buffer: Buffer, limits: LenientExtractLimits): LenientExtractOutcome => {
+  const eocd = findEocd(buffer)
+  if (eocd < 0) throw new Error('Not a valid ZIP archive.')
+
+  const entryCount = buffer.readUInt16LE(eocd + 10)
+  let pointer = buffer.readUInt32LE(eocd + 16)
+  const files: ExtractedZipFile[] = []
+  const skipped: SkippedZipEntry[] = []
+  let totalBytes = 0
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (pointer + 46 > buffer.length || buffer.readUInt32LE(pointer) !== CENTRAL_SIGNATURE) break
+
+    const method = buffer.readUInt16LE(pointer + 10)
+    const compressedSize = buffer.readUInt32LE(pointer + 20)
+    const nameLength = buffer.readUInt16LE(pointer + 28)
+    const extraLength = buffer.readUInt16LE(pointer + 30)
+    const commentLength = buffer.readUInt16LE(pointer + 32)
+    const localOffset = buffer.readUInt32LE(pointer + 42)
+    const name = buffer.toString('utf8', pointer + 46, pointer + 46 + nameLength)
+
+    // Advance to the next central-directory record before any skip.
+    pointer += 46 + nameLength + extraLength + commentLength
+
+    // Directory records and archive metadata carry no importable content — drop them silently.
+    if (name.endsWith('/')) continue
+    if (isUnsafePath(name)) continue
+    if (method !== 0 && method !== 8) {
+      skipped.push({ path: name, reason: 'unsupported compression method' })
+      continue
+    }
+    if (name.split('/').length - 1 > limits.maxDepth) {
+      skipped.push({ path: name, reason: `nested deeper than ${limits.maxDepth} levels` })
+      continue
+    }
+    if (files.length >= limits.maxFiles) {
+      skipped.push({ path: name, reason: `bundle has too many entries (limit ${limits.maxFiles})` })
+      continue
+    }
+
+    if (buffer.readUInt32LE(localOffset) !== LOCAL_SIGNATURE) continue
+    const localNameLength = buffer.readUInt16LE(localOffset + 26)
+    const localExtraLength = buffer.readUInt16LE(localOffset + 28)
+    const dataStart = localOffset + 30 + localNameLength + localExtraLength
+    const data = buffer.subarray(dataStart, dataStart + compressedSize)
+
+    // For a STORE entry the decompressed size is known up front, so an oversized one is skipped
+    // WITHOUT copying its bytes into memory (the common case for a nested, already-compressed .zip).
+    if (method === 0 && data.length > limits.maxFileBytes) {
+      skipped.push({ path: name, reason: `too large (limit ${mb(limits.maxFileBytes)})` })
+      continue
+    }
+    let content: Buffer
+    try {
+      content =
+        method === 0
+          ? Buffer.from(data)
+          : inflateRawSync(data, { maxOutputLength: limits.maxFileBytes })
+    } catch {
+      // A DEFLATE entry that would expand past maxFileBytes throws here (a bomb): skip it.
+      skipped.push({ path: name, reason: `too large (limit ${mb(limits.maxFileBytes)})` })
+      continue
+    }
+
+    if (totalBytes + content.length > limits.maxTotalBytes) {
+      skipped.push({ path: name, reason: `bundle exceeds the ${mb(limits.maxTotalBytes)} limit` })
+      continue
+    }
+    totalBytes += content.length
+    files.push({ path: name, content })
+  }
+
+  return { files, skipped }
+}
+
+export { extractZip, extractZipLenient }

--- a/src/main/skills/zip-extract.ts
+++ b/src/main/skills/zip-extract.ts
@@ -165,7 +165,14 @@ const extractZipLenient = (buffer: Buffer, limits: LenientExtractLimits): Lenien
 
     // Directory records and archive metadata carry no importable content — drop them silently.
     if (name.endsWith('/')) continue
-    if (isUnsafePath(name)) continue
+    if (isUnsafePath(name)) {
+      // Metadata entries were never part of a skill. Real unsafe paths, though, must be recorded so a
+      // loose skill root that owned one is rejected instead of imported silently incomplete.
+      if (!name.startsWith('__MACOSX/') && !name.startsWith('.')) {
+        skipped.push({ path: name, reason: 'unsafe path' })
+      }
+      continue
+    }
     if (method !== 0 && method !== 8) {
       skipped.push({ path: name, reason: 'unsupported compression method' })
       continue
@@ -179,10 +186,20 @@ const extractZipLenient = (buffer: Buffer, limits: LenientExtractLimits): Lenien
       continue
     }
 
-    if (buffer.readUInt32LE(localOffset) !== LOCAL_SIGNATURE) continue
+    // Read the local header to find where the data starts. A malformed/out-of-range offset must be
+    // RECORDED as skipped, never left to throw a RangeError (which would abort the whole bundle) and
+    // never silently dropped (which would let a loose skill root import missing this file).
+    if (localOffset + 30 > buffer.length || buffer.readUInt32LE(localOffset) !== LOCAL_SIGNATURE) {
+      skipped.push({ path: name, reason: 'malformed local header' })
+      continue
+    }
     const localNameLength = buffer.readUInt16LE(localOffset + 26)
     const localExtraLength = buffer.readUInt16LE(localOffset + 28)
     const dataStart = localOffset + 30 + localNameLength + localExtraLength
+    if (dataStart + compressedSize > buffer.length) {
+      skipped.push({ path: name, reason: 'entry data extends past end of archive' })
+      continue
+    }
     const data = buffer.subarray(dataStart, dataStart + compressedSize)
 
     // For a STORE entry the decompressed size is known up front, so an oversized one is skipped

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -89,8 +89,10 @@ import type {
   ImportSkillRequest,
   ImportSkillResult,
   ImportSkillZipRequest,
+  ImportSkillZipBatchRequest,
+  ImportSkillZipBatchResult,
   PreviewSkillZipRequest,
-  SkillBundlePreview,
+  SkillBundlePreviewResult,
   ScanRepoRequest,
   ScanRepoResult,
   ConnectorsSnapshot,
@@ -191,7 +193,8 @@ interface OpenScienceAPI {
     deleteSkill(request: DeleteSkillRequest): Promise<SkillView[]>
     importSkill(request: ImportSkillRequest): Promise<ImportSkillResult>
     importSkillZip(request: ImportSkillZipRequest): Promise<ImportSkillResult>
-    previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreview[]>
+    importSkillZipBatch(request: ImportSkillZipBatchRequest): Promise<ImportSkillZipBatchResult>
+    previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreviewResult>
     scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult>
     listConnectors(): Promise<ConnectorsSnapshot>
     getConnectorDetail(id: string): Promise<ConnectorDetailView>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -91,8 +91,10 @@ import type {
   ImportSkillRequest,
   ImportSkillResult,
   ImportSkillZipRequest,
+  ImportSkillZipBatchRequest,
+  ImportSkillZipBatchResult,
   PreviewSkillZipRequest,
-  SkillBundlePreview,
+  SkillBundlePreviewResult,
   ScanRepoRequest,
   ScanRepoResult,
   ConnectorsSnapshot,
@@ -208,7 +210,8 @@ type OpenScienceAPI = {
     deleteSkill: (request: DeleteSkillRequest) => Promise<SkillView[]>
     importSkill: (request: ImportSkillRequest) => Promise<ImportSkillResult>
     importSkillZip: (request: ImportSkillZipRequest) => Promise<ImportSkillResult>
-    previewSkillZip: (request: PreviewSkillZipRequest) => Promise<SkillBundlePreview[]>
+    importSkillZipBatch: (request: ImportSkillZipBatchRequest) => Promise<ImportSkillZipBatchResult>
+    previewSkillZip: (request: PreviewSkillZipRequest) => Promise<SkillBundlePreviewResult>
     scanRepoSkills: (request: ScanRepoRequest) => Promise<ScanRepoResult>
     listConnectors: () => Promise<ConnectorsSnapshot>
     getConnectorDetail: (id: string) => Promise<ConnectorDetailView>
@@ -458,8 +461,16 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('settings:import-skill', request) as Promise<ImportSkillResult>,
     importSkillZip: (request: ImportSkillZipRequest) =>
       ipcRenderer.invoke('settings:import-skill-zip', request) as Promise<ImportSkillResult>,
+    importSkillZipBatch: (request: ImportSkillZipBatchRequest) =>
+      ipcRenderer.invoke(
+        'settings:import-skill-zip-batch',
+        request
+      ) as Promise<ImportSkillZipBatchResult>,
     previewSkillZip: (request: PreviewSkillZipRequest) =>
-      ipcRenderer.invoke('settings:preview-skill-zip', request) as Promise<SkillBundlePreview[]>,
+      ipcRenderer.invoke(
+        'settings:preview-skill-zip',
+        request
+      ) as Promise<SkillBundlePreviewResult>,
     scanRepoSkills: (request: ScanRepoRequest) =>
       ipcRenderer.invoke('settings:scan-repo-skills', request) as Promise<ScanRepoResult>,
     listConnectors: () =>

--- a/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
@@ -55,25 +55,32 @@ beforeEach(() => {
       }
     ],
     createSkill: vi.fn().mockResolvedValue(undefined),
-    importSkillZip: vi
-      .fn()
-      .mockResolvedValue({ status: 'imported', id: 'imported-zip', skills: [] }),
-    previewSkillZip: vi.fn().mockResolvedValue([
-      {
-        subPath: 'skills/one',
-        name: 'One',
-        description: 'First bundled skill',
-        files: ['SKILL.md'],
-        alreadyImported: false
-      },
-      {
-        subPath: 'skills/two',
-        name: 'Two',
-        description: 'Second bundled skill',
-        files: ['SKILL.md'],
-        alreadyImported: false
-      }
-    ])
+    importSkillZipBatch: vi.fn().mockResolvedValue({
+      results: [
+        { subPath: 'skills/one', status: 'imported', id: 'imported-one' },
+        { subPath: 'skills/two', status: 'imported', id: 'imported-two' }
+      ],
+      skills: []
+    }),
+    previewSkillZip: vi.fn().mockResolvedValue({
+      previews: [
+        {
+          subPath: 'skills/one',
+          name: 'One',
+          description: 'First bundled skill',
+          files: ['SKILL.md'],
+          alreadyImported: false
+        },
+        {
+          subPath: 'skills/two',
+          name: 'Two',
+          description: 'Second bundled skill',
+          files: ['SKILL.md'],
+          alreadyImported: false
+        }
+      ],
+      skipped: []
+    })
   })
   container = document.createElement('div')
   document.body.appendChild(container)
@@ -132,16 +139,13 @@ describe('SkillUploadView (batch upload)', () => {
     clickButton('Import selected')
     await flush()
 
-    const importSkillZip = useSettingsStore.getState().importSkillZip
-    expect(importSkillZip).toHaveBeenCalledTimes(2)
-    expect(importSkillZip).toHaveBeenCalledWith(expect.any(String), {
-      subPath: 'skills/one',
-      replaceId: undefined
-    })
-    expect(importSkillZip).toHaveBeenCalledWith(expect.any(String), {
-      subPath: 'skills/two',
-      replaceId: undefined
-    })
+    // Both roots came from one file, so they import in a single batch call carrying every subPath.
+    const importSkillZipBatch = useSettingsStore.getState().importSkillZipBatch
+    expect(importSkillZipBatch).toHaveBeenCalledTimes(1)
+    expect(importSkillZipBatch).toHaveBeenCalledWith(expect.any(String), [
+      { subPath: 'skills/one', replaceId: undefined },
+      { subPath: 'skills/two', replaceId: undefined }
+    ])
     expect(onUploaded).toHaveBeenCalled()
   })
 
@@ -167,11 +171,11 @@ describe('SkillUploadView (batch upload)', () => {
       root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
     })
 
-    // Two 6 MiB bundles: each is under the 10 MiB per-bundle cap, but together they exceed the total.
+    // Two 40 MiB bundles: each is under the per-bundle cap, but together they exceed the total cap.
     const a = new File([new Uint8Array([1])], 'a.zip', { type: 'application/zip' })
     const b = new File([new Uint8Array([2])], 'b.zip', { type: 'application/zip' })
-    Object.defineProperty(a, 'size', { value: 6 * 1024 * 1024 })
-    Object.defineProperty(b, 'size', { value: 6 * 1024 * 1024 })
+    Object.defineProperty(a, 'size', { value: 40 * 1024 * 1024 })
+    Object.defineProperty(b, 'size', { value: 40 * 1024 * 1024 })
 
     await dropFiles([a, b])
 
@@ -184,9 +188,9 @@ describe('SkillUploadView (batch upload)', () => {
       root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
     })
 
-    // An 11 MiB bundle exceeds the 10 MiB cap; it must be rejected before previewSkillZip reads it.
+    // A 65 MiB bundle exceeds the per-bundle cap; it must be rejected before previewSkillZip reads it.
     const big = new File([new Uint8Array([1])], 'huge.zip', { type: 'application/zip' })
-    Object.defineProperty(big, 'size', { value: 11 * 1024 * 1024 })
+    Object.defineProperty(big, 'size', { value: 65 * 1024 * 1024 })
 
     await dropFiles([big])
 

--- a/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
@@ -154,9 +154,9 @@ describe('SkillUploadView (batch upload)', () => {
       root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
     })
 
-    // 6 MiB exceeds the 5 MiB per-file cap. file.size is checked before file.text() runs.
+    // 51 MiB exceeds the 50 MiB per-file cap. file.size is checked before file.text() runs.
     const big = new File(['x'], 'big.md', { type: 'text/markdown' })
-    Object.defineProperty(big, 'size', { value: 6 * 1024 * 1024 })
+    Object.defineProperty(big, 'size', { value: 51 * 1024 * 1024 })
     const textSpy = vi.spyOn(big, 'text')
 
     await dropFiles([big])
@@ -171,11 +171,11 @@ describe('SkillUploadView (batch upload)', () => {
       root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
     })
 
-    // Two 40 MiB bundles: each is under the per-bundle cap, but together they exceed the total cap.
+    // Two 130 MiB bundles: each is under the per-bundle cap, but together they exceed the total cap.
     const a = new File([new Uint8Array([1])], 'a.zip', { type: 'application/zip' })
     const b = new File([new Uint8Array([2])], 'b.zip', { type: 'application/zip' })
-    Object.defineProperty(a, 'size', { value: 40 * 1024 * 1024 })
-    Object.defineProperty(b, 'size', { value: 40 * 1024 * 1024 })
+    Object.defineProperty(a, 'size', { value: 130 * 1024 * 1024 })
+    Object.defineProperty(b, 'size', { value: 130 * 1024 * 1024 })
 
     await dropFiles([a, b])
 
@@ -188,9 +188,9 @@ describe('SkillUploadView (batch upload)', () => {
       root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
     })
 
-    // A 65 MiB bundle exceeds the per-bundle cap; it must be rejected before previewSkillZip reads it.
+    // A 257 MiB bundle exceeds the per-bundle cap; it must be rejected before previewSkillZip reads it.
     const big = new File([new Uint8Array([1])], 'huge.zip', { type: 'application/zip' })
-    Object.defineProperty(big, 'size', { value: 65 * 1024 * 1024 })
+    Object.defineProperty(big, 'size', { value: 257 * 1024 * 1024 })
 
     await dropFiles([big])
 

--- a/src/renderer/src/pages/settings/SkillUploadView.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.tsx
@@ -18,6 +18,23 @@ const ErrorBanner = ({ message }: { message: string }): React.JSX.Element => (
   </div>
 )
 
+// A muted note listing skills the bundle contained but couldn't import (too large, no SKILL.md, ...),
+// so a partial import tells the user exactly what was left out instead of failing silently.
+const SkippedNote = ({ items }: { items: SkippedEntry[] }): React.JSX.Element => (
+  <div className="mt-3 rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+    <p className="font-medium text-foreground">
+      Skipped {items.length} skill{items.length === 1 ? '' : 's'}
+    </p>
+    <ul className="mt-1 flex flex-col gap-0.5">
+      {items.map((item) => (
+        <li key={`${item.fileName}:${item.source}`} className="truncate">
+          {item.source} — {item.reason}
+        </li>
+      ))}
+    </ul>
+  </div>
+)
+
 type SkillUploadViewProps = {
   onUploaded: () => void
   onWriteInstead: () => void
@@ -49,9 +66,20 @@ type Candidate =
       body: string
     }
 
-// The outcome of parsing one picked file: zero-or-more candidates, plus an optional per-file error so
-// one bad file never blocks the others.
-type ParseResult = { candidates: Candidate[]; error?: string }
+// One skill a bundle contained but that couldn't be imported (too large, no SKILL.md, no name, ...),
+// tagged with the file it came from so the user can tell which upload it belongs to.
+type SkippedEntry = { fileName: string; source: string; reason: string }
+
+// The outcome of parsing one picked file: zero-or-more candidates, an optional per-file error (so one
+// bad file never blocks the others), and any skills inside the file that were individually skipped.
+type ParseResult = { candidates: Candidate[]; error?: string; skipped?: SkippedEntry[] }
+
+// Strips the electron IPC wrapper ("Error invoking remote method '…': Error: …") off a rejection so
+// the user sees only the human-readable message, never the internal method name.
+const cleanMessage = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.replace(/^Error invoking remote method '[^']*':\s*/, '').replace(/^Error:\s*/, '')
+}
 
 // Pulls name/description out of a .md frontmatter block, returning the stripped body (mirrors the
 // editor's consumeFrontmatter so an uploaded SKILL.md fills the same fields).
@@ -90,11 +118,12 @@ const SkillUploadView = ({
   onWriteInstead
 }: SkillUploadViewProps): React.JSX.Element => {
   const createSkill = useSettingsStore((state) => state.createSkill)
-  const importSkillZip = useSettingsStore((state) => state.importSkillZip)
+  const importSkillZipBatch = useSettingsStore((state) => state.importSkillZipBatch)
   const previewSkillZip = useSettingsStore((state) => state.previewSkillZip)
   const skills = useSettingsStore((state) => state.skills)
   const [candidates, setCandidates] = useState<Candidate[] | null>(null)
   const [errors, setErrors] = useState<string[]>([])
+  const [skipped, setSkipped] = useState<SkippedEntry[]>([])
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [summary, setSummary] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -105,9 +134,9 @@ const SkillUploadView = ({
     const isBundle = name.endsWith('.zip') || name.endsWith('.skill')
 
     // Reject on file.size BEFORE reading the file into memory / base64 / IPC. A bundle is bounded by
-    // the total-import cap (it may hold several files); a bare .md by the per-file cap.
+    // the whole-bundle cap (it may hold many skills); a bare .md by the per-file cap.
     const sizeLimit = isBundle
-      ? SKILL_IMPORT_LIMITS.maxTotalBytes
+      ? SKILL_IMPORT_LIMITS.maxBundleBytes
       : SKILL_IMPORT_LIMITS.maxFileBytes
     if (file.size > sizeLimit) {
       return { candidates: [], error: `${file.name}: file is too large (limit ${mb(sizeLimit)}).` }
@@ -116,8 +145,13 @@ const SkillUploadView = ({
     if (isBundle) {
       try {
         const base64 = await fileToBase64(file)
-        const previews = await previewSkillZip(base64)
-        if (previews.length === 0) {
+        const { previews, skipped } = await previewSkillZip(base64)
+        const skippedEntries = skipped.map((entry) => ({
+          fileName: file.name,
+          source: entry.source,
+          reason: entry.reason
+        }))
+        if (previews.length === 0 && skipped.length === 0) {
           return { candidates: [], error: `${file.name}: no skills found in the bundle.` }
         }
         return {
@@ -132,11 +166,11 @@ const SkillUploadView = ({
             files: preview.files,
             alreadyImported: preview.alreadyImported,
             replaceableId: preview.replaceableId
-          }))
+          })),
+          skipped: skippedEntries
         }
       } catch (error) {
-        const detail = error instanceof Error ? error.message : 'could not read the bundle.'
-        return { candidates: [], error: `${file.name}: ${detail}` }
+        return { candidates: [], error: `${file.name}: ${cleanMessage(error)}` }
       }
     }
 
@@ -174,17 +208,19 @@ const SkillUploadView = ({
       // Cap the whole selection before reading anything, so a batch drop can't allocate an unbounded
       // amount of memory across all files at once.
       const totalSize = files.reduce((sum, file) => sum + file.size, 0)
-      if (totalSize > SKILL_IMPORT_LIMITS.maxTotalBytes) {
+      if (totalSize > SKILL_IMPORT_LIMITS.maxBundleBytes) {
         setCandidates([])
         setErrors([
-          `Selection is too large (${mb(totalSize)}); upload at most ${mb(SKILL_IMPORT_LIMITS.maxTotalBytes)} at a time.`
+          `Selection is too large (${mb(totalSize)}); upload at most ${mb(SKILL_IMPORT_LIMITS.maxBundleBytes)} at a time.`
         ])
+        setSkipped([])
         setSelected(new Set())
         return
       }
       const results = await Promise.all(files.map(parseFile))
       setCandidates(results.flatMap((result) => result.candidates))
       setErrors(results.map((result) => result.error).filter((error): error is string => !!error))
+      setSkipped(results.flatMap((result) => result.skipped ?? []))
       // Default selection is empty — the user opts in per row (or via Select all).
       setSelected(new Set())
     } finally {
@@ -192,7 +228,9 @@ const SkillUploadView = ({
     }
   }
 
-  // Imports every checked candidate, tallying successes / skips (no-op re-imports) / failures.
+  // Imports every checked candidate, tallying successes / skips (no-op re-imports) / failures. Bundle
+  // candidates are grouped by their source file so a bundle holding many skills is decoded and unpacked
+  // ONCE (one batch call) instead of re-sent per skill.
   const importSelected = async (): Promise<void> => {
     if (busy || !candidates || selected.size === 0) return
     setBusy(true)
@@ -200,27 +238,52 @@ const SkillUploadView = ({
     let imported = 0
     let skipped = 0
     let failed = 0
-    for (const candidate of candidates.filter((entry) => selected.has(entry.key))) {
+
+    const chosen = candidates.filter((entry) => selected.has(entry.key))
+    const bundleGroups = new Map<string, Extract<Candidate, { kind: 'bundle' }>[]>()
+    const markdowns: Extract<Candidate, { kind: 'markdown' }>[] = []
+    for (const candidate of chosen) {
+      if (candidate.kind === 'bundle') {
+        const group = bundleGroups.get(candidate.base64) ?? []
+        group.push(candidate)
+        bundleGroups.set(candidate.base64, group)
+      } else {
+        markdowns.push(candidate)
+      }
+    }
+
+    for (const [base64, group] of bundleGroups) {
       try {
-        if (candidate.kind === 'bundle') {
-          const result = await importSkillZip(candidate.base64, {
+        const { results } = await importSkillZipBatch(
+          base64,
+          group.map((candidate) => ({
             subPath: candidate.subPath,
             replaceId: candidate.replaceableId
-          })
-          if (result.status === 'unchanged') skipped += 1
+          }))
+        )
+        for (const result of results) {
+          if (result.error) failed += 1
+          else if (result.status === 'unchanged') skipped += 1
           else imported += 1
-        } else {
-          await createSkill({
-            name: candidate.name,
-            description: candidate.description,
-            body: candidate.body
-          })
-          imported += 1
         }
+      } catch {
+        failed += group.length
+      }
+    }
+
+    for (const candidate of markdowns) {
+      try {
+        await createSkill({
+          name: candidate.name,
+          description: candidate.description,
+          body: candidate.body
+        })
+        imported += 1
       } catch {
         failed += 1
       }
     }
+
     setSummary(`Imported ${imported} · skipped ${skipped} · failed ${failed}`)
     setBusy(false)
     if (imported > 0) onUploaded()
@@ -354,6 +417,7 @@ const SkillUploadView = ({
         {errors.map((error) => (
           <ErrorBanner key={error} message={error} />
         ))}
+        {skipped.length > 0 ? <SkippedNote items={skipped} /> : null}
         {summary ? <p className="mt-3 text-xs text-muted-foreground">{summary}</p> : null}
 
         <div className="mt-4">
@@ -363,6 +427,7 @@ const SkillUploadView = ({
             onClick={() => {
               setCandidates(null)
               setErrors([])
+              setSkipped([])
               setSelected(new Set())
               setSummary(null)
             }}
@@ -412,6 +477,7 @@ const SkillUploadView = ({
       {errors.map((error) => (
         <ErrorBanner key={error} message={error} />
       ))}
+      {skipped.length > 0 ? <SkippedNote items={skipped} /> : null}
       {summary ? <p className="mt-3 text-xs text-muted-foreground">{summary}</p> : null}
 
       <div className="mt-5 text-center">

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -49,15 +49,22 @@ beforeEach(() => {
     importSkillZip: vi
       .fn()
       .mockResolvedValue({ status: 'imported', id: 'imported-zip', skills: [] }),
-    previewSkillZip: vi.fn().mockResolvedValue([
-      {
-        subPath: '',
-        name: 'Bundled',
-        description: 'From a bundle',
-        files: ['SKILL.md'],
-        alreadyImported: false
-      }
-    ]),
+    importSkillZipBatch: vi.fn().mockResolvedValue({
+      results: [{ subPath: '', status: 'imported', id: 'imported-zip' }],
+      skills: []
+    }),
+    previewSkillZip: vi.fn().mockResolvedValue({
+      previews: [
+        {
+          subPath: '',
+          name: 'Bundled',
+          description: 'From a bundle',
+          files: ['SKILL.md'],
+          alreadyImported: false
+        }
+      ],
+      skipped: []
+    }),
     scanRepoSkills: vi.fn().mockResolvedValue({
       skills: [
         {

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -31,6 +31,7 @@ type SettingsApi = {
   listSkills: ReturnType<typeof vi.fn>
   setSkillEnabled: ReturnType<typeof vi.fn>
   importSkillZip: ReturnType<typeof vi.fn>
+  importSkillZipBatch: ReturnType<typeof vi.fn>
   previewSkillZip: ReturnType<typeof vi.fn>
   listConnectors: ReturnType<typeof vi.fn>
   getConnectorDetail: ReturnType<typeof vi.fn>
@@ -117,7 +118,8 @@ beforeEach(() => {
     listSkills: vi.fn().mockResolvedValue([]),
     setSkillEnabled: vi.fn().mockResolvedValue([]),
     importSkillZip: vi.fn().mockResolvedValue({ status: 'imported', id: 'z', skills: [] }),
-    previewSkillZip: vi.fn().mockResolvedValue([]),
+    importSkillZipBatch: vi.fn().mockResolvedValue({ results: [], skills: [] }),
+    previewSkillZip: vi.fn().mockResolvedValue({ previews: [], skipped: [] }),
     listConnectors: vi
       .fn()
       .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
@@ -730,29 +732,62 @@ describe('settings store: openSettingsToSkill', () => {
 })
 
 describe('settings store: skill bundle upload', () => {
-  it('previewSkillZip returns one preview per skill root the bundle contains', async () => {
-    api.previewSkillZip.mockResolvedValue([
-      {
-        subPath: 'skills/alpha',
-        name: 'Alpha',
-        description: '',
-        files: ['SKILL.md'],
-        alreadyImported: false
-      },
-      {
-        subPath: 'skills/beta',
-        name: 'Beta',
-        description: '',
-        files: ['SKILL.md'],
-        alreadyImported: true
-      }
-    ])
+  it('previewSkillZip returns the importable previews plus any skipped skills', async () => {
+    api.previewSkillZip.mockResolvedValue({
+      previews: [
+        {
+          subPath: 'skills/alpha',
+          name: 'Alpha',
+          description: '',
+          files: ['SKILL.md'],
+          alreadyImported: false
+        },
+        {
+          subPath: 'skills/beta',
+          name: 'Beta',
+          description: '',
+          files: ['SKILL.md'],
+          alreadyImported: true
+        }
+      ],
+      skipped: [{ source: 'oversized.zip', reason: 'too large (limit 8 MB)' }]
+    })
 
-    const previews = await useSettingsStore.getState().previewSkillZip('YmFzZTY0')
+    const { previews, skipped } = await useSettingsStore.getState().previewSkillZip('YmFzZTY0')
 
     expect(api.previewSkillZip).toHaveBeenCalledWith({ dataBase64: 'YmFzZTY0' })
-    expect(previews).toHaveLength(2)
     expect(previews.map((preview) => preview.name)).toEqual(['Alpha', 'Beta'])
+    expect(skipped).toEqual([{ source: 'oversized.zip', reason: 'too large (limit 8 MB)' }])
+  })
+
+  it('importSkillZipBatch forwards every item and reconciles the skill list once', async () => {
+    api.importSkillZipBatch.mockResolvedValue({
+      results: [
+        { subPath: 'skills/alpha', status: 'imported', id: 'imported-alpha' },
+        { subPath: 'skills/beta', status: 'unchanged', id: 'imported-beta' }
+      ],
+      skills: [
+        {
+          id: 'imported-alpha',
+          name: 'Alpha',
+          description: '',
+          source: 'imported',
+          updatedAt: '',
+          enabled: true
+        }
+      ]
+    })
+
+    const result = await useSettingsStore
+      .getState()
+      .importSkillZipBatch('YmFzZTY0', [{ subPath: 'skills/alpha' }, { subPath: 'skills/beta' }])
+
+    expect(api.importSkillZipBatch).toHaveBeenCalledWith({
+      dataBase64: 'YmFzZTY0',
+      items: [{ subPath: 'skills/alpha' }, { subPath: 'skills/beta' }]
+    })
+    expect(result.results).toHaveLength(2)
+    expect(useSettingsStore.getState().skills.map((skill) => skill.id)).toEqual(['imported-alpha'])
   })
 
   it('importSkillZip forwards the subPath/replaceId opts and reconciles the skill list', async () => {

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -23,7 +23,8 @@ import type {
   CreateSkillRequest,
   UpdateSkillRequest,
   ImportSkillResult,
-  SkillBundlePreview,
+  ImportSkillZipBatchResult,
+  SkillBundlePreviewResult,
   ScanRepoResult,
   UpsertProviderRequest,
   ValidateProviderRequest,
@@ -168,8 +169,15 @@ type SettingsStore = SettingsStoreData & {
     dataBase64: string,
     opts?: { subPath?: string; replaceId?: string }
   ) => Promise<ImportSkillResult>
-  // Parses an uploaded bundle without importing it, for a confirm-before-import preview.
-  previewSkillZip: (dataBase64: string) => Promise<SkillBundlePreview[]>
+  // Imports several skills from ONE uploaded bundle in a single call (decoded/unpacked once), returning
+  // a per-item outcome. Per-item failures are reported inline without aborting the rest.
+  importSkillZipBatch: (
+    dataBase64: string,
+    items: { subPath: string; replaceId?: string }[]
+  ) => Promise<ImportSkillZipBatchResult>
+  // Parses an uploaded bundle without importing it, for a confirm-before-import preview. Returns the
+  // importable skills plus any the bundle contained that were skipped and why.
+  previewSkillZip: (dataBase64: string) => Promise<SkillBundlePreviewResult>
   // Scans a GitHub repo for importable skill directories (does not mutate state).
   scanRepoSkills: (repo: string) => Promise<ScanRepoResult>
   // Loads the bundled-connector list (enabled/auto-allow + NCBI credential state) from main.
@@ -695,6 +703,12 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       subPath: opts?.subPath,
       replaceId: opts?.replaceId
     })
+    set({ skills: result.skills })
+    return result
+  },
+
+  importSkillZipBatch: async (dataBase64, items) => {
+    const result = await window.api.settings.importSkillZipBatch({ dataBase64, items })
     set({ skills: result.skills })
     return result
   },

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -546,13 +546,14 @@ export type ImportSkillZipBatchRequest = {
 
 // Per-item outcome of a batch import: the same status as a single import on success, or an error
 // message on failure, keyed by the requested subPath. The refreshed skill list is returned once.
+// Per-item outcome: on success `status` (+ `id`) is set and `error` is absent; on failure `error` is
+// set and `status`/`id` are absent. The two are mutually exclusive, so a caller keys off `error`.
+export type ImportSkillZipBatchItemResult =
+  | { subPath: string; status: 'imported' | 'unchanged' | 'updated'; id: string; error?: undefined }
+  | { subPath: string; status?: undefined; id?: undefined; error: string }
+
 export type ImportSkillZipBatchResult = {
-  results: {
-    subPath: string
-    status: 'imported' | 'unchanged' | 'updated'
-    id?: string
-    error?: string
-  }[]
+  results: ImportSkillZipBatchItemResult[]
   skills: SkillView[]
 }
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -536,6 +536,26 @@ export type PreviewSkillZipRequest = {
   dataBase64: string
 }
 
+// Import several skills from ONE uploaded bundle in a single call, so a bundle holding many skills is
+// unpacked once instead of re-decoded per skill. Each item selects a skill root by subPath (and may
+// target an existing imported skill to replace).
+export type ImportSkillZipBatchRequest = {
+  dataBase64: string
+  items: { subPath: string; replaceId?: string }[]
+}
+
+// Per-item outcome of a batch import: the same status as a single import on success, or an error
+// message on failure, keyed by the requested subPath. The refreshed skill list is returned once.
+export type ImportSkillZipBatchResult = {
+  results: {
+    subPath: string
+    status: 'imported' | 'unchanged' | 'updated'
+    id?: string
+    error?: string
+  }[]
+  skills: SkillView[]
+}
+
 // The parsed contents of a bundle: the skill's name/description, the files it contains, whether an
 // identical bundle was already imported (same content signature), and — when the name collides with
 // exactly one existing imported skill of different content — the id of that skill, offered as a
@@ -547,6 +567,22 @@ export type SkillBundlePreview = {
   files: string[]
   alreadyImported: boolean
   replaceableId?: string
+}
+
+// One skill the bundle contained but that couldn't be imported (too large, no SKILL.md, no name, an
+// unreadable nested archive, ...). `source` identifies it within the bundle (the nested archive name
+// or subPath); `reason` is a plain-English explanation shown to the user. Surfaced so a partial import
+// tells the user exactly what was left out instead of failing the whole bundle.
+export type SkippedSkill = {
+  source: string
+  reason: string
+}
+
+// Result of previewing a bundle: the importable skills, plus any that were skipped and why. A bundle
+// with a mix of good and bad skills yields previews for the good ones and a skipped entry per bad one.
+export type SkillBundlePreviewResult = {
+  previews: SkillBundlePreview[]
+  skipped: SkippedSkill[]
 }
 
 // Scan a GitHub repo (owner/repo, owner/repo@ref, or a URL) for skill directories.

--- a/src/shared/skill-import-limits.ts
+++ b/src/shared/skill-import-limits.ts
@@ -5,16 +5,36 @@
 // limits are generous for a real skill (a SKILL.md plus a handful of reference files) and only trip on
 // abuse.
 export const SKILL_IMPORT_LIMITS = {
-  // Structural cap on the number of files in one import: high enough for a mega-zip carrying several
+  // Structural cap on the number of files in ONE skill: high enough for a mega-zip carrying several
   // skills, low enough to reject a pathological archive. Total size is the real limit.
   maxFiles: 256,
   // Maximum size of any single file (decompressed, for zip entries).
   maxFileBytes: 5 * 1024 * 1024,
-  // Maximum total size across all files in one import (decompressed).
+  // Maximum total decompressed size of ONE skill (all files in a single skill root / inner bundle).
   maxTotalBytes: 10 * 1024 * 1024,
   // Maximum directory nesting either source is allowed to descend (zip subdirectories / GitHub dirs).
   maxDepth: 8,
   // Maximum GitHub API/download requests one import may issue, so a wide or mostly-empty directory
   // tree can't trigger an unbounded number of requests even before any file budget is spent.
-  maxRequests: 512
+  maxRequests: 512,
+  // --- Multi-skill / nested-bundle caps ---------------------------------------------------------
+  // A single uploaded bundle may hold many skills, each as a nested .zip/.skill entry. These caps
+  // bound the OUTER bundle so a resilient (skip-the-bad, keep-the-good) import can't be turned into a
+  // memory bomb: the per-skill caps above still apply to each individual skill once it's unpacked.
+  //
+  // Largest nested skill archive we'll even attempt to unpack (compressed). An inner archive bigger
+  // than this is skipped as "too large" rather than decompressed, so one oversized skill never blocks
+  // the rest of the bundle.
+  maxSkillArchiveBytes: 8 * 1024 * 1024,
+  // Largest uploaded bundle overall (the outer .zip). Generous enough for a bundle of many small
+  // skills, bounded so a single upload can't exhaust memory.
+  maxBundleBytes: 64 * 1024 * 1024,
+  // Most skills one bundle may contribute, so a pathological archive of tiny skills can't produce an
+  // unbounded number of import candidates.
+  maxSkillsPerBundle: 256,
+  // Structural cap on the number of entries in the OUTER bundle walk (loose files + nested archives),
+  // above the per-skill file cap since one bundle may hold many skills. Decompressed size
+  // (maxBundleBytes) is the real memory guard; this only rejects an archive with a pathological entry
+  // count.
+  maxBundleEntries: 4096
 } as const

--- a/src/shared/skill-import-limits.ts
+++ b/src/shared/skill-import-limits.ts
@@ -8,10 +8,12 @@ export const SKILL_IMPORT_LIMITS = {
   // Structural cap on the number of files in ONE skill: high enough for a mega-zip carrying several
   // skills, low enough to reject a pathological archive. Total size is the real limit.
   maxFiles: 256,
-  // Maximum size of any single file (decompressed, for zip entries).
-  maxFileBytes: 5 * 1024 * 1024,
+  // Maximum size of any single file (decompressed, for zip entries). Set high because real skills
+  // legitimately bundle large reference assets (datasets, templates, model files) worth keeping.
+  maxFileBytes: 50 * 1024 * 1024,
   // Maximum total decompressed size of ONE skill (all files in a single skill root / inner bundle).
-  maxTotalBytes: 10 * 1024 * 1024,
+  // Comfortably above the single-file cap so a skill can carry a large file plus its other resources.
+  maxTotalBytes: 128 * 1024 * 1024,
   // Maximum directory nesting either source is allowed to descend (zip subdirectories / GitHub dirs).
   maxDepth: 8,
   // Maximum GitHub API/download requests one import may issue, so a wide or mostly-empty directory
@@ -24,11 +26,12 @@ export const SKILL_IMPORT_LIMITS = {
   //
   // Largest nested skill archive we'll even attempt to unpack (compressed). An inner archive bigger
   // than this is skipped as "too large" rather than decompressed, so one oversized skill never blocks
-  // the rest of the bundle.
-  maxSkillArchiveBytes: 8 * 1024 * 1024,
-  // Largest uploaded bundle overall (the outer .zip). Generous enough for a bundle of many small
-  // skills, bounded so a single upload can't exhaust memory.
-  maxBundleBytes: 64 * 1024 * 1024,
+  // the rest of the bundle. Sized so a skill archive carrying a large reference asset still unpacks.
+  maxSkillArchiveBytes: 64 * 1024 * 1024,
+  // Largest uploaded bundle overall (the outer .zip). Generous enough for a bundle of several sizeable
+  // skills, bounded so a single upload can't exhaust memory. NOTE: the decoded bundle plus its
+  // extracted entries are held in memory during import, so this is the dominant memory bound.
+  maxBundleBytes: 256 * 1024 * 1024,
   // Most skills one bundle may contribute, so a pathological archive of tiny skills can't produce an
   // unbounded number of import candidates.
   maxSkillsPerBundle: 256,


### PR DESCRIPTION
## Summary

Importing a bundle of skills used to fail wholesale when a single item was bad. In particular a common export shape — a `.zip` whose entries are themselves per-skill `.zip` bundles ("zip-of-zips") — produced zero skill roots and failed with `The bundle must contain a SKILL.md.`, because the importer only unpacked one level and never recursed into the nested archives. Separately, one skill with a missing name aborted the whole preview, and the size caps applied to the whole bundle so one oversized skill sank the rest.

This makes bundle import resilient: parse what's parseable, skip the rest with a clear reason.

## What changed

- **Nested archives**: recurse one level into nested `.zip`/`.skill` entries, surfacing each inner skill under a namespaced `subPath` (bounded to a single level to guard against zip bombs).
- **Lenient extraction** (`extractZipLenient`): skip individual entries that violate a cap (too large / too many / too deep) with a plain-English reason, instead of throwing for the whole archive. Strict `extractZip` is unchanged for the single-skill path.
- **Resilient preview**: `previewZip` now returns `{ previews, skipped }` and never throws for an empty/partial bundle; a root with a missing/blank name is skipped, not fatal.
- **Per-skill caps**: existing file/skill size and file-count caps now apply per skill; new outer-bundle caps `maxSkillArchiveBytes` (8 MB), `maxBundleBytes` (64 MB), `maxSkillsPerBundle` (256), `maxBundleEntries` (4096). One oversized skill (e.g. a 50 MB entry) is skipped, not the whole bundle.
- **Batch import** (`importFromZipBatch`): import many skills from one upload in a single pass (decoded/unpacked once) with per-item error isolation, instead of re-sending the bundle per skill.
- **Renderer**: the confirm screen lists skipped skills with their reasons; surfaced errors strip the `Error invoking remote method '…'` IPC wrapper so users see only the human-readable message; the bundle size gate is raised to the whole-bundle cap.

## Behavior on a real "export all my skills" bundle

A 52 MB zip of 139 per-skill archives now imports the 138 normal skills and lists the one 50 MB skill as skipped (`too large (limit 8 MB)`), instead of failing outright.

## Tests

- Lenient extraction: skips oversized / over-count / over-total entries with reasons; still throws on a structurally invalid archive.
- Discovery: one skill per nested archive (namespaced), keeps good skills while skipping a nested archive with no SKILL.md or a corrupt one.
- Resilient preview: no-name root is skipped, not fatal; empty bundle returns `{ previews: [], skipped: [] }`.
- Batch import: imports every selected nested skill in one pass; a per-item failure is reported without aborting the rest.

## Verification

`typecheck`, `lint` (0 errors), full `test` (2897 passing), and `format` all green.
