### PR TITLE
fix(skills): route GitHub import through proxy-aware net.fetch

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -29,6 +29,7 @@ const { getAppClaudeConfigDir } = await import('./provider-env')
 const { SkillRegistry } = await import('../skills/registry')
 const { managedClaudeDir } = await import('./managed-claude')
 const { managedOpencodeDir } = await import('./managed-opencode')
+const { netFetch } = await import('../skills/net-fetch')
 
 let storageRoot: string
 let repository: InstanceType<typeof SettingsRepository>
@@ -814,6 +815,43 @@ describe('SettingsService: skills', () => {
       'My Skill',
       'Demo'
     ])
+  })
+
+  // GitHub scan/import must go through the proxy-aware net.fetch, not Node's global fetch (which
+  // ignores the system/VPN proxy and gets a 403 in proxied environments). These lock the wiring so a
+  // regression back to the default fetch is caught.
+  it('imports a GitHub skill through the proxy-aware net.fetch', async () => {
+    const importFromGitHub = vi.fn().mockResolvedValue({ status: 'imported', id: 'imported-x' })
+    const service = new SettingsService({
+      repository,
+      storageRoot,
+      userClaudeDir: join(storageRoot, 'no-user-claude'),
+      skillRegistry: new SkillRegistry(await seedBundle()),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      userSkills: { importFromGitHub, list: () => Promise.resolve([]) } as any
+    })
+
+    await service.importSkill({ url: 'https://github.com/o/r/tree/main/skills/demo' })
+
+    expect(importFromGitHub).toHaveBeenCalledWith(
+      'https://github.com/o/r/tree/main/skills/demo',
+      netFetch
+    )
+  })
+
+  it('scans a GitHub repo through the proxy-aware net.fetch', async () => {
+    const scanRepo = vi.fn().mockResolvedValue([])
+    const service = new SettingsService({
+      repository,
+      storageRoot,
+      userClaudeDir: join(storageRoot, 'no-user-claude'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      userSkills: { scanRepo } as any
+    })
+
+    await service.scanRepoSkills({ repo: 'o/r' })
+
+    expect(scanRepo).toHaveBeenCalledWith('o/r', netFetch)
   })
 })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -19,7 +19,8 @@ vi.mock('electron', () => ({
       return decoded.slice('cipher:'.length)
     }
   },
-  app: { getPath: () => '/home', getAppPath: () => '/home/no-such-app-root', isPackaged: false }
+  app: { getPath: () => '/home', getAppPath: () => '/home/no-such-app-root', isPackaged: false },
+  net: { fetch: vi.fn() }
 }))
 
 const { SettingsService } = await import('./service')

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -110,6 +110,7 @@ import { getConnectorTools } from '../connectors/registry'
 import { renderConnectorInstructions } from '../connectors/skill-doc'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { UserSkillRepository } from '../skills/user-skill-repository'
+import { netFetch } from '../skills/net-fetch'
 import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limits'
 import { readSkillFile } from '../skills/skill-files'
 import type {
@@ -413,7 +414,7 @@ class SettingsService {
 
   // Imports a skill from a public GitHub URL (deduplicated), returning the outcome + refreshed list.
   async importSkill(request: ImportSkillRequest): Promise<ImportSkillResult> {
-    const outcome = await this.userSkills.importFromGitHub(request.url)
+    const outcome = await this.userSkills.importFromGitHub(request.url, netFetch)
 
     return { status: outcome.status, id: outcome.id, skills: await this.listSkills() }
   }
@@ -458,7 +459,7 @@ class SettingsService {
 
   // Scans a GitHub repo for importable skill directories (marking already-imported ones).
   async scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult> {
-    return { skills: await this.userSkills.scanRepo(request.repo) }
+    return { skills: await this.userSkills.scanRepo(request.repo, netFetch) }
   }
 
   // Projects a catalog skill into its renderer-safe view given the disabled set.

--- a/src/main/skills/net-fetch.test.ts
+++ b/src/main/skills/net-fetch.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const fetchMock = vi.fn()
+vi.mock('electron', () => ({ net: { fetch: fetchMock } }))
+
+const { netFetch } = await import('./net-fetch')
+
+describe('netFetch', () => {
+  beforeEach(() => fetchMock.mockReset())
+
+  it('delegates to Electron net.fetch with the given url and init', async () => {
+    const response = { ok: true, status: 200 }
+    fetchMock.mockResolvedValue(response)
+
+    const init = { headers: { 'User-Agent': 'open-science' } }
+    const result = await netFetch('https://api.github.com/repos/o/r', init)
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.github.com/repos/o/r', init)
+    expect(result).toBe(response)
+  })
+
+  it('propagates the Chromium network stack status (e.g. proxy-routed success)', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 })
+
+    const result = await netFetch('https://api.github.com/repos/o/r/git/trees/main?recursive=1')
+
+    expect(result.ok).toBe(true)
+    expect(result.status).toBe(200)
+  })
+})

--- a/src/main/skills/net-fetch.ts
+++ b/src/main/skills/net-fetch.ts
@@ -1,0 +1,9 @@
+import { net } from 'electron'
+
+import type { FetchLike } from './github-import'
+
+// Routes GitHub skill imports through Electron's Chromium network stack, which honors the system/VPN
+// proxy the user's browser uses. Node's global fetch (undici) ignores that proxy and takes a direct
+// path, so in proxied environments GitHub returns 403 for the direct requests while net.fetch succeeds.
+export const netFetch: FetchLike = (url, init) =>
+  net.fetch(url, init) as unknown as ReturnType<FetchLike>


### PR DESCRIPTION
## Problem

`settings:scan-repo-skills` (and GitHub skill import) fails with `GitHub API request failed (403).` on machines that rely on a system/VPN proxy — even though github.com works in the browser and `curl` (direct and via the local proxy) returns 200 with the app's exact headers and endpoints.

## Root cause

Skill import used Node's `globalThis.fetch` (undici), which **ignores the system/VPN proxy** and takes a direct network path. In proxied environments that direct path is intercepted and returns 403. The rest of the app (`http-server.ts`, `managed-preview-protocol.ts`) uses Electron's `net.fetch`, which routes through Chromium's proxy-aware network stack — the same path the user's browser uses.

A 403 (rather than a timeout or connection error) is the tell: the request reached an HTTP server that rejected it, so the problem is the client network path, not connectivity or rate limiting (rate limit was full).

## Fix

- Add `src/main/skills/net-fetch.ts` — a `FetchLike` adapter wrapping Electron `net.fetch`.
- `service.ts` passes it to `importFromGitHub(url, netFetch)` and `scanRepo(repo, netFetch)` via their existing `fetchImpl?` injection seam.
- Also covers the per-file raw.githubusercontent.com downloads in `fetchSkillFiles`.

## Tests

- New `net-fetch.test.ts` verifies the adapter delegates to `net.fetch` and propagates its response.
- `service.test.ts` electron mock gains `net: { fetch }`.
- typecheck, lint, format, and full suite (3043 passed / 43 skipped) all green.