### PR TITLE
feat(cli): manage the headless backend as a daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,19 +272,19 @@ npm run dev
 
 Useful commands:
 
-| Command               | Purpose                              |
-| --------------------- | ------------------------------------ |
-| `npm run dev`         | Start the development application    |
-| `npm run dev:web`     | Dev app + localhost web UI (127.0.0.1) |
-| `npm run dev:headless`| Dev backend + web UI, no Electron window |
-| `npm run lint`        | Run ESLint                           |
-| `npm run typecheck`   | Type-check main and renderer code    |
-| `npm test`            | Run the Vitest suite                 |
-| `npm run build`       | Type-check and build the application |
-| `npm run build:web`   | Build the optional localhost web UI  |
-| `npm run build:mac`   | Package macOS builds                 |
-| `npm run build:win`   | Package Windows builds               |
-| `npm run build:linux` | Package Linux builds                 |
+| Command                | Purpose                                  |
+| ---------------------- | ---------------------------------------- |
+| `npm run dev`          | Start the development application        |
+| `npm run dev:web`      | Dev app + localhost web UI (127.0.0.1)   |
+| `npm run dev:headless` | Dev backend + web UI, no Electron window |
+| `npm run lint`         | Run ESLint                               |
+| `npm run typecheck`    | Type-check main and renderer code        |
+| `npm test`             | Run the Vitest suite                     |
+| `npm run build`        | Type-check and build the application     |
+| `npm run build:web`    | Build the optional localhost web UI      |
+| `npm run build:mac`    | Package macOS builds                     |
+| `npm run build:win`    | Package Windows builds                   |
+| `npm run build:linux`  | Package Linux builds                     |
 
 Packaged output is written under `dist/`.
 
