### PR TITLE
fix(artifacts): harden the artifact lifecycle (parallel sessions, orphans, crash recovery, reviewer trust)

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1036,6 +1036,64 @@ describe('ACP runtime session management', () => {
     // is markedly slower on a cold Windows CI runner and can exceed the 5s default there.
   }, 30000)
 
+  it('attributes app-side artifact writes to the calling session while another turn is in flight', async () => {
+    const root = await createTemporaryRoot()
+    const artifactRepository = new ArtifactRepository(root)
+    const process = new FakeAgentProcess()
+    const gateA = createDeferred()
+    const gateB = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['remote-session-1', 'remote-session-2'], {
+      onPrompt: ({ sessionId }) =>
+        sessionId === 'remote-session-1' ? gateA.promise : gateB.promise
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/unused',
+        repository: artifactRepository
+      }
+    })
+
+    const sessionA = await runtime.createSession({ cwd: '/workspace' })
+    const sessionB = await runtime.createSession({ cwd: '/workspace' })
+
+    // Hold both turns open so both sessions have an active artifact run at the same time — the exact
+    // condition a single global "current run" mis-attributes.
+    const promptA = runtime.sendPrompt({ sessionId: sessionA.sessionId, text: 'a' })
+    const promptB = runtime.sendPrompt({ sessionId: sessionB.sessionId, text: 'b' })
+    // Both prompts have reached the agent, so both sessions' artifact runs are now active.
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(2))
+
+    const artifactA = await runtime.writeArtifactForCurrentRun(sessionA.sessionId, {
+      filename: 'a.txt',
+      content: 'from A'
+    })
+    const artifactB = await runtime.writeArtifactForCurrentRun(sessionB.sessionId, {
+      filename: 'b.txt',
+      content: 'from B'
+    })
+
+    // Each write lands in its own session's distinct run, never a shared global one.
+    expect(artifactA.sessionId).not.toBe(artifactB.sessionId)
+    expect(artifactA.runId).not.toBe(artifactB.runId)
+    expect(artifactA.path).toContain(artifactA.sessionId)
+    expect(artifactB.path).toContain(artifactB.sessionId)
+
+    // A write with no live run for the session fails closed instead of falling back to another run.
+    await expect(
+      runtime.writeArtifactForCurrentRun('unknown-session', { filename: 'x.txt', content: 'x' })
+    ).rejects.toThrow(/active assistant turn/)
+
+    gateA.resolve()
+    gateB.resolve()
+    await Promise.all([promptA, promptB])
+  })
+
   it('appends referenced artifacts as content blocks by file type', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -316,9 +316,11 @@ class AcpRuntime {
   private artifactSessionSequence = 0
   private artifactRunSequence = 0
   private notebookSessionSequence = 0
-  // The in-flight turn's artifact run, tracked so app-side tools (e.g. molecule preview) can attach a
-  // generated file to the current run. Set while a prompt is active, cleared in the prompt's finally.
-  private activeArtifactRun: { sessionId: string; run: ActiveArtifactRun } | undefined
+  // The in-flight artifact run keyed by app session id, so app-side tools (e.g. molecule preview)
+  // attach a generated file to the run of the session that triggered the call. Parallel sessions each
+  // keep their own entry — a single global field would let one session's turn capture another's write.
+  // An entry is set while that session's prompt is active and cleared in the prompt's finally.
+  private readonly activeArtifactRuns = new Map<string, ActiveArtifactRun>()
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -1216,9 +1218,11 @@ class AcpRuntime {
     try {
       // Create a fresh run context before prompting so MCP writes can be attributed to this turn.
       artifactRun = await this.activateArtifactRun(request.sessionId)
-      this.activeArtifactRun = artifactRun
-        ? { sessionId: request.sessionId, run: artifactRun }
-        : undefined
+      if (artifactRun) {
+        this.activeArtifactRuns.set(request.sessionId, artifactRun)
+      } else {
+        this.activeArtifactRuns.delete(request.sessionId)
+      }
       // Prepend a short steering nudge naming the picked skills. It goes only into the content sent to
       // the agent; the user-facing message event keeps the original text (which already shows /Name).
       // Framework-neutral delivery of the system-prompt guidance: Claude carries it in session _meta so
@@ -1326,8 +1330,8 @@ class AcpRuntime {
       // lock and the renderer starts the replay, this stale finally must not delete the replay's in-flight
       // lock (which would reopen same-session sends and misreport prompt-in-flight) or clear its active
       // artifact run. Identity/token comparisons scope each clear to the turn that still owns the state.
-      if (this.activeArtifactRun?.run === artifactRun) {
-        this.activeArtifactRun = undefined
+      if (artifactRun && this.activeArtifactRuns.get(request.sessionId) === artifactRun) {
+        this.activeArtifactRuns.delete(request.sessionId)
       }
       if (this.currentPromptTurnBySession.get(request.sessionId) === promptTurn) {
         this.currentPromptTurnBySession.delete(request.sessionId)
@@ -2053,20 +2057,26 @@ class AcpRuntime {
   // Writes an inline file into the in-flight turn's pending artifact run so it attaches to the resulting
   // message and surfaces to the renderer like any generated artifact. Used by app-side connector tools
   // (e.g. molecule preview). Throws when no assistant turn is active (e.g. a user-run notebook cell).
-  async writeArtifactForCurrentRun(input: {
-    filename: string
-    content: string
-    mimeType?: string
-  }): Promise<ArtifactFile> {
-    const active = this.activeArtifactRun
-    if (!active || !this.artifactRepository) {
+  async writeArtifactForCurrentRun(
+    sessionId: string,
+    input: {
+      filename: string
+      content: string
+      mimeType?: string
+    }
+  ): Promise<ArtifactFile> {
+    // Attribute the write to the run of the session that triggered it, resolved from the caller's
+    // session id — never a global "current" run, so a parallel session's in-flight turn cannot capture
+    // this file. Fail closed when the session has no active run.
+    const run = sessionId ? this.activeArtifactRuns.get(sessionId) : undefined
+    if (!run || !this.artifactRepository) {
       throw new Error('No active assistant turn to attach a generated file to.')
     }
 
     return this.artifactRepository.writePendingFile({
-      projectName: this.resolveSessionProjectName(active.sessionId),
-      sessionId: active.run.artifactSessionId,
-      runId: active.run.runId,
+      projectName: this.resolveSessionProjectName(sessionId),
+      sessionId: run.artifactSessionId,
+      runId: run.runId,
       filename: input.filename,
       mimeType: input.mimeType,
       source: { kind: 'inline', content: input.content, encoding: 'utf8' }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -392,6 +392,13 @@ class AcpRuntime {
     }))
   }
 
+  // Run ids of turns currently in flight, from live in-memory state (not the persisted current-run
+  // handoff, which survives a crash). The artifact orphan scan uses this to exclude files a running
+  // turn is still writing, while a crashed run — absent here — correctly surfaces as orphaned.
+  getActiveArtifactRunIds(): string[] {
+    return Array.from(this.activeArtifactRuns.values(), (run) => run.runId)
+  }
+
   // Resolves an application profile against per-session ACP capabilities and applies the real Agent
   // mode before any prompt is sent. The selected/effective projection is then shared with the UI and
   // the conservative fallback reviewer.

--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -294,4 +294,47 @@ describe('artifact IPC handlers', () => {
 
     expect('listMessageFiles' in handlers).toBe(false)
   })
+
+  it('excludes both prompt-active runs and unfinalized claims from the orphan scan', async () => {
+    const listProjectArtifacts = vi.fn().mockResolvedValue([])
+    const repository = { listProjectArtifacts } as unknown as ArtifactRepository
+    const runRegistry = new ArtifactRunRegistry()
+
+    // A run whose files were emitted and are awaiting the renderer's finalize call — it has left the
+    // runtime's prompt-active set but must still be treated as in-flight, not orphaned.
+    runRegistry.register({
+      projectName: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-awaiting-finalize'
+    })
+
+    const handlers = createArtifactHandlers(repository, runRegistry, {
+      getActiveArtifactRunIds: () => ['run-in-prompt']
+    })
+
+    await handlers.listProjectFiles({ projectName: 'default-project' })
+
+    const passedSet = listProjectArtifacts.mock.calls[0][1] as Set<string>
+    expect([...passedSet].sort()).toEqual(['run-awaiting-finalize', 'run-in-prompt'])
+  })
+
+  it('drops a run from the exclusion set once its claim is finalized', async () => {
+    const listProjectArtifacts = vi.fn().mockResolvedValue([])
+    const repository = { listProjectArtifacts } as unknown as ArtifactRepository
+    const runRegistry = new ArtifactRunRegistry()
+    const claimId = runRegistry.register({
+      projectName: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-done'
+    })
+    runRegistry.markFinalized(claimId, 'message-1')
+
+    const handlers = createArtifactHandlers(repository, runRegistry)
+    await handlers.listProjectFiles({ projectName: 'default-project' })
+
+    const passedSet = listProjectArtifacts.mock.calls[0][1] as Set<string>
+    expect(passedSet.has('run-done')).toBe(false)
+  })
 })

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -5,7 +5,8 @@ import type {
   FinalizeRunArtifactsRequest,
   ListProjectArtifactsRequest,
   OpenArtifactFileRequest,
-  ReadArtifactPreviewRequest
+  ReadArtifactPreviewRequest,
+  ReconcilePendingArtifactsRequest
 } from '../../shared/artifacts'
 import { resolveDataRoot } from '../storage-root'
 import { withDataRootWrite } from '../storage/migration-state'
@@ -15,6 +16,7 @@ import { ArtifactRunRegistry } from './run-registry'
 type ArtifactHandlers = {
   finalizeRunArtifacts: (request: FinalizeRunArtifactsRequest) => Promise<ArtifactFile[]>
   listProjectFiles: (request: ListProjectArtifactsRequest) => Promise<ArtifactFile[]>
+  reconcilePendingArtifacts: (request: ReconcilePendingArtifactsRequest) => Promise<ArtifactFile[]>
   openFile: (request: OpenArtifactFileRequest) => Promise<void>
   readPreview: (request: ReadArtifactPreviewRequest) => Promise<ArtifactPreviewResult>
 }
@@ -70,6 +72,8 @@ const createArtifactHandlers = (
         )
       ),
     listProjectFiles: (request) => repository.listProjectArtifacts(request.projectName),
+    reconcilePendingArtifacts: (request) =>
+      withDataRootWrite(() => repository.reconcilePendingArtifactPaths(request)),
     openFile: async (request) => {
       // Resolve through the repository first so shell.openPath never sees unmanaged locations.
       const filePath = await repository.resolveManagedFilePath(request)
@@ -135,6 +139,11 @@ const registerArtifactIpcHandlers = (
   )
   ipcMain.handle('artifacts:list-project-files', (_event, request: ListProjectArtifactsRequest) =>
     handlers.listProjectFiles(request)
+  )
+  ipcMain.handle(
+    'artifacts:reconcile-pending',
+    (_event, request: ReconcilePendingArtifactsRequest) =>
+      handlers.reconcilePendingArtifacts(request)
   )
   ipcMain.handle('artifacts:open-file', (_event, request: OpenArtifactFileRequest) =>
     handlers.openFile(request)

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -23,6 +23,9 @@ type ArtifactHandlers = {
 
 type ArtifactHandlerDependencies = {
   openPath?: (path: string) => Promise<string>
+  // Run ids of turns in flight right now (live runtime state). Their pending files are still being
+  // written, so the orphan scan excludes them; a crashed run is absent here and correctly surfaces.
+  getActiveArtifactRunIds?: () => string[]
 }
 
 // Serializes finalization per claim so duplicate renderer event processing cannot move files twice.
@@ -63,6 +66,7 @@ const createArtifactHandlers = (
   const finalizeLocks = new Map<string, Promise<void>>()
   const openPath =
     dependencies.openPath ?? ((filePath: string): Promise<string> => shell.openPath(filePath))
+  const getActiveArtifactRunIds = dependencies.getActiveArtifactRunIds ?? ((): string[] => [])
 
   return {
     finalizeRunArtifacts: (request) =>
@@ -71,7 +75,8 @@ const createArtifactHandlers = (
           finalizeRunArtifacts(repository, runRegistry, request)
         )
       ),
-    listProjectFiles: (request) => repository.listProjectArtifacts(request.projectName),
+    listProjectFiles: (request) =>
+      repository.listProjectArtifacts(request.projectName, new Set(getActiveArtifactRunIds())),
     reconcilePendingArtifacts: (request) =>
       withDataRootWrite(() => repository.reconcilePendingArtifactPaths(request)),
     openFile: async (request) => {
@@ -130,9 +135,10 @@ const createDefaultArtifactRepository = (): ArtifactRepository =>
 // Registers the renderer-visible artifact commands without exposing internal message-file listing.
 const registerArtifactIpcHandlers = (
   repository = createDefaultArtifactRepository(),
-  runRegistry = new ArtifactRunRegistry()
+  runRegistry = new ArtifactRunRegistry(),
+  getActiveArtifactRunIds?: () => string[]
 ): void => {
-  const handlers = createArtifactHandlers(repository, runRegistry)
+  const handlers = createArtifactHandlers(repository, runRegistry, { getActiveArtifactRunIds })
 
   ipcMain.handle('artifacts:finalize-run', (_event, request: FinalizeRunArtifactsRequest) =>
     handlers.finalizeRunArtifacts(request)

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -3,6 +3,7 @@ import { ipcMain, shell } from 'electron'
 import type { ArtifactFile, ArtifactPreviewResult } from '../../shared/artifacts'
 import type {
   FinalizeRunArtifactsRequest,
+  ListProjectArtifactsRequest,
   OpenArtifactFileRequest,
   ReadArtifactPreviewRequest
 } from '../../shared/artifacts'
@@ -13,6 +14,7 @@ import { ArtifactRunRegistry } from './run-registry'
 
 type ArtifactHandlers = {
   finalizeRunArtifacts: (request: FinalizeRunArtifactsRequest) => Promise<ArtifactFile[]>
+  listProjectFiles: (request: ListProjectArtifactsRequest) => Promise<ArtifactFile[]>
   openFile: (request: OpenArtifactFileRequest) => Promise<void>
   readPreview: (request: ReadArtifactPreviewRequest) => Promise<ArtifactPreviewResult>
 }
@@ -67,6 +69,7 @@ const createArtifactHandlers = (
           finalizeRunArtifacts(repository, runRegistry, request)
         )
       ),
+    listProjectFiles: (request) => repository.listProjectArtifacts(request.projectName),
     openFile: async (request) => {
       // Resolve through the repository first so shell.openPath never sees unmanaged locations.
       const filePath = await repository.resolveManagedFilePath(request)
@@ -129,6 +132,9 @@ const registerArtifactIpcHandlers = (
 
   ipcMain.handle('artifacts:finalize-run', (_event, request: FinalizeRunArtifactsRequest) =>
     handlers.finalizeRunArtifacts(request)
+  )
+  ipcMain.handle('artifacts:list-project-files', (_event, request: ListProjectArtifactsRequest) =>
+    handlers.listProjectFiles(request)
   )
   ipcMain.handle('artifacts:open-file', (_event, request: OpenArtifactFileRequest) =>
     handlers.openFile(request)

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -68,6 +68,12 @@ const createArtifactHandlers = (
     dependencies.openPath ?? ((filePath: string): Promise<string> => shell.openPath(filePath))
   const getActiveArtifactRunIds = dependencies.getActiveArtifactRunIds ?? ((): string[] => [])
 
+  // A pending run must be treated as in-flight (not orphaned) for its whole lifecycle: while the prompt
+  // runs (getActiveArtifactRunIds), AND after stop while its claim awaits the renderer's finalize call
+  // (runRegistry unfinalized claims) — the run leaves the runtime's active set at stop, before finalize.
+  const inFlightRunIds = (): Set<string> =>
+    new Set([...getActiveArtifactRunIds(), ...runRegistry.getUnfinalizedRunIds()])
+
   return {
     finalizeRunArtifacts: (request) =>
       withDataRootWrite(() =>
@@ -76,7 +82,7 @@ const createArtifactHandlers = (
         )
       ),
     listProjectFiles: (request) =>
-      repository.listProjectArtifacts(request.projectName, new Set(getActiveArtifactRunIds())),
+      repository.listProjectArtifacts(request.projectName, inFlightRunIds()),
     reconcilePendingArtifacts: (request) =>
       withDataRootWrite(() => repository.reconcilePendingArtifactPaths(request)),
     openFile: async (request) => {

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -398,7 +398,7 @@ describe('artifact repository', () => {
     await expect(repository.resolveManagedFilePath({ path: pendingPathA })).rejects.toThrow()
   })
 
-  it('recovers an unmarked artifact only when the same-name match is unambiguous (legacy)', async () => {
+  it('does NOT recover an unmarked stale pending path (absent marker == failed write, unsafe to guess)', async () => {
     const root = await createStorageRoot()
     const repository = new ArtifactRepository(root)
 
@@ -415,7 +415,8 @@ describe('artifact repository', () => {
       runId: 'run-1',
       messageId: 'message-1'
     })
-    // Remove the run marker to simulate an artifact finalized before markers existed.
+    // Remove the run marker: an absent marker (legacy artifact OR a failed best-effort write) is
+    // indistinguishable, so recovery must not guess even though the finalized file exists.
     await rm(join(root, 'artifacts', 'default-project', 'session-1', '.runs'), {
       recursive: true,
       force: true
@@ -430,12 +431,7 @@ describe('artifact repository', () => {
       'run-1',
       'legacy.txt'
     )
-    const resolved = await repository.resolveManagedFilePath({ path: pendingPath })
-    expect(resolved).toBe(
-      await realpath(
-        join(root, 'artifacts', 'default-project', 'session-1', 'message-1', 'legacy.txt')
-      )
-    )
+    await expect(repository.resolveManagedFilePath({ path: pendingPath })).rejects.toThrow()
   })
 
   it('does NOT recover an unmarked path when multiple same-named candidates exist', async () => {
@@ -804,11 +800,11 @@ describe('artifact repository', () => {
     await expect(repository.listProjectArtifacts('default-project')).resolves.toEqual([])
   })
 
-  it('excludes the active run (named by current-run.json) from the orphan scan', async () => {
+  it('excludes only the runs the caller reports as in-flight from the orphan scan', async () => {
     const root = await createStorageRoot()
     const repository = new ArtifactRepository(root)
 
-    // An in-flight turn: current-run.json names run-active, whose files are still being written.
+    // An in-flight turn (run-active): its files are still being written.
     await repository.writePendingFile({
       projectName: 'default-project',
       sessionId: 'session-1',
@@ -824,14 +820,37 @@ describe('artifact repository', () => {
       filename: 'orphan.txt',
       source: createInlineSource('dead')
     })
-    const handoff = getArtifactCurrentRunFilePath(root, 'default-project', 'session-1')
-    await writeFile(handoff, JSON.stringify({ runId: 'run-active' }), 'utf8')
 
+    // With run-active reported as live: only the dead run's file surfaces.
+    const liveFiles = await repository.listProjectArtifacts(
+      'default-project',
+      new Set(['run-active'])
+    )
+    expect(liveFiles.map((file) => file.name)).toEqual(['orphan.txt'])
+    expect(liveFiles[0].runId).toBe('run-dead')
+  })
+
+  it('surfaces every pending run when nothing is in flight (post-crash restart)', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    // A crash left a pending run AND its stale current-run.json handoff. On restart no run is live, so
+    // the crashed run's files must surface — the persisted handoff must NOT keep hiding them.
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-crashed',
+      filename: 'crashed.txt',
+      source: createInlineSource('x')
+    })
+    const handoff = getArtifactCurrentRunFilePath(root, 'default-project', 'session-1')
+    await writeFile(handoff, JSON.stringify({ runId: 'run-crashed' }), 'utf8')
+
+    // No active run ids (fresh runtime after restart).
     const files = await repository.listProjectArtifacts('default-project')
 
-    // Only the dead run's file surfaces; the in-flight run's half-written file is not shown as an orphan.
-    expect(files.map((file) => file.name)).toEqual(['orphan.txt'])
-    expect(files[0].runId).toBe('run-dead')
+    expect(files.map((file) => file.name)).toEqual(['crashed.txt'])
+    expect(files[0].runId).toBe('run-crashed')
   })
 
   it('returns an empty list when a project has no artifacts on disk', async () => {

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -294,6 +294,94 @@ describe('artifact repository', () => {
     expect(preview.content).toContain('img-bytes')
   })
 
+  it('recovers a same-named pending file to its own run, not the newest same-named file', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    // Two runs in one session each produce report.csv, finalized into different messages. The second
+    // finalize is newer, so a newest-mtime recovery would wrongly resolve run A's path to run B's file.
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-a',
+      filename: 'report.csv',
+      source: createInlineSource('run-a-content')
+    })
+    await repository.finalizeRunArtifacts({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-a',
+      messageId: 'message-a'
+    })
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-b',
+      filename: 'report.csv',
+      source: createInlineSource('run-b-content')
+    })
+    await repository.finalizeRunArtifacts({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-b',
+      messageId: 'message-b'
+    })
+
+    const pendingPathA = join(
+      root,
+      'artifacts',
+      'default-project',
+      'session-1',
+      '.pending',
+      'run-a',
+      'report.csv'
+    )
+    const resolved = await repository.resolveManagedFilePath({ path: pendingPathA })
+    expect(resolved).toBe(
+      await realpath(join(root, 'artifacts', 'default-project', 'session-1', 'message-a', 'report.csv'))
+    )
+    const preview = await repository.readManagedFilePreview({ path: pendingPathA })
+    expect(preview.content).toContain('run-a-content')
+  })
+
+  it('falls back to a newest-mtime scan when no run marker exists (legacy artifacts)', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      filename: 'legacy.txt',
+      source: createInlineSource('legacy')
+    })
+    await repository.finalizeRunArtifacts({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      messageId: 'message-1'
+    })
+    // Remove the run marker to simulate an artifact finalized before markers existed.
+    await rm(join(root, 'artifacts', 'default-project', 'session-1', '.runs'), {
+      recursive: true,
+      force: true
+    })
+
+    const pendingPath = join(
+      root,
+      'artifacts',
+      'default-project',
+      'session-1',
+      '.pending',
+      'run-1',
+      'legacy.txt'
+    )
+    const resolved = await repository.resolveManagedFilePath({ path: pendingPath })
+    expect(resolved).toBe(
+      await realpath(join(root, 'artifacts', 'default-project', 'session-1', 'message-1', 'legacy.txt'))
+    )
+  })
+
   it('still throws for a missing artifact path that was never finalized', async () => {
     const root = await createStorageRoot()
     const repository = new ArtifactRepository(root)

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -562,6 +562,59 @@ describe('artifact repository', () => {
     await expect(repository.listProjectArtifacts('default-project')).resolves.toEqual([])
   })
 
+  it('reconciles a crash-orphaned pending artifact into its message directory', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    // Simulate the crash window: a pending file was written and its path persisted, but finalize never
+    // ran (no run-registry claim survives a restart).
+    const pending = await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'artifact-session-1',
+      runId: 'run-7',
+      filename: 'chart.png',
+      mimeType: 'image/png',
+      source: createInlineSource('png')
+    })
+    expect(pending.path).toContain('.pending')
+
+    const finalized = await repository.reconcilePendingArtifactPaths({
+      projectName: 'default-project',
+      sessionId: 'app-session-1',
+      messageId: 'message-9',
+      pendingPaths: [pending.path]
+    })
+
+    expect(finalized.map((file) => file.name)).toEqual(['chart.png'])
+    expect(finalized[0].path).toBe(
+      join(root, 'artifacts', 'default-project', 'app-session-1', 'message-9', 'chart.png')
+    )
+    await expect(readFile(finalized[0].path, 'utf8')).resolves.toBe('png')
+
+    // Idempotent: replaying the reconcile (e.g. a second startup) returns the same finalized file.
+    const replayed = await repository.reconcilePendingArtifactPaths({
+      projectName: 'default-project',
+      sessionId: 'app-session-1',
+      messageId: 'message-9',
+      pendingPaths: [pending.path]
+    })
+    expect(replayed.map((file) => file.name)).toEqual(['chart.png'])
+  })
+
+  it('ignores non-pending paths during reconciliation instead of moving unrelated files', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    const finalized = await repository.reconcilePendingArtifactPaths({
+      projectName: 'default-project',
+      sessionId: 'app-session-1',
+      messageId: 'message-1',
+      pendingPaths: [join(root, 'artifacts', 'default-project', 'app-session-1', 'message-1', 'x.txt')]
+    })
+
+    expect(finalized).toEqual([])
+  })
+
   it('derives the project artifact directory from the app storage root', () => {
     // Build the expectation with join() so the separator matches the host the test runs on.
     expect(getProjectArtifactDir('/Users/example/.open-science', 'default-project')).toBe(

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -338,7 +338,9 @@ describe('artifact repository', () => {
     )
     const resolved = await repository.resolveManagedFilePath({ path: pendingPathA })
     expect(resolved).toBe(
-      await realpath(join(root, 'artifacts', 'default-project', 'session-1', 'message-a', 'report.csv'))
+      await realpath(
+        join(root, 'artifacts', 'default-project', 'session-1', 'message-a', 'report.csv')
+      )
     )
     const preview = await repository.readManagedFilePreview({ path: pendingPathA })
     expect(preview.content).toContain('run-a-content')
@@ -378,7 +380,9 @@ describe('artifact repository', () => {
     )
     const resolved = await repository.resolveManagedFilePath({ path: pendingPath })
     expect(resolved).toBe(
-      await realpath(join(root, 'artifacts', 'default-project', 'session-1', 'message-1', 'legacy.txt'))
+      await realpath(
+        join(root, 'artifacts', 'default-project', 'session-1', 'message-1', 'legacy.txt')
+      )
     )
   })
 
@@ -697,7 +701,9 @@ describe('artifact repository', () => {
       projectName: 'default-project',
       sessionId: 'app-session-1',
       messageId: 'message-1',
-      pendingPaths: [join(root, 'artifacts', 'default-project', 'app-session-1', 'message-1', 'x.txt')]
+      pendingPaths: [
+        join(root, 'artifacts', 'default-project', 'app-session-1', 'message-1', 'x.txt')
+      ]
     })
 
     expect(finalized).toEqual([])

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -398,7 +398,7 @@ describe('artifact repository', () => {
     await expect(repository.resolveManagedFilePath({ path: pendingPathA })).rejects.toThrow()
   })
 
-  it('falls back to a newest-mtime scan when no run marker exists (legacy artifacts)', async () => {
+  it('recovers an unmarked artifact only when the same-name match is unambiguous (legacy)', async () => {
     const root = await createStorageRoot()
     const repository = new ArtifactRepository(root)
 
@@ -436,6 +436,86 @@ describe('artifact repository', () => {
         join(root, 'artifacts', 'default-project', 'session-1', 'message-1', 'legacy.txt')
       )
     )
+  })
+
+  it('does NOT recover an unmarked path when multiple same-named candidates exist', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    // Two runs both produced report.csv into different messages, then BOTH markers were lost (e.g. the
+    // marker writes failed). Recovery must not guess between them — that is the cross-run mis-read.
+    for (const [runId, messageId, content] of [
+      ['run-a', 'message-a', 'a'],
+      ['run-b', 'message-b', 'b']
+    ] as const) {
+      await repository.writePendingFile({
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        runId,
+        filename: 'report.csv',
+        source: createInlineSource(content)
+      })
+      await repository.finalizeRunArtifacts({
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        runId,
+        messageId
+      })
+    }
+    await rm(join(root, 'artifacts', 'default-project', 'session-1', '.runs'), {
+      recursive: true,
+      force: true
+    })
+
+    const pendingPathA = join(
+      root,
+      'artifacts',
+      'default-project',
+      'session-1',
+      '.pending',
+      'run-a',
+      'report.csv'
+    )
+    await expect(repository.resolveManagedFilePath({ path: pendingPathA })).rejects.toThrow()
+  })
+
+  it('does NOT cross-read when a marker is present but corrupt and its target is gone', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    for (const [runId, messageId, content] of [
+      ['run-a', 'message-a', 'a'],
+      ['run-b', 'message-b', 'b']
+    ] as const) {
+      await repository.writePendingFile({
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        runId,
+        filename: 'report.csv',
+        source: createInlineSource(content)
+      })
+      await repository.finalizeRunArtifacts({
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        runId,
+        messageId
+      })
+    }
+    // Corrupt run-a's marker and delete its target file; run-b's identical-named file still exists.
+    const runsDir = join(root, 'artifacts', 'default-project', 'session-1', '.runs')
+    await writeFile(join(runsDir, 'run-a.json'), 'not json{', 'utf8')
+    await rm(join(root, 'artifacts', 'default-project', 'session-1', 'message-a', 'report.csv'))
+
+    const pendingPathA = join(
+      root,
+      'artifacts',
+      'default-project',
+      'session-1',
+      '.pending',
+      'run-a',
+      'report.csv'
+    )
+    await expect(repository.resolveManagedFilePath({ path: pendingPathA })).rejects.toThrow()
   })
 
   it('still throws for a missing artifact path that was never finalized', async () => {
@@ -722,6 +802,36 @@ describe('artifact repository', () => {
     await writeFile(handoff, JSON.stringify({ runId: 'x' }), 'utf8')
 
     await expect(repository.listProjectArtifacts('default-project')).resolves.toEqual([])
+  })
+
+  it('excludes the active run (named by current-run.json) from the orphan scan', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    // An in-flight turn: current-run.json names run-active, whose files are still being written.
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-active',
+      filename: 'in-progress.txt',
+      source: createInlineSource('partial')
+    })
+    // A genuinely orphaned pending run from an earlier crash.
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-dead',
+      filename: 'orphan.txt',
+      source: createInlineSource('dead')
+    })
+    const handoff = getArtifactCurrentRunFilePath(root, 'default-project', 'session-1')
+    await writeFile(handoff, JSON.stringify({ runId: 'run-active' }), 'utf8')
+
+    const files = await repository.listProjectArtifacts('default-project')
+
+    // Only the dead run's file surfaces; the in-flight run's half-written file is not shown as an orphan.
+    expect(files.map((file) => file.name)).toEqual(['orphan.txt'])
+    expect(files[0].runId).toBe('run-dead')
   })
 
   it('returns an empty list when a project has no artifacts on disk', async () => {

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -509,6 +509,59 @@ describe('artifact repository', () => {
     expect(files.map((file) => file.name)).toEqual(['alpha.txt', 'zeta.txt'])
   })
 
+  it('lists finalized artifacts across all sessions and excludes pending files', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    // Two sessions each finalize a file into a message directory.
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      filename: 'alpha.txt',
+      source: createInlineSource('a')
+    })
+    await repository.finalizeRunArtifacts({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      messageId: 'message-1'
+    })
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-2',
+      runId: 'run-2',
+      filename: 'beta.txt',
+      source: createInlineSource('b')
+    })
+    await repository.finalizeRunArtifacts({
+      projectName: 'default-project',
+      sessionId: 'session-2',
+      runId: 'run-2',
+      messageId: 'message-2'
+    })
+    // A never-finalized pending file must not be listed as a project artifact.
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-3',
+      filename: 'draft.txt',
+      source: createInlineSource('d')
+    })
+
+    const files = await repository.listProjectArtifacts('default-project')
+
+    expect(files.map((file) => file.name).sort()).toEqual(['alpha.txt', 'beta.txt'])
+    expect(files.map((file) => file.sessionId).sort()).toEqual(['session-1', 'session-2'])
+  })
+
+  it('returns an empty list when a project has no artifacts on disk', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    await expect(repository.listProjectArtifacts('default-project')).resolves.toEqual([])
+  })
+
   it('derives the project artifact directory from the app storage root', () => {
     // Build the expectation with join() so the separator matches the host the test runs on.
     expect(getProjectArtifactDir('/Users/example/.open-science', 'default-project')).toBe(

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -8,12 +8,16 @@ import {
   rm,
   writeFile
 } from 'node:fs/promises'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import type { ArtifactWriteSource } from '../../shared/artifacts'
-import { ArtifactRepository, getProjectArtifactDir } from './repository'
+import {
+  ArtifactRepository,
+  getArtifactCurrentRunFilePath,
+  getProjectArtifactDir
+} from './repository'
 
 let storageRoot: string | undefined
 
@@ -346,6 +350,54 @@ describe('artifact repository', () => {
     expect(preview.content).toContain('run-a-content')
   })
 
+  it('never falls back to another run when a marker exists but its target file is gone', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    // Same two-run setup, but run A's finalized file is deleted afterward (e.g. by the user). A marker
+    // for run A still exists, so recovery must NOT fall back to run B's same-named file — the artifact
+    // is simply gone.
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-a',
+      filename: 'report.csv',
+      source: createInlineSource('run-a-content')
+    })
+    await repository.finalizeRunArtifacts({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-a',
+      messageId: 'message-a'
+    })
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-b',
+      filename: 'report.csv',
+      source: createInlineSource('run-b-content')
+    })
+    await repository.finalizeRunArtifacts({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'run-b',
+      messageId: 'message-b'
+    })
+
+    await rm(join(root, 'artifacts', 'default-project', 'session-1', 'message-a', 'report.csv'))
+
+    const pendingPathA = join(
+      root,
+      'artifacts',
+      'default-project',
+      'session-1',
+      '.pending',
+      'run-a',
+      'report.csv'
+    )
+    await expect(repository.resolveManagedFilePath({ path: pendingPathA })).rejects.toThrow()
+  })
+
   it('falls back to a newest-mtime scan when no run marker exists (legacy artifacts)', async () => {
     const root = await createStorageRoot()
     const repository = new ArtifactRepository(root)
@@ -632,19 +684,44 @@ describe('artifact repository', () => {
       runId: 'run-2',
       messageId: 'message-2'
     })
-    // A never-finalized pending file must not be listed as a project artifact.
+    const files = await repository.listProjectArtifacts('default-project')
+
+    expect(files.map((file) => file.name).sort()).toEqual(['alpha.txt', 'beta.txt'])
+    expect(files.map((file) => file.sessionId).sort()).toEqual(['session-1', 'session-2'])
+  })
+
+  it('surfaces ownerless pending files (crash before attach) as orphaned artifacts', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    // A file written into a pending run whose turn crashed before the renderer attached it: no message
+    // owns it, so startup reconciliation cannot claim it. It must still be surfaced, not hidden forever.
     await repository.writePendingFile({
       projectName: 'default-project',
       sessionId: 'session-1',
-      runId: 'run-3',
+      runId: 'run-orphan',
       filename: 'draft.txt',
       source: createInlineSource('d')
     })
 
     const files = await repository.listProjectArtifacts('default-project')
 
-    expect(files.map((file) => file.name).sort()).toEqual(['alpha.txt', 'beta.txt'])
-    expect(files.map((file) => file.sessionId).sort()).toEqual(['session-1', 'session-2'])
+    expect(files.map((file) => file.name)).toEqual(['draft.txt'])
+    expect(files[0].runId).toBe('run-orphan')
+    expect(files[0].path).toContain('.pending')
+  })
+
+  it('does not list the current-run handoff file as an artifact', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    // The handoff lives directly in `.pending/` (a file, not a run subdir), so the subdirectory walk
+    // must skip it — otherwise it would show up as a bogus orphaned artifact.
+    const handoff = getArtifactCurrentRunFilePath(root, 'default-project', 'session-1')
+    await mkdir(dirname(handoff), { recursive: true })
+    await writeFile(handoff, JSON.stringify({ runId: 'x' }), 'utf8')
+
+    await expect(repository.listProjectArtifacts('default-project')).resolves.toEqual([])
   })
 
   it('returns an empty list when a project has no artifacts on disk', async () => {

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -28,6 +28,8 @@ import { readBoundedManagedFilePreview } from '../managed-file-preview'
 const ARTIFACTS_DIR = 'artifacts'
 const PENDING_DIR = '.pending'
 const METADATA_DIR = '.metadata'
+// Per-run markers recording which app session + message a finalized run moved into, keyed by run id.
+const RUNS_DIR = '.runs'
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 
 type ArtifactMetadata = {
@@ -249,6 +251,10 @@ class ArtifactRepository {
     const messageDir = this.getMessageDir(projectName, sessionId, messageId)
     const entries = await this.readFileEntries(pendingDir)
 
+    // Record where this run finalized so a stale `.pending/<run>` path recovers to this exact message,
+    // not the newest same-named file in the session. Written on every finalize (idempotent).
+    await this.writeRunMarker(projectName, sourceSessionId, runId, { sessionId, messageId })
+
     if (entries.length === 0) {
       // A repeated finalize may find files already moved; recover metadata and return the final state.
       await this.recoverMovedArtifactMetadata(pendingDir, messageDir)
@@ -454,23 +460,41 @@ class ArtifactRepository {
   }
 
   // Given a now-missing `.pending/<run>/<file>` artifact path, finds the same file after finalize moved
-  // it into a sibling message directory (`<session>/<messageId>/<file>`). Returns the newest match, or
-  // undefined when the path is not a pending path or no finalized copy exists. Path safety is still
-  // enforced by resolveManagedFilePath's root check on the returned path.
+  // it. Prefers the run marker written at finalize (`.runs/<run>.json`), which pins the exact app
+  // session + message the run produced — so two runs that both wrote `report.csv` never cross-resolve.
+  // Falls back to the newest same-named file in the session for legacy artifacts with no marker.
+  // Returns undefined when the path is not a pending path or no finalized copy exists. Path safety is
+  // still enforced by resolveManagedFilePath's root check on the returned path.
   private async recoverFinalizedPendingPath(requestedPath: string): Promise<string | undefined> {
-    const pendingDir = dirname(dirname(requestedPath)) // <session>/.pending
+    // requestedPath = <project>/<sourceSessionId>/.pending/<runId>/<file>
+    const runDir = dirname(requestedPath)
+    const runId = basename(runDir)
+    const pendingDir = dirname(runDir)
     if (basename(pendingDir) !== PENDING_DIR) return undefined
-    const sessionDir = dirname(pendingDir)
+    const sourceSessionDir = dirname(pendingDir)
     const filename = basename(requestedPath)
 
-    const entries = await readdir(sessionDir, { withFileTypes: true }).catch(() => null)
+    // Marker path: resolve directly from the source-session dir the stale path already points into.
+    const marker = SAFE_SEGMENT_PATTERN.test(runId)
+      ? await this.readRunMarker(join(sourceSessionDir, RUNS_DIR, `${runId}.json`))
+      : undefined
+
+    if (marker) {
+      const projectDir = dirname(sourceSessionDir)
+      const candidate = join(projectDir, marker.sessionId, marker.messageId, filename)
+      const candidateStat = await stat(candidate).catch(() => undefined)
+      if (candidateStat?.isFile()) return candidate
+    }
+
+    // Legacy fallback: no (or stale) marker. Scan the session's message dirs for the newest same name.
+    const entries = await readdir(sourceSessionDir, { withFileTypes: true }).catch(() => null)
     if (!entries) return undefined
 
     const matches: Array<{ path: string; mtimeMs: number }> = []
     for (const entry of entries) {
       if (!entry.isDirectory() || entry.name === PENDING_DIR || entry.name === METADATA_DIR)
         continue
-      const candidate = join(sessionDir, entry.name, filename)
+      const candidate = join(sourceSessionDir, entry.name, filename)
       const candidateStat = await stat(candidate).catch(() => undefined)
       if (candidateStat?.isFile()) matches.push({ path: candidate, mtimeMs: candidateStat.mtimeMs })
     }
@@ -484,6 +508,60 @@ class ArtifactRepository {
   ): Promise<ArtifactPreviewResult> {
     const filePath = await this.resolveManagedFilePath(request)
     return readBoundedManagedFilePreview(filePath, request, 'Invalid artifact preview encoding.')
+  }
+
+  // Resolves the per-run marker path under the source (artifact) session, keyed by run id — the same
+  // scope a stale pending path carries, so recovery can find it without knowing the app session id.
+  private getRunMarkerPath(projectName: string, sourceSessionId: string, runId: string): string {
+    return join(
+      getProjectArtifactDir(this.storageRoot, projectName),
+      sourceSessionId,
+      RUNS_DIR,
+      `${runId}.json`
+    )
+  }
+
+  // Persists the app session + message a run finalized into. Best-effort: a marker write failure must
+  // not fail the finalize itself (recovery still falls back to a newest-mtime scan).
+  private async writeRunMarker(
+    projectName: string,
+    sourceSessionId: string,
+    runId: string,
+    marker: { sessionId: string; messageId: string }
+  ): Promise<void> {
+    try {
+      const markerPath = this.getRunMarkerPath(projectName, sourceSessionId, runId)
+      await mkdir(dirname(markerPath), { recursive: true })
+      await writeFile(markerPath, `${JSON.stringify(marker)}\n`, 'utf8')
+    } catch {
+      // Non-fatal: the run still finalized; only same-name recovery precision is degraded.
+    }
+  }
+
+  // Reads a run marker written by a prior finalize, tolerating absent/corrupt markers (returns
+  // undefined so recovery falls back to its newest-mtime scan for legacy artifacts).
+  private async readRunMarker(
+    markerPath: string
+  ): Promise<{ sessionId: string; messageId: string } | undefined> {
+    try {
+      const parsed = JSON.parse(await readFile(markerPath, 'utf8')) as unknown
+
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        typeof (parsed as { sessionId?: unknown }).sessionId === 'string' &&
+        typeof (parsed as { messageId?: unknown }).messageId === 'string'
+      ) {
+        const { sessionId, messageId } = parsed as { sessionId: string; messageId: string }
+        if (SAFE_SEGMENT_PATTERN.test(sessionId) && SAFE_SEGMENT_PATTERN.test(messageId)) {
+          return { sessionId, messageId }
+        }
+      }
+
+      return undefined
+    } catch {
+      return undefined
+    }
   }
 
   // Builds the temporary directory for files generated during one active assistant turn.

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -378,17 +378,18 @@ class ArtifactRepository {
     return { artifactSessionId, runId }
   }
 
-  // Enumerates every finalized artifact on disk for one project, across all sessions and messages —
-  // including sessions whose metadata has since been deleted. Skips pending runs and sidecar metadata.
-  // Used to surface orphaned artifacts whose owning session no longer exists, so deleting a session or
-  // project never strands files that the user was promised would remain in the project.
+  // Enumerates every artifact on disk for one project, across all sessions — finalized files under
+  // message directories, plus files a crashed turn left behind in `.pending/<run>/` with no owning
+  // message (which startup reconciliation cannot claim). Skips sidecar metadata and the current-run
+  // handoff. Used to surface orphaned artifacts whose owning session/message no longer exists, so a
+  // delete or a mid-turn crash never strands files that the user was promised would remain.
   async listProjectArtifacts(projectName: string): Promise<ArtifactFile[]> {
     const project = assertSafePathSegment(projectName)
     const projectDir = getProjectArtifactDir(this.storageRoot, project)
     const files: ArtifactFile[] = []
 
     // Session and message dirs use safe segments; the pattern also skips the `.pending`/`.metadata`
-    // dot-directories, so only real session/message directories are traversed.
+    // dot-directories, so only real session/message directories are traversed here.
     for (const sessionId of await this.readSubdirectoryNames(projectDir)) {
       if (!SAFE_SEGMENT_PATTERN.test(sessionId)) continue
       const sessionDir = join(projectDir, sessionId)
@@ -396,9 +397,8 @@ class ArtifactRepository {
       for (const messageId of await this.readSubdirectoryNames(sessionDir)) {
         if (!SAFE_SEGMENT_PATTERN.test(messageId)) continue
         const messageDir = join(sessionDir, messageId)
-        const entries = await this.readFileEntries(messageDir)
 
-        for (const entry of entries) {
+        for (const entry of await this.readFileEntries(messageDir)) {
           const metadata = await this.readArtifactMetadata(messageDir, entry.name)
 
           files.push(
@@ -408,6 +408,31 @@ class ArtifactRepository {
               messageId,
               filename: entry.name,
               filePath: join(messageDir, entry.name),
+              mimeType: metadata.mimeType
+            })
+          )
+        }
+      }
+
+      // Ownerless pending files: a turn that crashed before the renderer attached its artifacts leaves
+      // files here with no message to reconcile against, so surface them rather than hide them forever.
+      // Only `.pending/<run>/` subdirectories hold artifacts; the `current-run.json` handoff is a plain
+      // file and is skipped by the subdirectory walk.
+      const pendingDir = join(sessionDir, PENDING_DIR)
+      for (const runId of await this.readSubdirectoryNames(pendingDir)) {
+        if (!SAFE_SEGMENT_PATTERN.test(runId)) continue
+        const runDir = join(pendingDir, runId)
+
+        for (const entry of await this.readFileEntries(runDir)) {
+          const metadata = await this.readArtifactMetadata(runDir, entry.name)
+
+          files.push(
+            await this.createArtifactFile({
+              projectName: project,
+              sessionId,
+              runId,
+              filename: entry.name,
+              filePath: join(runDir, entry.name),
               mimeType: metadata.mimeType
             })
           )
@@ -483,10 +508,13 @@ class ArtifactRepository {
       const projectDir = dirname(sourceSessionDir)
       const candidate = join(projectDir, marker.sessionId, marker.messageId, filename)
       const candidateStat = await stat(candidate).catch(() => undefined)
-      if (candidateStat?.isFile()) return candidate
+      // A marker pins the exact run→message this file finalized into. If that file is gone (the run's
+      // artifact was deleted), the artifact no longer exists — never fall back to a same-named file from
+      // a different run. The newest-mtime scan below is only for legacy artifacts that have no marker.
+      return candidateStat?.isFile() ? candidate : undefined
     }
 
-    // Legacy fallback: no (or stale) marker. Scan the session's message dirs for the newest same name.
+    // Legacy fallback: no marker exists. Scan the session's message dirs for the newest same name.
     const entries = await readdir(sourceSessionDir, { withFileTypes: true }).catch(() => null)
     if (!entries) return undefined
 

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -317,6 +317,46 @@ class ArtifactRepository {
     )
   }
 
+  // Enumerates every finalized artifact on disk for one project, across all sessions and messages —
+  // including sessions whose metadata has since been deleted. Skips pending runs and sidecar metadata.
+  // Used to surface orphaned artifacts whose owning session no longer exists, so deleting a session or
+  // project never strands files that the user was promised would remain in the project.
+  async listProjectArtifacts(projectName: string): Promise<ArtifactFile[]> {
+    const project = assertSafePathSegment(projectName)
+    const projectDir = getProjectArtifactDir(this.storageRoot, project)
+    const files: ArtifactFile[] = []
+
+    // Session and message dirs use safe segments; the pattern also skips the `.pending`/`.metadata`
+    // dot-directories, so only real session/message directories are traversed.
+    for (const sessionId of await this.readSubdirectoryNames(projectDir)) {
+      if (!SAFE_SEGMENT_PATTERN.test(sessionId)) continue
+      const sessionDir = join(projectDir, sessionId)
+
+      for (const messageId of await this.readSubdirectoryNames(sessionDir)) {
+        if (!SAFE_SEGMENT_PATTERN.test(messageId)) continue
+        const messageDir = join(sessionDir, messageId)
+        const entries = await this.readFileEntries(messageDir)
+
+        for (const entry of entries) {
+          const metadata = await this.readArtifactMetadata(messageDir, entry.name)
+
+          files.push(
+            await this.createArtifactFile({
+              projectName: project,
+              sessionId,
+              messageId,
+              filename: entry.name,
+              filePath: join(messageDir, entry.name),
+              mimeType: metadata.mimeType
+            })
+          )
+        }
+      }
+    }
+
+    return files
+  }
+
   // Resolves a renderer-provided artifact path only after canonical root and symlink checks pass.
   async resolveManagedFilePath(request: OpenArtifactFileRequest): Promise<string> {
     if (
@@ -399,6 +439,18 @@ class ArtifactRepository {
   // Builds the durable directory displayed under one completed assistant message.
   private getMessageDir(projectName: string, sessionId: string, messageId: string): string {
     return join(getProjectArtifactDir(this.storageRoot, projectName), sessionId, messageId)
+  }
+
+  // Reads only direct subdirectory names, returning an empty list when the directory does not exist.
+  private async readSubdirectoryNames(directory: string): Promise<string[]> {
+    try {
+      const entries = await readdir(directory, { withFileTypes: true })
+
+      return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name)
+    } catch (error) {
+      if (isMissingFileError(error)) return []
+      throw error
+    }
   }
 
   // Reads only direct files, returning an empty list when an artifact directory does not exist yet.

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -317,6 +317,61 @@ class ArtifactRepository {
     )
   }
 
+  // Re-finalizes artifacts a crash left in `.pending` after the in-memory run claim was lost: the
+  // session JSON persisted a `.pending/<run>/<file>` path, but the pending->message move never ran. Only
+  // the artifactSessionId + runId segments are read from each path; the pending directory is rebuilt
+  // from the storage root, so a corrupt stored path cannot point the move outside managed storage.
+  // Idempotent — finalizeRunArtifacts tolerates files already moved. Returns the message's final files.
+  async reconcilePendingArtifactPaths(request: {
+    projectName: string
+    sessionId: string
+    messageId: string
+    pendingPaths: string[]
+  }): Promise<ArtifactFile[]> {
+    const runs = new Map<string, { artifactSessionId: string; runId: string }>()
+
+    for (const pendingPath of request.pendingPaths) {
+      const parsed = this.parsePendingPath(pendingPath)
+      if (parsed) runs.set(`${parsed.artifactSessionId}/${parsed.runId}`, parsed)
+    }
+
+    for (const { artifactSessionId, runId } of runs.values()) {
+      await this.finalizeRunArtifacts({
+        projectName: request.projectName,
+        sessionId: request.sessionId,
+        sourceSessionId: artifactSessionId,
+        runId,
+        messageId: request.messageId
+      })
+    }
+
+    return this.listMessageFiles({
+      projectName: request.projectName,
+      sessionId: request.sessionId,
+      messageId: request.messageId
+    })
+  }
+
+  // Extracts the artifact session id and run id from a `.../<artifactSessionId>/.pending/<runId>/<file>`
+  // path. Returns undefined when the path is not a pending path or the segments are unsafe.
+  private parsePendingPath(
+    pendingPath: string
+  ): { artifactSessionId: string; runId: string } | undefined {
+    if (typeof pendingPath !== 'string' || pendingPath.length === 0) return undefined
+
+    const runDir = dirname(pendingPath)
+    const runId = basename(runDir)
+    const pendingDir = dirname(runDir)
+    if (basename(pendingDir) !== PENDING_DIR) return undefined
+
+    const artifactSessionId = basename(dirname(pendingDir))
+    if (!SAFE_SEGMENT_PATTERN.test(runId) || !SAFE_SEGMENT_PATTERN.test(artifactSessionId)) {
+      return undefined
+    }
+
+    return { artifactSessionId, runId }
+  }
+
   // Enumerates every finalized artifact on disk for one project, across all sessions and messages —
   // including sessions whose metadata has since been deleted. Skips pending runs and sidecar metadata.
   // Used to surface orphaned artifacts whose owning session no longer exists, so deleting a session or

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -24,12 +24,17 @@ import type {
   WritePendingArtifactFileRequest
 } from '../../shared/artifacts'
 import { readBoundedManagedFilePreview } from '../managed-file-preview'
+import { createLogger } from '../logger'
+
+const log = createLogger('artifacts:repository')
 
 const ARTIFACTS_DIR = 'artifacts'
 const PENDING_DIR = '.pending'
 const METADATA_DIR = '.metadata'
 // Per-run markers recording which app session + message a finalized run moved into, keyed by run id.
 const RUNS_DIR = '.runs'
+// Handoff file (directly under a session's .pending) naming the in-flight turn's run id for MCP writes.
+const CURRENT_RUN_FILE = 'current-run.json'
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 
 type ArtifactMetadata = {
@@ -181,7 +186,7 @@ const getArtifactCurrentRunFilePath = (
     getProjectArtifactDir(storageRoot, projectName),
     assertSafePathSegment(sessionId),
     PENDING_DIR,
-    'current-run.json'
+    CURRENT_RUN_FILE
   )
 
 // Owns app-managed artifact paths so callers never concatenate user-controlled segments.
@@ -417,10 +422,14 @@ class ArtifactRepository {
       // Ownerless pending files: a turn that crashed before the renderer attached its artifacts leaves
       // files here with no message to reconcile against, so surface them rather than hide them forever.
       // Only `.pending/<run>/` subdirectories hold artifacts; the `current-run.json` handoff is a plain
-      // file and is skipped by the subdirectory walk.
+      // file and is skipped by the subdirectory walk. The run named by that handoff is the in-flight
+      // turn, whose files are still being written and will finalize into a message shortly — skip it so
+      // a scan racing generation never shows half-written files as orphans.
       const pendingDir = join(sessionDir, PENDING_DIR)
+      const activeRunId = await this.readActiveRunId(pendingDir)
       for (const runId of await this.readSubdirectoryNames(pendingDir)) {
         if (!SAFE_SEGMENT_PATTERN.test(runId)) continue
+        if (runId === activeRunId) continue
         const runDir = join(pendingDir, runId)
 
         for (const entry of await this.readFileEntries(runDir)) {
@@ -500,34 +509,60 @@ class ArtifactRepository {
     const filename = basename(requestedPath)
 
     // Marker path: resolve directly from the source-session dir the stale path already points into.
-    const marker = SAFE_SEGMENT_PATTERN.test(runId)
+    const markerResult = SAFE_SEGMENT_PATTERN.test(runId)
       ? await this.readRunMarker(join(sourceSessionDir, RUNS_DIR, `${runId}.json`))
-      : undefined
+      : { present: false }
 
-    if (marker) {
+    // A marker file exists (the run WAS marked). Resolve ONLY to its pinned run→message target and
+    // never fall back to another run's same-named file. A missing target (artifact deleted) or a
+    // corrupt/unreadable marker both yield undefined — guessing here is the cross-run mis-read to avoid.
+    if (markerResult.present) {
+      if (!markerResult.marker) {
+        log.warn('artifact recovery skipped: run marker present but unreadable', { requestedPath })
+        return undefined
+      }
       const projectDir = dirname(sourceSessionDir)
-      const candidate = join(projectDir, marker.sessionId, marker.messageId, filename)
+      const candidate = join(
+        projectDir,
+        markerResult.marker.sessionId,
+        markerResult.marker.messageId,
+        filename
+      )
       const candidateStat = await stat(candidate).catch(() => undefined)
-      // A marker pins the exact run→message this file finalized into. If that file is gone (the run's
-      // artifact was deleted), the artifact no longer exists — never fall back to a same-named file from
-      // a different run. The newest-mtime scan below is only for legacy artifacts that have no marker.
       return candidateStat?.isFile() ? candidate : undefined
     }
 
-    // Legacy fallback: no marker exists. Scan the session's message dirs for the newest same name.
+    // No marker at all — a legacy artifact (finalized before markers) or a marker whose write failed.
+    // Scan the session's message dirs for the same filename, but recover ONLY when the match is
+    // UNAMBIGUOUS: a marker's absence doesn't prove the artifact is legacy, so if two runs produced the
+    // same filename, guessing could resolve one run's stale path to another run's file. 0 or 2+ → 404.
     const entries = await readdir(sourceSessionDir, { withFileTypes: true }).catch(() => null)
     if (!entries) return undefined
 
-    const matches: Array<{ path: string; mtimeMs: number }> = []
+    const matches: string[] = []
     for (const entry of entries) {
       if (!entry.isDirectory() || entry.name === PENDING_DIR || entry.name === METADATA_DIR)
         continue
       const candidate = join(sourceSessionDir, entry.name, filename)
       const candidateStat = await stat(candidate).catch(() => undefined)
-      if (candidateStat?.isFile()) matches.push({ path: candidate, mtimeMs: candidateStat.mtimeMs })
+      if (candidateStat?.isFile()) matches.push(candidate)
     }
-    matches.sort((left, right) => right.mtimeMs - left.mtimeMs)
-    return matches[0]?.path
+
+    if (matches.length === 1) {
+      log.warn('artifact recovered via unmarked single-candidate fallback', {
+        requestedPath,
+        recovered: matches[0]
+      })
+      return matches[0]
+    }
+
+    if (matches.length > 1) {
+      log.warn('artifact recovery skipped: no marker and multiple same-named candidates', {
+        requestedPath,
+        candidateCount: matches.length
+      })
+    }
+    return undefined
   }
 
   // Reads a small text preview from a managed artifact without exposing arbitrary filesystem reads.
@@ -549,8 +584,10 @@ class ArtifactRepository {
     )
   }
 
-  // Persists the app session + message a run finalized into. Best-effort: a marker write failure must
-  // not fail the finalize itself (recovery still falls back to a newest-mtime scan).
+  // Persists the app session + message a run finalized into. Written atomically (temp + rename) so a
+  // crash mid-write never leaves a half-written marker that would later read as corrupt. Best-effort: a
+  // failure must not fail the finalize itself — recovery then treats the run as unmarked and only
+  // recovers a stale path when the same-name match is unambiguous (never guessing across runs).
   private async writeRunMarker(
     projectName: string,
     sourceSessionId: string,
@@ -559,21 +596,35 @@ class ArtifactRepository {
   ): Promise<void> {
     try {
       const markerPath = this.getRunMarkerPath(projectName, sourceSessionId, runId)
+      const temporaryPath = `${markerPath}.${Date.now()}-${randomUUID()}.tmp`
       await mkdir(dirname(markerPath), { recursive: true })
-      await writeFile(markerPath, `${JSON.stringify(marker)}\n`, 'utf8')
+      await writeFile(temporaryPath, `${JSON.stringify(marker)}\n`, 'utf8')
+      await rename(temporaryPath, markerPath)
     } catch {
       // Non-fatal: the run still finalized; only same-name recovery precision is degraded.
     }
   }
 
-  // Reads a run marker written by a prior finalize, tolerating absent/corrupt markers (returns
-  // undefined so recovery falls back to its newest-mtime scan for legacy artifacts).
+  // Reads a run marker, distinguishing three states so recovery can act safely:
+  //   { present: false }            — no marker file (legacy artifact, or a marker write that failed).
+  //   { present: true }             — a marker file exists but is unreadable/corrupt/invalid.
+  //   { present: true, marker }     — a valid marker pinning the run's app session + message.
+  // The present-but-invalid case must NOT fall back to a same-name scan: the run WAS marked, so a
+  // damaged marker means "cannot resolve", not "guess among other runs' files".
   private async readRunMarker(
     markerPath: string
-  ): Promise<{ sessionId: string; messageId: string } | undefined> {
+  ): Promise<{ present: boolean; marker?: { sessionId: string; messageId: string } }> {
+    let raw: string
     try {
-      const parsed = JSON.parse(await readFile(markerPath, 'utf8')) as unknown
+      raw = await readFile(markerPath, 'utf8')
+    } catch (error) {
+      if (isMissingFileError(error)) return { present: false }
+      // Present but unreadable (e.g. permissions): treat as a damaged marker, not absent.
+      return { present: true }
+    }
 
+    try {
+      const parsed = JSON.parse(raw) as unknown
       if (
         typeof parsed === 'object' &&
         parsed !== null &&
@@ -582,13 +633,12 @@ class ArtifactRepository {
       ) {
         const { sessionId, messageId } = parsed as { sessionId: string; messageId: string }
         if (SAFE_SEGMENT_PATTERN.test(sessionId) && SAFE_SEGMENT_PATTERN.test(messageId)) {
-          return { sessionId, messageId }
+          return { present: true, marker: { sessionId, messageId } }
         }
       }
-
-      return undefined
+      return { present: true }
     } catch {
-      return undefined
+      return { present: true }
     }
   }
 
@@ -600,6 +650,23 @@ class ArtifactRepository {
   // Builds the durable directory displayed under one completed assistant message.
   private getMessageDir(projectName: string, sessionId: string, messageId: string): string {
     return join(getProjectArtifactDir(this.storageRoot, projectName), sessionId, messageId)
+  }
+
+  // Reads the run id of the in-flight turn from a session's `.pending/current-run.json` handoff, or
+  // undefined when no run is active (file absent, cleared to `{}`, or unreadable/corrupt).
+  private async readActiveRunId(pendingDir: string): Promise<string | undefined> {
+    try {
+      const parsed = JSON.parse(
+        await readFile(join(pendingDir, CURRENT_RUN_FILE), 'utf8')
+      ) as unknown
+      const runId =
+        typeof parsed === 'object' && parsed !== null
+          ? (parsed as { runId?: unknown }).runId
+          : undefined
+      return typeof runId === 'string' && runId.length > 0 ? runId : undefined
+    } catch {
+      return undefined
+    }
   }
 
   // Reads only direct subdirectory names, returning an empty list when the directory does not exist.

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -388,7 +388,15 @@ class ArtifactRepository {
   // message (which startup reconciliation cannot claim). Skips sidecar metadata and the current-run
   // handoff. Used to surface orphaned artifacts whose owning session/message no longer exists, so a
   // delete or a mid-turn crash never strands files that the user was promised would remain.
-  async listProjectArtifacts(projectName: string): Promise<ArtifactFile[]> {
+  //
+  // `activeRunIds` are the runs of turns the caller knows are IN FLIGHT right now (from live runtime
+  // state, not the persisted current-run.json handoff — that file survives a crash and would then hide
+  // the crashed run's files forever). Their pending files are still being written, so they are excluded
+  // from the orphan list; every other pending run is a crashed/ownerless run and is surfaced.
+  async listProjectArtifacts(
+    projectName: string,
+    activeRunIds: ReadonlySet<string> = new Set()
+  ): Promise<ArtifactFile[]> {
     const project = assertSafePathSegment(projectName)
     const projectDir = getProjectArtifactDir(this.storageRoot, project)
     const files: ArtifactFile[] = []
@@ -422,14 +430,13 @@ class ArtifactRepository {
       // Ownerless pending files: a turn that crashed before the renderer attached its artifacts leaves
       // files here with no message to reconcile against, so surface them rather than hide them forever.
       // Only `.pending/<run>/` subdirectories hold artifacts; the `current-run.json` handoff is a plain
-      // file and is skipped by the subdirectory walk. The run named by that handoff is the in-flight
-      // turn, whose files are still being written and will finalize into a message shortly — skip it so
-      // a scan racing generation never shows half-written files as orphans.
+      // file and is skipped by the subdirectory walk. A run the caller reports as in-flight is skipped
+      // (its files are mid-write and will finalize into a message shortly); a crashed run is NOT in that
+      // live set, so its leftover files correctly surface as orphans.
       const pendingDir = join(sessionDir, PENDING_DIR)
-      const activeRunId = await this.readActiveRunId(pendingDir)
       for (const runId of await this.readSubdirectoryNames(pendingDir)) {
         if (!SAFE_SEGMENT_PATTERN.test(runId)) continue
-        if (runId === activeRunId) continue
+        if (activeRunIds.has(runId)) continue
         const runDir = join(pendingDir, runId)
 
         for (const entry of await this.readFileEntries(runDir)) {
@@ -494,11 +501,11 @@ class ArtifactRepository {
   }
 
   // Given a now-missing `.pending/<run>/<file>` artifact path, finds the same file after finalize moved
-  // it. Prefers the run marker written at finalize (`.runs/<run>.json`), which pins the exact app
-  // session + message the run produced — so two runs that both wrote `report.csv` never cross-resolve.
-  // Falls back to the newest same-named file in the session for legacy artifacts with no marker.
-  // Returns undefined when the path is not a pending path or no finalized copy exists. Path safety is
-  // still enforced by resolveManagedFilePath's root check on the returned path.
+  // it, using ONLY the run marker written at finalize (`.runs/<run>.json`), which pins the exact app
+  // session + message the run produced. An unmarked run is never recovered by guessing among same-named
+  // files (that could cross-resolve to a different run's file); returns undefined instead. Also returns
+  // undefined when the path is not a pending path or the marker's target no longer exists. Path safety
+  // is still enforced by resolveManagedFilePath's root check on the returned path.
   private async recoverFinalizedPendingPath(requestedPath: string): Promise<string | undefined> {
     // requestedPath = <project>/<sourceSessionId>/.pending/<runId>/<file>
     const runDir = dirname(requestedPath)
@@ -532,36 +539,14 @@ class ArtifactRepository {
       return candidateStat?.isFile() ? candidate : undefined
     }
 
-    // No marker at all — a legacy artifact (finalized before markers) or a marker whose write failed.
-    // Scan the session's message dirs for the same filename, but recover ONLY when the match is
-    // UNAMBIGUOUS: a marker's absence doesn't prove the artifact is legacy, so if two runs produced the
-    // same filename, guessing could resolve one run's stale path to another run's file. 0 or 2+ → 404.
-    const entries = await readdir(sourceSessionDir, { withFileTypes: true }).catch(() => null)
-    if (!entries) return undefined
-
-    const matches: string[] = []
-    for (const entry of entries) {
-      if (!entry.isDirectory() || entry.name === PENDING_DIR || entry.name === METADATA_DIR)
-        continue
-      const candidate = join(sourceSessionDir, entry.name, filename)
-      const candidateStat = await stat(candidate).catch(() => undefined)
-      if (candidateStat?.isFile()) matches.push(candidate)
-    }
-
-    if (matches.length === 1) {
-      log.warn('artifact recovered via unmarked single-candidate fallback', {
-        requestedPath,
-        recovered: matches[0]
-      })
-      return matches[0]
-    }
-
-    if (matches.length > 1) {
-      log.warn('artifact recovery skipped: no marker and multiple same-named candidates', {
-        requestedPath,
-        candidateCount: matches.length
-      })
-    }
+    // No marker at all. This is a legacy artifact (finalized before markers existed) OR one whose
+    // best-effort marker write failed — the two are indistinguishable on disk. A same-name scan is
+    // therefore unsafe even with a single candidate: if the run's own file was deleted and a different
+    // run left an identically-named file, that lone candidate would be the WRONG run's file. So we do
+    // not guess at all — recovery of an unmarked stale pending path returns undefined (a real 404). New
+    // artifacts always carry a marker; the only loss is best-effort recovery of pre-marker legacy files,
+    // whose finalized paths are already what a reloaded session persists (it doesn't hold pending paths).
+    log.warn('artifact recovery skipped: stale pending path has no run marker', { requestedPath })
     return undefined
   }
 
@@ -594,14 +579,17 @@ class ArtifactRepository {
     runId: string,
     marker: { sessionId: string; messageId: string }
   ): Promise<void> {
+    const markerPath = this.getRunMarkerPath(projectName, sourceSessionId, runId)
+    const temporaryPath = `${markerPath}.${Date.now()}-${randomUUID()}.tmp`
     try {
-      const markerPath = this.getRunMarkerPath(projectName, sourceSessionId, runId)
-      const temporaryPath = `${markerPath}.${Date.now()}-${randomUUID()}.tmp`
       await mkdir(dirname(markerPath), { recursive: true })
       await writeFile(temporaryPath, `${JSON.stringify(marker)}\n`, 'utf8')
       await rename(temporaryPath, markerPath)
     } catch {
-      // Non-fatal: the run still finalized; only same-name recovery precision is degraded.
+      // Non-fatal: the run still finalized; an unmarked run just isn't recoverable via stale pending
+      // path. Remove any temp left behind so a failed write never litters the `.runs` dir (matches the
+      // atomic-write cleanup elsewhere in this repository).
+      await rm(temporaryPath, { force: true }).catch(() => undefined)
     }
   }
 
@@ -650,23 +638,6 @@ class ArtifactRepository {
   // Builds the durable directory displayed under one completed assistant message.
   private getMessageDir(projectName: string, sessionId: string, messageId: string): string {
     return join(getProjectArtifactDir(this.storageRoot, projectName), sessionId, messageId)
-  }
-
-  // Reads the run id of the in-flight turn from a session's `.pending/current-run.json` handoff, or
-  // undefined when no run is active (file absent, cleared to `{}`, or unreadable/corrupt).
-  private async readActiveRunId(pendingDir: string): Promise<string | undefined> {
-    try {
-      const parsed = JSON.parse(
-        await readFile(join(pendingDir, CURRENT_RUN_FILE), 'utf8')
-      ) as unknown
-      const runId =
-        typeof parsed === 'object' && parsed !== null
-          ? (parsed as { runId?: unknown }).runId
-          : undefined
-      return typeof runId === 'string' && runId.length > 0 ? runId : undefined
-    } catch {
-      return undefined
-    }
   }
 
   // Reads only direct subdirectory names, returning an empty list when the directory does not exist.

--- a/src/main/artifacts/run-registry.ts
+++ b/src/main/artifacts/run-registry.ts
@@ -43,6 +43,18 @@ class ArtifactRunRegistry {
     return claim
   }
 
+  // Run ids of claims registered but not yet finalized — files that have been emitted to the renderer
+  // and are awaiting its finalize call. The orphan scan must exclude these (a normal file mid-handoff,
+  // not an orphan) in addition to prompt-in-flight runs, since a run leaves the runtime's active set at
+  // stop, before the renderer finalizes. In-memory only, so a crash clears them and they resurface.
+  getUnfinalizedRunIds(): string[] {
+    const runIds: string[] = []
+    for (const claim of this.claims.values()) {
+      if (!claim.finalizedMessageId) runIds.push(claim.runId)
+    }
+    return runIds
+  }
+
   // Records the message that consumed a claim so finalize retries remain idempotent.
   markFinalized(claimId: string, messageId: string): void {
     const claim = this.resolve(claimId)

--- a/src/main/connectors/molecule-preview.test.ts
+++ b/src/main/connectors/molecule-preview.test.ts
@@ -13,10 +13,11 @@ describe('molecule preview handler', () => {
     })
     const handler = createMoleculePreviewHandler({ writeArtifactForCurrentRun })
 
-    const out = await handler({ smiles: ASPIRIN_SMILES, filename: 'aspirin' })
+    const out = await handler({ smiles: ASPIRIN_SMILES, filename: 'aspirin' }, { sessionId: 's-1' })
 
     expect(writeArtifactForCurrentRun).toHaveBeenCalledTimes(1)
-    const written = writeArtifactForCurrentRun.mock.calls[0][0]
+    const [sessionId, written] = writeArtifactForCurrentRun.mock.calls[0]
+    expect(sessionId).toBe('s-1')
     expect(written).toMatchObject({ filename: 'aspirin.mol', mimeType: 'chemical/x-mdl-molfile' })
     expect(written.content).toContain('V2000')
     expect(out).toMatchObject({
@@ -31,9 +32,19 @@ describe('molecule preview handler', () => {
     const writeArtifactForCurrentRun = vi.fn()
     const handler = createMoleculePreviewHandler({ writeArtifactForCurrentRun })
 
-    const out = await handler({ smiles: 'not-a-real-smiles' })
+    const out = await handler({ smiles: 'not-a-real-smiles' }, { sessionId: 's-1' })
 
     expect(out).toMatchObject({ valid: false })
+    expect(writeArtifactForCurrentRun).not.toHaveBeenCalled()
+  })
+
+  it('fails closed for a valid structure with no session context so it cannot attach to a parallel run', async () => {
+    const writeArtifactForCurrentRun = vi.fn()
+    const handler = createMoleculePreviewHandler({ writeArtifactForCurrentRun })
+
+    await expect(handler({ smiles: ASPIRIN_SMILES, filename: 'aspirin' })).rejects.toThrow(
+      /active session/
+    )
     expect(writeArtifactForCurrentRun).not.toHaveBeenCalled()
   })
 })

--- a/src/main/connectors/molecule-preview.ts
+++ b/src/main/connectors/molecule-preview.ts
@@ -1,12 +1,16 @@
 import { renderMoleculeStructure } from './descriptors/molecule'
 
-// Minimal view of the app runtime's artifact writer, so the handler stays testable with a fake.
+// Minimal view of the app runtime's artifact writer, so the handler stays testable with a fake. The
+// session id routes the write to the run of the session that invoked the tool.
 export type MoleculeArtifactWriter = {
-  writeArtifactForCurrentRun(input: {
-    filename: string
-    content: string
-    mimeType?: string
-  }): Promise<{ id: string; name: string; path: string }>
+  writeArtifactForCurrentRun(
+    sessionId: string,
+    input: {
+      filename: string
+      content: string
+      mimeType?: string
+    }
+  ): Promise<{ id: string; name: string; path: string }>
 }
 
 const MOLFILE_MIME = 'chemical/x-mdl-molfile'
@@ -16,11 +20,20 @@ const MOLFILE_MIME = 'chemical/x-mdl-molfile'
 // auto-opened in the preview panel by the renderer (workspace-events), so no extra IPC is needed.
 export const createMoleculePreviewHandler =
   (writer: MoleculeArtifactWriter) =>
-  async (args: Record<string, unknown>): Promise<unknown> => {
+  async (
+    args: Record<string, unknown>,
+    context: { sessionId?: string } = {}
+  ): Promise<unknown> => {
     const result = await renderMoleculeStructure(args)
     if (!result.valid) return result
 
-    const artifact = await writer.writeArtifactForCurrentRun({
+    // The artifact must attach to the calling session's run; without a session id it would fall back to
+    // a global "current" run and could land on a parallel session, so fail closed instead.
+    if (!context.sessionId) {
+      throw new Error('molecule preview requires an active session to attach the structure to.')
+    }
+
+    const artifact = await writer.writeArtifactForCurrentRun(context.sessionId, {
       filename: result.filename_suggestion,
       content: result.molfile,
       mimeType: MOLFILE_MIME

--- a/src/main/connectors/molecule-preview.ts
+++ b/src/main/connectors/molecule-preview.ts
@@ -20,10 +20,7 @@ const MOLFILE_MIME = 'chemical/x-mdl-molfile'
 // auto-opened in the preview panel by the renderer (workspace-events), so no extra IPC is needed.
 export const createMoleculePreviewHandler =
   (writer: MoleculeArtifactWriter) =>
-  async (
-    args: Record<string, unknown>,
-    context: { sessionId?: string } = {}
-  ): Promise<unknown> => {
+  async (args: Record<string, unknown>, context: { sessionId?: string } = {}): Promise<unknown> => {
     const result = await renderMoleculeStructure(args)
     if (!result.valid) return result
 

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -60,8 +60,8 @@ describe('ConnectorService', () => {
       resolveApiKey: () => undefined,
       localToolHandlers: { 'molecule/preview_molecule': localHandler }
     })
-    const out = await svc.call('molecule', 'preview_molecule', { smiles: 'C' })
-    expect(localHandler).toHaveBeenCalledWith({ smiles: 'C' })
+    const out = await svc.call('molecule', 'preview_molecule', { smiles: 'C' }, { sessionId: 's-1' })
+    expect(localHandler).toHaveBeenCalledWith({ smiles: 'C' }, { sessionId: 's-1' })
     expect(out).toEqual({ ok: true })
     expect(engine.call).not.toHaveBeenCalled()
   })

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -60,7 +60,12 @@ describe('ConnectorService', () => {
       resolveApiKey: () => undefined,
       localToolHandlers: { 'molecule/preview_molecule': localHandler }
     })
-    const out = await svc.call('molecule', 'preview_molecule', { smiles: 'C' }, { sessionId: 's-1' })
+    const out = await svc.call(
+      'molecule',
+      'preview_molecule',
+      { smiles: 'C' },
+      { sessionId: 's-1' }
+    )
     expect(localHandler).toHaveBeenCalledWith({ smiles: 'C' }, { sessionId: 's-1' })
     expect(out).toEqual({ ok: true })
     expect(engine.call).not.toHaveBeenCalled()

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -29,8 +29,19 @@ type ConnectorServiceDeps = {
   }) => Promise<ApprovalDecision>
   // Handlers for bundled tools that run privileged local code (e.g. write an artifact, open a preview)
   // instead of the read-only HTTP ParserEngine. Keyed by `${connector}/${method}`; invoked after the
-  // same enable/policy/approval gate as any other bundled call.
-  localToolHandlers?: Record<string, (args: Record<string, unknown>) => Promise<unknown>>
+  // same enable/policy/approval gate as any other bundled call. The call context carries the id of the
+  // session that triggered the call so a handler can attribute side effects (e.g. a generated artifact)
+  // to the right session instead of a global "current" one.
+  localToolHandlers?: Record<
+    string,
+    (args: Record<string, unknown>, context: ConnectorCallContext) => Promise<unknown>
+  >
+}
+
+// Optional routing context for a connector call. Present for calls that originate inside a session
+// (e.g. notebook host.mcp); absent for context-free callers.
+export type ConnectorCallContext = {
+  sessionId?: string
 }
 
 // Agent-agnostic gate: enforces enabled state + per-tool policy, prompts for approval on un-trusted
@@ -47,10 +58,15 @@ export class ConnectorService {
     return !(this.deps.getConnectors()?.disabledConnectorIds ?? []).includes(connector)
   }
 
-  async call(connector: string, method: string, args: Record<string, unknown>): Promise<unknown> {
+  async call(
+    connector: string,
+    method: string,
+    args: Record<string, unknown>,
+    context: ConnectorCallContext = {}
+  ): Promise<unknown> {
     const descriptor = getDescriptor(connector, method)
     const isBundled = descriptor !== undefined || ALL_CONNECTOR_IDS.includes(connector)
-    if (isBundled) return this.callBundled(connector, method, args, descriptor)
+    if (isBundled) return this.callBundled(connector, method, args, descriptor, context)
 
     const custom = (this.deps.getConnectors()?.customMcpServers ?? []).find(
       (s) => s.name === connector
@@ -63,7 +79,8 @@ export class ConnectorService {
     connector: string,
     method: string,
     args: Record<string, unknown>,
-    descriptor: ToolDescriptor | undefined
+    descriptor: ToolDescriptor | undefined,
+    context: ConnectorCallContext
   ): Promise<unknown> {
     if (!this.isEnabled(connector)) throw new Error(`connector not enabled: ${connector}`)
     if (!descriptor) throw new Error(`unknown tool: ${connector}/${method}`)
@@ -76,7 +93,7 @@ export class ConnectorService {
     // Bundled tools that need privileged local behavior run here, after the same gate, instead of the
     // read-only HTTP engine.
     const localHandler = this.deps.localToolHandlers?.[`${connector}/${method}`]
-    if (localHandler) return localHandler(args)
+    if (localHandler) return localHandler(args, context)
 
     return this.engine.call(descriptor, args, this.credentials())
   }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -190,9 +190,9 @@ const registerIpcHandlers = async ({
     current: undefined
   }
   const moleculePreviewHandler = createMoleculePreviewHandler({
-    writeArtifactForCurrentRun: (input) => {
+    writeArtifactForCurrentRun: (sessionId, input) => {
       if (!runtimeRef.current) throw new Error('Artifact runtime is not initialized.')
-      return runtimeRef.current.writeArtifactForCurrentRun(input)
+      return runtimeRef.current.writeArtifactForCurrentRun(sessionId, input)
     }
   })
   const connectorService = new ConnectorService({

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -285,7 +285,9 @@ const registerIpcHandlers = async ({
     getActivePromptSessions: () => runtime.getActivePromptSessions(),
     settingsService
   })
-  registerArtifactIpcHandlers(artifactRepository, artifactRunRegistry)
+  registerArtifactIpcHandlers(artifactRepository, artifactRunRegistry, () =>
+    runtimeRef.current ? runtimeRef.current.getActiveArtifactRunIds() : []
+  )
   registerUploadIpcHandlers(uploadRepository)
   registerSessionPersistenceIpcHandlers(sessionRepository)
   registerProjectIpcHandlers(projectRepository, previewStateRepository)

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -28,4 +28,32 @@ describe('mcpCall RPC', () => {
       result: { s: 'chemistry', m: 'pubchem_get_properties', a: { cids: [1] } }
     })
   })
+
+  it('forwards the caller session id as call context so writes attribute to the right session', async () => {
+    let seenContext: { sessionId?: string } | undefined
+    const capturing = {
+      call: async (
+        _s: string,
+        _m: string,
+        _a: Record<string, unknown>,
+        context?: { sessionId?: string }
+      ) => {
+        seenContext = context
+        return { ok: true }
+      }
+    }
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      connectorService: capturing as never
+    })
+    const { endpoint, token } = await server.ensureStarted()
+    await fetch(`${endpoint}`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        method: 'mcpCall',
+        params: { server: 'molecule', method: 'preview_molecule', args: {}, sessionId: 's-42' }
+      })
+    })
+    expect(seenContext).toEqual({ sessionId: 's-42' })
+  })
 })

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -15,7 +15,12 @@ type NotebookLocalRpcServerOptions = {
   token?: string
   host?: string
   connectorService?: {
-    call(server: string, method: string, args: Record<string, unknown>): Promise<unknown>
+    call(
+      server: string,
+      method: string,
+      args: Record<string, unknown>,
+      context?: { sessionId?: string }
+    ): Promise<unknown>
   }
 }
 
@@ -151,13 +156,16 @@ class NotebookLocalRpcServer {
 
   // Maps the narrow RPC method names to strongly-typed runtime service calls.
   private async dispatch(method: string, params: Record<string, unknown>): Promise<unknown> {
-    // mcpCall is not session-scoped, so it bypasses assertSessionParams below.
+    // mcpCall carries no runtime routing fields, so it bypasses assertSessionParams below. It does
+    // forward the caller's session id (already alias-resolved above) as call context so a local tool
+    // handler can attribute side effects to the session that invoked it.
     if (method === 'mcpCall') {
       if (!this.connectorService) throw new Error('Connector service is not configured.')
       const server = typeof params.server === 'string' ? params.server : ''
       const toolMethod = typeof params.method === 'string' ? params.method : ''
       const args = isRecord(params.args) ? params.args : {}
-      return this.connectorService.call(server, toolMethod, args)
+      const sessionId = typeof params.sessionId === 'string' ? params.sessionId : undefined
+      return this.connectorService.call(server, toolMethod, args, { sessionId })
     }
 
     assertSessionParams(params)

--- a/src/main/notebook/python-executor.ts
+++ b/src/main/notebook/python-executor.ts
@@ -54,9 +54,15 @@ class _Host:
             call_args = kwargs
         endpoint = os.environ.get("OPEN_SCIENCE_MCP_RPC_ENDPOINT")
         token = os.environ.get("OPEN_SCIENCE_MCP_RPC_TOKEN")
+        session_id = os.environ.get("OPEN_SCIENCE_MCP_RPC_SESSION_ID")
         if not endpoint:
             raise RuntimeError("host.mcp is unavailable: connector RPC endpoint not set")
-        payload = json.dumps({"method": "mcpCall", "params": {"server": server, "method": method, "args": call_args}}).encode("utf-8")
+        mcp_params = {"server": server, "method": method, "args": call_args}
+        # Tell the main process which session this call belongs to, so a connector that writes an
+        # artifact (e.g. molecule preview) attaches it to this session's run and never a parallel one.
+        if session_id:
+            mcp_params["sessionId"] = session_id
+        payload = json.dumps({"method": "mcpCall", "params": mcp_params}).encode("utf-8")
         req = urllib.request.Request(endpoint, data=payload, method="POST",
             headers={"content-type": "application/json", "authorization": "Bearer " + (token or "")})
         try:
@@ -444,6 +450,9 @@ class NotebookPythonExecutor implements NotebookExecutor {
           ? { OPEN_SCIENCE_MCP_RPC_ENDPOINT: request.mcpRpcEndpoint }
           : {}),
         ...(request.mcpRpcToken ? { OPEN_SCIENCE_MCP_RPC_TOKEN: request.mcpRpcToken } : {}),
+        // App session id this kernel belongs to, forwarded by host.mcp() so the main process attributes
+        // connector side effects (e.g. molecule preview artifacts) to the right session.
+        ...(request.sessionId ? { OPEN_SCIENCE_MCP_RPC_SESSION_ID: request.sessionId } : {}),
         // App-owned directories the notebook kernel must not read (e.g. materialized skill files).
         OPEN_SCIENCE_PROTECTED_DIRS: (request.protectedDirs ?? []).join(delimiter)
       }

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -35,6 +35,9 @@ type NotebookExecutionRequest = {
   // Connector RPC connection injected into the kernel spawn env for host.mcp().
   mcpRpcEndpoint?: string
   mcpRpcToken?: string
+  // App session id owning this kernel, injected into the spawn env so host.mcp() can tell the main
+  // process which session a connector call (e.g. molecule preview) belongs to.
+  sessionId?: string
 }
 
 type NotebookExecutionResult = {
@@ -351,7 +354,8 @@ class NotebookRuntimeService {
         protectedDirs: [getAppClaudeConfigDir(this.options.configRoot)],
         timeoutMs: request.timeoutMs,
         mcpRpcEndpoint: mcpRpc?.endpoint,
-        mcpRpcToken: mcpRpc?.token
+        mcpRpcToken: mcpRpc?.token,
+        sessionId: session.sessionId
       })
       .catch((error: unknown) => errorToExecutionResult(error, cwdBefore))
     // Replace the running record instead of appending so each run id has one durable entry.

--- a/src/main/reviewer/artifact-digest.test.ts
+++ b/src/main/reviewer/artifact-digest.test.ts
@@ -1,0 +1,89 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
+
+let storageRoot: string | undefined
+
+afterEach(async () => {
+  if (storageRoot) {
+    await rm(storageRoot, { recursive: true, force: true })
+    storageRoot = undefined
+  }
+})
+
+// A session whose agent turn produced one artifact, addressed by the reviewer version id layout
+// (`<sessionId>:<messageId>:<filename>` -> <project>/<sessionId>/<messageId>/<filename>).
+const buildSession = (): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Session',
+  cwd: '/tmp',
+  status: 'idle',
+  messages: [
+    {
+      id: 'u1',
+      role: 'user',
+      content: 'go',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1000,
+      updatedAt: 1000
+    },
+    {
+      id: 'a1',
+      role: 'agent',
+      content: 'done',
+      status: 'complete',
+      eventIds: [],
+      artifactIds: ['session-1:a1:report.csv'],
+      createdAt: 1002,
+      updatedAt: 1002
+    }
+  ],
+  createdAt: 1000,
+  updatedAt: 1002
+})
+
+const writeArtifact = async (root: string, contents: string): Promise<void> => {
+  const dir = join(root, 'artifacts', 'project-1', 'session-1', 'a1')
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'report.csv'), contents, 'utf8')
+}
+
+describe('resolveTurnScopeWithArtifactDigests', () => {
+  it('invalidates the producing block hash when the artifact bytes change on disk', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'reviewer-digest-'))
+    const session = buildSession()
+
+    await writeArtifact(storageRoot, 'a,b\n1,2\n')
+    const before = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+
+    // An external process rewrites the artifact; the id is unchanged but the bytes differ.
+    await writeArtifact(storageRoot, 'a,b\n9,9\n')
+    const after = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+
+    const hashOf = (scope: Awaited<ReturnType<typeof resolveTurnScopeWithArtifactDigests>>) =>
+      scope.blocks.find((block) => block.sourceId === 'a1')?.contentHash
+
+    expect(hashOf(after)).not.toBe(hashOf(before))
+  })
+
+  it('is stable when the artifact bytes are unchanged', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'reviewer-digest-'))
+    const session = buildSession()
+    await writeArtifact(storageRoot, 'a,b\n1,2\n')
+
+    const first = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+    const second = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+
+    const hashOf = (scope: Awaited<ReturnType<typeof resolveTurnScopeWithArtifactDigests>>) =>
+      scope.blocks.find((block) => block.sourceId === 'a1')?.contentHash
+
+    expect(hashOf(first)).toBe(hashOf(second))
+  })
+})

--- a/src/main/reviewer/artifact-digest.test.ts
+++ b/src/main/reviewer/artifact-digest.test.ts
@@ -88,4 +88,57 @@ describe('resolveTurnScopeWithArtifactDigests', () => {
 
     expect(hashOf(first)).toBe(hashOf(second))
   })
+
+  it('streams a large artifact fully (a late-byte edit still changes the hash)', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'reviewer-digest-'))
+    const session = buildSession()
+    const dir = join(storageRoot, 'artifacts', 'project-1', 'session-1', 'a1')
+    await mkdir(dir, { recursive: true })
+
+    // ~8 MB: comfortably larger than a stream chunk, so hashing must consume the whole file, not a head.
+    const big = Buffer.alloc(8 * 1024 * 1024, 7)
+    await writeFile(join(dir, 'report.csv'), big)
+    const before = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+
+    // Flip the very last byte only — a head-only or truncated read would miss this.
+    big[big.length - 1] = 8
+    await writeFile(join(dir, 'report.csv'), big)
+    const after = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+
+    const hashOf = (
+      scope: Awaited<ReturnType<typeof resolveTurnScopeWithArtifactDigests>>
+    ): string | undefined => scope.blocks.find((block) => block.sourceId === 'a1')?.contentHash
+
+    expect(hashOf(after)).not.toBe(hashOf(before))
+  })
+
+  it('hashes more artifacts than the concurrency limit and reflects a per-artifact edit', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'reviewer-digest-'))
+    const names = Array.from({ length: 10 }, (_, index) => `file-${index}.txt`)
+    const session: PersistedChatSession = {
+      ...buildSession(),
+      messages: [
+        buildSession().messages[0],
+        { ...buildSession().messages[1], artifactIds: names.map((name) => `session-1:a1:${name}`) }
+      ]
+    }
+    const dir = join(storageRoot, 'artifacts', 'project-1', 'session-1', 'a1')
+    await mkdir(dir, { recursive: true })
+    for (const name of names) await writeFile(join(dir, name), `content of ${name}`)
+
+    const first = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+    const second = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+
+    const hashOf = (
+      scope: Awaited<ReturnType<typeof resolveTurnScopeWithArtifactDigests>>
+    ): string | undefined => scope.blocks.find((block) => block.sourceId === 'a1')?.contentHash
+
+    // All 10 hashed deterministically across the batched passes.
+    expect(hashOf(first)).toBe(hashOf(second))
+
+    // Editing any one of them (past the first batch) still changes the block hash.
+    await writeFile(join(dir, 'file-9.txt'), 'edited')
+    const edited = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+    expect(hashOf(edited)).not.toBe(hashOf(first))
+  })
 })

--- a/src/main/reviewer/artifact-digest.test.ts
+++ b/src/main/reviewer/artifact-digest.test.ts
@@ -67,8 +67,9 @@ describe('resolveTurnScopeWithArtifactDigests', () => {
     await writeArtifact(storageRoot, 'a,b\n9,9\n')
     const after = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
 
-    const hashOf = (scope: Awaited<ReturnType<typeof resolveTurnScopeWithArtifactDigests>>) =>
-      scope.blocks.find((block) => block.sourceId === 'a1')?.contentHash
+    const hashOf = (
+      scope: Awaited<ReturnType<typeof resolveTurnScopeWithArtifactDigests>>
+    ): string | undefined => scope.blocks.find((block) => block.sourceId === 'a1')?.contentHash
 
     expect(hashOf(after)).not.toBe(hashOf(before))
   })
@@ -81,8 +82,9 @@ describe('resolveTurnScopeWithArtifactDigests', () => {
     const first = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
     const second = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
 
-    const hashOf = (scope: Awaited<ReturnType<typeof resolveTurnScopeWithArtifactDigests>>) =>
-      scope.blocks.find((block) => block.sourceId === 'a1')?.contentHash
+    const hashOf = (
+      scope: Awaited<ReturnType<typeof resolveTurnScopeWithArtifactDigests>>
+    ): string | undefined => scope.blocks.find((block) => block.sourceId === 'a1')?.contentHash
 
     expect(hashOf(first)).toBe(hashOf(second))
   })

--- a/src/main/reviewer/artifact-digest.ts
+++ b/src/main/reviewer/artifact-digest.ts
@@ -1,20 +1,27 @@
 import { createHash } from 'node:crypto'
-import { readFile, stat } from 'node:fs/promises'
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { pipeline } from 'node:stream/promises'
 
 import type { TurnScope } from '../../shared/reviewer'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { resolveArtifactPath } from './host-sdk'
 import { resolveTurnScope } from './scope'
 
-// Digest of an artifact's CURRENT on-disk bytes. Preferring a content hash means an external edit that
-// preserves size and mtime is still detected; the size+mtime fallback keeps a signal when the bytes
-// cannot be read in full, and a fully unreadable/missing artifact stays undefined (hashed as null,
-// still distinct from any present digest).
+// At most this many artifacts are hashed at once. Scientific artifacts can be large, so an unbounded
+// fan-out could hold many whole files in flight and exhaust the Electron main process.
+const DIGEST_CONCURRENCY = 4
+
+// Digest of an artifact's CURRENT on-disk bytes. Streams the file through the hash rather than reading
+// it whole, so a large artifact never lands in memory in one piece. Preferring a content hash means an
+// external edit that preserves size and mtime is still detected; the size+mtime fallback keeps a signal
+// when the bytes cannot be streamed, and a fully unreadable/missing artifact stays undefined (hashed as
+// null, still distinct from any present digest).
 const computeArtifactDigest = async (path: string): Promise<string | undefined> => {
   try {
-    return `sha256:${createHash('sha256')
-      .update(await readFile(path))
-      .digest('hex')}`
+    const hash = createHash('sha256')
+    await pipeline(createReadStream(path), hash)
+    return `sha256:${hash.digest('hex')}`
   } catch {
     try {
       const fileStat = await stat(path)
@@ -28,7 +35,7 @@ const computeArtifactDigest = async (path: string): Promise<string | undefined> 
 // Resolves the turn scope with every referenced artifact pinned to a digest of its current bytes, so a
 // stored review — and any finding locator anchored to a block that produced an artifact — goes stale
 // when that artifact is edited outside the app. The structural pass is cheap (no filesystem access);
-// only the turn's own artifacts are read for hashing.
+// only the turn's own artifacts are read, streamed, and hashed in bounded-concurrency batches.
 export const resolveTurnScopeWithArtifactDigests = async (
   session: PersistedChatSession,
   turnMessageId: string,
@@ -36,20 +43,23 @@ export const resolveTurnScopeWithArtifactDigests = async (
 ): Promise<TurnScope> => {
   const structural = resolveTurnScope(session, turnMessageId)
   const digests = new Map<string, string>()
+  const ids = structural.artifactVersionIds
 
-  await Promise.all(
-    structural.artifactVersionIds.map(async (id) => {
-      let path: string
-      try {
-        path = resolveArtifactPath(artifactStorageRoot, session.projectId, id)
-      } catch {
-        return
-      }
+  for (let start = 0; start < ids.length; start += DIGEST_CONCURRENCY) {
+    await Promise.all(
+      ids.slice(start, start + DIGEST_CONCURRENCY).map(async (id) => {
+        let path: string
+        try {
+          path = resolveArtifactPath(artifactStorageRoot, session.projectId, id)
+        } catch {
+          return
+        }
 
-      const digest = await computeArtifactDigest(path)
-      if (digest !== undefined) digests.set(id, digest)
-    })
-  )
+        const digest = await computeArtifactDigest(path)
+        if (digest !== undefined) digests.set(id, digest)
+      })
+    )
+  }
 
   return resolveTurnScope(session, turnMessageId, digests)
 }

--- a/src/main/reviewer/artifact-digest.ts
+++ b/src/main/reviewer/artifact-digest.ts
@@ -1,0 +1,53 @@
+import { createHash } from 'node:crypto'
+import { readFile, stat } from 'node:fs/promises'
+
+import type { TurnScope } from '../../shared/reviewer'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { resolveArtifactPath } from './host-sdk'
+import { resolveTurnScope } from './scope'
+
+// Digest of an artifact's CURRENT on-disk bytes. Preferring a content hash means an external edit that
+// preserves size and mtime is still detected; the size+mtime fallback keeps a signal when the bytes
+// cannot be read in full, and a fully unreadable/missing artifact stays undefined (hashed as null,
+// still distinct from any present digest).
+const computeArtifactDigest = async (path: string): Promise<string | undefined> => {
+  try {
+    return `sha256:${createHash('sha256').update(await readFile(path)).digest('hex')}`
+  } catch {
+    try {
+      const fileStat = await stat(path)
+      return `size-mtime:${fileStat.size}:${fileStat.mtimeMs}`
+    } catch {
+      return undefined
+    }
+  }
+}
+
+// Resolves the turn scope with every referenced artifact pinned to a digest of its current bytes, so a
+// stored review — and any finding locator anchored to a block that produced an artifact — goes stale
+// when that artifact is edited outside the app. The structural pass is cheap (no filesystem access);
+// only the turn's own artifacts are read for hashing.
+export const resolveTurnScopeWithArtifactDigests = async (
+  session: PersistedChatSession,
+  turnMessageId: string,
+  artifactStorageRoot: string
+): Promise<TurnScope> => {
+  const structural = resolveTurnScope(session, turnMessageId)
+  const digests = new Map<string, string>()
+
+  await Promise.all(
+    structural.artifactVersionIds.map(async (id) => {
+      let path: string
+      try {
+        path = resolveArtifactPath(artifactStorageRoot, session.projectId, id)
+      } catch {
+        return
+      }
+
+      const digest = await computeArtifactDigest(path)
+      if (digest !== undefined) digests.set(id, digest)
+    })
+  )
+
+  return resolveTurnScope(session, turnMessageId, digests)
+}

--- a/src/main/reviewer/artifact-digest.ts
+++ b/src/main/reviewer/artifact-digest.ts
@@ -12,7 +12,9 @@ import { resolveTurnScope } from './scope'
 // still distinct from any present digest).
 const computeArtifactDigest = async (path: string): Promise<string | undefined> => {
   try {
-    return `sha256:${createHash('sha256').update(await readFile(path)).digest('hex')}`
+    return `sha256:${createHash('sha256')
+      .update(await readFile(path))
+      .digest('hex')}`
   } catch {
     try {
       const fileStat = await stat(path)

--- a/src/main/reviewer/flag-stale-reviews.test.ts
+++ b/src/main/reviewer/flag-stale-reviews.test.ts
@@ -99,7 +99,8 @@ describe('flagStaleReviews', () => {
 
     const [result] = await flagStaleReviews([review], session, storageRoot)
 
-    expect(result.stale).toBeUndefined()
+    // Computed-not-stale is an explicit false (distinct from "couldn't compute" = undefined).
+    expect(result.stale).toBe(false)
   })
 
   it('never flags a running or errored review (no verdict to invalidate)', async () => {
@@ -147,6 +148,7 @@ describe('flagStaleReviews', () => {
 
     const [result] = await flagStaleReviews([fixLoopReview], session, storageRoot)
 
-    expect(result.stale).toBeUndefined()
+    // Correctly resolves the correction turn (a1) and finds it unchanged → explicit not-stale.
+    expect(result.stale).toBe(false)
   })
 })

--- a/src/main/reviewer/flag-stale-reviews.test.ts
+++ b/src/main/reviewer/flag-stale-reviews.test.ts
@@ -1,0 +1,136 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { ReviewWithChecks } from '../../shared/reviewer'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { flagStaleReviews } from './stale-reviews'
+import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
+
+let storageRoot: string | undefined
+
+afterEach(async () => {
+  if (storageRoot) {
+    await rm(storageRoot, { recursive: true, force: true })
+    storageRoot = undefined
+  }
+})
+
+const buildSession = (): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Session',
+  cwd: '/tmp',
+  status: 'idle',
+  messages: [
+    {
+      id: 'u1',
+      role: 'user',
+      content: 'go',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1000,
+      updatedAt: 1000
+    },
+    {
+      id: 'a1',
+      role: 'agent',
+      content: 'done',
+      status: 'complete',
+      eventIds: [],
+      artifactIds: ['session-1:a1:report.csv'],
+      createdAt: 1002,
+      updatedAt: 1002
+    }
+  ],
+  createdAt: 1000,
+  updatedAt: 1002
+})
+
+const buildReview = (
+  scope: Awaited<ReturnType<typeof resolveTurnScopeWithArtifactDigests>>,
+  overrides: Partial<ReviewWithChecks> = {}
+): ReviewWithChecks => ({
+  id: 'review-1',
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  turnMessageId: 'a1',
+  scope,
+  lifecycle: 'complete',
+  outcome: 'pass',
+  model: 'test',
+  reviewerLog: [],
+  checks: [],
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides
+})
+
+const writeArtifact = async (root: string, contents: string): Promise<void> => {
+  const dir = join(root, 'artifacts', 'project-1', 'session-1', 'a1')
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'report.csv'), contents, 'utf8')
+}
+
+describe('flagStaleReviews', () => {
+  it('flags a completed review when the artifact it audited was edited afterward', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'flag-stale-'))
+    const session = buildSession()
+    await writeArtifact(storageRoot, 'a,b\n1,2\n')
+    const scopeAtReviewTime = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+    const review = buildReview(scopeAtReviewTime)
+
+    // The artifact is edited outside the app after the review completed.
+    await writeArtifact(storageRoot, 'a,b\n9,9\n')
+
+    const [flagged] = await flagStaleReviews([review], session, storageRoot)
+
+    expect(flagged.stale).toBe(true)
+  })
+
+  it('does not flag a completed review when nothing about its turn has changed', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'flag-stale-'))
+    const session = buildSession()
+    await writeArtifact(storageRoot, 'a,b\n1,2\n')
+    const scope = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+    const review = buildReview(scope)
+
+    const [result] = await flagStaleReviews([review], session, storageRoot)
+
+    expect(result.stale).toBeUndefined()
+  })
+
+  it('never flags a running or errored review (no verdict to invalidate)', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'flag-stale-'))
+    const session = buildSession()
+    await writeArtifact(storageRoot, 'a,b\n1,2\n')
+    const scope = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+    const running = buildReview(scope, { lifecycle: 'running', outcome: null })
+    const errored = buildReview(scope, { lifecycle: 'error', outcome: null })
+
+    await writeArtifact(storageRoot, 'a,b\n9,9\n')
+
+    const [flaggedRunning, flaggedErrored] = await flagStaleReviews(
+      [running, errored],
+      session,
+      storageRoot
+    )
+
+    expect(flaggedRunning.stale).toBeUndefined()
+    expect(flaggedErrored.stale).toBeUndefined()
+  })
+
+  it('fails open (unflagged) when the session is missing, instead of hiding the verdict', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'flag-stale-'))
+    const session = buildSession()
+    await writeArtifact(storageRoot, 'a,b\n1,2\n')
+    const scope = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+    const review = buildReview(scope)
+
+    const [result] = await flagStaleReviews([review], undefined, storageRoot)
+
+    expect(result.stale).toBeUndefined()
+  })
+})

--- a/src/main/reviewer/flag-stale-reviews.test.ts
+++ b/src/main/reviewer/flag-stale-reviews.test.ts
@@ -133,4 +133,20 @@ describe('flagStaleReviews', () => {
 
     expect(result.stale).toBeUndefined()
   })
+
+  it('recomputes against scope.turnMessageId, so a fix-loop review is not falsely stale', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'flag-stale-'))
+    const session = buildSession()
+    await writeArtifact(storageRoot, 'a,b\n1,2\n')
+
+    // A fix-loop re-review: its SCOPE is the correction turn (a1), but the row is grouped under the
+    // ORIGINAL turn id (u1). Recomputing with review.turnMessageId (u1) would resolve a different turn
+    // and always mismatch; recomputing with scope.turnMessageId (a1) correctly matches when unchanged.
+    const scope = await resolveTurnScopeWithArtifactDigests(session, 'a1', storageRoot)
+    const fixLoopReview = buildReview(scope, { turnMessageId: 'u1' })
+
+    const [result] = await flagStaleReviews([fixLoopReview], session, storageRoot)
+
+    expect(result.stale).toBeUndefined()
+  })
 })

--- a/src/main/reviewer/host-sdk.ts
+++ b/src/main/reviewer/host-sdk.ts
@@ -353,7 +353,7 @@ const isLikelyText = (bytes: Buffer): boolean => {
 // Resolves an artifact file path from managed storage, reusing the layout owned by ArtifactRepository:
 // <storageRoot>/artifacts/<projectName>/<sessionId>/<messageId>/<filename>. The version id is the
 // colon-composite <sessionId>:<messageId>:<filename> assigned when the artifact is attached to a turn.
-const resolveArtifactPath = (
+export const resolveArtifactPath = (
   storageRoot: string,
   projectName: string,
   versionId: string

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -264,6 +264,24 @@ describe('reviewer IPC handlers', () => {
     await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
   })
 
+  it('fails closed when the idempotency lookup throws: no run, lock released, retryable', async () => {
+    // The lookup can't confirm the turn is un-reviewed — proceeding risks a duplicate, so refuse.
+    getReviewsForSession.mockRejectedValueOnce(new Error('db read failed'))
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    const result = await runHandler?.({}, { ...createRequest(), origin: 'auto' })
+
+    expect(result).toEqual({ started: false, reason: 'idempotency-check-failed' })
+    expect(runReview).not.toHaveBeenCalled()
+
+    // The lock must have been released: a follow-up auto request (lookup now recovered, no prior
+    // review) is not dropped as already-in-flight — it proceeds and starts.
+    const retry = await runHandler?.({}, { ...createRequest(), origin: 'auto' })
+    expect(retry).toEqual({ started: true })
+    await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
+  })
+
   it('lets a manual re-run bypass idempotency even when the turn already has a review', async () => {
     // Manual stale/error Re-run must force a fresh review — it never consults the auto-idempotency check.
     getReviewsForSession.mockResolvedValue([{ turnMessageId: 'message-1' }])

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -95,4 +95,50 @@ describe('reviewer IPC handlers', () => {
     const passed = runReview.mock.calls[0][0] as { artifactStorageRoot: string }
     expect(passed.artifactStorageRoot).toBe('/tmp/injected-data')
   })
+
+  it('forwards scopeTurnMessageId so a re-run audits the scope turn, grouped under turnMessageId', async () => {
+    runReview.mockClear()
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    // Re-running a fix-loop review: grouped under the original turn, but audit the correction turn.
+    runHandler?.(
+      {},
+      { ...createRequest(), turnMessageId: 'original', scopeTurnMessageId: 'correction' }
+    )
+
+    await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
+
+    const passed = runReview.mock.calls[0][0] as {
+      turnMessageId: string
+      scopeTurnMessageId?: string
+    }
+    expect(passed.turnMessageId).toBe('original')
+    expect(passed.scopeTurnMessageId).toBe('correction')
+  })
+
+  it('dedupes concurrent reviews of the same turn (double-click / multiple stale cards)', async () => {
+    runReview.mockClear()
+    // Hold runReview open so both synchronous triggers overlap in flight.
+    let resolveRun: (() => void) | undefined
+    runReview.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRun = () => resolve()
+        })
+    )
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    runHandler?.({}, createRequest())
+    runHandler?.({}, createRequest()) // same turn, still in flight → dropped
+
+    await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
+    resolveRun?.()
+    await Promise.resolve()
+    expect(runReview).toHaveBeenCalledTimes(1)
+
+    runReview.mockReset()
+    runReview.mockResolvedValue(undefined)
+  })
 })

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -150,7 +150,10 @@ describe('reviewer IPC handlers', () => {
 
     const runHandler = handlers.get(REVIEWER_IPC.RUN)
     runHandler?.({}, createRequest())
-    runHandler?.({}, createRequest()) // same turn, still in flight → dropped
+    // Same turn, still in flight → dropped with the non-retryable already-in-flight reason so the
+    // auto path does NOT retry it into a duplicate review.
+    const dropped = await runHandler?.({}, createRequest())
+    expect(dropped).toEqual({ started: false, reason: 'already-in-flight' })
 
     await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
     resolveRun?.()
@@ -166,8 +169,8 @@ describe('reviewer IPC handlers', () => {
     const runHandler = handlers.get(REVIEWER_IPC.RUN)
     const result = await runHandler?.({}, { ...createRequest(), turnMessageId: 'message-1' })
 
-    // No fabricated error review, no broadcast — just started:false, so the caller can retry the turn.
-    expect(result).toEqual({ started: false })
+    // No fabricated error review, no broadcast — started:false with a retryable reason.
+    expect(result).toEqual({ started: false, reason: 'load-failed' })
     expect(runReview).not.toHaveBeenCalled()
     expect(broadcastToRenderers).not.toHaveBeenCalled()
   })
@@ -183,7 +186,7 @@ describe('reviewer IPC handlers', () => {
     const runHandler = handlers.get(REVIEWER_IPC.RUN)
     const result = await runHandler?.({}, createRequest())
 
-    expect(result).toEqual({ started: false })
+    expect(result).toEqual({ started: false, reason: 'not-found' })
     expect(runReview).not.toHaveBeenCalled()
     expect(broadcastToRenderers).not.toHaveBeenCalled()
   })
@@ -201,7 +204,7 @@ describe('reviewer IPC handlers', () => {
     const runHandler = handlers.get(REVIEWER_IPC.RUN)
 
     const first = await runHandler?.({}, createRequest())
-    expect(first).toEqual({ started: false })
+    expect(first).toEqual({ started: false, reason: 'not-found' })
     expect(runReview).not.toHaveBeenCalled()
 
     const second = await runHandler?.({}, createRequest())
@@ -218,7 +221,8 @@ describe('reviewer IPC handlers', () => {
     const runHandler = handlers.get(REVIEWER_IPC.RUN)
     const result = await runHandler?.({}, createRequest())
 
-    expect(result).toEqual({ started: false })
+    // A genuine pre-push failure — not a persistence race, so not auto-retried.
+    expect(result).toEqual({ started: false, reason: 'run-failed' })
   })
 
   it('returns started:true when a review begins', async () => {

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -41,15 +41,21 @@ vi.mock('../projects/prisma-client', () => ({
   getProjectDbClient: vi.fn()
 }))
 
+// Shared, controllable session loader so a test can make the pre-runReview session load fail.
+const sessionLoadAll = vi.fn().mockResolvedValue({ sessions: [] })
 vi.mock('../session-persistence/repository', () => ({
   SessionRepository: class {
-    loadAll = vi.fn().mockResolvedValue({ sessions: [] })
+    loadAll = sessionLoadAll
   },
   // storage-root imports these names from the same module in production; keep them defined.
   DEV_SESSION_DIR_NAME: 'dev',
   PROD_SESSION_DIR_NAME: 'prod',
   getSessionPersistenceDir: () => CONFIG_ROOT
 }))
+
+// Capture broadcasts so a test can assert the start-failure error review reaches the renderer.
+const broadcastToRenderers = vi.fn()
+vi.mock('../renderer-broadcast', () => ({ broadcastToRenderers }))
 
 const { registerReviewerIpcHandlers } = await import('./ipc')
 
@@ -140,5 +146,29 @@ describe('reviewer IPC handlers', () => {
 
     runReview.mockReset()
     runReview.mockResolvedValue(undefined)
+  })
+
+  it('broadcasts an error review when the session load fails before runReview starts', async () => {
+    runReview.mockClear()
+    broadcastToRenderers.mockClear()
+    // The pre-runReview session load throws (e.g. DB/FS unavailable) — no Review row is ever created.
+    sessionLoadAll.mockRejectedValueOnce(new Error('session store unavailable'))
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    runHandler?.({}, { ...createRequest(), turnMessageId: 'message-1' })
+
+    // An error review-update is broadcast so the renderer can unlatch (Re-run) and show the failure.
+    await vi.waitFor(() => expect(broadcastToRenderers).toHaveBeenCalledTimes(1))
+    const [channel, payload] = broadcastToRenderers.mock.calls[0] as [
+      string,
+      { review: { lifecycle: string; turnMessageId: string } }
+    ]
+    expect(channel).toBe(REVIEWER_IPC.UPDATED)
+    expect(payload.review.lifecycle).toBe('error')
+    expect(payload.review.turnMessageId).toBe('message-1')
+    expect(runReview).not.toHaveBeenCalled()
+
+    sessionLoadAll.mockResolvedValue({ sessions: [] })
   })
 })

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -148,27 +148,32 @@ describe('reviewer IPC handlers', () => {
     runReview.mockResolvedValue(undefined)
   })
 
-  it('broadcasts an error review when the session load fails before runReview starts', async () => {
+  it('returns started:false without a review row or broadcast when the session load fails', async () => {
     runReview.mockClear()
     broadcastToRenderers.mockClear()
-    // The pre-runReview session load throws (e.g. DB/FS unavailable) — no Review row is ever created.
+    // The pre-runReview session load throws (e.g. DB/FS unavailable).
     sessionLoadAll.mockRejectedValueOnce(new Error('session store unavailable'))
     registerReviewerIpcHandlers({ acpRuntime })
 
     const runHandler = handlers.get(REVIEWER_IPC.RUN)
-    runHandler?.({}, { ...createRequest(), turnMessageId: 'message-1' })
+    const result = await runHandler?.({}, { ...createRequest(), turnMessageId: 'message-1' })
 
-    // An error review-update is broadcast so the renderer can unlatch (Re-run) and show the failure.
-    await vi.waitFor(() => expect(broadcastToRenderers).toHaveBeenCalledTimes(1))
-    const [channel, payload] = broadcastToRenderers.mock.calls[0] as [
-      string,
-      { review: { lifecycle: string; turnMessageId: string } }
-    ]
-    expect(channel).toBe(REVIEWER_IPC.UPDATED)
-    expect(payload.review.lifecycle).toBe('error')
-    expect(payload.review.turnMessageId).toBe('message-1')
+    // No fabricated error review, no broadcast — just started:false, so the caller can retry the turn.
+    expect(result).toEqual({ started: false })
     expect(runReview).not.toHaveBeenCalled()
+    expect(broadcastToRenderers).not.toHaveBeenCalled()
 
     sessionLoadAll.mockResolvedValue({ sessions: [] })
+  })
+
+  it('returns started:true when a review begins', async () => {
+    runReview.mockClear()
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    const result = await runHandler?.({}, createRequest())
+
+    expect(result).toEqual({ started: true })
+    await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
   })
 })

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -188,6 +188,27 @@ describe('reviewer IPC handlers', () => {
     expect(broadcastToRenderers).not.toHaveBeenCalled()
   })
 
+  it('releases the in-flight lock on a not-found start so a retry after the session appears starts', async () => {
+    // Models the persistence race: the first load misses the not-yet-flushed session (started:false),
+    // the retry sees it. The retry starting proves the not-found bail released the dedup lock (a stuck
+    // lock would drop the retry as "already in flight").
+    sessionLoadAll.mockReset()
+    sessionLoadAll
+      .mockResolvedValueOnce({ sessions: [] })
+      .mockResolvedValue({ sessions: [{ id: 'session-1' }] })
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+
+    const first = await runHandler?.({}, createRequest())
+    expect(first).toEqual({ started: false })
+    expect(runReview).not.toHaveBeenCalled()
+
+    const second = await runHandler?.({}, createRequest())
+    expect(second).toEqual({ started: true })
+    expect(runReview).toHaveBeenCalledTimes(1)
+  })
+
   it('returns started:false when runReview fails before signalling onStarted', async () => {
     // e.g. scope resolution or the createReview insert throws before the running row is pushed.
     runReview.mockReset()

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ReviewRunRequest } from '../../shared/reviewer'
 import { REVIEWER_IPC } from '../../shared/reviewer'
@@ -67,9 +67,21 @@ const createRequest = (): ReviewRunRequest => ({
   projectId: 'project-1'
 })
 
+// Default: a review that "starts" (signals onStarted so triggerReview resolves started:true) and
+// completes immediately. Individual tests override runReview for held/failed runs.
+beforeEach(() => {
+  runReview.mockReset()
+  runReview.mockImplementation((opts?: { onStarted?: () => void }) => {
+    opts?.onStarted?.()
+    return Promise.resolve(undefined)
+  })
+  broadcastToRenderers.mockClear()
+  sessionLoadAll.mockReset()
+  sessionLoadAll.mockResolvedValue({ sessions: [] })
+})
+
 describe('reviewer IPC handlers', () => {
   it('runs reviews with artifacts rooted at the data root, not the config root', async () => {
-    runReview.mockClear()
     registerReviewerIpcHandlers({ acpRuntime })
 
     const runHandler = handlers.get(REVIEWER_IPC.RUN)
@@ -143,14 +155,9 @@ describe('reviewer IPC handlers', () => {
     resolveRun?.()
     await Promise.resolve()
     expect(runReview).toHaveBeenCalledTimes(1)
-
-    runReview.mockReset()
-    runReview.mockResolvedValue(undefined)
   })
 
   it('returns started:false without a review row or broadcast when the session load fails', async () => {
-    runReview.mockClear()
-    broadcastToRenderers.mockClear()
     // The pre-runReview session load throws (e.g. DB/FS unavailable).
     sessionLoadAll.mockRejectedValueOnce(new Error('session store unavailable'))
     registerReviewerIpcHandlers({ acpRuntime })
@@ -162,8 +169,18 @@ describe('reviewer IPC handlers', () => {
     expect(result).toEqual({ started: false })
     expect(runReview).not.toHaveBeenCalled()
     expect(broadcastToRenderers).not.toHaveBeenCalled()
+  })
 
-    sessionLoadAll.mockResolvedValue({ sessions: [] })
+  it('returns started:false when runReview fails before signalling onStarted', async () => {
+    // e.g. scope resolution or the createReview insert throws before the running row is pushed.
+    runReview.mockReset()
+    runReview.mockRejectedValueOnce(new Error('createReview failed'))
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    const result = await runHandler?.({}, createRequest())
+
+    expect(result).toEqual({ started: false })
   })
 
   it('returns started:true when a review begins', async () => {

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -77,7 +77,8 @@ beforeEach(() => {
   })
   broadcastToRenderers.mockClear()
   sessionLoadAll.mockReset()
-  sessionLoadAll.mockResolvedValue({ sessions: [] })
+  // Default: the requested session exists, so triggerReview proceeds to runReview.
+  sessionLoadAll.mockResolvedValue({ sessions: [{ id: 'session-1' }] })
 })
 
 describe('reviewer IPC handlers', () => {
@@ -166,6 +167,22 @@ describe('reviewer IPC handlers', () => {
     const result = await runHandler?.({}, { ...createRequest(), turnMessageId: 'message-1' })
 
     // No fabricated error review, no broadcast — just started:false, so the caller can retry the turn.
+    expect(result).toEqual({ started: false })
+    expect(runReview).not.toHaveBeenCalled()
+    expect(broadcastToRenderers).not.toHaveBeenCalled()
+  })
+
+  it('returns started:false without calling runReview when the session id is gone', async () => {
+    // loadAll succeeds but the session was deleted between the card render and the click. Falling
+    // through to runReview would create a non-retriable error card that replaces the stale card the
+    // user was re-running; instead we bail with started:false so the existing card + Re-run survive.
+    sessionLoadAll.mockReset()
+    sessionLoadAll.mockResolvedValue({ sessions: [{ id: 'a-different-session' }] })
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    const result = await runHandler?.({}, createRequest())
+
     expect(result).toEqual({ started: false })
     expect(runReview).not.toHaveBeenCalled()
     expect(broadcastToRenderers).not.toHaveBeenCalled()

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -30,10 +30,11 @@ vi.mock('./orchestrator', () => ({
   runReview: (options: unknown) => runReview(options)
 }))
 
-// The repository/DB/session collaborators are irrelevant to the root split; stub them out.
+// Controllable review lookup so a test can make main's auto-idempotency check find an existing review.
+const getReviewsForSession = vi.fn().mockResolvedValue([])
 vi.mock('./repository', () => ({
   ReviewRepository: class {
-    getReviewsForSession = vi.fn().mockResolvedValue([])
+    getReviewsForSession = getReviewsForSession
   }
 }))
 
@@ -79,6 +80,9 @@ beforeEach(() => {
   sessionLoadAll.mockReset()
   // Default: the requested session exists, so triggerReview proceeds to runReview.
   sessionLoadAll.mockResolvedValue({ sessions: [{ id: 'session-1' }] })
+  getReviewsForSession.mockReset()
+  // Default: no prior review for the turn, so the auto-idempotency check lets the run proceed.
+  getReviewsForSession.mockResolvedValue([])
 })
 
 describe('reviewer IPC handlers', () => {
@@ -234,5 +238,42 @@ describe('reviewer IPC handlers', () => {
 
     expect(result).toEqual({ started: true })
     await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
+  })
+
+  it('refuses an auto review for a turn that already has a review (atomic idempotency)', async () => {
+    // The cross-renderer TOCTOU: even if the caller's local store looked empty, main is the single
+    // serialization point — a review already exists for this turn, so an auto request is a duplicate.
+    getReviewsForSession.mockResolvedValue([{ turnMessageId: 'message-1' }])
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    const result = await runHandler?.({}, { ...createRequest(), origin: 'auto' })
+
+    expect(result).toEqual({ started: false, reason: 'already-reviewed' })
+    expect(runReview).not.toHaveBeenCalled()
+  })
+
+  it('runs an auto review when no review exists yet for the turn', async () => {
+    getReviewsForSession.mockResolvedValue([{ turnMessageId: 'a-different-turn' }])
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    const result = await runHandler?.({}, { ...createRequest(), origin: 'auto' })
+
+    expect(result).toEqual({ started: true })
+    await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
+  })
+
+  it('lets a manual re-run bypass idempotency even when the turn already has a review', async () => {
+    // Manual stale/error Re-run must force a fresh review — it never consults the auto-idempotency check.
+    getReviewsForSession.mockResolvedValue([{ turnMessageId: 'message-1' }])
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    const result = await runHandler?.({}, { ...createRequest(), origin: 'manual' })
+
+    expect(result).toEqual({ started: true })
+    expect(getReviewsForSession).not.toHaveBeenCalled()
+    expect(runReview).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -152,6 +152,17 @@ const registerReviewerIpcHandlers = (
       return { started: false }
     }
 
+    // Session load succeeded but the id is gone (deleted between the card render and the click).
+    // Bail out exactly like the load-failure path: release the lock and report started:false with NO
+    // Review row. Falling through to runReview would create a non-retriable error card that replaces
+    // the (stale) card the user was trying to re-run, and an earlier turn has no composer entry to
+    // recover from — so the turn would be stuck. started:false keeps the existing card and its Re-run.
+    if (!session) {
+      inFlightReviewKeys.delete(inFlightKey)
+      log.warn('review start failed: session not found', { sessionId, turnMessageId })
+      return { started: false }
+    }
+
     log.info('review triggered', { sessionId, turnMessageId })
 
     // Resolve `started` only once the running Review row has actually been created and pushed

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -138,6 +138,32 @@ const registerReviewerIpcHandlers = (
     }
     inFlightReviewKeys.add(inFlightKey)
 
+    // Atomic per-turn idempotency for auto-review. The in-flight key (reserved synchronously above)
+    // serializes concurrent starts; this DB check — running while we hold that key — covers the other
+    // half: a run by another entry that has already COMPLETED and released its key. main is the single
+    // process every renderer's IPC funnels through, so together they are the real mutex the renderer's
+    // store check could only approximate (that check races across processes). If any review already
+    // exists for this turn, an auto request is a duplicate → refuse. Manual re-runs (Request review,
+    // stale/error Re-run) set origin='manual' and skip this so the user can force a fresh review.
+    if (request.origin === 'auto') {
+      try {
+        const existing = await reviewRepository.getReviewsForSession(sessionId)
+        if (existing.some((review) => review.turnMessageId === turnMessageId)) {
+          inFlightReviewKeys.delete(inFlightKey)
+          log.info('auto review skipped: turn already has a review', { sessionId, turnMessageId })
+          return { started: false, reason: 'already-reviewed' }
+        }
+      } catch (error) {
+        // A review-store read failure is non-fatal here: fall through and let the normal session
+        // load + run guard correctness. Worst case is the duplicate this check would have prevented.
+        log.warn('auto-review idempotency check failed; proceeding', {
+          sessionId,
+          turnMessageId,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+
     let session: PersistedChatSession | undefined
     try {
       const { sessions } = await sessionRepository.loadAll()

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -154,69 +154,79 @@ const registerReviewerIpcHandlers = (
 
     log.info('review triggered', { sessionId, turnMessageId })
 
-    // Run in the background; the review's lifecycle reaches the renderer via reviewer:updated events.
-    void (async () => {
-      try {
-        // Create an AbortController for this review's fix loop. The controller is registered
-        // before runReview starts so the abort-fix-loop handler can find it immediately.
-        const abortController = new AbortController()
-        const effectiveMainSessionId = mainSessionId ?? sessionId
-
-        await runReview({
-          sessionId,
-          turnMessageId,
-          scopeTurnMessageId,
-          projectId,
-          mainSessionId,
-          model: model ?? '',
-          getSession: () => session,
-          reviewRepository,
-          acpRuntime: options.acpRuntime,
-          // Artifacts live under the relocatable data root; DB/sessions stay on the config root.
-          artifactStorageRoot: dataRoot,
-          onReviewUpdate: (review: ReviewWithChecks) => {
-            broadcastReviewUpdate({ review })
-          },
-          // Before the correction prompt is sent, suppress the next auto-review for the main
-          // session so the [Auditor] correction turn's stop event does not re-trigger a review.
-          onCorrectionPrompt: () => {
-            if (mainSessionId) {
-              broadcastSuppressNextAutoReview(mainSessionId)
-            }
-          },
-          // If the correction turn fails to send, its stop never arrives — clear the suppression so
-          // the session's next real turn still gets auto-reviewed.
-          onCorrectionFailed: () => {
-            if (mainSessionId) {
-              broadcastSuppressNextAutoReview(mainSessionId, true)
-            }
-          },
-          // Broadcast fix-loop lifecycle events and register/deregister the abort controller.
-          onFixLoopStart: () => {
-            fixLoopAbortControllers.set(effectiveMainSessionId, abortController)
-            broadcastFixLoopStart(effectiveMainSessionId)
-          },
-          onFixLoopEnd: () => {
-            fixLoopAbortControllers.delete(effectiveMainSessionId)
-            broadcastFixLoopEnd(effectiveMainSessionId)
-          },
-          fixLoopAbortSignal: abortController.signal
-        })
-      } catch (error) {
-        // runReview never throws for expected failures (it records lifecycle='error' and broadcasts a
-        // real Review row). An unexpected throw here is logged; the review row, if any, carries the
-        // error state to the renderer.
-        log.error('runReview threw unexpectedly', {
-          sessionId,
-          turnMessageId,
-          error: error instanceof Error ? error.message : String(error)
-        })
-      } finally {
-        inFlightReviewKeys.delete(inFlightKey)
+    // Resolve `started` only once the running Review row has actually been created and pushed
+    // (runReview's onStarted). If runReview fails BEFORE that (scope resolution or the DB insert), it
+    // settles without onStarted → started:false, so the caller (Re-run) stays retriable. The full
+    // review (reviewer session + fix loop) continues in the background regardless.
+    return await new Promise<ReviewRunResult>((resolveStart) => {
+      let settled = false
+      const settle = (started: boolean): void => {
+        if (settled) return
+        settled = true
+        resolveStart({ started })
       }
-    })()
 
-    return { started: true }
+      // Create an AbortController for this review's fix loop. The controller is registered
+      // before runReview starts so the abort-fix-loop handler can find it immediately.
+      const abortController = new AbortController()
+      const effectiveMainSessionId = mainSessionId ?? sessionId
+
+      void runReview({
+        sessionId,
+        turnMessageId,
+        scopeTurnMessageId,
+        projectId,
+        mainSessionId,
+        model: model ?? '',
+        getSession: () => session,
+        reviewRepository,
+        acpRuntime: options.acpRuntime,
+        // Artifacts live under the relocatable data root; DB/sessions stay on the config root.
+        artifactStorageRoot: dataRoot,
+        onStarted: () => settle(true),
+        onReviewUpdate: (review: ReviewWithChecks) => {
+          broadcastReviewUpdate({ review })
+        },
+        // Before the correction prompt is sent, suppress the next auto-review for the main
+        // session so the [Auditor] correction turn's stop event does not re-trigger a review.
+        onCorrectionPrompt: () => {
+          if (mainSessionId) {
+            broadcastSuppressNextAutoReview(mainSessionId)
+          }
+        },
+        // If the correction turn fails to send, its stop never arrives — clear the suppression so
+        // the session's next real turn still gets auto-reviewed.
+        onCorrectionFailed: () => {
+          if (mainSessionId) {
+            broadcastSuppressNextAutoReview(mainSessionId, true)
+          }
+        },
+        // Broadcast fix-loop lifecycle events and register/deregister the abort controller.
+        onFixLoopStart: () => {
+          fixLoopAbortControllers.set(effectiveMainSessionId, abortController)
+          broadcastFixLoopStart(effectiveMainSessionId)
+        },
+        onFixLoopEnd: () => {
+          fixLoopAbortControllers.delete(effectiveMainSessionId)
+          broadcastFixLoopEnd(effectiveMainSessionId)
+        },
+        fixLoopAbortSignal: abortController.signal
+      })
+        .catch((error: unknown) => {
+          // runReview records expected failures as lifecycle='error' itself; an unexpected throw here
+          // (e.g. the createReview insert failed before onStarted) is logged and reported as not-started.
+          log.error('runReview threw unexpectedly', {
+            sessionId,
+            turnMessageId,
+            error: error instanceof Error ? error.message : String(error)
+          })
+        })
+        .finally(() => {
+          // If the run ended without ever signalling onStarted, no review actually began.
+          settle(false)
+          inFlightReviewKeys.delete(inFlightKey)
+        })
+    })
   }
 
   return { triggerReview }

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -4,7 +4,12 @@
 
 import { ipcMain } from 'electron'
 
-import type { ReviewWithChecks, ReviewRunRequest, ReviewUpdateEvent } from '../../shared/reviewer'
+import type {
+  ReviewWithChecks,
+  ReviewRunRequest,
+  ReviewRunResult,
+  ReviewUpdateEvent
+} from '../../shared/reviewer'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { REVIEWER_IPC } from '../../shared/reviewer'
 import { createLogger } from '../logger'
@@ -66,7 +71,7 @@ type ReviewerIpcOptions = {
 const registerReviewerIpcHandlers = (
   options: ReviewerIpcOptions
 ): {
-  triggerReview: (request: ReviewRunRequest) => void
+  triggerReview: (request: ReviewRunRequest) => Promise<ReviewRunResult>
 } => {
   const storageRoot = options.storageRoot ?? resolveStorageRoot()
   const dataRoot = options.dataRoot ?? resolveDataRoot()
@@ -84,9 +89,7 @@ const registerReviewerIpcHandlers = (
 
   // reviewer:run — trigger a review for a completed turn. Fire-and-forget: the renderer does
   // not await this; it receives reviewer:updated events as the lifecycle progresses.
-  ipcMain.handle(REVIEWER_IPC.RUN, (_event, request: ReviewRunRequest) => {
-    triggerReview(request)
-  })
+  ipcMain.handle(REVIEWER_IPC.RUN, (_event, request: ReviewRunRequest) => triggerReview(request))
 
   // reviewer:get-for-session — load persisted reviews for a session at startup, flagging any whose
   // audited turn has since changed (e.g. an artifact was edited after the review completed) so the UI
@@ -115,26 +118,45 @@ const registerReviewerIpcHandlers = (
     }
   })
 
-  const triggerReview = (request: ReviewRunRequest): void => {
+  // Returns whether a review actually STARTED. The session is loaded up front (not in the background)
+  // so a load failure — or an already-in-flight run for this turn — is reported as started:false with
+  // NO Review row created. That lets a caller (e.g. the ReviewerCard "Re-run") release its pending
+  // state and leave the turn retriable, instead of us fabricating a non-retriable error review.
+  const triggerReview = async (request: ReviewRunRequest): Promise<ReviewRunResult> => {
     const { sessionId, turnMessageId, scopeTurnMessageId, projectId, mainSessionId, model } =
       request
 
-    // Drop a duplicate run for a turn already being reviewed (double-click / multiple stale cards).
+    // Reserve the turn SYNCHRONOUSLY (before any await) so a double-click / multiple stale cards can't
+    // both pass the guard before the key is set. Released on the start-failure paths and, on success,
+    // in the background run's finally.
     const inFlightKey = `${sessionId}:${turnMessageId}`
     if (inFlightReviewKeys.has(inFlightKey)) {
       log.info('review skipped: already in flight for this turn', { sessionId, turnMessageId })
-      return
+      return { started: false }
     }
     inFlightReviewKeys.add(inFlightKey)
 
+    let session: PersistedChatSession | undefined
+    try {
+      const { sessions } = await sessionRepository.loadAll()
+      session = sessions.find((s) => s.id === sessionId)
+    } catch (error) {
+      // No Review row exists to update, so surface the failure only as started:false — the renderer
+      // keeps the (stale) card and its Re-run affordance so the user can try again.
+      inFlightReviewKeys.delete(inFlightKey)
+      log.error('review start failed: could not load session', {
+        sessionId,
+        turnMessageId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return { started: false }
+    }
+
     log.info('review triggered', { sessionId, turnMessageId })
 
-    // Load the session from disk in the background so the orchestrator has the full session JSON.
+    // Run in the background; the review's lifecycle reaches the renderer via reviewer:updated events.
     void (async () => {
       try {
-        const { sessions } = await sessionRepository.loadAll()
-        const session = sessions.find((s) => s.id === sessionId)
-
         // Create an AbortController for this review's fix loop. The controller is registered
         // before runReview starts so the abort-fix-loop handler can find it immediately.
         const abortController = new AbortController()
@@ -181,37 +203,20 @@ const registerReviewerIpcHandlers = (
           fixLoopAbortSignal: abortController.signal
         })
       } catch (error) {
-        // A failure BEFORE runReview (e.g. loading the session throws) produces no Review row and thus
-        // no lifecycle update — so a renderer that started this run (e.g. the ReviewerCard "Re-run"
-        // latch) would wait forever. Broadcast a synthetic error review for the turn so the renderer
-        // unlatches and shows the failure; a later successful load replaces it with the real state.
-        const message = error instanceof Error ? error.message : String(error)
-        log.error('review start failed before runReview', {
+        // runReview never throws for expected failures (it records lifecycle='error' and broadcasts a
+        // real Review row). An unexpected throw here is logged; the review row, if any, carries the
+        // error state to the renderer.
+        log.error('runReview threw unexpectedly', {
           sessionId,
           turnMessageId,
-          error: message
-        })
-        broadcastReviewUpdate({
-          review: {
-            id: `review-start-error-${Date.now()}`,
-            projectId,
-            sessionId,
-            turnMessageId,
-            scope: { turnMessageId, blocks: [], artifactVersionIds: [] },
-            lifecycle: 'error',
-            outcome: null,
-            errorMessage: message,
-            model: model ?? '',
-            reviewerLog: [],
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-            checks: []
-          }
+          error: error instanceof Error ? error.message : String(error)
         })
       } finally {
         inFlightReviewKeys.delete(inFlightKey)
       }
     })()
+
+    return { started: true }
   }
 
   return { triggerReview }

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -181,9 +181,32 @@ const registerReviewerIpcHandlers = (
           fixLoopAbortSignal: abortController.signal
         })
       } catch (error) {
-        log.error('runReview threw unexpectedly', {
+        // A failure BEFORE runReview (e.g. loading the session throws) produces no Review row and thus
+        // no lifecycle update — so a renderer that started this run (e.g. the ReviewerCard "Re-run"
+        // latch) would wait forever. Broadcast a synthetic error review for the turn so the renderer
+        // unlatches and shows the failure; a later successful load replaces it with the real state.
+        const message = error instanceof Error ? error.message : String(error)
+        log.error('review start failed before runReview', {
           sessionId,
-          error: error instanceof Error ? error.message : String(error)
+          turnMessageId,
+          error: message
+        })
+        broadcastReviewUpdate({
+          review: {
+            id: `review-start-error-${Date.now()}`,
+            projectId,
+            sessionId,
+            turnMessageId,
+            scope: { turnMessageId, blocks: [], artifactVersionIds: [] },
+            lifecycle: 'error',
+            outcome: null,
+            errorMessage: message,
+            model: model ?? '',
+            reviewerLog: [],
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            checks: []
+          }
         })
       } finally {
         inFlightReviewKeys.delete(inFlightKey)

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -132,7 +132,9 @@ const registerReviewerIpcHandlers = (
     const inFlightKey = `${sessionId}:${turnMessageId}`
     if (inFlightReviewKeys.has(inFlightKey)) {
       log.info('review skipped: already in flight for this turn', { sessionId, turnMessageId })
-      return { started: false }
+      // The turn IS being handled by the in-flight run — this is NOT a retry candidate. Retrying
+      // after the lock releases would launch a duplicate review (and possibly a second fix loop).
+      return { started: false, reason: 'already-in-flight' }
     }
     inFlightReviewKeys.add(inFlightKey)
 
@@ -149,7 +151,8 @@ const registerReviewerIpcHandlers = (
         turnMessageId,
         error: error instanceof Error ? error.message : String(error)
       })
-      return { started: false }
+      // Transient store read failure — no Review row, lock released. Safe (and worth) retrying.
+      return { started: false, reason: 'load-failed' }
     }
 
     // Session load succeeded but the id is gone (deleted between the card render and the click).
@@ -160,7 +163,9 @@ const registerReviewerIpcHandlers = (
     if (!session) {
       inFlightReviewKeys.delete(inFlightKey)
       log.warn('review start failed: session not found', { sessionId, turnMessageId })
-      return { started: false }
+      // The session may simply not be flushed to disk yet (async persistence queue) — a retry can
+      // catch it once the write lands, so report the race-shaped reason rather than a hard failure.
+      return { started: false, reason: 'not-found' }
     }
 
     log.info('review triggered', { sessionId, turnMessageId })
@@ -171,10 +176,10 @@ const registerReviewerIpcHandlers = (
     // review (reviewer session + fix loop) continues in the background regardless.
     return await new Promise<ReviewRunResult>((resolveStart) => {
       let settled = false
-      const settle = (started: boolean): void => {
+      const settle = (result: ReviewRunResult): void => {
         if (settled) return
         settled = true
-        resolveStart({ started })
+        resolveStart(result)
       }
 
       // Create an AbortController for this review's fix loop. The controller is registered
@@ -194,7 +199,7 @@ const registerReviewerIpcHandlers = (
         acpRuntime: options.acpRuntime,
         // Artifacts live under the relocatable data root; DB/sessions stay on the config root.
         artifactStorageRoot: dataRoot,
-        onStarted: () => settle(true),
+        onStarted: () => settle({ started: true }),
         onReviewUpdate: (review: ReviewWithChecks) => {
           broadcastReviewUpdate({ review })
         },
@@ -233,8 +238,9 @@ const registerReviewerIpcHandlers = (
           })
         })
         .finally(() => {
-          // If the run ended without ever signalling onStarted, no review actually began.
-          settle(false)
+          // If the run ended without ever signalling onStarted, no review actually began — this is a
+          // genuine pre-push failure (scope/insert), not a persistence race, so it is not auto-retried.
+          settle({ started: false, reason: 'run-failed' })
           inFlightReviewKeys.delete(inFlightKey)
         })
     })

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -5,9 +5,11 @@
 import { ipcMain } from 'electron'
 
 import type { ReviewWithChecks, ReviewRunRequest, ReviewUpdateEvent } from '../../shared/reviewer'
+import type { PersistedChatSession } from '../../shared/session-persistence'
 import { REVIEWER_IPC } from '../../shared/reviewer'
 import { createLogger } from '../logger'
 import { runReview } from './orchestrator'
+import { flagStaleReviews } from './stale-reviews'
 import { ReviewRepository } from './repository'
 import type { AcpRuntime } from '../acp/runtime'
 import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
@@ -81,9 +83,19 @@ const registerReviewerIpcHandlers = (
     triggerReview(request)
   })
 
-  // reviewer:get-for-session — load persisted reviews for a session at startup.
+  // reviewer:get-for-session — load persisted reviews for a session at startup, flagging any whose
+  // audited turn has since changed (e.g. an artifact was edited after the review completed) so the UI
+  // does not present a stale verdict as current.
   ipcMain.handle(REVIEWER_IPC.GET_FOR_SESSION, async (_event, sessionId: string) => {
-    return reviewRepository.getReviewsForSession(sessionId)
+    const reviews = await reviewRepository.getReviewsForSession(sessionId)
+    let session: PersistedChatSession | undefined
+    try {
+      const { sessions } = await sessionRepository.loadAll()
+      session = sessions.find((candidate) => candidate.id === sessionId)
+    } catch {
+      return reviews
+    }
+    return flagStaleReviews(reviews, session, dataRoot)
   })
 
   // reviewer:abort-fix-loop — renderer requests that the active fix loop for a session be aborted.

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -154,13 +154,17 @@ const registerReviewerIpcHandlers = (
           return { started: false, reason: 'already-reviewed' }
         }
       } catch (error) {
-        // A review-store read failure is non-fatal here: fall through and let the normal session
-        // load + run guard correctness. Worst case is the duplicate this check would have prevented.
-        log.warn('auto-review idempotency check failed; proceeding', {
+        // Fail CLOSED: if the lookup itself threw we cannot confirm the turn is un-reviewed, and
+        // proceeding could create a second review/fix-loop for a turn that already has one — exactly the
+        // cross-entry duplicate this check exists to prevent. Release the lock and report a retryable
+        // failure so the auto path re-runs the (now hopefully recovered) check instead of duplicating.
+        inFlightReviewKeys.delete(inFlightKey)
+        log.warn('auto-review idempotency check failed; refusing to start (fail-closed)', {
           sessionId,
           turnMessageId,
           error: error instanceof Error ? error.message : String(error)
         })
+        return { started: false, reason: 'idempotency-check-failed' }
       }
     }
 

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -77,6 +77,11 @@ const registerReviewerIpcHandlers = (
   // reviewer session id). Entries are created when a fix loop starts and deleted when it ends.
   const fixLoopAbortControllers = new Map<string, AbortController>()
 
+  // Guards against concurrent reviews of the same turn — e.g. a double-clicked "Re-run review" or two
+  // stale cards fired at once. Keyed by `${sessionId}:${turnMessageId}` (the grouping turn), cleared
+  // when the run settles. The renderer also disables its button, but this is the authoritative guard.
+  const inFlightReviewKeys = new Set<string>()
+
   // reviewer:run — trigger a review for a completed turn. Fire-and-forget: the renderer does
   // not await this; it receives reviewer:updated events as the lifecycle progresses.
   ipcMain.handle(REVIEWER_IPC.RUN, (_event, request: ReviewRunRequest) => {
@@ -111,7 +116,16 @@ const registerReviewerIpcHandlers = (
   })
 
   const triggerReview = (request: ReviewRunRequest): void => {
-    const { sessionId, turnMessageId, projectId, mainSessionId, model } = request
+    const { sessionId, turnMessageId, scopeTurnMessageId, projectId, mainSessionId, model } =
+      request
+
+    // Drop a duplicate run for a turn already being reviewed (double-click / multiple stale cards).
+    const inFlightKey = `${sessionId}:${turnMessageId}`
+    if (inFlightReviewKeys.has(inFlightKey)) {
+      log.info('review skipped: already in flight for this turn', { sessionId, turnMessageId })
+      return
+    }
+    inFlightReviewKeys.add(inFlightKey)
 
     log.info('review triggered', { sessionId, turnMessageId })
 
@@ -129,6 +143,7 @@ const registerReviewerIpcHandlers = (
         await runReview({
           sessionId,
           turnMessageId,
+          scopeTurnMessageId,
           projectId,
           mainSessionId,
           model: model ?? '',
@@ -170,6 +185,8 @@ const registerReviewerIpcHandlers = (
           sessionId,
           error: error instanceof Error ? error.message : String(error)
         })
+      } finally {
+        inFlightReviewKeys.delete(inFlightKey)
       }
     })()
   }

--- a/src/main/reviewer/orchestrator.start-contract.test.ts
+++ b/src/main/reviewer/orchestrator.start-contract.test.ts
@@ -19,14 +19,14 @@ vi.mock('./host-sdk', () => ({
     start = vi.fn().mockResolvedValue({ endpoint: 'http://127.0.0.1:0', token: 'tok' })
     stop = vi.fn().mockResolvedValue(undefined)
   },
-  buildReviewerHostPythonBootstrap: () => ''
+  buildReviewerHostPythonBootstrap: (): string => ''
 }))
 
 vi.mock('./mcp-server', () => ({
   ReviewerMcpServer: class {
     start = vi.fn().mockResolvedValue(undefined)
     stop = vi.fn().mockResolvedValue(undefined)
-    toAcpMcpServerConfig = () => ({})
+    toAcpMcpServerConfig = (): Record<string, never> => ({})
   }
 }))
 

--- a/src/main/reviewer/orchestrator.start-contract.test.ts
+++ b/src/main/reviewer/orchestrator.start-contract.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Review, ReviewWithChecks, TurnScope } from '../../shared/reviewer'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { ReviewRepository } from './repository'
+import type { AcpRuntime } from '../acp/runtime'
+
+// This is the REAL orchestrator side of the started-contract that ipc.ts depends on: runReview must
+// call onStarted only AFTER the running Review row has been created and pushed (onReviewUpdate), and
+// must NOT call it if the run fails before that (scope resolution or the createReview insert). The
+// ipc.test.ts suite can only assert the IPC's translation of a MOCK runReview; this file pins the
+// orchestrator behavior that translation relies on.
+
+// Stub the heavy reviewer collaborators so runReview reaches the reviewer-session step without opening
+// real HTTP/MCP servers. We force the session build to reject so the run errors out fast — onStarted
+// has already fired by then, which is exactly the ordering under test.
+vi.mock('./host-sdk', () => ({
+  ReviewerHostServer: class {
+    start = vi.fn().mockResolvedValue({ endpoint: 'http://127.0.0.1:0', token: 'tok' })
+    stop = vi.fn().mockResolvedValue(undefined)
+  },
+  buildReviewerHostPythonBootstrap: () => ''
+}))
+
+vi.mock('./mcp-server', () => ({
+  ReviewerMcpServer: class {
+    start = vi.fn().mockResolvedValue(undefined)
+    stop = vi.fn().mockResolvedValue(undefined)
+    toAcpMcpServerConfig = () => ({})
+  }
+}))
+
+const resolveTurnScopeWithArtifactDigests = vi.fn()
+vi.mock('./artifact-digest', () => ({
+  resolveTurnScopeWithArtifactDigests: (...args: unknown[]) =>
+    resolveTurnScopeWithArtifactDigests(...args)
+}))
+
+const { runReview } = await import('./orchestrator')
+
+const scope: TurnScope = { turnMessageId: 'turn-1', blocks: [], artifactVersionIds: [] }
+
+const runningReview = (): Review => ({
+  id: 'review-1',
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  turnMessageId: 'turn-1',
+  scope,
+  lifecycle: 'running',
+  outcome: null,
+  model: '',
+  reviewerLog: [],
+  createdAt: 1_000,
+  updatedAt: 1_000
+})
+
+const session = { id: 'session-1', cwd: '', messages: [] } as unknown as PersistedChatSession
+
+// The reviewer session build always rejects here: the run errors out right after onStarted, keeping
+// the test focused on the start-contract without needing a full reviewer drive.
+const acpRuntime = {
+  buildReviewerSession: vi.fn().mockRejectedValue(new Error('build failed')),
+  disposeReviewerSession: vi.fn()
+} as unknown as AcpRuntime
+
+const makeRepo = (createReview: ReviewRepository['createReview']): ReviewRepository =>
+  ({
+    createReview,
+    updateReview: vi.fn().mockImplementation(async (id: string, patch: Partial<Review>) => ({
+      ...runningReview(),
+      id,
+      ...patch
+    })),
+    addChecks: vi.fn().mockResolvedValue(undefined),
+    getReviewsForSession: vi.fn().mockResolvedValue([])
+  }) as unknown as ReviewRepository
+
+const baseOptions = (
+  reviewRepository: ReviewRepository,
+  hooks: { onStarted: () => void; onReviewUpdate: (r: ReviewWithChecks) => void }
+): Parameters<typeof runReview>[0] => ({
+  sessionId: 'session-1',
+  turnMessageId: 'turn-1',
+  projectId: 'project-1',
+  getSession: () => session,
+  reviewRepository,
+  acpRuntime,
+  artifactStorageRoot: '/tmp/data-root',
+  onStarted: hooks.onStarted,
+  onReviewUpdate: hooks.onReviewUpdate
+})
+
+describe('runReview started-contract (real orchestrator)', () => {
+  beforeEach(() => {
+    resolveTurnScopeWithArtifactDigests.mockReset()
+    resolveTurnScopeWithArtifactDigests.mockResolvedValue(scope)
+  })
+
+  it('calls onStarted exactly once, after the running row is created and pushed', async () => {
+    const events: string[] = []
+    const createReview = vi.fn().mockImplementation(async () => {
+      events.push('createReview')
+      return runningReview()
+    })
+    const onStarted = vi.fn().mockImplementation(() => events.push('onStarted'))
+    const onReviewUpdate = vi
+      .fn()
+      .mockImplementation((r: ReviewWithChecks) => events.push(`update:${r.lifecycle}`))
+
+    await runReview(baseOptions(makeRepo(createReview), { onStarted, onReviewUpdate }))
+
+    expect(onStarted).toHaveBeenCalledTimes(1)
+    // The running row must be created and pushed to the renderer before start is confirmed.
+    expect(events.slice(0, 3)).toEqual(['createReview', 'update:running', 'onStarted'])
+  })
+
+  it('never calls onStarted when the createReview insert fails before the push', async () => {
+    const onStarted = vi.fn()
+    const onReviewUpdate = vi.fn()
+    const createReview = vi.fn().mockRejectedValue(new Error('insert failed'))
+
+    // The pre-push failure propagates out of runReview (createReview runs before the try/catch), which
+    // is how ipc.ts's `.catch` reports started:false and leaves the turn retriable.
+    await expect(
+      runReview(baseOptions(makeRepo(createReview), { onStarted, onReviewUpdate }))
+    ).rejects.toThrow('insert failed')
+
+    expect(onStarted).not.toHaveBeenCalled()
+    expect(onReviewUpdate).not.toHaveBeenCalled()
+  })
+
+  it('never calls onStarted when scope resolution fails before the push', async () => {
+    resolveTurnScopeWithArtifactDigests.mockRejectedValueOnce(new Error('scope failed'))
+    const onStarted = vi.fn()
+    const onReviewUpdate = vi.fn()
+    const createReview = vi.fn().mockResolvedValue(runningReview())
+
+    await expect(
+      runReview(baseOptions(makeRepo(createReview), { onStarted, onReviewUpdate }))
+    ).rejects.toThrow('scope failed')
+
+    expect(onStarted).not.toHaveBeenCalled()
+    expect(createReview).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -607,7 +607,11 @@ const runScopedReview = async (options: {
   }
 
   // Resolve the correction turn's scope, pinning each artifact to a digest of its current bytes.
-  const scope = await resolveTurnScopeWithArtifactDigests(session, turnMessageId, artifactStorageRoot)
+  const scope = await resolveTurnScopeWithArtifactDigests(
+    session,
+    turnMessageId,
+    artifactStorageRoot
+  )
 
   // Create a new Review row sharing the originalTurnMessageId (not the correction turn's id),
   // so all iterations are grouped under the same original turn.
@@ -782,7 +786,11 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
     return withFindings
   }
 
-  const scope = await resolveTurnScopeWithArtifactDigests(session, turnMessageId, artifactStorageRoot)
+  const scope = await resolveTurnScopeWithArtifactDigests(
+    session,
+    turnMessageId,
+    artifactStorageRoot
+  )
 
   // Step 2: create the Review row (lifecycle='running') immediately so the renderer shows a spinner.
   let review = await reviewRepository.createReview({

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -34,8 +34,13 @@ const log = createLogger('reviewer:orchestrator')
 
 export type RunReviewOptions = {
   sessionId: string
-  // The turn to review: the agent message id (or user message id) for that turn.
+  // The turn to review: the agent message id (or user message id) for that turn. This is also the
+  // grouping id stored on the Review row.
   turnMessageId: string
+  // Turn whose content is audited when it differs from turnMessageId (e.g. re-running a fix-loop
+  // review). The scope is resolved from this turn; the row is still grouped under turnMessageId.
+  // Defaults to turnMessageId.
+  scopeTurnMessageId?: string
   // The project this session belongs to.
   projectId: string
   // Used to resolve the session's persisted data for turn-scope resolution.
@@ -747,6 +752,7 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
   const {
     sessionId,
     turnMessageId,
+    scopeTurnMessageId,
     projectId,
     getSession,
     reviewRepository,
@@ -786,9 +792,10 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
     return withFindings
   }
 
+  // Audit the scope turn (defaults to the grouping turn) but keep the row grouped under turnMessageId.
   const scope = await resolveTurnScopeWithArtifactDigests(
     session,
-    turnMessageId,
+    scopeTurnMessageId ?? turnMessageId,
     artifactStorageRoot
   )
 

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -41,6 +41,10 @@ export type RunReviewOptions = {
   // review). The scope is resolved from this turn; the row is still grouped under turnMessageId.
   // Defaults to turnMessageId.
   scopeTurnMessageId?: string
+  // Called once the running Review row has been created and pushed — i.e. the review is confirmed to
+  // have started. A failure before this point (scope resolution, the DB insert) throws without calling
+  // it, so the caller can report started:false and leave the turn retriable.
+  onStarted?: () => void
   // The project this session belongs to.
   projectId: string
   // Used to resolve the session's persisted data for turn-scope resolution.
@@ -760,6 +764,7 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
     artifactStorageRoot,
     model = '',
     onReviewUpdate,
+    onStarted,
     mainSessionId,
     onCorrectionPrompt,
     onCorrectionFailed,
@@ -811,6 +816,10 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
 
   const initialWithFindings: ReviewWithChecks = { ...review, checks: [] }
   onReviewUpdate?.(initialWithFindings)
+  // The running row now exists and has been pushed to the renderer — this is the point a caller can
+  // treat the review as genuinely "started". Anything that failed before here (scope resolution, the
+  // createReview insert) threw instead, so `started` is never reported for a run that never appeared.
+  onStarted?.()
 
   log.info('review created', { reviewId: review.id, blocks: scope.blocks.length })
 

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -23,7 +23,7 @@ import type {
   TurnScope
 } from '../../shared/reviewer'
 import type { ReviewRepository } from './repository'
-import { resolveTurnScope } from './scope'
+import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { ReviewerMcpServer } from './mcp-server'
 import { buildReviewerHostPythonBootstrap, ReviewerHostServer } from './host-sdk'
@@ -606,8 +606,8 @@ const runScopedReview = async (options: {
     return { ...errorReview, checks: [] }
   }
 
-  // Resolve the correction turn's scope.
-  const scope = resolveTurnScope(session, turnMessageId)
+  // Resolve the correction turn's scope, pinning each artifact to a digest of its current bytes.
+  const scope = await resolveTurnScopeWithArtifactDigests(session, turnMessageId, artifactStorageRoot)
 
   // Create a new Review row sharing the originalTurnMessageId (not the correction turn's id),
   // so all iterations are grouped under the same original turn.
@@ -782,7 +782,7 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
     return withFindings
   }
 
-  const scope = resolveTurnScope(session, turnMessageId)
+  const scope = await resolveTurnScopeWithArtifactDigests(session, turnMessageId, artifactStorageRoot)
 
   // Step 2: create the Review row (lifecycle='running') immediately so the renderer shows a spinner.
   let review = await reviewRepository.createReview({

--- a/src/main/reviewer/repository.test.ts
+++ b/src/main/reviewer/repository.test.ts
@@ -461,4 +461,68 @@ describe('review repository (integration)', () => {
     const others = stored.checks.filter((c) => c.claim !== 'ran 33 rows')
     expect(others.every((c) => c.reflagCount === 0)).toBe(true)
   })
+
+  it('rolls back the finding write when the version bump (touchReview) fails', async () => {
+    // Prove the atomicity guarantee: the finding mutation and the Review.updatedAt bump commit together
+    // or not at all. Use the REAL transaction (so rollback is real) but force the review.update inside
+    // it to throw, standing in for a version-bump failure after the finding write has been staged.
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-reviewer-'))
+    const realClient = createProjectDbClient(storageRoot)
+    await ensureProjectSchema(realClient)
+    client = realClient
+
+    // Client whose $transaction runs the real one but, once armed, hands the callback a tx whose
+    // review.update rejects — everything else (finding writes, $executeRaw) uses the real tx. Arming is
+    // deferred so the setup writes below (which also bump the version) succeed normally.
+    let failTouch = false
+    const failingClient = {
+      review: realClient.review,
+      finding: realClient.finding,
+      $executeRaw: realClient.$executeRaw.bind(realClient),
+      $transaction: ((callback: (tx: Record<string, unknown>) => Promise<unknown>) =>
+        realClient.$transaction((tx) => {
+          const txRecord = tx as unknown as {
+            review: { update: (...args: unknown[]) => Promise<unknown> }
+          }
+          return callback({
+            ...(tx as unknown as Record<string, unknown>),
+            review: {
+              ...txRecord.review,
+              update: (...args: unknown[]) =>
+                failTouch
+                  ? Promise.reject(new Error('touch failed'))
+                  : txRecord.review.update(...args)
+            }
+          })
+        })) as PrismaClient['$transaction']
+    } as unknown as PrismaClient
+
+    const repository = new ReviewRepository(() => Promise.resolve(failingClient))
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-rollback',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+    await repository.addChecks(review.id, [
+      {
+        status: 'fail',
+        claim: 'ran 33 rows',
+        evidence: 'tool_result shows 0 rows',
+        locator: { blockRef: { blockIndex: 0 }, contentHash: 'h1' },
+        sortIndex: 0
+      }
+    ])
+
+    // The reflag increment + touchReview run in one transaction; the forced touch failure rejects it.
+    failTouch = true
+    await expect(repository.incrementReflagCount(review.id, 'ran 33 rows')).rejects.toThrow(
+      /touch failed/
+    )
+    failTouch = false
+
+    // Read back with the real client: the reflag increment was rolled back (still 0), not left partial.
+    const [stored] = await repository.getReviewsForSession('session-rollback')
+    expect(stored.checks[0]!.reflagCount).toBe(0)
+  })
 })

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -22,10 +22,18 @@ type FindingSeverity = CheckStatus
 // Only the review/finding delegates are needed; typing to this subset keeps the repository unit-testable
 // with a lightweight mock instead of a real (engine-backed) PrismaClient.
 // $executeRaw is also included for the incrementReflagCount atomic update (issue 15).
-type ReviewClient = Pick<PrismaClient, 'review' | 'finding' | '$executeRaw'>
+type ReviewClient = Pick<PrismaClient, 'review' | 'finding' | '$executeRaw' | '$transaction'>
 
 // Resolves the Prisma client on demand so a failed initialization is not held forever (see projects/repository.ts).
 type ReviewClientProvider = () => Promise<ReviewClient>
+
+// Bumps a Review's updatedAt within the caller's transaction. Prisma's @updatedAt tracks writes to the
+// Review row, not to child Finding rows, so a finding-only mutation (resolution/reflag) would otherwise
+// leave updatedAt stale — and a slow focus-load could then overwrite newer pushed finding state at an
+// equal timestamp. Run inside the same transaction as the finding write so the two commit atomically.
+const touchReview = async (tx: Pick<PrismaClient, 'review'>, reviewId: string): Promise<void> => {
+  await tx.review.update({ where: { id: reviewId }, data: { updatedAt: new Date() } })
+}
 
 // JSON columns are parsed defensively: a corrupt value degrades to the given fallback rather than
 // throwing, so one bad row cannot break loading a whole session's reviews.
@@ -147,19 +155,21 @@ class ReviewRepository {
 
     const client = await this.getClient()
 
-    await client.finding.createMany({
-      data: checks.map((check, index) => ({
-        reviewId,
-        status: check.status,
-        resolution: check.resolution ?? 'open',
-        claim: check.claim,
-        evidence: check.evidence,
-        locator: JSON.stringify(check.locator ?? {}),
-        artifactVersionId: check.artifactVersionId ?? null,
-        sortIndex: check.sortIndex ?? index
-      }))
+    await client.$transaction(async (tx) => {
+      await tx.finding.createMany({
+        data: checks.map((check, index) => ({
+          reviewId,
+          status: check.status,
+          resolution: check.resolution ?? 'open',
+          claim: check.claim,
+          evidence: check.evidence,
+          locator: JSON.stringify(check.locator ?? {}),
+          artifactVersionId: check.artifactVersionId ?? null,
+          sortIndex: check.sortIndex ?? index
+        }))
+      })
+      await touchReview(tx, reviewId)
     })
-    await this.touchReview(reviewId)
   }
 
   /**
@@ -213,11 +223,15 @@ class ReviewRepository {
   // since resolution is meaningless for them (see design.md §4.2).
   async updateFindingResolutions(reviewId: string, resolution: FindingResolution): Promise<void> {
     const client = await this.getClient()
-    await client.finding.updateMany({
-      where: { reviewId, status: { in: ['warn', 'fail'] } },
-      data: { resolution }
+    // One transaction so the finding change and the version bump commit together (or not at all): a
+    // partial write leaving new findings under a stale updatedAt would let a focus-load keep old data.
+    await client.$transaction(async (tx) => {
+      await tx.finding.updateMany({
+        where: { reviewId, status: { in: ['warn', 'fail'] } },
+        data: { resolution }
+      })
+      await touchReview(tx, reviewId)
     })
-    await this.touchReview(reviewId)
   }
 
   // Updates the resolution for a single claim (by exact match) under a review.
@@ -228,11 +242,13 @@ class ReviewRepository {
     resolution: FindingResolution
   ): Promise<void> {
     const client = await this.getClient()
-    await client.finding.updateMany({
-      where: { reviewId, claim, status: { in: ['warn', 'fail'] } },
-      data: { resolution }
+    await client.$transaction(async (tx) => {
+      await tx.finding.updateMany({
+        where: { reviewId, claim, status: { in: ['warn', 'fail'] } },
+        data: { resolution }
+      })
+      await touchReview(tx, reviewId)
     })
-    await this.touchReview(reviewId)
   }
 
   // Increments reflagCount by 1 for all checks under a review whose claim matches the given string
@@ -240,24 +256,17 @@ class ReviewRepository {
   // over-correction. Leaves checks with a different claim untouched.
   async incrementReflagCount(reviewId: string, claim: string): Promise<void> {
     const client = await this.getClient()
-    // Use the $executeRaw tagged template because Prisma does not support a column += 1 increment
-    // in updateMany. The query is safe: reviewId and claim are bound as positional parameters by the
-    // tagged template (not string-interpolated), so this is not $executeRawUnsafe.
-    await client.$executeRaw`
-      UPDATE "Finding"
-      SET "reflagCount" = "reflagCount" + 1
-      WHERE "reviewId" = ${reviewId} AND "claim" = ${claim}
-    `
-    await this.touchReview(reviewId)
-  }
-
-  // Bumps the parent Review's updatedAt after a finding-only mutation. Prisma's @updatedAt tracks
-  // Review-row writes, not writes to child Finding rows, so without this a fix-loop resolution/reflag
-  // change would leave updatedAt stale — and a slow focus-load could then overwrite the newer pushed
-  // finding state (equal timestamps). Bumping it makes updatedAt a reliable freshness/version signal.
-  private async touchReview(reviewId: string): Promise<void> {
-    const client = await this.getClient()
-    await client.review.update({ where: { id: reviewId }, data: { updatedAt: new Date() } })
+    await client.$transaction(async (tx) => {
+      // Use the $executeRaw tagged template because Prisma does not support a column += 1 increment
+      // in updateMany. The query is safe: reviewId and claim are bound as positional parameters by the
+      // tagged template (not string-interpolated), so this is not $executeRawUnsafe.
+      await tx.$executeRaw`
+        UPDATE "Finding"
+        SET "reflagCount" = "reflagCount" + 1
+        WHERE "reviewId" = ${reviewId} AND "claim" = ${claim}
+      `
+      await touchReview(tx, reviewId)
+    })
   }
 
   // Test/diagnostic helper: total check rows, used to assert no orphans survive a cascade delete.

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -159,6 +159,7 @@ class ReviewRepository {
         sortIndex: check.sortIndex ?? index
       }))
     })
+    await this.touchReview(reviewId)
   }
 
   /**
@@ -216,6 +217,7 @@ class ReviewRepository {
       where: { reviewId, status: { in: ['warn', 'fail'] } },
       data: { resolution }
     })
+    await this.touchReview(reviewId)
   }
 
   // Updates the resolution for a single claim (by exact match) under a review.
@@ -230,6 +232,7 @@ class ReviewRepository {
       where: { reviewId, claim, status: { in: ['warn', 'fail'] } },
       data: { resolution }
     })
+    await this.touchReview(reviewId)
   }
 
   // Increments reflagCount by 1 for all checks under a review whose claim matches the given string
@@ -245,6 +248,16 @@ class ReviewRepository {
       SET "reflagCount" = "reflagCount" + 1
       WHERE "reviewId" = ${reviewId} AND "claim" = ${claim}
     `
+    await this.touchReview(reviewId)
+  }
+
+  // Bumps the parent Review's updatedAt after a finding-only mutation. Prisma's @updatedAt tracks
+  // Review-row writes, not writes to child Finding rows, so without this a fix-loop resolution/reflag
+  // change would leave updatedAt stale — and a slow focus-load could then overwrite the newer pushed
+  // finding state (equal timestamps). Bumping it makes updatedAt a reliable freshness/version signal.
+  private async touchReview(reviewId: string): Promise<void> {
+    const client = await this.getClient()
+    await client.review.update({ where: { id: reviewId }, data: { updatedAt: new Date() } })
   }
 
   // Test/diagnostic helper: total check rows, used to assert no orphans survive a cascade delete.

--- a/src/main/reviewer/scope.test.ts
+++ b/src/main/reviewer/scope.test.ts
@@ -5,7 +5,7 @@ import type {
   PersistedChatSession,
   PersistedToolActivity
 } from '../../shared/session-persistence'
-import { resolveTurnScope } from './scope'
+import { isTurnScopeStale, resolveTurnScope } from './scope'
 
 // Builds a persisted message with sensible defaults; callers override only what a case cares about.
 const message = (
@@ -162,5 +162,33 @@ describe('resolveTurnScope', () => {
       blocks: [],
       artifactVersionIds: []
     })
+  })
+})
+
+describe('isTurnScopeStale', () => {
+  it('is false for the identical scope recomputed twice', () => {
+    const scope = resolveTurnScope(buildSession(), 'a1', new Map([['art-1', 'sha256:aaa']]))
+    const again = resolveTurnScope(buildSession(), 'a1', new Map([['art-1', 'sha256:aaa']]))
+
+    expect(isTurnScopeStale(scope, again)).toBe(false)
+  })
+
+  it('is true when a block the stored review audited has changed since (e.g. artifact edit)', () => {
+    const stored = resolveTurnScope(buildSession(), 'a1', new Map([['art-1', 'sha256:aaa']]))
+    // The artifact was edited outside the app after the review ran — its digest changes.
+    const current = resolveTurnScope(buildSession(), 'a1', new Map([['art-1', 'sha256:bbb']]))
+
+    expect(isTurnScopeStale(stored, current)).toBe(true)
+  })
+
+  it("is true when the turn's own message content changed after the review ran", () => {
+    const stored = resolveTurnScope(buildSession(), 'a1')
+
+    const edited = buildSession()
+    const agentMessage = edited.messages.find((message) => message.id === 'a1')
+    if (agentMessage) agentMessage.content = 'agent a1 (edited)'
+    const current = resolveTurnScope(edited, 'a1')
+
+    expect(isTurnScopeStale(stored, current)).toBe(true)
   })
 })

--- a/src/main/reviewer/scope.test.ts
+++ b/src/main/reviewer/scope.test.ts
@@ -130,6 +130,30 @@ describe('resolveTurnScope', () => {
     expect(editedUserHash).toBe(baseUserHash)
   })
 
+  it('folds an artifact content digest into the block hash so external edits invalidate it', () => {
+    const withV1 = resolveTurnScope(buildSession(), 'a1', new Map([['art-1', 'sha256:aaa']]))
+    const withV1Again = resolveTurnScope(buildSession(), 'a1', new Map([['art-1', 'sha256:aaa']]))
+    const withV2 = resolveTurnScope(buildSession(), 'a1', new Map([['art-1', 'sha256:bbb']]))
+
+    const hashOf = (scope: ReturnType<typeof resolveTurnScope>): string | undefined =>
+      scope.blocks.find((block) => block.sourceId === 'a1')?.contentHash
+
+    // Same digest → same hash; a changed digest (external byte edit) → different hash.
+    expect(hashOf(withV1Again)).toBe(hashOf(withV1))
+    expect(hashOf(withV2)).not.toBe(hashOf(withV1))
+  })
+
+  it('does not change hashes of messages without artifacts when digests are supplied', () => {
+    const withoutDigests = resolveTurnScope(buildSession(), 'a1')
+    const withDigests = resolveTurnScope(buildSession(), 'a1', new Map([['art-1', 'sha256:aaa']]))
+
+    // u1 has no artifacts, so its hash is identical with or without a digest map — existing locators
+    // on artifact-free blocks stay valid across this change.
+    const u1 = (scope: ReturnType<typeof resolveTurnScope>): string | undefined =>
+      scope.blocks.find((block) => block.sourceId === 'u1')?.contentHash
+    expect(u1(withDigests)).toBe(u1(withoutDigests))
+  })
+
   it('returns an empty scope for an unknown turn message id', () => {
     const scope = resolveTurnScope(buildSession(), 'does-not-exist')
 

--- a/src/main/reviewer/scope.ts
+++ b/src/main/reviewer/scope.ts
@@ -43,13 +43,26 @@ const hashContent = (value: unknown): string =>
   createHash('sha256').update(stableStringify(value)).digest('hex')
 
 // Hashes only the durable, reviewer-relevant fields of a message so cosmetic/runtime churn does not
-// invalidate a locator, while any change to what the agent actually said or produced does.
-const hashMessage = (message: PersistedChatMessage): string =>
-  hashContent({
+// invalidate a locator, while any change to what the agent actually said or produced does. When
+// artifact digests are supplied, each referenced artifact's current content digest is folded in so an
+// external edit to a generated file invalidates this block's hash (and any finding locator anchored to
+// it) — the id alone never pinned the bytes. Messages with no artifacts keep their prior hash exactly,
+// so existing locators stay valid across this change.
+const hashMessage = (
+  message: PersistedChatMessage,
+  artifactDigests: ReadonlyMap<string, string>
+): string => {
+  const artifactIds = [...(message.artifactIds ?? [])].sort()
+
+  return hashContent({
     role: message.role,
     content: message.content,
-    artifactIds: [...(message.artifactIds ?? [])].sort()
+    artifactIds,
+    ...(artifactIds.length > 0
+      ? { artifactDigests: artifactIds.map((id) => artifactDigests.get(id) ?? null) }
+      : {})
   })
+}
 
 // Hashes the execution record of a tool activity — the ground truth the reviewer compares claims against.
 const hashActivity = (activity: PersistedToolActivity): string =>
@@ -100,7 +113,8 @@ const isUserMessage = (item: TurnItem): boolean =>
 // from other turns are never included. An unknown id yields an empty scope so callers can no-op safely.
 export const resolveTurnScope = (
   session: PersistedChatSession,
-  turnMessageId: string
+  turnMessageId: string,
+  artifactDigests: ReadonlyMap<string, string> = new Map()
 ): TurnScope => {
   const items = buildOrderedItems(session)
   const targetIndex = items.findIndex((item) => item.sourceId === turnMessageId)
@@ -126,7 +140,10 @@ export const resolveTurnScope = (
     kind: item.kind,
     sourceId: item.sourceId,
     blockIndex,
-    contentHash: item.kind === 'message' ? hashMessage(item.message) : hashActivity(item.activity)
+    contentHash:
+      item.kind === 'message'
+        ? hashMessage(item.message, artifactDigests)
+        : hashActivity(item.activity)
   }))
 
   const artifactVersionIds: string[] = []

--- a/src/main/reviewer/scope.ts
+++ b/src/main/reviewer/scope.ts
@@ -156,3 +156,15 @@ export const resolveTurnScope = (
 
   return { turnMessageId, blocks, artifactVersionIds }
 }
+
+// Reports whether a stored review scope no longer matches the freshly-resolved scope for the same turn.
+// A review is stale when any block it audited has since changed, disappeared, or was added — including
+// an artifact edit, which changes its producing message block's content hash (the digest is folded in
+// by resolveTurnScopeWithArtifactDigests). Used at load time so the UI can flag a review whose verdict
+// no longer describes the current turn instead of presenting a stale "No issues found" as current.
+export const isTurnScopeStale = (stored: TurnScope, current: TurnScope): boolean => {
+  const hashesOf = (scope: TurnScope): string =>
+    scope.blocks.map((block) => `${block.sourceId}:${block.contentHash}`).join('\n')
+
+  return hashesOf(stored) !== hashesOf(current)
+}

--- a/src/main/reviewer/stale-reviews.ts
+++ b/src/main/reviewer/stale-reviews.ts
@@ -17,19 +17,34 @@ export const flagStaleReviews = async (
   if (reviews.length === 0 || !session) return reviews
   const currentSession = session
 
-  return Promise.all(
-    reviews.map(async (review) => {
-      if (review.lifecycle !== 'complete') return review
-      try {
-        const current = await resolveTurnScopeWithArtifactDigests(
-          currentSession,
-          review.turnMessageId,
-          artifactStorageRoot
-        )
-        return isTurnScopeStale(review.scope, current) ? { ...review, stale: true } : review
-      } catch {
-        return review
-      }
-    })
-  )
+  // Sequential across reviews: resolveTurnScopeWithArtifactDigests already bounds concurrency *within*
+  // one scope, but a Promise.all here would multiply that by the number of reviews and could exhaust
+  // file descriptors on a session with a long review history (then fail-open, hiding staleness).
+  const flagged: ReviewWithChecks[] = []
+  for (const review of reviews) {
+    flagged.push(await flagOne(review, currentSession, artifactStorageRoot))
+  }
+  return flagged
+}
+
+// Recomputes one review's scope and returns it marked stale when it no longer matches.
+const flagOne = async (
+  review: ReviewWithChecks,
+  session: PersistedChatSession,
+  artifactStorageRoot: string
+): Promise<ReviewWithChecks> => {
+  if (review.lifecycle !== 'complete') return review
+  try {
+    // Recompute against the turn the stored scope was actually resolved for, not review.turnMessageId:
+    // a fix-loop re-review is grouped under the ORIGINAL turn id but its scope belongs to the correction
+    // turn, so using review.turnMessageId would resolve a different turn and mark it stale every time.
+    const current = await resolveTurnScopeWithArtifactDigests(
+      session,
+      review.scope.turnMessageId,
+      artifactStorageRoot
+    )
+    return isTurnScopeStale(review.scope, current) ? { ...review, stale: true } : review
+  } catch {
+    return review
+  }
 }

--- a/src/main/reviewer/stale-reviews.ts
+++ b/src/main/reviewer/stale-reviews.ts
@@ -27,7 +27,11 @@ export const flagStaleReviews = async (
   return flagged
 }
 
-// Recomputes one review's scope and returns it marked stale when it no longer matches.
+// Recomputes one review's scope and returns it with a DEFINITIVE stale flag (true/false) on success.
+// On failure — or for a non-complete review that has no verdict to invalidate — it leaves `stale`
+// untouched (typically undefined), which the renderer merge treats as "not computed" and therefore
+// must NOT use to clear an existing outdated flag. This is why success always sets an explicit boolean:
+// only an explicit value distinguishes "computed not-stale" from "couldn't compute".
 const flagOne = async (
   review: ReviewWithChecks,
   session: PersistedChatSession,
@@ -43,7 +47,7 @@ const flagOne = async (
       review.scope.turnMessageId,
       artifactStorageRoot
     )
-    return isTurnScopeStale(review.scope, current) ? { ...review, stale: true } : review
+    return { ...review, stale: isTurnScopeStale(review.scope, current) }
   } catch {
     return review
   }

--- a/src/main/reviewer/stale-reviews.ts
+++ b/src/main/reviewer/stale-reviews.ts
@@ -1,0 +1,35 @@
+// Staleness detection for persisted reviews, kept free of electron/IPC imports so it is directly
+// unit-testable and usable from any loader (IPC handler, CLI, future batch job).
+
+import type { ReviewWithChecks } from '../../shared/reviewer'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
+import { isTurnScopeStale } from './scope'
+
+// Marks each completed review whose audited turn no longer matches its current scope (e.g. an artifact
+// was edited after the review ran). Fail-open: a missing session or a recompute error leaves reviews
+// unflagged rather than hiding a real verdict. Running/error reviews have no verdict to invalidate.
+export const flagStaleReviews = async (
+  reviews: ReviewWithChecks[],
+  session: PersistedChatSession | undefined,
+  artifactStorageRoot: string
+): Promise<ReviewWithChecks[]> => {
+  if (reviews.length === 0 || !session) return reviews
+  const currentSession = session
+
+  return Promise.all(
+    reviews.map(async (review) => {
+      if (review.lifecycle !== 'complete') return review
+      try {
+        const current = await resolveTurnScopeWithArtifactDigests(
+          currentSession,
+          review.turnMessageId,
+          artifactStorageRoot
+        )
+        return isTurnScopeStale(review.scope, current) ? { ...review, stale: true } : review
+      } catch {
+        return review
+      }
+    })
+  )
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -19,7 +19,8 @@ import type {
   FinalizeRunArtifactsRequest,
   ListProjectArtifactsRequest,
   OpenArtifactFileRequest,
-  ReadArtifactPreviewRequest
+  ReadArtifactPreviewRequest,
+  ReconcilePendingArtifactsRequest
 } from '../shared/artifacts'
 import type {
   SaveBlobFileRequest,
@@ -255,6 +256,7 @@ interface OpenScienceAPI {
   artifacts: {
     finalizeRunArtifacts(request: FinalizeRunArtifactsRequest): Promise<ArtifactFile[]>
     listProjectFiles(request: ListProjectArtifactsRequest): Promise<ArtifactFile[]>
+    reconcilePendingArtifacts(request: ReconcilePendingArtifactsRequest): Promise<ArtifactFile[]>
     openFile(request: OpenArtifactFileRequest): Promise<void>
     readPreview(request: ReadArtifactPreviewRequest): Promise<ArtifactPreviewResult>
   }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -129,7 +129,12 @@ import type {
   StageUploadFilesRequest,
   UploadedAttachment
 } from '../shared/uploads'
-import type { ReviewWithChecks, ReviewRunRequest, ReviewUpdateEvent } from '../shared/reviewer'
+import type {
+  ReviewWithChecks,
+  ReviewRunRequest,
+  ReviewRunResult,
+  ReviewUpdateEvent
+} from '../shared/reviewer'
 
 type RemoveListener = () => void
 type AcpListener<Payload> = (payload: Payload) => void
@@ -326,7 +331,7 @@ interface OpenScienceAPI {
   }
   reviewer: {
     // Trigger a background review for the given turn. Fire-and-forget; updates come via onUpdated.
-    run(request: ReviewRunRequest): Promise<void>
+    run(request: ReviewRunRequest): Promise<ReviewRunResult>
     // Load persisted reviews for a session (called at workspace startup).
     getForSession(sessionId: string): Promise<ReviewWithChecks[]>
     // Subscribe to review lifecycle/findings updates pushed from the main process.

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -17,6 +17,7 @@ import type {
   ArtifactFile,
   ArtifactPreviewResult,
   FinalizeRunArtifactsRequest,
+  ListProjectArtifactsRequest,
   OpenArtifactFileRequest,
   ReadArtifactPreviewRequest
 } from '../shared/artifacts'
@@ -253,6 +254,7 @@ interface OpenScienceAPI {
   }
   artifacts: {
     finalizeRunArtifacts(request: FinalizeRunArtifactsRequest): Promise<ArtifactFile[]>
+    listProjectFiles(request: ListProjectArtifactsRequest): Promise<ArtifactFile[]>
     openFile(request: OpenArtifactFileRequest): Promise<void>
     readPreview(request: ReadArtifactPreviewRequest): Promise<ArtifactPreviewResult>
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -131,7 +131,12 @@ import type {
   StageUploadFilesRequest,
   UploadedAttachment
 } from '../shared/uploads'
-import type { ReviewWithChecks, ReviewRunRequest, ReviewUpdateEvent } from '../shared/reviewer'
+import type {
+  ReviewWithChecks,
+  ReviewRunRequest,
+  ReviewRunResult,
+  ReviewUpdateEvent
+} from '../shared/reviewer'
 import { REVIEWER_IPC } from '../shared/reviewer'
 import { subscribeCloseActivePane, WINDOW_CLOSE_CHANNEL } from '../shared/window-controls'
 
@@ -355,7 +360,7 @@ type OpenScienceAPI = {
     onProgress: (listener: AcpListener<MigrationProgress>) => RemoveListener
   }
   reviewer: {
-    run: (request: ReviewRunRequest) => Promise<void>
+    run: (request: ReviewRunRequest) => Promise<ReviewRunResult>
     getForSession: (sessionId: string) => Promise<ReviewWithChecks[]>
     onUpdated: (listener: AcpListener<ReviewUpdateEvent>) => RemoveListener
     onSuppressNextAutoReview: (
@@ -667,7 +672,7 @@ const api: OpenScienceAPI = {
   },
   reviewer: {
     run: (request: ReviewRunRequest) =>
-      ipcRenderer.invoke(REVIEWER_IPC.RUN, request) as Promise<void>,
+      ipcRenderer.invoke(REVIEWER_IPC.RUN, request) as Promise<ReviewRunResult>,
     getForSession: (sessionId: string) =>
       ipcRenderer.invoke(REVIEWER_IPC.GET_FOR_SESSION, sessionId) as Promise<ReviewWithChecks[]>,
     onUpdated: (listener) => onIpcMessage(REVIEWER_IPC.UPDATED, listener),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -278,7 +278,9 @@ type OpenScienceAPI = {
     // Lists every on-disk artifact for a project so orphaned files (owning session deleted) still show.
     listProjectFiles: (request: ListProjectArtifactsRequest) => Promise<ArtifactFile[]>
     // Re-finalizes pending artifacts left behind by a crash, returning the message's finalized files.
-    reconcilePendingArtifacts: (request: ReconcilePendingArtifactsRequest) => Promise<ArtifactFile[]>
+    reconcilePendingArtifacts: (
+      request: ReconcilePendingArtifactsRequest
+    ) => Promise<ArtifactFile[]>
     // Opens only managed files after the main process verifies the path.
     openFile: (request: OpenArtifactFileRequest) => Promise<void>
     // Reads a bounded text preview from managed generated files.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,6 +19,7 @@ import type {
   ArtifactFile,
   ArtifactPreviewResult,
   FinalizeRunArtifactsRequest,
+  ListProjectArtifactsRequest,
   OpenArtifactFileRequest,
   ReadArtifactPreviewRequest
 } from '../shared/artifacts'
@@ -273,6 +274,8 @@ type OpenScienceAPI = {
   artifacts: {
     // Finalizes files produced during one runtime event after the renderer has selected a message.
     finalizeRunArtifacts: (request: FinalizeRunArtifactsRequest) => Promise<ArtifactFile[]>
+    // Lists every on-disk artifact for a project so orphaned files (owning session deleted) still show.
+    listProjectFiles: (request: ListProjectArtifactsRequest) => Promise<ArtifactFile[]>
     // Opens only managed files after the main process verifies the path.
     openFile: (request: OpenArtifactFileRequest) => Promise<void>
     // Reads a bounded text preview from managed generated files.
@@ -569,6 +572,9 @@ const api: OpenScienceAPI = {
     // Keep generated file movement in the main process where filesystem trust checks live.
     finalizeRunArtifacts: (request) =>
       ipcRenderer.invoke('artifacts:finalize-run', request) as Promise<ArtifactFile[]>,
+    // Lists every on-disk artifact for a project so orphaned files (owning session deleted) still show.
+    listProjectFiles: (request) =>
+      ipcRenderer.invoke('artifacts:list-project-files', request) as Promise<ArtifactFile[]>,
     openFile: (request) => ipcRenderer.invoke('artifacts:open-file', request) as Promise<void>,
     // Keep preview reads on the same managed-file trust path as opening files.
     readPreview: (request) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,7 +21,8 @@ import type {
   FinalizeRunArtifactsRequest,
   ListProjectArtifactsRequest,
   OpenArtifactFileRequest,
-  ReadArtifactPreviewRequest
+  ReadArtifactPreviewRequest,
+  ReconcilePendingArtifactsRequest
 } from '../shared/artifacts'
 import type {
   SaveBlobFileRequest,
@@ -276,6 +277,8 @@ type OpenScienceAPI = {
     finalizeRunArtifacts: (request: FinalizeRunArtifactsRequest) => Promise<ArtifactFile[]>
     // Lists every on-disk artifact for a project so orphaned files (owning session deleted) still show.
     listProjectFiles: (request: ListProjectArtifactsRequest) => Promise<ArtifactFile[]>
+    // Re-finalizes pending artifacts left behind by a crash, returning the message's finalized files.
+    reconcilePendingArtifacts: (request: ReconcilePendingArtifactsRequest) => Promise<ArtifactFile[]>
     // Opens only managed files after the main process verifies the path.
     openFile: (request: OpenArtifactFileRequest) => Promise<void>
     // Reads a bounded text preview from managed generated files.
@@ -575,6 +578,9 @@ const api: OpenScienceAPI = {
     // Lists every on-disk artifact for a project so orphaned files (owning session deleted) still show.
     listProjectFiles: (request) =>
       ipcRenderer.invoke('artifacts:list-project-files', request) as Promise<ArtifactFile[]>,
+    // Re-finalizes crash-orphaned pending artifacts so the renderer can replace stale pending paths.
+    reconcilePendingArtifacts: (request) =>
+      ipcRenderer.invoke('artifacts:reconcile-pending', request) as Promise<ArtifactFile[]>,
     openFile: (request) => ipcRenderer.invoke('artifacts:open-file', request) as Promise<void>,
     // Keep preview reads on the same managed-file trust path as opening files.
     readPreview: (request) =>

--- a/src/renderer/src/components/ReviewerCard.render.test.tsx
+++ b/src/renderer/src/components/ReviewerCard.render.test.tsx
@@ -943,4 +943,28 @@ describe('ReviewerCard — stale review', () => {
 
     expect(container.querySelector('[data-testid="reviewer-stale-notice"]')).toBeNull()
   })
+
+  it('disables the Re-run button after the first click so a double-click fires once', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [], stale: true })
+    const onRerun = vi.fn()
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onRerun={onRerun} />)
+    })
+
+    const notice = container.querySelector('[data-testid="reviewer-stale-notice"]')
+    const rerunButton = [...notice!.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Re-run')
+    ) as HTMLButtonElement
+
+    // Two separate events (as a real double-click is): the first disables the button before the second.
+    await act(async () => {
+      rerunButton.click()
+    })
+    await act(async () => {
+      rerunButton.click()
+    })
+
+    expect(onRerun).toHaveBeenCalledTimes(1)
+    expect(rerunButton.disabled).toBe(true)
+  })
 })

--- a/src/renderer/src/components/ReviewerCard.render.test.tsx
+++ b/src/renderer/src/components/ReviewerCard.render.test.tsx
@@ -917,7 +917,7 @@ describe('ReviewerCard — stale review', () => {
 
   it('offers a Re-run button on a stale review that fires onRerun with the review', async () => {
     const review = makeReview({ outcome: 'pass', checks: [], stale: true })
-    const onRerun = vi.fn()
+    const onRerun = vi.fn().mockResolvedValue(true)
     await act(async () => {
       root.render(<ReviewerCard review={review} onRerun={onRerun} />)
     })
@@ -946,7 +946,7 @@ describe('ReviewerCard — stale review', () => {
 
   it('disables the Re-run button after the first click so a double-click fires once', async () => {
     const review = makeReview({ outcome: 'pass', checks: [], stale: true })
-    const onRerun = vi.fn()
+    const onRerun = vi.fn().mockResolvedValue(true)
     await act(async () => {
       root.render(<ReviewerCard review={review} onRerun={onRerun} />)
     })
@@ -966,5 +966,26 @@ describe('ReviewerCard — stale review', () => {
 
     expect(onRerun).toHaveBeenCalledTimes(1)
     expect(rerunButton.disabled).toBe(true)
+  })
+
+  it('re-enables the Re-run button when no review actually started', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [], stale: true })
+    // The run could not begin (e.g. session load failed) → resolves false.
+    const onRerun = vi.fn().mockResolvedValue(false)
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onRerun={onRerun} />)
+    })
+
+    const notice = container.querySelector('[data-testid="reviewer-stale-notice"]')
+    const rerunButton = [...notice!.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Re-run')
+    ) as HTMLButtonElement
+
+    await act(async () => {
+      rerunButton.click()
+    })
+
+    // Latch released: the button is usable again and the notice/turn stays retriable.
+    expect(rerunButton.disabled).toBe(false)
   })
 })

--- a/src/renderer/src/components/ReviewerCard.render.test.tsx
+++ b/src/renderer/src/components/ReviewerCard.render.test.tsx
@@ -914,4 +914,33 @@ describe('ReviewerCard — stale review', () => {
 
     expect(container.textContent).not.toContain('(outdated)')
   })
+
+  it('offers a Re-run button on a stale review that fires onRerun with the review', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [], stale: true })
+    const onRerun = vi.fn()
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onRerun={onRerun} />)
+    })
+
+    const notice = container.querySelector('[data-testid="reviewer-stale-notice"]')
+    expect(notice).not.toBeNull()
+    const rerunButton = [...notice!.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Re-run review')
+    )
+    expect(rerunButton).toBeTruthy()
+
+    await act(async () => {
+      rerunButton!.click()
+    })
+    expect(onRerun).toHaveBeenCalledWith(review)
+  })
+
+  it('shows no Re-run affordance for a non-stale review', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [] })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onRerun={vi.fn()} />)
+    })
+
+    expect(container.querySelector('[data-testid="reviewer-stale-notice"]')).toBeNull()
+  })
 })

--- a/src/renderer/src/components/ReviewerCard.render.test.tsx
+++ b/src/renderer/src/components/ReviewerCard.render.test.tsx
@@ -884,3 +884,34 @@ describe('ReviewerCard — error card', () => {
     expect(detail?.textContent).toContain('Argument `severity` is missing.')
   })
 })
+
+describe('ReviewerCard — stale review', () => {
+  it('marks a stale pass review as outdated instead of presenting it as current', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [], stale: true })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    expect(container.textContent).toContain('No issues found')
+    expect(container.textContent).toContain('(outdated)')
+  })
+
+  it('marks a stale flagged review as outdated', async () => {
+    const review = makeReview({ outcome: 'flagged', checks: [makeCheck()], stale: true })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    expect(container.textContent).toContain('1 finding')
+    expect(container.textContent).toContain('(outdated)')
+  })
+
+  it('does not mark a non-stale review as outdated', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [] })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} />)
+    })
+
+    expect(container.textContent).not.toContain('(outdated)')
+  })
+})

--- a/src/renderer/src/components/ReviewerCard.tsx
+++ b/src/renderer/src/components/ReviewerCard.tsx
@@ -21,6 +21,8 @@ type ReviewerCardProps = {
   className?: string
   // Called when the user clicks "Go to transcript" on any item card.
   onGoToTranscript?: (intent: GoToTranscriptIntent) => void
+  // Called when the user asks to re-run a stale review (its turn changed after it ran).
+  onRerun?: (review: ReviewWithChecks) => void
 }
 
 // Status badge styles (pass/warn/fail).
@@ -159,7 +161,8 @@ const CheckCard = ({
 export const ReviewerCard = ({
   review,
   className,
-  onGoToTranscript
+  onGoToTranscript,
+  onRerun
 }: ReviewerCardProps): React.JSX.Element => {
   const [expanded, setExpanded] = useState(false)
 
@@ -268,6 +271,27 @@ export const ReviewerCard = ({
           </span>
         )}
       </button>
+
+      {/* Stale notice + explicit re-run: the verdict above may no longer describe the turn (an artifact
+          was edited after the review ran). This is the actionable refresh path for THIS review's turn —
+          including earlier turns that the composer's "Request review" (last-turn only) cannot reach. */}
+      {isStale && (
+        <div
+          className="mt-2 flex items-center justify-between gap-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-1"
+          data-testid="reviewer-stale-notice"
+        >
+          <span className="text-[11px] text-amber-800">Turn changed after this review ran.</span>
+          {onRerun && (
+            <button
+              type="button"
+              className="shrink-0 rounded border border-amber-300 px-2 py-0.5 text-[11px] text-amber-800 hover:bg-amber-100 transition-colors"
+              onClick={() => onRerun(review)}
+            >
+              Re-run review
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Expanded error detail: full message in a scrollable monospace block (kept out of the status bar). */}
       {hasErrorDetail && expanded && (

--- a/src/renderer/src/components/ReviewerCard.tsx
+++ b/src/renderer/src/components/ReviewerCard.tsx
@@ -21,8 +21,10 @@ type ReviewerCardProps = {
   className?: string
   // Called when the user clicks "Go to transcript" on any item card.
   onGoToTranscript?: (intent: GoToTranscriptIntent) => void
-  // Called when the user asks to re-run a stale review (its turn changed after it ran).
-  onRerun?: (review: ReviewWithChecks) => void
+  // Called when the user asks to re-run a stale review (its turn changed after it ran). Resolves to
+  // whether a review actually started; a false result (e.g. session load failed) releases the button
+  // latch so the turn stays retriable.
+  onRerun?: (review: ReviewWithChecks) => Promise<boolean>
 }
 
 // Status badge styles (pass/warn/fail).
@@ -299,7 +301,11 @@ export const ReviewerCard = ({
               className="shrink-0 rounded border border-amber-300 px-2 py-0.5 text-[11px] text-amber-800 hover:bg-amber-100 transition-colors disabled:cursor-default disabled:opacity-50"
               onClick={() => {
                 setRerunRequested(true)
-                onRerun(review)
+                // Release the latch if no review actually started (e.g. the session couldn't load), so
+                // the button stays usable; on success the running-review push clears it via updatedAt.
+                void onRerun(review).then((started) => {
+                  if (!started) setRerunRequested(false)
+                })
               }}
             >
               {rerunRequested ? 'Re-running…' : 'Re-run review'}

--- a/src/renderer/src/components/ReviewerCard.tsx
+++ b/src/renderer/src/components/ReviewerCard.tsx
@@ -165,6 +165,15 @@ export const ReviewerCard = ({
   onRerun
 }: ReviewerCardProps): React.JSX.Element => {
   const [expanded, setExpanded] = useState(false)
+  // Latches on the first Re-run click so the button can't fire twice. Reset whenever the review updates
+  // (a fresh review row arrived, or its lifecycle/timestamp changed) so a later re-stale review can be
+  // re-run again. setState-during-render pattern, matching the composer popup's query reset.
+  const [rerunRequested, setRerunRequested] = useState(false)
+  const [lastReviewStamp, setLastReviewStamp] = useState(review.updatedAt)
+  if (lastReviewStamp !== review.updatedAt) {
+    setLastReviewStamp(review.updatedAt)
+    setRerunRequested(false)
+  }
 
   const isRunning = review.lifecycle === 'running'
   const isError = review.lifecycle === 'error'
@@ -284,10 +293,16 @@ export const ReviewerCard = ({
           {onRerun && (
             <button
               type="button"
-              className="shrink-0 rounded border border-amber-300 px-2 py-0.5 text-[11px] text-amber-800 hover:bg-amber-100 transition-colors"
-              onClick={() => onRerun(review)}
+              // Disable immediately on click so a double-click (or an impatient second click before the
+              // review flips to 'running') can't launch two reviews; main also dedups concurrent runs.
+              disabled={rerunRequested}
+              className="shrink-0 rounded border border-amber-300 px-2 py-0.5 text-[11px] text-amber-800 hover:bg-amber-100 transition-colors disabled:cursor-default disabled:opacity-50"
+              onClick={() => {
+                setRerunRequested(true)
+                onRerun(review)
+              }}
             >
-              Re-run review
+              {rerunRequested ? 'Re-running…' : 'Re-run review'}
             </button>
           )}
         </div>

--- a/src/renderer/src/components/ReviewerCard.tsx
+++ b/src/renderer/src/components/ReviewerCard.tsx
@@ -188,20 +188,30 @@ export const ReviewerCard = ({
   const canExpand = (isComplete && totalCheckCount > 0) || hasErrorDetail
   const isFlagged = isComplete && hasWarnOrFail
 
+  // The turn changed after this review ran (e.g. an artifact was edited) — the verdict may not
+  // describe the current turn. Computed at load time (see flagStaleReviews); only meaningful for a
+  // completed review, since running/error reviews have no verdict to go stale.
+  const isStale = isComplete && review.stale === true
+
   // Compact summary line.
   const summaryText = (): string => {
     if (isRunning) return 'Reviewing…'
     if (isError) return 'Review error'
-    if (isComplete && !hasWarnOrFail) return 'No issues found'
-    if (isComplete && hasWarnOrFail)
-      return `${warnFailCount} finding${warnFailCount === 1 ? '' : 's'}`
+    if (isComplete && !hasWarnOrFail)
+      return isStale ? 'No issues found (outdated)' : 'No issues found'
+    if (isComplete && hasWarnOrFail) {
+      const base = `${warnFailCount} finding${warnFailCount === 1 ? '' : 's'}`
+      return isStale ? `${base} (outdated)` : base
+    }
     return 'Review pending'
   }
 
-  // Status icon.
+  // Status icon. A stale complete review always shows the warning icon (amber), even a stale pass —
+  // the point is "this verdict may not reflect the turn anymore", not the original outcome.
   const statusIcon = ((): React.JSX.Element => {
     if (isRunning) return <Loader className="h-3 w-3 animate-spin text-text-400" />
     if (isError) return <AlertTriangle className="h-3 w-3 text-yellow-500" />
+    if (isStale) return <AlertTriangle className="h-3 w-3 text-amber-500" />
     if (isComplete && !hasWarnOrFail) return <ShieldCheck className="h-3 w-3 text-green-600" />
     if (isComplete && hasWarnOrFail) return <AlertTriangle className="h-3 w-3 text-red-500" />
     return <Loader className="h-3 w-3 text-text-400" />

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -528,7 +528,7 @@ describe('workspace runtime events', () => {
       vi.useFakeTimers()
       const reviewerRun = vi
         .fn()
-        .mockResolvedValueOnce({ started: false }) // session not on disk yet
+        .mockResolvedValueOnce({ started: false, reason: 'not-found' }) // session not on disk yet
         .mockResolvedValueOnce({ started: true }) // flushed by the time the retry runs
       vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
 
@@ -550,10 +550,64 @@ describe('workspace runtime events', () => {
       vi.unstubAllGlobals()
     })
 
-    it('stops retrying a persistently started:false auto-review at the attempt cap', async () => {
-      // Genuine deletion / persistent dedup: retries must be bounded, never an infinite loop.
+    it('does NOT retry an already-in-flight started:false (avoids launching a duplicate review)', async () => {
+      // The turn is already being reviewed. If a second auto trigger sees already-in-flight and the
+      // original run finishes/fails within the retry window, retrying would start a DUPLICATE review /
+      // fix-loop once the lock releases. The auto path must treat already-in-flight as already handled.
       vi.useFakeTimers()
-      const reviewerRun = vi.fn().mockResolvedValue({ started: false })
+      const reviewerRun = vi
+        .fn()
+        .mockResolvedValueOnce({ started: false, reason: 'already-in-flight' })
+        .mockResolvedValueOnce({ started: true }) // would be a DUPLICATE if wrongly retried
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+      await vi.runAllTimersAsync()
+
+      // Exactly one call: already-in-flight is non-retryable, so no duplicate is launched.
+      expect(reviewerRun).toHaveBeenCalledTimes(1)
+
+      vi.useRealTimers()
+      vi.unstubAllGlobals()
+    })
+
+    it('does NOT retry a run-failed started:false (a genuine pre-push failure, not a race)', async () => {
+      vi.useFakeTimers()
+      const reviewerRun = vi
+        .fn()
+        .mockResolvedValueOnce({ started: false, reason: 'run-failed' })
+        .mockResolvedValueOnce({ started: true })
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+      await vi.runAllTimersAsync()
+
+      expect(reviewerRun).toHaveBeenCalledTimes(1)
+
+      vi.useRealTimers()
+      vi.unstubAllGlobals()
+    })
+
+    it('stops retrying a persistent not-found auto-review at the attempt cap', async () => {
+      // A retryable reason that never resolves (e.g. session genuinely gone): retries must be bounded.
+      vi.useFakeTimers()
+      const reviewerRun = vi.fn().mockResolvedValue({ started: false, reason: 'not-found' })
       vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
 
       useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -6,9 +6,7 @@ import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
 } from '../../stores/preview-workbench-store'
-import { createInitialReviewState, useReviewStore } from '../../stores/review-store'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
-import type { ReviewWithChecks } from '../../../../shared/reviewer'
 import {
   applyWorkspaceRuntimeEvent,
   assembleReviewRunRequest,
@@ -61,8 +59,6 @@ describe('workspace runtime events', () => {
     vi.setSystemTime(new Date('2026-07-04T08:00:00.000Z'))
     useSessionStore.setState(createInitialSessionState())
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
-    // The auto-review idempotency guard reads the review store; start every test with it empty.
-    useReviewStore.setState(createInitialReviewState())
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',
       content: 'Summarize this'
@@ -657,13 +653,17 @@ describe('workspace runtime events', () => {
       vi.unstubAllGlobals()
     })
 
-    it('aborts a pending retry when another entry starts the review during the wait window', async () => {
-      // The retry-window duplicate: attempt 0 gets not-found (retryable) and enters the delay. During
-      // it, a manual/other-renderer/other-auto entry starts AND completes a review for this turn, so
-      // main's in-flight lock is already released by the next attempt. The store-backed idempotency
-      // guard must see the pushed review and NOT fire a second reviewer.run.
+    it('stops retrying once main reports already-reviewed (another entry handled the turn)', async () => {
+      // The retry-window race, resolved by main (not a renderer store check): attempt 0 gets not-found
+      // and waits; during the delay another entry starts AND completes a review, releasing the in-flight
+      // lock. Attempt 1 reaches main, which now sees an existing review for this turn and returns
+      // already-reviewed (non-retryable) — so no duplicate review is launched.
       vi.useFakeTimers()
-      const reviewerRun = vi.fn().mockResolvedValue({ started: false, reason: 'not-found' })
+      const reviewerRun = vi
+        .fn()
+        .mockResolvedValueOnce({ started: false, reason: 'not-found' })
+        .mockResolvedValueOnce({ started: false, reason: 'already-reviewed' })
+        .mockResolvedValue({ started: true }) // would be a DUPLICATE if wrongly retried again
       vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
 
       useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
@@ -675,34 +675,33 @@ describe('workspace runtime events', () => {
       })
 
       await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
-      // Let attempt 0 run + schedule the 400ms delay (without firing it yet).
-      await vi.advanceTimersByTimeAsync(0)
-      expect(reviewerRun).toHaveBeenCalledTimes(1)
-
-      // Another entry started & completed the review for this exact turn during the wait.
-      const turnMessageId = reviewerRun.mock.calls[0]![0]!.turnMessageId as string
-      useReviewStore.getState().handleReviewUpdate({
-        review: {
-          id: 'other-entry-review',
-          projectId: 'project-1',
-          sessionId: 'transport-session-1',
-          turnMessageId,
-          scope: { turnMessageId, blocks: [], artifactVersionIds: [] },
-          lifecycle: 'complete',
-          outcome: 'pass',
-          model: '',
-          reviewerLog: [],
-          createdAt: 1,
-          updatedAt: 1,
-          checks: []
-        } satisfies ReviewWithChecks
-      })
-
-      // Drive the delay → the next attempt's guard sees the review and bails without a second run.
       await vi.runAllTimersAsync()
-      expect(reviewerRun).toHaveBeenCalledTimes(1)
+
+      // Stopped at already-reviewed on attempt 1 — no third (duplicate) call.
+      expect(reviewerRun).toHaveBeenCalledTimes(2)
 
       vi.useRealTimers()
+      vi.unstubAllGlobals()
+    })
+
+    it('tags auto-review requests with origin auto so main can enforce per-turn idempotency', async () => {
+      const reviewerRun = vi.fn().mockResolvedValue({ started: true })
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(reviewerRun).toHaveBeenCalledWith(expect.objectContaining({ origin: 'auto' }))
+
       vi.unstubAllGlobals()
     })
   })

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -6,7 +6,9 @@ import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
 } from '../../stores/preview-workbench-store'
+import { createInitialReviewState, useReviewStore } from '../../stores/review-store'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
+import type { ReviewWithChecks } from '../../../../shared/reviewer'
 import {
   applyWorkspaceRuntimeEvent,
   assembleReviewRunRequest,
@@ -59,6 +61,8 @@ describe('workspace runtime events', () => {
     vi.setSystemTime(new Date('2026-07-04T08:00:00.000Z'))
     useSessionStore.setState(createInitialSessionState())
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    // The auto-review idempotency guard reads the review store; start every test with it empty.
+    useReviewStore.setState(createInitialReviewState())
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',
       content: 'Summarize this'
@@ -623,6 +627,80 @@ describe('workspace runtime events', () => {
 
       // AUTO_REVIEW_START_ATTEMPTS attempts, then it gives up.
       expect(reviewerRun).toHaveBeenCalledTimes(4)
+
+      vi.useRealTimers()
+      vi.unstubAllGlobals()
+    })
+
+    it('retries a load-failed auto-review (transient store read failure)', async () => {
+      vi.useFakeTimers()
+      const reviewerRun = vi
+        .fn()
+        .mockResolvedValueOnce({ started: false, reason: 'load-failed' }) // store read blipped
+        .mockResolvedValueOnce({ started: true }) // succeeds on retry
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+      await vi.runAllTimersAsync()
+
+      expect(reviewerRun).toHaveBeenCalledTimes(2)
+
+      vi.useRealTimers()
+      vi.unstubAllGlobals()
+    })
+
+    it('aborts a pending retry when another entry starts the review during the wait window', async () => {
+      // The retry-window duplicate: attempt 0 gets not-found (retryable) and enters the delay. During
+      // it, a manual/other-renderer/other-auto entry starts AND completes a review for this turn, so
+      // main's in-flight lock is already released by the next attempt. The store-backed idempotency
+      // guard must see the pushed review and NOT fire a second reviewer.run.
+      vi.useFakeTimers()
+      const reviewerRun = vi.fn().mockResolvedValue({ started: false, reason: 'not-found' })
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+      // Let attempt 0 run + schedule the 400ms delay (without firing it yet).
+      await vi.advanceTimersByTimeAsync(0)
+      expect(reviewerRun).toHaveBeenCalledTimes(1)
+
+      // Another entry started & completed the review for this exact turn during the wait.
+      const turnMessageId = reviewerRun.mock.calls[0]![0]!.turnMessageId as string
+      useReviewStore.getState().handleReviewUpdate({
+        review: {
+          id: 'other-entry-review',
+          projectId: 'project-1',
+          sessionId: 'transport-session-1',
+          turnMessageId,
+          scope: { turnMessageId, blocks: [], artifactVersionIds: [] },
+          lifecycle: 'complete',
+          outcome: 'pass',
+          model: '',
+          reviewerLog: [],
+          createdAt: 1,
+          updatedAt: 1,
+          checks: []
+        } satisfies ReviewWithChecks
+      })
+
+      // Drive the delay → the next attempt's guard sees the review and bails without a second run.
+      await vi.runAllTimersAsync()
+      expect(reviewerRun).toHaveBeenCalledTimes(1)
 
       vi.useRealTimers()
       vi.unstubAllGlobals()

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -521,6 +521,58 @@ describe('workspace runtime events', () => {
 
       vi.unstubAllGlobals()
     })
+
+    it('retries a started:false auto-review so a not-yet-persisted new session still gets reviewed', async () => {
+      // A brand-new session persists via an async queue; the first stop can beat the flush, so main's
+      // disk load reports started:false. The auto path must retry, not silently drop the first review.
+      vi.useFakeTimers()
+      const reviewerRun = vi
+        .fn()
+        .mockResolvedValueOnce({ started: false }) // session not on disk yet
+        .mockResolvedValueOnce({ started: true }) // flushed by the time the retry runs
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+      // Drive the retry delay + the fire-and-forget promise chain to completion.
+      await vi.runAllTimersAsync()
+
+      expect(reviewerRun).toHaveBeenCalledTimes(2)
+
+      vi.useRealTimers()
+      vi.unstubAllGlobals()
+    })
+
+    it('stops retrying a persistently started:false auto-review at the attempt cap', async () => {
+      // Genuine deletion / persistent dedup: retries must be bounded, never an infinite loop.
+      vi.useFakeTimers()
+      const reviewerRun = vi.fn().mockResolvedValue({ started: false })
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+      await vi.runAllTimersAsync()
+
+      // AUTO_REVIEW_START_ATTEMPTS attempts, then it gives up.
+      expect(reviewerRun).toHaveBeenCalledTimes(4)
+
+      vi.useRealTimers()
+      vi.unstubAllGlobals()
+    })
   })
 
   it('records finalize failures and retries when an artifact event is replayed', async () => {

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -628,6 +628,31 @@ describe('workspace runtime events', () => {
       vi.unstubAllGlobals()
     })
 
+    it('retries an idempotency-check-failed auto-review (main failed closed on a transient lookup)', async () => {
+      vi.useFakeTimers()
+      const reviewerRun = vi
+        .fn()
+        .mockResolvedValueOnce({ started: false, reason: 'idempotency-check-failed' }) // lookup threw
+        .mockResolvedValueOnce({ started: true }) // lookup recovered, no prior review → starts
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+      await vi.runAllTimersAsync()
+
+      expect(reviewerRun).toHaveBeenCalledTimes(2)
+
+      vi.useRealTimers()
+      vi.unstubAllGlobals()
+    })
+
     it('retries a load-failed auto-review (transient store read failure)', async () => {
       vi.useFakeTimers()
       const reviewerRun = vi

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -5,7 +5,6 @@ import { createPreviewFileItem } from '../../pages/workspace/preview-file-item'
 import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { isMediaOverflowError } from '../../../../shared/media-overflow'
-import { useReviewStore } from '../../stores/review-store'
 import { useSessionStore } from '../../stores/session-store'
 import { useSettingsStore } from '../../stores/settings-store'
 import { createRuntimeStreamId, isAssistantRuntimeChatMessageEvent } from './chat-events'
@@ -138,21 +137,17 @@ const triggerAutoReview = async (sessionId: string): Promise<void> => {
     if (!request) return
 
     // Retry a started:false a bounded number of times, but ONLY for reasons a persistence race can
-    // produce (the session may not be flushed to disk yet). An already-in-flight turn is already being
-    // reviewed, so retrying it would launch a duplicate review/fix-loop once the lock releases — treat
-    // it (and any non-retryable/absent reason, or a bridge that returns nothing) as done immediately.
+    // produce (the session may not be flushed to disk yet). Every other reason is terminal for the auto
+    // path: 'already-in-flight' / 'already-reviewed' mean the turn is (being) handled, 'run-failed' is a
+    // genuine failure for the user's manual Re-run — and a bridge that returns nothing is treated done.
     //
-    // The per-call reason only describes ONE call, so it can't make the whole retry task idempotent:
-    // during the delay another entry (manual, another renderer, another auto trigger) can start AND
-    // complete a review for this turn, releasing main's in-flight lock before our next attempt — which
-    // would then start a SECOND review without ever seeing already-in-flight. Guard every attempt with
-    // the review store: once any review exists for this turn (its running row has been pushed), the
-    // turn is handled and we stop. Combined with main's synchronous in-flight lock (which serializes
-    // truly-simultaneous starts into already-in-flight), this closes the retry-window duplicate.
+    // Idempotency across the whole retry task is enforced by MAIN, not here: it reserves the in-flight
+    // key synchronously and, for origin='auto', refuses a turn that already has a review. So even if
+    // another entry starts and finishes during our delay (releasing the lock), the next attempt reaches
+    // main and comes back 'already-reviewed' rather than launching a duplicate. A renderer-local store
+    // check could only race that cross-process window, so we rely on main's verdict.
     for (let attempt = 0; attempt < AUTO_REVIEW_START_ATTEMPTS; attempt++) {
-      if (useReviewStore.getState().getReviewForTurn(sessionId, request.turnMessageId)) return
-
-      const result = await window.api.reviewer.run(request)
+      const result = await window.api.reviewer.run({ ...request, origin: 'auto' })
       if (result?.started !== false) return
       if (!result.reason || !RETRYABLE_START_FAILURE_REASONS.has(result.reason)) return
       if (attempt < AUTO_REVIEW_START_ATTEMPTS - 1) await delay(AUTO_REVIEW_RETRY_DELAY_MS)

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -5,6 +5,7 @@ import { createPreviewFileItem } from '../../pages/workspace/preview-file-item'
 import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { isMediaOverflowError } from '../../../../shared/media-overflow'
+import { useReviewStore } from '../../stores/review-store'
 import { useSessionStore } from '../../stores/session-store'
 import { useSettingsStore } from '../../stores/settings-store'
 import { createRuntimeStreamId, isAssistantRuntimeChatMessageEvent } from './chat-events'
@@ -140,7 +141,17 @@ const triggerAutoReview = async (sessionId: string): Promise<void> => {
     // produce (the session may not be flushed to disk yet). An already-in-flight turn is already being
     // reviewed, so retrying it would launch a duplicate review/fix-loop once the lock releases — treat
     // it (and any non-retryable/absent reason, or a bridge that returns nothing) as done immediately.
+    //
+    // The per-call reason only describes ONE call, so it can't make the whole retry task idempotent:
+    // during the delay another entry (manual, another renderer, another auto trigger) can start AND
+    // complete a review for this turn, releasing main's in-flight lock before our next attempt — which
+    // would then start a SECOND review without ever seeing already-in-flight. Guard every attempt with
+    // the review store: once any review exists for this turn (its running row has been pushed), the
+    // turn is handled and we stop. Combined with main's synchronous in-flight lock (which serializes
+    // truly-simultaneous starts into already-in-flight), this closes the retry-window duplicate.
     for (let attempt = 0; attempt < AUTO_REVIEW_START_ATTEMPTS; attempt++) {
+      if (useReviewStore.getState().getReviewForTurn(sessionId, request.turnMessageId)) return
+
       const result = await window.api.reviewer.run(request)
       if (result?.started !== false) return
       if (!result.reason || !RETRYABLE_START_FAILURE_REASONS.has(result.reason)) return

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -105,7 +105,9 @@ const AUTO_REVIEW_RETRY_DELAY_MS = 400
 // deliberately (see ReviewRunNotStartedReason): retrying them risks a duplicate review or is pointless.
 const RETRYABLE_START_FAILURE_REASONS = new Set<ReviewRunNotStartedReason>([
   'not-found',
-  'load-failed'
+  'load-failed',
+  // The main-side idempotency lookup threw (fail-closed, no run started) — retry re-runs the check.
+  'idempotency-check-failed'
 ])
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -92,6 +92,16 @@ const assembleReviewRunRequest = (sessionId: string): ReviewRunRequest | undefin
   }
 }
 
+// Bounded retry for a started:false auto-review. A brand-new session is persisted through an async
+// queue, but this fires the instant the first turn stops — so main's disk load can momentarily miss
+// the session and report started:false. Since main treats not-found as "release the lock, no row",
+// a retry is safe: it either catches the now-flushed session, hits a genuine dedup/deletion (stays
+// false, we give up), or succeeds. Without it, the first turn of a new session is silently un-reviewed.
+const AUTO_REVIEW_START_ATTEMPTS = 4
+const AUTO_REVIEW_RETRY_DELAY_MS = 400
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
 // Triggers a background auto-review for the just-completed turn when autoReviewEnabled is on. The
 // default is off, so a session is auto-reviewed only when the switch was explicitly turned on. Uses
 // the shared assembleReviewRunRequest helper so the auto and manual paths pick the same turn and
@@ -118,7 +128,14 @@ const triggerAutoReview = async (sessionId: string): Promise<void> => {
 
     if (!request) return
 
-    await window.api.reviewer.run(request)
+    // Retry a started:false a bounded number of times so a not-yet-persisted new session's first
+    // turn isn't silently skipped. Anything other than an explicit false (started:true, or a bridge
+    // that doesn't report a result) is treated as done on the first attempt.
+    for (let attempt = 0; attempt < AUTO_REVIEW_START_ATTEMPTS; attempt++) {
+      const result = await window.api.reviewer.run(request)
+      if (result?.started !== false) return
+      if (attempt < AUTO_REVIEW_START_ATTEMPTS - 1) await delay(AUTO_REVIEW_RETRY_DELAY_MS)
+    }
   } catch {
     // Reviewer errors must never surface to the main session.
   }

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -1,6 +1,6 @@
 import type { AcpRuntimeEvent, AcpPermissionRequest } from '../../../../shared/acp'
 import type { ArtifactFile, FinalizeRunArtifactsRequest } from '../../../../shared/artifacts'
-import type { ReviewRunRequest } from '../../../../shared/reviewer'
+import type { ReviewRunNotStartedReason, ReviewRunRequest } from '../../../../shared/reviewer'
 import { createPreviewFileItem } from '../../pages/workspace/preview-file-item'
 import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
@@ -100,6 +100,14 @@ const assembleReviewRunRequest = (sessionId: string): ReviewRunRequest | undefin
 const AUTO_REVIEW_START_ATTEMPTS = 4
 const AUTO_REVIEW_RETRY_DELAY_MS = 400
 
+// Only these started:false reasons are retried — both are transient, create no Review row, and hold no
+// in-flight lock, so a retry cannot double-run a turn. 'already-in-flight' and 'run-failed' are omitted
+// deliberately (see ReviewRunNotStartedReason): retrying them risks a duplicate review or is pointless.
+const RETRYABLE_START_FAILURE_REASONS = new Set<ReviewRunNotStartedReason>([
+  'not-found',
+  'load-failed'
+])
+
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
 // Triggers a background auto-review for the just-completed turn when autoReviewEnabled is on. The
@@ -128,12 +136,14 @@ const triggerAutoReview = async (sessionId: string): Promise<void> => {
 
     if (!request) return
 
-    // Retry a started:false a bounded number of times so a not-yet-persisted new session's first
-    // turn isn't silently skipped. Anything other than an explicit false (started:true, or a bridge
-    // that doesn't report a result) is treated as done on the first attempt.
+    // Retry a started:false a bounded number of times, but ONLY for reasons a persistence race can
+    // produce (the session may not be flushed to disk yet). An already-in-flight turn is already being
+    // reviewed, so retrying it would launch a duplicate review/fix-loop once the lock releases — treat
+    // it (and any non-retryable/absent reason, or a bridge that returns nothing) as done immediately.
     for (let attempt = 0; attempt < AUTO_REVIEW_START_ATTEMPTS; attempt++) {
       const result = await window.api.reviewer.run(request)
       if (result?.started !== false) return
+      if (!result.reason || !RETRYABLE_START_FAILURE_REASONS.has(result.reason)) return
       if (attempt < AUTO_REVIEW_START_ATTEMPTS - 1) await delay(AUTO_REVIEW_RETRY_DELAY_MS)
     }
   } catch {

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -9,6 +9,7 @@ import { createInitialSessionState, useSessionStore } from '../../stores/session
 import {
   createStoreSaver,
   loadPersistedSessions,
+  reconcilePendingArtifacts,
   type SessionPersistenceApi
 } from './session-persistence'
 
@@ -44,6 +45,75 @@ const createApi = (overrides: Partial<SessionPersistenceApi> = {}): SessionPersi
 
 beforeEach(() => {
   useSessionStore.setState(createInitialSessionState())
+})
+
+describe('reconcilePendingArtifacts', () => {
+  it('re-finalizes a crash-orphaned pending artifact and replaces the message references', async () => {
+    const pendingPath = '/data/artifacts/proj-1/artifact-session/.pending/run-1/chart.png'
+    useSessionStore.getState().hydrateSessions([
+      createPersistedSession({
+        id: 'session-1',
+        projectId: 'proj-1',
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'done',
+            status: 'complete',
+            eventIds: [],
+            artifactIds: ['artifact-session:run-1:chart.png'],
+            createdAt: 1710000000000,
+            updatedAt: 1710000000000
+          }
+        ],
+        artifacts: [
+          {
+            id: 'artifact-session:run-1:chart.png',
+            kind: 'managed-file',
+            path: pendingPath,
+            name: 'chart.png',
+            mimeType: 'image/png'
+          }
+        ]
+      })
+    ])
+
+    const finalized = {
+      id: 'session-1:message-1:chart.png',
+      projectName: 'proj-1',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      name: 'chart.png',
+      path: '/data/artifacts/proj-1/session-1/message-1/chart.png',
+      fileUrl: 'file:///data/artifacts/proj-1/session-1/message-1/chart.png',
+      mimeType: 'image/png',
+      size: 3,
+      mtimeMs: 1710000000000
+    }
+    const api = { reconcilePendingArtifacts: vi.fn().mockResolvedValue([finalized]) }
+
+    await reconcilePendingArtifacts(api)
+
+    expect(api.reconcilePendingArtifacts).toHaveBeenCalledWith({
+      projectName: 'proj-1',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      pendingPaths: [pendingPath]
+    })
+
+    const session = useSessionStore.getState().sessions.find((item) => item.id === 'session-1')
+    expect(session?.messages[0].artifactIds).toEqual(['session-1:message-1:chart.png'])
+    expect(session?.artifacts?.map((artifact) => artifact.path)).toEqual([finalized.path])
+  })
+
+  it('leaves messages without pending artifacts untouched', async () => {
+    useSessionStore.getState().hydrateSessions([createPersistedSession({ id: 'session-1' })])
+    const api = { reconcilePendingArtifacts: vi.fn() }
+
+    await reconcilePendingArtifacts(api)
+
+    expect(api.reconcilePendingArtifacts).not.toHaveBeenCalled()
+  })
 })
 
 describe('renderer session persistence bridge', () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -37,7 +37,9 @@ const reconcilePendingArtifacts = async (api: ArtifactReconcileApi): Promise<voi
   for (const session of useSessionStore.getState().sessions) {
     if (session.isPending || !session.projectId) continue
 
-    const artifactsById = new Map((session.artifacts ?? []).map((artifact) => [artifact.id, artifact]))
+    const artifactsById = new Map(
+      (session.artifacts ?? []).map((artifact) => [artifact.id, artifact])
+    )
 
     for (const message of session.messages) {
       const pendingPaths = (message.artifactIds ?? [])
@@ -55,9 +57,11 @@ const reconcilePendingArtifacts = async (api: ArtifactReconcileApi): Promise<voi
         })
 
         if (finalized.length > 0) {
-          useSessionStore
-            .getState()
-            .replaceMessageArtifacts({ sessionId: session.id, messageId: message.id, artifacts: finalized })
+          useSessionStore.getState().replaceMessageArtifacts({
+            sessionId: session.id,
+            messageId: message.id,
+            artifacts: finalized
+          })
         }
       } catch (error) {
         reportPersistenceError(error)
@@ -205,10 +209,5 @@ const useSessionPersistence = (): boolean => {
   return isReady
 }
 
-export {
-  createStoreSaver,
-  loadPersistedSessions,
-  reconcilePendingArtifacts,
-  useSessionPersistence
-}
+export { createStoreSaver, loadPersistedSessions, reconcilePendingArtifacts, useSessionPersistence }
 export type { ArtifactReconcileApi, SessionPersistenceApi }

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 
+import type { ArtifactFile, ReconcilePendingArtifactsRequest } from '../../../../shared/artifacts'
 import type {
   DeleteSessionRequest,
   LoadAllSessionsResult,
@@ -14,6 +15,55 @@ type SessionPersistenceApi = {
   saveSession: (session: PersistedChatSession) => Promise<void>
   deleteSession: (request: DeleteSessionRequest) => Promise<void>
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
+}
+
+// The one artifact command startup reconciliation needs; kept narrow so it is trivial to fake in tests.
+type ArtifactReconcileApi = {
+  reconcilePendingArtifacts: (request: ReconcilePendingArtifactsRequest) => Promise<ArtifactFile[]>
+}
+
+// A crash between persisting a pending artifact reference and finalizing it strands the file in
+// `.pending/<run>/`. The path segment is stable across OSes, so detect it structurally.
+const isPendingArtifactPath = (path: string | undefined): path is string =>
+  typeof path === 'string' && path.split(/[\\/]/).includes('.pending')
+
+// Re-finalizes artifacts a prior crash left in `.pending` after the in-memory finalize claim was lost.
+// For each hydrated message still referencing a pending path, ask the main process to complete the
+// move (idempotent) and replace the message's stale references with the finalized files. Runs once at
+// startup after the store saver is subscribed, so each replacement is persisted. Per-message failures
+// are isolated and never block the rest; an empty result leaves references untouched so a file still
+// readable at its pending path is never dropped.
+const reconcilePendingArtifacts = async (api: ArtifactReconcileApi): Promise<void> => {
+  for (const session of useSessionStore.getState().sessions) {
+    if (session.isPending || !session.projectId) continue
+
+    const artifactsById = new Map((session.artifacts ?? []).map((artifact) => [artifact.id, artifact]))
+
+    for (const message of session.messages) {
+      const pendingPaths = (message.artifactIds ?? [])
+        .map((id) => artifactsById.get(id)?.path)
+        .filter(isPendingArtifactPath)
+
+      if (pendingPaths.length === 0) continue
+
+      try {
+        const finalized = await api.reconcilePendingArtifacts({
+          projectName: session.projectId,
+          sessionId: session.id,
+          messageId: message.id,
+          pendingPaths
+        })
+
+        if (finalized.length > 0) {
+          useSessionStore
+            .getState()
+            .replaceMessageArtifacts({ sessionId: session.id, messageId: message.id, artifacts: finalized })
+        }
+      } catch (error) {
+        reportPersistenceError(error)
+      }
+    }
+  }
 }
 
 type SessionStoreSnapshot = {
@@ -137,6 +187,11 @@ const useSessionPersistence = (): boolean => {
       unsubscribe = useSessionStore.subscribe((state) => {
         void save(state).catch(reportPersistenceError)
       })
+
+      // Recover any artifacts a prior crash left in `.pending`; runs after the saver subscribes so the
+      // finalized references are persisted. Fire-and-forget: it must not delay the workspace becoming
+      // interactive, and failures are already reported per message.
+      void reconcilePendingArtifacts(window.api.artifacts)
     }
 
     void startPersistence()
@@ -150,5 +205,10 @@ const useSessionPersistence = (): boolean => {
   return isReady
 }
 
-export { createStoreSaver, loadPersistedSessions, useSessionPersistence }
-export type { SessionPersistenceApi }
+export {
+  createStoreSaver,
+  loadPersistedSessions,
+  reconcilePendingArtifacts,
+  useSessionPersistence
+}
+export type { ArtifactReconcileApi, SessionPersistenceApi }

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -130,6 +130,65 @@ describe('buildProjectFileLibrary', () => {
       ]
     })
   })
+
+  it('surfaces on-disk artifacts not referenced by any session under an Orphaned group', async () => {
+    const { buildProjectFileLibrary, ORPHANED_ARTIFACTS_GROUP_ID } = await import(
+      './project-files-library'
+    )
+    const liveArtifact = {
+      id: 's-live:m1:live.png',
+      projectName: 'proj-1',
+      sessionId: 's-live',
+      name: 'live.png',
+      path: '/artifacts/proj-1/s-live/m1/live.png',
+      fileUrl: 'file:///artifacts/proj-1/s-live/m1/live.png',
+      mimeType: 'image/png',
+      size: 10,
+      mtimeMs: 1710000000000
+    }
+    const orphan = {
+      id: 's-gone:m9:orphan.csv',
+      projectName: 'proj-1',
+      sessionId: 's-gone',
+      name: 'orphan.csv',
+      path: '/artifacts/proj-1/s-gone/m9/orphan.csv',
+      fileUrl: 'file:///artifacts/proj-1/s-gone/m9/orphan.csv',
+      mimeType: 'text/csv',
+      size: 20,
+      mtimeMs: 1710000009000
+    }
+
+    const library = buildProjectFileLibrary(
+      [
+        createSession({
+          id: 's-live',
+          title: 'Live session',
+          artifacts: [
+            {
+              id: liveArtifact.id,
+              kind: 'managed-file',
+              path: liveArtifact.path,
+              fileUrl: liveArtifact.fileUrl,
+              name: liveArtifact.name,
+              mimeType: liveArtifact.mimeType,
+              size: liveArtifact.size,
+              mtimeMs: liveArtifact.mtimeMs
+            }
+          ]
+        })
+      ],
+      // Disk scan returns both the live file and one whose owning session was deleted.
+      [liveArtifact, orphan]
+    )
+
+    // The live session's file is not duplicated into the orphan group.
+    const orphanGroup = library.artifactGroups.find(
+      (group) => group.sessionId === ORPHANED_ARTIFACTS_GROUP_ID
+    )
+    expect(orphanGroup?.title).toBe('Orphaned')
+    expect(orphanGroup?.files.map((file) => file.name)).toEqual(['orphan.csv'])
+    expect(library.artifactGroups.some((group) => group.sessionId === 's-live')).toBe(true)
+  })
 })
 
 describe('ProjectFilesView', () => {
@@ -156,6 +215,7 @@ describe('ProjectFilesView', () => {
         release: vi.fn().mockResolvedValue(undefined)
       },
       artifacts: {
+        listProjectFiles: vi.fn().mockResolvedValue([]),
         readPreview: vi.fn().mockResolvedValue({
           content: 'ZmFrZS1pbWFnZQ==',
           encoding: 'base64',

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -132,9 +132,8 @@ describe('buildProjectFileLibrary', () => {
   })
 
   it('surfaces on-disk artifacts not referenced by any session under an Orphaned group', async () => {
-    const { buildProjectFileLibrary, ORPHANED_ARTIFACTS_GROUP_ID } = await import(
-      './project-files-library'
-    )
+    const { buildProjectFileLibrary, ORPHANED_ARTIFACTS_GROUP_ID } =
+      await import('./project-files-library')
     const liveArtifact = {
       id: 's-live:m1:live.png',
       projectName: 'proj-1',

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -24,6 +24,7 @@ import {
   type ProjectArtifactFileNode,
   type ProjectUploadFileNode
 } from './project-files-library'
+import { useProjectArtifactFiles } from './use-project-artifact-files'
 import {
   createPreviewFileItemFromArtifact,
   createPreviewFileItemFromUpload
@@ -388,7 +389,12 @@ const ProjectFilesView = (): React.JSX.Element => {
     () => allSessions.filter((session) => session.projectId === activeProjectId),
     [allSessions, activeProjectId]
   )
-  const library = useMemo(() => buildProjectFileLibrary(sessions), [sessions])
+  // On-disk artifacts include files whose owning session was deleted, surfaced as an "Orphaned" group.
+  const diskArtifacts = useProjectArtifactFiles(activeProjectId)
+  const library = useMemo(
+    () => buildProjectFileLibrary(sessions, diskArtifacts),
+    [sessions, diskArtifacts]
+  )
   const totalFileCount =
     library.uploadFiles.length +
     library.artifactGroups.reduce((total, group) => total + group.files.length, 0)

--- a/src/renderer/src/pages/workspace/SessionReviewerPanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionReviewerPanel.render.test.tsx
@@ -220,6 +220,28 @@ describe('SessionReviewerPanel — pass outcome', () => {
   })
 })
 
+describe('SessionReviewerPanel — stale review notice', () => {
+  it('shows a stale notice in the header when the review is flagged stale', () => {
+    const staleReview = makeReview({ stale: true })
+
+    act(() => {
+      root.render(<SessionReviewerPanel review={staleReview} activeFindingId={undefined} />)
+    })
+
+    expect(container.querySelector('[data-testid="reviewer-stale-notice"]')).not.toBeNull()
+  })
+
+  it('shows no stale notice for a fresh review', () => {
+    const review = makeReview()
+
+    act(() => {
+      root.render(<SessionReviewerPanel review={review} activeFindingId={undefined} />)
+    })
+
+    expect(container.querySelector('[data-testid="reviewer-stale-notice"]')).toBeNull()
+  })
+})
+
 describe('SessionReviewerPanel — GoToTranscript positioning', () => {
   it('highlights the active check when activeFindingId is set', () => {
     const review = makeReview({

--- a/src/renderer/src/pages/workspace/SessionReviewerPanel.tsx
+++ b/src/renderer/src/pages/workspace/SessionReviewerPanel.tsx
@@ -274,6 +274,15 @@ const SessionReviewerPanel = ({
         <p className="mt-0.5 text-[11px] text-text-300">
           {review.model} &middot; {new Date(review.createdAt).toLocaleString()}
         </p>
+        {review.stale && (
+          <p
+            data-testid="reviewer-stale-notice"
+            className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-[11px] text-amber-800"
+          >
+            This turn changed after the review ran (e.g. an artifact was edited). The result below
+            may be out of date — re-run the review to refresh it.
+          </p>
+        )}
       </div>
 
       {/* Scrollable body */}

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -260,15 +260,20 @@ const WorkspaceMessageScroller = ({
   // grouped under review.turnMessageId (so a fix-loop review refreshes in place), but the audited
   // content is review.scope.turnMessageId — the turn whose bytes actually changed. Fire-and-forget:
   // a fresh review supersedes the stale one via reviewer:updated; concurrent runs are deduped in main.
-  const handleRerunReview = (review: ReviewWithChecks): void => {
-    void window.api.reviewer.run({
-      sessionId: review.sessionId,
-      turnMessageId: review.turnMessageId,
-      scopeTurnMessageId: review.scope.turnMessageId,
-      projectId: review.projectId,
-      mainSessionId: review.sessionId,
-      model: useSettingsStore.getState().activeModel
-    })
+  const handleRerunReview = async (review: ReviewWithChecks): Promise<boolean> => {
+    try {
+      const result = await window.api.reviewer.run({
+        sessionId: review.sessionId,
+        turnMessageId: review.turnMessageId,
+        scopeTurnMessageId: review.scope.turnMessageId,
+        projectId: review.projectId,
+        mainSessionId: review.sessionId,
+        model: useSettingsStore.getState().activeModel
+      })
+      return result?.started ?? false
+    } catch {
+      return false
+    }
   }
 
   return (

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -256,12 +256,15 @@ const WorkspaceMessageScroller = ({
   }
 
   // Re-runs the review for a specific (stale) turn — the actionable refresh the stale notice offers.
-  // Unlike the composer's last-turn-only "Request review", this reaches any turn's review by its own
-  // turnMessageId. Fire-and-forget: a fresh review supersedes the stale one via reviewer:updated.
+  // Unlike the composer's last-turn-only "Request review", this reaches any turn's review. The row is
+  // grouped under review.turnMessageId (so a fix-loop review refreshes in place), but the audited
+  // content is review.scope.turnMessageId — the turn whose bytes actually changed. Fire-and-forget:
+  // a fresh review supersedes the stale one via reviewer:updated; concurrent runs are deduped in main.
   const handleRerunReview = (review: ReviewWithChecks): void => {
     void window.api.reviewer.run({
       sessionId: review.sessionId,
       turnMessageId: review.turnMessageId,
+      scopeTurnMessageId: review.scope.turnMessageId,
       projectId: review.projectId,
       mainSessionId: review.sessionId,
       model: useSettingsStore.getState().activeModel

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -268,7 +268,10 @@ const WorkspaceMessageScroller = ({
         scopeTurnMessageId: review.scope.turnMessageId,
         projectId: review.projectId,
         mainSessionId: review.sessionId,
-        model: useSettingsStore.getState().activeModel
+        model: useSettingsStore.getState().activeModel,
+        // Explicit user Re-run: bypass main's auto-only per-turn idempotency so the stale/error review
+        // is genuinely re-run rather than refused as already-reviewed.
+        origin: 'manual'
       })
       return result?.started ?? false
     } catch {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -28,7 +28,7 @@ import type { ArtifactMentionPart } from './WorkspaceMessageItem'
 import { createConversationItems } from './workspace-conversation-items'
 import { groupConversationItems } from './workspace-tool-activity-groups'
 import type { ActivityExpansionOverrides } from './workspace-tool-activity-groups'
-import type { GoToTranscriptIntent } from '../../../../shared/reviewer'
+import type { GoToTranscriptIntent, ReviewWithChecks } from '../../../../shared/reviewer'
 
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
@@ -105,6 +105,20 @@ const WorkspaceMessageScroller = ({
     if (currentSessionId) {
       void loadReviewsForSession(currentSessionId)
     }
+  }, [currentSessionId, loadReviewsForSession])
+
+  // Reload (which recomputes staleness against current artifact bytes) when the window regains focus.
+  // An artifact edited outside the app while this session stays open would otherwise keep showing its
+  // review as current until the user switched sessions away and back; a focus return is the natural
+  // moment an out-of-app edit could have happened.
+  useEffect(() => {
+    if (!currentSessionId) return
+
+    const onFocus = (): void => {
+      void loadReviewsForSession(currentSessionId)
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
   }, [currentSessionId, loadReviewsForSession])
 
   // Group expansion is keyed by session so switching conversations never reuses stale UI state.
@@ -241,6 +255,19 @@ const WorkspaceMessageScroller = ({
     openSessionReviewer(currentSessionId, intent)
   }
 
+  // Re-runs the review for a specific (stale) turn — the actionable refresh the stale notice offers.
+  // Unlike the composer's last-turn-only "Request review", this reaches any turn's review by its own
+  // turnMessageId. Fire-and-forget: a fresh review supersedes the stale one via reviewer:updated.
+  const handleRerunReview = (review: ReviewWithChecks): void => {
+    void window.api.reviewer.run({
+      sessionId: review.sessionId,
+      turnMessageId: review.turnMessageId,
+      projectId: review.projectId,
+      mainSessionId: review.sessionId,
+      model: useSettingsStore.getState().activeModel
+    })
+  }
+
   return (
     <MessageScrollerProvider
       key={activeSession?.id ?? 'empty-conversation'}
@@ -283,7 +310,11 @@ const WorkspaceMessageScroller = ({
                         <div className="px-4 pb-1 md:px-6">
                           <div className="mx-auto w-full max-w-[56rem]">
                             {/* Only "Go to transcript" navigates to the reviewer page; the card itself does not. */}
-                            <ReviewerCard review={review} onGoToTranscript={handleGoToTranscript} />
+                            <ReviewerCard
+                              review={review}
+                              onGoToTranscript={handleGoToTranscript}
+                              onRerun={handleRerunReview}
+                            />
                           </div>
                         </div>
                       ) : null}

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -721,7 +721,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
 
     if (!request) return
 
-    void window.api.reviewer.run(request)
+    // Explicit user action: bypass main's auto-only per-turn idempotency so a manual review always runs.
+    void window.api.reviewer.run({ ...request, origin: 'manual' })
   }
 
   // Revokes one always-allow grant for the visible session; new conversations have no grants.

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -226,9 +226,13 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     if (isReviewing) return true
     const reviews = state.reviewsBySession[activeSessionId]
     if (reviews) {
-      // Newest-first, so find() returns the most recent review for the last turn.
+      // Newest-first, so find() returns the most recent review for the last turn. Only a fresh,
+      // completed verdict blocks a new review; a stale one (turn changed) or an errored one must stay
+      // retriable so the user isn't stuck without any review entry point.
       const lastTurnReview = reviews.find((r) => r.turnMessageId === lastAgentMessage.id)
-      if (lastTurnReview && !lastTurnReview.stale) return true
+      if (lastTurnReview && lastTurnReview.lifecycle === 'complete' && !lastTurnReview.stale) {
+        return true
+      }
     }
     return false
   })

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -214,8 +214,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   })
   // "Request review" is disabled when:
   //   - there is no active session or no completed agent turn yet, OR
-  //   - the last turn already has a review (any lifecycle — no duplicate reviews), OR
+  //   - the last turn already has a NON-STALE review (no duplicate reviews), OR
   //   - any review for this session is currently running (no concurrency).
+  // A stale last-turn review (its turn changed after it ran) does NOT disable the button — re-running
+  // is the explicit refresh path the stale notice points the user to.
   const isRequestReviewDisabled = useReviewStore((state) => {
     if (!activeSessionId) return true
     if (!activeSession) return true
@@ -224,8 +226,9 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     if (isReviewing) return true
     const reviews = state.reviewsBySession[activeSessionId]
     if (reviews) {
-      const hasReviewForLastTurn = reviews.some((r) => r.turnMessageId === lastAgentMessage.id)
-      if (hasReviewForLastTurn) return true
+      // Newest-first, so find() returns the most recent review for the last turn.
+      const lastTurnReview = reviews.find((r) => r.turnMessageId === lastAgentMessage.id)
+      if (lastTurnReview && !lastTurnReview.stale) return true
     }
     return false
   })

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
@@ -84,6 +84,7 @@ beforeEach(() => {
       readPreview: vi.fn().mockResolvedValue({ content: '', encoding: 'base64', size: 0 })
     },
     artifacts: {
+      listProjectFiles: vi.fn().mockResolvedValue([]),
       readPreview: vi.fn().mockResolvedValue({ content: '', encoding: 'base64', size: 0 })
     }
   }

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -8,6 +8,7 @@ import { ArtifactFileIcon } from './artifact-file-icon'
 import { fuzzyScore, type FuzzyMatch } from './fuzzy-match'
 import { HighlightedText } from './HighlightedText'
 import { buildProjectFileLibrary } from '../project-files-library'
+import { useProjectArtifactFiles } from '../use-project-artifact-files'
 
 // The reference passed back to the composer when an artifact row is picked.
 export type PickedArtifact = {
@@ -46,12 +47,14 @@ export const ArtifactMentionPopup = ({
 }: ArtifactMentionPopupProps): React.JSX.Element | null => {
   const sessions = useSessionStore((state) => state.sessions)
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
+  const diskArtifacts = useProjectArtifactFiles(activeProjectId)
   const listboxId = useId()
 
-  // Derive the project's artifact library the same way the Files panel does: uploads then outputs.
+  // Derive the project's artifact library the same way the Files panel does: uploads then outputs, plus
+  // orphaned on-disk files so a deleted session's artifacts stay referenceable via `@`.
   const rows = useMemo<ArtifactRow[]>(() => {
     const projectSessions = sessions.filter((session) => session.projectId === activeProjectId)
-    const library = buildProjectFileLibrary(projectSessions)
+    const library = buildProjectFileLibrary(projectSessions, diskArtifacts)
 
     const uploadRows: ArtifactRow[] = library.uploadFiles.map((file) => ({
       id: file.id,
@@ -76,7 +79,7 @@ export const ArtifactMentionPopup = ({
     )
 
     return [...uploadRows, ...artifactRows]
-  }, [sessions, activeProjectId])
+  }, [sessions, activeProjectId, diskArtifacts])
 
   // Fuzzy-match the query against each filename, ranked best-first. Ranking happens within each section
   // so uploads still render before outputs — the flat highlight index depends on that order. Empty

--- a/src/renderer/src/pages/workspace/project-files-library.ts
+++ b/src/renderer/src/pages/workspace/project-files-library.ts
@@ -1,3 +1,4 @@
+import type { ArtifactFile } from '../../../../shared/artifacts'
 import type { ChatSession } from '@/stores/session-store'
 import { getUploadedAttachmentName } from '../../../../shared/uploads'
 
@@ -31,10 +32,33 @@ export type ProjectFileLibrary = {
   artifactGroups: ProjectArtifactGroup[]
 }
 
-// Derives the project file library from persisted session metadata without reading the file system.
-export const buildProjectFileLibrary = (sessions: ChatSession[]): ProjectFileLibrary => {
+// Stable session id for the group holding artifacts whose owning session no longer exists in metadata.
+export const ORPHANED_ARTIFACTS_GROUP_ID = '__orphaned_artifacts__'
+
+// Adapts an on-disk artifact record to the same MessageArtifact shape session-derived files use, so the
+// preview/download/@-mention paths treat an orphan exactly like any other managed file.
+const toMessageArtifact = (file: ArtifactFile): MessageArtifact => ({
+  id: file.id,
+  kind: 'managed-file',
+  path: file.path,
+  fileUrl: file.fileUrl,
+  name: file.name,
+  mimeType: file.mimeType,
+  size: file.size,
+  mtimeMs: file.mtimeMs
+})
+
+// Derives the project file library from persisted session metadata. When on-disk artifacts are passed
+// in, any whose file path is not already referenced by a live session is surfaced under an "Orphaned"
+// group — so deleting a session (or project) keeps its generated files reachable instead of stranding
+// them. Files that a live session still references are never duplicated into the orphan group.
+export const buildProjectFileLibrary = (
+  sessions: ChatSession[],
+  diskArtifacts: ArtifactFile[] = []
+): ProjectFileLibrary => {
   const uploadFiles: ProjectUploadFileNode[] = []
   const artifactGroups: ProjectArtifactGroup[] = []
+  const referencedPaths = new Set<string>()
 
   for (const session of sessions) {
     for (const message of session.messages) {
@@ -54,15 +78,21 @@ export const buildProjectFileLibrary = (sessions: ChatSession[]): ProjectFileLib
       }
     }
 
-    const files =
-      session.artifacts
-        ?.filter((artifact) => artifact.kind === 'managed-file' && Boolean(artifact.path))
-        .map((artifact) => ({
-          id: artifact.id,
-          name: getArtifactName(artifact),
-          size: artifact.size,
-          artifact
-        })) ?? []
+    const managedArtifacts =
+      session.artifacts?.filter(
+        (artifact) => artifact.kind === 'managed-file' && Boolean(artifact.path)
+      ) ?? []
+
+    for (const artifact of managedArtifacts) {
+      if (artifact.path) referencedPaths.add(artifact.path)
+    }
+
+    const files = managedArtifacts.map((artifact) => ({
+      id: artifact.id,
+      name: getArtifactName(artifact),
+      size: artifact.size,
+      artifact
+    }))
 
     if (files.length > 0) {
       artifactGroups.push({
@@ -71,6 +101,33 @@ export const buildProjectFileLibrary = (sessions: ChatSession[]): ProjectFileLib
         files
       })
     }
+  }
+
+  // Any on-disk artifact no live session still references is orphaned (its session was deleted, or it
+  // was left pending by a crash). Surface it so it stays previewable/downloadable rather than lost.
+  const orphanedFiles: ProjectArtifactFileNode[] = []
+  const seenOrphanPaths = new Set<string>()
+
+  for (const file of diskArtifacts) {
+    if (referencedPaths.has(file.path) || seenOrphanPaths.has(file.path)) continue
+    seenOrphanPaths.add(file.path)
+
+    const artifact = toMessageArtifact(file)
+    orphanedFiles.push({
+      id: artifact.id,
+      name: getArtifactName(artifact),
+      size: artifact.size,
+      artifact
+    })
+  }
+
+  if (orphanedFiles.length > 0) {
+    orphanedFiles.sort((left, right) => (right.artifact.mtimeMs ?? 0) - (left.artifact.mtimeMs ?? 0))
+    artifactGroups.push({
+      sessionId: ORPHANED_ARTIFACTS_GROUP_ID,
+      title: 'Orphaned',
+      files: orphanedFiles
+    })
   }
 
   uploadFiles.sort((left, right) => right.timestamp - left.timestamp)

--- a/src/renderer/src/pages/workspace/project-files-library.ts
+++ b/src/renderer/src/pages/workspace/project-files-library.ts
@@ -122,7 +122,9 @@ export const buildProjectFileLibrary = (
   }
 
   if (orphanedFiles.length > 0) {
-    orphanedFiles.sort((left, right) => (right.artifact.mtimeMs ?? 0) - (left.artifact.mtimeMs ?? 0))
+    orphanedFiles.sort(
+      (left, right) => (right.artifact.mtimeMs ?? 0) - (left.artifact.mtimeMs ?? 0)
+    )
     artifactGroups.push({
       sessionId: ORPHANED_ARTIFACTS_GROUP_ID,
       title: 'Orphaned',

--- a/src/renderer/src/pages/workspace/use-project-artifact-files.test.ts
+++ b/src/renderer/src/pages/workspace/use-project-artifact-files.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ArtifactFile } from '../../../../shared/artifacts'
+import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
+import { useProjectArtifactFiles } from './use-project-artifact-files'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Minimal renderHook mirroring the repo's other hook tests (no @testing-library/react dependency).
+const renderHook = <Value>(
+  hook: () => Value
+): { result: { current: Value }; rerender: () => void; unmount: () => void } => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const result = { current: undefined as unknown as Value }
+
+  const HookHarness = (): null => {
+    result.current = hook()
+    return null
+  }
+
+  const render = (): void => {
+    act(() => {
+      root.render(createElement(HookHarness))
+    })
+  }
+
+  render()
+
+  return { result, rerender: render, unmount: () => root.unmount() }
+}
+
+const artifact = (projectId: string, name: string): ArtifactFile => ({
+  id: `${projectId}:m:${name}`,
+  projectName: projectId,
+  sessionId: 's',
+  name,
+  path: `/artifacts/${projectId}/s/m/${name}`,
+  fileUrl: `file:///artifacts/${projectId}/s/m/${name}`,
+  size: 1,
+  mtimeMs: 1
+})
+
+let originalApi: unknown
+
+beforeEach(() => {
+  useSessionStore.setState(createInitialSessionState())
+  originalApi = (window as unknown as { api?: unknown }).api
+})
+
+afterEach(() => {
+  ;(window as unknown as { api?: unknown }).api = originalApi
+})
+
+describe('useProjectArtifactFiles', () => {
+  it('never returns the previous project files while the new project scan is in flight', async () => {
+    let resolveProjectB: ((files: ArtifactFile[]) => void) | undefined
+    const listProjectFiles = vi.fn((request: { projectName: string }) => {
+      if (request.projectName === 'project-a') {
+        return Promise.resolve([artifact('project-a', 'a.txt')])
+      }
+      // project-b's scan is held open so the test can observe the value while it is still pending.
+      return new Promise<ArtifactFile[]>((resolve) => {
+        resolveProjectB = resolve
+      })
+    })
+    ;(window as unknown as { api: unknown }).api = { artifacts: { listProjectFiles } }
+
+    let projectId = 'project-a'
+    const { result, rerender } = renderHook(() => useProjectArtifactFiles(projectId))
+
+    // Let project A's scan resolve.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(result.current.map((file) => file.name)).toEqual(['a.txt'])
+
+    // Switch to project B before its scan resolves.
+    projectId = 'project-b'
+    rerender()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Must not still show project A's file as project B's "Orphaned" artifact.
+    expect(result.current).toEqual([])
+
+    resolveProjectB?.([artifact('project-b', 'b.txt')])
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(result.current.map((file) => file.name)).toEqual(['b.txt'])
+  })
+
+  it('tolerates a missing or throwing bridge method without crashing', async () => {
+    ;(window as unknown as { api: unknown }).api = { artifacts: {} }
+
+    const { result } = renderHook(() => useProjectArtifactFiles('project-a'))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current).toEqual([])
+  })
+})

--- a/src/renderer/src/pages/workspace/use-project-artifact-files.ts
+++ b/src/renderer/src/pages/workspace/use-project-artifact-files.ts
@@ -10,7 +10,12 @@ import { useSessionStore } from '@/stores/session-store'
 // list: orphan recovery is additive, so a scan error must never blank out the session-derived library.
 export const useProjectArtifactFiles = (projectId: string | undefined): ArtifactFile[] => {
   const sessions = useSessionStore((state) => state.sessions)
-  const [diskArtifacts, setDiskArtifacts] = useState<ArtifactFile[]>([])
+  // Tag the loaded scan with the project it belongs to so a not-yet-refreshed result from the previous
+  // project is never returned for the current one.
+  const [scan, setScan] = useState<{ projectId: string | undefined; files: ArtifactFile[] }>({
+    projectId: undefined,
+    files: []
+  })
 
   // A stable signature of the project's session ids: changes on create/delete, not on every keystroke.
   const sessionSignature = sessions
@@ -36,7 +41,7 @@ export const useProjectArtifactFiles = (projectId: string | undefined): Artifact
     }
 
     void load().then((files) => {
-      if (!cancelled) setDiskArtifacts(files)
+      if (!cancelled) setScan({ projectId, files })
     })
 
     return () => {
@@ -44,5 +49,8 @@ export const useProjectArtifactFiles = (projectId: string | undefined): Artifact
     }
   }, [projectId, sessionSignature])
 
-  return diskArtifacts
+  // Until the scan for the CURRENT project resolves, return [] rather than the previous project's
+  // files — otherwise, on a project switch, they would briefly surface as this project's "Orphaned"
+  // artifacts in the Files panel and the @ picker, and could even be selected.
+  return scan.projectId === projectId ? scan.files : []
 }

--- a/src/renderer/src/pages/workspace/use-project-artifact-files.ts
+++ b/src/renderer/src/pages/workspace/use-project-artifact-files.ts
@@ -20,21 +20,24 @@ export const useProjectArtifactFiles = (projectId: string | undefined): Artifact
     .join(',')
 
   useEffect(() => {
-    if (!projectId) {
-      setDiskArtifacts([])
-      return
-    }
-
     let cancelled = false
 
-    void window.api.artifacts
-      .listProjectFiles({ projectName: projectId })
-      .then((files) => {
-        if (!cancelled) setDiskArtifacts(files)
-      })
-      .catch(() => {
-        if (!cancelled) setDiskArtifacts([])
-      })
+    // Resolve to [] when there is no project rather than calling setState synchronously in the effect
+    // body; setState only ever runs inside this async callback. The try/catch tolerates both a missing
+    // bridge method (e.g. an older/web preload without listProjectFiles) and a scan failure, so orphan
+    // recovery never crashes the panel or composer that mounts this hook.
+    const load = async (): Promise<ArtifactFile[]> => {
+      if (!projectId) return []
+      try {
+        return await window.api.artifacts.listProjectFiles({ projectName: projectId })
+      } catch {
+        return []
+      }
+    }
+
+    void load().then((files) => {
+      if (!cancelled) setDiskArtifacts(files)
+    })
 
     return () => {
       cancelled = true

--- a/src/renderer/src/pages/workspace/use-project-artifact-files.ts
+++ b/src/renderer/src/pages/workspace/use-project-artifact-files.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+
+import type { ArtifactFile } from '../../../../shared/artifacts'
+import { useSessionStore } from '@/stores/session-store'
+
+// Loads every on-disk artifact for a project (the storage project name matches the durable project id)
+// so the file library can surface files whose owning session was deleted. Re-fetches when the project
+// changes or when the set of sessions in it changes — the only events that can create or clear an
+// orphan (a delete removes the metadata that was keeping a file "owned"). Failures resolve to an empty
+// list: orphan recovery is additive, so a scan error must never blank out the session-derived library.
+export const useProjectArtifactFiles = (projectId: string | undefined): ArtifactFile[] => {
+  const sessions = useSessionStore((state) => state.sessions)
+  const [diskArtifacts, setDiskArtifacts] = useState<ArtifactFile[]>([])
+
+  // A stable signature of the project's session ids: changes on create/delete, not on every keystroke.
+  const sessionSignature = sessions
+    .filter((session) => session.projectId === projectId)
+    .map((session) => session.id)
+    .sort()
+    .join(',')
+
+  useEffect(() => {
+    if (!projectId) {
+      setDiskArtifacts([])
+      return
+    }
+
+    let cancelled = false
+
+    void window.api.artifacts
+      .listProjectFiles({ projectName: projectId })
+      .then((files) => {
+        if (!cancelled) setDiskArtifacts(files)
+      })
+      .catch(() => {
+        if (!cancelled) setDiskArtifacts([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [projectId, sessionSignature])
+
+  return diskArtifacts
+}

--- a/src/renderer/src/stores/review-store.test.ts
+++ b/src/renderer/src/stores/review-store.test.ts
@@ -234,6 +234,24 @@ describe('review store', () => {
     vi.unstubAllGlobals()
   })
 
+  it('a load that recomputed not-stale clears an existing outdated flag', async () => {
+    // The other half of three-state merging: an explicit false (a load that successfully recomputed
+    // and found the review is no longer outdated) must CLEAR a known stale=true, not just inherit it.
+    useReviewStore
+      .getState()
+      .handleReviewUpdate({ review: makeReview({ id: 'review-1', updatedAt: 1_000, stale: true }) })
+
+    const recomputedNotStale = [makeReview({ id: 'review-1', updatedAt: 2_000, stale: false })]
+    const getForSession = vi.fn().mockResolvedValue(recomputedNotStale)
+    vi.stubGlobal('window', { api: { reviewer: { getForSession } } })
+
+    await useReviewStore.getState().loadReviewsForSession('session-1')
+
+    const stored = useReviewStore.getState().getReviewsForSession('session-1')
+    expect(stored[0]?.stale).toBe(false)
+    vi.unstubAllGlobals()
+  })
+
   it('dedupes concurrent loads for the same session', async () => {
     let resolveLoad: ((value: ReviewWithChecks[]) => void) | undefined
     const getForSession = vi.fn().mockReturnValue(

--- a/src/renderer/src/stores/review-store.test.ts
+++ b/src/renderer/src/stores/review-store.test.ts
@@ -147,4 +147,46 @@ describe('review store', () => {
     expect(useReviewStore.getState().getReviewsForSession('session-1')).toEqual([])
     vi.unstubAllGlobals()
   })
+
+  it('does not let a stale load overwrite a newer review delivered by a push', async () => {
+    // A push completes the review while a slow focus-load is mid-flight holding an older snapshot.
+    useReviewStore.getState().handleReviewUpdate({
+      review: makeReview({ id: 'review-1', lifecycle: 'complete', updatedAt: 2_000 })
+    })
+
+    const staleSnapshot = [
+      makeReview({ id: 'review-1', lifecycle: 'running', outcome: null, updatedAt: 1_000 })
+    ]
+    const getForSession = vi.fn().mockResolvedValue(staleSnapshot)
+    vi.stubGlobal('window', { api: { reviewer: { getForSession } } })
+
+    await useReviewStore.getState().loadReviewsForSession('session-1')
+
+    // The newer pushed review (updatedAt 2000, complete) survives the merge.
+    const stored = useReviewStore.getState().getReviewsForSession('session-1')
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.lifecycle).toBe('complete')
+    expect(stored[0]?.updatedAt).toBe(2_000)
+    vi.unstubAllGlobals()
+  })
+
+  it('dedupes concurrent loads for the same session', async () => {
+    let resolveLoad: ((value: ReviewWithChecks[]) => void) | undefined
+    const getForSession = vi.fn().mockReturnValue(
+      new Promise<ReviewWithChecks[]>((resolve) => {
+        resolveLoad = resolve
+      })
+    )
+    vi.stubGlobal('window', { api: { reviewer: { getForSession } } })
+
+    const first = useReviewStore.getState().loadReviewsForSession('session-1')
+    const second = useReviewStore.getState().loadReviewsForSession('session-1')
+
+    resolveLoad?.([makeReview({ id: 'r' })])
+    await Promise.all([first, second])
+
+    // The in-flight guard drops the overlapping second call.
+    expect(getForSession).toHaveBeenCalledTimes(1)
+    vi.unstubAllGlobals()
+  })
 })

--- a/src/renderer/src/stores/review-store.test.ts
+++ b/src/renderer/src/stores/review-store.test.ts
@@ -148,6 +148,38 @@ describe('review store', () => {
     vi.unstubAllGlobals()
   })
 
+  it('keeps pushed finding data on an equal-timestamp load but still applies the load stale flag', async () => {
+    // A fix loop resolved a finding and pushed it. A focus-load, mid-flight, holds the OLDER snapshot
+    // (finding still open) at the SAME updatedAt (the concerning case) but freshly computed stale=true.
+    const resolvedCheck = makeCheck({ id: 'c1', resolution: 'resolved' })
+    const pushed = makeReview({
+      id: 'review-1',
+      updatedAt: 1_000,
+      checks: [resolvedCheck],
+      stale: false
+    })
+    useReviewStore.getState().handleReviewUpdate({ review: pushed })
+
+    const staleSnapshot = [
+      makeReview({
+        id: 'review-1',
+        updatedAt: 1_000,
+        checks: [makeCheck({ id: 'c1', resolution: 'open' })],
+        stale: true
+      })
+    ]
+    const getForSession = vi.fn().mockResolvedValue(staleSnapshot)
+    vi.stubGlobal('window', { api: { reviewer: { getForSession } } })
+
+    await useReviewStore.getState().loadReviewsForSession('session-1')
+
+    const stored = useReviewStore.getState().getReviewsForSession('session-1')
+    // Finding data is NOT reverted (still resolved), but the freshly-computed stale flag is applied.
+    expect(stored[0]?.checks[0]?.resolution).toBe('resolved')
+    expect(stored[0]?.stale).toBe(true)
+    vi.unstubAllGlobals()
+  })
+
   it('does not let a stale load overwrite a newer review delivered by a push', async () => {
     // A push completes the review while a slow focus-load is mid-flight holding an older snapshot.
     useReviewStore.getState().handleReviewUpdate({

--- a/src/renderer/src/stores/review-store.test.ts
+++ b/src/renderer/src/stores/review-store.test.ts
@@ -202,6 +202,38 @@ describe('review store', () => {
     vi.unstubAllGlobals()
   })
 
+  it('a plain push inherits the current outdated flag instead of dropping it', async () => {
+    // The review is flagged stale (a load computed it). A later push (e.g. a fix-loop finding change)
+    // carries no stale value — it must not silently clear the known outdated marker.
+    useReviewStore
+      .getState()
+      .handleReviewUpdate({ review: makeReview({ id: 'review-1', stale: true }) })
+
+    useReviewStore.getState().handleReviewUpdate({
+      review: makeReview({ id: 'review-1', checks: [makeCheck()], stale: undefined })
+    })
+
+    expect(useReviewStore.getState().getReviewsForSession('session-1')[0]?.stale).toBe(true)
+  })
+
+  it('a newer load that failed to recompute staleness keeps the existing outdated flag', async () => {
+    useReviewStore
+      .getState()
+      .handleReviewUpdate({ review: makeReview({ id: 'review-1', updatedAt: 1_000, stale: true }) })
+
+    // Newer payload, but stale could not be recomputed (undefined) — must inherit the current true.
+    const newerButUncomputed = [makeReview({ id: 'review-1', updatedAt: 2_000, stale: undefined })]
+    const getForSession = vi.fn().mockResolvedValue(newerButUncomputed)
+    vi.stubGlobal('window', { api: { reviewer: { getForSession } } })
+
+    await useReviewStore.getState().loadReviewsForSession('session-1')
+
+    const stored = useReviewStore.getState().getReviewsForSession('session-1')
+    expect(stored[0]?.updatedAt).toBe(2_000)
+    expect(stored[0]?.stale).toBe(true)
+    vi.unstubAllGlobals()
+  })
+
   it('dedupes concurrent loads for the same session', async () => {
     let resolveLoad: ((value: ReviewWithChecks[]) => void) | undefined
     const getForSession = vi.fn().mockReturnValue(

--- a/src/renderer/src/stores/review-store.ts
+++ b/src/renderer/src/stores/review-store.ts
@@ -21,13 +21,19 @@ type ReviewStore = ReviewStoreData & {
   getReviewForTurn: (sessionId: string, turnMessageId: string) => ReviewWithChecks | undefined
 }
 
-// Inserts or replaces a review in the list by id, keeping the list in createdAt desc order.
+// Inserts or replaces a review in the list by id, keeping the list in createdAt desc order. `stale` is
+// transient (never sent by a push and only computed on load), so a same-id update that doesn't carry an
+// explicit stale result inherits the current one — otherwise a plain reviewer:updated push would drop a
+// known "outdated" flag. An explicit false (a load that computed not-stale) still wins via ??.
 const upsertReview = (
   reviews: ReviewWithChecks[],
   updated: ReviewWithChecks
 ): ReviewWithChecks[] => {
+  const current = reviews.find((r) => r.id === updated.id)
+  const merged =
+    current && updated.stale === undefined ? { ...updated, stale: current.stale } : updated
   const without = reviews.filter((r) => r.id !== updated.id)
-  return [updated, ...without].sort((a, b) => b.createdAt - a.createdAt)
+  return [merged, ...without].sort((a, b) => b.createdAt - a.createdAt)
 }
 
 // Merges a freshly-loaded snapshot into the existing list. A focus-triggered load reads a DB snapshot
@@ -47,14 +53,17 @@ const mergeLoadedReviews = (
   const byId = new Map(existing.map((review) => [review.id, review]))
   for (const review of loaded) {
     const current = byId.get(review.id)
-    if (!current || review.updatedAt > current.updatedAt) {
+    if (!current) {
       byId.set(review.id, review)
-    } else if (review.stale !== undefined && review.stale !== current.stale) {
-      // Apply the load's staleness only when it was actually COMPUTED (an explicit boolean). A load
-      // that failed to recompute (session/scope error) leaves stale undefined; using it would wrongly
-      // clear a known outdated flag, re-presenting a stale verdict as valid.
-      byId.set(review.id, { ...current, stale: review.stale })
+      continue
     }
+    // `stale` is only meaningful when this load actually COMPUTED it (an explicit boolean); a load that
+    // failed to recompute leaves it undefined and must inherit the current flag — otherwise it would
+    // clear a known outdated marker. This holds on BOTH branches, so even a newer payload with a failed
+    // recompute keeps the existing stale rather than replacing it with undefined.
+    const stale = review.stale ?? current.stale
+    const base = review.updatedAt > current.updatedAt ? review : current
+    byId.set(review.id, base.stale === stale ? base : { ...base, stale })
   }
   return [...byId.values()].sort((a, b) => b.createdAt - a.createdAt)
 }

--- a/src/renderer/src/stores/review-store.ts
+++ b/src/renderer/src/stores/review-store.ts
@@ -30,21 +30,51 @@ const upsertReview = (
   return [updated, ...without].sort((a, b) => b.createdAt - a.createdAt)
 }
 
+// Merges a freshly-loaded snapshot into the existing list without letting a slow load overwrite newer
+// state. A focus-triggered load reads a DB snapshot and then does slow scope hashing; meanwhile a push
+// (e.g. a review completing) can update the store. So per review id, keep whichever has the newer
+// updatedAt, and preserve any existing review the snapshot didn't include (a just-created one).
+const mergeLoadedReviews = (
+  existing: ReviewWithChecks[],
+  loaded: ReviewWithChecks[]
+): ReviewWithChecks[] => {
+  const byId = new Map(existing.map((review) => [review.id, review]))
+  for (const review of loaded) {
+    const current = byId.get(review.id)
+    if (!current || review.updatedAt >= current.updatedAt) byId.set(review.id, review)
+  }
+  return [...byId.values()].sort((a, b) => b.createdAt - a.createdAt)
+}
+
 export const createInitialReviewState = (): ReviewStoreData => ({
   reviewsBySession: {}
 })
+
+// Session ids with a load in flight, so repeated focus events don't launch overlapping loads. Kept
+// outside the store (transient control state, not rendered) and cleared in loadReviewsForSession.
+const loadsInFlight = new Set<string>()
 
 export const useReviewStore = create<ReviewStore>((set, get) => ({
   ...createInitialReviewState(),
 
   loadReviewsForSession: async (sessionId: string) => {
+    // Dedup concurrent loads for the same session: focus can fire repeatedly, and each load runs slow
+    // scope hashing in main — overlapping loads would amplify that and race each other back.
+    if (loadsInFlight.has(sessionId)) return
+    loadsInFlight.add(sessionId)
     try {
       const reviews = (await window.api.reviewer.getForSession(sessionId)) as ReviewWithChecks[]
+      // Merge (not replace): a slow load must not overwrite a newer review a push delivered meanwhile.
       set((state) => ({
-        reviewsBySession: { ...state.reviewsBySession, [sessionId]: reviews }
+        reviewsBySession: {
+          ...state.reviewsBySession,
+          [sessionId]: mergeLoadedReviews(state.reviewsBySession[sessionId] ?? [], reviews)
+        }
       }))
     } catch {
       // Silently ignore load errors — the card will just not appear until next push event.
+    } finally {
+      loadsInFlight.delete(sessionId)
     }
   },
 

--- a/src/renderer/src/stores/review-store.ts
+++ b/src/renderer/src/stores/review-store.ts
@@ -35,9 +35,10 @@ const upsertReview = (
 // the store. A load carries two kinds of information that must be merged differently:
 //   - review/finding DATA: authoritative only when strictly newer than what's in the store. Fix-loop
 //     finding updates bump Review.updatedAt, so a stale load is strictly older and must NOT overwrite.
-//   - the `stale` flag: freshly computed against current bytes on THIS load, so it always applies (even
-//     when the load isn't newer — that's how a focus reload surfaces an edit to an otherwise-unchanged
-//     review). Applying it never reverts finding data; it only sets the flag on the retained review.
+//   - the `stale` flag: applied whenever the load actually COMPUTED it (an explicit boolean), even when
+//     the load isn't newer — that's how a focus reload surfaces an edit to an otherwise-unchanged
+//     review, and it only sets the flag on the retained review (never reverts finding data). A load that
+//     could NOT compute staleness leaves it undefined; that is ignored so it can't clear a known flag.
 // New reviews the snapshot didn't include (a just-created one) are preserved.
 const mergeLoadedReviews = (
   existing: ReviewWithChecks[],
@@ -48,7 +49,10 @@ const mergeLoadedReviews = (
     const current = byId.get(review.id)
     if (!current || review.updatedAt > current.updatedAt) {
       byId.set(review.id, review)
-    } else if (current.stale !== review.stale) {
+    } else if (review.stale !== undefined && review.stale !== current.stale) {
+      // Apply the load's staleness only when it was actually COMPUTED (an explicit boolean). A load
+      // that failed to recompute (session/scope error) leaves stale undefined; using it would wrongly
+      // clear a known outdated flag, re-presenting a stale verdict as valid.
       byId.set(review.id, { ...current, stale: review.stale })
     }
   }

--- a/src/renderer/src/stores/review-store.ts
+++ b/src/renderer/src/stores/review-store.ts
@@ -30,10 +30,15 @@ const upsertReview = (
   return [updated, ...without].sort((a, b) => b.createdAt - a.createdAt)
 }
 
-// Merges a freshly-loaded snapshot into the existing list without letting a slow load overwrite newer
-// state. A focus-triggered load reads a DB snapshot and then does slow scope hashing; meanwhile a push
-// (e.g. a review completing) can update the store. So per review id, keep whichever has the newer
-// updatedAt, and preserve any existing review the snapshot didn't include (a just-created one).
+// Merges a freshly-loaded snapshot into the existing list. A focus-triggered load reads a DB snapshot
+// and then does slow scope hashing; meanwhile a push (e.g. a fix-loop resolving a finding) can update
+// the store. A load carries two kinds of information that must be merged differently:
+//   - review/finding DATA: authoritative only when strictly newer than what's in the store. Fix-loop
+//     finding updates bump Review.updatedAt, so a stale load is strictly older and must NOT overwrite.
+//   - the `stale` flag: freshly computed against current bytes on THIS load, so it always applies (even
+//     when the load isn't newer — that's how a focus reload surfaces an edit to an otherwise-unchanged
+//     review). Applying it never reverts finding data; it only sets the flag on the retained review.
+// New reviews the snapshot didn't include (a just-created one) are preserved.
 const mergeLoadedReviews = (
   existing: ReviewWithChecks[],
   loaded: ReviewWithChecks[]
@@ -41,7 +46,11 @@ const mergeLoadedReviews = (
   const byId = new Map(existing.map((review) => [review.id, review]))
   for (const review of loaded) {
     const current = byId.get(review.id)
-    if (!current || review.updatedAt >= current.updatedAt) byId.set(review.id, review)
+    if (!current || review.updatedAt > current.updatedAt) {
+      byId.set(review.id, review)
+    } else if (current.stale !== review.stale) {
+      byId.set(review.id, { ...current, stale: review.stale })
+    }
   }
   return [...byId.values()].sort((a, b) => b.createdAt - a.createdAt)
 }

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -13,6 +13,7 @@ export const WEB_INVOKE_CHANNELS = {
   'acp.sendPrompt': 'acp:send-prompt',
   'acp.setPermissionProfile': 'acp:set-permission-profile',
   'artifacts.finalizeRunArtifacts': 'artifacts:finalize-run',
+  'artifacts.listProjectFiles': 'artifacts:list-project-files',
   'artifacts.openFile': 'artifacts:open-file',
   'artifacts.readPreview': 'artifacts:read-preview',
   'cli.getStatus': 'cli:get-status',

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -16,6 +16,7 @@ export const WEB_INVOKE_CHANNELS = {
   'artifacts.listProjectFiles': 'artifacts:list-project-files',
   'artifacts.openFile': 'artifacts:open-file',
   'artifacts.readPreview': 'artifacts:read-preview',
+  'artifacts.reconcilePendingArtifacts': 'artifacts:reconcile-pending',
   'cli.getStatus': 'cli:get-status',
   'cli.install': 'cli:install',
   'cli.uninstall': 'cli:uninstall',

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -107,6 +107,16 @@ export type ListProjectArtifactsRequest = {
   projectName: string
 }
 
+// Renderer request to re-finalize pending artifacts a crash left behind: the persisted message still
+// references `.pending/<run>/<file>` paths whose in-memory finalize claim was lost on restart. Returns
+// the message's finalized files so the renderer can replace the stale pending references.
+export type ReconcilePendingArtifactsRequest = {
+  projectName: string
+  sessionId: string
+  messageId: string
+  pendingPaths: string[]
+}
+
 // Internal repository list request after the app has resolved the logical project bucket.
 export type ListProjectMessageArtifactsRequest = ListMessageArtifactsRequest & {
   projectName: string

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -101,6 +101,12 @@ export type ListMessageArtifactsRequest = {
   messageId: string
 }
 
+// Renderer request to enumerate every finalized artifact on disk for one project, so the file library
+// can surface files whose owning session was deleted (the project name matches the durable project id).
+export type ListProjectArtifactsRequest = {
+  projectName: string
+}
+
 // Internal repository list request after the app has resolved the logical project bucket.
 export type ListProjectMessageArtifactsRequest = ListMessageArtifactsRequest & {
   projectName: string

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -172,6 +172,11 @@ export type ReviewRunRequest = {
   mainSessionId?: string
   // Provider/model tag recorded on the Review row (e.g. 'claude-opus-4-5'). Falls back to ''.
   model?: string
+  // Turn whose content is actually audited, when it differs from turnMessageId (the grouping id).
+  // Defaults to turnMessageId. Used when re-running a fix-loop review: the review row is grouped under
+  // the original turn (turnMessageId), but its scope belongs to the correction turn (scopeTurnMessageId)
+  // — re-running must re-audit that correction turn, not the original.
+  scopeTurnMessageId?: string
 }
 
 // IPC: pushed to renderer when a review's lifecycle/outcome/checks change.

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -204,8 +204,17 @@ export type ReviewUpdateEvent = {
 //   - 'already-reviewed': an auto-origin request for a turn that already has a review. This is main's
 //     atomic per-turn idempotency verdict (checked after the in-flight key is reserved), so the turn is
 //     definitively handled — never retry. Manual re-runs bypass this and never receive it.
+//   - 'idempotency-check-failed': the auto per-turn idempotency lookup itself threw, so main cannot
+//     confirm the turn is un-reviewed. Fail-closed — start nothing — but retryable: a retry re-runs the
+//     lookup, which may succeed (and then either proceed or return already-reviewed). Never risk a
+//     duplicate by proceeding on an unverified check.
 export type ReviewRunNotStartedReason =
-  'already-in-flight' | 'not-found' | 'load-failed' | 'run-failed' | 'already-reviewed'
+  | 'already-in-flight'
+  | 'not-found'
+  | 'load-failed'
+  | 'run-failed'
+  | 'already-reviewed'
+  | 'idempotency-check-failed'
 
 // IPC: result of reviewer:run. `started` is false when the run could not begin — no Review row is
 // created in that case, so the caller (e.g. a stale-review Re-run) can release its pending state and

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -184,6 +184,13 @@ export type ReviewUpdateEvent = {
   review: ReviewWithChecks
 }
 
+// IPC: result of reviewer:run. `started` is false when the run could not begin (the session couldn't
+// be loaded, or a run for this turn was already in flight) — no Review row is created in that case, so
+// the caller (e.g. a stale-review Re-run) can release its pending state and leave the turn retriable.
+export type ReviewRunResult = {
+  started: boolean
+}
+
 // Navigation intent emitted when the user clicks "Go to transcript" on a warn/fail check.
 // checkId and locator are optional: omitting them opens the Session reviewer page without
 // highlighting a specific check (used when navigating from a pass review).

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -177,7 +177,15 @@ export type ReviewRunRequest = {
   // the original turn (turnMessageId), but its scope belongs to the correction turn (scopeTurnMessageId)
   // — re-running must re-audit that correction turn, not the original.
   scopeTurnMessageId?: string
+  // Who requested the run. 'auto' (post-turn auto-review) is idempotent per turn: main refuses to start
+  // a second review for a turn that already has one, which is the atomic guarantee against duplicate
+  // runs from concurrent entry points. 'manual' (Request review / stale/error Re-run) intentionally
+  // bypasses that check so the user can force a fresh review. Defaults to 'manual' when omitted.
+  origin?: ReviewRunOrigin
 }
+
+// Distinguishes an automatic post-turn review from a user-initiated one — see ReviewRunRequest.origin.
+export type ReviewRunOrigin = 'auto' | 'manual'
 
 // IPC: pushed to renderer when a review's lifecycle/outcome/checks change.
 export type ReviewUpdateEvent = {
@@ -193,8 +201,11 @@ export type ReviewUpdateEvent = {
 //   - 'load-failed': the session store read threw (transient DB/FS). Retryable; creates no Review row.
 //   - 'run-failed': runReview threw before the running row was pushed (scope resolution / DB insert).
 //     A genuine failure, not a race — leave it to the user's manual Re-run rather than auto-retrying.
+//   - 'already-reviewed': an auto-origin request for a turn that already has a review. This is main's
+//     atomic per-turn idempotency verdict (checked after the in-flight key is reserved), so the turn is
+//     definitively handled — never retry. Manual re-runs bypass this and never receive it.
 export type ReviewRunNotStartedReason =
-  'already-in-flight' | 'not-found' | 'load-failed' | 'run-failed'
+  'already-in-flight' | 'not-found' | 'load-failed' | 'run-failed' | 'already-reviewed'
 
 // IPC: result of reviewer:run. `started` is false when the run could not begin — no Review row is
 // created in that case, so the caller (e.g. a stale-review Re-run) can release its pending state and

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -184,11 +184,25 @@ export type ReviewUpdateEvent = {
   review: ReviewWithChecks
 }
 
-// IPC: result of reviewer:run. `started` is false when the run could not begin (the session couldn't
-// be loaded, or a run for this turn was already in flight) — no Review row is created in that case, so
-// the caller (e.g. a stale-review Re-run) can release its pending state and leave the turn retriable.
+// Why a review did not start (set on ReviewRunResult when started is false). The auto-review caller
+// uses this to decide whether a retry could help:
+//   - 'already-in-flight': a run for this turn is already active → the turn IS being handled; retrying
+//     would launch a DUPLICATE review/fix-loop once the in-flight lock releases. Never retry.
+//   - 'not-found': the session wasn't on disk. A brand-new session persists via an async queue, so
+//     this can be a transient race the retry catches once the write lands. Retryable.
+//   - 'load-failed': the session store read threw (transient DB/FS). Retryable; creates no Review row.
+//   - 'run-failed': runReview threw before the running row was pushed (scope resolution / DB insert).
+//     A genuine failure, not a race — leave it to the user's manual Re-run rather than auto-retrying.
+export type ReviewRunNotStartedReason =
+  'already-in-flight' | 'not-found' | 'load-failed' | 'run-failed'
+
+// IPC: result of reviewer:run. `started` is false when the run could not begin — no Review row is
+// created in that case, so the caller (e.g. a stale-review Re-run) can release its pending state and
+// leave the turn retriable. `reason` (present only when started is false) says WHY, so the auto path
+// can retry a persistence-race cause without retrying an already-in-flight turn into a duplicate run.
 export type ReviewRunResult = {
   started: boolean
+  reason?: ReviewRunNotStartedReason
 }
 
 // Navigation intent emitted when the user clicks "Go to transcript" on a warn/fail check.

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -108,6 +108,10 @@ export type Review = {
   reviewerLog: ReviewerLogEntry[]
   createdAt: number
   updatedAt: number
+  // Transient (never persisted): set at load time when the turn's current scope no longer matches the
+  // scope this review was run against — e.g. an artifact was edited after the review completed. The UI
+  // uses it to stop presenting a stale "No issues found" as current. Computed by re-resolving the scope.
+  stale?: boolean
 }
 
 // A Review with its checks eagerly loaded, as returned by getReviewsForSession.


### PR DESCRIPTION
Fixes five reviewer findings on the generated-artifact lifecycle. One commit per finding.

## Findings addressed

- **F1 — Parallel sessions could attach an artifact to the wrong session.** The runtime tracked a single global `activeArtifactRun`, so an app-side connector write (e.g. molecule preview) from session A's turn could land in session B (or another project) once B started. Now the in-flight run is tracked **per app session**, and the caller's session id is threaded from the notebook `host.mcp` bridge through `ConnectorService` into `writeArtifactForCurrentRun`, failing closed when no session-scoped run is active.

- **F2 — Deleting a session (or project) stranded its artifacts.** The file library and `@` picker derived purely from session metadata, so deleting a session removed the only reference and the on-disk bytes vanished from the app despite the promise that they remain. Added a main-process scan of a project's on-disk artifacts; any file no live session references is surfaced under an **"Orphaned"** group, kept previewable / downloadable / `@`-referenceable. Both the Files panel and the mention popup read the scan through one shared, failure-tolerant hook.

- **F3 — Crash between pending-write and finalize orphaned the file.** The renderer persisted a pending artifact reference before finalize ran, but the finalize claim lived only in main-process memory. A crash in that window left the session JSON pointing at a `.pending/<run>/` path that nothing would finalize. On startup, persisted pending paths with a known owning message are re-finalized (idempotent move, rebuilt from the storage root so a corrupt path cannot escape) and the stale references replaced.

- **F4 — Same-name recovery could open the wrong file.** `recoverFinalizedPendingPath` scanned every message directory and returned the newest same-named file, so two runs that both produced `report.csv` could cross-resolve. A per-run marker written at finalize now pins the exact session + message a run moved into; legacy artifacts fall back to the prior newest-mtime scan.

- **F5 — The reviewer scope didn't pin artifact bytes.** The scope hash folded in artifact ids but not file contents, so an external edit to a finalized artifact left a stored review (and its finding locators) looking valid against changed bytes. A digest of each referenced artifact's current on-disk bytes is now folded into the producing message's block hash. Messages with no artifacts keep their prior hash, so existing locators stay valid. Full versioning/provenance remains future work.

## Testing

- Full suite green: 3071 passed, 43 skipped.
- `typecheck`, `lint`, `format` all clean.
- New coverage: per-session attribution + fail-closed (runtime, connector, mcpCall), orphan merge + disk scan, startup reconciliation, same-name run-scoped recovery + legacy fallback, and reviewer scope byte-pinning.