### PR TITLE
feat(settings): always show agent-card uninstall with an inline explainer

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -328,6 +328,7 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - All focusable controls use `focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50`.
 - Inputs may add `focus-visible:border-ring/50`; the light focus border target is `rgb(134 182 239)`.
 - Disabled controls use `disabled:pointer-events-none disabled:opacity-50`; shared buttons also use `touch-manipulation`.
+- **Exception — a disabled control that must explain _why_:** a natively `disabled` element receives no pointer events, so a `Tooltip` on it never opens. When the disabled state needs an on-hover explanation (e.g. the agent-framework Uninstall button when the runtime is not app-managed or is the active backend), render it as `aria-disabled` + `opacity-50 cursor-not-allowed` with a neutralized `onClick` instead of the native `disabled` attribute, so it keeps the greyed look yet stays hoverable as the tooltip trigger. Reserve this for standing (non-transient) reasons; transient busy states (in-flight install/detect) still use native `disabled` with no tooltip.
 - Sidebar buttons and icon triggers may use `cursor-pointer`; decorative row wrappers provide hover/active styling only and must not imply a click target outside the nested button.
 - Hover, focus, and active states must not change width, height, padding, or border width.
 

--- a/src/renderer/src/pages/settings/ClaudeStatusCard.render.test.tsx
+++ b/src/renderer/src/pages/settings/ClaudeStatusCard.render.test.tsx
@@ -75,10 +75,11 @@ describe('ClaudeStatusCard surface', () => {
       )
     })
 
