### PR TITLE
fix(update): recover from old-uninstaller failure during Windows updates

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,3 +1,62 @@
 !macro customUnInstall
   nsExec::ExecToLog 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\resources\windows-runtime-cache-uninstall.ps1"'
 !macroend
+
+# Resilient replacement for handleUninstallResult's default failure handling, installed via
+# electron-builder's customUnInstallCheck hooks below. During an in-app update the new installer
+# runs the OLD uninstaller and treats any non-zero exit code as fatal ("Failed to uninstall old
+# application files. Please try running the installer again.: <code>") — aborting the update.
+# That code is not trustworthy for our assisted installer (oneClick: false): electron-builder only
+# normalizes the uninstaller's exit code (quitSuccess, "avoid exit code 2") for ONE_CLICK builds,
+# so a benign trailing error leaks out as exit code 2 even when the old version was fully removed
+# (electron-userland/electron-builder#9593). And when the code IS real, it is usually a background
+# child still running from the install dir (micromamba provisioning, the CLI in Node mode, an
+# agent child) locking files — worth one more attempt after a force-kill instead of failing.
+# Recovery order:
+#   1. Exit code non-zero but the old executable is already gone -> the uninstall did its job
+#      despite the reported code; log and continue installing.
+#   2. Files remain -> force-kill processes running from the install dir, wait, and run the old
+#      uninstaller once more. Only if it still fails show the original dialog and quit.
+# Symbol constraints: handleUninstallResult is parsed BEFORE uninstallOldVersion and
+# CHECK_APP_RUNNING declare their globals ($installationDir, $PowerShellPath, ...), and makensis
+# treats unknown variables as errors — so this stays self-contained: only $appExe (set in the
+# install section before the uninstall pass), registers, built-in constants, and the literal
+# temp-uninstaller path uninstallOldVersion uses. For the SHELL_CONTEXT pass $INSTDIR is the old
+# install location (an update installs over it). The rare installMode==all HKEY_CURRENT_USER pass
+# targets a stray per-user install elsewhere; re-running its uninstaller against $INSTDIR is a
+# harmless no-op that lets the machine-wide install continue.
+!macro uninstallFailureRecovery
+  ${if} $R0 != 0
+    ${ifNot} ${FileExists} "$appExe"
+      DetailPrint `Old uninstaller exited with $R0 but the previous installation is already removed; continuing.`
+    ${else}
+      DetailPrint `Old uninstaller exited with $R0; closing leftover app processes and retrying once.`
+      # Force-kill anything still running from the install dir: path-prefix sweep via PowerShell
+      # (covers micromamba.exe and any other helper), then an image-name taskkill for machines
+      # where PowerShell is unavailable or policy-blocked. Both are best-effort; the retry below
+      # is the real verdict. $0 keeps the uninstaller arguments (/currentuser etc.) — neither
+      # nsExec call touches it.
+      nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -C "Get-CimInstance -ClassName Win32_Process | ? {$$_.Path -and $$_.Path.StartsWith('$INSTDIR', 'CurrentCultureIgnoreCase')} | % { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }"`
+      Pop $R1
+      nsExec::Exec `"$SYSDIR\cmd.exe" /C taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"`
+      Pop $R1
+      ClearErrors
+      Sleep 1000
+      ExecWait '"$PLUGINSDIR\old-uninstaller.exe" /S /KEEP_APP_DATA $0 _?=$INSTDIR' $R0
+      ${if} $R0 != 0
+        MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
+        DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
+        SetErrorLevel 2
+        Quit
+      ${endif}
+    ${endif}
+  ${endif}
+!macroend
+
+!macro customUnInstallCheck
+  !insertmacro uninstallFailureRecovery
+!macroend
+
+!macro customUnInstallCheckCurrentUser
+  !insertmacro uninstallFailureRecovery
+!macroend

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -30,13 +30,19 @@
     # matches on ExecutablePath (Win32_Process has no Path property) with a trailing-backslash
     # boundary so a sibling directory can never match, and receives the directory as an ARGUMENT —
     # never interpolated into the script source — so a custom install dir containing an apostrophe
