### PR TITLE
fix(acp): avoid inlining large attachments into prompt context

### DIFF
--- a/src/main/acp/attachment-content.test.ts
+++ b/src/main/acp/attachment-content.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
+  buildOversizedAttachmentNotice,
+  formatBytes,
+  isTabularAttachment,
+  isTextLikeAttachment
+} from './attachment-content'
+
+describe('isTextLikeAttachment', () => {
+  it('classifies by MIME type', () => {
+    expect(isTextLikeAttachment('x', 'text/plain')).toBe(true)
+    expect(isTextLikeAttachment('x', 'text/csv')).toBe(true)
+    expect(isTextLikeAttachment('x', 'application/json')).toBe(true)
+  })
+
+  it('classifies by extension when the MIME type is missing or generic', () => {
+    expect(isTextLikeAttachment('data.csv')).toBe(true)
+    expect(isTextLikeAttachment('reads.fastq')).toBe(true)
+    expect(isTextLikeAttachment('variants.vcf', 'application/octet-stream')).toBe(true)
+    expect(isTextLikeAttachment('tree.nwk')).toBe(true)
+  })
+
+  it('is case-insensitive on the extension', () => {
+    expect(isTextLikeAttachment('DATA.CSV')).toBe(true)
+  })
+
+  it('rejects binary files without a text MIME type or extension', () => {
+    expect(isTextLikeAttachment('archive.zip')).toBe(false)
+    expect(isTextLikeAttachment('reads.bam')).toBe(false)
+    expect(isTextLikeAttachment('noext')).toBe(false)
+  })
+})
+
+describe('isTabularAttachment', () => {
+  it('detects column-oriented files', () => {
+    expect(isTabularAttachment('data.csv')).toBe(true)
+    expect(isTabularAttachment('data.tsv')).toBe(true)
+    expect(isTabularAttachment('x', 'text/tab-separated-values')).toBe(true)
+  })
+
+  it('does not treat plain text or JSON as tabular', () => {
+    expect(isTabularAttachment('notes.txt')).toBe(false)
+    expect(isTabularAttachment('config.json')).toBe(false)
+  })
+})
+
+describe('formatBytes', () => {
+  it('renders binary units', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1024)).toBe('1.0 KB')
+    expect(formatBytes(19_112_059)).toBe('18.2 MB')
+  })
+})
+
+describe('buildOversizedAttachmentNotice', () => {
+  it('names the file, size, and preview and steers away from a full read', () => {
+    const notice = buildOversizedAttachmentNotice({
+      name: 'big.csv',
+      size: 19_112_059,
+      preview: 'id,name\n1,a\n2,b',
+      truncated: true,
+      tabular: true
+    })
+
+    expect(notice).toContain('"big.csv"')
+    expect(notice).toContain('18.2 MB')
+    expect(notice).toContain('id,name')
+    expect(notice).toContain('rows or columns')
+    expect(notice).toContain('Do not load the whole file')
+    expect(notice).toContain('… file continues')
+  })
+
+  it('uses line-range wording for non-tabular files and omits the continuation trailer when complete', () => {
+    const notice = buildOversizedAttachmentNotice({
+      name: 'notes.txt',
+      size: 700_000,
+      preview: 'first line',
+      truncated: false,
+      tabular: false
+    })
+
+    expect(notice).toContain('line ranges or sections')
+    expect(notice).not.toContain('file continues')
+  })
+})
+
+describe('MAX_EMBEDDED_TEXT_UPLOAD_BYTES', () => {
+  it('is 512 KB', () => {
+    expect(MAX_EMBEDDED_TEXT_UPLOAD_BYTES).toBe(512 * 1024)
+  })
+})

--- a/src/main/acp/attachment-content.test.ts
+++ b/src/main/acp/attachment-content.test.ts
@@ -31,6 +31,19 @@ describe('isTextLikeAttachment', () => {
     expect(isTextLikeAttachment('reads.bam')).toBe(false)
     expect(isTextLikeAttachment('noext')).toBe(false)
   })
