### PR TITLE
fix(artifacts): resolve relative artifact source paths against the session workspace

### DIFF
--- a/src/main/artifacts/mcp-server.test.ts
+++ b/src/main/artifacts/mcp-server.test.ts
@@ -116,6 +116,28 @@ describe('artifact MCP server', () => {
     await expect(readFile(artifact.path, 'utf8')).resolves.toBe('<svg />')
   })
 
+  it('treats a bare filename with no source as a localPath under the session workspace', async () => {
+    // The same convenience default outside a notebook turn: the agent saved into the session
+    // workspace (its cwd) with plain tools, then called write_artifact_file with just the filename.
+    // The static import roots double as the resolution base, so the bare name resolves.
+    const root = await createStorageRoot()
+    const workspace = join(root, 'workspace')
+    await mkdir(workspace, { recursive: true })
+    await writeFile(join(workspace, 'plot.svg'), '<svg />', 'utf8')
+    const repository = new ArtifactRepository(root)
+    const environment = {
+      ...(await createEnvironment(root, { runId: 'run-1' })),
+      allowedImportRoots: [workspace]
+    }
+
+    const artifact = await writeArtifactFileForCurrentRun(repository, environment, {
+      filename: 'plot.svg',
+      mimeType: 'image/svg+xml'
+    })
+
+    await expect(readFile(artifact.path, 'utf8')).resolves.toBe('<svg />')
+  })
+
   it('resolves a relative localPath against the handoff notebook data dir', async () => {
     const root = await createStorageRoot()
     const sessionRoot = join(root, 'notebook-session')
@@ -128,6 +150,57 @@ describe('artifact MCP server', () => {
       notebookDataDir: dataDir,
       notebookSessionRoot: sessionRoot
     })
+
+    const artifact = await writeArtifactFileForCurrentRun(repository, environment, {
+      filename: 'plot.svg',
+      source: { kind: 'localPath', path: 'plot.svg' }
+    })
+
+    await expect(readFile(artifact.path, 'utf8')).resolves.toBe('<svg />')
+  })
+
+  it('resolves an explicit relative localPath against the session workspace outside a notebook turn', async () => {
+    // Regression for the P2 follow-up: with no notebook data dir in the handoff, the static import
+    // roots (in production exactly the session workspace) serve as the resolution base, so a bare
+    // filename the agent saved into the workspace resolves instead of reporting "does not exist".
+    const root = await createStorageRoot()
+    const workspace = join(root, 'workspace')
+    await mkdir(workspace, { recursive: true })
+    await writeFile(join(workspace, 'plot.svg'), '<svg />', 'utf8')
+    const repository = new ArtifactRepository(root)
+    const environment = {
+      ...(await createEnvironment(root, { runId: 'run-1' })),
+      allowedImportRoots: [workspace]
+    }
+
+    const artifact = await writeArtifactFileForCurrentRun(repository, environment, {
+      filename: 'plot.svg',
+      source: { kind: 'localPath', path: 'plot.svg' }
+    })
+
+    await expect(readFile(artifact.path, 'utf8')).resolves.toBe('<svg />')
+  })
+
+  it('falls back to the session workspace when the file is not under the notebook data dir', async () => {
+    // A plain-chat turn inside a notebook-capable runtime: the handoff pins the notebook data dir
+    // (no kernel ran this turn, so nothing is there) while the agent saved with plain shell tools
+    // into the session workspace. The workspace base must catch what the data dir missed.
+    const root = await createStorageRoot()
+    const sessionRoot = join(root, 'notebook-session')
+    const dataDir = join(sessionRoot, 'data')
+    const workspace = join(root, 'workspace')
+    await mkdir(dataDir, { recursive: true })
+    await mkdir(workspace, { recursive: true })
+    await writeFile(join(workspace, 'plot.svg'), '<svg />', 'utf8')
+    const repository = new ArtifactRepository(root)
+    const environment = {
+      ...(await createEnvironment(root, {
+        runId: 'run-1',
+        notebookDataDir: dataDir,
+        notebookSessionRoot: sessionRoot
+      })),
+      allowedImportRoots: [workspace]
+    }
 
     const artifact = await writeArtifactFileForCurrentRun(repository, environment, {
       filename: 'plot.svg',

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -68,7 +68,7 @@ const writeArtifactFileToolSchema = {
           .string()
           .min(1)
           .describe(
-            'Path to an ALREADY-SAVED file. A bare filename or relative path (e.g. "plot.png") resolves against the notebook session data dir (the kernel cwd) — pass the same name you saved with. An absolute path also works. Do NOT rebuild a path from an env var; the kernel cwd already IS the data dir. The file must exist before you call this — the app copies it.'
+            'Path to an ALREADY-SAVED file. A bare filename or relative path (e.g. "plot.png") resolves against the notebook session data dir (the kernel cwd), or the session workspace when there is no notebook data dir this turn — pass the same name you saved with. An absolute path also works. Do NOT rebuild a path from an env var; the kernel cwd already IS the data dir. The file must exist before you call this — the app copies it.'
           )
       })
     ])
@@ -104,12 +104,16 @@ const readCurrentRunContext = async (currentRunFile: string): Promise<ArtifactRu
 }
 
 // Normalizes the legacy content/encoding shape and the new source shape into one repository input.