-    # breaks nothing and injects nothing. The image-name taskkill covers machines where
-    # PowerShell is unavailable or policy-blocked. Both are best-effort; the retry is the verdict.
+    # breaks nothing and injects nothing. The image-name taskkill is ONLY a fallback for when the
+    # sweep could not run (PowerShell missing or policy-blocked): it matches the exe name in ANY
+    # directory, so a second install or the portable zip copy would be killed too — acceptable
+    # solely when no path-scoped option exists. Both are best-effort; the retry is the verdict.
     # $0 keeps the uninstaller arguments (/currentuser etc.) — neither nsExec call touches it.
     nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -C "$$root = $$args[0].TrimEnd('\') + '\'; Get-CimInstance -ClassName Win32_Process | ? { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, 'CurrentCultureIgnoreCase') } | % { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }" "${DIR}"`
     Pop $R1
-    nsExec::Exec `"$SYSDIR\cmd.exe" /C taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"`
-    Pop $R1
+    # nsExec pushes "error" when powershell.exe cannot even start, otherwise its exit code — any
+    # non-zero means the sweep did not run, so only then widen to the image-name kill.
+    ${if} $R1 != 0
+      nsExec::Exec `"$SYSDIR\cmd.exe" /C taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"`
+      Pop $R1
+    ${endif}
     ClearErrors
     Sleep 1000
     ExecWait '"$PLUGINSDIR\old-uninstaller.exe" /S /KEEP_APP_DATA $0 _?=${DIR}' $R0

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -2,6 +2,16 @@
   nsExec::ExecToLog 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\resources\windows-runtime-cache-uninstall.ps1"'
 !macroend
 
+!macro customInit
+  # Cache any stray per-user install location NOW (install start), BEFORE any uninstall pass
+  # runs: the HKCU uninstall pass deletes this value on success, so customUnInstallCheckCurrentUser
+  # — which runs after that pass — could never read it there. Declared inside this macro (rather
+  # than at file scope) because customInit only expands into the installer build; a file-scope
+  # Var would be declared-but-unused in the uninstaller build, and makensis fails that warning.
+  Var /GLOBAL perUserInstallDirCache
+  ReadRegStr $perUserInstallDirCache HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}" InstallLocation
+!macroend
+
 # Resilient replacement for handleUninstallResult's default failure handling, installed via
 # electron-builder's customUnInstallCheck hooks below. During an in-app update the new installer
 # runs the OLD uninstaller and treats any non-zero exit code as fatal ("Failed to uninstall old
@@ -30,17 +40,21 @@
     # matches on ExecutablePath (Win32_Process has no Path property) with a trailing-backslash
     # boundary so a sibling directory can never match, and receives the directory as an ARGUMENT —
     # never interpolated into the script source — so a custom install dir containing an apostrophe
-    # breaks nothing and injects nothing. The image-name taskkill is ONLY a fallback for when the
-    # sweep could not run (PowerShell missing or policy-blocked): it matches the exe name in ANY
-    # directory, so a second install or the portable zip copy would be killed too — acceptable
-    # solely when no path-scoped option exists. Both are best-effort; the retry is the verdict.
+    # breaks nothing and injects nothing. The image-name taskkills are ONLY a fallback for when
+    # the sweep could not run (PowerShell missing or policy-blocked): they match by exe name in
+    # ANY directory — open-science.exe covers the app and its Electron-as-Node children (the
+    # CLI), micromamba.exe covers in-flight provisioning — so a second install, the portable zip
+    # copy, or an unrelated micromamba would be killed too. Acceptable solely when no path-scoped
+    # option exists. Both are best-effort; the retry is the verdict.
     # $0 keeps the uninstaller arguments (/currentuser etc.) — neither nsExec call touches it.
     nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -C "$$root = $$args[0].TrimEnd('\') + '\'; Get-CimInstance -ClassName Win32_Process | ? { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, 'CurrentCultureIgnoreCase') } | % { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }" "${DIR}"`
     Pop $R1
     # nsExec pushes "error" when powershell.exe cannot even start, otherwise its exit code — any
-    # non-zero means the sweep did not run, so only then widen to the image-name kill.
+    # non-zero means the sweep did not run, so only then widen to the image-name kills.
     ${if} $R1 != 0
       nsExec::Exec `"$SYSDIR\cmd.exe" /C taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"`
+      Pop $R1
+      nsExec::Exec `"$SYSDIR\cmd.exe" /C taskkill /F /IM micromamba.exe`
       Pop $R1
     ${endif}
     ClearErrors
@@ -65,16 +79,17 @@
 !macro customUnInstallCheckCurrentUser
   ${if} $R0 != 0
     # installMode==all pass: it removes a stray PER-USER install, which may live anywhere —
