### PR TITLE
ci(ai-review): replace ai-reviewed with type and ready-to-merge labels

### DIFF
--- a/.github/workflows/ai-review-labels.yml
+++ b/.github/workflows/ai-review-labels.yml
@@ -170,15 +170,15 @@ jobs:
               { jobName: 'Claude architecture review', header: '## Claude Architecture Review' },
               { jobName: 'Codex correctness review', header: '## Codex Correctness Review' },
             ];
-            // Jobs skipped by configuration (a disabled reviewer, or Codex on a non-'opened'
-            // event) never appear in this list. A reviewer job that ran but did not succeed
-            // must block the ready label instead of being silently ignored.
+            // Skipped reviewer jobs (a disabled reviewer, or Codex on a non-'opened' event) still
+            // appear in this list with conclusion 'skipped' and must be ignored; only a reviewer
+            // that actually ran but did not succeed may block the ready label.
             const present = reviewers
               .map((reviewer) => ({
                 ...reviewer,
                 job: jobs.jobs.find(({ name }) => name === reviewer.jobName),
               }))
-              .filter(({ job }) => job);
+              .filter(({ job }) => job && job.conclusion !== 'skipped' && job.conclusion !== 'neutral');
 
             const name = 'ready-to-merge';
             const removeReadyLabel = async () => {

--- a/.github/workflows/ai-review-labels.yml
+++ b/.github/workflows/ai-review-labels.yml
@@ -80,6 +80,24 @@ jobs:
               },
             };
             const label = type ? labelByType[type] : undefined;
+
+            // This workflow owns the mapped labels: drop any managed label that no longer
+            // matches the current type so retitling a pull request cannot leave stale ones.
+            const currentNames = new Set(pullRequest.labels.map(({ name }) => name));
+            for (const { name } of Object.values(labelByType)) {
+              if (name === label?.name || !currentNames.has(name)) continue;
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number,
+                  name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
+
             if (!label) {
               core.notice(`No built-in label maps to pull request type "${type ?? 'unknown'}".`);
               return;
@@ -143,12 +161,40 @@ jobs:
               { jobName: 'Claude architecture review', header: '## Claude Architecture Review' },
               { jobName: 'Codex correctness review', header: '## Codex Correctness Review' },
             ];
-            const succeeded = reviewers.filter(({ jobName }) =>
-              jobs.jobs.some((job) => job.name === jobName && job.conclusion === 'success'),
-            );
+            // Jobs skipped by configuration (a disabled reviewer, or Codex on a non-'opened'
+            // event) never appear in this list. A reviewer job that ran but did not succeed
+            // must block the ready label instead of being silently ignored.
+            const present = reviewers
+              .map((reviewer) => ({
+                ...reviewer,
+                job: jobs.jobs.find(({ name }) => name === reviewer.jobName),
+              }))
+              .filter(({ job }) => job);
 
-            if (succeeded.length === 0) {
-              core.notice('Skipping labels because no AI review job completed successfully.');
+            const name = 'ready-to-merge';
+            const removeReadyLabel = async () => {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number,
+                  name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            };
+
+            const unsuccessful = present.filter(({ job }) => job.conclusion !== 'success');
+            if (unsuccessful.length > 0) {
+              const names = unsuccessful.map(({ jobName }) => jobName).join(', ');
+              core.warning(`Reviewer job(s) did not succeed: ${names}; removing ${name}.`);
+              await removeReadyLabel();
+              return;
+            }
+
+            if (present.length === 0) {
+              core.notice('Skipping labels because no AI review job ran in this workflow run.');
               return;
             }
 
@@ -162,7 +208,7 @@ jobs:
             });
             const runStartedAt = new Date(context.payload.workflow_run.created_at);
             const verdicts = [];
-            for (const { jobName, header } of succeeded) {
+            for (const { jobName, header } of present) {
               const comment = comments
                 .filter(
                   ({ body, created_at }) =>
@@ -177,19 +223,9 @@ jobs:
               verdicts.push(verdict);
             }
 
-            const name = 'ready-to-merge';
             if (verdicts.includes('needs changes')) {
               core.notice('At least one reviewer requested changes; the pull request is not labeled.');
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pullRequest.number,
-                  name,
-                });
-              } catch (error) {
-                if (error.status !== 404) throw error;
-              }
+              await removeReadyLabel();
               return;
             }
 

--- a/.github/workflows/ai-review-labels.yml
+++ b/.github/workflows/ai-review-labels.yml
@@ -155,8 +155,10 @@ jobs:
               repo: context.repo.repo,
               run_id: context.payload.workflow_run.id,
             });