@@ -302,6 +302,25 @@ Open the authenticated URL printed by the application. Use `npm run dev:headless
 backend, tray, agent runtime, and localhost web service without opening an Electron window.
 Set `OPEN_SCIENCE_WEB_PORT` to choose a port (default `44100`). Explicitly quitting the
 application still shuts down agent and Notebook processes normally.
+
+### CLI daemon management
+
+The CLI manages the Electron headless process as a background service, so the browser is the only
+UI and closing the terminal does not stop active sessions:
+
+```bash
+npm run build
+npm run cli -- start       # starts the daemon and opens the authenticated URL
+npm run cli -- status
+npm run cli -- url
+npm run cli -- stop        # graceful agent and Notebook shutdown
+```
+
+Use `--no-open` to start without opening a browser, `--port <port>` to choose a port, and `--json`
+with `status` for machine-readable output. Development builds are discovered from the repository.
+For an installed build, the CLI checks standard installation locations; override discovery with
+`--app-path <executable>` or `OPEN_SCIENCE_APP_PATH`. Use `--config-root <directory>` when an
+explicit configuration location is required.
 
 ## Building From Source
 

--- a/cli/config-root.mjs
+++ b/cli/config-root.mjs
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { access, readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { isAbsolute, join, normalize } from 'node:path'
+
+export const DEV_CONFIG_DIR = '.open-science-project'
+export const PROD_CONFIG_DIR = '.open-science'
+export const STATE_FILE = 'web-service.json'
+export const TOKEN_FILE = 'web-token'
+
+const exists = async (path) => {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const resolveConfigRoot = ({ packaged = false, override, env = process.env } = {}) => {
+  const requested = override ?? env.OPEN_SCIENCE_CONFIG_ROOT ?? env.OPEN_SCIENCE_STORAGE_ROOT
+  if (requested) {
+    if (!isAbsolute(requested)) throw new Error('The config root must be an absolute path.')
+    return normalize(requested)
+  }
+  return join(homedir(), packaged ? PROD_CONFIG_DIR : DEV_CONFIG_DIR)
+}
+
+export const candidateConfigRoots = ({ override, env = process.env } = {}) => {
+  if (override ?? env.OPEN_SCIENCE_CONFIG_ROOT ?? env.OPEN_SCIENCE_STORAGE_ROOT) {
+    return [resolveConfigRoot({ override, env })]
+  }
+  return [resolveConfigRoot({ packaged: false, env }), resolveConfigRoot({ packaged: true, env })]
+}
+
+export const readStateFromRoot = async (configRoot) => {
+  try {
+    const state = JSON.parse(await readFile(join(configRoot, STATE_FILE), 'utf8'))
+    if (
+      !Number.isInteger(state.pid) ||
+      !Number.isInteger(state.port) ||
+      typeof state.startedAt !== 'string'
+    ) {
+      return undefined
+    }
+    return { ...state, configRoot: state.configRoot || configRoot }
+  } catch {
+    return undefined
+  }
+}
+
+export const findServiceState = async (options = {}) => {
+  for (const configRoot of candidateConfigRoots(options)) {
+    if (!(await exists(join(configRoot, STATE_FILE)))) continue
+    const state = await readStateFromRoot(configRoot)
+    if (state) return state
+  }
+  return undefined
+}
+
+export const readWebToken = async (configRoot) =>
+  (await readFile(join(configRoot, TOKEN_FILE), 'utf8')).trim()

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -149,7 +149,9 @@ const startCommand = async (options) => {
   const logPath = join(configRoot, 'cli-daemon.log')
   const logFd = openSync(logPath, 'a')
   const port = options.port ?? DEFAULT_PORT
-  const child = spawn(app.command, [...app.args, '--headless', `--serve=${port}`], {
+  // `--open-science-headless` instead of `--headless`: Chromium consumes `--headless` and renders
+  // native menus (like the tray context menu) invisibly on Windows (electron/electron#48982).
+  const child = spawn(app.command, [...app.args, '--open-science-headless', `--serve=${port}`], {
     detached: true,
     stdio: ['ignore', logFd, logFd],
     windowsHide: true,

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { closeSync, openSync } from 'node:fs'
+import { mkdir, readFile, rm } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { spawn, spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { findServiceState, readWebToken, resolveConfigRoot, STATE_FILE } from './config-root.mjs'
+import { locateApp } from './locate-app.mjs'
+
+const DEFAULT_PORT = 44100
+const START_TIMEOUT_MS = 30_000
+const STOP_TIMEOUT_MS = 15_000
+
+const usage = `Usage: open-science <command> [options]
+
+Commands:
+  start       Start the headless backend and localhost web UI
+  stop        Gracefully stop the backend
+  status      Show backend status
+  url         Print the authenticated web URL
+
+Options:
+  --port <port>          Web service port (default: 44100)
+  --app-path <path>      Installed Open Science executable
+  --config-root <path>   Config directory override
+  --no-open              Do not open the browser after start
+  --json                 Machine-readable output for status
+  -h, --help             Show this help`
+
+export const parseCliArgs = (argv) => {
+  const args = [...argv]
+  const command = args.shift()
+  const options = { open: true, json: false }
+  while (args.length > 0) {
+    const arg = args.shift()
+    if (arg === '--no-open') options.open = false
+    else if (arg === '--json') options.json = true
+    else if (arg === '-h' || arg === '--help') options.help = true
+    else if (arg === '--port' || arg === '--app-path' || arg === '--config-root') {
+      const value = args.shift()
+      if (!value) throw new Error(`${arg} requires a value.`)
+      options[arg.slice(2).replace('-p', 'P').replace('-r', 'R')] = value
+    } else {
+      throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+  if (options.port !== undefined) {
+    const port = Number.parseInt(options.port, 10)
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error(`Invalid port: ${options.port}`)
+    }
+    options.port = port
+  }
+  return { command, options }
+}
+
+export const isProcessAlive = (pid) => {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return error.code === 'EPERM'
+  }
+}
+
+const authenticatedUrl = async (state) => {
+  const token = await readWebToken(state.configRoot)
+  return `http://127.0.0.1:${state.port}/?token=${encodeURIComponent(token)}`
+}
+
+const healthCheck = async (state) => {
+  if (!state || !isProcessAlive(state.pid)) return false
+  try {
+    const token = await readWebToken(state.configRoot)
+    const response = await fetch(`http://127.0.0.1:${state.port}/api/bootstrap`, {
+      headers: { authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(1_500)
+    })
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+const sleep = (milliseconds) =>
+  new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds))
+
+const waitForState = async (configRoot, timeoutMs = START_TIMEOUT_MS) => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const state = await findServiceState({ override: configRoot })
+    if (await healthCheck(state)) return state
+    await sleep(250)
+  }
+  return undefined
+}
+
+const openBrowser = (url) => {
+  const [command, args] =
+    process.platform === 'win32'
+      ? ['cmd', ['/c', 'start', '', url]]
+      : process.platform === 'darwin'
+        ? ['open', [url]]
+        : ['xdg-open', [url]]
+  const child = spawn(command, args, { detached: true, stdio: 'ignore', windowsHide: true })
+  child.unref()
+}
+
+const removeStateFiles = async (configRoot) => {
+  await rm(join(configRoot, STATE_FILE), { force: true })
+}
+
+const readLogTail = async (logPath) => {
+  try {
+    const text = await readFile(logPath, 'utf8')
+    return text.split(/\r?\n/).slice(-30).join('\n')
+  } catch {
+    return ''
+  }
+}
+
+const startCommand = async (options) => {
+  const existing = await findServiceState({ override: options.configRoot })
+  if (await healthCheck(existing)) {
+    const url = await authenticatedUrl(existing)
+    console.log(`Open Science is already running (PID ${existing.pid}).`)
+    console.log(url)
+    if (options.open) openBrowser(url)
+    return
+  }
+
+  const app = await locateApp({ appPath: options.appPath })
+  if (app.packaged && options.configRoot) {
+    throw new Error('--config-root is only supported for development builds.')
+  }
+  const configRoot = resolveConfigRoot({
+    packaged: app.packaged,
+    override: options.configRoot,
+    env: app.packaged ? {} : process.env
+  })
+  await mkdir(configRoot, { recursive: true })
+  await removeStateFiles(configRoot)
+
+  const logPath = join(configRoot, 'cli-daemon.log')
+  const logFd = openSync(logPath, 'a')
+  const port = options.port ?? DEFAULT_PORT
+  const child = spawn(app.command, [...app.args, '--headless', `--serve=${port}`], {
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+    windowsHide: true,
+    env: {
+      ...process.env,
+      ...(app.packaged ? {} : { OPEN_SCIENCE_STORAGE_ROOT: configRoot }),
+      OPEN_SCIENCE_WEB_PORT: String(port)
+    }
+  })
+  child.unref()
+  closeSync(logFd)
+
+  const state = await waitForState(configRoot)
+  if (!state) {
+    const logTail = await readLogTail(logPath)
+    throw new Error(
+      `Open Science did not become healthy within ${START_TIMEOUT_MS / 1000}s.${logTail ? `\n\n${logTail}` : ''}`
+    )
+  }
+  const url = await authenticatedUrl(state)
+  console.log(`Open Science started (PID ${state.pid}).`)
+  console.log(url)
+  if (options.open) openBrowser(url)
+}
+
+const findCurrentState = async (options) => {
+  const state = await findServiceState({ override: options.configRoot })
+  if (!state) return undefined
+  if (!isProcessAlive(state.pid)) {
+    await removeStateFiles(state.configRoot)
+    return undefined
+  }
+  return state
+}
+
+const stopCommand = async (options) => {
+  const state = await findCurrentState(options)
+  if (!state) {
+    console.log('Open Science is not running.')
+    return
+  }
+  const token = await readWebToken(state.configRoot)
+  try {
+    const response = await fetch(`http://127.0.0.1:${state.port}/api/shutdown`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(3_000)
+    })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    await response.arrayBuffer()
+  } catch (error) {
+    console.warn(`Graceful shutdown failed: ${error.message}`)
+  }
+
+  const deadline = Date.now() + STOP_TIMEOUT_MS
+  while (Date.now() < deadline && isProcessAlive(state.pid)) await sleep(250)
+  if (isProcessAlive(state.pid)) {
+    console.warn('Graceful shutdown timed out; terminating the process tree.')
+    if (process.platform === 'win32') {
+      spawnSync('taskkill', ['/PID', String(state.pid), '/T', '/F'], { stdio: 'ignore' })
+    } else {
+      process.kill(state.pid, 'SIGTERM')
+    }
+  }
+  await removeStateFiles(state.configRoot)
+  console.log('Open Science stopped.')
+}
+
+const statusCommand = async (options) => {
+  const state = await findCurrentState(options)
+  const running = await healthCheck(state)
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        running
+          ? { running: true, ...state, url: await authenticatedUrl(state) }
+          : { running: false },
+        null,
+        2
+      )
+    )
+  } else if (running) {
+    console.log(`Open Science is running (PID ${state.pid}, port ${state.port}).`)
+    console.log(await authenticatedUrl(state))
+  } else {
+    console.log('Open Science is not running.')
+  }
+  if (!running) process.exitCode = 1
+}
+
+const urlCommand = async (options) => {
+  const state = await findCurrentState(options)
+  if (!(await healthCheck(state))) throw new Error('Open Science is not running.')
+  console.log(await authenticatedUrl(state))
+}
+
+export const runCli = async (argv = process.argv.slice(2)) => {
+  const { command, options } = parseCliArgs(argv)
+  if (options.help || !command || command === '-h' || command === '--help') {
+    console.log(usage)
+    return
+  }
+  if (command === 'start') await startCommand(options)
+  else if (command === 'stop') await stopCommand(options)
+  else if (command === 'status') await statusCommand(options)
+  else if (command === 'url') await urlCommand(options)
+  else throw new Error(`Unknown command: ${command}\n\n${usage}`)
+}
+
+const isEntryPoint =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))
+if (isEntryPoint) {
+  runCli().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  })
+}

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseCliArgs } from './index.mjs'
+
+describe('CLI argument parsing', () => {
+  it('parses start options', () => {
+    expect(
+      parseCliArgs([
+        'start',
+        '--port',
+        '44200',
+        '--app-path',
+        '/opt/open-science',
+        '--config-root',
+        '/tmp/open-science',
+        '--no-open'
+      ])
+    ).toEqual({
+      command: 'start',
+      options: {
+        open: false,
+        json: false,
+        port: 44200,
+        appPath: '/opt/open-science',
+        configRoot: '/tmp/open-science'
+      }
+    })
+  })
+
+  it('parses status JSON output and rejects invalid options', () => {
+    expect(parseCliArgs(['status', '--json'])).toEqual({
+      command: 'status',
+      options: { open: true, json: true }
+    })
+    expect(() => parseCliArgs(['start', '--port', '70000'])).toThrow('Invalid port')
+    expect(() => parseCliArgs(['start', '--unknown'])).toThrow('Unknown option')
+  })
+})

