### PR TITLE
fix(window): harden close/quit confirmation lifecycle (orphan + hung-modal fallbacks)

### DIFF
--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -403,56 +403,78 @@ describe('installAppLifecycle', () => {
     expect(app.exit).not.toHaveBeenCalled()
   })
 
-  it('recreates the window on cancel when there is no tray and no surviving window (non-darwin)', async () => {
-    // No-tray Windows/Linux orphan guard: X destroyed the window, window-all-closed issued the quit,
-    // the user cancelled — without recreating, the kept app would have no tray and no window (no UI).
-    const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
-    const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'cancel')
+  const cancelSessions: ActiveSessionInfo[] = [
+    { projectId: 'demo', sessionId: 's1', kind: 'agent' }
+  ]
+
+  it.each(['win32', 'linux'] as const)(
+    'recreates the destroyed window on cancel when there is no tray (%s)',
+    async (platform) => {
+      // No-tray orphan guard: X destroyed the window, window-all-closed issued the quit, the user
+      // cancelled — without recreating, the kept app would have no tray and no window (no UI).
+      const { app, windows } = setup({
+        platform,
+        trayHost: false,
+        detectActiveSessions: () => cancelSessions,
+        confirmClose: async (): Promise<CloseConfirmChoice> => 'cancel'
+      })
+      expect(windows).toHaveLength(1)
+      windows[0].destroyed = true // X destroyed it before the window-all-closed quit
+
+      app.emit('before-quit')
+      await flush()
+
+      expect(windows).toHaveLength(2)
+      expect(windows[1].destroyed).toBe(false)
+    }
+  )
+
+  it('does not fabricate a window on cancel in headless mode (window never existed)', async () => {
+    // Regression: headless web mode runs with createInitialWindow:false and no tray; the orphan guard
+    // must key off a destroyed *existing* window, not platform+tray, or it would conjure a window here.
     const { app, windows } = setup({
       platform: 'win32',
       trayHost: false,
       createInitialWindow: false,
-      detectActiveSessions: () => sessions,
-      confirmClose
+      detectActiveSessions: () => cancelSessions,
+      confirmClose: async (): Promise<CloseConfirmChoice> => 'cancel'
     })
     expect(windows).toHaveLength(0)
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(windows).toHaveLength(0)
+  })
+
+  it('does not recreate the window on cancel when a tray is present', async () => {
+    const { app, windows } = setup({
+      platform: 'win32',
+      trayHost: true,
+      detectActiveSessions: () => cancelSessions,
+      confirmClose: async (): Promise<CloseConfirmChoice> => 'cancel'
+    })
+    windows[0].destroyed = true
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(windows).toHaveLength(1) // no new window created
+  })
+
+  it('does not recreate the window on cancel on macOS (resident is its convention)', async () => {
+    const { app, windows } = setup({
+      platform: 'darwin',
+      trayHost: false,
+      detectActiveSessions: () => cancelSessions,
+      confirmClose: async (): Promise<CloseConfirmChoice> => 'cancel'
+    })
+    windows[0].destroyed = true
 
     app.emit('before-quit')
     await flush()
 
     expect(windows).toHaveLength(1)
-  })
-
-  it('does not recreate the window on cancel when a tray is present', async () => {
-    const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
-    const { app, windows } = setup({
-      platform: 'win32',
-      trayHost: true,
-      createInitialWindow: false,
-      detectActiveSessions: () => sessions,
-      confirmClose: async (): Promise<CloseConfirmChoice> => 'cancel'
-    })
-
-    app.emit('before-quit')
-    await flush()
-
-    expect(windows).toHaveLength(0)
-  })
-
-  it('does not recreate the window on cancel on macOS (resident is its convention)', async () => {
-    const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
-    const { app, windows } = setup({
-      platform: 'darwin',
-      trayHost: false,
-      createInitialWindow: false,
-      detectActiveSessions: () => sessions,
-      confirmClose: async (): Promise<CloseConfirmChoice> => 'cancel'
-    })
-
-    app.emit('before-quit')
-    await flush()
-
-    expect(windows).toHaveLength(0)
   })
 
   it('before-quit skips confirmation once quit is already confirmed (no double dialog)', async () => {

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -403,6 +403,58 @@ describe('installAppLifecycle', () => {
     expect(app.exit).not.toHaveBeenCalled()
   })
 
+  it('recreates the window on cancel when there is no tray and no surviving window (non-darwin)', async () => {
+    // No-tray Windows/Linux orphan guard: X destroyed the window, window-all-closed issued the quit,
+    // the user cancelled — without recreating, the kept app would have no tray and no window (no UI).
+    const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
+    const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'cancel')
+    const { app, windows } = setup({
+      platform: 'win32',
+      trayHost: false,
+      createInitialWindow: false,
+      detectActiveSessions: () => sessions,
+      confirmClose
+    })
+    expect(windows).toHaveLength(0)
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(windows).toHaveLength(1)
+  })
+
+  it('does not recreate the window on cancel when a tray is present', async () => {
+    const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
+    const { app, windows } = setup({
+      platform: 'win32',
+      trayHost: true,
+      createInitialWindow: false,
+      detectActiveSessions: () => sessions,
+      confirmClose: async (): Promise<CloseConfirmChoice> => 'cancel'
+    })
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(windows).toHaveLength(0)
+  })
+
+  it('does not recreate the window on cancel on macOS (resident is its convention)', async () => {
+    const sessions: ActiveSessionInfo[] = [{ projectName: 'demo', sessionId: 's1', kind: 'agent' }]
+    const { app, windows } = setup({
+      platform: 'darwin',
+      trayHost: false,
+      createInitialWindow: false,
+      detectActiveSessions: () => sessions,
+      confirmClose: async (): Promise<CloseConfirmChoice> => 'cancel'
+    })
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(windows).toHaveLength(0)
+  })
+
   it('before-quit skips confirmation once quit is already confirmed (no double dialog)', async () => {
     const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'quit')
     const { app, closeOpts, shutdownBackends } = setup({ confirmClose })

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -153,7 +153,13 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
           if (choice === 'quit') {
             quitConfirmed = true
             deps.quit()
+            return
           }
+          // Cancel with no tray and no surviving window would strand the app with no UI (no-tray
+          // Windows/Linux: X destroys the window -> window-all-closed quit -> Cancel): recreate the
+          // window so the app the user chose to keep stays reachable. macOS is exempt —
+          // window-closed-but-resident is its dock convention.
+          if (platform !== 'darwin' && !trayBox.current) showMainWindow()
         })
         .finally(() => {
           confirmInFlight = false

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -157,9 +157,14 @@ export const installAppLifecycle = (deps: AppLifecycleDeps): { showMainWindow: (
           }
           // Cancel with no tray and no surviving window would strand the app with no UI (no-tray
           // Windows/Linux: X destroys the window -> window-all-closed quit -> Cancel): recreate the
-          // window so the app the user chose to keep stays reachable. macOS is exempt —
-          // window-closed-but-resident is its dock convention.
-          if (platform !== 'darwin' && !trayBox.current) showMainWindow()
+          // window so the app the user chose to keep stays reachable. Gate on a window that existed
+          // and is now destroyed, NOT on platform+tray alone — headless web mode legitimately runs
+          // with no window (mainWindow never created) and must not have one fabricated here. macOS is
+          // exempt: window-closed-but-resident is its dock convention. The non-darwin/no-tray pair
+          // mirrors the window-all-closed quit path that produced this quit.
+          if (platform !== 'darwin' && !trayBox.current && mainWindow && mainWindow.isDestroyed()) {
+            showMainWindow()
+          }
         })
         .finally(() => {
           confirmInFlight = false

--- a/src/main/window-close-confirm.test.ts
+++ b/src/main/window-close-confirm.test.ts
@@ -25,9 +25,12 @@ const makeHarness = (
   choose: (choice: CloseConfirmResponse['choice']) => void
   reply: (payload: CloseConfirmResponse) => void
   fireGone: () => void
+  fireHang: () => void
+  fireRecover: () => void
 } => {
   let responder: ((payload: CloseConfirmResponse) => void) | undefined
   let goneCb: (() => void) | undefined
+  let hangCbs: { onHang: () => void; onRecover: () => void } | undefined
   const sent: CloseConfirmRequest[] = []
   const nativeFallback = vi.fn(async (): Promise<CloseConfirmChoice> => 'quit')
   const deps: CloseConfirmDeps = {
@@ -45,9 +48,16 @@ const makeHarness = (
         goneCb = undefined
       }
     },
+    onRendererUnresponsive: (cbs) => {
+      hangCbs = cbs
+      return () => {
+        hangCbs = undefined
+      }
+    },
     nativeFallback,
     newRequestId: () => 'req-1',
     ackTimeoutMs: 10,
+    hangGraceMs: 10,
     ...overrides
   }
   return {
@@ -57,9 +67,14 @@ const makeHarness = (
     ack: () => responder?.({ requestId: 'req-1', ack: true }),
     choose: (choice: CloseConfirmResponse['choice']) => responder?.({ requestId: 'req-1', choice }),
     reply: (payload: CloseConfirmResponse) => responder?.(payload),
-    fireGone: () => goneCb?.()
+    fireGone: () => goneCb?.(),
+    fireHang: () => hangCbs?.onHang(),
+    fireRecover: () => hangCbs?.onRecover()
   }
 }
+
+// Resolves after `ms` real milliseconds so a test can outlast a short ackTimeoutMs/hangGraceMs timer.
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
 describe('createCloseConfirm', () => {
   it('resolves quit immediately for the quit variant with no running work (no IPC)', async () => {
@@ -119,5 +134,36 @@ describe('createCloseConfirm', () => {
 
     const trayHarness = makeHarness({ isRendererAvailable: () => false, nativeFallback: rejecting })
     await expect(trayHarness.confirm('close-to-tray', [session])).resolves.toBe('minimize')
+  })
+
+  it('falls back after the grace period when an ACKed modal stays unresponsive', async () => {
+    const h = makeHarness({ ackTimeoutMs: 10_000, hangGraceMs: 10 })
+    const pending = h.confirm('quit', [session])
+    h.ack()
+    h.fireHang()
+    // The grace timer is armed but hasn't elapsed yet, so no fallback has fired.
+    expect(h.nativeFallback).not.toHaveBeenCalled()
+    await expect(pending).resolves.toBe('quit')
+    expect(h.nativeFallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fall back when a hung modal becomes responsive again before the grace elapses', async () => {
+    const h = makeHarness({ ackTimeoutMs: 10_000, hangGraceMs: 10 })
+    const pending = h.confirm('quit', [session])
+    h.ack()
+    h.fireHang()
+    h.fireRecover()
+    await wait(30) // outlast the (cancelled) grace timer
+    expect(h.nativeFallback).not.toHaveBeenCalled()
+    h.choose('cancel')
+    await expect(pending).resolves.toBe('cancel')
+  })
+
+  it('ignores a hang before ack: the ack timer still owns the pre-ack window', async () => {
+    const h = makeHarness({ ackTimeoutMs: 10, hangGraceMs: 10_000 })
+    const pending = h.confirm('quit', [session])
+    h.fireHang() // pre-ack: must not arm the (10s) hang timer
+    await expect(pending).resolves.toBe('quit') // resolved by the 10ms ack timeout, not the hang path
+    expect(h.nativeFallback).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/window-close-confirm.ts
+++ b/src/main/window-close-confirm.ts
@@ -83,6 +83,11 @@ export const createCloseConfirm = (
         resolve(choice)
       }
 
+      // Known limitation (cosmetic): when a fallback settles the confirm, a modal the renderer had
+      // already shown (ack path) stays on screen. A late click on it is dropped — the response
+      // listener is removed and `settled` guards it — so it merely closes locally with no effect.
+      // Fully dismissing it would need a main->renderer dismiss message; not worth the protocol
+      // surface for a rare hang/timeout case.
       const startFallback = (): void => {
         if (fallbackStarted) return
         fallbackStarted = true
@@ -105,7 +110,9 @@ export const createCloseConfirm = (
 
       // A sustained hang AFTER ack: the pre-ack window is already covered by ackTimer, and the modal
       // legitimately waits on the user, so only arm the grace timer once the renderer actually reports
-      // 'unresponsive'; a paired 'responsive' cancels it.
+      // 'unresponsive'; a paired 'responsive' cancels it. This chain is deliberately separate from
+      // onRenderGone: a crash/reload never emits 'responsive' (recovery is same-process only), so a
+      // reloaded renderer is covered by render-process-gone -> startFallback, not by this timer.
       const offHang = deps.onRendererUnresponsive?.({
         onHang: () => {
           if (!acked || settled) return

--- a/src/main/window-close-confirm.ts
+++ b/src/main/window-close-confirm.ts
@@ -22,15 +22,24 @@ export type CloseConfirmDeps = {
   isRendererAvailable: () => boolean
   // Subscribe to render-process-gone for the confirm window; returns an unsubscribe.
   onRenderGone: (cb: () => void) => () => void
+  // Subscribe to the confirm window's paired 'unresponsive'/'responsive' events; returns an
+  // unsubscribe. Lets the coordinator fall back only on a SUSTAINED hang (renderer alive but wedged,
+  // so render-process-gone never fires), never on a slow-but-alive renderer. Optional: absent in
+  // tests that don't exercise the hang path.
+  onRendererUnresponsive?: (cbs: { onHang: () => void; onRecover: () => void }) => () => void
   // Native fallback when the renderer can't answer (dead/hung, or no window at all). May reject;
   // the coordinator wraps it so a rejection never leaves the confirm unsettled.
   nativeFallback: (variant: CloseConfirmVariant) => Promise<CloseConfirmChoice>
   newRequestId: () => string
   // Grace period for the modal-mounted ack before falling back. Defaults to 500ms.
   ackTimeoutMs?: number
+  // Grace period after an ACKed modal goes 'unresponsive' before falling back. Defaults to 10s so a
+  // brief hang the renderer recovers from doesn't yank the modal out from under the user.
+  hangGraceMs?: number
 }
 
 const DEFAULT_ACK_TIMEOUT_MS = 500
+const DEFAULT_HANG_GRACE_MS = 10_000
 
 // Coordinates a close/quit confirmation. Main computes `sessions`, so the quit variant with an empty
 // list resolves without any IPC; otherwise the renderer renders the modal and replies the choice,
@@ -42,6 +51,7 @@ export const createCloseConfirm = (
   sessions: ActiveSessionInfo[]
 ) => Promise<CloseConfirmChoice>) => {
   const ackTimeoutMs = deps.ackTimeoutMs ?? DEFAULT_ACK_TIMEOUT_MS
+  const hangGraceMs = deps.hangGraceMs ?? DEFAULT_HANG_GRACE_MS
 
   return (variant, sessions) => {
     if (variant === 'quit' && sessions.length === 0) return Promise.resolve('quit')
@@ -60,13 +70,16 @@ export const createCloseConfirm = (
       let settled = false
       let acked = false
       let fallbackStarted = false
+      let hangTimer: ReturnType<typeof setTimeout> | undefined
 
       const finish = (choice: CloseConfirmChoice): void => {
         if (settled) return
         settled = true
         clearTimeout(ackTimer)
+        clearTimeout(hangTimer)
         offResponse()
         offGone()
+        offHang?.()
         resolve(choice)
       }
 
@@ -74,6 +87,7 @@ export const createCloseConfirm = (
         if (fallbackStarted) return
         fallbackStarted = true
         clearTimeout(ackTimer)
+        clearTimeout(hangTimer)
         void safeFallback().then(finish)
       }
 
@@ -88,6 +102,17 @@ export const createCloseConfirm = (
       })
 
       const offGone = deps.onRenderGone(startFallback)
+
+      // A sustained hang AFTER ack: the pre-ack window is already covered by ackTimer, and the modal
+      // legitimately waits on the user, so only arm the grace timer once the renderer actually reports
+      // 'unresponsive'; a paired 'responsive' cancels it.
+      const offHang = deps.onRendererUnresponsive?.({
+        onHang: () => {
+          if (!acked || settled) return
+          hangTimer = setTimeout(startFallback, hangGraceMs)
+        },
+        onRecover: () => clearTimeout(hangTimer)
+      })
 
       const ackTimer = setTimeout(() => {
         if (!acked) startFallback()
@@ -167,6 +192,16 @@ export const createElectronCloseConfirm = (
       if (!window) return () => undefined
       window.webContents.on('render-process-gone', cb)
       return () => window.webContents.off('render-process-gone', cb)
+    },
+    onRendererUnresponsive: ({ onHang, onRecover }) => {
+      const window = getWindow()
+      if (!window) return () => undefined
+      window.webContents.on('unresponsive', onHang)
+      window.webContents.on('responsive', onRecover)
+      return () => {
+        window.webContents.off('unresponsive', onHang)
+        window.webContents.off('responsive', onRecover)
+      }
     },
     nativeFallback: (variant) => nativeFallback(getWindow, variant),
     newRequestId: () => randomUUID()

--- a/src/renderer/src/lib/active-session-display.ts
+++ b/src/renderer/src/lib/active-session-display.ts
@@ -23,10 +23,14 @@ export const truncateLabel = (text: string): string =>
 // storage migration) shows names, not ids. Falls back progressively so a row is never blank:
 // project name -> cwd basename -> the project id main sent.
 //
-// Known limitation (cosmetic, self-healing): if the session isn't in THIS renderer's store — a
-// session started from another Web UI client, or the brief post-reload window before hydration — the
-// project name still resolves via info.projectId against the project store (and the row stays
-// clickable), but the title column degrades to the raw session id until the store catches up.
+// Known limitation (cosmetic): this reads a non-reactive store snapshot, so a modal already on screen
+// does NOT re-render when stores hydrate — a resolved value is fixed for that modal's lifetime and only
+// refreshes the next time the modal opens (or after a renderer reload/re-hydration). If a running
+// session isn't in THIS renderer's stores (started from another Web UI client, or the pre-hydration
+// window after a reload), the title falls back to the raw session id, and the project name falls back
+// to its id too when that project also isn't in this renderer's project store. Such a cross-renderer
+// session is not navigable either — clicking it switches project and cancels the close, but
+// selectSession no-ops on an id this renderer doesn't know.
 export const resolveActiveSessionDisplay = (info: ActiveSessionInfo): ActiveSessionDisplay => {
   const session = useSessionStore.getState().sessions.find((entry) => entry.id === info.sessionId)
   const projectId = session?.projectId ?? info.projectId


### PR DESCRIPTION
Two P3 robustness fixes for the close/quit confirmation shipped in #238, from review follow-up. Both target the "app left in a bad state" edge cases; independent of #241.

## 1. No-tray cancel → recreate the window (`app-lifecycle.ts`)

On no-tray Windows/Linux (tray creation failed), the titlebar X classifies as `close`, destroys the window, and `window-all-closed` issues a quit. If work is running, that quit shows the (native) Quit/Cancel confirmation — and if the user picks **Cancel**, the app was left running with **neither a tray nor a window**: no way to reach it.

Fix: on cancel, recreate the window when `platform !== 'darwin' && !trayBox.current` (reusing `showMainWindow`, which recreates when none survives). macOS is exempt — window-closed-but-resident is its dock convention.

## 2. Hung-modal fallback (`window-close-confirm.ts`)

After the modal acks, only a user choice or `render-process-gone` could settle the confirm. A renderer that **wedges but doesn't crash** makes Electron fire `unresponsive` (never `render-process-gone`), so the promise hung forever — pinning `confirmInFlight` and blocking every subsequent quit (the same deadlock class fixed earlier, via a different trigger).

Fix: subscribe to the confirm window's paired `unresponsive`/`responsive` events. On a post-ack `unresponsive`, arm a 10s grace timer; `responsive` cancels it; only a *sustained* hang falls back. No short post-ack timeout (that would misfire on a user simply deliberating). Pre-ack hangs are ignored — the existing ack timeout already owns that window.

## Testing

- `npm run typecheck` / `npm run lint` — clean
- `npm test` — **4066 pass**; adds 3 lifecycle tests (recreate-on-cancel + no-tray/with-tray/macOS controls) and 3 coordinator tests (sustained-hang fallback, recover-cancels-fallback, pre-ack-hang-ignored).

Desktop `npm run dev` smoke of the no-tray + hang paths is worth doing before merge, but they're hard to trigger by hand (tray-creation failure; a wedged renderer).