### PR TITLE
refactor(storage): rename ActiveSessionInfo.projectName → projectId; resolve names in the renderer

### DIFF
--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -348,7 +348,7 @@ describe('installAppLifecycle', () => {
   })
 
   it('resolveCloseAction resolves via confirmClose("close-to-tray", sessions)', async () => {
-    const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
+    const sessions: ActiveSessionInfo[] = [{ projectId: 'demo', sessionId: 's1', kind: 'agent' }]
     const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'minimize')
     const { closeOpts } = setup({ detectActiveSessions: () => sessions, confirmClose })
 
@@ -387,9 +387,7 @@ describe('installAppLifecycle', () => {
   })
 
   it('before-quit with active work + cancel keeps the app alive (no shutdown, no exit)', async () => {
-    const sessions: ActiveSessionInfo[] = [
-      { projectName: 'demo', sessionId: 's1', kind: 'notebook' }
-    ]
+    const sessions: ActiveSessionInfo[] = [{ projectId: 'demo', sessionId: 's1', kind: 'notebook' }]
     const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'cancel')
     const { app, shutdownBackends, quit } = setup({
       detectActiveSessions: () => sessions,
@@ -479,7 +477,7 @@ describe('installAppLifecycle', () => {
     // fire a second confirmClose('close-to-tray', ...) that overwrites the renderer's single request slot,
     // stranding the quit-confirm promise and permanently pinning confirmInFlight.
     let resolveConfirm: ((choice: CloseConfirmChoice) => void) | undefined
-    const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
+    const sessions: ActiveSessionInfo[] = [{ projectId: 'demo', sessionId: 's1', kind: 'agent' }]
     const confirmClose = vi.fn(
       () =>
         new Promise<CloseConfirmChoice>((resolve) => {

--- a/src/main/storage/detect-active.test.ts
+++ b/src/main/storage/detect-active.test.ts
@@ -9,9 +9,10 @@ describe('detectActiveSessions', () => {
       notebook: { getActiveNotebookSessions: () => [{ projectName: 'p', sessionId: 's2' }] }
     })
 
+    // The runtime source calls the storage key projectName; detect-active exposes it as projectId.
     expect(result).toEqual([
-      { projectName: 'p', sessionId: 's1', kind: 'agent' },
-      { projectName: 'p', sessionId: 's2', kind: 'notebook' }
+      { projectId: 'p', sessionId: 's1', kind: 'agent' },
+      { projectId: 'p', sessionId: 's2', kind: 'notebook' }
     ])
   })
 

--- a/src/main/storage/detect-active.ts
+++ b/src/main/storage/detect-active.ts
@@ -1,16 +1,14 @@
 // Aggregates the two authoritative sources of "actively running" sessions (an in-flight agent
-// prompt, or a notebook cell mid-execution) so the storage-migration flow can warn the user before
-// interrupting them. Pure function driven by structural deps so tests can pass fakes without
-// constructing the real runtimes.
+// prompt, or a notebook cell mid-execution) so the storage-migration and close/quit flows can warn
+// the user before interrupting them. Pure function driven by structural deps so tests can pass fakes
+// without constructing the real runtimes.
 
-export type ActiveSessionInfo = {
-  projectName: string
-  sessionId: string
-  kind: 'agent' | 'notebook'
-  // Optional; main doesn't hold session titles — the renderer maps sessionId -> title.
-  title?: string
-}
+import type { ActiveSessionInfo } from '../../shared/storage'
 
+export type { ActiveSessionInfo }
+
+// The runtime layer calls the artifact/notebook storage key `projectName`, but it holds the project
+// id; this module translates it to the honest `projectId` on the ActiveSessionInfo it exposes.
 type ActiveSessionSource = { projectName: string; sessionId: string }
 
 type ActiveDetectionDeps = {
@@ -21,8 +19,14 @@ type ActiveDetectionDeps = {
 // No dedup: an agent prompt and a notebook cell are distinct concerns, and a session can
 // legitimately have both running at once.
 export const detectActiveSessions = (deps: ActiveDetectionDeps): ActiveSessionInfo[] => [
-  ...deps.runtime.getActivePromptSessions().map((entry) => ({ ...entry, kind: 'agent' as const })),
-  ...deps.notebook
-    .getActiveNotebookSessions()
-    .map((entry) => ({ ...entry, kind: 'notebook' as const }))
+  ...deps.runtime.getActivePromptSessions().map((entry) => ({
+    projectId: entry.projectName,
+    sessionId: entry.sessionId,
+    kind: 'agent' as const
+  })),
+  ...deps.notebook.getActiveNotebookSessions().map((entry) => ({
+    projectId: entry.projectName,
+    sessionId: entry.sessionId,
+    kind: 'notebook' as const
+  }))
 ]

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -305,8 +305,8 @@ describe('storage IPC handlers', () => {
     registerStorageIpcHandlers(deps)
 
     await expect(invoke('storage:detect-active')).resolves.toEqual([
-      { projectName: 'p', sessionId: 'agent-1', kind: 'agent' },
-      { projectName: 'p', sessionId: 'nb-1', kind: 'notebook' }
+      { projectId: 'p', sessionId: 'agent-1', kind: 'agent' },
+      { projectId: 'p', sessionId: 'nb-1', kind: 'notebook' }
     ])
   })
 
@@ -328,7 +328,7 @@ describe('storage IPC handlers', () => {
     registerStorageIpcHandlers(deps)
 
     await expect(invoke('storage:detect-active')).resolves.toEqual([
-      { projectName: 'p', sessionId: 'nb-1', kind: 'notebook' }
+      { projectId: 'p', sessionId: 'nb-1', kind: 'notebook' }
     ])
   })
 

--- a/src/main/window-close-confirm.test.ts
+++ b/src/main/window-close-confirm.test.ts
@@ -9,7 +9,7 @@ import type {
 import { createCloseConfirm, type CloseConfirmDeps } from './window-close-confirm'
 
 const session: ActiveSessionInfo = {
-  projectName: 'my-analysis',
+  projectId: 'my-analysis',
   sessionId: 's1',
   kind: 'agent'
 }

--- a/src/renderer/src/components/CloseConfirmModal.render.test.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.render.test.tsx
@@ -92,7 +92,7 @@ describe('CloseConfirmModal', () => {
         requestId: 'r1',
         variant: 'close-to-tray',
         // main sends a project *id* here; the modal must resolve the human name instead.
-        sessions: [{ projectName: 'cmrqcvg5i0000vo387wdhdudj', sessionId: 's1', kind: 'agent' }]
+        sessions: [{ projectId: 'cmrqcvg5i0000vo387wdhdudj', sessionId: 's1', kind: 'agent' }]
       })
     })
     expect(sendResponse).toHaveBeenCalledWith({ requestId: 'r1', ack: true })
@@ -117,7 +117,7 @@ describe('CloseConfirmModal', () => {
       emit({
         requestId: 'r4',
         variant: 'quit',
-        sessions: [{ projectName: 'p1', sessionId: 's1', kind: 'agent' }]
+        sessions: [{ projectId: 'p1', sessionId: 's1', kind: 'agent' }]
       })
     })
     const row = await findButtonByName(/My Analysis — Fix data loader/)
@@ -142,7 +142,7 @@ describe('CloseConfirmModal', () => {
       emit({
         requestId: 'r3',
         variant: 'quit',
-        sessions: [{ projectName: 'p', sessionId: 'x', kind: 'notebook' }]
+        sessions: [{ projectId: 'p', sessionId: 'x', kind: 'notebook' }]
       })
     })
     const quitButton = await findButtonByName(/^quit$/i)

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -2,7 +2,7 @@ import { AlertDialog } from 'radix-ui'
 import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
-import { resolveActiveSessionDisplay } from '@/lib/active-session-display'
+import { resolveActiveSessionDisplay, truncateLabel } from '@/lib/active-session-display'
 import { useNavigationStore } from '@/stores/navigation-store'
 import type { ActiveSessionInfo } from '../../../shared/storage'
 import type {
@@ -16,12 +16,6 @@ type ActiveRequest = {
   variant: CloseConfirmVariant
   sessions: ActiveSessionInfo[]
 }
-
-// Cap each label so one long project name or title can't blow out the row; the li's title
-// attribute still carries the full text on hover.
-const MAX_LABEL_CHARS = 28
-const truncate = (text: string): string =>
-  text.length > MAX_LABEL_CHARS ? `${text.slice(0, MAX_LABEL_CHARS - 1).trimEnd()}…` : text
 
 // Subscribes to main's close/quit confirmation requests, lists running work (enriching each
 // session's title from the session store), and replies with the user's choice. Mounted once at
@@ -93,7 +87,7 @@ export const CloseConfirmModal = (): React.JSX.Element | null => {
                       disabled={!row.projectId}
                       className="block w-full truncate rounded-lg border border-border bg-muted/40 p-2 text-left text-foreground enabled:cursor-pointer enabled:hover:bg-muted disabled:cursor-default"
                     >
-                      {truncate(row.project)} — {truncate(row.title)}
+                      {truncateLabel(row.project)} — {truncateLabel(row.title)}
                     </button>
                   </li>
                 )

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -2,9 +2,8 @@ import { AlertDialog } from 'radix-ui'
 import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
+import { resolveActiveSessionDisplay } from '@/lib/active-session-display'
 import { useNavigationStore } from '@/stores/navigation-store'
-import { useProjectStore } from '@/stores/project-store'
-import { useSessionStore } from '@/stores/session-store'
 import type { ActiveSessionInfo } from '../../../shared/storage'
 import type {
   CloseConfirmChoice,
@@ -18,39 +17,11 @@ type ActiveRequest = {
   sessions: ActiveSessionInfo[]
 }
 
-type ResolvedRow = {
-  // The owning project's display name (not its id), resolved via the session's projectId.
-  project: string
-  title: string
-  // Present only when the session resolves to a project, so the row can navigate into it.
-  projectId?: string
-}
-
-const basename = (path: string): string => path.split(/[\\/]/).filter(Boolean).pop() ?? path
-
-// Cap each label so one long project name or title can't blow out the row; the button's title
+// Cap each label so one long project name or title can't blow out the row; the li's title
 // attribute still carries the full text on hover.
 const MAX_LABEL_CHARS = 28
 const truncate = (text: string): string =>
   text.length > MAX_LABEL_CHARS ? `${text.slice(0, MAX_LABEL_CHARS - 1).trimEnd()}…` : text
-
-// Resolves a running-session row to its display fields. main only knows the session's id + a stored
-// project *id*, so the human project NAME and title are looked up here from the renderer stores;
-// projectId is returned so the row can open that session. Falls back progressively so a row is never
-// blank: project name -> cwd basename -> whatever main sent.
-const resolveRow = (info: ActiveSessionInfo): ResolvedRow => {
-  const session = useSessionStore.getState().sessions.find((entry) => entry.id === info.sessionId)
-  const projectId = session?.projectId
-  const projectName = projectId
-    ? useProjectStore.getState().projects.find((project) => project.id === projectId)?.name
-    : undefined
-  const cwdName = session?.cwd ? basename(session.cwd) : undefined
-  return {
-    project: projectName ?? cwdName ?? info.projectName,
-    title: session?.title?.trim() || info.title?.trim() || info.sessionId,
-    projectId
-  }
-}
 
 // Subscribes to main's close/quit confirmation requests, lists running work (enriching each
 // session's title from the session store), and replies with the user's choice. Mounted once at
@@ -101,7 +72,7 @@ export const CloseConfirmModal = (): React.JSX.Element | null => {
           {hasSessions ? (
             <ul className="mt-3 space-y-1 text-xs">
               {request.sessions.map((session) => {
-                const row = resolveRow(session)
+                const row = resolveActiveSessionDisplay(session)
                 // Clicking a row cancels the close and jumps to that session so the user can check on
                 // it. Only navigable when we resolved its project (openSession needs the project id).
                 const openThisSession = (): void => {

--- a/src/renderer/src/lib/active-session-display.test.ts
+++ b/src/renderer/src/lib/active-session-display.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { resolveActiveSessionDisplay } from './active-session-display'
+import { useProjectStore } from '@/stores/project-store'
+import { useSessionStore } from '@/stores/session-store'
+import type { ActiveSessionInfo } from '../../../shared/storage'
+
+const seedProjects = (projects: { id: string; name: string }[]): void =>
+  useProjectStore.setState({ projects: projects as never, isLoaded: true, loadError: undefined })
+
+const seedSessions = (
+  sessions: { id: string; projectId?: string; title?: string; cwd?: string }[]
+): void => useSessionStore.setState({ sessions: sessions as never, selectedSessionId: undefined })
+
+afterEach(() => {
+  seedProjects([])
+  seedSessions([])
+})
+
+const info = (over: Partial<ActiveSessionInfo> = {}): ActiveSessionInfo => ({
+  projectId: 'proj-id',
+  sessionId: 's1',
+  kind: 'agent',
+  ...over
+})
+
+describe('resolveActiveSessionDisplay', () => {
+  it('resolves the human project name and title from the stores (never the id)', () => {
+    seedProjects([{ id: 'p1', name: 'My Analysis' }])
+    seedSessions([{ id: 's1', projectId: 'p1', title: 'Fix data loader' }])
+
+    expect(resolveActiveSessionDisplay(info({ projectId: 'p1' }))).toEqual({
+      project: 'My Analysis',
+      title: 'Fix data loader',
+      projectId: 'p1'
+    })
+  })
+
+  it('resolves the project name via the id main sent when the session is not in the store', () => {
+    seedProjects([{ id: 'p1', name: 'My Analysis' }])
+
+    const result = resolveActiveSessionDisplay(
+      info({ projectId: 'p1', sessionId: 'gone', title: 'T' })
+    )
+    expect(result.project).toBe('My Analysis')
+    expect(result.title).toBe('T')
+    expect(result.projectId).toBe('p1')
+  })
+
+  it('falls back to the cwd basename when the project is unknown', () => {
+    seedSessions([{ id: 's1', projectId: 'missing', cwd: '/Users/me/work/paper-repro' }])
+
+    expect(resolveActiveSessionDisplay(info({ sessionId: 's1' })).project).toBe('paper-repro')
+  })
+
+  it('falls back to the project id then the session id when nothing resolves', () => {
+    const result = resolveActiveSessionDisplay(
+      info({ projectId: 'raw-id', sessionId: 'raw-session' })
+    )
+    expect(result.project).toBe('raw-id')
+    expect(result.title).toBe('raw-session')
+    expect(result.projectId).toBe('raw-id')
+  })
+})

--- a/src/renderer/src/lib/active-session-display.test.ts
+++ b/src/renderer/src/lib/active-session-display.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { resolveActiveSessionDisplay } from './active-session-display'
+import { resolveActiveSessionDisplay, truncateLabel } from './active-session-display'
 import { useProjectStore } from '@/stores/project-store'
 import { useSessionStore } from '@/stores/session-store'
 import type { ActiveSessionInfo } from '../../../shared/storage'
@@ -60,5 +60,17 @@ describe('resolveActiveSessionDisplay', () => {
     expect(result.project).toBe('raw-id')
     expect(result.title).toBe('raw-session')
     expect(result.projectId).toBe('raw-id')
+  })
+})
+
+describe('truncateLabel', () => {
+  it('leaves short labels intact', () => {
+    expect(truncateLabel('My Analysis')).toBe('My Analysis')
+  })
+
+  it('caps long labels at 28 chars with an ellipsis', () => {
+    const result = truncateLabel('a'.repeat(40))
+    expect(result).toHaveLength(28)
+    expect(result.endsWith('…')).toBe(true)
   })
 })

--- a/src/renderer/src/lib/active-session-display.ts
+++ b/src/renderer/src/lib/active-session-display.ts
@@ -1,0 +1,31 @@
+import { useProjectStore } from '@/stores/project-store'
+import { useSessionStore } from '@/stores/session-store'
+import type { ActiveSessionInfo } from '../../../shared/storage'
+
+export type ActiveSessionDisplay = {
+  // The owning project's human name (never its id).
+  project: string
+  title: string
+  // Present when the session resolves to a project, so callers can navigate into it.
+  projectId?: string
+}
+
+const basename = (path: string): string => path.split(/[\\/]/).filter(Boolean).pop() ?? path
+
+// main only knows a session's id + its stored project *id*; the human project name and title live in
+// the renderer stores. Resolves both here so every "running session" surface (close/quit confirm,
+// storage migration) shows names, not ids. Falls back progressively so a row is never blank:
+// project name -> cwd basename -> the project id main sent.
+export const resolveActiveSessionDisplay = (info: ActiveSessionInfo): ActiveSessionDisplay => {
+  const session = useSessionStore.getState().sessions.find((entry) => entry.id === info.sessionId)
+  const projectId = session?.projectId ?? info.projectId
+  const projectName = projectId
+    ? useProjectStore.getState().projects.find((project) => project.id === projectId)?.name
+    : undefined
+  const cwdName = session?.cwd ? basename(session.cwd) : undefined
+  return {
+    project: projectName ?? cwdName ?? info.projectId,
+    title: session?.title?.trim() || info.title?.trim() || info.sessionId,
+    projectId
+  }
+}

--- a/src/renderer/src/lib/active-session-display.ts
+++ b/src/renderer/src/lib/active-session-display.ts
@@ -22,6 +22,11 @@ export const truncateLabel = (text: string): string =>
 // the renderer stores. Resolves both here so every "running session" surface (close/quit confirm,
 // storage migration) shows names, not ids. Falls back progressively so a row is never blank:
 // project name -> cwd basename -> the project id main sent.
+//
+// Known limitation (cosmetic, self-healing): if the session isn't in THIS renderer's store — a
+// session started from another Web UI client, or the brief post-reload window before hydration — the
+// project name still resolves via info.projectId against the project store (and the row stays
+// clickable), but the title column degrades to the raw session id until the store catches up.
 export const resolveActiveSessionDisplay = (info: ActiveSessionInfo): ActiveSessionDisplay => {
   const session = useSessionStore.getState().sessions.find((entry) => entry.id === info.sessionId)
   const projectId = session?.projectId ?? info.projectId

--- a/src/renderer/src/lib/active-session-display.ts
+++ b/src/renderer/src/lib/active-session-display.ts
@@ -6,11 +6,17 @@ export type ActiveSessionDisplay = {
   // The owning project's human name (never its id).
   project: string
   title: string
-  // Present when the session resolves to a project, so callers can navigate into it.
-  projectId?: string
+  // The resolved project id (may be empty for a project-less session; callers guard before nav).
+  projectId: string
 }
 
 const basename = (path: string): string => path.split(/[\\/]/).filter(Boolean).pop() ?? path
+
+// Caps a label so one long project name or title can't blow out a fixed-size row/list; callers keep
+// the full text available on hover.
+const MAX_LABEL_CHARS = 28
+export const truncateLabel = (text: string): string =>
+  text.length > MAX_LABEL_CHARS ? `${text.slice(0, MAX_LABEL_CHARS - 1).trimEnd()}…` : text
 
 // main only knows a session's id + its stored project *id*; the human project name and title live in
 // the renderer stores. Resolves both here so every "running session" surface (close/quit confirm,

--- a/src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
@@ -173,8 +173,8 @@ describe('StorageMigrationModal', () => {
   it('shows a confirm dialog listing active sessions; Cancel aborts without migrating', async () => {
     const api = installApi({
       detectActive: vi.fn().mockResolvedValue([
-        { projectName: 'proj-a', sessionId: 'sess-1', kind: 'agent' },
-        { projectName: 'proj-b', sessionId: 'sess-2', kind: 'notebook' }
+        { projectId: 'proj-a', sessionId: 'sess-1', kind: 'agent' },
+        { projectId: 'proj-b', sessionId: 'sess-2', kind: 'notebook' }
       ])
     })
     const onClose = vi.fn()
@@ -204,7 +204,7 @@ describe('StorageMigrationModal', () => {
     const api = installApi({
       detectActive: vi
         .fn()
-        .mockResolvedValue([{ projectName: 'proj-a', sessionId: 'sess-1', kind: 'agent' }])
+        .mockResolvedValue([{ projectId: 'proj-a', sessionId: 'sess-1', kind: 'agent' }])
     })
 
     await act(async () => {

--- a/src/renderer/src/pages/settings/StorageMigrationModal.tsx
+++ b/src/renderer/src/pages/settings/StorageMigrationModal.tsx
@@ -3,7 +3,7 @@ import { Check, RefreshCw, TriangleAlert } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
-import { resolveActiveSessionDisplay } from '@/lib/active-session-display'
+import { resolveActiveSessionDisplay, truncateLabel } from '@/lib/active-session-display'
 import { cn } from '@/lib/utils'
 import type {
   ActiveSessionInfo,
@@ -30,7 +30,7 @@ const PHASE_LABELS: Record<MigrationPhase, string> = {
 // not the raw ids main sends.
 const describeSession = (session: ActiveSessionInfo): string => {
   const display = resolveActiveSessionDisplay(session)
-  return `${session.kind}: ${display.project} / ${display.title}`
+  return `${session.kind}: ${truncateLabel(display.project)} / ${truncateLabel(display.title)}`
 }
 
 // m:ss elapsed clock for the migrating stage. A running timer (rather than a fabricated ETA) so

--- a/src/renderer/src/pages/settings/StorageMigrationModal.tsx
+++ b/src/renderer/src/pages/settings/StorageMigrationModal.tsx
@@ -3,6 +3,7 @@ import { Check, RefreshCw, TriangleAlert } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
+import { resolveActiveSessionDisplay } from '@/lib/active-session-display'
 import { cn } from '@/lib/utils'
 import type {
   ActiveSessionInfo,
@@ -25,9 +26,12 @@ const PHASE_LABELS: Record<MigrationPhase, string> = {
   delete: 'Cleaning up…'
 }
 
-// One readable line per running session for the confirm-dialog list.
-const describeSession = (session: ActiveSessionInfo): string =>
-  `${session.kind}: ${session.projectName}/${session.sessionId}`
+// One readable line per running session: the human project name + title (resolved from the stores),
+// not the raw ids main sends.
+const describeSession = (session: ActiveSessionInfo): string => {
+  const display = resolveActiveSessionDisplay(session)
+  return `${session.kind}: ${display.project} / ${display.title}`
+}
 
 // m:ss elapsed clock for the migrating stage. A running timer (rather than a fabricated ETA) so
 // that if a move ever hangs, the user — and a bug report — can say exactly how long it has run.
@@ -237,7 +241,7 @@ const StorageMigrationModal = ({
               </Dialog.Description>
               <ul className="mt-3 max-h-40 space-y-1 overflow-auto rounded-lg border border-border bg-muted/40 p-2 font-mono text-xs text-foreground">
                 {active.map((session) => (
-                  <li key={`${session.kind}-${session.projectName}-${session.sessionId}`}>
+                  <li key={`${session.kind}-${session.projectId}-${session.sessionId}`}>
                     {describeSession(session)}
                   </li>
                 ))}

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -28,7 +28,9 @@ export type StorageInfo = {
 }
 
 export type ActiveSessionInfo = {
-  projectName: string
+  // The owning project's id (the artifact/notebook storage key). main doesn't hold the human
+  // project name or session title — the renderer maps this id + sessionId to display strings.
+  projectId: string
   sessionId: string
   kind: 'agent' | 'notebook'
   title?: string


### PR DESCRIPTION
Stacked on #238 (base `feat/close-confirm-dialog`, not `main`, because it touches `CloseConfirmModal` which only exists on that branch).

## Why

`ActiveSessionInfo.projectName` never held a name — it carried the artifact/notebook **storage key**, which the app sets to the project **id** (`resolveSessionProjectName` → the same key `use-project-artifact-files` passes `projectId` into). The misnomer led both consumers to display raw ids: the close/quit confirm modal showed `cmrqcvg5i0000vo387wdhdudj`, and the storage-migration modal did the same.

## What

- **Honest field name:** `ActiveSessionInfo.projectName` → `projectId` (`src/shared/storage.ts`). The runtime layer keeps its internal storage-key naming; `detect-active.ts` translates it to `projectId` at that boundary, and the duplicate `ActiveSessionInfo` definition is consolidated into `shared/storage`.
- **One renderer mapping for both surfaces:** new `resolveActiveSessionDisplay(info)` (`src/renderer/src/lib/active-session-display.ts`) maps `sessionId`/`projectId` → human **project name** + **title** via the session/project stores, with a progressive fallback (project name → cwd basename → the id). Both `CloseConfirmModal` and `StorageMigrationModal` now use it, so neither shows ids.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — **4042 pass**; adds a `resolveActiveSessionDisplay` unit test (name resolution + all fallbacks); updates `detect-active` / storage-IPC / modal fixtures and expectations to `projectId`.

## Merge order

Merge #238 first, then this. (If #238 is squash-merged, I'll rebase this onto `main` before it merges.)