-            // Keep these names in sync with the reviewer job names in ai-review.yml; each entry
-            // maps a job to the comment header its reviewer posts on the pull request.
+            // Contract with ai-review.yml: jobName must match the reviewer job's `name:` field,
+            // and header plus the '**Verdict: mergeable|needs changes**' line must match the
+            // format each reviewer's prompt requires for its pull request comment. A rename or
+            // prompt-format change on either side silently disables labeling.
             const reviewers = [
               { jobName: 'Claude architecture review', header: '## Claude Architecture Review' },
               { jobName: 'Codex correctness review', header: '## Codex Correctness Review' },
@@ -217,7 +219,10 @@ jobs:
                 .at(-1);
               const verdict = comment?.body.match(/\*\*Verdict:\s*(mergeable|needs changes)\*\*/)?.[1];
               if (!verdict) {
-                core.warning(`No verdict comment found for "${jobName}"; skipping labels.`);
+                // Fail closed: an unconfirmed verdict must not leave a previously applied
+                // ready-to-merge label in place.
+                core.warning(`No verdict comment found for "${jobName}"; removing ${name}.`);
+                await removeReadyLabel();
                 return;
               }
               verdicts.push(verdict);

--- a/.github/workflows/ai-review-labels.yml
+++ b/.github/workflows/ai-review-labels.yml
@@ -163,7 +163,9 @@ jobs:
             // format each reviewer's prompt requires for its pull request comment. A rename or
             // prompt-format change on either side silently disables labeling. Verdicts are read
             // via issues.listComments, so reviewers must post timeline comments (as `gh pr
-            // comment` / issues.createComment does), not pull request reviews.
+            // comment` / issues.createComment does), not pull request reviews, and only comments
+            // authored by github-actions[bot] are trusted as verdicts.
+            // scripts/ai-review-workflows.test.ts asserts these strings do not drift apart.
             const reviewers = [
               { jobName: 'Claude architecture review', header: '## Claude Architecture Review' },
               { jobName: 'Codex correctness review', header: '## Codex Correctness Review' },
@@ -208,21 +210,25 @@ jobs:
               return;
             }
 
-            // A verdict only counts when its reviewer succeeded in this run and posted the
-            // comment after the run started, so stale comments from older commits are ignored.
+            // A verdict only counts when its reviewer succeeded in this run and the review bot
+            // posted the comment after the run started, so stale comments from older commits —
+            // and forged verdict comments from other authors — are ignored.
+            const runStartedAt = new Date(context.payload.workflow_run.created_at);
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pullRequest.number,
+              since: runStartedAt.toISOString(),
               per_page: 100,
             });
-            const runStartedAt = new Date(context.payload.workflow_run.created_at);
             const verdicts = [];
             for (const { jobName, header } of present) {
               const comment = comments
                 .filter(
-                  ({ body, created_at }) =>
-                    body?.includes(header) && new Date(created_at) >= runStartedAt,
+                  ({ body, created_at, user }) =>
+                    body?.includes(header) &&
+                    new Date(created_at) >= runStartedAt &&
+                    user?.login === 'github-actions[bot]',
                 )
                 .at(-1);
               const verdict = comment?.body.match(/\*\*Verdict:\s*(mergeable|needs changes)\*\*/)?.[1];

--- a/.github/workflows/ai-review-labels.yml
+++ b/.github/workflows/ai-review-labels.yml
@@ -6,16 +6,17 @@ on:
   pull_request_target:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
   workflow_run:
     workflows:
       - AI PR Review
     types: [completed]
 
 jobs:
-  clear_label:
-    name: Clear stale AI review label
-    if: ${{ github.event_name == 'pull_request_target' }}
+  reset_review_labels:
+    name: Reset review outcome labels
+    # A title edit does not change the reviewed commit, so outcome labels survive 'edited'.
+    if: ${{ github.event_name == 'pull_request_target' && github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     # Label operations on a pull request require pull-requests write; the label REST endpoints
     # return 403 with only issues write (GitHub reports "issues=write; pull_requests=write").
@@ -23,24 +24,86 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Remove ai-reviewed label
+      - name: Remove stale review outcome labels
         uses: actions/github-script@v8
         with:
           github-token: ${{ github.token }}
           script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                name: 'ai-reviewed',
-              });
-            } catch (error) {
-              if (error.status !== 404) throw error;
+            // 'ready-to-merge' goes stale once new commits arrive. 'ai-reviewed' is the retired
+            // predecessor label; removing it here cleans up pull requests that still carry it.
+            for (const name of ['ready-to-merge', 'ai-reviewed']) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
             }
 
