### PR TITLE
fix(web): review follow-ups for localhost web UI (#205)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      # Guards against src/preload drifting from the generated web API map. Pure Node and
+      # platform-independent, so hard-gate it on all three OSes rather than relying on the
+      # macOS-only vitest leg (the Linux/Windows test run is advisory).
+      - name: Check web API map
+        run: npm run check:web-api-map
+
       # Full test suite + coverage gate on macOS (thresholds live in vitest.config.ts).
       - name: Test (with coverage)
         if: matrix.os == 'macos-14'

--- a/scripts/dev-web.cjs
+++ b/scripts/dev-web.cjs
@@ -1,23 +1,36 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/explicit-function-return-type */
 
 // Starts electron-vite dev with the localhost web service enabled. Use --headless to skip the
 // initial Electron window while keeping the tray, agent runtime, and web UI available.
 const { spawnSync } = require('node:child_process')
 const path = require('node:path')
 
-const headless = process.argv.includes('--headless')
-if (!process.env.OPEN_SCIENCE_WEB_PORT?.trim()) {
-  process.env.OPEN_SCIENCE_WEB_PORT = '44100'
+const DEFAULT_WEB_PORT = '44100'
+
+// Builds the electron-vite invocation from argv/env: default the web port when unset and forward
+// --headless through electron-vite's `--` passthrough. Pure so it can be unit-tested without spawning.
+const buildDevWebCommand = (argv, env) => {
+  const headless = argv.includes('--headless')
+  const nextEnv = { ...env }
+  if (!nextEnv.OPEN_SCIENCE_WEB_PORT?.trim()) {
+    nextEnv.OPEN_SCIENCE_WEB_PORT = DEFAULT_WEB_PORT
+  }
+  const args = ['electron-vite', 'dev']
+  if (headless) args.push('--', '--headless')
+  return { command: 'npx', args, env: nextEnv }
 }
 
-const args = ['electron-vite', 'dev']
-if (headless) args.push('--', '--headless')
+const main = () => {
+  const { command, args, env } = buildDevWebCommand(process.argv, process.env)
+  const result = spawnSync(command, args, {
+    cwd: path.join(__dirname, '..'),
+    stdio: 'inherit',
+    env,
+    shell: process.platform === 'win32'
+  })
+  process.exit(result.status ?? 1)
+}
 
-const result = spawnSync('npx', args, {
-  cwd: path.join(__dirname, '..'),
-  stdio: 'inherit',
-  env: process.env,
-  shell: process.platform === 'win32'
-})
+if (require.main === module) main()
 
-process.exit(result.status ?? 1)
+module.exports = { buildDevWebCommand, DEFAULT_WEB_PORT }

--- a/scripts/dev-web.test.ts
+++ b/scripts/dev-web.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildDevWebCommand, DEFAULT_WEB_PORT } from './dev-web.cjs'
+
+describe('buildDevWebCommand', () => {
+  it('injects the default web port when unset', () => {
+    const { command, args, env } = buildDevWebCommand(['node', 'dev-web.cjs'], {})
+    expect(command).toBe('npx')
+    expect(args).toEqual(['electron-vite', 'dev'])
+    expect(env.OPEN_SCIENCE_WEB_PORT).toBe(DEFAULT_WEB_PORT)
+  })
+
+  it('respects an existing OPEN_SCIENCE_WEB_PORT', () => {
+    const { env } = buildDevWebCommand(['node', 'dev-web.cjs'], { OPEN_SCIENCE_WEB_PORT: '44200' })
+    expect(env.OPEN_SCIENCE_WEB_PORT).toBe('44200')
+  })
+
+  it('forwards --headless through electron-vite', () => {
+    const { args } = buildDevWebCommand(['node', 'dev-web.cjs', '--headless'], {})
+    expect(args).toEqual(['electron-vite', 'dev', '--', '--headless'])
+  })
+
+  it('does not add a passthrough separator without --headless', () => {
+    const { args } = buildDevWebCommand(['node', 'dev-web.cjs'], {})
+    expect(args).not.toContain('--')
+  })
+})

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -70,6 +70,17 @@ describe('startWebHttpServer', () => {
     })
     expect(await rpcResponse.json()).toEqual({ ok: true, result: { value: 1 } })
 
+    // Channels the browser reimplements client-side (native-dialog / window handlers) are rejected
+    // over /rpc without ever reaching the handler.
+    const blockedResponse = await fetch(`${base}/rpc/window%3Aclose`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ args: [] })
+    })
+    expect(blockedResponse.status).toBe(403)
+    expect(await blockedResponse.json()).toMatchObject({ ok: false })
+    expect(rpc.invoke).toHaveBeenCalledTimes(1)
+
     const socket = new WebSocket(`ws://127.0.0.1:${server.port}/events?client=test-client`, {
       headers: { cookie, origin: base }
     })

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -11,6 +11,17 @@ import type { RpcCapture } from './rpc-capture'
 
 const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 
+// Channels the web client reimplements in the browser (see src/renderer/web/bootstrap.ts) because
+// their main handlers require a real Electron WebContents: file:save-* open a native save dialog
+// parented to a window, and window:close resolves a BrowserWindow from the sender. The synthetic
+// RPC sender has neither, so a direct /rpc call would pop a desktop dialog or silently no-op. The
+// browser never routes these through /rpc, so reject them outright rather than expose that behavior.
+const WEB_CLIENT_OVERRIDDEN_CHANNELS = new Set([
+  'file:save-blob',
+  'file:save-managed',
+  'window:close'
+])
+
 const MIME_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
   '.html': 'text/html; charset=utf-8',
@@ -193,6 +204,10 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
 
       if (url.pathname.startsWith('/rpc/') && request.method === 'POST') {
         const channel = decodeURIComponent(url.pathname.slice('/rpc/'.length))
+        if (WEB_CLIENT_OVERRIDDEN_CHANNELS.has(channel)) {
+          json(response, 403, { ok: false, error: `Channel not available over web: ${channel}` })
+          return
+        }
         const body = (await readJsonBody(request)) as { args?: unknown[] }
         const clientId = String(request.headers['x-open-science-client'] ?? 'web')
         try {


### PR DESCRIPTION
## Summary

Follow-up fixes from the review of #205 (localhost web UI). Keeps the loopback-only scope; addresses two review items plus one CI hardening.

## Changes

- **`fix(web)` — reject browser-overridden channels over `/rpc`**: `/rpc/:channel` accepted any registered `ipcMain.handle` channel, which let a caller bypass the channels `bootstrap.ts` reimplements client-side (`file:save-blob`, `file:save-managed`, `window:close`). Those handlers need a real Electron `WebContents` — with the synthetic RPC sender, `file:save-*` pop a native save dialog on the desktop and `window:close` is a silent no-op. These three are now rejected at the web boundary with a 403. This is a targeted denylist rather than a full allowlist, proportional to the loopback-only + token-gated scope.
- **`test(web)` — cover the dev-web launcher**: extracted the port-defaulting and `--headless` passthrough in `scripts/dev-web.cjs` into a pure `buildDevWebCommand()` (the spawn is now guarded by `require.main`), and added unit tests for default-port injection, respecting an existing `OPEN_SCIENCE_WEB_PORT`, and `--headless` forwarding.
- **`ci` — hard-gate the web API map drift check on all platforms**: `check:web-api-map` only ran (hard-gated) via the macOS vitest leg; the Linux/Windows test leg is advisory. Added a dedicated, platform-independent CI step so preload/web-map drift is caught on all three runners.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run check:web-api-map`
- [x] `npx vitest run` — 290 files / 2979 tests pass
