### PR TITLE
fix(storage): create data root on onboarding pointer switch

### DIFF
--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -803,6 +803,47 @@ describe('storage IPC handlers', () => {
     expect(deps.relaunch).toHaveBeenCalledTimes(1)
   })
 
+  it('set-data-root-and-relaunch creates the derived target directory for a fresh empty folder', async () => {
+    // Regression: onboarding to a brand-new empty folder persisted settings.dataRoot but never
+    // created `<parent>/OpenScience`, so the next launch's startup guard read the configured-but-
+    // absent root as deleted and wrongly showed "Data folder not found". The handler must mkdir the
+    // target so the recorded root actually exists on disk.
+    initDataRoot(dataRoot)
+    expect(existsSync(target)).toBe(false)
+    const deps = fakeDeps()
+    registerStorageIpcHandlers(deps)
+
+    await expect(
+      invoke('storage:set-data-root-and-relaunch', { parent: targetParent, markOnboarding: true })
+    ).resolves.toEqual({ ok: true })
+
+    expect(existsSync(target)).toBe(true)
+    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target)
+  })
+
+  it('set-data-root-and-relaunch creates the target before persisting the pointer', async () => {
+    // Ordering guard: if the folder can't be created the pointer must not be recorded, otherwise the
+    // app would relaunch into the same missing-folder state the fix is meant to prevent.
+    initDataRoot(dataRoot)
+    const setDataRoot = vi.fn().mockImplementation(async () => {
+      // The directory must already exist by the time the pointer is persisted.
+      expect(existsSync(target)).toBe(true)
+    })
+    const deps = fakeDeps({
+      settingsService: {
+        setDataRoot,
+        markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
+        dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
+        getStoredSettings: vi.fn().mockResolvedValue({})
+      }
+    })
+    registerStorageIpcHandlers(deps)
+
+    await invoke('storage:set-data-root-and-relaunch', { parent: targetParent })
+
+    expect(setDataRoot).toHaveBeenCalledTimes(1)
+  })
+
   it('set-data-root-and-relaunch persists the derived target and relaunches on an adopt parent (no move, no engine)', async () => {
     initDataRoot(dataRoot)
     await mkdir(join(target, 'artifacts'), { recursive: true })

--- a/src/main/storage/ipc.ts
+++ b/src/main/storage/ipc.ts
@@ -392,7 +392,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
   // lands atomically with setDataRoot, in the same step as the relaunch: App.tsx's startup gate
   // reads onboardingCompletedAt, and flipping it from the renderer before this IPC resolves would
   // swap the wizard for Home (showing the OLD data root, and burying any failure below). Settings-
-  // adopt omits it (onboarding has already completed). Order is load-bearing: classify ->
+  // adopt omits it (onboarding has already completed). Order is load-bearing: classify -> mkdir ->
   // setDataRoot -> [markOnboardingComplete] -> relaunch. On an invalid parent, none of these run.
   ipcMain.handle(
     'storage:set-data-root-and-relaunch',

--- a/src/main/storage/ipc.ts
+++ b/src/main/storage/ipc.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { app, dialog, ipcMain } from 'electron'
@@ -406,6 +407,13 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         }
 
         const target = dataRootForPicked(request.parent)
+        // Create the data root now, before persisting the pointer. Unlike storage:migrate there is no
+        // copy phase to mkdir it, so a fresh onboarding folder ('move') would be recorded in
+        // settings.dataRoot without ever existing on disk - and the next launch's startup guard would
+        // read that explicitly-configured-but-absent root as deleted and wrongly show "Data folder not
+        // found". For an 'adopt' target the folder already exists, so this is a no-op. classifyDataRoot
+        // has already proven the parent writable, so failure here is genuinely unexpected.
+        await mkdir(target, { recursive: true })
         await deps.settingsService.setDataRoot(target)
         if (request.markOnboarding) {
           await deps.settingsService.markOnboardingComplete()


### PR DESCRIPTION
## Summary

Fixes the false **"Data folder not found"** dialog that appears after onboarding to a custom **empty** folder.

## Root cause

When a custom folder is picked in onboarding, `OnboardingWizard.handleRestart` calls `setDataRootAndRelaunch`, which reaches the `storage:set-data-root-and-relaunch` IPC handler. That handler persisted `settings.dataRoot = <parent>/OpenScience` via `setDataRoot` but **never created the directory** — unlike `storage:migrate`, it has no copy/mkdir phase.

On the next launch, `storage:get-info` computes:

```ts
dataRootMissing = Boolean(storedSettings.dataRoot) && (await isDataRootMissing(dataRoot))
```

Since `settings.dataRoot` is now explicitly set but `<parent>/OpenScience` was never created, `isDataRootMissing` returns `true` (ENOENT) and the startup guard shows the dialog. The default `~/OpenScience` case is immune only because `settings.dataRoot` stays unset there (the `Boolean()` short-circuits).

## Fix

`mkdir` the derived target before persisting the pointer, so the recorded data root actually exists on disk:

- `move` (fresh empty onboarding folder): the folder is created → no false nag on the next launch.
- `adopt` (folder already holds our data): `mkdir { recursive: true }` is a no-op.
- Ordering matters — the directory is created **before** `setDataRoot`, so a failed `mkdir` never records a pointer to a folder that doesn't exist.

This single point also covers the `DataRootMissingDialog`'s "Choose another location" recovery path, which shares the same handler.

## Tests

- `set-data-root-and-relaunch creates the derived target directory for a fresh empty folder`
- `set-data-root-and-relaunch creates the target before persisting the pointer`

Full gate green: typecheck, lint, format, and the full suite (3311 passed).
