### PR TITLE
fix(codex): distinguish native Codex from adapter in detection messages

### DIFF
--- a/src/main/settings/codex-detect.test.ts
+++ b/src/main/settings/codex-detect.test.ts
@@ -408,6 +408,57 @@ describe('detectNativeCodex', () => {
 
     expect(result).toBeUndefined()
   })
+
+  it('finds native Codex in augmented Homebrew dir even when absent from raw PATH', async () => {
+    // Regression: the ACP smoke test resolves codex through an augmented PATH that includes
+    // /opt/homebrew/bin. detectNativeCodex must search the same dirs so a successful adapter
+    // handshake never disagrees with the independent native-CLI probe (which would block Continue).
+    const { detectNativeCodex } = await import('./codex-detect')
+    const result = await detectNativeCodex({
+      platform: 'darwin',
+      env: { PATH: '/usr/bin' }, // raw PATH does NOT include /opt/homebrew/bin
+      homePath: '/Users/test',
+      getCodexVersion: (path) =>
+        path === '/opt/homebrew/bin/codex'
+          ? Promise.resolve('codex-cli 0.144.2')
+          : Promise.resolve(undefined),
+      resolveNpmBinDirs: () => Promise.resolve([])
+    })
+
+    expect(result).toEqual({ path: '/opt/homebrew/bin/codex', version: '0.144.2' })
+  })
+
+  it('finds native Codex in an npm global bin dir', async () => {
+    const { detectNativeCodex } = await import('./codex-detect')
+    const result = await detectNativeCodex({
+      platform: 'linux',
+      env: { PATH: '/usr/bin' },
+      homePath: '/home/user',
+      getCodexVersion: (path) =>
+        path === '/home/user/.npm-global/bin/codex'
+          ? Promise.resolve('codex-cli 0.144.2')
+          : Promise.resolve(undefined),
+      resolveNpmBinDirs: () => Promise.resolve(['/home/user/.npm-global/bin'])
+    })
+
+    expect(result).toEqual({ path: '/home/user/.npm-global/bin/codex', version: '0.144.2' })
+  })
+
+  it('finds native Codex in ~/.local/bin via homePath', async () => {
+    const { detectNativeCodex } = await import('./codex-detect')
+    const result = await detectNativeCodex({
+      platform: 'linux',
+      env: { PATH: '/usr/bin' },
+      homePath: '/home/user',
+      getCodexVersion: (path) =>
+        path === '/home/user/.local/bin/codex'
+          ? Promise.resolve('codex-cli 0.144.2')
+          : Promise.resolve(undefined),
+      resolveNpmBinDirs: () => Promise.resolve([])
+    })
+
+    expect(result).toEqual({ path: '/home/user/.local/bin/codex', version: '0.144.2' })
+  })
 })
 
 describe('detectCodexComponents', () => {

--- a/src/main/settings/codex-detect.test.ts
+++ b/src/main/settings/codex-detect.test.ts
@@ -342,3 +342,180 @@ describe('codex-detect: real ACP initialize smoke', () => {
     expect(result).toBeUndefined()
   })
 })
