### PR TITLE
feat(providers): add GLM Coding Plan endpoint under Zhipu (GLM)

### DIFF
--- a/src/renderer/src/pages/settings/provider-icons.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.tsx
@@ -13,8 +13,9 @@ import xiaomimimoLogo from '@/assets/provider-icons/xiaomimimo.svg'
 import type { OfficialVendorId } from '../../../../shared/provider-registry'
 
 // Official vendor brand marks, bundled as assets. Both Kimi providers (the general Moonshot platform
-// and Kimi For Coding) share the one Kimi mark. Any vendor without an entry falls back to a neutral
-// glyph rather than a made-up logo. Custom uses a plus-in-circle and local Claude a laptop.
+// and Kimi For Coding) share the one Kimi mark, and both GLM providers (pay-as-you-go Zhipu and the
+// GLM Coding Plan) share the one GLM mark. Any vendor without an entry falls back to a neutral glyph
+// rather than a made-up logo. Custom uses a plus-in-circle and local Claude a laptop.
 const VENDOR_LOGO: Partial<Record<OfficialVendorId, string>> = {
   openai: openaiLogo,
   anthropic: claudeLogo,
@@ -22,6 +23,7 @@ const VENDOR_LOGO: Partial<Record<OfficialVendorId, string>> = {
   minimax: minimaxLogo,
   stepfun: stepfunLogo,
   zhipu: zhipuLogo,
+  glmcodingplan: zhipuLogo,
   kimi: kimiLogo,
   kimiforcode: kimiLogo,
   openrouter: openrouterLogo,

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -59,6 +59,32 @@ describe('provider registry', () => {
     )
   })
 
+  it('routes the GLM Coding Plan through the /api/coding OpenAI path, per region', () => {
+    expect(vendorHasRegions('glmcodingplan')).toBe(true)
+    expect(resolveVendorApiEndpoints('glmcodingplan')).toEqual(['anthropic', 'openai'])
+    // The Anthropic route is unchanged from pay-as-you-go GLM.
+    expect(resolveVendorBaseUrl('glmcodingplan', 'global')).toBe('https://api.z.ai/api/anthropic')
+    expect(resolveVendorBaseUrl('glmcodingplan', 'china')).toBe(
+      'https://open.bigmodel.cn/api/anthropic'
+    )
+    // The OpenAI route swaps /api/paas/v4 for the coding-plan /api/coding/paas/v4.
+    expect(resolveVendorOpenAiBaseUrl('glmcodingplan', 'global')).toBe(
+      'https://api.z.ai/api/coding/paas/v4'
+    )
+    expect(resolveVendorOpenAiBaseUrl('glmcodingplan', 'china')).toBe(
+      'https://open.bigmodel.cn/api/coding/paas/v4'
+    )
+    // Quota-based plan: fixed catalog, no live model-list refresh.
+    expect(resolveVendorModelsUrl('glmcodingplan')).toBeUndefined()
+    expect(defaultVendorModel('glmcodingplan')).toBe('glm-5.2')
+    // The coding plan drops GLM's vision variant, so it serves no multimodal model.
+    expect(isVendorModelMultimodal('glmcodingplan', 'glm-5v-turbo')).toBe(false)
+    expect(isVendorModelMultimodal('glmcodingplan', 'glm-5.2')).toBe(false)
+    // Each region points at its own subscription console.
+    expect(resolveVendorApiKeyUrl('glmcodingplan', 'global')).toBe('https://z.ai/subscribe')
+    expect(resolveVendorApiKeyUrl('glmcodingplan', 'china')).toBe('https://bigmodel.cn/glm-coding')
+  })
+
   it('exposes the first catalog entry as the default model', () => {
     expect(defaultVendorModel('openai')).toBe('gpt-5.6-sol')
     expect(defaultVendorModel('zhipu')).toBe('glm-5.2')

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -14,6 +14,7 @@ export type OfficialVendorId =
   | 'anthropic'
   | 'deepseek'
   | 'zhipu'
+  | 'glmcodingplan'
   | 'kimi'
   | 'kimiforcode'
   | 'minimax'
@@ -153,6 +154,34 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     // GLM marks vision variants with a `v` after the major version (e.g. glm-5v-turbo); the pattern
     // also covers future `Nv` ids the live refresh may surface.
     multimodal: { multimodalModelPattern: /glm-\d+v/i }
+  },
+  {
+    id: 'glmcodingplan',
+    label: 'GLM Coding Plan',
+    // The GLM Coding Plan subscription (Z.AI's z.ai/subscribe, BigModel's glm-coding): a quota-based
+    // plan that reuses GLM's regions but routes the OpenAI path through `/api/coding/paas/v4` instead
+    // of `/api/paas/v4`. The Anthropic route (`/api/anthropic`) is unchanged from the pay-as-you-go
+    // GLM endpoint. Quota-based catalogs ship a fixed model list and expose no live model list.
+    apiEndpoints: ['anthropic', 'openai'],
+    regions: [
+      {
+        id: 'global',
+        label: 'Global (Z.AI)',
+        baseUrl: 'https://api.z.ai/api/anthropic',
+        openaiBaseUrl: 'https://api.z.ai/api/coding/paas/v4',
+        apiKeyUrl: 'https://z.ai/subscribe'
+      },
+      {
+        id: 'china',
+        label: 'China (BigModel)',
+        baseUrl: 'https://open.bigmodel.cn/api/anthropic',
+        openaiBaseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+        apiKeyUrl: 'https://bigmodel.cn/glm-coding'
+      }
+    ],
+    // The coding plan does not serve GLM's vision variant, so glm-5v-turbo is omitted and there is no
+    // `multimodal` rule (image input stays disabled for this endpoint).
+    models: ['glm-5.2', 'glm-5.1', 'glm-5', 'glm-5-turbo']
   },
   {
     id: 'kimi',


### PR DESCRIPTION
## Summary

Adds a **GLM Coding Plan** official vendor, sitting right after the pay-as-you-go Zhipu (GLM) entry in the provider picker — the same relationship `Kimi For Coding` has to `Kimi`.

- New vendor id `glmcodingplan`, label `GLM Coding Plan`, with **Global (Z.AI)** and **China (BigModel)** regions.
- Reuses GLM's regions but routes the OpenAI-compatible path through `/api/coding/paas/v4` instead of `/api/paas/v4`. The Anthropic route (`/api/anthropic`) is unchanged from pay-as-you-go GLM.
- Per-region subscription consoles: Global `https://z.ai/subscribe`, China `https://bigmodel.cn/glm-coding`.
- Reuses the existing GLM/Zhipu brand mark.
- Quota-based plan: ships a fixed catalog (`glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`) with no live model-list refresh. The coding plan does not serve GLM's vision variant, so `glm-5v-turbo` is omitted and image input stays disabled for this endpoint.

The pay-as-you-go `zhipu` vendor is left untouched (it keeps `glm-5v-turbo` and its vision pattern).

## Testing

- `npm run lint`, `npm run typecheck`, `npm run format` — clean
- `npx vitest run` — full suite green (added registry coverage asserting the `/api/coding` path swap, per-region key consoles, fixed catalog, and text-only behavior)