### PR TITLE
fix(acp): recover context overflow surfaced via provider error slugs

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3351,6 +3351,148 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('tags a slug-only request-size overflow as context-overflow recoverable', async () => {
+    const process = new FakeAgentProcess()
+    const events: Array<{ kind: string; recoverable?: string }> = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: () => {
+        // The ACP RequestError shape of a provider-relayed rejection: the message is the generic
+        // wrapper and the real reason lives in data.errorKind (here the HTTP 413 slug), so only the
+        // structured-kind check can recognize the overflow.
+        throw acp.RequestError.internalError({ errorKind: 'request_too_large' }, 'Internal error')
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: {
+        onEvent: (event) => events.push({ kind: event.kind, recoverable: event.recoverable })
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await expect(
+      runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'hi' })
+    ).rejects.toThrow()
+
+    expect(events).toContainEqual({ kind: 'error', recoverable: 'context-overflow' })
+  })
+
+  it('does not tag a generic invalid_request failure as context-overflow recoverable', async () => {
+    const process = new FakeAgentProcess()
+    const events: Array<{ kind: string; recoverable?: string }> = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: () => {
+        // A malformed-request rejection is not an overflow: resetting the agent context would destroy
+        // history without any chance of fixing the turn.
+        throw acp.RequestError.internalError(
+          { errorKind: 'invalid_request' },
+          'invalid_request: messages.0.content is required'
+        )
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: {
+        onEvent: (event) => events.push({ kind: event.kind, recoverable: event.recoverable })
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await expect(
+      runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'hi' })
+    ).rejects.toThrow()
+
+    const errorEvent = events.find((event) => event.kind === 'error')
+    expect(errorEvent).toBeDefined()
+    expect(errorEvent?.recoverable).toBeUndefined()
+  })
+
+  it('logs the provider rejection reason (message/code/data) when a prompt fails', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: () => {
+        throw acp.RequestError.internalError({ errorKind: 'request_too_large' }, 'provider blew up')
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await expect(
+      runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'hi' })
+    ).rejects.toThrow()
+
+    // Regression: a raw Error nested in the log payload serializes without its (non-enumerable)
+    // message, so the file log showed only { code, data, name } and hid the provider's reason.
+    // errorLogFields keeps the message, code, and data together.
+    expect(errorLogSpy).toHaveBeenCalledWith(
+      'prompt failed',
+      expect.objectContaining({
+        sessionId: 'remote-session-1',
+        error: 'Internal error: provider blew up',
+        code: -32603,
+        data: { errorKind: 'request_too_large' }
+      })
+    )
+  })
+
+  it('logs the artifact-emit failure reason (message/code/data) when the prompt failed', async () => {
+    const storageRoot = await createTemporaryRoot()
+    const repository = new ArtifactRepository(storageRoot)
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: () => {
+        throw new Error('agent exploded mid-turn')
+      }
+    })
+    // The prompt failure routes the finally block into a second emit attempt; making the repository
+    // read fail there exercises the 'artifact emit after prompt failure failed' log path. The error
+    // carries a `data` detail so the assertion below also pins its survival into the log record.
+    vi.spyOn(repository, 'listPendingRunFiles').mockRejectedValue(
+      Object.assign(new Error('disk exploded'), {
+        code: 'EIO',
+        data: { operation: 'listPendingRunFiles' }
+      })
+    )
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: storageRoot,
+        dataRoot: storageRoot,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        mcpCommand: '/usr/bin/electron',
+        repository
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await expect(
+      runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'make a file' })
+    ).rejects.toThrow()
+
+    // Same regression class as 'prompt failed': a raw nested Error would log without its message,
+    // and an incomplete serialization would drop the structured detail.
+    expect(errorLogSpy).toHaveBeenCalledWith(
+      'artifact emit after prompt failure failed',
+      expect.objectContaining({
+        sessionId: 'remote-session-1',
+        error: 'disk exploded',
+        code: 'EIO',
+        data: { operation: 'listPendingRunFiles' }
+      })
+    )
+  })
+
   it('rejects restored sessions when the agent does not advertise resume support', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, [], { supportsResume: false })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -241,6 +241,21 @@ const errorMessage = (error: unknown): string => {
   }
 }
 
