### PR TITLE
fix(codex): harden Codex subscription auth validation and sign-in flow

### DIFF
--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -1,8 +1,15 @@
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { describe, expect, it, vi } from 'vitest'
 
+import { codexSubscriptionStorageDir } from '../agent-framework/codex'
 import {
   CodexAuthController,
   createCodexAuthEnvironment,
+  ensureCodexAuthHome,
   type CodexAuthSession
 } from './codex-auth'
 
@@ -18,6 +25,24 @@ const session = (overrides: Partial<CodexAuthSession> = {}): CodexAuthSession =>
   logout: vi.fn().mockResolvedValue(undefined),
   close: vi.fn().mockResolvedValue(undefined),
   ...overrides
+})
+
+describe('ensureCodexAuthHome', () => {
+  it('creates the isolated home up front and never touches the shared profile', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-home-'))
+    try {
+      // Shared mode uses the user's real ~/.codex; nothing may be created under the storage root.
+      await ensureCodexAuthHome('shared', root)
+      expect(existsSync(codexSubscriptionStorageDir(root))).toBe(false)
+
+      // Codex exits hard when CODEX_HOME is missing (fatal on Windows), so the isolated home must
+      // exist before the first sign-in ever spawns the process.
+      await ensureCodexAuthHome('isolated', root)
+      expect(existsSync(codexSubscriptionStorageDir(root))).toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('createCodexAuthEnvironment', () => {

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -78,6 +78,30 @@ describe('CodexAuthController', () => {
     })
   })
 
+  it('treats api-key and gateway profiles as authenticated', async () => {
+    for (const type of ['api-key', 'gateway'] as const) {
+      const apiKeySession = session({
+        status: vi.fn().mockResolvedValue({ type })
+      })
+      const controller = new CodexAuthController({
+        openSession: vi.fn().mockResolvedValue(apiKeySession)
+      })
+
+      await expect(controller.getStatus('shared')).resolves.toEqual({
+        mode: 'shared',
+        supported: true,
+        authenticated: true
+      })
+
+      await expect(controller.loginIsolated()).resolves.toEqual({
+        mode: 'isolated',
+        supported: true,
+        authenticated: true
+      })
+      expect(apiKeySession.authenticateChatGpt).not.toHaveBeenCalled()
+    }
+  })
+
   it('signs into the isolated profile and confirms the resulting account', async () => {
     const isolated = session({
       status: vi

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -94,6 +94,12 @@ const capabilityFailure = (mode: CodexAuthMode): CodexAuthStatus => ({
   message: 'The installed codex-acp does not advertise ChatGPT authentication.'
 })
 
+// Any stored credential counts as authenticated, not just a ChatGPT login: a profile holding an
+// API key (or gateway auth) runs fine at runtime, so reporting it as signed out would be a false
+// negative that blocks an otherwise working provider.
+const isAuthenticated = (status: CodexAuthenticationStatus): boolean =>
+  status.type === 'chat-gpt' || status.type === 'api-key' || status.type === 'gateway'
+
 const toPublicStatus = (
   mode: CodexAuthMode,
   supported: boolean,
@@ -103,7 +109,7 @@ const toPublicStatus = (
     ? {
         mode,
         supported: true,
-        authenticated: status.type === 'chat-gpt'
+        authenticated: isAuthenticated(status)
       }
     : capabilityFailure(mode)
 
@@ -158,7 +164,7 @@ export class CodexAuthController {
       if (!supported) return capabilityFailure('isolated')
 
       const current = await waitForOperation(authSession.status(), abort.signal)
-      if (current.type !== 'chat-gpt') {
+      if (!isAuthenticated(current)) {
         await waitForOperation(authSession.authenticateChatGpt(), abort.signal)
       }
 

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -165,6 +165,9 @@ export class CodexAuthController {
       if (!supported) return capabilityFailure('isolated')
 
       const current = await waitForOperation(authSession.status(), abort.signal)
+      // api-key/gateway credentials short-circuit the browser flow here too: the isolated home is
+      // app-managed and holds exactly what the runtime would use, so any usable credential already
+      // present means no re-login is needed.
       if (!isAuthenticated(current)) {
         await waitForOperation(authSession.authenticateChatGpt(), abort.signal)
       }

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { mkdir } from 'node:fs/promises'
 import { Readable, Writable } from 'node:stream'
 
 import * as acp from '@agentclientprotocol/sdk'
@@ -217,12 +218,26 @@ export type CodexAuthControllerPort = Pick<
   'getStatus' | 'loginIsolated' | 'cancelLogin' | 'logoutIsolated'
 >
 
+// An auth session spawns Codex with CODEX_HOME pointed at the isolated home — which may not exist
+// yet before the first sign-in, and Codex exits hard when CODEX_HOME is missing (a fatal error on
+// Windows in particular). Runtime chat spawns get the same guarantee from the skill materializer;
+// auth sessions create it here. Shared mode touches nothing: it uses the user's real ~/.codex.
+export const ensureCodexAuthHome = async (
+  mode: CodexAuthMode,
+  storageRoot: string
+): Promise<void> => {
+  if (mode === 'isolated')
+    await mkdir(codexSubscriptionStorageDir(storageRoot), { recursive: true })
+}
+
 export const openCodexAuthSession = async ({
   adapterPath,
   nativePath,
   mode,
   storageRoot
 }: CodexAuthLaunch): Promise<CodexAuthSession> => {
+  await ensureCodexAuthHome(mode, storageRoot)
+
   const isJavaScript = /\.[cm]?js$/i.test(adapterPath)
   const needsShell = process.platform === 'win32' && /\.(cmd|bat)$/i.test(adapterPath)
   const command = isJavaScript ? process.execPath : needsShell ? `"${adapterPath}"` : adapterPath

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -39,6 +39,7 @@ type FakeSettingsService = Record<
   | 'setActiveProvider'
   | 'validateProvider'
   | 'cancelCodexLogin'
+  | 'loginIsolatedCodex'
   | 'logoutIsolatedCodex'
   | 'markOnboardingComplete'
   | 'listSkills'
@@ -83,6 +84,7 @@ const createFakeService = (): FakeSettingsService => ({
   setActiveProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
   validateProvider: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
   cancelCodexLogin: vi.fn(),
+  loginIsolatedCodex: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
   logoutIsolatedCodex: vi
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], activeProviderId: undefined }),
@@ -129,6 +131,7 @@ describe('settings IPC handlers', () => {
       'settings:set-active-provider',
       'settings:validate-provider',
       'settings:cancel-codex-login',
+      'settings:login-isolated-codex',
       'settings:logout-isolated-codex',
       'settings:mark-onboarding-complete'
     ]) {
@@ -174,6 +177,36 @@ describe('settings IPC handlers', () => {
     await invoke('settings:logout-isolated-codex')
 
     expect(onActiveProviderChanged).toHaveBeenCalledOnce()
+  })
+
+  it('reconnects the active provider only when the isolated login was actually applied', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const onActiveProviderChanged = vi.fn()
+    registerSettingsIpcHandlers({
+      service: asService(service),
+      onActiveProviderChanged
+    })
+
+    // Login succeeded and the active provider is still the isolated subscription: reconnect.
+    service.getSettingsView.mockResolvedValue({
+      claude: {},
+      providers: [{ id: CODEX_SUBSCRIPTION_PROVIDER_ID, type: 'codex-isolated' }],
+      activeProviderId: CODEX_SUBSCRIPTION_PROVIDER_ID
+    })
+    await invoke('settings:login-isolated-codex')
+    expect(onActiveProviderChanged).toHaveBeenCalledOnce()
+
+    // Login succeeded but the provider was switched to shared mid-flow (outcome discarded): the
+    // shared runtime's credentials didn't change, so a reconnect would be redundant.
+    onActiveProviderChanged.mockClear()
+    service.getSettingsView.mockResolvedValue({
+      claude: {},
+      providers: [{ id: CODEX_SUBSCRIPTION_PROVIDER_ID, type: 'codex-shared' }],
+      activeProviderId: CODEX_SUBSCRIPTION_PROVIDER_ID
+    })
+    await invoke('settings:login-isolated-codex')
+    expect(onActiveProviderChanged).not.toHaveBeenCalled()
   })
 
   it('routes mark-onboarding-complete to the service', async () => {

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -159,6 +159,19 @@ const registerSettingsIpcHandlers = ({
     service.validateProvider(request)
   )
   ipcMain.handle('settings:cancel-codex-login', () => service.cancelCodexLogin())
+  ipcMain.handle('settings:login-isolated-codex', async () => {
+    const result = await service.loginIsolatedCodex()
+
+    // A fresh login changes the credentials the live agent relies on; reconnect so it picks them up.
+    if (
+      result.ok &&
+      (await service.getSettingsView()).activeProviderId === CODEX_SUBSCRIPTION_PROVIDER_ID
+    ) {
+      onActiveProviderChanged?.()
+    }
+
+    return result
+  })
   ipcMain.handle('settings:logout-isolated-codex', async () => {
     const snapshot = await service.logoutIsolatedCodex()
 

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -162,12 +162,20 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:login-isolated-codex', async () => {
     const result = await service.loginIsolatedCodex()
 
-    // A fresh login changes the credentials the live agent relies on; reconnect so it picks them up.
-    if (
-      result.ok &&
-      (await service.getSettingsView()).activeProviderId === CODEX_SUBSCRIPTION_PROVIDER_ID
-    ) {
-      onActiveProviderChanged?.()
+    // A fresh login changes the credentials the live agent relies on; reconnect so it picks them
+    // up. Skip when the outcome was discarded by a mid-flow switch to shared — reconnecting the
+    // now-shared runtime would be redundant (its credentials didn't change).
+    if (result.ok) {
+      const snapshot = await service.getSettingsView()
+      const active = snapshot.providers.find(
+        (provider) => provider.id === snapshot.activeProviderId
+      )
+      if (
+        snapshot.activeProviderId === CODEX_SUBSCRIPTION_PROVIDER_ID &&
+        active?.type === 'codex-isolated'
+      ) {
+        onActiveProviderChanged?.()
+      }
     }
 
     return result

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -294,6 +294,41 @@ describe('SettingsService: providers', () => {
     })
   })
 
+  it('discards the sign-in outcome when the provider was switched to shared mid-flow', async () => {
+    let resolveLogin!: (status: {
+      mode: 'isolated'
+      supported: boolean
+      authenticated: boolean
+    }) => void
+    const codexAuth: CodexAuthControllerPort = {
+      getStatus: vi.fn(),
+      loginIsolated: vi.fn(
+        () =>
+          new Promise<{ mode: 'isolated'; supported: boolean; authenticated: boolean }>(
+            (resolve) => {
+              resolveLogin = resolve
+            }
+          )
+      ),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn()
+    }
+    const service = createService(undefined, { codexAuth })
+    await service.upsertProvider({ type: 'codex-isolated' })
+
+    // The provider is switched to shared while the browser flow is still open; the success landing
+    // afterwards must not stamp the (unauthenticated) shared profile as verified.
+    const pending = service.loginIsolatedCodex()
+    await service.upsertProvider({ type: 'codex-shared' })
+    resolveLogin({ mode: 'isolated', supported: true, authenticated: true })
+
+    await expect(pending).resolves.toMatchObject({ ok: true })
+    const stored = (await repository.getSettings()).providers[0]
+    expect(stored.type).toBe('codex-shared')
+    expect(stored.lastValidatedAt).toBeUndefined()
+    expect(stored.lastValidationFailure).toBeUndefined()
+  })
+
   it('keeps the Codex account default when a subscription is activated without a model', async () => {
     const service = createService()
     const provider = (await service.upsertProvider({ type: 'codex-shared' })).providers[0]

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -192,7 +192,7 @@ describe('SettingsService: providers', () => {
     expect((await repository.getSettings()).providers).toEqual([])
   })
 
-  it('validates shared and isolated subscriptions through their distinct ACP auth flows', async () => {
+  it('validates shared and isolated subscriptions through read-only status checks', async () => {
     const codexAuth: CodexAuthControllerPort = {
       getStatus: vi.fn().mockResolvedValue({
         mode: 'shared',
@@ -218,10 +218,80 @@ describe('SettingsService: providers', () => {
       service.validateProvider({ providerId: CODEX_ISOLATED_PROVIDER_ID })
     ).resolves.toMatchObject({ ok: true })
     expect(codexAuth.getStatus).toHaveBeenCalledWith('shared')
-    expect(codexAuth.loginIsolated).toHaveBeenCalledOnce()
+    expect(codexAuth.getStatus).toHaveBeenCalledWith('isolated')
+    // Validation never opens the browser login; that is the explicit sign-in action's job.
+    expect(codexAuth.loginIsolated).not.toHaveBeenCalled()
 
     const stored = await repository.getSettings()
     expect(stored.providers.every((provider) => provider.lastValidatedAt !== undefined)).toBe(true)
+  })
+
+  it('reports an unauthenticated isolated status without triggering sign-in', async () => {
+    const codexAuth: CodexAuthControllerPort = {
+      getStatus: vi.fn().mockResolvedValue({
+        mode: 'isolated',
+        supported: true,
+        authenticated: false
+      }),
+      loginIsolated: vi.fn(),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn()
+    }
+    const service = createService(undefined, { codexAuth })
+    await service.upsertProvider({ type: 'codex-isolated' })
+
+    const result = await service.validateProvider({ providerId: CODEX_ISOLATED_PROVIDER_ID })
+
+    expect(result).toMatchObject({
+      ok: false,
+      category: 'auth',
+      message: 'Not signed in. Use Sign in to connect your ChatGPT account.'
+    })
+    expect(codexAuth.loginIsolated).not.toHaveBeenCalled()
+    expect((await repository.getSettings()).providers[0].lastValidationFailure).toMatchObject({
+      category: 'auth'
+    })
+  })
+
+  it('records the explicit isolated sign-in outcome on the provider', async () => {
+    const codexAuth: CodexAuthControllerPort = {
+      getStatus: vi.fn(),
+      loginIsolated: vi.fn().mockResolvedValue({
+        mode: 'isolated',
+        supported: true,
+        authenticated: true
+      }),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn()
+    }
+    const service = createService(undefined, { codexAuth })
+    await service.upsertProvider({ type: 'codex-isolated' })
+
+    await expect(service.loginIsolatedCodex()).resolves.toMatchObject({
+      ok: true,
+      category: 'ok'
+    })
+    expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeDefined()
+
+    // A failed attempt (e.g. the user dismisses the browser flow) clears the verified stamp and
+    // records the reason, so the card flags the provider as unverified until a retry succeeds.
+    codexAuth.loginIsolated = vi.fn().mockResolvedValue({
+      mode: 'isolated',
+      supported: true,
+      authenticated: false,
+      message: 'Codex sign-in was cancelled.'
+    })
+    await expect(service.loginIsolatedCodex()).resolves.toMatchObject({
+      ok: false,
+      category: 'auth',
+      message: 'Codex sign-in was cancelled.'
+    })
+    const stored = (await repository.getSettings()).providers[0]
+    expect(stored.lastValidatedAt).toBeUndefined()
+    expect(stored.lastValidationFailure).toMatchObject({
+      category: 'auth',
+      message: 'Codex sign-in was cancelled.'
+    })
   })
 
   it('keeps the Codex account default when a subscription is activated without a model', async () => {
@@ -282,7 +352,7 @@ describe('SettingsService: providers', () => {
     }
     const service = createService(undefined, { codexAuth })
     await service.upsertProvider({ type: 'codex-isolated' })
-    await service.validateProvider({ providerId: CODEX_ISOLATED_PROVIDER_ID })
+    await service.loginIsolatedCodex()
 
     service.cancelCodexLogin()
     await service.logoutIsolatedCodex()

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1472,6 +1472,40 @@ class SettingsService {
     this.codexAuth.cancelLogin()
   }
 
+  // The explicit isolated sign-in — the only path that opens the browser login. Saving or testing a
+  // provider never does. The outcome is recorded like a validation result, so the provider card shows
+  // the verified check on success or the unverified warning (with the reason) on failure.
+  async loginIsolatedCodex(): Promise<ValidateProviderResult> {
+    const result = this.codexAuthValidationResult(await this.codexAuth.loginIsolated())
+
+    const settings = await this.repository.getSettings()
+    const provider = settings.providers.find(
+      (candidate) => candidate.id === codexSubscriptionProviderIdentity().id
+    )
+    if (provider) {
+      await this.repository.upsertProvider(
+        result.ok
+          ? {
+              ...provider,
+              lastValidatedAt: Date.now(),
+              lastValidationFailure: undefined
+            }
+          : {
+              ...provider,
+              lastValidatedAt: undefined,
+              lastValidationFailure: {
+                at: Date.now(),
+                category: result.category,
+                status: result.status,
+                message: result.message
+              }
+            }
+      )
+    }
+
+    return result
+  }
+
   async logoutIsolatedCodex(): Promise<SettingsSnapshot> {
     await this.codexAuth.logoutIsolated()
     const settings = await this.repository.getSettings()
@@ -1519,9 +1553,13 @@ class SettingsService {
 
     const result = isCodexSubscriptionProvider(resolved.provider.type)
       ? this.codexAuthValidationResult(
-          await (resolved.provider.type === 'codex-shared'
-            ? this.codexAuth.getStatus('shared')
-            : this.codexAuth.loginIsolated())
+          // Validation is a read-only status check in both modes: signing in is a separate explicit
+          // action (loginIsolatedCodex), so testing or saving a provider never pops a browser the
+          // user didn't ask for.
+          await this.codexAuth.getStatus(
+            resolved.provider.type === 'codex-shared' ? 'shared' : 'isolated'
+          ),
+          'Not signed in. Use Sign in to connect your ChatGPT account.'
         )
       : await validateProvider(resolved.provider, {
           runClaudeProbe:
@@ -1568,7 +1606,10 @@ class SettingsService {
     return result
   }
 
-  private codexAuthValidationResult(status: CodexAuthStatus): ValidateProviderResult {
+  private codexAuthValidationResult(
+    status: CodexAuthStatus,
+    isolatedFallback = 'Codex sign-in did not complete.'
+  ): ValidateProviderResult {
     if (status.authenticated) return { ok: true, category: 'ok' }
 
     return {
@@ -1582,7 +1623,7 @@ class SettingsService {
         status.message ??
         (status.mode === 'shared'
           ? 'No existing Codex login was found. Run `codex login` or use the isolated Open Science login.'
-          : 'Codex sign-in did not complete.')
+          : isolatedFallback)
     }
   }
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1482,26 +1482,29 @@ class SettingsService {
     const provider = settings.providers.find(
       (candidate) => candidate.id === codexSubscriptionProviderIdentity().id
     )
-    if (provider) {
-      await this.repository.upsertProvider(
-        result.ok
-          ? {
-              ...provider,
-              lastValidatedAt: Date.now(),
-              lastValidationFailure: undefined
+    // The provider can be edited while the browser flow is open. Unless the stored record is still
+    // the isolated subscription the login was started for, the outcome is stale and discarded —
+    // recording it could stamp a switched-to-shared (and unauthenticated) profile as verified.
+    if (provider?.type !== 'codex-isolated') return result
+
+    await this.repository.upsertProvider(
+      result.ok
+        ? {
+            ...provider,
+            lastValidatedAt: Date.now(),
+            lastValidationFailure: undefined
+          }
+        : {
+            ...provider,
+            lastValidatedAt: undefined,
+            lastValidationFailure: {
+              at: Date.now(),
+              category: result.category,
+              status: result.status,
+              message: result.message
             }
-          : {
-              ...provider,
-              lastValidatedAt: undefined,
-              lastValidationFailure: {
-                at: Date.now(),
-                category: result.category,
-                status: result.status,
-                message: result.message
-              }
-            }
-      )
-    }
+          }
+    )
 
     return result
   }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -213,6 +213,7 @@ interface OpenScienceAPI {
     setAgentFramework(request: SetAgentFrameworkRequest): Promise<SettingsSnapshot>
     validateProvider(request: ValidateProviderRequest): Promise<ValidateProviderResult>
     cancelCodexLogin(): Promise<void>
+    loginIsolatedCodex(): Promise<ValidateProviderResult>
     logoutIsolatedCodex(): Promise<SettingsSnapshot>
     refreshProviderModels(
       request: RefreshProviderModelsRequest

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -44,6 +44,7 @@ type PreloadApi = {
     uninstallOpencode: () => unknown
     uninstallCodex: () => unknown
     cancelCodexLogin: () => unknown
+    loginIsolatedCodex: () => unknown
     logoutIsolatedCodex: () => unknown
   }
   acp: {
@@ -170,6 +171,12 @@ const cases: ForwardingCase[] = [
     name: 'settings.cancelCodexLogin → settings:cancel-codex-login (no args)',
     invoke: (a) => a.settings.cancelCodexLogin(),
     channel: 'settings:cancel-codex-login',
+    args: []
+  },
+  {
+    name: 'settings.loginIsolatedCodex → settings:login-isolated-codex (no args)',
+    invoke: (a) => a.settings.loginIsolatedCodex(),
+    channel: 'settings:login-isolated-codex',
     args: []
   },
   {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -236,6 +236,7 @@ type OpenScienceAPI = {
     setAgentFramework: (request: SetAgentFrameworkRequest) => Promise<SettingsSnapshot>
     validateProvider: (request: ValidateProviderRequest) => Promise<ValidateProviderResult>
     cancelCodexLogin: () => Promise<void>
+    loginIsolatedCodex: () => Promise<ValidateProviderResult>
     logoutIsolatedCodex: () => Promise<SettingsSnapshot>
     refreshProviderModels: (
       request: RefreshProviderModelsRequest
@@ -553,6 +554,8 @@ const api: OpenScienceAPI = {
     validateProvider: (request) =>
       ipcRenderer.invoke('settings:validate-provider', request) as Promise<ValidateProviderResult>,
     cancelCodexLogin: () => ipcRenderer.invoke('settings:cancel-codex-login') as Promise<void>,
+    loginIsolatedCodex: () =>
+      ipcRenderer.invoke('settings:login-isolated-codex') as Promise<ValidateProviderResult>,
     logoutIsolatedCodex: () =>
       ipcRenderer.invoke('settings:logout-isolated-codex') as Promise<SettingsSnapshot>,
     refreshProviderModels: (request) =>

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -198,6 +198,17 @@ const OnboardingWizard = (): React.JSX.Element => {
   const [validationMessage, setValidationMessage] = useState<string | undefined>(undefined)
   const [validationOk, setValidationOk] = useState(false)
   const didRequestCheck = useRef(false)
+  // Mirrors the Settings teardown: a pending isolated sign-in lives in the main process for up to
+  // five minutes, and its guard rejects a second attempt as "already in progress". If the wizard
+  // unmounts mid-flow (app quit, relaunch, forced navigation), cancel it so the next attempt starts
+  // clean. The ref is written only from event handlers/effects, never during render.
+  const codexLoginPendingRef = useRef(false)
+  useEffect(
+    () => () => {
+      if (codexLoginPendingRef.current) void cancelCodexLogin()
+    },
+    [cancelCodexLogin]
+  )
   // Once the user manually picks an agent, stop auto-selecting; and only auto-select once per mount.
   const userPickedFramework = useRef(false)
   const autoSelectAttempted = useRef(false)
@@ -406,7 +417,11 @@ const OnboardingWizard = (): React.JSX.Element => {
         // Persisting alone never pops a browser; a cancelled login keeps the provider saved but
         // unverified, so the user can retry without re-entering anything.
         const providerId = await persistProvider(toUpsertRequest(formValue))
-        const validation = await loginIsolatedCodex()
+        // Arm the unmount teardown for exactly the duration of the main-process login.
+        codexLoginPendingRef.current = true
+        const validation = await loginIsolatedCodex().finally(() => {
+          codexLoginPendingRef.current = false
+        })
 
         setValidationOk(validation.ok)
         setValidationMessage(describeValidation(validation))

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -146,6 +146,9 @@ const OnboardingWizard = (): React.JSX.Element => {
   const closeEnvironmentRepair = useSettingsStore((state) => state.closeEnvironmentRepair)
   const installClaude = useSettingsStore((state) => state.installClaude)
   const saveAndActivateProvider = useSettingsStore((state) => state.saveAndActivateProvider)
+  const persistProvider = useSettingsStore((state) => state.persistProvider)
+  const setActiveProvider = useSettingsStore((state) => state.setActiveProvider)
+  const loginIsolatedCodex = useSettingsStore((state) => state.loginIsolatedCodex)
   const cancelCodexLogin = useSettingsStore((state) => state.cancelCodexLogin)
   const completeOnboarding = useSettingsStore((state) => state.completeOnboarding)
 
@@ -398,6 +401,25 @@ const OnboardingWizard = (): React.JSX.Element => {
     setValidationMessage(undefined)
 
     try {
+      if (formValue.type === 'codex-isolated') {
+        // Isolated sign-in is explicit: persist the provider first, then run the browser login.
+        // Persisting alone never pops a browser; a cancelled login keeps the provider saved but
+        // unverified, so the user can retry without re-entering anything.
+        const providerId = await persistProvider(toUpsertRequest(formValue))
+        const validation = await loginIsolatedCodex()
+
+        setValidationOk(validation.ok)
+        setValidationMessage(describeValidation(validation))
+
+        if (validation.ok) {
+          if (providerId) await setActiveProvider(providerId)
+          // Location is the last step now: it decides completeOnboarding vs. the relaunch, once the
+          // user confirms (or keeps) a location there.
+          setStep('location')
+        }
+        return
+      }
+
       const { validation } = await saveAndActivateProvider(toUpsertRequest(formValue))
 
       setValidationOk(validation.ok)

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -41,7 +41,12 @@ const renderList = (
   providers: ProviderView[],
   activeId?: string,
   busyId?: string,
-  callbacks: { onCancel?: () => void; onLogout?: () => void } = {}
+  callbacks: {
+    onCancel?: () => void
+    onLogin?: () => void
+    onLogout?: () => void
+    isCodexLoginPending?: boolean
+  } = {}
 ): void => {
   act(() => {
     root.render(
@@ -52,7 +57,9 @@ const renderList = (
         onEdit={noop}
         onDelete={noop}
         onTest={noop}
+        isCodexLoginPending={callbacks.isCodexLoginPending}
         onCancelCodexLogin={callbacks.onCancel}
+        onLoginIsolatedCodex={callbacks.onLogin}
         onLogoutIsolatedCodex={callbacks.onLogout}
       />
     )
@@ -259,8 +266,9 @@ describe('ProviderList', () => {
     expect(container.textContent).toContain('Codex subscription')
   })
 
-  it('offers cancel during isolated sign-in and sign out after validation', () => {
+  it('offers sign in for an unverified isolated provider, cancel while pending, sign out after', () => {
     const onCancel = vi.fn()
+    const onLogin = vi.fn()
     const onLogout = vi.fn()
     const isolated = provider({
       id: 'builtin-codex-isolated',
@@ -269,16 +277,28 @@ describe('ProviderList', () => {
       models: [],
       model: undefined,
       maskedKey: undefined,
-      hasKey: false
+      hasKey: false,
+      lastValidatedAt: undefined
     })
 
-    renderList([isolated], undefined, isolated.id, { onCancel, onLogout })
+    // Not signed in yet: the explicit sign-in action is offered alongside the read-only check.
+    renderList([isolated], undefined, undefined, { onLogin })
+    act(() => buttonByLabel('Sign in')?.click())
+    expect(onLogin).toHaveBeenCalledOnce()
+    expect(buttonByLabel('Check Codex login')).toBeDefined()
+
+    // While the browser login is open: cancel replaces the check and no second sign-in is offered.
+    renderList([isolated], undefined, undefined, { onCancel, isCodexLoginPending: true })
     act(() => buttonByLabel('Cancel sign-in')?.click())
     expect(onCancel).toHaveBeenCalledOnce()
+    expect(buttonByLabel('Sign in')).toBeUndefined()
+    expect(buttonByLabel('Check Codex login')).toBeUndefined()
 
-    renderList([isolated], undefined, undefined, { onCancel, onLogout })
+    // Signed in (verified): sign-in goes away, sign out is offered.
+    renderList([{ ...isolated, lastValidatedAt: 1 }], undefined, undefined, { onLogout })
     act(() => buttonByLabel('Sign out')?.click())
     expect(onLogout).toHaveBeenCalledOnce()
+    expect(buttonByLabel('Sign in')).toBeUndefined()
     expect(buttonByLabel('Edit')).toBeDefined()
     expect(buttonByLabel('Delete')).toBeDefined()
   })

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -1,4 +1,14 @@
-import { CircleCheck, LogOut, Pencil, PlugZap, Route, TriangleAlert, Trash2, X } from 'lucide-react'
+import {
+  CircleCheck,
+  LogIn,
+  LogOut,
+  Pencil,
+  PlugZap,
+  Route,
+  TriangleAlert,
+  Trash2,
+  X
+} from 'lucide-react'
 
 import type {
   ChatApiEndpoint,
@@ -26,7 +36,10 @@ type ProviderListProps = {
   onEdit: (provider: ProviderView) => void
   onDelete: (provider: ProviderView) => void
   onTest: (provider: ProviderView) => void
+  // True while the explicit isolated sign-in flow is open in the browser (cancellable).
+  isCodexLoginPending?: boolean
   onCancelCodexLogin?: () => void
+  onLoginIsolatedCodex?: () => void
   onLogoutIsolatedCodex?: () => void
 }
 
@@ -81,7 +94,9 @@ const ProviderList = ({
   onEdit,
   onDelete,
   onTest,
+  isCodexLoginPending = false,
   onCancelCodexLogin,
+  onLoginIsolatedCodex,
   onLogoutIsolatedCodex
 }: ProviderListProps): React.JSX.Element => {
   if (providers.length === 0) {
@@ -227,7 +242,7 @@ const ProviderList = ({
                   </div>
                 </div>
                 <div className="flex shrink-0 items-center gap-1.5">
-                  {provider.type === 'codex-isolated' && isBusy ? (
+                  {provider.type === 'codex-isolated' && isCodexLoginPending ? (
                     <SettingsIconAction
                       label="Cancel sign-in"
                       icon={X}
@@ -243,6 +258,15 @@ const ProviderList = ({
                       className="border border-border text-foreground"
                     />
                   )}
+                  {provider.type === 'codex-isolated' && !isVerified && !isCodexLoginPending ? (
+                    <SettingsIconAction
+                      label="Sign in"
+                      icon={LogIn}
+                      onClick={() => onLoginIsolatedCodex?.()}
+                      disabled={isBusy}
+                      className="border border-border text-foreground"
+                    />
+                  ) : null}
                   {provider.type === 'codex-isolated' && isVerified ? (
                     <SettingsIconAction
                       label="Sign out"

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -832,4 +832,83 @@ describe('SettingsPage Codex framework', () => {
       'The Codex adapter does not support authentication status.'
     )
   })
+
+  it('cancels a pending isolated sign-in when the dialog closes mid-flow', async () => {
+    const api = (window as unknown as { api: { settings: Record<string, unknown> } }).api
+    const provider = {
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      name: 'Codex subscription',
+      apiEndpoints: ['responses'],
+      models: [],
+      supportsImageInput: true,
+      hasKey: false,
+      needsKey: false
+    }
+    api.settings.getSettings = vi.fn().mockResolvedValue({
+      claude: {},
+      opencode: {},
+      codex: { resolvedPath: '/data/codex-acp', version: '1.1.4' },
+      providers: [provider],
+      agentFrameworkId: 'codex',
+      agentFrameworks: frameworks,
+      claudeManaged: false,
+      opencodeManaged: false,
+      codexManaged: true
+    })
+    // The browser flow never settles on its own; closing the dialog is what cancels it.
+    api.settings.loginIsolatedCodex = vi.fn(() => new Promise(() => undefined))
+    api.settings.cancelCodexLogin = vi.fn().mockResolvedValue(undefined)
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    const signIn = document.body.querySelector<HTMLButtonElement>('[aria-label="Sign in"]')
+    await act(async () => signIn?.click())
+    expect(document.body.querySelector('[aria-label="Cancel sign-in"]')).not.toBeNull()
+
+    await act(async () => {
+      root.render(<SettingsPage open={false} onClose={vi.fn()} />)
+    })
+
+    expect(api.settings.cancelCodexLogin).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces isolated sign-in failures instead of leaving an unhandled rejection', async () => {
+    const api = (window as unknown as { api: { settings: Record<string, unknown> } }).api
+    const provider = {
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      name: 'Codex subscription',
+      apiEndpoints: ['responses'],
+      models: [],
+      supportsImageInput: true,
+      hasKey: false,
+      needsKey: false
+    }
+    api.settings.getSettings = vi.fn().mockResolvedValue({
+      claude: {},
+      opencode: {},
+      codex: { resolvedPath: '/data/codex-acp', version: '1.1.4' },
+      providers: [provider],
+      agentFrameworkId: 'codex',
+      agentFrameworks: frameworks,
+      claudeManaged: false,
+      opencodeManaged: false,
+      codexManaged: true
+    })
+    api.settings.loginIsolatedCodex = vi
+      .fn()
+      .mockRejectedValue(new Error('The Codex adapter failed to spawn.'))
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    const signIn = document.body.querySelector<HTMLButtonElement>('[aria-label="Sign in"]')
+    await act(async () => signIn?.click())
+
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
+      'The Codex adapter failed to spawn.'
+    )
+  })
 })

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -186,6 +186,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const deleteProvider = useSettingsStore((state) => state.deleteProvider)
   const validateProvider = useSettingsStore((state) => state.validateProvider)
   const cancelCodexLogin = useSettingsStore((state) => state.cancelCodexLogin)
+  const loginIsolatedCodex = useSettingsStore((state) => state.loginIsolatedCodex)
   const logoutIsolatedCodex = useSettingsStore((state) => state.logoutIsolatedCodex)
   const refreshProviderModels = useSettingsStore((state) => state.refreshProviderModels)
   const pendingSkillId = useSettingsStore((state) => state.pendingSkillId)
@@ -216,6 +217,8 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const [statusMessage, setStatusMessage] = useState<string | undefined>(undefined)
   const [statusOk, setStatusOk] = useState(false)
   const [busyProviderId, setBusyProviderId] = useState<string | undefined>(undefined)
+  // True while the explicit isolated Codex sign-in is open in the browser; drives the cancel action.
+  const [isCodexLoginPending, setIsCodexLoginPending] = useState(false)
   const [providerTestError, setProviderTestError] = useState<string | undefined>(undefined)
 
   // Refresh settings whenever the dialog opens so external changes are reflected.
@@ -537,6 +540,18 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
       )
     } finally {
       setBusyProviderId(undefined)
+    }
+  }
+
+  // The explicit isolated sign-in: opens the browser login and records the outcome on the provider,
+  // so the card flips to verified (or shows the failure reason) when the flow settles.
+  const handleCodexLogin = async (): Promise<void> => {
+    setIsCodexLoginPending(true)
+
+    try {
+      await loginIsolatedCodex()
+    } finally {
+      setIsCodexLoginPending(false)
     }
   }
 
@@ -905,7 +920,9 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                         onEdit={openEdit}
                         onDelete={(provider) => void deleteProvider(provider.id)}
                         onTest={(provider) => void handleTest(provider)}
+                        isCodexLoginPending={isCodexLoginPending}
                         onCancelCodexLogin={() => void cancelCodexLogin()}
+                        onLoginIsolatedCodex={() => void handleCodexLogin()}
                         onLogoutIsolatedCodex={() => void logoutIsolatedCodex()}
                       />
                       {providerTestError ? (

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -544,16 +544,27 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   }
 
   // The explicit isolated sign-in: opens the browser login and records the outcome on the provider,
-  // so the card flips to verified (or shows the failure reason) when the flow settles.
+  // so the card flips to verified (or shows the failure reason) when the flow settles. Infrastructure
+  // failures (adapter spawn, IPC) surface through the same error line a failed test uses.
   const handleCodexLogin = async (): Promise<void> => {
     setIsCodexLoginPending(true)
+    setProviderTestError(undefined)
 
     try {
       await loginIsolatedCodex()
+    } catch (error) {
+      setProviderTestError(error instanceof Error ? error.message : 'Could not sign in to Codex.')
     } finally {
       setIsCodexLoginPending(false)
     }
   }
+
+  // A pending sign-in lives in the main process for up to five minutes — outliving this dialog, which
+  // stays mounted (only its `open` flag flips). Closing Settings mid-flow would orphan the flow (no
+  // cancel affordance on reopen), so tear it down together with the dialog.
+  useEffect(() => {
+    if (!open && isCodexLoginPending) void cancelCodexLogin()
+  }, [open, isCodexLoginPending, cancelCodexLogin])
 
   return (
     <Dialog.Root open={open} onOpenChange={(next) => (next ? undefined : onClose())}>

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -30,6 +30,7 @@ type SettingsApi = {
   upsertProvider: ReturnType<typeof vi.fn>
   validateProvider: ReturnType<typeof vi.fn>
   cancelCodexLogin: ReturnType<typeof vi.fn>
+  loginIsolatedCodex: ReturnType<typeof vi.fn>
   logoutIsolatedCodex: ReturnType<typeof vi.fn>
   refreshProviderModels: ReturnType<typeof vi.fn>
   setActiveProvider: ReturnType<typeof vi.fn>
@@ -128,6 +129,7 @@ beforeEach(() => {
     upsertProvider: vi.fn(),
     validateProvider: vi.fn(),
     cancelCodexLogin: vi.fn().mockResolvedValue(undefined),
+    loginIsolatedCodex: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
     logoutIsolatedCodex: vi.fn().mockResolvedValue(snapshot([])),
     refreshProviderModels: vi.fn(),
     setActiveProvider: vi.fn().mockImplementation((request: { id: string }) => {
@@ -321,6 +323,23 @@ describe('settings store: saveProvider keeps a provider whose test fails', () =>
     expect(result.validation.ok).toBe(false)
     expect(result.providerId).toBe('p_existing')
     expect(api.deleteProvider).not.toHaveBeenCalled()
+  })
+})
+
+describe('settings store: loginIsolatedCodex', () => {
+  it('returns the sign-in outcome and refreshes the snapshot so the result lands on the card', async () => {
+    api.loginIsolatedCodex.mockResolvedValue({
+      ok: false,
+      category: 'auth',
+      message: 'Codex sign-in was cancelled.'
+    } as ValidateProviderResult)
+    api.getSettings.mockResolvedValue(snapshot([providerView('p_codex')]))
+
+    const result = await useSettingsStore.getState().loginIsolatedCodex()
+
+    expect(result).toMatchObject({ ok: false, category: 'auth' })
+    expect(api.getSettings).toHaveBeenCalled()
+    expect(useSettingsStore.getState().providers).toHaveLength(1)
   })
 })
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -153,6 +153,9 @@ type SettingsStore = SettingsStoreData & {
   saveAndActivateProvider: (request: UpsertProviderRequest) => Promise<SaveProviderResult>
   validateProvider: (request: ValidateProviderRequest) => Promise<ValidateProviderResult>
   cancelCodexLogin: () => Promise<void>
+  // The explicit isolated sign-in — the only flow that opens the browser login. Resolves with the
+  // recorded outcome so callers can react (onboarding advances only on success).
+  loginIsolatedCodex: () => Promise<ValidateProviderResult>
   logoutIsolatedCodex: () => Promise<void>
   // Fetches a saved provider's live model list from the vendor and refreshes the cache on success.
   refreshProviderModels: (providerId: string) => Promise<RefreshProviderModelsResult>
@@ -655,6 +658,17 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   },
 
   cancelCodexLogin: () => window.api.settings.cancelCodexLogin(),
+
+  // Mirrors validateProvider's refresh: the recorded outcome (validated-at or failure) lives on the
+  // stored provider, so the snapshot and derived readiness are re-applied either way.
+  loginIsolatedCodex: async () => {
+    const result = await window.api.settings.loginIsolatedCodex()
+
+    set(applySnapshot(await window.api.settings.getSettings()))
+    await get().refreshPreflight()
+
+    return result
+  },
 
   logoutIsolatedCodex: async () => {
     set(applySnapshot(await window.api.settings.logoutIsolatedCodex()))

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -95,6 +95,7 @@ export const WEB_INVOKE_CHANNELS = {
   'settings.isNpmAvailable': 'settings:npm-available',
   'settings.listConnectors': 'settings:list-connectors',
   'settings.listSkills': 'settings:list-skills',
+  'settings.loginIsolatedCodex': 'settings:login-isolated-codex',
   'settings.logoutIsolatedCodex': 'settings:logout-isolated-codex',
   'settings.markOnboardingComplete': 'settings:mark-onboarding-complete',
   'settings.previewSkillZip': 'settings:preview-skill-zip',


### PR DESCRIPTION
## Summary

Three fixes to the Codex subscription (ChatGPT login) provider flow:

1. **Shared-mode false negative for API-key profiles.** Validation only accepted `chat-gpt` auth, so a Codex CLI profile configured with an API key (`codex login --api-key`) was reported as "No existing Codex login was found" even though it runs fine. `chat-gpt`, `api-key`, and `gateway` profiles now all count as authenticated, matching runtime behavior.

2. **Saving/testing a provider could pop an unexpected browser login and hang.** Validating a `codex-isolated` provider *performed* the sign-in (browser flow, up to a 5-minute timeout). Validation is now a read-only status check for both modes; the browser sign-in is a separate explicit action — a **Sign in** button on the provider card in Settings, and an explicit persist → sign-in → activate branch in onboarding. A cancelled/dismissed login keeps the provider saved but flagged unverified, instead of blocking the save.

3. **Isolated sign-in crashed on Windows when CODEX_HOME was missing.** Auth sessions spawn Codex with `CODEX_HOME` pointed at `<storageRoot>/codex-subscription`, which nothing created before the first sign-in — Codex exits with code 1 ("CODEX_HOME ... does not exist"). The isolated home is now created before any auth session spawns; shared mode keeps using the user's real profile untouched.

## Test plan

- [x] `vitest run` — 4440 passed (incl. new coverage: api-key/gateway auth, read-only isolated validation, sign-in outcome recording, CODEX_HOME creation)
- [x] `npm run typecheck` — clean
- [x] `eslint` on changed files — clean
- [ ] Manual: validate a shared provider backed by an API-key Codex profile — passes instead of false-negative
- [ ] Manual (Windows): trigger the isolated sign-in on a fresh install — browser flow opens instead of the CODEX_HOME exit-1 error