### PR TITLE
fix(renderer): size markdown table columns to content

### DIFF
--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -676,7 +676,7 @@
       }
 
       :where(th) {
-        @apply bg-bg-300 font-semibold;
+        @apply bg-bg-200 font-semibold;
       }
     }
 

--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -332,8 +332,6 @@
     [data-streamdown='mermaid'],
     [data-streamdown='mermaid-block'],
     [data-streamdown='table-wrapper'],
-    [data-streamdown='table'],
-    [data-streamdown='table'] > div,
     [data-streamdown='image-wrapper'],
     [data-streamdown='link'],
     img,
@@ -341,7 +339,6 @@
     li,
     blockquote,
     pre,
-    table,
     .katex-display
   ) {
     @apply max-w-full;
@@ -669,11 +666,13 @@
     }
 
     &:where(table) {
-      @apply w-full border-collapse text-[12px];
+      /* Overrides Streamdown's own `w-full` utility on the table element: size columns
+         to content and let the wrapper scroll horizontally instead of squeezing cells. */
+      @apply w-max! min-w-full border-collapse text-[12px];
 
       :where(th),
       :where(td) {
-        @apply border border-border-200 bg-bg-000 px-2 py-1.5 text-left align-top;
+        @apply max-w-[20rem] border border-border-200 bg-bg-000 px-2 py-1.5 text-left align-top break-words;
       }
 
       :where(th) {
@@ -700,7 +699,7 @@
       }
     }
 
-    &:where(p, li, td, th, blockquote) {
+    &:where(p, li, blockquote) {
       @apply break-words;
       overflow-wrap: anywhere;
     }


### PR DESCRIPTION
## Summary

Markdown tables rendered in chat messages were hard-pinned to the container width while every cell allowed breaking at any character. The browser's auto table layout therefore had no content-based signal and distributed column widths almost blindly, squeezing long-content columns (e.g. paper titles, DOIs) into per-character wrapping under narrow headers. Tables now size their columns to content: narrow tables still fill the container, wide tables scroll horizontally inside the existing wrapper, and no single cell can stretch the table beyond a 320px cap.

## Key Changes

- Chat markdown tables distribute column widths based on actual cell content instead of being compressed to header width — long titles and identifiers no longer wrap character-by-character.
- Tables wider than the message column now scroll horizontally within their container instead of crushing their cells.
- A single very long cell (e.g. a long abstract or URL) wraps at a 320px column cap rather than forcing the whole table wider.

## Impact

- Affects markdown table rendering in agent chat messages and any surface using `AgentMarkdown` (markdown file preview, release notes dialog, skill detail view).
- Styling-only change in `src/renderer/src/assets/agent-markdown.css`; no component or Streamdown configuration changes.
- Fullscreen table modal is untouched (it lives outside the `.agent-markdown` scope and already had sane wrapping rules).

## Test Results

- Compiled the Tailwind v4 entry `main.css` with `@tailwindcss/node`: all `@apply` utilities resolve; output contains `width: max-content !important`, `min-width: 100%` on tables and `max-width: 20rem` on cells.
- `npm run typecheck` output is identical to the unmodified `main` baseline (58 pre-existing errors unrelated to this change, e.g. missing `ws` types and stale prisma client).

## Potential Issues

- Visual verification in the running app (column distribution, scroll onset) is still recommended; CSS output was verified at build level only.
- Pre-existing, unrelated: `electron-vite build` fails because `openchemlib` is not installed (`MoleculePreview.tsx`).

## Authors

- Roxi <roxi3906@163.com>
