### PR TITLE
feat(window): confirm before close-to-tray / quit with running work

### DIFF
--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -448,4 +448,57 @@ describe('installAppLifecycle', () => {
     await flush()
     expect(quit).toHaveBeenCalledTimes(1)
   })
+
+  it('a titlebar X close-to-tray does not dispatch a second confirm while a quit-confirm is open', async () => {
+    // Cross-flow guard: tray/Ctrl+Q quit-confirm is already open (before-quit -> confirmClose('quit', ...)
+    // pending) when the user clicks the titlebar X. Without the shared confirmInFlight guard this would
+    // fire a second confirmClose('close-to-tray', ...) that overwrites the renderer's single request slot,
+    // stranding the quit-confirm promise and permanently pinning quitConfirmInFlight (see defect writeup).
+    let resolveConfirm: ((choice: CloseConfirmChoice) => void) | undefined
+    const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
+    const confirmClose = vi.fn(
+      () =>
+        new Promise<CloseConfirmChoice>((resolve) => {
+          resolveConfirm = resolve
+        })
+    )
+    const { app, closeOpts } = setup({ detectActiveSessions: () => sessions, confirmClose })
+
+    app.emit('before-quit') // opens the quit-confirm modal, confirmClose('quit', ...) pending
+    expect(confirmClose).toHaveBeenCalledTimes(1)
+    expect(confirmClose).toHaveBeenCalledWith('quit', sessions)
+
+    const choice = await closeOpts[0].resolveCloseAction() // titlebar X pressed while quit-confirm is open
+    expect(choice).toBe('cancel')
+    expect(confirmClose).toHaveBeenCalledTimes(1) // no second (close-to-tray) dispatch
+
+    resolveConfirm?.('cancel')
+    await flush()
+  })
+
+  it('tray Quit is a no-op (preventDefault only) while a close-to-tray confirm is open', async () => {
+    // Mirror of the above: titlebar X close-to-tray confirm is open when the user hits tray Quit /
+    // Ctrl+Q. The before-quit handler must preventDefault and return without starting a second
+    // confirmClose('quit', ...) dispatch, leaving the open close-to-tray confirm authoritative.
+    let resolveConfirm: ((choice: CloseConfirmChoice) => void) | undefined
+    const confirmClose = vi.fn(
+      () =>
+        new Promise<CloseConfirmChoice>((resolve) => {
+          resolveConfirm = resolve
+        })
+    )
+    const { app, closeOpts } = setup({ confirmClose })
+
+    const resolveCloseActionPromise = closeOpts[0].resolveCloseAction() // titlebar X, confirm pending
+    expect(confirmClose).toHaveBeenCalledTimes(1)
+    expect(confirmClose).toHaveBeenCalledWith('close-to-tray', [])
+
+    const event = app.emit('before-quit') // tray Quit / Ctrl+Q while the X confirm is open
+    expect(event.defaultPrevented).toBe(true)
+    expect(confirmClose).toHaveBeenCalledTimes(1) // no second (quit) dispatch
+
+    resolveConfirm?.('minimize')
+    await expect(resolveCloseActionPromise).resolves.toBe('minimize')
+    await flush()
+  })
 })

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { installAppLifecycle, type AppLifecycleDeps, type TrayHandlers } from './app-lifecycle'
+import type { ActiveSessionInfo } from '../shared/storage'
+import type { CloseConfirmChoice, CloseConfirmVariant } from '../shared/window-controls'
 
 type QuitEvent = { preventDefault: () => void; defaultPrevented: boolean }
 type Handler = (event: QuitEvent) => void
@@ -83,6 +85,12 @@ const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 
 const asWindow = (w: FakeWindow): import('electron').BrowserWindow =>
   w as unknown as import('electron').BrowserWindow
 
