### PR TITLE
fix(codex): trust api-key/gateway auth, bound status reads, and gate discarded sign-ins

### DIFF
--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -89,8 +89,12 @@ describe('CodexAuthController', () => {
       'private@example.test'
     )
 
+    // A signed-out adapter that also cannot offer ChatGPT login has nothing to connect: that is the
+    // genuine capability failure. (A signed-out adapter that DOES advertise chat-gpt is merely
+    // unauthenticated — covered below — not a capability failure.)
     const unsupported = session({
-      initialize: vi.fn().mockResolvedValue({ authMethods: [{ id: 'api-key' }] })
+      initialize: vi.fn().mockResolvedValue({ authMethods: [{ id: 'api-key' }] }),
+      status: vi.fn().mockResolvedValue({ type: 'unauthenticated' })
     })
     const unsupportedController = new CodexAuthController({
       openSession: vi.fn().mockResolvedValue(unsupported)
@@ -101,6 +105,28 @@ describe('CodexAuthController', () => {
       authenticated: false,
       message: 'The installed codex-acp does not advertise ChatGPT authentication.'
     })
+  })
+
+  it('reports a chat-gpt-less adapter that already holds a credential as authenticated', async () => {
+    // Regression: getStatus must not gate on the chat-gpt capability before reading status. An adapter
+    // advertising only api-key, already carrying an api-key/gateway credential, runs fine — reporting
+    // it signed out (a capability failure) would wrongly block an otherwise working provider.
+    for (const type of ['api-key', 'gateway'] as const) {
+      const credentialed = session({
+        initialize: vi.fn().mockResolvedValue({ authMethods: [{ id: 'api-key' }] }),
+        status: vi.fn().mockResolvedValue({ type })
+      })
+      const controller = new CodexAuthController({
+        openSession: vi.fn().mockResolvedValue(credentialed)
+      })
+
+      await expect(controller.getStatus('shared')).resolves.toEqual({
+        mode: 'shared',
+        supported: true,
+        authenticated: true
+      })
+      expect(vi.mocked(credentialed.close)).toHaveBeenCalledOnce()
+    }
   })
 
   it('treats api-key and gateway profiles as authenticated', async () => {
@@ -124,6 +150,54 @@ describe('CodexAuthController', () => {
         authenticated: true
       })
       expect(apiKeySession.authenticateChatGpt).not.toHaveBeenCalled()
+    }
+  })
+
+  it('reports an unauthenticated but chat-gpt-capable profile as supported, not a capability failure', async () => {
+    const signedOut = session({ status: vi.fn().mockResolvedValue({ type: 'unauthenticated' }) })
+    const controller = new CodexAuthController({
+      openSession: vi.fn().mockResolvedValue(signedOut)
+    })
+
+    await expect(controller.getStatus('shared')).resolves.toEqual({
+      mode: 'shared',
+      supported: true,
+      authenticated: false
+    })
+  })
+
+  it('times out a stalled status read and closes the late session', async () => {
+    vi.useFakeTimers()
+    let resolveStatus!: (value: { type: 'unauthenticated' }) => void
+    const stalledStatus = new Promise<{ type: 'unauthenticated' }>((resolve) => {
+      resolveStatus = resolve
+    })
+    const stalled = session({ status: vi.fn(() => stalledStatus) })
+    const controller = new CodexAuthController({
+      openSession: vi.fn().mockResolvedValue(stalled),
+      statusTimeoutMs: 10
+    })
+    let outcome: Awaited<ReturnType<CodexAuthController['getStatus']>> | undefined
+    const pending = controller.getStatus('shared').then((result) => {
+      outcome = result
+    })
+
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(10)
+    await pending
+
+    try {
+      expect(outcome).toEqual({
+        mode: 'shared',
+        supported: true,
+        authenticated: false,
+        message: 'Codex status check timed out.'
+      })
+      // The stalled read is abandoned, but the session must still be torn down, not leaked.
+      expect(vi.mocked(stalled.close)).toHaveBeenCalledOnce()
+    } finally {
+      resolveStatus({ type: 'unauthenticated' })
+      vi.useRealTimers()
     }
   })
 

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -423,4 +423,41 @@ describe('CodexAuthController', () => {
     })
     expect(vi.mocked(isolated.logout)).toHaveBeenCalledOnce()
   })