--- a/cli/locate-app.mjs
+++ b/cli/locate-app.mjs
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { access, readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { delimiter, dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const cliDir = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(cliDir, '..')
+const require = createRequire(import.meta.url)
+
+const exists = async (path) => {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const executableOnPath = async (name, env = process.env) => {
+  const suffixes = process.platform === 'win32' ? ['', '.exe', '.cmd'] : ['']
+  for (const directory of (env.PATH ?? '').split(delimiter).filter(Boolean)) {
+    for (const suffix of suffixes) {
+      const candidate = join(directory, `${name}${suffix}`)
+      if (await exists(candidate)) return candidate
+    }
+  }
+  return undefined
+}
+
+const defaultInstalledCandidates = (env = process.env) => {
+  if (process.platform === 'win32') {
+    return [
+      env.LOCALAPPDATA && join(env.LOCALAPPDATA, 'Programs', 'Open Science', 'Open Science.exe'),
+      env.PROGRAMFILES && join(env.PROGRAMFILES, 'Open Science', 'Open Science.exe')
+    ].filter(Boolean)
+  }
+  if (process.platform === 'darwin') {
+    return ['/Applications/Open Science.app/Contents/MacOS/Open Science']
+  }
+  return ['/usr/bin/open-science', '/usr/local/bin/open-science']
+}
+
+const locateDevelopmentApp = async () => {
+  const mainEntry = join(repositoryRoot, 'out', 'main', 'index.js')
+  const webEntry = join(repositoryRoot, 'out', 'web', 'index.html')
+  const electronModule = join(repositoryRoot, 'node_modules', 'electron')
+  if (!(await exists(mainEntry)) || !(await exists(webEntry)) || !(await exists(electronModule))) {
+    return undefined
+  }
+  const electronPath = require(electronModule)
+  if (!(await exists(electronPath))) return undefined
+  return {
+    command: electronPath,
+    args: [repositoryRoot],
+    packaged: false,
+    repositoryRoot
+  }
+}
+
+export const locateApp = async ({ appPath, env = process.env } = {}) => {
+  const explicit = appPath ?? env.OPEN_SCIENCE_APP_PATH
+  if (explicit) {
+    const command = resolve(explicit)
+    if (!(await exists(command))) throw new Error(`Open Science executable not found: ${command}`)
+    return { command, args: [], packaged: true, repositoryRoot }
+  }
+
+  const development = await locateDevelopmentApp()
+  if (development) return development
+
+  for (const candidate of defaultInstalledCandidates(env)) {
+    if (await exists(candidate)) {
+      return { command: candidate, args: [], packaged: true, repositoryRoot }
+    }
+  }
+
+  if (process.platform === 'linux') {
+    const command = await executableOnPath('open-science', env)
+    if (command) return { command, args: [], packaged: true, repositoryRoot }
+  }
+
+  const packageJson = JSON.parse(await readFile(join(repositoryRoot, 'package.json'), 'utf8'))
+  throw new Error(
+    `Could not locate ${packageJson.productName}. Run "npm run build" in the repository, install the app, or pass --app-path.`
+  )
+}
+
+export { repositoryRoot }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "bin": {
+        "open-science": "cli/index.mjs"
+      },
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "^0.58.1",
         "@agentclientprotocol/sdk": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "author": "aipoch",
   "license": "Apache-2.0",
   "homepage": "https://www.aipoch.com/open-science",
+  "bin": {
+    "open-science": "cli/index.mjs"
+  },
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint --cache .",
@@ -22,6 +25,7 @@
     "dev": "electron-vite dev",
     "dev:web": "node scripts/dev-app-branding.cjs && node scripts/dev-web.cjs",
     "dev:headless": "node scripts/dev-app-branding.cjs && node scripts/dev-web.cjs --headless",
+    "cli": "node cli/index.mjs",
     "build": "npm run typecheck && electron-vite build && npm run build:web",
     "postinstall": "prisma generate && electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",

--- a/scripts/dev-web.cjs
+++ b/scripts/dev-web.cjs
@@ -11,7 +11,9 @@ if (!process.env.OPEN_SCIENCE_WEB_PORT?.trim()) {
 }
 
 const args = ['electron-vite', 'dev']
-if (headless) args.push('--', '--headless')
+// Pass a namespaced flag to Electron: Chromium consumes a literal `--headless` and renders native
+// menus (like the tray context menu) invisibly on Windows (electron/electron#48982).
+if (headless) args.push('--', '--open-science-headless')
 
 const result = spawnSync('npx', args, {
   cwd: path.join(__dirname, '..'),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,7 +67,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { createAppTray },
         { installAppLifecycle },
         { installRpcCapture },
-        { parseWebModeOptions, startOptionalWebService }
+        { parseWebModeOptions, startOptionalWebService, buildAuthenticatedWebUrl }
       ] = await Promise.all([
         import('./ipc'),
         import('./windows'),
@@ -142,6 +142,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         isMigrationInProgress,
         createMainWindow,
         createAppTray,
+        buildAuthenticatedWebUrl,
         shutdownCoordinator,
         installAppLifecycle,
         log,
@@ -161,7 +162,27 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       ctx.installAppLifecycle({
         app,
         createMainWindow: ctx.createMainWindow,
-        createTray: (handlers) => ctx.createAppTray({ iconPath: icon, ...handlers }),
+        createTray: (handlers) => {
+          const webPort = ctx.webServer?.port
+          const headlessWeb = ctx.webMode.headless && webPort !== undefined
+          return ctx.createAppTray({
+            iconPath: icon,
+            ...handlers,
+            ...(headlessWeb
+              ? {
+                  headless: true,
+                  onOpenWeb: async () => {
+                    const { shell } = await import('electron')
+                    await shell.openExternal(await ctx.buildAuthenticatedWebUrl(webPort))
+                  },
+                  onCopyWebUrl: async () => {
+                    const { clipboard } = await import('electron')
+                    clipboard.writeText(await ctx.buildAuthenticatedWebUrl(webPort))
+                  }
+                }
+              : {})
+          })
+        },
         // Latching quit teardown via the shared coordinator (the same one the update gate uses). The
         // coordinator awaits the agent + kernel process trees so a Windows taskkill /T completes before
         // app.exit; runForQuit bounds it so a stuck backend can't hang quit.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -130,7 +130,11 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
       const { shutdownCoordinator } = await registerIpcHandlers({ mainEntryPath })
       const webServer = rpcCapture
-        ? await startOptionalWebService({ options: webMode, rpc: rpcCapture })
+        ? await startOptionalWebService({
+            options: webMode,
+            rpc: rpcCapture,
+            requestShutdown: () => app.quit()
+          })
         : undefined
 
       return {

--- a/src/main/tray.test.ts
+++ b/src/main/tray.test.ts
@@ -20,6 +20,12 @@ type TrayCall = {
   tooltip?: string
   contextMenu?: { template: MenuTemplateItem[] }
   clickHandler?: () => void
+  doubleClickHandler?: () => void
+  rightClickHandler?: () => void
+  poppedMenu?: {
+    menu: { template: MenuTemplateItem[] }
+    position?: { x: number; y: number }
+  }
 }
 
 let lastTray: TrayCall | undefined
@@ -63,8 +69,18 @@ class FakeTray {
     if (lastTray) lastTray.contextMenu = menu
   }
 
+  popUpContextMenu(
+    menu: { template: MenuTemplateItem[] },
+    position?: { x: number; y: number }
+  ): void {
+    if (lastTray) lastTray.poppedMenu = { menu, position }
+  }
+
   on(event: string, handler: () => void): void {
-    if (event === 'click' && lastTray) lastTray.clickHandler = handler
+    if (!lastTray) return
+    if (event === 'click') lastTray.clickHandler = handler
+    if (event === 'double-click') lastTray.doubleClickHandler = handler
+    if (event === 'right-click') lastTray.rightClickHandler = handler
   }
 }
 
@@ -83,6 +99,9 @@ vi.mock('electron', () => ({
   nativeImage: {
     createFromPath: () => makeImage('path'),
     createFromBitmap: () => makeImage('bitmap')
+  },
+  screen: {
+    getCursorScreenPoint: () => ({ x: 1200, y: 800 })
   }
 }))
 
@@ -159,6 +178,81 @@ describe('createAppTray', () => {
 
     lastTray?.clickHandler?.()
     expect(onShow).toHaveBeenCalledTimes(2)
+  })
+
+  it('builds a headless web menu and left click opens the web UI', () => {
+    const onOpenWeb = vi.fn()
+    const onCopyWebUrl = vi.fn()
+    const onQuit = vi.fn()
+
+    createAppTray({
+      iconPath: '/icons/tray.png',
+      onShow: vi.fn(),
+      onHide: vi.fn(),
+      onQuit,
+      headless: true,
+      onOpenWeb,
+      onCopyWebUrl
+    })
+
+    expect(lastTray?.tooltip).toBe('Open Science (Web)')
+    expect(lastTemplate?.filter((item) => item.label).map((item) => item.label)).toEqual([
+      'Open Web UI',
+      'Copy URL',
+      'Quit'
+    ])
+
+    findItem('Open Web UI').click?.()
+    findItem('Copy URL').click?.()
+    findItem('Quit').click?.()
+    lastTray?.clickHandler?.()
+
+    expect(onOpenWeb).toHaveBeenCalledTimes(2)
+    expect(onCopyWebUrl).toHaveBeenCalledTimes(1)
+    expect(onQuit).toHaveBeenCalledTimes(1)
+  })
+
+  describe('on Windows', () => {
+    beforeEach(() => {
+      setPlatform('win32')
+    })
+
+    it('pops the context menu on right click and uses double click for the primary action', () => {
+      const onShow = vi.fn()
+
+      createAppTray({
+        iconPath: '/icons/tray.png',
+        onShow,
+        onHide: vi.fn(),
+        onQuit: vi.fn()
+      })
+
+      expect(lastTray?.contextMenu).toBeUndefined()
+      lastTray?.rightClickHandler?.()
+      expect(lastTray?.poppedMenu?.menu.template).toBe(lastTemplate)
+      expect(lastTray?.poppedMenu?.position).toEqual({ x: 1200, y: 800 })
+      expect(lastTray?.clickHandler).toBeUndefined()
+
+      lastTray?.doubleClickHandler?.()
+      expect(onShow).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses double click to open the web UI in headless mode', () => {
+      const onOpenWeb = vi.fn()
+
+      createAppTray({
+        iconPath: '/icons/tray.png',
+        onShow: vi.fn(),
+        onHide: vi.fn(),
+        onQuit: vi.fn(),
+        headless: true,
+        onOpenWeb,
+        onCopyWebUrl: vi.fn()
+      })
+
+      lastTray?.doubleClickHandler?.()
+      expect(onOpenWeb).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('uses the full-color icon (not a template) on non-darwin platforms', () => {

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,4 +1,4 @@
-import { Menu, Tray, nativeImage, type NativeImage } from 'electron'
+import { Menu, Tray, nativeImage, screen, type NativeImage } from 'electron'
 
 import { createLogger } from './logger'
 
@@ -50,6 +50,9 @@ const createAppTray = (opts: {
   onShow: () => void
   onHide: () => void
   onQuit: () => void
+  headless?: boolean
+  onOpenWeb?: () => void | Promise<void>
+  onCopyWebUrl?: () => void | Promise<void>
 }): Tray | undefined => {
   try {
     // macOS gets a monochrome template glyph that follows the menu-bar appearance; other platforms use
@@ -60,19 +63,41 @@ const createAppTray = (opts: {
         : nativeImage.createFromPath(opts.iconPath)
     const tray = new Tray(icon)
 
-    // Right-click (or platform default) menu with the core actions.
-    const menu = Menu.buildFromTemplate([
-      { label: 'Show', click: () => opts.onShow() },
-      { label: 'Hide', click: () => opts.onHide() },
-      { type: 'separator' },
-      { label: 'Quit', click: () => opts.onQuit() }
-    ])
+    const headlessWeb = opts.headless && opts.onOpenWeb && opts.onCopyWebUrl
+    const menu = Menu.buildFromTemplate(
+      headlessWeb
+        ? [
+            { label: 'Open Web UI', click: () => void opts.onOpenWeb!() },
+            { label: 'Copy URL', click: () => void opts.onCopyWebUrl!() },
+            { type: 'separator' },
+            { label: 'Quit', click: () => opts.onQuit() }
+          ]
+        : [
+            { label: 'Show', click: () => opts.onShow() },
+            { label: 'Hide', click: () => opts.onHide() },
+            { type: 'separator' },
+            { label: 'Quit', click: () => opts.onQuit() }
+          ]
+    )
 
-    tray.setToolTip('Open Science')
-    tray.setContextMenu(menu)
+    tray.setToolTip(headlessWeb ? 'Open Science (Web)' : 'Open Science')
 
-    // Left click reveals the window on Windows/Linux where it is the expected affordance.
-    tray.on('click', () => opts.onShow())
+    const primaryAction = (): void => {
+      if (headlessWeb) void opts.onOpenWeb!()
+      else opts.onShow()
+    }
+
+    // Windows: setContextMenu suppresses right-click and single-click behavior is inconsistent.
+    // Pop the menu explicitly on right-click and use double-click for the primary action.
+    if (process.platform === 'win32') {
+      tray.on('right-click', () => {
+        tray.popUpContextMenu(menu, screen.getCursorScreenPoint())
+      })
+      tray.on('double-click', primaryAction)
+    } else {
+      tray.setContextMenu(menu)
+      tray.on('click', primaryAction)
+    }
 
     return tray
   } catch (error) {

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -84,4 +84,43 @@ describe('startWebHttpServer', () => {
     })
     socket.close()
   })
+
+  it('authenticates shutdown requests before invoking the callback', async () => {
+    const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
+    roots.push(staticRoot)
+    await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
+    const onShutdownRequest = vi.fn()
+    const server = await startWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot,
+      rpc: {
+        channels: () => [],
+        invoke: vi.fn(),
+        releaseClient: vi.fn(),
+        dispose: vi.fn()
+      },
+      onShutdownRequest,
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const endpoint = `http://127.0.0.1:${server.port}/api/shutdown`
+
+    expect((await fetch(endpoint, { method: 'POST' })).status).toBe(401)
+    expect(onShutdownRequest).not.toHaveBeenCalled()
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-token' }
+    })
+    expect(response.status).toBe(202)
+    expect(await response.json()).toEqual({ ok: true })
+    await vi.waitFor(() => expect(onShutdownRequest).toHaveBeenCalledOnce())
+  })
 })

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -29,6 +29,7 @@ type WebServerOptions = {
   token: string
   staticRoot: string
   rpc: RpcCapture
+  onShutdownRequest?: () => void
   bootstrap: {
     appName: string
     appVersion: string
@@ -188,6 +189,16 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
 
       if (url.pathname === '/api/bootstrap' && request.method === 'GET') {
         json(response, 200, { ...options.bootstrap, rpcChannels: options.rpc.channels() })
+        return
+      }
+
+      if (url.pathname === '/api/shutdown' && request.method === 'POST') {
+        if (!options.onShutdownRequest) {
+          json(response, 404, { ok: false, error: 'Shutdown is not available.' })
+          return
+        }
+        json(response, 202, { ok: true })
+        setImmediate(options.onShutdownRequest)
         return
       }
 

--- a/src/main/web-service/index.test.ts
+++ b/src/main/web-service/index.test.ts
@@ -15,7 +15,7 @@ describe('parseWebModeOptions', () => {
     expect(parseWebModeOptions(['electron', '--serve'], {}).enabled).toBe(true)
     expect(parseWebModeOptions(['electron', '--serve=0'], {}).port).toBe(0)
     expect(parseWebModeOptions(['electron'], { OPEN_SCIENCE_WEB_PORT: '44200' }).port).toBe(44200)
-    expect(parseWebModeOptions(['electron', '--headless'], {})).toMatchObject({
+    expect(parseWebModeOptions(['electron', '--open-science-headless'], {})).toMatchObject({
       enabled: true,
       headless: true
     })

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -8,23 +8,28 @@ import { loadOrCreateWebToken } from './auth'
 import { startWebHttpServer, type RunningWebServer } from './http-server'
 import type { WebModeOptions } from './options'
 import type { RpcCapture } from './rpc-capture'
+import { removeWebServiceState, writeWebServiceState } from './state-file'
 
 const startOptionalWebService = async ({
   options,
-  rpc
+  rpc,
+  requestShutdown
 }: {
   options: WebModeOptions
   rpc: RpcCapture
+  requestShutdown: () => void
 }): Promise<RunningWebServer | undefined> => {
   if (!options.enabled) return undefined
 
-  const token = await loadOrCreateWebToken(resolveConfigRoot())
+  const configRoot = resolveConfigRoot()
+  const token = await loadOrCreateWebToken(configRoot)
   const server = await startWebHttpServer({
     host: '127.0.0.1',
     port: options.port,
     token,
     staticRoot: join(app.getAppPath(), 'out', 'web'),
     rpc,
+    onShutdownRequest: requestShutdown,
     bootstrap: {
       appName: app.getName(),
       appVersion: app.getVersion(),
@@ -37,6 +42,18 @@ const startOptionalWebService = async ({
     }
   })
 
+  try {
+    await writeWebServiceState(configRoot, {
+      pid: process.pid,
+      port: server.port,
+      startedAt: new Date().toISOString(),
+      appVersion: app.getVersion()
+    })
+  } catch (error) {
+    await server.close()
+    throw error
+  }
+
   const url = `http://127.0.0.1:${server.port}/?token=${encodeURIComponent(token)}`
   createLogger('web-service').info('local web service started', {
     host: '127.0.0.1',
@@ -44,7 +61,16 @@ const startOptionalWebService = async ({
     url: `http://127.0.0.1:${server.port}/`
   })
   console.log(`Open Science Web: ${url}`)
-  return server
+  return {
+    port: server.port,
+    close: async () => {
+      try {
+        await server.close()
+      } finally {
+        await removeWebServiceState(configRoot)
+      }
+    }
+  }
 }
 
 export { parseWebModeOptions } from './options'

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -73,6 +73,11 @@ const startOptionalWebService = async ({
   }
 }
 
+const buildAuthenticatedWebUrl = async (port: number): Promise<string> => {
+  const token = await loadOrCreateWebToken(resolveConfigRoot())
+  return `http://127.0.0.1:${port}/?token=${encodeURIComponent(token)}`
+}
+
 export { parseWebModeOptions } from './options'
-export { startOptionalWebService }
+export { buildAuthenticatedWebUrl, startOptionalWebService }
 export type { RunningWebServer }

--- a/src/main/web-service/options.ts
+++ b/src/main/web-service/options.ts
@@ -10,7 +10,9 @@ const parseWebModeOptions = (
   argv: string[],
   env: NodeJS.ProcessEnv = process.env
 ): WebModeOptions => {
-  const headless = argv.includes('--headless')
+  // Deliberately NOT `--headless`: Chromium interprets that switch itself, which on Windows makes
+  // native menus (e.g. the tray context menu) render invisibly (electron/electron#48982).
+  const headless = argv.includes('--open-science-headless')
   const serveArg = argv.find((arg) => arg === '--serve' || arg.startsWith('--serve='))
   const envPort = env.OPEN_SCIENCE_WEB_PORT?.trim()
   const enabled = headless || Boolean(serveArg) || Boolean(envPort)

--- a/src/main/web-service/state-file.test.ts
+++ b/src/main/web-service/state-file.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  readWebServiceState,
+  removeWebServiceState,
+  statePathFor,
+  writeWebServiceState
+} from './state-file'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('web service state file', () => {
+  it('writes, reads, and removes a live state atomically', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-state-'))
+    roots.push(root)
+    const state = await writeWebServiceState(root, {
+      pid: process.pid,
+      port: 44100,
+      startedAt: '2026-07-19T00:00:00.000Z',
+      appVersion: '0.4.0'
+    })
+
+    expect(state.configRoot).toBe(root)
+    expect(await readWebServiceState(root)).toEqual(state)
+    expect(JSON.parse(await readFile(statePathFor(root), 'utf8'))).toEqual(state)
+
+    await removeWebServiceState(root)
+    expect(await readWebServiceState(root)).toBeUndefined()
+  })
+
+  it('removes stale and invalid state files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-state-'))
+    roots.push(root)
+    await writeFile(
+      statePathFor(root),
+      JSON.stringify({
+        pid: 2_147_483_647,
+        port: 44100,
+        startedAt: '2026-07-19T00:00:00.000Z',
+        appVersion: '0.4.0',
+        configRoot: root
+      })
+    )
+    expect(await readWebServiceState(root)).toBeUndefined()
+
+    await writeFile(statePathFor(root), '{broken')
+    expect(await readWebServiceState(root)).toBeUndefined()
+  })
+})

--- a/src/main/web-service/state-file.ts
+++ b/src/main/web-service/state-file.ts
@@ -1,0 +1,78 @@
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+const WEB_SERVICE_STATE_FILE = 'web-service.json'
+
+export type WebServiceState = {
+  pid: number
+  port: number
+  startedAt: string
+  appVersion: string
+  configRoot: string
+}
+
+const statePathFor = (configRoot: string): string => join(configRoot, WEB_SERVICE_STATE_FILE)
+
+const isProcessAlive = (pid: number): boolean => {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+const readWebServiceState = async (configRoot: string): Promise<WebServiceState | undefined> => {
+  const statePath = statePathFor(configRoot)
+  try {
+    const state = JSON.parse(await readFile(statePath, 'utf8')) as WebServiceState
+    if (
+      !Number.isInteger(state.pid) ||
+      !Number.isInteger(state.port) ||
+      typeof state.startedAt !== 'string' ||
+      typeof state.appVersion !== 'string' ||
+      typeof state.configRoot !== 'string'
+    ) {
+      throw new Error('Invalid web service state.')
+    }
+    if (!isProcessAlive(state.pid)) {
+      await rm(statePath, { force: true })
+      return undefined
+    }
+    return state
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    await rm(statePath, { force: true })
+    return undefined
+  }
+}
+
+const writeWebServiceState = async (
+  configRoot: string,
+  state: Omit<WebServiceState, 'configRoot'>
+): Promise<WebServiceState> => {
+  const completeState = { ...state, configRoot }
+  const statePath = statePathFor(configRoot)
+  const temporaryPath = `${statePath}.${process.pid}.tmp`
+  await mkdir(dirname(statePath), { recursive: true })
+  await writeFile(temporaryPath, `${JSON.stringify(completeState, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600
+  })
+  await rename(temporaryPath, statePath)
+  return completeState
+}
+
+const removeWebServiceState = async (configRoot: string): Promise<void> => {
+  await rm(statePathFor(configRoot), { force: true })
+}
+
+export {
+  WEB_SERVICE_STATE_FILE,
+  isProcessAlive,
+  readWebServiceState,
+  removeWebServiceState,
+  statePathFor,
+  writeWebServiceState
+}


### PR DESCRIPTION
## Summary
- Add \open-science start/stop/status/url\ CLI commands for browser-only daemon usage
- Persist daemon PID/port state and expose a token-authenticated graceful shutdown endpoint
- Support repository builds, standard installed-app locations, and explicit executable overrides
- Headless tray menu: Open Web UI / Copy URL / Quit (Windows: right-click menu, double-click opens web)
- Rename internal headless flag to \--open-science-headless\ to avoid Chromium making native tray menus invisible on Windows (electron/electron#48982)

## Test plan
- [x] \
pm run build\
- [x] \
pm run lint\
- [x] \
pm run typecheck\
- [x] focused Vitest suite (tray + web-service + CLI)
- [x] CLI E2E: start, authenticated health check, status, URL, duplicate start, graceful stop
- [x] state file removed and port released after stop
- [x] Windows tray: right-click shows menu, double-click opens web, Copy URL and Quit work

## Notes
Builds on the merged localhost web UI (#205). The full repository suite was also run: 2,939 tests passed, with 17 pre-existing Windows/timing-sensitive failures unrelated to this change.

Made with [Cursor](https://cursor.com)