### PR TITLE
fix(notebook): await recovery before bound runtime execution

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3336,6 +3336,77 @@ describe('v4 runtime bindings & agent tools', () => {
     expect(installRan).toBe(false)
   })
 
+  it('awaits startup recovery before executing bound external or named runtimes', async () => {
+    const root = await createStorageRoot()
+    const namedId = pythonBin(envPrefix(getRuntimeRoot(root), 'my-analysis'))
+    const namedRuntime: DiscoveredInterpreter = {
+      language: 'python',
+      provenance: 'agent-created',
+      envId: namedId,
+      interpreterPath: namedId,
+      label: 'my-analysis',
+      condaEnv: 'my-analysis',
+      version: '3.12',
+      runnable: true
+    }
+    const scenarios = [
+      {
+        label: 'external',
+        runtimeId: userPyA.envId,
+        discovered: [managedPy, userPyA],
+        enablement: {
+          enabled: { [userPyA.envId]: true },
+          installAuthorized: {}
+        }
+      },
+      {
+        label: 'named',
+        runtimeId: namedId,
+        discovered: [managedPy, namedRuntime],
+        enablement: { enabled: { [namedId]: true }, installAuthorized: {} }
+      }
+    ] satisfies Array<{
+      label: string
+      runtimeId: string
+      discovered: DiscoveredInterpreter[]
+      enablement: RuntimeEnablement
+    }>
+
+    for (const [index, scenario] of scenarios.entries()) {
+      const executions: NotebookExecutionRequest[] = []
+      const service = bindingService(root, {
+        discovered: scenario.discovered,
+        enablement: scenario.enablement,
+        executions
+      })
+      const sessionId = `recovery-${index}`
+      await service.bindRuntime({
+        sessionId,
+        workspaceCwd: root,
+        language: 'python',
+        runtimeId: scenario.runtimeId
+      })
+
+      let releaseRecovery!: () => void
+      const recoveryGate = new Promise<void>((resolve) => {
+        releaseRecovery = resolve
+      })
+      const ensureRecovered = vi
+        .spyOn(service, 'ensureRecovered')
+        .mockImplementation(() => recoveryGate)
+
+      const run = service.execute({ sessionId, workspaceCwd: root, code: '1' })
+      await vi.waitFor(() => expect(ensureRecovered).toHaveBeenCalledOnce())
+      expect(executions, scenario.label).toEqual([])
+
+      releaseRecovery()
+      const result = await run
+      ensureRecovered.mockRestore()
+      expect(result.status, scenario.label).toBe('completed')
+      expect(executions, scenario.label).toHaveLength(1)
+    }
+  })
+
   it('blocks a no-binding execute + install on a DEFAULT prefix an unknown-liveness orphan may hold', async () => {
     // After recovery, an interrupted materialize whose child could NOT be confirmed dead ('unknown' —
     // here a live pid with no recorded start time) must leave its prefix BLOCKED for this process, so a

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -1423,6 +1423,9 @@ class NotebookRuntimeService {
     // exactly like an executor spawn/crash — rather than throwing raw out of the run path and leaving no
     // run history for the agent to inspect.
     let interpreterResolveError: unknown
+    // Recovery starts before IPC registration but completes asynchronously. Wait before consulting its
+    // block sets so an external or named run cannot start while an unknown orphan is still being found.
+    await this.ensureRecovered()
     const binding = session.runtimeBindings.get(cell.language)
     // A managed/default run is gated by its real prefix via isPrefixRecoveryBlocked, which folds in the
     // corrupt-journal barrier AND honours a force Reset's per-prefix allowlist — so a reset (allowlisted)


### PR DESCRIPTION
## Summary

- wait for startup recovery before checking runtime recovery blocks during cell execution
- prevent bound external and named runtimes from starting before unknown-child recovery populates its block sets
- add a regression test covering both binding types

## Context

PR #256 absorbed the broader recovery-block work. This PR now contains only the remaining fire-and-forget startup race.

## Verification

- `npm run typecheck`
- `npm run lint` (0 errors; 5 pre-existing main warnings)
- `./node_modules/.bin/vitest run` (4594 passed, 66 skipped)
- Prettier and `git diff --check`