+
+describe('detectNativeCodex', () => {
+  it('detects native Codex on macOS in the ChatGPT.app bundle', async () => {
+    const { detectNativeCodex } = await import('./codex-detect')
+    const result = await detectNativeCodex({
+      platform: 'darwin',
+      env: { PATH: '/usr/bin' },
+      getCodexVersion: (path) =>
+        path === '/Applications/ChatGPT.app/Contents/Resources/codex'
+          ? Promise.resolve('codex-cli 0.144.2')
+          : Promise.resolve(undefined)
+    })
+
+    expect(result).toEqual({
+      path: '/Applications/ChatGPT.app/Contents/Resources/codex',
+      version: '0.144.2'
+    })
+  })
+
+  it('detects native Codex on Windows in LocalAppData', async () => {
+    const { detectNativeCodex } = await import('./codex-detect')
+    const result = await detectNativeCodex({
+      platform: 'win32',
+      env: {
+        PATH: 'C:\\Windows\\System32',
+        LOCALAPPDATA: 'C:\\Users\\User\\AppData\\Local'
+      },
+      getCodexVersion: (path) =>
+        path === win32.join('C:\\Users\\User\\AppData\\Local', 'Programs', 'ChatGPT', 'codex.exe')
+          ? Promise.resolve('codex-cli 0.144.2')
+          : Promise.resolve(undefined)
+    })
+
+    expect(result).toEqual({
+      path: 'C:\\Users\\User\\AppData\\Local\\Programs\\ChatGPT\\codex.exe',
+      version: '0.144.2'
+    })
+  })
+
+  it('detects native Codex on PATH', async () => {
+    const { detectNativeCodex } = await import('./codex-detect')
+    const result = await detectNativeCodex({
+      platform: 'linux',
+      env: { PATH: '/usr/bin:/usr/local/bin' },
+      getCodexVersion: (path) =>
+        path === '/usr/local/bin/codex'
+          ? Promise.resolve('codex-cli 0.144.2')
+          : Promise.resolve(undefined)
+    })
+
+    expect(result).toEqual({
+      path: '/usr/local/bin/codex',
+      version: '0.144.2'
+    })
+  })
+
+  it('returns undefined when no native Codex is found', async () => {
+    const { detectNativeCodex } = await import('./codex-detect')
+    const result = await detectNativeCodex({
+      platform: 'darwin',
+      env: { PATH: '/usr/bin' },
+      getCodexVersion: () => Promise.resolve(undefined)
+    })
+
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('detectCodexComponents', () => {
+  it('reports both components found when adapter passes smoke test', async () => {
+    const { detectCodexComponents } = await import('./codex-detect')
+    const result = await detectCodexComponents({
+      platform: 'darwin',
+      env: { PATH: '/usr/bin' },
+      homePath: '/Users/test',
+      isRunnable: (path) =>
+        Promise.resolve(
+          path === '/usr/local/bin/codex-acp' ||
+            path === '/Applications/ChatGPT.app/Contents/Resources/codex'
+        ),
+      getAdapterVersion: (path) =>
+        path === '/usr/local/bin/codex-acp'
+          ? Promise.resolve('codex-acp 1.0.0')
+          : Promise.resolve(undefined),
+      getCodexVersion: (path) =>
+        path === '/Applications/ChatGPT.app/Contents/Resources/codex'
+          ? Promise.resolve('codex-cli 0.144.2')
+          : Promise.resolve(undefined),
+      smokeInitialize: () => Promise.resolve(true),
+      resolveNpmBinDirs: () => Promise.resolve([])
+    })
+
+    expect(result).toMatchObject({
+      nativeCliFound: true,
+      nativeCliPath: '/Applications/ChatGPT.app/Contents/Resources/codex',
+      nativeCliVersion: '0.144.2',
+      adapterFound: true,
+      adapterPath: '/usr/local/bin/codex-acp',
+      adapterVersion: '1.0.0',
+      adapterFailureReason: undefined
+    })
+  })
+
+  it('reports native found but adapter missing when no adapter exists', async () => {
+    const { detectCodexComponents } = await import('./codex-detect')
+    const result = await detectCodexComponents({
+      platform: 'darwin',
+      env: { PATH: '/usr/bin' },
+      homePath: '/Users/test',
+      isRunnable: (path) =>
+        Promise.resolve(path === '/Applications/ChatGPT.app/Contents/Resources/codex'),
+      getAdapterVersion: () => Promise.resolve(undefined),
+      getCodexVersion: (path) =>
+        path === '/Applications/ChatGPT.app/Contents/Resources/codex'
+          ? Promise.resolve('codex-cli 0.144.2')
+          : Promise.resolve(undefined),
+      smokeInitialize: () => Promise.resolve(false),
+      resolveNpmBinDirs: () => Promise.resolve([])
+    })
+
+    expect(result).toMatchObject({
+      nativeCliFound: true,
+      nativeCliPath: '/Applications/ChatGPT.app/Contents/Resources/codex',
+      nativeCliVersion: '0.144.2',
+      adapterFound: false,
+      adapterPath: undefined,
+      adapterVersion: undefined
+    })
+  })
+
+  it('reports adapter smoke-test failure when version succeeds but initialization fails', async () => {
+    const { detectCodexComponents } = await import('./codex-detect')
+    const result = await detectCodexComponents({
+      platform: 'darwin',
+      env: { PATH: '/usr/bin' },
+      homePath: '/Users/test',
+      isRunnable: (path) => Promise.resolve(path === '/usr/local/bin/codex-acp'),
+      getAdapterVersion: (path) =>
+        path === '/usr/local/bin/codex-acp'
+          ? Promise.resolve('codex-acp 1.0.0')
+          : Promise.resolve(undefined),
+      getCodexVersion: () => Promise.resolve(undefined),
+      smokeInitialize: () => Promise.resolve(false),
+      resolveNpmBinDirs: () => Promise.resolve([])
+    })
+
+    expect(result).toMatchObject({
+      nativeCliFound: false,
+      adapterFound: true,
+      adapterPath: '/usr/local/bin/codex-acp',
+      adapterVersion: '1.0.0',
+      adapterFailureReason: 'smoke-test-failed'
+    })
+  })
+
+  it('reports version-probe failure when adapter exists but version check fails', async () => {
+    const { detectCodexComponents } = await import('./codex-detect')
+    const result = await detectCodexComponents({
+      platform: 'darwin',
+      env: { PATH: '/usr/bin' },
+      homePath: '/Users/test',
+      isRunnable: (path) => Promise.resolve(path === '/usr/local/bin/codex-acp'),
+      getAdapterVersion: () => Promise.resolve(undefined), // Version probe fails
+      getCodexVersion: () => Promise.resolve(undefined),
+      smokeInitialize: () => Promise.resolve(false),
+      resolveNpmBinDirs: () => Promise.resolve([])
+    })
+
+    expect(result).toMatchObject({
+      nativeCliFound: false,
+      adapterFound: true,
+      adapterPath: '/usr/local/bin/codex-acp',
+      adapterVersion: undefined,
+      adapterFailureReason: 'version-probe-failed'
+    })
+  })
+})

--- a/src/main/settings/codex-detect.ts
+++ b/src/main/settings/codex-detect.ts
@@ -380,10 +380,10 @@ const createDefaultDetectDeps = (): CodexDetectDeps => {
 // an adapter could pass its handshake by resolving codex through the augmented PATH while this probe,
 // scanning only the narrower raw PATH, reported the native CLI as missing and blocked Continue.
 const detectNativeCodex = async (
-  deps: Pick<
-    CodexDetectDeps,
-    'platform' | 'env' | 'homePath' | 'getCodexVersion' | 'resolveNpmBinDirs' | 'extraDirs'
-  > = createDefaultDetectDeps()
+  deps: Pick<CodexDetectDeps, 'platform' | 'env' | 'getCodexVersion'> &
+    Partial<
+      Pick<CodexDetectDeps, 'homePath' | 'resolveNpmBinDirs' | 'extraDirs'>
+    > = createDefaultDetectDeps()
 ): Promise<{ path: string; version: string } | undefined> => {
   const p = pathFor(deps.platform)
   const wellKnown: string[] = []

--- a/src/main/settings/codex-detect.ts
+++ b/src/main/settings/codex-detect.ts
@@ -374,8 +374,16 @@ const createDefaultDetectDeps = (): CodexDetectDeps => {
 
 // Checks for a native Codex CLI when the adapter is missing. Used to provide accurate diagnostic
 // messages distinguishing "adapter missing" from "Codex not installed at all".
+//
+// Searches the SAME directory set that collectCandidateDirs + the ACP smoke test use (raw PATH plus
+// the augmented well-known dirs: ~/.local/bin, Homebrew, /usr/local, npm global bin). Without this,
+// an adapter could pass its handshake by resolving codex through the augmented PATH while this probe,
+// scanning only the narrower raw PATH, reported the native CLI as missing and blocked Continue.
 const detectNativeCodex = async (
-  deps: Pick<CodexDetectDeps, 'platform' | 'env' | 'getCodexVersion'> = createDefaultDetectDeps()
+  deps: Pick<
+    CodexDetectDeps,
+    'platform' | 'env' | 'homePath' | 'getCodexVersion' | 'resolveNpmBinDirs' | 'extraDirs'
+  > = createDefaultDetectDeps()
 ): Promise<{ path: string; version: string } | undefined> => {
   const p = pathFor(deps.platform)
   const wellKnown: string[] = []
@@ -390,10 +398,29 @@ const detectNativeCodex = async (
     }
   }
 
-  // Also check PATH
+  // Search raw PATH plus the augmented dirs, mirroring collectCandidateDirs so this probe agrees
+  // with the adapter's own codex resolution during the smoke test.
   const pathDirs = (deps.env.PATH ?? '').split(p.delimiter).filter(Boolean)
+  const npmDirs = deps.resolveNpmBinDirs ? await deps.resolveNpmBinDirs().catch(() => []) : []
+  const augmentedDirs =
+    deps.platform === 'win32'
+      ? deps.env.APPDATA
+        ? [p.join(deps.env.APPDATA, 'npm')]
+        : []
+      : ['/opt/homebrew/bin', '/usr/local/bin']
+
+  const searchDirs = Array.from(
+    new Set([
+      ...pathDirs,
+      p.join(deps.homePath ?? '', '.local', 'bin'),
+      ...(deps.extraDirs ?? []),
+      ...augmentedDirs,
+      ...npmDirs
+    ])
+  ).filter(Boolean)
+
   const names = deps.platform === 'win32' ? ['codex.exe', 'codex.cmd', 'codex'] : ['codex']
-  const pathCandidates = pathDirs.flatMap((dir) => names.map((name) => p.join(dir, name)))
+  const pathCandidates = searchDirs.flatMap((dir) => names.map((name) => p.join(dir, name)))
 
   const candidates = Array.from(new Set([...wellKnown, ...pathCandidates]))
 

--- a/src/main/settings/codex-detect.ts
+++ b/src/main/settings/codex-detect.ts
@@ -118,6 +118,87 @@ const detectCodex = async (
   return undefined
 }
 
+// Performs detailed component-level detection for Codex, checking native CLI and ACP adapter
+// independently. Returns diagnostic information even when full pairing fails, so the UI can
+// distinguish "adapter missing" from "native Codex missing" from "both present but incompatible".
+const detectCodexComponents = async (
+  deps: CodexDetectDeps = createDefaultDetectDeps()
+): Promise<{
+  nativeCliFound: boolean
+  nativeCliPath?: string
+  nativeCliVersion?: string
+  adapterFound: boolean
+  adapterPath?: string
+  adapterVersion?: string
+  adapterFailureReason?: 'version-probe-failed' | 'smoke-test-failed'
+}> => {
+  const p = pathFor(deps.platform)
+
+  // Check for adapter first
+  const dirs = await collectCandidateDirs(deps)
+  const adapterNames =
+    deps.platform === 'win32'
+      ? ['codex-acp.cmd', 'codex-acp.exe', 'codex-acp.bat', 'codex-acp']
+      : ['codex-acp']
+  const adapterCandidates = dirs.flatMap((dir) => adapterNames.map((name) => p.join(dir, name)))
+
+  if (deps.managedAdapterPath) adapterCandidates.push(deps.managedAdapterPath)
+
+  let adapterFound = false
+  let adapterPath: string | undefined
+  let adapterVersion: string | undefined
+  let adapterFailureReason: 'version-probe-failed' | 'smoke-test-failed' | undefined
+
+  for (const candidate of Array.from(new Set(adapterCandidates))) {
+    if (!(await deps.isRunnable(candidate))) continue
+
+    const versionOutput = await deps.getAdapterVersion(candidate)
+    const version = versionOutput ? parseVersion(versionOutput) : undefined
+
+    if (!version) {
+      // Adapter exists but version probe failed - record this for diagnostics. Mark as found
+      // so service.ts can distinguish "present but broken" from "completely missing".
+      if (!adapterPath) {
+        adapterFound = true
+        adapterPath = candidate
+        adapterFailureReason = 'version-probe-failed'
+      }
+      continue
+    }
+
+    // Version probe succeeded - now check if smoke test passes
+    const smokeOk = await deps.smokeInitialize(candidate)
+    if (smokeOk) {
+      adapterFound = true
+      adapterPath = candidate
+      adapterVersion = version
+      adapterFailureReason = undefined
+      break
+    } else {
+      // Smoke test failed - adapter exists but can't initialize. Mark as found with failure.
+      if (!adapterPath) {
+        adapterFound = true
+        adapterPath = candidate
+        adapterVersion = version
+        adapterFailureReason = 'smoke-test-failed'
+      }
+    }
+  }
+
+  // Check for native Codex independently
+  const nativeCodex = await detectNativeCodex(deps)
+
+  return {
+    nativeCliFound: !!nativeCodex,
+    nativeCliPath: nativeCodex?.path,
+    nativeCliVersion: nativeCodex?.version,
+    adapterFound,
+    adapterPath,
+    adapterVersion,
+    adapterFailureReason
+  }
+}
+
 // Launches the adapter and drives one ACP initialize round-trip, returning true only on a valid
 // response. Mirrors the managed pair verifier but tolerates any launch shape (a `.js` entry run under
 // the bundled Node, or a native/`.cmd` wrapper on PATH) and resolves as soon as initialize succeeds.
@@ -291,10 +372,48 @@ const createDefaultDetectDeps = (): CodexDetectDeps => {
   }
 }
 
+// Checks for a native Codex CLI when the adapter is missing. Used to provide accurate diagnostic
+// messages distinguishing "adapter missing" from "Codex not installed at all".
+const detectNativeCodex = async (
+  deps: Pick<CodexDetectDeps, 'platform' | 'env' | 'getCodexVersion'> = createDefaultDetectDeps()
+): Promise<{ path: string; version: string } | undefined> => {
+  const p = pathFor(deps.platform)
+  const wellKnown: string[] = []
+
+  // Check common native Codex installation paths
+  if (deps.platform === 'darwin') {
+    wellKnown.push('/Applications/ChatGPT.app/Contents/Resources/codex')
+  } else if (deps.platform === 'win32') {
+    const localAppData = deps.env.LOCALAPPDATA
+    if (localAppData) {
+      wellKnown.push(p.join(localAppData, 'Programs', 'ChatGPT', 'codex.exe'))
+    }
+  }
+
+  // Also check PATH
+  const pathDirs = (deps.env.PATH ?? '').split(p.delimiter).filter(Boolean)
+  const names = deps.platform === 'win32' ? ['codex.exe', 'codex.cmd', 'codex'] : ['codex']
+  const pathCandidates = pathDirs.flatMap((dir) => names.map((name) => p.join(dir, name)))
+
+  const candidates = Array.from(new Set([...wellKnown, ...pathCandidates]))
+
+  for (const codexPath of candidates) {
+    const versionOutput = await deps.getCodexVersion(codexPath)
+    const version = versionOutput ? parseVersion(versionOutput) : undefined
+    if (version) {
+      return { path: codexPath, version }
+    }
+  }
+
+  return undefined
+}
+
 export {
   collectCandidateDirs,
   createDefaultDetectDeps,
   detectCodex,
+  detectCodexComponents,
+  detectNativeCodex,
   parseVersion,
   runAcpInitializeSmoke
 }

--- a/src/main/settings/environment-check.test.ts
+++ b/src/main/settings/environment-check.test.ts
@@ -296,4 +296,169 @@ describe('runEnvironmentCheck', () => {
       await rm(root, { recursive: true, force: true })
     }
   })
+
+  it('uses diagnostic message when runtime detection provides one', async () => {
+    const diagnosticMessage =
+      'Native Codex 0.144.2 is installed at /Applications/ChatGPT.app/Contents/Resources/codex, but the Codex ACP adapter required by Open Science is missing.'
+
+    const result = await runEnvironmentCheck({
+      storageRoot: '/data',
+      agentFrameworkId: 'codex',
+      frameworks: [
+        {
+          id: 'codex',
+          label: 'Codex',
+          runtime: { found: false, diagnostic: diagnosticMessage }
+        }
+      ],
+      encryptionAvailable: true,
+      deps: baseDeps()
+    })
+
+    const codexCheck = result.checks.find(
+      (check) => check.id === 'agent' && check.label === 'Codex runtime'
+    )
+    expect(codexCheck?.status).toBe('failed')
+    expect(codexCheck?.summary).toBe(diagnosticMessage)
+    expect(codexCheck?.detail).toBeUndefined()
+  })
+
+  it('falls back to generic message when no diagnostic is provided', async () => {
+    const result = await runEnvironmentCheck({
+      storageRoot: '/data',
+      agentFrameworkId: 'codex',
+      frameworks: [{ id: 'codex', label: 'Codex', runtime: { found: false } }],
+      encryptionAvailable: true,
+      deps: baseDeps()
+    })
+
+    const codexCheck = result.checks.find(
+      (check) => check.id === 'agent' && check.label === 'Codex runtime'
+    )
+    expect(codexCheck?.status).toBe('failed')
+    expect(codexCheck?.summary).toBe('Codex is not installed yet.')
+    expect(codexCheck?.detail).toBe(
+      'Automatic setup installs a self-contained runtime without Node.js, npm, or admin access.'
+    )
+  })
+
+  it('displays separate rows for Codex native CLI and adapter when component info is available', async () => {
+    const result = await runEnvironmentCheck({
+      storageRoot: '/data',
+      agentFrameworkId: 'codex',
+      frameworks: [
+        {
+          id: 'codex',
+          label: 'Codex',
+          runtime: {
+            found: false,
+            codexComponents: {
+              nativeCliFound: true,
+              nativeCliPath: '/Applications/ChatGPT.app/Contents/Resources/codex',
+              nativeCliVersion: '0.144.2',
+              adapterFound: false,
+              adapterPath: undefined,
+              adapterVersion: undefined
+            }
+          }
+        }
+      ],
+      encryptionAvailable: true,
+      deps: baseDeps()
+    })
+
+    const nativeCheck = result.checks.find((check) => check.label === 'Codex native CLI')
+    const adapterCheck = result.checks.find((check) => check.label === 'Codex ACP adapter')
+
+    expect(nativeCheck).toMatchObject({
+      id: 'agent',
+      label: 'Codex native CLI',
+      status: 'passed',
+      summary: 'Codex CLI 0.144.2 is installed.',
+      detail: '/Applications/ChatGPT.app/Contents/Resources/codex'
+    })
+
+    expect(adapterCheck).toMatchObject({
+      id: 'agent',
+      label: 'Codex ACP adapter',
+      status: 'failed',
+      summary: 'Codex ACP adapter is not installed.',
+      detail: undefined
+    })
+  })
+
+  it('shows both Codex components as passed when both are found', async () => {
+    const result = await runEnvironmentCheck({
+      storageRoot: '/data',
+      agentFrameworkId: 'codex',
+      frameworks: [
+        {
+          id: 'codex',
+          label: 'Codex',
+          runtime: {
+            found: true,
+            path: '/usr/local/bin/codex-acp',
+            version: '1.0.0',
+            codexComponents: {
+              nativeCliFound: true,
+              nativeCliPath: '/Applications/ChatGPT.app/Contents/Resources/codex',
+              nativeCliVersion: '0.144.2',
+              adapterFound: true,
+              adapterPath: '/usr/local/bin/codex-acp',
+              adapterVersion: '1.0.0'
+            }
+          }
+        }
+      ],
+      encryptionAvailable: true,
+      deps: baseDeps()
+    })
+
+    const nativeCheck = result.checks.find((check) => check.label === 'Codex native CLI')
+    const adapterCheck = result.checks.find((check) => check.label === 'Codex ACP adapter')
+
+    expect(nativeCheck).toMatchObject({
+      status: 'passed',
+      summary: 'Codex CLI 0.144.2 is installed.'
+    })
+
+    expect(adapterCheck).toMatchObject({
+      status: 'passed',
+      summary: 'Codex ACP adapter 1.0.0 is ready.'
+    })
+  })
+
+  it('marks non-selected Codex components as warnings when missing', async () => {
+    const result = await runEnvironmentCheck({
+      storageRoot: '/data',
+      agentFrameworkId: 'claude-code',
+      frameworks: [
+        {
+          id: 'claude-code',
+          label: 'Claude',
+          runtime: { found: true, path: '/usr/local/bin/claude', version: '2.1.0' }
+        },
+        {
+          id: 'codex',
+          label: 'Codex',
+          runtime: {
+            found: false,
+            codexComponents: {
+              nativeCliFound: false,
+              adapterFound: false
+            }
+          }
+        }
+      ],
+      encryptionAvailable: true,
+      deps: baseDeps()
+    })
+
+    const nativeCheck = result.checks.find((check) => check.label === 'Codex native CLI')
+    const adapterCheck = result.checks.find((check) => check.label === 'Codex ACP adapter')
+
+    expect(nativeCheck?.status).toBe('warning')
+    expect(adapterCheck?.status).toBe('warning')
+    expect(result.ready).toBe(true) // Non-selected framework doesn't block
+  })
 })

--- a/src/main/settings/environment-check.test.ts
+++ b/src/main/settings/environment-check.test.ts
@@ -387,6 +387,39 @@ describe('runEnvironmentCheck', () => {
     })
   })
 
+  it('omits the version when a paired native CLI has no resolvable version', async () => {
+    // Regression (spec P2): a paired external adapter can set nativeCliFound=true without a version
+    // (the path probe missed the binary but the handshake proved it works). The summary must not
+    // render "Codex CLI undefined is installed."
+    const result = await runEnvironmentCheck({
+      storageRoot: '/data',
+      agentFrameworkId: 'codex',
+      frameworks: [
+        {
+          id: 'codex',
+          label: 'Codex',
+          runtime: {
+            found: true,
+            codexComponents: {
+              nativeCliFound: true,
+              nativeCliPath: undefined,
+              nativeCliVersion: undefined,
+              adapterFound: true,
+              adapterPath: '/opt/tools/codex-acp',
+              adapterVersion: '1.1.4'
+            }
+          }
+        }
+      ],
+      encryptionAvailable: true,
+      deps: baseDeps()
+    })
+
+    const nativeCheck = result.checks.find((check) => check.label === 'Codex native CLI')
+    expect(nativeCheck?.status).toBe('passed')
+    expect(nativeCheck?.summary).toBe('Codex CLI is installed.')
+  })
+
   it('shows both Codex components as passed when both are found', async () => {
     const result = await runEnvironmentCheck({
       storageRoot: '/data',

--- a/src/main/settings/environment-check.ts
+++ b/src/main/settings/environment-check.ts
@@ -299,30 +299,80 @@ const runEnvironmentCheck = async ({
   // One runtime row per framework, shown together. Only the SELECTED framework's absence is a failure
   // (it blocks Continue); a non-selected framework that's missing is an informational warning, so the
   // user isn't forced to install both.
-  const runtimeChecks: EnvironmentCheckItem[] = frameworks.map(({ id, label, runtime }) => {
-    if (runtime.found) {
-      return {
+  const runtimeChecks: EnvironmentCheckItem[] = frameworks.flatMap(({ id, label, runtime }) => {
+    // For Codex with detailed component info, show separate rows for native CLI and adapter
+    if (id === 'codex' && runtime.codexComponents) {
+      const {
+        nativeCliFound,
+        nativeCliPath,
+        nativeCliVersion,
+        adapterFound,
+        adapterPath,
+        adapterVersion
+      } = runtime.codexComponents
+      const isSelected = id === agentFrameworkId
+
+      const nativeCheck: EnvironmentCheckItem = {
         id: 'agent',
-        label: `${label} runtime`,
-        status: 'passed',
-        summary: runtime.version ? `${label} ${runtime.version} is ready.` : `${label} is ready.`,
-        detail: runtime.path
+        label: 'Codex native CLI',
+        status: nativeCliFound ? 'passed' : isSelected ? 'failed' : 'warning',
+        summary: nativeCliFound
+          ? `Codex CLI ${nativeCliVersion} is installed.`
+          : isSelected
+            ? 'Native Codex CLI is not installed.'
+            : 'Native Codex CLI is not installed (optional — only needed if you switch to Codex).',
+        detail: nativeCliPath
       }
+
+      const adapterCheck: EnvironmentCheckItem = {
+        id: 'agent',
+        label: 'Codex ACP adapter',
+        status: adapterFound ? 'passed' : isSelected ? 'failed' : 'warning',
+        summary: adapterFound
+          ? `Codex ACP adapter ${adapterVersion} is ready.`
+          : isSelected
+            ? 'Codex ACP adapter is not installed.'
+            : 'Codex ACP adapter is not installed (optional — only needed if you switch to Codex).',
+        detail: adapterPath
+      }
+
+      return [nativeCheck, adapterCheck]
+    }
+
+    // For other frameworks or when Codex doesn't have component info, show single runtime row
+    if (runtime.found) {
+      return [
+        {
+          id: 'agent',
+          label: `${label} runtime`,
+          status: 'passed',
+          summary: runtime.version ? `${label} ${runtime.version} is ready.` : `${label} is ready.`,
+          detail: runtime.path
+        }
+      ]
     }
 
     const isSelected = id === agentFrameworkId
 
-    return {
-      id: 'agent',
-      label: `${label} runtime`,
-      status: isSelected ? 'failed' : 'warning',
-      summary: isSelected
+    // Use diagnostic detail when available (e.g., "native Codex exists but adapter is missing")
+    const summary = runtime.diagnostic
+      ? runtime.diagnostic
+      : isSelected
         ? `${label} is not installed yet.`
-        : `${label} is not installed (optional — only needed if you switch to it).`,
-      detail: isSelected
-        ? 'Automatic setup installs a self-contained runtime without Node.js, npm, or admin access.'
-        : undefined
-    }
+        : `${label} is not installed (optional — only needed if you switch to it).`
+
+    return [
+      {
+        id: 'agent',
+        label: `${label} runtime`,
+        status: isSelected ? 'failed' : 'warning',
+        summary,
+        detail:
+          isSelected && !runtime.diagnostic
+            ? 'Automatic setup installs a self-contained runtime without Node.js, npm, or admin access.'
+            : undefined
+      }
+    ]
   })
 
   const checks = [

--- a/src/main/settings/environment-check.ts
+++ b/src/main/settings/environment-check.ts
@@ -308,7 +308,8 @@ const runEnvironmentCheck = async ({
         nativeCliVersion,
         adapterFound,
         adapterPath,
-        adapterVersion
+        adapterVersion,
+        adapterFailureReason
       } = runtime.codexComponents
       const isSelected = id === agentFrameworkId
 
@@ -324,15 +325,22 @@ const runEnvironmentCheck = async ({
         detail: nativeCliPath
       }
 
+      // Adapter with a failure reason is marked as found but non-functional - treat as failed
+      const adapterWorking = adapterFound && !adapterFailureReason
+
       const adapterCheck: EnvironmentCheckItem = {
         id: 'agent',
         label: 'Codex ACP adapter',
-        status: adapterFound ? 'passed' : isSelected ? 'failed' : 'warning',
-        summary: adapterFound
+        status: adapterWorking ? 'passed' : isSelected ? 'failed' : 'warning',
+        summary: adapterWorking
           ? `Codex ACP adapter ${adapterVersion} is ready.`
-          : isSelected
-            ? 'Codex ACP adapter is not installed.'
-            : 'Codex ACP adapter is not installed (optional — only needed if you switch to Codex).',
+          : adapterFound && adapterFailureReason
+            ? adapterFailureReason === 'smoke-test-failed'
+              ? `Codex ACP adapter ${adapterVersion} failed to initialize.`
+              : `Codex ACP adapter exists but version detection failed.`
+            : isSelected
+              ? 'Codex ACP adapter is not installed.'
+              : 'Codex ACP adapter is not installed (optional — only needed if you switch to Codex).',
         detail: adapterPath
       }
 

--- a/src/main/settings/environment-check.ts
+++ b/src/main/settings/environment-check.ts
@@ -318,7 +318,9 @@ const runEnvironmentCheck = async ({
         label: 'Codex native CLI',
         status: nativeCliFound ? 'passed' : isSelected ? 'failed' : 'warning',
         summary: nativeCliFound
-          ? `Codex CLI ${nativeCliVersion} is installed.`
+          ? nativeCliVersion
+            ? `Codex CLI ${nativeCliVersion} is installed.`
+            : 'Codex CLI is installed.'
           : isSelected
             ? 'Native Codex CLI is not installed.'
             : 'Native Codex CLI is not installed (optional — only needed if you switch to Codex).',

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -68,6 +68,11 @@ const createService = (
     // When set, opencode detection resolves this path/version; otherwise it finds nothing.
     opencodeDetected?: { path: string; version: string }
     codexDetected?: { path: string; version: string; nativePath?: string; nativeVersion?: string }
+    // Simulates an external native Codex CLI reachable only via the augmented PATH (e.g. Homebrew),
+    // so getCodexVersion resolves for this path even though it's not the managed nativePath.
+    codexExternalNative?: { path: string; version: string }
+    // When false, the ACP smoke test fails (adapter present but can't initialize).
+    codexSmokeOk?: boolean
   } = {}
 ): InstanceType<typeof SettingsService> =>
   new SettingsService({
@@ -116,9 +121,11 @@ const createService = (
         Promise.resolve(
           path === options.codexDetected?.nativePath
             ? options.codexDetected.nativeVersion
-            : undefined
+            : path === options.codexExternalNative?.path
+              ? options.codexExternalNative.version
+              : undefined
         ),
-      smokeInitialize: () => Promise.resolve(true),
+      smokeInitialize: () => Promise.resolve(options.codexSmokeOk ?? true),
       resolveNpmBinDirs: () => Promise.resolve([]),
       managedAdapterPath: options.codexDetected?.nativePath
         ? options.codexDetected.path
@@ -591,6 +598,71 @@ describe('SettingsService: preflight & spawn config', () => {
       nativeVersion: '0.144.6'
     })
     expect(await service.getPreflight()).toMatchObject({ codexReady: true, agentReady: true })
+  })
+
+  it('reports both Codex components ready for an external adapter whose native CLI is on the augmented PATH', async () => {
+    // Regression (spec P1): an external adapter pairs successfully via the augmented PATH, but the
+    // independent native-CLI probe must search the SAME dirs (/usr/local/bin here) so it agrees with
+    // the smoke test. Otherwise native CLI would show missing and block Continue.
+    await repository.setAgentFramework('codex')
+    const service = createService(undefined, {
+      codexDetected: { path: '/opt/tools/codex-acp', version: 'codex-acp 1.1.4' },
+      codexExternalNative: { path: '/usr/local/bin/codex', version: 'codex-cli 0.144.6' }
+    })
+
+    const result = await service.checkEnvironment()
+    const agentRows = result.checks.filter((check) => check.id === 'agent')
+    const codexRows = agentRows.filter((row) => row.label.startsWith('Codex'))
+
+    expect(codexRows.map((row) => `${row.label}:${row.status}`)).toEqual([
+      'Codex native CLI:passed',
+      'Codex ACP adapter:passed'
+    ])
+    const nativeRow = codexRows.find((row) => row.label === 'Codex native CLI')
+    expect(nativeRow?.detail).toBe('/usr/local/bin/codex')
+    expect(result.ready).toBe(true)
+  })
+
+  it('trusts a paired external adapter for native readiness even when the path probe misses it', async () => {
+    // Regression (spec P1): the ACP handshake proves a working native CLI exists. If the independent
+    // probe can't pinpoint it (unusual install dir), native CLI must still count as found so a
+    // successful pairing never blocks Continue.
+    await repository.setAgentFramework('codex')
+    const service = createService(undefined, {
+      codexDetected: { path: '/opt/tools/codex-acp', version: 'codex-acp 1.1.4' }
+      // No codexExternalNative: probe finds nothing, but smoke test passed.
+    })
+
+    const result = await service.checkEnvironment()
+    const codexRows = result.checks
+      .filter((check) => check.id === 'agent')
+      .filter((row) => row.label.startsWith('Codex'))
+
+    expect(codexRows.map((row) => `${row.label}:${row.status}`)).toEqual([
+      'Codex native CLI:passed',
+      'Codex ACP adapter:passed'
+    ])
+    expect(result.ready).toBe(true)
+  })
+
+  it('marks the Codex adapter row failed when it is present but fails the ACP handshake', async () => {
+    // Regression (spec P1): an adapter whose --version succeeds but whose ACP initialize fails must
+    // surface as failed, not "ready". Full detection returns nothing, so component-level detection
+    // records adapterFound=true with a smoke-test-failed reason that the UI must honor.
+    await repository.setAgentFramework('codex')
+    const service = createService(undefined, {
+      codexDetected: { path: '/opt/tools/codex-acp', version: 'codex-acp 1.1.4' },
+      codexSmokeOk: false
+    })
+
+    const result = await service.checkEnvironment()
+    const adapterRow = result.checks.find(
+      (check) => check.id === 'agent' && check.label === 'Codex ACP adapter'
+    )
+
+    expect(adapterRow?.status).toBe('failed')
+    expect(adapterRow?.summary).toContain('failed to initialize')
+    expect(result.ready).toBe(false)
   })
 
   it('does not mark an app-managed Codex pair ready when its native binary is broken', async () => {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1799,9 +1799,10 @@ describe('checkEnvironment', () => {
     expect(agentRows.map((row) => row.label)).toEqual([
       'Claude Code runtime',
       'OpenCode runtime',
-      'Codex runtime'
+      'Codex native CLI',
+      'Codex ACP adapter'
     ])
-    expect(agentRows.map((row) => row.status)).toEqual(['passed', 'passed', 'warning'])
+    expect(agentRows.map((row) => row.status)).toEqual(['passed', 'passed', 'warning', 'warning'])
     expect(result.agentFrameworkId).toBe('opencode')
     expect(result.runtime).toEqual({
       found: true,
@@ -1835,7 +1836,8 @@ describe('checkEnvironment', () => {
     expect(agentRows.map((row) => `${row.label}:${row.status}`)).toEqual([
       'Claude Code runtime:passed',
       'OpenCode runtime:failed',
-      'Codex runtime:warning'
+      'Codex native CLI:warning',
+      'Codex ACP adapter:warning'
     ])
     // Selection drives readiness: the missing selected runtime blocks Continue even though Claude runs.
     expect(result.agentFrameworkId).toBe('opencode')

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -904,16 +904,18 @@ class SettingsService {
       await this.repository.setCodexInfo({ ...cached, ...cachedVersions })
 
       // Build codexComponents even for successful detection so onboarding shows separate rows.
-      // For non-managed cached adapters without a stored nativePath, probe independently.
       let nativeCliFound = !!cached.nativePath
       let nativeCliPath = cached.nativePath
       let nativeCliVersion = cachedVersions.nativeVersion
 
       if (!cached.nativePath) {
+        // A non-managed adapter only gets cached after passing the full smoke test, so a working
+        // native CLI exists. Trust that (mirroring the fresh-detect branch) rather than letting a
+        // narrow probe miss it and block Continue. The probe just enriches the path/version.
+        nativeCliFound = true
         const { detectNativeCodex } = await import('./codex-detect')
         const nativeCodex = await detectNativeCodex(this.codexDetectDeps)
         if (nativeCodex) {
-          nativeCliFound = true
           nativeCliPath = nativeCodex.path
           nativeCliVersion = nativeCodex.version
         }
@@ -953,12 +955,14 @@ class SettingsService {
       let nativeCliVersion = detected.managedCodexVersion
 
       if (!detected.managedCodexPath) {
-        // Non-managed adapter passed smoke test, which means a native CLI exists somewhere.
-        // Try to find it independently for display purposes.
+        // Non-managed adapter passed the ACP smoke test, which proves a working native CLI exists
+        // (the handshake spawns a real session). Trust that: mark native as found even if the
+        // independent probe below can't pinpoint the exact path, so a successful pairing never
+        // blocks Continue. The probe only enriches the display with a concrete path/version.
+        nativeCliFound = true
         const { detectNativeCodex } = await import('./codex-detect')
         const nativeCodex = await detectNativeCodex(this.codexDetectDeps)
         if (nativeCodex) {
-          nativeCliFound = true
           nativeCliPath = nativeCodex.path
           nativeCliVersion = nativeCodex.version
         }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -903,14 +903,29 @@ class SettingsService {
     if (cached?.resolvedPath && cachedVersions) {
       await this.repository.setCodexInfo({ ...cached, ...cachedVersions })
 
-      // Build codexComponents even for successful detection so onboarding shows separate rows
+      // Build codexComponents even for successful detection so onboarding shows separate rows.
+      // For non-managed cached adapters without a stored nativePath, probe independently.
+      let nativeCliFound = !!cached.nativePath
+      let nativeCliPath = cached.nativePath
+      let nativeCliVersion = cachedVersions.nativeVersion
+
+      if (!cached.nativePath) {
+        const { detectNativeCodex } = await import('./codex-detect')
+        const nativeCodex = await detectNativeCodex(this.codexDetectDeps)
+        if (nativeCodex) {
+          nativeCliFound = true
+          nativeCliPath = nativeCodex.path
+          nativeCliVersion = nativeCodex.version
+        }
+      }
+
       const codexComponents: ClaudeDetectResult['codexComponents'] = {
         adapterFound: true,
         adapterPath: cached.resolvedPath,
         adapterVersion: cachedVersions.version,
-        nativeCliFound: !!cached.nativePath,
-        nativeCliPath: cached.nativePath,
-        nativeCliVersion: cachedVersions.nativeVersion
+        nativeCliFound,
+        nativeCliPath,
+        nativeCliVersion
       }
 
       return {
@@ -930,14 +945,32 @@ class SettingsService {
         nativeVersion: detected.managedCodexVersion
       })
 
-      // Build codexComponents for successful detection
+      // Build codexComponents for successful detection. For managed adapters, use the bundled
+      // native CLI info. For PATH/npm adapters that passed smoke test, independently probe for
+      // native CLI so the UI can show both components.
+      let nativeCliFound = !!detected.managedCodexPath
+      let nativeCliPath = detected.managedCodexPath
+      let nativeCliVersion = detected.managedCodexVersion
+
+      if (!detected.managedCodexPath) {
+        // Non-managed adapter passed smoke test, which means a native CLI exists somewhere.
+        // Try to find it independently for display purposes.
+        const { detectNativeCodex } = await import('./codex-detect')
+        const nativeCodex = await detectNativeCodex(this.codexDetectDeps)
+        if (nativeCodex) {
+          nativeCliFound = true
+          nativeCliPath = nativeCodex.path
+          nativeCliVersion = nativeCodex.version
+        }
+      }
+
       const codexComponents: ClaudeDetectResult['codexComponents'] = {
         adapterFound: true,
         adapterPath: detected.adapterPath,
         adapterVersion: detected.adapterVersion,
-        nativeCliFound: !!detected.managedCodexPath,
-        nativeCliPath: detected.managedCodexPath,
-        nativeCliVersion: detected.managedCodexVersion
+        nativeCliFound,
+        nativeCliPath,
+        nativeCliVersion
       }
 
       return {
@@ -985,7 +1018,8 @@ class SettingsService {
         nativeCliVersion: components.nativeCliVersion,
         adapterFound: components.adapterFound,
         adapterPath: components.adapterPath,
-        adapterVersion: components.adapterVersion
+        adapterVersion: components.adapterVersion,
+        adapterFailureReason: components.adapterFailureReason
       }
     }
   }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -902,28 +902,92 @@ class SettingsService {
     const cachedVersions = await this.probeCodexRuntime(cached)
     if (cached?.resolvedPath && cachedVersions) {
       await this.repository.setCodexInfo({ ...cached, ...cachedVersions })
+
+      // Build codexComponents even for successful detection so onboarding shows separate rows
+      const codexComponents: ClaudeDetectResult['codexComponents'] = {
+        adapterFound: true,
+        adapterPath: cached.resolvedPath,
+        adapterVersion: cachedVersions.version,
+        nativeCliFound: !!cached.nativePath,
+        nativeCliPath: cached.nativePath,
+        nativeCliVersion: cachedVersions.nativeVersion
+      }
+
       return {
         found: true,
         path: cached.resolvedPath,
-        version: cachedVersions.version
+        version: cachedVersions.version,
+        codexComponents
       }
     }
 
     const detected = await detectCodex(this.codexDetectDeps)
-    if (!detected) {
-      if (cached?.resolvedPath && !(await this.pathExists(cached.resolvedPath))) {
-        await this.repository.clearCodexInfo()
+    if (detected) {
+      await this.repository.setCodexInfo({
+        resolvedPath: detected.adapterPath,
+        version: detected.adapterVersion,
+        nativePath: detected.managedCodexPath,
+        nativeVersion: detected.managedCodexVersion
+      })
+
+      // Build codexComponents for successful detection
+      const codexComponents: ClaudeDetectResult['codexComponents'] = {
+        adapterFound: true,
+        adapterPath: detected.adapterPath,
+        adapterVersion: detected.adapterVersion,
+        nativeCliFound: !!detected.managedCodexPath,
+        nativeCliPath: detected.managedCodexPath,
+        nativeCliVersion: detected.managedCodexVersion
       }
-      return { found: false }
+
+      return {
+        found: true,
+        path: detected.adapterPath,
+        version: detected.adapterVersion,
+        codexComponents
+      }
     }
 
-    await this.repository.setCodexInfo({
-      resolvedPath: detected.adapterPath,
-      version: detected.adapterVersion,
-      nativePath: detected.managedCodexPath,
-      nativeVersion: detected.managedCodexVersion
-    })
-    return { found: true, path: detected.adapterPath, version: detected.adapterVersion }
+    // Full detection failed. Perform detailed component-level detection to provide accurate
+    // diagnostic information distinguishing "adapter missing" from "native Codex missing" from
+    // "both present but incompatible".
+    if (cached?.resolvedPath && !(await this.pathExists(cached.resolvedPath))) {
+      await this.repository.clearCodexInfo()
+    }
+
+    const { detectCodexComponents } = await import('./codex-detect')
+    const components = await detectCodexComponents(this.codexDetectDeps)
+
+    // Build diagnostic message based on what was found
+    let diagnostic: string | undefined
+    if (components.nativeCliFound && !components.adapterFound) {
+      diagnostic = `Native Codex ${components.nativeCliVersion} is installed at ${components.nativeCliPath}, but the Codex ACP adapter required by Open Science is missing.`
+    } else if (!components.nativeCliFound && components.adapterFound) {
+      if (components.adapterFailureReason === 'smoke-test-failed') {
+        diagnostic = `Codex ACP adapter ${components.adapterVersion} is installed at ${components.adapterPath}, but it failed to initialize (native Codex CLI may be missing or incompatible).`
+      } else {
+        diagnostic = `Codex ACP adapter is installed at ${components.adapterPath}, but version detection failed.`
+      }
+    } else if (components.nativeCliFound && components.adapterFound) {
+      if (components.adapterFailureReason === 'smoke-test-failed') {
+        diagnostic = `Both native Codex ${components.nativeCliVersion} and ACP adapter ${components.adapterVersion} are installed, but the adapter failed to initialize with the native CLI.`
+      } else if (components.adapterFailureReason === 'version-probe-failed') {
+        diagnostic = `Native Codex ${components.nativeCliVersion} is installed, and an ACP adapter exists at ${components.adapterPath}, but the adapter's version could not be determined.`
+      }
+    }
+
+    return {
+      found: false,
+      diagnostic,
+      codexComponents: {
+        nativeCliFound: components.nativeCliFound,
+        nativeCliPath: components.nativeCliPath,
+        nativeCliVersion: components.nativeCliVersion,
+        adapterFound: components.adapterFound,
+        adapterPath: components.adapterPath,
+        adapterVersion: components.adapterVersion
+      }
+    }
   }
 
   private async probeCodexRuntime(

--- a/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
@@ -240,27 +240,7 @@ const EnvironmentSetupCard = ({
                 ) : (
                   <TerminalSquare aria-hidden="true" />
                 )}
-                {isInstalling
-                  ? 'Installing…'
-                  : (() => {
-                      // Specify what will be installed based on what's missing
-                      if (
-                        environment.agentFrameworkId === 'codex' &&
-                        environment.runtime.codexComponents
-                      ) {
-                        const { nativeCliFound, adapterFound } = environment.runtime.codexComponents
-                        if (!nativeCliFound && !adapterFound) {
-                          return 'Install Codex CLI + adapter'
-                        }
-                        if (!nativeCliFound) {
-                          return 'Install Codex CLI'
-                        }
-                        if (!adapterFound) {
-                          return 'Install ACP adapter'
-                        }
-                      }
-                      return 'Install missing runtime'
-                    })()}
+                {isInstalling ? 'Installing…' : 'Install missing runtime'}
               </Button>
             </div>
           ) : (

--- a/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
@@ -201,11 +201,32 @@ const EnvironmentSetupCard = ({
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="text-sm font-medium text-foreground">
-                  The agent runtime is the only missing item
+                  {(() => {
+                    // For Codex with component info, describe what's missing specifically
+                    if (
+                      environment.agentFrameworkId === 'codex' &&
+                      environment.runtime.codexComponents
+                    ) {
+                      const { nativeCliFound, adapterFound } = environment.runtime.codexComponents
+                      if (!nativeCliFound && !adapterFound) {
+                        return 'Both native Codex CLI and ACP adapter are missing'
+                      }
+                      if (!nativeCliFound) {
+                        return 'Native Codex CLI is the missing component'
+                      }
+                      if (!adapterFound) {
+                        return 'Codex ACP adapter is the missing component'
+                      }
+                    }
+                    return 'The agent runtime is the only missing item'
+                  })()}
                 </p>
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  Install it into Open Science using the {sourceLabel}, with the other trusted
-                  source as fallback; no Node.js, npm, or admin password is required.
+                  {environment.agentFrameworkId === 'codex' &&
+                  environment.runtime.codexComponents?.nativeCliFound &&
+                  !environment.runtime.codexComponents?.adapterFound
+                    ? `Install the Codex ACP adapter into Open Science using the ${sourceLabel}. The installer will set up a managed adapter paired with a bundled Codex CLI; no Node.js, npm, or admin password is required.`
+                    : `Install it into Open Science using the ${sourceLabel}, with the other trusted source as fallback; no Node.js, npm, or admin password is required.`}
                 </p>
               </div>
               <Button
@@ -219,7 +240,27 @@ const EnvironmentSetupCard = ({
                 ) : (
                   <TerminalSquare aria-hidden="true" />
                 )}
-                {isInstalling ? 'Installing…' : 'Install missing runtime'}
+                {isInstalling
+                  ? 'Installing…'
+                  : (() => {
+                      // Specify what will be installed based on what's missing
+                      if (
+                        environment.agentFrameworkId === 'codex' &&
+                        environment.runtime.codexComponents
+                      ) {
+                        const { nativeCliFound, adapterFound } = environment.runtime.codexComponents
+                        if (!nativeCliFound && !adapterFound) {
+                          return 'Install Codex CLI + adapter'
+                        }
+                        if (!nativeCliFound) {
+                          return 'Install Codex CLI'
+                        }
+                        if (!adapterFound) {
+                          return 'Install ACP adapter'
+                        }
+                      }
+                      return 'Install missing runtime'
+                    })()}
               </Button>
             </div>
           ) : (

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -101,6 +101,20 @@ export type ClaudeDetectResult = {
   found: boolean
   path?: string
   version?: string
+  // Diagnostic detail for when detection fails but partial components are present. Used to provide
+  // more accurate error messages (e.g., "Codex ACP adapter missing" vs "Codex not installed").
+  diagnostic?: string
+  // For Codex: separate detection state of native CLI and ACP adapter components. When present,
+  // the environment check can display distinct status for each component rather than collapsing
+  // them into a single "runtime" row. Omitted for Claude/OpenCode (single-binary runtimes).
+  codexComponents?: {
+    nativeCliFound: boolean
+    nativeCliPath?: string
+    nativeCliVersion?: string
+    adapterFound: boolean
+    adapterPath?: string
+    adapterVersion?: string
+  }
 }
 
 // A recorded failed validation, kept so the list can flag a provider as unverified and say why

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -114,6 +114,10 @@ export type ClaudeDetectResult = {
     adapterFound: boolean
     adapterPath?: string
     adapterVersion?: string
+    // When adapter exists but is non-functional (version probe or smoke test failed), this
+    // explains why. Environment check uses this to mark the adapter row as failed even when
+    // adapterFound is true.
+    adapterFailureReason?: 'version-probe-failed' | 'smoke-test-failed'
   }
 }
 


### PR DESCRIPTION
## Problem

During first-run onboarding, when a user has native Codex CLI installed (e.g., from ChatGPT.app) but lacks the Codex ACP adapter, the environment check displayed a single collapsed row:

```
❌ Codex runtime — ACTION NEEDED
   Codex is not installed yet.
```

This is misleading: native Codex **is** installed—only the adapter component is missing.

## Solution

The Codex runtime check now surfaces **two separate status rows**, one per component:
1. **Codex native CLI** — detected / not detected / present-but-broken
2. **Codex ACP adapter** — detected / not detected / present-but-failed-handshake

### Key Changes

1. **Type** (`src/shared/settings.ts`)
   - Added optional `codexComponents` to `ClaudeDetectResult`, including `adapterFailureReason` (`version-probe-failed` | `smoke-test-failed`) so the UI can distinguish "present but broken" from "missing".

2. **Component-level detection** (`src/main/settings/codex-detect.ts`)
   - `detectCodexComponents()` independently checks native CLI and adapter, recording granular failure reasons.
   - `detectNativeCodex()` searches the **same directory set as the ACP smoke test** (raw PATH + `~/.local/bin` + Homebrew/`/usr/local` + npm global bin), so a successful adapter handshake never disagrees with the independent native-CLI probe.

3. **Runtime resolution** (`src/main/settings/service.ts`)
   - `resolveCodexRuntime()` populates `codexComponents` for both cached and freshly-detected adapters.
   - A paired external adapter (passing ACP smoke test) is **trusted** for native readiness: `nativeCliFound=true` even if the path probe can't pinpoint the binary, so a working pairing never blocks Continue. The probe only enriches the displayed path/version.
   - `adapterFailureReason` is propagated so the adapter row reports `failed` when the adapter is present but the handshake fails.

4. **Separate rows** (`src/main/settings/environment-check.ts`)
   - Emits "Codex native CLI" and "Codex ACP adapter" rows instead of one collapsed "runtime" row.
   - An adapter with a `failureReason` is shown as **failed** (not "ready"), with a specific message.

5. **Onboarding copy** (`src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx`)
   - When only the adapter is missing, the explanation clarifies that the installer sets up a managed adapter paired with a bundled Codex CLI (no Node.js/npm/admin required).
   - The install **button** keeps the generic label "Install missing runtime" — per maintainer feedback, component-specific button text ("Install ACP adapter", etc.) was considered confusing to users; the per-component detail lives in the status rows above the button instead.

### User Experience

**Native present, adapter missing:**
```
✅ Codex native CLI — Codex CLI 0.144.2 is installed.
❌ Codex ACP adapter — ACTION NEEDED — Codex ACP adapter is not installed.
[Install missing runtime]
```

**Adapter present but fails to initialize:**
```
❌ Codex ACP adapter — ACTION NEEDED — Codex ACP adapter 1.1.4 failed to initialize.
```

**External adapter paired via Homebrew codex:**
```
✅ Codex native CLI — Codex CLI 0.144.6 is installed. (/usr/local/bin/codex)
✅ Codex ACP adapter — Codex ACP adapter 1.1.4 is ready.
```

## Testing

129 tests pass across the three affected suites:
- `codex-detect.test.ts` — component detection + native-CLI probe on augmented PATH (Homebrew, npm global bin, `~/.local/bin`)
- `environment-check.test.ts` — separate row rendering, failed-adapter status, non-selected warnings
- `service.test.ts` — external adapter + augmented-PATH native CLI both ready; paired adapter trusted when probe misses the path; adapter-present-but-handshake-failing surfaces as failed; four-runtime-row gating

### Known limitation (out of scope for #247)

Cached non-managed adapters are re-validated via `--version` only on each `checkEnvironment`, not a full ACP re-handshake. A re-handshake on every check would regress onboarding latency, and a non-managed adapter is only cached after passing the full smoke test initially. Tightening this is tracked separately.

Fixes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)