### PR TITLE
fix(onboarding): soften data-root notice from red to amber advisory

### DIFF
--- a/src/renderer/src/components/DataRootWarning.tsx
+++ b/src/renderer/src/components/DataRootWarning.tsx
@@ -1,12 +1,13 @@
 import { TriangleAlert } from 'lucide-react'
 
-// Shared warning shown wherever the data-root folder is chosen or displayed (onboarding's
+// Shared advisory shown wherever the data-root folder is chosen or displayed (onboarding's
 // Location step, Settings' Storage panel): the folder's contents are managed by the app and must
-// not be hand-edited, or projects/history can break.
+// not be hand-edited, or projects/history can break. Uses the amber "waiting" tone (role="note")
+// rather than the red destructive tone so it reads as guidance, not an error.
 const DataRootWarning = (): React.JSX.Element => (
   <p
-    role="alert"
-    className="flex items-start gap-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+    role="note"
+    className="flex items-start gap-2 rounded-lg border border-session-waiting/40 bg-session-waiting/10 px-3 py-2 text-xs text-session-waiting"
   >
     <TriangleAlert className="mt-px size-3.5 shrink-0" aria-hidden="true" />
     <span>


### PR DESCRIPTION
## Summary

The data-location notice used the red `destructive` tone with `role="alert"`, which made users feel something was wrong when nothing was. It now uses the app's existing amber `session-waiting` tone with `role="note"`, so it reads as guidance rather than an error.

Both surfaces render the same shared `DataRootWarning` component, so a single change covers both:
- **Settings → Storage** (`StoragePanel.tsx`)
- **Onboarding → Data location** (`OnboardingWizard.tsx`)

### Changes
- `text-destructive` / `bg-destructive/5` / `border-destructive/40` → `text-session-waiting` / `bg-session-waiting/10` / `border-session-waiting/40` (same amber tone already used by `EnvironmentSetupCard` for its warning state).
- `role="alert"` → `role="note"` so screen readers announce it as advisory, not an assertive error.
- Kept the `TriangleAlert` icon and the wording.

## Tested
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run test` — 2948 passed, 43 skipped
- `npx prettier --check` on the changed file — pass