### PR TITLE
feat(workspace): add copy and edit actions to user messages

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -5027,3 +5027,40 @@ describe('ACP runtime — failure-path robustness (errorMessage coercion + sync-
     }
   })
 })
+
+describe('prompt streaming after a context reset', () => {
+  it('streams the assistant reply as events for a prompt sent right after the reset', async () => {
+    const process = new FakeAgentProcess()
+    const events: Array<{ kind: string; sessionId?: string; role?: string; text?: string }> = []
+    // A second agent session id backs the fresh adoption the reset performs.
+    startFakeAgent(process, ['remote-session-1', 'remote-session-2'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onEvent: (event) => events.push(event) }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'first turn' })
+    await runtime.resetSessionContext({ sessionId: session.sessionId, cwd: '/workspace' })
+
+    events.length = 0
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'edited turn',
+      historyPreamble: 'first turn\n\nreply for first turn'
+    })
+
+    // The fresh agent session's reply streams through the same event channel, labelled with the
+    // app-facing session id so the renderer grows the truncated conversation.
+    const assistantChunks = events.filter(
+      (event) => event.kind === 'message' && event.role === 'assistant'
+    )
+    expect(assistantChunks.length).toBeGreaterThan(0)
+    expect(assistantChunks[0]).toMatchObject({
+      sessionId: session.sessionId,
+      text: 'reply for remote-session-2'
+    })
+  })
+})

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1593,22 +1593,19 @@ describe('resendEditedWorkspaceMessage', () => {
     vi.unstubAllGlobals()
   })
 
-  it('truncates at the edited message and resends with the kept history replayed', async () => {
+  it('shows the resent bubble as a live run immediately, then replays the kept history', async () => {
     seedConversation()
 
+    const resetGate = createDeferred<{ sessionId: string; cwd: string; contextReset: boolean }>()
     const runtime = {
       state: createSnapshot(['session-1']),
       createSession: vi.fn(),
       resumeSession: vi.fn(),
-      resetSessionContext: vi.fn().mockResolvedValue({
-        sessionId: 'session-1',
-        cwd: '/workspace/project',
-        contextReset: true
-      }),
+      resetSessionContext: vi.fn(() => resetGate.promise),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
-    const resent = await resendEditedWorkspaceMessage(runtime, {
+    const resentPromise = resendEditedWorkspaceMessage(runtime, {
       sessionId: 'session-1',
       messageId: 'user-2',
       text: 'second prompt, edited',
@@ -1618,6 +1615,26 @@ describe('resendEditedWorkspaceMessage', () => {
     })
     await flushRuntimeTasks()
 
+    // While the context reset is still in flight, the transcript already shows the adjusted prompt
+    // as a live run — the same immediate feedback as a composer send.
+    const duringReset = useSessionStore.getState().sessions[0]
+    expect(duringReset?.messages.map((message) => message.id)).toEqual([
+      'user-1',
+      'agent-1',
+      expect.any(String)
+    ])
+    expect(duringReset?.messages.at(-1)).toMatchObject({
+      role: 'user',
+      content: 'second prompt, edited'
+    })
+    expect(duringReset?.status).toBe('running')
+    expect(duringReset?.activeRun?.promptMessageId).toBe(duringReset?.messages.at(-1)?.id)
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+
+    resetGate.resolve({ sessionId: 'session-1', cwd: '/workspace/project', contextReset: true })
+    const resent = await resentPromise
+    await flushRuntimeTasks()
+
     expect(resent).toBe(true)
     expect(runtime.resetSessionContext).toHaveBeenCalledWith(
       'session-1',
@@ -1625,11 +1642,6 @@ describe('resendEditedWorkspaceMessage', () => {
       'default-project',
       'ask'
     )
-
-    // The edited message and every later turn are gone; the resend appends the adjusted prompt.
-    const messages = useSessionStore.getState().sessions[0]?.messages ?? []
-    expect(messages.map((message) => message.id)).toEqual(['user-1', 'agent-1', expect.any(String)])
-    expect(messages[2]).toMatchObject({ role: 'user', content: 'second prompt, edited' })
 
     // The kept turns replay as a text preamble (the edited turn is not duplicated into it), and the
     // picked skill goes out as a forced skill on the resent prompt.

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1682,6 +1682,56 @@ describe('resendEditedWorkspaceMessage', () => {
     ])
     expect(useSessionStore.getState().sessions[0]?.status).toBe('error')
   })
+
+  it('refuses the edit before truncating when the kept history needs image replay the model cannot take', async () => {
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'default-project',
+          title: 'Conversation',
+          cwd: '/workspace/project',
+          status: 'idle' as const,
+          messages: [
+            {
+              ...createMessage('user-1', 'user', 'first prompt', baseTime),
+              images: [{ id: 'img-1', mimeType: 'image/png', data: 'AQID', byteLength: 3 }]
+            },
+            createMessage('agent-1', 'agent', 'first answer', baseTime + 100),
+            createMessage('user-2', 'user', 'second prompt', baseTime + 200)
+          ],
+          createdAt: baseTime,
+          updatedAt: baseTime + 200
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    const resent = await resendEditedWorkspaceMessage(
+      runtime,
+      { sessionId: 'session-1', messageId: 'user-2', text: 'second prompt, edited' },
+      false
+    )
+
+    // The incompatible replay is rejected before the destructive cut: no reset, no prompt, and the
+    // transcript is untouched apart from the visible error.
+    expect(resent).toBe(false)
+    expect(runtime.resetSessionContext).not.toHaveBeenCalled()
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    const session = useSessionStore.getState().sessions[0]
+    expect(session?.messages.map((message) => message.id)).toEqual(['user-1', 'agent-1', 'user-2'])
+    expect(session?.status).toBe('error')
+    expect(session?.error).toContain('image replay')
+  })
 })
 
 describe('edit resend reply streaming', () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -2,7 +2,11 @@ import type { AcpRuntimeEvent, AcpStateSnapshot } from '../../../../shared/acp'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
+import {
+  createInitialSessionState,
+  useSessionStore,
+  type ChatMessage
+} from '../../stores/session-store'
 import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
@@ -15,6 +19,7 @@ import {
   processContextOverflowRecovery,
   processVisibleWorkspaceRuntimeEvents,
   recoverContextOverflowWorkspaceSession,
+  resendEditedWorkspaceMessage,
   resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage
 } from './useWorkspaceAgentRuntime'
@@ -1532,5 +1537,136 @@ describe('recovering from a request-size overflow', () => {
     )
 
     expect(recover).not.toHaveBeenCalled()
+  })
+})
+
+describe('resendEditedWorkspaceMessage', () => {
+  const baseTime = 1710000000000
+
+  const createMessage = (
+    id: string,
+    role: 'user' | 'agent',
+    content: string,
+    createdAt: number
+  ): ChatMessage => ({
+    id,
+    role,
+    content,
+    status: 'complete' as const,
+    eventIds: [],
+    createdAt,
+    updatedAt: createdAt
+  })
+
+  const seedConversation = (): void => {
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'default-project',
+          title: 'Conversation',
+          cwd: '/workspace/project',
+          status: 'idle' as const,
+          messages: [
+            createMessage('user-1', 'user', 'first prompt', baseTime),
+            createMessage('agent-1', 'agent', 'first answer', baseTime + 100),
+            createMessage('user-2', 'user', 'second prompt', baseTime + 200),
+            createMessage('agent-2', 'agent', 'second answer', baseTime + 300),
+            createMessage('user-3', 'user', 'third prompt', baseTime + 400)
+          ],
+          createdAt: baseTime,
+          updatedAt: baseTime + 400
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
+  }
+
+  beforeEach(() => {
+    useSessionStore.setState(createInitialSessionState())
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('truncates at the edited message and resends with the kept history replayed', async () => {
+    seedConversation()
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        cwd: '/workspace/project',
+        contextReset: true
+      }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    const resent = await resendEditedWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      messageId: 'user-2',
+      text: 'second prompt, edited',
+      parts: [{ type: 'text', text: 'second prompt, edited' }],
+      forcedSkillIds: ['skill-forecast'],
+      referencedArtifacts: []
+    })
+    await flushRuntimeTasks()
+
+    expect(resent).toBe(true)
+    expect(runtime.resetSessionContext).toHaveBeenCalledWith(
+      'session-1',
+      '/workspace/project',
+      'default-project',
+      'ask'
+    )
+
+    // The edited message and every later turn are gone; the resend appends the adjusted prompt.
+    const messages = useSessionStore.getState().sessions[0]?.messages ?? []
+    expect(messages.map((message) => message.id)).toEqual(['user-1', 'agent-1', expect.any(String)])
+    expect(messages[2]).toMatchObject({ role: 'user', content: 'second prompt, edited' })
+
+    // The kept turns replay as a text preamble (the edited turn is not duplicated into it), and the
+    // picked skill goes out as a forced skill on the resent prompt.
+    expect(runtime.sendPrompt.mock.calls[0]?.[1]).toBe('second prompt, edited')
+    const preamble = runtime.sendPrompt.mock.calls[0]?.[5]
+    expect(preamble).toContain('first prompt')
+    expect(preamble).toContain('first answer')
+    expect(preamble).not.toContain('second prompt')
+    expect(preamble).not.toContain('third prompt')
+    expect(runtime.sendPrompt.mock.calls[0]?.[3]).toEqual(['skill-forecast'])
+  })
+
+  it('keeps the transcript intact when the context reset fails', async () => {
+    seedConversation()
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockRejectedValue(new Error('ACP connection failed')),
+      sendPrompt: vi.fn()
+    }
+
+    const resent = await resendEditedWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      messageId: 'user-2',
+      text: 'second prompt, edited'
+    })
+
+    expect(resent).toBe(false)
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions[0]?.messages.map((message) => message.id)).toEqual([
+      'user-1',
+      'agent-1',
+      'user-2',
+      'agent-2',
+      'user-3'
+    ])
+    expect(useSessionStore.getState().sessions[0]?.status).toBe('error')
   })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1732,6 +1732,55 @@ describe('resendEditedWorkspaceMessage', () => {
     expect(session?.status).toBe('error')
     expect(session?.error).toContain('image replay')
   })
+
+  it('refuses the edit before truncating when the kept history has user-uploaded images', async () => {
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'default-project',
+          title: 'Conversation',
+          cwd: '/workspace/project',
+          status: 'idle' as const,
+          messages: [
+            {
+              ...createMessage('user-1', 'user', 'first prompt', baseTime),
+              uploads: [createAttachment({ name: 'photo.png', mimeType: 'image/png' })]
+            },
+            createMessage('agent-1', 'agent', 'first answer', baseTime + 100),
+            createMessage('user-2', 'user', 'second prompt', baseTime + 200)
+          ],
+          createdAt: baseTime,
+          updatedAt: baseTime + 200
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    const resent = await resendEditedWorkspaceMessage(
+      runtime,
+      { sessionId: 'session-1', messageId: 'user-2', text: 'second prompt, edited' },
+      false
+    )
+
+    // User uploads replay as image attachments, so they are gated exactly like agent-emitted images.
+    expect(resent).toBe(false)
+    expect(runtime.resetSessionContext).not.toHaveBeenCalled()
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    const session = useSessionStore.getState().sessions[0]
+    expect(session?.messages.map((message) => message.id)).toEqual(['user-1', 'agent-1', 'user-2'])
+    expect(session?.status).toBe('error')
+    expect(session?.error).toContain('image replay')
+  })
 })
 
 describe('edit resend reply streaming', () => {
@@ -1837,5 +1886,82 @@ describe('edit resend reply streaming', () => {
       status: 'streaming',
       responseToMessageId: afterResend?.activeRun?.promptMessageId
     })
+  })
+})
+
+describe('sendWorkspaceMessage replay image gate', () => {
+  const baseTime = 1710000000000
+
+  const createMessage = (
+    id: string,
+    role: 'user' | 'agent',
+    content: string,
+    createdAt: number
+  ): ChatMessage => ({
+    id,
+    role,
+    content,
+    status: 'complete',
+    eventIds: [],
+    createdAt,
+    updatedAt: createdAt
+  })
+
+  beforeEach(() => {
+    useSessionStore.setState(createInitialSessionState())
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('blocks the replay before dispatch when the kept history has user-uploaded images', async () => {
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'default-project',
+          title: 'Conversation',
+          cwd: '/workspace/project',
+          status: 'idle' as const,
+          messages: [
+            {
+              ...createMessage('user-1', 'user', 'first prompt', baseTime),
+              uploads: [createAttachment({ name: 'photo.png', mimeType: 'image/png' })]
+            },
+            createMessage('agent-1', 'agent', 'first answer', baseTime + 100)
+          ],
+          createdAt: baseTime,
+          updatedAt: baseTime + 100
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    const sent = await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'follow up',
+      cwd: '/workspace/project',
+      forceHistoryReplay: true,
+      supportsImageInput: false
+    })
+
+    // The user turn is recorded, but the replayed upload would become an image block the model
+    // cannot take, so nothing is dispatched and the session carries the gate's error.
+    expect(sent).toBeDefined()
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    const session = useSessionStore.getState().sessions[0]
+    expect(session?.status).toBe('error')
+    expect(session?.error).toContain('image replay')
   })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -11,6 +11,7 @@ import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
 } from '../../stores/preview-workbench-store'
+import { applyWorkspaceRuntimeEvent } from './workspace-events'
 import {
   createWorkspaceRuntimeEventProcessor,
   deleteWorkspaceSession,
@@ -1668,5 +1669,111 @@ describe('resendEditedWorkspaceMessage', () => {
       'user-3'
     ])
     expect(useSessionStore.getState().sessions[0]?.status).toBe('error')
+  })
+})
+
+describe('edit resend reply streaming', () => {
+  beforeEach(() => {
+    useSessionStore.setState(createInitialSessionState())
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('grows an agent bubble from streamed reply events after the truncate-and-resend', async () => {
+    const baseTime = 1710000000000
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'default-project',
+          title: 'Conversation',
+          cwd: '/workspace/project',
+          status: 'idle' as const,
+          messages: [
+            {
+              id: 'user-1',
+              role: 'user' as const,
+              content: 'first prompt',
+              status: 'complete' as const,
+              eventIds: [],
+              createdAt: baseTime,
+              updatedAt: baseTime
+            },
+            {
+              id: 'agent-1',
+              role: 'agent' as const,
+              content: 'first answer',
+              status: 'complete' as const,
+              eventIds: [],
+              createdAt: baseTime + 100,
+              updatedAt: baseTime + 100
+            },
+            {
+              id: 'user-2',
+              role: 'user' as const,
+              content: 'second prompt',
+              status: 'complete' as const,
+              eventIds: [],
+              createdAt: baseTime + 200,
+              updatedAt: baseTime + 200
+            }
+          ],
+          createdAt: baseTime,
+          updatedAt: baseTime + 200
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        cwd: '/workspace/project',
+        contextReset: true
+      }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    const resent = await resendEditedWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      messageId: 'user-2',
+      text: 'second prompt, edited'
+    })
+    await flushRuntimeTasks()
+
+    expect(resent).toBe(true)
+    const afterResend = useSessionStore.getState().sessions[0]
+    // The adjusted prompt is appended as the latest user turn and the run is live.
+    expect(afterResend?.messages.at(-1)).toMatchObject({
+      role: 'user',
+      content: 'second prompt, edited'
+    })
+    expect(afterResend?.status).toBe('running')
+
+    // The agent's streamed reply lands as a new bubble answering the resent prompt.
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'event-reply-1',
+        sessionId: 'session-1',
+        role: 'assistant',
+        messageId: 'agent-reply-1',
+        text: 'edited answer'
+      })
+    )
+
+    const messages = useSessionStore.getState().sessions[0]?.messages ?? []
+    expect(messages.at(-1)).toMatchObject({
+      role: 'agent',
+      content: 'edited answer',
+      status: 'streaming',
+      responseToMessageId: afterResend?.activeRun?.promptMessageId
+    })
   })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -345,6 +345,11 @@ const startPendingSessionPrompt = (
 }
 
 // Records the user's prompt before slow runtime work continues.
