### PR TITLE
feat: add full-screen file previews

### DIFF
--- a/src/renderer/src/pages/workspace/FilePreviewDialog.tsx
+++ b/src/renderer/src/pages/workspace/FilePreviewDialog.tsx
@@ -1,0 +1,39 @@
+import { Dialog } from 'radix-ui'
+
+import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+
+import { PreviewFileSurface } from './PreviewFileSurface'
+
+type FilePreviewDialogProps = {
+  item: PreviewFileItem | undefined
+  onClose: () => void
+}
+
+// The dialog is deliberately transient: Files tiles and panel previews can open it without
+// creating or removing a preview-workbench item.
+const FilePreviewDialog = ({ item, onClose }: FilePreviewDialogProps): React.JSX.Element | null => {
+  if (!item) return null
+
+  return (
+    <Dialog.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/50" />
+        {/* Keep the modal large enough for document renderers while leaving workspace context visible. */}
+        <Dialog.Content
+          aria-describedby={undefined}
+          className="fixed left-1/2 top-1/2 z-[60] flex h-[90vh] w-[90vw] max-w-none -translate-x-1/2 -translate-y-1/2 overflow-hidden overscroll-contain rounded-md bg-bg-000 text-text-000 shadow-dialog"
+        >
+          <Dialog.Title className="sr-only">Preview {item.title}</Dialog.Title>
+          <PreviewFileSurface item={item} onClose={onClose} tooltipClassName="z-[70]" />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+export { FilePreviewDialog }

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -1,0 +1,132 @@
+import { Maximize2, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+
+import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
+import { PreviewFileContent } from './previews/PreviewFileContent'
+
+type PreviewFileSurfaceProps = {
+  item: PreviewFileItem
+  contentKey?: string
+  renderContent?: boolean
+  tooltipClassName?: string
+  onClose: () => void
+  onOpenFullScreen?: () => void
+}
+
+// Keeps the identifying tail and extension visible while the flexible prefix owns the ellipsis.
+const MiddleEllipsisFileName = ({ name }: { name: string }): React.JSX.Element => {
+  const extensionIndex = name.lastIndexOf('.')
+  const extensionLength = extensionIndex > 0 ? name.length - extensionIndex : 0
+  const trailingLength = Math.min(name.length, Math.max(extensionLength + 10, 18))
+  const splitIndex = Math.max(1, name.length - trailingLength)
+
+  return (
+    <span className="flex min-w-0 max-w-full flex-1 items-center overflow-hidden whitespace-nowrap">
+      <span className="min-w-0 truncate">{name.slice(0, splitIndex)}</span>
+      <span
+        data-testid="preview-title-tail"
+        className="min-w-0 max-w-[65%] shrink overflow-hidden text-ellipsis [direction:rtl] [unicode-bidi:plaintext]"
+      >
+        {name.slice(splitIndex)}
+      </span>
+    </span>
+  )
+}
+
+// The optional callback makes the maximize action available only in the compact workbench panel;
+// the dialog reuses this header without exposing a nested full-screen action.
+const PreviewFileHeader = ({
+  item,
+  onClose,
+  onOpenFullScreen,
+  tooltipClassName
+}: Pick<
+  PreviewFileSurfaceProps,
+  'item' | 'onClose' | 'onOpenFullScreen' | 'tooltipClassName'
+>): React.JSX.Element => (
+  <header
+    data-testid="preview-card-header"
+    className="flex h-8 shrink-0 items-center gap-1 border-b border-border-300/50 px-2"
+  >
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="min-w-0 flex-1 text-[12px] font-medium text-text-000">
+            <MiddleEllipsisFileName name={item.name} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className={tooltipClassName}>{item.title}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+    <ManagedFileDownloadButton
+      source={item.source ?? 'artifact'}
+      path={item.path}
+      suggestedName={item.name}
+      className="bg-transparent shadow-none"
+    />
+    {onOpenFullScreen ? (
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="text-text-100 hover:text-text-000"
+              aria-label={`Open full screen preview of ${item.title}`}
+              onClick={onOpenFullScreen}
+            >
+              <Maximize2 aria-hidden="true" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent className={tooltipClassName}>Open full screen preview</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    ) : null}
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="text-text-100 hover:text-text-000"
+            aria-label={`Close preview of ${item.title}`}
+            onClick={onClose}
+          >
+            <X aria-hidden="true" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent className={tooltipClassName}>Close preview</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  </header>
+)
+
+// The content slot is shared by both presentations so every supported file type follows the same
+// renderer path. Callers can temporarily suppress it while another surface owns the preview.
+const PreviewFileSurface = ({
+  item,
+  contentKey,
+  renderContent = true,
+  tooltipClassName,
+  onClose,
+  onOpenFullScreen
+}: PreviewFileSurfaceProps): React.JSX.Element => (
+  <div className="flex size-full min-h-0 flex-col overflow-hidden">
+    <PreviewFileHeader
+      item={item}
+      onClose={onClose}
+      onOpenFullScreen={onOpenFullScreen}
+      tooltipClassName={tooltipClassName}
+    />
+    <div className="min-h-0 flex-1 overflow-y-auto bg-bg-000">
+      {renderContent ? <PreviewFileContent key={contentKey} item={item} /> : null}
+    </div>
+  </div>
+)
+
+export { MiddleEllipsisFileName, PreviewFileSurface }

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -150,11 +150,56 @@ describe('PreviewPanel', () => {
     expect(titleTail?.className).toContain('max-w-')
     expect(titleTail?.className).toContain('overflow-hidden')
     expect(header?.querySelector(`[aria-label="Download ${name}"]`)).not.toBeNull()
+    expect(
+      header?.querySelector(`[aria-label="Open full screen preview of ${name}"]`)
+    ).not.toBeNull()
     expect(header?.querySelector(`[aria-label="Close preview of ${name}"]`)).not.toBeNull()
     expect(tabBar?.getAttribute('role')).toBe('tablist')
     expect(tabBar?.querySelector('[role="tab"][aria-selected="true"]')).not.toBeNull()
     expect(container.querySelector('[role="tabpanel"]')).not.toBeNull()
     expect(tabBar?.querySelector(`[aria-label="Close preview of ${name}"]`)).not.toBeNull()
+  })
+
+  it('opens and closes a large file preview without removing the workbench tab', async () => {
+    const name = 'report.pdf'
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(
+      createFileItem({
+        title: name,
+        name,
+        path: `/workspace/${name}`,
+        format: 'pdf'
+      })
+    )
+
+    await renderPanel()
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(`[aria-label="Open full screen preview of ${name}"]`)
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    expect(dialog?.className).toContain('h-[90vh]')
+    expect(dialog?.className).toContain('w-[90vw]')
+    expect(dialog?.className).toContain('overscroll-contain')
+    expect(dialog?.querySelector('[data-testid="file-content"]')?.textContent).toContain(name)
+    expect(container.querySelector('[data-testid="file-content"]')).toBeNull()
+    expect(dialog?.querySelector(`[aria-label="Open full screen preview of ${name}"]`)).toBeNull()
+
+    await act(async () => {
+      dialog
+        ?.querySelector<HTMLButtonElement>(`[aria-label="Close preview of ${name}"]`)
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeItemId: 'item-1',
+      panelState: 'open'
+    })
+    expect(usePreviewWorkbenchStore.getState().items.map((item) => item.id)).toEqual(['item-1'])
   })
 
   it('supports keyboard navigation between preview tabs', async () => {

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -1,15 +1,14 @@
 import { X } from 'lucide-react'
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
 
-import { Button } from '@/components/ui/button'
 import { ResizablePanel } from '@/components/ui/resizable'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { PreviewFileItem, PreviewItem } from '@/stores/preview-workbench-store'
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 
-import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
+import { FilePreviewDialog } from './FilePreviewDialog'
+import { MiddleEllipsisFileName, PreviewFileSurface } from './PreviewFileSurface'
 import { PreviewFileContent } from './previews/PreviewFileContent'
 import { PreviewToolContent } from './previews/PreviewToolContent'
 
@@ -41,26 +40,6 @@ const PreviewActiveContent = ({
 
 const previewTabClassName =
   'group flex h-8 max-w-[160px] shrink-0 items-center gap-1 rounded-md pl-2 pr-1 text-[12px] transition-colors'
-
-// Keeps the identifying tail and extension visible while the flexible prefix owns the ellipsis.
-const MiddleEllipsisFileName = ({ name }: { name: string }): React.JSX.Element => {
-  const extensionIndex = name.lastIndexOf('.')
-  const extensionLength = extensionIndex > 0 ? name.length - extensionIndex : 0
-  const trailingLength = Math.min(name.length, Math.max(extensionLength + 10, 18))
-  const splitIndex = Math.max(1, name.length - trailingLength)
-
-  return (
-    <span className="flex min-w-0 max-w-full flex-1 items-center overflow-hidden whitespace-nowrap">
-      <span className="min-w-0 truncate">{name.slice(0, splitIndex)}</span>
-      <span
-        data-testid="preview-title-tail"
-        className="min-w-0 max-w-[65%] shrink overflow-hidden text-ellipsis [direction:rtl] [unicode-bidi:plaintext]"
-      >
-        {name.slice(splitIndex)}
-      </span>
-    </span>
-  )
-}
 
 const getPreviewTabId = (itemId: string): string => `preview-tab-${encodeURIComponent(itemId)}`
 const getPreviewPanelId = (itemId: string): string => `preview-panel-${encodeURIComponent(itemId)}`
@@ -193,53 +172,44 @@ const PreviewTabBar = ({
   )
 }
 
-// The compact card header centralizes the active preview's identity and file-level actions.
-const PreviewCardHeader = ({
+// Keep dialog state local to the active file panel. While the dialog owns the preview, unmount the
+// compact renderer so large files are not acquired and rendered twice at the same time.
+const PreviewFilePanel = ({
   item,
+  contentKey,
   onClose
 }: {
   item: PreviewFileItem
+  contentKey: string
   onClose: (id: string) => void
-}): React.JSX.Element => (
-  <header
-    data-testid="preview-card-header"
-    className="flex h-8 shrink-0 items-center gap-1 border-b border-border-300/50 px-2"
-  >
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="min-w-0 flex-1 text-[12px] font-medium text-text-000">
-            <MiddleEllipsisFileName name={item.name} />
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>{item.title}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-    <ManagedFileDownloadButton
-      source={item.source ?? 'artifact'}
-      path={item.path}
-      suggestedName={item.name}
-      className="bg-transparent shadow-none"
-    />
-    <TooltipProvider delayDuration={200}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            className="text-text-100 hover:text-text-000"
-            aria-label={`Close preview of ${item.title}`}
-            onClick={() => onClose(item.id)}
-          >
-            <X aria-hidden="true" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>Close preview</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  </header>
-)
+}): React.JSX.Element => {
+  const [isFullScreenOpen, setIsFullScreenOpen] = useState(false)
+
+  return (
+    <>
+      <section
+        data-testid="preview-card"
+        role="tabpanel"
+        id={getPreviewPanelId(item.id)}
+        aria-labelledby={getPreviewTabId(item.id)}
+        tabIndex={0}
+        className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-md bg-bg-000 shadow-card"
+      >
+        <PreviewFileSurface
+          item={item}
+          contentKey={contentKey}
+          renderContent={!isFullScreenOpen}
+          onClose={() => onClose(item.id)}
+          onOpenFullScreen={() => setIsFullScreenOpen(true)}
+        />
+      </section>
+      <FilePreviewDialog
+        item={isFullScreenOpen ? item : undefined}
+        onClose={() => setIsFullScreenOpen(false)}
+      />
+    </>
+  )
+}
 
 // Right-side workbench: a tab strip over every previewed file, plus content for the active tab.
 const PreviewPanel = ({
@@ -312,20 +282,12 @@ const PreviewPanel = ({
             }
 
             return item.type === 'file' ? (
-              <section
+              <PreviewFilePanel
                 key={item.id}
-                data-testid="preview-card"
-                role="tabpanel"
-                id={getPreviewPanelId(item.id)}
-                aria-labelledby={getPreviewTabId(item.id)}
-                tabIndex={0}
-                className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-md bg-bg-000 shadow-card"
-              >
-                <PreviewCardHeader item={item} onClose={removeItem} />
-                <div className="min-h-0 flex-1 overflow-y-auto bg-bg-000">
-                  <PreviewActiveContent key={activeContentKey} item={item} />
-                </div>
-              </section>
+                item={item}
+                contentKey={activeContentKey}
+                onClose={removeItem}
+              />
             ) : (
               <section
                 key={item.id}

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -980,17 +980,50 @@ describe('ProjectFilesView', () => {
     expect(previewSurface?.className).toContain('h-[82px]')
   })
 
-  it('opens upload and generated file preview items from their tiles', async () => {
+  it('opens an uploaded file in a large dialog without adding a workbench tab', async () => {
     await renderView([
       createSession({
         id: 'session-1',
-        title: 'Generated session',
         messages: [
           createMessage({
             id: 'message-1',
             uploads: [createUpload()]
           })
-        ],
+        ]
+      })
+    ])
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="Preview uploaded file user upload.png"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    expect(dialog?.className).toContain('h-[90vh]')
+    expect(dialog?.className).toContain('w-[90vw]')
+    expect(dialog?.querySelector('[aria-label="Download user upload.png"]')).not.toBeNull()
+    expect(
+      dialog?.querySelector('[aria-label="Open full screen preview of user upload.png"]')
+    ).toBeNull()
+    expect(usePreviewWorkbenchStore.getState().items).toEqual([])
+
+    await act(async () => {
+      dialog
+        ?.querySelector<HTMLButtonElement>('[aria-label="Close preview of user upload.png"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+    expect(container.querySelector('[data-testid="files-view"]')).not.toBeNull()
+  })
+
+  it('opens a generated file in a large dialog without adding a workbench tab', async () => {
+    await renderView([
+      createSession({
+        id: 'session-1',
+        title: 'Generated session',
         artifacts: [
           {
             id: 'artifact-1',
@@ -1006,31 +1039,17 @@ describe('ProjectFilesView', () => {
       })
     ])
 
-    const uploadButton = container.querySelector<HTMLButtonElement>(
-      '[aria-label="Preview uploaded file user upload.png"]'
-    )
-    const generatedButton = container.querySelector<HTMLButtonElement>(
-      '[aria-label="Preview generated file tree.png"]'
-    )
-
     await act(async () => {
-      uploadButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
-    await act(async () => {
-      generatedButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="Preview generated file tree.png"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(usePreviewWorkbenchStore.getState().items).toMatchObject([
-      {
-        id: 'upload:upload-1',
-        source: 'upload',
-        name: 'user upload.png'
-      },
-      {
-        id: 'artifact-1',
-        name: 'tree.png'
-      }
-    ])
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    expect(dialog?.querySelector('[aria-label="Download tree.png"]')).not.toBeNull()
+    expect(dialog?.querySelector('[aria-label="Open full screen preview of tree.png"]')).toBeNull()
+    expect(usePreviewWorkbenchStore.getState().items).toEqual([])
   })
 
   it('does not restart a pending thumbnail read when another tile becomes visible', async () => {

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { cn, formatByteSize } from '@/lib/utils'
 import { useNavigationStore } from '@/stores/navigation-store'
-import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
+import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 import { useSessionStore } from '@/stores/session-store'
 import type { ArtifactPreviewResult } from '../../../../shared/artifacts'
 
@@ -30,6 +30,7 @@ import {
 } from './preview-file-item'
 import type { MessageArtifact } from './preview-file-item'
 import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
+import { FilePreviewDialog } from './FilePreviewDialog'
 import { getPreviewThumbnailReadEncoding } from './preview-support'
 import { getPreviewFileReader } from './previews/preview-file-reader'
 import { useNearViewport } from './previews/useNearViewport'
@@ -380,9 +381,11 @@ const ProjectFilesFilterMenu = ({
 const ProjectFilesView = (): React.JSX.Element => {
   const allSessions = useSessionStore((state) => state.sessions)
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
-  const upsertAndActivateItem = usePreviewWorkbenchStore((state) => state.upsertAndActivateItem)
   const [collapsedSectionIds, setCollapsedSectionIds] = useState<Set<string>>(() => new Set())
   const [selectedFilterId, setSelectedFilterId] = useState('all')
+  // Files-tab previews are transient dialog state rather than workbench tabs.
+  const [dialogItem, setDialogItem] = useState<PreviewFileItem | undefined>(undefined)
+
   // Only the active project's sessions contribute files, so the library never mixes projects.
   const sessions = useMemo(
     () => allSessions.filter((session) => session.projectId === activeProjectId),
@@ -458,13 +461,15 @@ const ProjectFilesView = (): React.JSX.Element => {
   }
 
   const previewUploadFile = (file: ProjectUploadFileNode): void => {
-    upsertAndActivateItem(createPreviewFileItemFromUpload(file.attachment, file.sessionId))
+    // Preserve the upload source so the shared renderer and download action use its IPC path.
+    setDialogItem(createPreviewFileItemFromUpload(file.attachment, file.sessionId))
   }
 
   const previewArtifactFile = (file: ProjectArtifactFileNode, sessionId: string): void => {
+    // Invalid or deleted artifacts have no preview item and should leave the dialog closed.
     const previewItem = createPreviewFileItemFromArtifact(file.artifact, sessionId)
 
-    if (previewItem) upsertAndActivateItem(previewItem)
+    if (previewItem) setDialogItem(previewItem)
   }
 
   const uploadsCollapsed = collapsedSectionIds.has('uploads')
@@ -558,6 +563,7 @@ const ProjectFilesView = (): React.JSX.Element => {
           </section>
         ) : null}
       </div>
+      <FilePreviewDialog item={dialogItem} onClose={() => setDialogItem(undefined)} />
     </div>
   )
 }

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
@@ -1,4 +1,5 @@
 import { useReviewStore } from '@/stores/review-store'
+import { useNavigationStore } from '@/stores/navigation-store'
 import type { PreviewToolItem } from '@/stores/preview-workbench-store'
 
 import { NotebookPreview } from '../NotebookPreview'
@@ -34,7 +35,12 @@ export const PreviewToolContent = ({
 }: {
   item: PreviewToolItem
 }): React.JSX.Element | null => {
-  if (item.toolKind === 'files') return <ProjectFilesView />
+  const activeProjectId = useNavigationStore((state) => state.activeProjectId)
+
+  // Remount the Files tool per project so its transient dialog cannot outlive the project it opened.
+  if (item.toolKind === 'files') {
+    return <ProjectFilesView key={activeProjectId ?? 'no-active-project'} />
+  }
 
   if (item.toolKind === 'reviewer') return <SessionReviewerContent item={item} />
 


### PR DESCRIPTION
## Summary

Add a consistent full-screen preview experience for files across the right-side preview panel and the Files tab.

## Highlights

- Add a full-screen action to file previews in the right-side preview panel.
- Open file tiles from the Files tab in a 90vw by 90vh preview dialog.
- Keep the dialog header consistent with the compact preview while omitting the nested full-screen action.
- Preserve GENERATED message behavior by continuing to open those files in the right-side preview panel.

## Impact

- Affected user flows: right-side file previews, Files tab uploads and generated artifacts, and GENERATED file messages.
- The Files tab uses transient dialog state, while message-generated files continue to use the preview workbench.
- Switching projects remounts the Files view so a transient preview cannot cross project boundaries.

## Test Results

- 5 focused Vitest files passed, 76 tests passed.
- npm run lint -- --no-cache passed.
- npm run typecheck passed.
- Prettier check and git diff --check passed.
- npm run build:unpack passed.
- Packaged Electron verification confirmed a 90% viewport dialog, no nested full-screen action, and preserved preview-tab state after closing.

## Potential Issues

- Opening full screen temporarily unmounts the compact renderer to avoid duplicate file resources. Closing the dialog remounts it, so renderer-local state such as PDF page and scroll position is reset.

## Author

- Roxi