### PR TITLE
fix(managed-codex): fall back to copy+delete when rename throws EPERM or EXDEV on Windows

### DIFF
--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, sep } from 'node:path'
 import { Readable } from 'node:stream'
@@ -951,6 +951,138 @@ describe('installManagedCodex', () => {
       fsFaults.renameOnStagedMoveEio = false
       fsFaults.renameOnRestore = false
     }
+  })
+
+  it('does not retry the next registry when the local replace step fails', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
+    const platform = resolveManagedCodexPlatform({ platform: 'linux', arch: 'x64' })
+    const adapterTgz = buildTgz([
+      { name: 'package/dist/index.js', content: Buffer.from('adapter-local-fail'), mode: 0o755 }
+    ])
+    const nativeTgz = buildTgz([
+      {
+        name: `package/vendor/${platform.target}/bin/codex`,
+        content: Buffer.from('codex-local-fail'),
+        mode: 0o755
+      }
+    ])
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.includes('agentclientprotocol%2fcodex-acp')
+        ? { dist: { tarball: 'https://reg-a/adapter.tgz', integrity: sha512(adapterTgz) } }
+        : { dist: { tarball: 'https://reg-a/codex.tgz', integrity: sha512(nativeTgz) } }
+    const fetchJsonSpy = vi.fn(fetchJson)
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => ({
+      stream: Readable.from(url.includes('adapter') ? adapterTgz : nativeTgz)
+    })
+
+    // rename(staged→destination) throws EPERM, then the cp fallback also throws EPERM — a
+    // deterministic local filesystem failure, identical for every registry.
+    fsFaults.renameOnStagedMove = true
+    fsFaults.cpFailure = true
+    try {
+      const outcome = await installManagedCodex({
+        installId: 'codex-local-fail',
+        onEvent: () => undefined,
+        dataRoot: root,
+        registries: ['https://reg-a', 'https://reg-b'],
+        platform,
+        fetchJson: fetchJsonSpy,
+        fetchTarball,
+        verifyAdapter: () => Promise.resolve('1.1.4'),
+        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyPair: vi.fn().mockResolvedValue(undefined),
+        integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
+      })
+
+      expect(outcome.result.ok).toBe(false)
+      expect(outcome.result.error).toContain('copyfile')
+      // The second registry must never be contacted for a local filesystem failure
+      // (2 fetchJson calls = a single resolve round, all against reg-a).
+      expect(fetchJsonSpy).toHaveBeenCalledTimes(2)
+      expect(
+        fetchJsonSpy.mock.calls.every(([url]) => String(url).startsWith('https://reg-a/'))
+      ).toBe(true)
+    } finally {
+      fsFaults.renameOnStagedMove = false
+      fsFaults.cpFailure = false
+    }
+  })
+
+  it('keeps the backup-path error and the orphaned backup when restore fails', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
+    const platform = resolveManagedCodexPlatform({ platform: 'linux', arch: 'x64' })
+    const adapterTgz = buildTgz([
+      { name: 'package/dist/index.js', content: Buffer.from('adapter-orphan'), mode: 0o755 }
+    ])
+    const nativeTgz = buildTgz([
+      {
+        name: `package/vendor/${platform.target}/bin/codex`,
+        content: Buffer.from('codex-orphan'),
+        mode: 0o755
+      }
+    ])
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.includes('agentclientprotocol%2fcodex-acp')
+        ? { dist: { tarball: 'https://reg/adapter.tgz', integrity: sha512(adapterTgz) } }
+        : { dist: { tarball: 'https://reg/codex.tgz', integrity: sha512(nativeTgz) } }
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => ({
+      stream: Readable.from(url.includes('adapter') ? adapterTgz : nativeTgz)
+    })
+
+    // Pre-seed an existing install so the failed replace leaves an orphaned backup behind.
+    await mkdir(managedCodexRoot(root), { recursive: true })
+    await writeFile(join(managedCodexRoot(root), 'previous-runtime'), 'keep-me')
+
+    // rename(staged→destination) throws EPERM, cp throws EPERM, restore rename throws EPERM.
+    fsFaults.renameOnStagedMove = true
+    fsFaults.cpFailure = true
+    fsFaults.renameOnRestore = true
+    try {
+      const outcome = await installManagedCodex({
+        installId: 'codex-restore-orphan',
+        onEvent: () => undefined,
+        dataRoot: root,
+        registries: ['https://reg-a', 'https://reg-b'],
+        platform,
+        fetchJson,
+        fetchTarball,
+        verifyAdapter: () => Promise.resolve('1.1.4'),
+        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyPair: vi.fn().mockResolvedValue(undefined),
+        integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
+      })
+
+      expect(outcome.result.ok).toBe(false)
+      // The backup-path error must survive — not overwritten by a second registry round.
+      expect(outcome.result.error).toMatch(/backup retained at/)
+      // The orphaned backup dir is deliberately retained for manual recovery.
+      const entries = await readdir(root)
+      expect(entries.some((entry) => entry.startsWith('codex-managed.backup-'))).toBe(true)
+    } finally {
+      fsFaults.renameOnStagedMove = false
+      fsFaults.cpFailure = false
+      fsFaults.renameOnRestore = false
+    }
+  })
+
+  it('uninstall also removes orphaned backup dirs left behind by failed installs', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
+    await mkdir(join(managedCodexRoot(root), 'adapter', 'dist'), { recursive: true })
+    await writeFile(managedCodexAdapterEntry(root), 'adapter')
+    const orphanBackup = `${managedCodexRoot(root)}.backup-orphan`
+    await mkdir(orphanBackup, { recursive: true })
+    await writeFile(join(orphanBackup, 'stranded-runtime'), 'stuck')
+    await writeFile(join(root, 'unrelated-runtime'), 'keep-me')
+
+    await uninstallManagedCodex(root)
+
+    await expect(readFile(managedCodexAdapterEntry(root))).rejects.toThrow()
+    await expect(readFile(join(orphanBackup, 'stranded-runtime'))).rejects.toThrow()
+    expect(await readFile(join(root, 'unrelated-runtime'), 'utf8')).toBe('keep-me')
   })
 
   it('uninstalls only the managed Codex tree and is idempotent', async () => {

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -763,6 +763,127 @@ describe('installManagedCodex', () => {
     }
   })
 
+  it('restores the previous install when cp fails during EPERM fallback and restore succeeds', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
+    const platform = resolveManagedCodexPlatform({ platform: 'linux', arch: 'x64' })
+    const adapterTgz = buildTgz([
+      { name: 'package/dist/index.js', content: Buffer.from('adapter-restore'), mode: 0o755 }
+    ])
+    const nativeTgz = buildTgz([
+      {
+        name: `package/vendor/${platform.target}/bin/codex`,
+        content: Buffer.from('codex-restore'),
+        mode: 0o755
+      }
+    ])
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.includes('agentclientprotocol%2fcodex-acp')
+        ? { dist: { tarball: 'https://reg/adapter.tgz', integrity: sha512(adapterTgz) } }
+        : { dist: { tarball: 'https://reg/codex.tgz', integrity: sha512(nativeTgz) } }
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => ({
+      stream: Readable.from(url.includes('adapter') ? adapterTgz : nativeTgz)
+    })
+
+    // Pre-seed an existing install so hasBackup=true when the copy fallback runs.
+    await mkdir(managedCodexRoot(root), { recursive: true })
+    await writeFile(join(managedCodexRoot(root), 'previous-runtime'), 'keep-me')
+
+    // rename(staged→destination) throws EPERM, cp throws EPERM, the restore rename succeeds.
+    fsFaults.renameOnStagedMove = true
+    fsFaults.cpFailure = true
+    try {
+      const outcome = await installManagedCodex({
+        installId: 'codex-restore-ok',
+        onEvent: () => undefined,
+        dataRoot: root,
+        registries: ['https://reg'],
+        platform,
+        fetchJson,
+        fetchTarball,
+        verifyAdapter: () => Promise.resolve('1.1.4'),
+        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyPair: vi.fn().mockResolvedValue(undefined),
+        integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
+      })
+
+      // Install must fail with the raw copy error — no "backup retained" annotation needed,
+      // because the backup was successfully moved back into place.
+      expect(outcome.result.ok).toBe(false)
+      expect(outcome.result.error).toContain('copyfile')
+      expect(outcome.result.error).not.toMatch(/backup retained at/)
+      // The previous install must be back at the destination, intact.
+      expect(await readFile(join(managedCodexRoot(root), 'previous-runtime'), 'utf8')).toBe(
+        'keep-me'
+      )
+      expect(errorLogSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Failed to restore backup'),
+        expect.anything()
+      )
+    } finally {
+      fsFaults.renameOnStagedMove = false
+      fsFaults.cpFailure = false
+    }
+  })
+
+  it('logs the backup path when the destination→backup cp fallback also fails', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
+    const platform = resolveManagedCodexPlatform({ platform: 'linux', arch: 'x64' })
+    const adapterTgz = buildTgz([
+      { name: 'package/dist/index.js', content: Buffer.from('adapter-backup-fail'), mode: 0o755 }
+    ])
+    const nativeTgz = buildTgz([
+      {
+        name: `package/vendor/${platform.target}/bin/codex`,
+        content: Buffer.from('codex-backup-fail'),
+        mode: 0o755
+      }
+    ])
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.includes('agentclientprotocol%2fcodex-acp')
+        ? { dist: { tarball: 'https://reg/adapter.tgz', integrity: sha512(adapterTgz) } }
+        : { dist: { tarball: 'https://reg/codex.tgz', integrity: sha512(nativeTgz) } }
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => ({
+      stream: Readable.from(url.includes('adapter') ? adapterTgz : nativeTgz)
+    })
+
+    // Pre-seed an existing install so step 1 tries to back it up.
+    await mkdir(managedCodexRoot(root), { recursive: true })
+    await writeFile(join(managedCodexRoot(root), 'previous-runtime'), 'keep-me')
+
+    // rename(destination→backup) throws EPERM, then the cp fallback also throws EPERM.
+    fsFaults.renameOnDestBackup = true
+    fsFaults.cpFailure = true
+    try {
+      const outcome = await installManagedCodex({
+        installId: 'codex-backup-fail',
+        onEvent: () => undefined,
+        dataRoot: root,
+        registries: ['https://reg'],
+        platform,
+        fetchJson,
+        fetchTarball,
+        verifyAdapter: () => Promise.resolve('1.1.4'),
+        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyPair: vi.fn().mockResolvedValue(undefined),
+        integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
+      })
+
+      expect(outcome.result.ok).toBe(false)
+      // The failure must be logged with the backup path so the user can recover manually.
+      expect(errorLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to back up existing install'),
+        expect.anything()
+      )
+    } finally {
+      fsFaults.renameOnDestBackup = false
+      fsFaults.cpFailure = false
+    }
+  })
+
   it('uninstalls only the managed Codex tree and is idempotent', async () => {
     root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
     await mkdir(join(managedCodexRoot(root), 'adapter', 'dist'), { recursive: true })

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -6,6 +6,27 @@ import { Readable } from 'node:stream'
 import { gzipSync } from 'node:zlib'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+// When armed, the rename from the staged scratch dir to the final destination throws EPERM,
+// simulating the Windows "operation not permitted" error that triggered the bug report.
+const injectRenameEperm = vi.hoisted(() => ({ armed: false }))
+
+vi.mock('node:fs/promises', async (importActual) => {
+  const actual = await importActual<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    rename: vi.fn(async (src: string, dest: string) => {
+      if (injectRenameEperm.armed && src.includes('.codex-install-')) {
+        injectRenameEperm.armed = false
+        const err = Object.assign(new Error('EPERM: operation not permitted, rename'), {
+          code: 'EPERM'
+        })
+        throw err
+      }
+      return actual.rename(src, dest)
+    })
+  }
+})
+
 const { errorLogSpy, warnLogSpy } = vi.hoisted(() => ({
   errorLogSpy: vi.fn(),
   warnLogSpy: vi.fn()
@@ -556,6 +577,55 @@ describe('installManagedCodex', () => {
     expect(outcome.result.ok).toBe(false)
     expect(outcome.result.error).toMatch(/Codex binary failed its --version check/)
     expect(await readFile(join(managedCodexRoot(root), 'previous-runtime'), 'utf8')).toBe('keep-me')
+  })
+
+  it('falls back to copy+delete when rename throws EPERM (Windows antivirus / locked files)', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
+    const platform = resolveManagedCodexPlatform({ platform: 'linux', arch: 'x64' })
+    const adapterTgz = buildTgz([
+      { name: 'package/dist/index.js', content: Buffer.from('adapter-eperm'), mode: 0o755 }
+    ])
+    const nativeTgz = buildTgz([
+      {
+        name: `package/vendor/${platform.target}/bin/codex`,
+        content: Buffer.from('codex-eperm'),
+        mode: 0o755
+      }
+    ])
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.includes('agentclientprotocol%2fcodex-acp')
+        ? { dist: { tarball: 'https://reg/adapter.tgz', integrity: sha512(adapterTgz) } }
+        : { dist: { tarball: 'https://reg/codex.tgz', integrity: sha512(nativeTgz) } }
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => ({
+      stream: Readable.from(url.includes('adapter') ? adapterTgz : nativeTgz)
+    })
+
+    // Activate the EPERM rename injection (checked by the module-level mock below).
+    injectRenameEperm.armed = true
+
+    try {
+      const outcome = await installManagedCodex({
+        installId: 'codex-eperm',
+        onEvent: () => undefined,
+        dataRoot: root,
+        registries: ['https://reg'],
+        platform,
+        fetchJson,
+        fetchTarball,
+        verifyAdapter: () => Promise.resolve('1.1.4'),
+        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyPair: vi.fn().mockResolvedValue(undefined),
+        integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
+      })
+
+      expect(outcome.result.ok).toBe(true)
+      expect(await readFile(managedCodexAdapterEntry(root), 'utf8')).toBe('adapter-eperm')
+      expect(await readFile(managedCodexBinary(root, platform), 'utf8')).toBe('codex-eperm')
+    } finally {
+      injectRenameEperm.armed = false
+    }
   })
 
   it('uninstalls only the managed Codex tree and is idempotent', async () => {

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -6,23 +6,45 @@ import { Readable } from 'node:stream'
 import { gzipSync } from 'node:zlib'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// When armed, the rename from the staged scratch dir to the final destination throws EPERM,
-// simulating the Windows "operation not permitted" error that triggered the bug report.
-const injectRenameEperm = vi.hoisted(() => ({ armed: false }))
+// Injectable fault flags for the fs/promises mock — each targets one specific rename call:
+//   onStagedMove: throw EPERM when src is the .codex-install- scratch dir (staged→destination)
+//   onDestBackup: throw EPERM when dest contains .backup- (destination→backup, upgrade path)
+//   onRestore: throw EPERM when src contains .backup- (backup→destination restore)
+//   cp: throw EPERM from cp() to exercise the copy-failure→backup-restore branch
+const fsFaults = vi.hoisted(() => ({
+  renameOnStagedMove: false,
+  renameOnDestBackup: false,
+  renameOnRestore: false,
+  cpFailure: false
+}))
 
 vi.mock('node:fs/promises', async (importActual) => {
   const actual = await importActual<typeof import('node:fs/promises')>()
   return {
     ...actual,
     rename: vi.fn(async (src: string, dest: string) => {
-      if (injectRenameEperm.armed && src.includes('.codex-install-')) {
-        injectRenameEperm.armed = false
-        const err = Object.assign(new Error('EPERM: operation not permitted, rename'), {
-          code: 'EPERM'
-        })
-        throw err
+      if (fsFaults.renameOnStagedMove && src.includes('.codex-install-')) {
+        fsFaults.renameOnStagedMove = false
+        throw Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' })
+      }
+      if (fsFaults.renameOnDestBackup && dest.includes('.backup-')) {
+        fsFaults.renameOnDestBackup = false
+        throw Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' })
+      }
+      if (fsFaults.renameOnRestore && src.includes('.backup-')) {
+        fsFaults.renameOnRestore = false
+        throw Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' })
       }
       return actual.rename(src, dest)
+    }),
+    cp: vi.fn(async (src: string, dest: string, opts?: object) => {
+      if (fsFaults.cpFailure) {
+        fsFaults.cpFailure = false
+        throw Object.assign(new Error('EPERM: operation not permitted, copyfile'), {
+          code: 'EPERM'
+        })
+      }
+      return actual.cp(src, dest, opts as Parameters<typeof actual.cp>[2])
     })
   }
 })
@@ -579,7 +601,7 @@ describe('installManagedCodex', () => {
     expect(await readFile(join(managedCodexRoot(root), 'previous-runtime'), 'utf8')).toBe('keep-me')
   })
 
-  it('falls back to copy+delete when rename throws EPERM (Windows antivirus / locked files)', async () => {
+  it('falls back to copy+delete when staged→destination rename throws EPERM (first install)', async () => {
     root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
     const platform = resolveManagedCodexPlatform({ platform: 'linux', arch: 'x64' })
     const adapterTgz = buildTgz([
@@ -602,12 +624,10 @@ describe('installManagedCodex', () => {
       stream: Readable.from(url.includes('adapter') ? adapterTgz : nativeTgz)
     })
 
-    // Activate the EPERM rename injection (checked by the module-level mock below).
-    injectRenameEperm.armed = true
-
+    fsFaults.renameOnStagedMove = true
     try {
       const outcome = await installManagedCodex({
-        installId: 'codex-eperm',
+        installId: 'codex-eperm-staged',
         onEvent: () => undefined,
         dataRoot: root,
         registries: ['https://reg'],
@@ -624,7 +644,122 @@ describe('installManagedCodex', () => {
       expect(await readFile(managedCodexAdapterEntry(root), 'utf8')).toBe('adapter-eperm')
       expect(await readFile(managedCodexBinary(root, platform), 'utf8')).toBe('codex-eperm')
     } finally {
-      injectRenameEperm.armed = false
+      fsFaults.renameOnStagedMove = false
+    }
+  })
+
+  it('falls back to copy+delete when destination→backup rename throws EPERM (upgrade path)', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
+    const platform = resolveManagedCodexPlatform({ platform: 'linux', arch: 'x64' })
+    const adapterTgz = buildTgz([
+      { name: 'package/dist/index.js', content: Buffer.from('adapter-upgrade'), mode: 0o755 }
+    ])
+    const nativeTgz = buildTgz([
+      {
+        name: `package/vendor/${platform.target}/bin/codex`,
+        content: Buffer.from('codex-upgrade'),
+        mode: 0o755
+      }
+    ])
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.includes('agentclientprotocol%2fcodex-acp')
+        ? { dist: { tarball: 'https://reg/adapter.tgz', integrity: sha512(adapterTgz) } }
+        : { dist: { tarball: 'https://reg/codex.tgz', integrity: sha512(nativeTgz) } }
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => ({
+      stream: Readable.from(url.includes('adapter') ? adapterTgz : nativeTgz)
+    })
+
+    // Pre-seed an existing codex-managed dir (simulates an upgrade/reinstall scenario).
+    await mkdir(managedCodexRoot(root), { recursive: true })
+    await writeFile(join(managedCodexRoot(root), 'old-runtime'), 'old')
+
+    fsFaults.renameOnDestBackup = true
+    try {
+      const outcome = await installManagedCodex({
+        installId: 'codex-eperm-backup',
+        onEvent: () => undefined,
+        dataRoot: root,
+        registries: ['https://reg'],
+        platform,
+        fetchJson,
+        fetchTarball,
+        verifyAdapter: () => Promise.resolve('1.1.4'),
+        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyPair: vi.fn().mockResolvedValue(undefined),
+        integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
+      })
+
+      expect(outcome.result.ok).toBe(true)
+      expect(await readFile(managedCodexAdapterEntry(root), 'utf8')).toBe('adapter-upgrade')
+      expect(await readFile(managedCodexBinary(root, platform), 'utf8')).toBe('codex-upgrade')
+      // Old runtime must be gone from the final destination.
+      await expect(readFile(join(managedCodexRoot(root), 'old-runtime'))).rejects.toThrow()
+    } finally {
+      fsFaults.renameOnDestBackup = false
+    }
+  })
+
+  it('restores backup and surfaces error with backup path when cp fails during EPERM fallback', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
+    const platform = resolveManagedCodexPlatform({ platform: 'linux', arch: 'x64' })
+    const adapterTgz = buildTgz([
+      { name: 'package/dist/index.js', content: Buffer.from('adapter-cp-fail'), mode: 0o755 }
+    ])
+    const nativeTgz = buildTgz([
+      {
+        name: `package/vendor/${platform.target}/bin/codex`,
+        content: Buffer.from('codex-cp-fail'),
+        mode: 0o755
+      }
+    ])
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.includes('agentclientprotocol%2fcodex-acp')
+        ? { dist: { tarball: 'https://reg/adapter.tgz', integrity: sha512(adapterTgz) } }
+        : { dist: { tarball: 'https://reg/codex.tgz', integrity: sha512(nativeTgz) } }
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => ({
+      stream: Readable.from(url.includes('adapter') ? adapterTgz : nativeTgz)
+    })
+
+    // Pre-seed an existing install so hasBackup=true when the copy fallback runs.
+    await mkdir(managedCodexRoot(root), { recursive: true })
+    await writeFile(join(managedCodexRoot(root), 'previous-runtime'), 'keep-me')
+
+    // rename(staged→destination) throws EPERM, then cp also throws EPERM, then restore rename throws EPERM.
+    fsFaults.renameOnStagedMove = true
+    fsFaults.cpFailure = true
+    fsFaults.renameOnRestore = true
+    try {
+      const outcome = await installManagedCodex({
+        installId: 'codex-cp-fail',
+        onEvent: () => undefined,
+        dataRoot: root,
+        registries: ['https://reg'],
+        platform,
+        fetchJson,
+        fetchTarball,
+        verifyAdapter: () => Promise.resolve('1.1.4'),
+        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyPair: vi.fn().mockResolvedValue(undefined),
+        integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
+      })
+
+      // Install must fail.
+      expect(outcome.result.ok).toBe(false)
+      // Error must mention the backup path so the user can recover manually.
+      expect(outcome.result.error).toMatch(/backup retained at/)
+      // errorLog must have been called with the backup path.
+      expect(errorLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to restore backup'),
+        expect.anything()
+      )
+    } finally {
+      fsFaults.renameOnStagedMove = false
+      fsFaults.cpFailure = false
+      fsFaults.renameOnRestore = false
     }
   })
 

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -1069,19 +1069,28 @@ describe('installManagedCodex', () => {
     }
   })
 
-  it('uninstall also removes orphaned backup dirs left behind by failed installs', async () => {
+  it('uninstall removes only UUID-shaped backup dirs left behind by failed installs', async () => {
     root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
     await mkdir(join(managedCodexRoot(root), 'adapter', 'dist'), { recursive: true })
     await writeFile(managedCodexAdapterEntry(root), 'adapter')
-    const orphanBackup = `${managedCodexRoot(root)}.backup-orphan`
+    // Production backups are always directories named `<root>.backup-<uuid>`.
+    const orphanBackup = `${managedCodexRoot(root)}.backup-123e4567-e89b-42d3-a456-426614174000`
     await mkdir(orphanBackup, { recursive: true })
     await writeFile(join(orphanBackup, 'stranded-runtime'), 'stuck')
+    // Look-alikes sharing the prefix must survive: a non-UUID dir and a UUID-named plain file.
+    const notOurs = `${managedCodexRoot(root)}.backup-not-ours`
+    await mkdir(notOurs, { recursive: true })
+    await writeFile(join(notOurs, 'keep-me'), 'not-ours')
+    const uuidFile = `${managedCodexRoot(root)}.backup-223e4567-e89b-42d3-a456-426614174000`
+    await writeFile(uuidFile, 'not-a-dir')
     await writeFile(join(root, 'unrelated-runtime'), 'keep-me')
 
     await uninstallManagedCodex(root)
 
     await expect(readFile(managedCodexAdapterEntry(root))).rejects.toThrow()
     await expect(readFile(join(orphanBackup, 'stranded-runtime'))).rejects.toThrow()
+    expect(await readFile(join(notOurs, 'keep-me'), 'utf8')).toBe('not-ours')
+    expect(await readFile(uuidFile, 'utf8')).toBe('not-a-dir')
     expect(await readFile(join(root, 'unrelated-runtime'), 'utf8')).toBe('keep-me')
   })
 

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -8,11 +8,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 // Injectable fault flags for the fs/promises mock — each targets one specific rename call:
 //   onStagedMove: throw EPERM when src is the .codex-install- scratch dir (staged→destination)
+//   onStagedMoveEio: throw EIO on the same call (non-EPERM staged-failure path)
 //   onDestBackup: throw EPERM when dest contains .backup- (destination→backup, upgrade path)
 //   onRestore: throw EPERM when src contains .backup- (backup→destination restore)
 //   cp: throw EPERM from cp() to exercise the copy-failure→backup-restore branch
 const fsFaults = vi.hoisted(() => ({
   renameOnStagedMove: false,
+  renameOnStagedMoveEio: false,
   renameOnDestBackup: false,
   renameOnRestore: false,
   cpFailure: false
@@ -26,6 +28,10 @@ vi.mock('node:fs/promises', async (importActual) => {
       if (fsFaults.renameOnStagedMove && src.includes('.codex-install-')) {
         fsFaults.renameOnStagedMove = false
         throw Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' })
+      }
+      if (fsFaults.renameOnStagedMoveEio && src.includes('.codex-install-')) {
+        fsFaults.renameOnStagedMoveEio = false
+        throw Object.assign(new Error('EIO: i/o error, rename'), { code: 'EIO' })
       }
       if (fsFaults.renameOnDestBackup && dest.includes('.backup-')) {
         fsFaults.renameOnDestBackup = false
@@ -873,6 +879,9 @@ describe('installManagedCodex', () => {
       })
 
       expect(outcome.result.ok).toBe(false)
+      // The surfaced error must carry the real cause (the cp failure), not the original EPERM.
+      expect(outcome.result.error).toContain('copyfile')
+      expect(outcome.result.error).toMatch(/backup may be incomplete at/)
       // The failure must be logged with the backup path so the user can recover manually.
       expect(errorLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('Failed to back up existing install'),
@@ -881,6 +890,66 @@ describe('installManagedCodex', () => {
     } finally {
       fsFaults.renameOnDestBackup = false
       fsFaults.cpFailure = false
+    }
+  })
+
+  it('surfaces the backup path when a non-EPERM staged rename fails and restore also fails', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-codex-'))
+    const platform = resolveManagedCodexPlatform({ platform: 'linux', arch: 'x64' })
+    const adapterTgz = buildTgz([
+      { name: 'package/dist/index.js', content: Buffer.from('adapter-eio'), mode: 0o755 }
+    ])
+    const nativeTgz = buildTgz([
+      {
+        name: `package/vendor/${platform.target}/bin/codex`,
+        content: Buffer.from('codex-eio'),
+        mode: 0o755
+      }
+    ])
+    const fetchJson = async (url: string): Promise<unknown> =>
+      url.includes('agentclientprotocol%2fcodex-acp')
+        ? { dist: { tarball: 'https://reg/adapter.tgz', integrity: sha512(adapterTgz) } }
+        : { dist: { tarball: 'https://reg/codex.tgz', integrity: sha512(nativeTgz) } }
+    const fetchTarball = async (
+      url: string
+    ): Promise<{ stream: NodeJS.ReadableStream; totalBytes?: number }> => ({
+      stream: Readable.from(url.includes('adapter') ? adapterTgz : nativeTgz)
+    })
+
+    // Pre-seed an existing install so hasBackup=true when the staged rename fails.
+    await mkdir(managedCodexRoot(root), { recursive: true })
+    await writeFile(join(managedCodexRoot(root), 'previous-runtime'), 'keep-me')
+
+    // rename(staged→destination) throws EIO (not EPERM — no cp fallback), then the restore
+    // rename also throws EPERM: the previous install survives only at the backup path.
+    fsFaults.renameOnStagedMoveEio = true
+    fsFaults.renameOnRestore = true
+    try {
+      const outcome = await installManagedCodex({
+        installId: 'codex-eio-restore-fail',
+        onEvent: () => undefined,
+        dataRoot: root,
+        registries: ['https://reg'],
+        platform,
+        fetchJson,
+        fetchTarball,
+        verifyAdapter: () => Promise.resolve('1.1.4'),
+        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyPair: vi.fn().mockResolvedValue(undefined),
+        integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
+      })
+
+      expect(outcome.result.ok).toBe(false)
+      // The real cause (EIO) must surface, annotated with the backup path for manual recovery.
+      expect(outcome.result.error).toContain('EIO')
+      expect(outcome.result.error).toMatch(/backup retained at/)
+      expect(errorLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to restore backup'),
+        expect.anything()
+      )
+    } finally {
+      fsFaults.renameOnStagedMoveEio = false
+      fsFaults.renameOnRestore = false
     }
   })
 

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -578,7 +578,13 @@ const replaceDirectory = async (staged: string, destination: string): Promise<vo
         await cp(destination, backup, { recursive: true })
         await rm(destination, { recursive: true, force: true })
         hasBackup = true
-      } catch {
+      } catch (fallbackError) {
+        // The backup fallback failed partway: the existing install may be partially deleted and
+        // the backup may be incomplete — log its path so the user can recover manually.
+        log.error(
+          `Failed to back up existing install before replacement. Backup may be incomplete at: ${backup}`,
+          fallbackError
+        )
         throw error
       }
     } else {

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -3,6 +3,7 @@ import { spawn, spawnSync } from 'node:child_process'
 import { createReadStream } from 'node:fs'
 import {
   chmod,
+  cp,
   mkdir,
   mkdtemp,
   open,
@@ -570,9 +571,23 @@ const replaceDirectory = async (staged: string, destination: string): Promise<vo
 
   try {
     await rename(staged, destination)
-  } catch (error) {
-    if (hasBackup) await rename(backup, destination).catch(() => undefined)
-    throw error
+  } catch (renameError) {
+    const code = errorCode(renameError)
+    // On Windows, rename across directories can fail with EPERM (e.g. when antivirus or Windows
+    // Defender locks files) or EXDEV (cross-device move). Fall back to a recursive copy + delete.
+    if (code === 'EPERM' || code === 'EXDEV') {
+      try {
+        await cp(staged, destination, { recursive: true })
+        await rm(staged, { recursive: true, force: true }).catch(() => undefined)
+      } catch (copyError) {
+        await rm(destination, { recursive: true, force: true }).catch(() => undefined)
+        if (hasBackup) await rename(backup, destination).catch(() => undefined)
+        throw copyError
+      }
+    } else {
+      if (hasBackup) await rename(backup, destination).catch(() => undefined)
+      throw renameError
+    }
   }
 
   if (hasBackup) await rm(backup, { recursive: true, force: true }).catch(() => undefined)

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -562,26 +562,55 @@ const replaceDirectory = async (staged: string, destination: string): Promise<vo
   const backup = `${destination}.backup-${randomUUID()}`
   let hasBackup = false
 
+  // Step 1: move the existing destination aside as a backup.
+  // On Windows, rename can fail with EPERM when antivirus holds a lock on files inside the
+  // existing install, or EXDEV on a cross-device move (defensive — same-volume layout makes
+  // EXDEV unreachable in practice, but guarded for completeness). Fall back to cp+rm.
   try {
     await rename(destination, backup)
     hasBackup = true
   } catch (error) {
-    if (errorCode(error) !== 'ENOENT') throw error
+    const code = errorCode(error)
+    if (code === 'ENOENT') {
+      // Nothing to back up — first install.
+    } else if (code === 'EPERM' || code === 'EXDEV') {
+      try {
+        await cp(destination, backup, { recursive: true })
+        await rm(destination, { recursive: true, force: true })
+        hasBackup = true
+      } catch {
+        throw error
+      }
+    } else {
+      throw error
+    }
   }
 
+  // Step 2: move the staged runtime into the final destination.
   try {
     await rename(staged, destination)
   } catch (renameError) {
     const code = errorCode(renameError)
-    // On Windows, rename across directories can fail with EPERM (e.g. when antivirus or Windows
-    // Defender locks files) or EXDEV (cross-device move). Fall back to a recursive copy + delete.
     if (code === 'EPERM' || code === 'EXDEV') {
       try {
         await cp(staged, destination, { recursive: true })
         await rm(staged, { recursive: true, force: true }).catch(() => undefined)
       } catch (copyError) {
+        // Copy failed — try to restore the backup so the user's previous install survives.
         await rm(destination, { recursive: true, force: true }).catch(() => undefined)
-        if (hasBackup) await rename(backup, destination).catch(() => undefined)
+        if (hasBackup) {
+          try {
+            await rename(backup, destination)
+          } catch (restoreError) {
+            // Restore also failed; log the backup path so the user can recover manually.
+            log.error(
+              `Failed to restore backup after copy error. Backup retained at: ${backup}`,
+              restoreError
+            )
+            const msg = copyError instanceof Error ? copyError.message : String(copyError)
+            throw new Error(`${msg} (backup retained at ${backup})`)
+          }
+        }
         throw copyError
       }
     } else {

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -558,6 +558,24 @@ const errorCode = (error: unknown): string | undefined =>
     ? String((error as { code?: unknown }).code)
     : undefined
 
+// Move the backup back into place after a failed install step, then rethrow the original cause.
+// When even the restore fails, the previous install survives only at the random backup path —
+// log it and annotate the error so the caller can surface where to recover it manually.
+const restoreBackupOrThrow = async (
+  backup: string,
+  destination: string,
+  cause: unknown
+): Promise<never> => {
+  try {
+    await rename(backup, destination)
+  } catch (restoreError) {
+    log.error(`Failed to restore backup. Backup retained at: ${backup}`, restoreError)
+    const msg = cause instanceof Error ? cause.message : String(cause)
+    throw new Error(`${msg} (backup retained at ${backup})`)
+  }
+  throw cause
+}
+
 const replaceDirectory = async (staged: string, destination: string): Promise<void> => {
   const backup = `${destination}.backup-${randomUUID()}`
   let hasBackup = false
@@ -580,12 +598,14 @@ const replaceDirectory = async (staged: string, destination: string): Promise<vo
         hasBackup = true
       } catch (fallbackError) {
         // The backup fallback failed partway: the existing install may be partially deleted and
-        // the backup may be incomplete — log its path so the user can recover manually.
+        // the backup may be incomplete. Surface the real cause (not the original EPERM) plus
+        // the backup path so the user can recover manually.
         log.error(
           `Failed to back up existing install before replacement. Backup may be incomplete at: ${backup}`,
           fallbackError
         )
-        throw error
+        const msg = fallbackError instanceof Error ? fallbackError.message : String(fallbackError)
+        throw new Error(`${msg} (backup may be incomplete at ${backup})`)
       }
     } else {
       throw error
@@ -604,23 +624,11 @@ const replaceDirectory = async (staged: string, destination: string): Promise<vo
       } catch (copyError) {
         // Copy failed — try to restore the backup so the user's previous install survives.
         await rm(destination, { recursive: true, force: true }).catch(() => undefined)
-        if (hasBackup) {
-          try {
-            await rename(backup, destination)
-          } catch (restoreError) {
-            // Restore also failed; log the backup path so the user can recover manually.
-            log.error(
-              `Failed to restore backup after copy error. Backup retained at: ${backup}`,
-              restoreError
-            )
-            const msg = copyError instanceof Error ? copyError.message : String(copyError)
-            throw new Error(`${msg} (backup retained at ${backup})`)
-          }
-        }
+        if (hasBackup) await restoreBackupOrThrow(backup, destination, copyError)
         throw copyError
       }
     } else {
-      if (hasBackup) await rename(backup, destination).catch(() => undefined)
+      if (hasBackup) await restoreBackupOrThrow(backup, destination, renameError)
       throw renameError
     }
   }

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -7,6 +7,7 @@ import {
   mkdir,
   mkdtemp,
   open,
+  readdir,
   rename,
   rm,
   writeFile,
@@ -670,6 +671,11 @@ export const installManagedCodex = async ({
     const adapterTgz = join(scratch, 'adapter.tgz')
     const codexTgz = join(scratch, 'codex.tgz')
 
+    // Tracks whether the install has left the registry-dependent phase: the staged bits are
+    // byte-identical across registries (pinned versions + integrities), so a replaceDirectory
+    // failure is a deterministic local filesystem error — retrying the next registry would
+    // re-download the same bits into the same error and overwrite the backup path it carries.
+    let reachedLocalInstall = false
     try {
       onEvent({ kind: 'progress', installId, phase: 'resolving' })
       const adapter = await resolvePinnedPackage(
@@ -733,6 +739,7 @@ export const installManagedCodex = async ({
       // the final runtime, so anything Codex might write here must not ride along into the install.
       await verifyPair(stagedAdapter, stagedCodex, join(scratch, 'smoke-home'))
 
+      reachedLocalInstall = true
       await replaceDirectory(stagedRoot, managedCodexRoot(dataRoot))
 
       return {
@@ -744,6 +751,16 @@ export const installManagedCodex = async ({
       }
     } catch (error) {
       lastError = describeError(error)
+      if (reachedLocalInstall) {
+        // Local install failure — do not attribute it to the registry or try the next one.
+        onEvent({
+          kind: 'log',
+          installId,
+          stream: 'system',
+          chunk: `install failed: ${lastError}\n`
+        })
+        return { result: { installId, ok: false, error: lastError } }
+      }
       onEvent({
         kind: 'log',
         installId,
@@ -760,4 +777,14 @@ export const installManagedCodex = async ({
 
 export const uninstallManagedCodex = async (dataRoot: string): Promise<void> => {
   await rm(managedCodexRoot(dataRoot), { recursive: true, force: true }).catch(() => undefined)
+  // Failed installs can leave orphaned `codex-managed.backup-*` dirs (retained for manual
+  // recovery) — uninstall removes them along with the managed tree.
+  const entries = await readdir(dataRoot).catch(() => [] as string[])
+  await Promise.all(
+    entries
+      .filter((entry) => entry.startsWith('codex-managed.backup-'))
+      .map((entry) =>
+        rm(join(dataRoot, entry), { recursive: true, force: true }).catch(() => undefined)
+      )
+  )
 }

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { spawn, spawnSync } from 'node:child_process'
-import { createReadStream } from 'node:fs'
+import { createReadStream, type Dirent } from 'node:fs'
 import {
   chmod,
   cp,
@@ -775,16 +775,21 @@ export const installManagedCodex = async ({
   return { result: { installId, ok: false, error: lastError } }
 }
 
+// Backups are always directories named `codex-managed.backup-<uuid>` (see replaceDirectory) —
+// match that exact shape so uninstall never deletes look-alike entries sharing the prefix.
+const ORPHANED_BACKUP_PATTERN =
+  /^codex-managed\.backup-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
+
 export const uninstallManagedCodex = async (dataRoot: string): Promise<void> => {
   await rm(managedCodexRoot(dataRoot), { recursive: true, force: true }).catch(() => undefined)
-  // Failed installs can leave orphaned `codex-managed.backup-*` dirs (retained for manual
-  // recovery) — uninstall removes them along with the managed tree.
-  const entries = await readdir(dataRoot).catch(() => [] as string[])
+  // Failed installs can leave orphaned backups behind (retained for manual recovery) —
+  // uninstall removes them along with the managed tree.
+  const entries = await readdir(dataRoot, { withFileTypes: true }).catch(() => [] as Dirent[])
   await Promise.all(
     entries
-      .filter((entry) => entry.startsWith('codex-managed.backup-'))
+      .filter((entry) => entry.isDirectory() && ORPHANED_BACKUP_PATTERN.test(entry.name))
       .map((entry) =>
-        rm(join(dataRoot, entry), { recursive: true, force: true }).catch(() => undefined)
+        rm(join(dataRoot, entry.name), { recursive: true, force: true }).catch(() => undefined)
       )
   )
 }


### PR DESCRIPTION
## Summary

- On Windows, `fs.rename()` can fail with `EPERM` when antivirus software (e.g. Windows Defender) holds a file lock, or `EXDEV` on a cross-device move (defensive — the same-volume layout makes EXDEV unreachable in practice). This applies both to moving the staged scratch dir (`.codex-install-<id>/runtime`) into the final destination (`codex-managed`) and to moving an existing install aside as a backup on upgrade/reinstall.
- Both configured registries (`registry.npmjs.org` and `registry.npmmirror.com`) were catching this error as a registry failure, leaving the user unable to install the managed Codex runtime.
- `replaceDirectory` now catches `EPERM`/`EXDEV` on both renames (destination→backup and staged→destination) and falls back to `fs.cp()` + `fs.rm()`. If the copy itself fails, the backup is restored; if the restore also fails, the backup path is logged and included in the thrown error so the user can recover manually. Backup/restore failures always surface the real cause (not the original EPERM), and the step-1 backup fallback logs its backup path when it fails partway.
- Once the install reaches `replaceDirectory`, a failure is a deterministic local filesystem error (the staged bits are byte-identical across registries thanks to pinned versions + integrities), so it is returned immediately instead of being retried against the next registry. Download/verify errors still fall through to the next registry as before.
- `uninstallManagedCodex` also removes orphaned backups left behind by failed installs — matched strictly as directories named `codex-managed.backup-<uuid>` so look-alike entries sharing the prefix are never touched.

## Changes

- `src/main/settings/managed-codex.ts`: import `cp`/`readdir`; add copy+delete fallback for `EPERM`/`EXDEV` on both renames in `replaceDirectory`; shared `restoreBackupOrThrow` helper logs and annotates errors with the backup path when a restore fails; step-1 fallback failures throw the real cause with the backup path attached; local replace failures terminate the registry loop; uninstall cleans orphaned backup dirs (UUID-shaped names only, directories only)
- `src/main/settings/managed-codex.test.ts`: `vi.mock('node:fs/promises', ...)` with per-call fault flags (staged move EPERM/EIO, destination backup, restore, cp); new regression tests for the first-install fallback, the upgrade-path fallback, cp failure with failed/successful restore, step-1 fallback failure, non-EPERM staged failure with failed restore, local replace failure skipping the second registry, restore failure preserving the backup-path error and orphan, and uninstall orphan cleanup (UUID dir removed, non-UUID dir and UUID-named file preserved)

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run test` (managed-codex suite, 29 tests) — all pass
- [x] `npm run format` — passes
- [ ] Manual smoke on Windows: install managed Codex while Windows Defender is active — previously failed with `EPERM: operation not permitted, rename`; now completes successfully
