### PR TITLE
fix(notebook): harden runtime provisioning, crash recovery, and reset lifecycle

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -404,7 +404,30 @@ const registerIpcHandlers = async ({
       root: provisioningRoot,
       channel: mirror.condaChannel ?? process.env.OPEN_SCIENCE_CONDA_CHANNEL ?? 'conda-forge',
       caBundle: mirror.caBundle,
-      micromamba: { resourcesPath: process.resourcesPath }
+      micromamba: { resourcesPath: process.resourcesPath },
+      // Self-guard the provisioner's prefix writes (startup restore/upgrade/repair, named create, lazy
+      // materialize) against a prefix crash-recovery could not confirm free of a live orphan — closes
+      // the startup-gate path the UI-only assertProvisionAllowed guard did not cover. Reads the live
+      // blocked set at call time (recovery is awaited before the gate touches any prefix).
+      isPrefixBlocked: (prefix) => notebookService.isPrefixRecoveryBlocked(prefix),
+      // An explicit user Reset (repair with force) clears the in-memory block; the provisioner also
+      // clears the retained journal record + sidecar so the quarantine doesn't re-arm next startup.
+      clearPrefixBlock: (prefix) => notebookService.clearRecoveryBlock(prefix),
+      // Reset also clears an interrupted install's runtime-ID block, or bound sessions would still be
+      // rejected after the env rebuilds until the next restart.
+      clearRuntimeBlock: (runtimeId) => notebookService.clearRuntimeRecoveryBlock(runtimeId),
+      // A force Reset that finds the journal itself corrupt moves it aside and releases just THAT prefix
+      // from the global corrupt-journal barrier — other envs stay blocked until their own Reset/restart.
+      clearCorruptBlock: (prefix) => notebookService.clearCorruptRecoveryBlock(prefix),
+      // On an unconfirmed-child prefix-write failure, block the prefix in-process immediately so an
+      // in-session retry can't begin() a second op that races the first's possibly-live orphan.
+      blockPrefix: (prefix) => notebookService.blockPrefixRecovery(prefix),
+      // Lets a force Reset refuse a prefix an interrupted install (or prefix write) this session left with
+      // a possibly-live orphan — the provisioner can't see install failures in its own set.
+      isPrefixLiveUnconfirmed: (prefix) => notebookService.isPrefixLiveUnconfirmed(prefix),
+      // Share the service's per-env install lock so a default-env create/repair/upgrade serializes with
+      // a package install into the same env prefix instead of racing it on a separate lock.
+      withPrefixLock: (envName, fn) => notebookService.withEnvLock(envName, fn)
     })
     // One serialized wrapper shared by the startup gate and the notebook service's on-demand default
     // provisioning, so a concurrent build of the same default env (UI R-tab + an agent R run) can't

--- a/src/main/notebook/env-ipc.test.ts
+++ b/src/main/notebook/env-ipc.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -25,7 +25,8 @@ import type { ProvisionProgress, RuntimeProvisioner } from './provisioner'
 import {
   createNotebookEnvHandlers,
   registerNotebookEnvIpcHandlers,
-  runStartupGate
+  runStartupGate,
+  serializeProvisioner
 } from './env-ipc'
 
 const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisioner => ({
@@ -42,10 +43,10 @@ const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisi
 })
 
 describe('createNotebookEnvHandlers', () => {
-  it('status returns the provisioner status', () => {
+  it('status returns the provisioner status', async () => {
     const provisioner = fakeProvisioner()
     const handlers = createNotebookEnvHandlers(provisioner)
-    expect(handlers.status()).toEqual({
+    expect(await handlers.status()).toEqual({
       pythonReady: false,
       rReady: false,
       version: 0,
@@ -69,11 +70,99 @@ describe('createNotebookEnvHandlers', () => {
     expect(provisioner.provisionR).toHaveBeenCalledOnce()
   })
 
-  it('repair delegates by language', async () => {
+  it('repair delegates by language as an explicit force-recovery', async () => {
     const provisioner = fakeProvisioner()
     const handlers = createNotebookEnvHandlers(provisioner)
     await handlers.repair('r', () => {})
-    expect(provisioner.repair).toHaveBeenCalledWith('r', expect.any(Function))
+    // UI repair is the user's Reset: it force-clears the quarantine (force: true).
+    expect(provisioner.repair).toHaveBeenCalledWith('r', expect.any(Function), { force: true })
+  })
+
+  it('cancel forwards the language to the provisioner while that language is provisioning', () => {
+    const provisioner = fakeProvisioner({
+      // Keep R provisioning in flight so its language is pending when we cancel.
+      provisionR: vi.fn().mockReturnValue(new Promise<void>(() => {}))
+    })
+    const handlers = createNotebookEnvHandlers(provisioner)
+    void handlers.provision('r', () => {})
+    handlers.cancel('r')
+    expect(provisioner.cancel).toHaveBeenCalledWith('r')
+  })
+
+  it('cancel forwards the language to the provisioner while a Reset (repair) is in flight', () => {
+    // A Reset runs through repair; it must bump the per-language pending count (serializeLanguage), or
+    // the Cancel button shown during a Reset would be dropped as idle and the Reset be un-abortable.
+    const provisioner = fakeProvisioner({
+      repair: vi.fn().mockReturnValue(new Promise<void>(() => {})) // keep the Reset in flight
+    })
+    const handlers = createNotebookEnvHandlers(provisioner)
+    void handlers.repair('python', () => {})
+    handlers.cancel('python')
+    expect(provisioner.cancel).toHaveBeenCalledWith('python')
+  })
+
+  it('cancel is a NO-OP when the language is idle (does not arm the next unrelated provision)', () => {
+    const provisioner = fakeProvisioner()
+    const handlers = createNotebookEnvHandlers(provisioner)
+    handlers.cancel('r') // nothing provisioning -> must not reach the provisioner
+    expect(provisioner.cancel).not.toHaveBeenCalled()
+  })
+
+  it('idempotent: the production triple-wrap still forwards a queued cancel to the base provisioner', () => {
+    // In production the provisioner is wrapped 3x (main/ipc.ts, registerNotebookEnvIpcHandlers,
+    // createNotebookEnvHandlers). If each wrap owned its own queue+pending, a request queued at the
+    // OUTER layer wouldn't exist in an inner layer's pending, so cancel routed inward would be dropped
+    // as idle. Idempotent serialization collapses them to ONE queue, so a queued cancel reaches base.
+    let releasePython!: () => void
+    const base = fakeProvisioner({
+      provisionPython: vi.fn().mockReturnValue(
+        new Promise<void>((resolve) => {
+          releasePython = resolve
+        })
+      )
+    })
+    const wrapped = serializeProvisioner(serializeProvisioner(serializeProvisioner(base)))
+
+    void wrapped.provisionPython(() => {}) // running
+    void wrapped.provisionR(() => {}) // queued behind python (same single queue)
+    wrapped.cancel('r') // must reach base despite the triple wrap
+
+    expect(base.cancel).toHaveBeenCalledWith('r')
+    releasePython()
+  })
+
+  it('idempotent: re-wrapping an already-serialized provisioner returns the same instance', () => {
+    const once = serializeProvisioner(fakeProvisioner())
+    expect(serializeProvisioner(once)).toBe(once)
+  })
+
+  it('counts multiple pending requests for one language (cancel stays live until the last settles)', async () => {
+    // Two same-language requests must both be tracked; if the first to settle deleted the language, a
+    // cancel while the second is still in flight would be wrongly dropped as idle.
+    let releaseFirst!: () => void
+    let firstStarted = false
+    const base = fakeProvisioner({
+      provisionR: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((resolve) => {
+              firstStarted = true
+              releaseFirst = resolve
+            })
+        )
+        .mockImplementation(() => new Promise<void>(() => {})) // second stays pending
+    })
+    const wrapped = serializeProvisioner(base)
+
+    const first = wrapped.provisionR(() => {}) // running
+    void wrapped.provisionR(() => {}) // second queued (count = 2)
+    await vi.waitFor(() => expect(firstStarted).toBe(true))
+
+    releaseFirst() // first settles -> count drops to 1, NOT 0
+    await first
+    wrapped.cancel('r') // second still pending -> must still forward
+    expect(base.cancel).toHaveBeenCalledWith('r')
   })
 
   it('UI provision awaits recovery BEFORE touching a prefix (barrier)', async () => {
@@ -111,10 +200,10 @@ describe('createNotebookEnvHandlers', () => {
     expect(order).toEqual(['recovery', 'repair'])
   })
 
-  it('UI provision/repair refuses when the default env is recovery-blocked', async () => {
+  it('UI provision refuses when the default env is recovery-blocked (but repair is the recovery)', async () => {
     // After recovery leaves the default prefix blocked (an unknown-liveness orphan may still hold it),
-    // a UI provision/repair must refuse rather than materialize over it. The guard runs AFTER
-    // waitForRecovery so the blocked set is populated.
+    // a UI PROVISION must refuse rather than materialize over it. REPAIR is the explicit Reset/recovery
+    // — it deliberately bypasses that gate (force-clears the quarantine), so it must NOT refuse.
     const provisioner = fakeProvisioner()
     const assertProvisionAllowed = vi.fn((lang: string) => {
       if (lang === 'python') throw new Error('RUNTIME_RECOVERY_BLOCKED: python is recovering')
@@ -122,10 +211,12 @@ describe('createNotebookEnvHandlers', () => {
     const handlers = createNotebookEnvHandlers(provisioner, async () => {}, assertProvisionAllowed)
 
     await expect(handlers.provision('python', () => {})).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
-    await expect(handlers.repair('python', () => {})).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
-    // The provisioner is never touched when blocked.
     expect(provisioner.provisionPython).not.toHaveBeenCalled()
-    expect(provisioner.repair).not.toHaveBeenCalled()
+
+    // Repair (the Reset entry) proceeds — it's the recovery, so it force-clears rather than refusing.
+    await handlers.repair('python', () => {})
+    expect(provisioner.repair).toHaveBeenCalledWith('python', expect.any(Function), { force: true })
+
     // A non-blocked language still provisions.
     await handlers.provision('r', () => {})
     expect(provisioner.provisionR).toHaveBeenCalledOnce()
@@ -218,7 +309,7 @@ describe('registerNotebookEnvIpcHandlers', () => {
 
   it('status reports not-ready and provision/repair reject with an actionable reason', async () => {
     registerNotebookEnvIpcHandlers(undefined, '/tmp/nope')
-    const status = registered.get('notebook-env:status')?.({})
+    const status = await registered.get('notebook-env:status')?.({})
     expect(status).toMatchObject({ pythonReady: false, rReady: false, provisioning: false })
     await expect(registered.get('notebook-env:provision')?.({}, 'python')).rejects.toThrow(
       /micromamba/i
@@ -335,6 +426,42 @@ describe('runStartupGate', () => {
     await expect(runStartupGate(provisioner, dir, broadcast)).resolves.toBeUndefined()
     expect(broadcast).toHaveBeenCalledWith(
       expect.objectContaining({ phase: 'error', message: expect.stringContaining('boom') })
+    )
+  })
+
+  it('refuses to rebuild over a recovery-blocked prefix through the REAL provisioner self-guard', async () => {
+    // The startup gate drives repair/upgrade/restore through the provisioner, so the block guarantee
+    // must survive that real path — not just a mock guard on the UI handlers. Wire a real
+    // DefaultRuntimeProvisioner with the isPrefixBlocked dep ipc.ts injects (← isPrefixRecoveryBlocked),
+    // set up a marker-but-no-bin state so the planner picks 'repair', and assert the gate refuses:
+    // nothing is spawned, the (possibly-live) prefix is not deleted, and the error is broadcast.
+    const { writeReadyMarker, envPrefix, DEFAULT_PY_ENV } = await import('./runtime-paths')
+    const { DefaultRuntimeProvisioner } = await import('./provisioner')
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate-blocked-'))
+    const prefix = envPrefix(dir, DEFAULT_PY_ENV)
+    mkdirSync(prefix, { recursive: true }) // a partial prefix an orphan may still be writing
+    writeReadyMarker(dir, 0, 't') // marker present + no bin => planStartupAction === 'repair'
+
+    const runArgv = vi.fn().mockResolvedValue(undefined)
+    const provisioner = new DefaultRuntimeProvisioner({
+      root: dir,
+      mm: '/mm',
+      channel: 'conda-forge',
+      fetchBundle: async (spec) => ({ lockPath: join(dir, `${spec.name}.lock`) }),
+      runArgv,
+      verify: async () => undefined,
+      isPrefixBlocked: (p) => p === prefix
+    })
+    const broadcast = vi.fn()
+    await runStartupGate(provisioner, dir, broadcast)
+
+    expect(runArgv).not.toHaveBeenCalled() // no rebuild spawned
+    expect(existsSync(prefix)).toBe(true) // prefix not rm -rf'd out from under a possible survivor
+    expect(broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: 'error',
+        message: expect.stringMatching(/RUNTIME_RECOVERY_BLOCKED/)
+      })
     )
   })
 

--- a/src/main/notebook/env-ipc.ts
+++ b/src/main/notebook/env-ipc.ts
@@ -17,10 +17,10 @@ import { existsSync } from 'node:fs'
 
 // A small delegating surface so IPC behavior tests run without Electron wiring.
 export type NotebookEnvHandlers = {
-  status: () => ProvisionStatus
+  status: () => Promise<ProvisionStatus>
   provision: (lang: NotebookLanguage, onProgress: (p: ProvisionProgress) => void) => Promise<void>
   repair: (lang: NotebookLanguage, onProgress: (p: ProvisionProgress) => void) => Promise<void>
-  cancel: () => void
+  cancel: (language?: NotebookLanguage) => void
 }
 
 // The provisioner shares a single `provisioning` flag across python/R (A3 review carry-forward), so
@@ -28,8 +28,35 @@ export type NotebookEnvHandlers = {
 // every provisioning-affecting call is chained behind an in-flight promise: a call that arrives while
 // one is still running waits for it to settle (success or failure) before starting its own run,
 // instead of firing a conflicting run in parallel. `status` passes through unserialized (read-only).
+// Brands a serialized wrapper so serializeProvisioner is IDEMPOTENT. The provisioner is wrapped at
+// three sites (main/ipc.ts, registerNotebookEnvIpcHandlers, createNotebookEnvHandlers); without this,
+// each layer would own a SEPARATE queue + pending map, and a request queued at the OUTERMOST layer
+// would not yet exist in an inner layer's pending set — so cancel() routed inward would be dropped as
+// "idle" and never reach the provisioner. Collapsing to one wrapper gives one queue and one pending
+// map, so cancel(lang) sees the same in-flight state the provision was enqueued into.
+const SERIALIZED = Symbol('serializedProvisioner')
+
 export const serializeProvisioner = (provisioner: RuntimeProvisioner): RuntimeProvisioner => {
+  // Already serialized (wrapped by an outer call): return as-is so re-wrapping is a no-op and there is
+  // exactly one queue + one pending map for the whole chain.
+  if ((provisioner as { [SERIALIZED]?: true })[SERIALIZED]) return provisioner
+
   let inFlight: Promise<void> = Promise.resolve()
+  // Per-language COUNT of in-flight provisions (running OR queued behind the chain). A count, not a Set:
+  // two same-language requests must both be tracked, or the first to settle would delete the language
+  // while the second is still pending and a later cancel would be wrongly dropped as idle. This is the
+  // only layer that sees the queue, so it's where "No-op when idle" lives: cancel(lang) forwards only
+  // when count>0. Incremented synchronously when a language provision is requested (before it queues),
+  // decremented when that run settles.
+  const pending = new Map<NotebookLanguage, number>()
+  const retain = (language: NotebookLanguage): void => {
+    pending.set(language, (pending.get(language) ?? 0) + 1)
+  }
+  const release = (language: NotebookLanguage): void => {
+    const next = (pending.get(language) ?? 0) - 1
+    if (next <= 0) pending.delete(language)
+    else pending.set(language, next)
+  }
 
   const serialize = (run: () => Promise<void>): Promise<void> => {
     const next = inFlight.then(run, run)
@@ -39,17 +66,37 @@ export const serializeProvisioner = (provisioner: RuntimeProvisioner): RuntimePr
     return next
   }
 
-  return {
+  const serializeLanguage = (
+    language: NotebookLanguage,
+    run: () => Promise<void>
+  ): Promise<void> => {
+    retain(language)
+    return serialize(() => run().finally(() => release(language)))
+  }
+
+  const wrapped: RuntimeProvisioner = {
     status: () => provisioner.status(),
-    provisionPython: (onProgress) => serialize(() => provisioner.provisionPython(onProgress)),
-    provisionR: (onProgress) => serialize(() => provisioner.provisionR(onProgress)),
+    provisionPython: (onProgress) =>
+      serializeLanguage('python', () => provisioner.provisionPython(onProgress)),
+    provisionR: (onProgress) => serializeLanguage('r', () => provisioner.provisionR(onProgress)),
     upgradeIfNeeded: (onProgress) => serialize(() => provisioner.upgradeIfNeeded(onProgress)),
-    repair: (lang, onProgress) => serialize(() => provisioner.repair(lang, onProgress)),
+    // repair runs per-LANGUAGE (serializeLanguage, not plain serialize) so it bumps the pending count
+    // and cancel(lang) — the Cancel button shown during a Reset — actually forwards instead of being
+    // dropped as idle. A Reset that can't be cancelled would be a locked, un-abortable state.
+    repair: (lang, onProgress, opts) =>
+      serializeLanguage(lang, () => provisioner.repair(lang, onProgress, opts)),
     restoreRelocatedEnvs: (onProgress) =>
       serialize(() => provisioner.restoreRelocatedEnvs(onProgress)),
     // cancel is NOT serialized — it must interrupt the in-flight run immediately, not queue behind it.
-    cancel: () => provisioner.cancel()
+    // No-op when the language is idle (count 0); otherwise forward so the provisioner aborts a running
+    // run or arms a one-shot skip for a queued one. `undefined` (global cancel) always forwards.
+    cancel: (language) => {
+      if (language !== undefined && (pending.get(language) ?? 0) === 0) return
+      provisioner.cancel(language)
+    }
   }
+  ;(wrapped as { [SERIALIZED]?: true })[SERIALIZED] = true
+  return wrapped
 }
 
 export const createNotebookEnvHandlers = (
@@ -72,13 +119,27 @@ export const createNotebookEnvHandlers = (
     await run()
   }
   return {
-    status: () => serialized.status(),
+    // AWAIT recovery before reading status: recovery populates the blocked-prefix set (and hence
+    // status.*RecoveryBlocked) asynchronously. A renderer that reads status before recovery settles
+    // would see blocked=false and never surface Reset — the startup gate produces no progress event for
+    // an already-ready env, so there is no other signal that would later correct it.
+    status: async () => {
+      if (waitForRecovery) await waitForRecovery()
+      return serialized.status()
+    },
     provision: (lang, onProgress) =>
       afterRecovery(lang, () =>
         lang === 'r' ? serialized.provisionR(onProgress) : serialized.provisionPython(onProgress)
       ),
-    repair: (lang, onProgress) => afterRecovery(lang, () => serialized.repair(lang, onProgress)),
-    cancel: () => serialized.cancel()
+    // A UI-triggered repair is the EXPLICIT user recovery / Reset: it awaits recovery for ordering but
+    // does NOT assertProvisionAllowed (that would refuse a blocked runtime — the whole point of Reset is
+    // to clear the block), and it force-clears the quarantine before rebuilding. Auto/startup repair
+    // (runStartupGate) calls the provisioner directly without force and stays gated by the block.
+    repair: async (lang, onProgress) => {
+      if (waitForRecovery) await waitForRecovery()
+      await serialized.repair(lang, onProgress, { force: true })
+    },
+    cancel: (language) => serialized.cancel(language)
   }
 }
 
@@ -149,15 +210,16 @@ const RUNTIME_UNAVAILABLE_MESSAGE =
 // UI shows an actionable setup state, and provision/repair reject with a clear reason rather than the
 // channel being absent entirely (which would surface as a "No handler registered" crash in the renderer).
 const createUnavailableHandlers = (): NotebookEnvHandlers => ({
-  status: () => ({
-    pythonReady: false,
-    rReady: false,
-    version: DEFAULT_ENV_VERSION,
-    provisioning: false
-  }),
+  status: () =>
+    Promise.resolve({
+      pythonReady: false,
+      rReady: false,
+      version: DEFAULT_ENV_VERSION,
+      provisioning: false
+    }),
   provision: () => Promise.reject(new Error(RUNTIME_UNAVAILABLE_MESSAGE)),
   repair: () => Promise.reject(new Error(RUNTIME_UNAVAILABLE_MESSAGE)),
-  cancel: () => undefined
+  cancel: () => undefined // unavailable backend: no in-flight run to cancel (language ignored)
 })
 
 // Registers the notebook-env IPC surface and kicks off the startup readiness gate. Both the gate and
@@ -195,7 +257,9 @@ export const registerNotebookEnvIpcHandlers = (
   )
   // Synchronous best-effort abort of an in-flight provision; returns immediately (the aborted run
   // settles on its own and broadcasts its terminal progress).
-  ipcMain.handle('notebook-env:cancel', () => handlers.cancel())
+  ipcMain.handle('notebook-env:cancel', (_event, language?: NotebookLanguage) =>
+    handlers.cancel(language)
+  )
   if (serialized)
     void runStartupGate(serialized, root, broadcastNotebookEnvProgress, waitForRecovery)
 }

--- a/src/main/notebook/operation-journal.test.ts
+++ b/src/main/notebook/operation-journal.test.ts
@@ -1,11 +1,22 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { RuntimeOperationJournal, type RuntimeOperationRecord } from './operation-journal'
+import {
+  bootTokenProvesReboot,
+  isValidBootToken,
+  listOperationChildren,
+  readOperationChild,
+  recordOperationChildSync,
+  recordSpawnIntentSync,
+  removeOperationChildSync,
+  RuntimeOperationJournal,
+  UNREADABLE_RUNTIME_DIR,
+  type RuntimeOperationRecord
+} from './operation-journal'
 
 const roots: string[] = []
 const journalPath = async (): Promise<string> => {
@@ -102,6 +113,127 @@ describe('RuntimeOperationJournal', () => {
     expect(await journal.pending()).toEqual([])
   })
 
+  it('begin() throws on a corrupt journal instead of overwriting it (fail closed)', async () => {
+    const path = await journalPath()
+    const journal = new RuntimeOperationJournal(path)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, '{ not json', 'utf8')
+    // Overwriting would destroy the unreadable in-flight state; every prefix-writing caller begins
+    // fail-closed, so begin() must refuse rather than clobber it.
+    await expect(journal.begin(record({ operationId: 'op-1' }))).rejects.toThrow(
+      /RUNTIME_JOURNAL_CORRUPT/
+    )
+    // The corrupt file is preserved (not overwritten) for a later boot / Reset.
+    expect(await readFile(path, 'utf8')).toBe('{ not json')
+  })
+
+  it('readState distinguishes an absent journal from a corrupt one (recovery fail-safe)', async () => {
+    const path = await journalPath()
+    const journal = new RuntimeOperationJournal(path)
+    // Absent -> empty records (nothing was in flight), NOT corrupt.
+    expect(await journal.readState()).toEqual({ records: [] })
+    // A readable JSON array -> its (valid) records.
+    await journal.begin(record({ operationId: 'op-1' }))
+    const ok = await journal.readState()
+    expect(ok).not.toBe('corrupt')
+    expect(ok === 'corrupt' ? [] : ok.records).toHaveLength(1)
+    // Present but unparseable -> corrupt (recovery must fail safe, not read as "nothing in flight").
+    await writeFile(path, '{ not json', 'utf8')
+    expect(await journal.readState()).toBe('corrupt')
+    // A non-array JSON value is also corrupt.
+    await writeFile(path, '{"operationId":"x"}', 'utf8')
+    expect(await journal.readState()).toBe('corrupt')
+    // pending() still degrades to empty on corrupt (best-effort for the non-recovery callers).
+    expect(await journal.pending()).toEqual([])
+  })
+
+  it('treats a journal with ANY invalid entry as corrupt, not a healthy journal missing that entry', async () => {
+    const path = await journalPath()
+    const journal = new RuntimeOperationJournal(path)
+    await mkdir(dirname(path), { recursive: true })
+    // [{}] parses fine and is an array, but its one element isn't a valid record. Silently filtering it
+    // out would read this as a healthy EMPTY journal — opening the recovery barrier and letting the next
+    // begin() overwrite whatever evidence the invalid entry represented. Any bad element must corrupt
+    // the WHOLE journal instead.
+    await writeFile(path, JSON.stringify([{}]), 'utf8')
+    expect(await journal.readState()).toBe('corrupt')
+    expect(await journal.pending()).toEqual([])
+    await expect(journal.begin(record({ operationId: 'op-1' }))).rejects.toThrow(
+      /RUNTIME_JOURNAL_CORRUPT/
+    )
+  })
+
+  it('treats a record with a PRESENT-but-malformed childStartToken as corrupt (fail-closed)', async () => {
+    const path = await journalPath()
+    const journal = new RuntimeOperationJournal(path)
+    await mkdir(dirname(path), { recursive: true })
+    // A full child group but a token that isn't our decimal form. Accepting it would let a garbage token
+    // reach the reuse check and spuriously read as 'dead' (reconcile under a live worker). It must
+    // invalidate the record → whole journal corrupt (same rule as any other invalid entry).
+    const child = { childPid: 4242, childStartedAt: 111 }
+    await writeFile(
+      path,
+      JSON.stringify([{ ...record({ operationId: 'op-1' }), ...child, childStartToken: 'nope' }]),
+      'utf8'
+    )
+    expect(await journal.readState()).toBe('corrupt')
+    // A valid decimal token in a full child group is fine and round-trips.
+    await writeFile(
+      path,
+      JSON.stringify([{ ...record({ operationId: 'op-1' }), ...child, childStartToken: '80877' }]),
+      'utf8'
+    )
+    const ok = await journal.readState()
+    expect(ok === 'corrupt' ? [] : ok.records[0].childStartToken).toBe('80877')
+  })
+
+  it('treats PARTIAL child metadata (a lifecycle field without childPid) as corrupt', async () => {
+    // The child fields (childPid, childStartedAt, childStartToken) are written ATOMICALLY at spawn, so a
+    // record has either NO child fields or the full group. A stray childStartedAt / childStartToken with
+    // NO childPid can't be something we wrote — and worse, recovery treats "no childPid + no
+    // spawnAttempted" as DEAD and reconciles, so orphaned start metadata would be silently reconciled as
+    // "never spawned". It must corrupt the whole journal (block) instead. Likewise a pid with no start time.
+    const path = await journalPath()
+    const journal = new RuntimeOperationJournal(path)
+    await mkdir(dirname(path), { recursive: true })
+    const partials = [
+      { childStartedAt: 1 },
+      { childStartToken: '80877' },
+      { childStartedAt: 1, childStartToken: '80877' },
+      { childPid: 4242 } // pid without the start time it is always written with
+    ]
+    for (const partial of partials) {
+      await writeFile(
+        path,
+        JSON.stringify([{ ...record({ operationId: 'op-1' }), ...partial }]),
+        'utf8'
+      )
+      expect(await journal.readState()).toBe('corrupt')
+    }
+    // The all-absent shape (op never recorded a pid) is the OTHER valid shape and must round-trip.
+    await writeFile(path, JSON.stringify([record({ operationId: 'op-1' })]), 'utf8')
+    const ok = await journal.readState()
+    expect(ok === 'corrupt' ? undefined : ok.records[0].childPid).toBeUndefined()
+  })
+
+  it('quarantineCorrupt moves the journal aside so a fresh begin() succeeds again', async () => {
+    const path = await journalPath()
+    const journal = new RuntimeOperationJournal(path)
+    await mkdir(dirname(path), { recursive: true })
+    // Nothing to move yet -> false, not an error.
+    expect(await journal.quarantineCorrupt()).toBe(false)
+    await writeFile(path, '{ not json', 'utf8')
+    expect(await journal.readState()).toBe('corrupt')
+
+    expect(await journal.quarantineCorrupt()).toBe(true)
+
+    // The corrupt content is preserved under a sibling path, not deleted...
+    expect(existsSync(path)).toBe(false)
+    // ...and begin() now succeeds against a clean (absent) journal.
+    await journal.begin(record({ operationId: 'op-1' }))
+    expect(await journal.pending()).toHaveLength(1)
+  })
+
   it('serializes overlapping begins so concurrent writes never lose an entry', async () => {
     const path = await journalPath()
     const journal = new RuntimeOperationJournal(path)
@@ -138,5 +270,285 @@ describe('RuntimeOperationJournal', () => {
     )
     expect(await RuntimeOperationJournal.forPath(path).pending()).toHaveLength(8)
     expect(JSON.parse(await readFile(path, 'utf8'))).toHaveLength(8)
+  })
+})
+
+describe('operation child-PID sidecar', () => {
+  const runtimeRoot = async (): Promise<string> => {
+    const dir = await mkdtemp(join(tmpdir(), 'op-child-'))
+    roots.push(dir)
+    return dir
+  }
+
+  it('records a spawn intent (with a boot token when available), then converts it to a child PID', async () => {
+    const root = await runtimeRoot()
+    recordSpawnIntentSync(root, 'op-1')
+    const intent = readOperationChild(root, 'op-1')
+    // Always a spawning intent; on Linux it also carries a boot_id (a valid UUID), absent elsewhere. Not
+    // asserting the exact bootToken keeps this green cross-platform and in a /proc-restricted sandbox.
+    expect(intent).toMatchObject({ spawning: true })
+    if (intent !== 'corrupt' && intent !== undefined && 'spawning' in intent && intent.bootToken)
+      expect(isValidBootToken(intent.bootToken)).toBe(true)
+    // onChild converts the intent to the real PID.
+    recordOperationChildSync(root, 'op-1', { childPid: 4242, childStartedAt: 111 })
+    expect(readOperationChild(root, 'op-1')).toEqual({ childPid: 4242, childStartedAt: 111 })
+  })
+
+  it('returns undefined when no sidecar exists (op never reached the spawn stage)', async () => {
+    const root = await runtimeRoot()
+    expect(readOperationChild(root, 'never')).toBeUndefined()
+  })
+
+  it('recording throws (fail-closed) when the sidecar cannot be written', async () => {
+    // A path whose parent is a FILE can't hold a child file; the sync write must throw so the caller
+    // refuses to spawn / kills the child rather than proceeding unrecorded.
+    const root = await runtimeRoot()
+    await writeFile(join(root, 'not-a-dir'), 'x')
+    expect(() => recordSpawnIntentSync(join(root, 'not-a-dir'), 'op-1')).toThrow()
+  })
+
+  it('removeOperationChildSync clears the sidecar (and is a no-op when already gone)', async () => {
+    const root = await runtimeRoot()
+    recordOperationChildSync(root, 'op-1', { childPid: 7, childStartedAt: 1 })
+    removeOperationChildSync(root, 'op-1')
+    expect(readOperationChild(root, 'op-1')).toBeUndefined()
+    expect(() => removeOperationChildSync(root, 'op-1')).not.toThrow()
+  })
+
+  it('reads an EXISTING but corrupt sidecar as "corrupt" (fail-safe -> block), not absent', async () => {
+    const root = await runtimeRoot()
+    await writeFile(join(root, 'operation-child-op-1.json'), '{ not valid json')
+    expect(readOperationChild(root, 'op-1')).toBe('corrupt')
+  })
+
+  it('treats a non-number childStartedAt as corrupt (a string time would NaN the pid-reuse guard)', async () => {
+    const root = await runtimeRoot()
+    await writeFile(
+      join(root, 'operation-child-op-1.json'),
+      JSON.stringify({ childPid: 4242, childStartedAt: 'not-a-number' })
+    )
+    expect(readOperationChild(root, 'op-1')).toBe('corrupt')
+  })
+
+  it('reads a valid PID state only when BOTH fields are finite numbers', async () => {
+    const root = await runtimeRoot()
+    recordOperationChildSync(root, 'op-1', { childPid: 4242, childStartedAt: 111 })
+    expect(readOperationChild(root, 'op-1')).toEqual({ childPid: 4242, childStartedAt: 111 })
+  })
+
+  it('carries a VALID decimal childStartToken through', async () => {
+    const root = await runtimeRoot()
+    recordOperationChildSync(root, 'op-1', {
+      childPid: 4242,
+      childStartedAt: 111,
+      childStartToken: '80877'
+    })
+    expect(readOperationChild(root, 'op-1')).toEqual({
+      childPid: 4242,
+      childStartedAt: 111,
+      childStartToken: '80877'
+    })
+  })
+
+  it('treats a PRESENT-but-malformed childStartToken as corrupt (fail-closed), never tokenless', async () => {
+    // "bad" is JSON-legal but not a token we could have produced (readProcessStartToken only emits
+    // CANONICAL decimals). "000123" is the subtle one: a leading-zero decimal is equal-in-value to the
+    // live pid's "123" but NOT string-equal, so the byte-comparison reuse check would spuriously mismatch
+    // and misread a live child as reused → 'dead'. Dropping any of these to the tokenless path would let
+    // it masquerade as a legitimately tokenless record; all must fail closed to 'corrupt' (block).
+    const root = await runtimeRoot()
+    for (const bad of ['bad', '80877x', '', '-5', '3.5', '000123', '007', '0x1f']) {
+      await writeFile(
+        join(root, 'operation-child-op-1.json'),
+        JSON.stringify({ childPid: 4242, childStartedAt: 111, childStartToken: bad })
+      )
+      expect(readOperationChild(root, 'op-1')).toBe('corrupt')
+    }
+  })
+
+  it('treats a CONTRADICTORY {spawning + childPid} sidecar as corrupt (mutually-exclusive states)', async () => {
+    // A blob carrying BOTH spawning:true and a childPid is corruption/tampering: the two states are
+    // mutually exclusive. Accepting the pid alongside spawning would let a forged pid ride in, probe
+    // ESRCH, and let Reset SKIP the no-PID reboot gate. It must fail closed to 'corrupt' (block).
+    const root = await runtimeRoot()
+    await writeFile(
+      join(root, 'operation-child-op-1.json'),
+      JSON.stringify({ spawning: true, childPid: 4242, childStartedAt: 111 })
+    )
+    expect(readOperationChild(root, 'op-1')).toBe('corrupt')
+  })
+
+  it('treats a non-positive / non-integer childPid as corrupt (never a probeable pid)', async () => {
+    // 0 and negatives have special process.kill semantics (process group / "any process"), and a
+    // non-safe-integer is not a real pid — any of them could make a liveness probe signal the wrong
+    // target or spuriously succeed, bypassing the reboot gate. All must fail closed to 'corrupt'.
+    const root = await runtimeRoot()
+    for (const bad of [0, -1, -4242, 3.5, Number.MAX_SAFE_INTEGER + 1, 'x']) {
+      await writeFile(
+        join(root, 'operation-child-op-1.json'),
+        JSON.stringify({ childPid: bad, childStartedAt: 111 })
+      )
+      expect(readOperationChild(root, 'op-1')).toBe('corrupt')
+    }
+  })
+
+  it('treats a neither-shape sidecar (no spawning, no childPid) as corrupt', async () => {
+    const root = await runtimeRoot()
+    await writeFile(join(root, 'operation-child-op-1.json'), JSON.stringify({ bootToken: 'x' }))
+    expect(readOperationChild(root, 'op-1')).toBe('corrupt')
+  })
+
+  it('treats a non-finite childStartedAt as corrupt for a PID state', async () => {
+    // JSON can't hold NaN/Infinity, but null / a string can appear via tampering; childStartedAt must be
+    // a finite number when a pid is present (it is a real timestamp), else fail closed.
+    const root = await runtimeRoot()
+    for (const bad of [null, 'soon', {}]) {
+      await writeFile(
+        join(root, 'operation-child-op-1.json'),
+        JSON.stringify({ childPid: 4242, childStartedAt: bad })
+      )
+      expect(readOperationChild(root, 'op-1')).toBe('corrupt')
+    }
+  })
+
+  it('enforces EXACT shape: a bootToken on the PID variant is corrupt (intent-only field)', async () => {
+    // bootToken belongs ONLY to the {spawning} intent variant. On a recorded pid it is a foreign field:
+    // accepting it would let a pid ride alongside intent metadata, probe ESRCH, and skip the no-PID reboot
+    // gate. A well-formed boot_id must NOT rescue it — the mere presence of the field is corruption.
+    const root = await runtimeRoot()
+    await writeFile(
+      join(root, 'operation-child-op-1.json'),
+      JSON.stringify({
+        childPid: 4242,
+        childStartedAt: 111,
+        bootToken: '11111111-1111-4111-8111-111111111111'
+      })
+    )
+    expect(readOperationChild(root, 'op-1')).toBe('corrupt')
+  })
+
+  it('enforces EXACT shape: a PID-variant field on the {spawning} intent is corrupt', async () => {
+    // The intent variant carries ONLY {spawning, bootToken?}. A childStartedAt / childStartToken here is a
+    // PID-variant field bleeding in (torn write / tampering); it must fail closed, never be salvaged into
+    // a {spawning} intent that silently drops the stray pid metadata.
+    const root = await runtimeRoot()
+    for (const stray of [{ childStartedAt: 111 }, { childStartToken: '80877' }]) {
+      await writeFile(
+        join(root, 'operation-child-op-1.json'),
+        JSON.stringify({ spawning: true, ...stray })
+      )
+      expect(readOperationChild(root, 'op-1')).toBe('corrupt')
+    }
+  })
+
+  it('carries a VALID boot_id on the spawning intent, and fails a malformed one closed to corrupt', async () => {
+    const root = await runtimeRoot()
+    const boot = '11111111-1111-4111-8111-111111111111'
+    await writeFile(
+      join(root, 'operation-child-op-1.json'),
+      JSON.stringify({ spawning: true, bootToken: boot })
+    )
+    expect(readOperationChild(root, 'op-1')).toEqual({ spawning: true, bootToken: boot })
+    // Present-but-malformed boot token → corrupt (block), never silently dropped to a tokenless intent.
+    await writeFile(
+      join(root, 'operation-child-op-1.json'),
+      JSON.stringify({ spawning: true, bootToken: 'nope' })
+    )
+    expect(readOperationChild(root, 'op-1')).toBe('corrupt')
+  })
+})
+
+describe('listOperationChildren (journal-independent sidecar scan)', () => {
+  const runtimeRoot = async (): Promise<string> => {
+    const dir = await mkdtemp(join(tmpdir(), 'op-list-'))
+    roots.push(dir)
+    return dir
+  }
+
+  it('returns [] when the root does not exist', async () => {
+    expect(listOperationChildren(join(tmpdir(), 'op-list-absent-xyz'))).toEqual([])
+  })
+
+  it('enumerates every child sidecar by operationId, surfacing corrupt ones (fail-safe)', async () => {
+    const root = await runtimeRoot()
+    recordOperationChildSync(root, 'has-pid', { childPid: 7, childStartedAt: 1 })
+    await writeFile(join(root, 'operation-child-spawn.json'), JSON.stringify({ spawning: true }))
+    await writeFile(join(root, 'operation-child-bad.json'), '{ not json')
+    await writeFile(join(root, 'operation-journal.json'), '[]') // NOT a child sidecar — must be ignored
+
+    const found = listOperationChildren(root)
+    expect(found).toHaveLength(3)
+    expect(found.find((f) => f.operationId === 'has-pid')?.state).toEqual({
+      childPid: 7,
+      childStartedAt: 1
+    })
+    expect(found.find((f) => f.operationId === 'spawn')?.state).toEqual({ spawning: true })
+    // A corrupt sidecar is surfaced (recovery/Reset must treat it as a possible live writer), not dropped.
+    expect(found.find((f) => f.operationId === 'bad')?.state).toBe('corrupt')
+  })
+
+  it('fails CLOSED (corrupt sentinel) when the directory cannot be READ — NOT treated as empty', async () => {
+    // Only ENOENT proves "nothing ever spawned". Any other errno (EACCES/EIO/EMFILE/ENOTDIR/…) is not
+    // proof of absence — sidecars for live installers may exist but be unreadable — so listing must
+    // surface a corrupt sentinel that makes the Reset guard REFUSE, never an empty list (the old bug that
+    // let a corrupt-journal Reset quarantine + delete a prefix under a possibly-live writer). We simulate
+    // a non-ENOENT failure by pointing at a FILE, not a directory (readdirSync → ENOTDIR).
+    const asFile = join(await runtimeRoot(), 'not-a-dir')
+    await writeFile(asFile, 'x')
+    const found = listOperationChildren(asFile)
+    expect(found).toHaveLength(1)
+    expect(found[0].state).toBe('corrupt')
+    expect(found[0].operationId).toBe(UNREADABLE_RUNTIME_DIR)
+  })
+})
+
+describe('bootTokenProvesReboot (authoritative boot_id only — no wall-clock heuristic)', () => {
+  const A = '11111111-1111-4111-8111-111111111111' // two distinct, well-formed boot_id UUIDs
+  const B = '22222222-2222-4222-8222-222222222222'
+
+  it('is false when either token is missing (absence can never ASSERT a reboot)', () => {
+    expect(bootTokenProvesReboot(undefined, A)).toBe(false)
+    expect(bootTokenProvesReboot(A, undefined)).toBe(false)
+    expect(bootTokenProvesReboot(undefined, undefined)).toBe(false)
+  })
+
+  it('proves a reboot ONLY for two valid-but-DIFFERENT boot_id UUIDs; identical does not', () => {
+    expect(bootTokenProvesReboot(A, B)).toBe(true)
+    expect(bootTokenProvesReboot(A, A)).toBe(false)
+  })
+
+  it('is false when EITHER token is malformed (never compares garbage as a boot identity)', () => {
+    // A different-but-malformed string must NOT read as a reboot — the old loose "any different value"
+    // rule was exactly the P1 hole. Both sides must be well-formed boot_id UUIDs.
+    expect(bootTokenProvesReboot('not-a-uuid', A)).toBe(false)
+    expect(bootTokenProvesReboot(A, 'nope')).toBe(false)
+    expect(bootTokenProvesReboot('up:1000', 'up:9000')).toBe(false) // legacy up: scheme no longer honored
+    expect(bootTokenProvesReboot('', A)).toBe(false)
+  })
+
+  it('does NOT read a case-only difference as a reboot (same UUID, different letter case)', () => {
+    // The kernel emits boot_id lowercase and the comparison is case-SENSITIVE. An uppercased copy of the
+    // SAME UUID is the same boot, so it must never prove a reboot. We reject uppercase up front, so such a
+    // token is malformed on BOTH sides and the guard stays false (never a spurious no-PID Reset).
+    const upper = A.toUpperCase()
+    expect(bootTokenProvesReboot(A, upper)).toBe(false) // recorded lowercase, "current" uppercased-same
+    expect(bootTokenProvesReboot(upper, A)).toBe(false)
+    expect(bootTokenProvesReboot(upper, upper)).toBe(false)
+  })
+})
+
+describe('isValidBootToken', () => {
+  it('accepts only a well-formed LOWERCASE boot_id UUID', () => {
+    expect(isValidBootToken('11111111-1111-4111-8111-111111111111')).toBe(true)
+    expect(isValidBootToken('abcdef01-2345-6789-abcd-ef0123456789')).toBe(true)
+    // Uppercase / mixed-case hex is rejected: the kernel never emits it, and accepting it would let a
+    // case-only rewrite of the current boot_id compare unequal (case-sensitive) and fake a reboot.
+    expect(isValidBootToken('ABCDEF01-2345-6789-ABCD-EF0123456789')).toBe(false)
+    expect(isValidBootToken('11111111-1111-4111-8111-11111111111A')).toBe(false)
+    expect(isValidBootToken('up:1000')).toBe(false)
+    expect(isValidBootToken('11111111-1111-4111-8111')).toBe(false)
+    expect(isValidBootToken('')).toBe(false)
+    expect(isValidBootToken(undefined)).toBe(false)
+    expect(isValidBootToken(42)).toBe(false)
   })
 })

--- a/src/main/notebook/operation-journal.ts
+++ b/src/main/notebook/operation-journal.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
@@ -6,6 +7,230 @@ import { dirname, join } from 'node:path'
 // (provisioner/fetch) and the startup recovery side agree on one path without sharing an instance.
 export const operationJournalPath = (runtimeRoot: string): string =>
   join(runtimeRoot, 'operation-journal.json')
+
+// A childStartToken is ONLY ever written by readProcessStartToken as a CANONICAL decimal string (Linux
+// /proc/<pid>/stat field 22, which the kernel emits with no leading zeros). So the ONLY value we accept
+// back is that exact canonical shape. A present-but-other value — the JSON-legal string "bad", OR a
+// non-canonical decimal like "000123" — is NOT a token we could have produced. Leading zeros are the
+// subtle case: "000123" reads as equal-in-value to the live pid's "123" but is NOT string-equal, so the
+// reuse check (a byte comparison) would spuriously MISMATCH and misread a live child as reused → 'dead',
+// reconciling/deleting under a possibly-live worker. Rejecting non-canonical decimals up front closes
+// that. Callers treat an invalid token as: sidecar → 'corrupt' (block), journal record → invalid (whole
+// journal corrupt). Fail-closed.
+export const isValidChildStartToken = (value: unknown): value is string =>
+  typeof value === 'string' && /^(0|[1-9]\d*)$/.test(value)
+
+// A recorded childPid must be a POSITIVE safe integer — a real OS pid. Rejecting 0/negative/non-integer
+// (0 and negatives have special process.kill semantics — process groups / "any process" — and would make
+// a liveness probe signal the wrong target or spuriously succeed) closes a forgery path: a corrupt sidecar
+// can't smuggle a bogus pid that probes ESRCH and lets Reset skip the reboot gate.
+export const isValidChildPid = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+
+// An AUTHORITATIVE machine-boot identity, used as the sole proof force-Reset accepts that an unprobeable
+// no-PID orphan is gone. We use ONLY the Linux kernel boot_id (/proc/sys/kernel/random/boot_id) — a random
+// UUID the kernel regenerates on every boot, so a changed value is hard proof the box rebooted. We do NOT
+// derive anything from the wall clock or uptime: `now − uptime()` moves when NTP/manual time steps within
+// a single boot, and os.uptime() on macOS is itself wall-clock-derived, so either could FALSELY read as a
+// reboot and delete a prefix a live orphan still holds. Returns undefined off Linux or when boot_id can't
+// be read; callers MUST then refuse (never assume a reboot). This means the no-PID force-Reset escape
+// hatch is Linux-only — macOS/Windows have no pure-runtime authoritative boot identity, so there we keep
+// the record blocked rather than risk a wrong deletion.
+//
+// LOWERCASE ONLY, deliberately: the kernel emits boot_id as a lowercase UUID, and bootTokenProvesReboot
+// compares the two tokens as raw strings (case-SENSITIVE). If we accepted uppercase hex here, a persisted
+// token that differs from the current one by letter case alone would be the SAME boot yet compare unequal
+// — a spurious "reboot" that would wrongly clear a no-PID orphan's block. Restricting the accepted shape
+// to the kernel's actual lowercase output makes the string comparison exact without a normalization step.
+const BOOT_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+export const readBootToken = (): string | undefined => {
+  if (process.platform !== 'linux') return undefined
+  try {
+    const id = readFileSync('/proc/sys/kernel/random/boot_id', 'utf8').trim()
+    return BOOT_ID_RE.test(id) ? id : undefined
+  } catch {
+    return undefined
+  }
+}
+
+// A persisted bootToken must be exactly a kernel boot_id UUID. Anything else (present but malformed) is
+// corruption/tampering and is rejected up front, so a garbage value can never be compared as if it were a
+// real boot identity (which could otherwise read as a spurious reboot).
+export const isValidBootToken = (value: unknown): value is string =>
+  typeof value === 'string' && BOOT_ID_RE.test(value)
+
+// Whether `current` proves the machine rebooted since `recorded`. Fail-CLOSED: both must be present and
+// well-formed boot_id UUIDs; a reboot is proven ONLY by two valid-but-different UUIDs. Missing or malformed
+// either side → false (Reset refuses rather than delete a prefix a survivor might hold). This is exact
+// (no heuristic, no timing window): boot_id cannot repeat across boots, so there are no false positives.
+export const bootTokenProvesReboot = (
+  recorded: string | undefined,
+  current: string | undefined
+): boolean => isValidBootToken(recorded) && isValidBootToken(current) && recorded !== current
+
+// A per-operation SYNCHRONOUS sidecar that tracks the spawn lifecycle so recovery can tell, without a
+// live wall-clock guess, whether a crashed op could still have a live child:
+//   - absent            -> the op never reached the spawn stage (crashed during begin/prep) — no child.
+//   - { spawning: true } -> we were about to spawn / had just spawned but never recorded a PID — a child
+//                          MAY be alive, so recovery must BLOCK (never reconcile under a possible writer).
+//   - { childPid, … }    -> the child's PID is provably persisted — recovery probes it (tri-state).
+// Writes are synchronous (durable before the spawning code path yields) and FAIL-CLOSED: recording
+// throws on failure so the caller can refuse to spawn / kill the child rather than proceed unrecorded.
+// childStartToken (when present): a per-boot-stable kernel process identity captured at spawn (see
+// readProcessStartToken). It is used ONLY to FALSIFY reuse (a mismatch proves the pid is gone); a match is
+// never treated as license to signal. childStartedAt is retained for diagnostics but is NOT used for
+// liveness (a wall-clock value can't soundly prove a live pid dead). Both optional (absent off Linux /
+// legacy).
+// bootToken (on the {spawning} intent): the machine boot_id at spawn time (see readBootToken). It lives in
+// the sidecar — not just the journal — so force-Reset can prove a reboot even when the journal is corrupt/
+// unreadable. Absent off Linux (there the no-PID escape stays blocked).
+export type OperationChildState =
+  | { spawning: true; bootToken?: string }
+  | { childPid: number; childStartedAt: number; childStartToken?: string }
+
+const operationChildPath = (runtimeRoot: string, operationId: string): string =>
+  join(runtimeRoot, `operation-child-${operationId}.json`)
+
+const writeChildStateSync = (
+  runtimeRoot: string,
+  operationId: string,
+  state: OperationChildState
+): void => {
+  // Atomic temp+rename so a crash mid-write can't leave a torn sidecar that reads as neither state.
+  mkdirSync(runtimeRoot, { recursive: true })
+  const path = operationChildPath(runtimeRoot, operationId)
+  const temp = `${path}.${process.pid}-${randomUUID()}.tmp`
+  writeFileSync(temp, JSON.stringify(state), 'utf8')
+  renameSync(temp, path)
+}
+
+// Records the intent to spawn BEFORE spawning. Throws on failure (fail-closed): if we can't record the
+// intent we must not spawn, or a crash would leave a live child recovery can't account for. Captures the
+// machine boot_id (Linux) so a later force-Reset can prove the box rebooted — and thus that a crash-window
+// orphan whose PID never landed is gone — WITHOUT depending on the (possibly corrupt) journal.
+export const recordSpawnIntentSync = (runtimeRoot: string, operationId: string): void => {
+  writeChildStateSync(runtimeRoot, operationId, { spawning: true, bootToken: readBootToken() })
+}
+
+// Records the spawned child's PID, converting the intent. Throws on failure (fail-closed): the caller
+// must then kill the just-spawned child and fail, rather than leave an unrecorded orphan.
+export const recordOperationChildSync = (
+  runtimeRoot: string,
+  operationId: string,
+  child: { childPid: number; childStartedAt: number; childStartToken?: string }
+): void => {
+  writeChildStateSync(runtimeRoot, operationId, child)
+}
+
+// Reads a sidecar, distinguishing three cases the recovery side treats differently:
+//   - undefined  : the file is genuinely ABSENT (ENOENT) — the op never reached the spawn stage, so it
+//                  is safe to reconcile.
+//   - 'corrupt'  : the file EXISTS but couldn't be read/parsed or has an invalid shape. This is NOT
+//                  proof of "never spawned", so recovery must fail SAFE and BLOCK (a child may be live).
+//   - a state    : { spawning: true } or a fully-valid { childPid, childStartedAt } (BOTH must be finite
+//                  numbers — a string/NaN start time would break the pid-reuse guard and misjudge dead).
+export const readOperationChild = (
+  runtimeRoot: string,
+  operationId: string
+): OperationChildState | 'corrupt' | undefined => {
+  let raw: string
+  try {
+    raw = readFileSync(operationChildPath(runtimeRoot, operationId), 'utf8')
+  } catch (error) {
+    // Only a genuine "not found" means the op never spawned. Any other read failure (permissions, I/O)
+    // is not proof of absence — fail safe to corrupt so recovery blocks rather than assuming no child.
+    if ((error as { code?: string }).code === 'ENOENT') return undefined
+    return 'corrupt'
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return 'corrupt'
+    const { spawning, childPid, childStartedAt, childStartToken, bootToken } = parsed as {
+      spawning?: unknown
+      childPid?: unknown
+      childStartedAt?: unknown
+      childStartToken?: unknown
+      bootToken?: unknown
+    }
+    // The two states are MUTUALLY EXCLUSIVE: a sidecar is either a {spawning} intent (no pid yet) or a
+    // recorded {childPid} — never both. A blob carrying spawning:true AND a childPid is contradictory
+    // (corruption/tampering) and must fail CLOSED, or a forged pid could ride alongside spawning:true,
+    // probe ESRCH, and let Reset skip the no-PID reboot gate. Decide by which key is present, then require
+    // that state's shape to be exactly valid; any mismatch → 'corrupt' (block), never "never spawned".
+    const hasSpawning = spawning !== undefined
+    const hasPid = childPid !== undefined
+    if (hasSpawning === hasPid) return 'corrupt' // neither, or both → not a recognized single state
+    if (hasSpawning) {
+      if (spawning !== true) return 'corrupt'
+      // EXACT shape: the intent variant carries ONLY {spawning, bootToken?}. A childStartedAt/childStartToken
+      // here is a PID-variant field bleeding into an intent (corruption/tampering); fail CLOSED so a torn
+      // or forged blob can never be salvaged into a state it doesn't cleanly match.
+      if (childStartedAt !== undefined || childStartToken !== undefined) return 'corrupt'
+      // A bootToken PRESENT but not a valid boot_id is corruption — fail CLOSED. Absent is fine (off
+      // Linux): the no-PID escape then just stays blocked (bootTokenProvesReboot needs both sides).
+      if (bootToken !== undefined && !isValidBootToken(bootToken)) return 'corrupt'
+      return bootToken !== undefined ? { spawning: true, bootToken } : { spawning: true }
+    }
+    // EXACT shape: the PID variant carries ONLY {childPid, childStartedAt, childStartToken?}. A bootToken
+    // belongs to the {spawning} intent variant, never a recorded pid — its presence here means a pid could
+    // otherwise ride alongside intent metadata, probe ESRCH, and skip the no-PID reboot gate. Fail CLOSED.
+    // childPid must be a real (positive, safe-integer) pid and childStartedAt a finite number.
+    if (bootToken !== undefined) return 'corrupt'
+    if (!isValidChildPid(childPid)) return 'corrupt'
+    if (typeof childStartedAt !== 'number' || !Number.isFinite(childStartedAt)) return 'corrupt'
+    // A childStartToken PRESENT but not our decimal shape is corruption/tampering, not "no token": fail
+    // CLOSED rather than drop it to the tokenless path, so a malformed token can never masquerade as a
+    // legitimately tokenless record. Absent is fine (legacy / non-Linux).
+    if (childStartToken !== undefined && !isValidChildStartToken(childStartToken)) return 'corrupt'
+    return childStartToken !== undefined
+      ? { childPid, childStartedAt, childStartToken }
+      : { childPid, childStartedAt }
+  } catch {
+    return 'corrupt' // present but unparseable
+  }
+}
+
+export const removeOperationChildSync = (runtimeRoot: string, operationId: string): void => {
+  try {
+    rmSync(operationChildPath(runtimeRoot, operationId), { force: true })
+  } catch {
+    // Best-effort cleanup; a leftover sidecar for a cleared journal record is inert (recovery only
+    // processes records still in the journal).
+  }
+}
+
+// Enumerates every child-state sidecar in a runtime root, keyed by operationId, INDEPENDENT of the
+// journal. This is the journal-free view force-Reset needs when the journal itself is corrupt/unreadable:
+// the sidecars are separate files (written synchronously before each spawn), so they still tell us which
+// operations reached the spawn stage and whether a child MAY be live. A sidecar that can't be read is
+// surfaced as 'corrupt' (fail-safe → treat as a possible live writer), never silently dropped.
+const CHILD_FILE_RE = /^operation-child-(.+)\.json$/
+// Sentinel operationId for a directory we could NOT enumerate. It carries a 'corrupt' state so the Reset
+// guard treats an unreadable runtime root as "a live writer MAY exist" and refuses — see below.
+export const UNREADABLE_RUNTIME_DIR = ' unreadable-runtime-dir'
+export const listOperationChildren = (
+  runtimeRoot: string
+): Array<{ operationId: string; state: OperationChildState | 'corrupt' }> => {
+  let names: string[]
+  try {
+    names = readdirSync(runtimeRoot)
+  } catch (error) {
+    // ONLY a genuine "not found" means nothing ever spawned here (safe → empty). Any other failure
+    // (EACCES/EIO/EMFILE/…) is NOT proof of absence: sidecars for live installers may exist but be
+    // unreadable, so we must fail CLOSED — surface a corrupt sentinel that makes the Reset guard refuse
+    // rather than quarantine + delete a prefix under a possibly-live writer.
+    if ((error as { code?: string }).code === 'ENOENT') return []
+    return [{ operationId: UNREADABLE_RUNTIME_DIR, state: 'corrupt' }]
+  }
+  const out: Array<{ operationId: string; state: OperationChildState | 'corrupt' }> = []
+  for (const name of names) {
+    const m = CHILD_FILE_RE.exec(name)
+    if (!m) continue
+    const state = readOperationChild(runtimeRoot, m[1])
+    if (state !== undefined) out.push({ operationId: m[1], state }) // undefined = raced-away; skip
+  }
+  return out
+}
 
 // One in-flight, crash-recoverable runtime operation. Persisted BEFORE the operation runs (write
 // intent) and removed only after it commits, so a process that dies mid-operation leaves a record the
@@ -28,6 +253,17 @@ export type RuntimeOperationRecord = {
   // before cleaning staging / verifying / retrying.
   childPid?: number
   childStartedAt?: number
+  // The child's kernel start-time token (see readProcessStartToken), captured at spawn. Used ONLY as a
+  // pid-reuse FALSIFIER: a mismatch against the live pid's current token proves the pid was reused (our
+  // child is gone → 'dead'); a match is NOT treated as proof we may signal the pid (the token is tick-
+  // coarse), so it stays 'unknown' (block). Must be our decimal shape when present (isValidChildStartToken
+  // — a malformed value fails closed). Absent off Linux / on legacy records — a live pid with no token is
+  // then always 'unknown' (a wall-clock start time can't soundly prove a live pid dead).
+  childStartToken?: string
+  // TRANSIENT, recovery-only: set from the child-state sidecar during hydration when the op reached the
+  // spawn stage ({ spawning: true }) but no PID was ever recorded. It is never persisted to the journal;
+  // it tells recovery "a child MAY be live, PID unknown" so it blocks rather than reconciles.
+  spawnAttempted?: boolean
 }
 
 // One shared journal instance per journal path, so every caller (download / materialize / install)
@@ -66,14 +302,54 @@ export class RuntimeOperationJournal {
   // Prefer forPath() — a direct construction opts out of the shared-queue serialization guarantee.
   constructor(private readonly journalPath: string) {}
 
-  // The operations currently recorded as in-flight (empty when the journal is missing or corrupt).
-  async pending(): Promise<RuntimeOperationRecord[]> {
+  // The journal's on-disk state, distinguishing a genuinely-absent journal from a corrupt one so the
+  // startup-recovery side can fail SAFE instead of open:
+  //   - { records }     : the file is absent (ENOENT -> nothing was in flight) or a readable JSON array
+  //                       (invalid entries are filtered out).
+  //   - 'corrupt'       : the file EXISTS but could not be read (permissions/I/O) or does not parse to a
+  //                       JSON array. This is NOT proof that nothing was in flight, so recovery must
+  //                       treat it as "unknown in-flight work" and block rather than reconcile nothing.
+  async readState(): Promise<{ records: RuntimeOperationRecord[] } | 'corrupt'> {
+    let raw: string
     try {
-      const parsed = JSON.parse(await readFile(this.journalPath, 'utf8')) as unknown
-      return Array.isArray(parsed) ? parsed.filter(isOperationRecord) : []
-    } catch {
-      return []
+      raw = await readFile(this.journalPath, 'utf8')
+    } catch (error) {
+      if ((error as { code?: string }).code === 'ENOENT') return { records: [] }
+      return 'corrupt' // present but unreadable — not proof of "nothing in flight"
     }
+    try {
+      const parsed = JSON.parse(raw) as unknown
+      if (!Array.isArray(parsed)) return 'corrupt'
+      // ANY invalid entry makes the WHOLE journal suspect: we write only valid records, so a bad element
+      // means corruption/tampering. Filtering it out would silently treat a damaged journal as healthy
+      // (and let the next begin() overwrite the surviving evidence), so fail safe to 'corrupt' instead.
+      if (!parsed.every(isOperationRecord)) return 'corrupt'
+      return { records: parsed as RuntimeOperationRecord[] }
+    } catch {
+      return 'corrupt' // present but unparseable
+    }
+  }
+
+  // Moves a corrupt journal aside (preserved as evidence) so a fresh begin() can proceed after an
+  // explicit user recovery. Returns true if a file was moved, false if there was nothing to move
+  // (ENOENT). Throws on any other rename failure so the caller can REFUSE a destructive reset rather
+  // than delete a prefix it then can't rebuild (begin() would keep throwing on the still-present file).
+  async quarantineCorrupt(): Promise<boolean> {
+    try {
+      await rename(this.journalPath, `${this.journalPath}.corrupt-${Date.now()}`)
+      return true
+    } catch (error) {
+      if ((error as { code?: string }).code === 'ENOENT') return false
+      throw error
+    }
+  }
+
+  // The operations currently recorded as in-flight (empty when the journal is missing OR corrupt). The
+  // recovery path uses readState() instead, so it can fail safe on a corrupt journal; the runtime
+  // callers (begin/update/complete/hasRuntimeOperation) keep the best-effort empty-on-corrupt behavior.
+  async pending(): Promise<RuntimeOperationRecord[]> {
+    const state = await this.readState()
+    return state === 'corrupt' ? [] : state.records
   }
 
   // Whether an operation for this runtime is already in flight — the concurrency guard so no two
@@ -86,9 +362,18 @@ export class RuntimeOperationJournal {
   // an existing record with the same operationId is idempotent (e.g. re-begin after a phase change).
   async begin(record: RuntimeOperationRecord): Promise<void> {
     await this.enqueue(async () => {
-      const current = await this.pending()
+      const state = await this.readState()
+      // Fail CLOSED on a corrupt journal: reading it as empty and writing would OVERWRITE (destroy) the
+      // unreadable in-flight state, and every prefix-writing caller (materialize/named create/install)
+      // begins fail-closed, so throwing here refuses the whole operation rather than stranding a worker
+      // whose recovery record we just clobbered. The corrupt file is preserved for a later boot / Reset.
+      if (state === 'corrupt') {
+        throw new Error(
+          'RUNTIME_JOURNAL_CORRUPT: the operation journal is unreadable; refusing to overwrite it'
+        )
+      }
       await this.write([
-        ...current.filter((entry) => entry.operationId !== record.operationId),
+        ...state.records.filter((entry) => entry.operationId !== record.operationId),
         record
       ])
     })
@@ -143,6 +428,31 @@ export class RuntimeOperationJournal {
   }
 }
 
+// The child-identity fields (childPid, childStartedAt, childStartToken) are written ATOMICALLY together
+// in one journal update at spawn time (childStartToken only on Linux). So a record has exactly one of two
+// valid shapes: NO child fields at all (op never recorded a pid), or a full {childPid + childStartedAt}
+// group (+ optional childStartToken). Any partial subset — childStartedAt or childStartToken WITHOUT a
+// childPid, or a childPid WITHOUT childStartedAt — cannot be something we wrote; it means corruption/
+// tampering and must invalidate the record. This matters because recovery treats "no childPid + no
+// spawnAttempted" as DEAD and reconciles: a stray childStartedAt/childStartToken with no childPid would
+// otherwise be silently reconciled as if the op never spawned. Grouping fails the whole journal to
+// 'corrupt' instead (readState's "any invalid record → corrupt" rule), so recovery blocks, never guesses.
+const hasValidChildGroup = (record: Record<string, unknown>): boolean => {
+  const { childPid, childStartedAt, childStartToken } = record
+  if (childPid === undefined) {
+    // No pid → the whole group must be absent. A lone start time / token is orphaned metadata → corrupt.
+    return childStartedAt === undefined && childStartToken === undefined
+  }
+  // Pid present → require a real pid AND a finite start time (both are written together); token optional
+  // but, when present, must be our exact decimal shape.
+  return (
+    isValidChildPid(childPid) &&
+    typeof childStartedAt === 'number' &&
+    Number.isFinite(childStartedAt) &&
+    (childStartToken === undefined || isValidChildStartToken(childStartToken))
+  )
+}
+
 const isOperationRecord = (value: unknown): value is RuntimeOperationRecord => {
   if (typeof value !== 'object' || value === null) return false
   const record = value as Record<string, unknown>
@@ -151,6 +461,9 @@ const isOperationRecord = (value: unknown): value is RuntimeOperationRecord => {
     typeof record.kind === 'string' &&
     typeof record.runtimeId === 'string' &&
     typeof record.phase === 'string' &&
-    typeof record.startedAt === 'number'
+    typeof record.startedAt === 'number' &&
+    // Child fields are validated as a lifecycle GROUP (parity with the sidecar's exact-shape rule):
+    // all-absent or a complete {childPid + childStartedAt (+ token?)}, never a partial subset.
+    hasValidChildGroup(record)
   )
 }

--- a/src/main/notebook/operation-recovery.test.ts
+++ b/src/main/notebook/operation-recovery.test.ts
@@ -8,7 +8,9 @@ import { RuntimeOperationJournal, type RuntimeOperationRecord } from './operatio
 import {
   defaultOperationChildLiveness,
   reconcileInterruptedOperations,
-  type OperationRecoveryDeps
+  readProcessStartToken,
+  type OperationRecoveryDeps,
+  type ProcessStartTokenReader
 } from './operation-recovery'
 
 const roots: string[] = []
@@ -21,18 +23,24 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
-const record = (over: Partial<RuntimeOperationRecord> = {}): RuntimeOperationRecord => ({
-  operationId: 'op-1',
-  kind: 'download',
-  runtimeId: 'python-3.12',
-  phase: 'downloading',
-  startedAt: 100,
-  ...over
-})
+const record = (over: Partial<RuntimeOperationRecord> = {}): RuntimeOperationRecord => {
+  const base: RuntimeOperationRecord = {
+    operationId: 'op-1',
+    kind: 'download',
+    runtimeId: 'python-3.12',
+    phase: 'downloading',
+    startedAt: 100,
+    ...over
+  }
+  // Production writes childPid + childStartedAt ATOMICALLY (the journal now rejects a partial group), so
+  // a fixture with a childPid must carry a start time too. Default it here unless the case set one
+  // explicitly (including an explicit `undefined`, which the tokenless-liveness tests rely on).
+  if (base.childPid !== undefined && !('childStartedAt' in over)) base.childStartedAt = 100
+  return base
+}
 
 const makeDeps = (over: Partial<OperationRecoveryDeps> = {}): OperationRecoveryDeps => ({
   operationChildLiveness: vi.fn().mockResolvedValue('dead'),
-  terminateOperationChild: vi.fn().mockResolvedValue(undefined),
   cleanStaging: vi.fn().mockResolvedValue(undefined),
   verifyOrRebuildEnv: vi.fn().mockResolvedValue(undefined),
   markRepairRequired: vi.fn().mockResolvedValue(undefined),
@@ -46,12 +54,16 @@ describe('reconcileInterruptedOperations', () => {
     await journal.begin(
       record({ operationId: 'd', kind: 'download', targetPath: '/rt/.incoming-a' })
     )
+    // Prefix-writing ops carry a childPid so liveness is probed (mock 'dead') and they reconcile; a
+    // no-PID prefix-write would instead BLOCK (covered separately below).
     await journal.begin(
-      record({ operationId: 'm', kind: 'materialize', runtimeId: 'default-python' })
+      record({ operationId: 'm', kind: 'materialize', runtimeId: 'default-python', childPid: 111 })
     )
-    await journal.begin(record({ operationId: 'u', kind: 'upgrade', runtimeId: 'default-r' }))
     await journal.begin(
-      record({ operationId: 'i', kind: 'install', runtimeId: '/usr/bin/python3' })
+      record({ operationId: 'u', kind: 'upgrade', runtimeId: 'default-r', childPid: 112 })
+    )
+    await journal.begin(
+      record({ operationId: 'i', kind: 'install', runtimeId: '/usr/bin/python3', childPid: 113 })
     )
     await journal.begin(
       record({ operationId: 'x', kind: 'disable', runtimeId: '/usr/bin/python3' })
@@ -68,38 +80,167 @@ describe('reconcileInterruptedOperations', () => {
     expect(await journal.pending()).toEqual([])
   })
 
-  it('kills a surviving orphan child before reconciling', async () => {
+  it('BLOCKS (never kills or reconciles) a surviving orphan child instead of signalling it', async () => {
+    // Design: recovery never auto-signals a possibly-live orphan (no strict "safe to kill" guarantee).
+    // A live child surfaces as liveness 'unknown', so the op is blocked and its entry is LEFT for a
+    // later boot that sees the pid gone — the env self-heals without recovery ever killing anything.
     const journal = await newJournal()
     await journal.begin(record({ kind: 'download', childPid: 4242, targetPath: '/rt/.incoming-a' }))
-    const order: string[] = []
     const deps = makeDeps({
-      operationChildLiveness: vi.fn().mockResolvedValue('alive'),
-      terminateOperationChild: vi.fn().mockImplementation(async () => {
-        order.push('kill')
-      }),
-      cleanStaging: vi.fn().mockImplementation(async () => {
-        order.push('clean')
-      })
+      operationChildLiveness: vi.fn().mockResolvedValue('unknown'),
+      onReconciled: vi.fn()
     })
 
     await reconcileInterruptedOperations(journal, deps)
 
-    expect(deps.terminateOperationChild).toHaveBeenCalledTimes(1)
-    // Kill happens BEFORE cleaning staging (never clean under a live writer).
-    expect(order).toEqual(['kill', 'clean'])
-    expect(await journal.pending()).toEqual([])
+    expect(deps.blockUnknownChildTarget).toHaveBeenCalledTimes(1)
+    expect(deps.cleanStaging).not.toHaveBeenCalled() // never reconcile under a possible writer
+    expect(deps.onReconciled).toHaveBeenCalledWith(
+      expect.objectContaining({ childPid: 4242 }),
+      'skipped-child-unknown'
+    )
+    expect(await journal.pending()).toHaveLength(1) // entry left for a later boot
   })
 
-  it('does not check liveness or kill when no childPid was recorded', async () => {
+  it('a no-childPid STAGING op (download) is treated dead and reconciled without a liveness probe', async () => {
     const journal = await newJournal()
-    await journal.begin(record({ kind: 'materialize' })) // no childPid
+    await journal.begin(record({ kind: 'download', targetPath: '/rt/.incoming-a' })) // no childPid
     const deps = makeDeps()
 
     await reconcileInterruptedOperations(journal, deps)
 
+    // A download writes only throwaway staging, so a missing PID is safe to treat as dead: no probe,
+    // no block, just clean the staging.
     expect(deps.operationChildLiveness).not.toHaveBeenCalled()
-    expect(deps.terminateOperationChild).not.toHaveBeenCalled()
-    expect(deps.verifyOrRebuildEnv).toHaveBeenCalledTimes(1)
+    expect(deps.cleanStaging).toHaveBeenCalledTimes(1)
+    expect(await journal.pending()).toEqual([])
+  })
+
+  it('a no-childPid, no-sidecar PREFIX-WRITE is reconciled (child provably never spawned)', async () => {
+    // The PID is persisted SYNCHRONOUSLY at spawn, so a record with neither a journaled PID nor a
+    // sidecar reliably means the child never spawned — no live writer — safe to reconcile (no wall-clock
+    // guessing, no permanent block).
+    const journal = await newJournal()
+    await journal.begin(
+      record({
+        kind: 'materialize',
+        runtimeId: 'default-python',
+        targetPath: '/rt/envs/default-python'
+      })
+    ) // no childPid, no hydrateInterruptedChild -> no sidecar
+    const blocked: string[] = []
+    const deps = makeDeps({
+      blockUnknownChildTarget: vi.fn(async (r) => {
+        blocked.push(r.runtimeId)
+      })
+    })
+
+    const reconciled = await reconcileInterruptedOperations(journal, deps)
+
+    expect(deps.operationChildLiveness).not.toHaveBeenCalled() // no PID to probe
+    expect(deps.verifyOrRebuildEnv).toHaveBeenCalledTimes(1) // reconciled (rebuild-if-incomplete)
+    expect(blocked).toEqual([]) // never blocked
+    expect(reconciled.map((r) => r.operationId)).toEqual(['op-1'])
+    expect(await journal.pending()).toEqual([]) // cleared
+  })
+
+  it('hydrates a missing childPid from the sidecar, then probes it (unknown -> BLOCK)', async () => {
+    // A crash can lose the journal's async PID update; the synchronous sidecar still has it, so recovery
+    // hydrates the record and probes — here liveness is unknown, so the target is blocked (not deleted).
+    const journal = await newJournal()
+    await journal.begin(
+      record({
+        kind: 'materialize',
+        runtimeId: 'default-python',
+        targetPath: '/rt/envs/default-python'
+      })
+    ) // no journaled childPid
+    const blocked: string[] = []
+    const deps = makeDeps({
+      // The sidecar supplies the PID the async journal update lost.
+      hydrateInterruptedChild: (r) =>
+        r.childPid !== undefined ? r : { ...r, childPid: 4242, childStartedAt: 100 },
+      operationChildLiveness: vi.fn().mockResolvedValue('unknown'),
+      blockUnknownChildTarget: vi.fn(async (r) => {
+        blocked.push(r.runtimeId)
+      })
+    })
+
+    const reconciled = await reconcileInterruptedOperations(journal, deps)
+
+    expect(deps.operationChildLiveness).toHaveBeenCalledTimes(1) // probed via the hydrated PID
+    expect(deps.verifyOrRebuildEnv).not.toHaveBeenCalled() // not reconciled under a possible writer
+    expect(blocked).toEqual(['default-python'])
+    expect(reconciled).toEqual([])
+    expect((await journal.pending()).map((r) => r.operationId)).toEqual(['op-1']) // retained
+  })
+
+  it('BLOCKS a spawn-intent record with no PID (spawned, PID never recorded) without probing', async () => {
+    // The sidecar says { spawning: true } but no PID was ever converted — a crash in the spawn->record
+    // window. A child MAY be live, so block (never reconcile), and do NOT probe (there is no PID).
+    const journal = await newJournal()
+    await journal.begin(
+      record({
+        kind: 'materialize',
+        runtimeId: 'default-python',
+        targetPath: '/rt/envs/default-python'
+      })
+    ) // no journaled childPid
+    const blocked: string[] = []
+    const deps = makeDeps({
+      hydrateInterruptedChild: (r) =>
+        r.childPid !== undefined ? r : { ...r, spawnAttempted: true },
+      blockUnknownChildTarget: vi.fn(async (r) => {
+        blocked.push(r.runtimeId)
+      })
+    })
+
+    const reconciled = await reconcileInterruptedOperations(journal, deps)
+
+    expect(deps.operationChildLiveness).not.toHaveBeenCalled() // no PID -> nothing to probe
+    expect(deps.verifyOrRebuildEnv).not.toHaveBeenCalled()
+    expect(blocked).toEqual(['default-python'])
+    expect(reconciled).toEqual([])
+    expect((await journal.pending()).map((r) => r.operationId)).toEqual(['op-1']) // retained
+  })
+
+  it('across two startups on the SAME journal: unknown blocks + retains, then dead reconciles + clears', async () => {
+    // The block is a retained journal record, re-evaluated each startup. First startup can't confirm the
+    // child died -> block + keep the record. A later startup, once the pid is gone, probes 'dead' ->
+    // reconciles + clears the record, so it stops blocking. This is the bounded, PROVABLE recovery.
+    const journal = await newJournal()
+    await journal.begin(
+      record({
+        operationId: 'op-1',
+        kind: 'materialize',
+        runtimeId: 'default-python',
+        targetPath: '/rt/envs/default-python',
+        childPid: 4242,
+        childStartedAt: 100
+      })
+    )
+
+    // Startup 1: liveness unknown -> block, retain the record, do NOT reconcile.
+    const blocked: string[] = []
+    const first = await reconcileInterruptedOperations(
+      journal,
+      makeDeps({
+        operationChildLiveness: vi.fn().mockResolvedValue('unknown'),
+        blockUnknownChildTarget: vi.fn(async (r) => {
+          blocked.push(r.runtimeId)
+        })
+      })
+    )
+    expect(first).toEqual([])
+    expect(blocked).toEqual(['default-python'])
+    expect((await journal.pending()).map((r) => r.operationId)).toEqual(['op-1']) // retained
+
+    // Startup 2 (same journal): the pid is now gone -> dead -> reconcile + clear.
+    const secondDeps = makeDeps({ operationChildLiveness: vi.fn().mockResolvedValue('dead') })
+    const second = await reconcileInterruptedOperations(journal, secondDeps)
+    expect(secondDeps.verifyOrRebuildEnv).toHaveBeenCalledTimes(1)
+    expect(second.map((r) => r.operationId)).toEqual(['op-1'])
+    expect(await journal.pending()).toEqual([]) // cleared -> no longer blocks
   })
 
   it('on unknown liveness: BLOCKS the target, retains the journal, never cleans under a maybe-live writer', async () => {
@@ -124,10 +265,9 @@ describe('reconcileInterruptedOperations', () => {
 
     const reconciled = await reconcileInterruptedOperations(journal, deps)
 
-    // Not reconciled, not killed, not cleaned/rebuilt — but the target IS blocked so a fresh op can't
-    // race a possible survivor after the barrier opens, and the journal entry survives for a later boot.
+    // Not reconciled, not cleaned/rebuilt — but the target IS blocked so a fresh op can't race a
+    // possible survivor after the barrier opens, and the journal entry survives for a later boot.
     expect(reconciled).toEqual([])
-    expect(deps.terminateOperationChild).not.toHaveBeenCalled()
     expect(deps.cleanStaging).not.toHaveBeenCalled()
     expect(deps.verifyOrRebuildEnv).not.toHaveBeenCalled()
     expect(blocked).toEqual(['default-python'])
@@ -138,7 +278,8 @@ describe('reconcileInterruptedOperations', () => {
   it('leaves a failed op in the journal (retried next startup) without blocking the others', async () => {
     const journal = await newJournal()
     await journal.begin(record({ operationId: 'bad', kind: 'download' }))
-    await journal.begin(record({ operationId: 'good', kind: 'materialize' }))
+    // 'good' carries a childPid so it's probed 'dead' and reconciled (a no-PID materialize would block).
+    await journal.begin(record({ operationId: 'good', kind: 'materialize', childPid: 111 }))
     const deps = makeDeps({
       cleanStaging: vi.fn().mockRejectedValue(new Error('rm failed'))
     })
@@ -151,7 +292,7 @@ describe('reconcileInterruptedOperations', () => {
   })
 })
 
-describe('defaultOperationChildLiveness (tri-state pid-reuse guard)', () => {
+describe('defaultOperationChildLiveness (two-state pid-reuse guard: dead | unknown, never alive)', () => {
   it('reports a record with no childPid as dead', async () => {
     expect(await defaultOperationChildLiveness(record({ childPid: undefined }))).toBe('dead')
   })
@@ -161,8 +302,34 @@ describe('defaultOperationChildLiveness (tri-state pid-reuse guard)', () => {
     expect(await defaultOperationChildLiveness(record({ childPid: 2_147_483_646 }))).toBe('dead')
   })
 
+  it('reports "unknown" (not dead) when the initial probe fails with something other than ESRCH/EPERM', async () => {
+    // Only ESRCH (gone) and EPERM (exists, not ours to signal) justify 'dead'. An unexpected probe
+    // failure (e.g. EINVAL) is NOT proof the child is gone — recovery/Reset must fail safe to 'unknown'
+    // (block) rather than clean a prefix a live writer might still hold.
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('boom'), { code: 'EINVAL' })
+    })
+    try {
+      expect(await defaultOperationChildLiveness(record({ childPid: 4242 }))).toBe('unknown')
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('reports EPERM (exists, not ours) as dead just like ESRCH', async () => {
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('perm'), { code: 'EPERM' })
+    })
+    try {
+      expect(await defaultOperationChildLiveness(record({ childPid: 4242 }))).toBe('dead')
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
   it('reports a live pid with no recorded start time as unknown (cannot rule out reuse)', async () => {
-    // The old boolean check returned alive here and would SIGKILL it; tri-state refuses to guess.
+    // The old boolean check returned alive here and would SIGKILL it; the two-state guard refuses to
+    // guess — a live pid we can't prove reused is 'unknown' (block), never a signal.
     expect(
       await defaultOperationChildLiveness(
         record({ childPid: process.pid, childStartedAt: undefined })
@@ -170,31 +337,82 @@ describe('defaultOperationChildLiveness (tri-state pid-reuse guard)', () => {
     ).toBe('unknown')
   })
 
-  // Whether THIS environment can actually verify a pid's start time via `ps`. It can't on Windows (no
-  // ps) and can't in a locked-down sandbox where `ps -o etime` is denied ("operation not permitted") —
-  // in both, defaultOperationChildLiveness must return 'unknown' rather than guess. We probe it directly
-  // (a live pid whose recorded start time matches the pid's real start resolves 'alive' only when ps
-  // works) so the assertion below tracks the real capability instead of assuming it from
-  // process.platform. Keeps the test green on Windows AND in a ps-restricted sandbox, per the repo's
-  // sandbox-safe test rule.
-  //
-  // childStartedAt MUST be this worker's real start (Date.now() - uptime*1000), NOT Date.now(): the
-  // guard compares the recorded value against the start time `ps` reports and only says 'alive' within
-  // PID_REUSE_TOLERANCE_MS (10s). Passing Date.now() drifts by uptime*1000, so once the worker has run
-  // >10s the probe would wrongly read 'dead' and conclude ps is unavailable — flaky on slow/long workers.
-  // Using the real start keeps the delta ~0 so a working ps resolves 'alive' regardless of worker age.
-  const canVerifyPidStartTime = async (): Promise<boolean> =>
-    (await defaultOperationChildLiveness(
-      record({ childPid: process.pid, childStartedAt: Date.now() - process.uptime() * 1000 })
-    )) === 'alive'
+  // A live pid (process.pid) with an injectable token reader, so the token branch is deterministic and
+  // never depends on the sandbox's real /proc (and never signals a real process). The verdict is two-state
+  // ('dead' | 'unknown'): a live pid is 'dead' ONLY on a monotonic-token MISMATCH (proven reuse), else it
+  // is 'unknown' (block). There is NO wall-clock / ps fallback — that path was unsound (a clock step could
+  // make a LIVE child look reused → wrongly reconciled), so it was removed entirely.
+  const liveWith = (
+    recordExtra: { childStartedAt?: number; childStartToken?: string },
+    readToken: ProcessStartTokenReader = () => undefined
+  ): Promise<'dead' | 'unknown'> =>
+    defaultOperationChildLiveness(record({ childPid: process.pid, ...recordExtra }), readToken)
 
-  it('classifies a live pid whose start time is far from childStartedAt as REUSED when ps is available, else unknown', async () => {
-    // This process is alive but we claim its child started in 1970. When ps can read the real (recent)
-    // start time, the guard rejects the reused pid as 'dead' (never SIGKILLs an unrelated process). When
-    // ps is unavailable/denied, it cannot verify identity and must fail safe to 'unknown'.
-    const expected = (await canVerifyPidStartTime()) ? 'dead' : 'unknown'
-    expect(
-      await defaultOperationChildLiveness(record({ childPid: process.pid, childStartedAt: 0 }))
-    ).toBe(expected)
+  describe('token path — a token can only FALSIFY (prove reuse), never authorize a kill', () => {
+    it('reports DEAD when the live token DIFFERS (proven pid reuse)', async () => {
+      // The one sound "dead" for a live pid: the boot-relative start tick changed → a different process
+      // reused the pid → our child is provably gone → reconcile. (No signal is ever sent.)
+      expect(await liveWith({ childStartToken: '80877' }, () => '99999')).toBe('dead')
+    })
+
+    it('reports UNKNOWN when the live token MATCHES (might be our orphan — block, never kill)', async () => {
+      // A match means the pid COULD still be our orphan; the tick-coarse token is not strict identity, so
+      // we never treat it as license to signal. Collapses to the same 'unknown' as an unreadable token.
+      expect(await liveWith({ childStartToken: '80877' }, () => '80877')).toBe('unknown')
+    })
+
+    it('reports UNKNOWN when the recorded token cannot be re-read for the live pid', async () => {
+      // Live read failed (permissions, race) → can't even falsify → block.
+      expect(await liveWith({ childStartToken: '80877' }, () => undefined)).toBe('unknown')
+    })
+
+    it('DEMONSTRATES why non-canonical tokens must be rejected upstream: a raw compare misfires', async () => {
+      // The liveness probe TRUSTS its input is canonical and compares tokens as raw strings. So a
+      // leading-zero token "000123" reaches here it WOULD misread a value-equal live token "123" as a
+      // mismatch → 'dead' (reconcile under a live worker). This is exactly why isValidChildStartToken
+      // rejects "000123" as corrupt at the sidecar/journal boundary, so it can never reach this compare.
+      expect(await liveWith({ childStartToken: '000123' }, () => '123')).toBe('dead') // the misfire we prevent upstream
+      expect(await liveWith({ childStartToken: '123' }, () => '123')).toBe('unknown') // canonical: correctly blocks
+    })
+  })
+
+  describe('tokenless live pid is ALWAYS unknown (no wall-clock fallback — the P1 fix)', () => {
+    it('a live pid with no token is unknown regardless of any recorded start time', async () => {
+      // The removed ps-window path used to call some of these 'dead' by comparing wall-clock times. That
+      // was unsound: an NTP/manual clock step of a few seconds could push a still-running child outside
+      // the window and get its prefix deleted/rebuilt underneath it. Now: tokenless live pid → unknown.
+      expect(await liveWith({ childStartedAt: undefined })).toBe('unknown')
+      expect(await liveWith({ childStartedAt: 1_700_000_000_000 })).toBe('unknown')
+      expect(await liveWith({ childStartedAt: 0 })).toBe('unknown')
+    })
+  })
+
+  it('never returns a kill-authorizing verdict for a real live pid (sandbox-safe smoke)', async () => {
+    // Integration guard over the REAL token reader against this live test process (node/vitest). The
+    // verdict must never be 'dead' — that would let recovery/Reset reconcile (delete/verify) under a live
+    // process. We record THIS process's real token so on Linux the token path MATCHES → 'unknown'; on
+    // macOS/Windows (or a /proc-restricted sandbox) there is no token → 'unknown'. Either way: 'unknown'.
+    const verdict = await defaultOperationChildLiveness(
+      record({ childPid: process.pid, childStartToken: readProcessStartToken(process.pid) })
+    )
+    expect(verdict).toBe('unknown')
+  })
+
+  describe('readProcessStartToken', () => {
+    it('returns a stable non-empty token for a live pid on Linux, undefined elsewhere', () => {
+      // Deterministic per platform: on Linux /proc/self/stat yields the same starttime tick on repeated
+      // reads (identity is stable for a process's lifetime); off Linux there is no /proc so it is absent.
+      const first = readProcessStartToken(process.pid)
+      if (process.platform === 'linux') {
+        expect(first).toMatch(/^\d+$/)
+        expect(readProcessStartToken(process.pid)).toBe(first) // stable across reads
+      } else {
+        expect(first).toBeUndefined()
+      }
+    })
+
+    it('returns undefined for a pid that does not exist', () => {
+      expect(readProcessStartToken(2_147_483_646)).toBeUndefined()
+    })
   })
 })

--- a/src/main/notebook/operation-recovery.ts
+++ b/src/main/notebook/operation-recovery.ts
@@ -1,25 +1,29 @@
-import { spawn, type ChildProcess } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 
 import type { RuntimeOperationJournal, RuntimeOperationRecord } from './operation-journal'
 
 // Injected side-effects for reconciling ONE interrupted runtime operation, so the startup-recovery
 // orchestration is unit-tested without real processes, filesystem, or provisioner. See
 // notebook-runtime-crash-recovery.
-// Tri-state liveness of an operation's recorded child (micromamba/pip/R):
-//   - 'alive'   : positively confirmed the recorded pid is STILL our original child → kill it, then reconcile.
+// Two-state liveness of an operation's recorded child (micromamba/pip/R):
 //   - 'dead'    : positively confirmed gone / not ours (ESRCH/EPERM, or a reused pid) → safe to reconcile.
-//   - 'unknown' : could NOT determine (no `ps`, Windows, unparsable output) → a survivor MIGHT still be
-//                 writing, so we must NOT clean staging / a prefix; skip and leave the journal entry for a
-//                 later startup instead of destroying data under a possibly-live writer.
+//   - 'unknown' : could NOT prove the child died (a live pid whose reuse we can't prove — a matching or
+//                 unreadable start token, or no token at all on macOS/Windows/legacy) → a survivor MIGHT
+//                 still be writing, so we must NOT clean staging / a prefix nor signal it; block and leave
+//                 the journal entry for a later startup instead of destroying data under a live writer.
 // Collapsing 'unknown' into 'dead' (the old boolean) is exactly the bug: it cleaned live processes' dirs.
-export type OperationChildLiveness = 'alive' | 'dead' | 'unknown'
+//
+// There is deliberately NO 'alive' state. We never auto-signal a child: a persisted pid (+ start token)
+// can't give a strict "this live pid is still ours, safe to SIGKILL" guarantee (tick-coarse token; a
+// probe→kill race could hit a reused pid). So a confirmed-live child is 'unknown' — recovery BLOCKS its
+// target and leaves the entry, and the env self-heals on a later boot once the pid is gone. 'dead' means
+// provably gone or provably reused (safe to reconcile); 'unknown' means "might be live" (block).
+export type OperationChildLiveness = 'dead' | 'unknown'
 
 export type OperationRecoveryDeps = {
-  // Best-effort liveness of the operation's recorded child, as the tri-state above. Callers pass a
-  // platform check (see defaultOperationChildLiveness).
+  // Best-effort liveness of the operation's recorded child, as the two-state above. Callers pass a
+  // platform check (see defaultOperationChildLiveness). Never 'alive' — see the type note.
   operationChildLiveness: (record: RuntimeOperationRecord) => Promise<OperationChildLiveness>
-  // Kills a surviving orphan child before reconciling. Only called when liveness is 'alive'.
-  terminateOperationChild: (record: RuntimeOperationRecord) => Promise<void>
   // download: delete the partial ".incoming-*" staging dir (targetPath) so the next fetch starts clean.
   cleanStaging: (record: RuntimeOperationRecord) => Promise<void>
   // materialize/upgrade: verify the env prefix and rebuild it from its immutable lock if incomplete
@@ -37,6 +41,10 @@ export type OperationRecoveryDeps = {
   blockUnknownChildTarget: (record: RuntimeOperationRecord) => Promise<void>
   // Observed reconcile outcome per record (telemetry/tests). action is the branch taken.
   onReconciled?: (record: RuntimeOperationRecord, action: RecoveryAction) => void
+  // Fills in a record's childPid/childStartedAt from the SYNCHRONOUS PID sidecar when the journal's
+  // async childPid update was lost to a crash. Returns the record enriched (or unchanged). This is what
+  // makes a missing childPid provably mean "never spawned" (safe to reconcile) rather than a guess.
+  hydrateInterruptedChild?: (record: RuntimeOperationRecord) => RuntimeOperationRecord
 }
 
 export type RecoveryAction =
@@ -48,8 +56,9 @@ export type RecoveryAction =
   | 'skipped-child-unknown'
 
 // Reconciles every interrupted operation the journal recorded, run ONCE at startup. For each record:
-// if a child from the dead parent survived, kill it first (never reconcile under a live writer), then
-// run the kind-appropriate reconcile, then CLEAR the journal entry so it is never reprocessed. A
+// if a child from the dead parent might have survived ('unknown'), BLOCK its target and leave the entry
+// (never reconcile — nor signal — under a possibly-live writer); otherwise ('dead': provably gone or
+// reused) run the kind-appropriate reconcile, then CLEAR the journal entry so it is never reprocessed. A
 // failure on one operation is logged and its entry left for a later attempt, so one bad op cannot
 // block the rest. Returns the records that were reconciled + cleared.
 export const reconcileInterruptedOperations = async (
@@ -59,31 +68,42 @@ export const reconcileInterruptedOperations = async (
   const pending = await journal.pending()
   const reconciled: RuntimeOperationRecord[] = []
 
-  for (const record of pending) {
+  for (const raw of pending) {
     try {
+      // Fill in the childPid from the synchronous sidecar if the journal's async update was lost to a
+      // crash, so the checks below act on the child that actually spawned.
+      const record = deps.hydrateInterruptedChild?.(raw) ?? raw
+      // Decide liveness from the spawn-lifecycle sidecar (hydrated above), never a wall-clock guess:
+      //   - childPid present            -> probe it ('dead' | 'unknown').
+      //   - spawnAttempted, no childPid -> reached the spawn stage but the PID was never recorded (a
+      //                                    crash in the spawn→record window); a child MAY be live, so
+      //                                    treat as 'unknown' and BLOCK — never reconcile under a writer.
+      //   - neither                     -> the op never reached the spawn stage (no sidecar); there is no
+      //                                    child, so it is safe to reconcile ('dead').
       const liveness =
-        record.childPid === undefined ? 'dead' : await deps.operationChildLiveness(record)
+        record.childPid !== undefined
+          ? await deps.operationChildLiveness(record)
+          : record.spawnAttempted
+            ? 'unknown'
+            : 'dead'
       if (liveness === 'unknown') {
-        // We can't tell whether the recorded child survived (no `ps` / Windows / unparsable). A live
-        // orphan might still be writing staging or the prefix, so do NOT reconcile (which would delete
-        // it out from under the writer). BLOCK the target runtime/prefix so a fresh op can't race the
-        // possible survivor once the recovery barrier opens, and leave the journal entry so a later
-        // startup — when the pid is gone or verifiable — reconciles it. Never destroy data on a guess.
+        // We could not PROVE the recorded child died (its pid is still live and its identity can't be
+        // strictly confirmed, or the probe was unavailable). A survivor might still be writing staging or
+        // the prefix. We do NOT signal it (no strict "safe to kill" guarantee) and do NOT reconcile
+        // (which would delete data under a live writer): instead BLOCK the target runtime/prefix so a
+        // fresh op can't race the possible survivor once the recovery barrier opens, and leave the
+        // journal entry so a LATER startup — when the pid is provably gone — reconciles it. The env
+        // self-heals on a subsequent boot; we never destroy data on a guess.
         await deps.blockUnknownChildTarget(record)
         deps.onReconciled?.(record, 'skipped-child-unknown')
         continue
-      }
-      if (liveness === 'alive') {
-        // A live orphan from the previous process is still writing — kill it, THEN reconcile so we
-        // never clean staging / verify a prefix while it is mid-write.
-        await deps.terminateOperationChild(record)
       }
       await runReconcileAction(record, deps)
       await journal.complete(record.operationId)
       reconciled.push(record)
     } catch (error) {
       console.error(
-        `[notebook] operation recovery failed for ${record.operationId}; leaving journal entry`,
+        `[notebook] operation recovery failed for ${raw.operationId}; leaving journal entry`,
         error
       )
     }
@@ -118,69 +138,68 @@ const runReconcileAction = async (
   }
 }
 
-// Reads a POSIX process's elapsed run time (`ps -o etime=`) and converts it to an approximate start
-// time in epoch ms. Returns undefined if ps is unavailable/unparsable or the pid is gone. Format is
-// `[[dd-]hh:]mm:ss`. Used only to reject a REUSED pid (a different process now holding the recorded
-// pid), so approximate is fine.
-const posixProcessStartMs = (pid: number): Promise<number | undefined> =>
-  new Promise((resolve) => {
-    let ps: ChildProcess
-    try {
-      ps = spawn('ps', ['-o', 'etime=', '-p', String(pid)], { windowsHide: true })
-    } catch {
-      resolve(undefined)
-      return
-    }
-    let out = ''
-    ps.stdout?.on('data', (chunk: Buffer) => (out += chunk.toString()))
-    ps.on('error', () => resolve(undefined))
-    ps.on('close', () => {
-      const m = out.trim().match(/^(?:(?:(\d+)-)?(\d+):)?(\d+):(\d+)$/)
-      if (!m) {
-        resolve(undefined)
-        return
-      }
-      const [, dd, hh, mm, ss] = m
-      const seconds =
-        Number(dd ?? 0) * 86400 + Number(hh ?? 0) * 3600 + Number(mm) * 60 + Number(ss)
-      resolve(Date.now() - seconds * 1000)
-    })
-  })
+// The kernel's process start time for `pid` in clock ticks since boot, read from `/proc/<pid>/stat`
+// field 22. This is a REUSE FALSIFIER, not a hard identity: it is coarse (tick-granular — a pid reused
+// within the same tick could in principle read the same value), so we never treat a MATCH as proof we
+// may signal a pid. Its one sound use is the other direction — a token that DIFFERS from the record
+// proves the pid was reused and our child is gone. Recovery/Reset use it only to release a block ('dead'
+// on a proven-reused pid), never to authorize a kill; a match keeps the verdict 'unknown' (block). See
+// defaultOperationChildLiveness. Returns undefined off Linux (no /proc) or when the pid is gone / stat is
+// unreadable. stat's field 2 (comm) can contain spaces/parens, so we parse after the LAST ')' to reach
+// the fixed numeric tail; field 22 (starttime) is index 19 of that tail (fields 3..end).
+export const readProcessStartToken = (pid: number): string | undefined => {
+  if (process.platform !== 'linux') return undefined
+  let stat: string
+  try {
+    stat = readFileSync(`/proc/${pid}/stat`, 'utf8')
+  } catch {
+    return undefined
+  }
+  const lastParen = stat.lastIndexOf(')')
+  if (lastParen === -1) return undefined
+  const tail = stat
+    .slice(lastParen + 1)
+    .trim()
+    .split(/\s+/)
+  const starttime = tail[19] // field 22 overall; tail[0] is field 3 (state)
+  return starttime !== undefined && /^\d+$/.test(starttime) ? starttime : undefined
+}
 
-// A live pid whose start time differs from the recorded childStartedAt by more than this is treated as
-// a DIFFERENT process now holding a REUSED pid, not our orphan. Kept tight (was 60s): `ps -o etime`
-// resolves to whole seconds and there is only a few ms between spawning the child and recording
-// childStartedAt, so our own child's start time lands within a couple of seconds. A wide window let a
-// pid reused shortly after our child exited masquerade as ours. Wide enough to absorb etime rounding +
-// spawn latency, tight enough that a quickly-reused pid falls outside it and is classified 'dead'.
-const PID_REUSE_TOLERANCE_MS = 10_000
+// Seam for the token read so tests can inject a deterministic identity without a real /proc.
+export type ProcessStartTokenReader = (pid: number) => string | undefined
 
-// Tri-state liveness with a fail-SAFE pid-reuse guard. 'alive' means recovery will SIGKILL the pid, so
-// we only report 'alive' when we can POSITIVELY confirm the live pid is the SAME process we spawned.
-// When we genuinely cannot tell, we report 'unknown' — recovery then SKIPS the op (leaves the journal
-// entry) rather than either killing an unrelated process or cleaning a dir a survivor may still write:
-//   - No pid, or the pid is gone / not ours to signal (ESRCH/EPERM) → 'dead' (safe to reconcile).
-//   - childStartedAt recorded (the normal case): confirm via `ps` that the pid's start time matches.
-//       within tolerance → 'alive'; clearly different → 'dead' (pid reused, not ours);
-//       can't verify (no `ps`, Windows, ps failed / unparsable) → 'unknown'.
-//   - childStartedAt absent (legacy record, no start-time) with a LIVE pid: we can't rule out reuse, so
-//     'unknown' rather than assuming it is our child (old code returned alive and would kill it).
+// Two-state liveness ('dead' | 'unknown', never 'alive' — see OperationChildLiveness). We return 'dead'
+// ONLY when the child is PROVABLY gone or PROVABLY reused (safe to reconcile), and 'unknown' whenever a
+// live pid MIGHT still be our child (recovery/Reset then BLOCK — never signal, never reconcile). Every
+// "dead" verdict rests on a SOUND signal — an OS existence probe or a monotonic kernel token — never on a
+// wall-clock comparison (NTP/manual time steps could otherwise shift a reconstructed start time and make a
+// LIVE child look reused → wrongly reconciled). Concretely:
+//   - No pid recorded → 'dead' (the op never had a child to worry about).
+//   - process.kill(pid,0) throws ESRCH (gone) or EPERM (exists but not ours to signal — our child would be
+//     signalable) → our writer is gone either way → 'dead'. Any other errno is not proof → 'unknown'.
+//   - Live pid + recorded token: read the live pid's token. Present-and-DIFFERENT → 'dead' (PROVEN reuse;
+//     the boot-relative start tick is monotonic, so a changed value can only mean a different process now
+//     holds the pid). Equal, or unreadable → 'unknown' (a match is coarse and is NOT license to signal).
+//   - Live pid, NO token (legacy record / no /proc — macOS/Windows): we have no sound reuse signal, so
+//     'unknown'. A genuinely-live orphan therefore stays blocked until a later boot makes the pid ESRCH.
 export const defaultOperationChildLiveness = async (
-  record: RuntimeOperationRecord
+  record: RuntimeOperationRecord,
+  readToken: ProcessStartTokenReader = readProcessStartToken
 ): Promise<OperationChildLiveness> => {
   if (record.childPid === undefined) return 'dead'
   try {
     process.kill(record.childPid, 0)
-  } catch {
-    // ESRCH = gone; EPERM = owned by another user, so not our child. Either way, nothing of ours to
-    // kill and no writer of ours to protect → safe to reconcile.
-    return 'dead'
+  } catch (error) {
+    const code = (error as { code?: string }).code
+    if (code === 'ESRCH' || code === 'EPERM') return 'dead'
+    return 'unknown'
   }
-  // Live pid but no recorded start time (legacy): can't guard against reuse — don't guess it's ours.
-  if (record.childStartedAt === undefined) return 'unknown'
-  // Live pid, recorded start time, but no way to verify it (Windows has no ps here) — can't confirm.
-  if (process.platform === 'win32') return 'unknown'
-  const startedMs = await posixProcessStartMs(record.childPid)
-  if (startedMs === undefined) return 'unknown' // couldn't read/parse the start time — can't confirm
-  return Math.abs(startedMs - record.childStartedAt) <= PID_REUSE_TOLERANCE_MS ? 'alive' : 'dead'
+  // Live pid. The ONLY sound way to call it 'dead' now is a monotonic-token MISMATCH (proven reuse). A
+  // match, an unreadable token, or no token at all → 'unknown' (block); we never reconcile a live pid on a
+  // guess, and it self-heals once a later boot makes the pid ESRCH.
+  if (record.childStartToken !== undefined) {
+    const liveToken = readToken(record.childPid)
+    if (liveToken !== undefined && liveToken !== record.childStartToken) return 'dead'
+  }
+  return 'unknown'
 }

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -12,7 +12,12 @@ vi.mock('./micromamba', async (importActual) => ({
   resolveMicromamba: () => undefined
 }))
 
-import { installPackages, type InstallSpawn, type SpawnResult } from './package-manager'
+import {
+  defaultSpawn,
+  installPackages,
+  type InstallSpawn,
+  type SpawnResult
+} from './package-manager'
 import { micromambaCacheLockKey, selectMicromambaCache } from './micromamba-cache'
 import { withExclusiveCacheLock } from './pkgs-cache-lock'
 import {
@@ -52,6 +57,53 @@ const base = {
   storageRoot: '/root',
   condaChannel: 'https://mirror.test/conda-forge'
 }
+
+describe('defaultSpawn (fail-closed spawn hooks)', () => {
+  it('calls onBeforeSpawn before spawning, and fails closed (no spawn) when it throws', async () => {
+    const order: string[] = []
+    await defaultSpawn(
+      process.execPath,
+      ['-e', 'process.exit(0)'],
+      undefined,
+      () => order.push('child'),
+      () => order.push('before')
+    )
+    expect(order[0]).toBe('before')
+
+    let childSpawned = false
+    const result = await defaultSpawn(
+      process.execPath,
+      ['-e', 'process.exit(0)'],
+      undefined,
+      () => {
+        childSpawned = true
+      },
+      () => {
+        throw new Error('intent write failed')
+      }
+    )
+    expect(result.code).toBe(1)
+    expect(result.stderr).toMatch(/spawn intent/)
+    expect(childSpawned).toBe(false) // never spawned
+  })
+
+  it('kills the child and reports failure when onChild (PID recording) throws', async () => {
+    let killedPid: number | undefined
+    const result = await defaultSpawn(
+      process.execPath,
+      ['-e', 'setTimeout(() => {}, 60000)'],
+      undefined,
+      (pid) => {
+        killedPid = pid
+        throw new Error('sidecar write failed')
+      }
+    )
+    expect(result.code).toBe(1)
+    expect(result.stderr).toMatch(/Failed to record the installer worker/)
+    expect(killedPid).toBeGreaterThan(0)
+    await vi.waitFor(() => expect(() => process.kill(killedPid as number, 0)).toThrow())
+  })
+})
 
 describe('installPackages', () => {
   it('forwards the installer child PID through onChild (for crash-recovery journaling)', async () => {
@@ -346,6 +398,60 @@ describe('installPackages', () => {
     expect(result.log).toContain('retry install stdout')
     expect(result.error).toMatch(/short Windows package cache[^]*shorter data location/i)
     expect(result.error).not.toMatch(/LongPathsEnabled|administrator/i)
+  })
+
+  it('threads onBeforeSpawn through the conda path on BOTH the first spawn and the MAX_PATH retry', async () => {
+    // Regression: the conda runConda path used to call baseSpawn WITHOUT deps.onBeforeSpawn, so the
+    // {spawning} intent sidecar was never written before conda install/remove. A crash in the
+    // spawn→onChild window then left no sidecar and recovery misread it as "never spawned" — reconciling
+    // or retrying under a possibly-live installer. Both the first spawn and the fresh retry after MAX_PATH
+    // recovery must re-arm the intent, mirroring defaultSpawn's ordering (before, then child).
+    const storageRoot = mkdtempSync(join(tmpdir(), 'os-pm-conda-intent-'))
+    const cache = join(storageRoot, 'runtime', 'pkgs')
+    const leaf = 'broken-package-1.0-0'
+    const packageDir = join(cache, 'https', 'host', 'channel', 'noarch', leaf)
+    mkdirSync(packageDir, { recursive: true })
+    const missing = join(packageDir, 'Library', 'x'.repeat(280))
+    const results: SpawnResult[] = [
+      {
+        code: 1,
+        stdout: '',
+        stderr: `Invalid package cache, file '${missing}' is missing for '${leaf}.conda'; Package cache error`
+      },
+      { code: 0, stdout: 'ok', stderr: '' } // retry succeeds
+    ]
+    const order: string[] = []
+    let i = 0
+    // deps.onBeforeSpawn is threaded to baseSpawn as its 5th arg; a faithful stub invokes it (as the real
+    // defaultSpawn does) BEFORE reporting the child, so we can assert both that it ran and that it ran first.
+    const spawn: InstallSpawn = async (_command, _args, _env, onChild, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      order.push(`child#${i}`)
+      onChild?.(1000 + i)
+      return results[i++]
+    }
+
+    const result = await installPackages(
+      { language: 'python', packages: ['numpy'], environment: 'my-analysis' },
+      {
+        spawn,
+        ...base,
+        storageRoot,
+        pathExists: () => true,
+        onBeforeSpawn: () => order.push('intent'),
+        micromambaEnv: {
+          platform: 'win32',
+          env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' },
+          selectCache: () => ({ path: cache, lockKey: cache })
+        }
+      }
+    )
+
+    expect(result.ok).toBe(true)
+    // The intent fired before the child on the FIRST spawn AND again on the RETRY (old bug: zero intents,
+    // since runConda dropped deps.onBeforeSpawn entirely).
+    expect(order).toEqual(['intent', 'child#0', 'intent', 'child#1'])
+    expect(i).toBe(2)
   })
 
   it('rejects an empty package list without spawning', async () => {

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -20,6 +20,7 @@ import {
 } from './micromamba-cache'
 import { recoverWindowsMaxPathPackage } from './micromamba-cache-recovery'
 import { withExclusiveCacheLocks, withSharedCacheLocks } from './pkgs-cache-lock'
+import { CHILD_UNCONFIRMED, killAndConfirmExit } from './provisioner-runtime'
 import {
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
@@ -74,7 +75,11 @@ export type InstallSpawn = (
   env?: NodeJS.ProcessEnv,
   // Invoked with the spawned installer's PID so the caller can journal it for crash-recovery
   // supervision (a killed installer survivor is reaped before reconciling). Test spawns ignore it.
-  onChild?: (pid: number) => void
+  onChild?: (pid: number) => void,
+  // Invoked synchronously right before EACH spawn so the caller can (re)record the per-spawn intent. An
+  // R install spawns twice (conda then CRAN on fallback), so each must re-arm rather than trust the
+  // first spawn's PID. Throwing fails closed (nothing is spawned).
+  onBeforeSpawn?: () => void
 ) => Promise<SpawnResult>
 
 // condaChannel/pypiIndex/cranMirror are resolved PackageMirror values (see shared/mirror.ts);
@@ -99,6 +104,8 @@ export type InstallDeps = {
   // Invoked with each spawned installer's PID so the caller (managePackages) can journal it for
   // crash-recovery supervision of a surviving installer after a hard quit.
   onChild?: (pid: number) => void
+  // Invoked synchronously right before EACH spawn so the caller can (re)record the per-spawn intent.
+  onBeforeSpawn?: () => void
 }
 
 const DEFAULT_CONDA_CHANNEL = 'conda-forge'
@@ -143,10 +150,49 @@ const rCondaNames = (packages: string[]): string[] =>
 const condaReportsNotManaged = (log: string): boolean => /not (found|installed)/i.test(log)
 
 // Real spawn wrapper collecting stdout/stderr and the exit code; replaced by an injected spawn in tests.
-const defaultSpawn: InstallSpawn = (command, args, env, onChild) =>
-  new Promise((resolve) => {
+// Exported so its fail-closed spawn-intent / kill-on-record-failure branches are directly testable.
+export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBeforeSpawn) =>
+  new Promise((resolve, reject) => {
+    try {
+      onBeforeSpawn?.() // re-arm the per-spawn intent; fail closed if it can't be recorded
+    } catch (error) {
+      resolve({
+        code: 1,
+        stdout: '',
+        stderr: `Failed to record the spawn intent; not spawning: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      })
+      return
+    }
     const child = nodeSpawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'], env })
-    if (child.pid !== undefined) onChild?.(child.pid)
+    if (child.pid !== undefined) {
+      try {
+        onChild?.(child.pid)
+      } catch (error) {
+        // Recording the PID failed. FAIL CLOSED: kill it and only settle once it is CONFIRMED gone.
+        // If it can't be confirmed, REJECT with the CHILD_UNCONFIRMED marker so the caller retains the
+        // recovery evidence (a worker may still be writing) instead of clearing it.
+        void killAndConfirmExit(child).then((confirmed) => {
+          if (confirmed) {
+            resolve({
+              code: 1,
+              stdout: '',
+              stderr: `Failed to record the installer worker; aborted: ${
+                error instanceof Error ? error.message : String(error)
+              }`
+            })
+          } else {
+            reject(
+              new Error(
+                `${CHILD_UNCONFIRMED}: recording failed and the installer could not be confirmed stopped.`
+              )
+            )
+          }
+        })
+        return
+      }
+    }
     let stdout = ''
     let stderr = ''
     child.stdout?.on('data', (chunk) => {
@@ -193,7 +239,8 @@ export async function installPackages(
   // custom corporate CA is trusted by conda/pip/R. Wrapping here keeps every run() call site 2-arg.
   const baseSpawn = deps.spawn ?? defaultSpawn
   const spawnEnv: NodeJS.ProcessEnv = { ...process.env, ...caBundleEnv(deps.caBundle) }
-  const run: InstallSpawn = (command, args) => baseSpawn(command, args, spawnEnv, deps.onChild)
+  const run: InstallSpawn = (command, args) =>
+    baseSpawn(command, args, spawnEnv, deps.onChild, deps.onBeforeSpawn)
 
   if (req.packages.length === 0) {
     return { ok: false, needsRestart: false, log: '', error: 'No packages requested.' }
@@ -261,7 +308,10 @@ export async function installPackages(
       })
     ]
     const result = await withSharedCacheLocks(cacheKeys, () =>
-      baseSpawn(command, args, context.env, deps.onChild)
+      // Thread onBeforeSpawn so the {spawning} intent sidecar is written BEFORE conda spawns, exactly as
+      // the pip path does. Without it, a crash in the spawn→onChild window leaves no sidecar, and recovery
+      // would misread that as "never spawned" and reconcile/retry under a possibly-live installer.
+      baseSpawn(command, args, context.env, deps.onChild, deps.onBeforeSpawn)
     )
     if (result.code === 0) return result
     const evidence = `${result.stdout}\n${result.stderr}`
@@ -292,7 +342,9 @@ export async function installPackages(
     }
     if (!recovered) return result
     const retry = await withSharedCacheLocks(cacheKeys, () =>
-      baseSpawn(command, args, context.env, deps.onChild)
+      // The MAX_PATH retry is a fresh spawn — re-arm the intent sidecar for it too, or the same
+      // spawn→onChild crash window on the retry would be unrecoverable (no sidecar → misread as no child).
+      baseSpawn(command, args, context.env, deps.onChild, deps.onBeforeSpawn)
     )
     if (retry.code === 0) return retry
     return {

--- a/src/main/notebook/provisioner-runtime.test.ts
+++ b/src/main/notebook/provisioner-runtime.test.ts
@@ -2,9 +2,9 @@ import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { md5File, runMicromamba, verifyExecutable } from './provisioner-runtime'
+import { killAndConfirmExit, md5File, runMicromamba, verifyExecutable } from './provisioner-runtime'
 import { condaActivatedPath } from './runtime-paths'
 
 describe('verifyExecutable', () => {
@@ -83,6 +83,7 @@ describe('runMicromamba', () => {
         { MM_TIMEOUT_TOKEN: 'timeout-stderr-token' },
         undefined,
         undefined,
+        undefined,
         200
       )
     ).rejects.toThrow(/timed out[^]*timeout-stderr-token/i)
@@ -98,5 +99,84 @@ describe('runMicromamba', () => {
     abort.abort()
 
     await expect(running).rejects.toThrow(/^Runtime setup cancelled\.$/)
+  })
+
+  it('kills the child and rejects (fail-closed) when onChild throws (PID recording failed)', async () => {
+    // If recording the child fails, running on would strand an unrecorded orphan. runMicromamba must
+    // kill the just-spawned child and reject rather than proceed. A long-lived child proves the kill.
+    let killedPid: number | undefined
+    await expect(
+      runMicromamba(
+        [process.execPath, '-e', 'setTimeout(() => {}, 60000)'],
+        undefined,
+        undefined,
+        (pid) => {
+          killedPid = pid
+          throw new Error('sidecar write failed')
+        }
+      )
+    ).rejects.toThrow(/Failed to record the runtime worker/)
+    expect(killedPid).toBeGreaterThan(0)
+    // The child was signalled to die; poll briefly until it's reaped rather than racing the kill.
+    await vi.waitFor(() => expect(() => process.kill(killedPid as number, 0)).toThrow())
+  })
+
+  it('calls onBeforeSpawn immediately before spawning (per-spawn intent re-arm)', async () => {
+    const order: string[] = []
+    await runMicromamba(
+      [process.execPath, '-e', 'process.exit(0)'],
+      undefined,
+      undefined,
+      () => order.push('child'),
+      () => order.push('before')
+    )
+    expect(order).toEqual(['before', 'child']) // intent recorded before the PID
+  })
+
+  it('fails closed (does NOT spawn) when onBeforeSpawn throws', async () => {
+    let childSpawned = false
+    await expect(
+      runMicromamba(
+        [process.execPath, '-e', 'process.exit(0)'],
+        undefined,
+        undefined,
+        () => {
+          childSpawned = true
+        },
+        () => {
+          throw new Error('intent write failed')
+        }
+      )
+    ).rejects.toThrow(/spawn intent/)
+    expect(childSpawned).toBe(false) // onChild never fired -> nothing was spawned
+  })
+})
+
+describe('killAndConfirmExit', () => {
+  it('resolves true once the child actually exits', async () => {
+    const listeners: Record<string, () => void> = {}
+    const fake = {
+      exitCode: null,
+      signalCode: null,
+      kill: () => true,
+      once: (event: string, cb: () => void) => {
+        listeners[event] = cb
+      }
+    } as never
+    const pending = killAndConfirmExit(fake, 1000)
+    listeners.exit?.() // the child exits
+    expect(await pending).toBe(true)
+  })
+
+  it('resolves false when exit cannot be confirmed within the deadline (SIGTERM ignored)', async () => {
+    // A child that never emits exit (kill ignored) — the deadline elapses and we report UNconfirmed so
+    // the caller retains the recovery evidence rather than clearing it under a possibly-live worker.
+    const fake = {
+      exitCode: null,
+      signalCode: null,
+      kill: () => false,
+      once: () => undefined // never fires exit
+    } as never
+    expect(await killAndConfirmExit(fake, 40)).toBe(false)
   })
 })

--- a/src/main/notebook/provisioner-runtime.ts
+++ b/src/main/notebook/provisioner-runtime.ts
@@ -1,4 +1,4 @@
-import { execFile, spawn } from 'node:child_process'
+import { execFile, spawn, type ChildProcess } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { createReadStream } from 'node:fs'
 import { promisify } from 'node:util'
@@ -6,6 +6,50 @@ import { promisify } from 'node:util'
 import { condaActivatedPath } from './runtime-paths'
 
 const execFileAsync = promisify(execFile)
+
+// Marker on the error thrown when a child could NOT be confirmed stopped after a recording failure. The
+// caller must then RETAIN the crash-recovery evidence (sidecar + journal) rather than clearing it, since
+// a live worker may still be writing the prefix. See killAndConfirmExit / runMicromamba.
+export const CHILD_UNCONFIRMED = 'RUNTIME_CHILD_UNCONFIRMED'
+export const isChildUnconfirmedError = (error: unknown): boolean =>
+  error instanceof Error && error.message.includes(CHILD_UNCONFIRMED)
+
+// Kills a child and resolves ONLY once it has actually exited, escalating SIGTERM -> SIGKILL. Resolves
+// true when exit is confirmed, false when it can't be confirmed within the deadline (SIGTERM can be
+// ignored/delayed and kill() can return false, so a single kill() is not proof of exit). The caller
+// decides what an unconfirmed exit means (here: retain recovery evidence, fail closed).
+export const killAndConfirmExit = (child: ChildProcess, deadlineMs = 5000): Promise<boolean> =>
+  new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve(true)
+      return
+    }
+    let done = false
+    const finish = (confirmed: boolean): void => {
+      if (done) return
+      done = true
+      clearTimeout(escalate)
+      clearTimeout(giveUp)
+      resolve(confirmed)
+    }
+    child.once('exit', () => finish(true))
+    try {
+      child.kill('SIGTERM')
+    } catch {
+      // Already gone or un-signalable; the exit listener / timeout below still resolves.
+    }
+    const escalate = setTimeout(
+      () => {
+        try {
+          child.kill('SIGKILL')
+        } catch {
+          // Best-effort escalation.
+        }
+      },
+      Math.floor(deadlineMs / 2)
+    )
+    const giveUp = setTimeout(() => finish(false), deadlineMs)
+  })
 
 // Merges extra vars over the current process env for a subprocess (used to inject the CA-bundle vars
 // so an online provision behind an enterprise TLS proxy verifies HTTPS). Undefined → inherit as-is.
@@ -53,11 +97,31 @@ export const runMicromamba = (
   // Invoked with the spawned child's PID so the caller can journal it — crash recovery then kills a
   // surviving orphan (a micromamba the dead parent left running) before reconciling its target prefix.
   onChild?: (pid: number) => void,
+  // Invoked SYNCHRONOUSLY immediately before the spawn so the caller can (re)record the spawn intent for
+  // THIS spawn — a single op can spawn more than once (create + cache-repair retry), and each spawn must
+  // re-arm the intent so a crash before its PID is recorded blocks rather than trusting a prior PID.
+  // Throwing here fails closed: nothing is spawned.
+  onBeforeSpawn?: () => void,
   timeoutMs = 600_000
 ): Promise<void> =>
   new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
       reject(new Error('Runtime setup cancelled.'))
+      return
+    }
+
+    // Re-arm the per-spawn intent for THIS spawn before launching. Throwing fails closed: nothing is
+    // spawned, so a crash before the PID is recorded blocks rather than trusting a prior spawn's PID.
+    try {
+      onBeforeSpawn?.()
+    } catch (error) {
+      reject(
+        new Error(
+          `Failed to record the spawn intent; not spawning: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      )
       return
     }
 
@@ -68,7 +132,6 @@ export const runMicromamba = (
       env,
       stdio: ['ignore', 'pipe', 'pipe']
     })
-    if (child.pid !== undefined) onChild?.(child.pid)
 
     const maxTail = 16 * 1024
     let stdout = ''
@@ -104,6 +167,36 @@ export const runMicromamba = (
         .filter(Boolean)
         .join('\n')
 
+    // Record the spawned PID for crash-recovery supervision. If recording FAILS, fail closed: kill the
+    // child and only settle once it is CONFIRMED gone — the close handler then rejects with
+    // recordingError. If it can't be confirmed, reject with the CHILD_UNCONFIRMED marker so the caller
+    // RETAINS the recovery evidence (a worker may still be writing) instead of clearing it.
+    let recordingError: Error | undefined
+    if (child.pid !== undefined) {
+      try {
+        onChild?.(child.pid)
+      } catch (error) {
+        recordingError = new Error(
+          `Failed to record the runtime worker PID; aborted to avoid an unrecoverable process: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+        void killAndConfirmExit(child).then((confirmed) => {
+          if (!confirmed && !settled) {
+            settled = true
+            cleanup()
+            reject(
+              new Error(
+                `${CHILD_UNCONFIRMED}: recording failed and the runtime worker could not be confirmed ` +
+                  'stopped; leaving the operation for recovery to block.'
+              )
+            )
+          }
+          // If confirmed, the close handler below rejects with recordingError.
+        })
+      }
+    }
+
     child.once('error', (error) => {
       if (settled) return
       settled = true
@@ -114,6 +207,10 @@ export const runMicromamba = (
       if (settled) return
       settled = true
       cleanup()
+      if (recordingError) {
+        reject(recordingError)
+        return
+      }
       if (cancelled || signal?.aborted) {
         reject(new Error('Runtime setup cancelled.'))
         return

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { basename, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import { describe, expect, it, vi } from 'vitest'
 
@@ -14,6 +14,7 @@ import {
   rBin,
   readRReadyMarker,
   readReadyMarker,
+  readyMarkerPath,
   writeReadyMarker
 } from './runtime-paths'
 import {
@@ -27,11 +28,15 @@ import {
   type ProvisionProgress,
   type ProvisionerDeps
 } from './provisioner'
+import { CHILD_UNCONFIRMED } from './provisioner-runtime'
 import { envsLockDir } from './runtime-relocation'
+import { serializeProvisioner } from './env-ipc'
 import { withExclusiveCacheLock, withSharedCacheLock } from './pkgs-cache-lock'
 import { micromambaCacheLockKey, selectMicromambaCache } from './micromamba-cache'
 import {
   operationJournalPath,
+  recordOperationChildSync,
+  recordSpawnIntentSync,
   RuntimeOperationJournal,
   type RuntimeOperationRecord
 } from './operation-journal'
@@ -82,6 +87,55 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     expect(status.pythonReady).toBe(true)
     expect(status.version).toBe(DEFAULT_ENV_VERSION)
     expect(status.provisioning).toBe(false)
+  })
+
+  it('advances create-phase progress while micromamba extracts (no stall at the floor)', async () => {
+    // The create/extract phase reports nothing itself, so the bar must ease upward on a timer instead
+    // of freezing at the floor. Inject the tick scheduler so we drive ticks deterministically (no real
+    // wall-clock wait / interval-timing flakiness): capture the tick fn once the ticker is scheduled
+    // (after the create's journal I/O), fire it a few times, and assert monotonic progress between the
+    // floor and (never reaching) the ceiling.
+    const root = makeRoot()
+    let tick: (() => void) | undefined
+    let markScheduled!: () => void
+    const scheduled = new Promise<void>((resolve) => (markScheduled = resolve))
+    let resolveCreate: (() => void) | undefined
+    const deps = makeDeps(root, {
+      scheduleTick: (onTick) => {
+        tick = onTick
+        markScheduled()
+        return () => (tick = undefined)
+      },
+      runArgv: (argv: string[]) =>
+        new Promise<void>((resolve) => {
+          // Materialize the interpreter now so verify passes once we let the create resolve.
+          const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+          const bin = prefix.endsWith(DEFAULT_PY_ENV) ? pythonBin(prefix) : rBin(prefix)
+          mkdirSync(join(bin, '..'), { recursive: true })
+          writeFileSync(bin, 'x')
+          resolveCreate = resolve
+        })
+    })
+    const events: ProvisionProgress[] = []
+    const done = new DefaultRuntimeProvisioner(deps).provisionPython((p) => events.push(p))
+
+    await scheduled // the ticker is registered (create is now mid-flight)
+    tick?.()
+    tick?.()
+    tick?.()
+    const createProgress = events
+      .filter((e) => e.phase === 'create-python' && e.message.startsWith('Creating'))
+      .map((e) => e.progress)
+    // create-start floor + the three ticks above it, monotonic, never reaching the ceiling.
+    expect(createProgress).toHaveLength(4)
+    expect(createProgress[0]).toBeCloseTo(0.45)
+    for (let i = 1; i < createProgress.length; i++)
+      expect(createProgress[i]).toBeGreaterThan(createProgress[i - 1])
+    expect(createProgress.at(-1)).toBeLessThan(0.88)
+
+    resolveCreate?.()
+    await done
+    expect(events.at(-1)).toMatchObject({ phase: 'done', progress: 1 })
   })
 
   it('does not write the marker when create fails', async () => {
@@ -166,6 +220,88 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     await expect(run).rejects.toThrow(/cancelled/i)
   })
 
+  it('cancel(runningLang) aborts that run', async () => {
+    const root = makeRoot()
+    let seenSignal: AbortSignal | undefined
+    const deps = makeDeps(root, {
+      runArgv: (_argv, signal) =>
+        new Promise<void>((_resolve, reject) => {
+          seenSignal = signal
+          signal?.addEventListener('abort', () => reject(new Error('Runtime setup cancelled.')))
+        })
+    })
+    const provisioner = new DefaultRuntimeProvisioner(deps)
+    const run = provisioner.provisionPython(() => {})
+    await vi.waitFor(() => expect(seenSignal).toBeDefined())
+    provisioner.cancel('python') // targets the running language explicitly
+    await expect(run).rejects.toThrow(/cancelled/i)
+  })
+
+  it('cancel(otherLang) does NOT abort the running language (the R-cancels-Python bug)', async () => {
+    const root = makeRoot()
+    let resolveCreate: (() => void) | undefined
+    let seenSignal: AbortSignal | undefined
+    const deps = makeDeps(root, {
+      runArgv: (argv, signal) =>
+        new Promise<void>((resolve) => {
+          seenSignal = signal
+          const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+          const bin = pythonBin(prefix)
+          mkdirSync(join(bin, '..'), { recursive: true })
+          writeFileSync(bin, 'x')
+          resolveCreate = resolve
+        })
+    })
+    const provisioner = new DefaultRuntimeProvisioner(deps)
+    const py = provisioner.provisionPython(() => {})
+    await vi.waitFor(() => expect(seenSignal).toBeDefined()) // python create in flight
+    // Cancelling R while Python runs must NOT abort Python's signal.
+    provisioner.cancel('r')
+    expect(seenSignal?.aborted).toBe(false)
+    resolveCreate?.() // let python finish normally
+    await expect(py).resolves.toBeUndefined()
+    expect(provisioner.status().pythonReady).toBe(true)
+  })
+
+  it('PRIMITIVE: cancel(lang) arms a one-shot skip consumed by that language’s next run', async () => {
+    // This is the low-level provisioner primitive: it can't see the run queue, so it always arms a
+    // skip for a not-running language. The "No-op when idle" contract (don't cancel an UNQUEUED future
+    // run) is enforced one layer up by serializeProvisioner — see env-ipc.test.ts, which drives a real
+    // queue. Here we only pin the primitive: the arm is one-shot (consumed once), so a later run works.
+    const root = makeRoot()
+    const runArgv = vi.fn(async () => undefined)
+    const provisioner = new DefaultRuntimeProvisioner(makeDeps(root, { runArgv }))
+    provisioner.cancel('r')
+    await expect(provisioner.provisionR(() => {})).rejects.toThrow(/cancelled/i)
+    expect(runArgv).not.toHaveBeenCalled()
+    // The skip flag was consumed — a subsequent R provision runs normally.
+    await expect(provisioner.provisionR(() => {})).resolves.toBeUndefined()
+    expect(runArgv).toHaveBeenCalledOnce()
+  })
+
+  it('rebuilds a half-built prefix with conda-meta but no interpreter (Windows Retry wedge, 3.2)', async () => {
+    // A cancelled/crashed create can leave <prefix>/conda-meta with no interpreter. The old cleanup
+    // returned early on conda-meta, so every Retry re-ran `create -p` on the half-built prefix and
+    // failed forever. Assert the stale prefix is cleared before create and the env ends up materialized.
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    mkdirSync(join(prefix, 'conda-meta'), { recursive: true }) // conda-meta but no python bin
+    let condaMetaAtCreate: boolean | undefined
+    const deps = makeDeps(root, {
+      runArgv: async (argv) => {
+        const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        // The half-built prefix must have been removed before micromamba runs (not wedge it).
+        condaMetaAtCreate = existsSync(join(p, 'conda-meta'))
+        const bin = pythonBin(p)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      }
+    })
+    await new DefaultRuntimeProvisioner(deps).provisionPython(() => {})
+    expect(condaMetaAtCreate).toBe(false) // cleared before create
+    expect(existsSync(pythonBin(prefix))).toBe(true) // rebuilt successfully
+  })
+
   it('removes an invalid partial env and rebuilds it from the verified bundle on retry', async () => {
     const root = makeRoot()
     const prefix = envPrefix(root, DEFAULT_PY_ENV)
@@ -231,6 +367,40 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     expect(fetchBundle).toHaveBeenCalledTimes(2) // re-seeded after the repair
     expect(existsSync(bin)).toBe(true)
     expect(readReadyMarker(root)?.defaultEnvVersion).toBe(DEFAULT_ENV_VERSION)
+  })
+
+  it('re-arms the spawn intent before EACH create attempt (incl. the cache-repair retry)', async () => {
+    // A single materialize can spawn twice (create, then retry after a cache repair). The intent must be
+    // re-armed before EACH spawn — writing it once per op would leave the first spawn's exited PID in
+    // the sidecar while the retry runs, and recovery would reconcile under the live retry child.
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(pkgsCache(root), 'leftover-pkg'), { recursive: true })
+    writeFileSync(join(pkgsCache(root), 'leftover-pkg', 'partial'), 'x')
+    let creates = 0
+    let intents = 0
+    const runArgv = vi.fn(async (_argv, _signal, _onChild, onBeforeSpawn) => {
+      onBeforeSpawn?.() // real runMicromamba re-arms the intent here, before spawning
+      intents += 1
+      creates += 1
+      if (creates === 1) {
+        throw new Error(
+          'Found incorrect downloads. Aborting (remove_all: The directory is not empty.)'
+        )
+      }
+      mkdirSync(join(bin, '..'), { recursive: true })
+      writeFileSync(bin, 'ok')
+    })
+    const deps = makeDeps(root, {
+      fetchBundle: async () => ({ lockPath: join(root, 'python-3.12.lock') }),
+      runArgv
+    })
+
+    await new DefaultRuntimeProvisioner(deps).provisionPython(() => {})
+
+    expect(creates).toBe(2)
+    expect(intents).toBe(2) // intent re-armed before BOTH spawns, not once per op
   })
 
   it('repairs surgically: keeps complete packages + tarballs, removes only the incomplete extract', async () => {
@@ -529,6 +699,67 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
   })
 })
 
+// The real production pairing: serializeProvisioner (owns the queue) + DefaultRuntimeProvisioner (owns
+// running/skip). These drive an ACTUAL queue — python running while R waits behind it — so they verify
+// the queued-vs-idle cancel contract end-to-end rather than poking the primitive directly.
+describe('serializeProvisioner cancel over a real queue', () => {
+  it('cancelling a QUEUED language skips it without aborting the running one', async () => {
+    const root = makeRoot()
+    let resolvePyCreate: (() => void) | undefined
+    const rRunArgv = vi.fn()
+    const deps = makeDeps(root, {
+      runArgv: (argv: string[]) => {
+        const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        if (prefix.endsWith(DEFAULT_R_ENV)) {
+          rRunArgv()
+          const bin = rBin(prefix)
+          mkdirSync(join(bin, '..'), { recursive: true })
+          writeFileSync(bin, 'x')
+          return Promise.resolve()
+        }
+        // Python create hangs, so python stays the RUNNING language while R waits in the queue.
+        const bin = pythonBin(prefix)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+        return new Promise<void>((resolve) => {
+          resolvePyCreate = resolve
+        })
+      }
+    })
+    const serialized = serializeProvisioner(new DefaultRuntimeProvisioner(deps))
+
+    const py = serialized.provisionPython(() => {})
+    const r = serialized.provisionR(() => {}) // queued behind python
+    await vi.waitFor(() => expect(resolvePyCreate).toBeDefined()) // python is running
+
+    serialized.cancel('r') // cancel the QUEUED language
+    resolvePyCreate?.() // let python finish normally
+
+    await expect(py).resolves.toBeUndefined() // python was NOT aborted
+    await expect(r).rejects.toThrow(/cancelled/i) // R was skipped when its turn came
+    expect(rRunArgv).not.toHaveBeenCalled() // R never spawned micromamba
+  })
+
+  it('cancelling an IDLE language is a no-op — the next provision of it still runs', async () => {
+    const root = makeRoot()
+    const rRunArgv = vi.fn()
+    const deps = makeDeps(root, {
+      runArgv: async (argv: string[]) => {
+        const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        if (prefix.endsWith(DEFAULT_R_ENV)) rRunArgv()
+        const bin = prefix.endsWith(DEFAULT_R_ENV) ? rBin(prefix) : pythonBin(prefix)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      }
+    })
+    const serialized = serializeProvisioner(new DefaultRuntimeProvisioner(deps))
+
+    serialized.cancel('r') // nothing pending -> must be a no-op, NOT an armed skip
+    await expect(serialized.provisionR(() => {})).resolves.toBeUndefined()
+    expect(rRunArgv).toHaveBeenCalledOnce()
+  })
+})
+
 describe('DefaultRuntimeProvisioner.provisionR', () => {
   it('materializes R lazily without touching the python version marker', async () => {
     const root = makeRoot()
@@ -703,9 +934,14 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
     // producing. The create must hold the shared lock across its runArgv.
     const root = makeRoot()
     const order: string[] = []
+    let lockHeld!: () => void
+    const held = new Promise<void>((resolve) => {
+      lockHeld = resolve
+    })
     const { deps } = makeNamedEnvDeps(root, {
       runArgv: async (argv) => {
         order.push('create-start')
+        lockHeld() // runArgv runs inside the shared lock -> the lock is now held
         await new Promise((r) => setTimeout(r, 10))
         const idx = argv.indexOf('--prefix')
         const bin = pythonBin(argv[idx + 1])
@@ -716,8 +952,10 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
     })
     const provisioner = new DefaultRuntimeProvisioner(deps)
 
-    // Kick off the create, then immediately request the cache EXCLUSIVE on the same root.
+    // Kick off the create, wait until its runArgv holds the shared lock (the create now journals first,
+    // so the lock is taken a tick later), then request the cache EXCLUSIVE on the same root.
     const create = provisioner.createNamedEnvironment('my-analysis', 'python', ['numpy'])
+    await held
     const exclusive = withExclusiveCacheLock(selectMicromambaCache(root).lockKey, async () => {
       order.push('repair')
     })
@@ -726,6 +964,55 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
     // The exclusive repair waited for the create to fully release the shared lock — it never
     // interleaved between create-start and create-end.
     expect(order).toEqual(['create-start', 'create-end', 'repair'])
+  })
+
+  it('does not pass the running default-provision abort signal to its own micromamba (no cross-abort)', async () => {
+    // Regression: a named create runs on the RAW provisioner and can overlap a default provision (which
+    // sets this.abort). If named create forwarded this.abort?.signal, cancelling the default env would
+    // abort the unrelated named-env child. Here we hold a default python provision in its verify phase
+    // (this.abort SET, cache lock already released) and then run a named create; its micromamba must
+    // receive NO signal.
+    const root = makeRoot()
+    const pyPrefix = envPrefix(root, DEFAULT_PY_ENV)
+    const namedPrefix = envPrefix(root, 'my-analysis')
+    let namedSignal: AbortSignal | undefined
+    let sawNamedRun = false
+    let pyVerifyStarted = false
+    let resolvePyVerify: (() => void) | undefined
+    const deps = makeDeps(root, {
+      runArgv: async (argv, signal) => {
+        const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        if (prefix === namedPrefix) {
+          sawNamedRun = true
+          namedSignal = signal
+        }
+        const bin = pythonBin(prefix)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      },
+      verify: async (bin) => {
+        // Hang the DEFAULT python verify so its provision stays "running" (this.abort set) while the
+        // named create proceeds; the cache lock is already released (verify is outside it).
+        if (bin === pythonBin(pyPrefix)) {
+          pyVerifyStarted = true
+          await new Promise<void>((resolve) => {
+            resolvePyVerify = resolve
+          })
+        }
+      }
+    })
+    const provisioner = new DefaultRuntimeProvisioner(deps)
+    const py = provisioner.provisionPython(() => {})
+    await vi.waitFor(() => expect(pyVerifyStarted).toBe(true))
+
+    await provisioner.createNamedEnvironment('my-analysis', 'python')
+    expect(sawNamedRun).toBe(true)
+    // The named create's micromamba got NO abort signal, so cancelling the default provision can't
+    // abort it.
+    expect(namedSignal).toBeUndefined()
+
+    resolvePyVerify?.()
+    await py
   })
 })
 
@@ -768,6 +1055,118 @@ describe('DefaultRuntimeProvisioner.upgradeIfNeeded (shared pkgs cache lock)', (
     // The exclusive repair waited for the upgrade to release the shared lock — it never interleaved
     // between upgrade-start and upgrade-end.
     expect(order).toEqual(['upgrade-start', 'upgrade-end', 'repair'])
+  })
+
+  it('refuses the upgrade when the python prefix is recovery-blocked (no install spawned)', async () => {
+    const root = makeRoot()
+    writeReadyMarker(root, DEFAULT_ENV_VERSION - 1, 't') // stale marker -> would upgrade python
+    const runArgv = vi.fn(async () => undefined)
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: (prefix) => prefix === envPrefix(root, DEFAULT_PY_ENV)
+    })
+    await expect(new DefaultRuntimeProvisioner(deps).upgradeIfNeeded(() => {})).rejects.toThrow(
+      /RUNTIME_RECOVERY_BLOCKED/
+    )
+    expect(runArgv).not.toHaveBeenCalled()
+  })
+
+  it('skips the R upgrade when only the R prefix is recovery-blocked, still upgrading python', async () => {
+    const root = makeRoot()
+    writeReadyMarker(root, DEFAULT_ENV_VERSION - 1, 't')
+    // R materialized so the R-upgrade branch is reached, but its prefix is recovery-blocked -> skip it
+    // (a blocked R prefix must not fail the already-applied python upgrade).
+    const rbin = rBin(envPrefix(root, DEFAULT_R_ENV))
+    mkdirSync(join(rbin, '..'), { recursive: true })
+    writeFileSync(rbin, 'x')
+    const upgraded: string[] = []
+    const deps = makeDeps(root, {
+      runArgv: async (argv) => {
+        const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        upgraded.push(basename(prefix))
+        const bin = prefix.endsWith(DEFAULT_PY_ENV) ? pythonBin(prefix) : rBin(prefix)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      },
+      isPrefixBlocked: (prefix) => prefix === envPrefix(root, DEFAULT_R_ENV)
+    })
+    await new DefaultRuntimeProvisioner(deps).upgradeIfNeeded(() => {})
+    expect(upgraded).toContain(DEFAULT_PY_ENV)
+    expect(upgraded).not.toContain(DEFAULT_R_ENV)
+  })
+})
+
+// Every prefix-writing micromamba op must journal its child PID + target prefix, or a crash there
+// leaves no record for the next startup to block/kill — which is exactly what makes the self-guard
+// blind (review R2-A1). materialize is covered above; these cover the paths that previously ran
+// runArgv unjournaled: named create, relocation restore, and the bundle upgrade.
+describe('DefaultRuntimeProvisioner journals every prefix write', () => {
+  // Reads the in-flight journal record for `prefix` while runArgv is "running", then materializes the
+  // bin so verify() passes and the op reaches complete().
+  const journalingDeps = (
+    root: string,
+    prefix: string,
+    pid: number,
+    capture: (r: RuntimeOperationRecord) => void
+  ): Partial<ProvisionerDeps> => ({
+    runArgv: async (_argv: string[], _signal, onChild) => {
+      onChild?.(pid)
+      const journal = RuntimeOperationJournal.forPath(operationJournalPath(root))
+      await vi.waitFor(async () => {
+        const found = (await journal.pending()).find((r) => r.targetPath === prefix)
+        expect(found?.childPid).toBe(pid)
+        capture(found as RuntimeOperationRecord)
+      })
+      const bin = prefix.endsWith(DEFAULT_R_ENV) ? rBin(prefix) : pythonBin(prefix)
+      mkdirSync(join(bin, '..'), { recursive: true })
+      writeFileSync(bin, 'x')
+    }
+  })
+
+  it('journals a named-env create with the child pid, cleared on completion', async () => {
+    const root = makeRoot()
+    const prefix = envPrefix(root, 'my-analysis')
+    let during: RuntimeOperationRecord | undefined
+    const deps = makeDeps(
+      root,
+      journalingDeps(root, prefix, 777, (r) => (during = r))
+    )
+    await new DefaultRuntimeProvisioner(deps).createNamedEnvironment('my-analysis', 'python')
+    expect(during).toMatchObject({ runtimeId: 'my-analysis', targetPath: prefix, childPid: 777 })
+    expect(await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()).toEqual([])
+  })
+
+  it('journals a relocation restore with the child pid, cleared on completion', async () => {
+    const root = makeRoot()
+    const dir = envsLockDir(root)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, `${DEFAULT_PY_ENV}.lock`),
+      '@EXPLICIT\nhttps://conda.anaconda.org/conda-forge/noarch/x-1.conda#abc\n'
+    )
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    let during: RuntimeOperationRecord | undefined
+    const deps = makeDeps(
+      root,
+      journalingDeps(root, prefix, 888, (r) => (during = r))
+    )
+    await new DefaultRuntimeProvisioner(deps).restoreRelocatedEnvs(() => {})
+    expect(during).toMatchObject({ runtimeId: DEFAULT_PY_ENV, targetPath: prefix, childPid: 888 })
+    expect(await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()).toEqual([])
+  })
+
+  it('journals a bundle upgrade with the child pid, cleared on completion', async () => {
+    const root = makeRoot()
+    writeReadyMarker(root, DEFAULT_ENV_VERSION - 1, 't')
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    let during: RuntimeOperationRecord | undefined
+    const deps = makeDeps(
+      root,
+      journalingDeps(root, prefix, 999, (r) => (during = r))
+    )
+    await new DefaultRuntimeProvisioner(deps).upgradeIfNeeded(() => {})
+    expect(during).toMatchObject({ kind: 'upgrade', runtimeId: DEFAULT_PY_ENV, childPid: 999 })
+    expect(await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()).toEqual([])
   })
 })
 
@@ -848,6 +1247,75 @@ describe('DefaultRuntimeProvisioner.restoreRelocatedEnvs', () => {
       '@EXPLICIT\nhttps://conda.anaconda.org/conda-forge/noarch/x-1.conda#abc\n'
     )
   }
+
+  it('clears a half-built (conda-meta, no interpreter) prefix before the offline recreate (3.2 parity)', async () => {
+    // The create/materialize path removes a conda-meta-but-no-interpreter leftover; the restore path
+    // must too, or `create -p` wedges on it forever. Seed such a leftover and assert it's gone by the
+    // time runArgv is entered, and that the env is rebuilt.
+    const root = makeRoot()
+    writeLock(root, DEFAULT_PY_ENV)
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    mkdirSync(join(prefix, 'conda-meta'), { recursive: true }) // conda-meta but no python bin
+    let condaMetaAtCreate: boolean | undefined
+    const deps = makeDeps(root, {
+      runArgv: async (argv) => {
+        const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        condaMetaAtCreate = existsSync(join(p, 'conda-meta'))
+        const bin = pythonBin(p)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      }
+    })
+    await new DefaultRuntimeProvisioner(deps).restoreRelocatedEnvs(() => {})
+    expect(condaMetaAtCreate).toBe(false) // the wedged prefix was cleared before create
+    expect(existsSync(pythonBin(prefix))).toBe(true) // rebuilt
+  })
+
+  it('keeps a valid prefix AND its lock when the ready-marker write fails (no destructive rebuild)', async () => {
+    // A marker-write failure (permissions/disk) must NOT be read as "env corrupt": the existing valid
+    // relocated env is kept, its lock retained for a later launch, and it is NOT rebuilt (which would
+    // delete the relocated user packages). Force the failure by making the marker path a directory so
+    // the atomic rename can't land.
+    const root = makeRoot()
+    writeLock(root, DEFAULT_PY_ENV)
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(bin, '..'), { recursive: true }) // a valid, verifiable existing env
+    writeFileSync(bin, 'x')
+    mkdirSync(readyMarkerPath(root), { recursive: true }) // marker write will fail (rename onto a dir)
+    const runArgv = vi.fn(async () => undefined)
+    const deps = makeDeps(root, { runArgv }) // default verify resolves -> env is "valid"
+
+    await new DefaultRuntimeProvisioner(deps).restoreRelocatedEnvs(() => {})
+
+    expect(runArgv).not.toHaveBeenCalled() // NOT rebuilt
+    expect(existsSync(bin)).toBe(true) // prefix kept
+    expect(existsSync(join(envsLockDir(root), `${DEFAULT_PY_ENV}.lock`))).toBe(true) // lock retained
+  })
+
+  it('does NOT delete the old prefix when journal begin() fails closed (cleanup is inside the wrapper)', async () => {
+    // The prefix cleanup must run INSIDE withJournaledPrefixWrite, after begin() succeeds — so a
+    // fail-closed begin() never deletes the prefix without a recovery record. Force begin() to fail by
+    // making the journal path a directory (its atomic rename can't land) and assert the broken prefix
+    // survives and no create was attempted.
+    const root = makeRoot()
+    writeLock(root, DEFAULT_PY_ENV)
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    mkdirSync(join(prefix, 'conda-meta'), { recursive: true }) // broken partial restore would rebuild
+    writeFileSync(join(prefix, 'marker'), 'keep')
+    mkdirSync(operationJournalPath(root), { recursive: true }) // begin()'s rename now fails -> fail closed
+    const runArgv = vi.fn(async () => undefined)
+    const deps = makeDeps(root, { runArgv })
+
+    await new DefaultRuntimeProvisioner(deps).restoreRelocatedEnvs(() => {})
+
+    // begin() threw before the run callback executed, so nothing was deleted and no create ran.
+    expect(existsSync(join(prefix, 'conda-meta'))).toBe(true)
+    expect(existsSync(join(prefix, 'marker'))).toBe(true)
+    expect(runArgv).not.toHaveBeenCalled()
+    // The lock is retained for a later launch.
+    expect(existsSync(join(envsLockDir(root), `${DEFAULT_PY_ENV}.lock`))).toBe(true)
+  })
 
   it('recreates each env offline from its lock, stamps the marker, and consumes the locks', async () => {
     const root = makeRoot()
@@ -957,14 +1425,19 @@ describe('DefaultRuntimeProvisioner.restoreRelocatedEnvs', () => {
   it('holds the shared pkgs cache lock for its per-env recreate, so a concurrent exclusive repair cannot run mid-restore', async () => {
     // Regression: the offline recreate extracts into the SHARED pkgs cache, so it must hold the shared
     // lock — otherwise a corrupt-cache repair (cache-exclusive) could delete an incomplete extraction
-    // it is producing. The lock is taken synchronously per env, so we can race the exclusive right after
-    // kicking off restore (mirroring the createNamedEnvironment lock test).
+    // it is producing. The recreate now journals first, so wait until its runArgv holds the lock before
+    // racing the exclusive (mirroring the createNamedEnvironment / upgrade lock tests).
     const root = makeRoot()
     writeLock(root, DEFAULT_PY_ENV)
     const order: string[] = []
+    let lockHeld!: () => void
+    const held = new Promise<void>((resolve) => {
+      lockHeld = resolve
+    })
     const deps = makeDeps(root, {
       runArgv: async (argv) => {
         order.push('restore-start')
+        lockHeld()
         await new Promise((r) => setTimeout(r, 10))
         const pIdx = argv.findIndex((a) => a === '-p' || a === '--prefix')
         const bin = pythonBin(argv[pIdx + 1])
@@ -974,8 +1447,9 @@ describe('DefaultRuntimeProvisioner.restoreRelocatedEnvs', () => {
       }
     })
 
-    // Kick off the restore, then immediately request the cache EXCLUSIVE on the same root.
+    // Kick off the restore, wait until its recreate holds the shared lock, then request the EXCLUSIVE.
     const restore = new DefaultRuntimeProvisioner(deps).restoreRelocatedEnvs(() => {})
+    await held
     const exclusive = withExclusiveCacheLock(selectMicromambaCache(root).lockKey, async () => {
       order.push('repair')
     })
@@ -984,5 +1458,769 @@ describe('DefaultRuntimeProvisioner.restoreRelocatedEnvs', () => {
     // The exclusive repair waited for the recreate to release the shared lock — it never interleaved
     // between restore-start and restore-end.
     expect(order).toEqual(['restore-start', 'restore-end', 'repair'])
+  })
+})
+
+// The startup gate calls repair/upgrade/restore through the provisioner, so the block guarantee has to
+// live in the provisioner itself (ipc.ts injects isPrefixBlocked ← service.isPrefixRecoveryBlocked).
+// These prove a recovery-blocked prefix refuses every prefix-WRITE path — the coverage the UI-only
+// assertProvisionAllowed mock never exercised.
+describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)', () => {
+  const blocking = (
+    root: string,
+    blockedPrefix: string,
+    overrides: Partial<ProvisionerDeps> = {}
+  ): ProvisionerDeps =>
+    makeDeps(root, { isPrefixBlocked: (prefix) => prefix === blockedPrefix, ...overrides })
+
+  it('refuses provisionPython on a blocked prefix without spawning create', async () => {
+    const root = makeRoot()
+    const runArgv = vi.fn(async () => undefined)
+    const deps = blocking(root, envPrefix(root, DEFAULT_PY_ENV), { runArgv })
+    await expect(new DefaultRuntimeProvisioner(deps).provisionPython(() => {})).rejects.toThrow(
+      /RUNTIME_RECOVERY_BLOCKED/
+    )
+    expect(runArgv).not.toHaveBeenCalled()
+    expect(readReadyMarker(root)).toBeUndefined()
+  })
+
+  it('refuses repair without deleting the existing (possibly-live) prefix', async () => {
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'live-interpreter')
+    const runArgv = vi.fn(async () => undefined)
+    const deps = blocking(root, prefix, { runArgv })
+    await expect(new DefaultRuntimeProvisioner(deps).repair('python', () => {})).rejects.toThrow(
+      /RUNTIME_RECOVERY_BLOCKED/
+    )
+    // The interpreter a survivor may still hold was NOT rm -rf'd, and no rebuild was spawned.
+    expect(existsSync(bin)).toBe(true)
+    expect(runArgv).not.toHaveBeenCalled()
+  })
+
+  it('repair({ force }) clears the quarantine (block + journal) and rebuilds even when blocked', async () => {
+    // The explicit user Reset path: force-clears the block so the rebuild — and its inner materialize —
+    // are not refused, then re-provisions. Uses a STATEFUL block so clearing actually unblocks.
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    // Seed a retained journal record for the prefix (the quarantine's persistent side).
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(root))
+    await journal.begin({
+      operationId: 'stuck',
+      kind: 'materialize',
+      runtimeId: DEFAULT_PY_ENV,
+      phase: 'create',
+      startedAt: 1,
+      targetPath: prefix
+    })
+    const blocked = new Set([prefix])
+    const cleared: string[] = []
+    const runArgv = vi.fn(async (argv: string[], _s, _c, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+      const b = pythonBin(p)
+      mkdirSync(join(b, '..'), { recursive: true })
+      writeFileSync(b, 'x')
+    })
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: (p) => blocked.has(p),
+      clearPrefixBlock: (p) => {
+        blocked.delete(p)
+        cleared.push(p)
+      }
+    })
+
+    await new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+
+    expect(cleared).toEqual([prefix]) // in-memory block cleared
+    expect(await journal.pending()).toEqual([]) // retained record cleared -> won't re-arm next startup
+    expect(runArgv).toHaveBeenCalled() // rebuild ran (not refused)
+    expect(existsSync(pythonBin(prefix))).toBe(true)
+  })
+
+  it('repair({ force }) also clears an interrupted install’s runtime-ID block', async () => {
+    // An interrupted install blocks BOTH the prefix and the bound runtimeId. A prefix-only Reset would
+    // rebuild the env yet leave bound sessions rejected by blockedRuntimeIds until restart, so Reset must
+    // clear the runtime-ID block too (from the retained install record's runtimeId).
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(root))
+    await journal.begin({
+      operationId: 'stuck-install',
+      kind: 'install',
+      runtimeId: 'runtime-xyz',
+      phase: 'install-python',
+      startedAt: 1,
+      targetPath: prefix
+    })
+    const clearedRuntimes: string[] = []
+    const runArgv = vi.fn(async (argv: string[], _s, _c, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+      const b = pythonBin(p)
+      mkdirSync(join(b, '..'), { recursive: true })
+      writeFileSync(b, 'x')
+    })
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: () => false,
+      clearPrefixBlock: () => undefined,
+      clearRuntimeBlock: (id) => clearedRuntimes.push(id)
+    })
+
+    await new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+
+    expect(clearedRuntimes).toEqual(['runtime-xyz'])
+    expect(await journal.pending()).toEqual([])
+  })
+
+  it('repair({ force }) refuses when a recorded worker is still alive and cannot be stopped', async () => {
+    // Reset deletes + rebuilds the prefix, so it must never drop the block and delete evidence out from
+    // under a live worker. When the recorded child can't be confirmed stopped (confirmChildStopped ->
+    // false), Reset refuses rather than corrupting a live env. The kill/confirm is injected so the test
+    // never signals a real process.
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(root))
+    await journal.begin({
+      operationId: 'live',
+      kind: 'materialize',
+      runtimeId: DEFAULT_PY_ENV,
+      phase: 'create',
+      startedAt: 1,
+      childPid: 4242,
+      childStartedAt: Date.now(),
+      targetPath: prefix
+    })
+    const runArgv = vi.fn(async () => undefined)
+    const probed: number[] = []
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: () => true,
+      clearPrefixBlock: () => undefined,
+      confirmChildStopped: async ({ childPid }) => {
+        probed.push(childPid)
+        return false // still alive, could not be confirmed stopped
+      }
+    })
+
+    await expect(
+      new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+    ).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
+    expect(probed).toEqual([4242]) // the recorded worker was probed
+    // Refused before any rebuild, and the record is left in place (still quarantined).
+    expect(runArgv).not.toHaveBeenCalled()
+    expect(await journal.pending()).toHaveLength(1)
+  })
+
+  it('repair holds the env lock across the whole destructive rm+rebuild cycle', async () => {
+    // The rm and the rebuild must run under ONE exclusive env-lock hold, or a package install could slip
+    // in between and write into a half-deleted prefix. Assert the rm happens INSIDE the injected lock.
+    const root = makeRoot()
+    const order: string[] = []
+    const runArgv = vi.fn(async (argv: string[], _s, _c, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+      const b = pythonBin(p)
+      mkdirSync(join(b, '..'), { recursive: true })
+      writeFileSync(b, 'x')
+    })
+    const deps = makeDeps(root, {
+      runArgv,
+      withPrefixLock: async (envName, fn) => {
+        order.push(`lock:${envName}`)
+        try {
+          return await fn()
+        } finally {
+          order.push('unlock')
+        }
+      }
+    })
+
+    await new DefaultRuntimeProvisioner(deps).repair('python', () => {})
+
+    // The lock is taken for the default-python env, the rebuild (runArgv) runs while held, and the lock
+    // is only released after — one contiguous critical section.
+    expect(order[0]).toBe(`lock:${DEFAULT_PY_ENV}`)
+    expect(order[order.length - 1]).toBe('unlock')
+    expect(runArgv).toHaveBeenCalled()
+  })
+
+  const BOOT_A = '11111111-1111-4111-8111-111111111111'
+  const BOOT_B = '22222222-2222-4222-8222-222222222222'
+  // Writes a {spawning} sidecar with a chosen boot_id, deterministically (recordSpawnIntentSync would
+  // stamp the real machine boot_id, which is undefined off Linux — so we can't use it to test the gate).
+  const writeSpawnIntent = (root: string, operationId: string, bootToken: string): void =>
+    writeFileSync(
+      join(root, `operation-child-${operationId}.json`),
+      JSON.stringify({ spawning: true, bootToken })
+    )
+
+  it('Reset does not fall back to a stale journal PID for a {spawning} sidecar (reboot proven)', async () => {
+    // A {spawning} sidecar means a spawn was attempted but its PID is unknown. The journal may still hold
+    // an EARLIER spawn's PID — Reset must NOT probe/kill that stale pid (it may be exited or reused). With
+    // no verifiable pid, the ONLY thing that clears it is a proven machine reboot; here the live boot_id
+    // differs from the one in the sidecar → reboot proven → clear + rebuild, no probe.
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(root))
+    await journal.begin({
+      operationId: 'multi',
+      kind: 'materialize',
+      runtimeId: DEFAULT_PY_ENV,
+      phase: 'create',
+      startedAt: 1,
+      childPid: 4242, // a stale PID from an earlier spawn
+      childStartedAt: 1,
+      targetPath: prefix
+    })
+    writeSpawnIntent(root, 'multi', BOOT_A) // current spawn re-armed the intent; its PID never landed
+    const probed: Array<{ childPid: number }> = []
+    const runArgv = vi.fn(async (argv: string[], _s, _c, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+      const b = pythonBin(p)
+      mkdirSync(join(b, '..'), { recursive: true })
+      writeFileSync(b, 'x')
+    })
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: () => false,
+      clearPrefixBlock: () => undefined,
+      readBootToken: () => BOOT_B, // different boot_id → proves a reboot happened
+      confirmChildStopped: async (r) => {
+        probed.push(r)
+        return true
+      }
+    })
+
+    await new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+
+    // The stale journal PID was NOT probed (no fallback), and the rebuild proceeded.
+    expect(probed).toEqual([])
+    expect(runArgv).toHaveBeenCalled()
+    expect(await journal.pending()).toEqual([])
+  })
+
+  it('Reset REFUSES a no-verifiable-PID orphan when the machine has NOT rebooted', async () => {
+    // The unsound old behavior: a {spawning} sidecar with no recorded PID was cleared on any Reset, even
+    // an app-only restart — but an app restart does NOT prove a reparented micromamba/pip orphan exited.
+    // With the live boot_id equal to the sidecar's (same boot), Reset must refuse and NOT delete the
+    // prefix or clear the record, so the possibly-live orphan is never rm'd out from under.
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'x') // an existing interpreter that must survive the refused Reset
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(root))
+    await journal.begin({
+      operationId: 'multi',
+      kind: 'materialize',
+      runtimeId: DEFAULT_PY_ENV,
+      phase: 'create',
+      startedAt: 1,
+      targetPath: prefix
+    })
+    writeSpawnIntent(root, 'multi', BOOT_A) // spawn attempted, PID never landed
+    const runArgv = vi.fn(async () => undefined)
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: () => false,
+      clearPrefixBlock: () => undefined,
+      readBootToken: () => BOOT_A // SAME boot_id — no reboot proof
+    })
+
+    await expect(
+      new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+    ).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
+    // Nothing destructive: no rebuild spawned, the record is left, the existing interpreter survives.
+    expect(runArgv).not.toHaveBeenCalled()
+    expect(await journal.pending()).toHaveLength(1)
+    expect(existsSync(bin)).toBe(true)
+  })
+
+  it('blocks the prefix in-process after an unconfirmed-child failure, refusing an in-session retry', async () => {
+    // An unconfirmed-child failure (recording failed, the worker could not be confirmed stopped) leaves a
+    // possibly-live orphan. Retaining the journal record only guards the NEXT boot — so the provisioner
+    // must ALSO block the prefix in THIS process (deps.blockPrefix), or an in-session retry would spawn a
+    // second create that races the orphan on the same prefix. Uses a stateful block so blockPrefix
+    // actually feeds isPrefixBlocked, exactly as the service wires it.
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const blocked = new Set<string>()
+    let attempts = 0
+    const runArgv = vi.fn(async (_argv: string[], _s, _c, onBeforeSpawn) => {
+      attempts += 1
+      onBeforeSpawn?.()
+      throw new Error(`create failed: ${CHILD_UNCONFIRMED}`) // worker could not be confirmed stopped
+    })
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: (p) => blocked.has(p),
+      blockPrefix: (p) => blocked.add(p)
+    })
+    const provisioner = new DefaultRuntimeProvisioner(deps)
+
+    // First attempt fails unconfirmed and blocks the prefix in-process.
+    await expect(provisioner.provisionPython(() => {})).rejects.toThrow(CHILD_UNCONFIRMED)
+    expect(blocked.has(prefix)).toBe(true)
+    // The retained journal record is kept (guards next boot); the sidecar intent is not cleared.
+    expect(
+      (await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()).length
+    ).toBe(1)
+
+    // An in-session retry is now REFUSED by the block — it never spawns a second, racing create.
+    await expect(provisioner.provisionPython(() => {})).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
+    expect(attempts).toBe(1) // only the first attempt ever spawned
+  })
+
+  it('force Reset refuses a prefix this process left live-unconfirmed (no PID to kill)', async () => {
+    // After an unconfirmed-child failure THIS process recorded, the orphan's PID never landed, so there is
+    // nothing to probe/kill. A force Reset would rm + rebuild the prefix — potentially out from under that
+    // still-live orphan — so it must REFUSE this session (the block only clears on restart, when the
+    // spawning process is provably gone). Distinct from the {spawning}-sidecar test above, where the
+    // intent was injected WITHOUT this process attempting the spawn, so Reset proceeds.
+    const root = makeRoot()
+    const blocked = new Set<string>()
+    const runArgv = vi.fn(async (_argv: string[], _s, _c, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      throw new Error(`create failed: ${CHILD_UNCONFIRMED}`)
+    })
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: (p) => blocked.has(p),
+      blockPrefix: (p) => blocked.add(p),
+      clearPrefixBlock: (p) => blocked.delete(p)
+    })
+    const provisioner = new DefaultRuntimeProvisioner(deps)
+
+    await expect(provisioner.provisionPython(() => {})).rejects.toThrow(CHILD_UNCONFIRMED)
+
+    // Force Reset is refused BEFORE the destructive rm (the interpreter-less prefix is untouched) because
+    // this same process has an unconfirmed orphan for it.
+    await expect(provisioner.repair('python', () => {}, { force: true })).rejects.toThrow(
+      /RUNTIME_RECOVERY_BLOCKED/
+    )
+    // The retained journal record survives (still guarding recovery) — Reset did not clear it.
+    expect(
+      (await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()).length
+    ).toBe(1)
+  })
+
+  it('force Reset refuses a prefix an interrupted INSTALL left live-unconfirmed (injected dep)', async () => {
+    // A package install (in the service, not the provisioner) that failed unconfirmed marks its prefix
+    // live-unconfirmed in the SERVICE — the provisioner never sees that in its own set. Reset must still
+    // refuse via the injected isPrefixLiveUnconfirmed dep, or it would delete + rebuild the prefix out
+    // from under the possibly-live installer. A {spawning} sidecar (no verifiable pid) is present, which
+    // WITHOUT this dep would be treated as the no-pid escape and cleared. Mirrors ipc.ts wiring.
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(root))
+    await journal.begin({
+      operationId: 'install-orphan',
+      kind: 'install',
+      runtimeId: DEFAULT_PY_ENV,
+      phase: 'install-python',
+      startedAt: 1,
+      targetPath: prefix
+    })
+    recordSpawnIntentSync(root, 'install-orphan') // installer spawned; its PID never landed
+    const liveUnconfirmed = new Set([prefix]) // the service marked it (blockPrefixRecovery)
+    const runArgv = vi.fn(async () => undefined)
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: () => false,
+      clearPrefixBlock: () => undefined,
+      isPrefixLiveUnconfirmed: (p) => liveUnconfirmed.has(p)
+    })
+
+    await expect(
+      new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+    ).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
+    // Refused before the destructive rm — no rebuild spawned, journal record retained.
+    expect(runArgv).not.toHaveBeenCalled()
+    expect((await journal.pending()).length).toBe(1)
+  })
+
+  it('Reset verifies a recorded worker by pid AND start time (reuse guard)', async () => {
+    // A valid sidecar carries childStartedAt; Reset must pass it to the guard so a reused pid is rejected
+    // rather than a live unrelated process SIGKILLed.
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(root))
+    await journal.begin({
+      operationId: 'valid',
+      kind: 'materialize',
+      runtimeId: DEFAULT_PY_ENV,
+      phase: 'create',
+      startedAt: 1,
+      targetPath: prefix
+    })
+    recordOperationChildSync(root, 'valid', { childPid: 9931, childStartedAt: 1_700_000_000_000 })
+    let seen: { childPid: number; childStartedAt?: number } | undefined
+    const runArgv = vi.fn(async (argv: string[], _s, _c, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+      const b = pythonBin(p)
+      mkdirSync(join(b, '..'), { recursive: true })
+      writeFileSync(b, 'x')
+    })
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: () => false,
+      clearPrefixBlock: () => undefined,
+      confirmChildStopped: async (r) => {
+        seen = r
+        return true // treat as stopped so the rebuild proceeds
+      }
+    })
+
+    await new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+
+    expect(seen).toEqual({ childPid: 9931, childStartedAt: 1_700_000_000_000 })
+  })
+
+  it('cancelling a QUEUED Reset does not delete the environment', async () => {
+    // repair must consume a queued cancel BEFORE its destructive rm; otherwise a cancel leaves a
+    // deleted-but-not-rebuilt env. Seed a real prefix, arm a cancel, then repair must throw without rm.
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'x')
+    const runArgv = vi.fn(async () => undefined)
+    const provisioner = new DefaultRuntimeProvisioner(makeDeps(root, { runArgv }))
+    // Arm a cancel for python while nothing is running -> queued-skip on the next python run.
+    provisioner.cancel('python')
+
+    await expect(provisioner.repair('python', () => {})).rejects.toThrow(/cancelled/i)
+
+    // The env prefix was NOT deleted, and no rebuild spawned.
+    expect(existsSync(bin)).toBe(true)
+    expect(runArgv).not.toHaveBeenCalled()
+  })
+
+  it('restoreRelocatedEnvs runs each env restore under the shared env lock', async () => {
+    const root = makeRoot()
+    const dir = envsLockDir(root)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, `${DEFAULT_PY_ENV}.lock`), '{}')
+    const locked: string[] = []
+    const runArgv = vi.fn(async (argv: string[], _s, _c, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+      const b = pythonBin(p)
+      mkdirSync(join(b, '..'), { recursive: true })
+      writeFileSync(b, 'x')
+    })
+    const deps = makeDeps(root, {
+      runArgv,
+      withPrefixLock: async (envName, fn) => {
+        locked.push(envName)
+        return fn()
+      }
+    })
+
+    await new DefaultRuntimeProvisioner(deps).restoreRelocatedEnvs(() => {})
+
+    expect(locked).toContain(DEFAULT_PY_ENV)
+  })
+
+  it('status() reports a recovery-blocked default prefix', () => {
+    const root = makeRoot()
+    const blocked = new Set([envPrefix(root, DEFAULT_PY_ENV)])
+    const provisioner = new DefaultRuntimeProvisioner(
+      makeDeps(root, { isPrefixBlocked: (p) => blocked.has(p) })
+    )
+    const status = provisioner.status()
+    expect(status.pythonRecoveryBlocked).toBe(true)
+    expect(status.rRecoveryBlocked).toBe(false)
+  })
+
+  it('a corrupt journal Reset moves the journal aside BEFORE deleting the prefix (never delete-then-fail)', async () => {
+    // The bug: clearQuarantine used to read pending() (corrupt -> []), clear the block, and let repair
+    // proceed to rm the prefix — only for the REBUILD's begin() to then throw on the still-corrupt
+    // journal, leaving the env deleted, the block cleared, and the journal still corrupt (permanently
+    // unrecoverable without a restart). Force Reset must quarantine (move aside) the corrupt journal
+    // FIRST, so the rebuild's begin() succeeds.
+    const root = makeRoot()
+    const journalPath = operationJournalPath(root)
+    mkdirSync(root, { recursive: true })
+    writeFileSync(journalPath, '{ not json', 'utf8')
+    const cleared: string[] = []
+    let corruptCleared = false
+    // Mirror production: a corrupt journal blocks EVERY prefix until the clears fire, after which the
+    // state isPrefixBlocked reads flips to unblocked (so the rebuild's assertPrefixWritable passes).
+    let corruptBlocked = true
+    const clearedPrefixes = new Set<string>()
+    const runArgv = vi.fn(async (argv: string[], _s, _c, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+      const b = pythonBin(p)
+      mkdirSync(join(b, '..'), { recursive: true })
+      writeFileSync(b, 'x')
+    })
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: (p) => corruptBlocked && !clearedPrefixes.has(p),
+      clearPrefixBlock: (p) => {
+        cleared.push(p)
+        clearedPrefixes.add(p)
+      },
+      clearCorruptBlock: () => {
+        corruptCleared = true
+        corruptBlocked = false
+      }
+    })
+
+    await new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+
+    // The corrupt journal was moved aside (not left in place to keep failing begin()), the prefix block
+    // and the global corrupt block were both cleared, and the rebuild actually ran and succeeded.
+    expect(existsSync(journalPath)).toBe(false)
+    expect(cleared).toEqual([envPrefix(root, DEFAULT_PY_ENV)])
+    expect(corruptCleared).toBe(true)
+    expect(runArgv).toHaveBeenCalled()
+    expect(existsSync(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))).toBe(true)
+  })
+
+  it('a corrupt journal Reset REFUSES when a surviving sidecar shows a no-PID orphan and NO reboot', async () => {
+    // P1 fix: a corrupt journal can't enumerate records, but the child-state SIDECARS survive it. The old
+    // code quarantined + returned unconditionally, letting the caller rm a prefix a live orphan may still
+    // be writing. Now Reset scans the sidecars and applies the same gate: a {spawning} sidecar with no
+    // reboot proof must REFUSE — leaving the (still-corrupt) journal and the prefix untouched.
+    const root = makeRoot()
+    const journalPath = operationJournalPath(root)
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'x') // existing interpreter that must survive the refused Reset
+    writeFileSync(journalPath, '{ not json', 'utf8') // corrupt journal
+    writeSpawnIntent(root, 'orphan', BOOT_A) // a spawn whose PID never landed, on this boot
+    const runArgv = vi.fn(async () => undefined)
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: () => true,
+      readBootToken: () => BOOT_A // SAME boot → no reboot proof
+    })
+
+    await expect(
+      new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+    ).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
+    // Nothing destructive: the corrupt journal is NOT quarantined, no rebuild ran, the interpreter survives.
+    expect(existsSync(journalPath)).toBe(true)
+    expect(runArgv).not.toHaveBeenCalled()
+    expect(existsSync(bin)).toBe(true)
+  })
+
+  it('no-PID orphan Reset error message is platform-specific (Linux: reboot, others: manual cleanup)', async () => {
+    // On Linux, readBootToken returns boot_id and we can prove a reboot. On macOS/Windows it returns
+    // undefined, so bootTokenProvesReboot always fails — there's no programmatic reboot proof. The error
+    // message must reflect this: Linux users are told to reboot; macOS/Windows users are given the manual
+    // escape hatch (delete the recovery metadata files) since "reboot and retry" would be misleading.
+    const root = makeRoot()
+    const journalPath = operationJournalPath(root)
+    mkdirSync(dirname(journalPath), { recursive: true })
+    writeFileSync(journalPath, '{ not json', 'utf8') // corrupt journal
+    writeSpawnIntent(root, 'orphan', BOOT_A) // no-PID orphan with a Linux boot token
+    const runArgv = vi.fn(async () => undefined)
+
+    // Simulate a boot token available (Linux-like) but SAME boot (no reboot proof). The actual platform
+    // detection is process.platform, so we can't mock it in the test, but we can verify the error message
+    // contains appropriate guidance: on the real test platform (likely darwin/win32), it should mention
+    // manual cleanup; on Linux CI, it should mention reboot.
+    const deps = makeDeps(root, { runArgv, isPrefixBlocked: () => true, readBootToken: () => BOOT_A })
+    const error = await new DefaultRuntimeProvisioner(deps)
+      .repair('python', () => {}, { force: true })
+      .catch((e) => e)
+    expect(error.message).toMatch(/RUNTIME_RECOVERY_BLOCKED/)
+    // The guidance varies by platform: Linux → reboot, others → manual cleanup.
+    if (process.platform === 'linux') {
+      expect(error.message).toMatch(/Restart your computer.*reboot proves/)
+    } else {
+      expect(error.message).toMatch(/manually delete the recovery metadata files/)
+    }
+  })
+
+  it('a corrupt journal Reset REFUSES when a surviving sidecar is itself CORRUPT (unprobeable)', async () => {
+    // A corrupt sidecar (e.g. a contradictory {spawning + childPid} blob, or torn bytes) has no readable
+    // boot token and no verifiable pid — it MAY be a live writer, so the corrupt-journal Reset must refuse
+    // rather than quarantine + delete. Proves the sidecar-scan treats 'corrupt' as a possible live writer.
+    const root = makeRoot()
+    const journalPath = operationJournalPath(root)
+    const bin = pythonBin(envPrefix(root, DEFAULT_PY_ENV))
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'x')
+    writeFileSync(journalPath, '{ not json', 'utf8') // corrupt journal
+    // Contradictory (mutually-exclusive) sidecar → readOperationChild returns 'corrupt'.
+    writeFileSync(
+      join(root, 'operation-child-orphan.json'),
+      JSON.stringify({ spawning: true, childPid: 4242, childStartedAt: 1 })
+    )
+    const runArgv = vi.fn(async () => undefined)
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: () => true,
+      readBootToken: () => BOOT_B // even a "rebooted" reader can't clear a corrupt (tokenless) sidecar
+    })
+
+    await expect(
+      new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+    ).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
+    expect(existsSync(journalPath)).toBe(true) // not quarantined
+    expect(runArgv).not.toHaveBeenCalled()
+    expect(existsSync(bin)).toBe(true)
+  })
+
+  it('a corrupt journal Reset PROCEEDS when the surviving sidecar boot_id proves a reboot', async () => {
+    // The sidecar carries the boot_id from spawn time (journal-independent), so even with a corrupt
+    // journal a proven machine reboot clears the otherwise-unprobeable orphan: quarantine + rebuild.
+    const root = makeRoot()
+    const journalPath = operationJournalPath(root)
+    writeFileSync(journalPath, '{ not json', 'utf8')
+    writeSpawnIntent(root, 'orphan', BOOT_A) // orphan recorded on boot A
+    let corruptBlocked = true
+    const cleared = new Set<string>()
+    const runArgv = vi.fn(async (argv: string[], _s, _c, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+      const b = pythonBin(p)
+      mkdirSync(join(b, '..'), { recursive: true })
+      writeFileSync(b, 'x')
+    })
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: (p) => corruptBlocked && !cleared.has(p),
+      clearPrefixBlock: (p) => cleared.add(p),
+      clearCorruptBlock: () => (corruptBlocked = false),
+      readBootToken: () => BOOT_B // different boot_id → reboot proven
+    })
+
+    await new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+
+    // Journal quarantined, the orphan's stale sidecar removed, and the rebuild ran.
+    expect(existsSync(journalPath)).toBe(false)
+    expect(existsSync(join(root, 'operation-child-orphan.json'))).toBe(false)
+    expect(runArgv).toHaveBeenCalled()
+    expect(existsSync(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))).toBe(true)
+  })
+
+  it('a corrupt journal Reset STILL refuses a live-unconfirmed prefix (guard runs before the corrupt branch)', async () => {
+    // Regression: the live-unconfirmed guard must be checked BEFORE readState(). A corrupt journal used
+    // to early-return (quarantine + clear + return) without ever reaching that guard, so a prefix an
+    // interrupted install/prefix-write left with a possibly-live orphan would be cleared and the caller
+    // would rm it out from under that worker. The two conditions co-occur here: journal corrupt AND the
+    // prefix is live-unconfirmed → Reset must refuse and NOT move the journal aside or delete anything.
+    const root = makeRoot()
+    const journalPath = operationJournalPath(root)
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'x') // an existing interpreter that must survive the refused Reset
+    writeFileSync(journalPath, '{ not json', 'utf8')
+    const runArgv = vi.fn(async () => undefined)
+    let corruptCleared = false
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: () => true,
+      clearCorruptBlock: () => {
+        corruptCleared = true
+      },
+      // The service marked this prefix live-unconfirmed (e.g. an interrupted managed install).
+      isPrefixLiveUnconfirmed: (p) => p === prefix
+    })
+
+    await expect(
+      new DefaultRuntimeProvisioner(deps).repair('python', () => {}, { force: true })
+    ).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
+    // Nothing destructive happened: the corrupt journal is untouched (NOT quarantined), the corrupt block
+    // was NOT cleared, no rebuild spawned, and the existing interpreter still exists.
+    expect(existsSync(journalPath)).toBe(true)
+    expect(corruptCleared).toBe(false)
+    expect(runArgv).not.toHaveBeenCalled()
+    expect(existsSync(bin)).toBe(true)
+  })
+
+  it('a running Reset ignores a per-language cancel once past the destructive boundary', async () => {
+    // Once repair clears the quarantine and rm's the prefix there is no safe stopping point: aborting
+    // the rebuild would leave a missing/half-built env with the block+evidence already cleared. A
+    // per-language cancel arriving while the repair is executing must be ignored (a global/undefined
+    // cancel still aborts).
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'x')
+    // Holder so runArgv can close over the provisioner that is constructed with runArgv (forward ref).
+    const ref: { provisioner?: DefaultRuntimeProvisioner } = {}
+    // runArgv signature is (argv, signal, onChild, onBeforeSpawn) — signal is the 2nd arg.
+    const runArgv = vi.fn(async (argv: string[], signal, _c, onBeforeSpawn) => {
+      onBeforeSpawn?.()
+      // Fire the cancel WHILE the destructive rebuild is running (well past the rm). Because this repair
+      // is uninterruptible, the per-language cancel must be dropped and the run's signal NOT aborted.
+      ref.provisioner?.cancel('python')
+      expect(signal?.aborted).toBe(false)
+      const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+      const b = pythonBin(p)
+      mkdirSync(join(b, '..'), { recursive: true })
+      writeFileSync(b, 'x')
+    })
+    ref.provisioner = new DefaultRuntimeProvisioner(makeDeps(root, { runArgv }))
+
+    await ref.provisioner.repair('python', () => {})
+
+    // The rebuild was NOT aborted and the env is intact.
+    expect(runArgv).toHaveBeenCalled()
+    expect(existsSync(bin)).toBe(true)
+  })
+
+  it('a per-language cancel is dropped while idle (does not arm a future queued Reset)', () => {
+    // cancel(lang) while nothing is running/queued must be a pure no-op at this layer (no crash, no
+    // lingering arm) — env-ipc.serializeProvisioner is the layer that enforces "no-op when idle" for the
+    // UI, but the primitive itself must not misbehave if called directly.
+    const root = makeRoot()
+    const provisioner = new DefaultRuntimeProvisioner(makeDeps(root))
+    expect(() => provisioner.cancel('python')).not.toThrow()
+  })
+
+  it('refuses createNamedEnvironment on a blocked named prefix', async () => {
+    const root = makeRoot()
+    const runArgv = vi.fn(async () => undefined)
+    const deps = blocking(root, envPrefix(root, 'my-analysis'), { runArgv })
+    await expect(
+      new DefaultRuntimeProvisioner(deps).createNamedEnvironment('my-analysis', 'python')
+    ).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
+    expect(runArgv).not.toHaveBeenCalled()
+  })
+
+  it('restoreRelocatedEnvs skips a blocked prefix (leaves its lock) but restores the rest', async () => {
+    const root = makeRoot()
+    const dir = envsLockDir(root)
+    mkdirSync(dir, { recursive: true })
+    const lock = '@EXPLICIT\nhttps://conda.anaconda.org/conda-forge/noarch/x-1.conda#abc\n'
+    writeFileSync(join(dir, `${DEFAULT_PY_ENV}.lock`), lock)
+    writeFileSync(join(dir, 'my-analysis.lock'), lock)
+
+    const restored: string[] = []
+    const deps = blocking(root, envPrefix(root, 'my-analysis'), {
+      runArgv: async (argv) => {
+        const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        restored.push(basename(prefix))
+        const bin = prefix.endsWith(DEFAULT_PY_ENV) ? pythonBin(prefix) : rBin(prefix)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      }
+    })
+
+    await new DefaultRuntimeProvisioner(deps).restoreRelocatedEnvs(() => {})
+
+    // default-python restored + its lock consumed; the blocked named env was skipped and its lock kept
+    // for a later launch (when the pid is gone/verifiable) rather than rebuilt over a possible survivor.
+    expect(restored).toEqual([DEFAULT_PY_ENV])
+    expect(existsSync(join(dir, `${DEFAULT_PY_ENV}.lock`))).toBe(false)
+    expect(existsSync(join(dir, 'my-analysis.lock'))).toBe(true)
   })
 })

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -3,7 +3,20 @@ import { randomUUID } from 'node:crypto'
 import { dirname, join } from 'node:path'
 
 import type { NotebookLanguage } from '../../shared/notebook'
-import { operationJournalPath, RuntimeOperationJournal } from './operation-journal'
+import {
+  bootTokenProvesReboot,
+  listOperationChildren,
+  operationJournalPath,
+  readBootToken,
+  readOperationChild,
+  recordOperationChildSync,
+  recordSpawnIntentSync,
+  removeOperationChildSync,
+  RuntimeOperationJournal,
+  type OperationChildState,
+  type RuntimeOperationKind,
+  type RuntimeOperationRecord
+} from './operation-journal'
 import type {
   EnvironmentInfo,
   ProvisionProgress,
@@ -35,7 +48,8 @@ import {
   resolveMicromamba,
   type MicromambaDeps
 } from './micromamba'
-import { runMicromamba, verifyExecutable } from './provisioner-runtime'
+import { defaultOperationChildLiveness, readProcessStartToken } from './operation-recovery'
+import { isChildUnconfirmedError, runMicromamba, verifyExecutable } from './provisioner-runtime'
 import { envsLockDir } from './runtime-relocation'
 import {
   DEFAULT_ENV_VERSION,
@@ -130,6 +144,8 @@ export type ProvisionerDeps = {
     argv: string[],
     signal?: AbortSignal,
     onChild?: (pid: number) => void,
+    // Called synchronously right before each spawn so the caller can (re)record the per-spawn intent.
+    onBeforeSpawn?: () => void,
     cache?: MicromambaCache,
     maxCacheRelativePath?: number
   ) => Promise<void>
@@ -140,9 +156,112 @@ export type ProvisionerDeps = {
   bundleSource?: RuntimeBundleSource
   cache?: MicromambaCache
   platform?: NodeJS.Platform
+  // True when `prefix` is one crash-recovery could NOT confirm free of a live orphan writer (see
+  // runtime-service.blockedPrefixes). Every prefix-WRITING op here (materialize / named create /
+  // repair / upgrade / relocation restore) consults this and refuses rather than racing the possible
+  // survivor — so the startup gate's restore/upgrade/repair is guarded too, not just the UI handlers.
+  // Injected by main/ipc.ts from the notebook service; unset in unit tests (nothing is blocked).
+  isPrefixBlocked?: (prefix: string) => boolean
+  // Clears the in-memory recovery block for a prefix (service.blockedPrefixes). Called by an EXPLICIT
+  // user recovery (repair with force) so a quarantined runtime can be reset — the manual recovery entry
+  // the auto-path can't provide for an unprobeable/uncertain block.
+  clearPrefixBlock?: (prefix: string) => void
+  // Clears the in-memory recovery block for a runtime ID (service.blockedRuntimeIds). An interrupted
+  // install blocks the bound runtimeId (not a prefix), so a prefix-only Reset would rebuild the env yet
+  // leave bound sessions rejected until restart. clearQuarantine passes the runtimeIds of the retained
+  // install records for the reset prefix. Injected from main/ipc.ts; unset in unit tests.
+  clearRuntimeBlock?: (runtimeId: string) => void
+  // Releases just THIS prefix from the GLOBAL corrupt-journal write barrier (service.recoveryCorrupt).
+  // Called by a force Reset after it moves a corrupt journal aside. Per-prefix (not a global clear): a
+  // corrupt journal can't tell us which env had in-flight work, so resetting Python must NOT unblock R,
+  // named, and external targets — they stay blocked until their own Reset or a restart. Injected from
+  // ipc.ts; unset in unit tests.
+  clearCorruptBlock?: (prefix: string) => void
+  // Records, IN THIS PROCESS, that a prefix write here failed with a child we could not confirm stopped
+  // (a worker MAY still be writing it). Blocks the prefix immediately (service.blockedPrefixes) so an
+  // in-session retry can't begin() a SECOND concurrent op onto the same prefix while the first's orphan
+  // may still be live — the journal record alone only guards the NEXT boot. Injected from ipc.ts.
+  blockPrefix?: (prefix: string) => void
+  // True when a write in THIS process (a provisioner prefix write OR a package install — both funnel into
+  // service.blockPrefixRecovery) left `prefix` with a child that could not be confirmed stopped. A force
+  // Reset consults this in clearQuarantine and REFUSES rather than delete + rebuild the prefix out from
+  // under that possibly-live orphan. Covers the install path, whose live-unconfirmed state the provisioner
+  // never sees in its own set. Injected from ipc.ts; unset in unit tests (nothing live-unconfirmed).
+  isPrefixLiveUnconfirmed?: (prefix: string) => boolean
+  // Force-Reset worker guard: given a recorded child, returns true ONLY when it is provably stopped
+  // (pid gone/not-ours via ESRCH/EPERM, or a start-token MISMATCH proving pid reuse) — safe to delete +
+  // rebuild — and false whenever a live pid can't be strictly proven not-ours (Reset then refuses). It
+  // never signals the pid. childStartedAt is NOT consulted for liveness (a wall-clock value can't soundly
+  // prove a live pid dead); only the monotonic start token can. Defaults to the real probe; injected in
+  // tests so they never touch real processes.
+  confirmChildStopped?: (record: {
+    childPid: number
+    childStartedAt?: number
+    childStartToken?: string
+  }) => Promise<boolean>
+  // Current machine-boot token (see readBootToken), used by force-Reset to decide whether an unprobeable
+  // no-PID orphan is provably gone (the box rebooted since the record was written). Injected in tests to
+  // simulate "same boot" vs "rebooted" deterministically; defaults to the real reader.
+  readBootToken?: () => string | undefined
+  // Serializes a prefix-mutating section with the notebook service's per-env install lock, so a default
+  // env materialize/repair/upgrade never runs concurrently with a package install into the SAME env
+  // prefix. Without one shared lock the provisioner's serialize() and the service's envLock are
+  // independent, so a force-repair `rm -rf` could race an installer mid-write. Keyed by the env NAME
+  // (matching the service's envLock key). Injected from main/ipc.ts; unset in unit tests (runs
+  // unlocked). Passes fn's result through.
+  withPrefixLock?: <T>(envName: string, fn: () => Promise<T>) => Promise<T>
+  // Scheduler for the create-phase progress ticker. Defaults to a self-unref'ing setInterval; tests
+  // inject a manual one to drive ticks synchronously instead of waiting real wall-clock time. Returns
+  // a cancel fn that stops further ticks.
+  scheduleTick?: (onTick: () => void, ms: number) => () => void
+}
+
+// Default create-phase ticker scheduler: a setInterval that never keeps the process alive on its own.
+const defaultScheduleTick = (onTick: () => void, ms: number): (() => void) => {
+  const timer = setInterval(onTick, ms)
+  timer.unref?.()
+  return () => clearInterval(timer)
 }
 
 const defaultNow = (): string => Date.now().toString()
+
+// Force-Reset worker guard: given a recorded child, decide whether it is safely stopped so Reset may
+// delete + rebuild the prefix. Uses the SAME two-state liveness as recovery (never 'alive'), so it never
+// signals a process: it returns true ONLY when the child is provably gone or provably reused ('dead'),
+// and false when the pid is live and can't be strictly proven not-ours ('unknown') — Reset then refuses
+// rather than delete a prefix a survivor may hold. Injectable via ProvisionerDeps.confirmChildStopped.
+const defaultConfirmChildStopped = async (record: {
+  childPid: number
+  childStartedAt?: number
+  childStartToken?: string
+}): Promise<boolean> => {
+  // 'dead' = provably gone or provably reused → nothing of ours is writing, safe to Reset. 'unknown' =
+  // the pid is live and we can't strictly prove it isn't our worker; we do NOT signal it (no strict
+  // "safe to kill" guarantee) and refuse the Reset so we never delete a prefix a survivor may hold. The
+  // env self-heals once the worker exits and a later boot sees the pid gone.
+  return (await defaultOperationChildLiveness(record as RuntimeOperationRecord)) === 'dead'
+}
+
+// Wraps an onProgress sink so every event it forwards is tagged with the env's language (unless the
+// event already set one). provisionPython/provisionR/repair wrap here so all downstream emissions —
+// materialize, the create ticker, verify/ready/done — carry the language, letting the Settings UI show
+// python and R provisioning independently even though the two runs are serialized in the provisioner.
+const withLanguage =
+  (onProgress: (p: ProvisionProgress) => void, language: NotebookLanguage) =>
+  (p: ProvisionProgress): void =>
+    onProgress(p.language ? p : { ...p, language })
+
+// `micromamba create` (extract + link) is the LONGEST provisioning phase but emits no progress we can
+// read (runMicromamba buffers stdout), so the bar used to sit at a flat 0.5 for the whole phase and
+// look stalled. While the create runs we ease the reported progress from CREATE_FLOOR toward — but
+// never reaching — CREATE_CEIL, so the bar keeps advancing; the real verify/ready/done events (>= 0.9)
+// then overtake it. The floor sits just above the fetch/verify band (…→0.4) so the sequence is
+// monotonic on the common (no corrupt-cache) path.
+const CREATE_FLOOR = 0.45
+const CREATE_CEIL = 0.88
+const CREATE_TICK_MS = 700
+// Fraction of the remaining distance to CREATE_CEIL covered per tick — a gentle deceleration curve.
+const CREATE_TICK_GAIN = 0.12
 
 // The provisioning contract consumed via IPC by Workstream D (contract §4).
 export interface RuntimeProvisioner {
@@ -150,9 +269,17 @@ export interface RuntimeProvisioner {
   provisionPython(onProgress: (p: ProvisionProgress) => void): Promise<void>
   provisionR(onProgress: (p: ProvisionProgress) => void): Promise<void>
   upgradeIfNeeded(onProgress: (p: ProvisionProgress) => void): Promise<void>
-  repair(lang: NotebookLanguage, onProgress: (p: ProvisionProgress) => void): Promise<void>
-  // Aborts an in-flight provision/upgrade/repair (download + micromamba child). No-op when idle.
-  cancel(): void
+  // `force` = explicit user recovery: clears a recovery quarantine (block + retained journal record +
+  // sidecar) before rebuilding, so a stuck/uncertain runtime can be reset. Auto/startup repair omits it
+  // and stays gated by the block.
+  repair(
+    lang: NotebookLanguage,
+    onProgress: (p: ProvisionProgress) => void,
+    opts?: { force?: boolean }
+  ): Promise<void>
+  // Aborts an in-flight (or skips a queued) provision. Per-language: cancelling one language never
+  // aborts another's run. `undefined` aborts whatever is in flight. No-op when idle.
+  cancel(language?: NotebookLanguage): void
   // Rebuilds envs captured by a data-root relocation (see runtime-relocation.ts) offline from their
   // @EXPLICIT locks + the copied pkgs cache. No-op when no relocation bundle is present.
   restoreRelocatedEnvs(onProgress: (p: ProvisionProgress) => void): Promise<void>
@@ -161,6 +288,12 @@ export interface RuntimeProvisioner {
 export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   private provisioning = false
   private legacyCacheCleanupComplete = false
+  // Prefixes whose write in THIS process failed with a child we could not confirm stopped (a worker MAY
+  // still be live). A force Reset must NOT delete+rebuild such a prefix — its orphan can't be probed
+  // (its PID never landed) and could still be writing. Per-process (not persisted), so it is empty after
+  // a restart: post-restart the spawning process is provably gone, and a force Reset then proceeds (the
+  // documented escape hatch for an otherwise-stuck µs-window orphan). See clearQuarantine.
+  private readonly liveUnconfirmedPrefixes = new Set<string>()
 
   constructor(private readonly deps: ProvisionerDeps) {}
 
@@ -261,14 +394,310 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   }
 
   // Set for the duration of a provision/upgrade/repair so cancel() can abort the in-flight download
-  // (fetch signal) and micromamba create (execFile signal). Cleared in each op's finally.
+  // (fetch signal) and micromamba create (execFile signal). Cleared in each op's finally. Runs are
+  // serialized (env-ipc.serializeProvisioner), so at most one op is ever in flight -> one controller.
   private abort?: AbortController
+  // The language whose provision is currently in flight (python/r), so cancel(lang) can tell "abort the
+  // RUNNING one" from "a different, still-queued one".
+  private runningLanguage?: NotebookLanguage
+  // Languages whose provision was cancelled WHILE QUEUED (behind another language's in-flight run):
+  // provisionPython/provisionR throw at entry when their language is present, so the queued run is
+  // skipped instead of starting after the one the user was actually waiting on.
+  private readonly cancelRequested = new Set<NotebookLanguage>()
+  // Languages whose repair is CURRENTLY EXECUTING (past the cancel-check in runLanguage). Once a Reset
+  // crosses the destructive boundary (clearing the quarantine + rm -rf prefix) it must run to completion
+  // — aborting mid-repair leaves a deleted-but-not-rebuilt env with the evidence already cleared. A
+  // per-language cancel (from the UI's Cancel button) is ignored while the language is in this set; a
+  // global/quit cancel (abort without a language) still fires (app quit must take precedence).
+  private readonly uninterruptible = new Set<NotebookLanguage>()
 
-  // Aborts an in-flight provision: the download's fetch and the micromamba child both observe the
-  // signal and stop. A partial env prefix is cleaned before the next create (clearNonCondaPrefix), so
-  // a cancelled setup leaves nothing that blocks a later retry. No-op when nothing is provisioning.
-  cancel(): void {
-    this.abort?.abort(new Error('Runtime setup cancelled.'))
+  // Low-level per-language cancel PRIMITIVE. If `language` is the RUNNING one, abort its download/child;
+  // otherwise arm a one-shot skip so that language's NEXT run is skipped at entry; `undefined` aborts
+  // whatever is in flight. It cannot tell "queued" from "idle" (it doesn't see the run queue), so the
+  // "No-op when idle" contract is enforced one layer up in env-ipc.serializeProvisioner, which only
+  // forwards cancel for a language that actually has a pending run. Callers that bypass the serialized
+  // wrapper get the primitive's arm-skip behavior.
+  cancel(language?: NotebookLanguage): void {
+    // A per-language cancel is ignored while that language's repair is past the destructive boundary
+    // (uninterruptible). A global cancel (app quit) always fires regardless.
+    if (language !== undefined && this.uninterruptible.has(language)) return
+    if (language === undefined || language === this.runningLanguage) {
+      this.abort?.abort(new Error('Runtime setup cancelled.'))
+      return
+    }
+    this.cancelRequested.add(language)
+  }
+
+  // Throws if this language's provision was cancelled while queued; otherwise marks it running with a
+  // fresh abort controller. Returns the controller's cleanup for the caller's finally.
+  private beginLanguageRun(language: NotebookLanguage): void {
+    if (this.cancelRequested.delete(language)) {
+      throw new Error('Runtime setup cancelled.')
+    }
+    this.runningLanguage = language
+    this.abort = new AbortController()
+  }
+
+  private endLanguageRun(language: NotebookLanguage): void {
+    this.runningLanguage = undefined
+    this.abort = undefined
+    this.cancelRequested.delete(language)
+  }
+
+  // Emits eased create-phase progress on a timer for the duration of a create (see CREATE_* above), so
+  // the bar advances through micromamba's long opaque extract instead of freezing. Returns a stop fn
+  // that clears the timer (idempotent; safe to call more than once). The timer is unref'd so it never
+  // keeps the process alive on its own.
+  private startCreateTicker(spec: EnvSpec, onProgress: (p: ProvisionProgress) => void): () => void {
+    let progress = CREATE_FLOOR
+    const schedule = this.deps.scheduleTick ?? defaultScheduleTick
+    return schedule(() => {
+      progress += (CREATE_CEIL - progress) * CREATE_TICK_GAIN
+      onProgress({
+        phase: `create-${spec.language}`,
+        message: `Creating ${spec.name} environment…`,
+        progress
+      })
+    }, CREATE_TICK_MS)
+  }
+
+  // Journals a prefix-writing micromamba op (create / named create / relocation restore / upgrade) so a
+  // crash mid-write leaves a recoverable record: the next startup reconciles the prefix only once the
+  // recorded child is PROVABLY gone, and otherwise (liveness unconfirmed) BLOCKS the prefix so create/
+  // remove/repair/restore refuse to race the orphan (the whole point of the self-guard). It never signals
+  // the orphan — an unprobeable one clears only on a proven reboot. `run` performs the actual runArgv
+  // and MUST forward the provided onChild so the child PID is journaled. Journal begin() is FAIL-CLOSED:
+  // if we can't durably record the write-intent, the write is refused (a crash would leave no record for
+  // recovery to block on). The complete() below stays best-effort — a stale record is reconciled later.
+  private async withJournaledPrefixWrite(
+    kind: RuntimeOperationKind,
+    runtimeId: string,
+    prefix: string,
+    phase: string,
+    // `run` performs the actual spawn(s). It MUST pass `onBeforeSpawn` and `onChild` to runArgv so the
+    // per-spawn intent is re-armed and the PID recorded around EACH spawn (an op may spawn more than
+    // once: create + cache-repair retry).
+    run: (onBeforeSpawn: () => void, onChild: (pid: number) => void) => Promise<void>
+  ): Promise<void> {
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(this.deps.root))
+    const operationId = randomUUID()
+    // Fail CLOSED: if we can't record the write-intent, we can't crash-safely perform the write (a
+    // crash would leave nothing for recovery to block), so refuse rather than doing an un-recoverable
+    // prefix write. (complete() below stays best-effort — a stale record is harmless; the next startup
+    // reconciles it.)
+    await journal.begin({
+      operationId,
+      kind,
+      runtimeId,
+      phase,
+      startedAt: Date.now(),
+      targetPath: prefix
+    })
+    // Re-arm the spawn intent immediately before EACH spawn (fail-closed: throwing aborts the spawn).
+    // Writing it per-spawn — not once per op — means a second spawn (create retry) whose PID isn't
+    // recorded yet leaves a fresh "spawning" sidecar (block), not a stale earlier PID (reconcile).
+    const onBeforeSpawn = (): void => recordSpawnIntentSync(this.deps.root, operationId)
+    const onChild = (childPid: number): void => {
+      const childStartedAt = Date.now()
+      // Capture the kernel-native identity token NOW, while the child is provably alive, so recovery can
+      // later FALSIFY reuse (a changed token proves the pid is no longer ours). undefined off Linux — a
+      // tokenless live pid is then always 'unknown' (childStartedAt is retained only for diagnostics, not
+      // liveness: a wall-clock value can't soundly prove a live pid dead).
+      const childStartToken = readProcessStartToken(childPid)
+      // Convert the intent to the real PID SYNCHRONOUSLY (durable before this returns). Throws on
+      // failure so runArgv can kill the just-spawned child and fail closed rather than leave it
+      // unrecorded. The async journal update is the normal (non-crash) read path.
+      recordOperationChildSync(this.deps.root, operationId, {
+        childPid,
+        childStartedAt,
+        childStartToken
+      })
+      void journal
+        .update(operationId, { childPid, childStartedAt, childStartToken })
+        .catch(() => undefined)
+    }
+    let retainForRecovery = false
+    try {
+      await run(onBeforeSpawn, onChild)
+    } catch (error) {
+      // A recording failure whose child could NOT be confirmed stopped: a worker may still be writing
+      // the prefix, so KEEP the sidecar + journal record (recovery blocks) instead of clearing them.
+      if (isChildUnconfirmedError(error)) {
+        retainForRecovery = true
+        // Block the prefix IN THIS PROCESS now — not just via the retained journal entry, which only
+        // gates the next boot. Otherwise an in-session Retry would pass assertPrefixWritable and begin()
+        // a SECOND op (begin() does not reject a same-runtime record), spawning a worker that races the
+        // first's possibly-live orphan on the same prefix. Also mark it live-unconfirmed so a force Reset
+        // this session refuses to delete it out from under that orphan (clearQuarantine).
+        this.liveUnconfirmedPrefixes.add(prefix)
+        this.deps.blockPrefix?.(prefix)
+      }
+      throw error
+    } finally {
+      if (!retainForRecovery) {
+        removeOperationChildSync(this.deps.root, operationId)
+        await journal.complete(operationId).catch(() => undefined)
+      }
+    }
+  }
+
+  // Refuses to write a prefix crash-recovery flagged possibly-live (see ProvisionerDeps.isPrefixBlocked).
+  // Called at every prefix-write site so an unknown-liveness orphan blocks the write this session —
+  // covering the startup gate's restore/upgrade/repair, not just the UI provision/repair handlers.
+  private assertPrefixWritable(prefix: string): void {
+    if (this.deps.isPrefixBlocked?.(prefix)) {
+      throw new Error(
+        `RUNTIME_RECOVERY_BLOCKED: a previous operation on "${prefix}" was interrupted and its worker ` +
+          'process could not be confirmed stopped, so writing this environment now could corrupt it. ' +
+          // Honest: a probeable worker clears itself once it exits (re-checked each restart); an
+          // unprobeable/uncertain block will NOT clear on its own, so point the user at Reset.
+          'On restart it clears automatically once its worker is confirmed stopped; if it persists, ' +
+          'use Reset in Settings → Runtimes to recover this environment.'
+      )
+    }
+  }
+
+  // Reset guard for ONE spawn-lifecycle sidecar state. Throws RUNTIME_RECOVERY_BLOCKED if the state might
+  // still have a live writer we cannot account for; returns normally when it is provably safe to clear.
+  // Shared by the normal (per-record) and corrupt-journal (per-sidecar) Reset paths so both apply the
+  // identical, sound policy: probe a known pid, and for an unprobeable no-PID orphan demand a proven reboot.
+  private assertChildStateClearable(
+    prefix: string,
+    state: OperationChildState | 'corrupt',
+    confirmStopped: (record: {
+      childPid: number
+      childStartedAt?: number
+      childStartToken?: string
+    }) => Promise<boolean>
+  ): Promise<void> {
+    if (state !== 'corrupt' && 'childPid' in state) {
+      // A verifiable pid: probe it. confirmStopped returns true only for a provably-gone/reused child.
+      return confirmStopped(state).then((stopped) => {
+        if (!stopped)
+          throw new Error(
+            `RUNTIME_RECOVERY_BLOCKED: a worker process for "${prefix}" is still running and could ` +
+              'not be stopped, so the environment was not reset (resetting under a live worker could ' +
+              'corrupt it). Quit any running notebook work and try again, or restart the app.'
+          )
+      })
+    }
+    // No verifiable pid: either a {spawning} intent whose PID never landed, or a corrupt sidecar. A child
+    // MAY be live and is unprobeable — we can't signal it, and an APP restart does NOT prove a reparented
+    // micromamba/pip exited. Only a MACHINE reboot does. The boot_id captured in the {spawning} sidecar
+    // (journal-independent, so this holds even when the journal is corrupt) must prove the box rebooted;
+    // a corrupt sidecar has no readable token → always refuse. Never rm a prefix a live orphan may hold.
+    const recordedBoot = state !== 'corrupt' && 'spawning' in state ? state.bootToken : undefined
+    const readBoot = this.deps.readBootToken ?? readBootToken
+    if (!bootTokenProvesReboot(recordedBoot, readBoot())) {
+      // Platform-specific guidance: Linux can prove reboot via boot_id; macOS/Windows cannot, so we tell
+      // the user the manual escape hatch (deleting the recovery metadata) rather than an impossible reboot.
+      const isLinux = process.platform === 'linux'
+      const guidance = isLinux
+        ? 'Restart your computer, then try Reset again (a reboot proves the process is gone).'
+        : 'The process cannot be verified as stopped on this platform. If you are certain no install is ' +
+          'running, quit the app, manually delete the recovery metadata files in ' +
+          `"${this.deps.root}/operation-*.json", then relaunch and try Reset again.`
+      throw new Error(
+        `RUNTIME_RECOVERY_BLOCKED: an install/build process for "${prefix}" was interrupted before its ` +
+          'process id could be recorded, so it cannot be signalled or verified stopped. An app restart ' +
+          `does not guarantee that process exited. ${guidance}`
+      )
+    }
+    return Promise.resolve()
+  }
+
+  // Clears a recovery QUARANTINE for a prefix (an explicit user Reset): drops the in-memory block and
+  // clears every retained journal record + PID sidecar that targets this prefix, so the subsequent
+  // rebuild is not refused and the quarantine does not re-arm on the next startup. The user has decided
+  // to force recovery; this is the manual entry the auto-path can't provide for an uncertain block.
+  private async clearQuarantine(prefix: string): Promise<void> {
+    // A worker THIS process spawned but could not confirm stopped (its PID never landed, so it is
+    // unprobeable) may still be writing this prefix. Deleting + rebuilding now could corrupt it out from
+    // under that live orphan, and there is no pid to kill first — so refuse the Reset this session. Two
+    // sources: this provisioner's OWN prefix writes (local set) and a package install into the same prefix
+    // (the service's set, via the injected dep — the provisioner never sees install failures directly).
+    // Both are per-process in-memory sets, cleared on restart. After an app restart they are empty, so the
+    // records/sidecar loop below governs instead — and it demands a proven MACHINE reboot for a no-PID
+    // orphan (an app restart alone does NOT prove a reparented worker exited). Checked FIRST, before
+    // readState(): it catches the in-memory orphan recorded THIS session even when the journal is corrupt
+    // (the two can co-occur — an unreadable journal says nothing about the orphan we hold in memory).
+    if (this.liveUnconfirmedPrefixes.has(prefix) || this.deps.isPrefixLiveUnconfirmed?.(prefix)) {
+      throw new Error(
+        `RUNTIME_RECOVERY_BLOCKED: a worker process for "${prefix}" was started but could not be ` +
+          'confirmed stopped, and its process id was never recorded so it cannot be signalled. ' +
+          'Resetting now could corrupt the environment if that worker is still running. An app restart ' +
+          'does not prove a reparented install/build process exited — restart your computer, then try ' +
+          'Reset again (a reboot proves the process is gone).'
+      )
+    }
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(this.deps.root))
+    const confirmStopped = this.deps.confirmChildStopped ?? defaultConfirmChildStopped
+    const state = await journal.readState()
+    if (state === 'corrupt') {
+      // The journal is unreadable, so we can't map records to this prefix — but the child-state SIDECARS
+      // are separate files and survive a corrupt journal. A corrupt journal says NOTHING about whether an
+      // orphan is live, so we must NOT blindly rm the prefix (the old bug). Instead scan every sidecar and
+      // apply the SAME guard as the normal path: a probeable pid must be confirmed stopped; an unprobeable
+      // no-PID orphan needs a proven reboot (its boot_id lives in the sidecar, not the journal). We can't
+      // tell which sidecar targets THIS prefix, so any possibly-live writer anywhere refuses the Reset —
+      // the safe, conservative choice. assertChildStateClearable throws RUNTIME_RECOVERY_BLOCKED if unsafe.
+      for (const { state: childState } of listOperationChildren(this.deps.root))
+        await this.assertChildStateClearable(prefix, childState, confirmStopped)
+      // All clear (or nothing spawned). MOVE the corrupt journal aside (preserved as evidence) BEFORE the
+      // caller's rm, so the rebuild's begin() reads a clean/absent journal; it throws if it can't move the
+      // file → we do NOT proceed to delete the prefix. Then drop this prefix's sidecars so a later
+      // unrelated Reset isn't blocked by a now-stale entry.
+      await journal.quarantineCorrupt()
+      for (const { operationId } of listOperationChildren(this.deps.root))
+        removeOperationChildSync(this.deps.root, operationId)
+      this.deps.clearPrefixBlock?.(prefix)
+      // Release only THIS prefix from the global corrupt barrier — a corrupt journal can't tell us which
+      // env had in-flight work, so resetting one must not unblock the others. They stay blocked until
+      // their own Reset or a restart (which re-reads the now-quarantined journal as absent and clears).
+      this.deps.clearCorruptBlock?.(prefix)
+      return
+    }
+    const records = state.records.filter((record) => record.targetPath === prefix)
+    // A KNOWN worker may still be alive (e.g. Reset without a restart). Reset then deletes + rebuilds the
+    // prefix, so we must NOT drop the block and delete evidence out from under a live writer. For each
+    // record, resolve its spawn-lifecycle state and apply the shared guard (assertChildStateClearable): a
+    // probeable pid must be confirmed provably stopped; an unprobeable no-PID orphan (a spawn whose PID
+    // never landed) needs a proven machine reboot. Otherwise the Reset is refused (keep the quarantine).
+    for (const record of records) {
+      const sidecar = readOperationChild(this.deps.root, record.operationId)
+      // Resolve the state to guard on. A VALID sidecar is authoritative. When the sidecar is ABSENT we
+      // fall back to a legacy journal-recorded PID (older records had no sidecar); with neither, the op
+      // never reached the spawn stage → nothing to guard. A {spawning}/corrupt sidecar is passed through
+      // as-is (no verifiable pid) — never fall back to the journal's PID from an EARLIER spawn.
+      const childState: OperationChildState | 'corrupt' | undefined =
+        sidecar === undefined
+          ? record.childPid !== undefined
+            ? {
+                childPid: record.childPid,
+                childStartedAt: record.childStartedAt ?? 0,
+                childStartToken: record.childStartToken
+              }
+            : undefined
+          : sidecar
+      if (childState === undefined) continue // op never spawned → safe to clear
+      await this.assertChildStateClearable(prefix, childState, confirmStopped)
+    }
+    // The worker is confirmed gone (or was never recorded): drop the blocks and clear the retained
+    // journal records + sidecars for this prefix, so the rebuild isn't refused and the quarantine does
+    // not re-arm next startup. An interrupted install also blocks its runtimeId — clear that too, or a
+    // bound session would still be rejected by blockedRuntimeIds after the env rebuilds.
+    this.deps.clearPrefixBlock?.(prefix)
+    // Also release this prefix from the global corrupt-journal barrier. A FIRST corrupt Reset already
+    // moved the journal aside, so a LATER env's Reset reaches this (non-corrupt) branch and would never
+    // otherwise call clearCorruptBlock — leaving that env stuck under recoveryCorrupt until a restart.
+    // Idempotent (just allowlists the prefix); a no-op when the journal was never corrupt.
+    this.deps.clearCorruptBlock?.(prefix)
+    for (const record of records) {
+      if (record.kind === 'install' && record.runtimeId)
+        this.deps.clearRuntimeBlock?.(record.runtimeId)
+      removeOperationChildSync(this.deps.root, record.operationId)
+      await journal.complete(record.operationId).catch(() => undefined)
+    }
   }
 
   status(): ProvisionStatus {
@@ -278,41 +707,71 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       rReady: rReady(this.deps.root),
       version: marker?.defaultEnvVersion ?? 0,
       provisioning: this.provisioning,
-      bundleSource: this.deps.bundleSource
+      bundleSource: this.deps.bundleSource,
+      // Surface a recovery quarantine so the UI can offer Reset even when the interpreter/marker still
+      // read as ready (recovery blocks the prefix in memory without touching the marker).
+      pythonRecoveryBlocked: this.deps.isPrefixBlocked?.(envPrefix(this.deps.root, DEFAULT_PY_ENV)),
+      rRecoveryBlocked: this.deps.isPrefixBlocked?.(envPrefix(this.deps.root, DEFAULT_R_ENV))
     }
   }
 
-  async provisionPython(onProgress: (p: ProvisionProgress) => void): Promise<void> {
+  // Runs a prefix-mutating section under the injected per-env lock (the service's install lock) so a
+  // default-env create/repair/upgrade never runs concurrently with a package install into the SAME env
+  // prefix. No-op wrapper when unwired (unit tests). MUST NOT be called nested for the same env name —
+  // the lock is exclusive — so the lock lives at the top-level entries and the do*/materialize helpers
+  // it calls stay lock-free.
+  private withEnvPrefixLock<T>(envName: string, fn: () => Promise<T>): Promise<T> {
+    return this.deps.withPrefixLock ? this.deps.withPrefixLock(envName, fn) : fn()
+  }
+
+  // Wraps a language run so a QUEUED cancel is consumed (beginLanguageRun throws) BEFORE the run does
+  // any work, and the provisioning flag + abort controller cover the whole run. repair uses this too, so
+  // a cancel that arrived while the Reset was queued aborts BEFORE the destructive rm — never leaving a
+  // deleted-but-not-rebuilt env. The wrapped body must NOT call beginLanguageRun itself (single owner).
+  private async runLanguage(language: NotebookLanguage, run: () => Promise<void>): Promise<void> {
+    this.beginLanguageRun(language)
     this.provisioning = true
-    this.abort = new AbortController()
     try {
-      await this.materialize(DEFAULT_PYTHON_SPEC, onProgress)
-      // Python is the app gate: stamp the ready marker only after create+verify succeed.
-      writeReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
-      onProgress({ phase: 'done', message: 'Python environment ready', progress: 1 })
+      await run()
     } finally {
       this.provisioning = false
-      this.abort = undefined
+      this.endLanguageRun(language)
     }
   }
 
-  async provisionR(onProgress: (p: ProvisionProgress) => void): Promise<void> {
-    this.provisioning = true
-    this.abort = new AbortController()
-    try {
-      // R is lazy, but once present it has its own version marker. A legacy/stale R prefix is upgraded
-      // from the current explicit pack instead of being accepted merely because R.exe exists.
-      if (rMaterialized(this.deps.root) && !rReady(this.deps.root)) {
-        await this.upgradeOrRebuildR(onProgress)
-      } else {
-        await this.materialize(DEFAULT_R_SPEC, onProgress)
-      }
-      writeRReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
-      onProgress({ phase: 'done', message: 'R environment ready', progress: 1 })
-    } finally {
-      this.provisioning = false
-      this.abort = undefined
+  async provisionPython(rawProgress: (p: ProvisionProgress) => void): Promise<void> {
+    return this.withEnvPrefixLock(DEFAULT_PY_ENV, () =>
+      this.runLanguage('python', () => this.doProvisionPython(rawProgress))
+    )
+  }
+
+  // The provision work only — the language run (cancel check, provisioning flag) is owned by the caller
+  // (runLanguage), so repair can wrap its rm + this rebuild in ONE run without a double beginLanguageRun.
+  private async doProvisionPython(rawProgress: (p: ProvisionProgress) => void): Promise<void> {
+    const onProgress = withLanguage(rawProgress, 'python')
+    await this.materialize(DEFAULT_PYTHON_SPEC, onProgress)
+    // Python is the app gate: stamp the ready marker only after create+verify succeed.
+    writeReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
+    onProgress({ phase: 'done', message: 'Python environment ready', progress: 1 })
+  }
+
+  async provisionR(rawProgress: (p: ProvisionProgress) => void): Promise<void> {
+    return this.withEnvPrefixLock(DEFAULT_R_ENV, () =>
+      this.runLanguage('r', () => this.doProvisionR(rawProgress))
+    )
+  }
+
+  private async doProvisionR(rawProgress: (p: ProvisionProgress) => void): Promise<void> {
+    const onProgress = withLanguage(rawProgress, 'r')
+    // R is lazy, but once present it has its own version marker. A legacy/stale R prefix is upgraded
+    // from the current explicit pack instead of being accepted merely because R.exe exists.
+    if (rMaterialized(this.deps.root) && !rReady(this.deps.root)) {
+      await this.upgradeOrRebuildR(onProgress)
+    } else {
+      await this.materialize(DEFAULT_R_SPEC, onProgress)
     }
+    writeRReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
+    onProgress({ phase: 'done', message: 'R environment ready', progress: 1 })
   }
 
   async upgradeIfNeeded(onProgress: (p: ProvisionProgress) => void): Promise<void> {
@@ -320,14 +779,25 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     if (!marker || marker.defaultEnvVersion >= DEFAULT_ENV_VERSION) return
     this.provisioning = true
     try {
+      // Refuse to write the python prefix if recovery flagged it possibly-live — an additive
+      // `install --file` still writes into it, so it must not race a survivor either.
+      this.assertPrefixWritable(envPrefix(this.deps.root, DEFAULT_PY_ENV))
       // Apply the exact published baseline to the existing env. `install --file --offline` preserves
       // extra user packages while avoiding a repodata solve for the platform-maintained floor.
       onProgress({ phase: 'upgrade', message: 'Updating default packages…', progress: 0.1 })
-      await this.upgradeFromBundle(DEFAULT_PYTHON_SPEC, onProgress)
-      // R is upgraded additively only if already materialized (lazy; spec §6.5).
-      if (rMaterialized(this.deps.root)) {
+      // Hold the env lock around each additive `install --file` so it can't overlap a package install
+      // into the same env. Per-env (python then R), matching the service's install-lock key.
+      await this.withEnvPrefixLock(DEFAULT_PY_ENV, () =>
+        this.upgradeFromBundle(DEFAULT_PYTHON_SPEC, onProgress)
+      )
+      // R is upgraded additively only if already materialized (lazy; spec §6.5) AND not recovery-blocked
+      // — a blocked R prefix skips its upgrade rather than failing the (already-applied) python upgrade.
+      if (
+        rMaterialized(this.deps.root) &&
+        !this.deps.isPrefixBlocked?.(envPrefix(this.deps.root, DEFAULT_R_ENV))
+      ) {
         onProgress({ phase: 'upgrade-r', message: 'Updating R packages…', progress: 0.6 })
-        await this.upgradeOrRebuildR(onProgress)
+        await this.withEnvPrefixLock(DEFAULT_R_ENV, () => this.upgradeOrRebuildR(onProgress))
         writeRReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
       }
       writeReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
@@ -337,18 +807,54 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     }
   }
 
-  async repair(lang: NotebookLanguage, onProgress: (p: ProvisionProgress) => void): Promise<void> {
+  async repair(
+    lang: NotebookLanguage,
+    rawProgress: (p: ProvisionProgress) => void,
+    opts?: { force?: boolean }
+  ): Promise<void> {
+    const onProgress = withLanguage(rawProgress, lang)
     const spec = lang === 'r' ? DEFAULT_R_SPEC : DEFAULT_PYTHON_SPEC
-    // Manual repair / corruption path (spec §6.3): delete the env prefix then re-provision fresh. For
-    // python also clear the marker so a partially-deleted state cannot read as ready.
-    rmSync(envPrefix(this.deps.root, spec.name), { recursive: true, force: true })
-    if (lang === 'python') {
-      rmSync(readyMarkerPath(this.deps.root), { force: true })
-      await this.provisionPython(onProgress)
-    } else {
-      rmSync(rReadyMarkerPath(this.deps.root), { force: true })
-      await this.provisionR(onProgress)
-    }
+    const prefix = envPrefix(this.deps.root, spec.name)
+    // Hold the env lock across the WHOLE destructive cycle (quarantine clear / block check → rm →
+    // rebuild), so a package install into this env can't slip in between the rm and the rebuild and
+    // write into a half-deleted prefix. The rebuild calls the LOCK-FREE do* variants (not the public
+    // provision*), which would otherwise re-acquire this same exclusive lock and deadlock.
+    return this.withEnvPrefixLock(spec.name, () =>
+      // runLanguage consumes a QUEUED cancel (beginLanguageRun throws) BEFORE the rm below, so
+      // cancelling a queued Reset never leaves a deleted-but-not-rebuilt env.
+      this.runLanguage(lang, async () => {
+        // Mark this repair UNINTERRUPTIBLE before any destructive step: once we clear the quarantine
+        // and rm the prefix there is no safe stopping point — a per-language Cancel arriving mid-repair
+        // would abort the rebuild and leave a missing/half-built env with the block already cleared.
+        // (Global/quit cancel still works to handle app shutdown.)
+        this.uninterruptible.add(lang)
+        try {
+          if (opts?.force) {
+            // EXPLICIT user recovery: clear the quarantine (in-memory block + retained journal record +
+            // sidecar) so the rebuild below — and its inner materialize — aren't refused by the block
+            // guard. The user has accepted any interrupted worker is gone. This is the manual recovery.
+            await this.clearQuarantine(prefix)
+          } else {
+            // Refuse before deleting: a repair rm -rf + rebuild is the most destructive prefix write,
+            // so it must never run over a prefix an unknown-liveness orphan may still hold (the startup
+            // planner picks 'repair' on a partial prefix, the concrete path the barrier alone missed).
+            this.assertPrefixWritable(prefix)
+          }
+          // Manual repair / corruption path (spec §6.3): delete the env prefix then re-provision fresh.
+          // For python also clear the marker so a partially-deleted state cannot read as ready.
+          rmSync(envPrefix(this.deps.root, spec.name), { recursive: true, force: true })
+          if (lang === 'python') {
+            rmSync(readyMarkerPath(this.deps.root), { force: true })
+            await this.doProvisionPython(onProgress)
+          } else {
+            rmSync(rReadyMarkerPath(this.deps.root), { force: true })
+            await this.doProvisionR(onProgress)
+          }
+        } finally {
+          this.uninterruptible.delete(lang)
+        }
+      })
+    )
   }
 
   // Rebuilds envs captured by a data-root relocation (runtime-relocation.exportRuntimeLocks) offline
@@ -375,62 +881,101 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
 
     this.provisioning = true
     try {
-      let restoredPython = false
-      let restoredR = false
+      // Commit a DEFAULT env's ready marker BEFORE consuming (deleting) its lock, so a crash between the
+      // two never leaves a valid prefix with neither marker nor lock — which the startup planner would
+      // 'repair' (delete + rebuild), losing the relocated user packages. A crash after the marker but
+      // before the lock delete is safe: the next startup reads 'ready' and re-consumes the leftover lock
+      // idempotently.
+      const stampDefaultMarkerBeforeLock = (envName: string): void => {
+        const now = (this.deps.now ?? defaultNow)()
+        if (envName === DEFAULT_PY_ENV) writeReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, now)
+        else if (envName === DEFAULT_R_ENV)
+          writeRReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, now)
+      }
       for (const file of files) {
         const name = file.slice(0, -'.lock'.length)
-        const prefix = envPrefix(this.deps.root, name)
-        // A prior restore may have materialized the interpreter before being interrupted. Verify it
-        // before consuming the lock; a broken partial prefix is removed and rebuilt below.
-        const existingBin = existsSync(pythonBin(prefix))
-          ? pythonBin(prefix)
-          : existsSync(rBin(prefix))
-            ? rBin(prefix)
-            : undefined
-        if (existingBin) {
-          try {
-            await this.deps.verify(existingBin, prefix)
-            if (name === DEFAULT_PY_ENV) restoredPython = true
-            if (name === DEFAULT_R_ENV) restoredR = true
-            rmSync(join(dir, file), { force: true })
-            continue
-          } catch {
-            rmSync(prefix, { recursive: true, force: true })
+        // Serialize each env's restore with a package install into the SAME env (managePackages holds
+        // the same key): restore rm -rf's + rebuilds the prefix, and the startup gate runs async with
+        // IPC already registered, so without one shared lock a restore could race an installer mid-write.
+        await this.withEnvPrefixLock(name, async () => {
+          const prefix = envPrefix(this.deps.root, name)
+          // Skip (leave the lock for a later launch) if recovery flagged this prefix possibly-live: the
+          // restore path rm -rf's a broken partial and recreates, which must not race an orphan writer.
+          // Other envs still restore; a later restart re-checks the pid and unblocks.
+          if (this.deps.isPrefixBlocked?.(prefix)) return
+          // A prior restore may have materialized the interpreter before being interrupted. Verify it
+          // before consuming the lock; a broken partial prefix is removed and rebuilt below.
+          const existingBin = existsSync(pythonBin(prefix))
+            ? pythonBin(prefix)
+            : existsSync(rBin(prefix))
+              ? rBin(prefix)
+              : undefined
+          if (existingBin) {
+            let verified = false
+            try {
+              await this.deps.verify(existingBin, prefix)
+              verified = true
+            } catch {
+              // Broken partial — fall through to rebuild. The delete happens INSIDE the journal wrapper
+              // below (never before begin), so a fail-closed begin() can't leave the prefix deleted.
+            }
+            if (verified) {
+              // The env is VALID. Commit the marker (default env) then consume its lock. If either write
+              // fails (permissions / disk / path), KEEP the working prefix AND its lock — never rebuild a
+              // valid relocated env over a marker/fs hiccup; retry next launch.
+              try {
+                stampDefaultMarkerBeforeLock(name) // marker BEFORE lock delete (no data-loss window)
+                rmSync(join(dir, file), { force: true })
+              } catch {
+                // Marker/lock write failed — leave the working env and its lock intact for a later launch.
+              }
+              return
+            }
           }
-        }
-        onProgress({ phase: 'restore', message: `Restoring ${name}…`, progress: 0.5 })
-        try {
-          // Shared pkgs cache lock: this rebuild-from-lock extracts into the shared cache, so a
-          // concurrent corrupt-cache repair (cache-exclusive) can't delete an incomplete extraction.
-          await this.runWithMaxPathRecovery(
-            () =>
-              withSharedCacheLocks(this.cacheLockKeys(this.cache), () =>
-                this.deps.runArgv(
-                  createFromLockArgv(this.deps.mm, this.deps.root, prefix, join(dir, file)),
+          onProgress({ phase: 'restore', message: `Restoring ${name}…`, progress: 0.5 })
+          try {
+            // Journal the rebuild (child PID + prefix) so a crash mid-restore is recovered like a
+            // materialize. The prefix cleanup + create both run INSIDE the wrapper (after begin
+            // succeeds), so nothing is deleted un-recoverably if begin fails closed. Shared pkgs cache
+            // lock + MAX_PATH recovery: this rebuild-from-lock extracts into the shared cache, so a
+            // concurrent corrupt-cache repair (cache-exclusive) can't delete an incomplete extraction,
+            // and a Windows path-limit failure is retried once after a short cache recovery.
+            await this.withJournaledPrefixWrite(
+              'materialize',
+              name,
+              prefix,
+              'restore',
+              (onBeforeSpawn, onChild) =>
+                this.runWithMaxPathRecovery(
+                  () =>
+                    withSharedCacheLocks(this.cacheLockKeys(this.cache), () => {
+                      // Reaching here means the prefix is broken (verify failed) or a partial (e.g.
+                      // conda-meta with no interpreter, which would wedge `create -p` forever) — clear it
+                      // so the offline recreate starts clean. No abort signal: restore has no per-language
+                      // cancel path, and this.abort may belong to a concurrent default provision.
+                      rmSync(prefix, { recursive: true, force: true })
+                      return this.deps.runArgv(
+                        createFromLockArgv(this.deps.mm, this.deps.root, prefix, join(dir, file)),
+                        undefined,
+                        onChild,
+                        onBeforeSpawn,
+                        this.cache,
+                        DEFAULT_MAX_CACHE_RELATIVE_PATH
+                      )
+                    }),
                   undefined,
-                  undefined,
-                  this.cache,
-                  DEFAULT_MAX_CACHE_RELATIVE_PATH
+                  this.cache
                 )
-              ),
-            undefined,
-            this.cache
-          )
-          const bin = existsSync(pythonBin(prefix)) ? pythonBin(prefix) : rBin(prefix)
-          await this.deps.verify(bin, prefix)
-          if (name === DEFAULT_PY_ENV) restoredPython = true
-          if (name === DEFAULT_R_ENV) restoredR = true
-          rmSync(join(dir, file), { force: true })
-        } catch {
-          // Leave the lock in place: retried next launch; the readiness gate re-provisions defaults
-          // in the meantime so the app stays usable.
-        }
-      }
-      if (restoredPython) {
-        writeReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
-      }
-      if (restoredR) {
-        writeRReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
+            )
+            const bin = existsSync(pythonBin(prefix)) ? pythonBin(prefix) : rBin(prefix)
+            await this.deps.verify(bin, prefix)
+            stampDefaultMarkerBeforeLock(name) // marker BEFORE lock delete (no data-loss window)
+            rmSync(join(dir, file), { force: true })
+          } catch {
+            // Leave the lock in place: retried next launch; the readiness gate re-provisions defaults
+            // in the meantime so the app stays usable.
+          }
+        })
       }
       onProgress({ phase: 'done', message: 'Runtime restored', progress: 1 })
     } finally {
@@ -459,23 +1004,49 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           'choose a shorter name or data-root path.'
       )
     }
-    // Take the shared pkgs cache lock for the whole prefix cleanup + create: this create extracts into
-    // the SHARED cache, so a concurrent corrupt-cache repair (which takes the cache EXCLUSIVE and deletes
-    // incomplete extractions) must not run mid-create and delete a package dir we are still producing.
-    await this.runWithMaxPathRecovery(() =>
-      withSharedCacheLocks(this.cacheLockKeys(this.cache), async () => {
-        // Clear a half-built prefix from an interrupted prior create so micromamba doesn't abort on it.
-        this.clearNonCondaPrefix(prefix)
-        await this.deps.runArgv(
-          createFromPackagesArgv(this.deps.mm, this.deps.root, prefix, [this.deps.channel], pkgs),
-          undefined,
-          undefined,
-          this.cache,
-          DEFAULT_MAX_CACHE_RELATIVE_PATH
-        )
-      })
-    )
     const bin = language === 'python' ? pythonBin(prefix) : rBin(prefix)
+    // Refuse if recovery flagged this named prefix possibly-live (an orphan create/install may still
+    // be writing it) — the service also gates this, but self-guarding covers every caller.
+    this.assertPrefixWritable(prefix)
+    // Journal the create (child PID + prefix) so a crash mid-create is recovered like any other prefix
+    // write: a survivor is killed and, if unconfirmed, the prefix is blocked so a later create/remove
+    // can't race it. Take the shared pkgs cache lock (+ MAX_PATH recovery) for the whole prefix cleanup
+    // + create: this create extracts into the SHARED cache, so a concurrent corrupt-cache repair (which
+    // takes the cache EXCLUSIVE and deletes incomplete extractions) must not run mid-create and delete a
+    // package dir we are still producing, and a Windows path-limit failure is retried once after a short
+    // cache recovery.
+    await this.withJournaledPrefixWrite(
+      'materialize',
+      name,
+      prefix,
+      `create-${language}`,
+      (onBeforeSpawn, onChild) =>
+        this.runWithMaxPathRecovery(() =>
+          withSharedCacheLocks(this.cacheLockKeys(this.cache), async () => {
+            // Clear a half-built prefix from an interrupted prior create (incl. conda-meta-but-no-
+            // interpreter) so micromamba doesn't abort on it.
+            this.clearIncompletePrefix(prefix, bin)
+            // NO abort signal: this.abort belongs to the currently-running default provision (python/r),
+            // and a named create runs on the RAW provisioner concurrently with the serialized default one
+            // (ipc.ts wires them separately). Passing this.abort here would let a cancel of the default env
+            // abort this unrelated named-env child. Named create has no per-language cancel path of its own.
+            await this.deps.runArgv(
+              createFromPackagesArgv(
+                this.deps.mm,
+                this.deps.root,
+                prefix,
+                [this.deps.channel],
+                pkgs
+              ),
+              undefined,
+              onChild,
+              onBeforeSpawn,
+              this.cache,
+              DEFAULT_MAX_CACHE_RELATIVE_PATH
+            )
+          })
+        )
+    )
     await this.deps.verify(bin, prefix)
     return {
       name,
@@ -527,6 +1098,8 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   // Keeps a healthy legacy R prefix additive, but replaces an invalid partial prefix from the lock.
   private async upgradeOrRebuildR(onProgress: (p: ProvisionProgress) => void): Promise<void> {
     const prefix = envPrefix(this.deps.root, DEFAULT_R_ENV)
+    // Refuse before the rmSync-and-rebuild branch below can delete a possibly-live prefix.
+    this.assertPrefixWritable(prefix)
     try {
       await this.deps.verify(rBin(prefix), prefix)
     } catch {
@@ -558,36 +1131,55 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     }
     const prefix = envPrefix(this.deps.root, spec.name)
     const bin = spec.language === 'python' ? pythonBin(prefix) : rBin(prefix)
-    // Shared pkgs cache lock: this install extracts into the shared cache, so a concurrent corrupt-cache
-    // repair (cache-exclusive) must not delete an incomplete extraction mid-upgrade.
+    // Journal the upgrade (child PID + prefix) so a crash mid-install is recovered: the prefix is
+    // reconciled only once the survivor is provably gone, else it is blocked. Shared pkgs cache lock (+
+    // MAX_PATH recovery):
+    // this install extracts into the shared cache, so a concurrent corrupt-cache repair (cache-exclusive)
+    // must not delete an incomplete extraction mid-upgrade, and a Windows path-limit failure is retried
+    // once after a short cache recovery.
     const selected = this.cacheForBundle(spec, bundle)
     await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
-    await this.runWithMaxPathRecovery(
-      () =>
-        withSharedCacheLocks(this.cacheLockKeys(selected.cache), () =>
-          this.deps.runArgv(
-            installFromLockArgv(this.deps.mm, this.deps.root, prefix, bundle.lockPath),
-            this.abort?.signal,
-            undefined,
-            selected.cache,
-            selected.budget.maxCacheRelativePath || DEFAULT_MAX_CACHE_RELATIVE_PATH
-          )
-        ),
-      undefined,
-      selected.cache
+    await this.withJournaledPrefixWrite(
+      'upgrade',
+      spec.name,
+      prefix,
+      `upgrade-${spec.language}`,
+      (onBeforeSpawn, onChild) =>
+        this.runWithMaxPathRecovery(
+          () =>
+            withSharedCacheLocks(this.cacheLockKeys(selected.cache), () =>
+              this.deps.runArgv(
+                installFromLockArgv(this.deps.mm, this.deps.root, prefix, bundle.lockPath),
+                this.abort?.signal,
+                onChild,
+                onBeforeSpawn,
+                selected.cache,
+                selected.budget.maxCacheRelativePath || DEFAULT_MAX_CACHE_RELATIVE_PATH
+              )
+            ),
+          undefined,
+          selected.cache
+        )
     )
     await this.deps.verify(bin, prefix)
   }
 
-  // micromamba `create -p <prefix>` aborts with "Non-conda folder exists at prefix" when the prefix
-  // dir already exists without conda metadata — e.g. a prior create that was interrupted (crash,
-  // killed retry, or a partial extraction) after making the dir but before conda-meta was written.
-  // This routinely wedges a Retry on Windows (default-r left half-built). Clear such a leftover so
-  // the create starts clean; a real conda env (has conda-meta) is left untouched so we never nuke a
-  // working environment.
-  private clearNonCondaPrefix(prefix: string): void {
+  // Clears a HALF-BUILT prefix before a create so micromamba starts clean. A prefix is incomplete —
+  // and must be removed — unless it has BOTH conda-meta AND its interpreter binary. Two failure modes
+  // this fixes:
+  //   • Non-conda leftover (dir exists, no conda-meta): a create died before conda-meta was written;
+  //     `create -p` aborts with "Non-conda folder exists at prefix".
+  //   • conda-meta present but interpreter MISSING: a cancelled/crashed create (observed on Windows for
+  //     default-r) leaves conda-meta with no Rscript.exe. The old check returned early on conda-meta, so
+  //     every Retry re-ran `create -p` on that half-built prefix and failed permanently. Treat it as
+  //     incomplete and rebuild. Safe to delete here: the block-guard (assertPrefixWritable) has already
+  //     refused a prefix a live orphan might still be writing, so nothing else is producing this dir.
+  // A complete env returns via the idempotent verify path before reaching a create, so a real
+  // environment is never nuked here.
+  private clearIncompletePrefix(prefix: string, bin: string): void {
     if (!existsSync(prefix)) return
-    if (existsSync(join(prefix, 'conda-meta'))) return
+    const complete = existsSync(join(prefix, 'conda-meta')) && existsSync(bin)
+    if (complete) return
     rmSync(prefix, { recursive: true, force: true })
   }
 
@@ -596,6 +1188,9 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     onProgress: (p: ProvisionProgress) => void
   ): Promise<void> {
     const prefix = envPrefix(this.deps.root, spec.name)
+    // Refuse to touch a prefix recovery flagged possibly-live, even for the idempotent verify path
+    // below: an orphan may be mid-write, so treating a half-built interpreter as "ready" is unsafe.
+    this.assertPrefixWritable(prefix)
     const bin = spec.language === 'python' ? pythonBin(prefix) : rBin(prefix)
     // Idempotent: if the interpreter is already on disk the env is materialized, so skip fetch+create.
     // This makes a duplicate/concurrent provision (e.g. the UI R-tab and an on-demand agent run both
@@ -633,105 +1228,102 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     onProgress({
       phase: `create-${spec.language}`,
       message: `Creating ${spec.name} environment…`,
-      progress: 0.5
+      progress: CREATE_FLOOR
     })
-    // Journal the create so a process death mid-materialize is reconciled at next startup (the env
-    // prefix is verified and, if incomplete, removed so it rebuilds). Best-effort — journal I/O never
-    // fails the materialize. Cleared in the finally once verify succeeds/fails and the prefix is settled.
-    const journal = RuntimeOperationJournal.forPath(operationJournalPath(this.deps.root))
-    const operationId = randomUUID()
-    await journal
-      .begin({
-        operationId,
-        kind: 'materialize',
-        runtimeId: spec.name,
-        phase: `create-${spec.language}`,
-        startedAt: Date.now(),
-        targetPath: prefix
-      })
-      .catch(() => undefined)
-    const onChild = (childPid: number): void =>
-      // Record the micromamba child so startup recovery can kill a survivor before reconciling.
-      void journal
-        .update(operationId, { childPid, childStartedAt: Date.now() })
-        .catch(() => undefined)
+    // Select the cache scoped to this bundle (Windows budget) and clear any legacy over-budget URL
+    // packages before the create, so a Windows path-limit blocker doesn't fail the first attempt.
     const selected = this.cacheForBundle(spec, bundle)
     await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
-    const runCreate = (
-      lockPath: string,
-      cache: MicromambaCache = selected.cache,
-      budget = selected.budget
-    ): Promise<void> =>
-      // Take the shared pkgs cache lock so a concurrent corrupt-cache repair can't delete a package
-      // mid-create. The env prefix cleanup + create run inside it.
-      withSharedCacheLocks(this.cacheLockKeys(cache), () => {
-        // Clear a half-built prefix from an interrupted prior attempt so micromamba doesn't abort on it.
-        this.clearNonCondaPrefix(prefix)
-        return this.deps.runArgv(
-          createFromLockArgv(this.deps.mm, this.deps.root, prefix, lockPath),
-          this.abort?.signal,
-          onChild,
-          cache,
-          budget.maxCacheRelativePath || DEFAULT_MAX_CACHE_RELATIVE_PATH
-        )
-      })
-    try {
-      try {
-        await this.runWithMaxPathRecovery(
-          () => runCreate(bundle.lockPath),
-          () => {
-            onProgress({
-              phase: `create-${spec.language}`,
-              message: `Retrying ${spec.name} with the short Windows package cache…`,
-              progress: 0.5
-            })
-          },
-          selected.cache
-        )
-      } catch (error) {
-        // A corrupt pkgs cache (e.g. a prior interrupted extract left an incomplete package dir) makes
-        // create abort with "incorrect downloads" / "extracted directory cache". Do NOT wipe the whole
-        // shared cache — that would delete other envs' (and the other language's) tarballs needed for
-        // offline rebuild. Instead take the cache EXCLUSIVE and remove only INCOMPLETE extracted package
-        // dirs (missing info/repodata_record.json), preserving every tarball and complete package; then re-seed
-        // and retry the create ONCE. If nothing was incomplete, this isn't a corrupt-cache fault we can
-        // repair, so surface the original error rather than churn. A user cancel is never retried.
-        if (
-          this.abort?.signal.aborted ||
-          error instanceof MaxPathRetryError ||
-          !isCorruptPkgsCacheError(error)
-        )
-          throw error
-        const repaired = await withExclusiveCacheLocks(this.cacheLockKeys(selected.cache), () =>
-          Promise.resolve(removeIncompleteExtractedPackages(this.cacheRoots(selected.cache)))
-        )
-        if (!repaired) throw error
-        onProgress({
-          phase: `create-${spec.language}`,
-          message: `Repairing ${spec.name} package cache…`,
-          progress: 0.5
-        })
-        const reseeded = await this.deps.fetchBundle(
-          spec,
-          DEFAULT_ENV_VERSION,
-          onProgress,
-          this.abort?.signal
-        )
-        if (!reseeded) throw error
-        const retrySelected = this.cacheForBundle(spec, reseeded)
-        await runCreate(reseeded.lockPath, retrySelected.cache, retrySelected.budget)
+    // Journal the create (child PID + prefix) so a process death mid-materialize is reconciled at next
+    // startup: the recorded child is killed if it survived and, if liveness is unconfirmed, the prefix
+    // is blocked. verify() is read-only and stays outside the journaled window.
+    await this.withJournaledPrefixWrite(
+      'materialize',
+      spec.name,
+      prefix,
+      `create-${spec.language}`,
+      async (onBeforeSpawn, onChild) => {
+        const runCreate = (
+          lockPath: string,
+          cache: MicromambaCache = selected.cache,
+          budget = selected.budget
+        ): Promise<void> => {
+          // Advance the bar while micromamba extracts (it reports nothing itself). Stopped in the
+          // finally so a create failure/retry doesn't leave the timer running past this attempt.
+          const stopTicks = this.startCreateTicker(spec, onProgress)
+          // Take the shared pkgs cache lock so a concurrent corrupt-cache repair can't delete a package
+          // mid-create. The env prefix cleanup + create run inside it. onBeforeSpawn re-arms the intent
+          // for THIS attempt — the retry below is a second spawn and must not trust the first's PID.
+          return withSharedCacheLocks(this.cacheLockKeys(cache), () => {
+            // Clear a half-built prefix from an interrupted prior attempt (incl. conda-meta-but-no-
+            // interpreter) so micromamba doesn't abort on it.
+            this.clearIncompletePrefix(prefix, bin)
+            return this.deps.runArgv(
+              createFromLockArgv(this.deps.mm, this.deps.root, prefix, lockPath),
+              this.abort?.signal,
+              onChild,
+              onBeforeSpawn,
+              cache,
+              budget.maxCacheRelativePath || DEFAULT_MAX_CACHE_RELATIVE_PATH
+            )
+          }).finally(stopTicks)
+        }
+        try {
+          await this.runWithMaxPathRecovery(
+            () => runCreate(bundle.lockPath),
+            () => {
+              onProgress({
+                phase: `create-${spec.language}`,
+                message: `Retrying ${spec.name} with the short Windows package cache…`,
+                progress: CREATE_FLOOR
+              })
+            },
+            selected.cache
+          )
+        } catch (error) {
+          // A corrupt pkgs cache (e.g. a prior interrupted extract left an incomplete package dir) makes
+          // create abort with "incorrect downloads" / "extracted directory cache". Do NOT wipe the whole
+          // shared cache — that would delete other envs' (and the other language's) tarballs needed for
+          // offline rebuild. Instead take the cache EXCLUSIVE and remove only INCOMPLETE extracted
+          // package dirs (missing info/index.json), preserving every tarball and complete package; then
+          // re-seed and retry the create ONCE. If nothing was incomplete, this isn't a corrupt-cache
+          // fault we can repair, so surface the original error rather than churn. A cancel is never
+          // retried.
+          if (
+            this.abort?.signal.aborted ||
+            error instanceof MaxPathRetryError ||
+            !isCorruptPkgsCacheError(error)
+          )
+            throw error
+          const repaired = await withExclusiveCacheLocks(this.cacheLockKeys(selected.cache), () =>
+            Promise.resolve(removeIncompleteExtractedPackages(this.cacheRoots(selected.cache)))
+          )
+          if (!repaired) throw error
+          onProgress({
+            phase: `create-${spec.language}`,
+            message: `Repairing ${spec.name} package cache…`,
+            progress: CREATE_FLOOR
+          })
+          const reseeded = await this.deps.fetchBundle(
+            spec,
+            DEFAULT_ENV_VERSION,
+            onProgress,
+            this.abort?.signal
+          )
+          if (!reseeded) throw error
+          const retrySelected = this.cacheForBundle(spec, reseeded)
+          await runCreate(reseeded.lockPath, retrySelected.cache, retrySelected.budget)
+        }
       }
+    )
 
-      onProgress({
-        phase: `verify-${spec.language}`,
-        message: `Verifying ${spec.name} interpreter…`,
-        progress: 0.9
-      })
-      await this.deps.verify(bin, prefix)
-      onProgress({ phase: `${spec.language}-ready`, message: `${spec.name} ready`, progress: 0.95 })
-    } finally {
-      await journal.complete(operationId).catch(() => undefined)
-    }
+    onProgress({
+      phase: `verify-${spec.language}`,
+      message: `Verifying ${spec.name} interpreter…`,
+      progress: 0.9
+    })
+    await this.deps.verify(bin, prefix)
+    onProgress({ phase: `${spec.language}-ready`, message: `${spec.name} ready`, progress: 0.97 })
   }
 }
 
@@ -818,6 +1410,26 @@ export type ProductionProvisionerOptions = {
   // matters on the online paths.
   caBundle?: string
   cdnBase?: string
+  // Forwarded to ProvisionerDeps.isPrefixBlocked: lets the notebook service veto a prefix write the
+  // startup gate/UI would otherwise perform over a possibly-live orphan (see runtime-service).
+  isPrefixBlocked?: (prefix: string) => boolean
+  // Forwarded to ProvisionerDeps.clearPrefixBlock: an explicit user Reset clears the service's block.
+  clearPrefixBlock?: (prefix: string) => void
+  // Forwarded to ProvisionerDeps.clearRuntimeBlock: Reset also clears an interrupted install's runtime-ID
+  // block so bound sessions aren't rejected after the env rebuilds.
+  clearRuntimeBlock?: (runtimeId: string) => void
+  // Forwarded to ProvisionerDeps.clearCorruptBlock: a force Reset releases just the reset prefix from the
+  // global corrupt-journal barrier after moving the corrupt journal aside (other envs stay blocked).
+  clearCorruptBlock?: (prefix: string) => void
+  // Forwarded to ProvisionerDeps.blockPrefix: on an unconfirmed-child prefix-write failure, block the
+  // prefix in-process so an in-session retry can't race the possibly-live orphan.
+  blockPrefix?: (prefix: string) => void
+  // Forwarded to ProvisionerDeps.isPrefixLiveUnconfirmed: lets a force Reset refuse a prefix left
+  // live-unconfirmed by an interrupted install (or prefix write) this session.
+  isPrefixLiveUnconfirmed?: (prefix: string) => boolean
+  // Forwarded to ProvisionerDeps.withPrefixLock: shares the service's per-env install lock so a default
+  // env create/repair/upgrade never runs concurrently with an install into the same env prefix.
+  withPrefixLock?: <T>(envName: string, fn: () => Promise<T>) => Promise<T>
 }
 
 // Wires the real micromamba binary, CDN fetch, subprocess runner and interpreter verification into a
@@ -861,7 +1473,7 @@ export const createProductionProvisioner = (
       createLocalBundleAdapter(opts.root, bundleDir),
       createFetchBundleAdapter(opts.root, cdnBase)
     ]),
-    runArgv: (argv, signal, onChild, runCache, maxCacheRelativePath) =>
+    runArgv: (argv, signal, onChild, onBeforeSpawn, runCache, maxCacheRelativePath) =>
       runMicromamba(
         argv,
         micromambaSpawnEnv(
@@ -878,8 +1490,16 @@ export const createProductionProvisioner = (
           maxCacheRelativePath ?? DEFAULT_MAX_CACHE_RELATIVE_PATH
         ),
         signal,
-        onChild
+        onChild,
+        onBeforeSpawn
       ),
-    verify: (bin, prefix) => verifyExecutable(bin, { prefix, env: caEnv })
+    verify: (bin, prefix) => verifyExecutable(bin, { prefix, env: caEnv }),
+    isPrefixBlocked: opts.isPrefixBlocked,
+    clearPrefixBlock: opts.clearPrefixBlock,
+    clearRuntimeBlock: opts.clearRuntimeBlock,
+    clearCorruptBlock: opts.clearCorruptBlock,
+    blockPrefix: opts.blockPrefix,
+    isPrefixLiveUnconfirmed: opts.isPrefixLiveUnconfirmed,
+    withPrefixLock: opts.withPrefixLock
   })
 }

--- a/src/main/notebook/runtime-paths.ts
+++ b/src/main/notebook/runtime-paths.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
 import { delimiter, dirname, join, win32 } from 'node:path'
 
 import type { NotebookLanguage } from '../../shared/notebook'
@@ -186,12 +187,20 @@ export const readReadyMarker = (root: string): EnvReadyMarker | undefined => {
   }
 }
 
+// Atomically writes a ready marker (temp file + rename) so a crash mid-write can never leave a torn
+// marker that reads as neither present-and-valid nor absent — the restore path treats a marker write as
+// a commit point, so it must be all-or-nothing. Throws on failure (the caller decides whether that means
+// "keep the existing env" rather than rebuilding).
+const writeMarkerAtomic = (path: string, marker: EnvReadyMarker): void => {
+  mkdirSync(dirname(path), { recursive: true })
+  const temp = `${path}.${process.pid}-${randomUUID()}.tmp`
+  writeFileSync(temp, `${JSON.stringify(marker, null, 2)}\n`, 'utf8')
+  renameSync(temp, path)
+}
+
 // Writes .env-ready as pretty camelCase JSON, creating the runtime root if needed.
 export const writeReadyMarker = (root: string, version: number, preparedAt: string): void => {
-  const path = readyMarkerPath(root)
-  mkdirSync(dirname(path), { recursive: true })
-  const marker: EnvReadyMarker = { defaultEnvVersion: version, preparedAt }
-  writeFileSync(path, `${JSON.stringify(marker, null, 2)}\n`, 'utf8')
+  writeMarkerAtomic(readyMarkerPath(root), { defaultEnvVersion: version, preparedAt })
 }
 
 export const readRReadyMarker = (root: string): EnvReadyMarker | undefined => {
@@ -209,10 +218,7 @@ export const readRReadyMarker = (root: string): EnvReadyMarker | undefined => {
 }
 
 export const writeRReadyMarker = (root: string, version: number, preparedAt: string): void => {
-  const path = rReadyMarkerPath(root)
-  mkdirSync(dirname(path), { recursive: true })
-  const marker: EnvReadyMarker = { defaultEnvVersion: version, preparedAt }
-  writeFileSync(path, `${JSON.stringify(marker, null, 2)}\n`, 'utf8')
+  writeMarkerAtomic(rReadyMarkerPath(root), { defaultEnvVersion: version, preparedAt })
 }
 
 // True when a regular file exists at the path (mirrors Rust is_file()).

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -18,7 +18,13 @@ import {
 import { NotebookKernelExecutor } from './kernel-executor'
 import { effectiveMirrorAsync, resetAutoMirrorCache } from './mirror-probe'
 import { NotebookRunRepository, getRuntimeRoot } from './repository'
-import { RuntimeOperationJournal, operationJournalPath } from './operation-journal'
+import {
+  RuntimeOperationJournal,
+  operationJournalPath,
+  recordSpawnIntentSync
+} from './operation-journal'
+import { DefaultRuntimeProvisioner } from './provisioner'
+import { CHILD_UNCONFIRMED } from './provisioner-runtime'
 import type {
   InstallDeps as InstallDepsForTest,
   InstallRequest as InstallRequestForTest,
@@ -31,6 +37,7 @@ import {
   addRepairRequired,
   DEFAULT_ENV_VERSION,
   DEFAULT_PY_ENV,
+  DEFAULT_R_ENV,
   envPrefix,
   pythonBin,
   writeRReadyMarker
@@ -2180,7 +2187,9 @@ describe('notebook runtime service', () => {
           message: 'Could not prepare default-r: checksum mismatch',
           progress: 0,
           scope: 'r',
-          sessionId: 's'
+          sessionId: 's',
+          // Tagged so the Settings R card settles out of "preparing" on a first-use provision failure.
+          language: 'r'
         }
       ])
     })
@@ -3327,17 +3336,19 @@ describe('v4 runtime bindings & agent tools', () => {
     expect(installRan).toBe(false)
   })
 
-  it('blocks execute + install + provision on a prefix an unknown-liveness orphan may still hold', async () => {
+  it('blocks a no-binding execute + install on a DEFAULT prefix an unknown-liveness orphan may hold', async () => {
     // After recovery, an interrupted materialize whose child could NOT be confirmed dead ('unknown' —
     // here a live pid with no recorded start time) must leave its prefix BLOCKED for this process, so a
-    // fresh materialize/install/provision refuses rather than racing the possible survivor. Verifies the
-    // barrier resolving is not mistaken for "safe to write this prefix".
+    // fresh materialize/install refuses rather than racing the possible survivor. Verifies the barrier
+    // resolving is not mistaken for "safe to write this prefix". The provision/repair/restore side of
+    // this guarantee is exercised in provisioner.test.ts (the provisioner self-guards via the same
+    // isPrefixRecoveryBlocked predicate ipc.ts injects), and the named/external runtimeId side below.
     const root = await createStorageRoot()
     const runtimeRoot = getRuntimeRoot(root)
     const defaultPrefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
     const journal = new RuntimeOperationJournal(operationJournalPath(runtimeRoot))
-    // childPid alive (this process) + no childStartedAt => defaultOperationChildLiveness = 'unknown'
-    // deterministically, on every platform (it returns before consulting ps).
+    // childPid alive (this process) + no token => defaultOperationChildLiveness = 'unknown'
+    // deterministically, on every platform. childStartedAt is written atomically with childPid.
     await journal.begin({
       operationId: 'm',
       kind: 'materialize',
@@ -3345,6 +3356,7 @@ describe('v4 runtime bindings & agent tools', () => {
       phase: 'create',
       startedAt: 100,
       childPid: process.pid,
+      childStartedAt: 100,
       targetPath: defaultPrefix
     })
 
@@ -3360,8 +3372,10 @@ describe('v4 runtime bindings & agent tools', () => {
 
     await service.recoverInterruptedOperations()
 
-    // The default prefix is now recovery-blocked.
+    // The default prefix is now recovery-blocked — both via the language helper AND the raw-prefix
+    // predicate ipc.ts hands to the provisioner (so the startup gate self-guards through the same seam).
     expect(service.isDefaultEnvRecoveryBlocked('python')).toBe(true)
+    expect(service.isPrefixRecoveryBlocked(defaultPrefix)).toBe(true)
 
     // A no-binding execute (default env) fails rather than materializing over the blocked prefix.
     const run = await service.execute({ sessionId: 's', workspaceCwd: root, code: '1' })
@@ -3381,13 +3395,437 @@ describe('v4 runtime bindings & agent tools', () => {
     expect(installRan).toBe(false)
   })
 
-  it('restores a repaired binding to active across sessions after a successful repair install', async () => {
-    // A binding resolved while its runtime was repair-required is held unavailable/repair-required in
-    // memory. A completed repair install clears the disk flag AND must restore the in-memory binding to
-    // active (in every session), or it keeps refusing until a rebind.
+  it('re-derives the recovery block from the retained journal across sessions (persistent quarantine)', async () => {
+    // An unprobeable record is RETAINED (never auto-cleared on a guess), so the block is re-derived
+    // from the journal on every startup — a fresh service (a new session) blocks the same prefix. This
+    // is the service-side blockedPrefixes lifecycle: it lives only in memory and is rebuilt from the
+    // durable journal each session, so recovery only truly clears once the child is confirmed gone.
     const root = await createStorageRoot()
     const runtimeRoot = getRuntimeRoot(root)
-    // Flag the external runtime repair-required BEFORE binding, so the bind resolves it as unavailable.
+    const defaultPrefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    const journal = new RuntimeOperationJournal(operationJournalPath(runtimeRoot))
+    // Alive pid + NO childStartedAt => 'unknown' deterministically -> block + retain.
+    await journal.begin({
+      operationId: 'm',
+      kind: 'materialize',
+      runtimeId: DEFAULT_PY_ENV,
+      phase: 'create',
+      startedAt: 100,
+      childPid: process.pid,
+      childStartedAt: 100, // written atomically with childPid; alive + no token => 'unknown'
+      targetPath: defaultPrefix
+    })
+
+    // Session A blocks and RETAINS the record (does not clear it under a possible writer).
+    const serviceA = bindingService(root)
+    await serviceA.recoverInterruptedOperations()
+    expect(serviceA.isPrefixRecoveryBlocked(defaultPrefix)).toBe(true)
+    expect((await journal.pending()).map((r) => r.operationId)).toEqual(['m'])
+
+    // Session B (a fresh service on the same journal) re-derives the same block from the retained record.
+    const serviceB = bindingService(root)
+    await serviceB.recoverInterruptedOperations()
+    expect(serviceB.isPrefixRecoveryBlocked(defaultPrefix)).toBe(true)
+  })
+
+  it('integration: a real provisioner writes the spawn-intent sidecar; service recovery hydrates it and blocks', async () => {
+    // The production chain end-to-end (not mocks): a real DefaultRuntimeProvisioner rooted at the same
+    // runtime root the service recovers from journals the op + writes a synchronous spawn-intent sidecar
+    // before its create runs. We hang the create (simulating a crash mid-op that never records a PID),
+    // then a fresh service recovers from the SAME root: it hydrates the intent sidecar and BLOCKS the
+    // prefix (a child may be live), without probing/killing.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    const prefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    const provisioner = new DefaultRuntimeProvisioner({
+      root: runtimeRoot,
+      mm: '/mm',
+      channel: 'conda-forge',
+      fetchBundle: async (spec) => ({ lockPath: join(runtimeRoot, `${spec.name}.lock`) }),
+      // Real runMicromamba calls onBeforeSpawn right before spawning; mimic that (write the intent) then
+      // hang, modelling a crash after spawn but before the PID is recorded.
+      runArgv: (_argv, _signal, _onChild, onBeforeSpawn) => {
+        onBeforeSpawn?.()
+        return new Promise<void>(() => {})
+      },
+      verify: async () => undefined
+    })
+    void provisioner.provisionPython(() => {}) // leaves an interrupted materialize (do not await)
+
+    // Wait until the provisioner has journaled the op (its spawn-intent sidecar is written just before).
+    const journal = new RuntimeOperationJournal(operationJournalPath(runtimeRoot))
+    await vi.waitFor(async () => {
+      expect((await journal.pending()).some((r) => r.kind === 'materialize')).toBe(true)
+    })
+
+    const service = bindingService(root)
+    await service.recoverInterruptedOperations()
+    expect(service.isPrefixRecoveryBlocked(prefix)).toBe(true)
+  })
+
+  it('refuses an install when the journal cannot record it (begin fails closed, no spawn)', async () => {
+    // If the install can't be journaled for crash recovery, spawning the installer could strand a
+    // worker. managePackages must refuse with a structured error instead of installing.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    // Make the journal path unwritable: a FILE where the journal file's directory must be, so begin()'s
+    // mkdir/rename fails. operationJournalPath = <runtimeRoot>/operation-journal.json; block its parent.
+    await rm(runtimeRoot, { recursive: true, force: true })
+    // Replace the runtime root with a file so mkdir(dirname(journalPath)) fails on begin().
+    await writeFile(runtimeRoot, 'not-a-dir')
+
+    let installRan = false
+    const service = bindingService(root, {
+      installPackagesImpl: async () => {
+        installRan = true
+        return { ok: true, needsRestart: false, log: '' }
+      }
+    })
+    const result = await service.managePackages({
+      sessionId: 's',
+      workspaceCwd: root,
+      language: 'python',
+      packages: ['numpy']
+    })
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/RUNTIME_JOURNAL_UNWRITABLE/)
+    expect(installRan).toBe(false)
+  })
+
+  it('blocks a named-env REMOVE on a prefix an unknown-liveness orphan may still hold', async () => {
+    // After a restart there is no in-memory kernel state, so isEnvironmentLive() can't see a surviving
+    // installer — the prefix-block from recovery is the only thing standing between rm -rf and a live
+    // orphan still writing the named prefix. Assert the guard fires BEFORE the manager deletes anything.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    const namedPrefix = envPrefix(runtimeRoot, 'my-analysis')
+    const journal = new RuntimeOperationJournal(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'i',
+      kind: 'install',
+      runtimeId: 'my-analysis',
+      phase: 'install-python',
+      startedAt: 100,
+      childPid: process.pid, // alive + no token => 'unknown'
+      childStartedAt: 100, // written atomically with childPid
+      targetPath: namedPrefix
+    })
+
+    const removed: string[] = []
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      environmentManager: {
+        createNamedEnvironment: async (name, language) => ({
+          name,
+          language,
+          ready: true,
+          isDefault: false
+        }),
+        listEnvironments: () => [],
+        removeEnvironment: (name) => {
+          removed.push(name)
+          return []
+        }
+      }
+    })
+
+    await service.recoverInterruptedOperations()
+    expect(service.isPrefixRecoveryBlocked(namedPrefix)).toBe(true)
+
+    await expect(
+      service.manageEnvironments({ action: 'remove', name: 'my-analysis' })
+    ).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
+    // The rm -rf never reached the manager — nothing was deleted out from under a possible survivor.
+    expect(removed).toEqual([])
+  })
+
+  it('blocks a bound external execute + install by runtimeId after an interrupted external install', async () => {
+    // An external install writes the user's OWN env, not a path under runtimeRoot, so it is blocked by
+    // runtimeId (blockUnknownChildTarget), NOT a prefix. execute() and managePackages() must consume
+    // that runtimeId block for the bound runtime — the default-prefix guard alone would never fire here.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    const journal = new RuntimeOperationJournal(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'x',
+      kind: 'install',
+      runtimeId: userPyA.envId, // the external runtime's identity
+      phase: 'install-python',
+      startedAt: 100,
+      childPid: process.pid, // alive + no token => 'unknown'
+      childStartedAt: 100 // written atomically with childPid
+      // NOTE: no targetPath — an external install carries none (that is exactly the journal-target fix).
+    })
+
+    let installRan = false
+    const service = bindingService(root, {
+      discovered: [managedPy, userPyA],
+      enablement: {
+        enabled: { [userPyA.envId]: true },
+        installAuthorized: { [userPyA.envId]: true }
+      },
+      installPackagesImpl: async () => {
+        installRan = true
+        return { ok: true, needsRestart: false, log: '' }
+      }
+    })
+    await service.bindRuntime({
+      sessionId: 's',
+      workspaceCwd: root,
+      language: 'python',
+      runtimeId: userPyA.envId
+    })
+
+    await service.recoverInterruptedOperations()
+    // The external runtime is blocked by id; the app-managed DEFAULT prefix is NOT (no false-positive).
+    expect(service.isPrefixRecoveryBlocked(envPrefix(runtimeRoot, DEFAULT_PY_ENV))).toBe(false)
+
+    const run = await service.execute({ sessionId: 's', workspaceCwd: root, code: '1' })
+    expect(run.status).toBe('failed')
+    expect(run.text.traceback).toMatch(/RUNTIME_RECOVERY_BLOCKED/)
+
+    const install = await service.managePackages({
+      sessionId: 's',
+      workspaceCwd: root,
+      language: 'python',
+      packages: ['numpy']
+    })
+    expect(install.ok).toBe(false)
+    expect(install.error).toMatch(/RUNTIME_RECOVERY_BLOCKED/)
+    expect(installRan).toBe(false)
+  })
+
+  it('journals an external install by runtimeId with NO managed prefix as target', async () => {
+    // The bug: an external install recorded envPrefix(default) as its targetPath, so recovery would
+    // clean/block the unrelated app-managed default and never identify the real external runtime. Assert
+    // the in-flight journal record carries the external runtimeId and an UNDEFINED targetPath.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    const inspectJournal = new RuntimeOperationJournal(operationJournalPath(runtimeRoot))
+    let recordedDuringInstall: { runtimeId: string; targetPath?: string } | undefined
+
+    const service = bindingService(root, {
+      discovered: [managedPy, userPyA],
+      enablement: {
+        enabled: { [userPyA.envId]: true },
+        installAuthorized: { [userPyA.envId]: true }
+      },
+      installPackagesImpl: async () => {
+        // Read the journal WHILE the install is in flight (before the finally clears it).
+        const pending = await inspectJournal.pending()
+        const install = pending.find((r) => r.kind === 'install')
+        recordedDuringInstall = install
+          ? { runtimeId: install.runtimeId, targetPath: install.targetPath }
+          : undefined
+        return { ok: true, needsRestart: false, log: '' }
+      }
+    })
+    await service.bindRuntime({
+      sessionId: 's',
+      workspaceCwd: root,
+      language: 'python',
+      runtimeId: userPyA.envId
+    })
+
+    const result = await service.managePackages({
+      sessionId: 's',
+      workspaceCwd: root,
+      language: 'python',
+      packages: ['numpy']
+    })
+    expect(result.ok).toBe(true)
+    expect(recordedDuringInstall?.runtimeId).toBe(userPyA.envId)
+    expect(recordedDuringInstall?.targetPath).toBeUndefined()
+  })
+
+  it('refuses an install when the operation journal is corrupt (fail closed inside the lock)', async () => {
+    // begin() runs inside the env lock and throws on a corrupt journal; managePackages must map that to
+    // a structured refusal (no installer spawned) rather than proceeding without a recovery record.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    await mkdir(runtimeRoot, { recursive: true })
+    await writeFile(operationJournalPath(runtimeRoot), '{ not json', 'utf8')
+    let installRan = false
+    const service = bindingService(root, {
+      installPackagesImpl: async () => {
+        installRan = true
+        return { ok: true, needsRestart: false, log: '' }
+      }
+    })
+
+    const result = await service.managePackages({
+      sessionId: 's',
+      workspaceCwd: root,
+      language: 'python',
+      packages: ['numpy']
+    })
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/RUNTIME_JOURNAL_UNWRITABLE/)
+    expect(installRan).toBe(false)
+  })
+
+  it('blocks when a later spawn intent supersedes a stale journal PID (multi-spawn recovery)', async () => {
+    // Multi-spawn op (e.g. materialize's cache-repair retry): spawn #1's PID landed in the journal, then
+    // a second spawn was armed ({ spawning: true } sidecar) but crashed before its PID was recorded. The
+    // journal still names the (exited) first child. Trusting it would probe a dead pid, conclude 'dead',
+    // and clean the prefix while spawn #2 may still be writing. The sidecar is authoritative: a bare
+    // spawn intent must BLOCK regardless of the stale journal PID.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    const defaultPrefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    const journal = new RuntimeOperationJournal(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'm',
+      kind: 'materialize',
+      runtimeId: DEFAULT_PY_ENV,
+      phase: 'create',
+      startedAt: 100,
+      // A stale PID that is definitely GONE (would probe 'dead' and reconcile if trusted).
+      childPid: 2_147_483_646,
+      childStartedAt: 100,
+      targetPath: defaultPrefix
+    })
+    // The current spawn re-armed the sidecar to a bare intent (its PID never landed).
+    recordSpawnIntentSync(runtimeRoot, 'm')
+
+    const service = bindingService(root)
+    service.setDefaultEnvProvisioner({
+      provisionPython: async () => undefined,
+      provisionR: async () => undefined
+    })
+
+    await service.recoverInterruptedOperations()
+
+    // The sidecar intent wins over the stale journal PID -> the prefix is blocked, not reconciled.
+    expect(service.isPrefixRecoveryBlocked(defaultPrefix)).toBe(true)
+  })
+
+  it('fails safe on a corrupt operation journal by blocking the managed default prefixes', async () => {
+    // A corrupt/unreadable journal is NOT proof that nothing was in flight — an install may have been
+    // mid-write. Recovery can't know which prefix, so it blocks BOTH managed defaults for this session
+    // and leaves the journal untouched (a later boot / explicit Reset recovers), rather than reading it
+    // as empty and opening the barrier.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    await mkdir(runtimeRoot, { recursive: true })
+    await writeFile(operationJournalPath(runtimeRoot), '{ not json', 'utf8')
+
+    const service = bindingService(root)
+    await service.recoverInterruptedOperations()
+
+    expect(service.isPrefixRecoveryBlocked(envPrefix(runtimeRoot, DEFAULT_PY_ENV))).toBe(true)
+    expect(service.isPrefixRecoveryBlocked(envPrefix(runtimeRoot, DEFAULT_R_ENV))).toBe(true)
+    // The corrupt journal is left in place for a later boot to recover.
+    expect(existsSync(operationJournalPath(runtimeRoot))).toBe(true)
+  })
+
+  it('corrupt journal blocks ALL prefixes (not just the two managed defaults)', async () => {
+    // A corrupt journal means we can't enumerate what was in flight: a named env's orphan might still
+    // be writing, so blocking only the defaults would leave that env exposed. recoveryCorrupt must make
+    // isPrefixRecoveryBlocked return true for ANY prefix, including named-env and external targets.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    await mkdir(runtimeRoot, { recursive: true })
+    await writeFile(operationJournalPath(runtimeRoot), '{ not json', 'utf8')
+
+    const service = bindingService(root)
+    await service.recoverInterruptedOperations()
+
+    const namedPrefix = envPrefix(runtimeRoot, 'my-analysis')
+    const pyPrefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    expect(service.isPrefixRecoveryBlocked(namedPrefix)).toBe(true)
+    expect(service.isPrefixRecoveryBlocked(pyPrefix)).toBe(true)
+    // A force Reset releases only the prefix it reset from the global corrupt barrier — resetting the
+    // Python default must NOT unblock the named env (we can't know which env the corrupt journal's
+    // in-flight work targeted). The others stay blocked until their own Reset or a restart.
+    service.clearCorruptRecoveryBlock(pyPrefix)
+    expect(service.isPrefixRecoveryBlocked(pyPrefix)).toBe(false)
+    expect(service.isPrefixRecoveryBlocked(namedPrefix)).toBe(true)
+  })
+
+  it('lets an allowlisted default env EXECUTE cells after a corrupt-journal Reset (no restart needed)', async () => {
+    // Fix D: the execute path must gate a managed/default run by its per-prefix block (allowlist-aware),
+    // NOT the raw recoveryCorrupt flag. Otherwise a force-Reset Python env stays un-runnable until a
+    // restart even though its prefix was explicitly released. A DIFFERENT default (R) stays blocked.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    await mkdir(runtimeRoot, { recursive: true })
+    await writeFile(operationJournalPath(runtimeRoot), '{ not json', 'utf8')
+
+    const executions: NotebookExecutionRequest[] = []
+    const service = bindingService(root, { executions })
+    // A ready marker so the default-env readiness gate doesn't try to provision during execute.
+    service.setDefaultEnvProvisioner({
+      provisionPython: async () => undefined,
+      provisionR: async () => undefined
+    })
+    await service.recoverInterruptedOperations()
+
+    // Release ONLY the Python default prefix (what a force Reset of Python does via clearQuarantine).
+    service.clearCorruptRecoveryBlock(envPrefix(runtimeRoot, DEFAULT_PY_ENV))
+
+    // A no-binding Python execute now runs (reaches the executor) instead of failing recovery-blocked.
+    const pyRun = await service.execute({ sessionId: 's', workspaceCwd: root, code: '1' })
+    expect(pyRun.status).not.toBe('failed')
+    expect(executions.length).toBe(1)
+
+    // R was NOT reset, so its execute is still refused under the corrupt barrier.
+    const rRun = await service.execute({
+      sessionId: 's',
+      workspaceCwd: root,
+      language: 'r',
+      code: '1'
+    })
+    expect(rRun.status).toBe('failed')
+    expect(rRun.text.traceback).toMatch(/RUNTIME_RECOVERY_BLOCKED/)
+  })
+
+  it('blocks the install target in-process after an unconfirmed-child install failure, refusing a retry', async () => {
+    // An install whose worker could not be confirmed stopped leaves a possibly-live orphan. Retaining the
+    // journal record only guards the NEXT boot — so managePackages must ALSO block the runtimeId + prefix
+    // in THIS process, or an in-session retry would begin() a SECOND install racing the orphan. The
+    // installer throws the CHILD_UNCONFIRMED marker (recording failed, exit unconfirmed) on the first call
+    // only; the second must be refused before it ever runs.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    const pyPrefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    let installAttempts = 0
+    const service = bindingService(root, {
+      installPackagesImpl: async () => {
+        installAttempts += 1
+        throw new Error(`install failed: ${CHILD_UNCONFIRMED}`)
+      }
+    })
+
+    // The unconfirmed-child error propagates (only a begin() failure becomes a structured result); it is
+    // re-thrown after the in-process block is armed.
+    await expect(
+      service.managePackages({ language: 'python', packages: ['numpy'] })
+    ).rejects.toThrow(CHILD_UNCONFIRMED)
+    expect(installAttempts).toBe(1)
+    // The managed default's prefix is now blocked in-process (not just via the retained journal entry).
+    expect(service.isPrefixRecoveryBlocked(pyPrefix)).toBe(true)
+    // It is ALSO marked live-unconfirmed, so a force Reset this session refuses to delete it out from
+    // under the possibly-live installer (the provisioner reads this via the injected dep).
+    expect(service.isPrefixLiveUnconfirmed(pyPrefix)).toBe(true)
+
+    // An in-session retry is refused by the block — the installer is never spawned a second time.
+    const retry = await service.managePackages({ language: 'python', packages: ['numpy'] })
+    expect(retry.error).toMatch(/RUNTIME_RECOVERY_BLOCKED/)
+    expect(installAttempts).toBe(1)
+  })
+
+  it('restores a repaired binding to active in EVERY bound session after a successful repair install', async () => {
+    // A binding resolved while its runtime was repair-required is held unavailable/repair-required in
+    // memory. A completed repair install clears the disk flag AND must restore the in-memory binding to
+    // active in EVERY session that bound it — restoreRepairedBindings() walks all live sessions, so this
+    // uses TWO distinct sessions (s and t) bound to the SAME runtime and asserts both flip back.
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    // Flag the external runtime repair-required BEFORE binding, so each bind resolves it as unavailable.
     addRepairRequired(runtimeRoot, userPyA.envId)
     const service = bindingService(root, {
       discovered: [managedPy, userPyA],
@@ -3397,16 +3835,20 @@ describe('v4 runtime bindings & agent tools', () => {
       },
       installPackagesImpl: async () => ({ ok: true, needsRestart: false, log: '' })
     })
-    const bound = await service.bindRuntime({
-      sessionId: 's',
-      workspaceCwd: root,
-      language: 'python',
-      runtimeId: userPyA.envId
-    })
-    // Bound but unavailable/repair-required (installable — completing the install is the repair).
-    expect(bound.bound.status).toBe('unavailable')
-    expect(bound.bound.reason).toBe('repair-required')
 
+    // Bind the same repair-required runtime in two separate sessions.
+    for (const sessionId of ['s', 't']) {
+      const bound = await service.bindRuntime({
+        sessionId,
+        workspaceCwd: root,
+        language: 'python',
+        runtimeId: userPyA.envId
+      })
+      expect(bound.bound.status).toBe('unavailable')
+      expect(bound.bound.reason).toBe('repair-required')
+    }
+
+    // Repair via a completed install issued from session s only.
     const result = await service.managePackages({
       sessionId: 's',
       workspaceCwd: root,
@@ -3415,10 +3857,12 @@ describe('v4 runtime bindings & agent tools', () => {
     })
     expect(result.ok).toBe(true)
 
-    // The binding is now active again in the live session (not just the disk flag cleared).
-    const state = await service.state({ sessionId: 's', workspaceCwd: root })
-    expect(state.runtimeBindings.python?.status).toBe('active')
-    expect(state.runtimeBindings.python?.reason).toBeUndefined()
+    // BOTH sessions' bindings are active again — including session t, which never issued the install.
+    for (const sessionId of ['s', 't']) {
+      const state = await service.state({ sessionId, workspaceCwd: root })
+      expect(state.runtimeBindings.python?.status).toBe('active')
+      expect(state.runtimeBindings.python?.reason).toBeUndefined()
+    }
   })
 
   it('revokes a disabled runtime from a bound session so execution rejects (no silent fallback)', async () => {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -75,8 +75,20 @@ import {
   rscriptFor,
   windowsCondaPrefixForR
 } from './environment-discovery'
-import { operationJournalPath, RuntimeOperationJournal } from './operation-journal'
-import { reconcileInterruptedOperations, defaultOperationChildLiveness } from './operation-recovery'
+import {
+  operationJournalPath,
+  readOperationChild,
+  recordOperationChildSync,
+  recordSpawnIntentSync,
+  removeOperationChildSync,
+  RuntimeOperationJournal
+} from './operation-journal'
+import {
+  reconcileInterruptedOperations,
+  defaultOperationChildLiveness,
+  readProcessStartToken
+} from './operation-recovery'
+import { isChildUnconfirmedError } from './provisioner-runtime'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import { terminateProcessTree } from '../process-tree'
 
@@ -748,6 +760,33 @@ class NotebookRuntimeService {
   // is not enough, since the op wasn't actually reconciled. A later restart re-runs recovery against the
   // retained journal entry: if the pid is gone/verifiable then, it reconciles and the prefix clears.
   private readonly blockedPrefixes = new Set<string>()
+  // Runtime IDs an interrupted INSTALL left possibly-live (recovery couldn't confirm the child died).
+  // Prefix-keyed blocking doesn't fit an install: an EXTERNAL install writes the user's OWN env (not a
+  // path under runtimeRoot) and a managed named install's identity is its runtimeId, so execute() and
+  // managePackages() refuse a BOUND runtime by its runtimeId here — while managed materialize/create/
+  // remove/startup maintenance keep refusing by real prefix (blockedPrefixes). Cleared the same way:
+  // a later restart re-runs recovery and, once the pid is gone/verifiable, reconciles the journal entry.
+  private readonly blockedRuntimeIds = new Set<string>()
+  // GLOBAL write barrier set when the operation journal itself is corrupt/unreadable. A corrupt journal
+  // means we CANNOT enumerate what was in flight, so we can't know which prefix (if any) an orphan might
+  // still be writing — blocking only the two managed defaults (the original fix) left a possibly-live
+  // NAMED env, or an external install, free to be rm -rf'd. This flag makes every recovery-blocked check
+  // below (prefix, default-env, runtimeId) refuse EVERYTHING until an explicit Reset moves the corrupt
+  // journal aside (clearCorruptRecoveryBlock).
+  private recoveryCorrupt = false
+  // Prefixes an explicit force Reset released from recoveryCorrupt (see clearCorruptRecoveryBlock). While
+  // recoveryCorrupt is set (a corrupt journal blocks all prefixes), a prefix listed here is exempt — its
+  // env was reset and its corrupt journal moved aside, so it can rebuild while every OTHER env stays
+  // blocked. Empty on the normal path (recoveryCorrupt false makes it moot). Cleared implicitly on the
+  // next boot, which reads the now-absent journal and never sets recoveryCorrupt again.
+  private readonly corruptResetAllowlist = new Set<string>()
+  // Prefixes a write in THIS process left with a child we could not confirm stopped (an orphan MAY still
+  // be writing). A subset of blockedPrefixes, but tracked separately because a force Reset must treat it
+  // DIFFERENTLY from an ordinary recovery block: an ordinary block came from a PRIOR boot (the spawning
+  // process is gone, so Reset may delete+rebuild), whereas a live-unconfirmed prefix's orphan could still
+  // be running NOW — Reset must refuse it until a restart. Read by the provisioner via the injected
+  // isPrefixLiveUnconfirmed dep (clearQuarantine). Per-process, so it is empty after a restart.
+  private readonly liveUnconfirmedPrefixes = new Set<string>()
   private readonly runtimeDiscoveryImpl: (
     language: NotebookLanguage
   ) => Promise<DiscoveredInterpreter[]>
@@ -851,7 +890,11 @@ class NotebookRuntimeService {
       else await provisioner.provisionPython(reportProgress)
     } catch (error) {
       const message = `Could not prepare ${env}: ${error instanceof Error ? error.message : String(error)}`
-      reportProgress({ phase: 'error', message, progress: 0 })
+      // Tag the language so the Settings card for THIS runtime settles out of "preparing" — a first-use
+      // (auto) provision emits language-tagged progress, so an untagged error would leave the card
+      // spinning forever (the store only settles a slot on a language-tagged done/error). reportProgress
+      // also stamps scope + sessionId so the run stays attributed to this env.
+      reportProgress({ phase: 'error', message, progress: 0, language })
       throw new Error(message, { cause: error })
     }
   }
@@ -1381,7 +1424,30 @@ class NotebookRuntimeService {
     // run history for the agent to inspect.
     let interpreterResolveError: unknown
     const binding = session.runtimeBindings.get(cell.language)
-    if (binding && (binding.status ?? 'active') !== 'active') {
+    // A managed/default run is gated by its real prefix via isPrefixRecoveryBlocked, which folds in the
+    // corrupt-journal barrier AND honours a force Reset's per-prefix allowlist — so a reset (allowlisted)
+    // env runs cells again without a restart. An EXTERNAL run has no managed prefix, so it keeps the raw
+    // corrupt catch-all (plus its runtimeId block). resolveRunEnv gave us the env name above.
+    const isExternal = binding?.source === 'external'
+    const prefixBlocked =
+      !isExternal &&
+      this.isPrefixRecoveryBlocked(envPrefix(getRuntimeRoot(this.options.dataRoot), env))
+    if (
+      (binding?.runtimeId && this.blockedRuntimeIds.has(binding.runtimeId)) ||
+      prefixBlocked ||
+      (isExternal && this.recoveryCorrupt)
+    ) {
+      // Recovery flagged this BOUND runtime possibly-live after an interrupted install (external or a
+      // managed named env) — OR its managed prefix is recovery-blocked (per-prefix block or a not-yet-
+      // reset corrupt journal) — OR an external run under a corrupt journal we can't enumerate.
+      // ensureDefaultEnvReady only guards the DEFAULT prefix, so without this check a named/external run
+      // would proceed over an env a survivor may still be writing. Fail with the actionable message.
+      interpreterResolveError = new Error(
+        `RUNTIME_RECOVERY_BLOCKED: the bound ${cell.language} runtime is recovering from an interrupted ` +
+          'operation whose worker process could not be confirmed stopped, so running it now could ' +
+          'corrupt it. Restart the app to re-check and recover it before running cells.'
+      )
+    } else if (binding && (binding.status ?? 'active') !== 'active') {
       // No silent fallback: a disabled/unavailable bound runtime FAILS the run with an actionable
       // message rather than quietly running a different interpreter (the user would wrongly assume
       // their vars/packages/interpreter are unchanged). The agent recovers via list → switch. See
@@ -1999,12 +2065,22 @@ class NotebookRuntimeService {
       }
     }
 
-    // Refuse if recovery left the install target prefix blocked (an unknown-liveness orphan may still be
-    // writing it) — installing into a possibly-live env could corrupt it. Checked for every binding
-    // kind, since even an external install journals this prefix as its target. Returned as a structured
-    // error (not thrown) to match managePackages' other refusals — a tool call shouldn't surface a raw
-    // exception.
-    if (this.blockedPrefixes.has(envPrefix(runtimeRoot, envName))) {
+    // Refuse if recovery left this install's target possibly-live (an unknown-liveness orphan may still
+    // be writing it). An EXTERNAL binding is keyed by runtimeId (its real target is the user's own env,
+    // not a path under runtimeRoot — so the app-managed default prefix must NOT gate it); a managed/
+    // default target is keyed by its real prefix, plus its runtimeId for a bound managed named env.
+    // Returned as a structured error (not thrown) to match managePackages' other refusals.
+    const isExternal = binding?.source === 'external'
+    const runtimeIdBlocked =
+      binding?.runtimeId !== undefined && this.blockedRuntimeIds.has(binding.runtimeId)
+    // A managed/default install is gated by its real prefix via isPrefixRecoveryBlocked, which already
+    // folds in the corrupt-journal barrier AND honours a force Reset's per-prefix allowlist — so a reset
+    // (allowlisted) default env can be installed into again while other envs stay blocked. An EXTERNAL
+    // install has no managed prefix to key that allowlist on, so it keeps the raw corrupt catch-all.
+    const prefixBlocked =
+      !isExternal && this.isPrefixRecoveryBlocked(envPrefix(runtimeRoot, envName))
+    const corruptBlockedExternal = isExternal && this.recoveryCorrupt
+    if (runtimeIdBlocked || prefixBlocked || corruptBlockedExternal) {
       return {
         ok: false,
         needsRestart: false,
@@ -2021,18 +2097,14 @@ class NotebookRuntimeService {
     // never silently assumed to have succeeded. runtimeId is the bound runtime's identity (its envId)
     // so recovery flags exactly this env. Best-effort journal I/O; cleared in the finally on completion.
     const repairRuntimeId = binding?.runtimeId ?? envName
+    // targetPath is the app-managed prefix ONLY for a managed/default install — an EXTERNAL install
+    // writes the user's own env (outside runtimeRoot), so recording the default prefix here would make
+    // recovery wrongly clean/block the unrelated managed default. Recovery then blocks an external
+    // install by its runtimeId (blockUnknownChildTarget) instead of a prefix.
+    const journalTarget =
+      binding?.source === 'external' ? undefined : envPrefix(runtimeRoot, envName)
     const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
     const operationId = randomUUID()
-    await journal
-      .begin({
-        operationId,
-        kind: 'install',
-        runtimeId: repairRuntimeId,
-        phase: `install-${request.language}`,
-        startedAt: Date.now(),
-        targetPath: envPrefix(runtimeRoot, envName)
-      })
-      .catch(() => undefined)
     // The install target is the binding-resolved envName — NOT request.environment. v4 dropped the
     // per-call environment argument, but the package manager still reads req.environment (and the local
     // RPC forwards the raw request), so an old/direct caller could otherwise install into a DIFFERENT
@@ -2040,25 +2112,91 @@ class NotebookRuntimeService {
     // four agree.
     const pinnedRequest = { ...request, environment: envName }
     let result: InstallResult
+    let retainForRecovery = false
+    let begun = false // did journal.begin() succeed? distinguishes a begin failure from an install error
     try {
-      result = await this.envLock.withInstall(envName, () =>
-        this.installPackagesImpl(pinnedRequest, {
+      // Record the install intent INSIDE the env lock, not before it. A concurrent Reset holds this same
+      // env lock while it clearQuarantine()s the prefix's journal records; recording before acquiring the
+      // lock let the Reset delete THIS record between our begin() and the install starting, after which
+      // journal.update() no-ops and a crash would strand a sidecar with no journal record recovery scans.
+      result = await this.envLock.withInstall(envName, async () => {
+        // Fail CLOSED, like the provisioner's prefix writes: if we can't record the intent (journal
+        // begin — also throws on a corrupt journal), do NOT spawn the installer; a crash would otherwise
+        // leave an unrecorded child recovery can't reap. The begun flag routes this to a structured
+        // refusal below. (The per-spawn intent sidecar is re-armed by onBeforeSpawn, before EACH spawn.)
+        await journal.begin({
+          operationId,
+          kind: 'install',
+          runtimeId: repairRuntimeId,
+          phase: `install-${request.language}`,
+          startedAt: Date.now(),
+          targetPath: journalTarget
+        })
+        begun = true
+        return this.installPackagesImpl(pinnedRequest, {
           storageRoot: this.options.dataRoot,
           condaChannel: mirror.condaChannel,
           pypiIndex: mirror.pypiIndex,
           cranMirror: mirror.cranMirror,
           caBundle: mirror.caBundle,
           interpreter,
-          // Record each installer child's PID so startup recovery can kill a surviving conda/pip/R
-          // install before flagging the env repair-required.
-          onChild: (childPid) =>
+          // Re-arm the per-spawn intent immediately before EACH installer spawn (conda then CRAN), so a
+          // second spawn whose PID isn't recorded yet blocks rather than trusting the first's PID.
+          onBeforeSpawn: () => recordSpawnIntentSync(runtimeRoot, operationId),
+          // Record each installer child's PID so startup recovery can block on a surviving conda/pip/R
+          // install (never reconcile the env under it) until it is provably gone. Recovery never signals
+          // the child. Persisted SYNCHRONOUSLY (crash-safe) so a spawned child is always probeable; the
+          // async journal update is the normal read path.
+          onChild: (childPid) => {
+            const childStartedAt = Date.now()
+            // Kernel-native identity token captured while the child is alive, so recovery can FALSIFY
+            // pid reuse (a changed token proves the pid is no longer ours); undefined off Linux — see
+            // readProcessStartToken. Never used to authorize a signal.
+            const childStartToken = readProcessStartToken(childPid)
+            recordOperationChildSync(runtimeRoot, operationId, {
+              childPid,
+              childStartedAt,
+              childStartToken
+            })
             void journal
-              .update(operationId, { childPid, childStartedAt: Date.now() })
+              .update(operationId, { childPid, childStartedAt, childStartToken })
               .catch(() => undefined)
+          }
         })
-      )
+      })
+    } catch (error) {
+      // begin() failed (nothing spawned) → structured fail-closed refusal, no cleanup needed.
+      if (!begun) {
+        return {
+          ok: false,
+          needsRestart: false,
+          log: '',
+          error:
+            'RUNTIME_JOURNAL_UNWRITABLE: could not record this install for crash recovery, so it was ' +
+            `not started (installing without a recovery record could strand a worker process). ${
+              error instanceof Error ? error.message : String(error)
+            }`
+        }
+      }
+      // A recording failure whose installer couldn't be confirmed stopped: keep the sidecar + journal
+      // record so recovery blocks (a worker may still be writing) instead of clearing the evidence.
+      if (isChildUnconfirmedError(error)) {
+        retainForRecovery = true
+        // Block IN THIS PROCESS now, not just via the retained journal entry (which only guards the next
+        // boot): otherwise an in-session retry would pass the guard above and begin() a SECOND install,
+        // spawning an installer that races the first's possibly-live orphan. Block the bound runtimeId
+        // (the install's identity — external or managed named) and, for a managed install, its prefix.
+        // blockPrefixRecovery ALSO marks the prefix live-unconfirmed, so a force Reset this session
+        // refuses to delete + rebuild it out from under the possibly-live installer (clearQuarantine).
+        this.blockedRuntimeIds.add(repairRuntimeId)
+        if (journalTarget) this.blockPrefixRecovery(journalTarget)
+      }
+      throw error
     } finally {
-      await journal.complete(operationId).catch(() => undefined)
+      if (begun && !retainForRecovery) {
+        removeOperationChildSync(runtimeRoot, operationId)
+        await journal.complete(operationId).catch(() => undefined)
+      }
     }
     // A completed install of this runtime clears any prior repair-required flag: re-running the install
     // to completion IS the repair, so the runtime returns to a known-good state. Clearing the disk flag
@@ -2136,6 +2274,11 @@ class NotebookRuntimeService {
         // Let startup recovery finish before rm -rf'ing a prefix, same barrier create uses: recovery's
         // verify/rebuild of an interrupted op could otherwise race this delete on the same prefix.
         await this.ensureRecovered()
+        // Refuse if recovery flagged this prefix possibly-live (an unknown-liveness orphan may still be
+        // writing it). After a restart there is no in-memory kernel state, so isEnvironmentLive() above
+        // can't see a surviving installer — without this, rm -rf could delete a named prefix a survivor
+        // is still writing. Mirrors the 'create' guard; keyed by the same real prefix.
+        this.assertPrefixRecoverable(envPrefix(getRuntimeRoot(this.options.dataRoot), name))
         // Serialize the rm -rf against a concurrent install into the same env (design D4 / review A).
         return this.envLock.withInstall(name, async () => ({
           environments: manager.removeEnvironment(name)
@@ -2173,11 +2316,12 @@ class NotebookRuntimeService {
   }
 
   // Crash recovery (WS13): reconcile any runtime operation the previous process left in flight. Run
-  // ONCE at app startup, before new fetches/installs. For each journalled op: kill a surviving orphan
-  // child, then clean its staging / verify its prefix / flag it repair-required, then clear the entry.
-  // Best-effort — a failure is logged and the entry retried next startup. The download (staging
-  // cleanup), materialize (verify/rebuild the env prefix), and install (flag repair-required) paths all
-  // populate the journal, so each reconcile action below is wired to a real effect.
+  // ONCE at app startup, before new fetches/installs. For each journalled op: if a surviving orphan child
+  // MIGHT still be running, BLOCK its target and leave the entry (recovery never signals the orphan);
+  // only once the child is provably gone does it clean staging / verify the prefix / flag repair-required,
+  // then clear the entry. Best-effort — a failure is logged and the entry retried next startup. The
+  // download (staging cleanup), materialize (verify/rebuild the env prefix), and install (flag
+  // repair-required) paths all populate the journal, so each reconcile action below is wired to a real effect.
   async recoverInterruptedOperations(): Promise<void> {
     // Publish the in-flight recovery so new prefix-touching operations (materialize/install) can await
     // it — otherwise an old op's cleanup/delete could race a fresh fetch/install on the same prefix.
@@ -2202,7 +2346,7 @@ class NotebookRuntimeService {
   // Called by every path that would WRITE an env prefix, so an unknown-liveness orphan actually blocks
   // the write this session instead of only leaving a journal entry for next boot.
   private assertPrefixRecoverable(prefix: string): void {
-    if (this.blockedPrefixes.has(prefix)) {
+    if (this.isPrefixRecoveryBlocked(prefix)) {
       throw new Error(
         `RUNTIME_RECOVERY_BLOCKED: a previous operation on "${prefix}" was interrupted and its worker ` +
           'process could not be confirmed stopped, so writing this environment now could corrupt it. ' +
@@ -2219,22 +2363,125 @@ class NotebookRuntimeService {
       getRuntimeRoot(this.options.dataRoot),
       language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
     )
-    return this.blockedPrefixes.has(prefix)
+    return this.isPrefixRecoveryBlocked(prefix)
+  }
+
+  // Whether an arbitrary env prefix is recovery-blocked. Injected into the provisioner (ipc.ts) so its
+  // startup restore/upgrade/repair and named create self-refuse a possibly-live prefix — the guarantee
+  // the barrier alone didn't give the startup gate. Keyed by real prefix, matching blockedPrefixes.
+  // recoveryCorrupt (a corrupt journal — see runRecovery) blocks EVERY prefix, not just a specific one:
+  // an unreadable journal means we can't rule out an orphan writing an arbitrary (including named) env.
+  // A force Reset can exempt ONE prefix from that global block (corruptResetAllowlist) so it rebuilds
+  // while the others stay blocked; the explicit per-prefix block (blockedPrefixes) still applies to it.
+  isPrefixRecoveryBlocked(prefix: string): boolean {
+    if (this.blockedPrefixes.has(prefix)) return true
+    return this.recoveryCorrupt && !this.corruptResetAllowlist.has(prefix)
+  }
+
+  // Drops the in-memory recovery block for a prefix. Called by an EXPLICIT user recovery (repair with
+  // force, wired via ipc.ts) so a quarantined runtime can be reset. The provisioner also clears the
+  // retained journal record + sidecar for the prefix, so the quarantine won't re-arm next startup.
+  clearRecoveryBlock(prefix: string): void {
+    this.blockedPrefixes.delete(prefix)
+  }
+
+  // Drops the in-memory recovery block for a runtime ID. An interrupted INSTALL blocks the bound
+  // runtimeId (not a prefix), so a prefix-only Reset would rebuild the env yet still leave bound
+  // sessions rejected by blockedRuntimeIds until the next restart. The provisioner's Reset collects the
+  // runtimeIds of the retained install records for the reset prefix and clears them here too.
+  clearRuntimeRecoveryBlock(runtimeId: string): void {
+    this.blockedRuntimeIds.delete(runtimeId)
+  }
+
+  // Releases ONE prefix from the global corrupt-journal write barrier. Called by a force Reset (via the
+  // provisioner's clearQuarantine) after it has moved that env's corrupt journal aside. A corrupt journal
+  // means we can't know which env had in-flight work, so resetting Python must NOT unblock R, named, and
+  // external targets — they stay blocked (recoveryCorrupt still true) until their own Reset or a restart
+  // (which re-reads the now-absent journal and clears the barrier entirely). The user accepted the risk
+  // for the prefix they explicitly reset, and only that prefix. Idempotent.
+  clearCorruptRecoveryBlock(prefix: string): void {
+    this.corruptResetAllowlist.add(prefix)
+  }
+
+  // Records, in THIS process, that a prefix write failed with a child we could not confirm stopped — a
+  // worker MAY still be writing it. Blocks it immediately so an in-session retry can't begin() a second
+  // concurrent op onto the same prefix (the retained journal record only guards the next boot), AND marks
+  // it live-unconfirmed so a force Reset this session refuses to delete it out from under that orphan.
+  // Injected into the provisioner as blockPrefix (ipc.ts), and called directly by the install path.
+  blockPrefixRecovery(prefix: string): void {
+    this.blockedPrefixes.add(prefix)
+    this.liveUnconfirmedPrefixes.add(prefix)
+  }
+
+  // True when a write in THIS process left `prefix` with a child that could not be confirmed stopped (see
+  // blockPrefixRecovery). The provisioner consults this (injected) in clearQuarantine to REFUSE a force
+  // Reset that would otherwise delete + rebuild the prefix while that orphan may still be writing it. It
+  // is only the PER-PROCESS view: it goes false after a restart, but that does NOT by itself authorize a
+  // Reset — an app restart does not prove a reparented orphan exited. On the next launch, recovery re-gates
+  // from the DURABLE journal/sidecar and clears the block only once the child is provably gone (pid ESRCH /
+  // reused) or, for a no-PID orphan, a Linux machine-reboot proof (boot_id changed).
+  isPrefixLiveUnconfirmed(prefix: string): boolean {
+    return this.liveUnconfirmedPrefixes.has(prefix)
+  }
+
+  // Runs fn under the SAME exclusive per-env lock that package installs use (envLock.withInstall), so a
+  // default-env materialize/repair/upgrade in the provisioner serializes with an install into that env
+  // instead of racing it on a separate lock. Injected into the provisioner as withPrefixLock (ipc.ts).
+  // Keyed by env NAME, matching managePackages/named-env create/remove. The provisioner only calls this
+  // from its top-level entries (never re-entrantly), so it cannot deadlock against itself.
+  withEnvLock<T>(envName: string, fn: () => Promise<T>): Promise<T> {
+    return this.envLock.withInstall(envName, fn)
   }
 
   private async runRecovery(): Promise<void> {
-    const journal = RuntimeOperationJournal.forPath(
-      operationJournalPath(getRuntimeRoot(this.options.dataRoot))
-    )
-    await reconcileInterruptedOperations(journal, {
+    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    // Fail SAFE on a corrupt/unreadable journal: reconcileInterruptedOperations would read it as empty
+    // (nothing in flight) and open the recovery barrier, but a corrupt journal is NOT proof that no op
+    // was interrupted — an install/materialize may have been mid-write into ANY prefix (default, named,
+    // or an external install's runtimeId). We can't know which, so block EVERYTHING for this session
+    // (recoveryCorrupt — checked by every isPrefixRecoveryBlocked/isDefaultEnvRecoveryBlocked/
+    // assertPrefixRecoverable call, including named-env remove, which carries no journal record of its
+    // own and previously only checked the per-prefix set) and leave the journal untouched so a later
+    // boot — or an explicit Reset, which moves it aside — can recover.
+    if ((await journal.readState()) === 'corrupt') {
+      console.error(
+        '[notebook] operation journal is unreadable; blocking all runtime writes until recovery'
+      )
+      this.recoveryCorrupt = true
+      return
+    }
+    const reconciled = await reconcileInterruptedOperations(journal, {
       operationChildLiveness: defaultOperationChildLiveness,
-      terminateOperationChild: async (record) => {
-        if (record.childPid === undefined) return
-        try {
-          process.kill(record.childPid, 'SIGKILL')
-        } catch {
-          // Already gone — nothing to kill.
-        }
+      // Resolve the spawn lifecycle from the synchronous sidecar (see operation-journal): a recorded PID
+      // (recovering one the async journal update lost) is probed; a "spawning" intent with no PID means
+      // a child MAY be live so recovery must block (spawnAttempted); no sidecar means the op never
+      // reached the spawn stage and is safe to reconcile. Never a wall-clock guess.
+      hydrateInterruptedChild: (record) => {
+        // The synchronous sidecar is the AUTHORITATIVE record of the CURRENT spawn lifecycle: it is
+        // re-armed ({ spawning: true }) before EVERY spawn and converted to the PID on each spawn, so it
+        // always reflects the latest spawn. The journal's async childPid can be STALE — an op that
+        // spawns twice (materialize's cache-repair retry, or R's conda→CRAN) records spawn #1's PID in
+        // the journal; if it then crashed after spawn #2 started but before spawn #2's PID landed, the
+        // journal still names the (exited) first child. Trusting that would probe a dead pid, conclude
+        // 'dead', and clean the prefix while spawn #2 is still writing. So read the sidecar FIRST and let
+        // it override the journal.
+        const state = readOperationChild(runtimeRoot, record.operationId)
+        if (state === undefined) return record // no sidecar (legacy) -> fall back to the journal PID
+        // 'corrupt' (present but unreadable/invalid) or a bare spawn intent -> a child MAY be live but its
+        // PID is unknown. Block, and DROP any stale journal PID so recovery doesn't probe an earlier,
+        // already-exited child and wrongly conclude the target is free.
+        if (state === 'corrupt' || 'spawning' in state)
+          return {
+            ...record,
+            childPid: undefined,
+            childStartedAt: undefined,
+            childStartToken: undefined,
+            spawnAttempted: true
+          }
+        // Sidecar has the current PID -> probe it (overrides the journal). Its childStartToken (present
+        // only when the sidecar carried one) rides along in the spread as the authoritative identity.
+        return { ...record, ...state }
       },
       cleanStaging: async (record) => {
         if (record.targetPath) await rm(record.targetPath, { recursive: true, force: true })
@@ -2270,9 +2517,20 @@ class NotebookRuntimeService {
       // and commits by atomic rename, so an orphaned download can't corrupt a fresh fetch (a later
       // startup reaps the leftover). Its targetPath is that staging dir, which nothing else writes.
       blockUnknownChildTarget: async (record) => {
+        // An INSTALL is identified by its runtimeId, not a managed prefix: an external install's target
+        // is the user's own env (no path under runtimeRoot) and a managed named install's identity is
+        // its runtimeId. Block the runtimeId so execute()/managePackages() refuse the bound runtime.
+        if (record.kind === 'install') this.blockedRuntimeIds.add(record.runtimeId)
+        // materialize/upgrade name the real managed prefix they write — block it so managed materialize/
+        // create/remove/startup maintenance refuse it. (An external install carries no targetPath, so
+        // it never wrongly blocks the app-managed default here.)
         if (record.targetPath) this.blockedPrefixes.add(record.targetPath)
       }
     })
+    // Reconciled records are cleared from the journal, so their PID sidecars are now inert — remove them
+    // so they don't accumulate. A retained (unknown-blocked) record keeps its sidecar for the next
+    // startup's liveness probe.
+    for (const record of reconciled) removeOperationChildSync(runtimeRoot, record.operationId)
   }
 
   // Shuts down every live interpreter, used by app-level cleanup paths. Returns { reaped }: true only

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -342,7 +342,7 @@ interface OpenScienceAPI {
     getStatus(): Promise<ProvisionStatus>
     provision(lang: NotebookLanguage): Promise<void>
     repair(lang: NotebookLanguage): Promise<void>
-    cancel(): Promise<void>
+    cancel(lang?: NotebookLanguage): Promise<void>
     onProgress(listener: (progress: ProvisionProgress) => void): RemoveListener
   }
   runtime: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -377,7 +377,7 @@ type OpenScienceAPI = {
     getStatus: () => Promise<ProvisionStatus>
     provision: (lang: NotebookLanguage) => Promise<void>
     repair: (lang: NotebookLanguage) => Promise<void>
-    cancel: () => Promise<void>
+    cancel: (lang?: NotebookLanguage) => Promise<void>
     onProgress: (listener: (progress: ProvisionProgress) => void) => RemoveListener
   }
   runtime: {
@@ -764,7 +764,8 @@ const api: OpenScienceAPI = {
     getStatus: () => ipcRenderer.invoke('notebook-env:status') as Promise<ProvisionStatus>,
     provision: (lang) => ipcRenderer.invoke('notebook-env:provision', lang) as Promise<void>,
     repair: (lang) => ipcRenderer.invoke('notebook-env:repair', lang) as Promise<void>,
-    cancel: () => ipcRenderer.invoke('notebook-env:cancel') as Promise<void>,
+    cancel: (lang?: NotebookLanguage) =>
+      ipcRenderer.invoke('notebook-env:cancel', lang) as Promise<void>,
     onProgress: (listener) => onIpcMessage('notebook-env:progress', listener)
   },
   runtime: {

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.env.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.env.render.test.tsx
@@ -61,11 +61,12 @@ const provision = vi.fn(async () => {})
 const init = vi.fn(async () => {})
 const retry = vi.fn(async () => {})
 const cancel = vi.fn(async () => {})
+const reset = vi.fn(async () => {})
 
 beforeEach(() => {
   // Full replace (needs every action typed) so a stray real bridge call can never sneak in.
   useNotebookEnvStore.setState(
-    { ...createInitialNotebookEnvState(), init, provision, cancel, retry },
+    { ...createInitialNotebookEnvState(), init, provision, cancel, retry, reset },
     true
   )
   // The wizard reads storage info on mount (main's data-root step); stub it so the effect resolves.

--- a/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
@@ -55,6 +55,7 @@ let registerInterpreter: ReturnType<typeof vi.fn>
 let pickInterpreter: ReturnType<typeof vi.fn>
 let provision: ReturnType<typeof vi.fn>
 let cancelBridge: ReturnType<typeof vi.fn>
+let repairBridge: ReturnType<typeof vi.fn>
 
 const provisionStatus: ProvisionStatus = {
   pythonReady: false,
@@ -86,6 +87,7 @@ beforeEach(() => {
   pickInterpreter = vi.fn().mockResolvedValue('/usr/bin/python3')
   provision = vi.fn().mockRejectedValue(new Error('runtime CDN unavailable'))
   cancelBridge = vi.fn().mockResolvedValue(undefined)
+  repairBridge = vi.fn().mockResolvedValue(undefined)
   ;(window as unknown as { api: unknown }).api = {
     runtime: {
       listEnvironments,
@@ -100,7 +102,8 @@ beforeEach(() => {
       getStatus: vi.fn().mockResolvedValue(provisionStatus),
       onProgress: vi.fn(),
       provision,
-      cancel: cancelBridge
+      cancel: cancelBridge,
+      repair: repairBridge
     }
   }
   container = document.createElement('div')
@@ -235,8 +238,9 @@ describe('RuntimesPanel', () => {
     )
     await click(setupBtn ?? null)
     expect(provision).toHaveBeenCalledWith('r')
+    // The failure surfaces on R's OWN card (per-language error), and its button offers a retry.
     expect(
-      container.querySelector('[data-testid="runtimes-provision-error"]')?.textContent
+      container.querySelector('[data-testid="runtimes-provision-error-r"]')?.textContent
     ).toContain('runtime CDN unavailable')
     expect(container.textContent).toContain('Retry setup')
   })
@@ -261,12 +265,16 @@ describe('RuntimesPanel', () => {
     // the progress bar + Cancel). Drive the mirrored provisioning state into "preparing" at 30% for R.
     act(() =>
       useNotebookEnvStore.setState({
-        ui: {
-          kind: 'preparing',
-          scope: 'r',
-          phase: 'download',
-          message: 'Downloading managed R runtime (30%)',
-          progress: 0.3
+        byLang: {
+          r: {
+            preparing: true,
+            progress: {
+              phase: 'download',
+              message: 'Downloading managed R runtime (30%)',
+              progress: 0.3,
+              language: 'r'
+            }
+          }
         }
       })
     )
@@ -281,6 +289,53 @@ describe('RuntimesPanel', () => {
     expect(cancelBtn).toBeDefined()
     await click(cancelBtn ?? null)
     expect(cancelBridge).toHaveBeenCalled()
+  })
+
+  it('surfaces Reset in the app-managed SETUP card when a language is recovery-blocked', async () => {
+    await render()
+    // R has no provisioned managed env -> its section shows the setup card. A recovery-blocked error
+    // must turn the primary action into "Reset runtime" (not "Retry setup") wired to repair.
+    act(() =>
+      useNotebookEnvStore.setState({
+        byLang: {
+          r: {
+            preparing: false,
+            error: 'RUNTIME_RECOVERY_BLOCKED: a previous operation was interrupted'
+          }
+        }
+      })
+    )
+    const resetBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      /^reset runtime$/i.test((b.textContent ?? '').trim())
+    )
+    expect(resetBtn).toBeDefined()
+    await click(resetBtn ?? null)
+    expect(repairBridge).toHaveBeenCalledWith('r')
+  })
+
+  it('surfaces Reset even when a runnable managed env is still present (interrupted upgrade/install)', async () => {
+    await render()
+    // Python HAS a runnable app-managed env, so the normal card renders — but an interrupted
+    // upgrade/install may have quarantined its prefix. The recovery entry must still be reachable, or
+    // the user could never clear the block while the interpreter exists.
+    act(() =>
+      useNotebookEnvStore.setState({
+        byLang: {
+          python: {
+            preparing: false,
+            error: 'RUNTIME_RECOVERY_BLOCKED: a previous operation was interrupted'
+          }
+        }
+      })
+    )
+    const notice = container.querySelector('[data-testid="runtimes-recovery-blocked-python"]')
+    expect(notice).not.toBeNull()
+    const resetBtn = Array.from(notice?.querySelectorAll('button') ?? []).find((b) =>
+      /^reset runtime$/i.test((b.textContent ?? '').trim())
+    )
+    expect(resetBtn).toBeDefined()
+    await click(resetBtn ?? null)
+    expect(repairBridge).toHaveBeenCalledWith('python')
   })
 
   it('keeps Cancel clickable while a real Download-and-set-up is in flight (not locked by busy)', async () => {

--- a/src/renderer/src/pages/settings/RuntimesPanel.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.tsx
@@ -57,11 +57,6 @@ const RuntimesPanel = (): React.JSX.Element => {
   const [enablement, setEnablement] = useState<Enablements>({})
   const [loaded, setLoaded] = useState(false)
   const [busy, setBusy] = useState(false)
-  // The language whose app-managed setup THIS panel kicked off — set immediately on click so the
-  // Download button disables and Cancel appears without waiting for the first progress event. The
-  // store's own `preparing` state (below) covers the case where the panel was remounted (tab switch)
-  // while a setup started elsewhere is still running.
-  const [provisioningLang, setProvisioningLang] = useState<NotebookLanguage | null>(null)
   const [error, setError] = useState<string | null>(null)
   // Set while confirming a disable that would affect live sessions (WS11): the runtime being disabled
   // plus its current usage, so the dialog can warn before revoking.
@@ -73,8 +68,10 @@ const RuntimesPanel = (): React.JSX.Element => {
   const initEnv = useNotebookEnvStore((state) => state.init)
   const provisionEnv = useNotebookEnvStore((state) => state.provision)
   const cancelEnv = useNotebookEnvStore((state) => state.cancel)
-  const provisionUi = useNotebookEnvStore((state) => state.ui)
-  const provisionError = useNotebookEnvStore((state) => state.error)
+  const resetEnv = useNotebookEnvStore((state) => state.reset)
+  // Per-language provisioning state: python and R each track their own progress/preparing/error, so
+  // requesting one never makes the other's card look cancelled (the provisioner serializes the runs).
+  const byLang = useNotebookEnvStore((state) => state.byLang)
 
   useEffect(() => {
     void initEnv()
@@ -230,14 +227,25 @@ const RuntimesPanel = (): React.JSX.Element => {
     // the entire setup. `provisioningLang` (+ the store's preparing state) drives the button instead,
     // leaving Cancel clickable throughout.
     setError(null)
-    setProvisioningLang(language)
+    // The store tracks preparing per-language (byLang), so no local per-language flag is needed and
+    // Cancel stays clickable throughout without holding the shared `busy` flag.
     try {
       await provisionEnv(language)
       applyAll(await fetchAll())
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not refresh runtime readiness.')
-    } finally {
-      setProvisioningLang(null)
+    }
+  }
+
+  // Explicit recovery for a recovery-BLOCKED runtime (a prior setup's worker couldn't be confirmed
+  // stopped, so plain provision keeps refusing). Reset force-clears the quarantine and rebuilds.
+  const resetManaged = async (language: NotebookLanguage): Promise<void> => {
+    setError(null)
+    try {
+      await resetEnv(language)
+      applyAll(await fetchAll())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not reset the runtime.')
     }
   }
 
@@ -249,8 +257,6 @@ const RuntimesPanel = (): React.JSX.Element => {
       applyAll(await fetchAll())
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not cancel the setup.')
-    } finally {
-      setProvisioningLang(null)
     }
   }
 
@@ -348,22 +354,17 @@ const RuntimesPanel = (): React.JSX.Element => {
           {error}
         </p>
       )}
-      {error === null && provisionError !== undefined ? (
-        <p role="alert" className="text-sm text-destructive" data-testid="runtimes-provision-error">
-          {provisionError}
-        </p>
-      ) : null}
-
       {loading ? (
         <p className="text-sm text-muted-foreground">Detecting runtimes…</p>
       ) : (
         LANGUAGES.map(({ id, label, icon }) => {
           const list = envs[id]
-          // Preparing = this panel just kicked it off (immediate) OR the store reports a setup for this
-          // language in flight (covers a tab-switch remount where local state was lost).
-          const preparing =
-            provisioningLang === id ||
-            (provisionUi.kind === 'preparing' && provisionUi.scope === id)
+          // Per-language provisioning state — set immediately on click and cleared when THIS language's
+          // run settles, independent of the other language (fixes the concurrent python/R phantom-cancel).
+          const langState = byLang[id]
+          const preparing = langState?.preparing ?? false
+          const langProgress = langState?.progress
+          const langError = langState?.error
           const managedRunnable = managedRunnableFor(id)
 
           // App-managed goes FIRST; the user's own detected interpreters follow. A provisioned
@@ -406,7 +407,37 @@ const RuntimesPanel = (): React.JSX.Element => {
               <div className="space-y-2" data-testid={`runtimes-cards-${id}`}>
                 {/* App-managed FIRST: a real card once provisioned, else a setup card in the same frame. */}
                 {managedEnv ? (
-                  renderEnvCard(id, managedEnv)
+                  <>
+                    {renderEnvCard(id, managedEnv)}
+                    {/* An interrupted upgrade/install usually leaves the interpreter present (so the
+                        card above still renders), but recovery may have quarantined its prefix. Surface
+                        the block + Reset here too, or the recovery entry would be unreachable whenever a
+                        runnable managed env exists. */}
+                    {!preparing && langError?.includes('RUNTIME_RECOVERY_BLOCKED') ? (
+                      <div
+                        data-testid={`runtimes-recovery-blocked-${id}`}
+                        className="flex items-start justify-between gap-4 rounded-lg border border-destructive/40 bg-card p-3"
+                      >
+                        <p
+                          role="alert"
+                          className="text-[13px] text-destructive"
+                          data-testid={`runtimes-provision-error-${id}`}
+                        >
+                          {langError}
+                        </p>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="shrink-0"
+                          disabled={busy}
+                          onClick={() => void resetManaged(id)}
+                        >
+                          Reset runtime
+                        </Button>
+                      </div>
+                    ) : null}
+                  </>
                 ) : (
                   <div
                     data-testid="runtime-card"
@@ -421,30 +452,33 @@ const RuntimesPanel = (): React.JSX.Element => {
                           <Badge variant="secondary">App-managed</Badge>
                         </div>
                         <div className="mt-0.5 text-[13px] text-muted-foreground">
-                          {managedLine(
-                            managedRunnable,
-                            preparing,
-                            preparing && provisionUi.kind === 'preparing'
-                              ? provisionUi.message
-                              : undefined
-                          )}
+                          {managedLine(managedRunnable, preparing, langProgress?.message)}
                         </div>
-                        {preparing && provisionUi.kind === 'preparing' ? (
+                        {preparing ? (
                           <div
                             className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted"
                             role="progressbar"
                             aria-label={`Setting up ${label} runtime`}
-                            aria-valuenow={Math.round(provisionUi.progress * 100)}
+                            aria-valuenow={Math.round((langProgress?.progress ?? 0) * 100)}
                             aria-valuemin={0}
                             aria-valuemax={100}
                           >
                             <div
                               className="h-full rounded-full bg-primary transition-[width] duration-300"
                               style={{
-                                width: `${Math.max(2, Math.min(100, Math.round(provisionUi.progress * 100)))}%`
+                                width: `${Math.max(2, Math.min(100, Math.round((langProgress?.progress ?? 0) * 100)))}%`
                               }}
                             />
                           </div>
+                        ) : null}
+                        {!preparing && langError ? (
+                          <p
+                            role="alert"
+                            className="mt-1 text-[13px] text-destructive"
+                            data-testid={`runtimes-provision-error-${id}`}
+                          >
+                            {langError}
+                          </p>
                         ) : null}
                       </div>
                       {preparing ? (
@@ -466,9 +500,17 @@ const RuntimesPanel = (): React.JSX.Element => {
                           size="sm"
                           className="shrink-0"
                           disabled={busy}
-                          onClick={() => void provisionManaged(id)}
+                          onClick={() =>
+                            langError?.includes('RUNTIME_RECOVERY_BLOCKED')
+                              ? void resetManaged(id)
+                              : void provisionManaged(id)
+                          }
                         >
-                          {provisionError ? 'Retry setup' : 'Download and set up'}
+                          {langError?.includes('RUNTIME_RECOVERY_BLOCKED')
+                            ? 'Reset runtime'
+                            : langError
+                              ? 'Retry setup'
+                              : 'Download and set up'}
                         </Button>
                       )}
                     </div>

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -55,6 +55,36 @@ describe('notebook-env-store', () => {
     expect(useNotebookEnvStore.getState().status.pythonReady).toBe(true)
   })
 
+  it('maps a recovery-blocked status flag to a RUNTIME_RECOVERY_BLOCKED langError (surfaces Reset)', async () => {
+    // Recovery blocks a prefix in the main process WITHOUT touching the ready marker, so status can read
+    // ready. The store must translate the *RecoveryBlocked flag into a langError so the UI shows Reset.
+    const blocked: ProvisionStatus = { ...READY, pythonReady: true, pythonRecoveryBlocked: true }
+    installApi({ getStatus: vi.fn(async () => blocked) })
+    await useNotebookEnvStore.getState().init()
+    expect(useNotebookEnvStore.getState().byLang.python?.error).toContain(
+      'RUNTIME_RECOVERY_BLOCKED'
+    )
+    expect(useNotebookEnvStore.getState().byLang.r?.error).toBeUndefined()
+  })
+
+  it('clears the recovery-blocked langError once the block is gone', async () => {
+    // First hydrate blocked, then a later status refresh with the flag cleared drops the message.
+    let flag = true
+    const { emit } = installApi({
+      getStatus: vi.fn(async () => ({ ...READY, pythonRecoveryBlocked: flag }))
+    })
+    await useNotebookEnvStore.getState().init()
+    expect(useNotebookEnvStore.getState().byLang.python?.error).toContain(
+      'RUNTIME_RECOVERY_BLOCKED'
+    )
+    // A subsequent progress event re-reads status (now unblocked) and clears the recovery message.
+    flag = false
+    emit({ phase: 'done', message: 'ok', progress: 1, language: 'python' })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(useNotebookEnvStore.getState().byLang.python?.error).toBeUndefined()
+  })
+
   it('calling init() twice on the same bridge registers onProgress exactly once', async () => {
     const { api } = installApi()
     await useNotebookEnvStore.getState().init()
@@ -141,5 +171,138 @@ describe('notebook-env-store', () => {
     await useNotebookEnvStore.getState().provision('python')
     const { ui } = useNotebookEnvStore.getState()
     expect(ui).toEqual({ kind: 'preparing', scope: 'python', phase: '', message: '', progress: 0 })
+  })
+
+  it('routes a language-tagged progress event into that language byLang slot only', async () => {
+    const { emit } = installApi()
+    await useNotebookEnvStore.getState().init()
+    emit({ phase: 'create-r', message: 'Creating default-r…', progress: 0.5, language: 'r' })
+    const { byLang } = useNotebookEnvStore.getState()
+    expect(byLang.r).toMatchObject({ preparing: true, progress: { progress: 0.5, language: 'r' } })
+    // Python's slot is untouched by an R event.
+    expect(byLang.python).toBeUndefined()
+  })
+
+  it('settles a language byLang slot on its done/error event', async () => {
+    const { emit } = installApi()
+    await useNotebookEnvStore.getState().init()
+    emit({ phase: 'create-python', message: 'Creating…', progress: 0.6, language: 'python' })
+    expect(useNotebookEnvStore.getState().byLang.python?.preparing).toBe(true)
+    emit({ phase: 'done', message: 'Python environment ready', progress: 1, language: 'python' })
+    expect(useNotebookEnvStore.getState().byLang.python?.preparing).toBe(false)
+  })
+
+  it('keeps python preparing when R is requested concurrently (no phantom cancel — issue 3.1)', async () => {
+    // The reported bug: requesting python then R made python look cancelled. Model the serialized
+    // provisioner: python's request is still in flight (pending) when R is requested; both languages
+    // must read as preparing on their own slots, and python must NOT be cleared by R's request.
+    let resolvePython: (() => void) | undefined
+    const provision = vi.fn((lang: string) =>
+      lang === 'python'
+        ? new Promise<void>((r) => {
+            resolvePython = r
+          })
+        : Promise.resolve(undefined)
+    )
+    installApi({ provision })
+
+    const pythonRun = useNotebookEnvStore.getState().provision('python')
+    // R requested while python is still provisioning (queued behind it in the real provisioner).
+    await useNotebookEnvStore.getState().provision('r')
+
+    const mid = useNotebookEnvStore.getState().byLang
+    expect(mid.python?.preparing).toBe(true) // python still preparing, NOT cancelled by the R request
+    expect(mid.r?.preparing).toBe(false) // R's own request already settled (resolved bridge call)
+
+    resolvePython?.()
+    await pythonRun
+    expect(useNotebookEnvStore.getState().byLang.python?.preparing).toBe(false)
+  })
+
+  it('settles a language card on its own tagged error (auto-provision failure — issue B2)', async () => {
+    // A first-use (auto) provision emits language-tagged progress, so its failure MUST arrive tagged or
+    // the card stays stuck preparing. A tagged error settles that slot and records the message.
+    const { emit } = installApi()
+    await useNotebookEnvStore.getState().init()
+    emit({ phase: 'create-r', message: 'Creating…', progress: 0.5, language: 'r' })
+    expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(true)
+    emit({ phase: 'error', message: 'Could not prepare default-r', progress: 0, language: 'r' })
+    const { r } = useNotebookEnvStore.getState().byLang
+    expect(r?.preparing).toBe(false)
+    expect(r?.error).toBe('Could not prepare default-r')
+  })
+
+  it('an UNTAGGED error settles every preparing card (safety net — issue B2)', async () => {
+    // An error we can't attribute to a language (e.g. a startup-gate failure) must still clear every
+    // in-flight card, or a slot whose progress events were tagged would spin forever.
+    const { emit } = installApi()
+    await useNotebookEnvStore.getState().init()
+    emit({ phase: 'create-python', message: 'Creating…', progress: 0.5, language: 'python' })
+    emit({ phase: 'create-r', message: 'Creating…', progress: 0.5, language: 'r' })
+    emit({ phase: 'error', message: 'Environment preparation failed', progress: 0 }) // no language
+    const { byLang } = useNotebookEnvStore.getState()
+    expect(byLang.python?.preparing).toBe(false)
+    expect(byLang.r?.preparing).toBe(false)
+  })
+
+  it('cancel(lang) forwards the language to the bridge and clears that card (issue B1)', async () => {
+    const cancel = vi.fn(async () => undefined)
+    installApi({ cancel })
+    await useNotebookEnvStore.getState().init()
+    // R is preparing…
+    useNotebookEnvStore.setState({ byLang: { r: { preparing: true } } })
+    await useNotebookEnvStore.getState().cancel('r')
+    // …and cancelling it forwards 'r' (so main never aborts the OTHER language) and clears R's card.
+    expect(cancel).toHaveBeenCalledWith('r')
+    expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
+  })
+
+  it('reset(lang) force-recovers via bridge.repair and settles the card (explicit recovery entry)', async () => {
+    const repair = vi.fn(async () => undefined)
+    installApi({ repair })
+    await useNotebookEnvStore.getState().init()
+    // A card stuck on a recovery block.
+    useNotebookEnvStore.setState({
+      byLang: { python: { preparing: false, error: 'RUNTIME_RECOVERY_BLOCKED: …' } }
+    })
+    await useNotebookEnvStore.getState().reset('python')
+    expect(repair).toHaveBeenCalledWith('python') // force-recovery via the repair IPC
+    const { python } = useNotebookEnvStore.getState().byLang
+    expect(python?.preparing).toBe(false)
+    expect(python?.error).toBeUndefined() // cleared on success
+  })
+
+  it('cancelling a queued Reset re-surfaces the recovery-blocked message (not "cancelled")', async () => {
+    // The Reset never ran (it was cancelled while queued), so the block persists: status still reports
+    // pythonRecoveryBlocked. cancel()'s status refresh must reapply it, or the card would show a bare
+    // cleared/"cancelled" state and hide the Reset affordance until the component remounts.
+    const cancel = vi.fn(async () => undefined)
+    installApi({
+      cancel,
+      getStatus: vi.fn(async () => ({ ...READY, pythonRecoveryBlocked: true }))
+    })
+    await useNotebookEnvStore.getState().init()
+    useNotebookEnvStore.setState({
+      byLang: { python: { preparing: true, error: undefined } }
+    })
+    await useNotebookEnvStore.getState().cancel('python')
+    expect(useNotebookEnvStore.getState().byLang.python?.preparing).toBe(false)
+    expect(useNotebookEnvStore.getState().byLang.python?.error).toContain(
+      'RUNTIME_RECOVERY_BLOCKED'
+    )
+  })
+
+  it('a successful provision clears a stale recovery-blocked message for the OTHER language', async () => {
+    // provision(lang) only touches its own language card directly; the recovery-block reapply must still
+    // run off the returned status so an unrelated language's stale block message is refreshed too.
+    // Seed R's block through init() (so it holds the exact RECOVERY_BLOCKED_MESSAGE the clear compares
+    // against), then flip the flag off before provisioning python.
+    let rBlocked = true
+    installApi({ getStatus: vi.fn(async () => ({ ...READY, rRecoveryBlocked: rBlocked })) })
+    await useNotebookEnvStore.getState().init()
+    expect(useNotebookEnvStore.getState().byLang.r?.error).toContain('RUNTIME_RECOVERY_BLOCKED')
+    rBlocked = false
+    await useNotebookEnvStore.getState().provision('python')
+    expect(useNotebookEnvStore.getState().byLang.r?.error).toBeUndefined()
   })
 })

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -8,6 +8,15 @@ import type {
 } from '../../../shared/notebook-env'
 import { deriveProvisionUi, type ProvisionUiState } from '../pages/workspace/provisioning-view'
 
+// Per-language provisioning state, tracked ALONGSIDE the single-slot fields below. The provisioner
+// serializes python and R, but each has its own progress/preparing/error here so the Settings Runtimes
+// panel can render both cards independently — requesting one must never make the other look cancelled.
+export type LangProvisionState = {
+  progress?: ProvisionProgress
+  error?: string
+  preparing: boolean
+}
+
 export type NotebookEnvState = {
   status: ProvisionStatus
   progress?: ProvisionProgress
@@ -16,6 +25,9 @@ export type NotebookEnvState = {
   scope?: ProvisionScope
   // Derived view state (contract §4 UI): recomputed from status/scope/progress/error on every update.
   ui: ProvisionUiState
+  // Per-language tracking for the Settings panel (see LangProvisionState); the single-slot fields above
+  // still drive the python-centric onboarding/launch/gate surfaces unchanged.
+  byLang: Partial<Record<NotebookLanguage, LangProvisionState>>
 }
 
 type NotebookEnvStore = NotebookEnvState & {
@@ -23,6 +35,8 @@ type NotebookEnvStore = NotebookEnvState & {
   provision: (lang: NotebookLanguage) => Promise<void>
   cancel: (lang: NotebookLanguage) => Promise<void>
   retry: () => Promise<void>
+  // Explicit recovery for a recovery-BLOCKED runtime (repair force-clears the quarantine + rebuilds).
+  reset: (lang: NotebookLanguage) => Promise<void>
 }
 
 // Base status plus the ui the reducer derives from it, shared by the initial store state and tests.
@@ -40,11 +54,19 @@ export const createInitialNotebookEnvState = (): NotebookEnvState => {
     progress: undefined,
     error: undefined,
     scope: undefined,
-    ui: deriveProvisionUi(status, undefined, undefined, undefined)
+    ui: deriveProvisionUi(status, undefined, undefined, undefined),
+    byLang: {}
   }
 }
 
 const errorText = (e: unknown): string => (e instanceof Error ? e.message : String(e))
+
+// The langError the Settings panel keys off to show "Reset runtime". Recovery blocks a prefix in the
+// main process WITHOUT touching the ready marker, so status may still report ready — this message,
+// derived from ProvisionStatus.*RecoveryBlocked, is what makes the Reset affordance reachable in the UI.
+const RECOVERY_BLOCKED_MESSAGE =
+  'RUNTIME_RECOVERY_BLOCKED: a previous setup was interrupted and its worker could not be confirmed ' +
+  'stopped. Reset this runtime to recover it.'
 
 // Tracks which `window.api.notebookEnv` bridge instances already have a live `onProgress`
 // subscription, so a second `init()` call (App.tsx at launch + OnboardingWizard during onboarding,
@@ -65,6 +87,40 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         ui: deriveProvisionUi(next.status, next.scope, next.progress, next.error)
       }
     })
+
+  // Merges a patch into ONE language's provisioning slot (see byLang), leaving the other language's
+  // slot untouched — the key to python and R showing independent progress in Settings.
+  const applyLang = (language: NotebookLanguage, patch: Partial<LangProvisionState>): void =>
+    set((s) => ({
+      byLang: {
+        ...s.byLang,
+        [language]: { preparing: false, ...s.byLang[language], ...patch }
+      }
+    }))
+
+  // Reflect the main-process recovery quarantine (ProvisionStatus.*RecoveryBlocked) into each language's
+  // slot, so a blocked-but-ready env surfaces the Reset affordance. Only manages the recovery message:
+  // set it when blocked and not actively (re)building, clear only that specific message when unblocked —
+  // never stomping a live rebuild's progress or an unrelated provision error.
+  const applyRecoveryBlocks = (status: ProvisionStatus): void => {
+    const blocked: Record<NotebookLanguage, boolean> = {
+      python: status.pythonRecoveryBlocked ?? false,
+      r: status.rRecoveryBlocked ?? false
+    }
+    set((s) => {
+      const byLang = { ...s.byLang }
+      for (const language of ['python', 'r'] as const) {
+        const cur = byLang[language] ?? { preparing: false }
+        if (blocked[language]) {
+          if (cur.preparing || cur.error === RECOVERY_BLOCKED_MESSAGE) continue // let a rebuild settle
+          byLang[language] = { ...cur, preparing: false, error: RECOVERY_BLOCKED_MESSAGE }
+        } else if (cur.error === RECOVERY_BLOCKED_MESSAGE) {
+          byLang[language] = { ...cur, error: undefined } // block cleared (e.g. after Reset/restart)
+        }
+      }
+      return { byLang }
+    })
+  }
 
   return {
     ...createInitialNotebookEnvState(),
@@ -89,34 +145,84 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
                 : {}),
             error: progress.phase === 'error' ? progress.message : undefined
           })
-          void bridge.getStatus().then((status) => applyUi({ status }))
+          // Route a language-tagged event into that language's slot so its card advances/settles on its
+          // own. A run is done when it reports 'done' or 'error'; language-agnostic events (upgrade/
+          // restore) carry no language and only feed the single-slot ui above.
+          const language = progress.language
+          if (language) {
+            const settled = progress.phase === 'done' || progress.phase === 'error'
+            applyLang(language, {
+              progress,
+              error: progress.phase === 'error' ? progress.message : undefined,
+              preparing: !settled
+            })
+          } else if (progress.phase === 'error') {
+            // Safety net: an error we can't attribute to a language (e.g. a startup-gate failure) must
+            // still settle every preparing card, or a slot whose progress events were tagged would stay
+            // stuck spinning. Clear preparing for all in-flight languages without guessing whose it was.
+            set((s) => ({
+              byLang: Object.fromEntries(
+                Object.entries(s.byLang).map(([lang, state]) => [
+                  lang,
+                  { ...(state as LangProvisionState), preparing: false }
+                ])
+              )
+            }))
+          }
+          void bridge.getStatus().then((status) => {
+            applyUi({ status })
+            applyRecoveryBlocks(status)
+          })
         })
       }
       const status = await bridge.getStatus()
       applyUi({ status })
+      applyRecoveryBlocks(status)
     },
 
     provision: async (lang) => {
       const bridge = window.api?.notebookEnv
       const scope: ProvisionScope = lang
       applyUi({ scope, progress: undefined, error: undefined })
-      if (!bridge) return
+      // Mark this language preparing immediately (before the first progress event) so its card shows
+      // setup right away; clears when the run settles below or via its terminal progress event.
+      applyLang(lang, { preparing: true, error: undefined })
+      if (!bridge) {
+        applyLang(lang, { preparing: false })
+        return
+      }
       try {
         await bridge.provision(lang)
-        applyUi({ status: await bridge.getStatus() })
+        const status = await bridge.getStatus()
+        applyUi({ status })
+        // Clear preparing BEFORE applyRecoveryBlocks: it skips setting the block message while preparing
+        // is true (so it never stomps a LIVE rebuild's progress) — but this run has already finished, so
+        // the stale optimistic preparing:true set at entry must clear first or a lingering block would
+        // never surface.
+        applyLang(lang, { preparing: false })
+        applyRecoveryBlocks(status)
       } catch (e) {
         applyUi({ error: errorText(e) })
+        applyLang(lang, { preparing: false, error: errorText(e) })
       }
     },
 
     // Aborts an in-flight provision. The main process settles the aborted run and broadcasts its
     // terminal progress; refresh status so the UI leaves the preparing state promptly.
-    cancel: async () => {
+    cancel: async (lang) => {
       const bridge = window.api?.notebookEnv
+      // Clear this language's preparing state immediately so its card leaves the setup state promptly.
+      applyLang(lang, { preparing: false })
       if (!bridge) return
       try {
-        await bridge.cancel()
-        applyUi({ status: await bridge.getStatus() })
+        // Forward the language so cancelling this card never aborts the OTHER language's in-flight run.
+        await bridge.cancel(lang)
+        const status = await bridge.getStatus()
+        applyUi({ status })
+        // Reapply recovery blocks: if the cancelled run was a queued Reset whose block was never cleared,
+        // status.*RecoveryBlocked is still true and the Reset button must stay visible — not be replaced
+        // by an empty/cancelled state that hides it.
+        applyRecoveryBlocks(status)
       } catch (e) {
         applyUi({ error: errorText(e) })
       }
@@ -125,6 +231,29 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
     retry: async () => {
       const scope = get().scope
       await get().provision(scope === 'r' ? 'r' : 'python')
+    },
+
+    // Explicit user recovery for a runtime that is recovery-BLOCKED (a prior setup's worker couldn't be
+    // confirmed stopped). Repair force-clears the quarantine and rebuilds — the reachable "Reset" entry
+    // for a block that won't clear on its own. Tracked per-language like provision.
+    reset: async (lang) => {
+      const bridge = window.api?.notebookEnv
+      applyUi({ scope: lang, error: undefined })
+      applyLang(lang, { preparing: true, error: undefined })
+      if (!bridge) {
+        applyLang(lang, { preparing: false })
+        return
+      }
+      try {
+        await bridge.repair(lang)
+        const status = await bridge.getStatus()
+        applyUi({ status })
+        applyLang(lang, { preparing: false })
+        applyRecoveryBlocks(status)
+      } catch (e) {
+        applyUi({ error: errorText(e) })
+        applyLang(lang, { preparing: false, error: errorText(e) })
+      }
     }
   }
 })

--- a/src/shared/notebook-env.ts
+++ b/src/shared/notebook-env.ts
@@ -12,6 +12,10 @@ export type ProvisionProgress = {
   scope?: ProvisionOperationScope
   // Present for a provision triggered by one notebook run; other sessions remain visible and usable.
   sessionId?: string
+  // `language` attributes an event to the env it concerns so the Settings UI can show python and R
+  // provisioning independently — the provisioner serializes the two runs, but neither card should look
+  // cancelled when the other is requested (undefined for language-agnostic events: upgrade/restore).
+  language?: NotebookLanguage
 }
 export type RuntimeBundleSource = {
   kind: 'official' | 'override'
@@ -23,6 +27,11 @@ export type ProvisionStatus = {
   version: number
   provisioning: boolean
   bundleSource?: RuntimeBundleSource
+  // True when crash-recovery quarantined the language's app-managed default prefix (an interrupted
+  // worker couldn't be confirmed stopped). The env may still read as ready, so the UI needs this
+  // explicit signal to surface the Reset affordance instead of a normal, healthy-looking card.
+  pythonRecoveryBlocked?: boolean
+  rRecoveryBlocked?: boolean
 }
 
 // One named environment as surfaced by manage_environments(action:"list") and the UI's env selector.


### PR DESCRIPTION
## Summary

Hardens the notebook runtime provisioning, crash-recovery, and Reset lifecycle so an interrupted or crashed setup can never corrupt a managed environment, and so the user always has a reachable way to recover. This is the accumulated result of 10 review rounds on the provisioner / operation-journal / runtime-service / env-store path.

## What changed

**Provisioning UX**
- Python and R provisioning surface independently in Settings even though runs are serialized; the create progress bar keeps moving.
- Per-language cancel: cancelling one language never aborts the other.
- Half-built prefixes are rebuilt rather than trusted; cards settle on their own tagged error.

**Crash / hard-quit recovery**
- Every prefix-writing micromamba op is journaled with per-spawn intent and the child PID.
- On startup, interrupted operations are reconciled; a prefix whose worker cannot be confirmed stopped is blocked (fail-closed) rather than raced.
- Child liveness uses a pid-reuse-safe check (PID + start time) and is tri-state: `dead` / `alive` / `unknown`. Any probe error other than `ESRCH`/`EPERM` returns `unknown` (block) instead of guessing `dead`.
- A corrupt/unreadable journal blocks **all** prefixes (not just the two managed defaults), so a named env's possible orphan writer is covered. `readState()` treats any invalid entry as corrupt rather than silently reading the journal as healthy-empty.

**Reset (explicit recovery)**
- Reset on a corrupt journal quarantines (moves aside) the journal **before** deleting the prefix, so the rebuild's `begin()` succeeds — never delete-then-fail leaving the env gone, the block cleared, and the journal still corrupt.
- Reset is uninterruptible past the destructive boundary: a per-language cancel arriving mid-rebuild is dropped (a global cancel still aborts).
- The recovery block is enforced on the startup gate, named-env remove, relocation restore, and package management — not just the UI handlers.
- `status` awaits recovery before reporting; the store re-applies recovery blocks after provision/cancel/reset refreshes so a lingering block re-surfaces (surfacing Reset) instead of being masked.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test` — full suite green (`4098 passed | 65 skipped`), including 10 new tests covering the round-10 corrupt-journal-reset, global-block, liveness, and uninterruptible-reset paths.

## Note

This branch diverged at v0.5.0; `main` has advanced since. It currently has merge conflicts against `main` in the notebook-runtime files and will need a rebase before merge.