### PR TITLE
fix(uploads): keep inline image payload under the 5MB base64 provider limit

### DIFF
--- a/src/main/uploads/attachment-media.test.ts
+++ b/src/main/uploads/attachment-media.test.ts
@@ -80,6 +80,15 @@ afterEach(async () => {
   await rm(root, { recursive: true, force: true })
 })
 
+describe('MAX_IMAGE_PAYLOAD_BYTES', () => {
+  it('stays under the 5MB per-image provider limit after base64 growth', () => {
+    // Anthropic and OpenCode cap a single image near 5MB of base64; base64 inflates raw bytes ~4/3.
+    // Guards against raising the raw cap back to a value whose encoded form exceeds the provider limit.
+    const base64Bytes = Math.ceil(MAX_IMAGE_PAYLOAD_BYTES / 3) * 4
+    expect(base64Bytes).toBeLessThanOrEqual(5 * 1024 * 1024)
+  })
+})
+
 describe('buildImageContentData', () => {
   it('passes small images through untouched as raw base64', async () => {
     const filePath = join(root, 'small.png')

--- a/src/main/uploads/attachment-media.ts
+++ b/src/main/uploads/attachment-media.ts
@@ -7,8 +7,11 @@ import { pathToFileURL } from 'node:url'
 // blows past the model's per-image (~5MB) and total-request (~32MB) limits after base64 growth.
 export const MAX_INLINE_IMAGE_BYTES = 2 * 1024 * 1024
 
-// Anthropic rejects a single image whose payload exceeds 5MB; stay comfortably under it.
-export const MAX_IMAGE_PAYLOAD_BYTES = 4.5 * 1024 * 1024
+// A single image must stay under the provider per-image limit AFTER base64 growth. Anthropic rejects
+// an image near 5MB and OpenCode's default image config caps base64 at 5MB (5242880); base64 inflates
+// raw bytes ~33%. Cap the re-encoded raw payload at 3.5MB so its base64 form (~4.7MB) stays under 5MB
+// on both routes — the previous 4.5MB raw grew to ~6MB base64 and could be rejected or force a re-resize.
+export const MAX_IMAGE_PAYLOAD_BYTES = 3.5 * 1024 * 1024
 
 // Base64 image data shares the request with prompts and tools. Keep 8MB of a typical 32MB request
 // available for that non-image content even when the composer accepts its maximum attachment count.


### PR DESCRIPTION
## Summary

Follow-up to #224. `MAX_IMAGE_PAYLOAD_BYTES` capped the re-encoded image payload at **4.5 MB of raw bytes**, but base64 inflates raw bytes ~33%, so a maxed-out image reached **~6 MB base64** — over the per-image limit Anthropic enforces and over OpenCode's default image config cap (`max_base64_bytes: 5242880` = 5 MB). That risks a rejected request on the Anthropic route or an extra downstream re-resize.

## Change

- Lower `MAX_IMAGE_PAYLOAD_BYTES` to **3.5 MB raw**, so the base64 form (~4.7 MB) stays comfortably under 5 MB on both the Anthropic and OpenAI-compatible routes. Large images are downscaled to ≤1568 px and re-encoded before this cap applies, so the visible change is only that a few very detailed PNGs re-encode to JPEG slightly sooner.
- Add an invariant test asserting the cap's base64 form stays ≤ 5 MB, so raising the raw cap past that point fails a test instead of silently regressing.

## Testing

- `attachment-media.test.ts` (16 passed, incl. the new invariant).
- Full gate: typecheck, lint, format, `vitest run` (3310 passed).