### PR TITLE
fix(cli): route `open-science start` to the running app instead of hanging

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -183,6 +183,18 @@ export const terminateDaemon = async (pid, opts) => {
   return !isAlive(pid)
 }
 
+// Waits for an attached web service (one riding on the desktop app) to stop responding after a graceful
+// shutdown request. Returns true once it is no longer healthy. Never kills the pid — that process is the
+// user's app, not a daemon this CLI owns, so if it refuses to stop we fail loudly rather than force it.
+const waitForWebServiceStopped = async (state, deps, timeoutMs) => {
+  const deadline = deps.now() + timeoutMs
+  while (deps.now() < deadline) {
+    if (!(await healthCheck(state, deps))) return true
+    await deps.sleep(250)
+  }
+  return false
+}
+
 const readLogTail = async (logPath) => {
   try {
     const text = await readFile(logPath, 'utf8')
@@ -276,6 +288,20 @@ export const stopCommand = async (options, deps = DEFAULT_DEPS) => {
     await response.arrayBuffer()
   } catch (error) {
     deps.warn(`Graceful shutdown failed: ${error.message}`)
+  }
+
+  // Attached: the web service rides on the running desktop app. A graceful request stops only the web
+  // service; the app stays up. Never fall through to force-killing — that pid is the user's app.
+  if (state.attached) {
+    const stopped = await waitForWebServiceStopped(state, deps, STOP_TIMEOUT_MS)
+    if (!stopped) {
+      throw new Error(
+        `Could not stop the Open Science web service (PID ${state.pid}); the app is still serving.`
+      )
+    }
+    await deps.removeState(state.configRoot)
+    deps.log('Open Science web service stopped; the app is still running.')
+    return
   }
 
   const stopped = await terminateDaemon(state.pid, {

--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -136,6 +136,45 @@ describe('stopCommand', () => {
     expect(deps.warn).toHaveBeenCalledWith(expect.stringContaining('Graceful shutdown failed'))
     expect(deps.forceKill).toHaveBeenCalledWith(RUNNING_STATE.pid)
   })
+
+  it('stops only the web service and never kills the pid when the state is attached', async () => {
+    // Attached = the web service rides on the running desktop app. The /api/shutdown request succeeds,
+    // then the health-check endpoint stops responding (service down) — the app process itself stays up.
+    const deps = makeDeps({
+      findServiceState: vi.fn().mockResolvedValue({ ...RUNNING_STATE, attached: true }),
+      fetch: vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).endsWith('/api/shutdown')) {
+          return { ok: true, arrayBuffer: async () => new ArrayBuffer(0) }
+        }
+        throw new Error('connection refused')
+      })
+    })
+
+    await stopCommand({}, deps)
+
+    expect(deps.fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:44100/api/shutdown',
+      expect.objectContaining({ method: 'POST' })
+    )
+    // The pid is the user's app — it must never be signalled.
+    expect(deps.forceKill).not.toHaveBeenCalled()
+    expect(deps.removeState).toHaveBeenCalledWith(RUNNING_STATE.configRoot)
+    expect(deps.log).toHaveBeenCalledWith(
+      'Open Science web service stopped; the app is still running.'
+    )
+  })
+
+  it('fails loudly without killing the pid when an attached web service refuses to stop', async () => {
+    // Attached, but the service keeps answering health checks (never stops). We must fail rather than
+    // escalate to a force-kill, because that pid is the desktop app, not a daemon we own.
+    const deps = makeDeps({
+      findServiceState: vi.fn().mockResolvedValue({ ...RUNNING_STATE, attached: true })
+    })
+
+    await expect(stopCommand({}, deps)).rejects.toThrow(/still serving/)
+    expect(deps.forceKill).not.toHaveBeenCalled()
+    expect(deps.removeState).not.toHaveBeenCalled()
+  })
 })
 
 describe('statusCommand', () => {

--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -3,15 +3,16 @@ import { describe, expect, it, vi } from 'vitest'
 import { createSecondInstanceRelay, orchestrateAppStartup } from './app-startup'
 
 describe('createSecondInstanceRelay', () => {
-  it('records a signal that arrives before bind and drains it on bind', () => {
+  it('records a signal that arrives before bind and drains it on bind, with its argv', () => {
     const relay = createSecondInstanceRelay()
     const handler = vi.fn()
 
-    relay.signal()
+    relay.signal(['app', '--serve=44100'])
     expect(handler).not.toHaveBeenCalled()
 
     relay.bind(handler)
     expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(['app', '--serve=44100'])
   })
 
   it('forwards a signal that arrives after bind directly to the handler', () => {
@@ -21,20 +22,23 @@ describe('createSecondInstanceRelay', () => {
     relay.bind(handler)
     expect(handler).not.toHaveBeenCalled()
 
-    relay.signal()
-    relay.signal()
+    relay.signal(['app'])
+    relay.signal(['app', '--serve'])
     expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler).toHaveBeenNthCalledWith(2, ['app', '--serve'])
   })
 
-  it('drains only once when bound, even if multiple signals arrived first', () => {
+  it('drains every queued signal in arrival order when bound', () => {
     const relay = createSecondInstanceRelay()
     const handler = vi.fn()
 
-    relay.signal()
-    relay.signal()
+    relay.signal(['app', 'first'])
+    relay.signal(['app', 'second'])
     relay.bind(handler)
 
-    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler).toHaveBeenNthCalledWith(1, ['app', 'first'])
+    expect(handler).toHaveBeenNthCalledWith(2, ['app', 'second'])
   })
 })
 
@@ -42,13 +46,13 @@ describe('orchestrateAppStartup', () => {
   const makeDeps = (
     overrides: Partial<Parameters<typeof orchestrateAppStartup<{ tag: string }>>[0]> = {}
   ): Parameters<typeof orchestrateAppStartup<{ tag: string }>>[0] => {
-    const showMainWindow = vi.fn()
+    const onSecondInstance = vi.fn()
     return {
       acquireSingleInstanceLock: vi.fn(() => true),
       quit: vi.fn(),
       prepare: vi.fn(async () => ({ tag: 'ctx' })),
       installMigrationQuitGuard: vi.fn(),
-      installAppLifecycle: vi.fn(() => ({ showMainWindow })),
+      installAppLifecycle: vi.fn(() => ({ onSecondInstance })),
       ...overrides
     }
   }
@@ -79,43 +83,44 @@ describe('orchestrateAppStartup', () => {
     expect(deps.installAppLifecycle).toHaveBeenCalledWith({ tag: 'ctx' })
   })
 
-  it('surfaces the window for a second instance that arrives during startup', async () => {
-    const showMainWindow = vi.fn()
-    let signalDuringStartup: () => void = () => {}
+  it('drains a second instance that arrives during startup, forwarding its argv', async () => {
+    const onSecondInstance = vi.fn()
+    let signalDuringStartup: (argv: string[]) => void = () => {}
     const deps = makeDeps({
       // Capture the relay signal the lock is wired with, then fire it while prepare() is still running.
-      acquireSingleInstanceLock: vi.fn(({ onSecondInstance }) => {
-        signalDuringStartup = onSecondInstance
+      acquireSingleInstanceLock: vi.fn(({ onSecondInstance: signal }) => {
+        signalDuringStartup = signal
         return true
       }),
       prepare: vi.fn(async () => {
-        signalDuringStartup()
+        signalDuringStartup(['app', '--serve=44100'])
         return { tag: 'ctx' }
       }),
-      installAppLifecycle: vi.fn(() => ({ showMainWindow }))
+      installAppLifecycle: vi.fn(() => ({ onSecondInstance }))
     })
 
     await orchestrateAppStartup(deps)
 
-    // The handoff arrived before the window existed; it must be drained once the lifecycle is installed.
-    expect(showMainWindow).toHaveBeenCalledTimes(1)
+    // The handoff arrived before the lifecycle existed; it must be drained once it is installed.
+    expect(onSecondInstance).toHaveBeenCalledTimes(1)
+    expect(onSecondInstance).toHaveBeenCalledWith(['app', '--serve=44100'])
   })
 
-  it('routes a second instance that arrives after startup straight to the window', async () => {
-    const showMainWindow = vi.fn()
-    let signal: () => void = () => {}
+  it('routes a second instance that arrives after startup straight to the lifecycle handler', async () => {
+    const onSecondInstance = vi.fn()
+    let signal: (argv: string[]) => void = () => {}
     const deps = makeDeps({
-      acquireSingleInstanceLock: vi.fn(({ onSecondInstance }) => {
-        signal = onSecondInstance
+      acquireSingleInstanceLock: vi.fn(({ onSecondInstance: relaySignal }) => {
+        signal = relaySignal
         return true
       }),
-      installAppLifecycle: vi.fn(() => ({ showMainWindow }))
+      installAppLifecycle: vi.fn(() => ({ onSecondInstance }))
     })
 
     await orchestrateAppStartup(deps)
-    expect(showMainWindow).not.toHaveBeenCalled()
+    expect(onSecondInstance).not.toHaveBeenCalled()
 
-    signal()
-    expect(showMainWindow).toHaveBeenCalledTimes(1)
+    signal(['app'])
+    expect(onSecondInstance).toHaveBeenCalledWith(['app'])
   })
 })

--- a/src/main/app-startup.ts
+++ b/src/main/app-startup.ts
@@ -4,30 +4,29 @@
 // combination, not just each helper in isolation.
 
 // A late-bound relay for OS 'second-instance' events. The lock's handler must be supplied at lock time,
-// but the window that a second launch should surface does not exist until the lifecycle is installed.
-// The relay records a request that arrives in that window and drains it once a target is bound.
+// but the handler a second launch needs (surface the window, or start the web service for a --serve
+// request) does not exist until the lifecycle is installed. The relay queues the forwarded argv of any
+// request that arrives during that window and drains it, in order, once a target is bound.
 export type SecondInstanceRelay = {
-  // Wired into the single-instance lock as its onSecondInstance handler.
-  signal: () => void
-  // Bind the window surfacer once it exists; immediately drains a request that arrived during startup.
-  bind: (handler: () => void) => void
+  // Wired into the single-instance lock as its onSecondInstance handler; carries the launch's argv so the
+  // bound handler can tell a plain re-launch (surface the window) from a CLI --serve request.
+  signal: (argv: string[]) => void
+  // Bind the second-instance handler once it exists; immediately drains any requests queued during startup.
+  bind: (handler: (argv: string[]) => void) => void
 }
 
 export const createSecondInstanceRelay = (): SecondInstanceRelay => {
-  let pending = false
-  let handler: (() => void) | undefined
+  const pending: string[][] = []
+  let handler: ((argv: string[]) => void) | undefined
 
   return {
-    signal: () => {
-      if (handler) handler()
-      else pending = true
+    signal: (argv) => {
+      if (handler) handler(argv)
+      else pending.push(argv)
     },
     bind: (next) => {
       handler = next
-      if (pending) {
-        pending = false
-        handler()
-      }
+      while (pending.length > 0) handler(pending.shift() as string[])
     }
   }
 }
@@ -35,7 +34,7 @@ export const createSecondInstanceRelay = (): SecondInstanceRelay => {
 export type AppStartupDeps<Context> = {
   // Acquires the OS single-instance lock, wiring the relay's signal as the second-instance handler.
   // Returns false for a secondary launch (the caller must quit) and true for the primary.
-  acquireSingleInstanceLock: (opts: { onSecondInstance: () => void }) => boolean
+  acquireSingleInstanceLock: (opts: { onSecondInstance: (argv: string[]) => void }) => boolean
   // Quits this launch when it is a secondary instance.
   quit: () => void
   // Heavy post-lock preparation (backend module imports, app.whenReady, logger, IPC registration). Runs
@@ -45,8 +44,9 @@ export type AppStartupDeps<Context> = {
   // Installs the migration quit-guard. Must run before the lifecycle so its before-quit fires first: a
   // migration-cancelled quit leaves defaultPrevented set, which the lifecycle's quit cleanup honors.
   installMigrationQuitGuard: (context: Context) => void
-  // Installs the tray/window/quit lifecycle; returns the window surfacer for second-instance handoff.
-  installAppLifecycle: (context: Context) => { showMainWindow: () => void }
+  // Installs the tray/window/quit lifecycle; returns the second-instance handler for the relay to drain.
+  // The handler decides per forwarded argv whether to surface the window or start the web service.
+  installAppLifecycle: (context: Context) => { onSecondInstance: (argv: string[]) => void }
 }
 
 // Runs the ordered startup sequence: gate on the single-instance lock (quitting a secondary launch
@@ -64,6 +64,6 @@ export const orchestrateAppStartup = async <Context>(
 
   const context = await deps.prepare()
   deps.installMigrationQuitGuard(context)
-  const { showMainWindow } = deps.installAppLifecycle(context)
-  relay.bind(showMainWindow)
+  const { onSecondInstance } = deps.installAppLifecycle(context)
+  relay.bind(onSecondInstance)
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,7 +67,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { createAppTray },
         { installAppLifecycle },
         { installRpcCapture },
-        { parseWebModeOptions, createWebServiceController, buildAuthenticatedWebUrl }
+        { parseWebModeOptions, createWebServiceController, buildAuthenticatedWebUrl },
+        { routeSecondInstance }
       ] = await Promise.all([
         import('./ipc'),
         import('./windows'),
@@ -76,7 +77,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./tray'),
         import('./app-lifecycle'),
         import('./web-service/rpc-capture'),
-        import('./web-service')
+        import('./web-service'),
+        import('./second-instance-router')
       ])
 
       // Dev runs get a "(DEV)" suffix so the app name, macOS menu, and per-app paths (logs, userData)
@@ -146,7 +148,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         createMainWindow,
         createAppTray,
         buildAuthenticatedWebUrl,
-        parseWebModeOptions,
+        routeSecondInstance,
         shutdownCoordinator,
         installAppLifecycle,
         log,
@@ -204,23 +206,15 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         createInitialWindow: !ctx.webMode.headless
       })
 
-      // Route each second launch by its forwarded argv: a CLI `open-science start` forwards
-      // --serve/--open-science-headless, so start the web service on demand here (attached: this launch
-      // owns the app, not the web service) instead of opening a window. A plain re-launch (double-click)
-      // carries neither, so surface the existing window exactly as before.
-      const onSecondInstance = (argv: string[]): void => {
-        // Empty env: decide purely on the forwarded argv, never the primary's own environment.
-        const requested = ctx.parseWebModeOptions(argv, {})
-        if (requested.enabled) {
-          void ctx.webController
-            .ensureStarted(requested.port, { attached: true })
-            .catch((error) => {
-              ctx.log.error('on-demand web service start failed', error)
-            })
-          return
-        }
-        showMainWindow()
-      }
+      // Route each second launch by its forwarded argv (see second-instance-router): a CLI
+      // `open-science start` forwards --serve/--open-science-headless → start the web service on demand
+      // here (attached); a plain re-launch (double-click) → surface the existing window as before.
+      const onSecondInstance = (argv: string[]): void =>
+        ctx.routeSecondInstance(argv, {
+          ensureWebService: ctx.webController.ensureStarted,
+          showMainWindow,
+          onError: (error) => ctx.log.error('on-demand web service start failed', error)
+        })
       return { onSecondInstance }
     }
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,7 +67,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { createAppTray },
         { installAppLifecycle },
         { installRpcCapture },
-        { parseWebModeOptions, startOptionalWebService, buildAuthenticatedWebUrl }
+        { parseWebModeOptions, createWebServiceController, buildAuthenticatedWebUrl }
       ] = await Promise.all([
         import('./ipc'),
         import('./windows'),
@@ -126,16 +126,19 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       })
 
       const webMode = parseWebModeOptions(process.argv)
-      const rpcCapture = webMode.enabled ? installRpcCapture(ipcMain) : undefined
+      // Always install the capture layer BEFORE handlers register: it records ipcMain.handle handlers as
+      // they are added, so an on-demand web service (started later for a second launch's --serve request)
+      // can reach them. It only wraps ipcMain.handle — no server, no cost until something serves.
+      const rpcCapture = installRpcCapture(ipcMain)
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
       const { shutdownCoordinator } = await registerIpcHandlers({ mainEntryPath })
-      const webServer = rpcCapture
-        ? await startOptionalWebService({
-            options: webMode,
-            rpc: rpcCapture,
-            requestShutdown: () => app.quit()
-          })
-        : undefined
+      const webController = createWebServiceController({
+        rpc: rpcCapture,
+        requestQuit: () => app.quit()
+      })
+      // A launch that itself requested serving (a dedicated headless daemon, or an explicit --serve) is
+      // not attached: stopping it quits the process. On-demand starts for a running instance are attached.
+      if (webMode.enabled) await webController.ensureStarted(webMode.port, { attached: false })
 
       return {
         installMigrationQuitGuard,
@@ -143,11 +146,12 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         createMainWindow,
         createAppTray,
         buildAuthenticatedWebUrl,
+        parseWebModeOptions,
         shutdownCoordinator,
         installAppLifecycle,
         log,
         webMode,
-        webServer,
+        webController,
         rpcCapture
       }
     },
@@ -158,12 +162,12 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     // Install the tray, first window, and the quit/activate/window-all-closed handlers. shutdownBackends
     // is bound with the live backend handles; the agent teardown latches shutting-down and awaits the
     // process tree so a Windows taskkill /T completes before app.exit.
-    installAppLifecycle: (ctx) =>
-      ctx.installAppLifecycle({
+    installAppLifecycle: (ctx) => {
+      const { showMainWindow } = ctx.installAppLifecycle({
         app,
         createMainWindow: ctx.createMainWindow,
         createTray: (handlers) => {
-          const webPort = ctx.webServer?.port
+          const webPort = ctx.webController.runningPort()
           const headlessWeb = ctx.webMode.headless && webPort !== undefined
           return ctx.createAppTray({
             iconPath: icon,
@@ -190,8 +194,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           try {
             await ctx.shutdownCoordinator.runForQuit()
           } finally {
-            await ctx.webServer?.close()
-            ctx.rpcCapture?.dispose()
+            await ctx.webController.close()
+            ctx.rpcCapture.dispose()
           }
         },
         isMigrationInProgress: ctx.isMigrationInProgress,
@@ -199,6 +203,26 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         countWindows: () => BrowserWindow.getAllWindows().length,
         createInitialWindow: !ctx.webMode.headless
       })
+
+      // Route each second launch by its forwarded argv: a CLI `open-science start` forwards
+      // --serve/--open-science-headless, so start the web service on demand here (attached: this launch
+      // owns the app, not the web service) instead of opening a window. A plain re-launch (double-click)
+      // carries neither, so surface the existing window exactly as before.
+      const onSecondInstance = (argv: string[]): void => {
+        // Empty env: decide purely on the forwarded argv, never the primary's own environment.
+        const requested = ctx.parseWebModeOptions(argv, {})
+        if (requested.enabled) {
+          void ctx.webController
+            .ensureStarted(requested.port, { attached: true })
+            .catch((error) => {
+              ctx.log.error('on-demand web service start failed', error)
+            })
+          return
+        }
+        showMainWindow()
+      }
+      return { onSecondInstance }
+    }
   })
 }
 

--- a/src/main/second-instance-router.test.ts
+++ b/src/main/second-instance-router.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { routeSecondInstance } from './second-instance-router'
+
+const makeDeps = (): {
+  ensureWebService: ReturnType<
+    typeof vi.fn<(port: number, opts: { attached: boolean }) => Promise<unknown>>
+  >
+  showMainWindow: ReturnType<typeof vi.fn<() => void>>
+  onError: ReturnType<typeof vi.fn<(error: unknown) => void>>
+} => ({
+  ensureWebService: vi
+    .fn<(port: number, opts: { attached: boolean }) => Promise<unknown>>()
+    .mockResolvedValue({ port: 44100, url: 'http://127.0.0.1:44100/' }),
+  showMainWindow: vi.fn<() => void>(),
+  onError: vi.fn<(error: unknown) => void>()
+})
+
+describe('routeSecondInstance', () => {
+  it('starts the web service (attached) with the requested port for a --serve=PORT launch', () => {
+    const deps = makeDeps()
+    routeSecondInstance(['/app', '.', '--open-science-headless', '--serve=52020'], deps)
+
+    expect(deps.ensureWebService).toHaveBeenCalledWith(52020, { attached: true })
+    expect(deps.showMainWindow).not.toHaveBeenCalled()
+  })
+
+  it('starts the web service on the default port for bare --serve / --open-science-headless', () => {
+    const serve = makeDeps()
+    routeSecondInstance(['/app', '.', '--serve'], serve)
+    expect(serve.ensureWebService).toHaveBeenCalledWith(44100, { attached: true })
+
+    const headless = makeDeps()
+    routeSecondInstance(['/app', '.', '--open-science-headless'], headless)
+    expect(headless.ensureWebService).toHaveBeenCalledWith(44100, { attached: true })
+    expect(headless.showMainWindow).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the window and does not serve for a plain re-launch (double-click)', () => {
+    const deps = makeDeps()
+    routeSecondInstance(['/app', '.'], deps)
+
+    expect(deps.showMainWindow).toHaveBeenCalledTimes(1)
+    expect(deps.ensureWebService).not.toHaveBeenCalled()
+  })
+
+  it('decides purely on argv, ignoring any OPEN_SCIENCE_WEB_PORT in the primary env', () => {
+    const previous = process.env.OPEN_SCIENCE_WEB_PORT
+    process.env.OPEN_SCIENCE_WEB_PORT = '55555'
+    try {
+      const deps = makeDeps()
+      routeSecondInstance(['/app', '.'], deps)
+      // No --serve in argv -> a plain re-launch, even though the primary's env has a web port set.
+      expect(deps.showMainWindow).toHaveBeenCalledTimes(1)
+      expect(deps.ensureWebService).not.toHaveBeenCalled()
+    } finally {
+      if (previous === undefined) delete process.env.OPEN_SCIENCE_WEB_PORT
+      else process.env.OPEN_SCIENCE_WEB_PORT = previous
+    }
+  })
+
+  it('routes an on-demand start failure to onError instead of throwing into the OS event', async () => {
+    const deps = makeDeps()
+    const failure = new Error('port in use')
+    deps.ensureWebService.mockRejectedValueOnce(failure)
+
+    routeSecondInstance(['/app', '.', '--serve=44100'], deps)
+    // The rejection is handled on the microtask queue; let it settle.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(deps.onError).toHaveBeenCalledWith(failure)
+  })
+})

--- a/src/main/second-instance-router.ts
+++ b/src/main/second-instance-router.ts
@@ -1,0 +1,27 @@
+import { parseWebModeOptions } from './web-service/options'
+
+// Decides what a forwarded second-instance launch means, given only its argv — kept as a pure,
+// dependency-injected unit (no Electron imports) so the serve-vs-window branch is unit-testable.
+export type SecondInstanceRouterDeps = {
+  // Start (or reuse) the web service on THIS already-running instance. Always attached: this launch
+  // owns the app, not the web service, so a later `stop` must tear down only the service, not the app.
+  ensureWebService: (port: number, opts: { attached: boolean }) => Promise<unknown>
+  // Surface the existing main window for a plain re-launch (e.g. a double-click).
+  showMainWindow: () => void
+  // Report a failed on-demand start; must never throw back into the OS 'second-instance' event.
+  onError: (error: unknown) => void
+}
+
+// A CLI `open-science start` forwards --serve/--open-science-headless, so start the web service here
+// rather than opening a window. A plain re-launch carries neither, so surface the window as before.
+// Uses an empty env so the decision rests purely on the forwarded argv, never the primary's own env.
+export const routeSecondInstance = (argv: string[], deps: SecondInstanceRouterDeps): void => {
+  const requested = parseWebModeOptions(argv, {})
+  if (requested.enabled) {
+    void Promise.resolve(deps.ensureWebService(requested.port, { attached: true })).catch(
+      deps.onError
+    )
+    return
+  }
+  deps.showMainWindow()
+}

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createWebServiceController, type WebServiceControllerDeps } from './index'
+import type { RpcCapture } from './rpc-capture'
+
+type StartOptions = Parameters<WebServiceControllerDeps['startServer']>[0]
+
+// Builds a controller over fully faked I/O so the idempotency + attached logic is exercised without
+// Electron, the network, or the filesystem. `startServer` echoes the requested port and records the
+// options it was given (so the test can drive the captured onShutdownRequest).
+const makeController = (
+  overrides: Partial<WebServiceControllerDeps> = {},
+  requestQuit = vi.fn()
+): {
+  controller: ReturnType<typeof createWebServiceController>
+  startServer: ReturnType<typeof vi.fn>
+  writeState: ReturnType<typeof vi.fn>
+  removeState: ReturnType<typeof vi.fn>
+  serverClose: ReturnType<typeof vi.fn>
+  lastOptions: () => StartOptions
+  requestQuit: ReturnType<typeof vi.fn>
+} => {
+  const serverClose = vi.fn().mockResolvedValue(undefined)
+  const seen: StartOptions[] = []
+  const startServer = vi.fn(async (options: StartOptions) => {
+    seen.push(options)
+    return { port: options.port, close: serverClose }
+  })
+  const writeState = vi.fn().mockResolvedValue(undefined)
+  const removeState = vi.fn().mockResolvedValue(undefined)
+
+  const controller = createWebServiceController(
+    { rpc: {} as RpcCapture, requestQuit },
+    {
+      startServer,
+      resolveConfigRoot: () => '/fake/root',
+      loadWebToken: async () => 'tok-123',
+      writeState,
+      removeState,
+      appInfo: () => ({
+        appPath: '/fake/app',
+        appName: 'Open Science',
+        appVersion: '9.9.9',
+        versions: { electron: 'e', chrome: 'c', node: 'n' },
+        pid: 4242
+      }),
+      ...overrides
+    }
+  )
+
+  return {
+    controller,
+    startServer,
+    writeState,
+    removeState,
+    serverClose,
+    lastOptions: () => seen[seen.length - 1],
+    requestQuit
+  }
+}
+
+describe('createWebServiceController', () => {
+  it('starts once and records the port/url plus the attached flag in the state file', async () => {
+    const h = makeController()
+    const result = await h.controller.ensureStarted(44100, { attached: true })
+
+    expect(result).toEqual({ port: 44100, url: 'http://127.0.0.1:44100/?token=tok-123' })
+    expect(h.startServer).toHaveBeenCalledTimes(1)
+    expect(h.writeState).toHaveBeenCalledWith(
+      '/fake/root',
+      expect.objectContaining({ pid: 4242, port: 44100, appVersion: '9.9.9', attached: true })
+    )
+    expect(h.controller.isRunning()).toBe(true)
+    expect(h.controller.runningPort()).toBe(44100)
+  })
+
+  it('is idempotent: a second ensureStarted while running reuses the server (no second start)', async () => {
+    const h = makeController()
+    await h.controller.ensureStarted(44100, { attached: false })
+    const again = await h.controller.ensureStarted(59999, { attached: true })
+
+    expect(h.startServer).toHaveBeenCalledTimes(1)
+    // Reuses the already-running port, ignoring the second call's requested port/attached.
+    expect(again.port).toBe(44100)
+  })
+
+  it('dedupes concurrent ensureStarted calls into a single server start', async () => {
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const startServer = vi.fn(async (options: StartOptions) => {
+      await gate
+      return { port: options.port, close: vi.fn().mockResolvedValue(undefined) }
+    })
+    const h = makeController({ startServer })
+
+    const a = h.controller.ensureStarted(44100, { attached: false })
+    const b = h.controller.ensureStarted(44100, { attached: false })
+    release?.()
+    await Promise.all([a, b])
+
+    expect(startServer).toHaveBeenCalledTimes(1)
+  })
+
+  it('close stops the server, removes state, and allows a fresh start afterwards', async () => {
+    const h = makeController()
+    await h.controller.ensureStarted(44100, { attached: true })
+
+    await h.controller.close()
+    expect(h.serverClose).toHaveBeenCalledTimes(1)
+    expect(h.removeState).toHaveBeenCalledWith('/fake/root')
+    expect(h.controller.isRunning()).toBe(false)
+    expect(h.controller.runningPort()).toBeUndefined()
+
+    await h.controller.ensureStarted(44100, { attached: true })
+    expect(h.startServer).toHaveBeenCalledTimes(2)
+  })
+
+  it('an attached shutdown request tears down only the web service, never quitting the app', async () => {
+    const h = makeController()
+    await h.controller.ensureStarted(44100, { attached: true })
+
+    // The server was wired with an onShutdownRequest; invoking it (as /api/shutdown would) must close
+    // the web service without quitting the app.
+    h.lastOptions().onShutdownRequest?.()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(h.serverClose).toHaveBeenCalledTimes(1)
+    expect(h.removeState).toHaveBeenCalledWith('/fake/root')
+    expect(h.requestQuit).not.toHaveBeenCalled()
+  })
+
+  it('a non-attached (dedicated daemon) shutdown request quits the app', async () => {
+    const h = makeController()
+    await h.controller.ensureStarted(44100, { attached: false })
+
+    h.lastOptions().onShutdownRequest?.()
+
+    expect(h.requestQuit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -5,9 +5,9 @@ import { app } from 'electron'
 import { createLogger } from '../logger'
 import { resolveConfigRoot } from '../storage-root'
 import { loadOrCreateWebToken } from './auth'
-import { startWebHttpServer } from './http-server'
+import { startWebHttpServer, type RunningWebServer } from './http-server'
 import type { RpcCapture } from './rpc-capture'
-import { removeWebServiceState, writeWebServiceState } from './state-file'
+import { removeWebServiceState, writeWebServiceState, type WebServiceState } from './state-file'
 
 // A single-instance web service that can be started at launch (--serve) or later, on demand, when a
 // second launch forwards a --serve request to the already-running instance. Starting is idempotent: a
@@ -26,21 +26,55 @@ export type WebServiceController = {
   runningPort: () => number | undefined
 }
 
-const buildAuthenticatedWebUrl = async (port: number): Promise<string> => {
-  const token = await loadOrCreateWebToken(resolveConfigRoot())
-  return `http://127.0.0.1:${port}/?token=${encodeURIComponent(token)}`
+// The I/O the controller depends on, injectable so the idempotency/attached logic is unit-testable
+// without Electron, the network, or the filesystem. Production callers omit these and get the real ones.
+export type WebServiceControllerDeps = {
+  startServer: (options: Parameters<typeof startWebHttpServer>[0]) => Promise<RunningWebServer>
+  resolveConfigRoot: () => string
+  loadWebToken: (configRoot: string) => Promise<string>
+  writeState: (configRoot: string, state: Omit<WebServiceState, 'configRoot'>) => Promise<unknown>
+  removeState: (configRoot: string) => Promise<void>
+  appInfo: () => {
+    appPath: string
+    appName: string
+    appVersion: string
+    versions: { electron: string; chrome: string; node: string }
+    pid: number
+  }
 }
+
+const authUrl = (token: string, port: number): string =>
+  `http://127.0.0.1:${port}/?token=${encodeURIComponent(token)}`
+
+const buildAuthenticatedWebUrl = async (port: number): Promise<string> =>
+  authUrl(await loadOrCreateWebToken(resolveConfigRoot()), port)
 
 // Builds the controller. `rpc` is the always-installed capture layer (so handlers registered before any
 // serving are reachable over HTTP); `requestQuit` quits the whole app when a dedicated headless daemon
 // is asked to shut down. An attached service instead only tears itself down and leaves the app running.
-const createWebServiceController = ({
-  rpc,
-  requestQuit
-}: {
-  rpc: RpcCapture
-  requestQuit: () => void
-}): WebServiceController => {
+const createWebServiceController = (
+  { rpc, requestQuit }: { rpc: RpcCapture; requestQuit: () => void },
+  deps: Partial<WebServiceControllerDeps> = {}
+): WebServiceController => {
+  const startServer = deps.startServer ?? startWebHttpServer
+  const getConfigRoot = deps.resolveConfigRoot ?? resolveConfigRoot
+  const loadWebToken = deps.loadWebToken ?? loadOrCreateWebToken
+  const writeState = deps.writeState ?? writeWebServiceState
+  const removeState = deps.removeState ?? removeWebServiceState
+  const appInfo =
+    deps.appInfo ??
+    (() => ({
+      appPath: app.getAppPath(),
+      appName: app.getName(),
+      appVersion: app.getVersion(),
+      versions: {
+        electron: process.versions.electron,
+        chrome: process.versions.chrome,
+        node: process.versions.node
+      },
+      pid: process.pid
+    }))
+
   let running: { close: () => Promise<void>; port: number; configRoot: string } | undefined
   let starting: Promise<{ port: number; url: string }> | undefined
 
@@ -52,26 +86,23 @@ const createWebServiceController = ({
   }
 
   const start = async (port: number, attached: boolean): Promise<{ port: number; url: string }> => {
-    const configRoot = resolveConfigRoot()
-    const token = await loadOrCreateWebToken(configRoot)
-    const server = await startWebHttpServer({
+    const configRoot = getConfigRoot()
+    const token = await loadWebToken(configRoot)
+    const info = appInfo()
+    const server = await startServer({
       host: '127.0.0.1',
       port,
       token,
-      staticRoot: join(app.getAppPath(), 'out', 'web'),
+      staticRoot: join(info.appPath, 'out', 'web'),
       rpc,
       // Attached: a graceful shutdown request stops only the web service (the app keeps running). A
       // dedicated daemon quits the process, which is what stops it serving.
       onShutdownRequest: attached ? () => void close() : requestQuit,
       bootstrap: {
-        appName: app.getName(),
-        appVersion: app.getVersion(),
+        appName: info.appName,
+        appVersion: info.appVersion,
         platform: process.platform,
-        versions: {
-          electron: process.versions.electron,
-          chrome: process.versions.chrome,
-          node: process.versions.node
-        }
+        versions: info.versions
       }
     })
 
@@ -82,17 +113,17 @@ const createWebServiceController = ({
         try {
           await server.close()
         } finally {
-          await removeWebServiceState(configRoot)
+          await removeState(configRoot)
         }
       }
     }
 
     try {
-      await writeWebServiceState(configRoot, {
-        pid: process.pid,
+      await writeState(configRoot, {
+        pid: info.pid,
         port: server.port,
         startedAt: new Date().toISOString(),
-        appVersion: app.getVersion(),
+        appVersion: info.appVersion,
         attached
       })
     } catch (error) {
@@ -100,7 +131,7 @@ const createWebServiceController = ({
       throw error
     }
 
-    const url = `http://127.0.0.1:${server.port}/?token=${encodeURIComponent(token)}`
+    const url = authUrl(token, server.port)
     createLogger('web-service').info('local web service started', {
       host: '127.0.0.1',
       port: server.port,
@@ -114,7 +145,10 @@ const createWebServiceController = ({
     port: number,
     { attached }: { attached: boolean }
   ): Promise<{ port: number; url: string }> => {
-    if (running) return { port: running.port, url: await buildAuthenticatedWebUrl(running.port) }
+    if (running) {
+      const token = await loadWebToken(running.configRoot)
+      return { port: running.port, url: authUrl(token, running.port) }
+    }
     if (starting) return starting
     starting = start(port, attached).finally(() => {
       starting = undefined

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -5,72 +5,25 @@ import { app } from 'electron'
 import { createLogger } from '../logger'
 import { resolveConfigRoot } from '../storage-root'
 import { loadOrCreateWebToken } from './auth'
-import { startWebHttpServer, type RunningWebServer } from './http-server'
-import type { WebModeOptions } from './options'
+import { startWebHttpServer } from './http-server'
 import type { RpcCapture } from './rpc-capture'
 import { removeWebServiceState, writeWebServiceState } from './state-file'
 
-const startOptionalWebService = async ({
-  options,
-  rpc,
-  requestShutdown
-}: {
-  options: WebModeOptions
-  rpc: RpcCapture
-  requestShutdown: () => void
-}): Promise<RunningWebServer | undefined> => {
-  if (!options.enabled) return undefined
-
-  const configRoot = resolveConfigRoot()
-  const token = await loadOrCreateWebToken(configRoot)
-  const server = await startWebHttpServer({
-    host: '127.0.0.1',
-    port: options.port,
-    token,
-    staticRoot: join(app.getAppPath(), 'out', 'web'),
-    rpc,
-    onShutdownRequest: requestShutdown,
-    bootstrap: {
-      appName: app.getName(),
-      appVersion: app.getVersion(),
-      platform: process.platform,
-      versions: {
-        electron: process.versions.electron,
-        chrome: process.versions.chrome,
-        node: process.versions.node
-      }
-    }
-  })
-
-  try {
-    await writeWebServiceState(configRoot, {
-      pid: process.pid,
-      port: server.port,
-      startedAt: new Date().toISOString(),
-      appVersion: app.getVersion()
-    })
-  } catch (error) {
-    await server.close()
-    throw error
-  }
-
-  const url = `http://127.0.0.1:${server.port}/?token=${encodeURIComponent(token)}`
-  createLogger('web-service').info('local web service started', {
-    host: '127.0.0.1',
-    port: server.port,
-    url: `http://127.0.0.1:${server.port}/`
-  })
-  console.log(`Open Science Web: ${url}`)
-  return {
-    port: server.port,
-    close: async () => {
-      try {
-        await server.close()
-      } finally {
-        await removeWebServiceState(configRoot)
-      }
-    }
-  }
+// A single-instance web service that can be started at launch (--serve) or later, on demand, when a
+// second launch forwards a --serve request to the already-running instance. Starting is idempotent: a
+// second ensureStarted while one is running (or in flight) reuses it rather than binding a new port.
+export type WebServiceController = {
+  // Starts serving on `port` if not already serving; returns the live port and authenticated URL.
+  // `attached` records whether the service rides on a pre-existing instance (see WebServiceState).
+  ensureStarted: (
+    port: number,
+    opts: { attached: boolean }
+  ) => Promise<{ port: number; url: string }>
+  // Stops the web service and removes its state file. Idempotent; safe to call when not running.
+  close: () => Promise<void>
+  isRunning: () => boolean
+  // The live port when serving, else undefined (used to build the tray's "Open Web" URL).
+  runningPort: () => number | undefined
 }
 
 const buildAuthenticatedWebUrl = async (port: number): Promise<string> => {
@@ -78,6 +31,104 @@ const buildAuthenticatedWebUrl = async (port: number): Promise<string> => {
   return `http://127.0.0.1:${port}/?token=${encodeURIComponent(token)}`
 }
 
+// Builds the controller. `rpc` is the always-installed capture layer (so handlers registered before any
+// serving are reachable over HTTP); `requestQuit` quits the whole app when a dedicated headless daemon
+// is asked to shut down. An attached service instead only tears itself down and leaves the app running.
+const createWebServiceController = ({
+  rpc,
+  requestQuit
+}: {
+  rpc: RpcCapture
+  requestQuit: () => void
+}): WebServiceController => {
+  let running: { close: () => Promise<void>; port: number; configRoot: string } | undefined
+  let starting: Promise<{ port: number; url: string }> | undefined
+
+  const close = async (): Promise<void> => {
+    const current = running
+    running = undefined
+    if (!current) return
+    await current.close()
+  }
+
+  const start = async (port: number, attached: boolean): Promise<{ port: number; url: string }> => {
+    const configRoot = resolveConfigRoot()
+    const token = await loadOrCreateWebToken(configRoot)
+    const server = await startWebHttpServer({
+      host: '127.0.0.1',
+      port,
+      token,
+      staticRoot: join(app.getAppPath(), 'out', 'web'),
+      rpc,
+      // Attached: a graceful shutdown request stops only the web service (the app keeps running). A
+      // dedicated daemon quits the process, which is what stops it serving.
+      onShutdownRequest: attached ? () => void close() : requestQuit,
+      bootstrap: {
+        appName: app.getName(),
+        appVersion: app.getVersion(),
+        platform: process.platform,
+        versions: {
+          electron: process.versions.electron,
+          chrome: process.versions.chrome,
+          node: process.versions.node
+        }
+      }
+    })
+
+    running = {
+      port: server.port,
+      configRoot,
+      close: async () => {
+        try {
+          await server.close()
+        } finally {
+          await removeWebServiceState(configRoot)
+        }
+      }
+    }
+
+    try {
+      await writeWebServiceState(configRoot, {
+        pid: process.pid,
+        port: server.port,
+        startedAt: new Date().toISOString(),
+        appVersion: app.getVersion(),
+        attached
+      })
+    } catch (error) {
+      await close()
+      throw error
+    }
+
+    const url = `http://127.0.0.1:${server.port}/?token=${encodeURIComponent(token)}`
+    createLogger('web-service').info('local web service started', {
+      host: '127.0.0.1',
+      port: server.port,
+      attached
+    })
+    console.log(`Open Science Web: ${url}`)
+    return { port: server.port, url }
+  }
+
+  const ensureStarted = async (
+    port: number,
+    { attached }: { attached: boolean }
+  ): Promise<{ port: number; url: string }> => {
+    if (running) return { port: running.port, url: await buildAuthenticatedWebUrl(running.port) }
+    if (starting) return starting
+    starting = start(port, attached).finally(() => {
+      starting = undefined
+    })
+    return starting
+  }
+
+  return {
+    ensureStarted,
+    close,
+    isRunning: () => running !== undefined,
+    runningPort: () => running?.port
+  }
+}
+
 export { parseWebModeOptions } from './options'
-export { buildAuthenticatedWebUrl, startOptionalWebService }
-export type { RunningWebServer }
+export { buildAuthenticatedWebUrl, createWebServiceController }

--- a/src/main/web-service/state-file.test.ts
+++ b/src/main/web-service/state-file.test.ts
@@ -25,15 +25,45 @@ describe('web service state file', () => {
       pid: process.pid,
       port: 44100,
       startedAt: '2026-07-19T00:00:00.000Z',
-      appVersion: '0.4.0'
+      appVersion: '0.4.0',
+      attached: false
     })
 
     expect(state.configRoot).toBe(root)
+    expect(state.attached).toBe(false)
     expect(await readWebServiceState(root)).toEqual(state)
     expect(JSON.parse(await readFile(statePathFor(root), 'utf8'))).toEqual(state)
 
     await removeWebServiceState(root)
     expect(await readWebServiceState(root)).toBeUndefined()
+  })
+
+  it('preserves an attached flag and defaults it to false for pre-existing state files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-state-'))
+    roots.push(root)
+
+    const attached = await writeWebServiceState(root, {
+      pid: process.pid,
+      port: 44100,
+      startedAt: '2026-07-19T00:00:00.000Z',
+      appVersion: '0.4.0',
+      attached: true
+    })
+    expect((await readWebServiceState(root))?.attached).toBe(true)
+    expect(attached.attached).toBe(true)
+
+    // A state file written before `attached` existed reads back as a dedicated (non-attached) daemon.
+    await writeFile(
+      statePathFor(root),
+      JSON.stringify({
+        pid: process.pid,
+        port: 44100,
+        startedAt: '2026-07-19T00:00:00.000Z',
+        appVersion: '0.4.0',
+        configRoot: root
+      })
+    )
+    expect((await readWebServiceState(root))?.attached).toBe(false)
   })
 
   it('removes stale and invalid state files', async () => {

--- a/src/main/web-service/state-file.ts
+++ b/src/main/web-service/state-file.ts
@@ -9,6 +9,11 @@ export type WebServiceState = {
   startedAt: string
   appVersion: string
   configRoot: string
+  // True when the web service rides on an already-running instance (e.g. the desktop app), started on
+  // demand via a second-instance --serve request. `stop` then only tears down the web service and must
+  // never kill that pid — it is the user's app, not a daemon this launch owns. False for a dedicated
+  // headless daemon, where stopping the web service means quitting the process.
+  attached: boolean
 }
 
 const statePathFor = (configRoot: string): string => join(configRoot, WEB_SERVICE_STATE_FILE)
@@ -40,7 +45,8 @@ const readWebServiceState = async (configRoot: string): Promise<WebServiceState 
       await rm(statePath, { force: true })
       return undefined
     }
-    return state
+    // Coerce attached so a state file written before this field existed reads as a dedicated daemon.
+    return { ...state, attached: state.attached === true }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
     await rm(statePath, { force: true })


### PR DESCRIPTION
## Problem

When the desktop app was already running, `open-science start` hung for ~30s and then failed with `Open Science did not become healthy within 30s.` — on every start while the app was open.

Root cause: the CLI spawns `<app> --open-science-headless --serve=PORT`, but `orchestrateAppStartup` acquires the OS single-instance lock **before** `prepare()` parses `--serve`. So the spawned daemon is treated as an ordinary secondary launch and `app.quit()`s immediately — it never starts the web service and never writes `web-service.json`. The CLI then polls for 30s and fails. Tell-tale: `~/.open-science/cli-daemon.log` is 0 bytes (the daemon quit before the logger initialized in `prepare()`).

## Fix — route to the already-running instance

- **Always install `rpcCapture` before registering IPC handlers** (it only wraps `ipcMain.handle`), so a GUI-launched instance can serve on demand later. No server/cost until something actually serves.
- **`createWebServiceController`** replaces `startOptionalWebService`: idempotent `ensureStarted(port, { attached })` + `close()`. Start at launch when `--serve` is present, or on demand otherwise.
- **Forward the second-instance argv** through the relay. When it carries `--serve`/`--open-science-headless`, the primary starts the web service (`attached: true`) instead of surfacing a window. A plain re-launch (double-click) carries neither, so it surfaces the window exactly as before.
- **`attached` in `web-service.json`**: `open-science stop` on an attached service only tears down the web service via `/api/shutdown` and **never kills the pid** — that process is the user's app, not a daemon the CLI owns. A dedicated headless daemon keeps the existing force-kill-tree behavior.

## Tests

- Relay argv forwarding + serve-vs-window routing branches.
- `attached` state round-trip, with a pre-field default (old state files read as non-attached).
- Attached `stop`: web-only, never kills the pid; fails loudly if the service refuses to stop.

All 4 CONTRIBUTING checks green (typecheck, lint, full test 3030 passed, format).

## Manual verification (dev, end-to-end)

Launched an isolated primary instance (holding the single-instance lock, not serving), then ran the CLI against it:

- `open-science start` → `Open Science started (PID <primary>)` + URL; `web-service.json` had `attached: true`; `GET /api/bootstrap` → HTTP 200.
- `open-science stop` → `web service stopped; the app is still running`; state file removed; **primary still alive** (not killed).