### PR TITLE
fix(storage): stop false "data folder not found" nag on non-ENOENT stat errors

### DIFF
--- a/src/main/storage/ipc.ts
+++ b/src/main/storage/ipc.ts
@@ -13,6 +13,7 @@ import {
   samePath
 } from '../storage-root'
 import { detectActiveSessions } from './detect-active'
+import { isDataRootMissing } from './path-presence'
 import { beginMigration, clearMigrationPending, endMigrationCopy } from './migration-state'
 import { shutdownBackends } from '../lifecycle-shutdown'
 import {
@@ -95,7 +96,11 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
     let legacyDataMovePrompt = false
     try {
       const storedSettings = await deps.settingsService.getStoredSettings()
-      dataRootMissing = Boolean(storedSettings.dataRoot) && !existsSync(dataRoot)
+      // Only an explicitly-configured root that stat proves is gone (ENOENT/ENOTDIR) counts as
+      // missing. isDataRootMissing deliberately does NOT collapse other stat errors into "missing"
+      // the way a bare existsSync would, so a non-ENOENT failure (seen with non-ASCII paths on some
+      // Windows setups, or a transient drive/IO hiccup) can't nag the user to abandon real data.
+      dataRootMissing = Boolean(storedSettings.dataRoot) && (await isDataRootMissing(dataRoot))
 
       const configRoot = resolveConfigRoot()
       const legacyInPlace = !storedSettings.dataRoot && samePath(dataRoot, configRoot)

--- a/src/main/storage/path-presence.test.ts
+++ b/src/main/storage/path-presence.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, rmdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { isDataRootMissing } from './path-presence'
+
+// An errno error the way node's fs surfaces it.
+const errno = (code: string): NodeJS.ErrnoException =>
+  Object.assign(new Error(code), { code }) as NodeJS.ErrnoException
+
+describe('isDataRootMissing', () => {
+  const created: string[] = []
+
+  afterEach(async () => {
+    for (const dir of created.splice(0)) await rmdir(dir).catch(() => undefined)
+  })
+
+  it('reports not missing when the directory exists (real fs)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'os-presence-'))
+    created.push(dir)
+
+    expect(await isDataRootMissing(dir)).toBe(false)
+  })
+
+  it('reports missing when the directory is gone (real fs, ENOENT)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'os-presence-'))
+    await rmdir(dir)
+
+    expect(await isDataRootMissing(dir)).toBe(true)
+  })
+
+  it('treats ENOTDIR (a file where a dir was expected) as missing', async () => {
+    const statFn = vi.fn().mockRejectedValue(errno('ENOTDIR'))
+
+    expect(await isDataRootMissing('/whatever/OpenScience', { statFn })).toBe(true)
+  })
+
+  it('does NOT treat a non-ENOENT stat error as missing, and logs it', async () => {
+    const logger = { warn: vi.fn() }
+    // EPERM / EBUSY / EINVAL / encoding-class failures must not be collapsed into "deleted": doing so
+    // would nag the user to abandon real data. This is the regression the fix targets.
+    for (const code of ['EPERM', 'EBUSY', 'EINVAL', 'EIO']) {
+      const statFn = vi.fn().mockRejectedValue(errno(code))
+      expect(await isDataRootMissing('/mnt/data/OpenScience', { statFn, logger })).toBe(false)
+    }
+
+    expect(logger.warn).toHaveBeenCalledTimes(4)
+  })
+
+  it('regression: a non-ASCII (CJK) path whose stat throws a non-ENOENT error is not missing', async () => {
+    const logger = { warn: vi.fn() }
+    const cjkPath = 'F:\\openscience产生数据\\OpenScience'
+    const statFn = vi.fn().mockRejectedValue(errno('EINVAL'))
+
+    expect(await isDataRootMissing(cjkPath, { statFn, logger })).toBe(false)
+    // The diagnostic logs code points so a non-ASCII path failure is decodable from a packaged log.
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ code: 'EINVAL', pathCodePoints: expect.stringContaining('U+4EA7') })
+    )
+  })
+
+  it('reports missing for a CJK path that genuinely does not exist (ENOENT)', async () => {
+    const statFn = vi.fn().mockRejectedValue(errno('ENOENT'))
+
+    expect(await isDataRootMissing('F:\\openscience产生数据\\OpenScience', { statFn })).toBe(true)
+  })
+})

