### PR TITLE
fix(acp): deliver image attachments as pixels to opencode

### DIFF
--- a/src/main/acp/attachment-content.test.ts
+++ b/src/main/acp/attachment-content.test.ts
@@ -4,6 +4,7 @@ import {
   MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
   buildOversizedAttachmentNotice,
   formatBytes,
+  imageAttachmentMimeType,
   isTabularAttachment,
   isTextLikeAttachment
 } from './attachment-content'
@@ -60,6 +61,38 @@ describe('isTextLikeAttachment', () => {
     expect(isTextLikeAttachment('mol.sdf', 'chemical/x-mdl-sdfile')).toBe(true)
     // A compressed payload stays binary even with a text-looking name.
     expect(isTextLikeAttachment('reads.fastq', 'application/gzip')).toBe(false)
+  })
+})
+
+describe('imageAttachmentMimeType', () => {
+  it('resolves a concrete image MIME type', () => {
+    expect(imageAttachmentMimeType('x', 'image/png')).toBe('image/png')
+    expect(imageAttachmentMimeType('x', 'image/jpeg')).toBe('image/jpeg')
+    expect(imageAttachmentMimeType('x', 'IMAGE/WEBP')).toBe('image/webp')
+    expect(imageAttachmentMimeType('x', 'image/gif; foo=bar')).toBe('image/gif')
+  })
+
+  it('falls back to the extension when the MIME is missing or generic', () => {
+    // The reported bug: a screenshot dropped/pasted with no browser MIME must still be sent as pixels.
+    expect(imageAttachmentMimeType('image.png')).toBe('image/png')
+    expect(imageAttachmentMimeType('photo.JPG')).toBe('image/jpeg')
+    expect(imageAttachmentMimeType('shot.jpeg', 'application/octet-stream')).toBe('image/jpeg')
+    expect(imageAttachmentMimeType('anim.gif', 'binary/octet-stream')).toBe('image/gif')
+    expect(imageAttachmentMimeType('pic.webp')).toBe('image/webp')
+    expect(imageAttachmentMimeType('pic.avif')).toBe('image/avif')
+  })
+
+  it('lets a concrete non-image MIME stay authoritative', () => {
+    expect(imageAttachmentMimeType('image.png', 'application/pdf')).toBeUndefined()
+    expect(imageAttachmentMimeType('sheet.csv', 'text/csv')).toBeUndefined()
+  })
+
+  it('excludes SVG and unknown or non-image extensions', () => {
+    expect(imageAttachmentMimeType('logo.svg', 'image/svg+xml')).toBeUndefined()
+    expect(imageAttachmentMimeType('logo.svg')).toBeUndefined()
+    expect(imageAttachmentMimeType('archive.zip')).toBeUndefined()
+    expect(imageAttachmentMimeType('noext')).toBeUndefined()
+    expect(imageAttachmentMimeType('data.csv', 'application/octet-stream')).toBeUndefined()
   })
 })
 

--- a/src/main/acp/attachment-content.ts
+++ b/src/main/acp/attachment-content.ts
@@ -128,6 +128,34 @@ export const isTabularAttachment = (name: string, mimeType?: string): boolean =>
   return TABULAR_EXTENSIONS.has(fileExtension(name))
 }
 
+// Raster image extensions that vision-capable agents can read as pixels, mapped to the MIME type to
+// inline them as. SVG is deliberately absent: it is vector/text, not a raster type the providers accept
+// as image content. Matches the accepted set in ACP_MESSAGE_IMAGE_MIME_TYPES.
+const IMAGE_EXTENSION_MIME = new Map<string, string>([
+  ['png', 'image/png'],
+  ['jpg', 'image/jpeg'],
+  ['jpeg', 'image/jpeg'],
+  ['gif', 'image/gif'],
+  ['webp', 'image/webp'],
+  ['avif', 'image/avif']
+])
+
+// The image MIME type to inline a file as, or undefined when it is not a supported raster image. A
+// concrete image/* MIME wins; a missing or generic MIME (browsers omit it for some drag/drop and paste
+// sources) falls back to the file extension — so a `.png` upload is still sent as pixels rather than a
+// bare file link the model can only reach by writing code. A concrete non-image MIME is authoritative.
+export const imageAttachmentMimeType = (name: string, mimeType?: string): string | undefined => {
+  const essence = mimeEssence(mimeType)
+
+  if (essence && essence.startsWith('image/')) {
+    return essence === 'image/svg+xml' ? undefined : essence
+  }
+
+  if (essence && !GENERIC_MIME_TYPES.has(essence)) return undefined
+
+  return IMAGE_EXTENSION_MIME.get(fileExtension(name))
+}
+
 // Human-readable byte size for the notice (binary units, one decimal past KB).
 export const formatBytes = (bytes: number): string => {
   if (bytes < 1024) return `${bytes} B`

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -926,6 +926,61 @@ describe('ACP runtime session management', () => {
     ).resolves.toBe('hello from upload')
   })
 