+type CapturedCloseOpts = {
+  classifyClose: () => 'close' | 'hide' | 'confirm'
+  resolveCloseAction: () => Promise<CloseConfirmChoice>
+  requestQuit: () => void
+}
+
 type Harness = {
   app: FakeApp
   windows: FakeWindow[]
@@ -91,6 +99,8 @@ type Harness = {
   shutdownBackends: () => Promise<void>
   quit: ReturnType<typeof vi.fn>
   showMainWindow: () => void
+  closeOpts: CapturedCloseOpts[]
+  confirmClose: ReturnType<typeof vi.fn>
 }
 
 const setup = (
@@ -101,6 +111,11 @@ const setup = (
     >
   > & {
     trayHost?: boolean
+    detectActiveSessions?: () => ActiveSessionInfo[]
+    confirmClose?: (
+      variant: CloseConfirmVariant,
+      sessions: ActiveSessionInfo[]
+    ) => Promise<CloseConfirmChoice>
   } = {}
 ): Harness => {
   const app = makeFakeApp()
@@ -110,10 +125,16 @@ const setup = (
   let trayHandlers: TrayHandlers | undefined
   const shutdownBackends = overrides.shutdownBackends ?? vi.fn(async () => undefined)
   const quit = vi.fn()
+  const closeOpts: CapturedCloseOpts[] = []
+  const confirmClose = vi.fn(
+    overrides.confirmClose ?? ((): Promise<CloseConfirmChoice> => Promise.resolve('quit'))
+  )
+  const detectActiveSessions = overrides.detectActiveSessions ?? ((): ActiveSessionInfo[] => [])
 
   const { showMainWindow } = installAppLifecycle({
     app: app as unknown as AppLifecycleDeps['app'],
-    createMainWindow: () => {
+    createMainWindow: (opts) => {
+      closeOpts.push(opts)
       const w = makeFakeWindow()
       windows.push(w)
       return asWindow(w)
@@ -127,10 +148,31 @@ const setup = (
     quit,
     countWindows: () => windows.filter((w) => !w.destroyed).length,
     createInitialWindow: overrides.createInitialWindow,
-    platform: overrides.platform ?? 'linux'
+    platform: overrides.platform ?? 'linux',
+    detectActiveSessions,
+    createConfirmClose: () => confirmClose
   })
 
-  return { app, windows, tray, trayHandlers, shutdownBackends, quit, showMainWindow }
+  return {
+    app,
+    windows,
+    tray,
+    trayHandlers,
+    shutdownBackends,
+    quit,
+    showMainWindow,
+    closeOpts,
+    confirmClose
+  }
+}
+
+// Sets up with a single captured createMainWindow opts, for classifyClose assertions.
+const installWithCapturedOpts = (opts: {
+  platform: NodeJS.Platform
+  hasTray: boolean
+}): CapturedCloseOpts => {
+  const { closeOpts } = setup({ platform: opts.platform, trayHost: opts.hasTray })
+  return closeOpts[0]
 }
 
 describe('installAppLifecycle', () => {
@@ -148,12 +190,19 @@ describe('installAppLifecycle', () => {
   })
 
   it('runs an awaited backend teardown then exits on a normal quit', async () => {
-    const { app, tray, shutdownBackends } = setup()
+    // Default confirmClose resolves 'quit'; a normal quit goes through the confirm gate first,
+    // then the real Electron re-issues before-quit once requestQuit's quit() lands.
+    const { app, tray, shutdownBackends, quit } = setup()
 
     const event = app.emit('before-quit')
     expect(event.defaultPrevented).toBe(true)
+    expect(app.exit).not.toHaveBeenCalled() // still awaiting confirmation
+
+    await flush()
+    expect(quit).toHaveBeenCalledTimes(1)
     expect(app.exit).not.toHaveBeenCalled() // still awaiting shutdown
 
+    app.emit('before-quit') // re-issued quit, now confirmed
     await flush()
     expect(shutdownBackends).toHaveBeenCalledTimes(1)
     expect(tray?.destroy).toHaveBeenCalledTimes(1)
@@ -184,7 +233,9 @@ describe('installAppLifecycle', () => {
       isMigrationInProgress: (): boolean => false,
       quit: vi.fn(),
       countWindows: (): number => 1,
-      platform: 'linux'
+      platform: 'linux',
+      detectActiveSessions: (): ActiveSessionInfo[] => [],
+      createConfirmClose: () => (): Promise<CloseConfirmChoice> => Promise.resolve('quit')
     })
 
     app.emit('before-quit')
@@ -201,7 +252,8 @@ describe('installAppLifecycle', () => {
           release = resolve
         })
     )
-    const { app } = setup({ shutdownBackends })
+    const { app, closeOpts } = setup({ shutdownBackends })
+    closeOpts[0].requestQuit() // pre-confirm, so the next before-quit goes straight to cleanup
 
     app.emit('before-quit') // starts cleanup (pending)
     const second = app.emit('before-quit') // re-issued while running
@@ -269,5 +321,131 @@ describe('installAppLifecycle', () => {
     windows[0].destroyed = true
     app.emit('activate')
     expect(windows).toHaveLength(2)
+  })
+
+  it('classifyClose returns "close" on darwin', () => {
+    const captured = installWithCapturedOpts({ platform: 'darwin', hasTray: true })
+    expect(captured.classifyClose()).toBe('close')
+  })
+
+  it('classifyClose returns "confirm" on win32 with a tray', () => {
+    const captured = installWithCapturedOpts({ platform: 'win32', hasTray: true })
+    expect(captured.classifyClose()).toBe('confirm')
+  })
+
+  it('classifyClose returns "hide" on linux with a tray', () => {
+    const captured = installWithCapturedOpts({ platform: 'linux', hasTray: true })
+    expect(captured.classifyClose()).toBe('hide')
+  })
+
+  it('classifyClose returns "close" when no tray', () => {
+    const captured = installWithCapturedOpts({ platform: 'win32', hasTray: false })
+    expect(captured.classifyClose()).toBe('close')
+  })
+
+  it('resolveCloseAction resolves via confirmClose("close-to-tray", sessions)', async () => {
+    const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
+    const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'minimize')
+    const { closeOpts } = setup({ detectActiveSessions: () => sessions, confirmClose })
+
+    const choice = await closeOpts[0].resolveCloseAction()
+    expect(confirmClose).toHaveBeenCalledWith('close-to-tray', sessions)
+    expect(choice).toBe('minimize')
+  })
+
+  it('requestQuit sets quitConfirmed and calls quit', () => {
+    const { closeOpts, quit } = setup()
+    closeOpts[0].requestQuit()
+    expect(quit).toHaveBeenCalledTimes(1)
+  })
+
+  it('before-quit with no active work proceeds to shutdown (confirmClose resolves quit)', async () => {
+    const confirmClose = vi.fn(
+      (_variant: CloseConfirmVariant, sessions: ActiveSessionInfo[]): Promise<CloseConfirmChoice> =>
+        Promise.resolve(sessions.length === 0 ? 'quit' : 'cancel')
+    )
+    const { app, tray, shutdownBackends, quit } = setup({ confirmClose })
+
+    const event = app.emit('before-quit')
+    expect(event.defaultPrevented).toBe(true)
+    await flush()
+
+    expect(confirmClose).toHaveBeenCalledWith('quit', [])
+    expect(quit).toHaveBeenCalledTimes(1)
+
+    // requestQuit -> quit() drove by the app; simulate the resulting re-issued before-quit.
+    app.emit('before-quit')
+    await flush()
+
+    expect(shutdownBackends).toHaveBeenCalledTimes(1)
+    expect(tray?.destroy).toHaveBeenCalledTimes(1)
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('before-quit with active work + cancel keeps the app alive (no shutdown, no exit)', async () => {
+    const sessions: ActiveSessionInfo[] = [
+      { projectName: 'demo', sessionId: 's1', kind: 'notebook' }
+    ]
+    const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'cancel')
+    const { app, shutdownBackends, quit } = setup({
+      detectActiveSessions: () => sessions,
+      confirmClose
+    })
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(confirmClose).toHaveBeenCalledWith('quit', sessions)
+    expect(quit).not.toHaveBeenCalled()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
+  })
+
+  it('before-quit skips confirmation once quit is already confirmed (no double dialog)', async () => {
+    const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'quit')
+    const { app, closeOpts, shutdownBackends } = setup({ confirmClose })
+
+    closeOpts[0].requestQuit() // sets quitConfirmed then calls quit()
+    app.emit('before-quit') // the re-entered before-quit that quit() triggers
+
+    await flush()
+    expect(confirmClose).not.toHaveBeenCalled()
+    expect(shutdownBackends).toHaveBeenCalledTimes(1)
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('migration in progress bypasses the confirm gate', async () => {
+    const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'quit')
+    const { app, quit, shutdownBackends } = setup({
+      isMigrationInProgress: (): boolean => true,
+      confirmClose
+    })
+
+    const event = app.emit('before-quit')
+    await flush()
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(confirmClose).not.toHaveBeenCalled()
+    expect(quit).not.toHaveBeenCalled()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+  })
+
+  it('holds a re-issued quit while a confirm is already in flight', async () => {
+    let resolveConfirm: ((choice: CloseConfirmChoice) => void) | undefined
+    const confirmClose = vi.fn(
+      () =>
+        new Promise<CloseConfirmChoice>((resolve) => {
+          resolveConfirm = resolve
+        })
+    )
+    const { app, quit } = setup({ confirmClose })
+
+    app.emit('before-quit') // starts the confirm (pending)
+    app.emit('before-quit') // re-issued while the confirm is in flight
+    expect(confirmClose).toHaveBeenCalledTimes(1)
+
+    resolveConfirm?.('quit')
+    await flush()
+    expect(quit).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -430,6 +430,26 @@ describe('installAppLifecycle', () => {
     expect(shutdownBackends).not.toHaveBeenCalled()
   })
 
+  it('re-confirms a later Windows X after a confirmed quit was aborted by migration', async () => {
+    // A confirmed quit (Windows X -> Quit sets quitConfirmed) that the migration guard then aborts must
+    // not leave quitConfirmed latched — otherwise classifyClose would return 'close' and the next X
+    // would destroy the window without asking. The abort resets it so the next X re-confirms.
+    let migrating = false
+    const { app, closeOpts } = setup({
+      platform: 'win32',
+      trayHost: true,
+      isMigrationInProgress: (): boolean => migrating
+    })
+    const opts = closeOpts[0]
+
+    opts.requestQuit() // quitConfirmed = true
+    migrating = true
+    app.emit('before-quit') // aborted by migration -> resets quitConfirmed
+    migrating = false
+
+    expect(opts.classifyClose()).toBe('confirm')
+  })
+
   it('holds a re-issued quit while a confirm is already in flight', async () => {
     let resolveConfirm: ((choice: CloseConfirmChoice) => void) | undefined
     const confirmClose = vi.fn(
@@ -453,7 +473,7 @@ describe('installAppLifecycle', () => {
     // Cross-flow guard: tray/Ctrl+Q quit-confirm is already open (before-quit -> confirmClose('quit', ...)
     // pending) when the user clicks the titlebar X. Without the shared confirmInFlight guard this would
     // fire a second confirmClose('close-to-tray', ...) that overwrites the renderer's single request slot,
-    // stranding the quit-confirm promise and permanently pinning quitConfirmInFlight (see defect writeup).
+    // stranding the quit-confirm promise and permanently pinning confirmInFlight.
     let resolveConfirm: ((choice: CloseConfirmChoice) => void) | undefined
     const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
     const confirmClose = vi.fn(

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { installAppLifecycle, type AppLifecycleDeps, type TrayHandlers } from './app-lifecycle'
 import type { ActiveSessionInfo } from '../shared/storage'
-import type { CloseConfirmChoice, CloseConfirmVariant } from '../shared/window-controls'
+import type {
+  CloseClassification,
+  CloseConfirmChoice,
+  CloseConfirmVariant
+} from '../shared/window-controls'
 
 type QuitEvent = { preventDefault: () => void; defaultPrevented: boolean }
 type Handler = (event: QuitEvent) => void
@@ -86,7 +90,7 @@ const asWindow = (w: FakeWindow): import('electron').BrowserWindow =>
   w as unknown as import('electron').BrowserWindow
 
 type CapturedCloseOpts = {
-  classifyClose: () => 'close' | 'hide' | 'confirm'
+  classifyClose: () => CloseClassification
   resolveCloseAction: () => Promise<CloseConfirmChoice>
   requestQuit: () => void
 }

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -1,5 +1,8 @@
 import type { App, BrowserWindow, Tray } from 'electron'
 
+import type { ActiveSessionInfo } from '../shared/storage'
+import type { CloseConfirmChoice, CloseConfirmVariant } from '../shared/window-controls'
+
 // Menu action callbacks the tray is wired to.
 export type TrayHandlers = { onShow: () => void; onHide: () => void; onQuit: () => void }
 
@@ -9,8 +12,12 @@ export type TrayHandlers = { onShow: () => void; onHide: () => void; onQuit: () 
 export type AppLifecycleDeps = {
   // Only the event/exit surface is used; injectable so tests can drive the handlers directly.
   app: Pick<App, 'on' | 'exit'>
-  // Creates the main window; the lifecycle supplies the close-to-tray predicate it should honor.
-  createMainWindow: (opts: { shouldHideOnClose: () => boolean }) => BrowserWindow
+  // Creates the main window; the lifecycle supplies the close classification + confirm callbacks.
+  createMainWindow: (opts: {
+    classifyClose: () => 'close' | 'hide' | 'confirm'
+    resolveCloseAction: () => Promise<CloseConfirmChoice>
+    requestQuit: () => void
+  }) => BrowserWindow
   // Builds the tray; returns undefined on hosts without a tray (e.g. some Linux desktops).
   createTray: (handlers: TrayHandlers) => Tray | undefined
   // Bounded, best-effort backend teardown (agent tree + notebook kernels); never throws.
@@ -25,6 +32,13 @@ export type AppLifecycleDeps = {
   createInitialWindow?: boolean
   // Overridable for tests; defaults to the host platform.
   platform?: NodeJS.Platform
+  // Snapshot of sessions with running work (in-flight agent prompt or a notebook cell mid-execution),
+  // used to populate the confirmation list and to skip the quit dialog when nothing is running.
+  detectActiveSessions: () => ActiveSessionInfo[]
+  // Builds the close-confirm coordinator bound to the current main window (recreated on demand).
+  createConfirmClose: (
+    getWindow: () => BrowserWindow | undefined
+  ) => (variant: CloseConfirmVariant, sessions: ActiveSessionInfo[]) => Promise<CloseConfirmChoice>
 }
 
 // Installs the tray, the first window, and the quit/activate/window-all-closed handlers. Returns
@@ -34,19 +48,36 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
   const platform = deps.platform ?? process.platform
 
   let mainWindow: BrowserWindow | undefined
-  // Held in a box (not a plain `let`) so the close-to-tray predicate defined below can read it before
+  // Held in a box (not a plain `let`) so the close classification defined below can read it before
   // it is assigned — the tray, window, and predicate reference each other cyclically.
   const trayBox: { current: Tray | undefined } = { current: undefined }
   // Latches make the async quit cleanup idempotent: once started, further quits are held until exit.
   let shutdownStarted = false
   let shutdownFinished = false
+  // Set once the user has confirmed a quit (via the dialog or a prior 'confirm' close), so a re-issued
+  // before-quit skips straight to teardown instead of asking again.
+  let quitConfirmed = false
 
-  // Close-to-tray predicate, evaluated at close time: hide (stay resident) on Windows/Linux while the
-  // tray is active, unless a quit is already underway. macOS keeps its dock convention (real close).
-  const shouldHideOnClose = (): boolean =>
-    platform !== 'darwin' && Boolean(trayBox.current) && !shutdownStarted
+  const confirmClose = deps.createConfirmClose(() => mainWindow)
 
-  const openWindow = (): BrowserWindow => deps.createMainWindow({ shouldHideOnClose })
+  // Synchronous close classification, evaluated at close time. darwin keeps its dock convention (real
+  // close); a mid-quit or no-tray close proceeds; Windows asks (confirm); Linux keeps silent hide-to-tray.
+  const classifyClose = (): 'close' | 'hide' | 'confirm' => {
+    if (platform === 'darwin') return 'close'
+    if (!trayBox.current || shutdownStarted || quitConfirmed) return 'close'
+    if (platform === 'win32') return 'confirm'
+    return 'hide'
+  }
+
+  const openWindow = (): BrowserWindow =>
+    deps.createMainWindow({
+      classifyClose,
+      resolveCloseAction: () => confirmClose('close-to-tray', deps.detectActiveSessions()),
+      requestQuit: () => {
+        quitConfirmed = true
+        deps.quit()
+      }
+    })
 
   // Surfaces the main window, creating a fresh one when none exists or the last was closed (macOS keeps
   // the app alive with no window; the tray Show item and a second launch must be able to bring it back).
@@ -76,6 +107,7 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
   // migration guard (registered earlier) via defaultPrevented + isMigrationInProgress so a
   // migration-cancelled quit is respected. #177's will-quit guard remains a synchronous backstop for a
   // committed quit that never reaches this path.
+  let quitConfirmInFlight = false
   deps.app.on('before-quit', (event) => {
     if (shutdownFinished) return
     if (shutdownStarted) {
@@ -84,6 +116,25 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
       return
     }
     if (event.defaultPrevented || deps.isMigrationInProgress()) return
+
+    // Confirmation gate: unless the user already confirmed (e.g. Windows X -> Quit), confirm the
+    // quit. An empty active-session list makes confirmClose('quit', []) resolve 'quit' with no modal.
+    if (!quitConfirmed) {
+      event.preventDefault()
+      if (quitConfirmInFlight) return
+      quitConfirmInFlight = true
+      void confirmClose('quit', deps.detectActiveSessions())
+        .then((choice) => {
+          if (choice === 'quit') {
+            quitConfirmed = true
+            deps.quit()
+          }
+        })
+        .finally(() => {
+          quitConfirmInFlight = false
+        })
+      return
+    }
 
     event.preventDefault()
     shutdownStarted = true

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -57,6 +57,10 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
   // Set once the user has confirmed a quit (via the dialog or a prior 'confirm' close), so a re-issued
   // before-quit skips straight to teardown instead of asking again.
   let quitConfirmed = false
+  // Shared across both confirm-dispatching paths (titlebar X and tray/Ctrl+Q quit) so only one
+  // confirmation modal is ever open at a time. The renderer holds a single request slot; a second
+  // dispatch would silently overwrite the first and strand its promise forever (see app-lifecycle.test.ts).
+  let confirmInFlight = false
 
   const confirmClose = deps.createConfirmClose(() => mainWindow)
 
@@ -69,10 +73,22 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
     return 'hide'
   }
 
+  // Only one confirmation modal at a time: if a quit-confirm (or another close-confirm) is already
+  // open, do nothing for this X press so the in-flight decision stays authoritative.
+  const resolveCloseAction = async (): Promise<CloseConfirmChoice> => {
+    if (confirmInFlight) return 'cancel'
+    confirmInFlight = true
+    try {
+      return await confirmClose('close-to-tray', deps.detectActiveSessions())
+    } finally {
+      confirmInFlight = false
+    }
+  }
+
   const openWindow = (): BrowserWindow =>
     deps.createMainWindow({
       classifyClose,
-      resolveCloseAction: () => confirmClose('close-to-tray', deps.detectActiveSessions()),
+      resolveCloseAction,
       requestQuit: () => {
         quitConfirmed = true
         deps.quit()
@@ -107,7 +123,6 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
   // migration guard (registered earlier) via defaultPrevented + isMigrationInProgress so a
   // migration-cancelled quit is respected. #177's will-quit guard remains a synchronous backstop for a
   // committed quit that never reaches this path.
-  let quitConfirmInFlight = false
   deps.app.on('before-quit', (event) => {
     if (shutdownFinished) return
     if (shutdownStarted) {
@@ -121,8 +136,8 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
     // quit. An empty active-session list makes confirmClose('quit', []) resolve 'quit' with no modal.
     if (!quitConfirmed) {
       event.preventDefault()
-      if (quitConfirmInFlight) return
-      quitConfirmInFlight = true
+      if (confirmInFlight) return
+      confirmInFlight = true
       void confirmClose('quit', deps.detectActiveSessions())
         .then((choice) => {
           if (choice === 'quit') {
@@ -131,7 +146,7 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
           }
         })
         .finally(() => {
-          quitConfirmInFlight = false
+          confirmInFlight = false
         })
       return
     }

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -1,7 +1,11 @@
 import type { App, BrowserWindow, Tray } from 'electron'
 
 import type { ActiveSessionInfo } from '../shared/storage'
-import type { CloseConfirmChoice, CloseConfirmVariant } from '../shared/window-controls'
+import type {
+  CloseClassification,
+  CloseConfirmChoice,
+  CloseConfirmVariant
+} from '../shared/window-controls'
 
 // Menu action callbacks the tray is wired to.
 export type TrayHandlers = { onShow: () => void; onHide: () => void; onQuit: () => void }
@@ -14,7 +18,7 @@ export type AppLifecycleDeps = {
   app: Pick<App, 'on' | 'exit'>
   // Creates the main window; the lifecycle supplies the close classification + confirm callbacks.
   createMainWindow: (opts: {
-    classifyClose: () => 'close' | 'hide' | 'confirm'
+    classifyClose: () => CloseClassification
     resolveCloseAction: () => Promise<CloseConfirmChoice>
     requestQuit: () => void
   }) => BrowserWindow
@@ -66,7 +70,7 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
 
   // Synchronous close classification, evaluated at close time. darwin keeps its dock convention (real
   // close); a mid-quit or no-tray close proceeds; Windows asks (confirm); Linux keeps silent hide-to-tray.
-  const classifyClose = (): 'close' | 'hide' | 'confirm' => {
+  const classifyClose = (): CloseClassification => {
     if (platform === 'darwin') return 'close'
     if (!trayBox.current || shutdownStarted || quitConfirmed) return 'close'
     if (platform === 'win32') return 'confirm'
@@ -130,7 +134,13 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
       event.preventDefault()
       return
     }
-    if (event.defaultPrevented || deps.isMigrationInProgress()) return
+    if (event.defaultPrevented || deps.isMigrationInProgress()) {
+      // This quit is being aborted (e.g. the migration guard cancelled it). Clear any prior
+      // confirmation so it doesn't leak into a later close: otherwise classifyClose would return
+      // 'close' and the next Windows X would bypass the dialog and destroy the window.
+      quitConfirmed = false
+      return
+    }
 
     // Confirmation gate: unless the user already confirmed (e.g. Windows X -> Quit), confirm the
     // quit. An empty active-session list makes confirmClose('quit', []) resolve 'quit' with no modal.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -135,7 +135,9 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       // can reach them. It only wraps ipcMain.handle — no server, no cost until something serves.
       const rpcCapture = installRpcCapture(ipcMain)
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
-      const { runtime, notebook, shutdownCoordinator } = await registerIpcHandlers({ mainEntryPath })
+      const { runtime, notebook, shutdownCoordinator } = await registerIpcHandlers({
+        mainEntryPath
+      })
       const webController = createWebServiceController({
         rpc: rpcCapture,
         requestQuit: () => app.quit()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,8 +4,6 @@ import { fileURLToPath } from 'node:url'
 // SDK graph) are imported lazily inside the matching branch, and the Electron backend is imported only
 // after the single-instance lock is held — so no backend module loads before the lock in UI mode.
 import { ARTIFACT_MCP_SERVER_ARG, NOTEBOOK_MCP_SERVER_ARG } from './mcp-server-args'
-import { detectActiveSessions } from './storage/detect-active'
-import { createElectronCloseConfirm } from './window-close-confirm'
 
 const APP_NAME = 'Open Science'
 const APP_USER_MODEL_ID = 'com.aipoch.open-science'
@@ -70,7 +68,9 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { installAppLifecycle },
         { installRpcCapture },
         { parseWebModeOptions, createWebServiceController, buildAuthenticatedWebUrl },
-        { routeSecondInstance }
+        { routeSecondInstance },
+        { detectActiveSessions: computeActiveSessions },
+        { createElectronCloseConfirm }
       ] = await Promise.all([
         import('./ipc'),
         import('./windows'),
@@ -80,7 +80,9 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./app-lifecycle'),
         import('./web-service/rpc-capture'),
         import('./web-service'),
-        import('./second-instance-router')
+        import('./second-instance-router'),
+        import('./storage/detect-active'),
+        import('./window-close-confirm')
       ])
 
       // Dev runs get a "(DEV)" suffix so the app name, macOS menu, and per-app paths (logs, userData)
@@ -153,9 +155,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         createAppTray,
         buildAuthenticatedWebUrl,
         routeSecondInstance,
-        runtime,
-        notebook,
         shutdownCoordinator,
+        // Running-work snapshot + confirm coordinator, bound here where runtime/notebook are in scope.
+        detectActiveSessions: () => computeActiveSessions({ runtime, notebook }),
+        createConfirmClose: createElectronCloseConfirm,
         installAppLifecycle,
         log,
         webMode,
@@ -210,9 +213,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         quit: () => app.quit(),
         countWindows: () => BrowserWindow.getAllWindows().length,
         createInitialWindow: !ctx.webMode.headless,
-        detectActiveSessions: () =>
-          detectActiveSessions({ runtime: ctx.runtime, notebook: ctx.notebook }),
-        createConfirmClose: (getWindow) => createElectronCloseConfirm(getWindow)
+        detectActiveSessions: ctx.detectActiveSessions,
+        createConfirmClose: ctx.createConfirmClose
       })
 
       // Route each second launch by its forwarded argv (see second-instance-router): a CLI

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url'
 // SDK graph) are imported lazily inside the matching branch, and the Electron backend is imported only
 // after the single-instance lock is held — so no backend module loads before the lock in UI mode.
 import { ARTIFACT_MCP_SERVER_ARG, NOTEBOOK_MCP_SERVER_ARG } from './mcp-server-args'
+import { detectActiveSessions } from './storage/detect-active'
+import { createElectronCloseConfirm } from './window-close-confirm'
 
 const APP_NAME = 'Open Science'
 const APP_USER_MODEL_ID = 'com.aipoch.open-science'
@@ -133,7 +135,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       // can reach them. It only wraps ipcMain.handle — no server, no cost until something serves.
       const rpcCapture = installRpcCapture(ipcMain)
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
-      const { shutdownCoordinator } = await registerIpcHandlers({ mainEntryPath })
+      const { runtime, notebook, shutdownCoordinator } = await registerIpcHandlers({ mainEntryPath })
       const webController = createWebServiceController({
         rpc: rpcCapture,
         requestQuit: () => app.quit()
@@ -149,6 +151,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         createAppTray,
         buildAuthenticatedWebUrl,
         routeSecondInstance,
+        runtime,
+        notebook,
         shutdownCoordinator,
         installAppLifecycle,
         log,
@@ -203,7 +207,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         isMigrationInProgress: ctx.isMigrationInProgress,
         quit: () => app.quit(),
         countWindows: () => BrowserWindow.getAllWindows().length,
-        createInitialWindow: !ctx.webMode.headless
+        createInitialWindow: !ctx.webMode.headless,
+        detectActiveSessions: () =>
+          detectActiveSessions({ runtime: ctx.runtime, notebook: ctx.notebook }),
+        createConfirmClose: (getWindow) => createElectronCloseConfirm(getWindow)
       })
 
       // Route each second launch by its forwarded argv (see second-instance-router): a CLI

--- a/src/main/window-close-confirm.test.ts
+++ b/src/main/window-close-confirm.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ActiveSessionInfo } from '../shared/storage'
+import type {
+  CloseConfirmChoice,
+  CloseConfirmRequest,
+  CloseConfirmResponse
+} from '../shared/window-controls'
+import { createCloseConfirm, type CloseConfirmDeps } from './window-close-confirm'
+
+const session: ActiveSessionInfo = {
+  projectName: 'my-analysis',
+  sessionId: 's1',
+  kind: 'agent'
+}
+
+// Builds a coordinator with controllable renderer plumbing. `emit` lets the test play the renderer.
+const makeHarness = (
+  overrides: Partial<CloseConfirmDeps> = {}
+): {
+  confirm: ReturnType<typeof createCloseConfirm>
+  sent: CloseConfirmRequest[]
+  nativeFallback: ReturnType<typeof vi.fn>
+  ack: () => void
+  choose: (choice: CloseConfirmResponse['choice']) => void
+  reply: (payload: CloseConfirmResponse) => void
+  fireGone: () => void
+} => {
+  let responder: ((payload: CloseConfirmResponse) => void) | undefined
+  let goneCb: (() => void) | undefined
+  const sent: CloseConfirmRequest[] = []
+  const nativeFallback = vi.fn(async (): Promise<CloseConfirmChoice> => 'quit')
+  const deps: CloseConfirmDeps = {
+    send: (payload) => sent.push(payload),
+    onResponse: (cb) => {
+      responder = cb
+      return () => {
+        responder = undefined
+      }
+    },
+    isRendererAvailable: () => true,
+    onRenderGone: (cb) => {
+      goneCb = cb
+      return () => {
+        goneCb = undefined
+      }
+    },
+    nativeFallback,
+    newRequestId: () => 'req-1',
+    ackTimeoutMs: 10,
+    ...overrides
+  }
+  return {
+    confirm: createCloseConfirm(deps),
+    sent,
+    nativeFallback,
+    ack: () => responder?.({ requestId: 'req-1', ack: true }),
+    choose: (choice: CloseConfirmResponse['choice']) => responder?.({ requestId: 'req-1', choice }),
+    reply: (payload: CloseConfirmResponse) => responder?.(payload),
+    fireGone: () => goneCb?.()
+  }
+}
+
+describe('createCloseConfirm', () => {
+  it('resolves quit immediately for the quit variant with no running work (no IPC)', async () => {
+    const h = makeHarness()
+    await expect(h.confirm('quit', [])).resolves.toBe('quit')
+    expect(h.sent).toHaveLength(0)
+  })
+
+  it('sends a request and resolves the renderer choice', async () => {
+    const h = makeHarness()
+    const pending = h.confirm('close-to-tray', [session])
+    h.ack()
+    h.choose('minimize')
+    await expect(pending).resolves.toBe('minimize')
+    expect(h.sent[0]).toMatchObject({ variant: 'close-to-tray', sessions: [session] })
+  })
+
+  it('ignores a stale response with a mismatched requestId', async () => {
+    const h = makeHarness()
+    const pending = h.confirm('close-to-tray', [session])
+    h.ack()
+    h.reply({ requestId: 'other', choice: 'quit' })
+    h.choose('cancel')
+    await expect(pending).resolves.toBe('cancel')
+  })
+
+  it('falls back to the native dialog when the renderer never acks', async () => {
+    const h = makeHarness()
+    const pending = h.confirm('close-to-tray', [session])
+    await expect(pending).resolves.toBe('quit') // nativeFallback default
+    expect(h.nativeFallback).toHaveBeenCalledWith('close-to-tray')
+  })
+
+  it('falls back immediately when no renderer is available', async () => {
+    const h = makeHarness({ isRendererAvailable: () => false })
+    await expect(h.confirm('close-to-tray', [session])).resolves.toBe('quit')
+    expect(h.nativeFallback).toHaveBeenCalledWith('close-to-tray')
+  })
+
+  it('falls back once when the render process dies mid-modal', async () => {
+    const h = makeHarness({ ackTimeoutMs: 10_000 })
+    const pending = h.confirm('quit', [session])
+    h.ack()
+    h.fireGone()
+    await expect(pending).resolves.toBe('quit')
+    expect(h.nativeFallback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/window-close-confirm.test.ts
+++ b/src/main/window-close-confirm.test.ts
@@ -107,4 +107,17 @@ describe('createCloseConfirm', () => {
     await expect(pending).resolves.toBe('quit')
     expect(h.nativeFallback).toHaveBeenCalledTimes(1)
   })
+
+  it('still settles when the native fallback rejects (never strands the confirm)', async () => {
+    // A stranded promise would pin the caller's in-flight guard forever and block quit. If the native
+    // dialog rejects (e.g. the window was destroyed), quit proceeds and close-to-tray stays resident.
+    const rejecting = vi.fn(async (): Promise<CloseConfirmChoice> => {
+      throw new Error('dialog failed')
+    })
+    const quitHarness = makeHarness({ isRendererAvailable: () => false, nativeFallback: rejecting })
+    await expect(quitHarness.confirm('quit', [session])).resolves.toBe('quit')
+
+    const trayHarness = makeHarness({ isRendererAvailable: () => false, nativeFallback: rejecting })
+    await expect(trayHarness.confirm('close-to-tray', [session])).resolves.toBe('minimize')
+  })
 })

--- a/src/main/window-close-confirm.ts
+++ b/src/main/window-close-confirm.ts
@@ -3,16 +3,16 @@ import { randomUUID } from 'node:crypto'
 
 import type { ActiveSessionInfo } from '../shared/storage'
 import {
-  WINDOW_CLOSE_CONFIRM_REQUEST,
-  WINDOW_CLOSE_CONFIRM_RESPONSE,
+  WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL,
+  WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL,
   type CloseConfirmChoice,
   type CloseConfirmRequest,
   type CloseConfirmResponse,
   type CloseConfirmVariant
 } from '../shared/window-controls'
 
-// Structural (Electron-free) plumbing so the coordinator is unit-testable. The Electron glue that
-// satisfies this lives in createElectronCloseConfirm (added in a later task).
+// Structural (Electron-free) plumbing so the coordinator is unit-testable; the Electron glue that
+// satisfies this is createElectronCloseConfirm below.
 export type CloseConfirmDeps = {
   // Send the request to the renderer (webContents.send).
   send: (payload: CloseConfirmRequest) => void
@@ -22,8 +22,8 @@ export type CloseConfirmDeps = {
   isRendererAvailable: () => boolean
   // Subscribe to render-process-gone for the confirm window; returns an unsubscribe.
   onRenderGone: (cb: () => void) => () => void
-  // Native fallback when the renderer can't answer: a message box for close-to-tray, or 'quit' for
-  // the quit variant (a dead UI must never block quit).
+  // Native fallback when the renderer can't answer (dead/hung, or no window at all). May reject;
+  // the coordinator wraps it so a rejection never leaves the confirm unsettled.
   nativeFallback: (variant: CloseConfirmVariant) => Promise<CloseConfirmChoice>
   newRequestId: () => string
   // Grace period for the modal-mounted ack before falling back. Defaults to 500ms.
@@ -45,7 +45,14 @@ export const createCloseConfirm = (
 
   return (variant, sessions) => {
     if (variant === 'quit' && sessions.length === 0) return Promise.resolve('quit')
-    if (!deps.isRendererAvailable()) return deps.nativeFallback(variant)
+
+    // Never let a fallback rejection leave the confirm unsettled: a stranded promise would pin the
+    // caller's in-flight guard forever and permanently block quit. On failure, keep the app resident
+    // for close-to-tray and proceed for quit.
+    const safeFallback = (): Promise<CloseConfirmChoice> =>
+      deps.nativeFallback(variant).catch(() => (variant === 'quit' ? 'quit' : 'minimize'))
+
+    if (!deps.isRendererAvailable()) return safeFallback()
 
     const requestId = deps.newRequestId()
 
@@ -67,7 +74,7 @@ export const createCloseConfirm = (
         if (fallbackStarted) return
         fallbackStarted = true
         clearTimeout(ackTimer)
-        void deps.nativeFallback(variant).then(finish)
+        void safeFallback().then(finish)
       }
 
       const offResponse = deps.onResponse((payload) => {
@@ -91,26 +98,41 @@ export const createCloseConfirm = (
   }
 }
 
-// Native fallback when the renderer can't render the modal. close-to-tray shows an OS message box;
-// quit proceeds (returns 'quit') because a dead/gone UI must not be able to block quit.
+// Native fallback when the renderer can't render the modal (dead/hung, or no window — e.g. macOS
+// after the window was closed but the app stays resident). The coordinator only reaches this with
+// work running (an empty quit list fast-paths to 'quit'), so both variants still ASK: quit offers
+// Quit/Cancel, close-to-tray offers Minimize/Quit. A destroyed window can't parent a dialog, so fall
+// back to a windowless one.
 const nativeFallback = async (
   getWindow: () => BrowserWindow | undefined,
   variant: CloseConfirmVariant
 ): Promise<CloseConfirmChoice> => {
-  if (variant === 'quit') return 'quit'
+  const options =
+    variant === 'quit'
+      ? {
+          type: 'question' as const,
+          buttons: ['Cancel', 'Quit'],
+          defaultId: 0,
+          cancelId: 0,
+          title: 'Open Science',
+          message: 'Quit Open Science?',
+          detail: 'Work is still running and will be interrupted if you quit.'
+        }
+      : {
+          type: 'question' as const,
+          buttons: ['Minimize to tray', 'Quit'],
+          defaultId: 0,
+          cancelId: 0,
+          title: 'Open Science',
+          message: 'Minimize to tray or quit?',
+          detail: 'Background work may still be running.'
+        }
   const window = getWindow()
-  const options = {
-    type: 'question' as const,
-    buttons: ['Minimize to tray', 'Quit'],
-    defaultId: 0,
-    cancelId: 0,
-    title: 'Open Science',
-    message: 'Minimize to tray or quit?',
-    detail: 'Background work may still be running.'
-  }
-  const { response } = window
-    ? await dialog.showMessageBox(window, options)
-    : await dialog.showMessageBox(options)
+  const { response } =
+    window && !window.isDestroyed()
+      ? await dialog.showMessageBox(window, options)
+      : await dialog.showMessageBox(options)
+  if (variant === 'quit') return response === 1 ? 'quit' : 'cancel'
   return response === 1 ? 'quit' : 'minimize'
 }
 
@@ -120,11 +142,21 @@ export const createElectronCloseConfirm = (
   getWindow: () => BrowserWindow | undefined
 ): ((variant: CloseConfirmVariant, sessions: ActiveSessionInfo[]) => Promise<CloseConfirmChoice>) =>
   createCloseConfirm({
-    send: (payload) => getWindow()?.webContents.send(WINDOW_CLOSE_CONFIRM_REQUEST, payload),
+    // Reveal the window before asking: a tray/Ctrl+Q quit can arrive while the window is hidden
+    // (minimized to tray), and a modal sent to a hidden window would never be seen — leaving the
+    // confirm (and thus the quit) stuck. Restoring/showing/focusing guarantees the modal is visible.
+    send: (payload) => {
+      const window = getWindow()
+      if (!window || window.isDestroyed()) return
+      if (window.isMinimized()) window.restore()
+      if (!window.isVisible()) window.show()
+      window.focus()
+      window.webContents.send(WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL, payload)
+    },
     onResponse: (cb) => {
       const listener = (_event: unknown, payload: CloseConfirmResponse): void => cb(payload)
-      ipcMain.on(WINDOW_CLOSE_CONFIRM_RESPONSE, listener)
-      return () => ipcMain.removeListener(WINDOW_CLOSE_CONFIRM_RESPONSE, listener)
+      ipcMain.on(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL, listener)
+      return () => ipcMain.removeListener(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL, listener)
     },
     isRendererAvailable: () => {
       const window = getWindow()

--- a/src/main/window-close-confirm.ts
+++ b/src/main/window-close-confirm.ts
@@ -1,9 +1,14 @@
+import { BrowserWindow, dialog, ipcMain } from 'electron'
+import { randomUUID } from 'node:crypto'
+
 import type { ActiveSessionInfo } from '../shared/storage'
-import type {
-  CloseConfirmChoice,
-  CloseConfirmRequest,
-  CloseConfirmResponse,
-  CloseConfirmVariant
+import {
+  WINDOW_CLOSE_CONFIRM_REQUEST,
+  WINDOW_CLOSE_CONFIRM_RESPONSE,
+  type CloseConfirmChoice,
+  type CloseConfirmRequest,
+  type CloseConfirmResponse,
+  type CloseConfirmVariant
 } from '../shared/window-controls'
 
 // Structural (Electron-free) plumbing so the coordinator is unit-testable. The Electron glue that
@@ -85,3 +90,52 @@ export const createCloseConfirm = (
     })
   }
 }
+
+// Native fallback when the renderer can't render the modal. close-to-tray shows an OS message box;
+// quit proceeds (returns 'quit') because a dead/gone UI must not be able to block quit.
+const nativeFallback = async (
+  getWindow: () => BrowserWindow | undefined,
+  variant: CloseConfirmVariant
+): Promise<CloseConfirmChoice> => {
+  if (variant === 'quit') return 'quit'
+  const window = getWindow()
+  const options = {
+    type: 'question' as const,
+    buttons: ['Minimize to tray', 'Quit'],
+    defaultId: 0,
+    cancelId: 0,
+    title: 'Open Science',
+    message: 'Minimize to tray or quit?',
+    detail: 'Background work may still be running.'
+  }
+  const { response } = window
+    ? await dialog.showMessageBox(window, options)
+    : await dialog.showMessageBox(options)
+  return response === 1 ? 'quit' : 'minimize'
+}
+
+// Wires createCloseConfirm to Electron IPC + the current main window (via getWindow, since the window
+// can be recreated). Response listeners are per-confirm and removed when it settles.
+export const createElectronCloseConfirm = (
+  getWindow: () => BrowserWindow | undefined
+): ((variant: CloseConfirmVariant, sessions: ActiveSessionInfo[]) => Promise<CloseConfirmChoice>) =>
+  createCloseConfirm({
+    send: (payload) => getWindow()?.webContents.send(WINDOW_CLOSE_CONFIRM_REQUEST, payload),
+    onResponse: (cb) => {
+      const listener = (_event: unknown, payload: CloseConfirmResponse): void => cb(payload)
+      ipcMain.on(WINDOW_CLOSE_CONFIRM_RESPONSE, listener)
+      return () => ipcMain.removeListener(WINDOW_CLOSE_CONFIRM_RESPONSE, listener)
+    },
+    isRendererAvailable: () => {
+      const window = getWindow()
+      return Boolean(window && !window.isDestroyed() && !window.webContents.isDestroyed())
+    },
+    onRenderGone: (cb) => {
+      const window = getWindow()
+      if (!window) return () => undefined
+      window.webContents.on('render-process-gone', cb)
+      return () => window.webContents.off('render-process-gone', cb)
+    },
+    nativeFallback: (variant) => nativeFallback(getWindow, variant),
+    newRequestId: () => randomUUID()
+  })

--- a/src/main/window-close-confirm.ts
+++ b/src/main/window-close-confirm.ts
@@ -1,0 +1,87 @@
+import type { ActiveSessionInfo } from '../shared/storage'
+import type {
+  CloseConfirmChoice,
+  CloseConfirmRequest,
+  CloseConfirmResponse,
+  CloseConfirmVariant
+} from '../shared/window-controls'
+
+// Structural (Electron-free) plumbing so the coordinator is unit-testable. The Electron glue that
+// satisfies this lives in createElectronCloseConfirm (added in a later task).
+export type CloseConfirmDeps = {
+  // Send the request to the renderer (webContents.send).
+  send: (payload: CloseConfirmRequest) => void
+  // Subscribe to renderer responses for the lifetime of one confirm; returns an unsubscribe.
+  onResponse: (cb: (payload: CloseConfirmResponse) => void) => () => void
+  // Whether a live renderer exists to receive the request (window + webContents present, not gone).
+  isRendererAvailable: () => boolean
+  // Subscribe to render-process-gone for the confirm window; returns an unsubscribe.
+  onRenderGone: (cb: () => void) => () => void
+  // Native fallback when the renderer can't answer: a message box for close-to-tray, or 'quit' for
+  // the quit variant (a dead UI must never block quit).
+  nativeFallback: (variant: CloseConfirmVariant) => Promise<CloseConfirmChoice>
+  newRequestId: () => string
+  // Grace period for the modal-mounted ack before falling back. Defaults to 500ms.
+  ackTimeoutMs?: number
+}
+
+const DEFAULT_ACK_TIMEOUT_MS = 500
+
+// Coordinates a close/quit confirmation. Main computes `sessions`, so the quit variant with an empty
+// list resolves without any IPC; otherwise the renderer renders the modal and replies the choice,
+// with a native/proceed fallback if it can't.
+export const createCloseConfirm = (
+  deps: CloseConfirmDeps
+): ((
+  variant: CloseConfirmVariant,
+  sessions: ActiveSessionInfo[]
+) => Promise<CloseConfirmChoice>) => {
+  const ackTimeoutMs = deps.ackTimeoutMs ?? DEFAULT_ACK_TIMEOUT_MS
+
+  return (variant, sessions) => {
+    if (variant === 'quit' && sessions.length === 0) return Promise.resolve('quit')
+    if (!deps.isRendererAvailable()) return deps.nativeFallback(variant)
+
+    const requestId = deps.newRequestId()
+
+    return new Promise<CloseConfirmChoice>((resolve) => {
+      let settled = false
+      let acked = false
+      let fallbackStarted = false
+
+      const finish = (choice: CloseConfirmChoice): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(ackTimer)
+        offResponse()
+        offGone()
+        resolve(choice)
+      }
+
+      const startFallback = (): void => {
+        if (fallbackStarted) return
+        fallbackStarted = true
+        clearTimeout(ackTimer)
+        void deps.nativeFallback(variant).then(finish)
+      }
+
+      const offResponse = deps.onResponse((payload) => {
+        if (payload.requestId !== requestId) return
+        if (payload.ack) {
+          acked = true
+          clearTimeout(ackTimer)
+          return
+        }
+        if (payload.choice) finish(payload.choice)
+      })
+
+      const offGone = deps.onRenderGone(startFallback)
+
+      const ackTimer = setTimeout(() => {
+        if (!acked) startFallback()
+      }, ackTimeoutMs)
+
+      deps.send({ requestId, variant, sessions })
+    })
+  }
+}

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -397,10 +397,14 @@ describe('close chord interception', () => {
     expect(window.closeMock).not.toHaveBeenCalled()
   })
 
-  it('routes the Cmd/Ctrl+W direct-close fallback through the close-to-tray interceptor', () => {
+  it('routes the Cmd/Ctrl+W direct-close fallback through classifyClose', () => {
     // Renderer not ready, so the chord falls back to window.close(); with the tray resident that must
     // hide the window (via the 'close' interceptor) instead of actually closing it.
-    createMainWindow({ shouldHideOnClose: () => true })
+    createMainWindow({
+      classifyClose: () => 'hide',
+      resolveCloseAction: vi.fn(),
+      requestQuit: vi.fn()
+    })
     const window = currentWindow!
 
     fireInput(window, closeChord())
@@ -417,8 +421,12 @@ describe('createMainWindow close-to-tray interceptor', () => {
     lastWindow = undefined
   })
 
-  it('hides instead of closing when shouldHideOnClose returns true', () => {
-    createMainWindow({ shouldHideOnClose: () => true })
+  it('hides instead of closing when classifyClose returns "hide"', () => {
+    createMainWindow({
+      classifyClose: () => 'hide',
+      resolveCloseAction: vi.fn(),
+      requestQuit: vi.fn()
+    })
     const window = lastWindow!
     expect(window).toBeDefined()
 
@@ -430,9 +438,13 @@ describe('createMainWindow close-to-tray interceptor', () => {
     expect(window.isDestroyed()).toBe(false)
   })
 
-  it('evaluates the predicate at close time so a flipped flag allows a real quit', () => {
+  it('evaluates classifyClose at close time so a flipped flag allows a real quit', () => {
     let quitting = false
-    createMainWindow({ shouldHideOnClose: () => !quitting })
+    createMainWindow({
+      classifyClose: () => (quitting ? 'close' : 'hide'),
+      resolveCloseAction: vi.fn(),
+      requestQuit: vi.fn()
+    })
     const window = lastWindow!
 
     emitClose(window)
@@ -446,8 +458,12 @@ describe('createMainWindow close-to-tray interceptor', () => {
     expect(window.isDestroyed()).toBe(true)
   })
 
-  it('lets the window close when shouldHideOnClose returns false', () => {
-    createMainWindow({ shouldHideOnClose: () => false })
+  it('lets the window close when classifyClose returns "close"', () => {
+    createMainWindow({
+      classifyClose: () => 'close',
+      resolveCloseAction: vi.fn(),
+      requestQuit: vi.fn()
+    })
     const window = lastWindow!
 
     const event = emitClose(window)
@@ -466,5 +482,56 @@ describe('createMainWindow close-to-tray interceptor', () => {
     expect(event.defaultPrevented).toBe(false)
     expect(window.hideCalls).toBe(0)
     expect(window.isDestroyed()).toBe(true)
+  })
+})
+
+describe('createMainWindow close handling', () => {
+  it('lets the window close when classifyClose returns "close"', () => {
+    const requestQuit = vi.fn()
+    createMainWindow({ classifyClose: () => 'close', resolveCloseAction: vi.fn(), requestQuit })
+    const event = { preventDefault: vi.fn(), defaultPrevented: false }
+    currentWindow!.handlers.get('close')![0](event)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(currentWindow!.hideCalls).toBe(0)
+  })
+
+  it('hides to tray when classifyClose returns "hide"', () => {
+    createMainWindow({
+      classifyClose: () => 'hide',
+      resolveCloseAction: vi.fn(),
+      requestQuit: vi.fn()
+    })
+    const event = { preventDefault: vi.fn(), defaultPrevented: false }
+    currentWindow!.handlers.get('close')![0](event)
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(currentWindow!.hideCalls).toBe(1)
+  })
+
+  it('confirm -> minimize hides the window', async () => {
+    const resolveCloseAction = vi.fn(async () => 'minimize' as const)
+    createMainWindow({ classifyClose: () => 'confirm', resolveCloseAction, requestQuit: vi.fn() })
+    const event = { preventDefault: vi.fn(), defaultPrevented: false }
+    currentWindow!.handlers.get('close')![0](event)
+    expect(event.preventDefault).toHaveBeenCalled()
+    await vi.waitFor(() => expect(currentWindow!.hideCalls).toBe(1))
+  })
+
+  it('confirm -> quit calls requestQuit', async () => {
+    const requestQuit = vi.fn()
+    const resolveCloseAction = vi.fn(async () => 'quit' as const)
+    createMainWindow({ classifyClose: () => 'confirm', resolveCloseAction, requestQuit })
+    currentWindow!.handlers.get('close')![0]({ preventDefault: vi.fn(), defaultPrevented: false })
+    await vi.waitFor(() => expect(requestQuit).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not stack confirmations while one is in flight', () => {
+    let resolveFn: (c: 'cancel') => void = () => undefined
+    const resolveCloseAction = vi.fn(() => new Promise<'cancel'>((r) => (resolveFn = r)))
+    createMainWindow({ classifyClose: () => 'confirm', resolveCloseAction, requestQuit: vi.fn() })
+    const close = currentWindow!.handlers.get('close')![0]
+    close({ preventDefault: vi.fn(), defaultPrevented: false })
+    close({ preventDefault: vi.fn(), defaultPrevented: false })
+    expect(resolveCloseAction).toHaveBeenCalledTimes(1)
+    resolveFn('cancel')
   })
 })

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -14,7 +14,8 @@ import {
   CLOSE_ACTIVE_PANE_CHANNEL,
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
-  isCloseWindowChord
+  isCloseWindowChord,
+  type CloseConfirmChoice
 } from '../shared/window-controls'
 
 const rendererEntry = join(__dirname, '../renderer/index.html')
@@ -63,7 +64,16 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
   return window
 }
 
-const createMainWindow = (opts?: { shouldHideOnClose?: () => boolean }): BrowserWindow => {
+// How the main window resolves a close: classifyClose decides synchronously at close time
+// ('close' = let it close, 'hide' = minimize to tray, 'confirm' = ask via resolveCloseAction).
+// resolveCloseAction is awaited only for 'confirm'; requestQuit is called when the choice is quit.
+type MainWindowCloseOptions = {
+  classifyClose: () => 'close' | 'hide' | 'confirm'
+  resolveCloseAction: () => Promise<CloseConfirmChoice>
+  requestQuit: () => void
+}
+
+const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
   const window = createAppWindow({
     width: 1280,
     // The first-run environment summary needs enough vertical space to keep its Continue action
@@ -139,20 +149,35 @@ const createMainWindow = (opts?: { shouldHideOnClose?: () => boolean }): Browser
     if (rendererListenerReady && rendererResponsive) {
       window.webContents.send(CLOSE_ACTIVE_PANE_CHANNEL)
     } else {
-      // The chord's window-close fallback still honors close-to-tray: window.close() fires the 'close'
-      // event handled below, which hides (stays resident) instead of closing when the tray is active.
+      // The chord's window-close fallback now routes through classifyClose below: Windows surfaces the
+      // confirm dialog, Linux hides to tray, and everyone else closes.
       window.close()
     }
   })
 
-  // Close-to-tray: when the tray keeps the app resident, hide the window instead of closing it. The
-  // predicate is evaluated at close time so the caller can flip a quitting flag to allow a real exit.
-  // This also backs the Cmd/Ctrl+W fallback above — its window.close() routes through here.
+  // Close handling. classifyClose decides synchronously so darwin / no-tray / mid-quit still close
+  // instantly; 'hide' minimizes to tray (Linux); 'confirm' (Windows X) asks the user. The
+  // Cmd/Ctrl+W fallback window.close() routes through here unchanged.
+  let awaitingChoice = false
   window.on('close', (event) => {
-    if (opts?.shouldHideOnClose?.()) {
-      event.preventDefault()
+    const action = opts?.classifyClose?.() ?? 'close'
+    if (action === 'close') return
+    event.preventDefault()
+    if (action === 'hide') {
       window.hide()
+      return
     }
+    if (awaitingChoice) return
+    awaitingChoice = true
+    void opts!
+      .resolveCloseAction()
+      .then((choice) => {
+        if (choice === 'minimize') window.hide()
+        else if (choice === 'quit') opts!.requestQuit()
+      })
+      .finally(() => {
+        awaitingChoice = false
+      })
   })
 
   // In dev, mirror the "(DEV)" app suffix in the title bar. The renderer's <title> overwrites the

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -15,6 +15,7 @@ import {
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
   isCloseWindowChord,
+  type CloseClassification,
   type CloseConfirmChoice
 } from '../shared/window-controls'
 
@@ -68,7 +69,7 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
 // ('close' = let it close, 'hide' = minimize to tray, 'confirm' = ask via resolveCloseAction).
 // resolveCloseAction is awaited only for 'confirm'; requestQuit is called when the choice is quit.
 type MainWindowCloseOptions = {
-  classifyClose: () => 'close' | 'hide' | 'confirm'
+  classifyClose: () => CloseClassification
   resolveCloseAction: () => Promise<CloseConfirmChoice>
   requestQuit: () => void
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -147,6 +147,7 @@ import type {
   ReviewRunResult,
   ReviewUpdateEvent
 } from '../shared/reviewer'
+import type { CloseConfirmRequest, CloseConfirmResponse } from '../shared/window-controls'
 
 type RemoveListener = () => void
 type AcpListener<Payload> = (payload: Payload) => void
@@ -411,6 +412,10 @@ interface OpenScienceAPI {
     close(): Promise<void>
     // Fires when Cmd+W / Ctrl+W is pressed; the renderer decides pane-vs-window.
     onCloseActivePane(listener: () => void): RemoveListener
+    // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
+    onCloseConfirmRequest(listener: (payload: CloseConfirmRequest) => void): RemoveListener
+    // Renderer -> main: modal-mounted ack, then the user's choice, keyed by requestId.
+    sendCloseConfirmResponse(payload: CloseConfirmResponse): void
   }
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -824,8 +824,7 @@ const api: OpenScienceAPI = {
         listener
       ),
     onCloseConfirmRequest: (listener) => onIpcMessage(WINDOW_CLOSE_CONFIRM_REQUEST, listener),
-    sendCloseConfirmResponse: (payload) =>
-      ipcRenderer.send(WINDOW_CLOSE_CONFIRM_RESPONSE, payload)
+    sendCloseConfirmResponse: (payload) => ipcRenderer.send(WINDOW_CLOSE_CONFIRM_RESPONSE, payload)
   }
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -153,8 +153,8 @@ import { REVIEWER_IPC } from '../shared/reviewer'
 import {
   subscribeCloseActivePane,
   WINDOW_CLOSE_CHANNEL,
-  WINDOW_CLOSE_CONFIRM_REQUEST,
-  WINDOW_CLOSE_CONFIRM_RESPONSE,
+  WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL,
+  WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL,
   type CloseConfirmRequest,
   type CloseConfirmResponse
 } from '../shared/window-controls'
@@ -823,8 +823,10 @@ const api: OpenScienceAPI = {
         },
         listener
       ),
-    onCloseConfirmRequest: (listener) => onIpcMessage(WINDOW_CLOSE_CONFIRM_REQUEST, listener),
-    sendCloseConfirmResponse: (payload) => ipcRenderer.send(WINDOW_CLOSE_CONFIRM_RESPONSE, payload)
+    onCloseConfirmRequest: (listener) =>
+      onIpcMessage(WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL, listener),
+    sendCloseConfirmResponse: (payload) =>
+      ipcRenderer.send(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL, payload)
   }
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -150,7 +150,14 @@ import type {
   ReviewUpdateEvent
 } from '../shared/reviewer'
 import { REVIEWER_IPC } from '../shared/reviewer'
-import { subscribeCloseActivePane, WINDOW_CLOSE_CHANNEL } from '../shared/window-controls'
+import {
+  subscribeCloseActivePane,
+  WINDOW_CLOSE_CHANNEL,
+  WINDOW_CLOSE_CONFIRM_REQUEST,
+  WINDOW_CLOSE_CONFIRM_RESPONSE,
+  type CloseConfirmRequest,
+  type CloseConfirmResponse
+} from '../shared/window-controls'
 
 type RemoveListener = () => void
 type AcpListener<Payload> = (payload: Payload) => void
@@ -438,6 +445,10 @@ type OpenScienceAPI = {
     close: () => Promise<void>
     // Fires when Cmd+W / Ctrl+W is pressed; the renderer decides pane-vs-window.
     onCloseActivePane: (listener: () => void) => RemoveListener
+    // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
+    onCloseConfirmRequest: (listener: (payload: CloseConfirmRequest) => void) => RemoveListener
+    // Renderer -> main: modal-mounted ack, then the user's choice, keyed by requestId.
+    sendCloseConfirmResponse: (payload: CloseConfirmResponse) => void
   }
 }
 
@@ -811,7 +822,10 @@ const api: OpenScienceAPI = {
           send: (channel) => ipcRenderer.send(channel)
         },
         listener
-      )
+      ),
+    onCloseConfirmRequest: (listener) => onIpcMessage(WINDOW_CLOSE_CONFIRM_REQUEST, listener),
+    sendCloseConfirmResponse: (payload) =>
+      ipcRenderer.send(WINDOW_CLOSE_CONFIRM_RESPONSE, payload)
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { useSessionPersistence } from '@/lib/session-persistence/session-persistence'
+import { CloseConfirmModal } from '@/components/CloseConfirmModal'
 import { DataRootMissingDialog } from '@/components/DataRootMissingDialog'
 import { LegacyDataMoveDialog } from '@/components/LegacyDataMoveDialog'
 import { UpdateDialog } from '@/components/UpdateDialog'
@@ -120,6 +121,7 @@ const App = (): React.JSX.Element | null => {
       <SettingsPage open={isSettingsOpen} onClose={closeSettings} />
       <ConnectorApprovalDialog />
       <UpdateDialog />
+      <CloseConfirmModal />
       <DataRootMissingDialog
         open={missingDataRoot !== undefined}
         dataRoot={missingDataRoot ?? ''}

--- a/src/renderer/src/components/CloseConfirmModal.render.test.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.render.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CloseConfirmModal } from './CloseConfirmModal'
+import { useSessionStore } from '@/stores/session-store'
+import type { CloseConfirmRequest } from '../../../shared/window-controls'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let requestListener: ((payload: CloseConfirmRequest) => void) | undefined
+const sendResponse = vi.fn()
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  sendResponse.mockClear()
+  requestListener = undefined
+  // Test double: only window.api.window is exercised by this component.
+  window.api = {
+    window: {
+      onCloseConfirmRequest: (cb: (payload: CloseConfirmRequest) => void) => {
+        requestListener = cb
+        return () => (requestListener = undefined)
+      },
+      sendCloseConfirmResponse: sendResponse
+    }
+  } as unknown as typeof window.api
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+const emit = (payload: CloseConfirmRequest): void => requestListener?.(payload)
+
+const render = (): void => {
+  act(() => root.render(<CloseConfirmModal />))
+}
+
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+const findByText = async (pattern: RegExp): Promise<Element> => {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const match = Array.from(document.body.querySelectorAll('*')).find((el) =>
+      pattern.test(el.textContent ?? '')
+    )
+    if (match) return match
+    await flush()
+  }
+  throw new Error(`expected to find text matching ${pattern}`)
+}
+
+const findButtonByName = async (pattern: RegExp): Promise<HTMLButtonElement> => {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const match = Array.from(document.querySelectorAll('button')).find((button) =>
+      pattern.test(button.textContent ?? '')
+    )
+    if (match) return match
+    await flush()
+  }
+  throw new Error(`expected to find a button matching ${pattern}`)
+}
+
+describe('CloseConfirmModal', () => {
+  it('acks on request and lists the enriched session title', async () => {
+    useSessionStore.setState({
+      sessions: [{ id: 's1', title: 'Fix data loader' } as never],
+      selectedSessionId: undefined
+    })
+    render()
+    act(() => {
+      emit({
+        requestId: 'r1',
+        variant: 'close-to-tray',
+        sessions: [{ projectName: 'my-analysis', sessionId: 's1', kind: 'agent' }]
+      })
+    })
+    expect(sendResponse).toHaveBeenCalledWith({ requestId: 'r1', ack: true })
+    await findByText(/my-analysis/)
+    await findByText(/Fix data loader/)
+  })
+
+  it('replies quit / minimize from the close-to-tray buttons', async () => {
+    render()
+    act(() => {
+      emit({ requestId: 'r2', variant: 'close-to-tray', sessions: [] })
+    })
+    const minimizeButton = await findButtonByName(/minimize to tray/i)
+    act(() => minimizeButton.click())
+    expect(sendResponse).toHaveBeenCalledWith({ requestId: 'r2', choice: 'minimize' })
+  })
+
+  it('replies quit / cancel from the quit variant buttons', async () => {
+    render()
+    act(() => {
+      emit({
+        requestId: 'r3',
+        variant: 'quit',
+        sessions: [{ projectName: 'p', sessionId: 'x', kind: 'notebook' }]
+      })
+    })
+    const quitButton = await findButtonByName(/^quit$/i)
+    act(() => quitButton.click())
+    expect(sendResponse).toHaveBeenCalledWith({ requestId: 'r3', choice: 'quit' })
+  })
+
+  it('renders null and does not throw when the desktop bridge is absent (web build)', () => {
+    // Test double: web build omits the close-confirm channels entirely.
+    window.api = { window: {} } as unknown as typeof window.api
+    expect(() => render()).not.toThrow()
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/src/renderer/src/components/CloseConfirmModal.render.test.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.render.test.tsx
@@ -4,6 +4,8 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CloseConfirmModal } from './CloseConfirmModal'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { useProjectStore } from '@/stores/project-store'
 import { useSessionStore } from '@/stores/session-store'
 import type { CloseConfirmRequest } from '../../../shared/window-controls'
 
@@ -74,9 +76,14 @@ const findButtonByName = async (pattern: RegExp): Promise<HTMLButtonElement> => 
 }
 
 describe('CloseConfirmModal', () => {
-  it('acks on request and lists the enriched session title', async () => {
+  it('acks and shows the resolved project NAME (not the id main sent) plus the title', async () => {
+    useProjectStore.setState({
+      projects: [{ id: 'p1', name: 'My Analysis' } as never],
+      isLoaded: true,
+      loadError: undefined
+    })
     useSessionStore.setState({
-      sessions: [{ id: 's1', title: 'Fix data loader' } as never],
+      sessions: [{ id: 's1', projectId: 'p1', title: 'Fix data loader' } as never],
       selectedSessionId: undefined
     })
     render()
@@ -84,12 +91,39 @@ describe('CloseConfirmModal', () => {
       emit({
         requestId: 'r1',
         variant: 'close-to-tray',
-        sessions: [{ projectName: 'my-analysis', sessionId: 's1', kind: 'agent' }]
+        // main sends a project *id* here; the modal must resolve the human name instead.
+        sessions: [{ projectName: 'cmrqcvg5i0000vo387wdhdudj', sessionId: 's1', kind: 'agent' }]
       })
     })
     expect(sendResponse).toHaveBeenCalledWith({ requestId: 'r1', ack: true })
-    await findByText(/my-analysis/)
-    await findByText(/Fix data loader/)
+    await findByText(/My Analysis — Fix data loader/)
+    expect(document.body.textContent).not.toContain('cmrqcvg5i0000vo387wdhdudj')
+  })
+
+  it('opens the session and cancels the close when a running-session row is clicked', async () => {
+    const openSession = vi.fn()
+    useNavigationStore.setState({ openSession } as never)
+    useProjectStore.setState({
+      projects: [{ id: 'p1', name: 'My Analysis' } as never],
+      isLoaded: true,
+      loadError: undefined
+    })
+    useSessionStore.setState({
+      sessions: [{ id: 's1', projectId: 'p1', title: 'Fix data loader' } as never],
+      selectedSessionId: undefined
+    })
+    render()
+    act(() => {
+      emit({
+        requestId: 'r4',
+        variant: 'quit',
+        sessions: [{ projectName: 'p1', sessionId: 's1', kind: 'agent' }]
+      })
+    })
+    const row = await findButtonByName(/My Analysis — Fix data loader/)
+    act(() => row.click())
+    expect(openSession).toHaveBeenCalledWith('p1', 's1')
+    expect(sendResponse).toHaveBeenCalledWith({ requestId: 'r4', choice: 'cancel' })
   })
 
   it('replies quit / minimize from the close-to-tray buttons', async () => {

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from 'radix-ui'
+import { AlertDialog } from 'radix-ui'
 import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
@@ -48,54 +48,56 @@ export const CloseConfirmModal = (): React.JSX.Element | null => {
   if (!request) return null
 
   const isQuitVariant = request.variant === 'quit'
+  const hasSessions = request.sessions.length > 0
   const title = isQuitVariant ? 'Quit Open Science?' : 'Minimize or quit?'
+  const description = isQuitVariant
+    ? 'Work is still running and will be interrupted if you quit.'
+    : 'This app can keep running in the tray, or you can quit.'
 
   return (
-    <Dialog.Root open onOpenChange={(open) => (!open ? reply('cancel') : undefined)}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/50" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 z-[60] w-[min(420px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-card p-5 text-foreground shadow-dialog">
-          <Dialog.Title className="text-sm font-semibold">{title}</Dialog.Title>
-          {request.sessions.length > 0 ? (
-            <>
-              <Dialog.Description className="mt-1 text-xs text-muted-foreground">
-                Still running:
-              </Dialog.Description>
-              <ul className="mt-3 space-y-1 text-xs">
-                {request.sessions.map((session) => (
-                  <li
-                    key={`${session.kind}:${session.sessionId}`}
-                    className="rounded-lg border border-border bg-muted/40 p-2 text-foreground"
-                  >
-                    {session.projectName} — {resolveTitle(session.sessionId)}
-                  </li>
-                ))}
-              </ul>
-            </>
+    <AlertDialog.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) reply('cancel')
+      }}
+    >
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className="fixed inset-0 z-[60] bg-black/50" />
+        <AlertDialog.Content className="fixed left-1/2 top-1/2 z-[60] w-[min(420px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-card p-5 text-foreground shadow-dialog">
+          <AlertDialog.Title className="text-sm font-semibold">{title}</AlertDialog.Title>
+          <AlertDialog.Description className="mt-1 text-xs text-muted-foreground">
+            {description}
+          </AlertDialog.Description>
+          {hasSessions ? (
+            <ul className="mt-3 space-y-1 text-xs">
+              {request.sessions.map((session) => (
+                <li
+                  key={`${session.kind}:${session.sessionId}`}
+                  className="rounded-lg border border-border bg-muted/40 p-2 text-foreground"
+                >
+                  {session.projectName} — {resolveTitle(session.sessionId)}
+                </li>
+              ))}
+            </ul>
           ) : null}
           <div className="mt-4 flex justify-end gap-2">
             {isQuitVariant ? (
-              <>
-                <Button type="button" variant="ghost" onClick={() => reply('cancel')}>
+              <AlertDialog.Cancel asChild>
+                <Button type="button" variant="ghost">
                   Cancel
                 </Button>
-                <Button type="button" onClick={() => reply('quit')}>
-                  Quit
-                </Button>
-              </>
+              </AlertDialog.Cancel>
             ) : (
-              <>
-                <Button type="button" variant="ghost" onClick={() => reply('minimize')}>
-                  Minimize to tray
-                </Button>
-                <Button type="button" onClick={() => reply('quit')}>
-                  Quit
-                </Button>
-              </>
+              <Button type="button" variant="ghost" onClick={() => reply('minimize')}>
+                Minimize to tray
+              </Button>
             )}
+            <Button type="button" onClick={() => reply('quit')}>
+              Quit
+            </Button>
           </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
   )
 }

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -110,12 +110,16 @@ export const CloseConfirmModal = (): React.JSX.Element | null => {
                   reply('cancel')
                 }
                 return (
-                  <li key={`${session.kind}:${session.sessionId}`}>
+                  // title lives on the li, not the button: a disabled button dispatches no hover
+                  // events, so a button-level tooltip would be dead exactly on truncated unresolved rows.
+                  <li
+                    key={`${session.kind}:${session.sessionId}`}
+                    title={`${row.project} — ${row.title}`}
+                  >
                     <button
                       type="button"
                       onClick={openThisSession}
                       disabled={!row.projectId}
-                      title={`${row.project} — ${row.title}`}
                       className="block w-full truncate rounded-lg border border-border bg-muted/40 p-2 text-left text-foreground enabled:cursor-pointer enabled:hover:bg-muted disabled:cursor-default"
                     >
                       {truncate(row.project)} — {truncate(row.title)}

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -1,0 +1,101 @@
+import { Dialog } from 'radix-ui'
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { useSessionStore } from '@/stores/session-store'
+import type { ActiveSessionInfo } from '../../../shared/storage'
+import type {
+  CloseConfirmChoice,
+  CloseConfirmRequest,
+  CloseConfirmVariant
+} from '../../../shared/window-controls'
+
+type ActiveRequest = {
+  requestId: string
+  variant: CloseConfirmVariant
+  sessions: ActiveSessionInfo[]
+}
+
+// Maps a session id to its human title from the store, falling back to the id when unknown.
+const resolveTitle = (sessionId: string): string => {
+  const session = useSessionStore.getState().sessions.find((entry) => entry.id === sessionId)
+  return session?.title?.trim() || sessionId
+}
+
+// Subscribes to main's close/quit confirmation requests, lists running work (enriching each
+// session's title from the session store), and replies with the user's choice. Mounted once at
+// the app root. The web build omits the close-confirm bridge entirely (close-to-tray is desktop
+// only), so every call into window.api.window here must tolerate that absence.
+export const CloseConfirmModal = (): React.JSX.Element | null => {
+  const [request, setRequest] = useState<ActiveRequest | undefined>(undefined)
+
+  useEffect(() => {
+    const windowApi = window.api.window
+    if (!windowApi.onCloseConfirmRequest) return undefined
+    return windowApi.onCloseConfirmRequest((payload: CloseConfirmRequest) => {
+      windowApi.sendCloseConfirmResponse?.({ requestId: payload.requestId, ack: true })
+      setRequest(payload)
+    })
+  }, [])
+
+  const reply = (choice: CloseConfirmChoice): void => {
+    if (request) {
+      window.api.window.sendCloseConfirmResponse?.({ requestId: request.requestId, choice })
+    }
+    setRequest(undefined)
+  }
+
+  if (!request) return null
+
+  const isQuitVariant = request.variant === 'quit'
+  const title = isQuitVariant ? 'Quit Open Science?' : 'Minimize or quit?'
+
+  return (
+    <Dialog.Root open onOpenChange={(open) => (!open ? reply('cancel') : undefined)}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/50" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-[60] w-[min(420px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-card p-5 text-foreground shadow-dialog">
+          <Dialog.Title className="text-sm font-semibold">{title}</Dialog.Title>
+          {request.sessions.length > 0 ? (
+            <>
+              <Dialog.Description className="mt-1 text-xs text-muted-foreground">
+                Still running:
+              </Dialog.Description>
+              <ul className="mt-3 space-y-1 text-xs">
+                {request.sessions.map((session) => (
+                  <li
+                    key={`${session.kind}:${session.sessionId}`}
+                    className="rounded-lg border border-border bg-muted/40 p-2 text-foreground"
+                  >
+                    {session.projectName} — {resolveTitle(session.sessionId)}
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null}
+          <div className="mt-4 flex justify-end gap-2">
+            {isQuitVariant ? (
+              <>
+                <Button type="button" variant="ghost" onClick={() => reply('cancel')}>
+                  Cancel
+                </Button>
+                <Button type="button" onClick={() => reply('quit')}>
+                  Quit
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button type="button" variant="ghost" onClick={() => reply('minimize')}>
+                  Minimize to tray
+                </Button>
+                <Button type="button" onClick={() => reply('quit')}>
+                  Quit
+                </Button>
+              </>
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -2,6 +2,8 @@ import { AlertDialog } from 'radix-ui'
 import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { useProjectStore } from '@/stores/project-store'
 import { useSessionStore } from '@/stores/session-store'
 import type { ActiveSessionInfo } from '../../../shared/storage'
 import type {
@@ -16,10 +18,38 @@ type ActiveRequest = {
   sessions: ActiveSessionInfo[]
 }
 
-// Maps a session id to its human title from the store, falling back to the id when unknown.
-const resolveTitle = (sessionId: string): string => {
-  const session = useSessionStore.getState().sessions.find((entry) => entry.id === sessionId)
-  return session?.title?.trim() || sessionId
+type ResolvedRow = {
+  // The owning project's display name (not its id), resolved via the session's projectId.
+  project: string
+  title: string
+  // Present only when the session resolves to a project, so the row can navigate into it.
+  projectId?: string
+}
+
+const basename = (path: string): string => path.split(/[\\/]/).filter(Boolean).pop() ?? path
+
+// Cap each label so one long project name or title can't blow out the row; the button's title
+// attribute still carries the full text on hover.
+const MAX_LABEL_CHARS = 28
+const truncate = (text: string): string =>
+  text.length > MAX_LABEL_CHARS ? `${text.slice(0, MAX_LABEL_CHARS - 1).trimEnd()}…` : text
+
+// Resolves a running-session row to its display fields. main only knows the session's id + a stored
+// project *id*, so the human project NAME and title are looked up here from the renderer stores;
+// projectId is returned so the row can open that session. Falls back progressively so a row is never
+// blank: project name -> cwd basename -> whatever main sent.
+const resolveRow = (info: ActiveSessionInfo): ResolvedRow => {
+  const session = useSessionStore.getState().sessions.find((entry) => entry.id === info.sessionId)
+  const projectId = session?.projectId
+  const projectName = projectId
+    ? useProjectStore.getState().projects.find((project) => project.id === projectId)?.name
+    : undefined
+  const cwdName = session?.cwd ? basename(session.cwd) : undefined
+  return {
+    project: projectName ?? cwdName ?? info.projectName,
+    title: session?.title?.trim() || info.title?.trim() || info.sessionId,
+    projectId
+  }
 }
 
 // Subscribes to main's close/quit confirmation requests, lists running work (enriching each
@@ -70,14 +100,29 @@ export const CloseConfirmModal = (): React.JSX.Element | null => {
           </AlertDialog.Description>
           {hasSessions ? (
             <ul className="mt-3 space-y-1 text-xs">
-              {request.sessions.map((session) => (
-                <li
-                  key={`${session.kind}:${session.sessionId}`}
-                  className="rounded-lg border border-border bg-muted/40 p-2 text-foreground"
-                >
-                  {session.projectName} — {resolveTitle(session.sessionId)}
-                </li>
-              ))}
+              {request.sessions.map((session) => {
+                const row = resolveRow(session)
+                // Clicking a row cancels the close and jumps to that session so the user can check on
+                // it. Only navigable when we resolved its project (openSession needs the project id).
+                const openThisSession = (): void => {
+                  if (!row.projectId) return
+                  useNavigationStore.getState().openSession(row.projectId, session.sessionId)
+                  reply('cancel')
+                }
+                return (
+                  <li key={`${session.kind}:${session.sessionId}`}>
+                    <button
+                      type="button"
+                      onClick={openThisSession}
+                      disabled={!row.projectId}
+                      title={`${row.project} — ${row.title}`}
+                      className="block w-full truncate rounded-lg border border-border bg-muted/40 p-2 text-left text-foreground enabled:cursor-pointer enabled:hover:bg-muted disabled:cursor-default"
+                    >
+                      {truncate(row.project)} — {truncate(row.title)}
+                    </button>
+                  </li>
+                )
+              })}
             </ul>
           ) : null}
           <div className="mt-4 flex justify-end gap-2">

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -74,10 +74,14 @@ export const isCloseWindowChord = (input: KeyChordInput, platform: string): bool
 // --- Close/quit confirmation dialog (Windows X, and explicit quit when work is running) ---
 
 // Main -> renderer: show the close/quit confirmation modal for `variant`, listing `sessions`.
-export const WINDOW_CLOSE_CONFIRM_REQUEST = 'window:close-confirm-request'
+export const WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL = 'window:close-confirm-request'
 
 // Renderer -> main: modal mounted (ack) or the user chose an action (choice), keyed by requestId.
-export const WINDOW_CLOSE_CONFIRM_RESPONSE = 'window:close-confirm-response'
+export const WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL = 'window:close-confirm-response'
+
+// How a titlebar close resolves synchronously at close time: 'close' lets the window close, 'hide'
+// minimizes to tray, 'confirm' asks the user via the confirmation modal.
+export type CloseClassification = 'close' | 'hide' | 'confirm'
 
 // 'close-to-tray' = Windows X (Minimize vs Quit); 'quit' = explicit quit (Quit vs Cancel).
 export type CloseConfirmVariant = 'close-to-tray' | 'quit'

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -5,6 +5,8 @@
 // column) is open it closes that panel instead of the window. The main process intercepts the chord
 // and forwards it to the renderer, which decides whether to collapse the panel or close the window.
 
+import type { ActiveSessionInfo } from './storage'
+
 // Renderer -> main: close the focused window (the fallback when no pane is open).
 export const WINDOW_CLOSE_CHANNEL = 'window:close'
 
@@ -67,4 +69,31 @@ export const isCloseWindowChord = (input: KeyChordInput, platform: string): bool
   if (input.alt || input.shift) return false
 
   return platform === 'darwin' ? input.meta && !input.control : input.control && !input.meta
+}
+
+// --- Close/quit confirmation dialog (Windows X, and explicit quit when work is running) ---
+
+// Main -> renderer: show the close/quit confirmation modal for `variant`, listing `sessions`.
+export const WINDOW_CLOSE_CONFIRM_REQUEST = 'window:close-confirm-request'
+
+// Renderer -> main: modal mounted (ack) or the user chose an action (choice), keyed by requestId.
+export const WINDOW_CLOSE_CONFIRM_RESPONSE = 'window:close-confirm-response'
+
+// 'close-to-tray' = Windows X (Minimize vs Quit); 'quit' = explicit quit (Quit vs Cancel).
+export type CloseConfirmVariant = 'close-to-tray' | 'quit'
+
+// 'minimize' only occurs for the 'close-to-tray' variant; 'cancel' keeps the app/window as-is.
+export type CloseConfirmChoice = 'quit' | 'minimize' | 'cancel'
+
+export type CloseConfirmRequest = {
+  requestId: string
+  variant: CloseConfirmVariant
+  sessions: ActiveSessionInfo[]
+}
+
+// ack:true when the modal mounts (proves the renderer is alive); choice set when the user decides.
+export type CloseConfirmResponse = {
+  requestId: string
+  ack?: boolean
+  choice?: CloseConfirmChoice
 }


### PR DESCRIPTION
## Summary

On Windows, clicking the titlebar **X** silently minimized the app to the tray with no way to choose to quit and no warning about running work. This adds an in-app confirmation:

- **Windows titlebar X** → always shows a modal: *Minimize to tray* vs *Quit*, listing any running work.
- **Explicit quit** (macOS `Cmd+Q`, Windows `Ctrl+Q` / menu / tray Quit) → confirms *Quit* vs *Cancel* **only when work is running**; quits immediately otherwise.
- **macOS titlebar X** unchanged (window closes, app stays resident). **Linux** unchanged (silent hide-to-tray).

"Work running" = in-flight agent prompts + notebook cells mid-execution, reused from the existing `detectActiveSessions` (computed in main). Each row lists `project name — session title`.

No persisted "don't ask again" preference — always asks on the Windows X.

## Design

Main owns platform logic and computes the running list; a DI'd coordinator round-trips a request to a renderer modal and returns the choice, with a native-dialog / proceed-to-quit fallback when the renderer is unavailable.

- `src/shared/window-controls.ts` — IPC channels + `CloseConfirm*` types (reuses `ActiveSessionInfo`).
- `src/main/window-close-confirm.ts` — pure coordinator (`createCloseConfirm`) + Electron glue (`createElectronCloseConfirm`).
- `src/main/windows.ts` — `close` routes via `classifyClose` (`close`/`hide`/`confirm`) → `resolveCloseAction`/`requestQuit`.
- `src/main/app-lifecycle.ts` — platform classification + `before-quit` confirm gate; a single shared `confirmInFlight` guard serializes the X-close and quit paths.
- `src/main/index.ts` — wires `detectActiveSessions` + the coordinator into the lifecycle.
- `src/preload/index.ts` / `index.d.ts` — `onCloseConfirmRequest` / `sendCloseConfirmResponse` bridge.
- `src/renderer/src/components/CloseConfirmModal.tsx` — app-root modal; enriches session titles; guarded so the web build (no close-confirm channels) is inert.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — **4035 passed** (65 skipped), including new unit/render tests for the coordinator, close classification, the before-quit gate + cross-flow guard, and the modal.
- `npm run format` — applied

Desktop verification (`npm run dev`) recommended per repo convention.

## Notes

- Desktop-only by design: in the localhost web UI mode the modal is intentionally inert (no OS window/tray there), so the close-confirm channels are absent from the web-api-map.
- A concurrency bug found in review (native X and tray-Quit both clickable while the modal is open, stranding a confirm and leaving the app un-quittable) is fixed by the shared in-flight guard, with regression tests.