### PR TITLE
fix(settings): isolate install state per runtime to prevent phantom progress (#278)

### DIFF
--- a/src/renderer/src/pages/onboarding/EnvironmentSetupCard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentSetupCard.render.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { EnvironmentSetupCard } from './EnvironmentSetupCard'
+import type { EnvironmentCheckResult } from '../../../../shared/settings'
+
+// A not-ready, auto-installable environment so the "Install missing runtime" button renders.
+const environment: EnvironmentCheckResult = {
+  checkedAt: 1,
+  platform: 'darwin',
+  architecture: 'arm64',
+  checks: [],
+  ready: false,
+  canAutoInstall: true,
+  agentFrameworkId: 'claude-code',
+  runtime: { found: false }
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const installButton = (): HTMLButtonElement | undefined =>
+  Array.from(container.querySelectorAll('button')).find((b) =>
+    b.textContent?.includes('Install missing runtime')
+  ) as HTMLButtonElement | undefined
+
+describe('EnvironmentSetupCard install button lock', () => {
+  it('disables the install button while ANOTHER runtime installs (installBusy), without showing this runtime as installing', () => {
+    const onInstall = vi.fn()
+    act(() => {
+      root.render(
+        <EnvironmentSetupCard
+          environment={environment}
+          isChecking={false}
+          // This runtime is idle; a different runtime's install is in flight.
+          isInstalling={false}
+          installBusy={true}
+          installLogs={[]}
+          installProgress={null}
+          onCheck={vi.fn()}
+          onInstall={onInstall}
+        />
+      )
+    })
+
+    const button = installButton()
+    // Locked (can't start a second install that would hit the store guard and surface a phantom failure)…
+    expect(button?.disabled).toBe(true)
+    // …but still shows the idle label, not this runtime's "Installing…" state.
+    expect(button?.textContent).toContain('Install missing runtime')
+    expect(button?.textContent).not.toContain('Installing…')
+  })
+
+  it('leaves the install button enabled when no runtime is installing', () => {
+    act(() => {
+      root.render(
+        <EnvironmentSetupCard
+          environment={environment}
+          isChecking={false}
+          isInstalling={false}
+          installBusy={false}
+          installLogs={[]}
+          installProgress={null}
+          onCheck={vi.fn()}
+          onInstall={vi.fn()}
+        />
+      )
+    })
+
+    expect(installButton()?.disabled).toBe(false)
+  })
+})

--- a/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
@@ -24,7 +24,11 @@ import { describeInstallProgress } from '../settings/claude-install-progress'
 type EnvironmentSetupCardProps = {
   environment: EnvironmentCheckResult | undefined
   isChecking: boolean
+  // `isInstalling` drives this card's own progress/label (the selected runtime's install). `busy` locks
+  // the action buttons while ANY runtime installs — including one still finishing on the previously
+  // selected framework during an async switch — so a second install can't start. Defaults to isInstalling.
   isInstalling: boolean
+  busy?: boolean
   installLogs: string[]
   installProgress?: ClaudeInstallProgressEvent | null
   error?: string
@@ -148,12 +152,16 @@ const EnvironmentSetupCard = ({
   environment,
   isChecking,
   isInstalling,
+  busy,
   installLogs,
   installProgress,
   error,
   onCheck,
   onInstall
 }: EnvironmentSetupCardProps): React.JSX.Element => {
+  // Any install running (this runtime's or one finishing on a just-switched-away framework) locks the
+  // buttons; default to this card's own install when the caller doesn't pass a global signal.
+  const anyInstalling = busy ?? isInstalling
   const structuredProgress = installProgress ? describeInstallProgress(installProgress) : undefined
   const progress =
     structuredProgress?.fraction !== undefined
@@ -174,7 +182,7 @@ const EnvironmentSetupCard = ({
           variant="outline"
           size="sm"
           onClick={onCheck}
-          disabled={isChecking || isInstalling}
+          disabled={isChecking || anyInstalling}
         >
           <RefreshCw className={cn(isChecking && 'animate-spin')} aria-hidden="true" />
           {isChecking ? 'Checking…' : 'Check again'}

--- a/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
@@ -240,7 +240,11 @@ const EnvironmentSetupCard = ({
               <Button
                 type="button"
                 onClick={onInstall}
-                disabled={isInstalling || isChecking}
+                // Lock on anyInstalling (not just this runtime's isInstalling): while another runtime
+                // installs, clicking here would hit the store's single-install guard and surface its
+                // rejection as a phantom failure on this untouched runtime. Label still keys off
+                // isInstalling so only THIS runtime's install shows the "Installing…" state.
+                disabled={anyInstalling || isChecking}
                 className="shrink-0"
               >
                 {isInstalling ? (

--- a/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
@@ -28,7 +28,7 @@ type EnvironmentSetupCardProps = {
   // the action buttons while ANY runtime installs — including one still finishing on the previously
   // selected framework during an async switch — so a second install can't start. Defaults to isInstalling.
   isInstalling: boolean
-  busy?: boolean
+  installBusy?: boolean
   installLogs: string[]
   installProgress?: ClaudeInstallProgressEvent | null
   error?: string
@@ -152,7 +152,7 @@ const EnvironmentSetupCard = ({
   environment,
   isChecking,
   isInstalling,
-  busy,
+  installBusy,
   installLogs,
   installProgress,
   error,
@@ -161,7 +161,7 @@ const EnvironmentSetupCard = ({
 }: EnvironmentSetupCardProps): React.JSX.Element => {
   // Any install running (this runtime's or one finishing on a just-switched-away framework) locks the
   // buttons; default to this card's own install when the caller doesn't pass a global signal.
-  const anyInstalling = busy ?? isInstalling
+  const anyInstalling = installBusy ?? isInstalling
   const structuredProgress = installProgress ? describeInstallProgress(installProgress) : undefined
   const progress =
     structuredProgress?.fraction !== undefined

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.env.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.env.render.test.tsx
@@ -13,10 +13,26 @@ vi.mock('../../stores/settings-store', () => {
     claude: {},
     preflight: { claudeReady: true, activeProviderReady: false },
     isDetectingClaude: false,
-    isInstalling: false,
-    installLogs: [] as string[],
-    installProgress: undefined,
-    installError: undefined,
+    installStates: {
+      'claude-code': {
+        isInstalling: false,
+        installLogs: [] as string[],
+        installProgress: null,
+        installError: undefined
+      },
+      opencode: {
+        isInstalling: false,
+        installLogs: [],
+        installProgress: null,
+        installError: undefined
+      },
+      codex: {
+        isInstalling: false,
+        installLogs: [],
+        installProgress: null,
+        installError: undefined
+      }
+    },
     npmAvailable: true,
     encryptionAvailable: true,
     onboardingCompletedAt: undefined,
@@ -52,7 +68,8 @@ vi.mock('../../stores/settings-store', () => {
   const useSettingsStore = (sel: (s: typeof state) => unknown): unknown => sel(state)
   // The wizard reads endpoints via this selector; return a stable default so a provider looks usable.
   const selectFrameworkApiEndpoints = (): string[] => ['anthropic']
-  return { useSettingsStore, selectFrameworkApiEndpoints }
+  const selectAnyInstalling = (): boolean => false
+  return { useSettingsStore, selectFrameworkApiEndpoints, selectAnyInstalling }
 })
 
 let container: HTMLDivElement

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -898,8 +898,26 @@ describe('OnboardingWizard', () => {
         activeProviderReady: false
       },
       environmentCheck: environment(false),
-      isInstalling: true,
-      installLogs: ['Downloading Claude — 5 MB / 10.0 MB']
+      installStates: {
+        'claude-code': {
+          isInstalling: true,
+          installLogs: ['Downloading Claude — 5 MB / 10.0 MB'],
+          installProgress: null,
+          installError: undefined
+        },
+        opencode: {
+          isInstalling: false,
+          installLogs: [],
+          installProgress: null,
+          installError: undefined
+        },
+        codex: {
+          isInstalling: false,
+          installLogs: [],
+          installProgress: null,
+          installError: undefined
+        }
+      }
     })
 
     await act(async () => {

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -23,7 +23,11 @@ import type {
 } from '../../../../shared/settings'
 import { isProviderUsableByFramework } from '../../../../shared/settings'
 import { useNotebookEnvStore } from '@/stores/notebook-env-store'
-import { selectFrameworkApiEndpoints, useSettingsStore } from '@/stores/settings-store'
+import {
+  selectAnyInstalling,
+  selectFrameworkApiEndpoints,
+  useSettingsStore
+} from '@/stores/settings-store'
 import { DataRootWarning } from '@/components/DataRootWarning'
 import { ClaudeInstallCard } from '../settings/ClaudeInstallCard'
 import { ClaudeStatusCard } from '../settings/ClaudeStatusCard'
@@ -132,10 +136,15 @@ const OnboardingWizard = (): React.JSX.Element => {
   const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
   const preflight = useSettingsStore((state) => state.preflight)
   const isDetectingClaude = useSettingsStore((state) => state.isDetectingClaude)
-  const isInstalling = useSettingsStore((state) => state.isInstalling)
-  const installLogs = useSettingsStore((state) => state.installLogs)
-  const installProgress = useSettingsStore((state) => state.installProgress)
-  const storeInstallError = useSettingsStore((state) => state.installError)
+  // Onboarding shows one framework's card at a time, so read that framework's own install slice. Any
+  // install running still locks the framework switcher below (only one install runs at a time).
+  const installStates = useSettingsStore((state) => state.installStates)
+  const anyInstalling = useSettingsStore(selectAnyInstalling)
+  const activeInstall = installStates[agentFrameworkId]
+  const isInstalling = activeInstall.isInstalling
+  const installLogs = activeInstall.installLogs
+  const installProgress = activeInstall.installProgress
+  const storeInstallError = activeInstall.installError
   const npmAvailable = useSettingsStore((state) => state.npmAvailable)
   const encryptionAvailable = useSettingsStore((state) => state.encryptionAvailable)
   const onboardingCompletedAt = useSettingsStore((state) => state.onboardingCompletedAt)
@@ -636,6 +645,7 @@ const OnboardingWizard = (): React.JSX.Element => {
                           environment={environmentCheck}
                           isChecking={isCheckingEnvironment}
                           isInstalling={isInstalling}
+                          busy={anyInstalling}
                           installLogs={installLogs}
                           installProgress={installProgress}
                           error={
@@ -671,6 +681,7 @@ const OnboardingWizard = (): React.JSX.Element => {
                             installLogs={installLogs}
                             installProgress={installProgress}
                             installError={storeInstallError}
+                            installBusy={anyInstalling}
                             npmAvailable={npmAvailable}
                             onInstall={(source) => void handleInstall(source, 'codex')}
                           />
@@ -684,6 +695,7 @@ const OnboardingWizard = (): React.JSX.Element => {
                             installLogs={installLogs}
                             installProgress={installProgress}
                             installError={storeInstallError}
+                            installBusy={anyInstalling}
                             npmAvailable={npmAvailable}
                             onInstall={(source) => void handleInstall(source, 'opencode')}
                           />
@@ -705,6 +717,7 @@ const OnboardingWizard = (): React.JSX.Element => {
                                   installLogs={installLogs}
                                   installProgress={installProgress}
                                   installError={storeInstallError}
+                                  busy={anyInstalling}
                                   npmAvailable={npmAvailable}
                                   onInstall={(source) => void handleInstall(source, 'claude-code')}
                                   embedded
@@ -762,7 +775,7 @@ const OnboardingWizard = (): React.JSX.Element => {
                                   onClick={() => handlePickFramework(framework.id)}
                                   disabled={
                                     isCheckingEnvironment ||
-                                    isInstalling ||
+                                    anyInstalling ||
                                     isDetectingClaude ||
                                     isDetectingOpencode ||
                                     isDetectingCodex

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -645,7 +645,7 @@ const OnboardingWizard = (): React.JSX.Element => {
                           environment={environmentCheck}
                           isChecking={isCheckingEnvironment}
                           isInstalling={isInstalling}
-                          busy={anyInstalling}
+                          installBusy={anyInstalling}
                           installLogs={installLogs}
                           installProgress={installProgress}
                           error={
@@ -717,7 +717,7 @@ const OnboardingWizard = (): React.JSX.Element => {
                                   installLogs={installLogs}
                                   installProgress={installProgress}
                                   installError={storeInstallError}
-                                  busy={anyInstalling}
+                                  installBusy={anyInstalling}
                                   npmAvailable={npmAvailable}
                                   onInstall={(source) => void handleInstall(source, 'claude-code')}
                                   embedded

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -23,6 +23,10 @@ type ClaudeInstallCardProps = {
   // Whether npm is available on the host; disables/deprioritizes the npm source when false.
   npmAvailable: boolean
   onInstall: (source: ClaudeInstallSource) => void
+  // Whether another runtime's install is in flight. Only one install runs at a time, so this locks the
+  // source picker and Install button (without showing this card's own "Installing…" state) so a second
+  // install can't start and cross-contaminate the shared install-event channel. Defaults to isInstalling.
+  busy?: boolean
   embedded?: boolean
   // The install sources to offer; defaults to Claude's. Pass getOpencodeInstallSources to reuse this
   // card for OpenCode (same picker, progress bar, log pane, and copyable command).
@@ -39,9 +43,12 @@ const ClaudeInstallCard = ({
   installError,
   npmAvailable,
   onInstall,
+  busy,
   embedded = false,
   sources
 }: ClaudeInstallCardProps): React.JSX.Element => {
+  // The picker/Install button lock while THIS runtime installs or while ANY other install runs.
+  const locked = isInstalling || (busy ?? false)
   // Default to the app-managed download — it needs no Node.js/npm and works behind region blocks.
   const [source, setSource] = useState<ClaudeInstallSource>('managed')
   const [showLog, setShowLog] = useState(false)
@@ -80,7 +87,7 @@ const ClaudeInstallCard = ({
           </label>
           <Select
             value={source}
-            disabled={isInstalling}
+            disabled={locked}
             onValueChange={(next) => setSource(next as ClaudeInstallSource)}
           >
             <SelectTrigger id="install-source" aria-label="Install source">
@@ -140,7 +147,7 @@ const ClaudeInstallCard = ({
             type="button"
             size="sm"
             onClick={() => onInstall(source)}
-            disabled={isInstalling || npmMissing}
+            disabled={locked || npmMissing}
           >
             {isInstalling ? 'Installing…' : 'Install with one click'}
           </Button>

--- a/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
+++ b/src/renderer/src/pages/settings/ClaudeInstallCard.tsx
@@ -26,7 +26,7 @@ type ClaudeInstallCardProps = {
   // Whether another runtime's install is in flight. Only one install runs at a time, so this locks the
   // source picker and Install button (without showing this card's own "Installing…" state) so a second
   // install can't start and cross-contaminate the shared install-event channel. Defaults to isInstalling.
-  busy?: boolean
+  installBusy?: boolean
   embedded?: boolean
   // The install sources to offer; defaults to Claude's. Pass getOpencodeInstallSources to reuse this
   // card for OpenCode (same picker, progress bar, log pane, and copyable command).
@@ -43,12 +43,12 @@ const ClaudeInstallCard = ({
   installError,
   npmAvailable,
   onInstall,
-  busy,
+  installBusy,
   embedded = false,
   sources
 }: ClaudeInstallCardProps): React.JSX.Element => {
   // The picker/Install button lock while THIS runtime installs or while ANY other install runs.
-  const locked = isInstalling || (busy ?? false)
+  const locked = isInstalling || (installBusy ?? false)
   // Default to the app-managed download — it needs no Node.js/npm and works behind region blocks.
   const [source, setSource] = useState<ClaudeInstallSource>('managed')
   const [showLog, setShowLog] = useState(false)

--- a/src/renderer/src/pages/settings/CodexStatusCard.tsx
+++ b/src/renderer/src/pages/settings/CodexStatusCard.tsx
@@ -171,7 +171,7 @@ const CodexStatusCard = ({
               installLogs={installLogs}
               installProgress={installProgress}
               installError={installError}
-              busy={anyInstalling}
+              installBusy={anyInstalling}
               npmAvailable={npmAvailable}
               onInstall={(source) => {
                 if (source !== 'official-script') onInstall(source)

--- a/src/renderer/src/pages/settings/CodexStatusCard.tsx
+++ b/src/renderer/src/pages/settings/CodexStatusCard.tsx
@@ -18,10 +18,13 @@ type CodexStatusCardProps = {
   codexReady: boolean
   isDetecting: boolean
   onDetect: () => void
+  // `isInstalling` is Codex's OWN install state (drives this card's progress/label); `installBusy` is
+  // true while ANY runtime installs and only locks the controls (one install at a time).
   isInstalling: boolean
   installLogs: string[]
   installProgress: ClaudeInstallProgressEvent | null
   installError: string | undefined
+  installBusy?: boolean
   npmAvailable: boolean
   onInstall: (source: CodexInstallSource) => void
   active?: boolean
@@ -41,6 +44,7 @@ const CodexStatusCard = ({
   installLogs,
   installProgress,
   installError,
+  installBusy,
   npmAvailable,
   onInstall,
   active = false,
@@ -50,6 +54,8 @@ const CodexStatusCard = ({
   isUninstalling = false,
   onUninstall
 }: CodexStatusCardProps): React.JSX.Element => {
+  // Any install (this runtime's or another's) locks the uninstall button; default to this card's own.
+  const anyInstalling = installBusy ?? isInstalling
   const found = Boolean(codex.resolvedPath)
   const installSources = useMemo(() => getCodexInstallSources(), [])
   const selectable = Boolean(onSelect) && codexReady
@@ -108,7 +114,7 @@ const CodexStatusCard = ({
                 variant="destructive"
                 size="sm"
                 onClick={onUninstall}
-                disabled={active || isUninstalling || isDetecting}
+                disabled={active || isUninstalling || isDetecting || anyInstalling}
                 title={
                   active ? 'Switch to the other framework before uninstalling Codex' : undefined
                 }
@@ -165,6 +171,7 @@ const CodexStatusCard = ({
               installLogs={installLogs}
               installProgress={installProgress}
               installError={installError}
+              busy={anyInstalling}
               npmAvailable={npmAvailable}
               onInstall={(source) => {
                 if (source !== 'official-script') onInstall(source)

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
@@ -23,10 +23,13 @@ type OpencodeStatusCardProps = {
   isDetecting: boolean
   onDetect: () => void
   // Install picker (managed / npm / script, managed first) shown when opencode isn't detected.
+  // `isInstalling` is OpenCode's OWN install state (drives this card's progress/label); `installBusy`
+  // is true while ANY runtime installs and only locks the controls (one install at a time).
   isInstalling: boolean
   installLogs: string[]
   installProgress: ClaudeInstallProgressEvent | null
   installError: string | undefined
+  installBusy?: boolean
   npmAvailable: boolean
   onInstall: (source: ClaudeInstallSource) => void
   // Marks this as the runtime the selected agent framework uses, so it stands out when both cards show.
@@ -57,6 +60,7 @@ const OpencodeStatusCard = ({
   installLogs,
   installProgress,
   installError,
+  installBusy,
   npmAvailable,
   onInstall,
   active = false,
@@ -66,6 +70,8 @@ const OpencodeStatusCard = ({
   isUninstalling = false,
   onUninstall
 }: OpencodeStatusCardProps): React.JSX.Element => {
+  // Any install (this runtime's or another's) locks the uninstall button; default to this card's own.
+  const anyInstalling = installBusy ?? isInstalling
   const found = Boolean(opencode.resolvedPath)
   const installSources = useMemo(() => getOpencodeInstallSources(window.api?.platform), [])
   // Only a ready runtime can be chosen as the active framework — switching to a missing or unrunnable
@@ -126,7 +132,7 @@ const OpencodeStatusCard = ({
                 active={active}
                 isUninstalling={isUninstalling}
                 isDetecting={isDetecting}
-                isInstalling={isInstalling}
+                isInstalling={anyInstalling}
                 onUninstall={onUninstall}
               />
             ) : null}
@@ -171,6 +177,7 @@ const OpencodeStatusCard = ({
               installLogs={installLogs}
               installProgress={installProgress}
               installError={installError}
+              busy={anyInstalling}
               npmAvailable={npmAvailable}
               onInstall={onInstall}
             />

--- a/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
+++ b/src/renderer/src/pages/settings/OpencodeStatusCard.tsx
@@ -177,7 +177,7 @@ const OpencodeStatusCard = ({
               installLogs={installLogs}
               installProgress={installProgress}
               installError={installError}
-              busy={anyInstalling}
+              installBusy={anyInstalling}
               npmAvailable={npmAvailable}
               onInstall={onInstall}
             />

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -24,7 +24,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { useSettingsStore } from '@/stores/settings-store'
+import { selectAnyInstalling, useSettingsStore } from '@/stores/settings-store'
 import { ModelFrameworkCompatibilityAlert } from './ModelFrameworkCompatibilityAlert'
 import { ClaudeInstallCard } from './ClaudeInstallCard'
 import { ClaudeStatusCard } from './ClaudeStatusCard'
@@ -168,10 +168,12 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const isDetectingCodex = useSettingsStore((state) => state.isDetectingCodex)
   const detectCodex = useSettingsStore((state) => state.detectCodex)
   const installCodex = useSettingsStore((state) => state.installCodex)
-  const isInstalling = useSettingsStore((state) => state.isInstalling)
-  const installLogs = useSettingsStore((state) => state.installLogs)
-  const installProgress = useSettingsStore((state) => state.installProgress)
-  const installError = useSettingsStore((state) => state.installError)
+  // Per-runtime install slices: each card renders only its own progress/logs/error (issue #278).
+  const claudeInstall = useSettingsStore((state) => state.installStates['claude-code'])
+  const opencodeInstall = useSettingsStore((state) => state.installStates.opencode)
+  const codexInstall = useSettingsStore((state) => state.installStates.codex)
+  // Any install running locks the framework selector and every card's uninstall button.
+  const anyInstalling = useSettingsStore(selectAnyInstalling)
   const npmAvailable = useSettingsStore((state) => state.npmAvailable)
   const encryptionAvailable = useSettingsStore((state) => state.encryptionAvailable)
   const claudeManaged = useSettingsStore((state) => state.claudeManaged)
@@ -862,18 +864,19 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                           onDetect={() => void detectClaude()}
                           active={agentFrameworkId === 'claude-code'}
                           onSelect={() => requestSwitch('claude-code')}
-                          selectDisabled={isInstalling || isUninstalling}
+                          selectDisabled={anyInstalling || isUninstalling}
                           managed={claudeManaged}
                           isUninstalling={isUninstalling && pendingUninstall === 'claude'}
-                          isInstalling={isInstalling}
+                          isInstalling={anyInstalling}
                           onUninstall={() => setPendingUninstall('claude')}
                         />
                         {!preflight.claudeReady ? (
                           <ClaudeInstallCard
-                            isInstalling={isInstalling}
-                            installLogs={installLogs}
-                            installProgress={installProgress}
-                            installError={installError}
+                            isInstalling={claudeInstall.isInstalling}
+                            installLogs={claudeInstall.installLogs}
+                            installProgress={claudeInstall.installProgress}
+                            installError={claudeInstall.installError}
+                            busy={anyInstalling}
                             npmAvailable={npmAvailable}
                             onInstall={(source) => void installClaude(source)}
                           />
@@ -883,15 +886,16 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                           opencodeReady={preflight.opencodeReady}
                           isDetecting={isDetectingOpencode}
                           onDetect={() => void detectOpencode()}
-                          isInstalling={isInstalling}
-                          installLogs={installLogs}
-                          installProgress={installProgress}
-                          installError={installError}
+                          isInstalling={opencodeInstall.isInstalling}
+                          installLogs={opencodeInstall.installLogs}
+                          installProgress={opencodeInstall.installProgress}
+                          installError={opencodeInstall.installError}
+                          installBusy={anyInstalling}
                           npmAvailable={npmAvailable}
                           onInstall={(source) => void installOpencode(source)}
                           active={agentFrameworkId === 'opencode'}
                           onSelect={() => requestSwitch('opencode')}
-                          selectDisabled={isInstalling || isUninstalling}
+                          selectDisabled={anyInstalling || isUninstalling}
                           managed={opencodeManaged}
                           isUninstalling={isUninstalling && pendingUninstall === 'opencode'}
                           onUninstall={() => setPendingUninstall('opencode')}
@@ -901,15 +905,16 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                           codexReady={preflight.codexReady}
                           isDetecting={isDetectingCodex}
                           onDetect={() => void detectCodex()}
-                          isInstalling={isInstalling}
-                          installLogs={installLogs}
-                          installProgress={installProgress}
-                          installError={installError}
+                          isInstalling={codexInstall.isInstalling}
+                          installLogs={codexInstall.installLogs}
+                          installProgress={codexInstall.installProgress}
+                          installError={codexInstall.installError}
+                          installBusy={anyInstalling}
                           npmAvailable={npmAvailable}
                           onInstall={(source) => void installCodex(source)}
                           active={agentFrameworkId === 'codex'}
                           onSelect={() => requestSwitch('codex')}
-                          selectDisabled={isInstalling || isUninstalling}
+                          selectDisabled={anyInstalling || isUninstalling}
                           managed={codexManaged}
                           isUninstalling={isUninstalling && pendingUninstall === 'codex'}
                           onUninstall={() => setPendingUninstall('codex')}

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -876,7 +876,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                             installLogs={claudeInstall.installLogs}
                             installProgress={claudeInstall.installProgress}
                             installError={claudeInstall.installError}
-                            busy={anyInstalling}
+                            installBusy={anyInstalling}
                             npmAvailable={npmAvailable}
                             onInstall={(source) => void installClaude(source)}
                           />

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -10,6 +10,7 @@ import type {
 import { CODEX_SUBSCRIPTION_PROVIDER_ID } from '../../../shared/settings'
 import {
   createInitialSettingsState,
+  selectAnyInstalling,
   selectProviderModelOptions,
   useSettingsStore
 } from './settings-store'
@@ -1189,6 +1190,31 @@ describe('settings store: setAgentFramework', () => {
     resolveClaude({ installId: 'claude-1', ok: true })
     await firstPending
     expect(useSettingsStore.getState().installStates['claude-code'].isInstalling).toBe(false)
+  })
+
+  it('clearInstallLogs clears transient fields but preserves the install lock (isInstalling)', () => {
+    // Simulate a runtime mid-install with accumulated logs/progress/error.
+    useSettingsStore.setState((state) => ({
+      installStates: {
+        ...state.installStates,
+        codex: {
+          isInstalling: true,
+          installLogs: ['line 1', 'line 2'],
+          installProgress: { kind: 'progress', phase: 'download', message: 'x' } as never,
+          installError: 'stale error'
+        }
+      }
+    }))
+
+    useSettingsStore.getState().clearInstallLogs('codex')
+
+    const codex = useSettingsStore.getState().installStates.codex
+    expect(codex.installLogs).toEqual([])
+    expect(codex.installProgress).toBeNull()
+    expect(codex.installError).toBeUndefined()
+    // The lock must survive: dropping it mid-install would let a second install start.
+    expect(codex.isInstalling).toBe(true)
+    expect(selectAnyInstalling(useSettingsStore.getState())).toBe(true)
   })
 })
 

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
+  ClaudeInstallEvent,
   EnvironmentCheckResult,
   SettingsSnapshot,
   ValidateProviderResult,
@@ -23,6 +24,8 @@ type SettingsApi = {
   detectClaude: ReturnType<typeof vi.fn>
   detectOpencode: ReturnType<typeof vi.fn>
   detectCodex: ReturnType<typeof vi.fn>
+  installClaude: ReturnType<typeof vi.fn>
+  installOpencode: ReturnType<typeof vi.fn>
   installCodex: ReturnType<typeof vi.fn>
   uninstallCodex: ReturnType<typeof vi.fn>
   onInstallLog: ReturnType<typeof vi.fn>
@@ -121,6 +124,8 @@ beforeEach(() => {
         codex: { resolvedPath: '/bin/codex-acp', version: '1.1.4' }
       })
     }),
+    installClaude: vi.fn().mockResolvedValue({ installId: 'claude-1', ok: true }),
+    installOpencode: vi.fn().mockResolvedValue({ installId: 'opencode-1', ok: true }),
     installCodex: vi.fn().mockResolvedValue({ installId: 'codex-1', ok: true }),
     uninstallCodex: vi.fn().mockResolvedValue(snapshot([])),
     onInstallLog: vi.fn().mockReturnValue(vi.fn()),
@@ -1065,6 +1070,110 @@ describe('settings store: setAgentFramework', () => {
     await useSettingsStore.getState().uninstallCodex()
     expect(api.uninstallCodex).toHaveBeenCalledOnce()
     expect(useSettingsStore.getState().codex).toEqual({})
+  })
+
+  it('streams install events into the installing runtime slice only, leaving the others untouched (#278)', async () => {
+    // Capture the install-log listener and hold the install open so mid-install state is observable.
+    let emit: (event: ClaudeInstallEvent) => void = () => undefined
+    api.onInstallLog.mockImplementation((listener: (event: ClaudeInstallEvent) => void) => {
+      emit = listener
+      return vi.fn()
+    })
+    let resolveInstall: (result: { installId: string; ok: boolean }) => void = () => undefined
+    api.installCodex.mockImplementation(
+      () =>
+        new Promise<{ installId: string; ok: boolean }>((resolve) => {
+          resolveInstall = resolve
+        })
+    )
+
+    const pending = useSettingsStore.getState().installCodex()
+
+    // A progress tick and a log chunk arrive on the shared channel while Codex is installing.
+    emit({ kind: 'progress', installId: 'codex-1', phase: 'installing' })
+    emit({ kind: 'log', installId: 'codex-1', stream: 'stdout', chunk: 'Fetching adapter\n' })
+
+    const mid = useSettingsStore.getState().installStates
+    // Codex's slice reflects its own install...
+    expect(mid.codex.isInstalling).toBe(true)
+    expect(mid.codex.installProgress).toEqual({
+      kind: 'progress',
+      installId: 'codex-1',
+      phase: 'installing'
+    })
+    expect(mid.codex.installLogs).toEqual(['Fetching adapter\n'])
+    // ...while Claude's and OpenCode's slices stay pristine — no phantom install (the bug in #278).
+    expect(mid['claude-code']).toEqual({
+      isInstalling: false,
+      installLogs: [],
+      installProgress: null,
+      installError: undefined
+    })
+    expect(mid.opencode).toEqual({
+      isInstalling: false,
+      installLogs: [],
+      installProgress: null,
+      installError: undefined
+    })
+
+    resolveInstall({ installId: 'codex-1', ok: true })
+    await pending
+
+    // After completion the install flag clears and no error is recorded on a success.
+    const done = useSettingsStore.getState().installStates
+    expect(done.codex.isInstalling).toBe(false)
+    expect(done.codex.installError).toBeUndefined()
+  })
+
+  it('records an install failure on the runtime slice without disturbing the others', async () => {
+    api.installCodex.mockResolvedValue({
+      installId: 'codex-1',
+      ok: false,
+      error: 'Download failed'
+    })
+
+    await useSettingsStore.getState().installCodex()
+
+    const states = useSettingsStore.getState().installStates
+    expect(states.codex.installError).toBe('Download failed')
+    expect(states.codex.isInstalling).toBe(false)
+    expect(states['claude-code'].installError).toBeUndefined()
+    expect(states.opencode.installError).toBeUndefined()
+  })
+
+  it('refuses a second concurrent install so subscriptions can never cross-contaminate (#278)', async () => {
+    // Hold a Claude install open so a second install is attempted while the first is still in flight.
+    api.onInstallLog.mockReturnValue(vi.fn())
+    let resolveClaude: (result: { installId: string; ok: boolean }) => void = () => undefined
+    api.installClaude.mockImplementation(
+      () =>
+        new Promise<{ installId: string; ok: boolean }>((resolve) => {
+          resolveClaude = resolve
+        })
+    )
+
+    const firstPending = useSettingsStore.getState().installClaude('managed')
+    expect(useSettingsStore.getState().installStates['claude-code'].isInstalling).toBe(true)
+
+    // The store's atomic guard rejects the overlapping install for a different runtime — main is never
+    // asked to install, and the Codex slice stays pristine (no phantom install).
+    const blocked = await useSettingsStore.getState().installCodex()
+    expect(blocked).toEqual({
+      installId: '',
+      ok: false,
+      error: 'Another install is already in progress.'
+    })
+    expect(api.installCodex).not.toHaveBeenCalled()
+    expect(useSettingsStore.getState().installStates.codex).toEqual({
+      isInstalling: false,
+      installLogs: [],
+      installProgress: null,
+      installError: undefined
+    })
+
+    resolveClaude({ installId: 'claude-1', ok: true })
+    await firstPending
+    expect(useSettingsStore.getState().installStates['claude-code'].isInstalling).toBe(false)
   })
 })
 

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1141,6 +1141,21 @@ describe('settings store: setAgentFramework', () => {
     expect(states.opencode.installError).toBeUndefined()
   })
 
+  it('does not relabel a successful install as failed when the post-install reconcile throws', async () => {
+    api.installCodex.mockResolvedValue({ installId: 'codex-1', ok: true })
+    // The install succeeded, but the snapshot reconcile that follows it fails (transient IPC error).
+    api.getSettings.mockRejectedValueOnce(new Error('IPC channel closed'))
+
+    // The reconcile error is swallowed (the install succeeded), so the call resolves rather than throws.
+    const result = await useSettingsStore.getState().installCodex()
+    expect(result).toEqual({ installId: 'codex-1', ok: true })
+
+    const state = useSettingsStore.getState().installStates.codex
+    // No phantom failure: installError stays clear and the install flag is reset.
+    expect(state.installError).toBeUndefined()
+    expect(state.isInstalling).toBe(false)
+  })
+
   it('refuses a second concurrent install so subscriptions can never cross-contaminate (#278)', async () => {
     // Hold a Claude install open so a second install is attempted while the first is still in flight.
     api.onInstallLog.mockReturnValue(vi.fn())

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -656,7 +656,17 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         ? [runtime]
         : ['claude-code', 'opencode', 'codex']
       const installStates = { ...state.installStates }
-      for (const id of runtimes) installStates[id] = createInitialRuntimeInstallState()
+      // Clear only the transient display fields; preserve isInstalling. Resetting the whole slice would
+      // flip isInstalling to false mid-install, dropping the single-install lock (selectAnyInstalling)
+      // and letting a second install start — the exact invariant this store guards.
+      for (const id of runtimes) {
+        installStates[id] = {
+          ...installStates[id],
+          installLogs: [],
+          installProgress: null,
+          installError: undefined
+        }
+      }
       return { installStates }
     }),
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -394,21 +394,36 @@ const runRuntimeInstall = async (
   })
 
   try {
-    const result = await invoke()
+    // The install itself and the post-install snapshot reconcile are distinct concerns. Only an install
+    // failure (invoke throwing, or a non-ok result) may set installError; a reconcile that throws AFTER
+    // a successful install must not relabel it as failed (that would be a phantom failure on a runtime
+    // that actually installed).
+    let result: ClaudeInstallResult
+    try {
+      result = await invoke()
+    } catch (error) {
+      patchInstallState(set, runtime, {
+        installError: error instanceof Error ? error.message : 'Install failed.'
+      })
+      throw error
+    }
 
-    // A successful install re-detected/persisted the runtime in main; reload so the card reflects it.
-    set(applySnapshot(await window.api.settings.getSettings()))
-    await get().refreshPreflight()
+    // Record the outcome from the install result itself, before the (best-effort) reconcile below.
     patchInstallState(set, runtime, {
       installError: result.ok ? undefined : (result.error ?? 'Install failed.')
     })
 
+    // A successful install re-detected/persisted the runtime in main; reload so the card reflects it.
+    // Best-effort: a transient snapshot/preflight error leaves the card briefly stale (corrected on the
+    // next detect/refresh), which is preferable to overwriting a good install result with a failure.
+    try {
+      set(applySnapshot(await window.api.settings.getSettings()))
+      await get().refreshPreflight()
+    } catch {
+      // Intentionally swallowed — the install succeeded; installError already reflects `result`.
+    }
+
     return result
-  } catch (error) {
-    patchInstallState(set, runtime, {
-      installError: error instanceof Error ? error.message : 'Install failed.'
-    })
-    throw error
   } finally {
     unsubscribe()
     patchInstallState(set, runtime, { isInstalling: false, installProgress: null })

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { create, type StoreApi } from 'zustand'
 
 import type { OfficialVendorId } from '../../../shared/provider-registry'
 import {
@@ -57,6 +57,18 @@ type SaveProviderResult = {
   validation: ValidateProviderResult
 }
 
+// One runtime's install state. Each framework (Claude / OpenCode / Codex) owns an isolated copy, so an
+// install event is attributed to its runtime and rendered by that card only — starting a Codex install
+// never drives the OpenCode or Claude card (issue #278).
+type RuntimeInstallState = {
+  isInstalling: boolean
+  installLogs: string[]
+  // Latest progress tick driving this runtime's install bar; null when no install is active for it.
+  installProgress: ClaudeInstallProgressEvent | null
+  // Error message from this runtime's last install attempt; drives auto-expansion of its log pane.
+  installError: string | undefined
+}
+
 type SettingsStoreData = {
   isLoaded: boolean
   claude: ClaudeInfo
@@ -105,13 +117,9 @@ type SettingsStoreData = {
   isDetectingClaude: boolean
   isDetectingOpencode: boolean
   isDetectingCodex: boolean
-  isInstalling: boolean
-  installLogs: string[]
-  // Latest progress tick driving the install progress bar; null when no install is active.
-  installProgress: ClaudeInstallProgressEvent | null
-  // Error message from the last install attempt; drives auto-expansion of the log pane. Undefined on
-  // success or before the first attempt.
-  installError: string | undefined
+  // Per-runtime install state, keyed by framework id. Each runtime's install writes only to its own
+  // slice so its progress/logs/error render in its own card alone — never mirrored onto the others.
+  installStates: Record<AgentFrameworkId, RuntimeInstallState>
   // Explicit repair navigation. Completed users stay on Home during background checks and enter the
   // environment page only after choosing the required-item alert.
   isEnvironmentRepairOpen: boolean
@@ -137,7 +145,7 @@ type SettingsStore = SettingsStoreData & {
     source: ClaudeInstallSource,
     managedRegistry?: ManagedClaudeRegistry
   ) => Promise<ClaudeInstallResult>
-  // App-managed OpenCode install; shares the install progress/log state with installClaude.
+  // App-managed OpenCode install; writes only to the OpenCode install slice.
   installOpencode: (source?: ClaudeInstallSource) => Promise<ClaudeInstallResult>
   installCodex: (source?: CodexInstallSource) => Promise<ClaudeInstallResult>
   // Removes the app-managed runtime for a framework (guarded main-side to app-managed installs) and
@@ -145,7 +153,8 @@ type SettingsStore = SettingsStoreData & {
   uninstallClaude: () => Promise<void>
   uninstallOpencode: () => Promise<void>
   uninstallCodex: () => Promise<void>
-  clearInstallLogs: () => void
+  // Clears the transient logs/progress/error for one runtime (or every runtime when omitted).
+  clearInstallLogs: (runtime?: AgentFrameworkId) => void
   openEnvironmentRepair: () => void
   closeEnvironmentRepair: () => void
   // Persists the draft (create/update) without testing it, returning the affected provider id. The
@@ -238,6 +247,20 @@ type SettingsStore = SettingsStoreData & {
   setPackageMirror: (mirror: PackageMirror) => Promise<void>
 }
 
+const createInitialRuntimeInstallState = (): RuntimeInstallState => ({
+  isInstalling: false,
+  installLogs: [],
+  installProgress: null,
+  installError: undefined
+})
+
+// True while any runtime install is running. Only one install runs at a time, so the settings/onboarding
+// pages use this to lock the framework selector and every card's uninstall button during an install.
+export const selectAnyInstalling = (state: SettingsStoreData): boolean =>
+  state.installStates['claude-code'].isInstalling ||
+  state.installStates.opencode.isInstalling ||
+  state.installStates.codex.isInstalling
+
 const createInitialPreflight = (): Preflight => ({
   claudeReady: false,
   opencodeReady: false,
@@ -277,10 +300,11 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   isDetectingClaude: false,
   isDetectingOpencode: false,
   isDetectingCodex: false,
-  isInstalling: false,
-  installLogs: [],
-  installProgress: null,
-  installError: undefined,
+  installStates: {
+    'claude-code': createInitialRuntimeInstallState(),
+    opencode: createInitialRuntimeInstallState(),
+    codex: createInitialRuntimeInstallState()
+  },
   isEnvironmentRepairOpen: false,
   isSettingsOpen: false,
   pendingSkillId: undefined,
@@ -305,6 +329,84 @@ const applySnapshot = (snapshot: SettingsSnapshot): Partial<SettingsStoreData> =
   opencodeManaged: snapshot.opencodeManaged,
   codexManaged: snapshot.codexManaged ?? false
 })
+
+// Merges a patch into one runtime's install slice, leaving the other runtimes' slices untouched. This
+// isolation is the fix for issue #278: an install event only ever mutates the runtime it belongs to.
+const patchInstallState = (
+  set: StoreApi<SettingsStore>['setState'],
+  runtime: AgentFrameworkId,
+  patch: Partial<RuntimeInstallState>
+): void =>
+  set((state) => ({
+    installStates: {
+      ...state.installStates,
+      [runtime]: { ...state.installStates[runtime], ...patch }
+    }
+  }))
+
+// Shared install driver for all three runtimes. Streams the (single-channel) install events into the
+// given runtime's slice only, then reconciles the snapshot/preflight and records that runtime's error.
+// `onInstallLog` is a broadcast channel, so correct attribution requires exactly one live subscription:
+// the guard below enforces the single-install invariant in the store itself (not just via the UI lock),
+// so even a stray caller or a mid-switch UI race can't start a second install that cross-contaminates
+// another runtime's slice (issue #278). Every event the lone subscription sees therefore belongs to
+// `runtime`.
+const runRuntimeInstall = async (
+  set: StoreApi<SettingsStore>['setState'],
+  get: StoreApi<SettingsStore>['getState'],
+  runtime: AgentFrameworkId,
+  invoke: () => Promise<ClaudeInstallResult>
+): Promise<ClaudeInstallResult> => {
+  // Refuse to start a second concurrent install. The check + set is synchronous (no await between them),
+  // so it's atomic against the single-threaded event loop: two callers can't both pass the guard.
+  if (selectAnyInstalling(get())) {
+    return { installId: '', ok: false, error: 'Another install is already in progress.' }
+  }
+
+  patchInstallState(set, runtime, {
+    isInstalling: true,
+    installLogs: [],
+    installProgress: null,
+    installError: undefined
+  })
+
+  const unsubscribe = window.api.settings.onInstallLog((event) => {
+    if (event.kind === 'progress') {
+      patchInstallState(set, runtime, { installProgress: event })
+    } else {
+      set((state) => ({
+        installStates: {
+          ...state.installStates,
+          [runtime]: {
+            ...state.installStates[runtime],
+            installLogs: [...state.installStates[runtime].installLogs, event.chunk]
+          }
+        }
+      }))
+    }
+  })
+
+  try {
+    const result = await invoke()
+
+    // A successful install re-detected/persisted the runtime in main; reload so the card reflects it.
+    set(applySnapshot(await window.api.settings.getSettings()))
+    await get().refreshPreflight()
+    patchInstallState(set, runtime, {
+      installError: result.ok ? undefined : (result.error ?? 'Install failed.')
+    })
+
+    return result
+  } catch (error) {
+    patchInstallState(set, runtime, {
+      installError: error instanceof Error ? error.message : 'Install failed.'
+    })
+    throw error
+  } finally {
+    unsubscribe()
+    patchInstallState(set, runtime, { isInstalling: false, installProgress: null })
+  }
+}
 
 // Stable fallback reference so the selector returns the same array identity across renders
 // (a fresh literal would make useSettingsStore re-render every tick and loop).
@@ -493,91 +595,20 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     }
   },
 
-  // Runs a one-click install, streaming events into installProgress/installLogs, then refreshes
-  // settings/preflight. Log and progress share one channel, routed here by `kind`.
-  installClaude: async (source, managedRegistry) => {
-    set({ isInstalling: true, installLogs: [], installProgress: null, installError: undefined })
+  // Runs a one-click Claude install, streaming events into the Claude slice only, then refreshes
+  // settings/preflight. Log and progress share one channel, routed by `kind` into this runtime's card.
+  installClaude: async (source, managedRegistry) =>
+    runRuntimeInstall(set, get, 'claude-code', () =>
+      window.api.settings.installClaude({ source, managedRegistry })
+    ),
 
-    const unsubscribe = window.api.settings.onInstallLog((event) => {
-      if (event.kind === 'progress') {
-        set({ installProgress: event })
-      } else {
-        set((state) => ({ installLogs: [...state.installLogs, event.chunk] }))
-      }
-    })
+  // App-managed OpenCode install; streams into the OpenCode slice only.
+  installOpencode: async (source = 'managed') =>
+    runRuntimeInstall(set, get, 'opencode', () => window.api.settings.installOpencode({ source })),
 
-    try {
-      const result = await window.api.settings.installClaude({ source, managedRegistry })
-
-      // A successful install re-detects claude in main; reload so the cache reflects it.
-      const snapshot = await window.api.settings.getSettings()
-
-      set(applySnapshot(snapshot))
-      await get().refreshPreflight()
-
-      set({ installError: result.ok ? undefined : (result.error ?? 'Install failed.') })
-
-      return result
-    } catch (error) {
-      set({ installError: error instanceof Error ? error.message : 'Install failed.' })
-      throw error
-    } finally {
-      unsubscribe()
-      set({ isInstalling: false, installProgress: null })
-    }
-  },
-
-  // App-managed OpenCode install, mirroring installClaude's shared progress/log handling.
-  installOpencode: async (source = 'managed') => {
-    set({ isInstalling: true, installLogs: [], installProgress: null, installError: undefined })
-
-    const unsubscribe = window.api.settings.onInstallLog((event) => {
-      if (event.kind === 'progress') {
-        set({ installProgress: event })
-      } else {
-        set((state) => ({ installLogs: [...state.installLogs, event.chunk] }))
-      }
-    })
-
-    try {
-      const result = await window.api.settings.installOpencode({ source })
-
-      // A successful install persisted opencode's path/version in main; reload so the card reflects it.
-      set(applySnapshot(await window.api.settings.getSettings()))
-      await get().refreshPreflight()
-      set({ installError: result.ok ? undefined : (result.error ?? 'Install failed.') })
-
-      return result
-    } catch (error) {
-      set({ installError: error instanceof Error ? error.message : 'Install failed.' })
-      throw error
-    } finally {
-      unsubscribe()
-      set({ isInstalling: false, installProgress: null })
-    }
-  },
-
-  installCodex: async (source = 'managed') => {
-    set({ isInstalling: true, installLogs: [], installProgress: null, installError: undefined })
-    const unsubscribe = window.api.settings.onInstallLog((event) => {
-      if (event.kind === 'progress') set({ installProgress: event })
-      else set((state) => ({ installLogs: [...state.installLogs, event.chunk] }))
-    })
-
-    try {
-      const result = await window.api.settings.installCodex({ source })
-      set(applySnapshot(await window.api.settings.getSettings()))
-      await get().refreshPreflight()
-      set({ installError: result.ok ? undefined : (result.error ?? 'Install failed.') })
-      return result
-    } catch (error) {
-      set({ installError: error instanceof Error ? error.message : 'Install failed.' })
-      throw error
-    } finally {
-      unsubscribe()
-      set({ isInstalling: false, installProgress: null })
-    }
-  },
+  // App-managed / npm Codex install; streams into the Codex slice only.
+  installCodex: async (source = 'managed') =>
+    runRuntimeInstall(set, get, 'codex', () => window.api.settings.installCodex({ source })),
 
   // Removes the app-managed Claude runtime; main deletes it, re-detects, and may auto-switch the active
   // framework. Applies the refreshed snapshot and re-evaluates the readiness gate.
@@ -597,7 +628,15 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     await get().refreshPreflight()
   },
 
-  clearInstallLogs: () => set({ installLogs: [], installProgress: null, installError: undefined }),
+  clearInstallLogs: (runtime) =>
+    set((state) => {
+      const runtimes: AgentFrameworkId[] = runtime
+        ? [runtime]
+        : ['claude-code', 'opencode', 'codex']
+      const installStates = { ...state.installStates }
+      for (const id of runtimes) installStates[id] = createInitialRuntimeInstallState()
+      return { installStates }
+    }),
 
   openEnvironmentRepair: () => set({ isEnvironmentRepairOpen: true }),
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -359,6 +359,13 @@ const runRuntimeInstall = async (
 ): Promise<ClaudeInstallResult> => {
   // Refuse to start a second concurrent install. The check + set is synchronous (no await between them),
   // so it's atomic against the single-threaded event loop: two callers can't both pass the guard.
+  //
+  // This is a safety backstop, not a user-facing path: the UI already disables every Install button while
+  // any runtime installs (selectAnyInstalling + the cards' busy/installBusy props), so a user cannot reach
+  // this branch. It exists only for a stray/programmatic caller or a mid-switch race. The rejection is
+  // therefore intentionally silent — it writes to no slice (writing an error here would surface a phantom
+  // failure on a runtime the user never touched, the inverse of the #278 bug) and callers ignore the
+  // result. If a real UI trigger for this path is ever added, surface the error on the target slice then.
   if (selectAnyInstalling(get())) {
     return { installId: '', ok: false, error: 'Another install is already in progress.' }
   }


### PR DESCRIPTION
## Summary

Fixes #278. Starting an install for one agent runtime (e.g. Codex) drove the *other* runtime cards' (Claude, OpenCode) progress bars and logs, showing a phantom install that was never requested.

## Root cause

All three install methods (`installClaude`, `installOpencode`, `installCodex`) wrote to a single shared set of flat store fields — `isInstalling`, `installLogs`, `installProgress`, `installError`. Every card read those same fields, so any install's progress mirrored onto all three cards.

## Fix

Replace the flat fields with a per-runtime `installStates` record keyed by `AgentFrameworkId`. Each install streams its events into its own slice only; the other slices are never touched.

- `RuntimeInstallState` type + `createInitialRuntimeInstallState` factory
- `runRuntimeInstall` — shared driver owning subscribe/stream/unsubscribe, patching only its own slice
- `patchInstallState` — targeted immutable merge into one slice
- `selectAnyInstalling` — global lock so the framework selector and every card's Uninstall button still disable during any install (one install at a time is preserved)
- **Atomic single-install guard** inside `runRuntimeInstall`: it refuses to start a second install when any runtime is already installing (synchronous check+set, no `await` between). This enforces the single-install invariant in the store itself, so the shared broadcast `onInstallLog` channel can never have two subscribers cross-contaminating slices — independent of the UI lock. The rejection writes to no slice (a UI-unreachable backstop; surfacing an error would be a phantom failure on an untouched runtime)
- `installBusy` prop (unified across all four install-card prop types) locks a card's controls — without showing its own "Installing…" state — while another runtime installs, including one still finishing on a just-switched-away framework during an async framework switch. The onboarding automatic-install and check buttons lock on `anyInstalling`, not just this runtime's `isInstalling`
- Post-install reconcile (`getSettings` + `refreshPreflight`) is now best-effort in its own `try`: a transient reconcile error no longer relabels a successful install as failed
- `clearInstallLogs(runtime?)` clears only the transient logs/progress/error and preserves `isInstalling`, so it can't drop the install lock mid-install

## Testing

- Five new store tests: (1) install events stream into the installing runtime's slice only while the others stay pristine; (2) a failure records on the right slice alone; (3) a post-install reconcile throw does not relabel a successful install as failed; (4) a second concurrent install is refused so subscriptions can't cross-contaminate; (5) `clearInstallLogs` clears transient fields but preserves the install lock
- New `EnvironmentSetupCard.render.test.tsx`: the automatic-install button is disabled (and keeps its idle label) while another runtime installs, and enabled when idle
- Updated the two `OnboardingWizard` render tests for the per-runtime `installStates` store shape
- Full suite green: **4718 passed, 66 skipped**
- `typecheck:web`, `typecheck:node`, and `lint` clean on all changed files

## Known follow-up (non-blocking)

Install events are attributed to the sole live subscription rather than filtered by `installId`. Correct today because the atomic guard enforces exactly one subscriber; routing by `installId` would require tagging the main-process broadcast payload and is tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)