-    # $INSTDIR/$appExe describe the new (machine-wide) target, not it. Recover the real location
-    # from the registry; when it is unreadable, keep electron-builder's default fatal handling
-    # rather than retry against the wrong directory.
-    !insertmacro readReg $R9 "HKEY_CURRENT_USER" "${INSTALL_REGISTRY_KEY}" InstallLocation
-    ${if} $R9 == ""
+    # $INSTDIR/$appExe describe the new (machine-wide) target, not it. Use the location cached in
+    # customInit: reading the registry HERE is useless for the spurious-failure case, because a
+    # successful per-user uninstall deletes InstallLocation before returning its (untrustworthy)
+    # exit code. Empty cache means no per-user install was registered at install start; keep
+    # electron-builder's default fatal handling rather than retry against an unknown directory.
+    ${if} $perUserInstallDirCache == ""
       MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
       DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
       SetErrorLevel 2
       Quit
     ${endif}
-    !insertmacro uninstallFailureRecoveryAt $R9
+    !insertmacro uninstallFailureRecoveryAt $perUserInstallDirCache
   ${endif}
 !macroend

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -12,51 +12,63 @@
 # (electron-userland/electron-builder#9593). And when the code IS real, it is usually a background
 # child still running from the install dir (micromamba provisioning, the CLI in Node mode, an
 # agent child) locking files — worth one more attempt after a force-kill instead of failing.
-# Recovery order:
+# Recovery order (${DIR} = the installation this pass was uninstalling):
 #   1. Exit code non-zero but the old executable is already gone -> the uninstall did its job
 #      despite the reported code; log and continue installing.
 #   2. Files remain -> force-kill processes running from the install dir, wait, and run the old
 #      uninstaller once more. Only if it still fails show the original dialog and quit.
 # Symbol constraints: handleUninstallResult is parsed BEFORE uninstallOldVersion and
 # CHECK_APP_RUNNING declare their globals ($installationDir, $PowerShellPath, ...), and makensis
-# treats unknown variables as errors — so this stays self-contained: only $appExe (set in the
-# install section before the uninstall pass), registers, built-in constants, and the literal
-# temp-uninstaller path uninstallOldVersion uses. For the SHELL_CONTEXT pass $INSTDIR is the old
-# install location (an update installs over it). The rare installMode==all HKEY_CURRENT_USER pass
-# targets a stray per-user install elsewhere; re-running its uninstaller against $INSTDIR is a
-# harmless no-op that lets the machine-wide install continue.
-!macro uninstallFailureRecovery
-  ${if} $R0 != 0
-    ${ifNot} ${FileExists} "$appExe"
-      DetailPrint `Old uninstaller exited with $R0 but the previous installation is already removed; continuing.`
-    ${else}
-      DetailPrint `Old uninstaller exited with $R0; closing leftover app processes and retrying once.`
-      # Force-kill anything still running from the install dir: path-prefix sweep via PowerShell
-      # (covers micromamba.exe and any other helper), then an image-name taskkill for machines
-      # where PowerShell is unavailable or policy-blocked. Both are best-effort; the retry below
-      # is the real verdict. $0 keeps the uninstaller arguments (/currentuser etc.) — neither
-      # nsExec call touches it.
-      nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -C "Get-CimInstance -ClassName Win32_Process | ? {$$_.Path -and $$_.Path.StartsWith('$INSTDIR', 'CurrentCultureIgnoreCase')} | % { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }"`
-      Pop $R1
-      nsExec::Exec `"$SYSDIR\cmd.exe" /C taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"`
-      Pop $R1
-      ClearErrors
-      Sleep 1000
-      ExecWait '"$PLUGINSDIR\old-uninstaller.exe" /S /KEEP_APP_DATA $0 _?=$INSTDIR' $R0
-      ${if} $R0 != 0
-        MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
-        DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
-        SetErrorLevel 2
-        Quit
-      ${endif}
+# treats unknown variables as errors — so this stays self-contained: registers, built-in
+# constants, and the literal temp-uninstaller path uninstallOldVersion uses.
+!macro uninstallFailureRecoveryAt DIR
+  ${ifNot} ${FileExists} "${DIR}\${APP_EXECUTABLE_FILENAME}"
+    DetailPrint `Old uninstaller exited with $R0 but the previous installation is already removed; continuing.`
+  ${else}
+    DetailPrint `Old uninstaller exited with $R0; closing leftover app processes and retrying once.`
+    # Force-kill anything still running from the install dir, then retry. The PowerShell sweep
+    # matches on ExecutablePath (Win32_Process has no Path property) with a trailing-backslash
+    # boundary so a sibling directory can never match, and receives the directory as an ARGUMENT —
+    # never interpolated into the script source — so a custom install dir containing an apostrophe
+    # breaks nothing and injects nothing. The image-name taskkill covers machines where
+    # PowerShell is unavailable or policy-blocked. Both are best-effort; the retry is the verdict.
+    # $0 keeps the uninstaller arguments (/currentuser etc.) — neither nsExec call touches it.
+    nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -C "$$root = $$args[0].TrimEnd('\') + '\'; Get-CimInstance -ClassName Win32_Process | ? { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, 'CurrentCultureIgnoreCase') } | % { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }" "${DIR}"`
+    Pop $R1
+    nsExec::Exec `"$SYSDIR\cmd.exe" /C taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"`
+    Pop $R1
+    ClearErrors
+    Sleep 1000
+    ExecWait '"$PLUGINSDIR\old-uninstaller.exe" /S /KEEP_APP_DATA $0 _?=${DIR}' $R0
+    ${if} $R0 != 0
+      MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
+      DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
+      SetErrorLevel 2
+      Quit
     ${endif}
   ${endif}
 !macroend
 
 !macro customUnInstallCheck