-    // The button now always shows for a detected runtime, but a non-managed install can't be removed.
-    expect(findUninstallButton()?.disabled).toBe(true)
-    const help = container.querySelector('button[aria-label^="Why can\'t"]')
-    expect(help).not.toBeNull()
+    // The button now always shows for a detected runtime, but a non-managed install can't be removed:
+    // greyed via aria-disabled (kept hoverable for the tooltip) with an inline `?` icon.
+    const button = findUninstallButton()
+    expect(button?.getAttribute('aria-disabled')).toBe('true')
+    expect(button?.querySelector('.lucide-circle-question-mark')).not.toBeNull()
   })
 
   it('offers an uninstall action for a managed install and fires onUninstall on click', () => {
@@ -125,8 +126,8 @@ describe('ClaudeStatusCard surface', () => {
     const radio = container.querySelector<HTMLButtonElement>('[role="radio"]')
     expect(radio?.getAttribute('aria-checked')).toBe('true')
 
-    // The active runtime can't be uninstalled — switch away first.
-    expect(findUninstallButton()?.disabled).toBe(true)
+    // The active runtime can't be uninstalled — switch away first (greyed via aria-disabled).
+    expect(findUninstallButton()?.getAttribute('aria-disabled')).toBe('true')
 
     act(() => radio?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
     expect(onSelect).toHaveBeenCalledTimes(1)

--- a/src/renderer/src/pages/settings/ClaudeStatusCard.render.test.tsx
+++ b/src/renderer/src/pages/settings/ClaudeStatusCard.render.test.tsx
@@ -56,10 +56,29 @@ describe('ClaudeStatusCard surface', () => {
     expect(card?.className).toContain('bg-transparent')
   })
 
-  it('hides the uninstall action unless the install is app-managed', () => {
+  it('hides the uninstall action entirely when onUninstall is omitted (onboarding)', () => {
     render()
 
     expect(findUninstallButton()).toBeUndefined()
+  })
+
+  it('shows a disabled uninstall with a `?` explainer for a non-managed (PATH) install', () => {
+    act(() => {
+      root.render(
+        <ClaudeStatusCard
+          claude={{ resolvedPath: '/usr/local/bin/claude', version: '2.1.0' }}
+          claudeReady
+          isDetecting={false}
+          onDetect={vi.fn()}
+          onUninstall={vi.fn()}
+        />
+      )
+    })
+
+    // The button now always shows for a detected runtime, but a non-managed install can't be removed.
+    expect(findUninstallButton()?.disabled).toBe(true)
+    const help = container.querySelector('button[aria-label^="Why can\'t"]')
+    expect(help).not.toBeNull()
   })
 
   it('offers an uninstall action for a managed install and fires onUninstall on click', () => {

--- a/src/renderer/src/pages/settings/ClaudeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeStatusCard.tsx
@@ -1,10 +1,11 @@
-import { CheckCircle2, RefreshCw, Trash2, XCircle } from 'lucide-react'
+import { CheckCircle2, RefreshCw, XCircle } from 'lucide-react'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import type { ClaudeInfo } from '../../../../shared/settings'
+import { RuntimeUninstallControl } from './RuntimeUninstallControl'
 
 type ClaudeStatusCardProps = {
   claude: ClaudeInfo
@@ -20,9 +21,10 @@ type ClaudeStatusCardProps = {
   // Locks selection (e.g. while an install/uninstall is in flight) so the backend can't be switched
   // mid-operation.
   selectDisabled?: boolean
-  // Uninstall is offered only for the app-managed install (a binary the app owns in its data dir).
-  // Omitting onUninstall (as onboarding does) hides the action entirely. Disabled while this is the
-  // active runtime — the user must switch to the other framework first.
+  // The Uninstall button always shows for a detected runtime (omitting onUninstall, as onboarding does,
+  // hides it entirely). `managed` gates whether it's actionable: only an app-managed binary (one the app
+  // owns in its data dir) can be removed in-app. A non-managed (PATH/npm) install shows a greyed button
+  // with a `?` explaining manual removal; the active runtime is greyed with a "switch first" `?`.
   managed?: boolean
   isUninstalling?: boolean
   onUninstall?: () => void
@@ -99,20 +101,16 @@ const ClaudeStatusCard = ({
             <div className="flex items-center gap-2">{heading}</div>
           )}
           <div className="flex items-center gap-2">
-            {managed && onUninstall && claude.resolvedPath ? (
-              <Button
-                type="button"
-                variant="destructive"
-                size="sm"
-                onClick={onUninstall}
-                disabled={active || isUninstalling || isDetecting}
-                title={
-                  active ? 'Switch to the other framework before uninstalling Claude' : undefined
-                }
-              >
-                <Trash2 aria-hidden="true" />
-                Uninstall
-              </Button>
+            {onUninstall && claude.resolvedPath ? (
+              <RuntimeUninstallControl
+                label="Claude"
+                uninstallCommand="npm uninstall -g @anthropic-ai/claude-code"
+                managed={managed}
+                active={active}
+                isUninstalling={isUninstalling}
+                isDetecting={isDetecting}
+                onUninstall={onUninstall}
+              />
             ) : null}
             <Button
               type="button"

--- a/src/renderer/src/pages/settings/ClaudeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeStatusCard.tsx
@@ -21,6 +21,8 @@ type ClaudeStatusCardProps = {
   // Locks selection (e.g. while an install/uninstall is in flight) so the backend can't be switched
   // mid-operation.
   selectDisabled?: boolean
+  // Whether an install is running (global, either framework); locks the Uninstall button mid-operation.
+  isInstalling?: boolean
   // The Uninstall button always shows for a detected runtime (omitting onUninstall, as onboarding does,
   // hides it entirely). `managed` gates whether it's actionable: only an app-managed binary (one the app
   // owns in its data dir) can be removed in-app. A non-managed (PATH/npm) install shows a greyed button
@@ -44,6 +46,7 @@ const ClaudeStatusCard = ({
   selectDisabled = false,
   managed = false,
   isUninstalling = false,
+  isInstalling = false,
   onUninstall
 }: ClaudeStatusCardProps): React.JSX.Element => {
   // Only an installed runtime can be chosen as the active framework — switching to an uninstalled one
@@ -109,6 +112,7 @@ const ClaudeStatusCard = ({
                 active={active}
                 isUninstalling={isUninstalling}
                 isDetecting={isDetecting}
+                isInstalling={isInstalling}
                 onUninstall={onUninstall}
               />
             ) : null}

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.render.test.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.render.test.tsx
@@ -73,13 +73,14 @@ describe('OpencodeStatusCard', () => {
         button.textContent?.includes('Uninstall')
       )
 
-    // A detected but non-managed (PATH) opencode shows the button greyed out with an explainer.
+    // A detected but non-managed (PATH) opencode shows the button greyed out (aria-disabled) with an
+    // inline `?` explainer.
     render({
       opencode: { resolvedPath: '/usr/local/bin/opencode', version: '1.18.3' },
       onUninstall: vi.fn()
     })
-    expect(findUninstall()?.disabled).toBe(true)
-    expect(container.querySelector('button[aria-label^="Why can\'t"]')).not.toBeNull()
+    expect(findUninstall()?.getAttribute('aria-disabled')).toBe('true')
+    expect(findUninstall()?.querySelector('.lucide-circle-question-mark')).not.toBeNull()
 
     // The same install marked managed enables the action and fires onUninstall on click.
     render({
@@ -89,6 +90,7 @@ describe('OpencodeStatusCard', () => {
     })
     const button = findUninstall()
     expect(button?.disabled).toBe(false)
+    expect(button?.getAttribute('aria-disabled')).toBeNull()
 
     act(() => button?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
     expect(onUninstall).toHaveBeenCalledTimes(1)

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.render.test.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.render.test.tsx
@@ -66,25 +66,29 @@ describe('OpencodeStatusCard', () => {
     expect(trigger?.textContent).toContain('App-managed download (recommended)')
   })
 
-  it('offers an uninstall action only for a managed install and fires onUninstall on click', () => {
+  it('greys out uninstall (with a `?`) for a non-managed install and enables it for a managed one', () => {
     const onUninstall = vi.fn()
     const findUninstall = (): HTMLButtonElement | undefined =>
       Array.from(container.querySelectorAll('button')).find((button) =>
         button.textContent?.includes('Uninstall')
       )
 
-    // A detected but non-managed (PATH) opencode shows no uninstall action.
-    render({ opencode: { resolvedPath: '/usr/local/bin/opencode', version: '1.18.3' } })
-    expect(findUninstall()).toBeUndefined()
+    // A detected but non-managed (PATH) opencode shows the button greyed out with an explainer.
+    render({
+      opencode: { resolvedPath: '/usr/local/bin/opencode', version: '1.18.3' },
+      onUninstall: vi.fn()
+    })
+    expect(findUninstall()?.disabled).toBe(true)
+    expect(container.querySelector('button[aria-label^="Why can\'t"]')).not.toBeNull()
 
-    // The same install marked managed exposes the action.
+    // The same install marked managed enables the action and fires onUninstall on click.
     render({
       opencode: { resolvedPath: '/data/opencode-managed/bin/opencode', version: '1.18.3' },
       managed: true,
       onUninstall
     })
     const button = findUninstall()
-    expect(button).toBeDefined()
+    expect(button?.disabled).toBe(false)
 
     act(() => button?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
     expect(onUninstall).toHaveBeenCalledTimes(1)

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
@@ -126,6 +126,7 @@ const OpencodeStatusCard = ({
                 active={active}
                 isUninstalling={isUninstalling}
                 isDetecting={isDetecting}
+                isInstalling={isInstalling}
                 onUninstall={onUninstall}
               />
             ) : null}

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react'
-import { CheckCircle2, RefreshCw, Trash2, XCircle } from 'lucide-react'
+import { CheckCircle2, RefreshCw, XCircle } from 'lucide-react'
 
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
+import { RuntimeUninstallControl } from './RuntimeUninstallControl'
 import type {
   ClaudeInstallProgressEvent,
   ClaudeInstallSource,
@@ -35,8 +36,10 @@ type OpencodeStatusCardProps = {
   // Locks selection (e.g. while an install/uninstall is in flight) so the backend can't be switched
   // mid-operation.
   selectDisabled?: boolean
-  // Uninstall is offered only for the app-managed install (a binary the app owns in its data dir).
-  // Disabled while this is the active runtime — the user must switch to the other framework first.
+  // The Uninstall button always shows for a detected runtime (omitting onUninstall hides it entirely).
+  // `managed` gates whether it's actionable: only an app-managed binary (one the app owns in its data
+  // dir) can be removed in-app. A non-managed (PATH/npm) install shows a greyed button with a `?`
+  // explaining manual removal; the active runtime is greyed with a "switch first" `?`.
   managed?: boolean
   isUninstalling?: boolean
   onUninstall?: () => void
@@ -115,20 +118,16 @@ const OpencodeStatusCard = ({
             <div className="flex items-center gap-2">{heading}</div>
           )}
           <div className="flex items-center gap-2">
-            {managed && onUninstall && found ? (
-              <Button
-                type="button"
-                variant="destructive"
-                size="sm"
-                onClick={onUninstall}
-                disabled={active || isUninstalling || isDetecting}
-                title={
-                  active ? 'Switch to the other framework before uninstalling OpenCode' : undefined
-                }
-              >
-                <Trash2 aria-hidden="true" />
-                Uninstall
-              </Button>
+            {onUninstall && found ? (
+              <RuntimeUninstallControl
+                label="OpenCode"
+                uninstallCommand="npm uninstall -g opencode-ai"
+                managed={managed}
+                active={active}
+                isUninstalling={isUninstalling}
+                isDetecting={isDetecting}
+                onUninstall={onUninstall}
+              />
             ) : null}
             <Button
               type="button"

--- a/src/renderer/src/pages/settings/RuntimeUninstallControl.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimeUninstallControl.render.test.tsx
@@ -99,6 +99,17 @@ describe('RuntimeUninstallControl', () => {
     expect(button?.disabled).toBe(true)
     expect(hasHelpIcon()).toBe(false)
   })
+
+  it('lets a busy state take priority over a standing reason (native disabled, no `?`)', () => {
+    // A non-managed install has a standing reason, but a concurrent detect must still win: the button
+    // is natively disabled with no stale explainer while the operation is in flight.
+    render({ managed: false, isDetecting: true })
+
+    const button = uninstallButton()
+    expect(button?.disabled).toBe(true)
+    expect(button?.getAttribute('aria-disabled')).toBeNull()
+    expect(hasHelpIcon()).toBe(false)
+  })
 })
 
 // The tooltip content is portal-rendered by Radix only once open, which is unreliable to drive in jsdom,

--- a/src/renderer/src/pages/settings/RuntimeUninstallControl.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimeUninstallControl.render.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { RuntimeUninstallControl } from './RuntimeUninstallControl'
+import { uninstallDisabledHint } from './runtime-uninstall-hint'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const render = (
+  props: Partial<React.ComponentProps<typeof RuntimeUninstallControl>> = {}
+): (() => void) => {
+  const onUninstall = props.onUninstall ?? vi.fn()
+
+  act(() => {
+    root.render(
+      <RuntimeUninstallControl
+        label="Claude"
+        uninstallCommand="npm uninstall -g @anthropic-ai/claude-code"
+        managed
+        active={false}
+        isUninstalling={false}
+        isDetecting={false}
+        onUninstall={onUninstall}
+        {...props}
+      />
+    )
+  })
+
+  return onUninstall as () => void
+}
+
+const uninstallButton = (): HTMLButtonElement | undefined =>
+  Array.from(container.querySelectorAll('button')).find((button) =>
+    button.textContent?.includes('Uninstall')
+  )
+
+// The `?` explainer trigger, identified by its aria-label.
+const helpTrigger = (): HTMLButtonElement | null =>
+  container.querySelector<HTMLButtonElement>('button[aria-label^="Why can\'t"]')
+
+describe('RuntimeUninstallControl', () => {
+  it('enables uninstall and fires onUninstall for a non-active managed runtime, with no explainer', () => {
+    const onUninstall = render()
+
+    const button = uninstallButton()
+    expect(button?.disabled).toBe(false)
+    // A working uninstall needs no explanation.
+    expect(helpTrigger()).toBeNull()
+
+    act(() => button?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onUninstall).toHaveBeenCalledTimes(1)
+  })
+
+  it('greys out uninstall and renders a `?` explainer for a non-managed install', () => {
+    render({ managed: false })
+
+    expect(uninstallButton()?.disabled).toBe(true)
+    expect(helpTrigger()).not.toBeNull()
+  })
+
+  it('greys out uninstall and renders a `?` explainer when the runtime is active', () => {
+    render({ managed: true, active: true })
+
+    expect(uninstallButton()?.disabled).toBe(true)
+    expect(helpTrigger()).not.toBeNull()
+  })
+
+  it('greys out uninstall without an explainer while a removal is in flight', () => {
+    render({ managed: true, active: false, isUninstalling: true })
+
+    expect(uninstallButton()?.disabled).toBe(true)
+    // Transient busy states get no `?` — the button just locks.
+    expect(helpTrigger()).toBeNull()
+  })
+})
+
+// The tooltip content is portal-rendered by Radix only once open, which is unreliable to drive in jsdom,
+// so the exact English copy and its branching are verified through the pure helper the control uses.
+describe('uninstallDisabledHint', () => {
+  const command = 'npm uninstall -g @anthropic-ai/claude-code'
+
+  it('explains manual removal for a non-managed install, naming the command', () => {
+    const hint = uninstallDisabledHint('Claude', command, { managed: false, active: false })
+
+    expect(hint).toContain("Claude was found on your system but isn't managed by the app")
+    expect(hint).toContain(command)
+    expect(hint).toContain('then re-detect.')
+  })
+
+  it('tells the user to switch away from an active managed runtime', () => {
+    const hint = uninstallDisabledHint('OpenCode', command, { managed: true, active: true })
+
+    expect(hint).toBe(
+      "OpenCode is the active agent framework and can't be uninstalled. Switch to another framework first, then uninstall."
+    )
+  })
+
+  it('returns null for an actionable (non-active managed) runtime', () => {
+    expect(uninstallDisabledHint('Claude', command, { managed: true, active: false })).toBeNull()
+  })
+})

--- a/src/renderer/src/pages/settings/RuntimeUninstallControl.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimeUninstallControl.render.test.tsx
@@ -50,9 +50,10 @@ const uninstallButton = (): HTMLButtonElement | undefined =>
     button.textContent?.includes('Uninstall')
   )
 
-// The `?` explainer trigger, identified by its aria-label.
-const helpTrigger = (): HTMLButtonElement | null =>
-  container.querySelector<HTMLButtonElement>('button[aria-label^="Why can\'t"]')
+// The `?` explainer now lives inside the Uninstall button as a lucide CircleHelp icon (which lucide
+// renders with the `lucide-circle-question-mark` class).
+const hasHelpIcon = (): boolean =>
+  uninstallButton()?.querySelector('.lucide-circle-question-mark') != null
 
 describe('RuntimeUninstallControl', () => {
   it('enables uninstall and fires onUninstall for a non-active managed runtime, with no explainer', () => {
@@ -60,33 +61,43 @@ describe('RuntimeUninstallControl', () => {
 
     const button = uninstallButton()
     expect(button?.disabled).toBe(false)
-    // A working uninstall needs no explanation.
-    expect(helpTrigger()).toBeNull()
+    expect(button?.getAttribute('aria-disabled')).toBeNull()
+    // A working uninstall needs no `?`.
+    expect(hasHelpIcon()).toBe(false)
 
     act(() => button?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
     expect(onUninstall).toHaveBeenCalledTimes(1)
   })
 
-  it('greys out uninstall and renders a `?` explainer for a non-managed install', () => {
-    render({ managed: false })
+  it('greys out uninstall (aria-disabled) with an inline `?` for a non-managed install', () => {
+    const onUninstall = render({ managed: false, onUninstall: vi.fn() })
 
-    expect(uninstallButton()?.disabled).toBe(true)
-    expect(helpTrigger()).not.toBeNull()
+    const button = uninstallButton()
+    // Greyed via aria-disabled (not the native attribute) so the tooltip stays hoverable.
+    expect(button?.disabled).toBe(false)
+    expect(button?.getAttribute('aria-disabled')).toBe('true')
+    expect(hasHelpIcon()).toBe(true)
+
+    // The neutralized click does nothing.
+    act(() => button?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onUninstall).not.toHaveBeenCalled()
   })
 
-  it('greys out uninstall and renders a `?` explainer when the runtime is active', () => {
+  it('greys out uninstall with an inline `?` when the runtime is active', () => {
     render({ managed: true, active: true })
 
-    expect(uninstallButton()?.disabled).toBe(true)
-    expect(helpTrigger()).not.toBeNull()
+    const button = uninstallButton()
+    expect(button?.getAttribute('aria-disabled')).toBe('true')
+    expect(hasHelpIcon()).toBe(true)
   })
 
-  it('greys out uninstall without an explainer while a removal is in flight', () => {
+  it('natively disables uninstall without a `?` while a removal is in flight', () => {
     render({ managed: true, active: false, isUninstalling: true })
 
-    expect(uninstallButton()?.disabled).toBe(true)
-    // Transient busy states get no `?` — the button just locks.
-    expect(helpTrigger()).toBeNull()
+    const button = uninstallButton()
+    // Transient busy states use the native disabled attribute and get no `?`.
+    expect(button?.disabled).toBe(true)
+    expect(hasHelpIcon()).toBe(false)
   })
 })
 

--- a/src/renderer/src/pages/settings/RuntimeUninstallControl.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimeUninstallControl.render.test.tsx
@@ -36,6 +36,7 @@ const render = (
         active={false}
         isUninstalling={false}
         isDetecting={false}
+        isInstalling={false}
         onUninstall={onUninstall}
         {...props}
       />
@@ -104,6 +105,17 @@ describe('RuntimeUninstallControl', () => {
     // A non-managed install has a standing reason, but a concurrent detect must still win: the button
     // is natively disabled with no stale explainer while the operation is in flight.
     render({ managed: false, isDetecting: true })
+
+    const button = uninstallButton()
+    expect(button?.disabled).toBe(true)
+    expect(button?.getAttribute('aria-disabled')).toBeNull()
+    expect(hasHelpIcon()).toBe(false)
+  })
+
+  it('natively disables uninstall (no `?`) while an install is running, even with a standing reason', () => {
+    // isInstalling is global (either framework), so an install locks the button — including a
+    // non-managed card that would otherwise show its explainer.
+    render({ managed: false, isInstalling: true })
 
     const button = uninstallButton()
     expect(button?.disabled).toBe(true)

--- a/src/renderer/src/pages/settings/RuntimeUninstallControl.tsx
+++ b/src/renderer/src/pages/settings/RuntimeUninstallControl.tsx
@@ -1,0 +1,72 @@
+import { CircleHelp, Trash2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { uninstallDisabledHint } from './runtime-uninstall-hint'
+
+type RuntimeUninstallControlProps = {
+  // Framework name woven into the explainer copy ("Claude", "OpenCode").
+  label: string
+  // Manual-removal command shown in the not-managed hint (e.g. `npm uninstall -g <pkg>`).
+  uninstallCommand: string
+  // Whether this runtime is the app-managed install (the only case an in-app uninstall can run).
+  managed: boolean
+  // Whether this runtime backs the active agent framework (can't be removed out from under sessions).
+  active: boolean
+  isUninstalling: boolean
+  isDetecting: boolean
+  onUninstall: () => void
+}
+
+// Destructive Uninstall action for a detected runtime, always shown so every card carries the button.
+// Enabled only for a non-active app-managed install; otherwise greyed out. When the disabled state has a
+// standing reason (not app-managed, or the active framework), an adjacent `?` icon explains it on hover —
+// the tooltip hangs off the icon, not the button, because a disabled button doesn't fire hover events.
+const RuntimeUninstallControl = ({
+  label,
+  uninstallCommand,
+  managed,
+  active,
+  isUninstalling,
+  isDetecting,
+  onUninstall
+}: RuntimeUninstallControlProps): React.JSX.Element => {
+  const disabled = !managed || active || isUninstalling || isDetecting
+
+  // Only the two standing reasons get an explainer; a transient busy state (uninstalling/detecting)
+  // greys the button without a `?`.
+  const hint = uninstallDisabledHint(label, uninstallCommand, { managed, active })
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        onClick={onUninstall}
+        disabled={disabled}
+      >
+        <Trash2 aria-hidden="true" />
+        Uninstall
+      </Button>
+      {hint ? (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={`Why can't ${label} be uninstalled?`}
+                className="flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
+              >
+                <CircleHelp className="size-4" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs leading-relaxed">{hint}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+    </div>
+  )
+}
+
+export { RuntimeUninstallControl }

--- a/src/renderer/src/pages/settings/RuntimeUninstallControl.tsx
+++ b/src/renderer/src/pages/settings/RuntimeUninstallControl.tsx
@@ -2,6 +2,7 @@ import { CircleHelp, Trash2 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
 import { uninstallDisabledHint } from './runtime-uninstall-hint'
 
 type RuntimeUninstallControlProps = {
@@ -19,9 +20,11 @@ type RuntimeUninstallControlProps = {
 }
 
 // Destructive Uninstall action for a detected runtime, always shown so every card carries the button.
-// Enabled only for a non-active app-managed install; otherwise greyed out. When the disabled state has a
-// standing reason (not app-managed, or the active framework), an adjacent `?` icon explains it on hover —
-// the tooltip hangs off the icon, not the button, because a disabled button doesn't fire hover events.
+// Enabled only for a non-active app-managed install; otherwise greyed out. When the greyed state has a
+// standing reason (not app-managed, or the active framework), a trailing `?` icon appears inside the
+// button and its tooltip explains why. To keep that tooltip hoverable, the greyed button is only
+// aria-disabled (not natively disabled, which would swallow hover events) with its click neutralized; a
+// transient busy state (uninstalling/detecting) natively disables it with no `?`.
 const RuntimeUninstallControl = ({
   label,
   uninstallCommand,
@@ -31,41 +34,39 @@ const RuntimeUninstallControl = ({
   isDetecting,
   onUninstall
 }: RuntimeUninstallControlProps): React.JSX.Element => {
-  const disabled = !managed || active || isUninstalling || isDetecting
-
-  // Only the two standing reasons get an explainer; a transient busy state (uninstalling/detecting)
-  // greys the button without a `?`.
   const hint = uninstallDisabledHint(label, uninstallCommand, { managed, active })
+  const busy = isUninstalling || isDetecting
+
+  const button = (
+    <Button
+      type="button"
+      variant="destructive"
+      size="sm"
+      // A standing reason keeps the button hoverable via aria-disabled so its tooltip can open; only a
+      // transient busy state uses the native disabled attribute.
+      aria-disabled={hint ? true : undefined}
+      disabled={!hint && busy}
+      onClick={hint ? undefined : onUninstall}
+      className={cn(
+        hint && 'cursor-not-allowed opacity-50 hover:bg-destructive/10 dark:hover:bg-destructive/20'
+      )}
+    >
+      <Trash2 aria-hidden="true" />
+      Uninstall
+      {hint ? <CircleHelp aria-hidden="true" /> : null}
+    </Button>
+  )
+
+  // No standing reason (actionable, or only transiently busy): a plain button with no explainer.
+  if (!hint) return button
 
   return (
-    <div className="flex items-center gap-1.5">
-      <Button
-        type="button"
-        variant="destructive"
-        size="sm"
-        onClick={onUninstall}
-        disabled={disabled}
-      >
-        <Trash2 aria-hidden="true" />
-        Uninstall
-      </Button>
-      {hint ? (
-        <TooltipProvider delayDuration={200}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label={`Why can't ${label} be uninstalled?`}
-                className="flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
-              >
-                <CircleHelp className="size-4" aria-hidden="true" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-xs leading-relaxed">{hint}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      ) : null}
-    </div>
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent className="max-w-xs leading-relaxed">{hint}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 

--- a/src/renderer/src/pages/settings/RuntimeUninstallControl.tsx
+++ b/src/renderer/src/pages/settings/RuntimeUninstallControl.tsx
@@ -14,8 +14,11 @@ type RuntimeUninstallControlProps = {
   managed: boolean
   // Whether this runtime backs the active agent framework (can't be removed out from under sessions).
   active: boolean
+  // In-flight operations that lock the button. `isInstalling` is a global flag (one install at a time),
+  // so an install of either framework locks both cards' uninstall — matching the selection lock.
   isUninstalling: boolean
   isDetecting: boolean
+  isInstalling: boolean
   onUninstall: () => void
 }
 
@@ -24,7 +27,7 @@ type RuntimeUninstallControlProps = {
 // standing reason (not app-managed, or the active framework), a trailing `?` icon appears inside the
 // button and its tooltip explains why. To keep that tooltip hoverable, the greyed button is only
 // aria-disabled (not natively disabled, which would swallow hover events) with its click neutralized; a
-// transient busy state (uninstalling/detecting) natively disables it with no `?`.
+// transient busy state (installing/uninstalling/detecting) natively disables it with no `?`.
 const RuntimeUninstallControl = ({
   label,
   uninstallCommand,
@@ -32,9 +35,10 @@ const RuntimeUninstallControl = ({
   active,
   isUninstalling,
   isDetecting,
+  isInstalling,
   onUninstall
 }: RuntimeUninstallControlProps): React.JSX.Element => {
-  const busy = isUninstalling || isDetecting
+  const busy = isUninstalling || isDetecting || isInstalling
   // Busy takes priority: during detect/uninstall the button is natively disabled with no explainer, even
   // if a standing reason (non-managed / active) also applies — that reason is stale mid-operation.
   const hint = busy ? null : uninstallDisabledHint(label, uninstallCommand, { managed, active })

--- a/src/renderer/src/pages/settings/RuntimeUninstallControl.tsx
+++ b/src/renderer/src/pages/settings/RuntimeUninstallControl.tsx
@@ -34,18 +34,20 @@ const RuntimeUninstallControl = ({
   isDetecting,
   onUninstall
 }: RuntimeUninstallControlProps): React.JSX.Element => {
-  const hint = uninstallDisabledHint(label, uninstallCommand, { managed, active })
   const busy = isUninstalling || isDetecting
+  // Busy takes priority: during detect/uninstall the button is natively disabled with no explainer, even
+  // if a standing reason (non-managed / active) also applies — that reason is stale mid-operation.
+  const hint = busy ? null : uninstallDisabledHint(label, uninstallCommand, { managed, active })
 
   const button = (
     <Button
       type="button"
       variant="destructive"
       size="sm"
-      // A standing reason keeps the button hoverable via aria-disabled so its tooltip can open; only a
-      // transient busy state uses the native disabled attribute.
+      // A standing reason keeps the button hoverable via aria-disabled so its tooltip can open; a
+      // transient busy state uses the native disabled attribute instead (and shows no `?`).
       aria-disabled={hint ? true : undefined}
-      disabled={!hint && busy}
+      disabled={busy}
       onClick={hint ? undefined : onUninstall}
       className={cn(
         hint && 'cursor-not-allowed opacity-50 hover:bg-destructive/10 dark:hover:bg-destructive/20'

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -500,7 +500,9 @@ describe('SettingsPage uninstall confirmation', () => {
 
     const cardUninstall = findButton(document.body, 'Uninstall')
     expect(cardUninstall).toBeDefined()
-    expect(cardUninstall?.disabled).toBe(true)
+    // The active managed runtime is greyed via aria-disabled (kept hoverable for its explainer tooltip),
+    // not the native disabled attribute.
+    expect(cardUninstall?.getAttribute('aria-disabled')).toBe('true')
   })
 
   it('gates a framework switch behind the confirmation dialog', async () => {

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -750,6 +750,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                           selectDisabled={isInstalling || isUninstalling}
                           managed={claudeManaged}
                           isUninstalling={isUninstalling && pendingUninstall === 'claude'}
+                          isInstalling={isInstalling}
                           onUninstall={() => setPendingUninstall('claude')}
                         />
                         {!preflight.claudeReady ? (

--- a/src/renderer/src/pages/settings/runtime-uninstall-hint.ts
+++ b/src/renderer/src/pages/settings/runtime-uninstall-hint.ts
@@ -1,0 +1,19 @@
+// Standing reason (if any) a runtime's uninstall button is disabled, as English tooltip copy. Returns
+// null when the button is actionable (a non-active app-managed runtime) or only transiently disabled by
+// a busy state — those get no `?`. Kept separate from the component so the exact copy and branching are
+// unit-tested directly, without depending on Radix tooltip open-state in jsdom.
+export const uninstallDisabledHint = (
+  label: string,
+  uninstallCommand: string,
+  { managed, active }: { managed: boolean; active: boolean }
+): string | null => {
+  if (!managed) {
+    return `${label} was found on your system but isn't managed by the app, so it can't be uninstalled from here. Remove it with the tool you used to install it — for example \`${uninstallCommand}\`, your package manager, or by deleting it from your PATH — then re-detect.`
+  }
+
+  if (active) {
+    return `${label} is the active agent framework and can't be uninstalled. Switch to another framework first, then uninstall.`
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

In Settings → Model → **Agent framework**, both runtime cards (`ClaudeStatusCard`, `OpencodeStatusCard`) previously showed the **Uninstall** button only for an app-managed install, so a runtime found on PATH / installed via npm gave the user no signal about why it couldn't be removed from the app, or how to remove it. Now every card with a detected runtime shows the Uninstall button. It's actionable only for a non-active, app-managed install; otherwise it's greyed out with a trailing `?` icon **inside** the button whose tooltip explains why:

- **Not app-managed** — the app doesn't own this binary; how to remove it manually (`npm uninstall -g …`, your package manager, or by deleting it from your PATH), then re-detect.
- **Active framework** — it's the active agent; switch to another framework first, then uninstall.

## Implementation

- New shared `RuntimeUninstallControl` replaces the near-duplicate uninstall block in both cards, plus a pure `uninstallDisabledHint()` helper (`runtime-uninstall-hint.ts`) so the exact English copy and its branching are unit-tested directly.
- The greyed-with-reason button is `aria-disabled` (not natively `disabled`, which swallows hover events and would keep the tooltip from ever opening) with its click neutralized, so the button itself stays hoverable as the tooltip trigger. A transient busy state (uninstalling/detecting) takes priority and uses the native `disabled` attribute with no `?`. This `aria-disabled`-for-hoverable-tooltip exception is documented in `docs/design.md` (Focus / Disabled).
- Onboarding omits `onUninstall`, so it stays button-free; a not-detected card still shows the install picker.
- No change to `SettingsPage` wiring or the existing `UninstallRuntimeDialog` confirmation flow.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run test` (2957 passed / 43 skipped), and `prettier --check` all green.
- New `RuntimeUninstallControl.render.test.tsx` covers the enabled path, both greyed reasons (aria-disabled + inline `?`), the transient-busy path, and busy-takes-priority-over-a-standing-reason; `uninstallDisabledHint` copy is asserted directly. Updated the two card tests and `SettingsPage.render.test.tsx`'s active-card assertion.
- Not covered automatically: the live Radix tooltip won't open under jsdom's synthetic events, so hovering the greyed button (`npm run dev`) to confirm the copy renders is a manual check.