### PR TITLE
fix(reviewer): harden audit isolation and fix-loop integrity

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2,7 +2,7 @@ import * as acp from '@agentclientprotocol/sdk'
 import type { ContentBlock, SessionModeState } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { EventEmitter } from 'node:events'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
@@ -110,6 +110,7 @@ const startFakeAgent = (
     // When true, the agent does NOT advertise session/close capability, so the runtime must fall back to
     // the session/cancel notification on delete instead of a close request.
     supportsClose?: boolean
+    rejectModeChange?: boolean
     onPrompt?: (context: {
       sessionId: string
       text: string
@@ -195,6 +196,7 @@ const startFakeAgent = (
       return { modes: options.modes }
     })
     .onRequest(acp.methods.agent.session.setMode, (ctx) => {
+      if (options.rejectModeChange) throw new Error('set mode failed')
       modeChanges.push({ sessionId: ctx.params.sessionId, modeId: ctx.params.modeId })
       actions.push(`mode:${ctx.params.modeId}`)
       return {}
@@ -2451,6 +2453,42 @@ describe('ACP runtime session management', () => {
       })
     ).rejects.toThrow(/loopback HTTP open-science-reviewer/)
     expect(spawnAgent).not.toHaveBeenCalled()
+  })
+
+  it('removes the temporary reviewer directory when session startup fails', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['reviewer-session-1'], {
+      modes: createModes(['default'], 'unexpected-mode'),
+      rejectModeChange: true
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await expect(
+      runtime.buildReviewerSession({
+        cwd: '/workspace',
+        mcpServers: [
+          {
+            type: 'http',
+            name: 'open-science-reviewer',
+            url: 'http://127.0.0.1:1/mcp',
+            headers: []
+          }
+        ]
+      })
+    ).rejects.toThrow()
+
+    expect(fakeAgent.newSessions).toHaveLength(1)
+    const reviewerSession = fakeAgent.newSessions[0]
+    if (!reviewerSession) throw new Error('Reviewer session was not created before startup failed')
+    const reviewerCwd = reviewerSession.cwd
+    expect(reviewerCwd).toMatch(/open-science-reviewer-/)
+    await expect(stat(reviewerCwd)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(reviewerSessionIds(runtime).size).toBe(0)
+    expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(false)
   })
 
   it('rejects tools from every MCP namespace except the dedicated reviewer server', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -297,6 +297,13 @@ const startPermissionProbeAgent = (
     newSessionId: string
     toolCallId: string
     toolTitle: string
+    toolKind?: 'other' | 'execute'
+    permissionOptions?: Array<{
+      optionId: string
+      name: string
+      kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always'
+    }>
+    onPermissionResponse?: (response: unknown) => void
     resume?: 'ok' | 'notFound'
   }
 ): void => {
@@ -321,16 +328,19 @@ const startPermissionProbeAgent = (
     .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
       // opencode renames MCP tools <server>_<tool>; classification must come from the session's
       // recorded MCP server names, so this exercises the sessionMcpServerNames map end to end.
-      await ctx.client.request(acp.methods.client.session.requestPermission, {
+      const response = await ctx.client.request(acp.methods.client.session.requestPermission, {
         sessionId: ctx.params.sessionId,
         toolCall: {
           toolCallId: options.toolCallId,
           title: options.toolTitle,
-          kind: 'other',
+          kind: options.toolKind ?? 'other',
           status: 'pending'
         },
-        options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+        options: options.permissionOptions ?? [
+          { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }
+        ]
       })
+      options.onPermissionResponse?.(response)
 
       return { stopReason: 'end_turn' }
     })
@@ -2325,6 +2335,75 @@ describe('ACP runtime session management', () => {
     expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(false)
   })
 
+  it('refuses a non-loopback reviewer MCP before starting an agent connection', async () => {
+    const process = new FakeAgentProcess()
+    const spawnAgent = vi.fn(() => asAgentProcess(process))
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent
+    })
+
+    await expect(
+      runtime.buildReviewerSession({
+        cwd: '/workspace',
+        mcpServers: [
+          {
+            type: 'http',
+            name: 'open-science-reviewer',
+            url: 'https://example.com/mcp',
+            headers: []
+          }
+        ]
+      })
+    ).rejects.toThrow(/loopback HTTP open-science-reviewer/)
+    expect(spawnAgent).not.toHaveBeenCalled()
+  })
+
+  it('rejects tools from every MCP namespace except the dedicated reviewer server', async () => {
+    const process = new FakeAgentProcess()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'reviewer-session-1',
+      toolCallId: 'reviewer-foreign-mcp',
+      toolTitle: 'mcp__other-server__read_file',
+      toolKind: 'execute',
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    await session.prompt([{ type: 'text', text: 'attempt an out-of-scope command' }])
+
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'reject-once' }
+    })
+    // It is generically recognized as MCP for audit logging, but the reviewer gate rejects it because
+    // its namespace does not exactly match open-science-reviewer.
+    expect(auditedIsMcp('reviewer-foreign-mcp')).toBe(true)
+    runtime.disposeReviewerSession(session)
+  })
+
   it('clears reviewer auto-approval identities when the agent disconnects', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['reviewer-session-1'])
@@ -2334,7 +2413,17 @@ describe('ACP runtime session management', () => {
       spawnAgent: () => asAgentProcess(process)
     })
 
-    await runtime.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
+    await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
     expect(reviewerSessionIds(runtime)).toEqual(new Set(['reviewer-session-1']))
 
     await runtime.disconnect()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -297,7 +297,8 @@ const startPermissionProbeAgent = (
     newSessionId: string
     toolCallId: string
     toolTitle: string
-    toolKind?: 'other' | 'execute'
+    toolKind?: 'other' | 'execute' | 'read' | null
+    providerToolName?: string
     permissionOptions?: Array<{
       optionId: string
       name: string
@@ -333,8 +334,11 @@ const startPermissionProbeAgent = (
         toolCall: {
           toolCallId: options.toolCallId,
           title: options.toolTitle,
-          kind: options.toolKind ?? 'other',
-          status: 'pending'
+          status: 'pending',
+          ...(options.toolKind === null ? {} : { kind: options.toolKind ?? 'other' }),
+          ...(options.providerToolName
+            ? { _meta: { claudeCode: { toolName: options.providerToolName } } }
+            : {})
         },
         options: options.permissionOptions ?? [
           { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }
@@ -2301,7 +2305,8 @@ describe('ACP runtime session management', () => {
     startPermissionProbeAgent(process, {
       newSessionId: 'reviewer-session-1',
       toolCallId: 'reviewer-mcp',
-      toolTitle: 'open-science-reviewer_submit_findings'
+      toolTitle: 'Submit review checks',
+      providerToolName: 'open-science-reviewer_submit_findings'
     })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
@@ -2324,6 +2329,7 @@ describe('ACP runtime session management', () => {
     })
     expect(session.sessionId).toBe('reviewer-session-1')
     expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(true)
+    expect(sessionFrameworksMap(runtime).get('reviewer-session-1')).toBe('claude-code')
 
     // Drive a tool-call permission request through the reviewer session (auto-approved by the runtime).
     await session.prompt([{ type: 'text', text: 'review this turn' }])
@@ -2333,6 +2339,93 @@ describe('ACP runtime session management', () => {
     // Disposing the reviewer session unregisters its MCP names.
     runtime.disposeReviewerSession(session)
     expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(false)
+    expect(sessionFrameworksMap(runtime).has('reviewer-session-1')).toBe(false)
+  })
+
+  it.each([null, 'read'] as const)(
+    'auto-approves an exact reviewer provider tool identity with kind %s',
+    async (toolKind) => {
+      const process = new FakeAgentProcess()
+      let permissionResponse: unknown
+      startPermissionProbeAgent(process, {
+        newSessionId: 'reviewer-session-1',
+        toolCallId: `reviewer-provider-identity-${toolKind ?? 'missing'}`,
+        toolTitle: 'Read audited turn',
+        toolKind,
+        providerToolName: 'mcp__open-science-reviewer__read_turn',
+        permissionOptions: [
+          { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+          { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+        ],
+        onPermissionResponse: (response) => {
+          permissionResponse = response
+        }
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process)
+      })
+
+      const { session } = await runtime.buildReviewerSession({
+        cwd: '/workspace',
+        mcpServers: [
+          {
+            type: 'http',
+            name: 'open-science-reviewer',
+            url: 'http://127.0.0.1:1/mcp',
+            headers: []
+          }
+        ]
+      })
+      await session.prompt([{ type: 'text', text: 'read the audited turn' }])
+
+      expect(permissionResponse).toEqual({
+        outcome: { outcome: 'selected', optionId: 'allow-once' }
+      })
+      runtime.disposeReviewerSession(session)
+    }
+  )
+
+  it('auto-approves an exact opencode reviewer tool title when provider metadata is absent', async () => {
+    const process = new FakeAgentProcess()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'reviewer-session-1',
+      toolCallId: 'reviewer-opencode-identity',
+      toolTitle: 'open-science-reviewer_read_turn',
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: opencodeFramework
+    })
+
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    await session.prompt([{ type: 'text', text: 'read the audited turn' }])
+
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    runtime.disposeReviewerSession(session)
   })
 
   it('refuses a non-loopback reviewer MCP before starting an agent connection', async () => {
@@ -2401,6 +2494,90 @@ describe('ACP runtime session management', () => {
     // It is generically recognized as MCP for audit logging, but the reviewer gate rejects it because
     // its namespace does not exactly match open-science-reviewer.
     expect(auditedIsMcp('reviewer-foreign-mcp')).toBe(true)
+    runtime.disposeReviewerSession(session)
+  })
+
+  it('rejects opencode provider tools that spoof an exact reviewer MCP method title', async () => {
+    const process = new FakeAgentProcess()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'reviewer-session-1',
+      toolCallId: 'reviewer-spoofed-execute',
+      toolTitle: 'open-science-reviewer_read_turn',
+      toolKind: 'other',
+      providerToolName: 'Bash',
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: opencodeFramework
+    })
+
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    await session.prompt([{ type: 'text', text: 'attempt a spoofed execute call' }])
+
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'reject-once' }
+    })
+    runtime.disposeReviewerSession(session)
+  })
+
+  it('rejects unknown tools inside the reviewer MCP namespace', async () => {
+    const process = new FakeAgentProcess()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'reviewer-session-1',
+      toolCallId: 'reviewer-unknown-method',
+      toolTitle: 'mcp__open-science-reviewer__run_shell',
+      providerToolName: 'mcp__open-science-reviewer__run_shell',
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    await session.prompt([{ type: 'text', text: 'attempt an unknown reviewer tool' }])
+
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'reject-once' }
+    })
     runtime.disposeReviewerSession(session)
   })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -92,7 +92,7 @@ import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
 import { isMediaOverflowError } from '../../shared/media-overflow'
