### PR TITLE
fix(update): abort the download when the user cancels (#216)

### DIFF
--- a/src/main/update/downloader.test.ts
+++ b/src/main/update/downloader.test.ts
@@ -58,6 +58,35 @@ describe('downloadInstaller', () => {
     expect(existsSync(target)).toBe(false)
   })
 
+  it('aborts the download and cleans up the partial file when the signal fires', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'upd-'))
+    const target = join(dir, 'z.dmg')
+    const controller = new AbortController()
+    // Mimic real fetch: emit one chunk, then error the stream when the abort signal fires so the
+    // reader's next read rejects.
+    const fetchImpl = ((_url: unknown, init?: { signal?: AbortSignal }) => {
+      const body = new ReadableStream({
+        start(streamController) {
+          streamController.enqueue(new Uint8Array([1, 2, 3]))
+          init?.signal?.addEventListener('abort', () =>
+            streamController.error(new DOMException('The user aborted a request.', 'AbortError'))
+          )
+        }
+      })
+      return Promise.resolve(new Response(body, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const promise = downloadInstaller(
+      { url: 'https://cdn/z.dmg', size: 100, sha256: 'irrelevant' },
+      target,
+      { fetchImpl, signal: controller.signal }
+    )
+    controller.abort()
+
+    await expect(promise).rejects.toThrow()
+    expect(existsSync(target)).toBe(false)
+  })
+
   it('rejects and cleans up the partial file on a mid-stream error', async () => {
     dir = await mkdtemp(join(tmpdir(), 'upd-'))
     const target = join(dir, 'y.dmg')

--- a/src/main/update/downloader.ts
+++ b/src/main/update/downloader.ts
@@ -7,6 +7,8 @@ import type { PlatformDownload } from '../../shared/update'
 export type DownloadDeps = {
   fetchImpl?: typeof fetch
   onProgress?: (percent: number) => void
+  // Aborts the request/stream when signalled; the reader rejects and the partial file is cleaned up.
+  signal?: AbortSignal
 }
 
 // Streams the installer to `targetPath`, hashing as it goes. The sha256 comes from the manifest
@@ -18,7 +20,7 @@ export const downloadInstaller = async (
   deps: DownloadDeps = {}
 ): Promise<string> => {
   const fetchImpl = deps.fetchImpl ?? fetch
-  const response = await fetchImpl(download.url)
+  const response = await fetchImpl(download.url, { signal: deps.signal })
   if (!response.ok || !response.body) throw new Error(`Download failed: ${response.status}`)
 
   const hash = createHash('sha256')

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -127,6 +127,67 @@ describe('ElectronUpdaterStrategy', () => {
     expect(status.state).toBe('available')
   })
 
+  it('ignores a second download() while one is already in flight', async () => {
+    const updater = new FakeUpdater()
+    let release: (() => void) | undefined
+    updater.downloadUpdate = vi.fn(async () => {
+      await new Promise<void>((resolve) => (release = resolve))
+      updater.emit('update-downloaded', { version: '0.3.0' })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    await strategy.check()
+
+    const first = strategy.download()
+    const second = strategy.download()
+    expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
+
+    release?.()
+    await Promise.all([first, second])
+    expect(strategy.getStatus().state).toBe('ready')
+  })
+
+  it('supports cancel followed by an immediate retry to completion', async () => {
+    const updater = new FakeUpdater()
+    let calls = 0
+    let release: (() => void) | undefined
+    updater.downloadUpdate = vi.fn(async (token?: { cancelled: boolean }) => {
+      calls += 1
+      if (calls === 1) {
+        await new Promise<void>((resolve) => (release = resolve))
+        if (token?.cancelled) throw new Error('cancelled')
+      } else {
+        updater.emit('download-progress', { percent: 55 })
+        updater.emit('update-downloaded', { version: '0.3.0' })
+      }
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    await strategy.check()
+
+    const first = strategy.download()
+    const cancelled = await strategy.cancel()
+    expect(cancelled.state).toBe('available')
+
+    // Immediate retry: the token slot is free, so a fresh download starts and completes.
+    const retry = await strategy.download()
+    expect(retry.state).toBe('ready')
+    expect(updater.downloadUpdate).toHaveBeenCalledTimes(2)
+
+    // The first (cancelled) attempt settling later must not surface an error.
+    release?.()
+    const firstFinal = await first
+    expect(firstFinal.error).toBeUndefined()
+  })
+
   it('reports up-to-date when no update is available', async () => {
     const updater = new FakeUpdater()
     updater.checkForUpdates = vi.fn(async () => {

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -5,8 +5,17 @@ import { describe, expect, it, vi } from 'vitest'
 import { ElectronUpdaterStrategy } from './electron-updater-strategy'
 
 // The default autoUpdater is never exercised here (every test injects a FakeUpdater); mock the module
-// so importing the strategy doesn't pull a real Electron runtime into the test process.
-vi.mock('electron-updater', () => ({ autoUpdater: {} }))
+// so importing the strategy doesn't pull a real Electron runtime into the test process. A stub
+// CancellationToken stands in for the real class so the default token factory works in download().
+vi.mock('electron-updater', () => ({
+  autoUpdater: {},
+  CancellationToken: class {
+    cancelled = false
+    cancel(): void {
+      this.cancelled = true
+    }
+  }
+}))
 
 // Minimal fake of electron-updater's autoUpdater: an EventEmitter plus the methods/flags we drive.
 class FakeUpdater extends EventEmitter {
@@ -73,6 +82,49 @@ describe('ElectronUpdaterStrategy', () => {
     const status = await strategy.download()
     expect(broadcast).toHaveBeenCalledWith('update:progress', 42)
     expect(status.state).toBe('ready')
+  })
+
+  it('cancel aborts an in-flight download and resets the status to available', async () => {
+    const updater = new FakeUpdater()
+    let release: (() => void) | undefined
+    let seenToken: { cancelled: boolean } | undefined
+    // Hang the download until released, then mimic electron-updater rejecting a cancelled download.
+    updater.downloadUpdate = vi.fn(async (token?: { cancelled: boolean }) => {
+      seenToken = token
+      await new Promise<void>((resolve) => (release = resolve))
+      if (token?.cancelled) throw new Error('cancelled')
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    await strategy.check()
+
+    const downloading = strategy.download()
+    const cancelled = await strategy.cancel()
+    expect(cancelled.state).toBe('available')
+    expect(seenToken?.cancelled).toBe(true)
+
+    // The rejected downloadUpdate must not clobber the reset status with an error.
+    release?.()
+    const final = await downloading
+    expect(final.state).toBe('available')
+    expect(final.error).toBeUndefined()
+  })
+
+  it('cancel is a no-op when nothing is downloading', async () => {
+    const updater = new FakeUpdater()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    await strategy.check()
+    const status = await strategy.cancel()
+    expect(status.state).toBe('available')
   })
 
   it('reports up-to-date when no update is available', async () => {

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -17,17 +17,33 @@ vi.mock('electron-updater', () => ({
   }
 }))
 
-// Minimal fake of electron-updater's autoUpdater: an EventEmitter plus the methods/flags we drive.
+type FakeToken = { cancelled: boolean; cancel(): void }
+
+// Faithful fake of electron-updater's autoUpdater. Critically, downloadUpdate models AppUpdater's real
+// re-entrancy (out/AppUpdater.js): while a download is in progress it returns the SAME live
+// downloadPromise and IGNORES the passed token; the promise is only cleared in a finally after the
+// underlying download settles. This is what makes a naive "release the slot in cancel()" retry reuse
+// the cancelled download instead of starting a fresh one.
 class FakeUpdater extends EventEmitter {
   autoDownload = true
   autoInstallOnAppQuit = true
+  // The download body each call runs. Default: emit progress + downloaded and resolve. Tests override
+  // it to hang, to inspect the token, or to count real starts.
+  runDownload: (token?: FakeToken) => Promise<void> = async () => {
+    this.emit('download-progress', { percent: 42 })
+    this.emit('update-downloaded', { version: '0.3.0' })
+  }
+  private downloadPromise: Promise<void> | null = null
   checkForUpdates = vi.fn(async () => {
     this.emit('checking-for-update')
     this.emit('update-available', { version: '0.3.0', releaseNotes: 'notes' })
   })
-  downloadUpdate = vi.fn(async () => {
-    this.emit('download-progress', { percent: 42 })
-    this.emit('update-downloaded', { version: '0.3.0' })
+  downloadUpdate = vi.fn((token?: FakeToken): Promise<void> => {
+    if (this.downloadPromise != null) return this.downloadPromise
+    this.downloadPromise = this.runDownload(token).finally(() => {
+      this.downloadPromise = null
+    })
+    return this.downloadPromise
   })
   quitAndInstall = vi.fn()
 }
@@ -87,13 +103,13 @@ describe('ElectronUpdaterStrategy', () => {
   it('cancel aborts an in-flight download and resets the status to available', async () => {
     const updater = new FakeUpdater()
     let release: (() => void) | undefined
-    let seenToken: { cancelled: boolean } | undefined
+    let seenToken: FakeToken | undefined
     // Hang the download until released, then mimic electron-updater rejecting a cancelled download.
-    updater.downloadUpdate = vi.fn(async (token?: { cancelled: boolean }) => {
+    updater.runDownload = async (token) => {
       seenToken = token
       await new Promise<void>((resolve) => (release = resolve))
       if (token?.cancelled) throw new Error('cancelled')
-    })
+    }
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
@@ -130,10 +146,12 @@ describe('ElectronUpdaterStrategy', () => {
   it('ignores a second download() while one is already in flight', async () => {
     const updater = new FakeUpdater()
     let release: (() => void) | undefined
-    updater.downloadUpdate = vi.fn(async () => {
+    let starts = 0
+    updater.runDownload = async () => {
+      starts += 1
       await new Promise<void>((resolve) => (release = resolve))
       updater.emit('update-downloaded', { version: '0.3.0' })
-    })
+    }
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
@@ -144,27 +162,31 @@ describe('ElectronUpdaterStrategy', () => {
 
     const first = strategy.download()
     const second = strategy.download()
-    expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
+    expect(starts).toBe(1)
 
     release?.()
     await Promise.all([first, second])
+    expect(starts).toBe(1)
     expect(strategy.getStatus().state).toBe('ready')
   })
 
   it('supports cancel followed by an immediate retry to completion', async () => {
     const updater = new FakeUpdater()
-    let calls = 0
+    let starts = 0
     let release: (() => void) | undefined
-    updater.downloadUpdate = vi.fn(async (token?: { cancelled: boolean }) => {
-      calls += 1
-      if (calls === 1) {
+    // Models the real AppUpdater: the first (cancelled) download stays live until released; the retry
+    // must NOT reuse it. Only a strategy that drains the old lifecycle before retrying lets the fake's
+    // downloadPromise clear so downloadUpdate starts a genuine second download.
+    updater.runDownload = async (token) => {
+      starts += 1
+      if (starts === 1) {
         await new Promise<void>((resolve) => (release = resolve))
         if (token?.cancelled) throw new Error('cancelled')
       } else {
         updater.emit('download-progress', { percent: 55 })
         updater.emit('update-downloaded', { version: '0.3.0' })
       }
-    })
+    }
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
@@ -177,13 +199,13 @@ describe('ElectronUpdaterStrategy', () => {
     const cancelled = await strategy.cancel()
     expect(cancelled.state).toBe('available')
 
-    // Immediate retry: the token slot is free, so a fresh download starts and completes.
+    // Release the cancelled download so its live promise settles and clears, unblocking the retry's
+    // drain. A real retry then starts a second, genuine download that completes.
+    release?.()
     const retry = await strategy.download()
     expect(retry.state).toBe('ready')
-    expect(updater.downloadUpdate).toHaveBeenCalledTimes(2)
+    expect(starts).toBe(2)
 
-    // The first (cancelled) attempt settling later must not surface an error.
-    release?.()
     const firstFinal = await first
     expect(firstFinal.error).toBeUndefined()
   })

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron'
-import { autoUpdater } from 'electron-updater'
+import { autoUpdater, CancellationToken } from 'electron-updater'
 
 import { APP } from '../../shared/app-config'
 import type { UpdateStatus } from '../../shared/update'
@@ -10,6 +10,14 @@ import { broadcastToRenderers } from '../renderer-broadcast'
 // Minimal logger surface so tests inject a spy without pulling electron-log.
 type UpdaterLogger = { info: (msg: string) => void; error: (msg: string, err?: unknown) => void }
 
+// The slice of electron-updater's CancellationToken we drive: pass it to downloadUpdate() so the
+// in-flight HTTP download can be aborted, and read `cancelled` to distinguish a user cancel from a
+// real download failure.
+export interface MinimalCancellationToken {
+  readonly cancelled: boolean
+  cancel(): void
+}
+
 // Structural subset of electron-updater's autoUpdater we depend on, so tests can inject a fake without
 // pulling a real Electron runtime.
 export interface MinimalAutoUpdater {
@@ -17,7 +25,7 @@ export interface MinimalAutoUpdater {
   autoInstallOnAppQuit: boolean
   on(event: string, listener: (...args: unknown[]) => void): unknown
   checkForUpdates(): Promise<unknown>
-  downloadUpdate(): Promise<unknown>
+  downloadUpdate(cancellationToken?: MinimalCancellationToken): Promise<unknown>
   quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void
 }
 
@@ -25,6 +33,9 @@ export type ElectronUpdaterDeps = {
   updater?: MinimalAutoUpdater
   currentVersion?: string
   broadcast?: (channel: string, payload: unknown) => void
+  // Factory for the per-download cancellation token; defaults to electron-updater's CancellationToken.
+  // Injectable so tests can drive cancel() without the real class.
+  createCancellationToken?: () => MinimalCancellationToken
   // CDN manifest the release notes are read from (same version.json the installer flow uses).
   // Injectable for tests; defaults to the public stable manifest.
   fetchImpl?: typeof fetch
@@ -65,6 +76,9 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private readonly fetchImpl?: typeof fetch
   private readonly manifestUrl: string
   private readonly log: UpdaterLogger
+  private readonly createCancellationToken: () => MinimalCancellationToken
+  // The token for the current download, held so cancel() can abort it. Cleared once download() settles.
+  private downloadToken?: MinimalCancellationToken
   private status: UpdateStatus
   // In-flight manifest notes fetch for the current update, awaited by check() so the returned
   // status reflects the hydrated notes.
@@ -79,6 +93,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.fetchImpl = deps.fetchImpl
     this.manifestUrl = deps.manifestUrl ?? APP.update.manifestUrl
     this.log = deps.log ?? { info: () => {}, error: () => {} }
+    this.createCancellationToken = deps.createCancellationToken ?? (() => new CancellationToken())
     this.installGate = deps.installGate
     this.status = { state: 'idle', current: this.currentVersion, applyKind: 'restart' }
 
@@ -168,13 +183,32 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
 
   async download(): Promise<UpdateStatus> {
     this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
+    const token = this.createCancellationToken()
+    this.downloadToken = token
     try {
-      await this.updater.downloadUpdate()
+      await this.updater.downloadUpdate(token)
     } catch (error) {
-      this.setStatus({
-        state: 'error',
-        error: error instanceof Error ? error.message : 'Download failed'
-      })
+      // A user cancel rejects downloadUpdate too; don't surface it as an error. cancel() has already
+      // reset the status to 'available', so leave it untouched here.
+      if (!token.cancelled) {
+        this.setStatus({
+          state: 'error',
+          error: error instanceof Error ? error.message : 'Download failed'
+        })
+      }
+    } finally {
+      if (this.downloadToken === token) this.downloadToken = undefined
+    }
+    return this.status
+  }
+
+  // Aborts the in-flight electron-updater download by cancelling its token and resets the status to
+  // 'available' so the UI leaves the downloading state. No-op when nothing is downloading.
+  async cancel(): Promise<UpdateStatus> {
+    this.downloadToken?.cancel()
+    this.downloadToken = undefined
+    if (this.status.state === 'downloading') {
+      this.setStatus({ ...this.status, state: 'available', progress: undefined })
     }
     return this.status
   }

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -83,6 +83,9 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   // fully settled. A retry awaits this so it never reuses electron-updater's still-live downloadPromise
   // (which ignores a fresh token — see AppUpdater.downloadUpdate) or races an aborted download's cleanup.
   private downloadLifecycle?: Promise<void>
+  // Monotonic id per started download; the finally only clears downloadLifecycle when it is still the
+  // latest, so an older (drained) download can't clear a newer one's lifecycle.
+  private downloadGeneration = 0
   private status: UpdateStatus
   // In-flight manifest notes fetch for the current update, awaited by check() so the returned
   // status reflects the hydrated notes.
@@ -197,6 +200,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     // and await it INSIDE the new lifecycle — awaiting here (before claiming the token) would defer a
     // microtask and let a concurrent download() slip past the guard.
     const previous = this.downloadLifecycle
+    const generation = ++this.downloadGeneration
     const token = this.createCancellationToken()
     this.downloadToken = token
     this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
@@ -227,7 +231,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     try {
       await lifecycle
     } finally {
-      if (this.downloadLifecycle === lifecycle) this.downloadLifecycle = undefined
+      if (this.downloadGeneration === generation) this.downloadLifecycle = undefined
     }
     return this.status
   }

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -79,6 +79,10 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private readonly createCancellationToken: () => MinimalCancellationToken
   // The token for the current download, held so cancel() can abort it. Cleared once download() settles.
   private downloadToken?: MinimalCancellationToken
+  // The current download()'s lifecycle promise, resolved only after the underlying downloadUpdate has
+  // fully settled. A retry awaits this so it never reuses electron-updater's still-live downloadPromise
+  // (which ignores a fresh token — see AppUpdater.downloadUpdate) or races an aborted download's cleanup.
+  private downloadLifecycle?: Promise<void>
   private status: UpdateStatus
   // In-flight manifest notes fetch for the current update, awaited by check() so the returned
   // status reflects the hydrated notes.
@@ -182,31 +186,51 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   }
 
   async download(): Promise<UpdateStatus> {
-    // A download is already in flight; ignore repeat clicks / concurrent renderers. Starting a second
-    // would overwrite downloadToken and orphan the first download (cancel() could no longer stop it).
+    // An active download is in flight; ignore repeat clicks / concurrent renderers. Starting a second
+    // would overwrite downloadToken and orphan the first (cancel() could no longer stop it). This guard
+    // and the token claim below are synchronous so a racing download()/cancel() sees a consistent slot.
     if (this.downloadToken) return this.status
-    this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
+
+    // A just-cancelled download may still be settling: cancel() returns before electron-updater's
+    // underlying downloadPromise rejects. downloadUpdate() reuses that live promise and ignores a fresh
+    // token while it exists (see AppUpdater.downloadUpdate), so a retry must first drain it. Capture it
+    // and await it INSIDE the new lifecycle — awaiting here (before claiming the token) would defer a
+    // microtask and let a concurrent download() slip past the guard.
+    const previous = this.downloadLifecycle
     const token = this.createCancellationToken()
     this.downloadToken = token
-    try {
-      await this.updater.downloadUpdate(token)
-    } catch (error) {
-      // A user cancel rejects downloadUpdate too; don't surface it as an error. cancel() has already
-      // reset the status to 'available', so leave it untouched here.
-      if (!token.cancelled) {
-        this.setStatus({
-          state: 'error',
-          error: error instanceof Error ? error.message : 'Download failed'
-        })
+    this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
+
+    const lifecycle = (async () => {
+      try {
+        // Let the prior cancelled download's promise clear (and its cleanup finish) before starting.
+        if (previous) await previous
+        // A cancel() during the drain means never start this download.
+        if (token.cancelled) return
+        await this.updater.downloadUpdate(token)
+      } catch (error) {
+        // A user cancel rejects downloadUpdate too; don't surface it as an error. cancel() has already
+        // reset the status to 'available', so leave it untouched here.
+        if (!token.cancelled) {
+          this.setStatus({
+            state: 'error',
+            error: error instanceof Error ? error.message : 'Download failed'
+          })
+        }
+      } finally {
+        if (this.downloadToken === token) this.downloadToken = undefined
       }
-    } finally {
-      if (this.downloadToken === token) this.downloadToken = undefined
-    }
+    })()
+    this.downloadLifecycle = lifecycle
+    await lifecycle
+    if (this.downloadLifecycle === lifecycle) this.downloadLifecycle = undefined
     return this.status
   }
 
   // Aborts the in-flight electron-updater download by cancelling its token and resets the status to
-  // 'available' so the UI leaves the downloading state. No-op when nothing is downloading.
+  // 'available' so the UI leaves the downloading state. Does not clear downloadLifecycle: the next
+  // download() awaits it so it never reuses the still-settling (cancelled) downloadPromise. No-op when
+  // nothing is downloading.
   async cancel(): Promise<UpdateStatus> {
     this.downloadToken?.cancel()
     this.downloadToken = undefined

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -204,13 +204,15 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     const lifecycle = (async () => {
       try {
         // Let the prior cancelled download's promise clear (and its cleanup finish) before starting.
-        if (previous) await previous
+        // Swallow its outcome — it is owned by its own lifecycle.
+        if (previous) await previous.catch(() => {})
         // A cancel() during the drain means never start this download.
         if (token.cancelled) return
         await this.updater.downloadUpdate(token)
       } catch (error) {
         // A user cancel rejects downloadUpdate too; don't surface it as an error. cancel() has already
-        // reset the status to 'available', so leave it untouched here.
+        // reset the status to 'available', so leave it untouched here. Caught so the lifecycle never
+        // rejects and can't poison the next download()'s drain.
         if (!token.cancelled) {
           this.setStatus({
             state: 'error',
@@ -222,8 +224,11 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       }
     })()
     this.downloadLifecycle = lifecycle
-    await lifecycle
-    if (this.downloadLifecycle === lifecycle) this.downloadLifecycle = undefined
+    try {
+      await lifecycle
+    } finally {
+      if (this.downloadLifecycle === lifecycle) this.downloadLifecycle = undefined
+    }
     return this.status
   }
 

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -182,6 +182,9 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   }
 
   async download(): Promise<UpdateStatus> {
+    // A download is already in flight; ignore repeat clicks / concurrent renderers. Starting a second
+    // would overwrite downloadToken and orphan the first download (cancel() could no longer stop it).
+    if (this.downloadToken) return this.status
     this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
     const token = this.createCancellationToken()
     this.downloadToken = token

--- a/src/main/update/ipc.ts
+++ b/src/main/update/ipc.ts
@@ -17,6 +17,7 @@ export const registerUpdateIpcHandlers = (
   ipcMain.handle('update:get-status', (): UpdateStatus => strategy.getStatus())
   ipcMain.handle('update:check', (): Promise<UpdateStatus> => strategy.check())
   ipcMain.handle('update:download', (): Promise<UpdateStatus> => strategy.download())
+  ipcMain.handle('update:cancel', (): Promise<UpdateStatus> => strategy.cancel())
   ipcMain.handle('update:apply', (): Promise<UpdateStatus> => strategy.apply())
   return strategy
 }

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -315,6 +315,99 @@ describe('UpdateService.download', () => {
     expect(firstFinal.error).toBeUndefined()
   })
 
+  it('a cancel while a retry is still draining aborts it — no hidden download starts', async () => {
+    // Reproduces issue #216's core symptom for the retry path: cancel first, retry (which drains the
+    // cancelled download), then cancel again during that drain. A no-op cancel here would let the retry
+    // start a hidden download after the dialog closed.
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    const manifestForCheck = downloadManifest(100, 'irrelevant')
+    let installerFetches = 0
+    let onFirstFetch: (() => void) | undefined
+    let errorFirstStream: (() => void) | undefined
+    const firstFetched = new Promise<void>((resolve) => (onFirstFetch = resolve))
+    const fetchImpl = ((input: unknown) => {
+      if (String(input).endsWith('version.json')) {
+        return Promise.resolve(jsonResponse(manifestForCheck))
+      }
+      installerFetches += 1
+      const hanging = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]))
+          errorFirstStream = () =>
+            controller.error(new DOMException('The user aborted a request.', 'AbortError'))
+        }
+      })
+      onFirstFetch?.()
+      return Promise.resolve(new Response(hanging, { status: 200 }))
+    }) as unknown as typeof fetch
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target)
+    })
+
+    await service.check()
+    const first = service.download()
+    await firstFetched
+    expect((await service.cancel()).state).toBe('available')
+
+    // Retry drains the cancelled download; cancel it again while it is still draining.
+    const retry = service.download()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect((await service.cancel()).state).toBe('available')
+
+    // Let the first download settle so the retry's drain unblocks.
+    errorFirstStream?.()
+    const status = await retry
+    expect(status.state).toBe('available')
+    // The retry must NOT have started a second (hidden) download.
+    expect(installerFetches).toBe(1)
+
+    await first
+  })
+
+  it('recovers on a later download() after the save dialog throws (no poisoned lifecycle)', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    const fetchImpl = ((input: unknown) =>
+      String(input).endsWith('version.json')
+        ? Promise.resolve(jsonResponse(manifestForCheck))
+        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+    let saveCall = 0
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      // First prompt throws (e.g. a dialog failure); the second succeeds.
+      promptSavePath: () =>
+        saveCall++ === 0 ? Promise.reject(new Error('dialog failed')) : Promise.resolve(target)
+    })
+
+    await service.check()
+    const failed = await service.download()
+    expect(failed.state).toBe('error')
+    expect(failed.error).toBe('dialog failed')
+
+    // A poisoned lifecycle would rethrow 'dialog failed' here and never reopen the dialog.
+    const retry = await service.download()
+    expect(retry.state).toBe('ready')
+    expect(retry.localPath).toBe(target)
+    expect(existsSync(target)).toBe(true)
+  })
+
   it('rejects a download whose URL host differs from the manifest host, without fetching', async () => {
     const offHostManifest: UpdateManifest = {
       version: '0.3.0',

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -156,6 +156,50 @@ describe('UpdateService.download', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('cancel aborts an in-flight download, resets to available, and leaves no partial file', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    const manifestForCheck = downloadManifest(100, 'irrelevant')
+    let onInstallerFetch: (() => void) | undefined
+    const fetched = new Promise<void>((resolve) => (onInstallerFetch = resolve))
+    // The installer body hangs (one chunk, no end) and errors on abort, mimicking a real fetch.
+    const fetchImpl = ((input: unknown, init?: { signal?: AbortSignal }) => {
+      if (String(input).endsWith('version.json')) {
+        return Promise.resolve(jsonResponse(manifestForCheck))
+      }
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]))
+          init?.signal?.addEventListener('abort', () =>
+            controller.error(new DOMException('The user aborted a request.', 'AbortError'))
+          )
+        }
+      })
+      onInstallerFetch?.()
+      return Promise.resolve(new Response(body, { status: 200 }))
+    }) as unknown as typeof fetch
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target)
+    })
+
+    await service.check()
+    const downloading = service.download()
+    await fetched
+    const cancelled = await service.cancel()
+    expect(cancelled.state).toBe('available')
+
+    const final = await downloading
+    expect(final.state).toBe('available')
+    expect(final.error).toBeUndefined()
+    expect(existsSync(target)).toBe(false)
+  })
+
   it('rejects a download whose URL host differs from the manifest host, without fetching', async () => {
     const offHostManifest: UpdateManifest = {
       version: '0.3.0',

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -244,30 +244,35 @@ describe('UpdateService.download', () => {
     await first
   })
 
-  it('supports cancel followed by an immediate retry to completion', async () => {
+  it('a retry to the SAME path waits for the cancelled download to fully settle before starting', async () => {
+    // Same target for both attempts: the cancelled download's deferred rm(targetPath) would delete the
+    // retry's freshly written installer unless the retry first drains that download's cleanup. Proven
+    // deterministically by holding the first download open and asserting the retry starts NO second
+    // fetch until it is released — a naive retry fetches immediately and later loses its file to the rm.
     dir = await mkdtemp(join(tmpdir(), 'svc-'))
-    const target1 = join(dir, 'installer-1.dmg')
-    const target2 = join(dir, 'installer-2.dmg')
+    const target = join(dir, 'installer.dmg')
     const body = Buffer.from('installer-bytes')
     const manifestForCheck = downloadManifest(
       body.byteLength,
       createHash('sha256').update(body).digest('hex')
     )
-    let installerCall = 0
+    let installerFetches = 0
     let onFirstFetch: (() => void) | undefined
+    let errorFirstStream: (() => void) | undefined
     const firstFetched = new Promise<void>((resolve) => (onFirstFetch = resolve))
-    const fetchImpl = ((input: unknown, init?: { signal?: AbortSignal }) => {
+    const fetchImpl = ((input: unknown) => {
       if (String(input).endsWith('version.json')) {
         return Promise.resolve(jsonResponse(manifestForCheck))
       }
-      installerCall += 1
-      if (installerCall === 1) {
+      installerFetches += 1
+      if (installerFetches === 1) {
+        // Hangs after one chunk until we explicitly error it, so the first download (and its rm) only
+        // completes when the test decides — the drain point the retry must respect.
         const hanging = new ReadableStream({
           start(controller) {
             controller.enqueue(new Uint8Array([1, 2, 3]))
-            init?.signal?.addEventListener('abort', () =>
+            errorFirstStream = () =>
               controller.error(new DOMException('The user aborted a request.', 'AbortError'))
-            )
           }
         })
         onFirstFetch?.()
@@ -275,7 +280,6 @@ describe('UpdateService.download', () => {
       }
       return Promise.resolve(new Response(body, { status: 200 }))
     }) as unknown as typeof fetch
-    let saveCall = 0
     const service = new UpdateService({
       fetchImpl,
       platform: 'darwin',
@@ -283,7 +287,7 @@ describe('UpdateService.download', () => {
       currentVersion: '0.2.0',
       manifestUrl: 'https://statics.aipoch.com/version.json',
       broadcast: vi.fn(),
-      promptSavePath: () => Promise.resolve(saveCall++ === 0 ? target1 : target2)
+      promptSavePath: () => Promise.resolve(target)
     })
 
     await service.check()
@@ -292,10 +296,20 @@ describe('UpdateService.download', () => {
     const cancelled = await service.cancel()
     expect(cancelled.state).toBe('available')
 
-    const retry = await service.download()
-    expect(retry.state).toBe('ready')
-    expect(retry.localPath).toBe(target2)
-    expect(existsSync(target2)).toBe(true)
+    // Kick off the retry while the cancelled download is still settling.
+    const retry = service.download()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    // The retry must be draining the cancelled download, not racing it: no second fetch yet.
+    expect(installerFetches).toBe(1)
+
+    // Release the first download so it errors and runs its rm cleanup; only now may the retry proceed.
+    errorFirstStream?.()
+    const status = await retry
+    expect(status.state).toBe('ready')
+    expect(installerFetches).toBe(2)
+    // The retry's file, written after the cancelled download's rm, must survive.
+    expect(existsSync(target)).toBe(true)
+    expect(await readFile(target)).toEqual(body)
 
     const firstFinal = await first
     expect(firstFinal.error).toBeUndefined()

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -200,6 +200,107 @@ describe('UpdateService.download', () => {
     expect(existsSync(target)).toBe(false)
   })
 
+  it('ignores a second download() while one is already in flight', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    const manifestForCheck = downloadManifest(100, 'irrelevant')
+    let installerFetches = 0
+    let onInstallerFetch: (() => void) | undefined
+    const fetched = new Promise<void>((resolve) => (onInstallerFetch = resolve))
+    const fetchImpl = ((input: unknown, init?: { signal?: AbortSignal }) => {
+      if (String(input).endsWith('version.json')) {
+        return Promise.resolve(jsonResponse(manifestForCheck))
+      }
+      installerFetches += 1
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]))
+          init?.signal?.addEventListener('abort', () =>
+            controller.error(new DOMException('The user aborted a request.', 'AbortError'))
+          )
+        }
+      })
+      onInstallerFetch?.()
+      return Promise.resolve(new Response(body, { status: 200 }))
+    }) as unknown as typeof fetch
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target)
+    })
+
+    await service.check()
+    const first = service.download()
+    await fetched
+    const second = await service.download()
+    expect(second.state).toBe('downloading')
+    expect(installerFetches).toBe(1)
+
+    await service.cancel()
+    await first
+  })
+
+  it('supports cancel followed by an immediate retry to completion', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target1 = join(dir, 'installer-1.dmg')
+    const target2 = join(dir, 'installer-2.dmg')
+    const body = Buffer.from('installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    let installerCall = 0
+    let onFirstFetch: (() => void) | undefined
+    const firstFetched = new Promise<void>((resolve) => (onFirstFetch = resolve))
+    const fetchImpl = ((input: unknown, init?: { signal?: AbortSignal }) => {
+      if (String(input).endsWith('version.json')) {
+        return Promise.resolve(jsonResponse(manifestForCheck))
+      }
+      installerCall += 1
+      if (installerCall === 1) {
+        const hanging = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array([1, 2, 3]))
+            init?.signal?.addEventListener('abort', () =>
+              controller.error(new DOMException('The user aborted a request.', 'AbortError'))
+            )
+          }
+        })
+        onFirstFetch?.()
+        return Promise.resolve(new Response(hanging, { status: 200 }))
+      }
+      return Promise.resolve(new Response(body, { status: 200 }))
+    }) as unknown as typeof fetch
+    let saveCall = 0
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(saveCall++ === 0 ? target1 : target2)
+    })
+
+    await service.check()
+    const first = service.download()
+    await firstFetched
+    const cancelled = await service.cancel()
+    expect(cancelled.state).toBe('available')
+
+    const retry = await service.download()
+    expect(retry.state).toBe('ready')
+    expect(retry.localPath).toBe(target2)
+    expect(existsSync(target2)).toBe(true)
+
+    const firstFinal = await first
+    expect(firstFinal.error).toBeUndefined()
+  })
+
   it('rejects a download whose URL host differs from the manifest host, without fetching', async () => {
     const offHostManifest: UpdateManifest = {
       version: '0.3.0',

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -45,6 +45,8 @@ const installerFileName = (url: string): string => {
 // renderer stores stay in sync. All I/O is injectable for tests; production reads Electron/OS.
 export class UpdateService implements UpdateStrategy {
   private status: UpdateStatus
+  // Aborts the in-flight installer download; held so cancel() can stop it. Cleared once download settles.
+  private downloadAbort?: AbortController
   private readonly fetchImpl?: typeof fetch
   private readonly platform: NodeJS.Platform
   private readonly arch: string
@@ -149,18 +151,38 @@ export class UpdateService implements UpdateStrategy {
     if (!targetPath) return this.status
 
     this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
+    const abort = new AbortController()
+    this.downloadAbort = abort
     try {
       const localPath = await downloadInstaller(download, targetPath, {
         fetchImpl: this.fetchImpl,
-        onProgress: (percent) => this.broadcast('update:progress', percent)
+        onProgress: (percent) => this.broadcast('update:progress', percent),
+        signal: abort.signal
       })
       this.setStatus({ ...this.status, state: 'ready', progress: 100, localPath })
     } catch (error) {
-      this.setStatus({
-        ...this.status,
-        state: 'error',
-        error: error instanceof Error ? error.message : 'Download failed'
-      })
+      // A user cancel aborts the fetch, which rejects here; cancel() has already reset the status to
+      // 'available', so don't overwrite it with an error.
+      if (!abort.signal.aborted) {
+        this.setStatus({
+          ...this.status,
+          state: 'error',
+          error: error instanceof Error ? error.message : 'Download failed'
+        })
+      }
+    } finally {
+      if (this.downloadAbort === abort) this.downloadAbort = undefined
+    }
+    return this.status
+  }
+
+  // Aborts the in-flight installer download and resets the status to 'available' so the UI leaves the
+  // downloading state. No-op when nothing is downloading.
+  async cancel(): Promise<UpdateStatus> {
+    this.downloadAbort?.abort()
+    this.downloadAbort = undefined
+    if (this.status.state === 'downloading') {
+      this.setStatus({ ...this.status, state: 'available', progress: undefined })
     }
     return this.status
   }

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -51,6 +51,9 @@ export class UpdateService implements UpdateStrategy {
   // (including its partial-file rm cleanup on abort). A retry awaits this so an aborted download's
   // deferred rm can't delete a same-path retry's freshly written installer.
   private downloadLifecycle?: Promise<void>
+  // Monotonic id per started download; the finally only clears downloadLifecycle when it is still the
+  // latest, so an older (drained) download can't clear a newer one's lifecycle.
+  private downloadGeneration = 0
   private readonly fetchImpl?: typeof fetch
   private readonly platform: NodeJS.Platform
   private readonly arch: string
@@ -158,6 +161,7 @@ export class UpdateService implements UpdateStrategy {
     // Claim the slot synchronously, before any await, so a concurrent download() is rejected and a
     // cancel() during the drain (below) aborts this download instead of being a no-op.
     const previous = this.downloadLifecycle
+    const generation = ++this.downloadGeneration
     const abort = new AbortController()
     this.downloadAbort = abort
 
@@ -201,7 +205,7 @@ export class UpdateService implements UpdateStrategy {
     try {
       await lifecycle
     } finally {
-      if (this.downloadLifecycle === lifecycle) this.downloadLifecycle = undefined
+      if (this.downloadGeneration === generation) this.downloadLifecycle = undefined
     }
     return this.status
   }

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -47,6 +47,10 @@ export class UpdateService implements UpdateStrategy {
   private status: UpdateStatus
   // Aborts the in-flight installer download; held so cancel() can stop it. Cleared once download settles.
   private downloadAbort?: AbortController
+  // The current download()'s lifecycle promise, resolved only after downloadInstaller has fully settled
+  // (including its partial-file rm cleanup on abort). A retry awaits this so an aborted download's
+  // deferred rm can't delete a same-path retry's freshly written installer.
+  private downloadLifecycle?: Promise<void>
   private readonly fetchImpl?: typeof fetch
   private readonly platform: NodeJS.Platform
   private readonly arch: string
@@ -129,8 +133,13 @@ export class UpdateService implements UpdateStrategy {
   }
 
   async download(): Promise<UpdateStatus> {
-    // A download is already in flight; ignore repeat clicks / concurrent renderers. Starting a second
-    // would overwrite downloadAbort and orphan the first download (cancel() could no longer stop it).
+    // An active download is in flight; ignore repeat clicks / concurrent renderers immediately. Starting
+    // a second would overwrite downloadAbort and orphan the first (cancel() could no longer stop it).
+    if (this.downloadAbort) return this.status
+    // A just-cancelled download may still be settling (cancel() returns before downloadInstaller's abort
+    // cleanup — its partial-file rm — finishes). Wait it out so an aborted download can't delete a
+    // same-path retry's freshly written file, then re-check the guard.
+    await this.downloadLifecycle
     if (this.downloadAbort) return this.status
 
     const { download } = this.status
@@ -155,35 +164,37 @@ export class UpdateService implements UpdateStrategy {
     const abort = new AbortController()
     this.downloadAbort = abort
 
-    // Ask where to save (platform-aware). A dialog cancel — or a cancel() during the prompt — leaves
-    // the status untouched (stays 'available') and releases the slot.
-    const targetPath = await this.promptSavePath(installerFileName(download.url))
-    if (!targetPath || abort.signal.aborted) {
-      if (this.downloadAbort === abort) this.downloadAbort = undefined
-      return this.status
-    }
+    const lifecycle = (async () => {
+      // Ask where to save (platform-aware). A dialog cancel — or a cancel() during the prompt — leaves
+      // the status untouched (stays 'available').
+      const targetPath = await this.promptSavePath(installerFileName(download.url))
+      if (!targetPath || abort.signal.aborted) return
 
-    this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
-    try {
-      const localPath = await downloadInstaller(download, targetPath, {
-        fetchImpl: this.fetchImpl,
-        onProgress: (percent) => this.broadcast('update:progress', percent),
-        signal: abort.signal
-      })
-      this.setStatus({ ...this.status, state: 'ready', progress: 100, localPath })
-    } catch (error) {
-      // A user cancel aborts the fetch, which rejects here; cancel() has already reset the status to
-      // 'available', so don't overwrite it with an error.
-      if (!abort.signal.aborted) {
-        this.setStatus({
-          ...this.status,
-          state: 'error',
-          error: error instanceof Error ? error.message : 'Download failed'
+      this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
+      try {
+        const localPath = await downloadInstaller(download, targetPath, {
+          fetchImpl: this.fetchImpl,
+          onProgress: (percent) => this.broadcast('update:progress', percent),
+          signal: abort.signal
         })
+        this.setStatus({ ...this.status, state: 'ready', progress: 100, localPath })
+      } catch (error) {
+        // A user cancel aborts the fetch, which rejects here; cancel() has already reset the status to
+        // 'available', so don't overwrite it with an error.
+        if (!abort.signal.aborted) {
+          this.setStatus({
+            ...this.status,
+            state: 'error',
+            error: error instanceof Error ? error.message : 'Download failed'
+          })
+        }
       }
-    } finally {
+    })().finally(() => {
       if (this.downloadAbort === abort) this.downloadAbort = undefined
-    }
+    })
+    this.downloadLifecycle = lifecycle
+    await lifecycle
+    if (this.downloadLifecycle === lifecycle) this.downloadLifecycle = undefined
     return this.status
   }
 

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -133,13 +133,9 @@ export class UpdateService implements UpdateStrategy {
   }
 
   async download(): Promise<UpdateStatus> {
-    // An active download is in flight; ignore repeat clicks / concurrent renderers immediately. Starting
-    // a second would overwrite downloadAbort and orphan the first (cancel() could no longer stop it).
-    if (this.downloadAbort) return this.status
-    // A just-cancelled download may still be settling (cancel() returns before downloadInstaller's abort
-    // cleanup — its partial-file rm — finishes). Wait it out so an aborted download can't delete a
-    // same-path retry's freshly written file, then re-check the guard.
-    await this.downloadLifecycle
+    // An active download is in flight; ignore repeat clicks / concurrent renderers. The abort claim
+    // below is synchronous (before any await) so this guard and a cancel() during the drain both target
+    // a consistent slot — a cancel while a retry is still draining must abort it, not be a no-op.
     if (this.downloadAbort) return this.status
 
     const { download } = this.status
@@ -159,19 +155,26 @@ export class UpdateService implements UpdateStrategy {
       return this.status
     }
 
-    // Claim the in-flight slot synchronously, before the save-dialog await, so a concurrent download()
-    // is rejected by the guard above and cancel() can abort even while the save prompt is open.
+    // Claim the slot synchronously, before any await, so a concurrent download() is rejected and a
+    // cancel() during the drain (below) aborts this download instead of being a no-op.
+    const previous = this.downloadLifecycle
     const abort = new AbortController()
     this.downloadAbort = abort
 
     const lifecycle = (async () => {
-      // Ask where to save (platform-aware). A dialog cancel — or a cancel() during the prompt — leaves
-      // the status untouched (stays 'available').
-      const targetPath = await this.promptSavePath(installerFileName(download.url))
-      if (!targetPath || abort.signal.aborted) return
-
-      this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
       try {
+        // Drain any prior (e.g. just-cancelled) download so its partial-file rm can't delete a same-path
+        // retry's installer. Swallow its outcome — it is owned by its own lifecycle.
+        if (previous) await previous.catch(() => {})
+        // A cancel() during the drain means never start this download.
+        if (abort.signal.aborted) return
+
+        // Ask where to save (platform-aware). A dialog cancel — or a cancel() during the prompt —
+        // leaves the status untouched (stays 'available').
+        const targetPath = await this.promptSavePath(installerFileName(download.url))
+        if (!targetPath || abort.signal.aborted) return
+
+        this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
         const localPath = await downloadInstaller(download, targetPath, {
           fetchImpl: this.fetchImpl,
           onProgress: (percent) => this.broadcast('update:progress', percent),
@@ -179,8 +182,10 @@ export class UpdateService implements UpdateStrategy {
         })
         this.setStatus({ ...this.status, state: 'ready', progress: 100, localPath })
       } catch (error) {
-        // A user cancel aborts the fetch, which rejects here; cancel() has already reset the status to
-        // 'available', so don't overwrite it with an error.
+        // A user cancel aborts the fetch (rejects here); cancel() already reset the status to
+        // 'available', so leave it. Any other failure — including a save-dialog rejection — surfaces as
+        // an error the user can retry from. Caught here so the lifecycle never rejects and can't poison
+        // the next download()'s drain.
         if (!abort.signal.aborted) {
           this.setStatus({
             ...this.status,
@@ -188,13 +193,16 @@ export class UpdateService implements UpdateStrategy {
             error: error instanceof Error ? error.message : 'Download failed'
           })
         }
+      } finally {
+        if (this.downloadAbort === abort) this.downloadAbort = undefined
       }
-    })().finally(() => {
-      if (this.downloadAbort === abort) this.downloadAbort = undefined
-    })
+    })()
     this.downloadLifecycle = lifecycle
-    await lifecycle
-    if (this.downloadLifecycle === lifecycle) this.downloadLifecycle = undefined
+    try {
+      await lifecycle
+    } finally {
+      if (this.downloadLifecycle === lifecycle) this.downloadLifecycle = undefined
+    }
     return this.status
   }
 

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -129,6 +129,10 @@ export class UpdateService implements UpdateStrategy {
   }
 
   async download(): Promise<UpdateStatus> {
+    // A download is already in flight; ignore repeat clicks / concurrent renderers. Starting a second
+    // would overwrite downloadAbort and orphan the first download (cancel() could no longer stop it).
+    if (this.downloadAbort) return this.status
+
     const { download } = this.status
     if (!download) return this.status
 
@@ -146,13 +150,20 @@ export class UpdateService implements UpdateStrategy {
       return this.status
     }
 
-    // Ask where to save (platform-aware). A cancel leaves the status untouched (stays 'available').
-    const targetPath = await this.promptSavePath(installerFileName(download.url))
-    if (!targetPath) return this.status
-
-    this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
+    // Claim the in-flight slot synchronously, before the save-dialog await, so a concurrent download()
+    // is rejected by the guard above and cancel() can abort even while the save prompt is open.
     const abort = new AbortController()
     this.downloadAbort = abort
+
+    // Ask where to save (platform-aware). A dialog cancel — or a cancel() during the prompt — leaves
+    // the status untouched (stays 'available') and releases the slot.
+    const targetPath = await this.promptSavePath(installerFileName(download.url))
+    if (!targetPath || abort.signal.aborted) {
+      if (this.downloadAbort === abort) this.downloadAbort = undefined
+      return this.status
+    }
+
+    this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
     try {
       const localPath = await downloadInstaller(download, targetPath, {
         fetchImpl: this.fetchImpl,

--- a/src/main/update/strategy.ts
+++ b/src/main/update/strategy.ts
@@ -18,6 +18,9 @@ export interface UpdateStrategy {
   getStatus(): UpdateStatus
   check(): Promise<UpdateStatus>
   download(): Promise<UpdateStatus>
+  // Aborts an in-flight download, stops network activity, and returns the reset status (back to
+  // 'available' when a download was running). A no-op when nothing is downloading.
+  cancel(): Promise<UpdateStatus>
   // Applies a ready update: open the installer (mac) or quitAndInstall (win/linux).
   apply(): Promise<UpdateStatus>
   // Optional: inject the pre-install backend-shutdown gate. Only the in-place strategy uses it; the

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -234,6 +234,7 @@ interface OpenScienceAPI {
     getStatus(): Promise<UpdateStatus>
     check(): Promise<UpdateStatus>
     download(): Promise<UpdateStatus>
+    cancel(): Promise<UpdateStatus>
     apply(): Promise<UpdateStatus>
     onStatus(listener: (status: UpdateStatus) => void): RemoveListener
     onProgress(listener: (percent: number) => void): RemoveListener

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -253,6 +253,7 @@ type OpenScienceAPI = {
     getStatus: () => Promise<UpdateStatus>
     check: () => Promise<UpdateStatus>
     download: () => Promise<UpdateStatus>
+    cancel: () => Promise<UpdateStatus>
     apply: () => Promise<UpdateStatus>
     onStatus: (listener: (status: UpdateStatus) => void) => RemoveListener
     onProgress: (listener: (percent: number) => void) => RemoveListener
@@ -545,6 +546,7 @@ const api: OpenScienceAPI = {
     getStatus: () => ipcRenderer.invoke('update:get-status') as Promise<UpdateStatus>,
     check: () => ipcRenderer.invoke('update:check') as Promise<UpdateStatus>,
     download: () => ipcRenderer.invoke('update:download') as Promise<UpdateStatus>,
+    cancel: () => ipcRenderer.invoke('update:cancel') as Promise<UpdateStatus>,
     apply: () => ipcRenderer.invoke('update:apply') as Promise<UpdateStatus>,
     onStatus: (listener) => onIpcMessage('update:status', listener),
     onProgress: (listener) => onIpcMessage('update:progress', listener)

--- a/src/renderer/src/stores/update-store.test.ts
+++ b/src/renderer/src/stores/update-store.test.ts
@@ -134,8 +134,10 @@ describe('useUpdateStore', () => {
     expect(useUpdateStore.getState().status.state).toBe('available')
   })
 
-  it('closeDialog does not cancel when no download is running', () => {
-    const cancel = vi.fn()
+  it('closeDialog cancels unconditionally so a not-yet-broadcast download is still aborted', () => {
+    // The 'downloading' broadcast may not have arrived when the user clicks Cancel right after
+    // Download; closeDialog must still call cancel (a main-process no-op when nothing is downloading).
+    const cancel = vi.fn(() => Promise.resolve({ state: 'available', current: '0.2.0' }))
     ;(window as unknown as { api: unknown }).api = {
       update: { onStatus: vi.fn(), onProgress: vi.fn(), cancel }
     }
@@ -146,7 +148,7 @@ describe('useUpdateStore', () => {
 
     useUpdateStore.getState().closeDialog()
 
-    expect(cancel).not.toHaveBeenCalled()
+    expect(cancel).toHaveBeenCalledTimes(1)
     expect(useUpdateStore.getState().isDialogOpen).toBe(false)
   })
 

--- a/src/renderer/src/stores/update-store.test.ts
+++ b/src/renderer/src/stores/update-store.test.ts
@@ -114,6 +114,42 @@ describe('useUpdateStore', () => {
     expect(useUpdateStore.getState().isDialogOpen).toBe(false)
   })
 
+  it('closeDialog cancels an in-flight download', async () => {
+    const cancel = vi.fn(() =>
+      Promise.resolve({ state: 'available', current: '0.2.0', latest: '0.3.0' })
+    )
+    ;(window as unknown as { api: unknown }).api = {
+      update: { onStatus: vi.fn(), onProgress: vi.fn(), cancel }
+    }
+    useUpdateStore.setState({
+      status: { state: 'downloading', current: '0.2.0', latest: '0.3.0', progress: 40 },
+      isDialogOpen: true
+    })
+
+    useUpdateStore.getState().closeDialog()
+    await Promise.resolve()
+
+    expect(cancel).toHaveBeenCalledTimes(1)
+    expect(useUpdateStore.getState().isDialogOpen).toBe(false)
+    expect(useUpdateStore.getState().status.state).toBe('available')
+  })
+
+  it('closeDialog does not cancel when no download is running', () => {
+    const cancel = vi.fn()
+    ;(window as unknown as { api: unknown }).api = {
+      update: { onStatus: vi.fn(), onProgress: vi.fn(), cancel }
+    }
+    useUpdateStore.setState({
+      status: { state: 'available', current: '0.2.0', latest: '0.3.0' },
+      isDialogOpen: true
+    })
+
+    useUpdateStore.getState().closeDialog()
+
+    expect(cancel).not.toHaveBeenCalled()
+    expect(useUpdateStore.getState().isDialogOpen).toBe(false)
+  })
+
   it('check stores the returned status', async () => {
     ;(window as unknown as { api: unknown }).api = {
       update: {

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -51,11 +51,12 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
 
   openDialog: () => set({ isDialogOpen: true }),
 
-  // Closing the dialog mid-download aborts the download. The Cancel button and the X / overlay /
-  // Escape dismissals all route here, so any way of closing the dialog stops the background download
-  // rather than letting it run on invisibly.
+  // Closing the dialog aborts any in-flight download. Cancel a request unconditionally rather than
+  // gating on the local 'downloading' state: right after clicking Download the 'downloading' broadcast
+  // may not have arrived yet, so a guarded call would miss it and leave the download running — the
+  // exact race in issue #216. The main-process cancel() is a no-op when nothing is downloading.
   closeDialog: () => {
-    if (get().status.state === 'downloading') void get().cancel()
+    void get().cancel()
     set({ isDialogOpen: false })
   },
 
@@ -66,9 +67,9 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
   },
 
   cancel: async () => {
-    const api = window.api?.update
-    if (!api) return
-    set({ status: await api.cancel() })
+    const cancel = window.api?.update?.cancel
+    if (!cancel) return
+    set({ status: await cancel() })
   },
 
   apply: async () => {

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -12,6 +12,7 @@ type UpdateStore = {
   openDialog: () => void
   closeDialog: () => void
   download: () => Promise<void>
+  cancel: () => Promise<void>
   apply: () => Promise<void>
 }
 
@@ -50,12 +51,24 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
 
   openDialog: () => set({ isDialogOpen: true }),
 
-  closeDialog: () => set({ isDialogOpen: false }),
+  // Closing the dialog mid-download aborts the download. The Cancel button and the X / overlay /
+  // Escape dismissals all route here, so any way of closing the dialog stops the background download
+  // rather than letting it run on invisibly.
+  closeDialog: () => {
+    if (get().status.state === 'downloading') void get().cancel()
+    set({ isDialogOpen: false })
+  },
 
   download: async () => {
     const api = window.api?.update
     if (!api) return
     set({ status: await api.download() })
+  },
+
+  cancel: async () => {
+    const api = window.api?.update
+    if (!api) return
+    set({ status: await api.cancel() })
   },
 
   apply: async () => {

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -107,6 +107,7 @@ export const WEB_INVOKE_CHANNELS = {
   'storage.setDataRootAndRelaunch': 'storage:set-data-root-and-relaunch',
   'storage.validateDataRoot': 'storage:validate-data-root',
   'update.apply': 'update:apply',
+  'update.cancel': 'update:cancel',
   'update.check': 'update:check',
   'update.download': 'update:download',
   'update.getAppInfo': 'update:get-app-info',


### PR DESCRIPTION
## Summary

Fixes #216. Clicking **Cancel** (or dismissing the update dialog) while an update was downloading only closed the dialog — the background download kept running and resumed further along on the next open.

Neither update strategy could abort an in-flight download, and the renderer's Cancel button only flipped `isDialogOpen`. This gives both strategies a real cancel path, a correct retry path, and wires the UI to it.

## Changes

- **`UpdateStrategy.cancel()`** added to the interface; both implementations honor it.
- **`ElectronUpdaterStrategy`** (win/linux + signed stable macOS — the reporter's platform): passes a `CancellationToken` to `downloadUpdate()` and cancels it. `token.cancelled` distinguishes a user-cancel from a genuine failure, so a cancel doesn't flash an error and resets to `available`.
- **`UpdateService`** (macOS dev/nightly fallback): threads an `AbortController` through `downloadInstaller`, which forwards the signal to `fetch`; the existing catch removes the partial file.
- **IPC/preload**: new `update:cancel` channel + preload bridge (`index.ts` / `index.d.ts`) + regenerated `api-map.generated.ts`.
- **Renderer**: `update-store.closeDialog` cancels **unconditionally** (not gated on the local `downloading` state) so a cancel that lands before the `downloading` broadcast still aborts the download; the main-process `cancel()` is a no-op when idle. The Cancel button, X, overlay, and Escape all route here.
- **Concurrency & retry correctness**: both strategies reject a concurrent `download()` while one is in flight, and a retry after a cancel *drains* the previous download's lifecycle before starting. This matters because electron-updater's `downloadUpdate()` reuses its live `downloadPromise` and ignores a fresh token until it clears (`AppUpdater.downloadUpdate`), and because `UpdateService`'s aborted download runs a deferred partial-file `rm` that would otherwise delete a same-path retry's installer.

## Testing

- `ElectronUpdaterStrategy`: the test `FakeUpdater` now models `AppUpdater`'s real re-entrancy (reuse the live promise, ignore the passed token, clear in `finally`). Covers cancel → reset-to-available, concurrent `download()` ignored, and cancel-then-immediate-retry starting a genuine second download.
- `UpdateService`: cancel + partial-file cleanup, concurrent `download()` ignored, and a **same-path** retry that asserts no second fetch begins until the cancelled download fully drains (its `rm` can't clobber the retry's file). Both retry tests fail against a naive no-drain implementation.
- `downloadInstaller`: signal-driven abort + cleanup. Renderer store: `closeDialog` cancels even while still `available`.
- All required checks pass: `typecheck`, `lint`, full `test` (3055 passed), `format`, and the `check:web-api-map` drift gate.

## Scope note

A survey of the app-managed install surfaces (agent Claude/opencode installs, skill GitHub import, notebook runtime/env installs) found the updater is the only surface with an *existing* Cancel button, and it was the broken one. The others expose no cancel affordance at all (just a disabled "Installing…" spinner), so making them cancelable is net-new feature work — deferred to a follow-up. The agent managed-binary download (`downloadAndVerify`) shares this exact non-abortable streamed-fetch shape and is the natural companion for that follow-up.