+
+  it('lets a concrete non-text MIME override a text-looking extension', () => {
+    // A gzipped FASTQ keeps a .fastq name but is binary — the explicit MIME must win.
+    expect(isTextLikeAttachment('reads.fastq', 'application/gzip')).toBe(false)
+    expect(isTextLikeAttachment('data.csv', 'application/x-parquet')).toBe(false)
+    expect(isTextLikeAttachment('sheet.csv', 'application/vnd.ms-excel')).toBe(false)
+  })
+
+  it('falls back to the extension only for a missing or generic MIME', () => {
+    expect(isTextLikeAttachment('data.csv', 'application/octet-stream')).toBe(true)
+    expect(isTextLikeAttachment('data.csv', 'binary/octet-stream')).toBe(true)
+    expect(isTextLikeAttachment('archive.zip', 'application/octet-stream')).toBe(false)
+  })
 })
 
 describe('isTabularAttachment', () => {

--- a/src/main/acp/attachment-content.test.ts
+++ b/src/main/acp/attachment-content.test.ts
@@ -52,6 +52,15 @@ describe('isTextLikeAttachment', () => {
     // A generic MIME with a parameter still defers to the extension.
     expect(isTextLikeAttachment('data.csv', 'application/octet-stream; charset=binary')).toBe(true)
   })
+
+  it('accepts structured-suffix and chemical text MIME types', () => {
+    expect(isTextLikeAttachment('regions.geojson', 'application/geo+json')).toBe(true)
+    expect(isTextLikeAttachment('feed.xml', 'application/atom+xml')).toBe(true)
+    expect(isTextLikeAttachment('1abc.pdb', 'chemical/x-pdb')).toBe(true)
+    expect(isTextLikeAttachment('mol.sdf', 'chemical/x-mdl-sdfile')).toBe(true)
+    // A compressed payload stays binary even with a text-looking name.
+    expect(isTextLikeAttachment('reads.fastq', 'application/gzip')).toBe(false)
+  })
 })
 
 describe('isTabularAttachment', () => {

--- a/src/main/acp/attachment-content.test.ts
+++ b/src/main/acp/attachment-content.test.ts
@@ -44,6 +44,14 @@ describe('isTextLikeAttachment', () => {
     expect(isTextLikeAttachment('data.csv', 'binary/octet-stream')).toBe(true)
     expect(isTextLikeAttachment('archive.zip', 'application/octet-stream')).toBe(false)
   })
+
+  it('normalizes MIME casing and parameters before classifying', () => {
+    expect(isTextLikeAttachment('data.csv', 'Text/CSV')).toBe(true)
+    expect(isTextLikeAttachment('data.json', 'application/json; charset=utf-8')).toBe(true)
+    expect(isTextLikeAttachment('notes.txt', 'TEXT/PLAIN')).toBe(true)
+    // A generic MIME with a parameter still defers to the extension.
+    expect(isTextLikeAttachment('data.csv', 'application/octet-stream; charset=binary')).toBe(true)
+  })
 })
 
 describe('isTabularAttachment', () => {
@@ -56,6 +64,10 @@ describe('isTabularAttachment', () => {
   it('does not treat plain text or JSON as tabular', () => {
     expect(isTabularAttachment('notes.txt')).toBe(false)
     expect(isTabularAttachment('config.json')).toBe(false)
+  })
+
+  it('normalizes MIME casing and parameters', () => {
+    expect(isTabularAttachment('x', 'Text/CSV; charset=utf-8')).toBe(true)
   })
 })
 

--- a/src/main/acp/attachment-content.ts
+++ b/src/main/acp/attachment-content.ts
@@ -93,15 +93,25 @@ const mimeEssence = (mimeType?: string): string | undefined => {
   return essence ? essence : undefined
 }
 
-// True when the file can be read as UTF-8 text. An explicit text MIME wins; an explicit *non-text*,
+// True when the MIME essence names a text-bearing format directly. Covers text/*, JSON/XML and their
+// structured suffixes (RFC 6839 `+json`/`+xml`, e.g. application/geo+json, application/atom+xml), and the
+// `chemical/*` family, which the scientific formats we handle (PDB, MDL/SDF, MOL, SMILES) are all text.
+const isTextBearingMime = (essence: string): boolean =>
+  essence.startsWith('text/') ||
+  essence.startsWith('chemical/') ||
+  essence.endsWith('+json') ||
+  essence.endsWith('+xml') ||
+  essence === 'application/json' ||
+  essence === 'application/xml' ||
+  essence === 'application/x-ndjson'
+
+// True when the file can be read as UTF-8 text. A text-bearing MIME wins; an explicit *non-text*,
 // non-generic MIME (e.g. application/gzip, image/png) loses outright so a gzipped `.fastq` is never
 // treated as text. Only a missing or generic MIME defers to the known-text extension list.
 export const isTextLikeAttachment = (name: string, mimeType?: string): boolean => {
   const essence = mimeEssence(mimeType)
 
-  if (essence?.startsWith('text/')) return true
-  if (essence === 'application/json' || essence === 'application/xml') return true
-  if (essence === 'application/x-ndjson') return true
+  if (essence && isTextBearingMime(essence)) return true
 
   // A concrete non-text MIME is authoritative — do not second-guess it from the extension.
   if (essence && !GENERIC_MIME_TYPES.has(essence)) return false

--- a/src/main/acp/attachment-content.ts
+++ b/src/main/acp/attachment-content.ts
@@ -1,0 +1,137 @@
+// Pure helpers for turning an uploaded/referenced file into ACP prompt content. Kept free of fs/runtime
+// deps so the size/type decisions and the oversized-file notice text are unit-testable. The runtime
+// (runtime.ts) reads bytes and assembles the actual ContentBlock(s) around these decisions.
+
+// Text-like files at or under this size are embedded in full; anything larger is sent as a link plus a
+// bounded preview so a single big data file can never overflow the provider request. Lowered from 1 MB:
+// even a sub-1 MB wide table bloats the replayed history, and a large read is the real overflow source.
+export const MAX_EMBEDDED_TEXT_UPLOAD_BYTES = 512 * 1024
+
+// How much of an oversized text file to show as a preview. Enough for a header plus many sample rows so
+// the agent can plan targeted reads, while staying negligible against the request-size limit.
+export const ATTACHMENT_PREVIEW_BYTES = 16 * 1024
+
+// Clearly-text file extensions, including the common bioinformatics text formats, so a file whose MIME
+// type is missing or generic is still classified correctly (the renderer does not always send a MIME).
+const TEXT_LIKE_EXTENSIONS = new Set([
+  'txt',
+  'text',
+  'log',
+  'md',
+  'markdown',
+  'rst',
+  'csv',
+  'tsv',
+  'tab',
+  'psv',
+  'json',
+  'jsonl',
+  'ndjson',
+  'geojson',
+  'xml',
+  'yaml',
+  'yml',
+  'toml',
+  'ini',
+  'cfg',
+  'conf',
+  'tex',
+  'bib',
+  'fasta',
+  'fa',
+  'faa',
+  'fna',
+  'fastq',
+  'fq',
+  'vcf',
+  'bed',
+  'bedgraph',
+  'gff',
+  'gff3',
+  'gtf',
+  'sam',
+  'wig',
+  'nwk',
+  'newick',
+  'phy',
+  'aln',
+  'sto',
+  'clustal',
+  'pdb',
+  'sdf',
+  'mol',
+  'mol2',
+  'smi',
+  'smiles',
+  'gb',
+  'gbk',
+  'genbank',
+  'embl',
+  'maf'
+])
+
+// Column-oriented formats, so the reading hint can name rows/columns rather than generic ranges.
+const TABULAR_EXTENSIONS = new Set(['csv', 'tsv', 'tab', 'psv'])
+
+// Lower-cased extension after the final dot, or '' when the name has none.
+const fileExtension = (name: string): string => {
+  const dot = name.lastIndexOf('.')
+
+  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : ''
+}
+
+// True when the file can be read as UTF-8 text — by MIME (text/*, JSON) or by a known text extension.
+export const isTextLikeAttachment = (name: string, mimeType?: string): boolean => {
+  if (mimeType?.startsWith('text/') || mimeType === 'application/json') return true
+  if (mimeType === 'application/xml' || mimeType === 'application/x-ndjson') return true
+
+  return TEXT_LIKE_EXTENSIONS.has(fileExtension(name))
+}
+
+// True when the file is column-oriented (drives the rows/columns wording in the oversized notice).
+export const isTabularAttachment = (name: string, mimeType?: string): boolean => {
+  if (mimeType === 'text/csv' || mimeType === 'text/tab-separated-values') return true
+
+  return TABULAR_EXTENSIONS.has(fileExtension(name))
+}
+
+// Human-readable byte size for the notice (binary units, one decimal past KB).
+export const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`
+
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let value = bytes / 1024
+  let unit = 0
+
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+
+  return `${value.toFixed(1)} ${units[unit]}`
+}
+
+// Builds the text block that accompanies an oversized file's resource_link: it states why the file is
+// not inlined, tells the agent to read only what it needs, and shows a bounded preview of the start.
+export const buildOversizedAttachmentNotice = (input: {
+  name: string
+  size: number
+  preview: string
+  truncated: boolean
+  tabular: boolean
+}): string => {
+  const { name, size, preview, truncated, tabular } = input
+  const readHint = tabular
+    ? 'the header row and only the specific rows or columns you need'
+    : 'only the specific line ranges or sections you need'
+  const trailer = truncated ? '\n\n… file continues beyond this preview.' : ''
+
+  return [
+    `[Attached file "${name}" (${formatBytes(size)}) is too large to include in full and is available on disk via the linked resource below.`,
+    `Do not load the whole file — read ${readHint}. For analysis over the full file, compute in the notebook rather than reading it into the conversation.`,
+    'Preview of the start of the file:',
+    '',
+    preview,
+    trailer
+  ].join('\n')
+}

--- a/src/main/acp/attachment-content.ts
+++ b/src/main/acp/attachment-content.ts
@@ -84,24 +84,36 @@ const fileExtension = (name: string): string => {
 // (Browsers/OSes emit application/octet-stream for unrecognized types, including plain-text data files.)
 const GENERIC_MIME_TYPES = new Set(['application/octet-stream', 'binary/octet-stream'])
 
+// The lower-cased MIME essence (type/subtype) with any parameters and casing stripped, or undefined when
+// none was given. A real MIME arrives as `Text/CSV` or `application/json; charset=utf-8`, so every
+// comparison must run against this — not the raw string — or a valid text MIME reads as a concrete binary.
+const mimeEssence = (mimeType?: string): string | undefined => {
+  const essence = mimeType?.split(';', 1)[0]?.trim().toLowerCase()
+
+  return essence ? essence : undefined
+}
+
 // True when the file can be read as UTF-8 text. An explicit text MIME wins; an explicit *non-text*,
 // non-generic MIME (e.g. application/gzip, image/png) loses outright so a gzipped `.fastq` is never
 // treated as text. Only a missing or generic MIME defers to the known-text extension list.
 export const isTextLikeAttachment = (name: string, mimeType?: string): boolean => {
-  if (mimeType?.startsWith('text/') || mimeType === 'application/json') return true
-  if (mimeType === 'application/xml' || mimeType === 'application/x-ndjson') return true
+  const essence = mimeEssence(mimeType)
 
-  const normalizedMime = mimeType?.trim().toLowerCase()
+  if (essence?.startsWith('text/')) return true
+  if (essence === 'application/json' || essence === 'application/xml') return true
+  if (essence === 'application/x-ndjson') return true
 
   // A concrete non-text MIME is authoritative — do not second-guess it from the extension.
-  if (normalizedMime && !GENERIC_MIME_TYPES.has(normalizedMime)) return false
+  if (essence && !GENERIC_MIME_TYPES.has(essence)) return false
 
   return TEXT_LIKE_EXTENSIONS.has(fileExtension(name))
 }
 
 // True when the file is column-oriented (drives the rows/columns wording in the oversized notice).
 export const isTabularAttachment = (name: string, mimeType?: string): boolean => {
-  if (mimeType === 'text/csv' || mimeType === 'text/tab-separated-values') return true
+  const essence = mimeEssence(mimeType)
+
+  if (essence === 'text/csv' || essence === 'text/tab-separated-values') return true
 
   return TABULAR_EXTENSIONS.has(fileExtension(name))
 }

--- a/src/main/acp/attachment-content.ts
+++ b/src/main/acp/attachment-content.ts
@@ -80,10 +80,21 @@ const fileExtension = (name: string): string => {
   return dot >= 0 ? name.slice(dot + 1).toLowerCase() : ''
 }
 
-// True when the file can be read as UTF-8 text — by MIME (text/*, JSON) or by a known text extension.
+// Generic/opaque MIME values that carry no real format signal, so the extension is the better guide.
+// (Browsers/OSes emit application/octet-stream for unrecognized types, including plain-text data files.)
+const GENERIC_MIME_TYPES = new Set(['application/octet-stream', 'binary/octet-stream'])
+
+// True when the file can be read as UTF-8 text. An explicit text MIME wins; an explicit *non-text*,
+// non-generic MIME (e.g. application/gzip, image/png) loses outright so a gzipped `.fastq` is never
+// treated as text. Only a missing or generic MIME defers to the known-text extension list.
 export const isTextLikeAttachment = (name: string, mimeType?: string): boolean => {
   if (mimeType?.startsWith('text/') || mimeType === 'application/json') return true
   if (mimeType === 'application/xml' || mimeType === 'application/x-ndjson') return true
+
+  const normalizedMime = mimeType?.trim().toLowerCase()
+
+  // A concrete non-text MIME is authoritative — do not second-guess it from the extension.
+  if (normalizedMime && !GENERIC_MIME_TYPES.has(normalizedMime)) return false
 
   return TEXT_LIKE_EXTENSIONS.has(fileExtension(name))
 }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1037,6 +1037,61 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('sends an oversized text upload as a bounded preview + resource_link, never the full contents', async () => {
+    const root = await createTemporaryRoot()
+    const uploadRepository = new UploadRepository(root)
+    // A >512 KB CSV: a unique marker after the preview window must never reach the prompt.
+    const header = 'id,name,value\n'
+    const filler = Array.from({ length: 60_000 }, (_, i) => `${i},row,${i}`).join('\n')
+    const tailMarker = '\nSENTINEL_PAST_PREVIEW_WINDOW'
+    const csvBody = `${header}${filler}${tailMarker}`
+    expect(Buffer.byteLength(csvBody, 'utf8')).toBeGreaterThan(512 * 1024)
+    const stagedAttachments = await uploadRepository.stageFiles({
+      files: [
+        { name: 'big.csv', mimeType: 'text/csv', content: Buffer.from(csvBody).toString('base64') }
+      ]
+    })
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploadRepository }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'analyze this table',
+      attachments: stagedAttachments
+    })
+
+    expect(receivedPrompts).toHaveLength(1)
+    const [prompt] = receivedPrompts
+    // Order is preserved: user text, then the file's preview notice, then its link.
+    expect(prompt[0]).toEqual({ type: 'text', text: 'analyze this table' })
+    const notice = prompt[1] as Extract<ContentBlock, { type: 'text' }>
+    expect(notice.type).toBe('text')
+    expect(notice.text).toContain('big.csv')
+    expect(notice.text).toContain('too large to include in full')
+    expect(notice.text).toContain('id,name,value')
+    expect(prompt[2]).toMatchObject({
+      type: 'resource_link',
+      name: 'big.csv',
+      mimeType: 'text/csv',
+      uri: expect.stringContaining('/uploads/default-project/remote-session-1/big.csv')
+    })
+    // The full contents are never inlined: no `resource` block, and the past-preview marker never ships.
+    expect(prompt.some((block) => block.type === 'resource')).toBe(false)
+    expect(JSON.stringify(prompt)).not.toContain('SENTINEL_PAST_PREVIEW_WINDOW')
+  })
+
   it('adopts a fresh agent session under the same app id on a context reset', async () => {
     const process = new FakeAgentProcess()
     const receivedPrompts: ContentBlock[][] = []
@@ -1471,6 +1526,55 @@ describe('ACP runtime session management', () => {
       'Notebook tool instructions (only applies when using open-science-notebook tools)'
     )
     expect(fakeAgent.prompts[0].text).not.toContain('<open_science_artifact_instructions>')
+  })
+
+  it('delivers the large-data-file guidance to Claude session metadata on create and resume', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['remote-session-1'], { supportsResume: true })
+    // No artifacts/notebook configured: the large-file guidance is unconditional, unlike the MCP-gated
+    // artifact/notebook appends, so it must still ride the Claude system-prompt preset.
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework
+    })
+
+    // Resume a different id than the created one so the runtime performs a real session/resume (an
+    // already-attached id short-circuits), mirroring the artifact-guidance create+resume coverage.
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.resumeSession({ sessionId: 'remote-session-2', cwd: '/workspace' })
+
+    expect(fakeAgent.newSessions[0]._meta).toMatchObject({
+      systemPrompt: {
+        preset: 'claude_code',
+        append: expect.stringContaining('open_science_large_file_instructions')
+      }
+    })
+    expect(fakeAgent.resumedSessions[0]._meta).toMatchObject({
+      systemPrompt: {
+        append: expect.stringContaining('open_science_large_file_instructions')
+      }
+    })
+  })
+
+  it('delivers the large-data-file guidance to opencode as a prompt prefix', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['oc-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: opencodeFramework
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'hello opencode' })
+
+    // opencode has no system-prompt preset, so the guidance rides the prompt prefix ahead of user text.
+    expect(fakeAgent.newSessions[0]._meta).toBeUndefined()
+    expect(fakeAgent.prompts[0].text).toContain('open_science_large_file_instructions')
+    expect(fakeAgent.prompts[0].text).toContain('hello opencode')
   })
 
   it('serves artifact/notebook MCP over the http host for an http-only framework', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -54,6 +54,14 @@ import {
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { matchSessionModelOption } from './session-config'
 import { describePromptError } from './prompt-error'
+import {
+  ATTACHMENT_PREVIEW_BYTES,
+  MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
+  buildOversizedAttachmentNotice,
+  isTabularAttachment,
+  isTextLikeAttachment
+} from './attachment-content'
+import { readBoundedManagedFilePreview } from '../managed-file-preview'
 import { AcpPermissionBroker } from './permission-broker'
 import { isMcpToolName } from './permission-policy'
 import { applyCurrentModeUpdate } from './permission-profile-controller'
@@ -204,8 +212,18 @@ const SKILLS_READ_GUARD_SYSTEM_PROMPT_APPEND = [
   '</open_science_skill_privacy_instructions>'
 ].join('\n')
 
-// Small text uploads are embedded directly; larger files stay as links to avoid huge prompt payloads.
-const MAX_EMBEDDED_TEXT_UPLOAD_BYTES = 1024 * 1024
+// Steers the agent away from reading large attached data files in their entirety, since a single big
+// read (esp. under frameworks whose read/bash tools do not hard-cap output) can exceed the provider's
+// request-size limit and break the conversation. Framework-neutral: Claude carries it in the system
+// prompt preset, opencode as a prompt prefix.
+const LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND = [
+  '<open_science_large_file_instructions>',
+  'Large attached data files (CSV, TSV, TXT, JSON, FASTA/FASTQ, VCF, and similar tabular or text data) are provided as a file reference plus a short preview, not as full inline content.',
+  'Never read, cat, or print such a file in its entirety — a single large read can exceed the request-size limit and break the conversation.',
+  'Inspect structure first (columns, row count, a few sample rows), then read only the specific line ranges, rows, or columns you need.',
+  'To analyze, filter, or aggregate over a large file, load it in the notebook (e.g. pandas) and compute there instead of reading its contents into the conversation.',
+  '</open_science_large_file_instructions>'
+].join('\n')
 
 // Converts unknown thrown values into user-visible error text.
 const errorMessage = (error: unknown): string => {
@@ -1599,20 +1617,26 @@ class AcpRuntime {
         attachments
       )
 
-      // Keep the user's text first, then append files in the same order they were added.
+      // Keep the user's text first, then append files in the same order they were added. A file may
+      // expand to several blocks (an oversized text file becomes a preview notice + a resource link);
+      // route each through appendBlock so image blocks still honor the per-request inline budget.
       for (const attachment of finalizedAttachments) {
-        const block = await this.createAttachmentContentBlock(sessionId, attachment)
-        appendBlock(
-          block,
-          this.imageOverflowResourceLink(block, attachment.originalName, attachment.size)
-        )
+        const blocks = await this.createAttachmentContentBlock(sessionId, attachment)
+        for (const block of blocks) {
+          appendBlock(
+            block,
+            this.imageOverflowResourceLink(block, attachment.originalName, attachment.size)
+          )
+        }
       }
     }
 
     // `@`-mentioned artifacts reuse the same per-type block builder as uploads, in mention order.
     for (const reference of referencedArtifacts) {
-      const block = await this.createReferencedArtifactContentBlock(sessionId, reference)
-      appendBlock(block, this.imageOverflowResourceLink(block, reference.name))
+      const blocks = await this.createReferencedArtifactContentBlock(sessionId, reference)
+      for (const block of blocks) {
+        appendBlock(block, this.imageOverflowResourceLink(block, reference.name))
+      }
     }
 
     return contentBlocks
@@ -1639,7 +1663,7 @@ class AcpRuntime {
   private async createAttachmentContentBlock(
     sessionId: string,
     attachment: UploadedAttachment
-  ): Promise<ContentBlock> {
+  ): Promise<ContentBlock[]> {
     if (!this.uploadRepository) throw new Error('Upload storage is not configured.')
 
     const filePath = await this.uploadRepository.resolveManagedUploadPath({ path: attachment.path })
@@ -1659,7 +1683,7 @@ class AcpRuntime {
   private async createReferencedArtifactContentBlock(
     sessionId: string,
     reference: ArtifactReference
-  ): Promise<ContentBlock> {
+  ): Promise<ContentBlock[]> {
     const filePath = await this.resolveReferencedArtifactPath(reference)
     const { size } = await stat(filePath)
 
@@ -1693,7 +1717,7 @@ class AcpRuntime {
     name: string
     mimeType?: string
     size: number
-  }): Promise<ContentBlock> {
+  }): Promise<ContentBlock[]> {
     const { sessionId, absolutePath, uri, name, mimeType, size } = descriptor
 
     // Images are embedded as base64 so vision-capable agents receive the actual pixels.
@@ -1712,44 +1736,66 @@ class AcpRuntime {
       const alreadyInlined = this.sessionInlineImageBytes.get(sessionId) ?? 0
 
       if (!canInlineImageInSession(alreadyInlined, data.length, this.inlineImageBudgetBytes)) {
-        return { type: 'resource_link', uri, name, title: name, mimeType, size }
+        return [{ type: 'resource_link', uri, name, title: name, mimeType, size }]
       }
 
       this.sessionInlineImageBytes.set(sessionId, alreadyInlined + data.length)
 
-      return { type: 'image', data, mimeType: outMimeType, uri }
+      return [{ type: 'image', data, mimeType: outMimeType, uri }]
     }
 
     // PDFs are never inlined as base64 (a 20MB file overflows the 32MB request limit); instead we
     // extract selectable text so the model reads readable content. Page images are a future option.
     if (this.isPdfFile(name, mimeType)) {
-      return this.createPdfContentBlock(name, absolutePath, uri)
+      return [await this.createPdfContentBlock(name, absolutePath, uri)]
     }
 
-    // Small text-like files are embedded for direct reading; oversized text falls through to a link.
-    if (
-      (mimeType?.startsWith('text/') || mimeType === 'application/json') &&
-      size <= MAX_EMBEDDED_TEXT_UPLOAD_BYTES
-    ) {
-      return {
-        type: 'resource',
-        resource: {
-          uri,
-          mimeType,
-          text: await readFile(absolutePath, 'utf8')
-        }
+    if (isTextLikeAttachment(name, mimeType)) {
+      // Small text-like files are embedded for direct reading.
+      if (size <= MAX_EMBEDDED_TEXT_UPLOAD_BYTES) {
+        return [
+          {
+            type: 'resource',
+            resource: { uri, mimeType, text: await readFile(absolutePath, 'utf8') }
+          }
+        ]
       }
+
+      // Oversized text/tabular files are never inlined — a full read is the main request-size overflow
+      // source. Send a bounded preview (structure + a few rows) plus a link so the agent reads only what
+      // it needs instead of loading the whole file into context.
+      const preview = await readBoundedManagedFilePreview(
+        absolutePath,
+        { path: absolutePath, maxBytes: ATTACHMENT_PREVIEW_BYTES, encoding: 'utf8' },
+        'Attachment preview requires UTF-8 encoding.'
+      )
+
+      return [
+        {
+          type: 'text',
+          text: buildOversizedAttachmentNotice({
+            name,
+            size,
+            preview: preview.content,
+            truncated: preview.truncated,
+            tabular: isTabularAttachment(name, mimeType)
+          })
+        },
+        { type: 'resource_link', uri, name, title: name, mimeType, size }
+      ]
     }
 
     // Binary and large files are passed as resource links so agents can decide how to fetch them.
-    return {
-      type: 'resource_link',
-      uri,
-      name,
-      title: name,
-      mimeType,
-      size
-    }
+    return [
+      {
+        type: 'resource_link',
+        uri,
+        name,
+        title: name,
+        mimeType,
+        size
+      }
+    ]
   }
 
   // Recognizes PDFs by MIME type or extension since the renderer does not always send a MIME type.
@@ -2150,6 +2196,7 @@ class AcpRuntime {
     // omit it otherwise so the agent isn't told to use tools it wasn't given.
     return [
       SKILLS_READ_GUARD_SYSTEM_PROMPT_APPEND,
+      LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND,
       ...(this.artifactToolingAvailable() ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
       ...(this.notebookToolingAvailable() ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : [])
     ]


### PR DESCRIPTION
## Summary

Large uploaded / `@`-referenced text files (especially bioinformatics CSV/TSV/TXT and similar) were either embedded in full or, once past 1 MB, sent as a bare link. When the agent then read such a file, a single multi-MB content part could exceed the model provider's request-size limit — e.g. opencode via a Responses gateway rejecting a 19 MB text part (`content text: string too long`) — breaking the conversation and its replayed history.

The upload path already capped inline text, so the overflow's real source is the agent reading a big file. opencode's `read` tool auto-truncates, but there is **no** opencode config knob to cap tool output globally (an open upstream feature request), and non-`read` paths like `cat` aren't capped — so the fix works app-side plus via instructions.

## Changes

- **Lower the inline text threshold** from 1 MB to 512 KB (`MAX_EMBEDDED_TEXT_UPLOAD_BYTES`).
- **Oversized text/tabular files → preview + link**: instead of the full contents, send a bounded 16 KB preview text block (structure + sample rows) plus a `resource_link`, so the agent reads only what it needs.
- **MIME-aware classification** (`attachment-content.ts`): a text-bearing MIME wins (`text/*`, `application/json`/`xml`, RFC 6839 `+json`/`+xml` structured suffixes, and the `chemical/*` family); a concrete non-text MIME (e.g. `application/gzip`) is authoritative and loses; only a missing or generic MIME (`application/octet-stream`) defers to the file-extension list (which covers common bioinformatics formats). MIME essence is normalized (casing + parameters stripped) before any comparison.
- **New framework-neutral system-prompt instruction** steering the agent away from reading/cat-ing large data files whole — the practical guardrail for frameworks (opencode) whose read/bash tool output the app cannot hard-cap from outside.
- Extracted the size/type decisions and notice text into a pure, unit-tested module (`src/main/acp/attachment-content.ts`).

## Scope

4 files, limited to the attachment-overflow fix:
- `src/main/acp/attachment-content.ts` (new pure module)
- `src/main/acp/attachment-content.test.ts` (new)
- `src/main/acp/runtime.ts` (block builders + system-prompt append)
- `src/main/acp/runtime.test.ts` (runtime coverage)

The artifact-lifecycle work that was previously mixed in has been removed and lives in its own PR.

## Testing

- `attachment-content.test.ts`: 15 unit tests (classification by MIME + extension, MIME precedence/normalization, structured-suffix + `chemical/*` acceptance, oversized-notice formatting).
- `runtime.test.ts`: 3 added integration tests — oversized upload yields `[preview text, resource_link]` in attachment order with neither full contents nor a past-preview marker inlined; large-file guidance reaches Claude create/resume `_meta` and opencode's prompt prefix.
- Full `src/main/acp` suite: **180 pass**.
- `typecheck` (node + web), ESLint, Prettier: clean.

Rebased onto current `main` (on top of the Codex ACP PR #212); the new per-request image budget, file `stat`, tooling gates, history attachments, and Codex tests are all preserved.