-  mark_complete:
-    name: Mark AI review complete
+  apply_type_labels:
+    name: Apply type labels
+    # Adding an existing label is a no-op, so this job also heals labels removed by hand.
+    if: ${{ github.event_name == 'pull_request_target' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Label the pull request from its conventional type
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            // Keep the allowed types in sync with commit-message-check.yml and CONTRIBUTING.md.
+            const typePattern = '(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)';
+            const pullRequest = context.payload.pull_request;
+            const type =
+              pullRequest.title.match(new RegExp(`^${typePattern}(\\([^)]*\\))?!?:`))?.[1] ??
+              pullRequest.head.ref.match(new RegExp(`^${typePattern}/`))?.[1];
+
+            const labelByType = {
+              feat: { name: 'enhancement', color: 'a2eeef', description: 'New feature or request' },
+              fix: { name: 'bug', color: 'd73a4a', description: "Something isn't working" },
+              docs: {
+                name: 'documentation',
+                color: '0075ca',
+                description: 'Improvements or additions to documentation',
+              },
+              chore: {
+                name: 'chore',
+                color: 'ededed',
+                description: 'Maintenance, cleanup, or tooling — no product behavior change',
+              },
+            };
+            const label = type ? labelByType[type] : undefined;
+            if (!label) {
+              core.notice(`No built-in label maps to pull request type "${type ?? 'unknown'}".`);
+              return;
+            }
+
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ...label,
+              });
+            } catch (error) {
+              if (error.status !== 422) throw error;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequest.number,
+              labels: [label.name],
+            });
+
+  apply_review_outcome:
+    name: Apply review outcome labels
     if: >-
       ${{ github.event_name == 'workflow_run' &&
           github.event.workflow_run.event == 'pull_request' &&
@@ -52,7 +115,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Add ai-reviewed label for the latest reviewed commit
+      - name: Label the pull request from the latest review verdicts
         uses: actions/github-script@v8
         with:
           github-token: ${{ github.token }}
@@ -65,7 +128,7 @@ jobs:
             });
 
             if (currentPullRequest.head.sha !== context.payload.workflow_run.head_sha) {
-              core.notice('Skipping label because a newer pull request commit exists.');
+              core.notice('Skipping labels because a newer pull request commit exists.');
               return;
             }
 
@@ -74,29 +137,69 @@ jobs:
               repo: context.repo.repo,
               run_id: context.payload.workflow_run.id,
             });
