### PR TITLE
ci(review): grant pull-requests write to AI review label jobs

### DIFF
--- a/.github/workflows/ai-review-labels.yml
+++ b/.github/workflows/ai-review-labels.yml
@@ -17,8 +17,11 @@ jobs:
     name: Clear stale AI review label
     if: ${{ github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
+    # Label operations on a pull request require pull-requests write; the label REST endpoints
+    # return 403 with only issues write (GitHub reports "issues=write; pull_requests=write").
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - name: Remove ai-reviewed label
         uses: actions/github-script@v8
@@ -47,7 +50,7 @@ jobs:
     permissions:
       actions: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Add ai-reviewed label for the latest reviewed commit
         uses: actions/github-script@v8

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+# yamllint config. CI does not run yamllint; this only tunes local editor plugins.
+extends: default
+
+rules:
+  # Workflow files embed inline scripts and long comments; do not flag long lines.
+  line-length: disable


### PR DESCRIPTION
## Summary

The **AI Review Labels** workflow failed with HTTP 403 `Resource not accessible by integration` when clearing the stale `ai-reviewed` label (e.g. run on PR #264). Label REST operations on a *pull request* require `pull-requests: write`, not just `issues: write` — GitHub's own response advertised the required scopes as `issues=write; pull_requests=write`.

- `clear_label` declared only `issues: write` → denied on `removeLabel`.
- `mark_complete` declared `pull-requests: read` → would be denied next on `addLabels`.

The `pull_request`-triggered jobs in `ai-review.yml` (`claude_review`, `post_codex_feedback`) already declare `pull-requests: write`, which is why their comment posting works on the same PR.

## Change

Grant `pull-requests: write` to both label jobs, with an inline comment explaining the requirement.

## Testing

- `js-yaml` parse confirms the workflow is well-formed and both jobs now carry `issues: write` + `pull-requests: write`.