### PR TITLE
test(coverage): expand boundary coverage

### DIFF
--- a/src/main/acp/agent-process.test.ts
+++ b/src/main/acp/agent-process.test.ts
@@ -1,6 +1,36 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { buildAgentSpawnEnv, toUnpackedAsarPath } from './agent-process'
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  resolveExecutable: vi.fn((path: string) => path),
+  augmentedPathEnv: vi.fn((env: NodeJS.ProcessEnv) => ({ ...env, PATH: '/augmented/bin' })),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ spawn: mocks.spawn }))
+vi.mock('./claude-executable', () => ({
+  resolveClaudeExecutableForSpawn: mocks.resolveExecutable
+}))
+vi.mock('../settings/shell-path', () => ({ augmentedPathEnv: mocks.augmentedPathEnv }))
+vi.mock('../logger', () => ({
+  createLogger: () => ({ info: mocks.info, warn: mocks.warn, error: mocks.error })
+}))
+
+import { buildAgentSpawnEnv, spawnClaudeAgentAcp, toUnpackedAsarPath } from './agent-process'
+
+const originalDebugAgent = process.env.OPEN_SCIENCE_DEBUG_AGENT
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete process.env.OPEN_SCIENCE_DEBUG_AGENT
+})
+
+afterEach(() => {
+  if (originalDebugAgent === undefined) delete process.env.OPEN_SCIENCE_DEBUG_AGENT
+  else process.env.OPEN_SCIENCE_DEBUG_AGENT = originalDebugAgent
+})
 
 describe('ACP agent process packaging paths', () => {
   it('uses the real unpacked path for executables resolved inside app.asar', () => {
@@ -84,5 +114,58 @@ describe('buildAgentSpawnEnv', () => {
     // Native credential stores are keyed to Claude's implicit config context.
     expect(env.CLAUDE_CONFIG_DIR).toBeUndefined()
     expect(env.CLAUDE_CODE_EXECUTABLE).toBe('/bin/claude')
+  })
+})
+
+describe('spawnClaudeAgentAcp', () => {
+  it('rejects startup without a detected Claude executable', () => {
+    expect(() => spawnClaudeAgentAcp()).toThrow(
+      'Claude executable path is not configured. Complete Claude detection in settings first.'
+    )
+    expect(mocks.spawn).not.toHaveBeenCalled()
+  })
+
+  it('spawns the packaged ACP entry through Electron-as-Node with isolated provider env', () => {
+    const child = { on: vi.fn() }
+    mocks.spawn.mockReturnValue(child)
+    mocks.resolveExecutable.mockReturnValue('/resolved/claude')
+
+    expect(
+      spawnClaudeAgentAcp({
+        executablePath: '/bin/claude',
+        envOverrides: {
+          CLAUDE_CONFIG_DIR: '/provider/config',
+          ANTHROPIC_AUTH_TOKEN: 'secret'
+        }
+      })
+    ).toBe(child)
+
+    const [runtime, args, options] = mocks.spawn.mock.calls[0]!
+    expect(runtime).toBe(process.execPath)
+    expect(args).toEqual([expect.stringContaining('claude-agent-acp/dist/index.js')])
+    expect(options).toMatchObject({
+      stdio: 'pipe',
+      windowsHide: true,
+      env: expect.objectContaining({
+        PATH: '/augmented/bin',
+        CLAUDE_CODE_EXECUTABLE: '/resolved/claude',
+        CLAUDE_CONFIG_DIR: '/provider/config',
+        ANTHROPIC_AUTH_TOKEN: 'secret',
+        ELECTRON_RUN_AS_NODE: '1'
+      })
+    })
+    expect(child.on).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(child.on).toHaveBeenCalledWith('exit', expect.any(Function))
+  })
+
+  it('enables SDK diagnostics only when explicitly requested', () => {
+    process.env.OPEN_SCIENCE_DEBUG_AGENT = '1'
+    mocks.spawn.mockReturnValue({ on: vi.fn() })
+
+    spawnClaudeAgentAcp({ executablePath: '/bin/claude' })
+
+    expect(mocks.spawn.mock.calls[0]?.[2]?.env).toEqual(
+      expect.objectContaining({ DEBUG_CLAUDE_AGENT_SDK: '1' })
+    )
   })
 })

--- a/src/main/notebook/ipc.test.ts
+++ b/src/main/notebook/ipc.test.ts
@@ -1,7 +1,23 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NotebookRuntimeService } from './runtime-service'
-import { createNotebookHandlers } from './ipc'
+
+const { ipcHandlers } = vi.hoisted(() => ({
+  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+      ipcHandlers.set(channel, handler)
+  }
+}))
+
+import { createNotebookHandlers, registerNotebookIpcHandlers } from './ipc'
+
+beforeEach(() => {
+  ipcHandlers.clear()
+})
 
 describe('notebook IPC handlers', () => {
   it('delegates renderer notebook commands to the shared runtime service', async () => {
@@ -73,5 +89,59 @@ describe('notebook IPC handlers', () => {
       sessionId: 'session-1',
       workspaceCwd: '/workspace'
     })
+  })
+
+  it('registers every notebook channel and forwards the renderer payload unchanged', async () => {
+    const service = {
+      state: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+      getSessionReference: vi.fn().mockResolvedValue(null),
+      beginCodeCell: vi.fn().mockResolvedValue({ cellId: 'cell-1', writeId: 'write-1' }),
+      appendCodeCell: vi.fn().mockResolvedValue({ receivedBytes: 5 }),
+      finishCodeCell: vi.fn().mockResolvedValue({ status: 'idle' }),
+      runCell: vi.fn().mockResolvedValue({ runId: 'run-1', status: 'completed' }),
+      execute: vi.fn().mockResolvedValue({ runId: 'run-2', status: 'completed' }),
+      restart: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+      shutdown: vi.fn().mockResolvedValue({ sessionId: 'session-1', status: 'shutdown' })
+    } as unknown as NotebookRuntimeService
+    registerNotebookIpcHandlers(service)
+
+    expect([...ipcHandlers.keys()]).toEqual([
+      'notebook:state',
+      'notebook:reference',
+      'notebook:begin-code-cell',
+      'notebook:append-code-cell',
+      'notebook:finish-code-cell',
+      'notebook:run-cell',
+      'notebook:execute',
+      'notebook:restart',
+      'notebook:shutdown'
+    ])
+
+    const session = { sessionId: 'session-1', workspaceCwd: '/workspace' }
+    const begin = { ...session }
+    const append = { ...session, cellId: 'cell-1', writeId: 'write-1', delta: 'hello' }
+    const finish = { ...session, cellId: 'cell-1', writeId: 'write-1' }
+    const run = { ...session, cellId: 'cell-1', source: 'user' as const }
+    const execute = { ...session, code: 'print(1)', source: 'user' as const }
+
+    await ipcHandlers.get('notebook:state')?.(undefined, session)
+    await ipcHandlers.get('notebook:reference')?.(undefined, session)
+    await ipcHandlers.get('notebook:begin-code-cell')?.(undefined, begin)
+    await ipcHandlers.get('notebook:append-code-cell')?.(undefined, append)
+    await ipcHandlers.get('notebook:finish-code-cell')?.(undefined, finish)
+    await ipcHandlers.get('notebook:run-cell')?.(undefined, run)
+    await ipcHandlers.get('notebook:execute')?.(undefined, execute)
+    await ipcHandlers.get('notebook:restart')?.(undefined, session)
+    await ipcHandlers.get('notebook:shutdown')?.(undefined, session)
+
+    expect(service.state).toHaveBeenCalledWith(session)
+    expect(service.getSessionReference).toHaveBeenCalledWith(session)
+    expect(service.beginCodeCell).toHaveBeenCalledWith(begin)
+    expect(service.appendCodeCell).toHaveBeenCalledWith(append)
+    expect(service.finishCodeCell).toHaveBeenCalledWith(finish)
+    expect(service.runCell).toHaveBeenCalledWith(run)
+    expect(service.execute).toHaveBeenCalledWith(execute)
+    expect(service.restart).toHaveBeenCalledWith(session)
+    expect(service.shutdown).toHaveBeenCalledWith(session)
   })
 })