-            // Keep these names in sync with the reviewer job names in ai-review.yml.
-            const reviewJobs = jobs.jobs.filter(
-              ({ name }) => name === 'Claude architecture review' || name === 'Codex correctness review',
+            // Keep these names in sync with the reviewer job names in ai-review.yml; each entry
+            // maps a job to the comment header its reviewer posts on the pull request.
+            const reviewers = [
+              { jobName: 'Claude architecture review', header: '## Claude Architecture Review' },
+              { jobName: 'Codex correctness review', header: '## Codex Correctness Review' },
+            ];
+            const succeeded = reviewers.filter(({ jobName }) =>
+              jobs.jobs.some((job) => job.name === jobName && job.conclusion === 'success'),
             );
 
-            if (reviewJobs.length === 0) {
-              core.warning('No recognized AI review jobs were found; check the job-name contract.');
+            if (succeeded.length === 0) {
+              core.notice('Skipping labels because no AI review job completed successfully.');
               return;
             }
 
-            if (!reviewJobs.some(({ conclusion }) => conclusion === 'success')) {
-              core.notice('Skipping label because no AI review job completed successfully.');
+            // A verdict only counts when its reviewer succeeded in this run and posted the
+            // comment after the run started, so stale comments from older commits are ignored.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequest.number,
+              per_page: 100,
+            });
+            const runStartedAt = new Date(context.payload.workflow_run.created_at);
+            const verdicts = [];
+            for (const { jobName, header } of succeeded) {
+              const comment = comments
+                .filter(
+                  ({ body, created_at }) =>
+                    body?.includes(header) && new Date(created_at) >= runStartedAt,
+                )
+                .at(-1);
+              const verdict = comment?.body.match(/\*\*Verdict:\s*(mergeable|needs changes)\*\*/)?.[1];
+              if (!verdict) {
+                core.warning(`No verdict comment found for "${jobName}"; skipping labels.`);
+                return;
+              }
+              verdicts.push(verdict);
+            }
+
+            const name = 'ready-to-merge';
+            if (verdicts.includes('needs changes')) {
+              core.notice('At least one reviewer requested changes; the pull request is not labeled.');
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number,
+                  name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
               return;
             }
 
-            const name = 'ai-reviewed';
             try {
               await github.rest.issues.createLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 name,
                 color: '1f883d',
-                description: 'At least one automated AI reviewer completed successfully.',
+                description: 'All completed AI reviewers found this pull request mergeable.',
               });
             } catch (error) {
               if (error.status !== 422) throw error;

--- a/.github/workflows/ai-review-labels.yml
+++ b/.github/workflows/ai-review-labels.yml
@@ -47,7 +47,10 @@ jobs:
   apply_type_labels:
     name: Apply type labels
     # Adding an existing label is a no-op, so this job also heals labels removed by hand.
-    if: ${{ github.event_name == 'pull_request_target' }}
+    # Body-only edits cannot change the type, so 'edited' events without a title change skip it.
+    if: >-
+      ${{ github.event_name == 'pull_request_target' &&
+          (github.event.action != 'edited' || github.event.changes.title) }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -158,7 +161,9 @@ jobs:
             // Contract with ai-review.yml: jobName must match the reviewer job's `name:` field,
             // and header plus the '**Verdict: mergeable|needs changes**' line must match the
             // format each reviewer's prompt requires for its pull request comment. A rename or
-            // prompt-format change on either side silently disables labeling.
+            // prompt-format change on either side silently disables labeling. Verdicts are read
+            // via issues.listComments, so reviewers must post timeline comments (as `gh pr
+            // comment` / issues.createComment does), not pull request reviews.
             const reviewers = [
               { jobName: 'Claude architecture review', header: '## Claude Architecture Review' },
               { jobName: 'Codex correctness review', header: '## Codex Correctness Review' },
@@ -196,7 +201,10 @@ jobs:
             }
 
             if (present.length === 0) {
-              core.notice('Skipping labels because no AI review job ran in this workflow run.');
+              // Usually means the job-name contract with ai-review.yml drifted, so warn loudly;
+              // fail closed because a stale ready-to-merge label must not survive this state.
+              core.warning('No recognized AI review job ran in this workflow run; check the contract.');
+              await removeReadyLabel();
               return;
             }
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -74,7 +74,10 @@ jobs:
             are found, write **No architectural or integration issues found.** Be concise.
 
             Post the review as a PR comment via `gh pr comment`.
+          # API-key accounts resolve Claude Code's default model to the latest Opus; pin sonnet
+          # explicitly so review cost and latency stay predictable.
           claude_args: |
+            --model sonnet
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Read,Grep,Glob"
 
   codex_review:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -43,6 +43,9 @@ jobs:
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           CLAUDE_CODE_ATTRIBUTION_HEADER: ${{ vars.CLAUDE_CODE_ATTRIBUTION_HEADER }}
+          # Long 1M-context runs have errored out mid-review through the relay gateway; cap the
+          # window at 200k so Claude Code auto-compacts instead of failing the whole run.
+          CLAUDE_CODE_DISABLE_1M_CONTEXT: '1'
         with:
           # The action validates this input before it starts Claude Code. The custom gateway still
           # uses ANTHROPIC_AUTH_TOKEN and ANTHROPIC_BASE_URL from the environment above.
@@ -73,8 +76,14 @@ jobs:
             **Impact:** and **Recommendation:** labels. If no architectural or integration issues
             are found, write **No architectural or integration issues found.** Be concise.
 
+            Budget at most 10 tool calls: inspect the diff, read only files directly affected by
+            the change, then post the review. Do not explore the wider repository.
+
             Post the review as a PR comment via `gh pr comment`.
+          # Cap agentic turns so a slow gateway cannot stretch a review indefinitely; the prompt
+          # budgets fewer calls, so hitting the cap means the run was already unhealthy.
           claude_args: |
+            --max-turns 15
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Read,Grep,Glob"
 
   codex_review:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -74,10 +74,7 @@ jobs:
             are found, write **No architectural or integration issues found.** Be concise.
 
             Post the review as a PR comment via `gh pr comment`.
-          # API-key accounts resolve Claude Code's default model to the latest Opus; pin sonnet
-          # explicitly so review cost and latency stay predictable.
           claude_args: |
-            --model sonnet
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Read,Grep,Glob"
 
   codex_review:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -166,8 +166,9 @@ jobs:
             particular, verify that the branch name uses <type>/<short-description>, with a
             lowercase hyphen-separated description and one of these allowed prefixes: feat, fix,
             docs, style, refactor, perf, test, build, ci, chore, or revert. Also verify that the
-            PR title uses <type>(<scope>): <description>, with a required lowercase scope, an
-            allowed type, and a lowercase imperative description.
+            PR title uses <type>(<scope>): <description>, with an allowed type, a hyphen-separated
+            scope and an imperative description that both start with a lowercase letter (uppercase
+            is allowed inside for proper nouns and technical terms).
 
             The Claude architecture job checks module ownership, maintainability, packaging, and
             cross-platform integration. Complement that review by prioritizing high-confidence,

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -21,8 +21,10 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const allowedTypes = 'feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert';
+            // Scope and description must start lowercase, but uppercase is allowed inside for
+            // proper nouns and technical terms (CRAN, R, Windows, macOS, ...).
             const subjectPattern = new RegExp(
-              `^(${allowedTypes})\\([a-z][a-z0-9-]*\\)!?: [a-z][a-z0-9 .,'/_()-]*$`,
+              `^(${allowedTypes})\\([a-z][A-Za-z0-9-]*\\)!?: [a-z][A-Za-z0-9 .,'/_()-]*$`,
             );
             const commits = await github.paginate(github.rest.pulls.listCommits, {
               owner: context.repo.owner,
@@ -40,6 +42,7 @@ jobs:
                 .join('\n');
               core.setFailed(
                 `Each commit subject must use <type>(<scope>): <description> with an allowed type, ` +
-                  `a lowercase hyphen-separated scope, and a lowercase description.\n${details}`,
+                  `a hyphen-separated scope and a description that both start with a lowercase letter ` +
+                  `(uppercase is allowed inside for proper nouns and technical terms).\n${details}`,
               );
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,8 +110,9 @@ Every commit subject must follow Conventional Commits with a scope:
 This format is checked for every commit in a pull request.
 
 Use the same standard type prefixes listed under [Branch names](#branch-names).
-The scope should be a short, lowercase, hyphen-separated name for the affected
-area.
+The scope should be a short, hyphen-separated name for the affected area that
+starts with a lowercase letter; uppercase is allowed inside for proper nouns
+and technical terms (for example `macOS`).
 
 ```text
 feat(projects): add sidebar filter
@@ -119,7 +120,9 @@ fix(notebook): prevent kernel startup timeout
 ci(review): unify automated AI reviews
 ```
 
-- Write a clear, lowercase, imperative-mood description.
+- Write a clear, imperative-mood description that starts with a lowercase
+  letter; uppercase is allowed inside for proper nouns and technical terms (for
+  example `detect user-installed CRAN R on Windows`).
 - Keep the subject concise; use the body to explain the _why_ when it is not
   obvious from the diff.
 - Add `!` before the colon and a `BREAKING CHANGE:` footer for breaking changes,

--- a/scripts/ai-review-labels.test.ts
+++ b/scripts/ai-review-labels.test.ts
@@ -1,0 +1,252 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { load } from 'js-yaml'
+import { describe, expect, it, vi } from 'vitest'
+
+// Behavior tests for the inline github-script blocks in ai-review-labels.yml: each script is
+// extracted from the workflow and executed against mocked GitHub APIs, so the tests exercise the
+// exact code that ships instead of a reimplementation.
+type WorkflowJob = { steps: { with?: { script?: string } }[] }
+const workflow = load(
+  readFileSync(join(process.cwd(), '.github/workflows/ai-review-labels.yml'), 'utf8')
+) as { jobs: Record<string, WorkflowJob> }
+
+type MockJob = { name: string; conclusion: string }
+type MockComment = { body: string; created_at: string; user: { login: string } }
+type MockFn = ReturnType<typeof vi.fn>
+type MockGithub = {
+  rest: {
+    pulls: { get: MockFn }
+    actions: { listJobsForWorkflowRun: MockFn }
+    issues: {
+      listComments: MockFn
+      createLabel: MockFn
+      addLabels: MockFn
+      removeLabel: MockFn
+    }
+  }
+  paginate: MockFn
+}
+type MockCore = { notice: MockFn; warning: MockFn; setFailed: MockFn }
+type Context = { repo: { owner: string; repo: string }; payload: Record<string, unknown> }
+
+const RUN_STARTED_AT = '2026-01-01T00:00:00Z'
+const AFTER_RUN = '2026-01-01T00:05:00Z'
+const BEFORE_RUN = '2025-12-31T23:55:00Z'
+const BOT = 'github-actions[bot]'
+
+function makeGithub({
+  jobs = [] as MockJob[],
+  comments = [] as MockComment[],
+  prHeadSha = 'sha1',
+  labels = [] as string[]
+} = {}): { github: MockGithub; added: string[][]; removed: string[]; created: string[] } {
+  const added: string[][] = []
+  const removed: string[] = []
+  const created: string[] = []
+  const github = {
+    rest: {
+      pulls: { get: vi.fn(async () => ({ data: { head: { sha: prHeadSha } } })) },
+      actions: {
+        listJobsForWorkflowRun: vi.fn(async () => ({ data: { jobs } }))
+      },
+      issues: {
+        listComments: vi.fn(),
+        // The label always exists in these tests; the workflow tolerates the 422 either way.
+        createLabel: vi.fn(async ({ name }: { name: string }) => {
+          created.push(name)
+          const error = new Error('already exists') as Error & { status: number }
+          error.status = 422
+          throw error
+        }),
+        addLabels: vi.fn(async ({ labels: names }: { labels: string[] }) => {
+          added.push(names)
+        }),
+        removeLabel: vi.fn(async ({ name }: { name: string }) => {
+          if (!labels.includes(name)) {
+            const error = new Error('not found') as Error & { status: number }
+            error.status = 404
+            throw error
+          }
+          removed.push(name)
+        })
+      }
+    },
+    paginate: vi.fn(async () => comments)
+  }
+  return { github, added, removed, created }
+}
+
+async function runJob(jobId: string, context: Context, github: MockGithub): Promise<MockCore> {
+  const script = workflow.jobs[jobId].steps[0].with?.script
+  if (!script) throw new Error(`job ${jobId} has no inline script`)
+  const core = { notice: vi.fn(), warning: vi.fn(), setFailed: vi.fn() }
+  const run = new Function('github', 'context', 'core', `return (async () => {\n${script}\n})()`)
+  await run(github, context, core)
+  return core
+}
+
+const repo = { owner: 'o', repo: 'r' }
+
+function reviewContext(overrides: Record<string, unknown> = {}): Context {
+  return {
+    repo,
+    payload: {
+      workflow_run: {
+        id: 1,
+        head_sha: 'sha1',
+        created_at: RUN_STARTED_AT,
+        pull_requests: [{ number: 7 }],
+        ...overrides
+      }
+    }
+  }
+}
+
+function pullRequestContext(overrides: Record<string, unknown> = {}): Context {
+  return {
+    repo,
+    payload: {
+      pull_request: {
+        number: 7,
+        title: 'feat(ai-review): add thing',
+        head: { ref: 'feat/ai-review-thing' },
+        labels: [],
+        ...overrides
+      }
+    }
+  }
+}
+
+const verdictComment = (
+  header: string,
+  verdict: string,
+  login = BOT,
+  createdAt = AFTER_RUN
+): MockComment => ({
+  body: `${header}\n**Verdict: ${verdict}**`,
+  created_at: createdAt,
+  user: { login }
+})
+
+describe('apply_review_outcome', () => {
+  const claudeJob: MockJob = { name: 'Claude architecture review', conclusion: 'success' }
+
+  it('labels ready-to-merge when the skipped reviewer is ignored and the rest mergeable', async () => {
+    const { github, added, removed } = makeGithub({
+      jobs: [claudeJob, { name: 'Codex correctness review', conclusion: 'skipped' }],
+      comments: [verdictComment('## Claude Architecture Review', 'mergeable')]
+    })
+    await runJob('apply_review_outcome', reviewContext(), github)
+    expect(added).toEqual([['ready-to-merge']])
+    expect(removed).toEqual([])
+    expect(github.paginate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ since: new Date(RUN_STARTED_AT).toISOString() })
+    )
+  })
+
+  it('fails closed when a reviewer job ran but did not succeed', async () => {
+    const { github, added, removed } = makeGithub({
+      jobs: [claudeJob, { name: 'Codex correctness review', conclusion: 'failure' }],
+      comments: [verdictComment('## Claude Architecture Review', 'mergeable')],
+      labels: ['ready-to-merge']
+    })
+    await runJob('apply_review_outcome', reviewContext(), github)
+    expect(added).toEqual([])
+    expect(removed).toEqual(['ready-to-merge'])
+  })
+
+  it('removes the label when any verdict is needs changes', async () => {
+    const { github, added, removed } = makeGithub({
+      jobs: [claudeJob],
+      comments: [verdictComment('## Claude Architecture Review', 'needs changes')],
+      labels: ['ready-to-merge']
+    })
+    await runJob('apply_review_outcome', reviewContext(), github)
+    expect(added).toEqual([])
+    expect(removed).toEqual(['ready-to-merge'])
+  })
+
+  it('ignores a forged verdict comment from a non-bot author and fails closed', async () => {
+    const { github, added, removed } = makeGithub({
+      jobs: [claudeJob],
+      comments: [verdictComment('## Claude Architecture Review', 'mergeable', 'contributor')],
+      labels: ['ready-to-merge']
+    })
+    await runJob('apply_review_outcome', reviewContext(), github)
+    expect(added).toEqual([])
+    expect(removed).toEqual(['ready-to-merge'])
+  })
+
+  it('ignores verdict comments posted before the run started and fails closed', async () => {
+    const { github, added, removed } = makeGithub({
+      jobs: [claudeJob],
+      comments: [verdictComment('## Claude Architecture Review', 'mergeable', BOT, BEFORE_RUN)],
+      labels: ['ready-to-merge']
+    })
+    await runJob('apply_review_outcome', reviewContext(), github)
+    expect(added).toEqual([])
+    expect(removed).toEqual(['ready-to-merge'])
+  })
+
+  it('does nothing when a newer pull request commit exists', async () => {
+    const { github, added, removed } = makeGithub({ prHeadSha: 'newer-sha' })
+    await runJob('apply_review_outcome', reviewContext(), github)
+    expect(added).toEqual([])
+    expect(removed).toEqual([])
+  })
+})
+
+describe('apply_type_labels', () => {
+  it('maps the conventional type from the title to the built-in label', async () => {
+    const { github, added, removed } = makeGithub()
+    await runJob('apply_type_labels', pullRequestContext(), github)
+    expect(added).toEqual([['enhancement']])
+    expect(removed).toEqual([])
+  })
+
+  it('falls back to the branch name when the title is not conventional', async () => {
+    const { github, added } = makeGithub()
+    await runJob(
+      'apply_type_labels',
+      pullRequestContext({ title: 'Improve the docs', head: { ref: 'docs/readme-update' } }),
+      github
+    )
+    expect(added).toEqual([['documentation']])
+  })
+
+  it('removes the stale managed label when the pull request type changes', async () => {
+    const { github, added, removed } = makeGithub({ labels: ['enhancement'] })
+    await runJob(
+      'apply_type_labels',
+      pullRequestContext({ title: 'fix(notebook): stop crash', labels: [{ name: 'enhancement' }] }),
+      github
+    )
+    expect(removed).toEqual(['enhancement'])
+    expect(added).toEqual([['bug']])
+  })
+
+  it('drops managed labels when the type has no mapping but keeps unmanaged ones', async () => {
+    const { github, added, removed } = makeGithub({ labels: ['bug', 'duplicate'] })
+    await runJob(
+      'apply_type_labels',
+      pullRequestContext({
+        title: 'ci(review): tweak workflow',
+        labels: [{ name: 'bug' }, { name: 'duplicate' }]
+      }),
+      github
+    )
+    expect(removed).toEqual(['bug'])
+    expect(added).toEqual([])
+  })
+})
+
+describe('reset_review_labels', () => {
+  it('removes stale outcome labels and tolerates missing ones', async () => {
+    const { github, removed } = makeGithub({ labels: ['ready-to-merge'] })
+    await runJob('reset_review_labels', pullRequestContext(), github)
+    expect(removed).toEqual(['ready-to-merge'])
+  })
+})

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+// ai-review-labels.yml consumes reviewer job names and comment headers produced by ai-review.yml.
+// That contract is otherwise invisible: a rename on either side silently disables verdict-based
+// labeling, so assert the two workflow files stay in sync.
+const reviewWorkflow = readFileSync(join(process.cwd(), '.github/workflows/ai-review.yml'), 'utf8')
+const labelsWorkflow = readFileSync(
+  join(process.cwd(), '.github/workflows/ai-review-labels.yml'),
+  'utf8'
+)
+
+const jobNames = [...labelsWorkflow.matchAll(/jobName: '([^']+)'/g)].map(([, name]) => name)
+const headers = [...labelsWorkflow.matchAll(/header: '([^']+)'/g)].map(([, header]) => header)
+
+describe('AI review workflow contract', () => {
+  it('declares at least one reviewer pairing in ai-review-labels.yml', () => {
+    expect(jobNames.length).toBeGreaterThan(0)
+    expect(headers.length).toBe(jobNames.length)
+  })
+
+  it.each(jobNames)('keeps reviewer job name "%s" in ai-review.yml', (jobName) => {
+    expect(reviewWorkflow).toContain(`name: ${jobName}`)
+  })
+
+  it.each(headers)('keeps comment header "%s" in an ai-review.yml prompt', (header) => {
+    expect(reviewWorkflow).toContain(header)
+  })
+
+  it('keeps the verdict format consumed by ai-review-labels.yml in the reviewer prompts', () => {
+    expect(reviewWorkflow).toContain('**Verdict: mergeable**')
+    expect(reviewWorkflow).toContain('**Verdict: needs changes**')
+  })
+})


### PR DESCRIPTION
## Summary

**AI review labels (`ai-review-labels.yml`)**
- Replace the `ai-reviewed` completion badge with labels that carry meaning: **`ready-to-merge`** when the AI reviewers actually report a mergeable verdict, and built-in **type labels** (`enhancement` / `bug` / `documentation` / `chore`) mapped from the pull request's conventional type (title first, branch name as fallback). Managed type labels are removed when the PR is retitled to a different or unmapped type.
- `apply_review_outcome` parses the `**Verdict: mergeable|needs changes**` line from the Claude/Codex review comments posted during the same workflow run. Job success alone only means the review ran — a review with findings also succeeds. The label is added only when every reviewer that ran in that run reported mergeable, and removed on `needs changes`, on a failed reviewer job, on a missing verdict comment, or when no recognized reviewer ran (fail closed with `core.warning`).
- Reviewer jobs skipped by configuration (a disabled reviewer, or Codex on a non-`opened` event) show up in the Jobs API with conclusion `skipped` and are explicitly **ignored** — they never block the label.
- Only verdict comments authored by `github-actions[bot]` at or after the run start count, so forged or stale verdicts cannot flip the label. Comment listing passes `since` to bound API usage.
- `reset_review_labels` clears stale `ready-to-merge` on new commits and removes the retired `ai-reviewed` from PRs that still carry it. Title edits do not reset it; body-only edits skip type reconciliation entirely.

**Claude reviewer bounds (`ai-review.yml`)**
- Two consecutive long runs failed mid-review with `is_error:true` after ~10 minutes on `claude-opus-4-8[1m]` through the relay gateway (Sonnet 5 is not served by the gateway). To keep reviews short and reliable: `--max-turns 15`, a 200k context window via `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` (auto-compact instead of erroring), and a 10-tool-call budget in the prompt (inspect the diff and directly affected files only).

**Commit subject case rules (`commit-message-check.yml`, `ai-review.yml` Codex prompt, `CONTRIBUTING.md`)**
- Scope and description must still start with a lowercase letter, but uppercase is now allowed inside both for proper nouns and technical terms (`feat(notebook): detect user-installed CRAN R on Windows`, `feat(macOS): …` previously failed the check).

**Tests**
- `scripts/ai-review-labels.test.ts` (new) extracts the workflow's inline `github-script` blocks and executes them against mocked GitHub APIs: type mapping, branch fallback, stale-label cleanup, skipped vs failed reviewers, forged/stale verdict rejection, fail-closed paths, and the `since` filter.
- `scripts/ai-review-workflows.test.ts` keeps the cross-file contract (job names, comment headers, verdict format) between `ai-review.yml` and `ai-review-labels.yml` from drifting.

## Test plan

- `vitest run scripts/ai-review-labels.test.ts scripts/ai-review-workflows.test.ts` — 17/17 pass; `eslint` clean on both files.
- `actionlint` passes on all three modified workflows; every embedded script passes `node --check`.
- Commit-subject regex exercised against positive/negative cases (`CRAN R on Windows` passes; leading-uppercase scope/description still fails).
- `pull_request_target` / `workflow_run` jobs run from the base branch, so label behavior on this PR still comes from the old logic in `main` until merge; the `ai-review.yml` bounds take effect immediately on this PR's own review runs.

## Follow-up

- After merge, the repository-level `ai-reviewed` label can be deleted (`gh label delete ai-reviewed`); existing PRs are cleaned up automatically as they synchronize.
- The relaxed commit-subject check only takes effect for PRs whose branch contains it — other open PRs need a rebase/merge from `main` after this lands.