+// Shared by the send path and the edit-resend pre-check so both reject incompatible image replays
+// with the same wording.
+const IMAGE_REPLAY_UNSUPPORTED_MESSAGE =
+  'This conversation needs image replay, but the selected model does not support image input.'
+
 const sendWorkspaceMessage = async (
   runtime: WorkspaceMessageRuntime,
   {
@@ -491,12 +496,7 @@ const sendWorkspaceMessage = async (
       historyPreamble = buildHistoryPreamble(historyMessages)
       const media = buildHistoryReplayMedia(historyMessages)
       if (supportsImageInput === false && media.images.length > 0) {
-        useSessionStore
-          .getState()
-          .failRun(
-            targetSessionId,
-            'This conversation needs image replay, but the selected model does not support image input.'
-          )
+        useSessionStore.getState().failRun(targetSessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
         return appended
       }
       historyAttachments = media.attachments
@@ -757,9 +757,20 @@ const resendEditedWorkspaceMessage = async (
 
   const resumeCwd = session.cwd || runtime.state.cwd
   const content = input.text.trim()
+  const cutIndex = session.messages.findIndex((message) => message.id === input.messageId)
 
-  if (!resumeCwd || !content) return false
-  if (!session.messages.some((message) => message.id === input.messageId)) return false
+  if (!resumeCwd || !content || cutIndex < 0) return false
+
+  // Validate replay compatibility before the destructive cut: a kept history with images cannot be
+  // replayed on a model without image input, and discovering that after the truncation would leave
+  // the later turns dropped with no prompt dispatched.
+  if (
+    supportsImageInput === false &&
+    buildHistoryReplayMedia(session.messages.slice(0, cutIndex)).images.length > 0
+  ) {
+    useSessionStore.getState().failRun(input.sessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
+    return false
+  }
 
   // The optimistic cut + append: the edited message and every later turn drop out, and the adjusted
   // prompt takes their place as a live run with its bubble and waiting indicator already visible.

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -43,6 +43,10 @@ type SendWorkspaceMessageInput = {
   // internal re-resume below runs against an already-attached session and can't report the reset
   // again, so this forces the prior turns to be replayed as a history preamble on the re-sent turn.
   forceHistoryReplay?: boolean
+  // Set by the edit-resend path, which appends the adjusted prompt optimistically (with its run
+  // already marked) so the bubble and waiting indicator show immediately. The duplicate-submit
+  // guard and the local append are skipped, and the replayed history stops before this message.
+  preAppendedMessageId?: string
   // Current Provider capability, injected by the hook so context replay cannot bypass image gating.
   supportsImageInput?: boolean
 }
@@ -355,6 +359,7 @@ const sendWorkspaceMessage = async (
     referencedArtifacts,
     parts,
     forceHistoryReplay,
+    preAppendedMessageId,
     supportsImageInput
   }: SendWorkspaceMessageInput
 ): Promise<SendWorkspaceMessageResult | undefined> => {
@@ -371,7 +376,12 @@ const sendWorkspaceMessage = async (
       .getState()
       .sessions.find((session) => session.id === targetSessionId)
 
-    if (currentSession?.status === 'running' || currentSession?.status === 'waiting-permission') {
+    // A pre-appended prompt already marked its own run, so the duplicate-submit guard must not
+    // reject the send that belongs to it.
+    if (
+      !preAppendedMessageId &&
+      (currentSession?.status === 'running' || currentSession?.status === 'waiting-permission')
+    ) {
       return undefined
     }
 
@@ -419,17 +429,30 @@ const sendWorkspaceMessage = async (
       resumeCwd = targetCwd
     }
 
-    const appended = useSessionStore.getState().appendUserMessage({
-      sessionId: targetSessionId,
-      content,
-      attachments,
-      parts,
-      cwd: targetCwd,
-      projectId: projectId ?? currentSession?.projectId
-    })
+    const appended = preAppendedMessageId
+      ? { sessionId: targetSessionId, messageId: preAppendedMessageId }
+      : useSessionStore.getState().appendUserMessage({
+          sessionId: targetSessionId,
+          content,
+          attachments,
+          parts,
+          cwd: targetCwd,
+          projectId: projectId ?? currentSession?.projectId
+        })
 
     // appendUserMessage can reject stale session ids after local deletion or hydration changes.
     if (!appended) return undefined
+
+    // A pre-appended prompt replays only the turns that precede it, so the resent turn is not
+    // duplicated into its own preamble.
+    const preAppendedCutIndex =
+      preAppendedMessageId && currentSession
+        ? currentSession.messages.findIndex((message) => message.id === preAppendedMessageId)
+        : -1
+    const historyMessages =
+      currentSession && preAppendedCutIndex >= 0
+        ? currentSession.messages.slice(0, preAppendedCutIndex)
+        : currentSession?.messages
 
     // Persisted sessions are marked running locally before async resume closes duplicate submits.
     // A resume that lands on a freshly-adopted session (framework switch, or an unresumable restart)
@@ -462,11 +485,11 @@ const sendWorkspaceMessage = async (
 
     // Replay prior turns when this resume reset the agent's context, or the caller already knows a reset
     // happened (interrupted-resume path — its internal re-resume above hits an already-attached session
-    // and can't report the reset again). currentSession was captured before the new user message was
-    // appended, so this is the prior conversation only — the turn being sent is not duplicated in.
-    if ((contextResetFromResume || forceHistoryReplay) && currentSession) {
-      historyPreamble = buildHistoryPreamble(currentSession.messages)
-      const media = buildHistoryReplayMedia(currentSession.messages)
+    // and can't report the reset again). historyMessages ends before the newly appended user message,
+    // so this is the prior conversation only — the turn being sent is not duplicated in.
+    if ((contextResetFromResume || forceHistoryReplay) && historyMessages) {
+      historyPreamble = buildHistoryPreamble(historyMessages)
+      const media = buildHistoryReplayMedia(historyMessages)
       if (supportsImageInput === false && media.images.length > 0) {
         useSessionStore
           .getState()
@@ -481,11 +504,11 @@ const sendWorkspaceMessage = async (
     }
 
     const resumeFallback =
-      forcedSkillIds && forcedSkillIds.length > 0 && currentSession
+      forcedSkillIds && forcedSkillIds.length > 0 && historyMessages
         ? (() => {
-            const media = buildHistoryReplayMedia(currentSession.messages)
+            const media = buildHistoryReplayMedia(historyMessages)
             return {
-              historyPreamble: buildHistoryPreamble(currentSession.messages),
+              historyPreamble: buildHistoryPreamble(historyMessages),
               historyAttachments: media.attachments,
               historyImages: supportsImageInput === false ? undefined : media.images
             }
@@ -717,10 +740,12 @@ const recoverContextOverflowWorkspaceSession = async (
   return true
 }
 
-// Resends an inline-edited prompt by truncating the conversation at the edited message: the agent
-// session is reset to a fresh context (ACP has no history truncation), the edited message and every
-// later turn are dropped, and the kept turns are replayed as a text preamble on the resent prompt.
-// Returns false when the reset fails so the transcript stays intact and the error is visible.
+// Resends an inline-edited prompt by truncating the conversation at the edited message. The cut and
+// the adjusted prompt's bubble are applied optimistically — the run is marked and the waiting
+// indicator shows immediately, like a composer send — then the agent session is reset (ACP has no
+// history truncation) and the kept turns are replayed as a text preamble on the resent prompt. A
+// failed reset rolls the transcript back so nothing is lost. Returns false when the flow cannot
+// start or the reset fails.
 const resendEditedWorkspaceMessage = async (
   runtime: WorkspaceMessageRuntime,
   input: ResendEditedMessageInput & { sessionId: string; messageId: string },
@@ -731,11 +756,25 @@ const resendEditedWorkspaceMessage = async (
   if (!session) return false
 
   const resumeCwd = session.cwd || runtime.state.cwd
+  const content = input.text.trim()
 
-  if (!resumeCwd) return false
+  if (!resumeCwd || !content) return false
+  if (!session.messages.some((message) => message.id === input.messageId)) return false
 
-  // Guard the reset round-trip with the neutral compacting state so no prompt or second edit can race it.
-  useSessionStore.getState().beginCompaction(input.sessionId)
+  // The optimistic cut + append: the edited message and every later turn drop out, and the adjusted
+  // prompt takes their place as a live run with its bubble and waiting indicator already visible.
+  const preEditSession = session
+  useSessionStore.getState().truncateSessionFromMessage(input.sessionId, input.messageId)
+  const appended = useSessionStore.getState().appendUserMessage({
+    sessionId: input.sessionId,
+    content,
+    attachments: [],
+    parts: input.parts,
+    cwd: resumeCwd,
+    projectId: session.projectId
+  })
+
+  if (!appended) return false
 
   try {
     await runtime.resetSessionContext(
@@ -745,16 +784,18 @@ const resendEditedWorkspaceMessage = async (
       session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
     )
   } catch (error) {
+    // Roll the transcript back to the pre-edit state so a failed reset deletes nothing, then
+    // surface the failure on the restored conversation.
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((item) => (item.id === input.sessionId ? preEditSession : item))
+    }))
     useSessionStore.getState().failRun(input.sessionId, getResumeFailureMessage(error))
     return false
   }
 
-  // Cut only after the reset succeeds so a failed reset leaves the full transcript intact.
-  useSessionStore.getState().truncateSessionFromMessage(input.sessionId, input.messageId)
-
   await sendWorkspaceMessage(runtime, {
     sessionId: input.sessionId,
-    text: input.text,
+    text: content,
     attachments: [],
     parts: input.parts,
     cwd: resumeCwd,
@@ -764,6 +805,7 @@ const resendEditedWorkspaceMessage = async (
     referencedArtifacts: input.referencedArtifacts,
     // The fresh agent session lost the prior context, so replay the truncated transcript.
     forceHistoryReplay: true,
+    preAppendedMessageId: appended.messageId,
     supportsImageInput
   })
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -495,7 +495,10 @@ const sendWorkspaceMessage = async (
     if ((contextResetFromResume || forceHistoryReplay) && historyMessages) {
       historyPreamble = buildHistoryPreamble(historyMessages)
       const media = buildHistoryReplayMedia(historyMessages)
-      if (supportsImageInput === false && media.images.length > 0) {
+      if (
+        supportsImageInput === false &&
+        (media.images.length > 0 || media.attachments.length > 0)
+      ) {
         useSessionStore.getState().failRun(targetSessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
         return appended
       }
@@ -761,12 +764,14 @@ const resendEditedWorkspaceMessage = async (
 
   if (!resumeCwd || !content || cutIndex < 0) return false
 
-  // Validate replay compatibility before the destructive cut: a kept history with images cannot be
-  // replayed on a model without image input, and discovering that after the truncation would leave
-  // the later turns dropped with no prompt dispatched.
+  // Validate replay compatibility before the destructive cut: a kept history with images — whether
+  // agent-emitted blocks or user uploads — cannot be replayed on a model without image input, and
+  // discovering that after the truncation would leave the later turns dropped with no prompt dispatched.
+  const replayMedia = buildHistoryReplayMedia(session.messages.slice(0, cutIndex))
+
   if (
     supportsImageInput === false &&
-    buildHistoryReplayMedia(session.messages.slice(0, cutIndex)).images.length > 0
+    (replayMedia.images.length > 0 || replayMedia.attachments.length > 0)
   ) {
     useSessionStore.getState().failRun(input.sessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
     return false

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -52,6 +52,18 @@ type SendWorkspaceMessageResult = {
   messageId: string
 }
 
+// Payload of an inline edit resend: the adjusted prompt text plus the mentions it carries. The
+// session/message ids stay separate because they address the truncation point, not the prompt.
+type ResendEditedMessageInput = {
+  text: string
+  // Structured mention segments of the edited draft, persisted so the resent bubble renders pills.
+  parts?: MessagePart[]
+  // Skills picked in the inline editor; force-loaded and nudged for the resent turn only.
+  forcedSkillIds?: string[]
+  // Files referenced via `@` mentions in the inline editor; attached to the resent prompt.
+  referencedArtifacts?: ArtifactReference[]
+}
+
 type WorkspaceMessageRuntime = Pick<
   ReturnType<typeof useAcpRuntime>,
   'state' | 'createSession' | 'resumeSession' | 'resetSessionContext' | 'sendPrompt'
@@ -705,6 +717,59 @@ const recoverContextOverflowWorkspaceSession = async (
   return true
 }
 
+// Resends an inline-edited prompt by truncating the conversation at the edited message: the agent
+// session is reset to a fresh context (ACP has no history truncation), the edited message and every
+// later turn are dropped, and the kept turns are replayed as a text preamble on the resent prompt.
+// Returns false when the reset fails so the transcript stays intact and the error is visible.
+const resendEditedWorkspaceMessage = async (
+  runtime: WorkspaceMessageRuntime,
+  input: ResendEditedMessageInput & { sessionId: string; messageId: string },
+  supportsImageInput?: boolean
+): Promise<boolean> => {
+  const session = useSessionStore.getState().sessions.find((item) => item.id === input.sessionId)
+
+  if (!session) return false
+
+  const resumeCwd = session.cwd || runtime.state.cwd
+
+  if (!resumeCwd) return false
+
+  // Guard the reset round-trip with the neutral compacting state so no prompt or second edit can race it.
+  useSessionStore.getState().beginCompaction(input.sessionId)
+
+  try {
+    await runtime.resetSessionContext(
+      input.sessionId,
+      resumeCwd,
+      session.projectId,
+      session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
+    )
+  } catch (error) {
+    useSessionStore.getState().failRun(input.sessionId, getResumeFailureMessage(error))
+    return false
+  }
+
+  // Cut only after the reset succeeds so a failed reset leaves the full transcript intact.
+  useSessionStore.getState().truncateSessionFromMessage(input.sessionId, input.messageId)
+
+  await sendWorkspaceMessage(runtime, {
+    sessionId: input.sessionId,
+    text: input.text,
+    attachments: [],
+    parts: input.parts,
+    cwd: resumeCwd,
+    projectId: session.projectId,
+    permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+    forcedSkillIds: input.forcedSkillIds,
+    referencedArtifacts: input.referencedArtifacts,
+    // The fresh agent session lost the prior context, so replay the truncated transcript.
+    forceHistoryReplay: true,
+    supportsImageInput
+  })
+
+  return true
+}
+
 // Scans runtime error events for the request-size overflow and triggers one auto-recovery per event.
 // handledEventIds dedups across the repeated event snapshots a bounded window re-delivers; the recovery
 // runs only for attached sessions (a detached one uses the normal Resume path) and only once per cooldown.
@@ -815,6 +880,11 @@ const useWorkspaceAgentRuntime = (): {
   permissionProfiles: Record<string, SessionPermissionProfileState>
   permissionGrants: Record<string, AcpPermissionGrant[]>
   sendMessage: (input: SendWorkspaceMessageInput) => Promise<SendWorkspaceMessageResult | undefined>
+  resendEditedMessage: (
+    sessionId: string,
+    messageId: string,
+    input: ResendEditedMessageInput
+  ) => Promise<boolean>
   cancelRun: (sessionId: string) => Promise<void>
   resumeInterruptedSession: (sessionId: string) => Promise<void>
   deleteRuntimeSession: (sessionId: string) => Promise<boolean>
@@ -872,6 +942,14 @@ const useWorkspaceAgentRuntime = (): {
   const sendMessage = useCallback(
     (input: SendWorkspaceMessageInput): Promise<SendWorkspaceMessageResult | undefined> =>
       sendWorkspaceMessage(runtime, { ...input, supportsImageInput }),
+    [runtime, supportsImageInput]
+  )
+
+  // Truncates the conversation at the edited message, then resends the adjusted prompt with the
+  // kept history replayed into the reset agent context.
+  const resendEditedMessage = useCallback(
+    (sessionId: string, messageId: string, input: ResendEditedMessageInput): Promise<boolean> =>
+      resendEditedWorkspaceMessage(runtime, { sessionId, messageId, ...input }, supportsImageInput),
     [runtime, supportsImageInput]
   )
 
@@ -951,6 +1029,7 @@ const useWorkspaceAgentRuntime = (): {
     permissionProfiles: runtime.state.permissionProfiles,
     permissionGrants: runtime.state.permissionGrants,
     sendMessage,
+    resendEditedMessage,
     cancelRun,
     resumeInterruptedSession,
     deleteRuntimeSession,
@@ -968,6 +1047,7 @@ export {
   processContextOverflowRecovery,
   processVisibleWorkspaceRuntimeEvents,
   recoverContextOverflowWorkspaceSession,
+  resendEditedWorkspaceMessage,
   resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage,
   useWorkspaceAgentRuntime

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -102,7 +102,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         onRequestReview={vi.fn()}
         isRequestReviewDisabled={false}
         canEditMessage={true}
-        onEditMessage={vi.fn()}
+        onSendEditedMessage={vi.fn()}
         {...props}
       />
     )

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -101,6 +101,8 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         onAutoReviewToggle={vi.fn()}
         onRequestReview={vi.fn()}
         isRequestReviewDisabled={false}
+        canEditMessage={true}
+        onEditMessage={vi.fn()}
         {...props}
       />
     )

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -109,9 +109,10 @@ type ConversationPanelProps = {
   onRequestReview: () => void
   // True when "Request review" should be disabled: no completed turn, already reviewed, or currently reviewing.
   isRequestReviewDisabled: boolean
-  // Inline editing of a sent prompt is only allowed once the run settles; confirm resends the doc.
+  // Inline editing of a sent prompt is only allowed once the run settles; confirming truncates the
+  // conversation at that message and resends the adjusted doc.
   canEditMessage: boolean
-  onSendEditedMessage: (doc: ComposerDoc) => void
+  onSendEditedMessage: (messageId: string, doc: ComposerDoc) => void
 }
 
 // Middle chat surface owns the visible conversation and local message composer UI.

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -30,7 +30,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { cn } from '@/lib/utils'
-import type { ChatMessage, ChatSession } from '@/stores/session-store'
+import type { ChatSession } from '@/stores/session-store'
 
 import { ComposerEditor } from './composer/ComposerEditor'
 import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
@@ -109,9 +109,9 @@ type ConversationPanelProps = {
   onRequestReview: () => void
   // True when "Request review" should be disabled: no completed turn, already reviewed, or currently reviewing.
   isRequestReviewDisabled: boolean
-  // Editing a sent user prompt reloads it into the composer draft; only allowed once the run settles.
+  // Inline editing of a sent prompt is only allowed once the run settles; confirm resends the doc.
   canEditMessage: boolean
-  onEditMessage: (message: ChatMessage) => void
+  onSendEditedMessage: (doc: ComposerDoc) => void
 }
 
 // Middle chat surface owns the visible conversation and local message composer UI.
@@ -147,11 +147,9 @@ const ConversationPanel = ({
   onRequestReview,
   isRequestReviewDisabled,
   canEditMessage,
-  onEditMessage
+  onSendEditedMessage
 }: ConversationPanelProps): React.JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
-  // Lets the edit-message action move focus into the composer after the draft doc is applied.
-  const composerEditorContainerRef = useRef<HTMLDivElement | null>(null)
   // Local so the interrupted banner can show a spinner and block a double-resume until the request settles.
   const [isResuming, setIsResuming] = useState(false)
 
@@ -177,15 +175,6 @@ const ConversationPanel = ({
   const handleSubmit = (): void => {
     if (!canEditDraft) return
     onSendMessage(docToSkillIds(draftDoc))
-  }
-
-  // Reloads a sent user prompt into the composer draft, then moves focus into the editor so the
-  // adjusted prompt can be resent as a new turn without reaching for the mouse.
-  const handleEditMessage = (message: ChatMessage): void => {
-    onEditMessage(message)
-    window.requestAnimationFrame(() => {
-      composerEditorContainerRef.current?.querySelector<HTMLElement>('[role="textbox"]')?.focus()
-    })
   }
 
   // Converts the hidden file input selection into the shared staging callback.
@@ -241,7 +230,7 @@ const ConversationPanel = ({
         <WorkspaceMessageScroller
           activeSession={activeSession}
           canEditMessage={canEditMessage}
-          onEditMessage={handleEditMessage}
+          onSendEditedMessage={onSendEditedMessage}
         />
 
         <div className="relative shrink-0">
@@ -353,7 +342,7 @@ const ConversationPanel = ({
                         </div>
                       ) : null}
 
-                      <div className="relative min-w-0 flex-1" ref={composerEditorContainerRef}>
+                      <div className="relative min-w-0 flex-1">
                         {/* Draft editing waits for persistence hydration to avoid targeting the wrong session. */}
                         <ComposerEditor
                           doc={draftDoc}

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -30,7 +30,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { cn } from '@/lib/utils'
-import type { ChatSession } from '@/stores/session-store'
+import type { ChatMessage, ChatSession } from '@/stores/session-store'
 
 import { ComposerEditor } from './composer/ComposerEditor'
 import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
@@ -109,6 +109,9 @@ type ConversationPanelProps = {
   onRequestReview: () => void
   // True when "Request review" should be disabled: no completed turn, already reviewed, or currently reviewing.
   isRequestReviewDisabled: boolean
+  // Editing a sent user prompt reloads it into the composer draft; only allowed once the run settles.
+  canEditMessage: boolean
+  onEditMessage: (message: ChatMessage) => void
 }
 
 // Middle chat surface owns the visible conversation and local message composer UI.
@@ -142,9 +145,13 @@ const ConversationPanel = ({
   onClearPermissionGrants,
   onAutoReviewToggle,
   onRequestReview,
-  isRequestReviewDisabled
+  isRequestReviewDisabled,
+  canEditMessage,
+  onEditMessage
 }: ConversationPanelProps): React.JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
+  // Lets the edit-message action move focus into the composer after the draft doc is applied.
+  const composerEditorContainerRef = useRef<HTMLDivElement | null>(null)
   // Local so the interrupted banner can show a spinner and block a double-resume until the request settles.
   const [isResuming, setIsResuming] = useState(false)
 
@@ -170,6 +177,15 @@ const ConversationPanel = ({
   const handleSubmit = (): void => {
     if (!canEditDraft) return
     onSendMessage(docToSkillIds(draftDoc))
+  }
+
+  // Reloads a sent user prompt into the composer draft, then moves focus into the editor so the
+  // adjusted prompt can be resent as a new turn without reaching for the mouse.
+  const handleEditMessage = (message: ChatMessage): void => {
+    onEditMessage(message)
+    window.requestAnimationFrame(() => {
+      composerEditorContainerRef.current?.querySelector<HTMLElement>('[role="textbox"]')?.focus()
+    })
   }
 
   // Converts the hidden file input selection into the shared staging callback.
@@ -222,7 +238,11 @@ const ConversationPanel = ({
           </button>
         </header>
 
-        <WorkspaceMessageScroller activeSession={activeSession} />
+        <WorkspaceMessageScroller
+          activeSession={activeSession}
+          canEditMessage={canEditMessage}
+          onEditMessage={handleEditMessage}
+        />
 
         <div className="relative shrink-0">
           <div
@@ -333,7 +353,7 @@ const ConversationPanel = ({
                         </div>
                       ) : null}
 
-                      <div className="relative min-w-0 flex-1">
+                      <div className="relative min-w-0 flex-1" ref={composerEditorContainerRef}>
                         {/* Draft editing waits for persistence hydration to avoid targeting the wrong session. */}
                         <ComposerEditor
                           doc={draftDoc}

--- a/src/renderer/src/pages/workspace/EditMessageConfirmDialog.tsx
+++ b/src/renderer/src/pages/workspace/EditMessageConfirmDialog.tsx
@@ -32,10 +32,10 @@ const EditMessageConfirmDialog = ({
       <AlertDialog.Overlay className="fixed inset-0 z-50 bg-black/25 backdrop-blur-[2px]" />
       <AlertDialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(420px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-bg-000 p-6 text-text-000 shadow-dialog">
         <AlertDialog.Title className="text-base font-semibold text-text-000">
-          Resend and delete later turns?
+          Resend and overwrite later turns?
         </AlertDialog.Title>
         <AlertDialog.Description className="mt-2 text-sm leading-relaxed text-text-100">
-          Sending this edited prompt will permanently delete the {subsequentTurns}{' '}
+          Sending this edited prompt will overwrite the {subsequentTurns}{' '}
           {subsequentTurns === 1 ? 'turn' : 'turns'} that follow it in this conversation. This
           action cannot be undone.
         </AlertDialog.Description>
@@ -47,7 +47,7 @@ const EditMessageConfirmDialog = ({
           </AlertDialog.Cancel>
           <AlertDialog.Action asChild>
             <Button type="button" className={confirmButtonClassName} onClick={onConfirm}>
-              Delete and resend
+              Overwrite and resend
             </Button>
           </AlertDialog.Action>
         </div>

--- a/src/renderer/src/pages/workspace/EditMessageConfirmDialog.tsx
+++ b/src/renderer/src/pages/workspace/EditMessageConfirmDialog.tsx
@@ -12,7 +12,7 @@ type EditMessageConfirmDialogProps = {
 const cancelButtonClassName =
   'border-border-200 bg-bg-000 text-text-000 hover:bg-bg-200 hover:text-text-000'
 const confirmButtonClassName =
-  'border-transparent bg-danger-000 text-white hover:bg-danger-000/90 hover:text-white'
+  'border-transparent bg-amber-500 text-white hover:bg-amber-500/90 hover:text-white'
 
 // Confirms the destructive half of an inline edit: the turns after the edited message are
 // permanently dropped before the adjusted prompt is resent.

--- a/src/renderer/src/pages/workspace/EditMessageConfirmDialog.tsx
+++ b/src/renderer/src/pages/workspace/EditMessageConfirmDialog.tsx
@@ -1,0 +1,59 @@
+import { AlertDialog } from 'radix-ui'
+
+import { Button } from '@/components/ui/button'
+
+type EditMessageConfirmDialogProps = {
+  open: boolean
+  subsequentTurns: number
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+const cancelButtonClassName =
+  'border-border-200 bg-bg-000 text-text-000 hover:bg-bg-200 hover:text-text-000'
+const confirmButtonClassName =
+  'border-transparent bg-danger-000 text-white hover:bg-danger-000/90 hover:text-white'
+
+// Confirms the destructive half of an inline edit: the turns after the edited message are
+// permanently dropped before the adjusted prompt is resent.
+const EditMessageConfirmDialog = ({
+  open,
+  subsequentTurns,
+  onCancel,
+  onConfirm
+}: EditMessageConfirmDialogProps): React.JSX.Element => (
+  <AlertDialog.Root
+    open={open}
+    onOpenChange={(nextOpen) => {
+      if (!nextOpen) onCancel()
+    }}
+  >
+    <AlertDialog.Portal>
+      <AlertDialog.Overlay className="fixed inset-0 z-50 bg-black/25 backdrop-blur-[2px]" />
+      <AlertDialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(420px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-bg-000 p-6 text-text-000 shadow-dialog">
+        <AlertDialog.Title className="text-base font-semibold text-text-000">
+          Resend and delete later turns?
+        </AlertDialog.Title>
+        <AlertDialog.Description className="mt-2 text-sm leading-relaxed text-text-100">
+          Sending this edited prompt will permanently delete the {subsequentTurns}{' '}
+          {subsequentTurns === 1 ? 'turn' : 'turns'} that follow it in this conversation. This
+          action cannot be undone.
+        </AlertDialog.Description>
+        <div className="mt-6 flex justify-end gap-2">
+          <AlertDialog.Cancel asChild>
+            <Button type="button" variant="outline" className={cancelButtonClassName}>
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action asChild>
+            <Button type="button" className={confirmButtonClassName} onClick={onConfirm}>
+              Delete and resend
+            </Button>
+          </AlertDialog.Action>
+        </div>
+      </AlertDialog.Content>
+    </AlertDialog.Portal>
+  </AlertDialog.Root>
+)
+
+export { EditMessageConfirmDialog }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -246,10 +246,10 @@ describe('WorkspaceMessageItem user message actions', () => {
 
     // The resend waits for explicit confirmation, and the dialog names the deletion cost.
     expect(onSendEditedMessage).not.toHaveBeenCalled()
-    expect(getDialog()?.textContent).toContain('Resend and delete later turns?')
+    expect(getDialog()?.textContent).toContain('Resend and overwrite later turns?')
     expect(getDialog()?.textContent).toContain('3 turns')
 
-    await click(getDialogButton('Delete and resend'))
+    await click(getDialogButton('Overwrite and resend'))
 
     expect(onSendEditedMessage).toHaveBeenCalledWith('message-1', {
       nodes: [{ type: 'text', text: 'Prompt text' }]

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 // Pins the user-bubble hover actions and the inline edit flow: copy writes the prompt to the
-// clipboard, and edit swaps the bubble for a multi-line editor whose confirm resends the prompt.
+// clipboard, edit swaps the bubble for a multi-line editor, and confirming resends the prompt —
+// with a warning first when several later turns would be deleted.
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { JSX, PropsWithChildren } from 'react'
@@ -40,7 +41,11 @@ const noop = (): void => {}
 
 const renderItem = async (
   message: ChatMessage,
-  options: { canEditMessage?: boolean; onSendEditedMessage?: (doc: ComposerDoc) => void } = {}
+  options: {
+    canEditMessage?: boolean
+    onSendEditedMessage?: (messageId: string, doc: ComposerDoc) => void
+    subsequentTurns?: number
+  } = {}
 ): Promise<void> => {
   await act(async () => {
     root.render(
@@ -52,6 +57,7 @@ const renderItem = async (
         onPreviewMentionArtifact={noop}
         canEditMessage={options.canEditMessage ?? false}
         onSendEditedMessage={options.onSendEditedMessage}
+        subsequentTurns={options.subsequentTurns ?? 0}
       />
     )
   })
@@ -65,6 +71,30 @@ const getButton = (label: string): HTMLButtonElement => {
 
 const getEditor = (): HTMLElement | null =>
   container.querySelector<HTMLElement>('[role="textbox"][aria-label="Edit message"]')
+
+// The editor card's Send/Cancel buttons are plain text buttons inside the item container.
+const getEditorCardButton = (label: string): HTMLButtonElement => {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent === label
+  )
+  if (!button) throw new Error(`button "${label}" not found`)
+  return button as HTMLButtonElement
+}
+
+// The confirmation dialog renders in a body-level portal, outside the item container.
+const getDialog = (): HTMLElement | null =>
+  document.querySelector<HTMLElement>('[role="alertdialog"]')
+
+const getDialogButton = (label: string): HTMLButtonElement => {
+  const dialog = getDialog()
+  const button = dialog
+    ? Array.from(dialog.querySelectorAll('button')).find(
+        (candidate) => candidate.textContent === label
+      )
+    : undefined
+  if (!button) throw new Error(`dialog button "${label}" not found`)
+  return button as HTMLButtonElement
+}
 
 const click = async (element: HTMLElement): Promise<void> => {
   await act(async () => {
@@ -172,11 +202,7 @@ describe('WorkspaceMessageItem user message actions', () => {
     await click(getButton('Edit message'))
     expect(getEditor()).not.toBeNull()
 
-    const cancelButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Cancel'
-    )
-    if (!cancelButton) throw new Error('Cancel button not found')
-    await click(cancelButton)
+    await click(getEditorCardButton('Cancel'))
 
     expect(getEditor()).toBeNull()
     expect(onSendEditedMessage).not.toHaveBeenCalled()
@@ -184,25 +210,71 @@ describe('WorkspaceMessageItem user message actions', () => {
     expect(container.textContent).toContain('Prompt text')
   })
 
-  it('resends the adjusted prompt as a new turn and closes the editor', async () => {
+  it('resends the adjusted prompt and closes the editor when few turns follow', async () => {
     const onSendEditedMessage = vi.fn()
-    await renderItem(createMessage(), { canEditMessage: true, onSendEditedMessage })
+    await renderItem(createMessage(), {
+      canEditMessage: true,
+      onSendEditedMessage,
+      subsequentTurns: 1
+    })
 
     await click(getButton('Edit message'))
     const editor = getEditor()
     if (!editor) throw new Error('editor not found')
 
     await typeIntoEditor(editor, 'edited prompt')
+    await click(getEditorCardButton('Send'))
 
-    const sendButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Send'
-    )
-    if (!sendButton) throw new Error('Send button not found')
-    await click(sendButton)
-
-    expect(onSendEditedMessage).toHaveBeenCalledWith({
+    // With fewer than two later turns the resend proceeds without the destructive warning.
+    expect(getDialog()).toBeNull()
+    expect(onSendEditedMessage).toHaveBeenCalledWith('message-1', {
       nodes: [{ type: 'text', text: 'edited prompt' }]
     })
     expect(getEditor()).toBeNull()
+  })
+
+  it('warns before a destructive resend when several turns follow the edited message', async () => {
+    const onSendEditedMessage = vi.fn()
+    await renderItem(createMessage(), {
+      canEditMessage: true,
+      onSendEditedMessage,
+      subsequentTurns: 3
+    })
+
+    await click(getButton('Edit message'))
+    await click(getEditorCardButton('Send'))
+
+    // The resend waits for explicit confirmation, and the dialog names the deletion cost.
+    expect(onSendEditedMessage).not.toHaveBeenCalled()
+    expect(getDialog()?.textContent).toContain('Resend and delete later turns?')
+    expect(getDialog()?.textContent).toContain('3 turns')
+
+    await click(getDialogButton('Delete and resend'))
+
+    expect(onSendEditedMessage).toHaveBeenCalledWith('message-1', {
+      nodes: [{ type: 'text', text: 'Prompt text' }]
+    })
+    expect(getDialog()).toBeNull()
+    expect(getEditor()).toBeNull()
+  })
+
+  it('keeps the editor open when the deletion warning is cancelled', async () => {
+    const onSendEditedMessage = vi.fn()
+    await renderItem(createMessage(), {
+      canEditMessage: true,
+      onSendEditedMessage,
+      subsequentTurns: 2
+    })
+
+    await click(getButton('Edit message'))
+    await click(getEditorCardButton('Send'))
+    expect(getDialog()).not.toBeNull()
+
+    await click(getDialogButton('Cancel'))
+
+    expect(onSendEditedMessage).not.toHaveBeenCalled()
+    expect(getDialog()).toBeNull()
+    // The editor stays open so the adjusted draft is not lost.
+    expect(getEditor()).not.toBeNull()
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+// Pins the user-bubble hover actions: copy writes the prompt to the clipboard, and edit is gated
+// by the settled-run flag and hands the message back so the page can reload it into the composer.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { JSX, PropsWithChildren } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChatMessage } from '@/stores/session-store'
+
+import { WorkspaceMessageItem } from './WorkspaceMessageItem'
+
+// Keep the transcript row and markdown surface as thin wrappers so the test never loads Shiki.
+vi.mock('@/components/ui/message-scroller', () => ({
+  MessageScrollerItem: ({ children }: PropsWithChildren): JSX.Element => <div>{children}</div>
+}))
+
+vi.mock('@/components/streamdown/AgentMarkdown', () => ({
+  AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+const writeText = vi.fn().mockResolvedValue(undefined)
+
+const createMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: 'message-1',
+  role: 'user',
+  content: 'Prompt text',
+  status: 'complete',
+  eventIds: [],
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000,
+  ...overrides
+})
+
+const noop = (): void => {}
+
+const renderItem = async (
+  message: ChatMessage,
+  options: { canEditMessage?: boolean; onEditMessage?: (message: ChatMessage) => void } = {}
+): Promise<void> => {
+  await act(async () => {
+    root.render(
+      <WorkspaceMessageItem
+        message={message}
+        onPreviewArtifact={noop}
+        onPreviewUploadAttachment={noop}
+        onOpenSkillMention={noop}
+        onPreviewMentionArtifact={noop}
+        canEditMessage={options.canEditMessage ?? false}
+        onEditMessage={options.onEditMessage}
+      />
+    )
+  })
+}
+
+const getButton = (label: string): HTMLButtonElement => {
+  const button = container.querySelector<HTMLButtonElement>(`[aria-label="${label}"]`)
+  if (!button) throw new Error(`button "${label}" not found`)
+  return button
+}
+
+const click = async (element: HTMLElement): Promise<void> => {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+beforeEach(() => {
+  writeText.mockClear()
+  Object.defineProperty(window.navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+describe('WorkspaceMessageItem user message actions', () => {
+  it('renders copy and edit actions next to user bubbles only', async () => {
+    await renderItem(createMessage())
+
+    expect(container.querySelector('[aria-label="Copy message"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="Edit message"]')).not.toBeNull()
+
+    await renderItem(createMessage({ role: 'agent' }))
+
+    expect(container.querySelector('[aria-label="Copy message"]')).toBeNull()
+    expect(container.querySelector('[aria-label="Edit message"]')).toBeNull()
+  })
+
+  it('copies the message content and confirms with a transient check state', async () => {
+    vi.useFakeTimers()
+    try {
+      await renderItem(createMessage({ content: 'copy me' }))
+
+      await click(getButton('Copy message'))
+
+      expect(writeText).toHaveBeenCalledWith('copy me')
+      // The resolved clipboard write swaps the icon to a check until the reset timer fires.
+      expect(container.querySelector('[aria-label="Copied"]')).not.toBeNull()
+
+      act(() => {
+        vi.advanceTimersByTime(2000)
+      })
+
+      expect(container.querySelector('[aria-label="Copy message"]')).not.toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps edit disabled while the run has not settled', async () => {
+    const onEditMessage = vi.fn()
+    await renderItem(createMessage(), { canEditMessage: false, onEditMessage })
+
+    const editButton = getButton('Edit message')
+    expect(editButton.disabled).toBe(true)
+
+    await click(editButton)
+    expect(onEditMessage).not.toHaveBeenCalled()
+  })
+
+  it('hands the message back for editing once the run has settled', async () => {
+    const onEditMessage = vi.fn()
+    const message = createMessage()
+    await renderItem(message, { canEditMessage: true, onEditMessage })
+
+    const editButton = getButton('Edit message')
+    expect(editButton.disabled).toBe(false)
+
+    await click(editButton)
+    expect(onEditMessage).toHaveBeenCalledWith(message)
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-// Pins the user-bubble hover actions: copy writes the prompt to the clipboard, and edit is gated
-// by the settled-run flag and hands the message back so the page can reload it into the composer.
+// Pins the user-bubble hover actions and the inline edit flow: copy writes the prompt to the
+// clipboard, and edit swaps the bubble for a multi-line editor whose confirm resends the prompt.
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { JSX, PropsWithChildren } from 'react'
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/stores/session-store'
 
+import type { ComposerDoc } from './composer/composer-doc'
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
 
 // Keep the transcript row and markdown surface as thin wrappers so the test never loads Shiki.
@@ -39,7 +40,7 @@ const noop = (): void => {}
 
 const renderItem = async (
   message: ChatMessage,
-  options: { canEditMessage?: boolean; onEditMessage?: (message: ChatMessage) => void } = {}
+  options: { canEditMessage?: boolean; onSendEditedMessage?: (doc: ComposerDoc) => void } = {}
 ): Promise<void> => {
   await act(async () => {
     root.render(
@@ -50,7 +51,7 @@ const renderItem = async (
         onOpenSkillMention={noop}
         onPreviewMentionArtifact={noop}
         canEditMessage={options.canEditMessage ?? false}
-        onEditMessage={options.onEditMessage}
+        onSendEditedMessage={options.onSendEditedMessage}
       />
     )
   })
@@ -62,9 +63,20 @@ const getButton = (label: string): HTMLButtonElement => {
   return button
 }
 
+const getEditor = (): HTMLElement | null =>
+  container.querySelector<HTMLElement>('[role="textbox"][aria-label="Edit message"]')
+
 const click = async (element: HTMLElement): Promise<void> => {
   await act(async () => {
     element.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+// Replaces the inline editor's text and lets the editor emit the updated doc, mimicking a typing pass.
+const typeIntoEditor = async (editor: HTMLElement, text: string): Promise<void> => {
+  await act(async () => {
+    editor.textContent = text
+    editor.dispatchEvent(new InputEvent('input', { bubbles: true }))
   })
 }
 
@@ -119,26 +131,78 @@ describe('WorkspaceMessageItem user message actions', () => {
     }
   })
 
-  it('keeps edit disabled while the run has not settled', async () => {
-    const onEditMessage = vi.fn()
-    await renderItem(createMessage(), { canEditMessage: false, onEditMessage })
+  it('keeps the editor closed while the run has not settled', async () => {
+    const onSendEditedMessage = vi.fn()
+    await renderItem(createMessage(), { canEditMessage: false, onSendEditedMessage })
 
     const editButton = getButton('Edit message')
     expect(editButton.disabled).toBe(true)
 
     await click(editButton)
-    expect(onEditMessage).not.toHaveBeenCalled()
+    expect(getEditor()).toBeNull()
+    expect(onSendEditedMessage).not.toHaveBeenCalled()
   })
 
-  it('hands the message back for editing once the run has settled', async () => {
-    const onEditMessage = vi.fn()
-    const message = createMessage()
-    await renderItem(message, { canEditMessage: true, onEditMessage })
+  it('opens an inline editor prefilled from the message, restoring mention chips', async () => {
+    await renderItem(
+      createMessage({
+        content: 'Run /forecast now',
+        parts: [
+          { type: 'text', text: 'Run ' },
+          { type: 'skill', id: 'skill-forecast', name: 'forecast' },
+          { type: 'text', text: ' now' }
+        ]
+      }),
+      { canEditMessage: true }
+    )
 
-    const editButton = getButton('Edit message')
-    expect(editButton.disabled).toBe(false)
+    await click(getButton('Edit message'))
 
-    await click(editButton)
-    expect(onEditMessage).toHaveBeenCalledWith(message)
+    const editor = getEditor()
+    expect(editor).not.toBeNull()
+    expect(editor?.textContent).toBe('Run /forecast now')
+    // The structured skill segment comes back as a chip, not flattened text.
+    expect(editor?.querySelector('[data-mention-type="skill"]')).not.toBeNull()
+  })
+
+  it('cancels editing and restores the bubble without resending', async () => {
+    const onSendEditedMessage = vi.fn()
+    await renderItem(createMessage(), { canEditMessage: true, onSendEditedMessage })
+
+    await click(getButton('Edit message'))
+    expect(getEditor()).not.toBeNull()
+
+    const cancelButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Cancel'
+    )
+    if (!cancelButton) throw new Error('Cancel button not found')
+    await click(cancelButton)
+
+    expect(getEditor()).toBeNull()
+    expect(onSendEditedMessage).not.toHaveBeenCalled()
+    // The original bubble content is back.
+    expect(container.textContent).toContain('Prompt text')
+  })
+
+  it('resends the adjusted prompt as a new turn and closes the editor', async () => {
+    const onSendEditedMessage = vi.fn()
+    await renderItem(createMessage(), { canEditMessage: true, onSendEditedMessage })
+
+    await click(getButton('Edit message'))
+    const editor = getEditor()
+    if (!editor) throw new Error('editor not found')
+
+    await typeIntoEditor(editor, 'edited prompt')
+
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Send'
+    )
+    if (!sendButton) throw new Error('Send button not found')
+    await click(sendButton)
+
+    expect(onSendEditedMessage).toHaveBeenCalledWith({
+      nodes: [{ type: 'text', text: 'edited prompt' }]
+    })
+    expect(getEditor()).toBeNull()
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -10,6 +10,14 @@ import type { MessagePart } from '../../../../shared/session-persistence'
 import { getUploadedAttachmentName } from '../../../../shared/uploads'
 
 import { ArtifactPreview } from './artifact-preview'
+import { ComposerEditor } from './composer/ComposerEditor'
+import {
+  docFromMessageParts,
+  docFromText,
+  docIsEmpty,
+  emptyDoc,
+  type ComposerDoc
+} from './composer/composer-doc'
 import {
   ARTIFACT_PREVIEW_BYTES,
   getArtifactName,
@@ -30,9 +38,9 @@ type WorkspaceMessageItemProps = {
   onOpenSkillMention: (skillId: string, name: string) => void
   onPreviewMentionArtifact: (part: ArtifactMentionPart) => void
   artifacts?: MessageArtifact[]
-  // Edit reloads the prompt into the composer draft; only enabled once the session's run settles.
+  // Inline editing is only enabled once the session's run settles; confirm resends as a new turn.
   canEditMessage?: boolean
-  onEditMessage?: (message: ChatMessage) => void
+  onSendEditedMessage?: (doc: ComposerDoc) => void
 }
 
 const ARTIFACT_GALLERY_VISIBLE_COUNT = 5
@@ -48,6 +56,15 @@ const userMessageActionsClassName =
   'flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100'
 const userMessageActionButtonClassName =
   'flex size-6 items-center justify-center rounded-md text-text-300 transition-colors duration-200 ease-out hover:bg-bg-200 hover:text-text-100 disabled:cursor-not-allowed disabled:opacity-50'
+// Inline editing replaces the bubble with a bordered multi-line editor card aligned to the right.
+const editCardClassName =
+  'flex w-[85%] max-w-[56rem] flex-col gap-2 rounded-2xl border border-border-200 bg-bg-000 px-3 py-2 shadow-card'
+const editCancelButtonClassName =
+  'flex h-7 items-center rounded-md px-2.5 text-[12px] font-medium text-text-300 transition-colors duration-200 ease-out hover:bg-bg-200 hover:text-text-100'
+const editSendButtonClassName =
+  'flex h-7 items-center rounded-md bg-primary px-2.5 text-[12px] font-medium text-primary-foreground transition-colors duration-200 ease-out hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-primary'
+// The inline editor ignores pasted files; plain-text paste is handled by the editor itself.
+const ignoreEditPaste = (): void => {}
 // Staged uploads render as gray file pills inside the sent bubble.
 const uploadedAttachmentButtonClassName =
   'inline-flex max-w-full items-center gap-1.5 rounded-md border border-border-200 bg-bg-200 px-2 py-0.5 text-left text-[13px] leading-5 text-text-000 transition-colors hover:bg-bg-000 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
@@ -343,12 +360,16 @@ const WorkspaceMessageItem = ({
   onOpenSkillMention,
   onPreviewMentionArtifact,
   canEditMessage = false,
-  onEditMessage,
+  onSendEditedMessage,
   artifacts = []
 }: WorkspaceMessageItemProps): React.JSX.Element => {
   const isUserMessage = message.role === 'user'
   const uploads = message.uploads ?? []
   const [copied, setCopied] = useState(false)
+  // Inline editing swaps the bubble for a multi-line editor; the doc starts from the message's
+  // structured parts so mention chips survive the round-trip.
+  const [isEditing, setIsEditing] = useState(false)
+  const [editDoc, setEditDoc] = useState<ComposerDoc>(emptyDoc)
   const copyResetTimeoutRef = useRef<number | null>(null)
 
   // Clear a pending copied-state reset so it never fires setState after unmount.
@@ -368,6 +389,29 @@ const WorkspaceMessageItem = ({
     })
   }
 
+  // Opens the inline editor with the prompt rebuilt as a composer doc (mention chips restored when
+  // the message carries structured parts, plain text otherwise).
+  const handleStartEdit = (): void => {
+    setEditDoc(
+      message.parts && message.parts.length > 0
+        ? docFromMessageParts(message.parts)
+        : docFromText(message.content)
+    )
+    setIsEditing(true)
+  }
+
+  const handleCancelEdit = (): void => {
+    setIsEditing(false)
+  }
+
+  // Confirms the inline edit: the adjusted prompt is resent as a new turn, then the editor closes.
+  const handleConfirmEdit = (): void => {
+    if (!canEditMessage || docIsEmpty(editDoc)) return
+
+    onSendEditedMessage?.(editDoc)
+    setIsEditing(false)
+  }
+
   return (
     <MessageScrollerItem
       key={message.id}
@@ -378,50 +422,83 @@ const WorkspaceMessageItem = ({
       <div className="px-4 pb-1 pt-5 md:px-6">
         {/* User prompts stay compact; assistant responses remain a readable transcript surface. */}
         {isUserMessage ? (
-          <div className="group flex items-center justify-end gap-1">
-            {/* Copy/edit actions ride to the left of the user bubble, surfaced on hover or focus. */}
-            <div className={userMessageActionsClassName}>
-              <button
-                type="button"
-                className={userMessageActionButtonClassName}
-                aria-label={copied ? 'Copied' : 'Copy message'}
-                onClick={handleCopyMessage}
-              >
-                {copied ? (
-                  <Check className="size-3.5" strokeWidth={2} aria-hidden="true" />
-                ) : (
-                  <Copy className="size-3.5" strokeWidth={2} aria-hidden="true" />
-                )}
-              </button>
-              <button
-                type="button"
-                className={userMessageActionButtonClassName}
-                aria-label="Edit message"
-                disabled={!canEditMessage}
-                onClick={() => onEditMessage?.(message)}
-              >
-                <Pencil className="size-3.5" strokeWidth={2} aria-hidden="true" />
-              </button>
-            </div>
-            <div className={userMessageBubbleClassName}>
-              <MessageUploadAttachmentList
-                attachments={uploads}
-                onPreviewUploadAttachment={onPreviewUploadAttachment}
-              />
-              {/* Structured parts drive styled pills; plain content is the backward-compatible fallback. */}
-              {message.parts && message.parts.length > 0 ? (
-                <MessagePartsContent
-                  parts={message.parts}
-                  onOpenSkillMention={onOpenSkillMention}
-                  onPreviewMentionArtifact={onPreviewMentionArtifact}
+          isEditing ? (
+            <div className="flex justify-end">
+              {/* Inline editing swaps the bubble for a multi-line editor; confirm resends the prompt. */}
+              <div className={editCardClassName}>
+                <ComposerEditor
+                  doc={editDoc}
+                  onDocChange={setEditDoc}
+                  onSubmit={handleConfirmEdit}
+                  onPaste={ignoreEditPaste}
+                  placeholder="Edit your message"
+                  ariaLabel="Edit message"
                 />
-              ) : message.content ? (
-                <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
-                  {message.content}
-                </p>
-              ) : null}
+                <div className="flex items-center justify-end gap-1">
+                  <button
+                    type="button"
+                    className={editCancelButtonClassName}
+                    onClick={handleCancelEdit}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className={editSendButtonClassName}
+                    disabled={!canEditMessage || docIsEmpty(editDoc)}
+                    onClick={handleConfirmEdit}
+                  >
+                    Send
+                  </button>
+                </div>
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="group flex items-center justify-end gap-1">
+              {/* Copy/edit actions ride to the left of the user bubble, surfaced on hover or focus. */}
+              <div className={userMessageActionsClassName}>
+                <button
+                  type="button"
+                  className={userMessageActionButtonClassName}
+                  aria-label={copied ? 'Copied' : 'Copy message'}
+                  onClick={handleCopyMessage}
+                >
+                  {copied ? (
+                    <Check className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                  ) : (
+                    <Copy className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  className={userMessageActionButtonClassName}
+                  aria-label="Edit message"
+                  disabled={!canEditMessage}
+                  onClick={handleStartEdit}
+                >
+                  <Pencil className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                </button>
+              </div>
+              <div className={userMessageBubbleClassName}>
+                <MessageUploadAttachmentList
+                  attachments={uploads}
+                  onPreviewUploadAttachment={onPreviewUploadAttachment}
+                />
+                {/* Structured parts drive styled pills; plain content is the backward-compatible fallback. */}
+                {message.parts && message.parts.length > 0 ? (
+                  <MessagePartsContent
+                    parts={message.parts}
+                    onOpenSkillMention={onOpenSkillMention}
+                    onPreviewMentionArtifact={onPreviewMentionArtifact}
+                  />
+                ) : message.content ? (
+                  <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                    {message.content}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          )
         ) : (
           <div className={cn(assistantMessageSurfaceClassName, 'select-text overflow-visible')}>
             {message.content ? (

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -3,8 +3,8 @@ import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { cn, formatByteSize } from '@/lib/utils'
 import type { ChatMessage, ChatSession } from '@/stores/session-store'
 import { Collapsible } from 'radix-ui'
-import { FileText, Image as ImageIcon } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { Check, Copy, FileText, Image as ImageIcon, Pencil } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 import type { ArtifactPreviewResult } from '../../../../shared/artifacts'
 import type { MessagePart } from '../../../../shared/session-persistence'
 import { getUploadedAttachmentName } from '../../../../shared/uploads'
@@ -30,6 +30,9 @@ type WorkspaceMessageItemProps = {
   onOpenSkillMention: (skillId: string, name: string) => void
   onPreviewMentionArtifact: (part: ArtifactMentionPart) => void
   artifacts?: MessageArtifact[]
+  // Edit reloads the prompt into the composer draft; only enabled once the session's run settles.
+  canEditMessage?: boolean
+  onEditMessage?: (message: ChatMessage) => void
 }
 
 const ARTIFACT_GALLERY_VISIBLE_COUNT = 5
@@ -40,6 +43,11 @@ const artifactGalleryClassName = 'grid max-w-full grid-cols-[repeat(auto-fill,12
 
 const userMessageBubbleClassName =
   'max-w-[90%] break-words rounded-2xl bg-bg-300 px-3.5 py-2 text-sm text-message-user-text md:max-w-[min(85%,56rem)] md:px-4 md:py-2.5 md:text-[15px]'
+// Hover actions (copy / edit) sit to the left of the user bubble, revealed on row hover or focus.
+const userMessageActionsClassName =
+  'flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100'
+const userMessageActionButtonClassName =
+  'flex size-6 items-center justify-center rounded-md text-text-300 transition-colors duration-200 ease-out hover:bg-bg-200 hover:text-text-100 disabled:cursor-not-allowed disabled:opacity-50'
 // Staged uploads render as gray file pills inside the sent bubble.
 const uploadedAttachmentButtonClassName =
   'inline-flex max-w-full items-center gap-1.5 rounded-md border border-border-200 bg-bg-200 px-2 py-0.5 text-left text-[13px] leading-5 text-text-000 transition-colors hover:bg-bg-000 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
@@ -334,10 +342,31 @@ const WorkspaceMessageItem = ({
   onPreviewUploadAttachment,
   onOpenSkillMention,
   onPreviewMentionArtifact,
+  canEditMessage = false,
+  onEditMessage,
   artifacts = []
 }: WorkspaceMessageItemProps): React.JSX.Element => {
   const isUserMessage = message.role === 'user'
   const uploads = message.uploads ?? []
+  const [copied, setCopied] = useState(false)
+  const copyResetTimeoutRef = useRef<number | null>(null)
+
+  // Clear a pending copied-state reset so it never fires setState after unmount.
+  useEffect(
+    () => () => {
+      if (copyResetTimeoutRef.current !== null) window.clearTimeout(copyResetTimeoutRef.current)
+    },
+    []
+  )
+
+  // Copies the prompt text and briefly swaps the icon to confirm the clipboard write succeeded.
+  const handleCopyMessage = (): void => {
+    void navigator.clipboard.writeText(message.content).then(() => {
+      setCopied(true)
+      if (copyResetTimeoutRef.current !== null) window.clearTimeout(copyResetTimeoutRef.current)
+      copyResetTimeoutRef.current = window.setTimeout(() => setCopied(false), 2000)
+    })
+  }
 
   return (
     <MessageScrollerItem
@@ -349,7 +378,31 @@ const WorkspaceMessageItem = ({
       <div className="px-4 pb-1 pt-5 md:px-6">
         {/* User prompts stay compact; assistant responses remain a readable transcript surface. */}
         {isUserMessage ? (
-          <div className="flex justify-end">
+          <div className="group flex items-center justify-end gap-1">
+            {/* Copy/edit actions ride to the left of the user bubble, surfaced on hover or focus. */}
+            <div className={userMessageActionsClassName}>
+              <button
+                type="button"
+                className={userMessageActionButtonClassName}
+                aria-label={copied ? 'Copied' : 'Copy message'}
+                onClick={handleCopyMessage}
+              >
+                {copied ? (
+                  <Check className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                ) : (
+                  <Copy className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                )}
+              </button>
+              <button
+                type="button"
+                className={userMessageActionButtonClassName}
+                aria-label="Edit message"
+                disabled={!canEditMessage}
+                onClick={() => onEditMessage?.(message)}
+              >
+                <Pencil className="size-3.5" strokeWidth={2} aria-hidden="true" />
+              </button>
+            </div>
             <div className={userMessageBubbleClassName}>
               <MessageUploadAttachmentList
                 attachments={uploads}

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -11,6 +11,7 @@ import { getUploadedAttachmentName } from '../../../../shared/uploads'
 
 import { ArtifactPreview } from './artifact-preview'
 import { ComposerEditor } from './composer/ComposerEditor'
+import { EditMessageConfirmDialog } from './EditMessageConfirmDialog'
 import {
   docFromMessageParts,
   docFromText,
@@ -38,9 +39,12 @@ type WorkspaceMessageItemProps = {
   onOpenSkillMention: (skillId: string, name: string) => void
   onPreviewMentionArtifact: (part: ArtifactMentionPart) => void
   artifacts?: MessageArtifact[]
-  // Inline editing is only enabled once the session's run settles; confirm resends as a new turn.
+  // Inline editing is only enabled once the session's run settles; confirming truncates the
+  // conversation at this message and resends the adjusted doc as a fresh turn.
   canEditMessage?: boolean
-  onSendEditedMessage?: (doc: ComposerDoc) => void
+  onSendEditedMessage?: (messageId: string, doc: ComposerDoc) => void
+  // Number of user turns after this message; drives the destructive-resend warning threshold.
+  subsequentTurns?: number
 }
 
 const ARTIFACT_GALLERY_VISIBLE_COUNT = 5
@@ -65,6 +69,8 @@ const editSendButtonClassName =
   'flex h-7 items-center rounded-md bg-primary px-2.5 text-[12px] font-medium text-primary-foreground transition-colors duration-200 ease-out hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-primary'
 // The inline editor ignores pasted files; plain-text paste is handled by the editor itself.
 const ignoreEditPaste = (): void => {}
+// Resending an edit drops every turn after the edited one; from this many turns up, ask first.
+const EDIT_TRUNCATION_WARNING_TURNS = 2
 // Staged uploads render as gray file pills inside the sent bubble.
 const uploadedAttachmentButtonClassName =
   'inline-flex max-w-full items-center gap-1.5 rounded-md border border-border-200 bg-bg-200 px-2 py-0.5 text-left text-[13px] leading-5 text-text-000 transition-colors hover:bg-bg-000 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
@@ -361,6 +367,7 @@ const WorkspaceMessageItem = ({
   onPreviewMentionArtifact,
   canEditMessage = false,
   onSendEditedMessage,
+  subsequentTurns = 0,
   artifacts = []
 }: WorkspaceMessageItemProps): React.JSX.Element => {
   const isUserMessage = message.role === 'user'
@@ -370,6 +377,8 @@ const WorkspaceMessageItem = ({
   // structured parts so mention chips survive the round-trip.
   const [isEditing, setIsEditing] = useState(false)
   const [editDoc, setEditDoc] = useState<ComposerDoc>(emptyDoc)
+  // True while the destructive-resend confirmation dialog is open.
+  const [isConfirmingEdit, setIsConfirmingEdit] = useState(false)
   const copyResetTimeoutRef = useRef<number | null>(null)
 
   // Clear a pending copied-state reset so it never fires setState after unmount.
@@ -404,12 +413,24 @@ const WorkspaceMessageItem = ({
     setIsEditing(false)
   }
 
-  // Confirms the inline edit: the adjusted prompt is resent as a new turn, then the editor closes.
+  // The destructive resend itself: the conversation is truncated at this message and the adjusted
+  // prompt is resent as a fresh turn, then the editor closes.
+  const confirmEditedResend = (): void => {
+    onSendEditedMessage?.(message.id, editDoc)
+    setIsConfirmingEdit(false)
+    setIsEditing(false)
+  }
+
+  // Confirms the inline edit; with several later turns at stake, ask before the destructive resend.
   const handleConfirmEdit = (): void => {
     if (!canEditMessage || docIsEmpty(editDoc)) return
 
-    onSendEditedMessage?.(editDoc)
-    setIsEditing(false)
+    if (subsequentTurns >= EDIT_TRUNCATION_WARNING_TURNS) {
+      setIsConfirmingEdit(true)
+      return
+    }
+
+    confirmEditedResend()
   }
 
   return (
@@ -512,6 +533,12 @@ const WorkspaceMessageItem = ({
           </div>
         )}
       </div>
+      <EditMessageConfirmDialog
+        open={isConfirmingEdit}
+        subsequentTurns={subsequentTurns}
+        onCancel={() => setIsConfirmingEdit(false)}
+        onConfirm={confirmEditedResend}
+      />
     </MessageScrollerItem>
   )
 }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -147,7 +147,13 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspaceMessageScroller activeSession={session} />)
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={session}
+          canEditMessage={false}
+          onEditMessage={vi.fn()}
+        />
+      )
     })
 
     const card = container.querySelector<HTMLButtonElement>(
@@ -204,7 +210,13 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspaceMessageScroller activeSession={session} />)
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={session}
+          canEditMessage={false}
+          onEditMessage={vi.fn()}
+        />
+      )
     })
 
     const card = container.querySelector<HTMLButtonElement>(
@@ -235,7 +247,13 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspaceMessageScroller activeSession={session} />)
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={session}
+          canEditMessage={false}
+          onEditMessage={vi.fn()}
+        />
+      )
     })
 
     const uploadButton = container.querySelector<HTMLButtonElement>(
@@ -303,7 +321,13 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspaceMessageScroller activeSession={session} />)
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={session}
+          canEditMessage={false}
+          onEditMessage={vi.fn()}
+        />
+      )
     })
     expect(window.api.artifacts.readPreview).not.toHaveBeenCalled()
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -151,7 +151,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         <WorkspaceMessageScroller
           activeSession={session}
           canEditMessage={false}
-          onEditMessage={vi.fn()}
+          onSendEditedMessage={vi.fn()}
         />
       )
     })
@@ -214,7 +214,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         <WorkspaceMessageScroller
           activeSession={session}
           canEditMessage={false}
-          onEditMessage={vi.fn()}
+          onSendEditedMessage={vi.fn()}
         />
       )
     })
@@ -251,7 +251,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         <WorkspaceMessageScroller
           activeSession={session}
           canEditMessage={false}
-          onEditMessage={vi.fn()}
+          onSendEditedMessage={vi.fn()}
         />
       )
     })
@@ -325,7 +325,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         <WorkspaceMessageScroller
           activeSession={session}
           canEditMessage={false}
-          onEditMessage={vi.fn()}
+          onSendEditedMessage={vi.fn()}
         />
       )
     })

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -138,7 +138,13 @@ const createUpload = (overrides: Partial<UploadedAttachment> = {}): UploadedAtta
 const renderScroller = async (session: ChatSession): Promise<string> => {
   const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
 
-  return renderToStaticMarkup(<WorkspaceMessageScroller activeSession={session} />)
+  return renderToStaticMarkup(
+    <WorkspaceMessageScroller
+      activeSession={session}
+      canEditMessage={false}
+      onEditMessage={vi.fn()}
+    />
+  )
 }
 
 describe('WorkspaceMessageScroller loading render', () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -195,7 +195,7 @@ describe('WorkspaceMessageScroller loading render', () => {
     expect(html).toContain('Answer text')
   })
 
-  it('does not render loading for permission waits or missing active runs', async () => {
+  it('keeps the loading row during permission waits and hides it without an active run', async () => {
     const runningSession = createSession({
       activeRun: {
         promptMessageId: 'prompt-1',
@@ -204,12 +204,41 @@ describe('WorkspaceMessageScroller loading render', () => {
       messages: [createMessage({ id: 'prompt-1' })]
     })
 
+    // A permission wait is still mid-run, so the transcript keeps the working indicator.
     await expect(
       renderScroller({ ...runningSession, status: 'waiting-permission' })
-    ).resolves.not.toContain('role="status"')
+    ).resolves.toContain('role="status"')
     await expect(
       renderScroller({ ...runningSession, activeRun: undefined })
     ).resolves.not.toContain('role="status"')
+  })
+
+  it('renders the loading row for a follow-up prompt after a tool-calling turn', async () => {
+    const html = await renderScroller(
+      createSession({
+        activeRun: {
+          promptMessageId: 'prompt-2',
+          startedAt: 1710000000200
+        },
+        messages: [
+          createMessage({ id: 'prompt-1', content: 'First prompt', sortIndex: 1 }),
+          createMessage({
+            id: 'reply-1',
+            role: 'agent',
+            content: 'First answer',
+            status: 'complete',
+            streamId: 'stream-1',
+            responseToMessageId: 'prompt-1',
+            sortIndex: 2
+          }),
+          createMessage({ id: 'prompt-2', content: 'Follow up', sortIndex: 4 })
+        ],
+        activities: [createActivity({ id: 'tool-1', sortIndex: 3 })]
+      })
+    )
+
+    expect(html).toContain('role="status"')
+    expect(html).toContain('Agent is responding')
   })
 
   it('renders generated artifact gallery cards under agent messages', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -204,9 +204,27 @@ describe('WorkspaceMessageScroller loading render', () => {
       messages: [createMessage({ id: 'prompt-1' })]
     })
 
-    // A permission wait is still mid-run, so the transcript keeps the working indicator.
+    // A permission wait is still mid-run, so the transcript keeps the working indicator — even
+    // when the agent already streamed visible text before asking.
     await expect(
       renderScroller({ ...runningSession, status: 'waiting-permission' })
+    ).resolves.toContain('role="status"')
+    await expect(
+      renderScroller({
+        ...runningSession,
+        status: 'waiting-permission',
+        messages: [
+          createMessage({ id: 'prompt-1' }),
+          createMessage({
+            id: 'reply-1',
+            role: 'agent',
+            content: "I'll inspect the files",
+            status: 'streaming',
+            streamId: 'stream-1',
+            responseToMessageId: 'prompt-1'
+          })
+        ]
+      })
     ).resolves.toContain('role="status"')
     await expect(
       renderScroller({ ...runningSession, activeRun: undefined })

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -142,7 +142,7 @@ const renderScroller = async (session: ChatSession): Promise<string> => {
     <WorkspaceMessageScroller
       activeSession={session}
       canEditMessage={false}
-      onEditMessage={vi.fn()}
+      onSendEditedMessage={vi.fn()}
     />
   )
 }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -33,9 +33,10 @@ import type { ComposerDoc } from './composer/composer-doc'
 
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
-  // Gates inline editing of sent user prompts; the handler resends the edited doc as a new turn.
+  // Gates inline editing of sent user prompts; the handler truncates at the edited message and
+  // resends the adjusted doc as a fresh turn.
   canEditMessage: boolean
-  onSendEditedMessage: (doc: ComposerDoc) => void
+  onSendEditedMessage: (messageId: string, doc: ComposerDoc) => void
 }
 
 type SessionScopedActivityGroupState = {
@@ -149,6 +150,18 @@ const WorkspaceMessageScroller = ({
       : {}
   const conversationItems = groupConversationItems(createConversationItems(activeSession))
   const showAgentLoadingMessage = shouldShowAgentLoadingMessage(activeSession)
+
+  // Counts the user turns after each message; the destructive-resend warning keys off turns, not
+  // raw message count, so a single follow-up turn stays warning-free.
+  const subsequentTurnCountByMessageId = new Map<string, number>()
+  if (activeSession) {
+    let subsequentTurns = 0
+    for (let index = activeSession.messages.length - 1; index >= 0; index -= 1) {
+      const message = activeSession.messages[index]
+      subsequentTurnCountByMessageId.set(message.id, subsequentTurns)
+      if (message.role === 'user') subsequentTurns += 1
+    }
+  }
 
   // Transient "no longer available" pill shown when a mention target can't be opened.
   const [mentionNotice, setMentionNotice] = useState<string | null>(null)
@@ -323,6 +336,7 @@ const WorkspaceMessageScroller = ({
                         onPreviewMentionArtifact={onPreviewMentionArtifact}
                         canEditMessage={canEditMessage}
                         onSendEditedMessage={onSendEditedMessage}
+                        subsequentTurns={subsequentTurnCountByMessageId.get(item.message.id) ?? 0}
                         artifacts={artifacts}
                       />
                       {review ? (

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -32,6 +32,9 @@ import type { GoToTranscriptIntent, ReviewWithChecks } from '../../../../shared/
 
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
+  // Gates the per-message edit action; the handler reloads a user prompt into the composer draft.
+  canEditMessage: boolean
+  onEditMessage: (message: ChatSession['messages'][number]) => void
 }
 
 type SessionScopedActivityGroupState = {
@@ -94,7 +97,9 @@ const openSessionReviewer = (sessionId: string, intent: GoToTranscriptIntent): v
 
 // Owns transcript scrolling and session-scoped expansion state for activity groups.
 const WorkspaceMessageScroller = ({
-  activeSession
+  activeSession,
+  canEditMessage,
+  onEditMessage
 }: WorkspaceMessageScrollerProps): React.JSX.Element => {
   const currentSessionId = activeSession?.id
   const getReviewForTurn = useReviewStore((state) => state.getReviewForTurn)
@@ -315,6 +320,8 @@ const WorkspaceMessageScroller = ({
                         onPreviewUploadAttachment={onPreviewUploadAttachment}
                         onOpenSkillMention={onOpenSkillMention}
                         onPreviewMentionArtifact={onPreviewMentionArtifact}
+                        canEditMessage={canEditMessage}
+                        onEditMessage={onEditMessage}
                         artifacts={artifacts}
                       />
                       {review ? (

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -29,12 +29,13 @@ import { createConversationItems } from './workspace-conversation-items'
 import { groupConversationItems } from './workspace-tool-activity-groups'
 import type { ActivityExpansionOverrides } from './workspace-tool-activity-groups'
 import type { GoToTranscriptIntent, ReviewWithChecks } from '../../../../shared/reviewer'
+import type { ComposerDoc } from './composer/composer-doc'
 
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
-  // Gates the per-message edit action; the handler reloads a user prompt into the composer draft.
+  // Gates inline editing of sent user prompts; the handler resends the edited doc as a new turn.
   canEditMessage: boolean
-  onEditMessage: (message: ChatSession['messages'][number]) => void
+  onSendEditedMessage: (doc: ComposerDoc) => void
 }
 
 type SessionScopedActivityGroupState = {
@@ -99,7 +100,7 @@ const openSessionReviewer = (sessionId: string, intent: GoToTranscriptIntent): v
 const WorkspaceMessageScroller = ({
   activeSession,
   canEditMessage,
-  onEditMessage
+  onSendEditedMessage
 }: WorkspaceMessageScrollerProps): React.JSX.Element => {
   const currentSessionId = activeSession?.id
   const getReviewForTurn = useReviewStore((state) => state.getReviewForTurn)
@@ -321,7 +322,7 @@ const WorkspaceMessageScroller = ({
                         onOpenSkillMention={onOpenSkillMention}
                         onPreviewMentionArtifact={onPreviewMentionArtifact}
                         canEditMessage={canEditMessage}
-                        onEditMessage={onEditMessage}
+                        onSendEditedMessage={onSendEditedMessage}
                         artifacts={artifacts}
                       />
                       {review ? (

--- a/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-// Pins the edit-sent-message flow: the gate follows the same settled-run conditions as sending, and
-// editing rebuilds the composer draft from the sent message, restoring structured mention chips.
+// Pins the inline edit-resend flow: the gate follows the same settled-run conditions as sending, and
+// confirming an inline edit resends the adjusted prompt as a new turn without attachments.
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -19,14 +19,12 @@ import {
   type ChatSession
 } from '@/stores/session-store'
 
-import { type ComposerDoc } from './composer/composer-doc'
+import { emptyDoc, type ComposerDoc } from './composer/composer-doc'
 
-// Capture the ConversationPanel props the page computes, notably canEditMessage and the edit handler.
+// Capture the ConversationPanel props the page computes, notably canEditMessage and the resend handler.
 let conversationProps: {
-  draftDoc: ComposerDoc
   canEditMessage: boolean
-  onDraftDocChange: (doc: ComposerDoc) => void
-  onEditMessage: (message: ChatMessage) => void
+  onSendEditedMessage: (doc: ComposerDoc) => void
 }
 
 const runtime = vi.hoisted(() => ({
@@ -110,6 +108,14 @@ const promptMessage: ChatMessage = {
   updatedAt: 1710000000000
 }
 
+const editedDoc: ComposerDoc = {
+  nodes: [
+    { type: 'text', text: 'Run ' },
+    { type: 'skill', id: 'skill-forecast', name: 'forecast' },
+    { type: 'text', text: ' tomorrow' }
+  ]
+}
+
 const setSession = (overrides: Partial<ChatSession>): void => {
   useSessionStore.setState({
     sessions: [createSession(overrides)],
@@ -117,7 +123,7 @@ const setSession = (overrides: Partial<ChatSession>): void => {
   })
 }
 
-describe('WorkspacePage edit sent message', () => {
+describe('WorkspacePage inline edit resend', () => {
   let container: HTMLDivElement
   let root: Root
 
@@ -169,38 +175,50 @@ describe('WorkspacePage edit sent message', () => {
     })
   }
 
-  it('reloads the sent prompt into the composer draft, restoring mention chips', async () => {
+  it('resends the edited prompt as a new turn with its skills and artifacts resolved', async () => {
     await renderPage()
 
     expect(conversationProps.canEditMessage).toBe(true)
 
-    // An in-progress draft is replaced by the edited prompt, matching resend-as-new-turn semantics.
     await act(async () => {
-      conversationProps.onDraftDocChange({ nodes: [{ type: 'text', text: 'typed draft' }] })
-    })
-    await act(async () => {
-      conversationProps.onEditMessage(promptMessage)
+      conversationProps.onSendEditedMessage(editedDoc)
     })
 
-    expect(conversationProps.draftDoc).toEqual({
-      nodes: [
-        { type: 'text', text: 'Run ' },
-        { type: 'skill', id: 'skill-forecast', name: 'forecast' },
-        { type: 'text', text: ' now' }
-      ]
-    })
-
-    // Messages without structured parts fall back to their plain text content.
-    await act(async () => {
-      conversationProps.onEditMessage({
-        ...promptMessage,
-        id: 'message-2',
-        content: 'plain prompt',
-        parts: undefined
+    // The resend carries the doc's text, mention parts, and skill ids, and never attaches files.
+    expect(runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-a',
+        text: 'Run /forecast tomorrow',
+        attachments: [],
+        referencedArtifacts: [],
+        parts: editedDoc.nodes,
+        forcedSkillIds: ['skill-forecast']
       })
-    })
+    )
+  })
 
-    expect(conversationProps.draftDoc).toEqual({ nodes: [{ type: 'text', text: 'plain prompt' }] })
+  it('refuses to resend while a run is active or the edited doc is empty', async () => {
+    await renderPage()
+
+    await act(async () => {
+      setSession({ status: 'running', messages: [promptMessage] })
+    })
+    expect(conversationProps.canEditMessage).toBe(false)
+
+    await act(async () => {
+      conversationProps.onSendEditedMessage(editedDoc)
+    })
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
+
+    await act(async () => {
+      setSession({ messages: [promptMessage] })
+    })
+    expect(conversationProps.canEditMessage).toBe(true)
+
+    await act(async () => {
+      conversationProps.onSendEditedMessage(emptyDoc)
+    })
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
   })
 
   it('gates editing while a run is active and restores it once settled', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
@@ -24,11 +24,12 @@ import { emptyDoc, type ComposerDoc } from './composer/composer-doc'
 // Capture the ConversationPanel props the page computes, notably canEditMessage and the resend handler.
 let conversationProps: {
   canEditMessage: boolean
-  onSendEditedMessage: (doc: ComposerDoc) => void
+  onSendEditedMessage: (messageId: string, doc: ComposerDoc) => void
 }
 
 const runtime = vi.hoisted(() => ({
   sendMessage: vi.fn(),
+  resendEditedMessage: vi.fn(),
   cancelRun: vi.fn(),
   deleteRuntimeSession: vi.fn(),
   respondToPermission: vi.fn()
@@ -46,6 +47,7 @@ vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
     actionError: null,
     pendingPermissions: [],
     sendMessage: runtime.sendMessage,
+    resendEditedMessage: runtime.resendEditedMessage,
     cancelRun: runtime.cancelRun,
     deleteRuntimeSession: runtime.deleteRuntimeSession,
     respondToPermission: runtime.respondToPermission
@@ -175,26 +177,22 @@ describe('WorkspacePage inline edit resend', () => {
     })
   }
 
-  it('resends the edited prompt as a new turn with its skills and artifacts resolved', async () => {
+  it('routes the edited prompt through the truncate-and-resend runtime flow', async () => {
     await renderPage()
 
     expect(conversationProps.canEditMessage).toBe(true)
 
     await act(async () => {
-      conversationProps.onSendEditedMessage(editedDoc)
+      conversationProps.onSendEditedMessage('message-1', editedDoc)
     })
 
-    // The resend carries the doc's text, mention parts, and skill ids, and never attaches files.
-    expect(runtime.sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: 'sess-a',
-        text: 'Run /forecast tomorrow',
-        attachments: [],
-        referencedArtifacts: [],
-        parts: editedDoc.nodes,
-        forcedSkillIds: ['skill-forecast']
-      })
-    )
+    // The runtime receives the truncation point plus the adjusted prompt with its mentions resolved.
+    expect(runtime.resendEditedMessage).toHaveBeenCalledWith('sess-a', 'message-1', {
+      text: 'Run /forecast tomorrow',
+      parts: editedDoc.nodes,
+      forcedSkillIds: ['skill-forecast'],
+      referencedArtifacts: []
+    })
   })
 
   it('refuses to resend while a run is active or the edited doc is empty', async () => {
@@ -206,9 +204,9 @@ describe('WorkspacePage inline edit resend', () => {
     expect(conversationProps.canEditMessage).toBe(false)
 
     await act(async () => {
-      conversationProps.onSendEditedMessage(editedDoc)
+      conversationProps.onSendEditedMessage('message-1', editedDoc)
     })
-    expect(runtime.sendMessage).not.toHaveBeenCalled()
+    expect(runtime.resendEditedMessage).not.toHaveBeenCalled()
 
     await act(async () => {
       setSession({ messages: [promptMessage] })
@@ -216,9 +214,9 @@ describe('WorkspacePage inline edit resend', () => {
     expect(conversationProps.canEditMessage).toBe(true)
 
     await act(async () => {
-      conversationProps.onSendEditedMessage(emptyDoc)
+      conversationProps.onSendEditedMessage('message-1', emptyDoc)
     })
-    expect(runtime.sendMessage).not.toHaveBeenCalled()
+    expect(runtime.resendEditedMessage).not.toHaveBeenCalled()
   })
 
   it('gates editing while a run is active and restores it once settled', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+// Pins the edit-sent-message flow: the gate follows the same settled-run conditions as sending, and
+// editing rebuilds the composer draft from the sent message, restoring structured mention chips.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as React from 'react'
+
+import { useNavigationStore } from '@/stores/navigation-store'
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore
+} from '@/stores/preview-workbench-store'
+import { useProjectStore } from '@/stores/project-store'
+import {
+  createInitialSessionState,
+  useSessionStore,
+  type ChatMessage,
+  type ChatSession
+} from '@/stores/session-store'
+
+import { type ComposerDoc } from './composer/composer-doc'
+
+// Capture the ConversationPanel props the page computes, notably canEditMessage and the edit handler.
+let conversationProps: {
+  draftDoc: ComposerDoc
+  canEditMessage: boolean
+  onDraftDocChange: (doc: ComposerDoc) => void
+  onEditMessage: (message: ChatMessage) => void
+}
+
+const runtime = vi.hoisted(() => ({
+  sendMessage: vi.fn(),
+  cancelRun: vi.fn(),
+  deleteRuntimeSession: vi.fn(),
+  respondToPermission: vi.fn()
+}))
+
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: (): React.JSX.Element => <div data-testid="resize-handle" />
+}))
+
+vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
+  useWorkspaceAgentRuntime: () => ({
+    actionError: null,
+    pendingPermissions: [],
+    sendMessage: runtime.sendMessage,
+    cancelRun: runtime.cancelRun,
+    deleteRuntimeSession: runtime.deleteRuntimeSession,
+    respondToPermission: runtime.respondToPermission
+  })
+}))
+
+vi.mock('./WorkspaceSidebar', () => ({
+  WorkspaceSidebar: (): React.JSX.Element => <aside />
+}))
+
+vi.mock('./ConversationPanel', () => ({
+  ConversationPanel: (props: typeof conversationProps): React.JSX.Element => {
+    conversationProps = props
+    return <section data-testid="conversation" />
+  }
+}))
+
+vi.mock('./PreviewPanel', () => ({
+  PreviewPanel: (): React.JSX.Element => <div data-testid="preview-panel" />
+}))
+
+vi.mock('./RenameSessionDialog', () => ({
+  RenameSessionDialog: (): React.JSX.Element => <div />
+}))
+
+vi.mock('./DeleteSessionDialog', () => ({
+  DeleteSessionDialog: (): React.JSX.Element => <div />
+}))
+
+const { WorkspacePage } = await import('./WorkspacePage')
+
+const createSession = (overrides: Partial<ChatSession> = {}): ChatSession => {
+  const now = Date.now()
+
+  return {
+    id: 'sess-a',
+    projectId: 'proj-1',
+    title: 'sess-a',
+    cwd: '/workspace/proj-1',
+    status: 'idle',
+    messages: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides
+  }
+}
+
+const promptMessage: ChatMessage = {
+  id: 'message-1',
+  role: 'user',
+  content: 'Run /forecast now',
+  status: 'complete',
+  eventIds: [],
+  parts: [
+    { type: 'text', text: 'Run ' },
+    { type: 'skill', id: 'skill-forecast', name: 'forecast' },
+    { type: 'text', text: ' now' }
+  ],
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000
+}
+
+const setSession = (overrides: Partial<ChatSession>): void => {
+  useSessionStore.setState({
+    sessions: [createSession(overrides)],
+    selectedSessionId: 'sess-a'
+  })
+}
+
+describe('WorkspacePage edit sent message', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    useProjectStore.setState({ projects: [] })
+    useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ messages: [promptMessage] })],
+      selectedSessionId: 'sess-a'
+    })
+    vi.clearAllMocks()
+
+    window.api = {
+      notebook: {
+        onAvailable: vi.fn(() => vi.fn()),
+        getReference: vi.fn(() => Promise.resolve(null))
+      },
+      preview: {
+        load: vi.fn(() => Promise.resolve(undefined)),
+        save: vi.fn(() => Promise.resolve())
+      },
+      uploads: { deleteUpload: vi.fn(), stageFiles: vi.fn() },
+      reviewer: {
+        onUpdated: vi.fn(() => vi.fn()),
+        onSuppressNextAutoReview: vi.fn(() => vi.fn()),
+        onFixLoopStart: vi.fn(() => vi.fn()),
+        onFixLoopEnd: vi.fn(() => vi.fn()),
+        abortFixLoop: vi.fn(() => Promise.resolve())
+      }
+    } as never
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  const renderPage = async (): Promise<void> => {
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+    })
+  }
+
+  it('reloads the sent prompt into the composer draft, restoring mention chips', async () => {
+    await renderPage()
+
+    expect(conversationProps.canEditMessage).toBe(true)
+
+    // An in-progress draft is replaced by the edited prompt, matching resend-as-new-turn semantics.
+    await act(async () => {
+      conversationProps.onDraftDocChange({ nodes: [{ type: 'text', text: 'typed draft' }] })
+    })
+    await act(async () => {
+      conversationProps.onEditMessage(promptMessage)
+    })
+
+    expect(conversationProps.draftDoc).toEqual({
+      nodes: [
+        { type: 'text', text: 'Run ' },
+        { type: 'skill', id: 'skill-forecast', name: 'forecast' },
+        { type: 'text', text: ' now' }
+      ]
+    })
+
+    // Messages without structured parts fall back to their plain text content.
+    await act(async () => {
+      conversationProps.onEditMessage({
+        ...promptMessage,
+        id: 'message-2',
+        content: 'plain prompt',
+        parts: undefined
+      })
+    })
+
+    expect(conversationProps.draftDoc).toEqual({ nodes: [{ type: 'text', text: 'plain prompt' }] })
+  })
+
+  it('gates editing while a run is active and restores it once settled', async () => {
+    await renderPage()
+
+    expect(conversationProps.canEditMessage).toBe(true)
+
+    await act(async () => {
+      setSession({ status: 'running', messages: [promptMessage] })
+    })
+    expect(conversationProps.canEditMessage).toBe(false)
+
+    await act(async () => {
+      setSession({ status: 'waiting-permission', messages: [promptMessage] })
+    })
+    expect(conversationProps.canEditMessage).toBe(false)
+
+    await act(async () => {
+      setSession({ fixLoopActive: true, messages: [promptMessage] })
+    })
+    expect(conversationProps.canEditMessage).toBe(false)
+
+    // Compaction recovery idles the session but must keep the gate closed until the replay finishes.
+    await act(async () => {
+      setSession({ messages: [promptMessage] })
+    })
+    await act(async () => {
+      useSessionStore.getState().beginCompaction('sess-a')
+    })
+    expect(conversationProps.canEditMessage).toBe(false)
+
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+    })
+    expect(conversationProps.canEditMessage).toBe(true)
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -19,7 +19,7 @@ import {
   PROJECT_FILES_PREVIEW_ID,
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
-import type { ChatSession } from '@/stores/session-store'
+import type { ChatMessage, ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
 import { useReviewStore } from '@/stores/review-store'
 import {
@@ -31,6 +31,8 @@ import type { StageUploadFile, UploadedAttachment } from '../../../../shared/upl
 
 import { planComposerAttachmentIntake } from './composer-attachment-intake'
 import {
+  docFromMessageParts,
+  docFromText,
   docIsEmpty,
   docToArtifactRefs,
   docToText,
@@ -256,6 +258,14 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     !activeSession?.fixLoopActive &&
     // Auto-recovery drops the session to idle while it resets context and replays the transcript; block
     // sends in that window so a manual prompt can't race the recovery resend into the same session.
+    !activeSession?.compacting
+  // Re-editing a sent prompt is allowed under the same settled-run conditions as sending, so the
+  // resent prompt can never overlap an in-flight turn, permission wait, fix loop, or compaction.
+  const canEditMessage =
+    isSessionPersistenceReady &&
+    activeSession?.status !== 'running' &&
+    activeSession?.status !== 'waiting-permission' &&
+    !activeSession?.fixLoopActive &&
     !activeSession?.compacting
   const canChangePermissionProfile =
     isSessionPersistenceReady &&
@@ -571,6 +581,16 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     })
   }
 
+  // Reloads a sent user prompt into the composer draft, restoring structured mention chips when the
+  // message carries them. The current draft is replaced, matching the resend-as-new-turn semantics.
+  const editSentMessage = (message: ChatMessage): void => {
+    setDraftDoc(
+      message.parts && message.parts.length > 0
+        ? docFromMessageParts(message.parts)
+        : docFromText(message.content)
+    )
+  }
+
   // Sends the current draft only after hydration so restored selection cannot overwrite intent.
   // ConversationPanel owns preventDefault and passes the skills picked as inline chips.
   const sendCurrentMessage = (forcedSkillIds: string[]): void => {
@@ -831,6 +851,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             onAutoReviewToggle={changeAutoReviewEnabled}
             onRequestReview={requestManualReview}
             isRequestReviewDisabled={isRequestReviewDisabled}
+            canEditMessage={canEditMessage}
+            onEditMessage={editSentMessage}
           />
 
           <ResizableHandle

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -19,7 +19,7 @@ import {
   PROJECT_FILES_PREVIEW_ID,
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
-import type { ChatMessage, ChatSession } from '@/stores/session-store'
+import type { ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
 import { useReviewStore } from '@/stores/review-store'
 import {
@@ -31,10 +31,9 @@ import type { StageUploadFile, UploadedAttachment } from '../../../../shared/upl
 
 import { planComposerAttachmentIntake } from './composer-attachment-intake'
 import {
-  docFromMessageParts,
-  docFromText,
   docIsEmpty,
   docToArtifactRefs,
+  docToSkillIds,
   docToText,
   emptyDoc,
   type ComposerDoc
@@ -581,14 +580,23 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     })
   }
 
-  // Reloads a sent user prompt into the composer draft, restoring structured mention chips when the
-  // message carries them. The current draft is replaced, matching the resend-as-new-turn semantics.
-  const editSentMessage = (message: ChatMessage): void => {
-    setDraftDoc(
-      message.parts && message.parts.length > 0
-        ? docFromMessageParts(message.parts)
-        : docFromText(message.content)
-    )
+  // Resends an inline-edited prompt as a new turn in the current session. The edited doc carries no
+  // attachments, and the gate mirrors canEditMessage so a resend never overlaps an in-flight turn.
+  const sendEditedMessage = (doc: ComposerDoc): void => {
+    if (!canEditMessage || docIsEmpty(doc)) return
+
+    void sendMessage({
+      sessionId: activeSession?.id,
+      text: docToText(doc),
+      attachments: [],
+      referencedArtifacts: docToArtifactRefs(doc),
+      parts: doc.nodes,
+      cwd: activeSession?.cwd,
+      projectId: activeSession?.projectId ?? scopedProjectId,
+      projectName: activeSession?.projectId ?? scopedProjectId,
+      permissionProfile: activePermissionProfile,
+      forcedSkillIds: docToSkillIds(doc)
+    })
   }
 
   // Sends the current draft only after hydration so restored selection cannot overwrite intent.
@@ -852,7 +860,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             onRequestReview={requestManualReview}
             isRequestReviewDisabled={isRequestReviewDisabled}
             canEditMessage={canEditMessage}
-            onEditMessage={editSentMessage}
+            onSendEditedMessage={sendEditedMessage}
           />
 
           <ResizableHandle

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -156,6 +156,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     permissionProfiles,
     permissionGrants,
     sendMessage,
+    resendEditedMessage,
     cancelRun,
     resumeInterruptedSession,
     deleteRuntimeSession,
@@ -580,22 +581,17 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     })
   }
 
-  // Resends an inline-edited prompt as a new turn in the current session. The edited doc carries no
-  // attachments, and the gate mirrors canEditMessage so a resend never overlaps an in-flight turn.
-  const sendEditedMessage = (doc: ComposerDoc): void => {
-    if (!canEditMessage || docIsEmpty(doc)) return
+  // Resends an inline-edited prompt: the conversation is truncated at the edited message, the agent
+  // context resets, and the kept turns replay as a preamble on the resent prompt. The gate mirrors
+  // canEditMessage so a resend never overlaps an in-flight turn.
+  const sendEditedMessage = (messageId: string, doc: ComposerDoc): void => {
+    if (!canEditMessage || docIsEmpty(doc) || !activeSession) return
 
-    void sendMessage({
-      sessionId: activeSession?.id,
+    void resendEditedMessage(activeSession.id, messageId, {
       text: docToText(doc),
-      attachments: [],
-      referencedArtifacts: docToArtifactRefs(doc),
       parts: doc.nodes,
-      cwd: activeSession?.cwd,
-      projectId: activeSession?.projectId ?? scopedProjectId,
-      projectName: activeSession?.projectId ?? scopedProjectId,
-      permissionProfile: activePermissionProfile,
-      forcedSkillIds: docToSkillIds(doc)
+      forcedSkillIds: docToSkillIds(doc),
+      referencedArtifacts: docToArtifactRefs(doc)
     })
   }
 

--- a/src/renderer/src/pages/workspace/agent-loading-message.test.ts
+++ b/src/renderer/src/pages/workspace/agent-loading-message.test.ts
@@ -219,4 +219,33 @@ describe('agent loading message state', () => {
       })
     ).toBe(false)
   })
+
+  it('keeps loading during a permission wait even after visible agent content arrives', async () => {
+    const { shouldShowAgentLoadingMessage } = await loadAgentLoadingMessageModule()
+
+    // The agent streamed text, then paused on a tool permission: the wait is on the user's
+    // decision, not on agent output, so the indicator stays.
+    expect(
+      shouldShowAgentLoadingMessage(
+        createSession({
+          status: 'waiting-permission',
+          activeRun: {
+            promptMessageId: 'prompt-1',
+            startedAt: 1710000000100
+          },
+          messages: [
+            createMessage({ id: 'prompt-1' }),
+            createMessage({
+              id: 'reply-1',
+              role: 'agent',
+              content: "I'll inspect the files",
+              status: 'streaming',
+              streamId: 'stream-1',
+              responseToMessageId: 'prompt-1'
+            })
+          ]
+        })
+      )
+    ).toBe(true)
+  })
 })

--- a/src/renderer/src/pages/workspace/agent-loading-message.test.ts
+++ b/src/renderer/src/pages/workspace/agent-loading-message.test.ts
@@ -194,7 +194,7 @@ describe('agent loading message state', () => {
     ).toBe(false)
   })
 
-  it('does not show loading for permission waits or sessions without an active run', async () => {
+  it('keeps loading during permission waits and hides it only without an active run', async () => {
     const { shouldShowAgentLoadingMessage } = await loadAgentLoadingMessageModule()
     const runningSession = createSession({
       activeRun: {
@@ -204,12 +204,13 @@ describe('agent loading message state', () => {
       messages: [createMessage({ id: 'prompt-1' })]
     })
 
+    // A permission wait is still mid-run: the row stays so the transcript keeps a working indicator.
     expect(
       shouldShowAgentLoadingMessage({
         ...runningSession,
         status: 'waiting-permission'
       })
-    ).toBe(false)
+    ).toBe(true)
     expect(
       shouldShowAgentLoadingMessage({
         ...runningSession,

--- a/src/renderer/src/pages/workspace/agent-loading-message.ts
+++ b/src/renderer/src/pages/workspace/agent-loading-message.ts
@@ -11,11 +11,12 @@ const hasVisibleAgentMessageAfterPrompt = (session: ChatSession, promptIndex: nu
     )
 
 // The loading row is derived UI state: it belongs to the active run, not persisted history. A
-// permission wait is still mid-run (the turn resumes on the decision), so the row stays visible
-// alongside the approval controls instead of leaving the transcript looking frozen.
+// permission wait pauses the run on a user decision rather than ending it, so the row stays visible
+// alongside the approval controls — even when the agent already streamed visible content.
 const shouldShowAgentLoadingMessage = (session: ChatSession | undefined): boolean => {
   if (!session || !session.activeRun) return false
-  if (session.status !== 'running' && session.status !== 'waiting-permission') return false
+  if (session.status === 'waiting-permission') return true
+  if (session.status !== 'running') return false
 
   const promptIndex = session.messages.findIndex(
     (message) => message.id === session.activeRun?.promptMessageId

--- a/src/renderer/src/pages/workspace/agent-loading-message.ts
+++ b/src/renderer/src/pages/workspace/agent-loading-message.ts
@@ -10,9 +10,12 @@ const hasVisibleAgentMessageAfterPrompt = (session: ChatSession, promptIndex: nu
         (message.content.trim().length > 0 || Boolean(message.images?.length))
     )
 
-// The loading row is derived UI state: it belongs to the active run, not persisted history.
+// The loading row is derived UI state: it belongs to the active run, not persisted history. A
+// permission wait is still mid-run (the turn resumes on the decision), so the row stays visible
+// alongside the approval controls instead of leaving the transcript looking frozen.
 const shouldShowAgentLoadingMessage = (session: ChatSession | undefined): boolean => {
-  if (!session || session.status !== 'running' || !session.activeRun) return false
+  if (!session || !session.activeRun) return false
+  if (session.status !== 'running' && session.status !== 'waiting-permission') return false
 
   const promptIndex = session.messages.findIndex(
     (message) => message.id === session.activeRun?.promptMessageId

--- a/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import {
   applyDocToDom,
   docArtifactCount,
+  docFromMessageParts,
   docFromText,
   docIsEmpty,
   docToArtifactRefs,
@@ -246,5 +247,60 @@ describe('applyDocToDom + domToDoc round-trip', () => {
     expect(chip?.getAttribute('data-mention-filename')).toBe('fig.png')
     expect(chip?.getAttribute('contenteditable')).toBe('false')
     expect(chip?.textContent).toBe('@fig.png')
+  })
+})
+
+describe('docFromMessageParts', () => {
+  it('restores text, skill, and artifact chips from a sent message parts list', () => {
+    const doc = docFromMessageParts([
+      { type: 'text', text: 'Run ' },
+      { type: 'skill', id: 'skill-forecast', name: 'forecast' },
+      { type: 'text', text: ' on ' },
+      {
+        type: 'artifact',
+        id: 'artifact-1',
+        name: 'clinical trial03.pdf',
+        path: '/p/clinical trial03.pdf',
+        source: 'artifact',
+        versionId: 'v2'
+      }
+    ])
+
+    expect(doc).toEqual({
+      nodes: [
+        { type: 'text', text: 'Run ' },
+        { type: 'skill', id: 'skill-forecast', name: 'forecast' },
+        { type: 'text', text: ' on ' },
+        {
+          type: 'artifact',
+          id: 'artifact-1',
+          name: 'clinical trial03.pdf',
+          path: '/p/clinical trial03.pdf',
+          source: 'artifact',
+          versionId: 'v2'
+        }
+      ]
+    })
+  })
+
+  it('reproduces the sent message text when rendered back to plain text', () => {
+    const doc = docFromMessageParts([
+      { type: 'text', text: 'Run ' },
+      { type: 'skill', id: 'skill-forecast', name: 'forecast' },
+      { type: 'text', text: ' on ' },
+      {
+        type: 'artifact',
+        id: 'artifact-1',
+        name: 'clinical trial03.pdf',
+        path: '/p/clinical trial03.pdf',
+        source: 'artifact'
+      }
+    ])
+
+    expect(docToText(doc)).toBe('Run /forecast on @clinical trial03.pdf')
+  })
+
+  it('returns the empty doc for an empty parts list', () => {
+    expect(docFromMessageParts([])).toEqual(emptyDoc)
   })
 })

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -3,6 +3,7 @@
 // bridge the model to the contenteditable editor.
 
 import type { ArtifactReference } from '../../../../../shared/artifacts'
+import type { MessagePart } from '../../../../../shared/session-persistence'
 
 // One artifact/upload reference chip in the composer doc. Mirrors ArtifactReference plus the DOM
 // label; `source` distinguishes a user upload from a generated output for the runtime resolver.
@@ -73,6 +74,25 @@ export const docArtifactCount = (doc: ComposerDoc): number =>
 // Hydrate a plain-text draft into a single text node; empty text yields the empty doc.
 export const docFromText = (text: string): ComposerDoc =>
   text === '' ? emptyDoc : { nodes: [{ type: 'text', text }] }
+
+// Rebuild a draft doc from a sent user message's structured parts, restoring skill/artifact chips
+// so re-editing the message round-trips mentions instead of flattening them into plain text.
+export const docFromMessageParts = (parts: MessagePart[]): ComposerDoc => {
+  const nodes: ComposerNode[] = parts.map((part) => {
+    if (part.type === 'text') return { type: 'text', text: part.text }
+    if (part.type === 'skill') return { type: 'skill', id: part.id, name: part.name }
+    return {
+      type: 'artifact',
+      id: part.id,
+      name: part.name,
+      path: part.path,
+      source: part.source,
+      versionId: part.versionId
+    }
+  })
+
+  return nodes.length === 0 ? emptyDoc : { nodes }
+}
 
 // A doc is empty when it has no chips and no non-whitespace text.
 export const docIsEmpty = (doc: ComposerDoc): boolean =>

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -220,9 +220,8 @@ describe('conversation message scroller integration', () => {
     expect(conversationPanelSource).toContain(
       "import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'"
     )
-    expect(conversationPanelSource).toContain(
-      '<WorkspaceMessageScroller activeSession={activeSession} />'
-    )
+    expect(conversationPanelSource).toContain('<WorkspaceMessageScroller')
+    expect(conversationPanelSource).toContain('activeSession={activeSession}')
     expect(conversationPanelSource).not.toContain('@/components/ui/scroll-area')
     expect(conversationPanelSource).not.toContain('<ScrollArea')
   })
@@ -260,7 +259,9 @@ describe('conversation message scroller integration', () => {
     const workspaceMessageItemSource = readFileSync(workspaceMessageItemPath, 'utf8')
     const workspaceMessageScrollerSource = readFileSync(workspaceMessageScrollerPath, 'utf8')
 
-    expect(workspaceMessageItemSource).toContain('className="flex justify-end"')
+    expect(workspaceMessageItemSource).toContain(
+      'className="group flex items-center justify-end gap-1"'
+    )
     expect(workspaceMessageItemSource).toContain(
       "'max-w-[90%] break-words rounded-2xl bg-bg-300 px-3.5 py-2 text-sm text-message-user-text md:max-w-[min(85%,56rem)] md:px-4 md:py-2.5 md:text-[15px]'"
     )

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -7,7 +7,14 @@ import {
   type PersistedChatSession
 } from '../../../shared/session-persistence'
 import type { UploadedAttachment } from '../../../shared/uploads'
-import { createInitialSessionState, toPersistedSession, useSessionStore } from './session-store'
+import {
+  createInitialSessionState,
+  toPersistedSession,
+  useSessionStore,
+  type ChatMessage,
+  type ChatSession,
+  type ToolActivity
+} from './session-store'
 
 const createArtifactFile = (overrides: Partial<ArtifactFile> = {}): ArtifactFile => ({
   id: 'artifact-session-1:run-1:result.txt',
@@ -1422,5 +1429,129 @@ describe('session store', () => {
       expect(session.messages[0]).toMatchObject({ role: 'user', content: 'Read the files' })
       expect(session.messages[1]).toMatchObject({ content: 'I started', status: 'error' })
     })
+  })
+})
+
+describe('truncateSessionFromMessage', () => {
+  const baseTime = 1710000000000
+
+  const createMessage = (
+    id: string,
+    role: 'user' | 'agent',
+    createdAt: number,
+    overrides: Partial<ChatMessage> = {}
+  ): ChatMessage => ({
+    id,
+    role,
+    content: `${id} content`,
+    status: 'complete' as const,
+    eventIds: [],
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides
+  })
+
+  const createActivity = (id: string, createdAt: number): ToolActivity => ({
+    id,
+    kind: 'tool' as const,
+    title: `activity ${id}`,
+    status: 'completed' as const,
+    eventIds: [`${id}-event`],
+    sortIndex: createdAt,
+    createdAt,
+    updatedAt: createdAt
+  })
+
+  const seedSession = (overrides: Partial<ChatSession> = {}): void => {
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'default-project',
+          title: 'session-1',
+          cwd: '/workspace/project',
+          status: 'idle' as const,
+          messages: [
+            createMessage('user-1', 'user', baseTime),
+            createMessage('agent-1', 'agent', baseTime + 100),
+            createMessage('user-2', 'user', baseTime + 200),
+            createMessage('agent-2', 'agent', baseTime + 300)
+          ],
+          createdAt: baseTime,
+          updatedAt: baseTime + 300,
+          ...overrides
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
+  }
+
+  beforeEach(() => {
+    useSessionStore.setState(createInitialSessionState())
+  })
+
+  it('drops the cut message and every later turn, clearing run and banner state', () => {
+    seedSession({
+      status: 'error',
+      error: 'previous failure',
+      activeRun: { promptMessageId: 'user-2', startedAt: baseTime + 200 },
+      interrupted: true
+    })
+
+    useSessionStore.getState().truncateSessionFromMessage('session-1', 'user-2')
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.messages.map((message) => message.id)).toEqual(['user-1', 'agent-1'])
+    expect(session.status).toBe('idle')
+    expect(session.activeRun).toBeUndefined()
+    expect(session.error).toBeUndefined()
+    expect(session.interrupted).toBeUndefined()
+  })
+
+  it('cuts later activities by creation time and keeps earlier ones', () => {
+    seedSession({
+      activities: [
+        createActivity('act-1', baseTime + 150),
+        createActivity('act-2', baseTime + 250),
+        createActivity('act-3', baseTime + 350)
+      ]
+    })
+
+    useSessionStore.getState().truncateSessionFromMessage('session-1', 'user-2')
+
+    expect(
+      useSessionStore.getState().sessions[0].activities?.map((activity) => activity.id)
+    ).toEqual(['act-1'])
+  })
+
+  it('advances filesRevision only when removed messages carry file references', () => {
+    seedSession({
+      filesRevision: 3,
+      messages: [
+        createMessage('user-1', 'user', baseTime),
+        createMessage('agent-1', 'agent', baseTime + 100),
+        createMessage('user-2', 'user', baseTime + 200, {
+          uploads: [createUploadAttachment()]
+        })
+      ]
+    })
+
+    useSessionStore.getState().truncateSessionFromMessage('session-1', 'user-2')
+    expect(useSessionStore.getState().sessions[0].filesRevision).toBe(4)
+
+    seedSession({ filesRevision: 3 })
+    useSessionStore.getState().truncateSessionFromMessage('session-1', 'user-2')
+    expect(useSessionStore.getState().sessions[0].filesRevision).toBe(3)
+  })
+
+  it('ignores unknown session or message ids', () => {
+    seedSession()
+    const before = useSessionStore.getState().sessions[0]
+
+    useSessionStore.getState().truncateSessionFromMessage('session-unknown', 'user-2')
+    useSessionStore.getState().truncateSessionFromMessage('session-1', 'message-unknown')
+
+    expect(useSessionStore.getState().sessions[0]).toBe(before)
   })
 })

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -192,6 +192,7 @@ type SessionStore = SessionStoreData & {
   ) => void
   markDisconnected: (sessionId: string) => void
   removeMessage: (sessionId: string, messageId: string) => void
+  truncateSessionFromMessage: (sessionId: string, messageId: string) => void
   upsertToolActivity: (input: UpsertToolActivityInput) => void
   setPermissionPending: (sessionId: string) => void
   clearPermissionPending: (sessionId: string) => void
@@ -1248,6 +1249,42 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         return {
           ...session,
           messages: session.messages.filter((message) => message.id !== messageId),
+          filesRevision: hasFiles ? (session.filesRevision ?? 0) + 1 : session.filesRevision,
+          updatedAt: Date.now()
+        }
+      })
+    }))
+  },
+
+  // Drops a message and every turn after it for an edited resend. Activities are cut by timestamp
+  // because message sortIndex is transient (stripped on persist) while createdAt is durable on both
+  // sides of hydration. The kept turns are what the resend replays into the fresh agent context.
+  truncateSessionFromMessage: (sessionId, messageId) => {
+    if (!sessionId || !messageId) return
+
+    set((state) => ({
+      sessions: state.sessions.map((session) => {
+        if (session.id !== sessionId) return session
+        const cutIndex = session.messages.findIndex((message) => message.id === messageId)
+        if (cutIndex < 0) return session
+
+        const cutMessage = session.messages[cutIndex]
+        const removed = session.messages.slice(cutIndex)
+        const hasFiles = removed.some(
+          (message) => (message.uploads?.length ?? 0) > 0 || (message.artifactIds?.length ?? 0) > 0
+        )
+
+        return {
+          ...session,
+          status: 'idle',
+          messages: session.messages.slice(0, cutIndex),
+          activities: session.activities?.filter(
+            (activity) => activity.createdAt < cutMessage.createdAt
+          ),
+          activeRun: undefined,
+          agentStatus: undefined,
+          error: undefined,
+          interrupted: undefined,
           filesRevision: hasFiles ? (session.filesRevision ?? 0) + 1 : session.filesRevision,
           updatedAt: Date.now()
         }


### PR DESCRIPTION
Closes #279.

## Problem

Sent user prompts in the workspace conversation cannot be reused: copying a prompt means manually selecting the bubble text, and correcting a prompt means retyping it — including any `/skill` or `@artifact` mentions — in the composer.

## Proposed change

Add hover/focus-revealed Copy and Edit actions to the left of each user message bubble:

- **Copy** writes the prompt text to the clipboard and briefly swaps the icon to a check to confirm the write succeeded.
- **Edit** expands the bubble in place into a multi-line editor (reusing `ComposerEditor`, so `/` skill and `@` artifact mention triggers work as in the composer), prefilled from the sent message. Messages with structured mention segments (`parts`) are rebuilt as composer chips via a new `docFromMessageParts` helper instead of being flattened to plain text; plain messages fall back to their text content.

Confirming an edit performs a **truncate-and-resend**:

1. If two or more user turns follow the edited message, a confirmation dialog first warns that those turns will be overwritten.
2. The cut and the adjusted prompt are applied **optimistically**: the edited message plus every later turn drops from the persisted transcript (`truncateSessionFromMessage`, which also cuts later tool activities and clears run/error/interrupted state), and the adjusted prompt is appended immediately — so the bubble and the waiting indicator show at the edit location, exactly like a composer send.
3. The agent session is then reset to a fresh context (`resetSessionContext`) and the adjusted prompt is sent with the kept history replayed as a text preamble (`forceHistoryReplay` via a new `preAppendedMessageId` send option, which skips the duplicate-append and cuts the replay at the resent message), with its skill/artifact mentions resolved (`forcedSkillIds` / `referencedArtifacts`). Replay compatibility is validated **before** the cut — a kept history with images, whether agent-emitted blocks or user uploads, cannot replay on a model without image input, so the edit is rejected with the transcript untouched; the same widened gate now also covers the generic send path. If the reset fails, the transcript is rolled back to its pre-edit state.

Editing is gated on the same settled-run conditions as sending (`canEditMessage` in `WorkspacePage`): the edit button is disabled while the session is running, waiting on a permission decision, in a fix loop, or compacting, and the resend itself is rejected under the same conditions. The optimistic append marks the session running right away, so no prompt or second edit can race the reset round-trip.

## Scope and non-goals

- The resend replaces the edited message and everything after it; there is **no branch switching**. ACP (SDK 1.2.1) has no message-edit/history-truncation method, and `session/fork` is unstable and not advertised by claude-agent-acp, codex-acp, or `opencode acp`, so protocol-level branching is not currently possible for any of the three supported agents. Likewise, `session/load`/`session/resume` only restore full sessions, which is why the kept history must be replayed as a preamble after the context reset.
- The resend is text/mentions only; the original message's file attachments are not re-staged. Files generated by deleted turns remain in the project.
- Renderer + renderer-store changes only: the only main-process API used is the existing `resetSessionContext`.

## Acceptance criteria and validation

- Copy and Edit buttons appear only on user bubbles, on row hover or keyboard focus; Copy shows a transient check state after a successful write.
- Edit is disabled while the session is running, awaiting permission, in a fix loop, or compacting; it re-enables once the run settles.
- The inline editor restores mention chips; Enter or Send confirms, Cancel restores the bubble.
- The waiting indicator stays visible while a turn waits on a tool permission decision — a permission wait is mid-run, so the transcript keeps its working indicator alongside the approval controls, even if the agent already streamed text before asking.
- With ≥2 later user turns, a dialog warns before anything is deleted; confirming truncates and resends, cancelling keeps the editor open.
- After the resend, the transcript contains only the turns before the edited message plus the adjusted prompt; the bubble and waiting indicator appear immediately, and the agent receives those kept turns as a replayed preamble.
- `npm run typecheck`, `npm run lint` (0 errors), and `npm run test` pass. New coverage: `truncateSessionFromMessage` store tests, `resendEditedWorkspaceMessage` runtime tests (optimistic append, replay, rollback on reset failure), `WorkspaceMessageItem.actions.test.tsx` (actions, inline editor, warning dialog), `WorkspacePage.edit-message.test.tsx` (gate + resend wiring), reply-streaming integration tests at both the main and renderer layers, and `docFromMessageParts` cases in `composer-doc.test.ts`.

## Review focus

- The optimistic truncate → reset → replay ordering in `resendEditedWorkspaceMessage` (the cut and the resent bubble apply up front; a failed reset rolls the transcript back) and the timestamp-based activity cut in `truncateSessionFromMessage` (message `sortIndex` is transient, `createdAt` is durable).
- The pre-cut replay compatibility check (agent images and user-uploaded image attachments) that rejects the edit before anything is dropped.
- The `canEditMessage` gate enforced on the bubble, on the inline Send button, and in the page's resend entry point.
- The ≥2-turn warning threshold (`EDIT_TRUNCATION_WARNING_TURNS`) and dialog copy.