-import { REVIEWER_MCP_SERVER_NAME } from '../../shared/reviewer'
+import { REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_TOOLS } from '../../shared/reviewer'
 import {
   buildImageContentData,
   canInlineImageInSession,
@@ -256,6 +256,16 @@ class SpawnFailure {
 }
 
 const log = createLogger('acp')
+
+const REVIEWER_MCP_OPENCODE_TOOL_NAMES = new Set(
+  Object.values(REVIEWER_MCP_TOOLS).map((toolName) => `${REVIEWER_MCP_SERVER_NAME}_${toolName}`)
+)
+const REVIEWER_MCP_PROVIDER_TOOL_NAMES = new Set([
+  ...REVIEWER_MCP_OPENCODE_TOOL_NAMES,
+  ...Object.values(REVIEWER_MCP_TOOLS).map(
+    (toolName) => `mcp__${REVIEWER_MCP_SERVER_NAME}__${toolName}`
+  )
+])
 
 // Logs an error without ever throwing back into the caller. Used on failure paths where a throwing
 // logger (or a hostile payload) must never mask the original error being handled/re-thrown.
@@ -2553,7 +2563,11 @@ class AcpRuntime {
       // Approve only their dedicated, scope-bounded MCP. Bash, filesystem, network, other MCP servers,
       // and unknown tools are rejected without involving the renderer.
       if (this.reviewerSessionIds.has(params.sessionId)) {
-        return this.resolveReviewerPermission(params, mcpServerNames)
+        return this.resolveReviewerPermission(
+          params,
+          mcpServerNames,
+          this.sessionFrameworks.get(params.sessionId)
+        )
       }
 
       if (!this.sessions.has(appSessionId)) {
@@ -2587,18 +2601,23 @@ class AcpRuntime {
   // uses a one-shot reject when offered and otherwise cancels; it never falls through to an allow option.
   private resolveReviewerPermission(
     params: RequestPermissionRequest,
-    mcpServerNames: readonly string[]
+    mcpServerNames: readonly string[],
+    frameworkId: string | undefined
   ): RequestPermissionResponse {
     const toolName = extractProviderToolName(params.toolCall)
-    const belongsToReviewerMcp = (name: string | null | undefined): boolean =>
-      name != null &&
-      (name === REVIEWER_MCP_SERVER_NAME ||
-        name.startsWith(`${REVIEWER_MCP_SERVER_NAME}_`) ||
-        name.startsWith(`mcp__${REVIEWER_MCP_SERVER_NAME}__`))
+    const reportedTitle = params.toolCall.title
+    const opencodeToolName =
+      toolName == null &&
+      frameworkId === 'opencode' &&
+      typeof reportedTitle === 'string' &&
+      REVIEWER_MCP_OPENCODE_TOOL_NAMES.has(reportedTitle)
+        ? reportedTitle
+        : undefined
     const isReviewerMcp =
       mcpServerNames.length === 1 &&
       mcpServerNames[0] === REVIEWER_MCP_SERVER_NAME &&
-      (belongsToReviewerMcp(params.toolCall.title) || belongsToReviewerMcp(toolName))
+      ((toolName != null && REVIEWER_MCP_PROVIDER_TOOL_NAMES.has(toolName)) ||
+        opencodeToolName != null)
 
     if (!isReviewerMcp) {
       const rejectOption =
@@ -2867,8 +2886,9 @@ class AcpRuntime {
   }
 
   private clearReviewerSessionState(): void {
-    for (const reviewerCwd of this.reviewerSessionDirectories.values()) {
+    for (const [sessionId, reviewerCwd] of this.reviewerSessionDirectories) {
       this.removeReviewerDirectory(reviewerCwd)
+      this.sessionFrameworks.delete(sessionId)
     }
     this.reviewerSessionDirectories.clear()
     this.reviewerSessionIds.clear()
@@ -2977,6 +2997,7 @@ class AcpRuntime {
       this.reviewerSessionIds.add(session.sessionId)
       this.reviewerSessionDirectories.set(session.sessionId, reviewerCwd)
       this.sessionMcpServerNames.set(session.sessionId, mcpServerNames)
+      this.sessionFrameworks.set(session.sessionId, this.framework.id)
 
       return { session, promptPrefix: setup.promptPrefix }
     } catch (error) {
@@ -2990,6 +3011,7 @@ class AcpRuntime {
   disposeReviewerSession(session: import('@agentclientprotocol/sdk').ActiveSession): void {
     this.reviewerSessionIds.delete(session.sessionId)
     this.sessionMcpServerNames.delete(session.sessionId)
+    this.sessionFrameworks.delete(session.sessionId)
     const reviewerCwd = this.reviewerSessionDirectories.get(session.sessionId)
     this.reviewerSessionDirectories.delete(session.sessionId)
     session.dispose()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -12,8 +12,10 @@ import type {
   SessionNotification
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { rmSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { pathToFileURL } from 'node:url'
 
@@ -90,6 +92,7 @@ import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
 import { isMediaOverflowError } from '../../shared/media-overflow'
+import { REVIEWER_MCP_SERVER_NAME } from '../../shared/reviewer'
 import {
   buildImageContentData,
   canInlineImageInSession,
@@ -324,10 +327,11 @@ class AcpRuntime {
   // than hardcoded so it can't drift from what createMcpServers wires up.
   private readonly sessionMcpServerNames = new Map<string, string[]>()
   // Ephemeral background reviewer sessions (built via buildReviewerSession). They are deliberately kept
-  // out of `this.sessions` — not tracked in the snapshot, not user-facing — but their tool calls still
-  // trigger permission requests over the shared agent connection. This set lets the permission handler
-  // recognise them and auto-approve without prompting (design §3: background review, no user interaction).
+  // out of `this.sessions` — not tracked in the snapshot, not user-facing. Their permission requests are
+  // handled by a strict allowlist: only the scope-bounded reviewer MCP is approved; every built-in tool is
+  // rejected. Each session also gets an empty temporary cwd so ungated read-only tools see no project data.
   private readonly reviewerSessionIds = new Set<string>()
+  private readonly reviewerSessionDirectories = new Map<string, string>()
   // A replaced agent's own session id -> the app-facing id it was adopted under (after a provider
   // switch), so agent-origin events/permissions relabel into the conversation the renderer tracks.
   private readonly agentToAppSessionId = new Map<string, string>()
@@ -1247,7 +1251,7 @@ class AcpRuntime {
     for (const timer of this.cancelTimers.values()) this.clearTimer(timer)
     this.cancelTimers.clear()
     this.permissionBroker.cancelAll()
-    this.reviewerSessionIds.clear()
+    this.clearReviewerSessionState()
     this.promptInFlightSessionIds.clear()
 
     for (const session of this.sessions.values()) {
@@ -2545,11 +2549,11 @@ class AcpRuntime {
     })
 
     try {
-      // Background reviewer sessions run unattended with a restricted toolset: auto-approve their tool
-      // calls instead of routing to the renderer (which never sees these sessions) or throwing "Unknown
-      // ACP session" because they are intentionally not in `this.sessions`. See design §3.
+      // Background reviewer sessions run unattended and are intentionally absent from `this.sessions`.
+      // Approve only their dedicated, scope-bounded MCP. Bash, filesystem, network, other MCP servers,
+      // and unknown tools are rejected without involving the renderer.
       if (this.reviewerSessionIds.has(params.sessionId)) {
-        return this.autoApproveReviewerPermission(params)
+        return this.resolveReviewerPermission(params, mcpServerNames)
       }
 
       if (!this.sessions.has(appSessionId)) {
@@ -2578,26 +2582,53 @@ class AcpRuntime {
     }
   }
 
-  // Selects an allow option for an unattended reviewer tool call. Prefers a one-shot allow (the reviewer
-  // session is ephemeral, so remembering an "always" grant is pointless) and falls back to allow_always,
-  // then the first option. A request with no allow option is cancelled rather than left hanging.
-  private autoApproveReviewerPermission(
-    params: RequestPermissionRequest
+  // Grants only the dedicated reviewer MCP. The old implementation selected the first available option
+  // for every reviewer request, which effectively approved Bash/network/filesystem tools. A denied call
+  // uses a one-shot reject when offered and otherwise cancels; it never falls through to an allow option.
+  private resolveReviewerPermission(
+    params: RequestPermissionRequest,
+    mcpServerNames: readonly string[]
   ): RequestPermissionResponse {
+    const toolName = extractProviderToolName(params.toolCall)
+    const belongsToReviewerMcp = (name: string | null | undefined): boolean =>
+      name != null &&
+      (name === REVIEWER_MCP_SERVER_NAME ||
+        name.startsWith(`${REVIEWER_MCP_SERVER_NAME}_`) ||
+        name.startsWith(`mcp__${REVIEWER_MCP_SERVER_NAME}__`))
+    const isReviewerMcp =
+      mcpServerNames.length === 1 &&
+      mcpServerNames[0] === REVIEWER_MCP_SERVER_NAME &&
+      (belongsToReviewerMcp(params.toolCall.title) || belongsToReviewerMcp(toolName))
+
+    if (!isReviewerMcp) {
+      const rejectOption =
+        params.options.find((option) => option.kind === 'reject_once') ??
+        params.options.find((option) => option.kind === 'reject_always')
+
+      log.warn('rejecting non-reviewer tool requested by background reviewer', {
+        sessionId: params.sessionId,
+        tool: toolName ?? params.toolCall.kind,
+        toolCallId: params.toolCall?.toolCallId
+      })
+
+      return rejectOption
+        ? { outcome: { outcome: 'selected', optionId: rejectOption.optionId } }
+        : { outcome: { outcome: 'cancelled' } }
+    }
+
     const allowOption =
       params.options.find((option) => option.kind === 'allow_once') ??
-      params.options.find((option) => option.kind === 'allow_always') ??
-      params.options[0]
+      params.options.find((option) => option.kind === 'allow_always')
 
     if (!allowOption) {
-      log.warn('reviewer permission request had no allow option; cancelling', {
+      log.warn('reviewer MCP permission request had no allow option; cancelling', {
         sessionId: params.sessionId,
         toolCallId: params.toolCall?.toolCallId
       })
       return { outcome: { outcome: 'cancelled' } }
     }
 
-    log.debug('auto-approving reviewer tool call', {
+    log.debug('approving scope-bounded reviewer MCP tool call', {
       sessionId: params.sessionId,
       toolCallId: params.toolCall?.toolCallId,
       optionId: allowOption.optionId
@@ -2747,7 +2778,7 @@ class AcpRuntime {
     for (const timer of this.cancelTimers.values()) this.clearTimer(timer)
     this.cancelTimers.clear()
     this.permissionBroker.cancelAll()
-    this.reviewerSessionIds.clear()
+    this.clearReviewerSessionState()
     this.sessions.clear()
     this.sessionCwds.clear()
     this.sessionInlineImageBytes.clear()
@@ -2835,11 +2866,32 @@ class AcpRuntime {
     this.callbacks.onStateChanged?.(this.getSnapshot())
   }
 
+  private clearReviewerSessionState(): void {
+    for (const reviewerCwd of this.reviewerSessionDirectories.values()) {
+      this.removeReviewerDirectory(reviewerCwd)
+    }
+    this.reviewerSessionDirectories.clear()
+    this.reviewerSessionIds.clear()
+  }
+
+  private removeReviewerDirectory(reviewerCwd: string): void {
+    try {
+      rmSync(reviewerCwd, { recursive: true, force: true })
+    } catch (error) {
+      log.warn('failed to remove temporary reviewer directory', {
+        reviewerCwd,
+        error: errorMessage(error)
+      })
+    }
+  }
+
   // Creates an ephemeral reviewer ACP session using the existing agent connection. The reviewer
   // session is isolated from main agent sessions: it is not tracked in this.sessions, does not
   // appear in the snapshot, and callers are responsible for disposing it. This allows background
   // review to run in parallel with the main session without affecting the main state machine.
   async buildReviewerSession(request: {
+    // Used only to establish/reuse the shared agent connection. The reviewer session itself runs in an
+    // app-created empty temporary directory so built-in read tools cannot see the audited workspace.
     cwd: string
     mcpServers: McpServer[]
     systemPromptAppend?: string
@@ -2849,28 +2901,88 @@ class AcpRuntime {
     // opencode has no preset so the rubric rides back as a prompt prefix the caller must prepend.
     promptPrefix?: string
   }> {
+    const mcpServerNames = this.mcpServerNamesOf(request.mcpServers)
+    const reviewerMcp = request.mcpServers[0]
+    const reviewerMcpHttp =
+      reviewerMcp && 'type' in reviewerMcp && reviewerMcp.type === 'http' ? reviewerMcp : undefined
+    let reviewerMcpUrl: URL | undefined
+    try {
+      reviewerMcpUrl = reviewerMcpHttp ? new URL(reviewerMcpHttp.url) : undefined
+    } catch {
+      reviewerMcpUrl = undefined
+    }
+    if (
+      request.mcpServers.length !== 1 ||
+      mcpServerNames.length !== 1 ||
+      mcpServerNames[0] !== REVIEWER_MCP_SERVER_NAME ||
+      !reviewerMcpHttp ||
+      reviewerMcpUrl?.protocol !== 'http:' ||
+      reviewerMcpUrl.hostname !== '127.0.0.1'
+    ) {
+      throw new Error(
+        `Reviewer sessions require exactly one loopback HTTP ${REVIEWER_MCP_SERVER_NAME} MCP server.`
+      )
+    }
+
     const connection = await this.ensureConnected(request.cwd)
+    const reviewerCwd = await mkdtemp(join(tmpdir(), 'open-science-reviewer-'))
 
     const setup = this.framework.buildSessionSetup({
       systemPromptAppends: request.systemPromptAppend ? [request.systemPromptAppend] : []
     })
+    const reviewerMeta: Record<string, unknown> = {
+      ...(setup.meta ?? {}),
+      // claude-agent-acp's framework-neutral legacy switch; harmless to agents that ignore it.
+      disableBuiltInTools: true
+    }
+    if (this.framework.id === 'claude-code') {
+      const claudeCode =
+        typeof reviewerMeta.claudeCode === 'object' && reviewerMeta.claudeCode !== null
+          ? (reviewerMeta.claudeCode as Record<string, unknown>)
+          : {}
+      const claudeOptions =
+        typeof claudeCode.options === 'object' && claudeCode.options !== null
+          ? (claudeCode.options as Record<string, unknown>)
+          : {}
+      reviewerMeta.claudeCode = {
+        ...claudeCode,
+        options: { ...claudeOptions, tools: [] }
+      }
+    }
 
-    const session = await connection.agent
-      .buildSession({
-        cwd: request.cwd,
-        mcpServers: request.mcpServers,
-        ...(setup.meta ? { _meta: setup.meta } : {})
-      })
-      .start()
+    try {
+      const session = await connection.agent
+        .buildSession({
+          cwd: reviewerCwd,
+          mcpServers: request.mcpServers,
+          _meta: reviewerMeta
+        })
+        .start()
 
-    // Register so the permission handler recognises this session and auto-approves its tool calls.
-    // The orchestrator must call disposeReviewerSession() to unregister and tear it down.
-    this.reviewerSessionIds.add(session.sessionId)
-    // Record the reviewer's MCP server names too, so its MCP tool calls are audited as MCP (they are
-    // still auto-approved via reviewerSessionIds, but the isMcp classification must stay accurate).
-    this.sessionMcpServerNames.set(session.sessionId, this.mcpServerNamesOf(request.mcpServers))
+      try {
+        // Apply the framework's Ask baseline before prompting. The dedicated reviewer MCP is
+        // then selectively approved by resolveReviewerPermission; all other permission requests fail.
+        const permission = this.framework.mapPermissionProfile('ask', session.modes)
+        if (permission.modeId && permission.modeId !== session.modes?.currentModeId) {
+          await connection.agent.request(acp.methods.agent.session.setMode, {
+            sessionId: session.sessionId,
+            modeId: permission.modeId
+          })
+        }
+      } catch (error) {
+        session.dispose()
+        throw error
+      }
 
-    return { session, promptPrefix: setup.promptPrefix }
+      this.reviewerSessionIds.add(session.sessionId)
+      this.reviewerSessionDirectories.set(session.sessionId, reviewerCwd)
+      this.sessionMcpServerNames.set(session.sessionId, mcpServerNames)
+
+      return { session, promptPrefix: setup.promptPrefix }
+    } catch (error) {
+      this.removeReviewerDirectory(reviewerCwd)
+      throw error
+    }
   }
 
   // Disposes an ephemeral reviewer session and unregisters it from the auto-approve set. Safe to call
@@ -2878,7 +2990,10 @@ class AcpRuntime {
   disposeReviewerSession(session: import('@agentclientprotocol/sdk').ActiveSession): void {
     this.reviewerSessionIds.delete(session.sessionId)
     this.sessionMcpServerNames.delete(session.sessionId)
+    const reviewerCwd = this.reviewerSessionDirectories.get(session.sessionId)
+    this.reviewerSessionDirectories.delete(session.sessionId)
     session.dispose()
+    if (reviewerCwd) this.removeReviewerDirectory(reviewerCwd)
   }
 }
 

--- a/src/main/projects/prisma-client.test.ts
+++ b/src/main/projects/prisma-client.test.ts
@@ -103,7 +103,7 @@ describe('project prisma client (integration)', () => {
     expect(stored.checks[0]!.reflagCount).toBe(0)
 
     // Increment and verify the Prisma client can read the updated value.
-    await reviewRepo.incrementReflagCount(review.id, 'test claim')
+    await reviewRepo.incrementReflagCount(review.id, stored.checks[0]!.id)
     const [updated] = await reviewRepo.getReviewsForSession('s1')
     expect(updated.checks[0]!.reflagCount).toBe(1)
 

--- a/src/main/reviewer/correction.test.ts
+++ b/src/main/reviewer/correction.test.ts
@@ -96,10 +96,11 @@ const callSubmitFindings = async (
   mcpBaseUrl: string,
   token: string,
   checks: Array<{
-    status: 'warn' | 'fail'
+    status: 'pass' | 'warn' | 'fail'
     claim: string
     evidence: string
-    locator: {
+    sourceFindingId?: string
+    locator?: {
       blockRef: { messageId?: string; activityId?: string; blockIndex: number }
       contentHash: string
     }
@@ -186,10 +187,11 @@ const startFakeAgent = (
     mainSessionId: string
     simulateFindingsViaHttp?: boolean
     checksToSubmit?: Array<{
-      status: 'warn' | 'fail'
+      status: 'pass' | 'warn' | 'fail'
       claim: string
       evidence: string
-      locator: {
+      sourceFindingId?: string
+      locator?: {
         blockRef: { messageId?: string; activityId?: string; blockIndex: number }
         contentHash: string
       }
@@ -355,6 +357,7 @@ describe('single-round auditor correction', () => {
       acpRuntime: runtime,
       artifactStorageRoot: temporaryRoot!,
       mainSessionId: 'main-session-1',
+      sessionRefreshTimeoutMs: 0,
       onCorrectionPrompt: (text) => correctionPrompts.push(text)
     })
 
@@ -387,10 +390,11 @@ describe('single-round auditor correction', () => {
 
   it('does not inject an [Auditor] message for a pass review', async () => {
     const process = new FakeAgentProcess()
-    // No simulateFindingsViaHttp → reviewer calls submit_findings with empty array (not called → treated as pass)
     startFakeAgent(process, {
       reviewerSessionId: 'reviewer-session-1',
-      mainSessionId: 'main-session-1'
+      mainSessionId: 'main-session-1',
+      simulateFindingsViaHttp: true,
+      checksToSubmit: []
     })
 
     const runtime = new AcpRuntime({
@@ -466,7 +470,8 @@ describe('single-round auditor correction', () => {
       reviewRepository: repository,
       acpRuntime: runtime,
       artifactStorageRoot: temporaryRoot!,
-      mainSessionId: 'main-session-1'
+      mainSessionId: 'main-session-1',
+      sessionRefreshTimeoutMs: 0
     })
 
     // v2: checks not findings
@@ -483,7 +488,7 @@ describe('single-round auditor correction', () => {
     await client.$disconnect()
   })
 
-  it('Phase 3 fix loop triggers internal re-review (not via external onRunReviewCalled)', async () => {
+  it('does not re-review a stale session snapshot when the correction was not persisted', async () => {
     const process = new FakeAgentProcess()
     const checksToSubmit = [
       {
@@ -526,6 +531,7 @@ describe('single-round auditor correction', () => {
       acpRuntime: runtime,
       artifactStorageRoot: temporaryRoot!,
       mainSessionId: 'main-session-1',
+      sessionRefreshTimeoutMs: 0,
       onCorrectionPrompt: (text) => correctionPrompts.push(text),
       onRunReviewCalled: () => {
         runReviewCallCount++
@@ -538,14 +544,14 @@ describe('single-round auditor correction', () => {
     // The fix loop attempted at least one correction round.
     expect(correctionPrompts.length).toBeGreaterThanOrEqual(1)
 
-    // Phase 3: the fix loop spawns more than 1 reviewer session (initial + re-review(s)).
-    // Note: the correction.test.ts fake agent reuses the same MCP server reference for all
-    // reviewer sessions (single-session design); the re-review may fail and terminate early.
-    // The key invariant: re-reviews are driven internally, not via external calls.
+    // No fresh correction message exists in the supplied session state, so re-reviewing would audit
+    // the old turn and could produce a false resolution. The loop stops before spawning one.
     const reviewerSessions = agentState.newSessions.filter(
       (s) => s.sessionId === 'reviewer-session-1'
     )
-    expect(reviewerSessions.length).toBeGreaterThanOrEqual(2)
+    expect(reviewerSessions).toHaveLength(1)
+    const stored = await repository.getReviewsForSession('session-1')
+    expect(stored[0]?.checks[0]?.resolution).toBe('unaddressed')
 
     await client.$disconnect()
   })

--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -66,6 +66,7 @@ const callSubmitFindings = async (
     status: 'pass' | 'warn' | 'fail'
     claim: string
     evidence: string
+    sourceFindingId?: string
     locator?: {
       blockRef: { messageId?: string; activityId?: string; blockIndex: number }
       contentHash: string
@@ -144,6 +145,7 @@ type ReReviewChecks = Array<{
   status: 'pass' | 'warn' | 'fail'
   claim: string
   evidence: string
+  sourceFindingId?: string
   locator?: {
     blockRef: { messageId?: string; activityId?: string; blockIndex: number }
     contentHash: string
@@ -264,7 +266,15 @@ const startFixLoopFakeAgent = (
           } else {
             // Re-review round (roundIndex >= 1): use re-review checks for this round
             const reReviewRoundIndex = roundIndex - 1
-            const reReviewChecks = options.reReviewChecksByRound?.[reReviewRoundIndex] ?? []
+            const trackedFindingIds = [...text.matchAll(/"sourceFindingId":"([^"]+)"/g)].map(
+              (match) => match[1]!
+            )
+            const reReviewChecks = (options.reReviewChecksByRound?.[reReviewRoundIndex] ?? []).map(
+              (check, index) => ({
+                ...check,
+                sourceFindingId: check.sourceFindingId ?? trackedFindingIds[index]
+              })
+            )
             await callSubmitFindings(reviewerMcp.url, token, reReviewChecks)
           }
         }
@@ -481,6 +491,91 @@ describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
   })
 })
 
+describe('fix loop: newly discovered issues remain in the automatic remediation loop', () => {
+  it('carries a new re-review finding into the next round and resolves it by its own id', async () => {
+    const process = new FakeAgentProcess()
+    const shared = makeSharedSession(makeSession())
+    const correctionPrompts: string[] = []
+
+    const agentState = startFixLoopFakeAgent(
+      process,
+      {
+        mainSessionId: 'main-session-1',
+        initialChecks: [
+          {
+            status: 'fail',
+            claim: 'Original incorrect result',
+            evidence: 'The first output is contradictory',
+            locator: { blockRef: { blockIndex: 1 }, contentHash: 'original' }
+          }
+        ],
+        reReviewChecksByRound: [
+          [
+            {
+              status: 'pass',
+              claim: 'Original result is fixed',
+              evidence: 'The correction now matches the record'
+            },
+            {
+              status: 'fail',
+              claim: 'Correction introduced a new unit error',
+              evidence: 'The corrected value is labeled with the wrong unit',
+              locator: { blockRef: { blockIndex: 1 }, contentHash: 'new-issue' }
+            }
+          ],
+          [
+            {
+              status: 'pass',
+              claim: 'The newly introduced unit error is fixed',
+              evidence: 'The value and unit now agree'
+            }
+          ]
+        ],
+        onCorrectionPrompt: (text) => correctionPrompts.push(text)
+      },
+      shared
+    )
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => shared.getSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1'
+    })
+
+    expect(correctionPrompts).toHaveLength(2)
+    expect(
+      agentState.sessions.filter((session) => session.sessionId.startsWith('reviewer-session'))
+    ).toHaveLength(3)
+    const checks = (await repository.getReviewsForSession('session-1')).flatMap(
+      (review) => review.checks
+    )
+    expect(checks.find((check) => check.claim === 'Original incorrect result')?.resolution).toBe(
+      'resolved'
+    )
+    expect(
+      checks.find((check) => check.claim === 'Correction introduced a new unit error')?.resolution
+    ).toBe('resolved')
+
+    await client.$disconnect()
+  })
+})
+
 describe('fix loop: cap at 3 rounds → unaddressed', () => {
   it('stops after 3 rounds; remaining warn/fail set to unaddressed; exactly 3 injections', async () => {
     const process = new FakeAgentProcess()
@@ -577,8 +672,8 @@ describe('fix loop: cap at 3 rounds → unaddressed', () => {
   })
 })
 
-describe('fix loop: over-correction increments reflagCount', () => {
-  it('increments reflagCount when the same claim fails again on re-review', async () => {
+describe('fix loop: stable finding identity survives reviewer paraphrases', () => {
+  it('increments reflagCount instead of resolving when the same issue is reworded', async () => {
     const process = new FakeAgentProcess()
     const shared = makeSharedSession(makeSession())
 
@@ -594,12 +689,12 @@ describe('fix loop: over-correction increments reflagCount', () => {
             locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc' }
           }
         ],
-        // Round 1: over-correction — same claim fails again
+        // Round 1: the reviewer describes the same tracked issue with different wording.
         reReviewChecksByRound: [
           [
             {
               status: 'fail',
-              claim: 'Value should be 42',
+              claim: 'The corrected value is still not the expected forty-two',
               evidence: 'Now shows 100 — over-corrected',
               locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc2' }
             }
@@ -608,7 +703,7 @@ describe('fix loop: over-correction increments reflagCount', () => {
           [
             {
               status: 'pass',
-              claim: 'Value should be 42',
+              claim: 'The value now matches the expected result',
               evidence: 'Now correct'
             }
           ]

--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -19,7 +19,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from '../acp/runtime'
 import { ReviewRepository } from './repository'
@@ -567,6 +567,70 @@ describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
         )
       )
     ).toBe(true)
+
+    await client.$disconnect()
+  })
+})
+
+describe('fix loop: cancellation', () => {
+  it('stops before the first correction round when cancelled as the loop starts', async () => {
+    const process = new FakeAgentProcess()
+    const shared = makeSharedSession(makeSession())
+    const correctionPrompts: string[] = []
+    const abortController = new AbortController()
+    const onFixLoopStart = vi.fn(() => abortController.abort())
+    const onFixLoopEnd = vi.fn()
+
+    const agentState = startFixLoopFakeAgent(
+      process,
+      {
+        mainSessionId: 'main-session-1',
+        initialChecks: [
+          {
+            status: 'fail',
+            claim: 'Agent claimed 42 results',
+            evidence: 'Tool output shows 0 results',
+            locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc123' }
+          }
+        ],
+        onCorrectionPrompt: (text) => correctionPrompts.push(text)
+      },
+      shared
+    )
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => shared.getSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1',
+      onCorrectionPrompt: (text) => correctionPrompts.push(text),
+      onFixLoopStart,
+      onFixLoopEnd,
+      fixLoopAbortSignal: abortController.signal
+    })
+
+    expect(onFixLoopStart).toHaveBeenCalledTimes(1)
+    expect(onFixLoopEnd).toHaveBeenCalledTimes(1)
+    expect(correctionPrompts).toEqual([])
+    expect(
+      agentState.sessions.filter((session) => session.sessionId.startsWith('reviewer-session'))
+    ).toHaveLength(1)
+    expect(review.checks[0]?.resolution).toBe('open')
 
     await client.$disconnect()
   })

--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -489,6 +489,87 @@ describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
 
     await client.$disconnect()
   })
+
+  it('waits for a complete correction message before starting re-review', async () => {
+    const process = new FakeAgentProcess()
+    const shared = makeSharedSession(makeSession())
+    let correctionPolls = 0
+
+    startFixLoopFakeAgent(
+      process,
+      {
+        mainSessionId: 'main-session-1',
+        initialChecks: [
+          {
+            status: 'fail',
+            claim: 'Agent claimed 42 results',
+            evidence: 'Tool output shows 0 results',
+            locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc123' }
+          }
+        ],
+        reReviewChecksByRound: [
+          [
+            {
+              status: 'pass',
+              claim: 'Agent claimed 42 results',
+              evidence: 'Correction confirmed: results now correct'
+            }
+          ]
+        ]
+      },
+      shared
+    )
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => {
+        const session = shared.getSession()
+        const correction = session.messages.find((message) => message.id === 'correction-msg-1')
+        if (!correction) return session
+
+        correctionPolls++
+        if (correctionPolls > 1) return session
+
+        return {
+          ...session,
+          messages: session.messages.map((message) =>
+            message.id === correction.id
+              ? { ...message, status: 'error', content: 'Partial correction was interrupted.' }
+              : message
+          )
+        }
+      },
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1'
+    })
+
+    expect(correctionPolls).toBeGreaterThanOrEqual(2)
+    const reviews = await repository.getReviewsForSession('session-1')
+    expect(
+      reviews.some((review) =>
+        review.checks.some(
+          (check) => check.claim === 'Agent claimed 42 results' && check.resolution === 'resolved'
+        )
+      )
+    ).toBe(true)
+
+    await client.$disconnect()
+  })
 })
 
 describe('fix loop: newly discovered issues remain in the automatic remediation loop', () => {

--- a/src/main/reviewer/host-sdk.ts
+++ b/src/main/reviewer/host-sdk.ts
@@ -1,11 +1,7 @@
-// Host SDK for the reviewer REPL sandbox. Provides scope-narrowed read functions that the reviewer
-// calls from Python code to access the audited turn's data. All access is validated against the
-// TurnScope produced by resolveTurnScope; out-of-scope ids are rejected.
-//
-// The "host" module is injected into the reviewer Python sandbox via an HTTP RPC endpoint (mirroring
-// how the notebook MCP server's host.mcp() works). The reviewer REPL's Python bridge boots a _Host
-// object; calls to host.read_turn() / host.query_execution_log() / host.read_artifact() POST to this
-// server and get back JSON.
+// Turn-scoped evidence access for the reviewer. Production calls the public read methods through the
+// dedicated reviewer MCP server, which validates every activity/artifact id against TurnScope. The
+// authenticated HTTP adapter remains for compatibility tests and older callers, but the reviewer no
+// longer receives its endpoint/token or executes a Python bootstrap.
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { readFile } from 'node:fs/promises'
@@ -73,8 +69,7 @@ export type ArtifactContent = TabularArtifactContent | RawArtifactContent
 // tell a guessing reviewer exactly what IS available (it likes to try e.g. `list_artifacts`).
 export const SUPPORTED_HOST_METHODS = ['read_turn', 'query_execution_log', 'read_artifact'] as const
 
-// The HTTP RPC server that backs the host.* Python functions in the reviewer sandbox.
-// It verifies every requested id against the TurnScope so the reviewer can only see this turn.
+// Scope-enforcing evidence reader with a legacy authenticated HTTP adapter.
 export class ReviewerHostServer {
   private server: Server
   readonly token: string
@@ -172,7 +167,7 @@ export class ReviewerHostServer {
   }
 
   // Returns the ordered blocks for this turn with their content and metadata.
-  private readTurn(): OrderedBlock[] {
+  readTurn(): OrderedBlock[] {
     const messageMap = new Map(this.session.messages.map((m) => [m.id, m]))
     const activityMap = new Map((this.session.activities ?? []).map((a) => [a.id, a]))
 
@@ -209,7 +204,7 @@ export class ReviewerHostServer {
   }
 
   // Returns execution records for this turn's activities, optionally filtered to one activity.
-  private queryExecutionLog(activityId?: string): ExecRecord[] {
+  queryExecutionLog(activityId?: string): ExecRecord[] {
     const activityIds = new Set(
       this.scope.blocks.filter((b) => b.kind === 'activity').map((b) => b.sourceId)
     )
@@ -240,7 +235,7 @@ export class ReviewerHostServer {
   // Tabular artifacts (CSV/TSV) are returned as { kind:'tabular'; columns; rowCount } so the
   // reviewer can address by column name without visual row alignment. Non-tabular artifacts
   // return { kind:'raw'; content; encoding }.
-  private async readArtifact(id: string): Promise<ArtifactContent> {
+  async readArtifact(id: string): Promise<ArtifactContent> {
     if (!this.scope.artifactVersionIds.includes(id)) {
       throw new Error(
         `Artifact id ${JSON.stringify(id)} is not in this turn's scope. ` +

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -44,9 +44,11 @@ vi.mock('../projects/prisma-client', () => ({
 
 // Shared, controllable session loader so a test can make the pre-runReview session load fail.
 const sessionLoadAll = vi.fn().mockResolvedValue({ sessions: [] })
+const sessionLoadOne = vi.fn().mockResolvedValue({ id: 'session-1' })
 vi.mock('../session-persistence/repository', () => ({
   SessionRepository: class {
     loadAll = sessionLoadAll
+    loadSession = sessionLoadOne
   },
   // storage-root imports these names from the same module in production; keep them defined.
   DEV_SESSION_DIR_NAME: 'dev',
@@ -78,8 +80,10 @@ beforeEach(() => {
   })
   broadcastToRenderers.mockClear()
   sessionLoadAll.mockReset()
-  // Default: the requested session exists, so triggerReview proceeds to runReview.
   sessionLoadAll.mockResolvedValue({ sessions: [{ id: 'session-1' }] })
+  sessionLoadOne.mockReset()
+  // Default: the requested session exists, so triggerReview proceeds to runReview.
+  sessionLoadOne.mockResolvedValue({ id: 'session-1' })
   getReviewsForSession.mockReset()
   // Default: no prior review for the turn, so the auto-idempotency check lets the run proceed.
   getReviewsForSession.mockResolvedValue([])
@@ -140,6 +144,27 @@ describe('reviewer IPC handlers', () => {
     expect(passed.scopeTurnMessageId).toBe('correction')
   })
 
+  it('passes a live session loader to the orchestrator instead of a review-start snapshot', async () => {
+    sessionLoadOne
+      .mockResolvedValueOnce({ id: 'session-1', messages: [{ id: 'original-turn' }] })
+      .mockResolvedValueOnce({ id: 'session-1', messages: [{ id: 'correction-turn' }] })
+    registerReviewerIpcHandlers({ acpRuntime })
+
+    const runHandler = handlers.get(REVIEWER_IPC.RUN)
+    await runHandler?.({}, createRequest())
+    await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
+
+    const passed = runReview.mock.calls[0][0] as {
+      getSession: () => Promise<{ messages: Array<{ id: string }> } | undefined>
+    }
+    const refreshed = await passed.getSession()
+
+    expect(refreshed?.messages[0]?.id).toBe('correction-turn')
+    expect(sessionLoadOne).toHaveBeenCalledTimes(2)
+    expect(sessionLoadOne).toHaveBeenNthCalledWith(1, 'project-1', 'session-1')
+    expect(sessionLoadOne).toHaveBeenNthCalledWith(2, 'project-1', 'session-1')
+  })
+
   it('dedupes concurrent reviews of the same turn (double-click / multiple stale cards)', async () => {
     runReview.mockClear()
     // Hold runReview open so both synchronous triggers overlap in flight.
@@ -167,7 +192,7 @@ describe('reviewer IPC handlers', () => {
 
   it('returns started:false without a review row or broadcast when the session load fails', async () => {
     // The pre-runReview session load throws (e.g. DB/FS unavailable).
-    sessionLoadAll.mockRejectedValueOnce(new Error('session store unavailable'))
+    sessionLoadOne.mockRejectedValueOnce(new Error('session store unavailable'))
     registerReviewerIpcHandlers({ acpRuntime })
 
     const runHandler = handlers.get(REVIEWER_IPC.RUN)
@@ -180,11 +205,10 @@ describe('reviewer IPC handlers', () => {
   })
 
   it('returns started:false without calling runReview when the session id is gone', async () => {
-    // loadAll succeeds but the session was deleted between the card render and the click. Falling
+    // The direct session load succeeds but the session was deleted between card render and click. Falling
     // through to runReview would create a non-retriable error card that replaces the stale card the
     // user was re-running; instead we bail with started:false so the existing card + Re-run survive.
-    sessionLoadAll.mockReset()
-    sessionLoadAll.mockResolvedValue({ sessions: [{ id: 'a-different-session' }] })
+    sessionLoadOne.mockResolvedValueOnce(undefined)
     registerReviewerIpcHandlers({ acpRuntime })
 
     const runHandler = handlers.get(REVIEWER_IPC.RUN)
@@ -199,10 +223,8 @@ describe('reviewer IPC handlers', () => {
     // Models the persistence race: the first load misses the not-yet-flushed session (started:false),
     // the retry sees it. The retry starting proves the not-found bail released the dedup lock (a stuck
     // lock would drop the retry as "already in flight").
-    sessionLoadAll.mockReset()
-    sessionLoadAll
-      .mockResolvedValueOnce({ sessions: [] })
-      .mockResolvedValue({ sessions: [{ id: 'session-1' }] })
+    sessionLoadOne.mockReset()
+    sessionLoadOne.mockResolvedValueOnce(undefined).mockResolvedValue({ id: 'session-1' })
     registerReviewerIpcHandlers({ acpRuntime })
 
     const runHandler = handlers.get(REVIEWER_IPC.RUN)

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -168,10 +168,17 @@ const registerReviewerIpcHandlers = (
       }
     }
 
+    // Direct, repeatable loader used both for the start gate and every fix-loop refresh. The previous
+    // closure returned the `session` variable below forever, so a correction turn could never appear.
+    const loadCurrentSession = async (): Promise<PersistedChatSession | undefined> => {
+      if (projectId) return sessionRepository.loadSession(projectId, sessionId)
+      const { sessions } = await sessionRepository.loadAll()
+      return sessions.find((candidate) => candidate.id === sessionId)
+    }
+
     let session: PersistedChatSession | undefined
     try {
-      const { sessions } = await sessionRepository.loadAll()
-      session = sessions.find((s) => s.id === sessionId)
+      session = await loadCurrentSession()
     } catch (error) {
       // No Review row exists to update, so surface the failure only as started:false — the renderer
       // keeps the (stale) card and its Re-run affordance so the user can try again.
@@ -224,7 +231,9 @@ const registerReviewerIpcHandlers = (
         projectId,
         mainSessionId,
         model: model ?? '',
-        getSession: () => session,
+        // Reload on every orchestrator request. In particular, the post-correction read must observe
+        // the newly persisted [Auditor] and agent messages instead of the review-start snapshot.
+        getSession: loadCurrentSession,
         reviewRepository,
         acpRuntime: options.acpRuntime,
         // Artifacts live under the relocatable data root; DB/sessions stay on the config root.

--- a/src/main/reviewer/lifecycle.test.ts
+++ b/src/main/reviewer/lifecycle.test.ts
@@ -175,8 +175,9 @@ type FakeAgentState = {
   promptsReceived: Map<string, string[]>
   closedSessions: string[]
   // Records the outcome of any permission request the reviewer session raised (regression coverage for
-  // background reviewer auto-approval — an un-tracked reviewer session must not be rejected as unknown).
+  // background reviewer permission handling, including the exact allow/reject option selected).
   reviewerPermissionOutcomes: string[]
+  reviewerPermissionOptionIds: Array<string | undefined>
 }
 
 const startFakeAgent = (
@@ -204,7 +205,8 @@ const startFakeAgent = (
     newSessions: [],
     promptsReceived: new Map(),
     closedSessions: [],
-    reviewerPermissionOutcomes: []
+    reviewerPermissionOutcomes: [],
+    reviewerPermissionOptionIds: []
   }
 
   acp
@@ -261,6 +263,9 @@ const startFakeAgent = (
           ]
         })
         state.reviewerPermissionOutcomes.push(permission.outcome.outcome)
+        state.reviewerPermissionOptionIds.push(
+          permission.outcome.outcome === 'selected' ? permission.outcome.optionId : undefined
+        )
       }
 
       // If this is the reviewer session, simulate submit_findings via HTTP.
@@ -336,8 +341,8 @@ describe('reviewer app lifecycle integration', () => {
       startFakeAgent(process, {
         reviewerSessionId: 'reviewer-session-1',
         mainSessionId: 'main-session-1',
-        // No checks submitted → pass
-        simulateFindingsViaHttp: false
+        // An explicit empty submission is a valid pass.
+        simulateFindingsViaHttp: true
       })
 
       const runtime = new AcpRuntime({
@@ -387,14 +392,14 @@ describe('reviewer app lifecycle integration', () => {
       await client.$disconnect()
     })
 
-    it('auto-approves the reviewer session tool calls instead of rejecting them as unknown', async () => {
+    it('rejects an out-of-scope reviewer execution request without breaking the review', async () => {
       const process = new FakeAgentProcess()
       const state = startFakeAgent(process, {
         reviewerSessionId: 'reviewer-session-1',
         mainSessionId: 'main-session-1',
-        // The reviewer raises a permission request (as it would when running Python in its REPL).
+        // The reviewer raises the legacy Python execution request that must now be denied.
         requestPermissionFromReviewer: true,
-        simulateFindingsViaHttp: false
+        simulateFindingsViaHttp: true
       })
 
       const runtime = new AcpRuntime({
@@ -420,10 +425,11 @@ describe('reviewer app lifecycle integration', () => {
         artifactStorageRoot: temporaryRoot!
       })
 
-      // The reviewer's permission request was auto-approved (selected), not rejected/thrown.
+      // The request is handled unattended, but the selected option is the explicit rejection.
       expect(state.reviewerPermissionOutcomes).toEqual(['selected'])
-      // The review still completed end-to-end.
+      expect(state.reviewerPermissionOptionIds).toEqual(['reject-once'])
       expect(review.lifecycle).toBe('complete')
+      expect(review.outcome).toBe('pass')
 
       await client.$disconnect()
     })
@@ -529,6 +535,7 @@ describe('reviewer app lifecycle integration', () => {
         reviewRepository: repository,
         acpRuntime: runtime,
         artifactStorageRoot: temporaryRoot!,
+        sessionRefreshTimeoutMs: 0,
         onCorrectionPrompt: (text) => correctionPrompts.push(text)
       })
 
@@ -640,6 +647,7 @@ describe('reviewer app lifecycle integration', () => {
         reviewRepository: repository,
         acpRuntime: runtime,
         artifactStorageRoot: temporaryRoot!,
+        sessionRefreshTimeoutMs: 0,
         onCorrectionPrompt: (text) => correctionPrompts.push(text),
         onRunReviewCalled: () => {
           runReviewCallCount++
@@ -650,14 +658,14 @@ describe('reviewer app lifecycle integration', () => {
       // The fix loop is driven by runFixLoop (internal), not by external runReview re-calls.
       expect(runReviewCallCount).toBe(0)
 
-      // Phase 3: the fix loop triggers internal re-reviews — multiple reviewer sessions spawn.
-      // The fake agent keeps returning the same findings for each reviewer session, so the loop
-      // runs 3 rounds (cap) and ends with unaddressed. At minimum 4 sessions: initial + 3 re-reviews.
+      // The fake persistence snapshot never gains a correction message. The loop must fail closed
+      // instead of re-reviewing the original stale turn and falsely resolving the issue.
       const reviewerSessions = agentState.newSessions.filter(
         (s) => s.sessionId === 'reviewer-session-1'
       )
-      // The key invariant: re-reviews are driven internally (not via external trigger).
-      expect(reviewerSessions.length).toBeGreaterThan(1)
+      expect(reviewerSessions).toHaveLength(1)
+      const stored = await repository.getReviewsForSession('session-1')
+      expect(stored[0]?.checks[0]?.resolution).toBe('unaddressed')
 
       await client.$disconnect()
     })

--- a/src/main/reviewer/mcp-server.test.ts
+++ b/src/main/reviewer/mcp-server.test.ts
@@ -629,6 +629,75 @@ describe('ReviewerMcpServer HTTP transport', () => {
     }
   })
 
+  it('accepts exactly one of two concurrent submit_findings calls', async () => {
+    let submissionsStarted = 0
+    let releaseSubmission: (() => void) | undefined
+    const submissionGate = new Promise<void>((resolve) => {
+      releaseSubmission = resolve
+    })
+    const releaseTimer = setTimeout(() => releaseSubmission?.(), 100)
+    const onSubmit = vi.fn(async () => {
+      submissionsStarted++
+      if (submissionsStarted === 2) releaseSubmission?.()
+      await submissionGate
+    })
+    const server = new ReviewerMcpServer(scope, onSubmit)
+    const { endpoint, token } = await server.start()
+
+    try {
+      const { sessionId, headers } = await initialize(endpoint, token)
+      const calls = await Promise.all([
+        callTool(endpoint, sessionId, headers, 'submit_findings', { checks: [] }, 2),
+        callTool(endpoint, sessionId, headers, 'submit_findings', { checks: [] }, 3)
+      ])
+
+      expect(calls.map((call) => call.result?.isError === true).sort()).toEqual([false, true])
+      expect(calls.find((call) => call.result?.isError)?.result?.content?.[0]?.text).toContain(
+        'already called'
+      )
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    } finally {
+      clearTimeout(releaseTimer)
+      releaseSubmission?.()
+      await server.stop()
+    }
+  })
+
+  it('allows submit_findings to retry after the submission handler fails', async () => {
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('persistence failed'))
+      .mockResolvedValueOnce(undefined)
+    const server = new ReviewerMcpServer(scope, onSubmit)
+    const { endpoint, token } = await server.start()
+
+    try {
+      const { sessionId, headers } = await initialize(endpoint, token)
+      const failed = await callTool(
+        endpoint,
+        sessionId,
+        headers,
+        'submit_findings',
+        { checks: [] },
+        2
+      )
+      expect(failed.result?.isError).toBe(true)
+
+      const retry = await callTool(
+        endpoint,
+        sessionId,
+        headers,
+        'submit_findings',
+        { checks: [] },
+        3
+      )
+      expect(retry.result?.isError).not.toBe(true)
+      expect(onSubmit).toHaveBeenCalledTimes(2)
+    } finally {
+      await server.stop()
+    }
+  })
+
   it('rejects submit_findings with a summary field (schema-level validation)', async () => {
     // The MCP SDK may strip unknown fields before passing to the handler, but the schema
     // itself rejects summary. Verify at the schema level (the HTTP transport test for this

--- a/src/main/reviewer/mcp-server.test.ts
+++ b/src/main/reviewer/mcp-server.test.ts
@@ -5,10 +5,11 @@
 // v2 (issue 12): submit_findings accepts checks[] (status pass|warn|fail) not findings[]+severity.
 // summary is no longer accepted (strict schema). Pass checks may omit their locator.
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 
 import { mapChecksToScope, submitFindingsInputSchema, ReviewerMcpServer } from './mcp-server'
 import type { TurnScope } from '../../shared/reviewer'
+import type { ArtifactContent, ExecRecord, OrderedBlock } from './host-sdk'
 
 const scope: TurnScope = {
   turnMessageId: 'msg-2',
@@ -300,6 +301,65 @@ describe('ReviewerMcpServer HTTP transport', () => {
     return json ? JSON.parse(json) : {}
   }
 
+  const initialize = async (
+    endpoint: string,
+    token: string
+  ): Promise<{ sessionId: string; headers: Record<string, string> }> => {
+    const headers = {
+      authorization: `Bearer ${token}`,
+      accept: MCP_ACCEPT,
+      'content-type': 'application/json'
+    }
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0' }
+        }
+      })
+    })
+    const sessionId = response.headers.get('mcp-session-id')
+    expect(response.status).toBe(200)
+    expect(sessionId).toBeTruthy()
+    await response.text()
+    await fetch(endpoint, {
+      method: 'POST',
+      headers: { ...headers, 'mcp-session-id': sessionId! },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
+    })
+    return { sessionId: sessionId!, headers }
+  }
+
+  const callTool = async (
+    endpoint: string,
+    sessionId: string,
+    headers: Record<string, string>,
+    name: string,
+    args: Record<string, unknown>,
+    id = 2
+  ): Promise<{ result?: { content?: Array<{ text?: string }>; isError?: boolean } }> => {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { ...headers, 'mcp-session-id': sessionId },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method: 'tools/call',
+        params: { name, arguments: args }
+      })
+    })
+    expect(response.status).toBe(200)
+    return parseSse(await response.text()) as {
+      result?: { content?: Array<{ text?: string }>; isError?: boolean }
+    }
+  }
+
   it('reuses the session transport for the GET SSE stream and still serves tool calls', async () => {
     const server = new ReviewerMcpServer(scope, async () => undefined)
     const { endpoint, token } = await server.start()
@@ -389,6 +449,181 @@ describe('ReviewerMcpServer HTTP transport', () => {
       })
       expect(response.status).toBe(400)
       await response.text()
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('exposes evidence only through the scope-bounded reviewer MCP tools', async () => {
+    const readTurn = vi.fn<() => OrderedBlock[]>().mockReturnValue([
+      {
+        blockIndex: 0,
+        id: 'message:msg-2',
+        kind: 'message',
+        sourceId: 'msg-2',
+        contentHash: 'real-hash-msg-2',
+        role: 'agent',
+        content: '42 results'
+      }
+    ])
+    const queryExecutionLog = vi
+      .fn<(activityId?: string) => ExecRecord[]>()
+      .mockReturnValue([
+        { activityId: 'act-9', title: 'analysis', status: 'completed', terminalExitCode: 0 }
+      ])
+    const readArtifact = vi.fn<(id: string) => Promise<ArtifactContent>>().mockResolvedValue({
+      id: 'artifact-csv',
+      kind: 'tabular',
+      columns: { value: ['42'] },
+      rowCount: 1
+    })
+    const server = new ReviewerMcpServer(scope, async () => undefined, {
+      readTurn,
+      queryExecutionLog,
+      readArtifact
+    })
+    const { endpoint, token } = await server.start()
+
+    try {
+      const { sessionId, headers } = await initialize(endpoint, token)
+      const turn = await callTool(endpoint, sessionId, headers, 'read_turn', {})
+      const execution = await callTool(
+        endpoint,
+        sessionId,
+        headers,
+        'query_execution_log',
+        { activityId: 'act-9' },
+        3
+      )
+      const artifact = await callTool(
+        endpoint,
+        sessionId,
+        headers,
+        'read_artifact',
+        { id: 'artifact-csv' },
+        4
+      )
+
+      expect(JSON.parse(turn.result?.content?.[0]?.text ?? 'null')).toEqual(
+        readTurn.mock.results[0]?.value
+      )
+      expect(JSON.parse(execution.result?.content?.[0]?.text ?? 'null')).toEqual(
+        queryExecutionLog.mock.results[0]?.value
+      )
+      expect(JSON.parse(artifact.result?.content?.[0]?.text ?? 'null')).toEqual(
+        await readArtifact.mock.results[0]?.value
+      )
+      expect(queryExecutionLog).toHaveBeenCalledWith('act-9')
+      expect(readArtifact).toHaveBeenCalledWith('artifact-csv')
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('requires exactly one stable disposition per tracked finding and rejects duplicate submission', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const server = new ReviewerMcpServer(scope, onSubmit, undefined, ['finding-1'])
+    const { endpoint, token } = await server.start()
+
+    try {
+      const { sessionId, headers } = await initialize(endpoint, token)
+      const missing = await callTool(endpoint, sessionId, headers, 'submit_findings', {
+        checks: []
+      })
+      expect(missing.result?.isError).toBe(true)
+      expect(missing.result?.content?.[0]?.text).toContain('Missing disposition')
+
+      const duplicatedDisposition = await callTool(
+        endpoint,
+        sessionId,
+        headers,
+        'submit_findings',
+        {
+          checks: [
+            {
+              sourceFindingId: 'finding-1',
+              status: 'pass',
+              claim: 'First disposition',
+              evidence: 'First verification'
+            },
+            {
+              sourceFindingId: 'finding-1',
+              status: 'pass',
+              claim: 'Second disposition',
+              evidence: 'Second verification'
+            }
+          ]
+        },
+        3
+      )
+      expect(duplicatedDisposition.result?.isError).toBe(true)
+      expect(duplicatedDisposition.result?.content?.[0]?.text).toContain('Duplicate disposition')
+
+      const unknown = await callTool(
+        endpoint,
+        sessionId,
+        headers,
+        'submit_findings',
+        {
+          checks: [
+            {
+              sourceFindingId: 'invented-finding',
+              status: 'pass',
+              claim: 'Invented identity',
+              evidence: 'Not a tracked finding'
+            }
+          ]
+        },
+        4
+      )
+      expect(unknown.result?.isError).toBe(true)
+      expect(unknown.result?.content?.[0]?.text).toContain('Unknown sourceFindingId')
+
+      const valid = await callTool(
+        endpoint,
+        sessionId,
+        headers,
+        'submit_findings',
+        {
+          checks: [
+            {
+              sourceFindingId: 'finding-1',
+              status: 'fail',
+              claim: 'Paraphrased description of the same unresolved defect',
+              evidence: 'The corrected output is still contradictory',
+              locator: { blockRef: { blockIndex: 0 }, contentHash: 'ignored' }
+            }
+          ]
+        },
+        5
+      )
+      expect(valid.result?.isError).not.toBe(true)
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit.mock.calls[0]?.[0]?.[0]).toMatchObject({
+        sourceFindingId: 'finding-1',
+        claim: 'Paraphrased description of the same unresolved defect'
+      })
+
+      const duplicate = await callTool(
+        endpoint,
+        sessionId,
+        headers,
+        'submit_findings',
+        {
+          checks: [
+            {
+              sourceFindingId: 'finding-1',
+              status: 'pass',
+              claim: 'Resolved',
+              evidence: 'Verified'
+            }
+          ]
+        },
+        6
+      )
+      expect(duplicate.result?.isError).toBe(true)
+      expect(duplicate.result?.content?.[0]?.text).toContain('already called')
+      expect(onSubmit).toHaveBeenCalledTimes(1)
     } finally {
       await server.stop()
     }

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -16,7 +16,12 @@ import { z } from 'zod'
 
 import type { McpServer } from '@agentclientprotocol/sdk'
 
-import { REVIEWER_MCP_SERVER_NAME, type NewCheck, type TurnScope } from '../../shared/reviewer'
+import {
+  REVIEWER_MCP_SERVER_NAME,
+  REVIEWER_MCP_TOOLS,
+  type NewCheck,
+  type TurnScope
+} from '../../shared/reviewer'
 import { assertBlockInScope, type ReviewerHostServer } from './host-sdk'
 import { createLogger } from '../logger'
 
@@ -163,7 +168,7 @@ export class ReviewerMcpServer {
   private _endpoint: string | undefined
   private readonly transports = new Map<string, StreamableHTTPServerTransport>()
   private readonly trackedFindingIds: ReadonlySet<string>
-  private findingsSubmitted = false
+  private findingsSubmissionState: 'idle' | 'submitting' | 'submitted' = 'idle'
 
   constructor(
     private readonly scope: TurnScope,
@@ -226,7 +231,7 @@ export class ReviewerMcpServer {
 
     if (this.evidence) {
       server.registerTool(
-        'read_turn',
+        REVIEWER_MCP_TOOLS.readTurn,
         {
           title: 'Read audited turn',
           description:
@@ -240,7 +245,7 @@ export class ReviewerMcpServer {
       )
 
       server.registerTool(
-        'query_execution_log',
+        REVIEWER_MCP_TOOLS.queryExecutionLog,
         {
           title: 'Read audited execution log',
           description:
@@ -267,7 +272,7 @@ export class ReviewerMcpServer {
       )
 
       server.registerTool(
-        'read_artifact',
+        REVIEWER_MCP_TOOLS.readArtifact,
         {
           title: 'Read audited artifact',
           description:
@@ -290,7 +295,7 @@ export class ReviewerMcpServer {
     }
 
     server.registerTool(
-      'submit_findings',
+      REVIEWER_MCP_TOOLS.submitFindings,
       {
         title: 'Submit review checks',
         description:
@@ -301,7 +306,7 @@ export class ReviewerMcpServer {
         inputSchema: submitFindingsInputSchema.shape
       },
       async (input) => {
-        if (this.findingsSubmitted) {
+        if (this.findingsSubmissionState !== 'idle') {
           return {
             content: [
               { type: 'text', text: 'Validation error: submit_findings was already called.' }
@@ -348,8 +353,14 @@ export class ReviewerMcpServer {
           }
         }
 
-        await this.onSubmitFindings(newChecks, this.scope, {})
-        this.findingsSubmitted = true
+        this.findingsSubmissionState = 'submitting'
+        try {
+          await this.onSubmitFindings(newChecks, this.scope, {})
+          this.findingsSubmissionState = 'submitted'
+        } catch (error) {
+          this.findingsSubmissionState = 'idle'
+          throw error
+        }
 
         return {
           content: [

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -1,4 +1,5 @@
-// In-process HTTP MCP server that exposes `submit_findings` to the reviewer ACP session.
+// In-process HTTP MCP server that exposes scope-bounded evidence reads and `submit_findings` to the
+// reviewer ACP session. It is the reviewer's only approved capability.
 // Uses the MCP Streamable HTTP transport so the agent connects via URL (McpServerHttp).
 // The server is created per review run and shut down after the reviewer session disposes.
 //
@@ -15,13 +16,16 @@ import { z } from 'zod'
 
 import type { McpServer } from '@agentclientprotocol/sdk'
 
-import type { NewCheck, TurnScope } from '../../shared/reviewer'
-import { assertBlockInScope } from './host-sdk'
+import { REVIEWER_MCP_SERVER_NAME, type NewCheck, type TurnScope } from '../../shared/reviewer'
+import { assertBlockInScope, type ReviewerHostServer } from './host-sdk'
 import { createLogger } from '../logger'
 
-const REVIEWER_MCP_SERVER_NAME = 'open-science-reviewer'
-
 const log = createLogger('reviewer:mcp')
+
+type ReviewerEvidenceAccess = Pick<
+  ReviewerHostServer,
+  'readTurn' | 'queryExecutionLog' | 'readArtifact'
+>
 
 // Zod schema for the optional locator on a check submitted by the reviewer.
 const checkLocatorSchema = z.object({
@@ -53,6 +57,14 @@ const checkSchema = z.object({
       'Supporting evidence from the turn (cite block ids / exec-log entries / artifact content you read). ' +
         'For pass checks: describe what you verified and why it passed. ' +
         'For warn/fail: describe the contradiction found.'
+    ),
+  sourceFindingId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Stable id of an original finding being re-evaluated. Required for every tracked finding ' +
+        'during a fix-loop re-review; never invent or rewrite this id.'
     ),
   locator: checkLocatorSchema
     .optional()
@@ -101,6 +113,7 @@ export const mapChecksToScope = (
         status: c.status,
         claim: c.claim,
         evidence: c.evidence,
+        sourceFindingId: c.sourceFindingId,
         locator: undefined,
         artifactVersionId: c.artifactVersionId,
         sortIndex: i
@@ -123,6 +136,7 @@ export const mapChecksToScope = (
       status: c.status,
       claim: c.claim,
       evidence: c.evidence,
+      sourceFindingId: c.sourceFindingId,
       locator: { blockRef, contentHash: block.contentHash },
       artifactVersionId: c.artifactVersionId,
       sortIndex: i
@@ -148,11 +162,16 @@ export class ReviewerMcpServer {
   private readonly token: string
   private _endpoint: string | undefined
   private readonly transports = new Map<string, StreamableHTTPServerTransport>()
+  private readonly trackedFindingIds: ReadonlySet<string>
+  private findingsSubmitted = false
 
   constructor(
     private readonly scope: TurnScope,
-    private readonly onSubmitFindings: SubmitFindingsHandler
+    private readonly onSubmitFindings: SubmitFindingsHandler,
+    private readonly evidence?: ReviewerEvidenceAccess,
+    trackedFindingIds: readonly string[] = []
   ) {
+    this.trackedFindingIds = new Set(trackedFindingIds)
     this.token = randomUUID()
     this.mcpServer = this.buildMcpServer()
     this.httpServer = createServer((req, res) => {
@@ -205,6 +224,71 @@ export class ReviewerMcpServer {
       version: '1.0.0'
     })
 
+    if (this.evidence) {
+      server.registerTool(
+        'read_turn',
+        {
+          title: 'Read audited turn',
+          description:
+            'Return the ordered message and tool-activity blocks in the audited turn. The server ' +
+            'enforces the turn scope; no other conversation data is available.',
+          inputSchema: {}
+        },
+        async () => ({
+          content: [{ type: 'text', text: JSON.stringify(this.evidence!.readTurn()) }]
+        })
+      )
+
+      server.registerTool(
+        'query_execution_log',
+        {
+          title: 'Read audited execution log',
+          description:
+            'Return tool input, output, terminal output, and exit codes for activities in the ' +
+            'audited turn. An out-of-scope activity id is rejected.',
+          inputSchema: {
+            activityId: z.string().optional().describe('Optional in-scope activity id')
+          }
+        },
+        async ({ activityId }) => {
+          try {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(this.evidence!.queryExecutionLog(activityId))
+                }
+              ]
+            }
+          } catch (error) {
+            return this.toolError(error)
+          }
+        }
+      )
+
+      server.registerTool(
+        'read_artifact',
+        {
+          title: 'Read audited artifact',
+          description:
+            'Read one artifact attached to the audited turn. CSV/TSV data is returned by column; ' +
+            'an out-of-scope artifact id is rejected.',
+          inputSchema: { id: z.string().min(1).describe('In-scope artifact version id') }
+        },
+        async ({ id }) => {
+          try {
+            return {
+              content: [
+                { type: 'text', text: JSON.stringify(await this.evidence!.readArtifact(id)) }
+              ]
+            }
+          } catch (error) {
+            return this.toolError(error)
+          }
+        }
+      )
+    }
+
     server.registerTool(
       'submit_findings',
       {
@@ -217,6 +301,15 @@ export class ReviewerMcpServer {
         inputSchema: submitFindingsInputSchema.shape
       },
       async (input) => {
+        if (this.findingsSubmitted) {
+          return {
+            content: [
+              { type: 'text', text: 'Validation error: submit_findings was already called.' }
+            ],
+            isError: true
+          }
+        }
+
         let parsed: SubmitFindingsInput
 
         try {
@@ -231,6 +324,15 @@ export class ReviewerMcpServer {
         }
 
         log.info('submit_findings received', { count: parsed.checks.length })
+
+        const trackingError = this.validateTrackedDispositions(parsed.checks)
+        if (trackingError) {
+          log.warn('submit_findings tracking validation failed', { error: trackingError })
+          return {
+            content: [{ type: 'text', text: `Validation error: ${trackingError}` }],
+            isError: true
+          }
+        }
 
         // Back-fill each locator's contentHash from its scope block and reject out-of-scope
         // locators (design.md:114 single-sourcing contract). A bad locator is a validation error.
@@ -247,6 +349,7 @@ export class ReviewerMcpServer {
         }
 
         await this.onSubmitFindings(newChecks, this.scope, {})
+        this.findingsSubmitted = true
 
         return {
           content: [
@@ -260,6 +363,37 @@ export class ReviewerMcpServer {
     )
 
     return server
+  }
+
+  // A fix-loop re-review must disposition every original finding by stable database id exactly once.
+  // New issues may be submitted without sourceFindingId, but wording can never resolve or re-flag an
+  // existing finding. Initial reviews reject source ids because there is nothing to track yet.
+  private validateTrackedDispositions(checks: SubmitFindingsInput['checks']): string | undefined {
+    const supplied = new Set<string>()
+
+    for (const check of checks) {
+      const id = check.sourceFindingId
+      if (!id) continue
+      if (!this.trackedFindingIds.has(id)) return `Unknown sourceFindingId ${JSON.stringify(id)}.`
+      if (supplied.has(id))
+        return `Duplicate disposition for sourceFindingId ${JSON.stringify(id)}.`
+      supplied.add(id)
+    }
+
+    const missing = [...this.trackedFindingIds].filter((id) => !supplied.has(id))
+    if (missing.length > 0) {
+      return `Missing disposition for tracked finding id(s): ${missing.join(', ')}.`
+    }
+
+    return undefined
+  }
+
+  private toolError(error: unknown): {
+    content: Array<{ type: 'text'; text: string }>
+    isError: true
+  } {
+    const message = error instanceof Error ? error.message : String(error)
+    return { content: [{ type: 'text', text: message }], isError: true }
   }
 
   private async handleHttpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -229,7 +229,8 @@ export class ReviewerMcpServer {
       version: '1.0.0'
     })
 
-    if (this.evidence) {
+    const evidence = this.evidence
+    if (evidence) {
       server.registerTool(
         REVIEWER_MCP_TOOLS.readTurn,
         {
@@ -240,7 +241,7 @@ export class ReviewerMcpServer {
           inputSchema: {}
         },
         async () => ({
-          content: [{ type: 'text', text: JSON.stringify(this.evidence!.readTurn()) }]
+          content: [{ type: 'text', text: JSON.stringify(evidence.readTurn()) }]
         })
       )
 
@@ -261,7 +262,7 @@ export class ReviewerMcpServer {
               content: [
                 {
                   type: 'text',
-                  text: JSON.stringify(this.evidence!.queryExecutionLog(activityId))
+                  text: JSON.stringify(evidence.queryExecutionLog(activityId))
                 }
               ]
             }
@@ -283,9 +284,7 @@ export class ReviewerMcpServer {
         async ({ id }) => {
           try {
             return {
-              content: [
-                { type: 'text', text: JSON.stringify(await this.evidence!.readArtifact(id)) }
-              ]
+              content: [{ type: 'text', text: JSON.stringify(await evidence.readArtifact(id)) }]
             }
           } catch (error) {
             return this.toolError(error)
@@ -422,11 +421,12 @@ export class ReviewerMcpServer {
 
     let transport: StreamableHTTPServerTransport
 
-    if (sessionId && this.transports.has(sessionId)) {
+    const existingTransport = sessionId ? this.transports.get(sessionId) : undefined
+    if (existingTransport) {
       // Established session: every follow-up request (POST messages, GET SSE stream, DELETE) carries
       // the mcp-session-id, so reuse its transport. Crucially the GET that opens the SSE stream lands
       // here — connecting a second transport to the shared McpServer would throw "Already connected".
-      transport = this.transports.get(sessionId)!
+      transport = existingTransport
     } else if (!sessionId && req.method === 'POST') {
       // The initialize request is the only one without a session id: create the transport, register it
       // as soon as the session id is assigned, and connect the McpServer to it exactly once.

--- a/src/main/reviewer/orchestrator-prompt.test.ts
+++ b/src/main/reviewer/orchestrator-prompt.test.ts
@@ -1,12 +1,10 @@
-// Unit test for buildReviewerPrompt: the host client handed to the reviewer must come from the single
-// source of truth (buildReviewerHostPythonBootstrap), not a second hand-written copy that can drift
-// from the server's actual method set.
+// Unit tests for the isolated reviewer prompt: it advertises only the scope-bounded MCP evidence tools,
+// carries no executable bootstrap/secret, and binds fix-loop dispositions to stable finding ids.
 
 import { describe, expect, it } from 'vitest'
 
 import { buildReviewerPrompt } from './orchestrator'
-import { buildReviewerHostPythonBootstrap } from './host-sdk'
-import type { TurnScope } from '../../shared/reviewer'
+import type { ReviewCheck, TurnScope } from '../../shared/reviewer'
 
 const scope: TurnScope = {
   turnMessageId: 'msg-1',
@@ -16,26 +14,36 @@ const scope: TurnScope = {
   artifactVersionIds: []
 }
 
-describe('buildReviewerPrompt — single-source host client', () => {
-  it('embeds the exact bootstrap client (no independent hand-written copy)', () => {
-    const endpoint = 'http://127.0.0.1:5555'
-    const token = 'tok-xyz'
+describe('buildReviewerPrompt — isolated evidence access', () => {
+  it('advertises only MCP evidence tools and carries no Bash/Python bootstrap or bearer secret', () => {
+    const prompt = buildReviewerPrompt(scope)
 
-    const prompt = buildReviewerPrompt(scope, endpoint, token)
-
-    // The prompt must contain the bootstrap verbatim — this is what guarantees there is only one
-    // definition of the client and its method set.
-    expect(prompt).toContain(buildReviewerHostPythonBootstrap(endpoint, token))
-    expect(prompt).toContain(endpoint)
-    expect(prompt).toContain(token)
+    expect(prompt).toContain('read_turn')
+    expect(prompt).toContain('query_execution_log')
+    expect(prompt).toContain('read_artifact')
+    expect(prompt).not.toContain('http://')
+    expect(prompt).not.toContain('Bearer')
+    expect(prompt).not.toContain('```python')
+    expect(prompt).toContain('Do not use Bash')
   })
 
-  it('tells the reviewer to re-run setup per process rather than assuming a pre-loaded host', () => {
-    const prompt = buildReviewerPrompt(scope, 'http://x', 't')
+  it('requires every fix-loop finding to be dispositioned by stable id', () => {
+    const tracked: ReviewCheck[] = [
+      {
+        id: 'finding-stable-1',
+        reviewId: 'review-1',
+        status: 'fail',
+        resolution: 'open',
+        claim: 'The count is wrong',
+        evidence: 'Output says 3',
+        sortIndex: 0,
+        reflagCount: 0
+      }
+    ]
+    const prompt = buildReviewerPrompt(scope, tracked)
 
-    // The reviewer runs Python via Bash (fresh process each time); the prompt must make that explicit
-    // so the model does not skip setup assuming a persistent pre-injected `host`.
-    expect(prompt).toContain('fresh process')
-    expect(prompt).toContain('no pre-loaded `host`')
+    expect(prompt).toContain('sourceFindingId')
+    expect(prompt).toContain('finding-stable-1')
+    expect(prompt).toContain('exactly once')
   })
 })

--- a/src/main/reviewer/orchestrator.test.ts
+++ b/src/main/reviewer/orchestrator.test.ts
@@ -12,7 +12,7 @@ import * as acp from '@agentclientprotocol/sdk'
 import type { ContentBlock } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { EventEmitter } from 'node:events'
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
@@ -297,7 +297,9 @@ afterEach(async () => {
 describe('reviewer orchestrator', () => {
   it('creates a reviewer session with the correct buildSession config', async () => {
     const process = new FakeAgentProcess()
-    const { newSessions } = startFakeReviewerAgent(process, 'reviewer-session-1')
+    const { newSessions } = startFakeReviewerAgent(process, 'reviewer-session-1', {
+      simulateFindingsViaHttp: true
+    })
 
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
@@ -321,9 +323,10 @@ describe('reviewer orchestrator', () => {
       artifactStorageRoot: temporaryRoot!
     })
 
-    // buildSession was called with the correct cwd.
+    // Reviewer execution is isolated from the audited workspace in an empty temporary directory.
     expect(newSessions).toHaveLength(1)
-    expect(newSessions[0]?.cwd).toBe('/workspace')
+    expect(newSessions[0]?.cwd).toContain('open-science-reviewer-')
+    expect(newSessions[0]?.cwd).not.toBe('/workspace')
 
     // The reviewer MCP server (HTTP type) was included.
     const mcpServers = (newSessions[0]?.mcpServers ?? []) as Array<{ type?: string; name?: string }>
@@ -333,6 +336,10 @@ describe('reviewer orchestrator', () => {
 
     // _meta includes a systemPrompt with append (rubric).
     const meta = newSessions[0]?._meta as Record<string, unknown> | undefined
+    expect(meta?.disableBuiltInTools).toBe(true)
+    expect(
+      (meta?.claudeCode as { options?: { tools?: unknown[] } } | undefined)?.options?.tools ?? null
+    ).toEqual([])
     const systemPrompt = meta?.systemPrompt as Record<string, unknown> | undefined
     expect(systemPrompt?.type).toBe('preset')
     expect(systemPrompt?.preset).toBe('claude_code')
@@ -342,11 +349,12 @@ describe('reviewer orchestrator', () => {
     // Review was persisted.
     expect(review.sessionId).toBe('session-1')
     expect(review.turnMessageId).toBe('msg-2')
+    await expect(access(newSessions[0]!.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
 
     await client.$disconnect()
   })
 
-  it('sets lifecycle=complete and outcome=pass when no findings are submitted', async () => {
+  it('fails closed when the reviewer stops without submitting findings', async () => {
     const process = new FakeAgentProcess()
     startFakeReviewerAgent(process, 'reviewer-session-1')
 
@@ -372,9 +380,9 @@ describe('reviewer orchestrator', () => {
       artifactStorageRoot: temporaryRoot!
     })
 
-    // No submit_findings was called (agent didn't simulate it), so it defaults to pass.
-    expect(review.lifecycle).toBe('complete')
-    expect(review.outcome).toBe('pass')
+    expect(review.lifecycle).toBe('error')
+    expect(review.outcome).toBeNull()
+    expect(review.errorMessage).toContain('without calling submit_findings')
     expect(review.checks).toHaveLength(0)
 
     await client.$disconnect()
@@ -533,7 +541,7 @@ describe('reviewer orchestrator', () => {
 
   it('calls onReviewUpdate on lifecycle transitions', async () => {
     const process = new FakeAgentProcess()
-    startFakeReviewerAgent(process, 'reviewer-session-1')
+    startFakeReviewerAgent(process, 'reviewer-session-1', { simulateFindingsViaHttp: true })
 
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -1,5 +1,5 @@
 // Orchestrator for the auto-review pipeline. `runReview` is called after each turn completes;
-// it spawns a fresh-context reviewer ACP session, injects the rubric + reviewer MCP + host SDK,
+// it spawns a fresh-context reviewer ACP session, injects the rubric + scope-bounded reviewer MCP,
 // drives the reviewer to completion, persists findings, and then disposes the session.
 //
 // Phase 3: after a review with warn/fail, `runFixLoop` drives the bounded re-review loop:
@@ -26,11 +26,15 @@ import type { ReviewRepository } from './repository'
 import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { ReviewerMcpServer } from './mcp-server'
-import { buildReviewerHostPythonBootstrap, ReviewerHostServer } from './host-sdk'
+import { ReviewerHostServer } from './host-sdk'
 import { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } from './rubric'
 import { injectAuditorMessage } from './correction'
 
 const log = createLogger('reviewer:orchestrator')
+
+type SessionProvider = (
+  sessionId: string
+) => PersistedChatSession | undefined | Promise<PersistedChatSession | undefined>
 
 export type RunReviewOptions = {
   sessionId: string
@@ -49,12 +53,12 @@ export type RunReviewOptions = {
   projectId: string
   // Used to resolve the session's persisted data for turn-scope resolution.
   // For the fix loop, this is called after each correction turn so it must return the LATEST session.
-  getSession: (sessionId: string) => PersistedChatSession | undefined
+  getSession: SessionProvider
   // Repository for persisting review rows + checks.
   reviewRepository: ReviewRepository
   // The ACP runtime that owns the agent connection (used to spawn the reviewer session).
   acpRuntime: AcpRuntime
-  // Storage root for artifact reads (used by the reviewer host SDK).
+  // Storage root for artifact reads (used by the scope-bounded evidence reader).
   artifactStorageRoot: string
   // The model/provider tag to record on the Review row.
   model?: string
@@ -86,15 +90,20 @@ export type RunReviewOptions = {
   // AbortSignal to stop the fix loop early (e.g. when the user presses cancel). When aborted,
   // the loop exits at the next round boundary without further [Auditor] injections.
   fixLoopAbortSignal?: AbortSignal
+  // How long the fix loop waits for the correction turn to reach durable session storage. The main
+  // agent can finish before the renderer's persistence queue flushes, so a single immediate read races.
+  sessionRefreshTimeoutMs?: number
 }
 
 // Default drive-loop guards. The wall-clock timeout is the primary backstop against a reviewer that
 // never stops (it is the only guard that catches a reviewer stuck streaming thoughts forever, since
 // those do not count toward the update cap — see below). The update cap is a secondary backstop
 // against a fast-looping reviewer that spins through discrete actions. Reviews do real multi-step
-// verification (several Python cells + reasoning), so the timeout is generous.
+// evidence tracing, so the timeout is generous.
 const DEFAULT_REVIEWER_TIMEOUT_MS = 900_000
 const DEFAULT_REVIEWER_MAX_UPDATES = 1000
+const DEFAULT_SESSION_REFRESH_TIMEOUT_MS = 10_000
+const SESSION_REFRESH_POLL_MS = 50
 
 // Streaming content deltas are emitted one-per-chunk as the reviewer writes its message/thinking, so
 // their count tracks how much it *says*, not how much it *does*. Counting them toward the loop cap
@@ -338,13 +347,11 @@ type FixLoopOptions = {
   sessionId: string
   // The original turn's message id (shared across all Review rows in this closure).
   originalTurnMessageId: string
-  // The reviewId whose warn/fail checks are being tracked.
-  originalReviewId: string
   // The currently-open warn/fail checks to carry forward into each re-review.
   openChecks: ReviewCheck[]
   projectId: string
   mainSessionId: string
-  getSession: (sessionId: string) => PersistedChatSession | undefined
+  getSession: SessionProvider
   reviewRepository: ReviewRepository
   acpRuntime: AcpRuntime
   artifactStorageRoot: string
@@ -355,25 +362,54 @@ type FixLoopOptions = {
   reviewerTimeoutMs: number
   reviewerMaxUpdates: number
   maxRounds: number
+  sessionRefreshTimeoutMs: number
   // Optional abort signal: when aborted, the loop exits at the next round boundary.
   abortSignal?: AbortSignal
+}
+
+const waitForCorrectionAgentMessage = async (options: {
+  sessionId: string
+  messageIdsBefore: ReadonlySet<string>
+  getSession: SessionProvider
+  timeoutMs: number
+  abortSignal?: AbortSignal
+}): Promise<
+  | {
+      session: PersistedChatSession
+      message: PersistedChatSession['messages'][number]
+    }
+  | undefined
+> => {
+  const deadline = Date.now() + options.timeoutMs
+
+  for (;;) {
+    if (options.abortSignal?.aborted) return undefined
+
+    const latest = await options.getSession(options.sessionId)
+    const correction = latest?.messages.find(
+      (message) => !options.messageIdsBefore.has(message.id) && message.role === 'agent'
+    )
+    if (latest && correction) return { session: latest, message: correction }
+
+    if (Date.now() >= deadline) return undefined
+    await new Promise<void>((resolve) => setTimeout(resolve, SESSION_REFRESH_POLL_MS))
+  }
 }
 
 // Runs the Phase 3 bounded re-review loop. For each round (up to maxRounds):
 // 1. Injects [Auditor] with the still-open warn/fail checks.
 // 2. The main agent produces a correction turn.
 // 3. Re-reviews the correction turn's new blocks.
-// 4. Updates resolutions on the original review's checks from re-review results:
-//    - claim passes in re-review → resolved
-//    - same claim flagged again → incrementReflagCount on original check; stays open
-//    - claim not mentioned in re-review → stays open
+// 4. Updates each original finding by its stable sourceFindingId:
+//    - pass → resolved
+//    - warn/fail → incrementReflagCount; stays open
+//    - missing/unknown/duplicate id → submission rejected, original stays open
 // 5. If all resolved or cap reached, stops.
 // Cap termination marks remaining open warn/fail checks as 'unaddressed'.
 const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
   const {
     sessionId,
     originalTurnMessageId,
-    originalReviewId,
     projectId,
     mainSessionId,
     getSession,
@@ -387,10 +423,20 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
     reviewerTimeoutMs,
     reviewerMaxUpdates,
     maxRounds,
+    sessionRefreshTimeoutMs,
     abortSignal
   } = options
 
   let openChecks = [...options.openChecks]
+  const markOpenChecksUnaddressed = async (): Promise<void> => {
+    for (const openCheck of openChecks) {
+      await reviewRepository.updateFindingResolution(
+        openCheck.reviewId,
+        openCheck.id,
+        'unaddressed'
+      )
+    }
+  }
 
   for (let round = 0; round < maxRounds; round++) {
     if (openChecks.length === 0) break
@@ -401,12 +447,27 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
       return
     }
 
-    // Step A: record the last known message id before the correction prompt, so we can detect
-    // the correction turn's new agent message after sendPrompt returns.
-    const sessionBefore = getSession(sessionId)
-    const messagesBefore = sessionBefore?.messages ?? []
-    const lastMessageIdBefore =
-      messagesBefore.length > 0 ? messagesBefore[messagesBefore.length - 1]!.id : null
+    // Step A: record every known message id before the correction prompt. The provider is awaited on
+    // every use; production reloads durable storage rather than returning the initial review snapshot.
+    let sessionBefore: PersistedChatSession | undefined
+    try {
+      sessionBefore = await getSession(sessionId)
+    } catch (error) {
+      log.warn('fix loop: failed to load durable session before correction', {
+        sessionId,
+        round,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      await markOpenChecksUnaddressed()
+      return
+    }
+    if (!sessionBefore) {
+      log.warn('fix loop: durable session disappeared before correction', { sessionId, round })
+      await markOpenChecksUnaddressed()
+      return
+    }
+    const messagesBefore = sessionBefore.messages
+    const messageIdsBefore = new Set(messagesBefore.map((message) => message.id))
 
     // Step B: inject [Auditor] with the currently-open warn/fail checks.
     let correctionFailed = false
@@ -430,48 +491,56 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
         round,
         openCount: openChecks.length
       })
-      await reviewRepository.updateFindingResolutions(originalReviewId, 'unaddressed')
+      await markOpenChecksUnaddressed()
       return
     }
 
-    // Step C: reload the session to see the correction turn's new messages.
-    const sessionAfter = getSession(sessionId)
-    if (!sessionAfter) {
-      log.warn('session not found after correction in fix loop', { sessionId, round })
-      await reviewRepository.updateFindingResolutions(originalReviewId, 'unaddressed')
+    // Step C: wait for the new agent message to reach durable storage. sendPrompt completion and the
+    // renderer persistence queue are independent, so an immediate one-shot reload is still racy.
+    let correctionState:
+      | { session: PersistedChatSession; message: PersistedChatSession['messages'][number] }
+      | undefined
+    try {
+      correctionState = await waitForCorrectionAgentMessage({
+        sessionId,
+        messageIdsBefore,
+        getSession,
+        timeoutMs: sessionRefreshTimeoutMs,
+        abortSignal
+      })
+    } catch (error) {
+      log.warn('fix loop: failed while refreshing durable correction turn', {
+        sessionId,
+        round,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      await markOpenChecksUnaddressed()
       return
     }
-
-    // Find the first new agent message added after the correction prompt. This is the
-    // correction turn's response — use it as the turnMessageId for the re-review scope.
-    const messagesAfter = sessionAfter.messages ?? []
-    const newMessages = lastMessageIdBefore
-      ? (() => {
-          const cutoffIndex = messagesAfter.findIndex((m) => m.id === lastMessageIdBefore)
-          return cutoffIndex >= 0 ? messagesAfter.slice(cutoffIndex + 1) : messagesAfter
-        })()
-      : messagesAfter
-
-    const correctionAgentMsg = newMessages.find((m) => m.role === 'agent')
-    if (!correctionAgentMsg) {
-      log.warn(
-        'no new agent message after correction in fix loop — using auditor msg as scope marker',
-        {
+    if (!correctionState) {
+      if (abortSignal?.aborted) {
+        log.info('fix loop: aborted while waiting for durable correction turn', {
           sessionId,
-          round,
-          newMessageCount: newMessages.length
-        }
-      )
-      // Fall back to re-reviewing the whole session's last agent message.
+          round
+        })
+        return
+      }
+      log.warn('correction turn did not reach durable session storage; refusing stale re-review', {
+        sessionId,
+        round,
+        timeoutMs: sessionRefreshTimeoutMs
+      })
+      await markOpenChecksUnaddressed()
+      return
     }
 
-    const correctionTurnMessageId = correctionAgentMsg?.id ?? originalTurnMessageId
+    const correctionTurnMessageId = correctionState.message.id
 
     // Step D: run a re-review scoped to the correction turn's new blocks.
     // This creates a new Review row sharing the original turnMessageId.
     log.info('fix loop: running re-review', { sessionId, round, correctionTurnMessageId })
 
-    const reReviewResult = await runScopedReview({
+    const scopedResult = await runScopedReview({
       sessionId,
       turnMessageId: correctionTurnMessageId,
       originalTurnMessageId,
@@ -483,14 +552,17 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
       model,
       onReviewUpdate,
       reviewerTimeoutMs,
-      reviewerMaxUpdates
+      reviewerMaxUpdates,
+      trackedChecks: openChecks,
+      sessionSnapshot: correctionState.session
     })
+    const reReviewResult = scopedResult.review
 
     // Step E: compute resolution transitions for the original review's open checks.
     // - If the re-review errored: count as a round but mark remaining unaddressed and stop.
-    // - If the re-review has no warn/fail (all pass or empty): all open checks → resolved.
-    // - If the re-review flags the same claim: incrementReflagCount; stays open.
-    // - If the re-review flags a different claim: original open check stays open.
+    // - Each original finding is matched only by sourceFindingId, never by model-generated prose.
+    // - A pass disposition resolves it; warn/fail increments reflagCount and keeps it open.
+    // - Missing dispositions are rejected by MCP and stay open defensively if one slips through.
 
     if (reReviewResult.lifecycle === 'error') {
       log.warn('fix loop: re-review errored — marking remaining checks unaddressed', {
@@ -498,45 +570,63 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
         round,
         openCount: openChecks.length
       })
-      for (const openCheck of openChecks) {
-        await reviewRepository.updateFindingResolutionForClaim(
-          originalReviewId,
-          openCheck.claim,
-          'unaddressed'
-        )
-      }
+      await markOpenChecksUnaddressed()
       return
     }
 
-    const reReviewWarnFail = reReviewResult.checks.filter(
-      (c) => c.status === 'warn' || c.status === 'fail'
+    const dispositionsByFindingId = new Map(
+      scopedResult.submittedChecks
+        .filter((check) => check.sourceFindingId)
+        .map((check) => [check.sourceFindingId!, check] as const)
     )
-    const reReviewWarnFailClaims = new Set(reReviewWarnFail.map((c) => c.claim))
 
     const stillOpenChecks: ReviewCheck[] = []
 
     for (const openCheck of openChecks) {
-      if (reReviewWarnFailClaims.has(openCheck.claim)) {
-        // Same claim flagged again → over-correction; increment reflagCount and keep open.
-        await reviewRepository.incrementReflagCount(originalReviewId, openCheck.claim)
-        log.info('fix loop: claim re-flagged (over-correction)', {
+      const disposition = dispositionsByFindingId.get(openCheck.id)
+      if (!disposition) {
+        // The MCP server rejects incomplete submissions, so this is defensive fail-closed behavior.
+        log.error('fix loop: scoped re-review omitted a tracked finding disposition', {
           sessionId,
           round,
-          claim: openCheck.claim
+          findingId: openCheck.id
+        })
+        stillOpenChecks.push(openCheck)
+      } else if (disposition.status === 'warn' || disposition.status === 'fail') {
+        await reviewRepository.incrementReflagCount(openCheck.reviewId, openCheck.id)
+        log.info('fix loop: finding re-flagged', {
+          sessionId,
+          round,
+          findingId: openCheck.id
         })
         stillOpenChecks.push(openCheck)
       } else {
-        // Claim not flagged in re-review → resolved.
-        await reviewRepository.updateFindingResolutionForClaim(
-          originalReviewId,
-          openCheck.claim,
-          'resolved'
-        )
-        log.info('fix loop: claim resolved', { sessionId, round, claim: openCheck.claim })
+        await reviewRepository.updateFindingResolution(openCheck.reviewId, openCheck.id, 'resolved')
+        log.info('fix loop: finding resolved', { sessionId, round, findingId: openCheck.id })
       }
     }
 
-    openChecks = stillOpenChecks
+    const newIssueSortIndexes = new Set(
+      scopedResult.submittedChecks
+        .filter(
+          (check) => !check.sourceFindingId && (check.status === 'warn' || check.status === 'fail')
+        )
+        .map((check) => check.sortIndex)
+    )
+    const newlyOpenChecks = reReviewResult.checks.filter(
+      (check) =>
+        newIssueSortIndexes.has(check.sortIndex) &&
+        (check.status === 'warn' || check.status === 'fail')
+    )
+    if (newlyOpenChecks.length > 0) {
+      log.info('fix loop: carrying newly discovered findings into the next round', {
+        sessionId,
+        round,
+        count: newlyOpenChecks.length
+      })
+    }
+
+    openChecks = [...stillOpenChecks, ...newlyOpenChecks]
 
     if (openChecks.length === 0) {
       log.info('fix loop: all checks resolved', { sessionId, rounds: round + 1 })
@@ -557,13 +647,7 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
       maxRounds,
       remaining: openChecks.length
     })
-    for (const openCheck of openChecks) {
-      await reviewRepository.updateFindingResolutionForClaim(
-        originalReviewId,
-        openCheck.claim,
-        'unaddressed'
-      )
-    }
+    await markOpenChecksUnaddressed()
   }
 }
 
@@ -575,7 +659,7 @@ const runScopedReview = async (options: {
   turnMessageId: string // the correction turn's agent message id
   originalTurnMessageId: string // shared across all Review rows in this fix-loop closure
   projectId: string
-  getSession: (sessionId: string) => PersistedChatSession | undefined
+  getSession: SessionProvider
   reviewRepository: ReviewRepository
   acpRuntime: AcpRuntime
   artifactStorageRoot: string
@@ -583,7 +667,9 @@ const runScopedReview = async (options: {
   onReviewUpdate?: (review: ReviewWithChecks) => void
   reviewerTimeoutMs: number
   reviewerMaxUpdates: number
-}): Promise<ReviewWithChecks> => {
+  trackedChecks: ReviewCheck[]
+  sessionSnapshot?: PersistedChatSession
+}): Promise<{ review: ReviewWithChecks; submittedChecks: NewCheck[] }> => {
   const {
     sessionId,
     turnMessageId,
@@ -596,10 +682,14 @@ const runScopedReview = async (options: {
     model,
     onReviewUpdate,
     reviewerTimeoutMs,
-    reviewerMaxUpdates
+    reviewerMaxUpdates,
+    trackedChecks,
+    sessionSnapshot
   } = options
 
-  const session = getSession(sessionId)
+  // Use the exact durable snapshot that proved the correction message exists. A second independent
+  // read could regress to an older file during concurrent persistence and reintroduce stale auditing.
+  const session = sessionSnapshot ?? (await getSession(sessionId))
 
   if (!session) {
     log.warn('session not found for scoped re-review', { sessionId })
@@ -612,7 +702,7 @@ const runScopedReview = async (options: {
       errorMessage: `Session ${sessionId} not found during re-review`,
       model
     })
-    return { ...errorReview, checks: [] }
+    return { review: { ...errorReview, checks: [] }, submittedChecks: [] }
   }
 
   // Resolve the correction turn's scope, pinning each artifact to a digest of its current bytes.
@@ -639,24 +729,27 @@ const runScopedReview = async (options: {
   log.info('scoped re-review created', { reviewId: review.id, blocks: scope.blocks.length })
 
   // Run the reviewer session (same flow as the initial review).
-  let reviewerSession: ReturnType<typeof Object.create> | undefined
-  let hostServer: ReviewerHostServer | undefined
+  let reviewerSession: ActiveSession | undefined
   let mcpServer: ReviewerMcpServer | undefined
   let checksReceived: NewCheck[] = []
   let checksSubmitted = false
   const capturedLog: ReviewerLogEntry[] = []
 
   try {
-    hostServer = new ReviewerHostServer(session, scope, artifactStorageRoot)
-    const { endpoint: hostEndpoint, token: hostToken } = await hostServer.start()
+    const evidence = new ReviewerHostServer(session, scope, artifactStorageRoot)
 
-    mcpServer = new ReviewerMcpServer(scope, async (checks: NewCheck[]) => {
-      checksReceived = checks
-      checksSubmitted = true
-    })
+    mcpServer = new ReviewerMcpServer(
+      scope,
+      async (checks: NewCheck[]) => {
+        checksReceived = checks
+        checksSubmitted = true
+      },
+      evidence,
+      trackedChecks.map((check) => check.id)
+    )
     await mcpServer.start()
 
-    const reviewerPrompt = buildReviewerPrompt(scope, hostEndpoint, hostToken)
+    const reviewerPrompt = buildReviewerPrompt(scope, trackedChecks)
     const systemPromptAppend = REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
     const cwd = session.cwd || homedir()
 
@@ -685,25 +778,32 @@ const runScopedReview = async (options: {
 
     review = await reviewRepository.updateReview(review.id, {
       lifecycle: 'error',
-      errorMessage: errorMsg
+      errorMessage: errorMsg,
+      reviewerLog: capturedLog
     })
     const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
     onReviewUpdate?.(errorWithChecks)
-    return errorWithChecks
+    return { review: errorWithChecks, submittedChecks: [] }
   } finally {
     if (reviewerSession) acpRuntime.disposeReviewerSession(reviewerSession)
     await mcpServer?.stop().catch(() => undefined)
-    await hostServer?.stop().catch(() => undefined)
+  }
+
+  if (!checksSubmitted) {
+    const errorMessage = 'Reviewer stopped without calling submit_findings.'
+    log.error('scoped re-review protocol incomplete', { reviewId: review.id, error: errorMessage })
+    review = await reviewRepository.updateReview(review.id, {
+      lifecycle: 'error',
+      errorMessage,
+      reviewerLog: capturedLog
+    })
+    const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
+    onReviewUpdate?.(errorWithChecks)
+    return { review: errorWithChecks, submittedChecks: [] }
   }
 
   // Persist checks and complete the review.
   try {
-    if (!checksSubmitted) {
-      log.warn('re-reviewer did not call submit_findings; treating as pass', {
-        reviewId: review.id
-      })
-    }
-
     await reviewRepository.addChecks(review.id, checksReceived)
 
     const hasWarnOrFailCheck = checksReceived.some(
@@ -720,11 +820,12 @@ const runScopedReview = async (options: {
     log.error('scoped re-review persistence failed', { reviewId: review.id, error: errorMsg })
     review = await reviewRepository.updateReview(review.id, {
       lifecycle: 'error',
-      errorMessage: errorMsg
+      errorMessage: errorMsg,
+      reviewerLog: capturedLog
     })
     const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
     onReviewUpdate?.(errorWithChecks)
-    return errorWithChecks
+    return { review: errorWithChecks, submittedChecks: [] }
   }
 
   // Load the final review with checks.
@@ -746,7 +847,7 @@ const runScopedReview = async (options: {
   }
 
   onReviewUpdate?.(finalReview)
-  return finalReview
+  return { review: finalReview, submittedChecks: checksReceived }
 }
 
 // Drives one complete auto-review cycle: scope resolution → DB record → reviewer session →
@@ -773,13 +874,14 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
     fixLoopMaxRounds = 3,
     onFixLoopStart,
     onFixLoopEnd,
-    fixLoopAbortSignal
+    fixLoopAbortSignal,
+    sessionRefreshTimeoutMs = DEFAULT_SESSION_REFRESH_TIMEOUT_MS
   } = options
 
   log.info('runReview started', { sessionId, turnMessageId })
 
   // Step 1: resolve the turn scope.
-  const session = getSession(sessionId)
+  const session = await getSession(sessionId)
 
   if (!session) {
     log.warn('session not found for review', { sessionId })
@@ -825,30 +927,29 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
 
   // Step 3: run the reviewer session. All failures inside are caught and set lifecycle='error'.
   let reviewerSession: ActiveSession | undefined
-  let hostServer: ReviewerHostServer | undefined
   let mcpServer: ReviewerMcpServer | undefined
   let checksReceived: NewCheck[] = []
   let checksSubmitted = false
   const capturedLog: ReviewerLogEntry[] = []
 
   try {
-    // Start the host SDK server (provides read_turn / query_execution_log / read_artifact).
-    hostServer = new ReviewerHostServer(session, scope, artifactStorageRoot)
-    const { endpoint: hostEndpoint, token: hostToken } = await hostServer.start()
+    // Evidence reads and submission share one authenticated MCP server. The evidence object enforces
+    // turn/artifact scope server-side; no host token or Bash bootstrap is exposed to the model.
+    const evidence = new ReviewerHostServer(session, scope, artifactStorageRoot)
 
-    // Start the submit_findings MCP server.
-    mcpServer = new ReviewerMcpServer(scope, async (checks: NewCheck[]) => {
-      checksReceived = checks
-      checksSubmitted = true
-      log.info('submit_findings received by MCP handler', { count: checks.length })
-    })
-    // The endpoint/token are consumed via mcpServer.toAcpMcpServerConfig() below.
+    mcpServer = new ReviewerMcpServer(
+      scope,
+      async (checks: NewCheck[]) => {
+        checksReceived = checks
+        checksSubmitted = true
+        log.info('submit_findings received by MCP handler', { count: checks.length })
+      },
+      evidence
+    )
     await mcpServer.start()
 
-    // Build the reviewer prompt: passes the turn scope metadata and host SDK endpoint.
-    const reviewerPrompt = buildReviewerPrompt(scope, hostEndpoint, hostToken)
+    const reviewerPrompt = buildReviewerPrompt(scope)
 
-    // Combine the rubric with the host SDK Python setup instructions.
     const systemPromptAppend = REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
 
     // Spawn the reviewer ACP session (clean context, reviewer-only tools).
@@ -865,7 +966,7 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
 
     // Send the prompt and drive the session to completion. A timeout / update cap guards against a
     // hung or fast-looping reviewer that never stops: on expiry this throws, the catch below sets
-    // lifecycle='error', and the finally disposes the session + host/MCP servers.
+    // lifecycle='error', and the finally disposes the session + MCP server.
     // opencode gets the rubric via a prompt prefix (Claude via _meta, prefix empty).
     const reviewerPromptText = built.promptPrefix
       ? `${built.promptPrefix}\n\n${reviewerPrompt}`
@@ -889,7 +990,8 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
 
     review = await reviewRepository.updateReview(review.id, {
       lifecycle: 'error',
-      errorMessage: errorMsg
+      errorMessage: errorMsg,
+      reviewerLog: capturedLog
     })
     const errorWithFindings: ReviewWithChecks = { ...review, checks: [] }
     onReviewUpdate?.(errorWithFindings)
@@ -899,16 +1001,24 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
     // Always dispose the reviewer session and shut down the servers.
     if (reviewerSession) acpRuntime.disposeReviewerSession(reviewerSession)
     await mcpServer?.stop().catch(() => undefined)
-    await hostServer?.stop().catch(() => undefined)
+  }
+
+  if (!checksSubmitted) {
+    const errorMessage = 'Reviewer stopped without calling submit_findings.'
+    log.error('review protocol incomplete', { reviewId: review.id, error: errorMessage })
+    review = await reviewRepository.updateReview(review.id, {
+      lifecycle: 'error',
+      errorMessage,
+      reviewerLog: capturedLog
+    })
+    const errorWithFindings: ReviewWithChecks = { ...review, checks: [] }
+    onReviewUpdate?.(errorWithFindings)
+    return errorWithFindings
   }
 
   // Step 4: persist checks and set lifecycle='complete'.
   // outcome = flagged iff at least one check is warn or fail; otherwise pass.
   try {
-    if (!checksSubmitted) {
-      log.warn('reviewer did not call submit_findings; treating as pass', { reviewId: review.id })
-    }
-
     await reviewRepository.addChecks(review.id, checksReceived)
 
     const hasWarnOrFailCheck = checksReceived.some(
@@ -967,7 +1077,6 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
       await runFixLoop({
         sessionId,
         originalTurnMessageId: turnMessageId,
-        originalReviewId: review.id,
         openChecks: finalReview.checks.filter((c) => c.status === 'warn' || c.status === 'fail'),
         projectId,
         mainSessionId,
@@ -982,6 +1091,7 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
         reviewerTimeoutMs,
         reviewerMaxUpdates,
         maxRounds: fixLoopMaxRounds,
+        sessionRefreshTimeoutMs,
         abortSignal: fixLoopAbortSignal
       })
     } finally {
@@ -1001,14 +1111,11 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
   return finalReview
 }
 
-// Builds the initial prompt sent to the reviewer session. It passes the turn scope as structured
-// context and provides the host client via the single-sourced bootstrap (see host-sdk.ts) — the
-// reviewer runs Python through Bash, so each fresh process must re-run this setup; there is no
-// pre-loaded `host` object.
+// Builds the prompt sent to the isolated reviewer session. All evidence is available only through the
+// scope-bounded reviewer MCP; no executable bootstrap, filesystem path, or bearer token enters the prompt.
 export const buildReviewerPrompt = (
   scope: TurnScope,
-  hostEndpoint: string,
-  hostToken: string
+  trackedChecks: readonly ReviewCheck[] = []
 ): string => {
   const blockSummary =
     scope.blocks.length === 0
@@ -1025,20 +1132,34 @@ export const buildReviewerPrompt = (
       ? 'No artifacts in this turn.'
       : `Artifact version ids: ${scope.artifactVersionIds.join(', ')}`
 
+  const trackedSummary =
+    trackedChecks.length === 0
+      ? []
+      : [
+          '',
+          'This is a fix-loop re-review. Disposition every tracked finding exactly once by copying',
+          '`sourceFindingId` unchanged into its check. Use pass if fixed, warn/fail if it remains:',
+          JSON.stringify(
+            trackedChecks.map((check) => ({
+              sourceFindingId: check.id,
+              previousStatus: check.status,
+              claim: check.claim,
+              evidence: check.evidence
+            }))
+          ),
+          'You may report a newly discovered issue without sourceFindingId, but omission of any tracked',
+          'finding or reuse of an unknown/duplicate id is rejected.'
+        ]
+
   return [
     `You are reviewing turn: ${scope.turnMessageId}`,
     '',
     blockSummary,
     artifactSummary,
+    ...trackedSummary,
     '',
-    'To read the turn data, run Python via Bash. Each invocation is a fresh process, so include this',
-    'host client setup at the top of every snippet — there is no pre-loaded `host`:',
-    '',
-    '```python',
-    buildReviewerHostPythonBootstrap(hostEndpoint, hostToken),
-    '# Then read the turn:',
-    'blocks = host.read_turn()',
-    '```',
+    'Use only the reviewer MCP tools: read_turn, query_execution_log, and read_artifact.',
+    'They expose only this audited scope. Do not use Bash, filesystem, network, or other tools.',
     '',
     'After reading the turn data, apply the rubric, then call submit_findings once with your findings.',
     'Call submit_findings with an empty array if you find no issues.'

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -387,7 +387,10 @@ const waitForCorrectionAgentMessage = async (options: {
 
     const latest = await options.getSession(options.sessionId)
     const correction = latest?.messages.find(
-      (message) => !options.messageIdsBefore.has(message.id) && message.role === 'agent'
+      (message) =>
+        !options.messageIdsBefore.has(message.id) &&
+        message.role === 'agent' &&
+        message.status === 'complete'
     )
     if (latest && correction) return { session: latest, message: correction }
 

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -578,9 +578,9 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
     }
 
     const dispositionsByFindingId = new Map(
-      scopedResult.submittedChecks
-        .filter((check) => check.sourceFindingId)
-        .map((check) => [check.sourceFindingId!, check] as const)
+      scopedResult.submittedChecks.flatMap((check) =>
+        check.sourceFindingId ? [[check.sourceFindingId, check] as const] : []
+      )
     )
 
     const stillOpenChecks: ReviewCheck[] = []

--- a/src/main/reviewer/repository.test.ts
+++ b/src/main/reviewer/repository.test.ts
@@ -371,8 +371,8 @@ describe('review repository (integration)', () => {
     expect(stored.checks[1]!.reflagCount).toBe(0)
   })
 
-  // Phase 3 storage: incrementReflagCount raises by 1 for the matching claim only.
-  it('incrementReflagCount bumps reflagCount by 1 for the matching claim, leaves others untouched', async () => {
+  // Phase 3 storage: incrementReflagCount raises by 1 for the stable finding ID only.
+  it('incrementReflagCount bumps reflagCount by 1 for the targeted finding, leaves others untouched', async () => {
     const repository = await createRepository()
 
     const review = await repository.createReview({
@@ -399,7 +399,9 @@ describe('review repository (integration)', () => {
       }
     ])
 
-    await repository.incrementReflagCount(review.id, 'ran 33 rows')
+    const [before] = await repository.getReviewsForSession('session-reflag-increment')
+    const targetId = before.checks.find((check) => check.claim === 'ran 33 rows')!.id
+    await repository.incrementReflagCount(review.id, targetId)
 
     const [stored] = await repository.getReviewsForSession('session-reflag-increment')
     const findClaim = (claim: string): ReviewCheck => stored.checks.find((c) => c.claim === claim)!
@@ -409,7 +411,7 @@ describe('review repository (integration)', () => {
     expect(findClaim('axis label mismatch').reflagCount).toBe(0)
   })
 
-  // Calling incrementReflagCount twice on the same claim accumulates correctly.
+  // Calling incrementReflagCount twice on the same finding accumulates correctly.
   it('incrementReflagCount is cumulative across multiple calls', async () => {
     const repository = await createRepository()
 
@@ -430,8 +432,10 @@ describe('review repository (integration)', () => {
       }
     ])
 
-    await repository.incrementReflagCount(review.id, 'value mismatch')
-    await repository.incrementReflagCount(review.id, 'value mismatch')
+    const [before] = await repository.getReviewsForSession('session-reflag-cumulative')
+    const targetId = before.checks[0]!.id
+    await repository.incrementReflagCount(review.id, targetId)
+    await repository.incrementReflagCount(review.id, targetId)
 
     const [stored] = await repository.getReviewsForSession('session-reflag-cumulative')
     expect(stored.checks[0]!.reflagCount).toBe(2)
@@ -449,7 +453,9 @@ describe('review repository (integration)', () => {
     })
 
     await repository.addChecks(review.id, checks())
-    await repository.incrementReflagCount(review.id, 'ran 33 rows')
+    const [before] = await repository.getReviewsForSession('session-reflag-all')
+    const targetId = before.checks.find((check) => check.claim === 'ran 33 rows')!.id
+    await repository.incrementReflagCount(review.id, targetId)
 
     const [stored] = await repository.getReviewsForSession('session-reflag-all')
 
@@ -516,7 +522,8 @@ describe('review repository (integration)', () => {
 
     // The reflag increment + touchReview run in one transaction; the forced touch failure rejects it.
     failTouch = true
-    await expect(repository.incrementReflagCount(review.id, 'ran 33 rows')).rejects.toThrow(
+    const [before] = await repository.getReviewsForSession('session-rollback')
+    await expect(repository.incrementReflagCount(review.id, before.checks[0]!.id)).rejects.toThrow(
       /touch failed/
     )
     failTouch = false

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -234,37 +234,39 @@ class ReviewRepository {
     })
   }
 
-  // Updates the resolution for a single claim (by exact match) under a review.
-  // Used by the Phase 3 fix loop to set per-claim resolution from re-review results.
-  async updateFindingResolutionForClaim(
+  // Updates one original finding by its stable database id. Review model prose is deliberately not part
+  // of the identity: a re-review may paraphrase a claim without accidentally resolving a live issue.
+  async updateFindingResolution(
     reviewId: string,
-    claim: string,
+    findingId: string,
     resolution: FindingResolution
   ): Promise<void> {
     const client = await this.getClient()
     await client.$transaction(async (tx) => {
-      await tx.finding.updateMany({
-        where: { reviewId, claim, status: { in: ['warn', 'fail'] } },
+      const updated = await tx.finding.updateMany({
+        where: { id: findingId, reviewId, status: { in: ['warn', 'fail'] } },
         data: { resolution }
       })
+      if (updated.count !== 1) {
+        throw new Error(`Finding ${findingId} does not belong to review ${reviewId}.`)
+      }
       await touchReview(tx, reviewId)
     })
   }
 
-  // Increments reflagCount by 1 for all checks under a review whose claim matches the given string
-  // (exact match, case-sensitive). Used in the Phase 3 fix loop when a claim is re-flagged after an
-  // over-correction. Leaves checks with a different claim untouched.
-  async incrementReflagCount(reviewId: string, claim: string): Promise<void> {
+  // Increments reflagCount for exactly one stable finding id. The review id is included so a malformed
+  // re-review can never mutate a finding from another review.
+  async incrementReflagCount(reviewId: string, findingId: string): Promise<void> {
     const client = await this.getClient()
     await client.$transaction(async (tx) => {
-      // Use the $executeRaw tagged template because Prisma does not support a column += 1 increment
-      // in updateMany. The query is safe: reviewId and claim are bound as positional parameters by the
-      // tagged template (not string-interpolated), so this is not $executeRawUnsafe.
-      await tx.$executeRaw`
+      const updated = await tx.$executeRaw`
         UPDATE "Finding"
         SET "reflagCount" = "reflagCount" + 1
-        WHERE "reviewId" = ${reviewId} AND "claim" = ${claim}
+        WHERE "reviewId" = ${reviewId} AND "id" = ${findingId}
       `
+      if (updated !== 1) {
+        throw new Error(`Finding ${findingId} does not belong to review ${reviewId}.`)
+      }
       await touchReview(tx, reviewId)
     })
   }

--- a/src/main/reviewer/rubric.ts
+++ b/src/main/reviewer/rubric.ts
@@ -3,42 +3,40 @@
 //
 // Source: docs/draft/reviewer/design-references/reviewer-agent-profile.yaml (system_prompt).
 // This file is a single-hop port of the yaml discipline to this repo's tool framing
-// (host SDK + REPL instead of the yaml's repl/read_file). Keep it here so it evolves
+// (scope-bounded MCP evidence tools instead of the yaml's repl/read_file). Keep it here so it evolves
 // independently of the orchestrator and design.md §5 does not drift (design.md §5 mirrors
 // the sections below; any change here should propagate to design.md §5).
 //
 // Adaptation notes (yaml → this repo):
-//   - yaml excludes `python`; here Python IS the host SDK entry point — the portable rule
-//     is "trace, don't recompute", not "no python".
+//   - Arbitrary code execution is intentionally unavailable; the portable rule is "trace, don't
+//     recompute" through deterministic evidence tools.
 //   - yaml: query_target_history, compacted-history drift, forged-pointer harness markers —
 //     Phase-1 has none of these mechanisms; omissions are noted with [PHASE-1 OMIT] comments.
-//   - yaml: repl + read_file → here: a `host` Python client (set up from the reviewer prompt) whose
-//     methods POST to the app's host RPC server. It is NOT auto-injected — the reviewer runs Python
-//     through Bash, so each fresh process re-runs the setup snippet from the prompt.
+//   - yaml: repl + read_file → here: dedicated reviewer MCP tools whose handlers validate every id
+//     against the immutable turn scope.
 
 export const REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND = [
   '<reviewer_instructions>',
 
   // §5.1 — Role and framework
-  // Adapted from yaml:61-74. Key adaptation: host SDK replaces yaml's repl/read_file.
+  // Adapted from yaml:61-74. Key adaptation: reviewer MCP replaces yaml's repl/read_file.
   'You are the REVIEWER — an independent reviewer assigned to audit one completed turn of the main agent.',
   'You work in a CLEAN CONTEXT: no main chat history, no prior work — only the material',
   "in this turn's scope.",
   '',
-  'You read the turn through a `host` Python client (set it up from the snippet in the task prompt;',
-  'you run Python via Bash, so re-run the setup in each fresh process). Use it before judging:',
-  '  host.read_turn()                      — ordered block list for this turn (messages + tool activities)',
-  '  host.query_execution_log(activityId?) — rawInput / rawOutput / terminalOutput / terminalExitCode',
-  '  host.read_artifact(id)                — tabular artifacts (CSV/TSV): {kind:"tabular", columns:{col:[values]}, rowCount}',
+  'Read the turn only through the dedicated reviewer MCP evidence tools before judging:',
+  '  read_turn()                      — ordered block list for this turn (messages + tool activities)',
+  '  query_execution_log(activityId?) — rawInput / rawOutput / terminalOutput / terminalExitCode',
+  '  read_artifact(id)                — tabular artifacts (CSV/TSV): {kind:"tabular", columns:{col:[values]}, rowCount}',
   '                                          other artifacts: {kind:"raw", content, encoding}',
   '                                          Address tabular data by column name, e.g. result["columns"]["gene_id"]',
   '',
   // yaml:67-68: "Trace, don't recompute."
   'TRACE, NOT RECOMPUTE. If the agent claims a number, find the record that produced it and compare —',
   'a CONTRADICTION is the finding. Reading a saved artifact cell is TRACING, not recomputation.',
-  // yaml:76-81: tabular parsing guidance — adapted to host.read_artifact
+  // yaml:76-81: tabular parsing guidance — adapted to read_artifact
   'For tabular artifacts: never eyeball-align a multi-column CSV row against its header.',
-  'Use host.read_artifact(id) to parse by column name — the response already structures columns for you.',
+  'Use read_artifact(id) to parse by column name — the response already structures columns for you.',
   'Reading a saved artifact cell this way is tracing, not recomputation.',
   '',
   // yaml:83-85
@@ -177,17 +175,17 @@ export const REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND = [
   'TRACE AGAINST THE RECORD:',
   '  • A found contradiction convicts. An unfound source NEVER convicts.',
   '    (Only exception: fabricated external references — see above.)',
-  '  • evidence field: cite ONLY what you READ via host.read_turn / host.query_execution_log /',
-  '    host.read_artifact, or computed yourself in the REPL. Never inject background knowledge.',
+  '  • evidence field: cite ONLY what you READ via read_turn / query_execution_log /',
+  '    read_artifact. Never inject background knowledge.',
   '',
-  'REPL TARGETED TRACING:',
+  'TARGETED TRACING:',
   // yaml:76-81 — adapted to host SDK; "tracing, not recomputation" framing preserved
-  '  • Use host.* to pull facts. Use data-analysis packages for targeted spot checks:',
+  '  • Use the reviewer evidence tools to pull facts for targeted spot checks:',
   '    parse a table cell by column name, cross-check a value against a recorded artifact.',
   '  • Reading a saved artifact cell is TRACING, not recomputation — do it when it helps.',
   '  • ONLY target already-recorded outputs / saved artifacts.',
-  '  • REPL is a precision tracing aid, not a default action — use it for targeted spot-checks',
-  '    against recorded evidence, not to redo analysis from scratch.',
+  '  • Use already-structured tool responses for precision checks against recorded evidence;',
+  '    do not redo analysis from scratch.',
   "  • When your targeted check contradicts the agent's reported value → finding.",
   "    evidence must cite both the agent's value and your verification output.",
   '',
@@ -215,7 +213,7 @@ export const REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND = [
   'Do NOT write any prose before or after the call — your structured findings are the deliverable;',
   'a prose summary is ignored and wastes tokens.',
   'Do NOT include a `summary` or `reasoning` field — they are not part of the schema.',
-  'Your full action trace (thinking, tool calls, REPL results) is captured automatically',
+  'Your full action trace (thinking, tool calls, and tool results) is captured automatically',
   'from the session stream.',
   'Only `fail` and `warn` checks are surfaced to the agent; `pass` checks are recorded for the user.',
   'In that single call provide:',
@@ -233,7 +231,7 @@ export const REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND = [
   '                  Example (pass): "I loaded artifact csv-1 and counted 33 rows — matching',
   '                  the 33 the agent reported in msg[2]."',
   '                  Example (fail): "Agent stated 42 samples (msg[0]). I parsed artifact-csv',
-  '                  with host.read_artifact and found 33 rows."',
+  '                  with read_artifact and found 33 rows."',
   '      - locator:  Optional block-level pointer { blockRef: { blockIndex: N }, contentHash: "..." }.',
   '                  Provide for warn/fail checks (points to the claim being flagged).',
   '                  May be omitted for pass checks.',

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -69,6 +69,39 @@ describe('session persistence repository (per-session files)', () => {
     })
   })
 
+  it('loads one session directly so callers can refresh durable state between turns', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    await repository.saveSession(createSession({ title: 'Before correction' }))
+
+    await expect(repository.loadSession('project-a', 'session-1')).resolves.toMatchObject({
+      id: 'session-1',
+      title: 'Before correction'
+    })
+
+    await repository.saveSession(
+      createSession({
+        title: 'After correction',
+        messages: [
+          ...createSession().messages,
+          {
+            id: 'message-2',
+            role: 'agent',
+            content: 'Correction complete',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1710000000200,
+            updatedAt: 1710000000200
+          }
+        ]
+      })
+    )
+
+    const refreshed = await repository.loadSession('project-a', 'session-1')
+    expect(refreshed?.title).toBe('After correction')
+    expect(refreshed?.messages.at(-1)?.id).toBe('message-2')
+    await expect(repository.loadSession('project-a', 'missing')).resolves.toBeUndefined()
+  })
+
   it('sanitizes embedded message images before writing session JSON', async () => {
     const repository = new SessionRepository(await createStorageRoot())
     const session = createSession({

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -103,6 +103,20 @@ class SessionRepository {
     return (await this.loadAllWithDiagnostics()).result
   }
 
+  // Loads one durable session directly instead of scanning every project/session file. Reviewer fix
+  // loops call this after each correction turn so every re-review sees newly persisted messages rather
+  // than retaining the snapshot that existed when the initial review started.
+  async loadSession(
+    projectId: string,
+    sessionId: string
+  ): Promise<PersistedChatSession | undefined> {
+    const read = await this.readSessionFile(
+      this.sessionFilePath(projectId, sessionId),
+      assertSafeSegment(projectId)
+    )
+    return read.session
+  }
+
   // Reports whether the sessions tree was fully scanned so DB reconciliation never acts on a partial
   // read. Cleanup of previously renamed project tombstones is best-effort and does not re-expose them.
   async loadAllWithDiagnostics(): Promise<SessionLoadDiagnostics> {

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -52,6 +52,10 @@ export type ReviewLifecycle = 'running' | 'complete' | 'error'
 // Result of a completed review: no warn/fail checks = pass, at least one warn/fail = flagged.
 export type ReviewOutcome = 'pass' | 'flagged'
 
+// The only MCP server an unattended reviewer session may use. Keeping the name in shared code lets
+// the orchestrator and ACP permission gate enforce the same allowlist without importing each other.
+export const REVIEWER_MCP_SERVER_NAME = 'open-science-reviewer'
+
 // The check status: pass = verified and ok; warn = minor issue; fail = serious issue.
 // No 'inconclusive' — use 'warn' with appropriate evidence when verification is uncertain.
 export type CheckStatus = 'pass' | 'warn' | 'fail'
@@ -151,6 +155,9 @@ export type NewCheck = {
   status: CheckStatus
   claim: string
   evidence: string
+  // Stable identity of an original warn/fail finding being re-evaluated in the fix loop. Re-review
+  // submissions must disposition every tracked finding exactly once; prose is never used as identity.
+  sourceFindingId?: string
   locator?: FindingLocator // optional — pass checks may omit it
   artifactVersionId?: string
   resolution?: FindingResolution

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -55,6 +55,12 @@ export type ReviewOutcome = 'pass' | 'flagged'
 // The only MCP server an unattended reviewer session may use. Keeping the name in shared code lets
 // the orchestrator and ACP permission gate enforce the same allowlist without importing each other.
 export const REVIEWER_MCP_SERVER_NAME = 'open-science-reviewer'
+export const REVIEWER_MCP_TOOLS = {
+  readTurn: 'read_turn',
+  queryExecutionLog: 'query_execution_log',
+  readArtifact: 'read_artifact',
+  submitFindings: 'submit_findings'
+} as const
 
 // The check status: pass = verified and ok; warn = minor issue; fail = serious issue.
 // No 'inconclusive' — use 'warn' with appropriate evidence when verification is uncertain.


### PR DESCRIPTION
## Executive summary

This PR hardens the built-in Reviewer/Auditor introduced by #159 after tracing the current production IPC, ACP runtime, reviewer tool surface, persistence layer, and correction loop on the latest `main`.

The audit found four still-active correctness/security defects and one historical cost/default issue:

1. **Critical security design risk:** a hidden, unattended Reviewer session could request tools outside the evidence API and the runtime would automatically approve them. Because the material under review includes user/agent/tool-controlled text, a prompt injection could attempt to turn an auditor into an unobserved local execution or data-access agent.
2. **High integrity risk:** production re-review read a one-time `Session` snapshot captured when review started. The correction round could therefore be judged against stale pre-fix content.
3. **High integrity risk:** issue continuity was inferred by exact equality of model-authored `claim` text. A harmless paraphrase could falsely resolve an unfixed issue, while identical wording could conflate distinct issues.
4. **High integrity risk:** if the Reviewer stopped without calling `submit_findings()`, the run logged a warning but persisted an empty result as `pass` — converting an incomplete audit into “No issues found.”
5. **Cost/default risk:** auto-review originally shipped enabled. This was already corrected by #183; this PR preserves and regression-verifies the latest default-off behavior.

The changes replace prompt-only reviewer isolation with an application-enforced capability boundary, make re-review consume a newly persisted durable session, give findings stable database-backed identities, and fail closed whenever an audit is incomplete or fresh correction state cannot be proven.

## Severity and impact analysis

### 1. [Critical] Unattended Reviewer permissions created a privilege-escalation path

#### Previous behavior

The Reviewer was described as scoped, but its effective runtime permissions were broader than the Host SDK:

- the prompt bootstrapped the Host SDK through Bash/Python and disclosed an HTTP bearer token;
- the ACP runtime recognized a background reviewer session and automatically selected an approval option for permission requests;
- the approval decision was not restricted to the expected reviewer server or evidence methods;
- a generic MCP name, built-in shell/filesystem tool, or another provider tool could therefore be approved without an interactive user decision;
- the Reviewer consumes untrusted/transitive content: conversation text, agent output, tool output, terminal output, and generated artifacts. Prompt instructions inside that material must be treated as attacker-controlled input, not as a security boundary.

#### Potential impact

Depending on the ACP backend and tools installed for that backend, a successful instruction-confusion/prompt-injection path could have caused the hidden Reviewer to request local command execution, read data outside the reviewed turn, or use unrelated network/MCP capabilities. This is especially serious because the session is automatic and background-only: the user would not receive the normal permission prompt that protects an interactive agent session.

The old scoped Host SDK correctly constrained requests made *through that SDK*, but it did not constrain capabilities available beside the SDK. “Use only this API” in a system prompt is guidance; it is not authorization enforcement.

#### Root cause

The original implementation had to solve two operational problems at once: ACP did not know about the hidden session through the normal interactive path, and reviews needed to run unattended. The `reviewerSessionIds` exception solved those problems by trusting the entire session, while data scope was enforced separately in the Host SDK. That split left an authorization gap between “which records the SDK returns” and “which tools the model can invoke.”

#### Fix

- Expose one authenticated, per-review, loopback-only MCP server named `open-science-reviewer`.
- Move `read_turn`, `query_execution_log`, `read_artifact`, and `submit_findings` onto that same MCP server. Evidence access continues to use the existing server-side scope validation.
- Remove the Bash/Python bootstrap and remove the Host SDK token/URL from the prompt.
- Allow automatic permission handling only for the exact reviewer MCP namespace. Reject foreign MCP servers, Bash, filesystem, network, legacy Python execution, and every other built-in/tool namespace.
- Validate that the reviewer configuration contains exactly one loopback HTTP MCP server before the ACP connection is started.
- For Claude-backed reviewer sessions, explicitly disable built-in tools and pass an empty tool list. Unknown metadata remains harmless for other backends; the permission gate still denies non-reviewer capabilities.
- Start the Reviewer in a unique empty temporary working directory, set Ask mode, and remove the directory on normal disposal, disconnect, or startup failure.
- Keep the reviewer MCP server name in shared code so runtime authorization and server registration cannot silently drift.

#### Security boundary statement

This creates an application-level capability sandbox: the Reviewer receives only the four scoped MCP capabilities and every other permission request is denied. It is intentionally **not** described as a kernel, container, or micro-VM sandbox. If an ACP provider ignores both its declared tool configuration and the ACP permission protocol, OS-level containment would still require a separate process/container isolation project. The important change here is that ordinary reviewer safety no longer depends on the model obeying a prompt.

### 2. [High] Re-review could inspect a stale pre-correction Session

#### Previous behavior

Production IPC loaded a `Session` once and passed `getSession: () => session` into the orchestrator. The orchestrator API looked like a provider of current state, but the closure always returned the review-start snapshot.

After `[Auditor]` injected a correction request and the main Agent produced a new turn, the next Reviewer could therefore receive old messages. A fallback path could then select the original reviewed turn when no correction message appeared in the stale snapshot.

#### Potential impact

- a correction could be marked resolved without the Reviewer ever seeing it;
- a valid fix could be repeatedly re-flagged because only old output was visible;
- the advertised “fix and re-review up to three times” loop could spend several Agent/Reviewer calls without auditing the new work;
- ReviewerCard status could present false confidence even though the evidence set never advanced.

This is an integrity failure in the core guarantee of the feature: a re-review that does not reliably include the correction is not a re-review.

#### Root cause

The orchestrator evolved to require a state provider, but the production IPC retained snapshot semantics. In addition, renderer-to-main session persistence is asynchronous, so one immediate read after the Agent turn is not sufficient proof that the correction is durably visible.

#### Fix

- Add `SessionRepository.loadSession(projectId, sessionId)` as a direct durable loader.
- Wire the initial review gate and every fix-loop refresh to that loader instead of a captured object.
- Allow async session providers in the orchestrator.
- After a correction turn, poll durable storage for a bounded interval until a newer Agent message is actually present.
- Carry the exact durable snapshot that proved the correction exists into the next review; do not perform a second read that could regress or race.
- If the session disappears, loading fails, or no new Agent message becomes durable before the timeout, fail closed: do not re-review the old turn and do not claim the prior findings were resolved.
- Preserve cancellation semantics: a user cancellation exits without misclassifying the run as a stale-session failure.

### 3. [High] Exact claim-text matching could silently resolve the same defect

#### Previous behavior

The fix loop built a set of `warn`/`fail` claim strings from the new review. An old finding was considered still present only if the new model emitted exactly the same `claim` text.

Model-authored prose is not a stable identifier. For example, “the chart uses kilograms but labels pounds” and “the y-axis unit is incorrect: values are kg, label says lb” describe the same unresolved defect but compare unequal.

#### Potential impact

- unresolved findings could be marked `resolved` after a paraphrase;
- `reflagCount` could under-report repeated failures;
- distinct findings with the same claim text could be updated together or attributed incorrectly;
- repository mutations based on prose could affect the wrong lifecycle record;
- new defects introduced by a correction could be lost instead of entering the next correction round.

#### Root cause

The first implementation used the claim as both display content and cross-review identity. This avoided adding a protocol field but made lifecycle correctness depend on nondeterministic natural-language output.

#### Fix

- Add `sourceFindingId` to the re-review submission contract.
- Embed the database ID of every open finding in the tracked re-review prompt.
- Require exactly one disposition for every tracked ID.
- Reject missing, duplicate, or unknown tracked IDs at the MCP boundary.
- Continue accepting findings without `sourceFindingId` as genuinely new issues.
- Update resolution and `reflagCount` by `(reviewId, findingId)`, never by claim text, and assert that exactly one row was changed.
- Carry newly discovered findings into the following correction round and resolve them through their own stable IDs.
- Reject a second successful `submit_findings()` call so one run cannot overwrite or ambiguously redefine its result.

### 4. [High] Missing `submit_findings()` was treated as a clean pass

#### Previous behavior

If the model returned, crashed, refused, lost tool access, or otherwise ended without calling `submit_findings()`, the code emitted a warning and continued with an empty checks array. The review outcome then became `pass` and the UI could show “No issues found.”

#### Potential impact

This is the most dangerous possible failure semantic for an auditor: inability to complete the audit was indistinguishable from affirmative evidence that no problems existed. Provider regressions, token exhaustion, MCP failures, or prompt injection that suppressed submission could all become false-green reviews.

#### Root cause

Submission was treated as optional output collection instead of the commit point of the review protocol. Empty findings and absent findings collapsed to the same representation.

#### Fix

- A Reviewer must call `submit_findings()` exactly once, including when the valid result is an empty findings list.
- Ending without a successful submission now raises a lifecycle error and records diagnostic logs.
- The incomplete run is not persisted as `pass` and cannot render as “No issues found.”
- Multiple successful submissions are rejected.

### 5. [Medium / cost] Auto-review default-on behavior

#183 already changed auto-review to opt-in on the current main branch. This PR does not duplicate or revert that fix. Existing/default-session and workspace-event regression tests remain green, covering legacy/corrupt session defaults and confirming that a normal Agent turn does not automatically start a review unless enabled.

## New enforced workflow

```text
Agent turn completes
  -> fresh Reviewer starts in an empty temporary cwd
  -> runtime exposes only open-science-reviewer MCP
  -> Reviewer reads scoped evidence through server-side access checks
  -> Reviewer must submit exactly once
     -> no submission: lifecycle error, never pass
     -> findings: persist with stable IDs
  -> correction is requested
  -> wait for a newer Agent message in durable session storage
     -> not observed: fail closed, never inspect stale turn
     -> observed: re-review the proven fresh snapshot
  -> every prior finding receives one sourceFindingId disposition
  -> new findings are carried into the next round
  -> pass, cancellation, or three-round cap terminates the loop
```

## Additional hardening and maintainability improvements

- Evidence tools and submission now share one transport, authentication context, lifecycle, and audit log.
- Reviewer prompts contain neither a bearer secret nor executable bootstrap snippets.
- Loopback validation happens before spawning the ACP subprocess.
- Temporary-directory cleanup covers success, disconnect, and partial startup failure and logs cleanup failures without hiding the primary error.
- Repository update assertions turn silent identity corruption into an explicit failure.
- Fresh-snapshot polling makes the renderer/main persistence boundary observable and testable.
- Per-check `reviewId` handling prevents findings introduced during re-review from being mutated through the original review record.
- Error paths preserve logs for diagnosis rather than presenting an empty success record.

## Test coverage

New and updated tests cover:

- exact reviewer MCP allowlisting and denial of foreign MCP/Bash/filesystem/legacy Python requests;
- rejection of non-loopback reviewer servers before ACP spawn;
- empty temporary cwd creation and cleanup;
- backend metadata that removes Claude built-in tools;
- live MCP protocol calls for all evidence tools;
- missing, unknown, and duplicate `sourceFindingId` dispositions;
- duplicate submission rejection;
- paraphrased re-flags preserving the same finding and incrementing `reflagCount`;
- newly introduced correction defects surviving into the next round and resolving by their own IDs;
- durable session reload before/after a correction;
- IPC proving that successive `getSession()` calls observe changed persisted state;
- stale/missing correction state refusing re-review;
- missing `submit_findings()` producing an error rather than a pass;
- normal pass, user cancellation, and three-round-cap behavior.

Validation on latest `main` (`f91b53b`):

- `npm run typecheck` - passed
- `npm run lint` - passed
- `npm test` - passed: **374 files passed, 7 skipped; 4,343 tests passed, 65 skipped**
- `npm run build` - passed for Electron main/preload/renderer and web targets
- `git diff --check` - passed

The production build still prints the repository's pre-existing 3Dmol `eval` warning and Vite chunk-size warnings; neither is introduced or changed by this PR.

## Review guidance

The highest-value review points are:

1. the exact permission decision in `src/main/acp/runtime.ts`;
2. MCP request validation and tracked-finding protocol in `src/main/reviewer/mcp-server.ts`;
3. durable fresh-session proof and fail-closed transitions in `src/main/reviewer/orchestrator.ts`;
4. production session loading in `src/main/reviewer/ipc.ts` and `src/main/session-persistence/repository.ts`.

## Scope note

This PR intentionally focuses on correctness and application-level confinement of the existing Reviewer architecture. A future defense-in-depth project could put the entire ACP reviewer subprocess in an OS sandbox/container, but that is no longer required to prevent the normal Reviewer path from obtaining unrelated application tools: those capabilities are now absent and denied by construction.