--- a/src/main/storage/path-presence.ts
+++ b/src/main/storage/path-presence.ts
@@ -1,0 +1,51 @@
+import { stat } from 'node:fs/promises'
+
+import { createLogger } from '../logger'
+
+// Errno codes that unambiguously mean "the path is not there": the leaf is gone (ENOENT) or a path
+// segment is a file rather than a directory (ENOTDIR). On Windows a genuinely disconnected drive or
+// deleted folder also surfaces as ENOENT ("The system cannot find the path specified"), so treating
+// these as missing keeps the intended "data folder not found" dialog working.
+const MISSING_CODES = new Set(['ENOENT', 'ENOTDIR'])
+
+// Minimal logger shape so callers can inject one (and tests can assert) without importing electron.
+type PresenceLogger = Pick<ReturnType<typeof createLogger>, 'warn'>
+
+// Renders a string as its Unicode code points (e.g. "F:\\产" -> "U+0046 U+003A U+005C U+4EA7") so a
+// non-ASCII path that trips a stat failure on Windows can be diagnosed from logs without leaking the
+// raw path text into every field. Kept off the hot path — only built when a stat error is logged.
+const toCodePoints = (value: string): string =>
+  Array.from(value)
+    .map((ch) => `U+${(ch.codePointAt(0) ?? 0).toString(16).toUpperCase().padStart(4, '0')}`)
+    .join(' ')
+
+// Decides whether a configured data root should be reported as MISSING (which drives the destructive
+// "Data folder not found -> continue with an empty folder" prompt). This exists because a bare
+// existsSync/statSync-in-try-catch collapses EVERY failure into "false", so a non-ENOENT stat error
+// (a transient I/O hiccup, a permission error, or an encoding/`ERROR_NO_UNICODE_TRANSLATION`-class
+// failure seen with non-ASCII paths on some Windows setups) was being misread as "the folder was
+// deleted" and nagged the user on every launch.
+//
+// Contract: return true ONLY when stat proves the path is absent (ENOENT/ENOTDIR). Any other error is
+// indeterminate — we cannot conclude the data is gone, and wrongly offering to start empty risks
+// abandoning the user's real data — so we return false (don't nag) and log the code + code points.
+export const isDataRootMissing = async (
+  path: string,
+  deps: { statFn?: (p: string) => Promise<unknown>; logger?: PresenceLogger } = {}
+): Promise<boolean> => {
+  const statFn = deps.statFn ?? stat
+  const logger = deps.logger ?? createLogger('storage')
+  try {
+    await statFn(path)
+    return false
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code && MISSING_CODES.has(code)) return true
+
+    logger.warn('data root existence check inconclusive; not treating as missing', {
+      code: code ?? 'UNKNOWN',
+      pathCodePoints: toCodePoints(path)
+    })
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

On Windows, the "Data folder not found" dialog was shown on every launch when `settings.dataRoot` contained non-ASCII (CJK) characters, e.g. `F:\openscience产生数据\OpenScience` — even though the folder was present.

Root cause: `storage:get-info` computed the missing flag as `Boolean(storedSettings.dataRoot) && !existsSync(dataRoot)`. `existsSync` (a `statSync` wrapped in a bare try/catch) collapses **every** stat failure into `false`, not just "does not exist" (ENOENT). On the affected setup, `stat` of the CJK path on an external `F:` drive fails with a **non-ENOENT** error, which was misread as "the folder was deleted." The app then nagged the user with the destructive "Continue with an empty folder" prompt on each launch.

The path displayed in the dialog and the path passed to `existsSync` are the same `resolveDataRoot()` string, so this is not a settings round-trip / encoding-corruption issue — it is purely the over-broad error handling of `existsSync`.

## Changes

- Add `src/main/storage/path-presence.ts` → `isDataRootMissing()`: classify presence explicitly. Only `ENOENT`/`ENOTDIR` count as missing (a genuinely deleted folder or disconnected drive still surfaces the dialog as intended). Any other error is indeterminate → return `false` (do not nag; wrongly offering to start empty risks abandoning real data) and log the errno code plus the path's Unicode code points for diagnosis.
- Wire it into `storage:get-info`, replacing the bare `existsSync` for the missing check. `existsSync` is retained for the legacy config-root marker probes (always local, ASCII paths).
- `statFn`/`logger` are injectable for deterministic tests; production call is unchanged.

## Tested

- New `src/main/storage/path-presence.test.ts` (6 cases): existing dir, ENOENT-missing (real fs), ENOTDIR-missing, non-ENOENT errors (EPERM/EBUSY/EINVAL/EIO) not treated as missing + logged, and CJK-path regression cases (non-ENOENT → not missing; ENOENT → missing).
- `npm run typecheck` — clean.
- `npm run lint` — clean.
- `npm test` — 282 files / 2954 tests passing.
- `prettier --check` on changed files — clean.

## Notes

Not reproducible on macOS, so the fix is intentionally conservative (fail-safe toward "not missing") and adds a diagnostic `warn` log (errno code + path code points) so, if it recurs, the exact `stat` failure on the affected Windows machine is visible in packaged logs.