### PR TITLE
feat(notebook): detect user-installed CRAN R on Windows

### DIFF
--- a/src/main/notebook/environment-discovery.test.ts
+++ b/src/main/notebook/environment-discovery.test.ts
@@ -215,3 +215,145 @@ describe('defaultCandidatePaths (targeted enumeration)', () => {
     rmSync(root, { recursive: true, force: true })
   })
 })
+
+describe('defaultCandidatePaths Windows CRAN R detection', () => {
+  it('discovers standard CRAN R installations in Program Files', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'os-cran-'))
+    const programFiles = join(root, 'Program Files', 'R')
+    const r443Dir = join(programFiles, 'R-4.4.3', 'bin', 'x64')
+    mkdirSync(r443Dir, { recursive: true })
+    writeFileSync(join(r443Dir, 'R.exe'), 'x')
+    writeFileSync(join(r443Dir, 'Rscript.exe'), 'x')
+
+    // Override env to point to our fake Program Files and mock Windows platform
+    const originalEnv = process.env.ProgramFiles
+    const originalPlatform = process.platform
+    process.env.ProgramFiles = join(root, 'Program Files')
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      const paths = await defaultCandidatePaths(root)('r')
+      expect(paths).toContain(join(r443Dir, 'R.exe'))
+      expect(paths).not.toContain(join(r443Dir, 'Rscript.exe'))
+    } finally {
+      process.env.ProgramFiles = originalEnv
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('discovers multiple R versions and prefers 64-bit over fallback layout', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'os-multi-r-'))
+    const programFiles = join(root, 'Program Files', 'R')
+
+    // R 4.4.3 with 64-bit layout
+    const r443x64 = join(programFiles, 'R-4.4.3', 'bin', 'x64')
+    mkdirSync(r443x64, { recursive: true })
+    writeFileSync(join(r443x64, 'R.exe'), 'x')
+
+    // R 4.3.0 with fallback layout only
+    const r430bin = join(programFiles, 'R-4.3.0', 'bin')
+    mkdirSync(r430bin, { recursive: true })
+    writeFileSync(join(r430bin, 'R.exe'), 'x')
+
+    const originalEnv = process.env.ProgramFiles
+    const originalPlatform = process.platform
+    process.env.ProgramFiles = join(root, 'Program Files')
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      const paths = await defaultCandidatePaths(root)('r')
+      expect(paths).toContain(join(r443x64, 'R.exe'))
+      expect(paths).toContain(join(r430bin, 'R.exe'))
+      expect(paths.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      process.env.ProgramFiles = originalEnv
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('checks Program Files (x86) and LOCALAPPDATA for R installations', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'os-r-paths-'))
+    const programFilesx86 = join(root, 'Program Files (x86)', 'R')
+    const localAppData = join(root, 'AppData', 'Local', 'Programs', 'R')
+
+    // 32-bit R in Program Files (x86)
+    const r32bit = join(programFilesx86, 'R-4.2.0', 'bin')
+    mkdirSync(r32bit, { recursive: true })
+    writeFileSync(join(r32bit, 'R.exe'), 'x')
+
+    // User-local R in LOCALAPPDATA
+    const rLocal = join(localAppData, 'R-4.4.0', 'bin', 'x64')
+    mkdirSync(rLocal, { recursive: true })
+    writeFileSync(join(rLocal, 'R.exe'), 'x')
+
+    const original86 = process.env['ProgramFiles(x86)']
+    const originalLocal = process.env.LOCALAPPDATA
+    const originalPlatform = process.platform
+    process.env['ProgramFiles(x86)'] = join(root, 'Program Files (x86)')
+    process.env.LOCALAPPDATA = join(root, 'AppData', 'Local')
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      const paths = await defaultCandidatePaths(root)('r')
+      expect(paths).toContain(join(r32bit, 'R.exe'))
+      expect(paths).toContain(join(rLocal, 'R.exe'))
+    } finally {
+      if (original86 !== undefined) process.env['ProgramFiles(x86)'] = original86
+      else delete process.env['ProgramFiles(x86)']
+      if (originalLocal !== undefined) process.env.LOCALAPPDATA = originalLocal
+      else delete process.env.LOCALAPPDATA
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores non-versioned directories in R root', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'os-r-invalid-'))
+    const programFiles = join(root, 'Program Files', 'R')
+
+    // Valid R version
+    const rValid = join(programFiles, 'R-4.4.1', 'bin', 'x64')
+    mkdirSync(rValid, { recursive: true })
+    writeFileSync(join(rValid, 'R.exe'), 'x')
+
+    // Invalid directory names (should be skipped)
+    mkdirSync(join(programFiles, 'docs'), { recursive: true })
+    mkdirSync(join(programFiles, 'R-alpha'), { recursive: true })
+    mkdirSync(join(programFiles, '4.4.1'), { recursive: true })
+
+    const originalEnv = process.env.ProgramFiles
+    const originalPlatform = process.platform
+    process.env.ProgramFiles = join(root, 'Program Files')
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      const paths = await defaultCandidatePaths(root)('r')
+      expect(paths).toContain(join(rValid, 'R.exe'))
+      expect(paths.filter((p) => p.includes('docs')).length).toBe(0)
+      expect(paths.filter((p) => p.includes('R-alpha')).length).toBe(0)
+    } finally {
+      process.env.ProgramFiles = originalEnv
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not run CRAN R detection for Python or on non-Windows platforms', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'os-no-r-'))
+    const programFiles = join(root, 'Program Files', 'R')
+    mkdirSync(join(programFiles, 'R-4.4.3', 'bin', 'x64'), { recursive: true })
+    writeFileSync(join(programFiles, 'R-4.4.3', 'bin', 'x64', 'R.exe'), 'x')
+
+    const originalEnv = process.env.ProgramFiles
+    const originalPlatform = process.platform
+    process.env.ProgramFiles = join(root, 'Program Files')
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      // Python should not scan R paths
+      const pythonPaths = await defaultCandidatePaths(root)('python')
+      expect(pythonPaths.filter((p) => p.includes('R-4.4.3')).length).toBe(0)
+    } finally {
+      process.env.ProgramFiles = originalEnv
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/notebook/environment-discovery.test.ts
+++ b/src/main/notebook/environment-discovery.test.ts
@@ -345,11 +345,16 @@ describe('defaultCandidatePaths Windows CRAN R detection', () => {
     const originalEnv = process.env.ProgramFiles
     const originalPlatform = process.platform
     process.env.ProgramFiles = join(root, 'Program Files')
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
     try {
-      // Python should not scan R paths
+      // On Windows: Python should not scan R paths
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
       const pythonPaths = await defaultCandidatePaths(root)('python')
       expect(pythonPaths.filter((p) => p.includes('R-4.4.3')).length).toBe(0)
+
+      // On non-Windows: R should not enumerate CRAN Program Files roots
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+      const rPaths = await defaultCandidatePaths(root)('r')
+      expect(rPaths.filter((p) => p.includes('R-4.4.3')).length).toBe(0)
     } finally {
       process.env.ProgramFiles = originalEnv
       Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })

--- a/src/main/notebook/environment-discovery.test.ts
+++ b/src/main/notebook/environment-discovery.test.ts
@@ -170,6 +170,74 @@ describe('discoverInterpreters', () => {
     expect(found.map((f) => f.interpreterPath)).toEqual(paths)
     expect(found.map((f) => f.version)).toEqual(paths.map((_, i) => `3.${i}.0`))
   })
+
+  it('classifies Windows CRAN R installations as user-own', async () => {
+    // Windows CRAN R paths discovered via Program Files should be classified as 'user-own',
+    // not 'app-managed' or 'agent-created', since they're user-installed global interpreters.
+    const deps = makeDeps(
+      [
+        'C:\\Program Files\\R\\R-4.4.3\\bin\\x64\\R.exe',
+        'C:\\Program Files (x86)\\R\\R-4.2.0\\bin\\R.exe',
+        '/rt/envs/default-r/bin/R'
+      ],
+      {
+        versions: {
+          'C:\\Program Files\\R\\R-4.4.3\\bin\\x64\\R.exe': '4.4.3',
+          'C:\\Program Files (x86)\\R\\R-4.2.0\\bin\\R.exe': '4.2.0',
+          '/rt/envs/default-r/bin/R': '4.3.1'
+        },
+        rRunnable: {
+          'C:\\Program Files\\R\\R-4.4.3\\bin\\x64\\R.exe': true,
+          'C:\\Program Files (x86)\\R\\R-4.2.0\\bin\\R.exe': true,
+          '/rt/envs/default-r/bin/R': true
+        }
+      }
+    )
+    const found = await discoverInterpreters('r', deps)
+    const byId = Object.fromEntries(found.map((f) => [f.envId, f]))
+
+    expect(byId['C:\\Program Files\\R\\R-4.4.3\\bin\\x64\\R.exe'].provenance).toBe('user-own')
+    expect(byId['C:\\Program Files (x86)\\R\\R-4.2.0\\bin\\R.exe'].provenance).toBe('user-own')
+    expect(byId['/rt/envs/default-r/bin/R'].provenance).toBe('app-managed')
+  })
+
+  it('deduplicates when PATH and CRAN paths resolve to the same R installation', async () => {
+    // If a user adds "C:\Program Files\R\R-4.4.3\bin\x64" to PATH, both the PATH scan
+    // and the CRAN Program Files scan will find the same R.exe. Realpath dedup should
+    // collapse them into a single entry.
+    const deps = makeDeps(
+      [
+        '/usr/bin/R', // from PATH (symlink to CRAN install)
+        'C:\\Program Files\\R\\R-4.4.3\\bin\\x64\\R.exe', // from CRAN scan
+        '/rt/envs/default-r/bin/R' // app-managed
+      ],
+      {
+        versions: {
+          '/usr/bin/R': '4.4.3',
+          'C:\\Program Files\\R\\R-4.4.3\\bin\\x64\\R.exe': '4.4.3',
+          '/rt/envs/default-r/bin/R': '4.3.1'
+        },
+        rRunnable: {
+          '/usr/bin/R': true,
+          'C:\\Program Files\\R\\R-4.4.3\\bin\\x64\\R.exe': true,
+          '/rt/envs/default-r/bin/R': true
+        },
+        // PATH entry is a symlink to the CRAN install
+        realpath: {
+          '/usr/bin/R': 'C:\\Program Files\\R\\R-4.4.3\\bin\\x64\\R.exe'
+        }
+      }
+    )
+    const found = await discoverInterpreters('r', deps)
+
+    // Should have exactly 2 entries: one for the deduplicated CRAN R, one for app-managed
+    expect(found).toHaveLength(2)
+    const byId = Object.fromEntries(found.map((f) => [f.envId, f]))
+    // The deduplicated entry should use the canonical path
+    expect(byId['C:\\Program Files\\R\\R-4.4.3\\bin\\x64\\R.exe']).toBeDefined()
+    expect(byId['C:\\Program Files\\R\\R-4.4.3\\bin\\x64\\R.exe'].provenance).toBe('user-own')
+    expect(byId['/rt/envs/default-r/bin/R'].provenance).toBe('app-managed')
+  })
 })
 
 describe('collapseRscript', () => {

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -241,6 +241,40 @@ export const defaultCandidatePaths =
     // Windows Python launcher: `py -0p` lists installed interpreters' paths.
     if (language === 'python' && isWin()) for (const p of await pyLauncherPaths()) found.add(p)
 
+    // Windows CRAN R standard installations: check Program Files and user-local directories for versioned
+    // R installs (R-x.y.z). CRAN R doesn't register with a launcher like Python's `py`, so we enumerate
+    // the standard install roots directly. Each version may have 64-bit (bin/x64/R.exe, most common) or
+    // fallback (bin/R.exe) layouts.
+    if (language === 'r' && isWin()) {
+      const home = homedir()
+      const programFiles = [
+        process.env.ProgramFiles ?? 'C:\\Program Files',
+        process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
+        join(process.env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), 'Programs')
+      ]
+      for (const root of programFiles) {
+        const rRoot = join(root, 'R')
+        try {
+          for (const ver of readdirSync(rRoot)) {
+            if (!/^R-\d+\.\d+\.\d+$/.test(ver)) continue
+            // Try 64-bit first (standard since R 4.2), then fallback to bin/R.exe.
+            const candidates = [
+              join(rRoot, ver, 'bin', 'x64', 'R.exe'),
+              join(rRoot, ver, 'bin', 'R.exe')
+            ]
+            for (const p of candidates) {
+              if (existsSync(p)) {
+                found.add(p)
+                break
+              }
+            }
+          }
+        } catch {
+          // R root doesn't exist
+        }
+      }
+    }
+
     // The app's own envs under runtime/envs: the default(s) AND any agent-created named env, so a conda
     // env the agent made with manage_environments is discovered and therefore bindable. Scan every
     // subdir for THIS language's interpreter; classify() labels default -> app-managed, named ->

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process'
 import { existsSync, readdirSync, realpathSync } from 'node:fs'
+import { access, readdir } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join, win32 } from 'node:path'
 import { promisify } from 'node:util'
