### PR TITLE
feat(settings): add reasoning effort selection to model settings

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4766,6 +4766,71 @@ describe('ACP runtime — session effort', () => {
     })
   })
 
+  it('resolves a live effort change against the options reported after a model switch', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-live'], {
+      configOptions: [
+        {
+          type: 'select',
+          id: 'model',
+          name: 'Model',
+          category: 'model',
+          currentValue: 'model-a',
+          options: [{ value: 'model-b', name: 'Model B' }]
+        } as SessionConfigOption,
+        thoughtLevelOption(['low', 'high'])
+      ],
+      // The model switch narrows the effort set: the session/new options are now stale.
+      updatedConfigOptions: [thoughtLevelOption(['low', 'medium'])]
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/claude',
+        env: {},
+        sessionModel: 'model-b'
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    const applied = await runtime.applyReasoningEffortChange('max')
+
+    // The post-switch set tops out at 'medium'; the stale session/new set would wrongly yield 'high'.
+    expect(applied).toBe(true)
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-live', configId: 'effort', value: 'medium' }
+    ])
+  })
+
+  it('reports failure so the caller reconnects when a live apply is rejected', async () => {
+    const process = new FakeAgentProcess()
+    const agentOptions: Parameters<typeof startFakeAgent>[2] = {
+      configOptions: [thoughtLevelOption(['low', 'high'])]
+    }
+    const fakeAgent = startFakeAgent(process, ['s-live'], agentOptions)
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/claude',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    agentOptions.rejectSetConfigOption = true
+    const applied = await runtime.applyReasoningEffortChange('high')
+
+    // The level never reached the agent: returning false lets the caller reconnect instead of
+    // leaving the UI showing a level the agent never received.
+    expect(applied).toBe(false)
+    expect(fakeAgent.configChanges).toEqual([])
+  })
+
   it('declines the live change when the framework bakes effort into its spawn config', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['s-effort'], {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -129,6 +129,7 @@ const startFakeAgent = (
   closedSessions: string[]
   cancelledSessions: string[]
   modeChanges: Array<{ sessionId: string; modeId: string }>
+  configChanges: Array<{ sessionId: string; configId: string; value: string | boolean }>
   actions: string[]
 } => {
   const authRequests: unknown[] = []
@@ -144,6 +145,7 @@ const startFakeAgent = (
   const closedSessions: string[] = []
   const cancelledSessions: string[] = []
   const modeChanges: Array<{ sessionId: string; modeId: string }> = []
+  const configChanges: Array<{ sessionId: string; configId: string; value: string | boolean }> = []
   const actions: string[] = []
   let sessionIndex = 0
 
@@ -208,8 +210,15 @@ const startFakeAgent = (
       actions.push(`mode:${ctx.params.modeId}`)
       return {}
     })
-    .onRequest(acp.methods.agent.session.setConfigOption, () => {
+    .onRequest(acp.methods.agent.session.setConfigOption, (ctx) => {
       if (options.rejectSetConfigOption) throw acp.RequestError.internalError()
+
+      configChanges.push({
+        sessionId: ctx.params.sessionId,
+        configId: ctx.params.configId,
+        value: ctx.params.value
+      })
+
       return { configOptions: options.configOptions ?? [] }
     })
     .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
@@ -260,6 +269,7 @@ const startFakeAgent = (
     closedSessions,
     cancelledSessions,
     modeChanges,
+    configChanges,
     actions
   }
 }
@@ -4574,6 +4584,108 @@ describe('ACP runtime — connect failure logging', () => {
 
     const call = errorLogSpy.mock.calls.find(([message]) => message === 'agent connection failed')
     expect((call?.[1] as { framework: string }).framework).toBe('opencode')
+  })
+})
+
+describe('ACP runtime — session effort', () => {
+  // A select option like the thought_level selector opencode/Claude Code advertise from session/new.
+  const thoughtLevelOption = (values: string[]): SessionConfigOption =>
+    ({
+      type: 'select',
+      id: 'effort',
+      name: 'Effort',
+      category: 'thought_level',
+      currentValue: values[0],
+      options: values.map((value) => ({ value, name: value }))
+    }) as SessionConfigOption
+
+  const createEffortRuntime = (
+    process: FakeAgentProcess,
+    sessionEffort: string | undefined
+  ): AcpRuntime =>
+    new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...opencodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/opencode',
+        env: {},
+        sessionEffort
+      })
+    })
+
+  it('applies the resolved backend effort via the thought_level config option', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-effort'], {
+      configOptions: [thoughtLevelOption(['low', 'medium', 'high'])]
+    })
+    const runtime = createEffortRuntime(process, 'high')
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-effort', configId: 'effort', value: 'high' }
+    ])
+  })
+
+  it('sends no set_config_option request when the resolved backend carries no effort', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-effort'], {
+      configOptions: [thoughtLevelOption(['low', 'high'])]
+    })
+    const runtime = createEffortRuntime(process, undefined)
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    // Undefined means "don't override": the agent keeps its own default.
+    expect(fakeAgent.configChanges).toEqual([])
+  })
+
+  it('clamps the desired level to the closest advertised value', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-effort'], {
+      configOptions: [thoughtLevelOption(['low', 'medium'])]
+    })
+    const runtime = createEffortRuntime(process, 'max')
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    // 'max' is not advertised; the model's top level takes its place instead of a no-op.
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-effort', configId: 'effort', value: 'medium' }
+    ])
+  })
+
+  it('sends no request when the agent advertises no recognizable effort level', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-effort'], {
+      configOptions: [thoughtLevelOption(['default'])]
+    })
+    const runtime = createEffortRuntime(process, 'max')
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    // Only the 'default' sentinel is offered: nothing to clamp onto, the agent keeps its default.
+    expect(fakeAgent.configChanges).toEqual([])
+  })
+
+  it('swallows a set_config_option rejection instead of failing the session', async () => {
+    warnLogSpy.mockClear()
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-effort'], {
+      configOptions: [thoughtLevelOption(['low', 'high'])],
+      rejectSetConfigOption: true
+    })
+    const runtime = createEffortRuntime(process, 'high')
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+
+    // Best-effort: the failure is logged, the session still comes up.
+    expect(session.sessionId).toBe('s-effort')
+    expect(fakeAgent.configChanges).toEqual([])
+    const call = warnLogSpy.mock.calls.find(([message]) => message === 'set session effort failed')
+    expect(call).toBeDefined()
+    expect((call?.[1] as { sessionId: string }).sessionId).toBe('s-effort')
   })
 })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -103,6 +103,10 @@ const startFakeAgent = (
     supportsResume?: boolean
     modes?: SessionModeState
     configOptions?: SessionConfigOption[]
+    // Option set the set_config_option RESPONSE reports back. Agents rebuild their options when a
+    // switch invalidates them (effort levels are model-dependent), so this can differ from the
+    // session/new set; defaults to echoing configOptions.
+    updatedConfigOptions?: SessionConfigOption[]
     rejectSetConfigOption?: boolean
     // When true, the resume handler rejects with the ACP "Resource not found" (-32002) — the signal a
     // replaced agent (e.g. after a provider switch) gives for a session id it does not hold.
@@ -219,7 +223,7 @@ const startFakeAgent = (
         value: ctx.params.value
       })
 
-      return { configOptions: options.configOptions ?? [] }
+      return { configOptions: options.updatedConfigOptions ?? options.configOptions ?? [] }
     })
     .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
       // Flatten text blocks because these tests only exercise plain prompts.
@@ -4601,7 +4605,8 @@ describe('ACP runtime — session effort', () => {
 
   const createEffortRuntime = (
     process: FakeAgentProcess,
-    sessionEffort: string | undefined
+    sessionEffort: string | undefined,
+    sessionModel?: string
   ): AcpRuntime =>
     new AcpRuntime({
       appVersion: '0.1.0',
@@ -4610,6 +4615,7 @@ describe('ACP runtime — session effort', () => {
         framework: { ...opencodeFramework, spawn: () => asAgentProcess(process) },
         executablePath: '/bin/opencode',
         env: {},
+        sessionModel,
         sessionEffort
       })
     })
@@ -4652,6 +4658,36 @@ describe('ACP runtime — session effort', () => {
 
     // 'max' is not advertised; the model's top level takes its place instead of a no-op.
     expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-effort', configId: 'effort', value: 'medium' }
+    ])
+  })
+
+  it('resolves effort against the option set reported after a model switch', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-effort'], {
+      configOptions: [
+        {
+          type: 'select',
+          id: 'model',
+          name: 'Model',
+          category: 'model',
+          currentValue: 'model-a',
+          options: [{ value: 'model-b', name: 'Model B' }]
+        } as SessionConfigOption,
+        thoughtLevelOption(['low', 'high'])
+      ],
+      // Effort levels are model-dependent: model-b tops out at 'medium', not the 'high' the
+      // session originally advertised.
+      updatedConfigOptions: [thoughtLevelOption(['low', 'medium'])]
+    })
+    const runtime = createEffortRuntime(process, 'max', 'model-b')
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    // Clamping against the pre-switch set would apply 'high' — invalid for model-b. The post-switch
+    // set yields 'medium' instead.
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-effort', configId: 'model', value: 'model-b' },
       { sessionId: 's-effort', configId: 'effort', value: 'medium' }
     ])
   })

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4706,6 +4706,83 @@ describe('ACP runtime — session effort', () => {
     expect(fakeAgent.configChanges).toEqual([])
   })
 