-// relativeBaseDir is the notebook kernel cwd for this turn (undefined outside a notebook turn); it
-// decides whether the bare-filename convenience default is meaningful.
+// relativeBaseDir is the turn's primary resolution base (notebook data dir, else the first static
+// import root); it decides whether the bare-filename convenience default is meaningful.
 const normalizeArtifactToolWriteInput = (
   input: ArtifactToolWriteInput,
   relativeBaseDir: string | undefined
 ): ArtifactWriteSource => {
+  // An explicit source passes through untouched; the repository resolves a relative localPath
+  // against the turn's ordered base dirs (never the MCP/app process cwd) and rejects when the turn
+  // carries no base at all, so the caller gets a clear "pass an absolute path" error instead of a
+  // spurious not-found from the wrong cwd.
   if (input.source) return input.source
 
   if (typeof input.content === 'string') {
@@ -121,13 +125,13 @@ const normalizeArtifactToolWriteInput = (
   }
 
   // Neither source nor inline content. The bare-filename default only makes sense when there is a
-  // notebook data dir to resolve it against (kernel cwd): `write_artifact_file(filename: "plot.png")`
-  // right after `plt.savefig("plot.png")` just works. Outside a notebook turn there is no base, so a
-  // bare filename would silently resolve against the MCP process cwd and fail the allow-root check —
+  // base dir to resolve it against (kernel cwd or session workspace): `write_artifact_file(filename:
+  // "plot.png")` right after `plt.savefig("plot.png")` just works. With no base at all a bare
+  // filename would silently resolve against the MCP process cwd and fail the allow-root check —
   // keep the explicit contract error instead so the caller learns what to pass.
   if (!relativeBaseDir) {
     throw new Error(
-      'write_artifact_file requires source or content when no notebook session data dir is available.'
+      'write_artifact_file requires source or content: no notebook session data dir or allowed import root to resolve a bare filename against.'
     )
   }
 
@@ -141,7 +145,15 @@ const writeArtifactFileForCurrentRun = async (
   input: ArtifactToolWriteInput
 ): Promise<ArtifactFile> => {
   const context = await readCurrentRunContext(environment.currentRunFile)
-  const source = normalizeArtifactToolWriteInput(input, context.notebookDataDir)
+  // Ordered resolution bases for relative paths: the handoff's notebook data dir first (kernel cwd
+  // wins when both produced a same-named file this turn), then the static import roots — which in
+  // production are exactly the session workspace, so a plain shell save resolves there. The bases
+  // are a subset of the authorized roots, so a probed hit can never fail the allow-root check.
+  const relativeBaseDirs = [
+    ...(context.notebookDataDir ? [context.notebookDataDir] : []),
+    ...environment.allowedImportRoots
+  ]
+  const source = normalizeArtifactToolWriteInput(input, relativeBaseDirs[0])
 
   return repository.writePendingFile(
     {
@@ -159,7 +171,7 @@ const writeArtifactFileForCurrentRun = async (
       allowedImportRoots: context.notebookSessionRoot
         ? [...environment.allowedImportRoots, context.notebookSessionRoot]
         : environment.allowedImportRoots,
-      relativeBaseDir: context.notebookDataDir
+      relativeBaseDirs
     }
   )
 }
@@ -179,7 +191,7 @@ const createArtifactMcpServer = (
     {
       title: 'Write artifact file',
       description:
-        'Attach a file this turn generated as a downloadable artifact (chart, image, report, CSV, archive, …). The file must ALREADY EXIST on disk before you call this. Simplest use inside a notebook: save with a relative name (e.g. plt.savefig("plot.png") / R png("plot.png")) then call this with just `filename: "plot.png"` — the app resolves it against the notebook session data dir (the kernel cwd) and copies it. You may also pass an explicit `source`: {kind:"localPath", path} where path is a bare filename, a path relative to the notebook data dir, or an absolute path to an already-saved file; or {kind:"inline", content} for small in-memory text. The app assigns session/message ownership; do not call this before the file is written.',
+        'Attach a file this turn generated as a downloadable artifact (chart, image, report, CSV, archive, …). The file must ALREADY EXIST on disk before you call this. Simplest use inside a notebook: save with a relative name (e.g. plt.savefig("plot.png") / R png("plot.png")) then call this with just `filename: "plot.png"` — the app resolves it against the notebook session data dir (the kernel cwd) and copies it. You may also pass an explicit `source`: {kind:"localPath", path} where path is a bare filename, a path relative to the notebook data dir or session workspace, or an absolute path to an already-saved file; or {kind:"inline", content} for small in-memory text. The app assigns session/message ownership; do not call this before the file is written.',
       inputSchema: writeArtifactFileToolSchema
     },
     async (input) => {

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -104,11 +104,12 @@ const readCurrentRunContext = async (currentRunFile: string): Promise<ArtifactRu
 }
 
 // Normalizes the legacy content/encoding shape and the new source shape into one repository input.
-// relativeBaseDir is the turn's primary resolution base (notebook data dir, else the first static
-// import root); it decides whether the bare-filename convenience default is meaningful.
+// hasRelativeBase only gates whether the bare-filename convenience default is meaningful; the
+// actual relative-path resolution (the ordered multi-base probe) happens exclusively in the
+// repository layer.
 const normalizeArtifactToolWriteInput = (
   input: ArtifactToolWriteInput,
-  relativeBaseDir: string | undefined
+  hasRelativeBase: boolean
 ): ArtifactWriteSource => {
   // An explicit source passes through untouched; the repository resolves a relative localPath
   // against the turn's ordered base dirs (never the MCP/app process cwd) and rejects when the turn
@@ -129,7 +130,7 @@ const normalizeArtifactToolWriteInput = (
   // "plot.png")` right after `plt.savefig("plot.png")` just works. With no base at all a bare
   // filename would silently resolve against the MCP process cwd and fail the allow-root check —
   // keep the explicit contract error instead so the caller learns what to pass.
-  if (!relativeBaseDir) {
+  if (!hasRelativeBase) {
     throw new Error(
       'write_artifact_file requires source or content: no notebook session data dir or allowed import root to resolve a bare filename against.'
     )
@@ -147,13 +148,16 @@ const writeArtifactFileForCurrentRun = async (
   const context = await readCurrentRunContext(environment.currentRunFile)
   // Ordered resolution bases for relative paths: the handoff's notebook data dir first (kernel cwd
   // wins when both produced a same-named file this turn), then the static import roots — which in
-  // production are exactly the session workspace, so a plain shell save resolves there. The bases
-  // are a subset of the authorized roots, so a probed hit can never fail the allow-root check.
+  // production are exactly the session workspace, so a plain shell save resolves there. Every entry
+  // is BOTH an authorization boundary and a resolution base: if the static roots ever grow beyond
+  // the session workspace (e.g. a shared asset dir), a same-named file there silently shadows
+  // later bases — keep the list intentional. Bases ⊆ authorized roots, so a probed hit can never
+  // fail the allow-root check.
   const relativeBaseDirs = [
     ...(context.notebookDataDir ? [context.notebookDataDir] : []),
     ...environment.allowedImportRoots
   ]
-  const source = normalizeArtifactToolWriteInput(input, relativeBaseDirs[0])
+  const source = normalizeArtifactToolWriteInput(input, relativeBaseDirs.length > 0)
 
   return repository.writePendingFile(
     {

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -171,7 +171,9 @@ const writeArtifactFileForCurrentRun = async (
     {
       // The kernel's final session root (from the per-turn handoff) is the authoritative import root
       // for notebook writes; add it to the static roots so a resolved relative path is accepted even
-      // when the env was built under a pre-start alias.
+      // when the env was built under a pre-start alias. Authorization-only: it must NOT also join
+      // relativeBaseDirs — a relative name resolves against the kernel cwd (notebookDataDir), never
+      // against the session root.
       allowedImportRoots: context.notebookSessionRoot
         ? [...environment.allowedImportRoots, context.notebookSessionRoot]
         : environment.allowedImportRoots,

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -129,7 +129,7 @@ describe('artifact repository', () => {
         filename: 'plot.png',
         source: { kind: 'localPath', path: 'plot.png' }
       },
-      { allowedImportRoots: [dataDir], relativeBaseDir: dataDir }
+      { allowedImportRoots: [dataDir], relativeBaseDirs: [dataDir] }
     )
 
     await expect(readFile(artifact.path)).resolves.toEqual(Buffer.from([9, 8, 7]))
@@ -152,10 +152,87 @@ describe('artifact repository', () => {
         filename: 'chart.png',
         source: { kind: 'localPath', path: sourcePath }
       },
-      { allowedImportRoots: [dataDir], relativeBaseDir: dataDir }
+      { allowedImportRoots: [dataDir], relativeBaseDirs: [dataDir] }
     )
 
     await expect(readFile(artifact.path)).resolves.toEqual(Buffer.from([4, 5, 6]))
+  })
+
+  it('falls back to the next relative base dir when the file is not under the first', async () => {
+    // A plain-chat turn inside a notebook-capable runtime: the base list leads with the notebook
+    // data dir (no kernel ran, so nothing is there) and the session workspace second; the file the
+    // agent saved with plain shell tools must still resolve.
+    const root = await createStorageRoot()
+    const dataDir = join(root, 'notebook-session', 'data')
+    const workspace = join(root, 'workspace')
+    await mkdir(dataDir, { recursive: true })
+    await mkdir(workspace, { recursive: true })
+    await writeFile(join(workspace, 'plot.png'), Buffer.from([1, 1, 1]))
+
+    const repository = new ArtifactRepository(root)
+    const artifact = await repository.writePendingFile(
+      {
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        filename: 'plot.png',
+        source: { kind: 'localPath', path: 'plot.png' }
+      },
+      { allowedImportRoots: [dataDir, workspace], relativeBaseDirs: [dataDir, workspace] }
+    )
+
+    await expect(readFile(artifact.path)).resolves.toEqual(Buffer.from([1, 1, 1]))
+  })
+
+  it('prefers the first relative base dir when the file exists under several', async () => {
+    // The notebook data dir leads the base list, so a same-named file the agent left in the session
+    // workspace must not shadow the kernel output of the current turn.
+    const root = await createStorageRoot()
+    const dataDir = join(root, 'notebook-session', 'data')
+    const workspace = join(root, 'workspace')
+    await mkdir(dataDir, { recursive: true })
+    await mkdir(workspace, { recursive: true })
+    await writeFile(join(dataDir, 'plot.png'), Buffer.from([9, 9, 9]))
+    await writeFile(join(workspace, 'plot.png'), Buffer.from([2, 2, 2]))
+
+    const repository = new ArtifactRepository(root)
+    const artifact = await repository.writePendingFile(
+      {
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        filename: 'plot.png',
+        source: { kind: 'localPath', path: 'plot.png' }
+      },
+      { allowedImportRoots: [dataDir, workspace], relativeBaseDirs: [dataDir, workspace] }
+    )
+
+    await expect(readFile(artifact.path)).resolves.toEqual(Buffer.from([9, 9, 9]))
+  })
+
+  it('rejects a relative local source path when no relative base dir is set', async () => {
+    // Without a notebook data dir there is no base to resolve against; falling back to the process
+    // cwd (the app process for the in-process HTTP MCP host) reports "does not exist" even when the
+    // file sits inside an allowed root. Reject up front and demand an absolute path instead.
+    const root = await createStorageRoot()
+    const allowedRoot = join(root, 'workspace')
+    await mkdir(allowedRoot, { recursive: true })
+    await writeFile(join(allowedRoot, 'plot.png'), Buffer.from([1, 2, 3]))
+
+    const repository = new ArtifactRepository(root)
+
+    const attempt = repository.writePendingFile(
+      {
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        filename: 'plot.png',
+        source: { kind: 'localPath', path: 'plot.png' }
+      },
+      { allowedImportRoots: [allowedRoot] }
+    )
+    await expect(attempt).rejects.toThrow(/does not exist/)
+    await expect(attempt).rejects.toThrow(/absolute path/i)
   })
 
   it('rejects local source files outside allowed import roots', async () => {

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -175,7 +175,7 @@ const resolveAllowedImportFilePath = async (
 
   if (!resolvedFilePath) {
     throw new Error(
-      `Artifact local source path does not exist: "${filePath}". Save the file to disk (inside the notebook session workspace) before calling write_artifact_file, or pass inline content instead.`
+      `Artifact local source path does not exist: "${filePath}". Save the file to disk (inside the notebook session workspace) before calling write_artifact_file, pass an absolute path to an already-saved file, or use inline content instead.`
     )
   }
   const resolvedRoots = (

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -43,10 +43,12 @@ type ArtifactMetadata = {
 
 type ArtifactRepositoryWriteOptions = {
   allowedImportRoots?: string[]
-  // Base directory a RELATIVE localPath is resolved against — the notebook kernel's cwd (the session
-  // data dir). Lets the agent pass the same bare filename it saved (e.g. "plot.png") instead of
-  // rebuilding a brittle absolute path. Absolute paths ignore this (path.resolve drops the base).
-  relativeBaseDir?: string
+  // Ordered base directories a RELATIVE localPath is resolved against — the notebook kernel's cwd
+  // (the session data dir) first, then the session workspace. Lets the agent pass the same bare
+  // filename it saved (e.g. "plot.png") whether it saved through the kernel or with plain shell
+  // tools; the first base where the file EXISTS wins. Absolute paths ignore these. With no bases a
+  // relative path is REJECTED — it is never resolved against the process cwd.
+  relativeBaseDirs?: string[]
 }
 
 // Accepts only path segments that cannot escape the managed artifact layout.
@@ -137,30 +139,44 @@ const importRootsError = (filePath: string, allowedImportRoots: string[]): Error
 const resolveAllowedImportFilePath = async (
   filePath: string,
   allowedImportRoots: string[],
-  relativeBaseDir?: string
+  relativeBaseDirs: string[] = []
 ): Promise<string> => {
   if (allowedImportRoots.length === 0) {
     throw importRootsError(filePath, allowedImportRoots)
   }
 
-  // Resolve a relative path against the notebook data dir (the kernel's cwd) when provided, so a bare
-  // "plot.png" points at the file the agent just saved — not the MCP process's own cwd. An absolute
-  // path is unaffected: path.resolve ignores earlier segments once it hits an absolute one.
-  const requestedPath =
-    relativeBaseDir && !isAbsolute(filePath)
-      ? resolve(relativeBaseDir, filePath)
-      : resolve(filePath)
+  // A relative path with no base dir must NOT fall back to path.resolve's default (the process cwd):
+  // the HTTP MCP host runs inside the app process, whose cwd is not the session workspace, so the
+  // file would report "does not exist" even when it sits inside an allowed root — or worse, pick up
+  // an unrelated same-named file under cwd. Reject and ask for an absolute path instead.
+  if (relativeBaseDirs.length === 0 && !isAbsolute(filePath)) {
+    throw new Error(
+      `Artifact local source path does not exist: "${filePath}". A relative path resolves against the notebook session data dir or the session workspace, but this turn carries neither — pass an absolute path to the already-saved file instead.`
+    )
+  }
 
-  let resolvedFilePath: string
-  try {
-    resolvedFilePath = await realpath(requestedPath)
-  } catch (error) {
-    if (isMissingFileError(error)) {
-      throw new Error(
-        `Artifact local source path does not exist: "${filePath}". Save the file to disk (inside the notebook session workspace) before calling write_artifact_file, or pass inline content instead.`
-      )
+  // Resolve a relative path against the turn's base dirs in order — the notebook data dir (the
+  // kernel's cwd) first, then the session workspace — taking the first candidate that EXISTS, so a
+  // bare "plot.png" points at the file the agent just saved wherever it saved it, never at the MCP
+  // process's own cwd. An absolute path skips the bases entirely.
+  const candidates = isAbsolute(filePath)
+    ? [resolve(filePath)]
+    : relativeBaseDirs.map((baseDir) => resolve(baseDir, filePath))
+
+  let resolvedFilePath: string | undefined
+  for (const candidate of candidates) {
+    try {
+      resolvedFilePath = await realpath(candidate)
+      break
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
     }
-    throw error
+  }
+
+  if (!resolvedFilePath) {
+    throw new Error(
+      `Artifact local source path does not exist: "${filePath}". Save the file to disk (inside the notebook session workspace) before calling write_artifact_file, or pass inline content instead.`
+    )
   }
   const resolvedRoots = (
     await Promise.all(
@@ -226,7 +242,7 @@ class ArtifactRepository {
         const sourcePath = await resolveAllowedImportFilePath(
           request.source.path,
           options.allowedImportRoots ?? [],
-          options.relativeBaseDir
+          options.relativeBaseDirs
         )
 
         await copyFile(sourcePath, temporaryPath)


### PR DESCRIPTION
## Problem

An explicit relative `source.localPath` outside a notebook turn depended on the MCP process cwd. `normalizeArtifactToolWriteInput` passed an explicit source through untouched, and with no notebook data dir in the per-turn handoff, `resolveAllowedImportFilePath` resolved the relative path against `process.cwd()`. The HTTP MCP host runs inside the app process, whose cwd is not the session workspace — so `source: { kind: "localPath", path: "plot.svg" }` reported "does not exist" even when the file existed inside an allowed import root.

## Fix

`writePendingFile` now takes ordered `relativeBaseDirs` and probes them in order, taking the first candidate that exists:

1. the handoff's notebook data dir first (kernel cwd wins when both produced a same-named file this turn),
2. then the static import roots — in production exactly the session workspace, so a plain shell save resolves there.

The bases are a subset of the authorized roots, so a probed hit can never fail the allow-root check. A relative path with no base at all is still rejected with a clear "pass an absolute path" error instead of silently resolving against the process cwd. The bare-filename convenience default (no `source`) benefits the same way: it works whenever any base exists and only errors when the turn carries neither a notebook data dir nor an import root.

No runtime/handoff changes: the session workspace was already the static allowed import root, so it doubles as the fallback resolution base.

## Tests

- Inverted the P2 reproduction into a success case: explicit relative `localPath` with the file inside the allowed workspace root now resolves outside a notebook turn.
- Added coverage for: workspace fallback when the handoff pins a notebook data dir but no kernel ran, notebook-first priority on same-named files, the bare-filename default resolving under the session workspace, and the no-base rejection backstop.
- Full suite green: 375 files / 4458 tests; `typecheck:node` + eslint clean.