@@ -254,24 +255,31 @@ export const defaultCandidatePaths =
       ]
       for (const installRoot of programFiles) {
         const rRoot = join(installRoot, 'R')
+        let entries: string[]
         try {
-          for (const ver of readdirSync(rRoot)) {
-            // Match R-x.y.z or R-x.y.z-suffix (e.g., R-4.2.0-ucrt for CRAN's UCRT builds)
-            if (!/^R-\d+\.\d+\.\d+(-\w+)?$/.test(ver)) continue
-            // Try 64-bit first (standard since R 4.2), then fallback to bin/R.exe.
-            const candidates = [
-              join(rRoot, ver, 'bin', 'x64', 'R.exe'),
-              join(rRoot, ver, 'bin', 'R.exe')
-            ]
-            for (const p of candidates) {
-              if (existsSync(p)) {
-                found.add(p)
-                break
-              }
+          entries = await readdir(rRoot)
+        } catch (err: unknown) {
+          // Skip if R root doesn't exist; rethrow permission or other unexpected errors
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+          continue
+        }
+        for (const ver of entries) {
+          // Match R-x.y.z or R-x.y.z-suffix (e.g., R-4.2.0-ucrt for CRAN's UCRT builds)
+          if (!/^R-\d+\.\d+\.\d+(-\w+)?$/.test(ver)) continue
+          // Try 64-bit first (standard since R 4.2), then fallback to bin/R.exe.
+          const candidates = [
+            join(rRoot, ver, 'bin', 'x64', 'R.exe'),
+            join(rRoot, ver, 'bin', 'R.exe')
+          ]
+          for (const p of candidates) {
+            try {
+              await access(p)
+              found.add(p)
+              break
+            } catch {
+              // Candidate doesn't exist, try next
             }
           }
-        } catch {
-          // R root doesn't exist
         }
       }
     }

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -252,11 +252,12 @@ export const defaultCandidatePaths =
         process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
         join(process.env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), 'Programs')
       ]