--- a/src/main/projects/ipc.test.ts
+++ b/src/main/projects/ipc.test.ts
@@ -1,6 +1,24 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createProjectHandlers } from './ipc'
+import type { PreviewStateRepository } from './preview-repository'
+import type { ProjectRepository } from './repository'
+
+const { ipcHandlers } = vi.hoisted(() => ({
+  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+      ipcHandlers.set(channel, handler)
+  }
+}))
+
+import { createProjectHandlers, registerProjectIpcHandlers } from './ipc'
+
+beforeEach(() => {
+  ipcHandlers.clear()
+})
 
 describe('createProjectHandlers', () => {
   it('routes deletion through the project deletion coordinator', async () => {
@@ -72,6 +90,60 @@ describe('createProjectHandlers', () => {
     await handlers.update({ id: 'project-1', name: 'Renamed' })
 
     expect(order).toEqual(['recover', 'get', 'recover', 'create', 'recover', 'update'])
+  })
+
+  it('registers project and preview channels with exact request forwarding', async () => {
+    const repository = {
+      list: vi.fn().mockResolvedValue([project]),
+      get: vi.fn().mockResolvedValue(project),
+      create: vi.fn().mockResolvedValue(project),
+      update: vi.fn().mockResolvedValue(project)
+    } as unknown as ProjectRepository
+    const previewRepository = {
+      get: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined)
+    } as unknown as PreviewStateRepository
+    const deletionCoordinator = {
+      deleteProject: vi.fn().mockResolvedValue(undefined),
+      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined)
+    }
+    registerProjectIpcHandlers(repository, previewRepository, deletionCoordinator)
+
+    expect([...ipcHandlers.keys()]).toEqual([
+      'projects:list',
+      'projects:get',
+      'projects:create',
+      'projects:update',
+      'projects:delete',
+      'preview:load',
+      'preview:save',
+      'preview:delete'
+    ])
+
+    const createRequest = { name: 'Project' }
+    const updateRequest = { id: 'project-1', name: 'Renamed' }
+    const previewState = { openTabs: [], activeTabId: null }
+
+    await ipcHandlers.get('projects:list')?.()
+    await ipcHandlers.get('projects:get')?.(undefined, 'project-1')
+    await ipcHandlers.get('projects:create')?.(undefined, createRequest)
+    await ipcHandlers.get('projects:update')?.(undefined, updateRequest)
+    await ipcHandlers.get('projects:delete')?.(undefined, { id: 'project-1' })
+    await ipcHandlers.get('preview:load')?.(undefined, { projectId: 'project-1' })
+    await ipcHandlers.get('preview:save')?.(undefined, {
+      projectId: 'project-1',
+      state: previewState
+    })
+    await ipcHandlers.get('preview:delete')?.(undefined, { projectId: 'project-1' })
+
+    expect(repository.get).toHaveBeenCalledWith('project-1')
+    expect(repository.create).toHaveBeenCalledWith(createRequest)
+    expect(repository.update).toHaveBeenCalledWith(updateRequest)
+    expect(deletionCoordinator.deleteProject).toHaveBeenCalledWith('project-1')
+    expect(previewRepository.get).toHaveBeenCalledWith('project-1')
+    expect(previewRepository.save).toHaveBeenCalledWith('project-1', previewState)
+    expect(previewRepository.delete).toHaveBeenCalledWith('project-1')
   })
 })
 

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -1,8 +1,28 @@
-import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { ReviewRepository } from '../reviewer/repository'
-import { createSessionPersistenceHandlers, type SessionPersistenceBackend } from './ipc'
+
+const { ipcHandlers } = vi.hoisted(() => ({
+  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+      ipcHandlers.set(channel, handler)
+  }
+}))
+
+import {
+  createSessionPersistenceHandlers,
+  registerSessionPersistenceIpcHandlers,
+  type SessionPersistenceBackend
+} from './ipc'
+
+beforeEach(() => {
+  ipcHandlers.clear()
+})
 
 const createSession = (): PersistedChatSession => ({
   id: 'session-1',
@@ -103,5 +123,38 @@ describe('session persistence IPC handlers', () => {
     await handlers.deleteSession({ projectId: 'project-a', sessionId: 'session-1' })
 
     expect(order).toEqual(['session', 'reviews'])
+  })
+
+  it('registers each persistence channel and forwards renderer requests', async () => {
+    const session = createSession()
+    const loadResult = { sessions: [session], manifest: { version: 1 as const } }
+    const repository: SessionPersistenceBackend = {
+      loadAll: vi.fn().mockResolvedValue(loadResult),
+      saveSession: vi.fn().mockResolvedValue(undefined),
+      deleteSession: vi.fn().mockResolvedValue(undefined),
+      deleteProjectSessions: vi.fn().mockResolvedValue(undefined),
+      saveManifest: vi.fn().mockResolvedValue(undefined)
+    }
+    const reviewRepository = createMockReviewRepository()
+    registerSessionPersistenceIpcHandlers(repository, reviewRepository)
+
+    expect([...ipcHandlers.keys()]).toEqual([
+      'sessions:load-all',
+      'sessions:save-session',
+      'sessions:delete-session',
+      'sessions:save-manifest'
+    ])
+
+    const deleteRequest = { projectId: 'project-a', sessionId: 'session-1' }
+    const manifestRequest = { lastProjectId: 'project-a', lastSessionId: 'session-1' }
+    await expect(ipcHandlers.get('sessions:load-all')?.()).resolves.toBe(loadResult)
+    await ipcHandlers.get('sessions:save-session')?.(undefined, session)
+    await ipcHandlers.get('sessions:delete-session')?.(undefined, deleteRequest)
+    await ipcHandlers.get('sessions:save-manifest')?.(undefined, manifestRequest)
+
+    expect(repository.saveSession).toHaveBeenCalledWith(session)
+    expect(repository.deleteSession).toHaveBeenCalledWith('project-a', 'session-1')
+    expect(reviewRepository.deleteReviewsForSession).toHaveBeenCalledWith('session-1')
+    expect(repository.saveManifest).toHaveBeenCalledWith(manifestRequest)
   })
 })

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -540,12 +540,17 @@ describe('storage IPC handlers', () => {
     await writeFile(join(dataRoot, 'artifacts', 'keep.txt'), 'must survive')
 
     let releaseSetDataRoot: (() => void) | undefined
+    let signalSetDataRootStarted!: () => void
+    const setDataRootStarted = new Promise<void>((resolve) => {
+      signalSetDataRootStarted = resolve
+    })
     const deps = fakeDeps({
       settingsService: {
         setDataRoot: vi.fn(
           () =>
             new Promise<void>((resolve) => {
               releaseSetDataRoot = resolve
+              signalSetDataRootStarted()
             })
         ),
         markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
@@ -557,7 +562,9 @@ describe('storage IPC handlers', () => {
     await invoke('storage:migrate', { parent: targetParent })
 
     const commitPromise = invoke('storage:commit-and-relaunch', { parent: targetParent })
-    await tick()
+    // Wait for the commit to own the resolution lock; a fixed delay flakes when coverage instrumentation
+    // slows filesystem work and can otherwise leave the mocked persistence promise unresolved.
+    await setDataRootStarted
     await invoke('storage:discard-migrated-copy', { parent: targetParent })
     releaseSetDataRoot?.()
     await commitPromise

--- a/src/main/update/ipc.test.ts
+++ b/src/main/update/ipc.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { APP } from '../../shared/app-config'
+import type { UpdateStrategy } from './strategy'
+
+const handlers = new Map<string, () => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: () => unknown) => handlers.set(channel, handler)
+  }
+}))
+
+const { registerUpdateIpcHandlers } = await import('./ipc')
+
+const status = { state: 'available' as const, current: '0.5.1', latest: '0.5.2' }
+
+const createStrategy = (): UpdateStrategy => ({
+  getStatus: vi.fn(() => status),
+  check: vi.fn().mockResolvedValue(status),
+  download: vi.fn().mockResolvedValue(status),
+  cancel: vi.fn().mockResolvedValue(status),
+  apply: vi.fn().mockResolvedValue(status)
+})
+
+describe('registerUpdateIpcHandlers', () => {
+  beforeEach(() => {
+    handlers.clear()
+  })
+
+  it('registers every renderer update command and returns the supplied strategy', async () => {
+    const strategy = createStrategy()
+
+    expect(registerUpdateIpcHandlers(strategy)).toBe(strategy)
+    expect([...handlers.keys()]).toEqual([
+      'update:get-app-info',
+      'update:get-status',
+      'update:check',
+      'update:download',
+      'update:cancel',
+      'update:apply'
+    ])
+
+    expect(handlers.get('update:get-app-info')?.()).toEqual({
+      name: APP.name,
+      version: status.current,
+      copyright: APP.copyright
+    })
+    expect(handlers.get('update:get-status')?.()).toBe(status)
+    await expect(handlers.get('update:check')?.()).resolves.toBe(status)
+    await expect(handlers.get('update:download')?.()).resolves.toBe(status)
+    await expect(handlers.get('update:cancel')?.()).resolves.toBe(status)
+    await expect(handlers.get('update:apply')?.()).resolves.toBe(status)
+
+    expect(strategy.check).toHaveBeenCalledTimes(1)
+    expect(strategy.download).toHaveBeenCalledTimes(1)
+    expect(strategy.cancel).toHaveBeenCalledTimes(1)
+    expect(strategy.apply).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/update/scheduler.test.ts
+++ b/src/main/update/scheduler.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { UpdateStrategy } from './strategy'
+import { startUpdateScheduler } from './scheduler'
+
+const status = { state: 'idle' as const, current: '0.5.1' }
+
+const createStrategy = (): UpdateStrategy => ({
+  getStatus: vi.fn(() => status),
+  check: vi.fn().mockResolvedValue(status),
+  download: vi.fn().mockResolvedValue(status),
+  cancel: vi.fn().mockResolvedValue(status),
+  apply: vi.fn().mockResolvedValue(status)
+})
+
+describe('startUpdateScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('checks immediately and then at the requested interval', async () => {
+    const strategy = createStrategy()
+    const stop = startUpdateScheduler(strategy, 1_000)
+
+    expect(strategy.check).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(strategy.check).toHaveBeenCalledTimes(4)
+
+    stop()
+  })
+
+  it('stops future checks when the caller tears down the scheduler', async () => {
+    const strategy = createStrategy()
+    const stop = startUpdateScheduler(strategy, 1_000)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    stop()
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(strategy.check).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  settings: {
+    isLoaded: false,
+    onboardingCompletedAt: undefined as number | undefined,
+    isEnvironmentRepairOpen: false,
+    isSettingsOpen: false,
+    isSettingsLoaded: true,
+    enqueueApproval: vi.fn(),
+    load: vi.fn().mockResolvedValue(undefined),
+    checkEnvironment: vi.fn().mockResolvedValue(undefined),
+    closeSettings: vi.fn()
+  },
+  navigation: { view: 'home' as 'home' | 'workspace' },
+  environment: {
+    ui: { state: 'idle' },
+    init: vi.fn().mockResolvedValue(undefined),
+    retry: vi.fn().mockResolvedValue(undefined)
+  },
+  loadProjects: vi.fn().mockResolvedValue(undefined),
+  initUpdates: vi.fn(),
+  sessionPersistenceReady: true,
+  startupView: 'home' as 'home' | 'onboarding',
+  getInfo: vi.fn()
+}))
+
+vi.mock('@/lib/session-persistence/session-persistence', () => ({
+  useSessionPersistence: () => mocks.sessionPersistenceReady
+}))
+vi.mock('@/hooks/useCloseActivePaneShortcut', () => ({
+  useCloseActivePaneShortcut: vi.fn()
+}))
+vi.mock('@/stores/navigation-store', () => ({
+  useNavigationStore: <T,>(selector: (state: typeof mocks.navigation) => T): T =>
+    selector(mocks.navigation)
+}))
+vi.mock('@/stores/notebook-env-store', () => ({
+  useNotebookEnvStore: <T,>(selector: (state: typeof mocks.environment) => T): T =>
+    selector(mocks.environment)
+}))
+vi.mock('@/stores/project-store', () => ({
+  useProjectStore: <T,>(selector: (state: { loadProjects: typeof mocks.loadProjects }) => T): T =>
+    selector({ loadProjects: mocks.loadProjects })
+}))
+vi.mock('@/stores/settings-store', () => ({
+  useSettingsStore: <T,>(selector: (state: typeof mocks.settings) => T): T =>
+    selector(mocks.settings)
+}))
+vi.mock('@/stores/update-store', () => ({
+  useUpdateStore: <T,>(selector: (state: { init: typeof mocks.initUpdates }) => T): T =>
+    selector({ init: mocks.initUpdates })
+}))
+vi.mock('@/pages/onboarding/startup-gate', () => ({
+  resolveStartupView: vi.fn(() => mocks.startupView)
+}))
+
+vi.mock('@/components/CloseConfirmModal', () => ({
+  CloseConfirmModal: (): React.JSX.Element => <div data-testid="close-confirm" />
+}))
+vi.mock('@/components/DataRootMissingDialog', () => ({
+  DataRootMissingDialog: ({
+    open,
+    dataRoot
+  }: {
+    open: boolean
+    dataRoot: string
+  }): React.JSX.Element => <div data-testid="missing-root">{open ? dataRoot : 'closed'}</div>
+}))
+vi.mock('@/components/LegacyDataMoveDialog', () => ({
+  LegacyDataMoveDialog: ({ currentDataRoot }: { currentDataRoot: string }): React.JSX.Element => (
+    <div data-testid="legacy-move">{currentDataRoot}</div>
+  )
+}))
+vi.mock('@/components/UpdateDialog', () => ({
+  UpdateDialog: (): React.JSX.Element => <div data-testid="update-dialog" />
+}))
+vi.mock('@/pages/home/HomePage', () => ({
+  HomePage: (): React.JSX.Element => <div data-testid="home-page" />
+}))
+vi.mock('@/pages/onboarding/OnboardingWizard', () => ({
+  OnboardingWizard: (): React.JSX.Element => <div data-testid="onboarding-page" />
+}))
+vi.mock('@/pages/settings/ConnectorApprovalDialog', () => ({
+  ConnectorApprovalDialog: (): React.JSX.Element => <div data-testid="approval-dialog" />
+}))
+vi.mock('@/pages/settings/SettingsPage', () => ({
+  SettingsPage: ({ open }: { open: boolean }): React.JSX.Element => (
+    <div data-testid="settings-page">{open ? 'open' : 'closed'}</div>
+  )
+}))
+vi.mock('@/pages/workspace/EnvStatusBanner', () => ({
+  EnvStatusBanner: (): React.JSX.Element => <div data-testid="env-banner" />
+}))
+vi.mock('@/pages/workspace/WorkspacePage', () => ({
+  WorkspacePage: ({
+    isSessionPersistenceReady
+  }: {
+    isSessionPersistenceReady: boolean
+  }): React.JSX.Element => (
+    <div data-testid="workspace-page">{String(isSessionPersistenceReady)}</div>
+  )
+}))
+
+import App from './App'
+
+describe('App startup routing', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    mocks.settings.isLoaded = false
+    mocks.settings.onboardingCompletedAt = undefined
+    mocks.settings.isEnvironmentRepairOpen = false
+    mocks.settings.isSettingsOpen = false
+    mocks.navigation.view = 'home'
+    mocks.startupView = 'home'
+    mocks.sessionPersistenceReady = true
+    mocks.getInfo.mockResolvedValue({
+      dataRoot: '/workspace/OpenScience',
+      dataRootMissing: false,
+      legacyDataMovePrompt: false,
+      defaultParent: '/workspace'
+    })
+    window.api = {
+      storage: { getInfo: mocks.getInfo },
+      settings: { onConnectorApprovalRequest: vi.fn(() => vi.fn()) }
+    } as unknown as Window['api']
+  })
+
+  afterEach(async () => {
+    await act(async () => root?.unmount())
+    container.remove()
+  })
+
+  const render = async (): Promise<void> => {
+    root = createRoot(container)
+    await act(async () => root.render(<App />))
+  }
+
+  it('keeps the shell blank until settings have loaded', async () => {
+    await render()
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('routes first-run users to onboarding after settings hydration', async () => {
+    mocks.settings.isLoaded = true
+    mocks.startupView = 'onboarding'
+
+    await render()
+
+    expect(container.querySelector('[data-testid="onboarding-page"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
+  })
+
+  it('loads startup services and renders Home with the shared overlays', async () => {
+    mocks.settings.isLoaded = true
+
+    await render()
+
+    expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="env-banner"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="settings-page"]')?.textContent).toBe('closed')
+    expect(mocks.initUpdates).toHaveBeenCalled()
+    expect(mocks.environment.init).toHaveBeenCalled()
+    expect(mocks.loadProjects).toHaveBeenCalled()
+    expect(mocks.settings.load).toHaveBeenCalled()
+    expect(mocks.settings.checkEnvironment).toHaveBeenCalled()
+    expect(mocks.getInfo).toHaveBeenCalled()
+  })
+
+  it('renders Workspace and exposes a missing data-root recovery dialog', async () => {
+    mocks.settings.isLoaded = true
+    mocks.navigation.view = 'workspace'
+    mocks.getInfo.mockResolvedValue({
+      dataRoot: '/Volumes/Science/OpenScience',
+      dataRootMissing: true,
+      legacyDataMovePrompt: false,
+      defaultParent: '/Users/example'
+    })
+
+    await render()
+
+    expect(container.querySelector('[data-testid="workspace-page"]')?.textContent).toBe('true')
+    expect(container.querySelector('[data-testid="missing-root"]')?.textContent).toBe(
+      '/Volumes/Science/OpenScience'
+    )
+  })
+})

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -195,6 +195,55 @@ describe('PreviewFileContent', () => {
     expect(container.textContent).toContain('beta')
   })
 
+  it('renders a truncated TSV table with bounded rows and columns', async () => {
+    const headers = Array.from({ length: 26 }, (_, index) => `column-${index + 1}`)
+    const rows = Array.from({ length: 101 }, (_, rowIndex) =>
+      headers.map((_, columnIndex) => `r${rowIndex + 1}c${columnIndex + 1}`).join('\t')
+    )
+    vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
+      content: [headers.join('\t'), ...rows].join('\n'),
+      encoding: 'utf8',
+      size: 10_000,
+      truncated: true
+    })
+
+    await renderFile(createFileItem({ format: 'csv', name: 'measurements.tsv' }))
+
+    expect(container.textContent).toContain('100+ rows · 26 columns')
+    expect(container.textContent).toContain('Showing 100 rows · 24 columns')
+    expect(container.textContent).toContain('2 more columns hidden in this preview')
+    expect(container.textContent).toContain('r1c1')
+    expect(container.textContent).not.toContain('r101c1')
+  })
+
+  it('shows the parser error without discarding CSV rows that can still be previewed', async () => {
+    vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
+      content: 'sample,value\ncontrol,1\n"incomplete,2',
+      encoding: 'utf8',
+      size: 37,
+      truncated: false
+    })
+
+    await renderFile(createFileItem({ format: 'csv', name: 'results.csv' }))
+
+    expect(container.textContent).toContain('control')
+    expect(container.querySelector('.text-danger-000')?.textContent).not.toBe('')
+  })
+
+  it('uses the CSV fallback for a non-UTF8 preview', async () => {
+    vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
+      content: 'AAECAw==',
+      encoding: 'base64',
+      size: 4,
+      truncated: false
+    })
+
+    await renderFile(createFileItem({ format: 'csv', name: 'binary.csv' }))
+
+    expect(container.textContent).toContain("CSV couldn't be read for preview")
+    expect(container.querySelector('table')).toBeNull()
+  })
+
   it('loads the next bounded page of a large text preview on demand', async () => {
     vi.mocked(window.api.artifacts.readPreview).mockImplementation(async (request) =>
       request.offset === 5

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx
@@ -1,0 +1,103 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PreviewToolItem } from '@/stores/preview-workbench-store'
+
+const mocks = vi.hoisted(() => ({
+  activeProjectId: 'project-1' as string | undefined,
+  getReviewsForSession: vi.fn()
+}))
+
+vi.mock('@/stores/navigation-store', () => ({
+  useNavigationStore: <T,>(selector: (state: { activeProjectId?: string }) => T): T =>
+    selector({ activeProjectId: mocks.activeProjectId })
+}))
+vi.mock('@/stores/review-store', () => ({
+  useReviewStore: <T,>(
+    selector: (state: { getReviewsForSession: typeof mocks.getReviewsForSession }) => T
+  ): T => selector({ getReviewsForSession: mocks.getReviewsForSession })
+}))
+vi.mock('../NotebookPreview', () => ({
+  NotebookPreview: ({ item }: { item: PreviewToolItem }): React.JSX.Element => (
+    <div data-testid="notebook-preview">{item.notebook?.sessionId}</div>
+  )
+}))
+vi.mock('../ProjectFilesView', () => ({
+  ProjectFilesView: (): React.JSX.Element => <div data-testid="project-files">files</div>
+}))
+vi.mock('../SessionReviewerPanel', () => ({
+  SessionReviewerPanel: ({
+    review,
+    activeFindingId
+  }: {
+    review: { id: string }
+    activeFindingId?: string
+  }): React.JSX.Element => (
+    <div data-testid="reviewer-panel">
+      {review.id}:{activeFindingId ?? ''}
+    </div>
+  )
+}))
+
+import { PreviewToolContent } from './PreviewToolContent'
+
+const createItem = (overrides: Partial<PreviewToolItem>): PreviewToolItem => ({
+  id: 'tool-1',
+  sessionId: 'session-1',
+  title: 'Tool',
+  type: 'tool',
+  ...overrides
+})
+
+const render = (item: PreviewToolItem): string =>
+  renderToStaticMarkup(<PreviewToolContent item={item} />)
+
+describe('PreviewToolContent', () => {
+  beforeEach(() => {
+    mocks.activeProjectId = 'project-1'
+    mocks.getReviewsForSession.mockReturnValue([])
+  })
+
+  it('routes project file tools through a project-scoped remount boundary', () => {
+    expect(render(createItem({ toolKind: 'files' }))).toContain('data-testid="project-files"')
+  })
+
+  it('shows the reviewer empty state when the requested session has no reviews', () => {
+    const html = render(createItem({ toolKind: 'reviewer', reviewerSessionId: 'review-session' }))
+
+    expect(mocks.getReviewsForSession).toHaveBeenCalledWith('review-session')
+    expect(html).toContain('No review available for this session.')
+  })
+
+  it('selects the requested review and forwards the active finding', () => {
+    mocks.getReviewsForSession.mockReturnValue([{ id: 'older' }, { id: 'target' }])
+
+    const html = render(
+      createItem({
+        toolKind: 'reviewer',
+        reviewerSessionId: 'review-session',
+        reviewerReviewId: 'target',
+        reviewerActiveFindingId: 'finding-4'
+      })
+    )
+
+    expect(html).toContain('target:finding-4')
+  })
+
+  it('renders notebook tools only when their notebook reference is present', () => {
+    expect(
+      render(
+        createItem({
+          toolKind: 'notebook',
+          notebook: {
+            sessionId: 'notebook-session',
+            projectName: 'Project',
+            workspaceCwd: '/workspace'
+          }
+        })
+      )
+    ).toContain('notebook-session')
+    expect(render(createItem({ toolKind: 'notebook' }))).toBe('')
+    expect(render(createItem({}))).toBe('')
+  })
+})

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx
@@ -92,7 +92,11 @@ describe('PreviewToolContent', () => {
           notebook: {
             sessionId: 'notebook-session',
             projectName: 'Project',
-            workspaceCwd: '/workspace'
+            workspaceCwd: '/workspace',
+            notebookSessionRoot: '/data/notebooks/Project/notebook-session',
+            dataRoot: '/data',
+            runtimeRoot: '/data/runtime',
+            runJsonPath: '/data/notebooks/Project/notebook-session/run.json'
           }
         })
       )

--- a/src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+
+const mocks = vi.hoisted(() => ({
+  state: { current: undefined as unknown },
+  fromSmiles: vi.fn(),
+  fromMolfile: vi.fn()
+}))
+
+vi.mock('../usePreviewFileContent', () => ({
+  usePreviewFileContent: (): unknown => mocks.state.current
+}))
+vi.mock('openchemlib', () => ({
+  Molecule: {
+    fromSmiles: mocks.fromSmiles,
+    fromMolfile: mocks.fromMolfile
+  }
+}))
+
+import { MoleculePreviewRenderer } from './MoleculePreview'
+
+const item = (name: string): PreviewFileItem => ({
+  id: `artifact:${name}`,
+  sessionId: 'session-1',
+  title: name,
+  type: 'file',
+  path: `/workspace/${name}`,
+  name,
+  format: 'molecule'
+})
+
+const readyState = (content: string, overrides: Record<string, unknown> = {}): unknown => ({
+  status: 'ready',
+  preview: { content, encoding: 'utf8', truncated: false, ...overrides },
+  pagination: {
+    pageNumber: 1,
+    hasPrevious: false,
+    hasNext: false,
+    previousPage: vi.fn(),
+    nextPage: vi.fn()
+  }
+})
+
+describe('MoleculePreviewRenderer', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let restoreLayout: (() => void) | undefined
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    mocks.fromSmiles.mockReset()
+    mocks.fromMolfile.mockReset()
+    const width = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+    const height = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight')
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 640
+    })
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get: () => 400
+    })
+    restoreLayout = () => {
+      if (width) Object.defineProperty(HTMLElement.prototype, 'clientWidth', width)
+      else delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth
+      if (height) Object.defineProperty(HTMLElement.prototype, 'clientHeight', height)
+      else delete (HTMLElement.prototype as { clientHeight?: number }).clientHeight
+    }
+  })
+
+  afterEach(async () => {
+    await act(async () => root?.unmount())
+    container.remove()
+    restoreLayout?.()
+  })
+
+  const render = async (file: PreviewFileItem): Promise<void> => {
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<MoleculePreviewRenderer item={file} />)
+      await Promise.resolve()
+    })
+  }
+
+  it('renders SMILES through OpenChemLib with the available canvas size', async () => {
+    const toSVG = vi.fn(() => '<svg data-testid="molecule-svg"></svg>')
+    mocks.fromSmiles.mockReturnValue({ toSVG })
+    mocks.state.current = readyState('CCO')
+
+    await render(item('ethanol.smi'))
+    await vi.waitFor(() => expect(mocks.fromSmiles).toHaveBeenCalledWith('CCO'))
+
+    expect(toSVG).toHaveBeenCalledWith(
+      640,
+      400,
+      expect.stringMatching(/^mol-/),
+      expect.objectContaining({ autoCrop: true, autoCropMargin: 16 })
+    )
+    expect(container.querySelector('[data-testid="molecule-svg"]')).not.toBeNull()
+  })
+
+  it('shows an in-place rendering error when OpenChemLib rejects a molecule', async () => {
+    mocks.fromSmiles.mockImplementation(() => {
+      throw new Error('invalid SMILES')
+    })
+    mocks.state.current = readyState('not-a-smiles')
+
+    await render(item('broken.smi'))
+    await vi.waitFor(() => expect(container.textContent).toContain('invalid SMILES'))
+
+    expect(container.textContent).toContain('Structure could not be rendered')
+  })
+
+  it('uses source content rather than attempting to parse an incomplete molecule fragment', async () => {
+    mocks.state.current = readyState('partial molfile', { truncated: true })
+
+    await render(item('large.sdf'))
+
+    expect(container.textContent).toContain('partial molfile')
+    expect(mocks.fromMolfile).not.toHaveBeenCalled()
+  })
+
+  it('uses the structure fallback for non-UTF8 previews', async () => {
+    mocks.state.current = readyState('AAECAw==', { encoding: 'base64' })
+
+    await render(item('binary.mol'))
+
+    expect(container.textContent).toContain("Structure file couldn't be read for preview")
+    expect(mocks.fromMolfile).not.toHaveBeenCalled()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,21 @@ export default defineConfig({
         lines: 66,
         functions: 62,
         branches: 57,
-        statements: 64
+        statements: 64,
+        // Keep the now-covered update wiring from being masked by the global aggregate.
+        'src/main/update/**': {
+          lines: 85,
+          functions: 75,
+          branches: 70,
+          statements: 80
+        },
+        // CSV is a user-facing renderer with bounded-data and fallback behavior worth protecting.
+        'src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx': {
+          lines: 95,
+          functions: 95,
+          branches: 80,
+          statements: 95
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

The global coverage gate hid untested main-process IPC registration and renderer entry/preview paths. Several boundary tests also relied on timing assumptions under coverage instrumentation.

## Proposed change

- Add registration and request-forwarding tests for notebook, projects, session persistence, and update IPC.
- Cover ACP agent spawn configuration and missing-executable behavior.
- Cover App startup routing, tool previews, CSV/TSV boundaries, and molecule preview states.
- Add module-specific coverage floors for update wiring and CSV preview.
- Replace the storage migration race test delay with an explicit async barrier.

## Scope and non-goals

This pull request changes tests and coverage configuration only. No product runtime behavior or documentation is changed.

## Acceptance criteria and validation

- `npm run test`: 380 files passed, 4,476 tests passed, 66 conditional skips.
- `npm run test:coverage`: lines 87.45%, functions 83.68%.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run check:web-api-map` passed.

## Review focus

Please review the IPC boundary assertions, the ACP process mocks, and the renderer startup/preview fixtures for behavioral coverage rather than implementation coupling.