+
+  it('times out a stalled sign-out and closes the session instead of hanging', async () => {
+    // logoutIsolated is user-triggered and now issues its own status round-trip, so it must fail
+    // closed on a stalled adapter like the reads do — not freeze the Settings sign-out.
+    vi.useFakeTimers()
+    let resolveStatus!: (value: { type: 'unauthenticated' }) => void
+    const stalledStatus = new Promise<{ type: 'unauthenticated' }>((resolve) => {
+      resolveStatus = resolve
+    })
+    const isolated = session({ status: vi.fn(() => stalledStatus) })
+    const controller = new CodexAuthController({
+      openSession: vi.fn().mockResolvedValue(isolated),
+      statusTimeoutMs: 10
+    })
+    let outcome: Awaited<ReturnType<CodexAuthController['logoutIsolated']>> | undefined
+    const pending = controller.logoutIsolated().then((result) => {
+      outcome = result
+    })
+
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(10)
+    await pending
+
+    try {
+      expect(outcome).toEqual({
+        mode: 'isolated',
+        supported: true,
+        authenticated: false,
+        message: 'Codex sign-out timed out.'
+      })
+      expect(vi.mocked(isolated.logout)).not.toHaveBeenCalled()
+      expect(vi.mocked(isolated.close)).toHaveBeenCalledOnce()
+    } finally {
+      resolveStatus({ type: 'unauthenticated' })
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -153,6 +153,57 @@ describe('CodexAuthController', () => {
     }
   })
 
+  it('signs in and out of a chat-gpt-less isolated profile that already holds a credential', async () => {
+    // Regression: loginIsolated/logoutIsolated must not gate on the chat-gpt capability before reading
+    // status, mirroring getStatus. An isolated home carrying an api-key/gateway credential on a build
+    // that never advertises chat-gpt must still report authenticated and stay sign-out-able.
+    for (const type of ['api-key', 'gateway'] as const) {
+      const credentialed = session({
+        initialize: vi.fn().mockResolvedValue({ authMethods: [{ id: 'api-key' }] }),
+        status: vi.fn().mockResolvedValue({ type })
+      })
+      const controller = new CodexAuthController({
+        openSession: vi.fn().mockResolvedValue(credentialed)
+      })
+
+      await expect(controller.loginIsolated()).resolves.toEqual({
+        mode: 'isolated',
+        supported: true,
+        authenticated: true
+      })
+      // No ChatGPT browser flow: the existing credential is exactly what the runtime would use.
+      expect(credentialed.authenticateChatGpt).not.toHaveBeenCalled()
+
+      await expect(controller.logoutIsolated()).resolves.toEqual({
+        mode: 'isolated',
+        supported: true,
+        authenticated: false
+      })
+      expect(vi.mocked(credentialed.logout)).toHaveBeenCalledOnce()
+    }
+  })
+
+  it('still reports a capability failure for a signed-out chat-gpt-less isolated profile', async () => {
+    // The gate remains for the genuine case: signed out AND no ChatGPT login means nothing to do.
+    const signedOut = session({
+      initialize: vi.fn().mockResolvedValue({ authMethods: [{ id: 'api-key' }] }),
+      status: vi.fn().mockResolvedValue({ type: 'unauthenticated' })
+    })
+    const controller = new CodexAuthController({
+      openSession: vi.fn().mockResolvedValue(signedOut)
+    })
+
+    await expect(controller.loginIsolated()).resolves.toEqual({
+      mode: 'isolated',
+      supported: false,
+      authenticated: false,
+      message: 'The installed codex-acp does not advertise ChatGPT authentication.'
+    })
+    expect(signedOut.authenticateChatGpt).not.toHaveBeenCalled()
+    await expect(controller.logoutIsolated()).resolves.toMatchObject({ supported: false })
+    expect(signedOut.logout).not.toHaveBeenCalled()
+  })
+
   it('reports an unauthenticated but chat-gpt-capable profile as supported, not a capability failure', async () => {
     const signedOut = session({ status: vi.fn().mockResolvedValue({ type: 'unauthenticated' }) })
     const controller = new CodexAuthController({

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -295,6 +295,32 @@ describe('CodexAuthController', () => {
     expect(vi.mocked(isolated.close)).toHaveBeenCalledOnce()
   })
 
+  it('rejects a second concurrent sign-in without opening a second session', async () => {
+    // The in-progress slot must be claimed synchronously, in the same tick as the guard, so two
+    // rapid calls (no await between them) cannot both pass the guard and open two browser flows.
+    const isolated = session({
+      status: vi.fn().mockResolvedValue({ type: 'unauthenticated' }),
+      authenticateChatGpt: vi.fn(() => new Promise<void>(() => undefined))
+    })
+    const openSession = vi.fn().mockResolvedValue(isolated)
+    const controller = new CodexAuthController({ openSession, loginTimeoutMs: 60_000 })
+
+    const first = controller.loginIsolated()
+    const second = controller.loginIsolated()
+
+    await expect(second).resolves.toEqual({
+      mode: 'isolated',
+      supported: true,
+      authenticated: false,
+      message: 'A Codex sign-in is already in progress.'
+    })
+    expect(openSession).toHaveBeenCalledOnce()
+
+    // The first login still owns the slot and remains cancellable.
+    controller.cancelLogin()
+    await expect(first).resolves.toMatchObject({ message: 'Codex sign-in was cancelled.' })
+  })
+
   it('times out while isolated login initialization is stalled', async () => {
     vi.useFakeTimers()
     let resolveInitialize!: (value: { authMethods: { id: string }[] }) => void

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -133,17 +133,18 @@ export class CodexAuthController {
   // Runs an adapter interaction against a freshly opened session under a hard deadline, so every
   // status/login/logout round-trip fails closed rather than hanging on a stalled codex-acp. Owns the
   // full lifecycle: open (racing the deadline), late-close of a session that only arrives after the
-  // abort, timeout, and teardown. `register` lets a caller expose the AbortController (loginIsolated
-  // stores it so cancelLogin can abort in flight); `onAborted` maps a timeout/cancel into a result.
+  // abort, timeout, and teardown. The caller supplies the AbortController so it can register it
+  // synchronously before any await (loginIsolated stores it in activeLogin, before this async helper
+  // is even entered, so its re-entrancy guard cannot race); `onAborted` maps a timeout/cancel into a
+  // result, and `onSettled` runs in the finally for caller-side teardown (clearing activeLogin).
   private async withBoundedSession(
     mode: CodexAuthMode,
     timeoutMs: number,
     run: (session: CodexAuthSession, signal: AbortSignal) => Promise<CodexAuthStatus>,
     onAborted: (reason: unknown) => CodexAuthStatus,
-    register?: (abort: AbortController | undefined) => void
+    abort: AbortController = new AbortController(),
+    onSettled?: () => void
   ): Promise<CodexAuthStatus> {
-    const abort = new AbortController()
-    register?.(abort)
     const timeout = setTimeout(() => abort.abort('timeout'), timeoutMs)
     let authSession: CodexAuthSession | undefined
 
@@ -161,7 +162,7 @@ export class CodexAuthController {
       throw error
     } finally {
       clearTimeout(timeout)
-      register?.(undefined)
+      onSettled?.()
       await authSession?.close()
     }
   }
@@ -198,6 +199,12 @@ export class CodexAuthController {
       }
     }
 
+    // Claim the in-progress slot synchronously, in the same tick as the guard above and before the
+    // async helper is entered, so two rapid calls cannot both pass the guard and open two browser
+    // sign-ins. cancelLogin aborts this same controller; onSettled clears the slot on teardown.
+    const abort = new AbortController()
+    this.activeLogin = abort
+
     return this.withBoundedSession(
       'isolated',
       this.loginTimeoutMs,
@@ -226,8 +233,9 @@ export class CodexAuthController {
             ? 'Codex sign-in timed out after five minutes.'
             : 'Codex sign-in was cancelled.'
       }),
-      (abort) => {
-        this.activeLogin = abort
+      abort,
+      () => {
+        this.activeLogin = undefined
       }
     )
   }

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -41,6 +41,10 @@ export type CodexAuthLaunch = {
 type CodexAuthControllerOptions = {
   openSession: (mode: CodexAuthMode) => Promise<CodexAuthSession>
   loginTimeoutMs?: number
+  // Bounds the read-only status check (open + initialize + status). Unlike the browser login this
+  // never waits on a human, so a much shorter deadline keeps a stalled adapter from hanging save/test
+  // indefinitely.
+  statusTimeoutMs?: number
 }
 
 const CODEX_ENV_KEYS = [
@@ -117,23 +121,55 @@ const toPublicStatus = (
 export class CodexAuthController {
   private readonly openSession: (mode: CodexAuthMode) => Promise<CodexAuthSession>
   private readonly loginTimeoutMs: number
+  private readonly statusTimeoutMs: number
   private activeLogin: AbortController | undefined
 
   constructor(options: CodexAuthControllerOptions) {
     this.openSession = options.openSession
     this.loginTimeoutMs = options.loginTimeoutMs ?? 5 * 60_000
+    this.statusTimeoutMs = options.statusTimeoutMs ?? 30_000
   }
 
   async getStatus(mode: CodexAuthMode): Promise<CodexAuthStatus> {
-    const authSession = await this.openSession(mode)
+    const abort = new AbortController()
+    const timeout = setTimeout(() => abort.abort('timeout'), this.statusTimeoutMs)
+    let authSession: CodexAuthSession | undefined
+
     try {
-      const initialized = await authSession.initialize()
+      // Close a session that only arrives after the deadline so a stalled open never leaks a process.
+      const sessionPromise = this.openSession(mode)
+      void sessionPromise
+        .then(async (session) => {
+          if (abort.signal.aborted && authSession !== session) await session.close()
+        })
+        .catch(() => undefined)
+      authSession = await waitForOperation(sessionPromise, abort.signal)
+
+      const initialized = await waitForOperation(authSession.initialize(), abort.signal)
       const supported = initialized.authMethods?.some((method) => method.id === 'chat-gpt') ?? false
+
+      // Read the live status regardless of the advertised methods: an adapter can hold a usable
+      // api-key/gateway credential without offering ChatGPT login, and that profile is authenticated.
+      // Only when the profile is signed out AND ChatGPT login is unavailable is there nothing to do —
+      // that is the genuine capability failure.
+      const status = await waitForOperation(authSession.status(), abort.signal)
+      if (isAuthenticated(status)) return toPublicStatus(mode, true, status)
       if (!supported) return capabilityFailure(mode)
 
-      return toPublicStatus(mode, true, await authSession.status())
+      return toPublicStatus(mode, true, status)
+    } catch (error) {
+      if (abort.signal.aborted) {
+        return {
+          mode,
+          supported: true,
+          authenticated: false,
+          message: 'Codex status check timed out.'
+        }
+      }
+      throw error
     } finally {
-      await authSession.close()
+      clearTimeout(timeout)
+      await authSession?.close()
     }
   }
 

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -198,13 +198,14 @@ export class CodexAuthController {
       authSession = await waitForOperation(sessionPromise, abort.signal)
       const initialized = await waitForOperation(authSession.initialize(), abort.signal)
       const supported = initialized.authMethods?.some((method) => method.id === 'chat-gpt') ?? false
-      if (!supported) return capabilityFailure('isolated')
 
+      // Read credential status before the capability gate, mirroring getStatus. An api-key/gateway
+      // credential already in the app-managed isolated home is exactly what the runtime would use, so
+      // any usable credential short-circuits the browser flow — even on a build that never advertises
+      // chat-gpt. Only a signed-out profile on such a build has nothing to do: the capability failure.
       const current = await waitForOperation(authSession.status(), abort.signal)
-      // api-key/gateway credentials short-circuit the browser flow here too: the isolated home is
-      // app-managed and holds exactly what the runtime would use, so any usable credential already
-      // present means no re-login is needed.
       if (!isAuthenticated(current)) {
+        if (!supported) return capabilityFailure('isolated')
         await waitForOperation(authSession.authenticateChatGpt(), abort.signal)
       }
 
@@ -242,7 +243,12 @@ export class CodexAuthController {
     try {
       const initialized = await authSession.initialize()
       const supported = initialized.authMethods?.some((method) => method.id === 'chat-gpt') ?? false
-      if (!supported) return capabilityFailure('isolated')
+
+      // Clear whatever credential the isolated home holds, mirroring getStatus/loginIsolated: an
+      // api-key/gateway login must be sign-out-able even on a build that never advertises chat-gpt.
+      // Only a signed-out profile on such a build has nothing to clear — the capability failure.
+      const current = await authSession.status()
+      if (!isAuthenticated(current) && !supported) return capabilityFailure('isolated')
 
       await authSession.logout()
       return { mode: 'isolated', supported: true, authenticated: false }

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -130,13 +130,24 @@ export class CodexAuthController {
     this.statusTimeoutMs = options.statusTimeoutMs ?? 30_000
   }
 
-  async getStatus(mode: CodexAuthMode): Promise<CodexAuthStatus> {
+  // Runs an adapter interaction against a freshly opened session under a hard deadline, so every
+  // status/login/logout round-trip fails closed rather than hanging on a stalled codex-acp. Owns the
+  // full lifecycle: open (racing the deadline), late-close of a session that only arrives after the
+  // abort, timeout, and teardown. `register` lets a caller expose the AbortController (loginIsolated
+  // stores it so cancelLogin can abort in flight); `onAborted` maps a timeout/cancel into a result.
+  private async withBoundedSession(
+    mode: CodexAuthMode,
+    timeoutMs: number,
+    run: (session: CodexAuthSession, signal: AbortSignal) => Promise<CodexAuthStatus>,
+    onAborted: (reason: unknown) => CodexAuthStatus,
+    register?: (abort: AbortController | undefined) => void
+  ): Promise<CodexAuthStatus> {
     const abort = new AbortController()
-    const timeout = setTimeout(() => abort.abort('timeout'), this.statusTimeoutMs)
+    register?.(abort)
+    const timeout = setTimeout(() => abort.abort('timeout'), timeoutMs)
     let authSession: CodexAuthSession | undefined
 
     try {
-      // Close a session that only arrives after the deadline so a stalled open never leaks a process.
       const sessionPromise = this.openSession(mode)
       void sessionPromise
         .then(async (session) => {
@@ -144,33 +155,37 @@ export class CodexAuthController {
         })
         .catch(() => undefined)
       authSession = await waitForOperation(sessionPromise, abort.signal)
-
-      const initialized = await waitForOperation(authSession.initialize(), abort.signal)
-      const supported = initialized.authMethods?.some((method) => method.id === 'chat-gpt') ?? false
-
-      // Read the live status regardless of the advertised methods: an adapter can hold a usable
-      // api-key/gateway credential without offering ChatGPT login, and that profile is authenticated.
-      // Only when the profile is signed out AND ChatGPT login is unavailable is there nothing to do —
-      // that is the genuine capability failure.
-      const status = await waitForOperation(authSession.status(), abort.signal)
-      if (isAuthenticated(status)) return toPublicStatus(mode, true, status)
-      if (!supported) return capabilityFailure(mode)
-
-      return toPublicStatus(mode, true, status)
+      return await run(authSession, abort.signal)
     } catch (error) {
-      if (abort.signal.aborted) {
-        return {
-          mode,
-          supported: true,
-          authenticated: false,
-          message: 'Codex status check timed out.'
-        }
-      }
+      if (abort.signal.aborted) return onAborted(abort.signal.reason)
       throw error
     } finally {
       clearTimeout(timeout)
+      register?.(undefined)
       await authSession?.close()
     }
+  }
+
+  async getStatus(mode: CodexAuthMode): Promise<CodexAuthStatus> {
+    return this.withBoundedSession(
+      mode,
+      this.statusTimeoutMs,
+      async (session, signal) => {
+        const initialized = await waitForOperation(session.initialize(), signal)
+        const supported = initialized.authMethods?.some((method) => method.id === 'chat-gpt') ?? false
+
+        // Read the live status regardless of the advertised methods: an adapter can hold a usable
+        // api-key/gateway credential without offering ChatGPT login, and that profile is
+        // authenticated. Only when the profile is signed out AND ChatGPT login is unavailable is there
+        // nothing to do — that is the genuine capability failure.
+        const status = await waitForOperation(session.status(), signal)
+        if (isAuthenticated(status)) return toPublicStatus(mode, true, status)
+        if (!supported) return capabilityFailure(mode)
+
+        return toPublicStatus(mode, true, status)
+      },
+      () => ({ mode, supported: true, authenticated: false, message: 'Codex status check timed out.' })
+    )
   }
 
   async loginIsolated(): Promise<CodexAuthStatus> {
@@ -183,55 +198,38 @@ export class CodexAuthController {
       }
     }
 
-    const abort = new AbortController()
-    this.activeLogin = abort
-    const timeout = setTimeout(() => abort.abort('timeout'), this.loginTimeoutMs)
-    let authSession: CodexAuthSession | undefined
+    return this.withBoundedSession(
+      'isolated',
+      this.loginTimeoutMs,
+      async (session, signal) => {
+        const initialized = await waitForOperation(session.initialize(), signal)
+        const supported = initialized.authMethods?.some((method) => method.id === 'chat-gpt') ?? false
 
-    try {
-      const sessionPromise = this.openSession('isolated')
-      void sessionPromise
-        .then(async (session) => {
-          if (abort.signal.aborted && authSession !== session) await session.close()
-        })
-        .catch(() => undefined)
-      authSession = await waitForOperation(sessionPromise, abort.signal)
-      const initialized = await waitForOperation(authSession.initialize(), abort.signal)
-      const supported = initialized.authMethods?.some((method) => method.id === 'chat-gpt') ?? false
-
-      // Read credential status before the capability gate, mirroring getStatus. An api-key/gateway
-      // credential already in the app-managed isolated home is exactly what the runtime would use, so
-      // any usable credential short-circuits the browser flow — even on a build that never advertises
-      // chat-gpt. Only a signed-out profile on such a build has nothing to do: the capability failure.
-      const current = await waitForOperation(authSession.status(), abort.signal)
-      if (!isAuthenticated(current)) {
-        if (!supported) return capabilityFailure('isolated')
-        await waitForOperation(authSession.authenticateChatGpt(), abort.signal)
-      }
-
-      return toPublicStatus(
-        'isolated',
-        true,
-        await waitForOperation(authSession.status(), abort.signal)
-      )
-    } catch (error) {
-      if (abort.signal.aborted) {
-        return {
-          mode: 'isolated',
-          supported: true,
-          authenticated: false,
-          message:
-            abort.signal.reason === 'timeout'
-              ? 'Codex sign-in timed out after five minutes.'
-              : 'Codex sign-in was cancelled.'
+        // Read credential status before the capability gate, mirroring getStatus. An api-key/gateway
+        // credential already in the app-managed isolated home is exactly what the runtime would use,
+        // so any usable credential short-circuits the browser flow — even on a build that never
+        // advertises chat-gpt. Only a signed-out profile on such a build has nothing to do.
+        const current = await waitForOperation(session.status(), signal)
+        if (!isAuthenticated(current)) {
+          if (!supported) return capabilityFailure('isolated')
+          await waitForOperation(session.authenticateChatGpt(), signal)
         }
+
+        return toPublicStatus('isolated', true, await waitForOperation(session.status(), signal))
+      },
+      (reason) => ({
+        mode: 'isolated',
+        supported: true,
+        authenticated: false,
+        message:
+          reason === 'timeout'
+            ? 'Codex sign-in timed out after five minutes.'
+            : 'Codex sign-in was cancelled.'
+      }),
+      (abort) => {
+        this.activeLogin = abort
       }
-      throw error
-    } finally {
-      clearTimeout(timeout)
-      this.activeLogin = undefined
-      await authSession?.close()
-    }
+    )
   }
 
   cancelLogin(): void {
@@ -239,22 +237,31 @@ export class CodexAuthController {
   }
 
   async logoutIsolated(): Promise<CodexAuthStatus> {
-    const authSession = await this.openSession('isolated')
-    try {
-      const initialized = await authSession.initialize()
-      const supported = initialized.authMethods?.some((method) => method.id === 'chat-gpt') ?? false
+    // Bounded like the reads: logout is user-triggered from Settings and now issues its own status
+    // round-trip, so a stalled adapter must fail closed here too rather than freeze sign-out.
+    return this.withBoundedSession(
+      'isolated',
+      this.statusTimeoutMs,
+      async (session, signal) => {
+        const initialized = await waitForOperation(session.initialize(), signal)
+        const supported = initialized.authMethods?.some((method) => method.id === 'chat-gpt') ?? false
 
-      // Clear whatever credential the isolated home holds, mirroring getStatus/loginIsolated: an
-      // api-key/gateway login must be sign-out-able even on a build that never advertises chat-gpt.
-      // Only a signed-out profile on such a build has nothing to clear — the capability failure.
-      const current = await authSession.status()
-      if (!isAuthenticated(current) && !supported) return capabilityFailure('isolated')
+        // Clear whatever credential the isolated home holds, mirroring getStatus/loginIsolated: an
+        // api-key/gateway login must be sign-out-able even on a build that never advertises chat-gpt.
+        // Only a signed-out profile on such a build has nothing to clear — the capability failure.
+        const current = await waitForOperation(session.status(), signal)
+        if (!isAuthenticated(current) && !supported) return capabilityFailure('isolated')
 
-      await authSession.logout()
-      return { mode: 'isolated', supported: true, authenticated: false }
-    } finally {
-      await authSession.close()
-    }
+        await waitForOperation(session.logout(), signal)
+        return { mode: 'isolated', supported: true, authenticated: false }
+      },
+      () => ({
+        mode: 'isolated',
+        supported: true,
+        authenticated: false,
+        message: 'Codex sign-out timed out.'
+      })
+    )
   }
 }
 

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -163,7 +163,8 @@ describe('settings IPC handlers', () => {
   it('reconnects the active Codex subscription after isolated logout', async () => {
     handlers.clear()
     const service = createFakeService()
-    service.logoutIsolatedCodex.mockResolvedValue({
+    service.logoutIsolatedCodex.mockResolvedValue({ ok: true, category: 'ok' })
+    service.getSettingsView.mockResolvedValue({
       claude: {},
       providers: [],
       activeProviderId: CODEX_SUBSCRIPTION_PROVIDER_ID
@@ -177,6 +178,28 @@ describe('settings IPC handlers', () => {
     await invoke('settings:logout-isolated-codex')
 
     expect(onActiveProviderChanged).toHaveBeenCalledOnce()
+  })
+
+  it('does not reconnect when isolated logout times out', async () => {
+    // Reconnecting when the sign-out timed out would re-authenticate with the credential that is
+    // still in place — the opposite of what the user intended. Skip the reconnect so the live
+    // agent keeps its existing session until a retry clears the credential.
+    handlers.clear()
+    const service = createFakeService()
+    service.logoutIsolatedCodex.mockResolvedValue({
+      ok: false,
+      category: 'timeout',
+      message: 'Codex sign-out timed out.'
+    })
+    const onActiveProviderChanged = vi.fn()
+    registerSettingsIpcHandlers({
+      service: asService(service),
+      onActiveProviderChanged
+    })
+
+    await invoke('settings:logout-isolated-codex')
+
+    expect(onActiveProviderChanged).not.toHaveBeenCalled()
   })
 
   it('reconnects the active provider only when the isolated login was actually applied', async () => {

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -181,13 +181,19 @@ const registerSettingsIpcHandlers = ({
     return result
   })
   ipcMain.handle('settings:logout-isolated-codex', async () => {
-    const snapshot = await service.logoutIsolatedCodex()
+    const result = await service.logoutIsolatedCodex()
 
-    if (snapshot.activeProviderId === CODEX_SUBSCRIPTION_PROVIDER_ID) {
-      onActiveProviderChanged?.()
+    // Reconnect only when the sign-out actually cleared the credential. A timed-out sign-out leaves
+    // it in place, so forcing the live agent to reconnect would just re-authenticate against the
+    // credential we failed to remove.
+    if (result.ok) {
+      const snapshot = await service.getSettingsView()
+      if (snapshot.activeProviderId === CODEX_SUBSCRIPTION_PROVIDER_ID) {
+        onActiveProviderChanged?.()
+      }
     }
 
-    return snapshot
+    return result
   })
   ipcMain.handle(
     'settings:refresh-provider-models',

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -402,6 +402,65 @@ describe('SettingsService: providers', () => {
     expect(stored.lastValidationFailure).toBeUndefined()
   })
 
+  it('preserves the verified markers when isolated sign-out times out', async () => {
+    // The P1 fix: a timed-out sign-out never called logout(), so the credential may still be in the
+    // isolated home. Clearing lastValidatedAt would falsely mark the provider as signed out while
+    // the credential is usable — instead preserve the verified state and return the failure so the
+    // user knows to retry.
+    const codexAuth = {
+      getStatus: vi.fn(),
+      loginIsolated: vi.fn().mockResolvedValue({
+        mode: 'isolated',
+        supported: true,
+        authenticated: true
+      }),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn().mockResolvedValue({
+        mode: 'isolated',
+        supported: true,
+        authenticated: false,
+        message: 'Codex sign-out timed out.'
+      })
+    }
+    const service = createService(undefined, { codexAuth })
+    await service.upsertProvider({ type: 'codex-isolated' })
+    await service.loginIsolatedCodex()
+
+    const result = await service.logoutIsolatedCodex()
+
+    expect(result).toEqual({ ok: false, category: 'timeout', message: 'Codex sign-out timed out.' })
+    const stored = (await repository.getSettings()).providers[0]
+    expect(stored.lastValidatedAt).toBeGreaterThan(0)
+    expect(stored.lastValidationFailure).toBeUndefined()
+  })
+
+  it('returns success when isolated sign-out completes cleanly', async () => {
+    const codexAuth = {
+      getStatus: vi.fn(),
+      loginIsolated: vi.fn().mockResolvedValue({
+        mode: 'isolated',
+        supported: true,
+        authenticated: true
+      }),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn().mockResolvedValue({
+        mode: 'isolated',
+        supported: true,
+        authenticated: false
+      })
+    }
+    const service = createService(undefined, { codexAuth })
+    await service.upsertProvider({ type: 'codex-isolated' })
+    await service.loginIsolatedCodex()
+
+    const result = await service.logoutIsolatedCodex()
+
+    expect(result).toEqual({ ok: true, category: 'ok' })
+    const stored = (await repository.getSettings()).providers[0]
+    expect(stored.lastValidatedAt).toBeUndefined()
+    expect(stored.lastValidationFailure).toBeUndefined()
+  })
+
   it('encrypts the key on upsert and never exposes plaintext in the view', async () => {
     const service = createService()
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -269,7 +269,8 @@ describe('SettingsService: providers', () => {
 
     await expect(service.loginIsolatedCodex()).resolves.toMatchObject({
       ok: true,
-      category: 'ok'
+      category: 'ok',
+      applied: true
     })
     expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeDefined()
 
@@ -322,7 +323,9 @@ describe('SettingsService: providers', () => {
     await service.upsertProvider({ type: 'codex-shared' })
     resolveLogin({ mode: 'isolated', supported: true, authenticated: true })
 
-    await expect(pending).resolves.toMatchObject({ ok: true })
+    // ok reflects the sign-in itself, but applied:false marks it as discarded so a success-gated
+    // caller (onboarding) does not advance on a profile the store never recorded it against.
+    await expect(pending).resolves.toMatchObject({ ok: true, applied: false })
     const stored = (await repository.getSettings()).providers[0]
     expect(stored.type).toBe('codex-shared')
     expect(stored.lastValidatedAt).toBeUndefined()
@@ -606,6 +609,44 @@ describe('SettingsService: validation', () => {
     const stored = (await repository.getSettings()).providers[0]
     expect(stored.lastValidatedAt).toBeUndefined()
     expect(stored.lastValidationFailure).toMatchObject({ category: 'auth' })
+  })
+
+  it('marks a superseded validation as not applied and leaves the newer stamp intact', async () => {
+    const service = createService()
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+
+    // A slow probe lets a second, faster validation start and bump the generation before the first
+    // resolves. The first is stale: it must report applied:false and never write over the newer run.
+    let releaseSlow!: () => void
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseSlow = () => resolve({ status: 401 } as Response)
+          })
+      )
+      .mockResolvedValue({ status: 200 } as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const slow = service.validateProvider({ providerId: created.id })
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+    const fast = await service.validateProvider({ providerId: created.id })
+    expect(fast).toMatchObject({ ok: true, applied: true })
+
+    releaseSlow()
+    await expect(slow).resolves.toMatchObject({ ok: false, applied: false })
+
+    // The newer success stands: the superseded failure must not have cleared it.
+    expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeGreaterThan(0)
   })
 
   it.each([

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1484,8 +1484,10 @@ class SettingsService {
     )
     // The provider can be edited while the browser flow is open. Unless the stored record is still
     // the isolated subscription the login was started for, the outcome is stale and discarded —
-    // recording it could stamp a switched-to-shared (and unauthenticated) profile as verified.
-    if (provider?.type !== 'codex-isolated') return result
+    // recording it could stamp a switched-to-shared (and unauthenticated) profile as verified. Flag
+    // it as not-applied so a caller gating navigation on success (onboarding) does not advance on a
+    // result the stored provider never received.
+    if (provider?.type !== 'codex-isolated') return { ...result, applied: false }
 
     await this.repository.upsertProvider(
       result.ok
@@ -1506,7 +1508,7 @@ class SettingsService {
           }
     )
 
-    return result
+    return { ...result, applied: true }
   }
 
   async logoutIsolatedCodex(): Promise<SettingsSnapshot> {
@@ -1572,17 +1574,22 @@ class SettingsService {
         })
 
     if (resolved.storedId) {
+      // Each early return here means the tested target no longer matches what is stored (a newer test
+      // superseded this one, the provider was deleted, or it was edited mid-flight). The outcome is
+      // real but was not recorded, so `applied: false` tells a success-gated caller not to advance.
       if (this.providerValidationGenerations.get(resolved.storedId) !== validationGeneration) {
-        return result
+        return { ...result, applied: false }
       }
       const latestSettings = await this.repository.getSettings()
       const stored = latestSettings.providers.find((provider) => provider.id === resolved.storedId)
-      if (!stored) return result
+      if (!stored) return { ...result, applied: false }
       const latestResolved = this.resolveProvider(
         stored,
         latestSettings.activeProviderId === stored.id ? latestSettings.activeModel : undefined
       )
-      if (!this.sameValidationTarget(resolved.provider, latestResolved)) return result
+      if (!this.sameValidationTarget(resolved.provider, latestResolved)) {
+        return { ...result, applied: false }
+      }
 
       // Success stamps the validated time and clears any prior failure. A failure keeps the provider
       // but records why, so the list can flag it and the model pickers exclude it until it passes.
@@ -1604,6 +1611,8 @@ class SettingsService {
               }
             }
       )
+
+      return { ...result, applied: true }
     }
 
     return result

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1511,13 +1511,20 @@ class SettingsService {
     return { ...result, applied: true }
   }
 
-  async logoutIsolatedCodex(): Promise<SettingsSnapshot> {
-    await this.codexAuth.logoutIsolated()
+  async logoutIsolatedCodex(): Promise<ValidateProviderResult> {
+    const status = await this.codexAuth.logoutIsolated()
+
+    // A sign-out is confirmed only when the adapter acknowledged it cleanly, which is the only path
+    // that sets no message. A timeout or capability failure leaves the status ambiguous — the
+    // credential may still be in the isolated home — so we preserve the verified markers and surface
+    // the failure rather than falsely reporting the account as signed out.
+    const succeeded = status.authenticated === false && status.message === undefined
+
     const settings = await this.repository.getSettings()
     const provider = settings.providers.find(
       (candidate) => candidate.id === codexSubscriptionProviderIdentity().id
     )
-    if (provider) {
+    if (provider && succeeded) {
       await this.repository.upsertProvider({
         ...provider,
         lastValidatedAt: undefined,
@@ -1525,7 +1532,15 @@ class SettingsService {
       })
     }
 
-    return this.getSettingsView()
+    if (!succeeded) {
+      return {
+        ok: false,
+        category: status.message?.toLowerCase().includes('timed out') ? 'timeout' : 'unknown',
+        message: status.message ?? 'Codex sign-out did not complete.'
+      }
+    }
+
+    return { ok: true, category: 'ok' }
   }
 
   // Activates a provider and the model to run within it. An omitted/unknown model falls back to the

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -214,7 +214,7 @@ interface OpenScienceAPI {
     validateProvider(request: ValidateProviderRequest): Promise<ValidateProviderResult>
     cancelCodexLogin(): Promise<void>
     loginIsolatedCodex(): Promise<ValidateProviderResult>
-    logoutIsolatedCodex(): Promise<SettingsSnapshot>
+    logoutIsolatedCodex(): Promise<ValidateProviderResult>
     refreshProviderModels(
       request: RefreshProviderModelsRequest
     ): Promise<RefreshProviderModelsResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -237,7 +237,7 @@ type OpenScienceAPI = {
     validateProvider: (request: ValidateProviderRequest) => Promise<ValidateProviderResult>
     cancelCodexLogin: () => Promise<void>
     loginIsolatedCodex: () => Promise<ValidateProviderResult>
-    logoutIsolatedCodex: () => Promise<SettingsSnapshot>
+    logoutIsolatedCodex: () => Promise<ValidateProviderResult>
     refreshProviderModels: (
       request: RefreshProviderModelsRequest
     ) => Promise<RefreshProviderModelsResult>
@@ -557,7 +557,7 @@ const api: OpenScienceAPI = {
     loginIsolatedCodex: () =>
       ipcRenderer.invoke('settings:login-isolated-codex') as Promise<ValidateProviderResult>,
     logoutIsolatedCodex: () =>
-      ipcRenderer.invoke('settings:logout-isolated-codex') as Promise<SettingsSnapshot>,
+      ipcRenderer.invoke('settings:logout-isolated-codex') as Promise<ValidateProviderResult>,
     refreshProviderModels: (request) =>
       ipcRenderer.invoke(
         'settings:refresh-provider-models',

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -3,9 +3,20 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { EnvironmentCheckResult } from '../../../../shared/settings'
+import type { EnvironmentCheckResult, ValidateProviderResult } from '../../../../shared/settings'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import { OnboardingWizard } from './OnboardingWizard'
+
+// The Codex authentication picker is a Radix Select, which calls pointer-capture and scroll APIs
+// jsdom does not implement.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = (): void => undefined
+}
 
 let container: HTMLDivElement
 let root: Root
@@ -70,6 +81,44 @@ const goToLocationStep = async (): Promise<void> => {
   await clickButton(/continue/i)
   await fillRequiredProviderFields()
   await clickButton(/test & continue/i)
+}
+
+// Opens a Radix Select trigger and clicks an option by visible text (options portal to body). Mirrors
+// the proven ActiveModelSelect.render.test.tsx pattern, since jsdom needs the pointer events.
+const selectOption = async (triggerLabel: string, optionText: string): Promise<void> => {
+  const trigger = document.body.querySelector<HTMLButtonElement>(`[aria-label="${triggerLabel}"]`)
+  await act(async () => {
+    trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+    trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+  const option = Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).find(
+    (candidate) => candidate.textContent?.includes(optionText)
+  )
+  await act(async () => {
+    option?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, button: 0 }))
+    option?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+// A Codex-ready environment so the wizard opens straight onto the Codex provider step on Continue.
+const codexReadyState = (): Partial<ReturnType<typeof createInitialSettingsState>> => ({
+  agentFrameworkId: 'codex' as const,
+  preflight: {
+    claudeReady: false,
+    opencodeReady: false,
+    codexReady: true,
+    agentFrameworkId: 'codex' as const,
+    agentReady: true,
+    activeProviderReady: false
+  },
+  environmentCheck: { ...environment(true), agentFrameworkId: 'codex' as const }
+})
+
+// Walks to the Codex provider step and switches the auth picker to the isolated "Sign in with Open
+// Science" mode — the only path that runs the browser login (loginIsolatedCodex).
+const goToIsolatedCodexStep = async (): Promise<void> => {
+  await clickButton(/^continue$/i)
+  await selectOption('Codex authentication', 'Sign in with Open Science')
 }
 
 beforeEach(() => {
@@ -455,6 +504,101 @@ describe('OnboardingWizard', () => {
     expect(container.querySelector('[aria-label="Model"]')).toBeNull()
     expect(container.querySelector('[aria-label="API format"]')).toBeNull()
     expect(container.querySelector('[aria-label="API key"]')).toBeNull()
+  })
+
+  it('runs the isolated Codex sign-in then advances to the location step', async () => {
+    const persistProvider = vi.fn().mockResolvedValue('builtin-codex-isolated')
+    const loginIsolatedCodex = vi
+      .fn()
+      .mockResolvedValue({ ok: true, category: 'ok', applied: true })
+    const setActiveProvider = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      ...codexReadyState(),
+      persistProvider,
+      loginIsolatedCodex,
+      setActiveProvider
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+    await goToIsolatedCodexStep()
+    await clickButton(/sign in & continue/i)
+
+    // Persist happens before the browser login, and only a recorded success activates + advances.
+    expect(persistProvider).toHaveBeenCalledOnce()
+    expect(loginIsolatedCodex).toHaveBeenCalledOnce()
+    expect(setActiveProvider).toHaveBeenCalledWith('builtin-codex-isolated')
+    expect(container.textContent).toContain('Where should Open Science store your data?')
+  })
+
+  it('keeps the user on the provider step when the isolated sign-in fails', async () => {
+    const setActiveProvider = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      ...codexReadyState(),
+      persistProvider: vi.fn().mockResolvedValue('builtin-codex-isolated'),
+      loginIsolatedCodex: vi.fn().mockResolvedValue({
+        ok: false,
+        category: 'auth',
+        applied: true,
+        message: 'Codex sign-in was cancelled.'
+      }),
+      setActiveProvider
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+    await goToIsolatedCodexStep()
+    await clickButton(/sign in & continue/i)
+
+    // A failed sign-in never activates and never leaves the provider step; the reason is surfaced.
+    expect(setActiveProvider).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('Codex sign-in was cancelled.')
+    expect(container.textContent).not.toContain('Where should Open Science store your data?')
+  })
+
+  it('does not advance when an authenticated sign-in was discarded (applied:false)', async () => {
+    const setActiveProvider = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      ...codexReadyState(),
+      persistProvider: vi.fn().mockResolvedValue('builtin-codex-isolated'),
+      // ok but discarded: the provider was switched/edited mid-login, so the store never recorded it.
+      loginIsolatedCodex: vi.fn().mockResolvedValue({ ok: true, category: 'ok', applied: false }),
+      setActiveProvider
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+    await goToIsolatedCodexStep()
+    await clickButton(/sign in & continue/i)
+
+    expect(setActiveProvider).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('The Codex provider changed during sign-in')
+    expect(container.textContent).not.toContain('Where should Open Science store your data?')
+  })
+
+  it('cancels an in-flight isolated sign-in when the wizard unmounts', async () => {
+    const cancelCodexLogin = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      ...codexReadyState(),
+      persistProvider: vi.fn().mockResolvedValue('builtin-codex-isolated'),
+      // Never resolves: the login is still pending when the wizard unmounts (app quit/relaunch).
+      loginIsolatedCodex: vi.fn(() => new Promise<ValidateProviderResult>(() => undefined)),
+      cancelCodexLogin
+    })
+
+    await act(async () => {
+      root.render(<OnboardingWizard />)
+    })
+    await goToIsolatedCodexStep()
+    await clickButton(/sign in & continue/i)
+
+    // Teardown must abort the main-process login so the next attempt starts clean.
+    expect(cancelCodexLogin).not.toHaveBeenCalled()
+    await act(async () => root.unmount())
+    expect(cancelCodexLogin).toHaveBeenCalledOnce()
   })
 
   const twoFrameworks = [

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -423,6 +423,17 @@ const OnboardingWizard = (): React.JSX.Element => {
           codexLoginPendingRef.current = false
         })
 
+        // A discarded sign-in (the provider was switched/edited while the browser flow was open) can
+        // report ok but was never recorded on the stored provider — advancing would finish onboarding
+        // on an unverified profile. Keep the user here to retry against the provider they now have.
+        if (validation.applied === false) {
+          setValidationOk(false)
+          setValidationMessage(
+            'The Codex provider changed during sign-in. Review the selection and try again.'
+          )
+          return
+        }
+
         setValidationOk(validation.ok)
         setValidationMessage(describeValidation(validation))
 
@@ -436,6 +447,15 @@ const OnboardingWizard = (): React.JSX.Element => {
       }
 
       const { validation } = await saveAndActivateProvider(toUpsertRequest(formValue))
+
+      // A validation superseded by a newer test (or a provider removed/edited mid-test) reports its
+      // outcome but was not recorded; do not finish onboarding on a result the stored provider never
+      // received.
+      if (validation.applied === false) {
+        setValidationOk(false)
+        setValidationMessage('The provider changed during testing. Try again.')
+        return
+      }
 
       setValidationOk(validation.ok)
       setValidationMessage(describeValidation(validation))

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -771,10 +771,7 @@ describe('SettingsPage Codex framework', () => {
       agentReady: true,
       activeProviderReady: true
     })
-    const logoutIsolatedCodex = vi.fn().mockResolvedValue({
-      ...snapshot,
-      providers: [{ ...provider, lastValidatedAt: undefined }]
-    })
+    const logoutIsolatedCodex = vi.fn().mockResolvedValue({ ok: true, category: 'ok' })
     api.settings.logoutIsolatedCodex = logoutIsolatedCodex
 
     await act(async () => {
@@ -784,6 +781,58 @@ describe('SettingsPage Codex framework', () => {
     await act(async () => signOut?.click())
 
     expect(logoutIsolatedCodex).toHaveBeenCalledOnce()
+    const errorAlert = document.body.querySelector('[role="alert"]')
+    expect(errorAlert).toBeNull()
+  })
+
+  it('surfaces a Codex sign-out timeout through the provider error alert', async () => {
+    const api = (window as unknown as { api: { settings: Record<string, unknown> } }).api
+    const provider = {
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      name: 'Codex subscription',
+      apiEndpoints: ['responses'],
+      models: ['gpt-5.6-sol'],
+      supportsImageInput: true,
+      hasKey: false,
+      needsKey: false,
+      verified: true,
+      lastValidatedAt: Date.now()
+    }
+    const snapshot = {
+      claude: {},
+      opencode: {},
+      codex: { resolvedPath: '/data/codex-acp', version: '1.1.4' },
+      providers: [provider],
+      activeProviderId: provider.id,
+      activeModel: 'gpt-5.6-sol',
+      agentFrameworkId: 'codex',
+      agentFrameworks: frameworks,
+      claudeManaged: false,
+      opencodeManaged: false,
+      codexManaged: true
+    }
+    api.settings.getSettings = vi.fn().mockResolvedValue(snapshot)
+    api.settings.getPreflight = vi.fn().mockResolvedValue({
+      codexReady: true,
+      agentFrameworkId: 'codex',
+      agentReady: true,
+      activeProviderReady: true
+    })
+    const logoutIsolatedCodex = vi
+      .fn()
+      .mockResolvedValue({ ok: false, category: 'timeout', message: 'Codex sign-out timed out.' })
+    api.settings.logoutIsolatedCodex = logoutIsolatedCodex
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    const signOut = document.body.querySelector<HTMLButtonElement>('[aria-label="Sign out"]')
+    await act(async () => signOut?.click())
+
+    expect(logoutIsolatedCodex).toHaveBeenCalledOnce()
+    const errorAlert = document.body.querySelector('[role="alert"]')
+    expect(errorAlert?.textContent).toBe('Codex sign-out timed out.')
   })
 
   it('shows Codex login-check IPC failures instead of leaving an unhandled rejection', async () => {

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -559,6 +559,21 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
     }
   }
 
+  const handleCodexLogout = async (): Promise<void> => {
+    setProviderTestError(undefined)
+
+    try {
+      const result = await logoutIsolatedCodex()
+      // A timeout or other failure leaves the credential in place; surface the reason so the user
+      // knows to retry rather than assuming they are signed out.
+      if (!result.ok) {
+        setProviderTestError(result.message ?? 'Codex sign-out did not complete. Try again.')
+      }
+    } catch (error) {
+      setProviderTestError(error instanceof Error ? error.message : 'Could not sign out of Codex.')
+    }
+  }
+
   // A pending sign-in lives in the main process for up to five minutes — outliving this dialog, which
   // stays mounted (only its `open` flag flips). Closing Settings mid-flow would orphan the flow (no
   // cancel affordance on reopen), so tear it down together with the dialog.
@@ -934,7 +949,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                         isCodexLoginPending={isCodexLoginPending}
                         onCancelCodexLogin={() => void cancelCodexLogin()}
                         onLoginIsolatedCodex={() => void handleCodexLogin()}
-                        onLogoutIsolatedCodex={() => void logoutIsolatedCodex()}
+                        onLogoutIsolatedCodex={() => void handleCodexLogout()}
                       />
                       {providerTestError ? (
                         <p className="text-sm text-destructive" role="alert">

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -156,7 +156,9 @@ type SettingsStore = SettingsStoreData & {
   // The explicit isolated sign-in — the only flow that opens the browser login. Resolves with the
   // recorded outcome so callers can react (onboarding advances only on success).
   loginIsolatedCodex: () => Promise<ValidateProviderResult>
-  logoutIsolatedCodex: () => Promise<void>
+  // The explicit isolated sign-out. Resolves with the outcome so callers can surface a failure
+  // (e.g. a timeout where the credential may still be in place) rather than silently succeeding.
+  logoutIsolatedCodex: () => Promise<ValidateProviderResult>
   // Fetches a saved provider's live model list from the vendor and refreshes the cache on success.
   refreshProviderModels: (providerId: string) => Promise<RefreshProviderModelsResult>
   // Activates a provider and, optionally, a specific model within it (composer model switch). An
@@ -671,8 +673,13 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   },
 
   logoutIsolatedCodex: async () => {
-    set(applySnapshot(await window.api.settings.logoutIsolatedCodex()))
+    const result = await window.api.settings.logoutIsolatedCodex()
+    // Refresh the snapshot regardless of outcome: a failed sign-out preserves the verified markers
+    // on the provider (credential still in place), a successful one clears them. Either way the
+    // store must reflect the true stored state rather than a stale cached view.
+    set(applySnapshot(await window.api.settings.getSettings()))
     await get().refreshPreflight()
+    return result
   },
 
   // Fetches a provider's live models from the vendor; on success the persisted list is reflected here.

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -305,6 +305,12 @@ export type ValidateProviderResult = {
   category: ValidationCategory
   status?: number
   message?: string
+  // Whether the outcome was actually recorded on the stored provider. A result can be authenticated
+  // (`ok: true`) yet discarded — the provider was switched, deleted, or superseded by a newer test
+  // while an async sign-in/probe was in flight. Callers that gate navigation on success (onboarding)
+  // must treat `applied === false` as "do not advance": the stored provider does not reflect it.
+  // Absent means applied (the ordinary synchronous path).
+  applied?: boolean
 }
 
 // Request to refresh a saved provider's model list from the vendor's live API (fills the bundled


### PR DESCRIPTION
## Summary

Addresses four issues in the Codex auth + onboarding flow surfaced in review of the Codex sign-in work.

- **Spec P1 — trust api-key/gateway auth (`codex-auth.ts`)**: `getStatus` gated on the `chat-gpt` capability *before* reading live status, so an adapter advertising only `api-key` (already holding a usable api-key/gateway credential) was reported as a capability failure — wrongly blocking an otherwise working provider. It now reads status first and treats any authenticated method (`api-key`/`chat-gpt`/`gateway`) as authenticated, returning a capability failure only when the profile is signed out **and** ChatGPT login is unavailable.
- **P2 — bounded status read (`codex-auth.ts`)**: `getStatus` had no timeout, so a stalled `codex-acp` hung save/test indefinitely. It now reuses `loginIsolated`'s abort + late-close pattern, bounded by a new `statusTimeoutMs` (default 30s), and closes a session that only arrives after the deadline.
- **P1 — gate discarded sign-ins (`shared/settings.ts`, `service.ts`, `OnboardingWizard.tsx`)**: a sign-in/validation can succeed yet be discarded when the provider was switched, deleted, or superseded by a newer test mid-flow. Those paths returned `ok: true` with no signal, so onboarding advanced and finished on a profile the store never recorded. `ValidateProviderResult` gains an optional `applied` flag; discard paths set `applied: false` and both wizard branches keep the user on the provider step to retry.
- **Standards — onboarding UI coverage**: adds render tests for the isolated Codex flow (success→advance, failure→stay, discarded→stay, unmount→`cancelCodexLogin`), covering the previously-untested teardown ref and the persist→login→activate branch.

## Testing

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run test` — 4,526 pass / 66 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)