### PR TITLE
feat(providers): add MiniMax OpenAI and Responses endpoints

### DIFF
--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -47,6 +47,16 @@ describe('provider registry', () => {
     expect(resolveVendorBaseUrl('minimax')).toBe('https://api.minimax.io/anthropic')
   })
 
+  it('serves MiniMax over Anthropic, OpenAI, and Responses per region', () => {
+    // MiniMax exposes the Anthropic route plus the OpenAI /v1/chat/completions and /v1/responses.
+    expect(resolveVendorApiEndpoints('minimax')).toEqual(['anthropic', 'openai', 'responses'])
+    expect(resolveVendorOpenAiBaseUrl('minimax', 'global')).toBe('https://api.minimax.io/v1')
+    expect(resolveVendorOpenAiBaseUrl('minimax', 'china')).toBe('https://api.minimaxi.com/v1')
+    // Unknown / missing region falls back to the first region's OpenAI base.
+    expect(resolveVendorOpenAiBaseUrl('minimax')).toBe('https://api.minimax.io/v1')
+    expect(resolveVendorOpenAiBaseUrl('minimax', 'nope')).toBe('https://api.minimax.io/v1')
+  })
+
   it('routes GLM to Z.AI overseas and BigModel in China, on both endpoints', () => {
     expect(vendorHasRegions('zhipu')).toBe(true)
     expect(resolveVendorBaseUrl('zhipu', 'global')).toBe('https://api.z.ai/api/anthropic')

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -217,17 +217,24 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'minimax',
     label: 'MiniMax',
+    // MiniMax serves the Anthropic /v1/messages route under `/anthropic`, plus the OpenAI-compatible
+    // /v1/chat/completions and OpenAI Responses /v1/responses under `/v1`, from a Global host (.io) and
+    // a mainland-China one (.com). `baseUrl` is the Anthropic route; `openaiBaseUrl` is the `/v1` base
+    // clients append `/chat/completions` to, and the Responses probe derives `/v1/responses` from it.
+    apiEndpoints: ['anthropic', 'openai', 'responses'],
     regions: [
       {
         id: 'global',
         label: 'Global',
         baseUrl: 'https://api.minimax.io/anthropic',
+        openaiBaseUrl: 'https://api.minimax.io/v1',
         apiKeyUrl: 'https://platform.minimax.io/user-center/basic-information/interface-key'
       },
       {
         id: 'china',
         label: 'China',
         baseUrl: 'https://api.minimaxi.com/anthropic',
+        openaiBaseUrl: 'https://api.minimaxi.com/v1',
         apiKeyUrl: 'https://platform.minimaxi.com/user-center/basic-information/interface-key'
       }
     ],


### PR DESCRIPTION
## Summary

MiniMax serves three routes on each of its two hosts — the Anthropic `/v1/messages` route (under `/anthropic`), the OpenAI-compatible `/v1/chat/completions`, and OpenAI Responses `/v1/responses` (both under `/v1`) — but the registry only declared the Anthropic route. This adds the missing two, mirroring StepFun's three-endpoint shape.

- Declare `apiEndpoints: ['anthropic', 'openai', 'responses']` on the MiniMax vendor.
- Add a per-region `openaiBaseUrl`: `https://api.minimax.io/v1` (Global) and `https://api.minimaxi.com/v1` (China).

The Responses probe derives `/v1/responses` from `openaiBaseUrl` (stripping a trailing `/v1`), so China resolves to `https://api.minimaxi.com/v1/responses`, matching MiniMax's documented endpoint:

```
curl https://api.minimaxi.com/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer xxx" \
  -d '{ "model": "MiniMax-M3", "input": "hello" }'
```

This is a data-only registry change; the endpoint URLs are derived generically off `openaiBaseUrl`, so no wiring code changed. Codex can now drive MiniMax over the Responses bridge and OpenCode over the OpenAI route.

## Testing

- Added a registry test asserting MiniMax's endpoints and per-region OpenAI bases (Global, China, and fallback).