+  it('inlines an image attachment as pixels when the browser sent no usable MIME type', async () => {
+    const root = await createTemporaryRoot()
+    const uploadRepository = new UploadRepository(root)
+    // Some drag/drop and paste sources omit the MIME (undefined) or send a generic octet-stream; the
+    // runtime must still recognize these as images by extension and send real pixels, not a file link.
+    const stagedAttachments = await uploadRepository.stageFiles({
+      files: [
+        {
+          name: 'no-mime.png',
+          mimeType: undefined,
+          content: Buffer.from('png-a').toString('base64')
+        },
+        {
+          name: 'generic.png',
+          mimeType: 'application/octet-stream',
+          content: Buffer.from('png-b').toString('base64')
+        }
+      ]
+    })
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploadRepository }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'what is in these',
+      attachments: stagedAttachments
+    })
+
+    expect(receivedPrompts).toHaveLength(1)
+    // Both files are sent as base64 image blocks with the extension-derived canonical MIME — not the
+    // resource_link a missing/generic MIME would have produced before the fallback existed.
+    expect(receivedPrompts[0][1]).toMatchObject({
+      type: 'image',
+      mimeType: 'image/png',
+      data: Buffer.from('png-a').toString('base64')
+    })
+    expect(receivedPrompts[0][2]).toMatchObject({
+      type: 'image',
+      mimeType: 'image/png',
+      data: Buffer.from('png-b').toString('base64')
+    })
+  })
+
   it('degrades an image attachment to a resource link when replay images consume the inline budget', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -58,6 +58,7 @@ import {
   ATTACHMENT_PREVIEW_BYTES,
   MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
   buildOversizedAttachmentNotice,
+  imageAttachmentMimeType,
   isTabularAttachment,
   isTextLikeAttachment
 } from './attachment-content'
@@ -1721,11 +1722,15 @@ class AcpRuntime {
     const { sessionId, absolutePath, uri, name, mimeType, size } = descriptor
 
     // Images are embedded as base64 so vision-capable agents receive the actual pixels.
-    // Large images are downscaled/re-encoded first so one file cannot overflow the request.
-    if (mimeType?.startsWith('image/')) {
+    // Large images are downscaled/re-encoded first so one file cannot overflow the request. Detection
+    // falls back to the file extension so a `.png` with a missing/generic MIME (some drag/drop and paste
+    // sources omit it) is still inlined as pixels instead of degrading to a bare file link.
+    const imageMimeType = imageAttachmentMimeType(name, mimeType)
+
+    if (imageMimeType) {
       const { data, mimeType: outMimeType } = await buildImageContentData(
         absolutePath,
-        mimeType,
+        imageMimeType,
         size
       )
 
@@ -1736,7 +1741,7 @@ class AcpRuntime {
       const alreadyInlined = this.sessionInlineImageBytes.get(sessionId) ?? 0
 
       if (!canInlineImageInSession(alreadyInlined, data.length, this.inlineImageBudgetBytes)) {
-        return [{ type: 'resource_link', uri, name, title: name, mimeType, size }]
+        return [{ type: 'resource_link', uri, name, title: name, mimeType: imageMimeType, size }]
       }
 
       this.sessionInlineImageBytes.set(sessionId, alreadyInlined + data.length)

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -129,6 +129,25 @@ describe('opencodeFramework.prepareModelConfig', () => {
     expect(config.env?.OPENCODE_CONFIG_CONTENT).not.toContain('"k"')
   })
 
+  it('declares image capability in the pinned layer for a multimodal model', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      {
+        type: 'custom',
+        baseUrl: 'https://gw/v1',
+        model: 'kimi-k3',
+        key: 'k',
+        apiEndpoints: ['openai'],
+        supportsImageInput: true
+      },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    expect(content.provider['openai-compatible'].models).toEqual({
+      'kimi-k3': { attachment: true, modalities: { input: ['text', 'image'] } }
+    })
+  })
+
   it('mirrors the config file provider/model in the OPENCODE_CONFIG_CONTENT layer (no divergence)', () => {
     const config = opencodeFramework.prepareModelConfig(
       {
@@ -315,6 +334,40 @@ describe('buildOpencodeConfig', () => {
       })
     )
     expect(both.model).toBe('openai-compatible/m')
+  })
+
+  it('declares image capability on the model when it supports image input', () => {
+    // opencode strips image parts for a registered model that does not advertise vision, so a
+    // multimodal model must carry the attachment capability and an image input modality.
+    const config = JSON.parse(
+      buildOpencodeConfig({
+        type: 'custom',
+        baseUrl: 'https://gw/v1',
+        model: 'kimi-k3',
+        key: 'k',
+        apiEndpoints: ['openai'],
+        supportsImageInput: true
+      })
+    )
+
+    expect(config.provider['openai-compatible'].models).toEqual({
+      'kimi-k3': { attachment: true, modalities: { input: ['text', 'image'] } }
+    })
+  })
+
+  it('leaves a text-only model without image capability', () => {
+    const config = JSON.parse(
+      buildOpencodeConfig({
+        type: 'custom',
+        baseUrl: 'https://gw/v1',
+        model: 'deepseek-v4-flash',
+        key: 'k',
+        apiEndpoints: ['openai'],
+        supportsImageInput: false
+      })
+    )
+
+    expect(config.provider['openai-compatible'].models).toEqual({ 'deepseek-v4-flash': {} })
   })
 
   it('uses the OpenAI base for a dual-endpoint vendor, not its Anthropic base (DeepSeek)', () => {

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -114,6 +114,14 @@ const resolveOpencodeEndpoint = (
   return { bareModel, providerId, npm, baseURL }
 }
 
+// The opencode per-model capability block. opencode strips image parts before calling the provider for
+// any model whose config does not declare vision — custom and freshly-registered models default to
+// text-only — so a base64 image sent over ACP silently never reaches the provider. A multimodal model
+// must therefore advertise both the attachment capability and an image input modality. Empty (text-only)
+// otherwise, so a non-vision model is never told it can accept images.
+const buildModelCapabilities = (provider: ResolvedProvider): Record<string, unknown> =>
+  provider.supportsImageInput ? { attachment: true, modalities: { input: ['text', 'image'] } } : {}
+
 // The app-authoritative config layer (model + provider block + permission policy) passed verbatim to
 // opencode via OPENCODE_CONFIG_CONTENT, which opencode deep-merges ABOVE both the app-owned global config
 // and any project config. Pinning the provider/model/baseURL here (not just permission) means a
@@ -133,7 +141,7 @@ const buildAppConfigContent = (provider: ResolvedProvider): Record<string, unkno
           ...(baseURL ? { baseURL } : {}),
           ...(provider.key ? { apiKey: `{env:${OPENCODE_API_KEY_ENV}}` } : {})
         },
-        ...(bareModel ? { models: { [bareModel]: {} } } : {})
+        ...(bareModel ? { models: { [bareModel]: buildModelCapabilities(provider) } } : {})
       }
     }
   }
@@ -188,8 +196,11 @@ const buildOpencodeConfig = (
           // so the decrypted key is never persisted to opencode.json (see prepareModelConfig).
           ...(provider.key ? { apiKey: `{env:${OPENCODE_API_KEY_ENV}}` } : {})
         },
-        // Register the model so opencode treats a non-catalog id as a real, selectable model.
-        ...(bareModel ? { models: { ...baseModels, [bareModel]: {} } } : {})
+        // Register the model so opencode treats a non-catalog id as a real, selectable model, declaring
+        // its image capability when the active model is multimodal (else opencode strips image parts).
+        ...(bareModel
+          ? { models: { ...baseModels, [bareModel]: buildModelCapabilities(provider) } }
+          : {})
       }
     }
   }

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -19,6 +19,9 @@ export type ResolvedProvider = {
   // Which chat APIs the endpoint speaks; opencode uses this to pick anthropic vs openai-compatible.
   // Absent ⇒ ['anthropic'].
   apiEndpoints?: readonly ChatApiEndpoint[]
+  // Whether the active model accepts image input. opencode strips image parts for a custom/registered
+  // model whose config does not declare vision, so this is surfaced into its per-model capabilities.
+  supportsImageInput?: boolean
 }
 
 export type ProviderEnvOptions = {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1,5 +1,5 @@
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname, join, normalize } from 'node:path'
 import { tmpdir } from 'node:os'
 import { execPath } from 'node:process'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -1222,10 +1222,14 @@ describe('SettingsService: onboarding', () => {
   it('persists a new dataRoot across a fresh read', async () => {
     const service = createService()
 
-    await service.setDataRoot('/mnt/new-data')
+    // The repository canonicalizes dataRoot to the host separator on read (for samePath comparisons),
+    // so build the fixture the same way — a bare POSIX literal comes back with backslashes on Windows
+    // and would fail the round-trip.
+    const dataRoot = normalize('/mnt/new-data')
+    await service.setDataRoot(dataRoot)
 
     const settings = await service.getStoredSettings()
-    expect(settings.dataRoot).toBe('/mnt/new-data')
+    expect(settings.dataRoot).toBe(dataRoot)
   })
 })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1363,7 +1363,10 @@ describe('SettingsService: skills', () => {
       codexDetectDeps: {
         env: { PATH: dirname(adapterPath) },
         homePath: '/home',
-        platform: 'linux',
+        // Detection walks PATH with the host's path rules; this test's adapterPath/PATH are real
+        // on-disk host paths, so mock the host platform (a fixed 'linux' shreds a Windows drive letter
+        // like C:\… when splitting PATH on ':' , so detection would never match the file it created).
+        platform: process.platform,
         isRunnable: (path) => Promise.resolve(path === adapterPath),
         getAdapterVersion: () => Promise.resolve('codex-acp 1.1.4'),
         getCodexVersion: () => Promise.resolve(undefined),

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -653,6 +653,32 @@ describe('SettingsService: preflight & spawn config', () => {
     })
   })
 
+  it('declares the model image capability in the resolved OpenCode backend config', async () => {
+    // resolveActiveAgentBackend honors this forced-framework env above stored settings; set it
+    // explicitly (a prior Codex test leaves it stubbed to 'codex') so this resolves OpenCode.
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
+    await repository.setAgentFramework('opencode')
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.19.0' }
+    })
+    const provider = (
+      await service.upsertProvider({ type: 'official', name: 'Kimi', vendorId: 'kimi', key: 'k' })
+    ).providers[0]
+    await service.setActiveProvider(provider.id)
+
+    const backend = await service.resolveActiveAgentBackend()
+
+    // End-to-end guard for the whole capability chain: resolveProvider must carry supportsImageInput
+    // for the multimodal default (kimi-k3) and prepareModelConfig must surface it, so OpenCode receives
+    // the model as image-capable instead of a bare entry whose image parts it would strip. Deleting the
+    // wiring in resolveProvider or buildModelCapabilities makes this fail.
+    const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    expect(content.provider['openai-compatible'].models['kimi-k3']).toEqual({
+      attachment: true,
+      modalities: { input: ['text', 'image'] }
+    })
+  })
+
   it('resolves a Chat Completions provider through the Codex Responses bridge', async () => {
     const localFetch = globalThis.fetch
     let upstreamRequest: Record<string, unknown> | undefined

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1173,6 +1173,29 @@ describe('SettingsService: image-input capability', () => {
     expect(view?.models).toEqual(['claude-opus-5-unreleased'])
     expect(view?.supportsImageInput).toBe(true)
   })
+
+  it('uses the vendor default model, not the refreshed catalog head, for the capability fallback', async () => {
+    const service = createService()
+    // A refresh reorders Kimi's catalog so a text-only id leads, while the spawned default stays kimi-k3.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({ data: [{ id: 'kimi-k2.7-code' }, { id: 'kimi-k3' }] })
+      })
+    )
+    const created = (
+      await service.upsertProvider({ type: 'official', name: 'Kimi', vendorId: 'kimi', key: 'k' })
+    ).providers[0]
+    await service.refreshProviderModels({ providerId: created.id })
+
+    // With no active model, the capability must match the model resolveProvider actually spawns — the
+    // vendor default kimi-k3 (multimodal) — not the refreshed list head kimi-k2.7-code (text-only), or
+    // OpenCode would keep stripping images from a default that supports them.
+    const view = (await service.getSettingsView()).providers.find((p) => p.id === created.id)
+    expect(view?.models[0]).toBe('kimi-k2.7-code')
+    expect(view?.supportsImageInput).toBe(true)
+  })
 })
 
 describe('SettingsService: onboarding', () => {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1926,9 +1926,13 @@ class SettingsService {
     // Custom providers: respect the user-configured supportsImageInput flag
     if (provider.type === 'custom') return provider.supportsImageInput === true
 
-    // Official vendors: check the model against the vendor's multimodalModels registry
+    // Official vendors: check the model against the vendor's multimodalModels registry. When no model
+    // is active, fall back to the vendor's default model — the exact id resolveProvider spawns — not the
+    // first of the (possibly live-refreshed) catalog, so the capability always matches the model actually
+    // sent. Otherwise a refreshed list whose first entry is text-only would strip images from a default
+    // that supports them (e.g. Kimi's default kimi-k3).
     if (provider.type === 'official' && provider.vendorId) {
-      const modelToCheck = activeModel ?? this.availableModels(provider)[0]
+      const modelToCheck = activeModel ?? defaultVendorModel(provider.vendorId)
       return isVendorModelMultimodal(provider.vendorId, modelToCheck)
     }
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1985,7 +1985,8 @@ class SettingsService {
         openaiBaseUrl: resolveVendorOpenAiBaseUrl(provider.vendorId, provider.region),
         model: modelOverride ?? defaultVendorModel(provider.vendorId),
         key,
-        apiEndpoints: this.resolveProviderApiEndpoints(provider)
+        apiEndpoints: this.resolveProviderApiEndpoints(provider),
+        supportsImageInput: this.providerSupportsImageInput(provider, modelOverride)
       }
     }
 
@@ -1994,7 +1995,8 @@ class SettingsService {
       baseUrl: provider.baseUrl,
       model: modelOverride ?? provider.model,
       key,
-      apiEndpoints: this.resolveProviderApiEndpoints(provider)
+      apiEndpoints: this.resolveProviderApiEndpoints(provider),
+      supportsImageInput: this.providerSupportsImageInput(provider, modelOverride)
     }
   }
 


### PR DESCRIPTION
## Summary

Vision-capable models under the **opencode** framework could not see attached images — the model would refuse ("this model doesn't support image input") or write code to open the file. Two independent, app-side causes:

1. **Image sent as a file link instead of pixels.** `buildFileContentBlock` only inlined a file as an image when its MIME type began with `image/`. Browsers omit the MIME for some drag/drop and paste sources, so a `.png` arrived with no MIME, fell through to the generic branch, and was sent as a `resource_link`. opencode handed the model a file path, so the model tried to open it with code rather than seeing pixels.

2. **opencode stripped the image before calling the provider.** opencode treats a registered model whose config does not declare vision as text-only and drops image parts (see opencode issues [#13310](https://github.com/anomalyco/opencode/issues/13310), [#15040](https://github.com/anomalyco/opencode/issues/15040)). The app registered the model as an empty `{}`, so even a correct image block never reached the provider.

## Changes

- Add `imageAttachmentMimeType(name, mimeType)` in `attachment-content.ts`: a concrete `image/*` MIME wins; a missing or generic MIME falls back to the file extension (`png/jpg/jpeg/gif/webp/avif`), mirroring how `isTextLikeAttachment` already handles missing MIME. SVG and concrete non-image MIMEs are excluded. Wired into `buildFileContentBlock` (covers both uploads and `@`-mentions).
- Declare the model's image capability in the opencode provider config (`{ attachment: true, modalities: { input: ['text', 'image'] } }`) when the active model supports image input — in both the written config and the authoritative `OPENCODE_CONFIG_CONTENT` layer. Field names confirmed against opencode's own config schema.
- Thread `supportsImageInput` onto `ResolvedProvider`, set from the existing registry-backed `providerSupportsImageInput`. Text-only models (e.g. DeepSeek chat) correctly get no image capability.

## Testing

- New/extended unit tests: `imageAttachmentMimeType` (extension fallback, generic-MIME fallback, concrete-non-image authoritative, SVG excluded); opencode config declares image capability for a multimodal model and leaves a text-only model bare — in both config builders.
- Full gate: typecheck, lint, format, `vitest run` (3294 passed).
- Verified live under opencode: a multimodal model (kimi-k3) now receives a `type:'image'` block and reads the image; a text-only model correctly does not.