+  it('live-applies an effort change to open sessions without a respawn', async () => {
+    const process = new FakeAgentProcess()
+    const spawn = vi.fn(() => asAgentProcess(process))
+    const fakeAgent = startFakeAgent(process, ['s-live', 's-live-2'], {
+      configOptions: [thoughtLevelOption(['default', 'low', 'medium', 'high'])]
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn },
+        executablePath: '/bin/claude',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    expect(fakeAgent.configChanges).toEqual([])
+
+    const applied = await runtime.applyReasoningEffortChange('max')
+
+    // The open session gets the closest advertised level over ACP, still on the original process.
+    expect(applied).toBe(true)
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-live', configId: 'effort', value: 'high' }
+    ])
+
+    // Sessions created later in the same process inherit the new level.
+    await runtime.createSession({ cwd: '/workspace' })
+    expect(fakeAgent.configChanges[1]).toMatchObject({ configId: 'effort', value: 'high' })
+  })
+
+  it('hands control back to the agent default when the level is cleared live', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-live'], {
+      configOptions: [thoughtLevelOption(['default', 'low', 'high'])]
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/claude',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.applyReasoningEffortChange('max')
+
+    const applied = await runtime.applyReasoningEffortChange('default')
+
+    // The advertised 'default' sentinel clears the previously forced level.
+    expect(applied).toBe(true)
+    expect(fakeAgent.configChanges.at(-1)).toEqual({
+      sessionId: 's-live',
+      configId: 'effort',
+      value: 'default'
+    })
+  })
+
+  it('declines the live change when the framework bakes effort into its spawn config', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-effort'], {
+      configOptions: [thoughtLevelOption(['low', 'high'])]
+    })
+    // createEffortRuntime drives the opencode framework, which advertises no live effort channel.
+    const runtime = createEffortRuntime(process, 'high')
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    const applied = await runtime.applyReasoningEffortChange('low')
+
+    // The caller reconnects instead: nothing is sent, and the pending level stays as resolved.
+    expect(applied).toBe(false)
+    expect(fakeAgent.configChanges).toEqual([])
+  })
+
   it('swallows a set_config_option rejection instead of failing the session', async () => {
     warnLogSpy.mockClear()
     const process = new FakeAgentProcess()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4848,6 +4848,54 @@ describe('ACP runtime — session effort', () => {
     expect(fakeAgent.configChanges).toEqual([])
   })
 
+  it('falls back to a reconnect when no Codex session advertises an effort option', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-codex'], {
+      // An adapter build that surfaces no thought_level option at all.
+      configOptions: [],
+      modes: {
+        currentModeId: 'agent',
+        availableModes: ['read-only', 'agent'].map((id) => ({ id, name: id }))
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const applied = await runtime.applyReasoningEffortChange('high')
+
+    // Codex bakes effort into its spawn config, so only a reconnect delivers it here — the UI must
+    // not report a level the running session never received.
+    expect(applied).toBe(false)
+    expect(fakeAgent.configChanges).toEqual([])
+  })
+
+  it('reports success without a reconnect when a Claude session simply lacks effort support', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['s-claude'], { configOptions: [] })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/claude',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    // Claude has no config channel to fall back to: the model doesn't support effort, and a
+    // respawn can't change that — report success rather than restarting for nothing.
+    expect(await runtime.applyReasoningEffortChange('high')).toBe(true)
+  })
+
   it('swallows a set_config_option rejection instead of failing the session', async () => {
     warnLogSpy.mockClear()
     const process = new FakeAgentProcess()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -9,6 +9,7 @@ import { PassThrough, Readable, Writable } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from './runtime'
+import type { ReasoningEffort } from '../../shared/settings'
 import { terminateProcessTree } from '../process-tree'
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { claudeCodeFramework, codexFramework, opencodeFramework } from '../agent-framework'
@@ -4605,7 +4606,7 @@ describe('ACP runtime — session effort', () => {
 
   const createEffortRuntime = (
     process: FakeAgentProcess,
-    sessionEffort: string | undefined,
+    sessionEffort: ReasoningEffort | undefined,
     sessionModel?: string
   ): AcpRuntime =>
     new AcpRuntime({

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -54,7 +54,7 @@ import {
   toAcpRuntimeEvent
 } from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
-import { matchSessionModelOption } from './session-config'
+import { matchSessionModelOption, resolveSessionEffortOption } from './session-config'
 import { describePromptError } from './prompt-error'
 import {
   ATTACHMENT_PREVIEW_BYTES,
@@ -397,6 +397,9 @@ class AcpRuntime {
   // frameworks (Claude). Refreshed from the resolved backend on each connect.
   private pendingSessionModel: string | undefined
   private pendingSessionModelRequired = false
+  // Reasoning-effort level to apply per session via the ACP thought_level configOption; undefined
+  // means "don't override" (the agent keeps its own default). Refreshed on each connect.
+  private pendingSessionEffort: string | undefined
   // One-shot ACP authentication material resolved alongside the spawn config. It is cleared after
   // initialize so the decrypted key is not retained by the runtime longer than necessary.
   private pendingAuthentication: ResolvedAgentBackend['authentication']
@@ -575,6 +578,39 @@ class AcpRuntime {
           `The selected model "${this.pendingSessionModel}" could not be applied: ${message}`
         )
       }
+    }
+  }
+
+  // Applies the user's reasoning-effort preference to a freshly built/resumed session via the ACP
+  // thought_level configOption. No-op when no explicit level is set (pendingSessionEffort undefined —
+  // the agent then keeps its own default) or when the agent advertises no effort option. The desired
+  // level is resolved to the closest advertised one, so a level the model lacks still lands on its
+  // nearest rung. Best-effort: a failure is logged, never fatal to the session.
+  private async applySessionEffort(session: ActiveSession): Promise<void> {
+    if (!this.pendingSessionEffort || !this.connection) return
+
+    const configOptions = (
+      session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } }
+    ).newSessionResponse?.configOptions
+    const selection = resolveSessionEffortOption(configOptions, this.pendingSessionEffort)
+
+    if (!selection) {
+      log.info('no session effort option to apply', { desiredEffort: this.pendingSessionEffort })
+      return
+    }
+
+    try {
+      await this.connection.agent.request(acp.methods.agent.session.setConfigOption, {
+        sessionId: session.sessionId,
+        configId: selection.configId,
+        value: selection.value
+      })
+      log.info('session effort applied', { sessionId: session.sessionId, effort: selection.value })
+    } catch (error) {
+      log.warn('set session effort failed', {
+        sessionId: session.sessionId,
+        error: error instanceof Error ? error.message : String(error)
+      })
     }
   }
 
@@ -855,6 +891,7 @@ class AcpRuntime {
 
       log.info('createSession: applySessionModel', { sessionId: session.sessionId })
       await this.applySessionModel(session)
+      await this.applySessionEffort(session)
 
       this.sessions.set(session.sessionId, session)
       this.sessionCwds.set(session.sessionId, sessionCwd)
@@ -1101,6 +1138,7 @@ class AcpRuntime {
     }
 
     await this.applySessionModel(session)
+    await this.applySessionEffort(session)
 
     this.sessions.set(request.sessionId, session)
     this.sessionCwds.set(request.sessionId, sessionCwd)
@@ -1164,6 +1202,7 @@ class AcpRuntime {
     }
 
     await this.applySessionModel(adopted)
+    await this.applySessionEffort(adopted)
     this.adoptSession(
       request.sessionId,
       adopted,
@@ -1423,6 +1462,7 @@ class AcpRuntime {
       backend.framework.id === 'codex' && backend.providerConfiguration !== undefined
     this.pendingSessionModel = backend.sessionModel
     this.pendingSessionModelRequired = backend.sessionModelRequired ?? false
+    this.pendingSessionEffort = backend.sessionEffort
     this.pendingAuthentication = backend.authentication
     this.pendingProviderConfiguration = backend.providerConfiguration
 
@@ -1432,6 +1472,7 @@ class AcpRuntime {
       framework: backend.framework.id,
       backendId: backend.backendId ?? '(unspecified)',
       sessionModel: backend.sessionModel ?? '(framework default)',
+      sessionEffort: backend.sessionEffort ?? '(agent default)',
       args: backend.args ?? [],
       executablePath: backend.executablePath,
       // Log env keys but not values (may contain credentials)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -647,6 +647,7 @@ class AcpRuntime {
     if (!this.connection) return true
 
     let allApplied = true
+    let appliedToAny = false
 
     for (const session of this.sessions.values()) {
       const configOptions =
@@ -663,8 +664,18 @@ class AcpRuntime {
         continue
       }
 
-      if (!(await this.sendSessionEffort(session, selection))) allApplied = false
+      if (!(await this.sendSessionEffort(session, selection))) {
+        allApplied = false
+      } else {
+        appliedToAny = true
+      }
     }
+
+    // No open session could take the level over ACP. For Claude there is no other channel — the
+    // model simply doesn't support effort, and a respawn can't change that. Codex also bakes the
+    // level into its spawn config (model_reasoning_effort), so a reconnect DOES deliver it: report
+    // failure rather than leaving the UI showing a level the running session never received.
+    if (!appliedToAny && this.sessions.size > 0 && this.framework.id === 'codex') return false
 
     return allApplied
   }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -41,6 +41,7 @@ import {
   type PermissionProfileId,
   type SessionPermissionProfileState
 } from '../../shared/permission-profiles'
+import type { ReasoningEffort } from '../../shared/settings'
 import {
   claudeCodeFramework,
   type AgentFramework,
@@ -399,7 +400,7 @@ class AcpRuntime {
   private pendingSessionModelRequired = false
   // Reasoning-effort level to apply per session via the ACP thought_level configOption; undefined
   // means "don't override" (the agent keeps its own default). Refreshed on each connect.
-  private pendingSessionEffort: string | undefined
+  private pendingSessionEffort: ReasoningEffort | undefined
   // One-shot ACP authentication material resolved alongside the spawn config. It is cleared after
   // initialize so the decrypted key is not retained by the runtime longer than necessary.
   private pendingAuthentication: ResolvedAgentBackend['authentication']

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -41,7 +41,7 @@ import {
   type PermissionProfileId,
   type SessionPermissionProfileState
 } from '../../shared/permission-profiles'
-import type { ReasoningEffort } from '../../shared/settings'
+import { DEFAULT_REASONING_EFFORT, type ReasoningEffort } from '../../shared/settings'
 import {
   claudeCodeFramework,
   type AgentFramework,
@@ -55,7 +55,11 @@ import {
   toAcpRuntimeEvent
 } from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
-import { matchSessionModelOption, resolveSessionEffortOption } from './session-config'
+import {
+  matchSessionModelOption,
+  resolveSessionEffortOption,
+  type SessionModelSelection
+} from './session-config'
 import { describePromptError } from './prompt-error'
 import {
   ATTACHMENT_PREVIEW_BYTES,
@@ -614,8 +618,48 @@ class AcpRuntime {
       return
     }
 
+    await this.sendSessionEffort(session, selection)
+  }
+
+  // Live-applies a reasoning-effort change to every open session — the ACP equivalent of a model
+  // switch, no respawn. Returns false when the active framework only carries effort in its baked
+  // spawn config (opencode advertises no thought_level option), so the caller falls back to the
+  // provider-switch reconnect. On success pendingSessionEffort tracks the new level, so sessions
+  // created later in this process inherit it; the persisted setting covers the next respawn.
+  // Per-session failures are logged, never fatal.
+  async applyReasoningEffortChange(effort: ReasoningEffort): Promise<boolean> {
+    if (!this.framework.supportsLiveEffortChange) return false
+
+    this.pendingSessionEffort = effort === DEFAULT_REASONING_EFFORT ? undefined : effort
+    if (!this.connection) return true
+
+    for (const session of this.sessions.values()) {
+      const configOptions = (
+        session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } }
+      ).newSessionResponse?.configOptions
+      const selection = resolveSessionEffortOption(configOptions, effort)
+
+      if (!selection) {
+        log.info('no session effort option to apply', {
+          desiredEffort: effort,
+          sessionId: session.sessionId
+        })
+        continue
+      }
+
+      await this.sendSessionEffort(session, selection)
+    }
+
+    return true
+  }
+
+  // Sends one resolved effort selection to a session. Best-effort: a failure is logged, never fatal.
+  private async sendSessionEffort(
+    session: ActiveSession,
+    selection: SessionModelSelection
+  ): Promise<void> {
     try {
-      await this.connection.agent.request(acp.methods.agent.session.setConfigOption, {
+      await this.connection?.agent.request(acp.methods.agent.session.setConfigOption, {
         sessionId: session.sessionId,
         configId: selection.configId,
         value: selection.value

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -584,11 +584,10 @@ class AcpRuntime {
         }
       )) as { configOptions?: SessionConfigOption[] | null }
       log.info('session model applied', { sessionId: session.sessionId, model: selection.value })
-      const updatedOptions = response?.configOptions ?? configOptions
-      // The model switch rebuilds the agent's options (effort rungs are model-dependent); remember
-      // the fresh set so a later live effort change resolves against the model actually running.
-      this.latestSessionConfigOptions.set(session.sessionId, updatedOptions)
-      return updatedOptions
+      // The model switch rebuilds the agent's options (effort rungs are model-dependent). The
+      // caller commits the fresh set to latestSessionConfigOptions once the session is registered,
+      // so the map never holds an entry for a session that failed to attach.
+      return response?.configOptions ?? configOptions
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       log.warn('set session model failed', {
@@ -636,15 +635,18 @@ class AcpRuntime {
   // switch, no respawn. Returns false when the active framework only carries effort in its baked
   // spawn config (opencode advertises no thought_level option), or when applying to a session
   // genuinely failed — the caller then falls back to the provider-switch reconnect rather than
-  // leaving the UI showing a level the agent never received. Sessions that simply advertise no
-  // effort option are skipped (a reconnect could not give their model one either). On success
-  // pendingSessionEffort tracks the new level, so sessions created later in this process inherit
-  // it; the persisted setting covers the next respawn.
+  // leaving the UI showing a level the agent never received. All sessions are attempted even after
+  // a failure, so the set never straddles two levels longer than the reconnect takes. Sessions that
+  // simply advertise no effort option are skipped (a reconnect could not give their model one
+  // either). On success pendingSessionEffort tracks the new level, so sessions created later in
+  // this process inherit it; the persisted setting covers the next respawn.
   async applyReasoningEffortChange(effort: ReasoningEffort): Promise<boolean> {
     if (!this.framework.supportsLiveEffortChange) return false
 
     this.pendingSessionEffort = effort === DEFAULT_REASONING_EFFORT ? undefined : effort
     if (!this.connection) return true
+
+    let allApplied = true
 
     for (const session of this.sessions.values()) {
       const configOptions =
@@ -661,10 +663,10 @@ class AcpRuntime {
         continue
       }
 
-      if (!(await this.sendSessionEffort(session, selection))) return false
+      if (!(await this.sendSessionEffort(session, selection))) allApplied = false
     }
 
-    return true
+    return allApplied
   }
 
   // Sends one resolved effort selection to a session. Best-effort: a failure is logged (never
@@ -971,6 +973,11 @@ class AcpRuntime {
       await this.applySessionEffort(session, updatedConfigOptions)
 
       this.sessions.set(session.sessionId, session)
+      // Committed only now: the options map must never hold an entry for a session that failed to
+      // attach (a throw between apply and registration would orphan it).
+      if (updatedConfigOptions) {
+        this.latestSessionConfigOptions.set(session.sessionId, updatedConfigOptions)
+      }
       this.sessionCwds.set(session.sessionId, sessionCwd)
       this.sessionMcpServerNames.set(session.sessionId, this.mcpServerNamesOf(mcpServers))
       this.sessionProjectNames.set(session.sessionId, projectName)
@@ -1085,6 +1092,7 @@ class AcpRuntime {
       attached.dispose()
       this.agentToAppSessionId.delete(attached.sessionId)
       this.sessions.delete(request.sessionId)
+      this.latestSessionConfigOptions.delete(attached.sessionId)
       this.latestSessionConfigOptions.delete(request.sessionId)
     }
 
@@ -1219,6 +1227,9 @@ class AcpRuntime {
     await this.applySessionEffort(session, updatedConfigOptions)
 
     this.sessions.set(request.sessionId, session)
+    if (updatedConfigOptions) {
+      this.latestSessionConfigOptions.set(request.sessionId, updatedConfigOptions)
+    }
     this.sessionCwds.set(request.sessionId, sessionCwd)
     this.sessionMcpServerNames.set(request.sessionId, this.mcpServerNamesOf(mcpServers))
     this.sessionProjectNames.set(request.sessionId, projectName)
@@ -1288,6 +1299,11 @@ class AcpRuntime {
       projectName,
       this.mcpServerNamesOf(mcpServers)
     )
+    // Keyed by the agent session id, matching the live-effort lookup over this.sessions values:
+    // an adopted session's agent id differs from the app id it is registered under.
+    if (updatedConfigOptions) {
+      this.latestSessionConfigOptions.set(adopted.sessionId, updatedConfigOptions)
+    }
     this.emitState()
 
     return {
@@ -1864,6 +1880,8 @@ class AcpRuntime {
       // Drop the reverse (underlying agent id -> app id) mapping an adopted session registered, so a
       // reused agent id or a late agent event can no longer route to this deleted app session.
       this.agentToAppSessionId.delete(session.sessionId)
+      // The options cache is keyed by the agent session id (differs from the app id when adopted).
+      this.latestSessionConfigOptions.delete(session.sessionId)
     }
 
     // App-session-keyed cleanup runs whether or not a live session is attached. A framework switch

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -539,9 +539,12 @@ class AcpRuntime {
   // frameworks that select the model over the protocol (opencode). No-op for env-driven frameworks
   // (pendingSessionModel undefined). Optional selections keep the agent default when no matching option
   // exists or application fails; required selections fail visibly rather than silently running another
-  // model.
-  private async applySessionModel(session: ActiveSession): Promise<void> {
-    if (!this.pendingSessionModel || !this.connection) return
+  // model. Returns the agent's post-application configOptions when it reports them — effort levels are
+  // model-dependent, so callers resolving further options must use the set from AFTER the model switch.
+  private async applySessionModel(
+    session: ActiveSession
+  ): Promise<SessionConfigOption[] | null | undefined> {
+    if (!this.pendingSessionModel || !this.connection) return undefined
 
     const configOptions = (
       session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } }
@@ -556,16 +559,20 @@ class AcpRuntime {
           `The selected model "${this.pendingSessionModel}" is not available for this Codex account.`
         )
       }
-      return
+      return undefined
     }
 
     try {
-      await this.connection.agent.request(acp.methods.agent.session.setConfigOption, {
-        sessionId: session.sessionId,
-        configId: selection.configId,
-        value: selection.value
-      })
+      const response = (await this.connection.agent.request(
+        acp.methods.agent.session.setConfigOption,
+        {
+          sessionId: session.sessionId,
+          configId: selection.configId,
+          value: selection.value
+        }
+      )) as { configOptions?: SessionConfigOption[] | null }
       log.info('session model applied', { sessionId: session.sessionId, model: selection.value })
+      return response?.configOptions ?? configOptions
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       log.warn('set session model failed', {
@@ -578,6 +585,7 @@ class AcpRuntime {
           `The selected model "${this.pendingSessionModel}" could not be applied: ${message}`
         )
       }
+      return undefined
     }
   }
 
@@ -585,14 +593,20 @@ class AcpRuntime {
   // thought_level configOption. No-op when no explicit level is set (pendingSessionEffort undefined —
   // the agent then keeps its own default) or when the agent advertises no effort option. The desired
   // level is resolved to the closest advertised one, so a level the model lacks still lands on its
-  // nearest rung. Best-effort: a failure is logged, never fatal to the session.
-  private async applySessionEffort(session: ActiveSession): Promise<void> {
+  // nearest rung. `configOptions` should be the agent's latest option set (e.g. returned by a model
+  // switch just before); falls back to the session's original response. Best-effort: a failure is
+  // logged, never fatal to the session.
+  private async applySessionEffort(
+    session: ActiveSession,
+    configOptions?: SessionConfigOption[] | null
+  ): Promise<void> {
     if (!this.pendingSessionEffort || !this.connection) return
 
-    const configOptions = (
-      session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } }
-    ).newSessionResponse?.configOptions
-    const selection = resolveSessionEffortOption(configOptions, this.pendingSessionEffort)
+    const effectiveOptions =
+      configOptions ??
+      (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
+        .newSessionResponse?.configOptions
+    const selection = resolveSessionEffortOption(effectiveOptions, this.pendingSessionEffort)
 
     if (!selection) {
       log.info('no session effort option to apply', { desiredEffort: this.pendingSessionEffort })
@@ -890,8 +904,8 @@ class AcpRuntime {
       }
 
       log.info('createSession: applySessionModel', { sessionId: session.sessionId })
-      await this.applySessionModel(session)
-      await this.applySessionEffort(session)
+      const updatedConfigOptions = await this.applySessionModel(session)
+      await this.applySessionEffort(session, updatedConfigOptions)
 
       this.sessions.set(session.sessionId, session)
       this.sessionCwds.set(session.sessionId, sessionCwd)
@@ -1137,8 +1151,8 @@ class AcpRuntime {
       throw error
     }
 
-    await this.applySessionModel(session)
-    await this.applySessionEffort(session)
+    const updatedConfigOptions = await this.applySessionModel(session)
+    await this.applySessionEffort(session, updatedConfigOptions)
 
     this.sessions.set(request.sessionId, session)
     this.sessionCwds.set(request.sessionId, sessionCwd)
@@ -1201,8 +1215,8 @@ class AcpRuntime {
       throw error
     }
 
-    await this.applySessionModel(adopted)
-    await this.applySessionEffort(adopted)
+    const updatedConfigOptions = await this.applySessionModel(adopted)
+    await this.applySessionEffort(adopted, updatedConfigOptions)
     this.adoptSession(
       request.sessionId,
       adopted,

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -405,6 +405,13 @@ class AcpRuntime {
   // Reasoning-effort level to apply per session via the ACP thought_level configOption; undefined
   // means "don't override" (the agent keeps its own default). Refreshed on each connect.
   private pendingSessionEffort: ReasoningEffort | undefined
+  // The latest configOptions each session reported — seeded from session/new and refreshed after a
+  // model switch (effort rungs are model-dependent, so the original set goes stale). The live effort
+  // path resolves against this, never against the possibly-outdated session/new response.
+  private readonly latestSessionConfigOptions = new Map<
+    string,
+    SessionConfigOption[] | null | undefined
+  >()
   // One-shot ACP authentication material resolved alongside the spawn config. It is cleared after
   // initialize so the decrypted key is not retained by the runtime longer than necessary.
   private pendingAuthentication: ResolvedAgentBackend['authentication']
@@ -577,7 +584,11 @@ class AcpRuntime {
         }
       )) as { configOptions?: SessionConfigOption[] | null }
       log.info('session model applied', { sessionId: session.sessionId, model: selection.value })
-      return response?.configOptions ?? configOptions
+      const updatedOptions = response?.configOptions ?? configOptions
+      // The model switch rebuilds the agent's options (effort rungs are model-dependent); remember
+      // the fresh set so a later live effort change resolves against the model actually running.
+      this.latestSessionConfigOptions.set(session.sessionId, updatedOptions)
+      return updatedOptions
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       log.warn('set session model failed', {
@@ -623,10 +634,12 @@ class AcpRuntime {
 
   // Live-applies a reasoning-effort change to every open session — the ACP equivalent of a model
   // switch, no respawn. Returns false when the active framework only carries effort in its baked
-  // spawn config (opencode advertises no thought_level option), so the caller falls back to the
-  // provider-switch reconnect. On success pendingSessionEffort tracks the new level, so sessions
-  // created later in this process inherit it; the persisted setting covers the next respawn.
-  // Per-session failures are logged, never fatal.
+  // spawn config (opencode advertises no thought_level option), or when applying to a session
+  // genuinely failed — the caller then falls back to the provider-switch reconnect rather than
+  // leaving the UI showing a level the agent never received. Sessions that simply advertise no
+  // effort option are skipped (a reconnect could not give their model one either). On success
+  // pendingSessionEffort tracks the new level, so sessions created later in this process inherit
+  // it; the persisted setting covers the next respawn.
   async applyReasoningEffortChange(effort: ReasoningEffort): Promise<boolean> {
     if (!this.framework.supportsLiveEffortChange) return false
 
@@ -634,9 +647,10 @@ class AcpRuntime {
     if (!this.connection) return true
 
     for (const session of this.sessions.values()) {
-      const configOptions = (
-        session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } }
-      ).newSessionResponse?.configOptions
+      const configOptions =
+        this.latestSessionConfigOptions.get(session.sessionId) ??
+        (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
+          .newSessionResponse?.configOptions
       const selection = resolveSessionEffortOption(configOptions, effort)
 
       if (!selection) {
@@ -647,17 +661,19 @@ class AcpRuntime {
         continue
       }
 
-      await this.sendSessionEffort(session, selection)
+      if (!(await this.sendSessionEffort(session, selection))) return false
     }
 
     return true
   }
 
-  // Sends one resolved effort selection to a session. Best-effort: a failure is logged, never fatal.
+  // Sends one resolved effort selection to a session. Best-effort: a failure is logged (never
+  // thrown) and reported as false, so live callers can escalate while build-time callers stay
+  // non-fatal.
   private async sendSessionEffort(
     session: ActiveSession,
     selection: SessionModelSelection
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await this.connection?.agent.request(acp.methods.agent.session.setConfigOption, {
         sessionId: session.sessionId,
@@ -665,11 +681,13 @@ class AcpRuntime {
         value: selection.value
       })
       log.info('session effort applied', { sessionId: session.sessionId, effort: selection.value })
+      return true
     } catch (error) {
       log.warn('set session effort failed', {
         sessionId: session.sessionId,
         error: error instanceof Error ? error.message : String(error)
       })
+      return false
     }
   }
 
@@ -1067,6 +1085,7 @@ class AcpRuntime {
       attached.dispose()
       this.agentToAppSessionId.delete(attached.sessionId)
       this.sessions.delete(request.sessionId)
+      this.latestSessionConfigOptions.delete(request.sessionId)
     }
 
     // The fresh agent session holds no history, so the accumulated media is gone; start its budget clean.
@@ -1430,6 +1449,7 @@ class AcpRuntime {
     this.sessionCwds.clear()
     this.sessionInlineImageBytes.clear()
     this.currentPromptTurnBySession.clear()
+    this.latestSessionConfigOptions.clear()
     this.sessionMcpServerNames.clear()
     this.sessionProjectNames.clear()
     this.permissionProfiles.clear()
@@ -1860,6 +1880,7 @@ class AcpRuntime {
     this.sessionCwds.delete(request.sessionId)
     this.sessionInlineImageBytes.delete(request.sessionId)
     this.currentPromptTurnBySession.delete(request.sessionId)
+    this.latestSessionConfigOptions.delete(request.sessionId)
     this.sessionMcpServerNames.delete(request.sessionId)
     this.sessionProjectNames.delete(request.sessionId)
     this.sessionFrameworks.delete(request.sessionId)
@@ -2981,6 +3002,7 @@ class AcpRuntime {
     this.sessionCwds.clear()
     this.sessionInlineImageBytes.clear()
     this.currentPromptTurnBySession.clear()
+    this.latestSessionConfigOptions.clear()
     this.sessionMcpServerNames.clear()
     this.sessionProjectNames.clear()
     this.artifactSessionIds.clear()

--- a/src/main/acp/session-config.test.ts
+++ b/src/main/acp/session-config.test.ts
@@ -152,10 +152,21 @@ describe('resolveSessionEffortOption', () => {
     })
   })
 
+  it('matches the literal default sentinel when the agent advertises it', () => {
+    // Claude Code's effort select includes a 'default' value meaning "clear any forced level" —
+    // a live change back to Default uses it to hand control back to the agent.
+    const options = [effortOption(['default', 'low', 'high'])]
+
+    expect(resolveSessionEffortOption(options, 'default')).toEqual({
+      configId: 'thought_level',
+      value: 'default'
+    })
+  })
+
   it('returns undefined when there is nothing usable to apply', () => {
     // Only the 'default' sentinel advertised: no real level to clamp onto.
     expect(resolveSessionEffortOption([effortOption(['default'])], 'high')).toBeUndefined()
-    // 'default'/unknown desired levels never reach the agent.
+    // 'default' without an advertised sentinel cannot be cleared; unknown levels never apply.
     expect(resolveSessionEffortOption([effortOption(['low'])], 'default')).toBeUndefined()
     expect(resolveSessionEffortOption([effortOption(['low'])], 'turbo')).toBeUndefined()
     expect(resolveSessionEffortOption([effortOption(['low'])], undefined)).toBeUndefined()

--- a/src/main/acp/session-config.test.ts
+++ b/src/main/acp/session-config.test.ts
@@ -1,7 +1,7 @@
 import type { SessionConfigOption } from '@agentclientprotocol/sdk'
 import { describe, expect, it } from 'vitest'
 
-import { matchSessionModelOption } from './session-config'
+import { matchSessionModelOption, resolveSessionEffortOption } from './session-config'
 
 // Builds a minimal `model` select option like opencode returns from session/new.
 const modelOption = (
@@ -71,5 +71,101 @@ describe('matchSessionModelOption', () => {
       configId: 'primary_model',
       value: 'x/y-model'
     })
+  })
+})
+
+// Builds a minimal `thought_level` select option like an agent returns from session/new.
+const effortOption = (
+  values: string[],
+  extra: Partial<SessionConfigOption> = {}
+): SessionConfigOption =>
+  ({
+    type: 'select',
+    id: 'thought_level',
+    name: 'Thought level',
+    category: 'thought_level',
+    currentValue: values[0],
+    options: values.map((value) => ({ value, name: value })),
+    ...extra
+  }) as SessionConfigOption
+
+describe('resolveSessionEffortOption', () => {
+  it('matches the desired level exactly when the model advertises it', () => {
+    const options = [effortOption(['low', 'medium', 'high'])]
+
+    expect(resolveSessionEffortOption(options, 'high')).toEqual({
+      configId: 'thought_level',
+      value: 'high'
+    })
+  })
+
+  it('falls back to the effort id when the category differs', () => {
+    // Claude Code advertises the option as id `effort`, not under the thought_level category.
+    const options = [effortOption(['low', 'high'], { id: 'effort', category: undefined })]
+
+    expect(resolveSessionEffortOption(options, 'low')).toEqual({
+      configId: 'effort',
+      value: 'low'
+    })
+  })
+
+  it('flattens grouped select options', () => {
+    const grouped = {
+      type: 'select',
+      id: 'effort',
+      name: 'Effort',
+      currentValue: 'low',
+      options: [{ name: 'Levels', options: [{ value: 'max', name: 'Max' }] }]
+    } as unknown as SessionConfigOption
+
+    expect(resolveSessionEffortOption([grouped], 'max')).toEqual({
+      configId: 'effort',
+      value: 'max'
+    })
+  })
+
+  it('clamps max to the model\u2019s highest advertised level, skipping the default sentinel', () => {
+    // Claude Code's effort select: a 'default' sentinel plus the model's supported levels.
+    const options = [effortOption(['default', 'low', 'medium', 'high'])]
+
+    expect(resolveSessionEffortOption(options, 'max')).toEqual({
+      configId: 'thought_level',
+      value: 'high'
+    })
+  })
+
+  it('clamps low to the model\u2019s lowest advertised level', () => {
+    const options = [effortOption(['medium', 'high'])]
+
+    expect(resolveSessionEffortOption(options, 'low')).toEqual({
+      configId: 'thought_level',
+      value: 'medium'
+    })
+  })
+
+  it('resolves equidistant levels to the lower (cheaper) one', () => {
+    const options = [effortOption(['medium', 'xhigh'])]
+
+    expect(resolveSessionEffortOption(options, 'high')).toEqual({
+      configId: 'thought_level',
+      value: 'medium'
+    })
+  })
+
+  it('returns undefined when there is nothing usable to apply', () => {
+    // Only the 'default' sentinel advertised: no real level to clamp onto.
+    expect(resolveSessionEffortOption([effortOption(['default'])], 'high')).toBeUndefined()
+    // 'default'/unknown desired levels never reach the agent.
+    expect(resolveSessionEffortOption([effortOption(['low'])], 'default')).toBeUndefined()
+    expect(resolveSessionEffortOption([effortOption(['low'])], 'turbo')).toBeUndefined()
+    expect(resolveSessionEffortOption([effortOption(['low'])], undefined)).toBeUndefined()
+    expect(resolveSessionEffortOption([], 'high')).toBeUndefined()
+    expect(resolveSessionEffortOption(undefined, 'high')).toBeUndefined()
+  })
+
+  it('does not mistake the model option for an effort option', () => {
+    const options = [modelOption(['high'])]
+
+    expect(resolveSessionEffortOption(options, 'high')).toBeUndefined()
   })
 })

--- a/src/main/acp/session-config.ts
+++ b/src/main/acp/session-config.ts
@@ -57,3 +57,58 @@ export const matchSessionModelOption = (
 
   return { configId: option.id, value: match }
 }
+
+// Canonical reasoning-effort scale, weakest to strongest. Effort levels are a relative scale: each
+// model advertises its own subset (Claude models draw from low/medium/high/xhigh/max), so a desired
+// level maps onto the closest advertised rung.
+const EFFORT_SCALE = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+
+const effortRank = (value: string): number =>
+  EFFORT_SCALE.indexOf(value as (typeof EFFORT_SCALE)[number])
+
+// Finds the session's reasoning-effort select option (the ACP `thought_level` category; Claude Code
+// advertises it as `effort`) and resolves the desired level to the closest value the agent actually
+// offers: exact match first, otherwise the advertised level nearest on the canonical scale (ties go
+// to the lower, cheaper level — e.g. 'max' on a model topping out at 'high' applies 'high'). Returns
+// undefined when there is no effort option or it advertises no recognizable level, so the agent
+// keeps its own default rather than erroring.
+export const resolveSessionEffortOption = (
+  configOptions: readonly SessionConfigOption[] | null | undefined,
+  desiredEffort: string | undefined
+): SessionModelSelection | undefined => {
+  const desiredRank = desiredEffort ? effortRank(desiredEffort) : -1
+
+  if (desiredRank < 0) return undefined
+
+  const option = (configOptions ?? []).find(
+    (candidate) =>
+      candidate.type === 'select' &&
+      (candidate.category === 'thought_level' || candidate.id === 'effort')
+  )
+
+  if (!option || option.type !== 'select') return undefined
+
+  // Only real levels are clamp targets — sentinels like 'default' (the agent's own default) are not.
+  const candidates = collectSelectValues(option.options)
+    .map((value) => ({ value, rank: effortRank(value) }))
+    .filter((candidate) => candidate.rank >= 0)
+
+  if (candidates.length === 0) return undefined
+
+  const exact = candidates.find((candidate) => candidate.rank === desiredRank)
+
+  if (exact) return { configId: option.id, value: exact.value }
+
+  let nearest = candidates[0]
+
+  for (const candidate of candidates) {
+    const distance = Math.abs(candidate.rank - desiredRank)
+    const bestDistance = Math.abs(nearest.rank - desiredRank)
+
+    if (distance < bestDistance || (distance === bestDistance && candidate.rank < nearest.rank)) {
+      nearest = candidate
+    }
+  }
+
+  return { configId: option.id, value: nearest.value }
+}

--- a/src/main/acp/session-config.ts
+++ b/src/main/acp/session-config.ts
@@ -71,15 +71,13 @@ const effortRank = (value: string): number =>
 // offers: exact match first, otherwise the advertised level nearest on the canonical scale (ties go
 // to the lower, cheaper level — e.g. 'max' on a model topping out at 'high' applies 'high'). Returns
 // undefined when there is no effort option or it advertises no recognizable level, so the agent
-// keeps its own default rather than erroring.
+// keeps its own default rather than erroring. The 'default' desired level is special: it matches the
+// agent's literal 'default' sentinel (Claude Code advertises one to mean "clear any forced level"),
+// so a live change can hand control back to the agent.
 export const resolveSessionEffortOption = (
   configOptions: readonly SessionConfigOption[] | null | undefined,
   desiredEffort: string | undefined
 ): SessionModelSelection | undefined => {
-  const desiredRank = desiredEffort ? effortRank(desiredEffort) : -1
-
-  if (desiredRank < 0) return undefined
-
   const option = (configOptions ?? []).find(
     (candidate) =>
       candidate.type === 'select' &&
@@ -88,8 +86,19 @@ export const resolveSessionEffortOption = (
 
   if (!option || option.type !== 'select') return undefined
 
+  const values = collectSelectValues(option.options)
+
+  // Clearing back to the agent default is only possible when the sentinel is explicitly advertised.
+  if (desiredEffort === 'default') {
+    return values.includes('default') ? { configId: option.id, value: 'default' } : undefined
+  }
+
+  const desiredRank = desiredEffort ? effortRank(desiredEffort) : -1
+
+  if (desiredRank < 0) return undefined
+
   // Only real levels are clamp targets — sentinels like 'default' (the agent's own default) are not.
-  const candidates = collectSelectValues(option.options)
+  const candidates = values
     .map((value) => ({ value, rank: effortRank(value) }))
     .filter((candidate) => candidate.rank >= 0)
 

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -25,6 +25,9 @@ export const claudeCodeFramework: AgentFramework = {
   supportsSkills: true,
   // Claude launches stdio MCP servers directly — the app's artifact/notebook tooling relies on this.
   acceptsStdioMcp: true,
+  // The adapter advertises an `effort` select (category thought_level) and applies changes to live
+  // sessions via applyFlagSettings — no respawn needed.
+  supportsLiveEffortChange: true,
   // Claude Code speaks only Anthropic /v1/messages.
   supportedApiTypes: ['anthropic'],
 

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -3,7 +3,12 @@ import { join } from 'node:path'
 
 import { describe, expect, it, vi } from 'vitest'
 
-import { CODEX_BRIDGE_MODEL, createCodexFramework, normalizeResponsesBaseUrl } from './codex'
+import {
+  CODEX_BRIDGE_MODEL,
+  buildCodexConfig,
+  createCodexFramework,
+  normalizeResponsesBaseUrl
+} from './codex'
 
 const fakeChild = {} as ChildProcessWithoutNullStreams
 
@@ -276,5 +281,39 @@ describe('codexFramework', () => {
     })
     expect(env.OPENAI_API_KEY).toBeUndefined()
     expect(env.CODEX_PATH).toBeUndefined()
+  })
+})
+
+describe('buildCodexConfig reasoning effort', () => {
+  it.each([
+    ['low', 'low'],
+    ['medium', 'medium'],
+    ['high', 'high'],
+    // Codex config tops out at xhigh; the app's top level 'max' maps onto it.
+    ['max', 'xhigh']
+  ] as const)('maps the %s level to model_reasoning_effort %s', (effort, expected) => {
+    expect(buildCodexConfig({ reasoningEffort: effort }).model_reasoning_effort).toBe(expected)
+  })
+
+  it.each([undefined, 'default'] as const)('omits model_reasoning_effort for %s', (effort) => {
+    expect(buildCodexConfig({ reasoningEffort: effort })).not.toHaveProperty(
+      'model_reasoning_effort'
+    )
+  })
+
+  it('threads the ctx level into the serialized CODEX_CONFIG env', () => {
+    const framework = createCodexFramework()
+    const config = framework.prepareModelConfig(
+      {
+        type: 'custom',
+        apiEndpoints: ['responses'],
+        baseUrl: 'https://gateway.example/v1',
+        model: 'gpt-5',
+        key: 'sk-plaintext-secret'
+      },
+      { storageRoot: '/data', executablePath: '/runtime/codex-acp', reasoningEffort: 'max' }
+    )
+
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '').model_reasoning_effort).toBe('xhigh')
   })
 })

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -12,6 +12,7 @@ import {
 } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import { augmentedPathEnv } from '../settings/shell-path'
+import type { ReasoningEffort } from '../../shared/settings'
 import type {
   AgentFramework,
   AgentAuthentication,
@@ -93,11 +94,23 @@ const buildCodexConfig = (provider: {
   baseUrl?: string
   model?: string
   key?: string
+  reasoningEffort?: ReasoningEffort
 }): Record<string, unknown> => {
   const baseUrl = normalizeResponsesBaseUrl(provider.baseUrl)
+  // Codex config takes low|medium|high|xhigh; the app's top level 'max' maps onto 'xhigh'.
+  // 'default' is filtered upstream (never reaches here), but stay defensive and omit it too.
+  const codexEffort =
+    provider.reasoningEffort === 'max'
+      ? 'xhigh'
+      : provider.reasoningEffort === 'low' ||
+          provider.reasoningEffort === 'medium' ||
+          provider.reasoningEffort === 'high'
+        ? provider.reasoningEffort
+        : undefined
 
   return {
     ...(provider.model ? { model: provider.model } : {}),
+    ...(codexEffort ? { model_reasoning_effort: codexEffort } : {}),
     model_provider: CODEX_PROVIDER_ID,
     model_providers: {
       [CODEX_PROVIDER_ID]: {
@@ -229,7 +242,8 @@ export const createCodexFramework = ({
             ...provider,
             model: codexModel,
             baseUrl: bridge?.baseUrl ?? provider.baseUrl,
-            key: useBridge ? undefined : provider.key
+            key: useBridge ? undefined : provider.key,
+            reasoningEffort: ctx.reasoningEffort
           })
         ),
         MODEL_PROVIDER: CODEX_PROVIDER_ID,

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -192,6 +192,9 @@ export const createCodexFramework = ({
   displayName: 'Codex',
   supportsSkills: true,
   acceptsStdioMcp: true,
+  // codex-acp advertises a thought_level effort option and honors set_config_option on live sessions
+  // (verified live), so an effort change does not need a respawn.
+  supportsLiveEffortChange: true,
   supportedApiTypes: ['responses'],
 
   spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams {

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -193,7 +193,9 @@ export const createCodexFramework = ({
   supportsSkills: true,
   acceptsStdioMcp: true,
   // codex-acp advertises a thought_level effort option and honors set_config_option on live sessions
-  // (verified live), so an effort change does not need a respawn.
+  // (verified live: a session accepted effort 'high' over ACP). If a future adapter stops
+  // advertising it, the runtime's no-applied-session guard falls back to a reconnect so the baked
+  // model_reasoning_effort config takes over.
   supportsLiveEffortChange: true,
   supportedApiTypes: ['responses'],
 

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -173,6 +173,61 @@ describe('opencodeFramework.prepareModelConfig', () => {
       fileConfig.provider['openai-compatible'].options.baseURL
     )
   })
+
+  it('declares the reasoning effort on the model in both config layers', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      { storageRoot: '/data', executablePath: '/bin/opencode', reasoningEffort: 'low' }
+    )
+
+    const fileConfig = JSON.parse(
+      config.configFiles?.find((file) => file.path.endsWith('opencode.json'))?.content ?? '{}'
+    )
+    const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+
+    // Both layers carry the per-model knob so neither the written file nor the pinned layer drops it.
+    expect(fileConfig.provider.anthropic.models).toEqual({
+      m: { options: { reasoningEffort: 'low' } }
+    })
+    expect(content.provider.anthropic.models).toEqual({
+      m: { options: { reasoningEffort: 'low' } }
+    })
+  })
+
+  it("clamps the app's top level 'max' to opencode's 'high' in both layers", () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      { storageRoot: '/data', executablePath: '/bin/opencode', reasoningEffort: 'max' }
+    )
+
+    const fileConfig = JSON.parse(
+      config.configFiles?.find((file) => file.path.endsWith('opencode.json'))?.content ?? '{}'
+    )
+    const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+
+    // opencode's reasoningEffort follows the AI SDK levels, which top out at 'high'.
+    expect(fileConfig.provider.anthropic.models).toEqual({
+      m: { options: { reasoningEffort: 'high' } }
+    })
+    expect(content.provider.anthropic.models).toEqual({
+      m: { options: { reasoningEffort: 'high' } }
+    })
+  })
+
+  it('leaves the model block empty when no reasoning effort is set', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    const fileConfig = JSON.parse(
+      config.configFiles?.find((file) => file.path.endsWith('opencode.json'))?.content ?? '{}'
+    )
+    const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+
+    expect(fileConfig.provider.anthropic.models).toEqual({ m: {} })
+    expect(content.provider.anthropic.models).toEqual({ m: {} })
+  })
 })
 
 describe('buildOpencodeConfig', () => {
@@ -368,6 +423,21 @@ describe('buildOpencodeConfig', () => {
     )
 
     expect(config.provider['openai-compatible'].models).toEqual({ 'deepseek-v4-flash': {} })
+  })
+
+  it('declares the reasoning effort passed as the fourth argument on the model', () => {
+    const config = JSON.parse(
+      buildOpencodeConfig(
+        { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+        {},
+        [],
+        'medium'
+      )
+    )
+
+    expect(config.provider.anthropic.models).toEqual({
+      m: { options: { reasoningEffort: 'medium' } }
+    })
   })
 
   it('uses the OpenAI base for a dual-endpoint vendor, not its Anthropic base (DeepSeek)', () => {

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -8,6 +8,7 @@ import {
 } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import { preferredEndpoint } from '../../shared/settings'
+import type { ReasoningEffort } from '../../shared/settings'
 import { openAiCompletionsBase } from '../settings/base-url'
 import { augmentedPathEnv } from '../settings/shell-path'
 import type { ResolvedProvider } from '../settings/provider-env'
@@ -118,9 +119,23 @@ const resolveOpencodeEndpoint = (
 // any model whose config does not declare vision — custom and freshly-registered models default to
 // text-only — so a base64 image sent over ACP silently never reaches the provider. A multimodal model
 // must therefore advertise both the attachment capability and an image input modality. Empty (text-only)
-// otherwise, so a non-vision model is never told it can accept images.
-const buildModelCapabilities = (provider: ResolvedProvider): Record<string, unknown> =>
-  provider.supportsImageInput ? { attachment: true, modalities: { input: ['text', 'image'] } } : {}
+// otherwise, so a non-vision model is never told it can accept images. A reasoning-effort preference is
+// declared via the model's `options.reasoningEffort`, opencode's per-model knob passed through to the
+// AI SDK provider; providers that don't support it ignore the option.
+const buildModelCapabilities = (
+  provider: ResolvedProvider,
+  reasoningEffort?: ReasoningEffort
+): Record<string, unknown> => ({
+  ...(provider.supportsImageInput
+    ? { attachment: true, modalities: { input: ['text', 'image'] } }
+    : {}),
+  ...(reasoningEffort ? { options: { reasoningEffort: clampOpencodeEffort(reasoningEffort) } } : {})
+})
+
+// opencode's reasoningEffort follows the AI SDK levels, which top out at 'high'; the app's top level
+// 'max' clamps down to it. 'default' is filtered upstream and never reaches here.
+const clampOpencodeEffort = (effort: ReasoningEffort): 'low' | 'medium' | 'high' =>
+  effort === 'low' || effort === 'medium' ? effort : 'high'
 
 // The app-authoritative config layer (model + provider block + permission policy) passed verbatim to
 // opencode via OPENCODE_CONFIG_CONTENT, which opencode deep-merges ABOVE both the app-owned global config
@@ -128,7 +143,10 @@ const buildModelCapabilities = (provider: ResolvedProvider): Record<string, unkn
 // lower-precedence config — e.g. the user's own ~/.opencode — cannot repoint the active provider's
 // baseURL or switch the model to an attacker-defined provider while inheriting the app's key ref, so the
 // real key can only ever go to the app's own endpoint. The key stays an env reference, never plaintext.
-const buildAppConfigContent = (provider: ResolvedProvider): Record<string, unknown> => {
+const buildAppConfigContent = (
+  provider: ResolvedProvider,
+  reasoningEffort?: ReasoningEffort
+): Record<string, unknown> => {
   const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
 
   return {
@@ -141,7 +159,9 @@ const buildAppConfigContent = (provider: ResolvedProvider): Record<string, unkno
           ...(baseURL ? { baseURL } : {}),
           ...(provider.key ? { apiKey: `{env:${OPENCODE_API_KEY_ENV}}` } : {})
         },
-        ...(bareModel ? { models: { [bareModel]: buildModelCapabilities(provider) } } : {})
+        ...(bareModel
+          ? { models: { [bareModel]: buildModelCapabilities(provider, reasoningEffort) } }
+          : {})
       }
     }
   }
@@ -155,7 +175,8 @@ const buildAppConfigContent = (provider: ResolvedProvider): Record<string, unkno
 const buildOpencodeConfig = (
   provider: ResolvedProvider,
   baseConfig: Record<string, unknown> = {},
-  instructionPaths: string[] = []
+  instructionPaths: string[] = [],
+  reasoningEffort?: ReasoningEffort
 ): string => {
   const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
 
@@ -199,7 +220,12 @@ const buildOpencodeConfig = (
         // Register the model so opencode treats a non-catalog id as a real, selectable model, declaring
         // its image capability when the active model is multimodal (else opencode strips image parts).
         ...(bareModel
-          ? { models: { ...baseModels, [bareModel]: buildModelCapabilities(provider) } }
+          ? {
+              models: {
+                ...baseModels,
+                [bareModel]: buildModelCapabilities(provider, reasoningEffort)
+              }
+            }
           : {})
       }
     }
@@ -262,7 +288,12 @@ export const opencodeFramework: AgentFramework = {
       configFiles.push({ path: instructionsPath, content: ctx.instructions })
     }
 
-    configFiles[0].content = buildOpencodeConfig(provider, {}, instructionPaths)
+    configFiles[0].content = buildOpencodeConfig(
+      provider,
+      {},
+      instructionPaths,
+      ctx.reasoningEffort
+    )
 
     return {
       env: {
@@ -287,7 +318,9 @@ export const opencodeFramework: AgentFramework = {
         // against the only remaining non-repo surface, the user's own ~/.opencode: it cannot repoint the
         // active provider's baseURL or swap the model to an attacker provider while inheriting the app's
         // `{env:...}` key ref. The key itself never rides this layer, only its env reference.
-        OPENCODE_CONFIG_CONTENT: JSON.stringify(buildAppConfigContent(provider)),
+        OPENCODE_CONFIG_CONTENT: JSON.stringify(
+          buildAppConfigContent(provider, ctx.reasoningEffort)
+        ),
         // Pass the decrypted key ONLY via the environment; the config references it as `{env:...}`.
         ...(provider.key ? { [OPENCODE_API_KEY_ENV]: provider.key } : {})
       },

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -247,6 +247,9 @@ export const opencodeFramework: AgentFramework = {
   // ACP has no stdio flag — stdio is the baseline transport. So opencode uses the SAME stdio artifact/
   // notebook config as Claude; the http MCP host stays in the runtime but no framework needs it.
   acceptsStdioMcp: true,
+  // opencode's ACP server advertises no thought_level option (verified live) — effort only rides the
+  // generated config's per-model options, so a change must respawn to take effect.
+  supportsLiveEffortChange: false,
   // opencode speaks both Anthropic /v1/messages and OpenAI /v1/chat/completions.
   supportedApiTypes: ['anthropic', 'openai'],
 

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -3,7 +3,7 @@ import type { SessionModeState } from '@agentclientprotocol/sdk'
 
 import type { PermissionProfileApplication } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
-import type { AgentFrameworkId, ChatApiEndpoint } from '../../shared/settings'
+import type { AgentFrameworkId, ChatApiEndpoint, ReasoningEffort } from '../../shared/settings'
 import type { ResolvedProvider } from '../settings/provider-env'
 import type { ResponsesBridgeConnection } from '../settings/responses-bridge'
 
@@ -59,6 +59,10 @@ export type ModelConfigContext = {
   // skill loading; the adapter writes it and wires it into the agent's instruction mechanism so the
   // agent learns host.mcp instead of reimplementing connector calls with raw HTTP. Empty ⇒ omitted.
   instructions?: string
+  // The user's reasoning-effort preference ('default'/undefined ⇒ don't override; the framework
+  // injects nothing and the agent keeps its own default). Each framework maps the level onto its
+  // native config channel — Codex's model_reasoning_effort, opencode's model options.
+  reasoningEffort?: ReasoningEffort
 }
 
 // System-prompt guidance the runtime wants appended for a session (artifact routing, notebook, skill
@@ -136,6 +140,9 @@ export type ResolvedAgentBackend = {
   // Subscription backends must run the model selected in the UI. When true, a missing/rejected live
   // model option fails session creation instead of silently using the agent's account default.
   sessionModelRequired?: boolean
+  // Reasoning-effort level to apply per session via the ACP `thought_level` configOption, resolved
+  // to the closest level the agent advertises. Undefined ⇒ the agent keeps its own default.
+  sessionEffort?: string
   authentication?: AgentAuthentication
   providerConfiguration?: AgentProviderConfiguration
 }

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -117,6 +117,12 @@ export interface AgentFramework {
   // (currently stdio) is gated off for such frameworks until it is exposed over http/sse.
   readonly acceptsStdioMcp: boolean
 
+  // Whether a reasoning-effort change can be applied LIVE to open sessions via the ACP thought_level
+  // configOption, without a respawn. True where the adapter advertises that option (verified live:
+  // Claude Code, codex-acp). False where effort only rides the baked spawn config (opencode ignores
+  // the protocol option), so a change must respawn to regenerate it.
+  readonly supportsLiveEffortChange: boolean
+
   // Chat endpoints this framework can drive. A provider is only selectable when it shares one:
   // Claude Code speaks Anthropic /v1/messages; opencode speaks both.
   readonly supportedApiTypes: readonly ChatApiEndpoint[]

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -142,7 +142,7 @@ export type ResolvedAgentBackend = {
   sessionModelRequired?: boolean
   // Reasoning-effort level to apply per session via the ACP `thought_level` configOption, resolved
   // to the closest level the agent advertises. Undefined ⇒ the agent keeps its own default.
-  sessionEffort?: string
+  sessionEffort?: ReasoningEffort
   authentication?: AgentAuthentication
   providerConfiguration?: AgentProviderConfiguration
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -342,6 +342,7 @@ const registerIpcHandlers = async ({
   registerSettingsIpcHandlers({
     service: settingsService,
     onActiveProviderChanged: () => void runtime.requestProviderReconnect(),
+    onReasoningEffortChanged: (effort) => runtime.applyReasoningEffortChange(effort),
     onSkillsChanged: () => void runtime.requestSkillsReload(),
     // Re-sync bundled + custom skill docs and refresh the in-memory snapshot the connector
     // service reads, then request a skills reload. The reload respawns the agent on next idle so a

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -34,6 +34,7 @@ type FakeSettingsService = Record<
   | 'uninstallOpencode'
   | 'uninstallCodex'
   | 'setAgentFramework'
+  | 'setReasoningEffort'
   | 'upsertProvider'
   | 'deleteProvider'
   | 'setActiveProvider'
@@ -79,6 +80,9 @@ const createFakeService = (): FakeSettingsService => ({
   setAgentFramework: vi
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], agentFrameworkId: 'opencode' }),
+  setReasoningEffort: vi
+    .fn()
+    .mockResolvedValue({ claude: {}, providers: [], reasoningEffort: 'high' }),
   upsertProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
   deleteProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
   setActiveProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
@@ -504,6 +508,23 @@ describe('settings IPC handlers', () => {
     // The handler unwraps the request to the bare framework id the service expects.
     expect(service.setAgentFramework).toHaveBeenCalledWith('opencode')
     // Switching frameworks swaps the backend binary, so the live agent must be dropped like a provider switch.
+    expect(onActiveProviderChanged).toHaveBeenCalledOnce()
+    expect(result).toBe(snapshot)
+  })
+
+  it('persists the reasoning effort and respawns the agent on set-reasoning-effort', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const snapshot = { claude: {}, providers: [], reasoningEffort: 'high' }
+    service.setReasoningEffort.mockResolvedValue(snapshot)
+    const onActiveProviderChanged = vi.fn()
+    registerSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+
+    const result = await invoke('settings:set-reasoning-effort', { effort: 'high' })
+
+    // The handler unwraps the request to the bare effort level the service expects.
+    expect(service.setReasoningEffort).toHaveBeenCalledWith('high')
+    // The level is baked into the spawn env/config, so the live agent must be dropped like a provider switch.
     expect(onActiveProviderChanged).toHaveBeenCalledOnce()
     expect(result).toBe(snapshot)
   })

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -512,19 +512,45 @@ describe('settings IPC handlers', () => {
     expect(result).toBe(snapshot)
   })
 
-  it('persists the reasoning effort and respawns the agent on set-reasoning-effort', async () => {
+  it('applies the level live without respawning when the framework supports it', async () => {
     handlers.clear()
     const service = createFakeService()
     const snapshot = { claude: {}, providers: [], reasoningEffort: 'high' }
     service.setReasoningEffort.mockResolvedValue(snapshot)
     const onActiveProviderChanged = vi.fn()
-    registerSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+    const onReasoningEffortChanged = vi.fn().mockResolvedValue(true)
+    registerSettingsIpcHandlers({
+      service: asService(service),
+      onActiveProviderChanged,
+      onReasoningEffortChanged
+    })
 
     const result = await invoke('settings:set-reasoning-effort', { effort: 'high' })
 
-    // The handler unwraps the request to the bare effort level the service expects.
+    // A live ACP application (Claude Code, Codex) makes the level stick without a respawn.
     expect(service.setReasoningEffort).toHaveBeenCalledWith('high')
-    // The level is baked into the spawn env/config, so the live agent must be dropped like a provider switch.
+    expect(onReasoningEffortChanged).toHaveBeenCalledWith('high')
+    expect(onActiveProviderChanged).not.toHaveBeenCalled()
+    expect(result).toBe(snapshot)
+  })
+
+  it('respawns the agent when the framework cannot apply the level live', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const snapshot = { claude: {}, providers: [], reasoningEffort: 'high' }
+    service.setReasoningEffort.mockResolvedValue(snapshot)
+    const onActiveProviderChanged = vi.fn()
+    const onReasoningEffortChanged = vi.fn().mockResolvedValue(false)
+    registerSettingsIpcHandlers({
+      service: asService(service),
+      onActiveProviderChanged,
+      onReasoningEffortChanged
+    })
+
+    const result = await invoke('settings:set-reasoning-effort', { effort: 'high' })
+
+    // opencode bakes effort into its spawn config, so the provider-switch reconnect delivers it.
+    expect(service.setReasoningEffort).toHaveBeenCalledWith('high')
     expect(onActiveProviderChanged).toHaveBeenCalledOnce()
     expect(result).toBe(snapshot)
   })

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -529,6 +529,26 @@ describe('settings IPC handlers', () => {
     expect(result).toBe(snapshot)
   })
 
+  it('rejects an unknown reasoning effort without touching the service or the agent', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const onActiveProviderChanged = vi.fn()
+    registerSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+
+    // Renderer payloads are untyped at runtime: garbage must fail at the boundary, not persist.
+    await expect(invoke('settings:set-reasoning-effort', { effort: 'ultra' })).rejects.toThrow(
+      'Unknown reasoning effort'
+    )
+    await expect(invoke('settings:set-reasoning-effort', { effort: 3 })).rejects.toThrow(
+      'Unknown reasoning effort'
+    )
+    await expect(invoke('settings:set-reasoning-effort', {})).rejects.toThrow(
+      'Unknown reasoning effort'
+    )
+    expect(service.setReasoningEffort).not.toHaveBeenCalled()
+    expect(onActiveProviderChanged).not.toHaveBeenCalled()
+  })
+
   it('surfaces a service error thrown by install-opencode', async () => {
     handlers.clear()
     const service = createFakeService()

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron'
 
 import {
   CODEX_SUBSCRIPTION_PROVIDER_ID,
+  isReasoningEffort,
   type CreateSkillRequest,
   type DeleteProviderRequest,
   type DeleteSkillRequest,
@@ -159,6 +160,12 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle(
     'settings:set-reasoning-effort',
     async (_event, request: SetReasoningEffortRequest) => {
+      // Renderer payloads are untyped at runtime: reject anything outside the known levels instead
+      // of persisting a value the agent-mapping layers can't interpret.
+      if (!isReasoningEffort(request?.effort)) {
+        throw new Error(`Unknown reasoning effort: ${String(request?.effort)}`)
+      }
+
       log.info('set reasoning effort requested', { effort: request.effort })
       const snapshot = await service.setReasoningEffort(request.effort)
 

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -25,6 +25,7 @@ import {
   type SetConnectorEnabledRequest,
   type SetNcbiCredentialsRequest,
   type SetPackageMirrorRequest,
+  type SetReasoningEffortRequest,
   type SetSkillEnabledRequest,
   type SetToolPermissionRequest,
   type UpdateSkillRequest,
@@ -150,6 +151,19 @@ const registerSettingsIpcHandlers = ({
 
       // Switching frameworks needs a fresh agent process, exactly like a provider switch — the live
       // process is a different backend binary, so the choice only takes effect on reconnect.
+      onActiveProviderChanged?.()
+
+      return snapshot
+    }
+  )
+  ipcMain.handle(
+    'settings:set-reasoning-effort',
+    async (_event, request: SetReasoningEffortRequest) => {
+      log.info('set reasoning effort requested', { effort: request.effort })
+      const snapshot = await service.setReasoningEffort(request.effort)
+
+      // The level is baked into the spawn env/config, so it only reaches the agent via a reconnect —
+      // the same mechanism a provider/framework switch uses. Subsequent requests then run at it.
       onActiveProviderChanged?.()
 
       return snapshot

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -3,6 +3,7 @@ import { ipcMain } from 'electron'
 import {
   CODEX_SUBSCRIPTION_PROVIDER_ID,
   isReasoningEffort,
+  type ReasoningEffort,
   type CreateSkillRequest,
   type DeleteProviderRequest,
   type DeleteSkillRequest,
@@ -47,6 +48,10 @@ export type SettingsIpcOptions = {
   service?: SettingsService
   // Called after the active provider changes so the ACP runtime can drop its stale connection.
   onActiveProviderChanged?: () => void
+  // Called after the reasoning effort changes so the ACP runtime can live-apply it to open sessions.
+  // Returns true when the level was applied over ACP (no reconnect needed); false means the active
+  // framework only carries effort in its spawn config and onActiveProviderChanged must fire instead.
+  onReasoningEffortChanged?: (effort: ReasoningEffort) => Promise<boolean>
   // Called after a skill is toggled so the ACP runtime reloads skills on its next reconnect.
   onSkillsChanged?: () => void
   // Called after a connector/tool/credential change so bundled + custom skill docs re-sync.
@@ -63,6 +68,7 @@ const broadcastInstallEvent = (event: ClaudeInstallEvent): void => {
 const registerSettingsIpcHandlers = ({
   service = createDefaultSettingsService(),
   onActiveProviderChanged,
+  onReasoningEffortChanged,
   onSkillsChanged,
   onConnectorsChanged
 }: SettingsIpcOptions = {}): void => {
@@ -169,9 +175,14 @@ const registerSettingsIpcHandlers = ({
       log.info('set reasoning effort requested', { effort: request.effort })
       const snapshot = await service.setReasoningEffort(request.effort)
 
-      // The level is baked into the spawn env/config, so it only reaches the agent via a reconnect —
-      // the same mechanism a provider/framework switch uses. Subsequent requests then run at it.
-      onActiveProviderChanged?.()
+      // Live-capable frameworks (Claude Code, Codex) apply the level to open sessions over ACP —
+      // no respawn, the way a model switch feels. Others (opencode) bake effort into the spawn
+      // config, so only the provider-switch reconnect can deliver it.
+      const appliedLive = (await onReasoningEffortChanged?.(request.effort)) ?? false
+
+      if (!appliedLive) {
+        onActiveProviderChanged?.()
+      }
 
       return snapshot
     }

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -88,6 +88,33 @@ describe('settings repository', () => {
     expect(settings.opencodeVersion).toBe('1.18.3')
   })
 
+  it('persists the reasoning effort across a sanitized read and a reload', async () => {
+    const root = await createStorageRoot()
+    const repository = new SettingsRepository(root)
+
+    await repository.setReasoningEffort('high')
+
+    // sanitizeSettings must not strip the level on read-back, or the selector can never switch.
+    expect((await repository.getSettings()).reasoningEffort).toBe('high')
+
+    // A fresh repository on the same storage dir models an app restart: the level is read back.
+    const reloaded = await new SettingsRepository(root).getSettings()
+    expect(reloaded.reasoningEffort).toBe('high')
+  })
+
+  it.each(['default', 'low', 'medium', 'high', 'max'] as const)(
+    'keeps the %s reasoning effort on load',
+    (effort) => {
+      expect(sanitizeSettings({ reasoningEffort: effort }).reasoningEffort).toBe(effort)
+    }
+  )
+
+  it('drops an unknown reasoning effort on load', () => {
+    expect(sanitizeSettings({ reasoningEffort: 'ultra' }).reasoningEffort).toBeUndefined()
+    expect(sanitizeSettings({ reasoningEffort: 42 }).reasoningEffort).toBeUndefined()
+    expect(sanitizeSettings({}).reasoningEffort).toBeUndefined()
+  })
+
   it('persists the Codex adapter and paired native runtime across a sanitized read', async () => {
     const repository = new SettingsRepository(await createStorageRoot())
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -15,7 +15,8 @@ import {
   SETTINGS_FILE_VERSION,
   codexSubscriptionProviderIdentity,
   isCodexSubscriptionProvider,
-  isCodexSubscriptionProviderId
+  isCodexSubscriptionProviderId,
+  isReasoningEffort
 } from '../../shared/settings'
 import { isOfficialVendorId } from '../../shared/provider-registry'
 import type { PackageMirror } from '../../shared/mirror'
@@ -431,13 +432,7 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
   // Reasoning-effort preference; only the known levels survive so a bad value can't leak through.
   const reasoningEffort = asString(value.reasoningEffort)
 
-  if (
-    reasoningEffort === 'default' ||
-    reasoningEffort === 'low' ||
-    reasoningEffort === 'medium' ||
-    reasoningEffort === 'high' ||
-    reasoningEffort === 'max'
-  ) {
+  if (isReasoningEffort(reasoningEffort)) {
     settings.reasoningEffort = reasoningEffort
   }
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -7,6 +7,7 @@ import type {
   ClaudeInfo,
   ProviderType,
   ProviderValidationFailure,
+  ReasoningEffort,
   ValidationCategory
 } from '../../shared/settings'
 import {
@@ -427,6 +428,19 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
     settings.agentFrameworkId = agentFrameworkId
   }
 
+  // Reasoning-effort preference; only the known levels survive so a bad value can't leak through.
+  const reasoningEffort = asString(value.reasoningEffort)
+
+  if (
+    reasoningEffort === 'default' ||
+    reasoningEffort === 'low' ||
+    reasoningEffort === 'medium' ||
+    reasoningEffort === 'high' ||
+    reasoningEffort === 'max'
+  ) {
+    settings.reasoningEffort = reasoningEffort
+  }
+
   const opencodePath = asString(value.opencodePath)
 
   if (opencodePath) {
@@ -624,6 +638,11 @@ class SettingsRepository {
   // Persists the selected agent backend; applied on the next reconnect.
   async setAgentFramework(id: AgentFrameworkId): Promise<StoredSettings> {
     return this.mutate((settings) => ({ ...settings, agentFrameworkId: id }))
+  }
+
+  // Persists the reasoning-effort preference; applied to sessions created after the next reconnect.
+  async setReasoningEffort(effort: ReasoningEffort): Promise<StoredSettings> {
+    return this.mutate((settings) => ({ ...settings, reasoningEffort: effort }))
   }
 
   // Records the detected opencode executable path + version for later spawns + the settings status card.

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -508,18 +508,36 @@ describe('Responses-compatible bridge conversion', () => {
     ).toMatchObject({ model: 'deepseek-v4-flash' })
   })
 
-  it('translates the reasoning effort into the Chat Completions parameter', () => {
+  it('translates the reasoning effort into the Chat Completions parameter when explicitly chosen', () => {
     expect(
-      responsesToChatRequest({ model: 'model-a', input: 'hi', reasoning: { effort: 'high' } })
+      responsesToChatRequest(
+        { model: 'model-a', input: 'hi', reasoning: { effort: 'high' } },
+        undefined,
+        undefined,
+        [],
+        { forwardReasoningEffort: true }
+      )
     ).toMatchObject({ reasoning_effort: 'high' })
     expect(
-      responsesToChatRequest({ model: 'model-a', input: 'hi', reasoning: { effort: 'low' } })
+      responsesToChatRequest(
+        { model: 'model-a', input: 'hi', reasoning: { effort: 'low' } },
+        undefined,
+        undefined,
+        [],
+        { forwardReasoningEffort: true }
+      )
     ).toMatchObject({ reasoning_effort: 'low' })
   })
 
   it('clamps the Codex-only xhigh effort to high for Chat Completions', () => {
     expect(
-      responsesToChatRequest({ model: 'model-a', input: 'hi', reasoning: { effort: 'xhigh' } })
+      responsesToChatRequest(
+        { model: 'model-a', input: 'hi', reasoning: { effort: 'xhigh' } },
+        undefined,
+        undefined,
+        [],
+        { forwardReasoningEffort: true }
+      )
     ).toMatchObject({ reasoning_effort: 'high' })
   })
 
@@ -527,11 +545,27 @@ describe('Responses-compatible bridge conversion', () => {
     // 'none' has no Chat Completions equivalent — the upstream default stands. No reasoning block
     // means nothing is sent either.
     expect(
-      responsesToChatRequest({ model: 'model-a', input: 'hi', reasoning: { effort: 'none' } })
+      responsesToChatRequest(
+        { model: 'model-a', input: 'hi', reasoning: { effort: 'none' } },
+        undefined,
+        undefined,
+        [],
+        { forwardReasoningEffort: true }
+      )
     ).not.toHaveProperty('reasoning_effort')
-    expect(responsesToChatRequest({ model: 'model-a', input: 'hi' })).not.toHaveProperty(
-      'reasoning_effort'
-    )
+    expect(
+      responsesToChatRequest({ model: 'model-a', input: 'hi' }, undefined, undefined, [], {
+        forwardReasoningEffort: true
+      })
+    ).not.toHaveProperty('reasoning_effort')
+  })
+
+  it('strips the reasoning effort unless the user explicitly chose a level', () => {
+    // Codex emits its own default effort even when the app never configured one; forwarding that
+    // would change what existing bridged users send to gateways that may reject unknown params.
+    expect(
+      responsesToChatRequest({ model: 'model-a', input: 'hi', reasoning: { effort: 'high' } })
+    ).not.toHaveProperty('reasoning_effort')
   })
 
   it('surfaces a nested upstream error instead of hiding it behind HTTP status', () => {
@@ -608,7 +642,7 @@ describe('Responses-compatible bridge conversion', () => {
     }
   })
 
-  it('forwards the reasoning effort to the upstream gateway', async () => {
+  it('forwards the reasoning effort to the upstream gateway when explicitly chosen', async () => {
     let upstreamRequest: Record<string, unknown> | undefined
     const upstreamFetch = vi.fn(
       async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
@@ -630,7 +664,7 @@ describe('Responses-compatible bridge conversion', () => {
       }
     )
     const bridge = new ResponsesBridge(
-      { baseUrl: 'https://vendor.example/v1', key: 'upstream-key' },
+      { baseUrl: 'https://vendor.example/v1', key: 'upstream-key', forwardReasoningEffort: true },
       upstreamFetch
     )
     const connection = await bridge.start()
@@ -654,6 +688,58 @@ describe('Responses-compatible bridge conversion', () => {
       // The Codex-only 'xhigh' reaches the gateway as 'high', not dropped.
       expect(response.status).toBe(200)
       expect(upstreamRequest).toMatchObject({ reasoning_effort: 'high' })
+    } finally {
+      await bridge.close()
+    }
+  })
+
+  it('strips the reasoning effort when the user never chose a level', async () => {
+    let upstreamRequest: Record<string, unknown> | undefined
+    const upstreamFetch = vi.fn(
+      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        upstreamRequest = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return new Response(
+          [
+            'data: ' +
+              JSON.stringify({
+                id: 'chat-effort-2',
+                model: 'model-a',
+                choices: [{ index: 0, delta: { role: 'assistant', content: 'ok' } }]
+              }),
+            '',
+            'data: [DONE]',
+            ''
+          ].join('\n'),
+          { headers: { 'content-type': 'text/event-stream' } }
+        )
+      }
+    )
+    // No forwardReasoningEffort: Codex's own default effort must not change what existing bridged
+    // users send upstream.
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', key: 'upstream-key' },
+      upstreamFetch
+    )
+    const connection = await bridge.start()
+
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'model-a',
+          input: 'hi',
+          reasoning: { effort: 'high' },
+          stream: true
+        })
+      })
+      await response.text()
+
+      expect(response.status).toBe(200)
+      expect(upstreamRequest).not.toHaveProperty('reasoning_effort')
     } finally {
       await bridge.close()
     }

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -745,6 +745,65 @@ describe('Responses-compatible bridge conversion', () => {
     }
   })
 
+  it('flips effort forwarding on a live bridge without replacing its target', async () => {
+    let upstreamRequest: Record<string, unknown> | undefined
+    const upstreamFetch = vi.fn(
+      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        upstreamRequest = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return new Response(
+          [
+            'data: ' +
+              JSON.stringify({
+                id: 'chat-effort-flip',
+                model: 'model-a',
+                choices: [{ index: 0, delta: { role: 'assistant', content: 'ok' } }]
+              }),
+            '',
+            'data: [DONE]',
+            ''
+          ].join('\n'),
+          { headers: { 'content-type': 'text/event-stream' } }
+        )
+      }
+    )
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', key: 'upstream-key' },
+      upstreamFetch
+    )
+    const connection = await bridge.start()
+    const post = (): Promise<string> =>
+      fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'model-a',
+          input: 'hi',
+          reasoning: { effort: 'high' },
+          stream: true
+        })
+      }).then((response) => response.text())
+
+    try {
+      await post()
+      expect(upstreamRequest).not.toHaveProperty('reasoning_effort')
+
+      // The user picks a level (Codex applies it live over ACP — the bridge never reconnects).
+      bridge.setForwardReasoningEffort(true)
+      await post()
+      expect(upstreamRequest).toMatchObject({ reasoning_effort: 'high' })
+
+      // Back to default: stripping restored on the same live bridge.
+      bridge.setForwardReasoningEffort(false)
+      await post()
+      expect(upstreamRequest).not.toHaveProperty('reasoning_effort')
+    } finally {
+      await bridge.close()
+    }
+  })
+
   it('restores a namespaced MCP call when its Chat id, name, and arguments are fragmented', async () => {
     let upstreamRequest: Record<string, unknown> | undefined
     const upstreamFetch = vi.fn(

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -508,6 +508,32 @@ describe('Responses-compatible bridge conversion', () => {
     ).toMatchObject({ model: 'deepseek-v4-flash' })
   })
 
+  it('translates the reasoning effort into the Chat Completions parameter', () => {
+    expect(
+      responsesToChatRequest({ model: 'model-a', input: 'hi', reasoning: { effort: 'high' } })
+    ).toMatchObject({ reasoning_effort: 'high' })
+    expect(
+      responsesToChatRequest({ model: 'model-a', input: 'hi', reasoning: { effort: 'low' } })
+    ).toMatchObject({ reasoning_effort: 'low' })
+  })
+
+  it('clamps the Codex-only xhigh effort to high for Chat Completions', () => {
+    expect(
+      responsesToChatRequest({ model: 'model-a', input: 'hi', reasoning: { effort: 'xhigh' } })
+    ).toMatchObject({ reasoning_effort: 'high' })
+  })
+
+  it('omits the reasoning effort when there is nothing portable to send', () => {
+    // 'none' has no Chat Completions equivalent — the upstream default stands. No reasoning block
+    // means nothing is sent either.
+    expect(
+      responsesToChatRequest({ model: 'model-a', input: 'hi', reasoning: { effort: 'none' } })
+    ).not.toHaveProperty('reasoning_effort')
+    expect(responsesToChatRequest({ model: 'model-a', input: 'hi' })).not.toHaveProperty(
+      'reasoning_effort'
+    )
+  })
+
   it('surfaces a nested upstream error instead of hiding it behind HTTP status', () => {
     expect(
       upstreamErrorMessage('{"error":{"message":"Model deepseek-v4-flash does not exist"}}', 400)
@@ -577,6 +603,57 @@ describe('Responses-compatible bridge conversion', () => {
       expect(output).toContain('response.output_text.delta')
       expect(output).toContain('bridge-ok')
       expect(output).toContain('response.completed')
+    } finally {
+      await bridge.close()
+    }
+  })
+
+  it('forwards the reasoning effort to the upstream gateway', async () => {
+    let upstreamRequest: Record<string, unknown> | undefined
+    const upstreamFetch = vi.fn(
+      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        upstreamRequest = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return new Response(
+          [
+            'data: ' +
+              JSON.stringify({
+                id: 'chat-effort-1',
+                model: 'model-a',
+                choices: [{ index: 0, delta: { role: 'assistant', content: 'ok' } }]
+              }),
+            '',
+            'data: [DONE]',
+            ''
+          ].join('\n'),
+          { headers: { 'content-type': 'text/event-stream' } }
+        )
+      }
+    )
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', key: 'upstream-key' },
+      upstreamFetch
+    )
+    const connection = await bridge.start()
+
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'model-a',
+          input: 'hi',
+          reasoning: { effort: 'xhigh' },
+          stream: true
+        })
+      })
+      await response.text()
+
+      // The Codex-only 'xhigh' reaches the gateway as 'high', not dropped.
+      expect(response.status).toBe(200)
+      expect(upstreamRequest).toMatchObject({ reasoning_effort: 'high' })
     } finally {
       await bridge.close()
     }

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -1061,6 +1061,13 @@ export class ResponsesBridge {
     if (changed) this.reasoningByCallId.clear()
   }
 
+  // Updates only the effort-forwarding policy on the live target, for when the user's reasoning-effort
+  // setting changes without a reconnect (Codex applies level changes live over ACP). Deliberately not
+  // a setTarget: the upstream provider is unchanged, so the reasoning cache must be preserved.
+  setForwardReasoningEffort(forward: boolean): void {
+    this.target = { ...this.target, forwardReasoningEffort: forward }
+  }
+
   async start(): Promise<ResponsesBridgeConnection> {
     if (this.connection) return this.connection
     const token = randomBytes(24).toString('hex')

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -23,6 +23,11 @@ export type ResponsesBridgeTarget = {
   model?: string
   namespacedTools?: ResponsesBridgeNamespacedTool[]
   connectorInstructions?: ResponsesBridgeConnectorInstruction[]
+  // Forward reasoning.effort upstream as reasoning_effort ONLY when the user explicitly picked a
+  // level. Codex emits its own default effort even when the app never configured one, so
+  // unconditional forwarding would change what existing bridged users send to their gateway —
+  // and gateways fronting non-OpenAI models often reject unknown parameters.
+  forwardReasoningEffort?: boolean
 }
 
 export type ResponsesBridgeNamespacedTool = {
@@ -572,7 +577,8 @@ export const responsesToChatRequest = (
   body: JsonObject,
   upstreamModel?: string,
   reasoningByCallId?: Map<string, string>,
-  namespacedTools: readonly ResponsesBridgeNamespacedTool[] = []
+  namespacedTools: readonly ResponsesBridgeNamespacedTool[] = [],
+  options?: { forwardReasoningEffort?: boolean }
 ): JsonObject => {
   for (const field of UNSUPPORTED_FIELDS) {
     if (body[field] !== undefined && body[field] !== null) {
@@ -643,13 +649,16 @@ export const responsesToChatRequest = (
   const toolChoice = hasTools ? requestedToolChoice : undefined
   const stream = body.stream !== false
 
-  // Translate the Responses reasoning effort into the Chat Completions equivalent (validated above).
-  // OpenAI-shaped gateways take `reasoning_effort`; the Codex-only 'xhigh' clamps to 'high', and
-  // 'none' is omitted — Chat Completions has no "reasoning off" switch, so the upstream default
-  // stands. A gateway that doesn't know the parameter rejects it explicitly, which beats the
-  // selected effort silently vanishing.
+  // Translate the Responses reasoning effort into the Chat Completions equivalent (validated above),
+  // but only when the app's user explicitly picked a level: Codex also emits its own default effort,
+  // and forwarding that would change what existing bridged users send upstream. OpenAI-shaped
+  // gateways take `reasoning_effort`; the Codex-only 'xhigh' clamps to 'high', and 'none' is
+  // omitted — Chat Completions has no "reasoning off" switch, so the upstream default stands.
   const requestedEffort =
-    body.reasoning && typeof body.reasoning === 'object' && !Array.isArray(body.reasoning)
+    options?.forwardReasoningEffort &&
+    body.reasoning &&
+    typeof body.reasoning === 'object' &&
+    !Array.isArray(body.reasoning)
       ? (body.reasoning as JsonObject).effort
       : undefined
   const chatReasoningEffort =
@@ -1136,7 +1145,8 @@ export class ResponsesBridge {
         connectorSelection.body,
         this.target.model,
         this.reasoningByCallId,
-        namespacedTools
+        namespacedTools,
+        { forwardReasoningEffort: this.target.forwardReasoningEffort }
       )
 
       // Reveals which real model actually serves the turn (Codex only ever sees the internal catalog

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -615,7 +615,8 @@ export const responsesToChatRequest = (
     ) {
       throw new Error(`Unsupported Responses reasoning summary: ${String(summary)}`)
     }
-    // These known Codex preferences have no portable Chat Completions equivalent and are omitted.
+    // The summary preference has no portable Chat Completions equivalent and is omitted; the
+    // effort is translated below.
   }
   if (body.store !== undefined && body.store !== false && body.store !== null) {
     throw new Error('Stored Responses are not supported by this gateway')
@@ -642,6 +643,25 @@ export const responsesToChatRequest = (
   const toolChoice = hasTools ? requestedToolChoice : undefined
   const stream = body.stream !== false
 
+  // Translate the Responses reasoning effort into the Chat Completions equivalent (validated above).
+  // OpenAI-shaped gateways take `reasoning_effort`; the Codex-only 'xhigh' clamps to 'high', and
+  // 'none' is omitted — Chat Completions has no "reasoning off" switch, so the upstream default
+  // stands. A gateway that doesn't know the parameter rejects it explicitly, which beats the
+  // selected effort silently vanishing.
+  const requestedEffort =
+    body.reasoning && typeof body.reasoning === 'object' && !Array.isArray(body.reasoning)
+      ? (body.reasoning as JsonObject).effort
+      : undefined
+  const chatReasoningEffort =
+    requestedEffort === 'xhigh'
+      ? 'high'
+      : requestedEffort === 'minimal' ||
+          requestedEffort === 'low' ||
+          requestedEffort === 'medium' ||
+          requestedEffort === 'high'
+        ? requestedEffort
+        : undefined
+
   return {
     model: upstreamModel ?? body.model,
     messages: inputToMessages(body, reasoningByCallId, namespacedTools),
@@ -655,6 +675,7 @@ export const responsesToChatRequest = (
     ...(body.max_output_tokens === undefined || body.max_output_tokens === null
       ? {}
       : { max_tokens: body.max_output_tokens }),
+    ...(chatReasoningEffort ? { reasoning_effort: chatReasoningEffort } : {}),
     stream,
     ...(stream ? { stream_options: body.stream_options ?? { include_usage: true } } : {})
   }

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2623,4 +2623,83 @@ describe('SettingsService: reasoning effort', () => {
     await repository.setReasoningEffort('default')
     expect((await service.resolveActiveAgentBackend()).sessionEffort).toBeUndefined()
   })
+
+  it('updates the live bridge forwarding policy when the level changes', async () => {
+    const localFetch = globalThis.fetch
+    let upstreamRequest: Record<string, unknown> | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        upstreamRequest = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return new Response(
+          [
+            'data: ' +
+              JSON.stringify({
+                id: 'chat-effort-policy',
+                model: 'deepseek-v4-flash',
+                choices: [{ index: 0, delta: {}, finish_reason: 'stop' }]
+              }),
+            '',
+            'data: [DONE]',
+            ''
+          ].join('\n'),
+          { headers: { 'content-type': 'text/event-stream' } }
+        )
+      })
+    )
+    const adapterPath = join(storageRoot, 'bin', 'codex-acp')
+    await mkdir(dirname(adapterPath), { recursive: true })
+    await writeFile(adapterPath, '', 'utf8')
+    const service = createService(undefined, {
+      codexDetected: { path: adapterPath, version: 'codex-acp 1.1.4' }
+    })
+    await repository.setCodexInfo({
+      resolvedPath: adapterPath,
+      version: '1.1.4',
+      nativePath: '/data/codex-managed/native/codex',
+      nativeVersion: '0.144.6'
+    })
+    await repository.setAgentFramework('codex')
+    const provider = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'DeepSeek',
+        apiEndpoints: ['openai'],
+        baseUrl: 'https://api.deepseek.com',
+        model: 'deepseek-v4-flash',
+        key: 'test-key'
+      })
+    ).providers[0]
+    await service.setActiveProvider(provider.id)
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
+    const backend = await service.resolveActiveAgentBackend()
+    const post = (): Promise<string> =>
+      localFetch(`${backend.providerConfiguration?.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: backend.providerConfiguration?.headers.authorization ?? '',
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'gpt-5.5',
+          input: 'hi',
+          reasoning: { effort: 'high' },
+          stream: true
+        })
+      }).then((response) => response.text())
+
+    // No explicit choice yet: Codex's own default effort is stripped, as pre-feature.
+    await post()
+    expect(upstreamRequest).not.toHaveProperty('reasoning_effort')
+
+    // An explicit level forwards — Codex applies it live over ACP, no reconnect touches the bridge.
+    await service.setReasoningEffort('high')
+    await post()
+    expect(upstreamRequest).toMatchObject({ reasoning_effort: 'high' })
+
+    // Back to 'default': stripping is restored so Codex's own effort can't leak upstream.
+    await service.setReasoningEffort('default')
+    await post()
+    expect(upstreamRequest).not.toHaveProperty('reasoning_effort')
+  })
 })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2530,3 +2530,97 @@ describe('SettingsService: uninstall managed runtime', () => {
     expect(snapshot.agentFrameworkId).toBe('codex')
   })
 })
+
+describe('SettingsService: reasoning effort', () => {
+  it("projects 'default' when no reasoning effort is stored", async () => {
+    const service = createService()
+
+    expect((await service.getSettingsView()).reasoningEffort).toBe('default')
+  })
+
+  it('projects the stored level into the settings view', async () => {
+    const service = createService()
+
+    await repository.setReasoningEffort('low')
+
+    expect((await service.getSettingsView()).reasoningEffort).toBe('low')
+  })
+
+  it('persists the level and returns the refreshed snapshot', async () => {
+    const service = createService()
+
+    const snapshot = await service.setReasoningEffort('max')
+
+    expect(snapshot.reasoningEffort).toBe('max')
+    expect((await repository.getSettings()).reasoningEffort).toBe('max')
+  })
+
+  it('surfaces the stored level as sessionEffort on the resolved OpenCode backend', async () => {
+    // resolveActiveAgentBackend honors this forced-framework env above stored settings; set it
+    // explicitly (a prior test may leave it stubbed) so this resolves OpenCode.
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
+    await repository.setAgentFramework('opencode')
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.19.0' }
+    })
+    const provider = (
+      await service.upsertProvider({ type: 'official', name: 'Kimi', vendorId: 'kimi', key: 'k' })
+    ).providers[0]
+    await service.setActiveProvider(provider.id)
+    await repository.setReasoningEffort('high')
+
+    const backend = await service.resolveActiveAgentBackend()
+
+    expect(backend.sessionEffort).toBe('high')
+    // The level also reaches the framework's own config channel (opencode model options).
+    const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    expect(content.provider['openai-compatible'].models['kimi-k3']).toEqual(
+      expect.objectContaining({ options: { reasoningEffort: 'high' } })
+    )
+  })
+
+  it('surfaces sessionEffort on the Claude backend too (the early-return path)', async () => {
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'claude-code')
+    const service = createService()
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+    const provider = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+    await service.setActiveProvider(provider.id)
+    await repository.setReasoningEffort('low')
+
+    const backend = await service.resolveActiveAgentBackend()
+
+    expect(backend.framework.id).toBe('claude-code')
+    expect(backend.sessionEffort).toBe('low')
+  })
+
+  it("leaves sessionEffort undefined when the level is 'default' or unset", async () => {
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'claude-code')
+    const service = createService()
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+    const provider = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+    await service.setActiveProvider(provider.id)
+
+    // Unset: nothing stored yet.
+    expect((await service.resolveActiveAgentBackend()).sessionEffort).toBeUndefined()
+
+    // 'default' means "don't override": the agent keeps its own default effort.
+    await repository.setReasoningEffort('default')
+    expect((await service.resolveActiveAgentBackend()).sessionEffort).toBeUndefined()
+  })
+})

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2167,7 +2167,7 @@ class SettingsService {
       framework.id === 'codex' && (provider.apiEndpoints?.includes('openai') ?? false)
     const enabledConnectorIds = this.enabledConnectorIds(settings.connectors)
     const responsesBridge = needsResponsesBridge
-      ? await this.ensureResponsesBridge(provider, enabledConnectorIds)
+      ? await this.ensureResponsesBridge(provider, enabledConnectorIds, sessionEffort !== undefined)
       : await this.disableResponsesBridge()
     const modelConfig = framework.prepareModelConfig(provider, {
       storageRoot: this.storageRoot,
@@ -2206,7 +2206,8 @@ class SettingsService {
 
   private async ensureResponsesBridge(
     provider: ResolvedProvider,
-    enabledConnectorIds: string[]
+    enabledConnectorIds: string[],
+    forwardReasoningEffort: boolean
   ): Promise<ResponsesBridgeConnection> {
     // Resolve to the OpenAI base the bridge appends `/chat/completions` to: an official vendor's exact
     // versioned base, or a custom gateway root normalized to `<root>/v1`.
@@ -2217,6 +2218,7 @@ class SettingsService {
       baseUrl: targetBaseUrl,
       key: provider.key,
       model: provider.model,
+      forwardReasoningEffort,
       namespacedTools: [...CODEX_BRIDGE_NOTEBOOK_TOOLS, ...CODEX_BRIDGE_ARTIFACT_TOOLS],
       connectorInstructions: enabledConnectorIds.map((id) => {
         const metadata = CONNECTOR_CATALOG.find((connector) => connector.id === id)

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2074,7 +2074,13 @@ class SettingsService {
         : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
     const framework = getAgentFramework(frameworkId)
     // 'default' means "don't override": nothing is sent over ACP or framework config, so the agent
-    // keeps its own default effort.
+    // keeps its own default effort. A concrete level is delivered through two channels deliberately
+    // (defense-in-depth, mirroring how sessionModel reaches opencode): the framework's own config
+    // (Codex model_reasoning_effort, opencode model options) covers agents that ignore the protocol,
+    // while sessionEffort drives the ACP thought_level configOption — Claude Code's only channel —
+    // and, being applied per session after spawn, wins over the baked config when both fire. The
+    // channels clamp 'max' independently (Codex config → xhigh, opencode config → high, ACP → the
+    // nearest advertised rung), which is accepted: each stays within its own supported set.
     const sessionEffort =
       settings.reasoningEffort && settings.reasoningEffort !== DEFAULT_REASONING_EFFORT
         ? settings.reasoningEffort

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -48,6 +48,7 @@ import type {
   ImportSkillZipBatchRequest,
   ImportSkillZipBatchResult,
   PreviewSkillZipRequest,
+  ReasoningEffort,
   SkillBundlePreviewResult,
   ScanRepoRequest,
   ScanRepoResult,
@@ -60,6 +61,7 @@ import {
   CODEX_ISOLATED_PROVIDER_ID,
   CODEX_SHARED_PROVIDER_ID,
   codexSubscriptionProviderIdentity,
+  DEFAULT_REASONING_EFFORT,
   isCodexSubscriptionProvider,
   isProviderUsableByFramework
 } from '../../shared/settings'
@@ -422,6 +424,7 @@ class SettingsService {
       ),
       onboardingCompletedAt: settings.onboardingCompletedAt,
       packageMirror: settings.packageMirror,
+      reasoningEffort: settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
       agentFrameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
       agentFrameworks: listAgentFrameworks().map((framework) => ({
         id: framework.id,
@@ -558,6 +561,13 @@ class SettingsService {
   // Selects the agent backend to drive; the caller reconnects so the choice applies to the next spawn.
   async setAgentFramework(id: AgentFrameworkId): Promise<SettingsSnapshot> {
     await this.repository.setAgentFramework(id)
+
+    return this.getSettingsView()
+  }
+
+  // Sets the reasoning-effort preference; the caller reconnects so it applies to subsequent sessions.
+  async setReasoningEffort(effort: ReasoningEffort): Promise<SettingsSnapshot> {
+    await this.repository.setReasoningEffort(effort)
 
     return this.getSettingsView()
   }
@@ -2063,6 +2073,12 @@ class SettingsService {
         ? forced
         : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
     const framework = getAgentFramework(frameworkId)
+    // 'default' means "don't override": nothing is sent over ACP or framework config, so the agent
+    // keeps its own default effort.
+    const sessionEffort =
+      settings.reasoningEffort && settings.reasoningEffort !== DEFAULT_REASONING_EFFORT
+        ? settings.reasoningEffort
+        : undefined
 
     // Enforce provider↔framework compatibility up front so an incompatible pair fails with a clear
     // message instead of spawning an agent that can't use the credentials — e.g. OpenCode + a Local
@@ -2110,7 +2126,8 @@ class SettingsService {
         framework,
         backendId: `${framework.id}:${activeProvider.id}`,
         executablePath,
-        env: envOverrides
+        env: envOverrides,
+        sessionEffort
       }
     }
 
@@ -2150,6 +2167,7 @@ class SettingsService {
       storageRoot: this.storageRoot,
       executablePath,
       responsesBridge,
+      reasoningEffort: sessionEffort,
       // Connector conventions + tools, so opencode uses host.mcp instead of raw HTTP (it has no skill
       // docs like Claude). Enabled bundled connectors only.
       instructions: renderConnectorInstructions(enabledConnectorIds)
@@ -2174,6 +2192,7 @@ class SettingsService {
       ...(framework.id === 'codex' && isCodexSubscriptionProvider(provider.type) && sessionModel
         ? { sessionModelRequired: true }
         : {}),
+      sessionEffort,
       authentication: modelConfig.authentication,
       providerConfiguration: modelConfig.providerConfiguration
     }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -565,9 +565,15 @@ class SettingsService {
     return this.getSettingsView()
   }
 
-  // Sets the reasoning-effort preference; the caller reconnects so it applies to subsequent sessions.
+  // Sets the reasoning-effort preference. Where the framework supports it the caller applies the
+  // level live over ACP (otherwise it reconnects); the persisted value drives the next spawn.
   async setReasoningEffort(effort: ReasoningEffort): Promise<SettingsSnapshot> {
     await this.repository.setReasoningEffort(effort)
+
+    // A live bridge never sees resolveActiveAgentBackend again until the next provider switch, so its
+    // forwarding policy must be updated in place: an explicit level forwards, 'default' restores
+    // stripping so Codex's own default effort never leaks upstream.
+    this.responsesBridge?.setForwardReasoningEffort(effort !== DEFAULT_REASONING_EFFORT)
 
     return this.getSettingsView()
   }

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -3,7 +3,8 @@ import type {
   ClaudeInfo,
   CodexInfo,
   ProviderType,
-  ProviderValidationFailure
+  ProviderValidationFailure,
+  ReasoningEffort
 } from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import type { OfficialVendorId } from '../../shared/provider-registry'
@@ -96,6 +97,8 @@ export type StoredSettings = {
   claude?: ClaudeInfo
   // Selected agent backend. Absent means the default (Claude Code). Switching needs a reconnect.
   agentFrameworkId?: AgentFrameworkId
+  // Reasoning-effort preference. Absent (or 'default') means the agent keeps its own default.
+  reasoningEffort?: ReasoningEffort
   // Detected opencode executable path + reported version (for the status card). Absent = detect on PATH.
   opencodePath?: string
   opencodeVersion?: string

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -99,6 +99,7 @@ import type {
   SetActiveProviderRequest,
   SetPackageMirrorRequest,
   SetAgentFrameworkRequest,
+  SetReasoningEffortRequest,
   SetSkillEnabledRequest,
   SettingsSnapshot,
   SkillDetailView,
@@ -211,6 +212,7 @@ interface OpenScienceAPI {
     deleteProvider(request: DeleteProviderRequest): Promise<SettingsSnapshot>
     setActiveProvider(request: SetActiveProviderRequest): Promise<SettingsSnapshot>
     setAgentFramework(request: SetAgentFrameworkRequest): Promise<SettingsSnapshot>
+    setReasoningEffort(request: SetReasoningEffortRequest): Promise<SettingsSnapshot>
     validateProvider(request: ValidateProviderRequest): Promise<ValidateProviderResult>
     cancelCodexLogin(): Promise<void>
     loginIsolatedCodex(): Promise<ValidateProviderResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -101,6 +101,7 @@ import type {
   SetActiveProviderRequest,
   SetPackageMirrorRequest,
   SetAgentFrameworkRequest,
+  SetReasoningEffortRequest,
   SetSkillEnabledRequest,
   SettingsSnapshot,
   SkillDetailView,
@@ -234,6 +235,7 @@ type OpenScienceAPI = {
     deleteProvider: (request: DeleteProviderRequest) => Promise<SettingsSnapshot>
     setActiveProvider: (request: SetActiveProviderRequest) => Promise<SettingsSnapshot>
     setAgentFramework: (request: SetAgentFrameworkRequest) => Promise<SettingsSnapshot>
+    setReasoningEffort: (request: SetReasoningEffortRequest) => Promise<SettingsSnapshot>
     validateProvider: (request: ValidateProviderRequest) => Promise<ValidateProviderResult>
     cancelCodexLogin: () => Promise<void>
     loginIsolatedCodex: () => Promise<ValidateProviderResult>
@@ -551,6 +553,8 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('settings:set-active-provider', request) as Promise<SettingsSnapshot>,
     setAgentFramework: (request) =>
       ipcRenderer.invoke('settings:set-agent-framework', request) as Promise<SettingsSnapshot>,
+    setReasoningEffort: (request) =>
+      ipcRenderer.invoke('settings:set-reasoning-effort', request) as Promise<SettingsSnapshot>,
     validateProvider: (request) =>
       ipcRenderer.invoke('settings:validate-provider', request) as Promise<ValidateProviderResult>,
     cancelCodexLogin: () => ipcRenderer.invoke('settings:cancel-codex-login') as Promise<void>,

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
@@ -6,16 +6,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import { ReasoningEffortSelect } from './ReasoningEffortSelect'
 
-// Radix Select calls pointer-capture and scroll APIs jsdom does not implement.
-if (!Element.prototype.hasPointerCapture) {
-  Element.prototype.hasPointerCapture = (): boolean => false
-  Element.prototype.setPointerCapture = (): void => undefined
-  Element.prototype.releasePointerCapture = (): void => undefined
-}
-if (!Element.prototype.scrollIntoView) {
-  Element.prototype.scrollIntoView = (): void => undefined
-}
-
 let container: HTMLDivElement
 let root: Root
 
@@ -32,36 +22,17 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-// Open the Select trigger and click an option by its visible text (portalled to body).
-const openEffortSelect = (): void => {
-  const trigger = document.body.querySelector<HTMLButtonElement>('[aria-label="Reasoning effort"]')
-  act(() => {
-    trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
-    trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-  })
-}
-
-const clickEffortOption = (text: string): void => {
-  const item = Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).find(
-    (candidate) => candidate.textContent?.includes(text)
-  )
-  act(() => {
-    item?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, button: 0 }))
-    item?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-  })
-}
-
 describe('ReasoningEffortSelect', () => {
-  it('renders the selector showing the current level', async () => {
+  it('marks the current level as the checked segment', async () => {
     useSettingsStore.setState({ reasoningEffort: 'high' })
 
     await act(async () => {
       root.render(<ReasoningEffortSelect />)
     })
 
-    expect(container.querySelector('[aria-label="Reasoning effort"]')?.textContent).toContain(
-      'High'
-    )
+    const checked = container.querySelector('[role="radio"][aria-checked="true"]')
+    expect(checked?.textContent).toBe('High')
+    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(5)
   })
 
   it('calls the store action with the picked level', async () => {
@@ -72,8 +43,12 @@ describe('ReasoningEffortSelect', () => {
       root.render(<ReasoningEffortSelect />)
     })
 
-    openEffortSelect()
-    clickEffortOption('Max')
+    const maxSegment = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="radio"]')
+    ).find((button) => button.textContent === 'Max')
+    act(() => {
+      maxSegment?.click()
+    })
 
     expect(setReasoningEffort).toHaveBeenCalledWith('max')
   })

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { ReasoningEffortSelect } from './ReasoningEffortSelect'
+
+// Radix Select calls pointer-capture and scroll APIs jsdom does not implement.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = (): void => undefined
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  useSettingsStore.setState(createInitialSettingsState())
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+// Open the Select trigger and click an option by its visible text (portalled to body).
+const openEffortSelect = (): void => {
+  const trigger = document.body.querySelector<HTMLButtonElement>('[aria-label="Reasoning effort"]')
+  act(() => {
+    trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+    trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+const clickEffortOption = (text: string): void => {
+  const item = Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).find(
+    (candidate) => candidate.textContent?.includes(text)
+  )
+  act(() => {
+    item?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, button: 0 }))
+    item?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+describe('ReasoningEffortSelect', () => {
+  it('renders the selector showing the current level', async () => {
+    useSettingsStore.setState({ reasoningEffort: 'high' })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(container.querySelector('[aria-label="Reasoning effort"]')?.textContent).toContain(
+      'High'
+    )
+  })
+
+  it('calls the store action with the picked level', async () => {
+    const setReasoningEffort = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({ reasoningEffort: 'default', setReasoningEffort })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    openEffortSelect()
+    clickEffortOption('Max')
+
+    expect(setReasoningEffort).toHaveBeenCalledWith('max')
+  })
+})

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
@@ -1,0 +1,43 @@
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
+import { useSettingsStore } from '@/stores/settings-store'
+import type { ReasoningEffort } from '../../../../shared/settings'
+
+// Reasoning-effort choices shown in Settings > Model, in display order. 'default' keeps the
+// agent's own default (nothing is sent); the concrete levels form a relative scale that each
+// agent/model maps onto its closest supported rung.
+const REASONING_EFFORT_OPTIONS: { value: ReasoningEffort; label: string }[] = [
+  { value: 'default', label: 'Default' },
+  { value: 'max', label: 'Max' },
+  { value: 'high', label: 'High' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'low', label: 'Low' }
+]
+
+// The reasoning-effort selector for Settings > Model: how hard the agent thinks per request.
+// Changing it reconnects the agent, so subsequent requests run at the new level.
+const ReasoningEffortSelect = (): React.JSX.Element => {
+  const reasoningEffort = useSettingsStore((state) => state.reasoningEffort)
+  const setReasoningEffort = useSettingsStore((state) => state.setReasoningEffort)
+
+  return (
+    <Select
+      value={reasoningEffort}
+      onValueChange={(value) => void setReasoningEffort(value as ReasoningEffort)}
+    >
+      <SelectTrigger aria-label="Reasoning effort">
+        <span>
+          {REASONING_EFFORT_OPTIONS.find((option) => option.value === reasoningEffort)?.label}
+        </span>
+      </SelectTrigger>
+      <SelectContent>
+        {REASONING_EFFORT_OPTIONS.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+export { ReasoningEffortSelect }

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
 import type { ReasoningEffort } from '../../../../shared/settings'
@@ -18,6 +20,9 @@ const REASONING_EFFORT_OPTIONS: { value: ReasoningEffort; label: string }[] = [
 const ReasoningEffortSelect = (): React.JSX.Element => {
   const reasoningEffort = useSettingsStore((state) => state.reasoningEffort)
   const setReasoningEffort = useSettingsStore((state) => state.setReasoningEffort)
+  // The slide is a click affordance: enable it only after the user interacts, so the thumb never
+  // sweeps across on first paint when the persisted level loads.
+  const [interactive, setInteractive] = useState(false)
   const selectedIndex = Math.max(
     0,
     REASONING_EFFORT_OPTIONS.findIndex((option) => option.value === reasoningEffort)
@@ -31,7 +36,10 @@ const ReasoningEffortSelect = (): React.JSX.Element => {
     >
       <span
         aria-hidden="true"
-        className="absolute inset-y-0.5 left-0.5 w-14 rounded-md bg-card shadow-sm transition-transform duration-150 motion-reduce:transition-none"
+        className={cn(
+          'absolute inset-y-0.5 left-0.5 w-16 rounded-md bg-card shadow-sm',
+          interactive && 'transition-transform duration-150 motion-reduce:transition-none'
+        )}
         style={{ transform: `translateX(${selectedIndex * 100}%)` }}
       />
       {REASONING_EFFORT_OPTIONS.map((option) => (
@@ -40,9 +48,12 @@ const ReasoningEffortSelect = (): React.JSX.Element => {
           type="button"
           role="radio"
           aria-checked={reasoningEffort === option.value}
-          onClick={() => void setReasoningEffort(option.value)}
+          onClick={() => {
+            setInteractive(true)
+            void setReasoningEffort(option.value)
+          }}
           className={cn(
-            'relative z-10 flex h-7 w-14 items-center justify-center rounded-md text-xs font-medium transition-colors motion-reduce:transition-none',
+            'relative z-10 flex h-7 w-16 items-center justify-center rounded-md text-xs font-medium transition-colors motion-reduce:transition-none',
             reasoningEffort === option.value
               ? 'text-foreground'
               : 'text-muted-foreground hover:text-foreground'

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
@@ -16,7 +16,9 @@ const REASONING_EFFORT_OPTIONS: { value: ReasoningEffort; label: string }[] = [
 ]
 
 // Segmented effort selector: the highlight block slides to the picked level. Fixed-width segments
-// keep the thumb math exact. Mirrored on ToolPermissionControl's radiogroup pattern.
+// keep the thumb math exact. Mirrored on ToolPermissionControl's radiogroup pattern. The new level
+// applies to open sessions live where the framework allows it (Claude Code, Codex), otherwise on
+// the next reconnect (opencode).
 const ReasoningEffortSelect = (): React.JSX.Element => {
   const reasoningEffort = useSettingsStore((state) => state.reasoningEffort)
   const setReasoningEffort = useSettingsStore((state) => state.setReasoningEffort)

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
@@ -1,42 +1,57 @@
-import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
 import type { ReasoningEffort } from '../../../../shared/settings'
 
-// Reasoning-effort choices shown in Settings > Model, in display order. 'default' keeps the
-// agent's own default (nothing is sent); the concrete levels form a relative scale that each
-// agent/model maps onto its closest supported rung.
+// Reasoning-effort choices shown in Settings > Model, left to right from lightest to strongest.
+// 'default' keeps the agent's own default (nothing is sent); the concrete levels form a relative
+// scale that each agent/model maps onto its closest supported rung.
 const REASONING_EFFORT_OPTIONS: { value: ReasoningEffort; label: string }[] = [
   { value: 'default', label: 'Default' },
-  { value: 'max', label: 'Max' },
-  { value: 'high', label: 'High' },
+  { value: 'low', label: 'Low' },
   { value: 'medium', label: 'Medium' },
-  { value: 'low', label: 'Low' }
+  { value: 'high', label: 'High' },
+  { value: 'max', label: 'Max' }
 ]
 
-// The reasoning-effort selector for Settings > Model: how hard the agent thinks per request.
-// Changing it reconnects the agent, so subsequent requests run at the new level.
+// Segmented effort selector: the highlight block slides to the picked level. Fixed-width segments
+// keep the thumb math exact. Mirrored on ToolPermissionControl's radiogroup pattern.
 const ReasoningEffortSelect = (): React.JSX.Element => {
   const reasoningEffort = useSettingsStore((state) => state.reasoningEffort)
   const setReasoningEffort = useSettingsStore((state) => state.setReasoningEffort)
+  const selectedIndex = Math.max(
+    0,
+    REASONING_EFFORT_OPTIONS.findIndex((option) => option.value === reasoningEffort)
+  )
 
   return (
-    <Select
-      value={reasoningEffort}
-      onValueChange={(value) => void setReasoningEffort(value as ReasoningEffort)}
+    <div
+      role="radiogroup"
+      aria-label="Reasoning effort"
+      className="relative grid w-fit grid-cols-5 rounded-lg bg-muted p-0.5"
     >
-      <SelectTrigger aria-label="Reasoning effort">
-        <span>
-          {REASONING_EFFORT_OPTIONS.find((option) => option.value === reasoningEffort)?.label}
-        </span>
-      </SelectTrigger>
-      <SelectContent>
-        {REASONING_EFFORT_OPTIONS.map((option) => (
-          <SelectItem key={option.value} value={option.value}>
-            {option.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+      <span
+        aria-hidden="true"
+        className="absolute inset-y-0.5 left-0.5 w-14 rounded-md bg-card shadow-sm transition-transform duration-150 motion-reduce:transition-none"
+        style={{ transform: `translateX(${selectedIndex * 100}%)` }}
+      />
+      {REASONING_EFFORT_OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          role="radio"
+          aria-checked={reasoningEffort === option.value}
+          onClick={() => void setReasoningEffort(option.value)}
+          className={cn(
+            'relative z-10 flex h-7 w-14 items-center justify-center rounded-md text-xs font-medium transition-colors motion-reduce:transition-none',
+            reasoningEffort === option.value
+              ? 'text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
   )
 }
 

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -954,18 +954,20 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                         <ReasoningEffortSelect />
                       </SettingsRow>
 
-                      <ProviderList
-                        providers={visibleProviders}
-                        activeProviderId={activeProviderId}
-                        busyProviderId={busyProviderId}
-                        onEdit={openEdit}
-                        onDelete={(provider) => void deleteProvider(provider.id)}
-                        onTest={(provider) => void handleTest(provider)}
-                        isCodexLoginPending={isCodexLoginPending}
-                        onCancelCodexLogin={() => void cancelCodexLogin()}
-                        onLoginIsolatedCodex={() => void handleCodexLogin()}
-                        onLogoutIsolatedCodex={() => void handleCodexLogout()}
-                      />
+                      <div className="mt-3">
+                        <ProviderList
+                          providers={visibleProviders}
+                          activeProviderId={activeProviderId}
+                          busyProviderId={busyProviderId}
+                          onEdit={openEdit}
+                          onDelete={(provider) => void deleteProvider(provider.id)}
+                          onTest={(provider) => void handleTest(provider)}
+                          isCodexLoginPending={isCodexLoginPending}
+                          onCancelCodexLogin={() => void cancelCodexLogin()}
+                          onLoginIsolatedCodex={() => void handleCodexLogin()}
+                          onLogoutIsolatedCodex={() => void handleCodexLogout()}
+                        />
+                      </div>
                       {providerTestError ? (
                         <p className="text-sm text-destructive" role="alert">
                           {providerTestError}

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -944,13 +944,12 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                         label="Reasoning effort"
                         description={
                           <>
-                            How much reasoning the agent puts into each request — higher levels
-                            think longer, lower levels respond faster. Applied to subsequent
-                            requests; a level the active model doesn&apos;t offer maps to its
-                            closest supported one.
+                            Higher levels think longer, lower levels respond faster. Applies to
+                            subsequent requests.
                           </>
                         }
                         className={`border-b border-border${providers.length > 0 ? '' : ' pt-0'}`}
+                        controlClassName="w-auto justify-self-end"
                       >
                         <ReasoningEffortSelect />
                       </SettingsRow>

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -49,6 +49,7 @@ import {
   type ProviderFormValue
 } from './provider-form-value'
 import { ProviderList } from './ProviderList'
+import { ReasoningEffortSelect } from './ReasoningEffortSelect'
 import { SettingsRow, SettingsSection } from './SettingsLayout'
 import { UninstallRuntimeDialog } from './UninstallRuntimeDialog'
 import { SwitchFrameworkDialog } from './SwitchFrameworkDialog'
@@ -938,6 +939,21 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                           <ActiveModelSelect />
                         </SettingsRow>
                       ) : null}
+
+                      <SettingsRow
+                        label="Reasoning effort"
+                        description={
+                          <>
+                            How much reasoning the agent puts into each request — higher levels
+                            think longer, lower levels respond faster. Applied to subsequent
+                            requests; a level the active model doesn&apos;t offer maps to its
+                            closest supported one.
+                          </>
+                        }
+                        className={`border-b border-border${providers.length > 0 ? '' : ' pt-0'}`}
+                      >
+                        <ReasoningEffortSelect />
+                      </SettingsRow>
 
                       <ProviderList
                         providers={visibleProviders}

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -27,6 +27,7 @@ type SettingsApi = {
   uninstallCodex: ReturnType<typeof vi.fn>
   onInstallLog: ReturnType<typeof vi.fn>
   setAgentFramework: ReturnType<typeof vi.fn>
+  setReasoningEffort: ReturnType<typeof vi.fn>
   upsertProvider: ReturnType<typeof vi.fn>
   validateProvider: ReturnType<typeof vi.fn>
   cancelCodexLogin: ReturnType<typeof vi.fn>
@@ -70,7 +71,8 @@ const snapshot = (providers: SettingsSnapshot['providers']): SettingsSnapshot =>
   codex: {},
   claudeManaged: false,
   opencodeManaged: false,
-  codexManaged: false
+  codexManaged: false,
+  reasoningEffort: 'default'
 })
 
 const providerView = (id: string): SettingsSnapshot['providers'][number] => ({
@@ -126,6 +128,11 @@ beforeEach(() => {
       callLog.push(`setFramework:${request.id}`)
       return Promise.resolve({ ...snapshot([]), agentFrameworkId: request.id })
     }),
+    setReasoningEffort: vi
+      .fn()
+      .mockImplementation((request: { effort: string }) =>
+        Promise.resolve({ ...snapshot([]), reasoningEffort: request.effort })
+      ),
     upsertProvider: vi.fn(),
     validateProvider: vi.fn(),
     cancelCodexLogin: vi.fn().mockResolvedValue(undefined),
@@ -1058,5 +1065,32 @@ describe('settings store: setAgentFramework', () => {
     await useSettingsStore.getState().uninstallCodex()
     expect(api.uninstallCodex).toHaveBeenCalledOnce()
     expect(useSettingsStore.getState().codex).toEqual({})
+  })
+})
+
+describe('settings store: setReasoningEffort', () => {
+  it('forwards the level to main and caches the returned snapshot', async () => {
+    await useSettingsStore.getState().setReasoningEffort('high')
+
+    expect(api.setReasoningEffort).toHaveBeenCalledWith({ effort: 'high' })
+    expect(useSettingsStore.getState().reasoningEffort).toBe('high')
+  })
+
+  it('keeps the current level and logs when main rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    api.setReasoningEffort.mockRejectedValue(new Error('ipc down'))
+
+    await useSettingsStore.getState().setReasoningEffort('low')
+
+    expect(useSettingsStore.getState().reasoningEffort).toBe('default')
+    expect(consoleError).toHaveBeenCalledWith('Failed to set reasoning effort', expect.any(Error))
+  })
+
+  it('load() picks up a non-default level from the settings snapshot', async () => {
+    api.getSettings.mockResolvedValue({ ...snapshot([]), reasoningEffort: 'max' })
+
+    await useSettingsStore.getState().load()
+
+    expect(useSettingsStore.getState().reasoningEffort).toBe('max')
   })
 })

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1076,7 +1076,26 @@ describe('settings store: setReasoningEffort', () => {
     expect(useSettingsStore.getState().reasoningEffort).toBe('high')
   })
 
-  it('keeps the current level and logs when main rejects', async () => {
+  it('applies the picked level optimistically before main confirms', async () => {
+    let resolveIpc: (value: SettingsSnapshot) => void = () => undefined
+    api.setReasoningEffort.mockImplementation(
+      () =>
+        new Promise<SettingsSnapshot>((resolve) => {
+          resolveIpc = resolve
+        })
+    )
+
+    const pending = useSettingsStore.getState().setReasoningEffort('max')
+
+    // The selector must not wait for the reconnect-bearing IPC round trip.
+    expect(useSettingsStore.getState().reasoningEffort).toBe('max')
+
+    resolveIpc({ ...snapshot([]), reasoningEffort: 'max' })
+    await pending
+    expect(useSettingsStore.getState().reasoningEffort).toBe('max')
+  })
+
+  it('reverts to the previous level and logs when main rejects', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     api.setReasoningEffort.mockRejectedValue(new Error('ipc down'))
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -734,12 +734,17 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     }
   },
 
-  // Sets the reasoning-effort level; main reconnects so subsequent requests run at it. Surfaces
-  // failures to the console instead of silently reverting the selector (mirrors setAgentFramework).
+  // Sets the reasoning-effort level; main reconnects so subsequent requests run at it. The IPC round
+  // trip includes that reconnect, which is too slow to gate the selector on — apply the pick
+  // optimistically, reconcile from the returned snapshot, and revert if the write fails.
   setReasoningEffort: async (effort) => {
+    const previous = get().reasoningEffort
+    set({ reasoningEffort: effort })
+
     try {
       set(applySnapshot(await window.api.settings.setReasoningEffort({ effort })))
     } catch (error) {
+      set({ reasoningEffort: previous })
       console.error('Failed to set reasoning effort', error)
     }
   },

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand'
 import type { OfficialVendorId } from '../../../shared/provider-registry'
 import {
   codexSubscriptionProviderIdentity,
+  DEFAULT_REASONING_EFFORT,
   isCodexSubscriptionProvider,
   providerValidationFailed
 } from '../../../shared/settings'
@@ -26,6 +27,7 @@ import type {
   ProviderType,
   ProviderView,
   RefreshProviderModelsResult,
+  ReasoningEffort,
   SettingsSnapshot,
   SkillView,
   CreateSkillRequest,
@@ -119,6 +121,8 @@ type SettingsStoreData = {
   pendingSkillId?: string
   // Configured package mirror (conda/pip); undefined means public hosts (unconfigured).
   packageMirror?: PackageMirror
+  // Reasoning-effort preference applied to agent requests; 'default' leaves the agent's own default.
+  reasoningEffort: ReasoningEffort
 }
 
 type SettingsStore = SettingsStoreData & {
@@ -166,6 +170,8 @@ type SettingsStore = SettingsStoreData & {
   setActiveProvider: (providerId: string, model?: string) => Promise<void>
   // Switches the agent backend (main reconnects so the next prompt uses it).
   setAgentFramework: (id: AgentFrameworkId) => Promise<void>
+  // Sets the reasoning-effort level (main reconnects so subsequent requests run at it).
+  setReasoningEffort: (effort: ReasoningEffort) => Promise<void>
   deleteProvider: (providerId: string) => Promise<void>
   openSettings: () => void
   closeSettings: () => void
@@ -278,7 +284,8 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   isEnvironmentRepairOpen: false,
   isSettingsOpen: false,
   pendingSkillId: undefined,
-  packageMirror: undefined
+  packageMirror: undefined,
+  reasoningEffort: DEFAULT_REASONING_EFFORT
 })
 
 // Applies a fresh main-process snapshot to the renderer cache.
@@ -289,6 +296,7 @@ const applySnapshot = (snapshot: SettingsSnapshot): Partial<SettingsStoreData> =
   providers: snapshot.providers,
   onboardingCompletedAt: snapshot.onboardingCompletedAt,
   packageMirror: isMirrorConfigured(snapshot.packageMirror) ? snapshot.packageMirror : undefined,
+  reasoningEffort: snapshot.reasoningEffort,
   agentFrameworkId: snapshot.agentFrameworkId,
   agentFrameworks: snapshot.agentFrameworks,
   opencode: snapshot.opencode,
@@ -723,6 +731,16 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       await get().refreshPreflight()
     } catch (error) {
       console.error('Failed to switch agent framework', error)
+    }
+  },
+
+  // Sets the reasoning-effort level; main reconnects so subsequent requests run at it. Surfaces
+  // failures to the console instead of silently reverting the selector (mirrors setAgentFramework).
+  setReasoningEffort: async (effort) => {
+    try {
+      set(applySnapshot(await window.api.settings.setReasoningEffort({ effort })))
+    } catch (error) {
+      console.error('Failed to set reasoning effort', error)
     }
   },
 

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -110,6 +110,7 @@ export const WEB_INVOKE_CHANNELS = {
   'settings.setCustomServerEnabled': 'settings:set-custom-server-enabled',
   'settings.setNcbiCredentials': 'settings:set-ncbi-credentials',
   'settings.setPackageMirror': 'settings:set-package-mirror',
+  'settings.setReasoningEffort': 'settings:set-reasoning-effort',
   'settings.setSkillEnabled': 'settings:set-skill-enabled',
   'settings.setToolPermission': 'settings:set-tool-permission',
   'settings.uninstallClaude': 'settings:uninstall-claude',

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -197,6 +197,14 @@ export const providerValidationFailed = (provider: {
 // the main-process AgentFramework registry is keyed by the same union.
 export type AgentFrameworkId = 'claude-code' | 'opencode' | 'codex'
 
+// How much reasoning effort the user asks the agent to spend. 'default' means "don't override": the
+// agent keeps its own default and nothing is sent. The concrete levels form a relative scale
+// (low < medium < high < max): each agent/model maps the level onto its own supported rungs, using
+// the closest one it has (e.g. 'max' becomes the model's top level).
+export type ReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'max'
+
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = 'default'
+
 // Renderer-facing descriptor for one selectable agent framework (built from the main registry).
 export type AgentFrameworkView = {
   id: AgentFrameworkId
@@ -233,6 +241,9 @@ export type SettingsSnapshot = {
   onboardingCompletedAt?: number
   // Non-secret package-mirror overrides (conda/pypi/cran). Absent means public hosts.
   packageMirror?: PackageMirror
+  // The user's reasoning-effort preference for agent requests. 'default' leaves the agent's own
+  // default untouched; concrete levels apply to subsequent requests when the agent supports them.
+  reasoningEffort: ReasoningEffort
 }
 
 // Request to set (or clear, via omitted fields) the package-mirror configuration.
@@ -240,6 +251,10 @@ export type SetPackageMirrorRequest = PackageMirror
 
 export type SetAgentFrameworkRequest = {
   id: AgentFrameworkId
+}
+
+export type SetReasoningEffortRequest = {
+  effort: ReasoningEffort
 }
 
 // The hard startup gates. Kept as plain booleans so the wizard can target the first unmet step.

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -205,6 +205,12 @@ export type ReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'max'
 
 export const DEFAULT_REASONING_EFFORT: ReasoningEffort = 'default'
 
+const REASONING_EFFORTS: readonly ReasoningEffort[] = ['default', 'low', 'medium', 'high', 'max']
+
+// Runtime guard for untrusted values (IPC payloads, settings.json): only the known levels pass.
+export const isReasoningEffort = (value: unknown): value is ReasoningEffort =>
+  typeof value === 'string' && (REASONING_EFFORTS as readonly string[]).includes(value)
+
 // Renderer-facing descriptor for one selectable agent framework (built from the main registry).
 export type AgentFrameworkView = {
   id: AgentFrameworkId


### PR DESCRIPTION
## Summary

Adds a **Reasoning effort** setting letting users trade off deeper reasoning against faster responses, as requested in #235. The control is a horizontal segmented selector — **Default / Low / Medium / High / Max** — with the selection persisted in `settings.json` across restarts and applied to subsequent agent requests **when the active provider supports it**.

## Deviations from #235 (deliberate, maintainer-confirmed)

Two intentional adjustments to the issue's acceptance criteria, called out explicitly:

1. **Placement: Settings > Model, not Settings > General.** The issue asks for General, but the selector lives in the Model panel's Providers section, next to Active model. Reasoning effort is a per-request model/agent behavior knob — it pairs naturally with the model picker, and the General panel currently holds only app-level utilities (diagnostics, CLI, community links).
2. **A fifth choice, Default, beyond the issue's four levels.** `default` means "don't override": nothing is sent and agents keep their own defaults. It is the persisted initial value, so **existing users see zero behavior change on upgrade** — without it, whichever level we defaulted to would have been force-applied to every agent that previously ran at its own default. The four issue-requested levels are all present and behave as asked.

## How levels map onto agents

The four levels form a **relative scale** (`low < medium < high < xhigh < max`); each framework maps the choice onto what the active model actually supports — a level the model doesn't offer resolves to its **closest advertised rung** (ties go to the cheaper one):

- **Claude Code** — ACP `session/set_config_option` on the adapter's `thought_level`/`effort` option.
- **Codex** — `model_reasoning_effort` in `CODEX_CONFIG` (`max → xhigh`), plus the ACP option when advertised; the Responses bridge forwards `reasoning_effort` upstream **only** when the user explicitly picked a level (never Codex's own default).
- **OpenCode** — `options.reasoningEffort` in the per-model block of both generated config layers (`max → high`, the AI SDK ceiling).

**Live switching:** Claude Code and Codex apply level changes to open sessions over ACP with **no respawn** (the way a model switch feels); picking Default sends the adapter's `default` sentinel to hand control back. OpenCode advertises no live effort channel, so it reconnects to rebake its generated config — deferred while a prompt is in flight, with the conversation resumed afterwards.

## Tests

- 50+ new cases across every layer: repository sanitize/round-trip, service projection + backend resolution, IPC boundary validation + live/reconnect routing, effort-option matching/clamping/default-sentinel, runtime apply (post-model-switch re-resolution, live multi-session apply, failure fallback to reconnect), Codex/OpenCode config generation, bridge outgoing-request assertions (forward vs. strip), store optimistic update/revert, segmented-control rendering.
- Full suite green: `typecheck`, `lint`, `vitest` (4656 passed), Prettier-clean, web api map regenerated.

## Reviewer notes

- The Codex/OpenCode ACP adapters are downloaded at runtime; their config channels are covered at the generation level. Live smoke-tested locally: Claude Code and Codex accepted levels over ACP; OpenCode's generated config carried the level (its ACP advertises no effort option, handled by the config channel).
- Gateway-dependent behavior varies by provider (e.g. DeepSeek maps `low/medium → high` and auto-`max`es agent requests) — expected per the issue's "when supported" clause.

Closes #235
