### PR TITLE
fix(workspace): overlay env status banner to stop clipping page bottom

### DIFF
--- a/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
+++ b/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
@@ -1,8 +1,11 @@
 import type { ProvisionUiState } from './provisioning-view'
 
-// Thin top-of-app banner for the launch-time upgrade gate (spec §6.2). First-run python preparation
+// Floating top-of-app pill for the launch-time upgrade gate (spec §6.2). First-run python preparation
 // is surfaced by the onboarding step and the notebook pane gate instead, so this banner only shows for
 // an in-progress background upgrade or a blocking failure — never for the initial python bootstrap.
+// It overlays content instead of taking layout space: the pages below are h-screen with
+// overflow-hidden, so an in-flow banner would push their bottom edge (the composer toolbar) out of
+// the viewport and clip it (issue #244).
 const EnvStatusBanner = ({
   ui,
   onRetry
@@ -16,7 +19,7 @@ const EnvStatusBanner = ({
   return (
     <div
       data-testid="env-status-banner"
-      className="flex w-full items-center justify-center gap-3 bg-bg-200 px-4 py-1.5 text-center text-xs text-text-100"
+      className="fixed left-1/2 top-2 z-50 flex max-w-[min(90vw,640px)] -translate-x-1/2 items-center justify-center gap-2 rounded-full border border-border-100 bg-bg-200 px-3 py-1 text-center text-xs text-text-100 shadow-md"
     >
       {ui.kind === 'error' ? (
         <>


### PR DESCRIPTION
## Summary

- Fixes #244: on v0.5.0 the bottom of the page (composer toolbar) is cut off, in windowed and full-screen modes alike.
- Root cause is not DPI: the `EnvStatusBanner` added in v0.5.0 renders **in-flow** above pages that are `h-screen` + `overflow-hidden` (`WorkspacePage`, `body`). Whenever the banner is visible — background env upgrade after the update, or a blocking python provisioning error that persists across launches — banner height + 100vh exceeds the viewport and the page bottom is clipped with no way to scroll.
- Fix: render the banner as a small floating pill (`fixed`, top-center, rounded, bordered, shadow, `max-w` capped) that overlays content instead of consuming layout height. `h-screen` pages now always fit the viewport exactly.

## Changes

- `src/renderer/src/pages/workspace/EnvStatusBanner.tsx`: in-flow full-width bar → floating overlay pill; display conditions, testids, and Retry behavior unchanged; header comment updated to document why it must stay an overlay.

## Test plan

- [x] `npx vitest run src/renderer/src/pages/workspace/EnvStatusBanner.render.test.tsx` — pass
- [x] Home/Workspace related suites (HomePage, send-gate, notebook-hydration, preview-panel-resize, draft-preservation, image-staging) — pass
- [x] `npm run typecheck:web` — pass
- [ ] Visual check on Windows hi-DPI (125%/150%) — maintainer verification appreciated