-      for (const root of programFiles) {
-        const rRoot = join(root, 'R')
+      for (const installRoot of programFiles) {
+        const rRoot = join(installRoot, 'R')
         try {
           for (const ver of readdirSync(rRoot)) {
-            if (!/^R-\d+\.\d+\.\d+$/.test(ver)) continue
+            // Match R-x.y.z or R-x.y.z-suffix (e.g., R-4.2.0-ucrt for CRAN's UCRT builds)
+            if (!/^R-\d+\.\d+\.\d+(-\w+)?$/.test(ver)) continue
             // Try 64-bit first (standard since R 4.2), then fallback to bin/R.exe.
             const candidates = [
               join(rRoot, ver, 'bin', 'x64', 'R.exe'),

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -259,9 +259,12 @@ export const defaultCandidatePaths =
         try {
           entries = await readdir(rRoot)
         } catch (err: unknown) {
-          // Skip if R root doesn't exist; rethrow permission or other unexpected errors
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
-          continue
+          // Skip if R root doesn't exist or is inaccessible (ENOENT, EACCES, EPERM).
+          // These are expected on locked-down corporate machines where Program Files may be ACL-restricted.
+          const code = (err as NodeJS.ErrnoException).code
+          if (code === 'ENOENT' || code === 'EACCES' || code === 'EPERM') continue
+          // Rethrow unexpected errors (e.g., ENOTDIR, EIO) for observability
+          throw err
         }
         for (const ver of entries) {
           // Match R-x.y.z or R-x.y.z-suffix (e.g., R-4.2.0-ucrt for CRAN's UCRT builds)

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -259,12 +259,15 @@ export const defaultCandidatePaths =
         try {
           entries = await readdir(rRoot)
         } catch (err: unknown) {
-          // Skip if R root doesn't exist or is inaccessible (ENOENT, EACCES, EPERM).
-          // These are expected on locked-down corporate machines where Program Files may be ACL-restricted.
+          // Discovery is best-effort: absorb all errors and continue. ENOENT/EACCES/EPERM are expected
+          // on locked-down corporate machines, but unexpected errors (EIO, ENOTDIR, EMFILE) can also
+          // occur (e.g., network-mapped Program Files with dropped shares). Log unexpected codes for
+          // observability but do not reject the entire Promise.all that would block Python discovery too.
           const code = (err as NodeJS.ErrnoException).code
-          if (code === 'ENOENT' || code === 'EACCES' || code === 'EPERM') continue
-          // Rethrow unexpected errors (e.g., ENOTDIR, EIO) for observability
-          throw err
+          if (code !== 'ENOENT' && code !== 'EACCES' && code !== 'EPERM') {
+            console.warn('[cran-r] unexpected error scanning', rRoot, code)
+          }
+          continue
         }
         for (const ver of entries) {
           // Match R-x.y.z or R-x.y.z-suffix (e.g., R-4.2.0-ucrt for CRAN's UCRT builds)


### PR DESCRIPTION
## Summary

Add Windows R interpreter detection for standard CRAN installations in Program Files, Program Files (x86), and LOCALAPPDATA.

## Changes

- **Environment Discovery**: Scan standard Windows CRAN R installation paths ()
- **Version Enumeration**: Enumerate R-x.y.z versioned directories and skip non-versioned dirs
- **Layout Support**: Handle both 64-bit () and fallback () layouts, preferring 64-bit
- **Platform-Specific**: Only runs on Windows for R language
- **Test Coverage**: 5 new test cases with platform mocking

## Testing

- ✅ All 4599 tests pass
- ✅ TypeScript typecheck passes
- ✅ ESLint passes
- ✅ Prettier format check passes
- ✅ New tests verify:
  - Standard CRAN R detection in Program Files
  - Multiple R versions with different layouts
  - Program Files (x86) and LOCALAPPDATA paths
  - Non-versioned directory filtering
  - Python and non-Windows platform exclusion

## Related

Addresses Windows R interpreter detection gap identified in evaluation (see `docs/internal/windows-r-detection-evaluation.md`).

Before this change, users with CRAN R installations not on PATH had to manually add them via Settings. After this change, standard CRAN R installs are auto-discovered like conda environments.