### PR TITLE
test: raise vitest testTimeout to 15s to fix CI flake

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
     // under .claude/worktrees — those hold full source + node_modules copies that would otherwise be
     // discovered and run as duplicate (and often stale) suites during local runs.
     exclude: [...configDefaults.exclude, '**/.claude/**'],
+    // Lift the 5s default: the full coverage run instruments 4400+ tests across parallel workers on a
+    // shared CI runner, so a fast fully-mocked test can still be CPU-starved past 5s and time out
+    // spuriously. 15s absorbs that contention without masking a genuine hang (real work is far slower).
+    testTimeout: 15000,
     coverage: {
       provider: 'v8',
       // text for the CI log, lcov for upload/tooling, html for local inspection.


### PR DESCRIPTION
## Problem

The Nightly build failed on a spurious test timeout ([run 29828871202](https://github.com/aipoch/open-science/actions/runs/29828871202)):

```
Error: Test timed out in 5000ms.
 ❯ src/main/settings/service.test.ts:1900:3
   'gates on the selected framework: OpenCode selected but missing blocks while Claude passes'
```

## Root cause

The failing test is **not** slow work — every dependency it touches (`detectDeps`, `opencodeDetectDeps`, `codexDetectDeps`, filesystem probes) is fully injected/mocked, and it passes in ~4s locally and in isolation. It timed out because vitest's **5000ms default is too tight for the full coverage run**: `vitest run --coverage` instruments 4400+ tests across parallel workers on a shared macOS CI runner, and under that CPU contention even a fast mocked test can be starved past 5s. The specific test that trips is non-deterministic (a later re-run instead flaked on `logger.test.ts`), which is the signature of load-induced starvation rather than a real hang.

## Fix

Raise the global `testTimeout` to 15s in `vitest.config.ts`. This absorbs runner contention without masking a genuine hang — real slow tests (network connectors) already carry explicit 30–120s per-test overrides, and 15s is far below those while comfortably above any mocked test's true runtime.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run format` (prettier check) — pass
- `npm run test:coverage` — full suite green (4370 passed, 66 skipped)
- Target file `src/main/settings/service.test.ts` — 86/86 pass