-  !insertmacro uninstallFailureRecovery
+  ${if} $R0 != 0
+    # SHELL_CONTEXT pass: the old installation sits at $INSTDIR (an update installs over it).
+    !insertmacro uninstallFailureRecoveryAt $INSTDIR
+  ${endif}
 !macroend
 
 !macro customUnInstallCheckCurrentUser
-  !insertmacro uninstallFailureRecovery
+  ${if} $R0 != 0
+    # installMode==all pass: it removes a stray PER-USER install, which may live anywhere —
+    # $INSTDIR/$appExe describe the new (machine-wide) target, not it. Recover the real location
+    # from the registry; when it is unreadable, keep electron-builder's default fatal handling
+    # rather than retry against the wrong directory.
+    !insertmacro readReg $R9 "HKEY_CURRENT_USER" "${INSTALL_REGISTRY_KEY}" InstallLocation
+    ${if} $R9 == ""
+      MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
+      DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
+      SetErrorLevel 2
+      Quit
+    ${endif}
+    !insertmacro uninstallFailureRecoveryAt $R9
+  ${endif}
 !macroend

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -38,3 +38,55 @@ describe('packaging config', () => {
     expect(hook).toContain('micromamba')
   })
 })
+
+describe('NSIS installer include (build/installer.nsh)', () => {
+  const include = readFileSync(join(repoRoot, 'build/installer.nsh'), 'utf8')
+
+  it('overrides the failed-uninstall handling for both registry passes', () => {
+    // electron-builder's handleUninstallResult turns ANY non-zero old-uninstaller exit code into
+    // a fatal "Failed to uninstall old application files" dialog. The assisted installer
+    // (oneClick: false) gets no exit-code normalization (quitSuccess is ONE_CLICK-only), so the
+    // code is not trustworthy — the include must install the resilient handler for both the
+    // SHELL_CONTEXT and the HKEY_CURRENT_USER passes.
+    expect(include).toMatch(/!macro customUnInstallCheck\b/)
+    expect(include).toMatch(/!macro customUnInstallCheckCurrentUser\b/)
+  })
+
+  it('continues the install when the old version is already gone despite a non-zero exit code', () => {
+    // The spurious-exit-2 case: the uninstall completed but a benign trailing error leaked as the
+    // process exit code. Detect it by the old executable no longer existing and keep installing.
+    expect(include).toContain('${FileExists} "$appExe"')
+  })
+
+  it('force-kills install-dir processes and retries the old uninstaller once before failing', () => {
+    // The real-lock case: a background child running from the install dir (micromamba
+    // provisioning, the CLI in Node mode, an agent child) still holds files. Sweep by install-dir
+    // path prefix (PowerShell) and by image name (taskkill fallback), then retry once; only a
+    // repeated failure keeps the original fatal dialog + exit code 2.
+    expect(include).toContain(`$$_.Path.StartsWith('$INSTDIR', 'CurrentCultureIgnoreCase')`)
+    expect(include).toContain('taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"')
+    expect(include).toContain(
+      `ExecWait '"$PLUGINSDIR\\old-uninstaller.exe" /S /KEEP_APP_DATA $0 _?=$INSTDIR' $R0`
+    )
+    expect(include).toContain('$(uninstallFailed): $R0')
+    expect(include).toContain('SetErrorLevel 2')
+  })
+
+  it('never references symbols declared only after handleUninstallResult is parsed', () => {
+    // makensis treats unknown variables as errors (electron-builder builds with warnings as
+    // errors): handleUninstallResult is parsed BEFORE uninstallOldVersion / CHECK_APP_RUNNING
+    // declare their globals, so the hook body must stay self-contained. Comment lines are
+    // stripped before checking — they may name the variables while explaining this.
+    const code = include
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n')
+    expect(code).not.toContain('$installationDir')
+    expect(code).not.toContain('$uninstallerFileNameTemp')
+    expect(code).not.toContain('$PowerShellPath')
+    expect(code).not.toContain('$CmdPath')
+    expect(code).not.toContain('$IsPowerShellAvailable')
+    expect(code).not.toContain('IS_POWERSHELL_AVAILABLE')
+    expect(code).not.toContain('KILL_PROCESS')
+  })
+})

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -88,12 +88,13 @@ describe('NSIS installer include (build/installer.nsh)', () => {
 
   it('retries the old uninstaller exactly once', () => {
     // A single follow-up attempt after the kill; the original ExecWait lives in
-    // electron-builder's uninstallOldVersion, so exactly one may appear here.
+    // electron-builder's uninstallOldVersion, so exactly one may appear here. Assert the
+    // invocation's semantic parts rather than the full literal line, so a benign reformat
+    // (flag reorder, whitespace) does not break the test without a behavior change.
     const attempts = include.match(/ExecWait '"\$PLUGINSDIR\\old-uninstaller\.exe/g) ?? []
     expect(attempts).toHaveLength(1)
-    expect(include).toContain(
-      `ExecWait '"$PLUGINSDIR\\old-uninstaller.exe" /S /KEEP_APP_DATA $0 _?=\${DIR}' $R0`
-    )
+    expect(include).toContain('/S /KEEP_APP_DATA $0')
+    expect(include).toContain('_?=${DIR}')
   })
 
   it('passes the install dir to PowerShell as an argument, with a directory-boundary match', () => {
@@ -134,5 +135,21 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(code).not.toContain('$IsPowerShellAvailable')
     expect(code).not.toContain('IS_POWERSHELL_AVAILABLE')
     expect(code).not.toContain('KILL_PROCESS')
+  })
+
+  it('the installed electron-builder still inserts the customUnInstallCheck hooks', () => {
+    // The recovery runs only if app-builder-lib's handleUninstallResult keeps inserting these two
+    // macro names. electron-builder is a caret-ranged dependency, so a routine bump could rename
+    // or drop the insertion points — the macros would compile into dead code while every
+    // assertion above stays green. Guard the integration contract itself so such an upgrade
+    // fails here instead of silently reverting to the fatal dialog.
+    const installUtil = readFileSync(
+      join(repoRoot, 'node_modules/app-builder-lib/templates/nsis/include/installUtil.nsh'),
+      'utf8'
+    )
+    expect(installUtil).toContain('!ifmacrodef customUnInstallCheck')
+    expect(installUtil).toContain('!insertmacro customUnInstallCheck')
+    expect(installUtil).toContain('!ifmacrodef customUnInstallCheckCurrentUser')
+    expect(installUtil).toContain('!insertmacro customUnInstallCheckCurrentUser')
   })
 })

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -55,21 +55,46 @@ describe('NSIS installer include (build/installer.nsh)', () => {
   it('continues the install when the old version is already gone despite a non-zero exit code', () => {
     // The spurious-exit-2 case: the uninstall completed but a benign trailing error leaked as the
     // process exit code. Detect it by the old executable no longer existing and keep installing.
-    expect(include).toContain('${FileExists} "$appExe"')
+    // The sentinel is parameterized on the pass's own install dir ($INSTDIR for SHELL_CONTEXT,
+    // the registry-read per-user dir for HKEY_CURRENT_USER).
+    expect(include).toContain('${FileExists} "${DIR}\\${APP_EXECUTABLE_FILENAME}"')
   })
 
   it('force-kills install-dir processes and retries the old uninstaller once before failing', () => {
     // The real-lock case: a background child running from the install dir (micromamba
-    // provisioning, the CLI in Node mode, an agent child) still holds files. Sweep by install-dir
-    // path prefix (PowerShell) and by image name (taskkill fallback), then retry once; only a
-    // repeated failure keeps the original fatal dialog + exit code 2.
-    expect(include).toContain(`$$_.Path.StartsWith('$INSTDIR', 'CurrentCultureIgnoreCase')`)
+    // provisioning, the CLI in Node mode, an agent child) still holds files. Sweep by executable
+    // path (Win32_Process has ExecutablePath, NOT Path) and by image name (taskkill fallback),
+    // then retry once; only a repeated failure keeps the original fatal dialog + exit code 2.
+    expect(include).toContain('$$_.ExecutablePath')
+    expect(include).not.toContain('$$_.Path.')
     expect(include).toContain('taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"')
     expect(include).toContain(
-      `ExecWait '"$PLUGINSDIR\\old-uninstaller.exe" /S /KEEP_APP_DATA $0 _?=$INSTDIR' $R0`
+      `ExecWait '"$PLUGINSDIR\\old-uninstaller.exe" /S /KEEP_APP_DATA $0 _?=\${DIR}' $R0`
     )
     expect(include).toContain('$(uninstallFailed): $R0')
     expect(include).toContain('SetErrorLevel 2')
+  })
+
+  it('passes the install dir to PowerShell as an argument, with a directory-boundary match', () => {
+    // Custom install dirs may contain apostrophes: interpolating the path into the script source
+    // would break the command (or worse, inject into it). The dir goes in as $args[0] and the
+    // prefix match is anchored with a trailing backslash so sibling directories never match.
+    expect(include).toContain('$$args[0].TrimEnd')
+    expect(include).toContain('$$_.ExecutablePath.StartsWith($$root')
+    expect(include).not.toContain(`StartsWith('$INSTDIR'`)
+  })
+
+  it('targets the real per-user install location in the current-user hook', () => {
+    // The installMode==all HKCU pass removes a stray per-user install, which may live anywhere —
+    // $INSTDIR/$appExe describe the new machine-wide target. The hook must read InstallLocation
+    // from HKCU and fall back to the default fatal handling when it is unreadable, rather than
+    // retry against the wrong directory.
+    expect(include).toContain(
+      '!insertmacro readReg $R9 "HKEY_CURRENT_USER" "${INSTALL_REGISTRY_KEY}" InstallLocation'
+    )
+    expect(include).toMatch(/\$\{if\} \$R9 == ""/)
+    expect(include).toContain('!insertmacro uninstallFailureRecoveryAt $R9')
+    expect(include).toContain('!insertmacro uninstallFailureRecoveryAt $INSTDIR')
   })
 
   it('never references symbols declared only after handleUninstallResult is parsed', () => {

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -68,11 +68,32 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(include).toContain('$$_.ExecutablePath')
     expect(include).not.toContain('$$_.Path.')
     expect(include).toContain('taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"')
+    expect(include).toContain('$(uninstallFailed): $R0')
+    expect(include).toContain('SetErrorLevel 2')
+  })
+
+  it('runs the image-name taskkill only as a fallback when the PowerShell sweep cannot run', () => {
+    // taskkill /IM matches the exe name in ANY directory — a second install or the portable zip
+    // copy would be killed too, discarding unsaved work. It must fire only when the path-scoped
+    // PowerShell sweep failed to run (nsExec pushes "error" or a non-zero exit code).
+    const code = include
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n')
+    expect(code.match(/taskkill/g) ?? []).toHaveLength(1)
+    expect(code).toMatch(
+      /Pop \$R1[\s\S]*?\$\{if\} \$R1 != 0\s+nsExec::Exec `"\$SYSDIR\\cmd\.exe" \/C taskkill/
+    )
+  })
+
+  it('retries the old uninstaller exactly once', () => {
+    // A single follow-up attempt after the kill; the original ExecWait lives in
+    // electron-builder's uninstallOldVersion, so exactly one may appear here.
+    const attempts = include.match(/ExecWait '"\$PLUGINSDIR\\old-uninstaller\.exe/g) ?? []
+    expect(attempts).toHaveLength(1)
     expect(include).toContain(
       `ExecWait '"$PLUGINSDIR\\old-uninstaller.exe" /S /KEEP_APP_DATA $0 _?=\${DIR}' $R0`
     )
-    expect(include).toContain('$(uninstallFailed): $R0')
-    expect(include).toContain('SetErrorLevel 2')
   })
 
   it('passes the install dir to PowerShell as an argument, with a directory-boundary match', () => {

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -75,12 +75,16 @@ describe('NSIS installer include (build/installer.nsh)', () => {
   it('runs the image-name taskkill only as a fallback when the PowerShell sweep cannot run', () => {
     // taskkill /IM matches the exe name in ANY directory — a second install or the portable zip
     // copy would be killed too, discarding unsaved work. It must fire only when the path-scoped
-    // PowerShell sweep failed to run (nsExec pushes "error" or a non-zero exit code).
+    // PowerShell sweep failed to run (nsExec pushes "error" or a non-zero exit code). micromamba
+    // is included: its image name differs from the app exe, so the app-exe kill alone cannot
+    // cover an in-flight provisioning lock on PowerShell-blocked machines.
     const code = include
       .split('\n')
       .filter((line) => !/^\s*#/.test(line))
       .join('\n')
-    expect(code.match(/taskkill/g) ?? []).toHaveLength(1)
+    expect(code.match(/taskkill/g) ?? []).toHaveLength(2)
+    expect(code).toContain('taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"')
+    expect(code).toContain('taskkill /F /IM micromamba.exe')
     expect(code).toMatch(
       /Pop \$R1[\s\S]*?\$\{if\} \$R1 != 0\s+nsExec::Exec `"\$SYSDIR\\cmd\.exe" \/C taskkill/
     )
@@ -106,17 +110,31 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(include).not.toContain(`StartsWith('$INSTDIR'`)
   })
 
-  it('targets the real per-user install location in the current-user hook', () => {
-    // The installMode==all HKCU pass removes a stray per-user install, which may live anywhere —
-    // $INSTDIR/$appExe describe the new machine-wide target. The hook must read InstallLocation
-    // from HKCU and fall back to the default fatal handling when it is unreadable, rather than
-    // retry against the wrong directory.
-    expect(include).toContain(
-      '!insertmacro readReg $R9 "HKEY_CURRENT_USER" "${INSTALL_REGISTRY_KEY}" InstallLocation'
-    )
-    expect(include).toMatch(/\$\{if\} \$R9 == ""/)
-    expect(include).toContain('!insertmacro uninstallFailureRecoveryAt $R9')
+  it('caches the per-user install location before the HKCU uninstall pass deletes it', () => {
+    // A successful per-user uninstall deletes HKCU InstallLocation, so reading it inside the hook
+    // — after the pass — always comes up empty in exactly the spurious-failure case the hook
+    // exists for. customInit runs before any uninstall pass; the hook must consume its cached
+    // value and fall back to the default fatal handling only when no per-user install was
+    // registered at install start.
+    expect(include).toMatch(/\$\{if\} \$perUserInstallDirCache == ""/)
+    expect(include).toContain('!insertmacro uninstallFailureRecoveryAt $perUserInstallDirCache')
     expect(include).toContain('!insertmacro uninstallFailureRecoveryAt $INSTDIR')
+    // The cache is declared inside customInit itself: a file-scope Var would be declared-but-
+    // unused in the uninstaller build, which makensis fails as a warning.
+    const initHook = include.match(/!macro customInit([\s\S]*?)!macroend/)?.[1] ?? ''
+    expect(initHook).toMatch(
+      /Var \/GLOBAL perUserInstallDirCache[\s\S]*ReadRegStr \$perUserInstallDirCache HKEY_CURRENT_USER "\$\{INSTALL_REGISTRY_KEY\}" InstallLocation/
+    )
+    // The hook itself must not re-read the registry after the pass — that pins the broken order.
+    // (Comments may name the value while explaining; strip them before checking.)
+    const hkcuHook = (
+      include.match(/!macro customUnInstallCheckCurrentUser([\s\S]*?)!macroend/)?.[1] ?? ''
+    )
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n')
+    expect(hkcuHook).not.toContain('readReg')
+    expect(hkcuHook).not.toContain('InstallLocation')
   })
 
   it('never references symbols declared only after handleUninstallResult is parsed', () => {

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -83,11 +83,12 @@ describe('NSIS installer include (build/installer.nsh)', () => {
       .filter((line) => !/^\s*#/.test(line))
       .join('\n')
     expect(code.match(/taskkill/g) ?? []).toHaveLength(2)
-    expect(code).toContain('taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"')
-    expect(code).toContain('taskkill /F /IM micromamba.exe')
-    expect(code).toMatch(
-      /Pop \$R1[\s\S]*?\$\{if\} \$R1 != 0\s+nsExec::Exec `"\$SYSDIR\\cmd\.exe" \/C taskkill/
-    )
+    // Capture the whole guard block and assert BOTH kills live inside it — asserting only the
+    // first one's position would still pass with micromamba's taskkill moved outside the guard.
+    const guardBlock = code.match(/\$\{if\} \$R1 != 0([\s\S]*?)\$\{endif\}/)?.[1] ?? ''
+    expect(guardBlock).toContain('taskkill /F /IM "${APP_EXECUTABLE_FILENAME}"')
+    expect(guardBlock).toContain('taskkill /F /IM micromamba.exe')
+    expect(guardBlock.match(/taskkill/g) ?? []).toHaveLength(2)
   })
 
   it('retries the old uninstaller exactly once', () => {
@@ -169,5 +170,17 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(installUtil).toContain('!insertmacro customUnInstallCheck')
     expect(installUtil).toContain('!ifmacrodef customUnInstallCheckCurrentUser')
     expect(installUtil).toContain('!insertmacro customUnInstallCheckCurrentUser')
+  })
+
+  it('the installed electron-builder still inserts customInit before the uninstall passes', () => {
+    // The per-user install-dir cache only ever runs if installer.nsi keeps inserting customInit
+    // in .onInit. Losing that insertion point leaves the HKCU hook with an always-empty cache —
+    // the exact fatal-path regression the cache fixed — while every source-text test stays green.
+    const installerNsi = readFileSync(
+      join(repoRoot, 'node_modules/app-builder-lib/templates/nsis/installer.nsi'),
+      'utf8'
+    )
+    expect(installerNsi).toContain('!ifmacrodef customInit')
+    expect(installerNsi).toContain('!insertmacro customInit')
   })
 })


### PR DESCRIPTION
## Problem

Windows users updating in-app hit a fatal NSIS dialog: `Failed to uninstall old application files. Please try running the installer again.: 2`. The update aborts and the app has to be reinstalled manually (reported by two users on Windows).

Root cause analysis:

- During an update the new installer runs the **old** uninstaller and treats any non-zero exit code as fatal (`handleUninstallResult` in electron-builder's NSIS templates): dialog, `SetErrorLevel 2`, `Quit`.
- Our installer is assisted (`oneClick: false`). electron-builder normalizes the uninstaller's exit code (`quitSuccess`, "avoid exit code 2") only for ONE_CLICK builds, so on the assisted path a benign trailing error can leak out as **exit code 2 even when the old version was fully removed** — same signature as [electron-userland/electron-builder#9593](https://github.com/electron-userland/electron-builder/issues/9593) (no leftover processes; manually re-running the same uninstaller succeeds).
- When the code *is* real, the lock typically comes from a background child running from the install dir: `resources\micromamba.exe` during in-flight runtime provisioning, the `open-science` CLI in Node mode, or an agent child. The app's pre-update install gate already reaps the agent + kernel trees; the installer-side recovery added here covers what the gate cannot see, at the point of failure.

## Proposed change

Define electron-builder's `customUnInstallCheck` / `customUnInstallCheckCurrentUser` hooks in `build/installer.nsh`. They replace `handleUninstallResult`'s failure path in the **new** installer, so the fix engages when updating **to** a build that contains it — from any old version, including the currently affected ones. Recovery order:

1. Old uninstaller exited non-zero but the old executable (``) is already gone → the uninstall did its job despite the reported code; log and continue installing.
2. Files remain → force-kill whatever still runs from the install dir (PowerShell path-prefix sweep + image-name `taskkill` fallback for PowerShell-restricted machines), wait, and rerun the old uninstaller once. Only if that retry also fails, show the original dialog and quit with exit code 2 (no worse than today).

The hook body is deliberately self-contained (``, registers, built-in constants, the literal `\old-uninstaller.exe` path): `handleUninstallResult` is parsed *before* `uninstallOldVersion`/`CHECK_APP_RUNNING` declare their globals, and makensis treats unknown variables as errors — referencing ``/`` fails the installer compile (caught in local validation, see below).

## Scope and non-goals

- NSIS include + packaging tests only; no app-runtime code changes.
- The pre-update install gate (agent/kernel teardown) is unchanged. Extending it to cancel in-flight micromamba provisioning before `quitAndInstall` is a possible follow-up; the kill + retry here already covers that lock class at the point of failure.
- macOS / Linux update paths untouched.
- Takes effect for updates **to** a release containing it (the hook runs in the new installer); no migration needed.

## Acceptance criteria and validation

- `build/installer.nsh` defines both hooks with the recovery order above; `build/packaging.test.ts` pins the contract (hooks registered for both registry passes, ``-gone short-circuit, kill + single retry, fatal dialog preserved, no late-declared symbols).
- **NSIS compile validated locally**: `npx electron-builder --win nsis --publish never` builds `open-science-0.5.1-win-arm64-setup.exe` with makensis under warnings-as-errors. The first draft referenced `uninstallOldVersion`'s late-declared globals and failed this compile; the final version compiles both the installer and uninstaller passes cleanly.
- `npm run typecheck`, `npm run lint` (0 errors), and `npm run test` (381 files / 4691 tests passed) are green.
- Not exercised end-to-end on a physical Windows machine (none available here); the recovery flow reuses the same primitives electron-builder's own templates use (`nsExec` process sweep, `ExecWait` retry semantics).

## Review focus

- The ``-gone short-circuit: continuing the install when the reported failure is spurious (mirrors the default handler's own "cannot launch uninstaller → continue" asymmetry).
- `$0` preservation: it still carries the uninstaller arguments (`/currentuser` etc.) for the retry; the chosen kill primitives never touch it.
- The installMode==all HKCU-pass caveat documented in the include comment (retry targets `$INSTDIR`; harmless no-op in that rare path).