+// The ACP agent tags a provider-relayed failure with the upstream error type in `data.errorKind`
+// (e.g. `request_too_large` for an HTTP 413). Read it so the overflow check can match the slug even
+// when the message text comes in a wording the pattern does not cover. Total: any shape but a string
+// kind collapses to undefined, and a hostile getter never escapes.
+const acpErrorKind = (error: unknown): string | undefined => {
+  try {
+    const data = (error as { data?: unknown } | null)?.data
+    const kind = (data as { errorKind?: unknown } | null | undefined)?.errorKind
+
+    return typeof kind === 'string' ? kind : undefined
+  } catch {
+    return undefined
+  }
+}
+
 // Internal wrapper thrown when framework.spawn() fails, carrying the framework the spawn targeted so
 // connectFresh can label the failure with the right backend. It never mutates the original throwable
 // (which may be a frozen/non-extensible Error, a write-rejecting Proxy, or a non-Error value) and holds
@@ -1522,12 +1537,19 @@ class AcpRuntime {
         this.handleSessionUpdate(message.notification, request.sessionId)
       }
     } catch (error) {
-      log.error('prompt failed', { sessionId: request.sessionId, error })
+      // errorLogFields keeps the RequestError message/code/data visible in the file log — a raw Error
+      // nested in the payload serializes without its (non-enumerable) message, which once hid the
+      // provider's real rejection reason from the log.
+      log.error('prompt failed', { sessionId: request.sessionId, ...errorLogFields(error) })
       const text = describePromptError(error, { model: this.pendingSessionModel })
       // Tag a request-size overflow as recoverable so the renderer compacts-and-retries (reset context +
       // replay a text transcript) instead of dead-ending; the error still throws to drive that recovery.
+      // The structured errorKind slug is checked alongside the message text: providers relay the same
+      // overflow in different wordings, and a slug-only match needs no message at all.
       const recoverable =
-        isMediaOverflowError(text) || isMediaOverflowError(errorMessage(error))
+        isMediaOverflowError(text) ||
+        isMediaOverflowError(errorMessage(error)) ||
+        isMediaOverflowError(acpErrorKind(error))
           ? 'context-overflow'
           : undefined
       this.pushEvent({
@@ -1548,7 +1570,7 @@ class AcpRuntime {
         } catch (error) {
           log.error('artifact emit after prompt failure failed', {
             sessionId: request.sessionId,
-            error
+            ...errorLogFields(error)
           })
         }
       }

--- a/src/shared/media-overflow.test.ts
+++ b/src/shared/media-overflow.test.ts
@@ -16,10 +16,28 @@ describe('isMediaOverflowError', () => {
     ).toBe(true)
   })
 
+  it('matches the provider HTTP 413 forms (message and error-type slug)', () => {
+    expect(isMediaOverflowError('request_too_large')).toBe(true)
+    expect(isMediaOverflowError('Request entity too large')).toBe(true)
+  })
+
+  it('matches third-party endpoint context-overflow wording', () => {
+    expect(
+      isMediaOverflowError(
+        "This model's maximum context length is 65536 tokens. However, your request has 89012 input tokens."
+      )
+    ).toBe(true)
+    expect(isMediaOverflowError('context_length_exceeded')).toBe(true)
+    expect(isMediaOverflowError('prompt is too long: 213450 tokens > 200000 maximum')).toBe(true)
+  })
+
   it('does not match unrelated failures', () => {
     expect(isMediaOverflowError('The requested resource was not found')).toBe(false)
     expect(isMediaOverflowError('Upload rejected: file is too large (limit 10MB)')).toBe(false)
     expect(isMediaOverflowError('rate limit exceeded')).toBe(false)
+    // A generic invalid_request (e.g. a malformed field) is NOT an overflow: tagging it recoverable
+    // would reset the agent context for an error a retry cannot fix.
+    expect(isMediaOverflowError('invalid_request: messages.0.content is required')).toBe(false)
   })
 
   it('is safe on empty input', () => {

--- a/src/shared/media-overflow.ts
+++ b/src/shared/media-overflow.ts
@@ -1,14 +1,18 @@
 // Recognizes the "conversation grew past the provider's request-size limit" failure so the app can
 // auto-recover (reset the agent context, replay a text-only transcript) instead of dead-ending.
 //
-// Two distinct signatures describe the same underlying condition:
+// Several signatures describe the same underlying condition, depending on who rejected the request:
 //   - `media_unstrippable`: the backend's own compaction gave up because accumulated base64 media
 //     blocks cannot be stripped from the history it would summarize.
-//   - `Request too large (max 32MB)`: the provider (Anthropic 413) rejected the turn because the
-//     replayed history plus this turn exceeded the request ceiling.
-// Matching either is enough to trigger recovery; both are specific enough not to catch unrelated
-// "too large" messages (e.g. an oversized upload rejected before it ever reaches the model).
-const MEDIA_OVERFLOW_PATTERN = /media[_\s-]?unstrippable|request too large/i
+//   - `Request too large (max 32MB)`: the agent CLI's own client-side ceiling tripped before dispatch.
+//   - `request_too_large` / `request entity too large`: the provider's HTTP 413 surfaced upstream.
+//   - `maximum context length` / `context length exceeded` / `prompt is too long`: the wording most
+//     Anthropic-compatible third-party endpoints (e.g. DeepSeek) use for the same overflow.
+// Matching any is enough to trigger recovery; all are specific enough not to catch unrelated failures
+// (an oversized upload rejected before it reaches the model, a rate-limit error, or a generic
+// invalid_request about a malformed field).
+const MEDIA_OVERFLOW_PATTERN =
+  /media[_\s-]?unstrippable|request[_\s-]?(?:entity[_\s-]?)?too[_\s-]?large|maximum context length|context[_\s-]?length[_\s-]?exceeded|prompt is too long/i
 
 // Whether a failed-prompt message indicates the request outgrew the provider's size limit.
 export const isMediaOverflowError = (message: string | undefined | null): boolean =>


### PR DESCRIPTION
## Problem

A user hit a dead-end **Agent run failed** after their conversation outgrew the provider's request-size limit (accumulated PDF page images from the agent's own file reads). The backend's own compaction ran but the request was still too large, and the final prompt failure arrived as a `-32603` RequestError the app did not recognize as an overflow — so the existing auto-recovery (reset agent context + replay a bounded text transcript) never fired.

The auto-recovery only triggered when the failure message matched `request too large` / `media_unstrippable`. Providers relay the same overflow in their own wording, so anything else dead-ends the session.

## Changes

- **`src/shared/media-overflow.ts`** — widen the overflow pattern to cover the HTTP 413 forms (`request_too_large` slug, `request entity too large`) and the context-length wordings Anthropic-compatible endpoints use (`maximum context length`, `context_length_exceeded`, `prompt is too long`). Generic `invalid_request` (e.g. a malformed field) and rate-limit errors are deliberately still excluded: tagging those recoverable would reset the agent context for errors a retry cannot fix.
- **`src/main/acp/runtime.ts`** — the recoverable tag now also matches the structured `data.errorKind` the ACP agent attaches to provider-relayed failures, so a slug-only overflow is recognized without depending on message text.
- **`src/main/acp/runtime.ts`** — `prompt failed` (and the adjacent artifact-cleanup log) now log via `errorLogFields`, so the nested RequestError keeps its message/code/data in the file log. Previously the raw Error serialized without its non-enumerable `message`, which hid the provider's real rejection reason from the log (visible in the user's main.log).

## Tests

- `media-overflow.test.ts`: positive cases for the 413 slug/phrase and third-party context-overflow wording; negative cases keep generic `invalid_request`, rate-limit, and oversized-upload messages unmatched.
- `runtime.test.ts`: an end-to-end case asserting a slug-only overflow (`data.errorKind: request_too_large`, generic message) is tagged `recoverable: 'context-overflow'`; a generic `invalid_request` failure is not; and log regression tests pinning that both the `prompt failed` and the `artifact emit after prompt failure failed` records carry the real message/code/data (the latter driven through a failing artifact repository read so the finally-block emit path is exercised).
- Full suite green: 374 files / 4340 tests; typecheck + eslint clean.

## Notes

- If a future log shows yet another provider wording for the same condition, extend `MEDIA_OVERFLOW_PATTERN` with the observed text.
- Out of scope: the case where the overflow text arrives as ordinary streamed message content and the turn still ends `end_turn` (observed in the same user's log) — the recovery listens on prompt-failure events only.

