### PR TITLE
fix(codex): drive native-Responses providers directly, not via the bridge

### DIFF
--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -100,6 +100,47 @@ describe('codexFramework', () => {
     expect(config.env?.CODEX_CONFIG).not.toContain('upstream-secret')
   })
 
+  it('drives a native-Responses vendor directly on its OpenAI /v1 base, ignoring the bridge', () => {
+    const framework = createCodexFramework()
+    // A dual-endpoint vendor (e.g. MiniMax) advertises openai + responses and keeps its Anthropic
+    // route in baseUrl and its OpenAI/Responses /v1 root in openaiBaseUrl. Even if a bridge object
+    // is present, native Responses must post to the vendor's own /v1 base with the vendor key.
+    const config = framework.prepareModelConfig(
+      {
+        type: 'custom',
+        apiEndpoints: ['anthropic', 'openai', 'responses'],
+        baseUrl: 'https://api.minimaxi.com/anthropic',
+        openaiBaseUrl: 'https://api.minimaxi.com/v1',
+        model: 'MiniMax-M3',
+        key: 'mm-secret'
+      },
+      {
+        storageRoot: '/data',
+        executablePath: '/runtime/codex-acp',
+        responsesBridge: { baseUrl: 'http://127.0.0.1:43123/v1', token: 'local-token' }
+      }
+    )
+
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).toMatchObject({
+      model: 'MiniMax-M3',
+      model_providers: {
+        'open-science': {
+          base_url: 'https://api.minimaxi.com/v1',
+          requires_openai_auth: true,
+          wire_api: 'responses'
+        }
+      }
+    })
+    // Direct native path: vendor key auth, no bridge provider-configuration, no bridge model.
+    expect(config.authentication).toEqual({
+      methodId: 'api-key',
+      _meta: { 'api-key': { apiKey: 'mm-secret' } }
+    })
+    expect(config.providerConfiguration).toBeUndefined()
+    expect(config.sessionModel).toBeUndefined()
+    expect(config.env?.CODEX_CONFIG).not.toContain('127.0.0.1:43123')
+  })
+
   it('reuses the normal Codex profile for a shared subscription without overriding it', () => {
     const framework = createCodexFramework()
     const config = framework.prepareModelConfig(

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -231,6 +231,13 @@ export const createCodexFramework = ({
     const useBridge =
       bridge !== undefined && !(provider.apiEndpoints?.includes('responses') ?? false)
     const codexModel = useBridge ? CODEX_BRIDGE_MODEL : provider.model
+    // Native Responses is driven directly. A dual-endpoint vendor keeps its Anthropic route in
+    // `baseUrl` and its OpenAI/Responses `/v1` root in `openaiBaseUrl`, so post to the latter; a
+    // Responses-only provider (e.g. OpenAI) carries its base in `baseUrl`. When bridging, the local
+    // bridge URL wins.
+    const responsesBaseUrl = useBridge
+      ? bridge.baseUrl
+      : (provider.openaiBaseUrl ?? provider.baseUrl)
     const authentication: AgentAuthentication | undefined =
       provider.key && !useBridge
         ? {
@@ -246,7 +253,7 @@ export const createCodexFramework = ({
           buildCodexConfig({
             ...provider,
             model: codexModel,
-            baseUrl: bridge?.baseUrl ?? provider.baseUrl,
+            baseUrl: responsesBaseUrl,
             key: useBridge ? undefined : provider.key,
             reasoningEffort: ctx.reasoningEffort
           })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1308,6 +1308,52 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(pubmedSkill).toContain('host.mcp')
   })
 
+  it('drives a native-Responses official vendor directly, without starting the bridge', async () => {
+    // MiniMax advertises anthropic + openai + responses. Codex must drive native Responses on the
+    // vendor's own OpenAI /v1 base with the vendor key — NOT spin up the Chat Completions bridge and
+    // post to its local URL (which would authenticate with the vendor key instead of the bridge token).
+    const adapterPath = join(storageRoot, 'bin', 'codex-acp')
+    await mkdir(dirname(adapterPath), { recursive: true })
+    await writeFile(adapterPath, '', 'utf8')
+    const service = createService(undefined, {
+      codexDetected: { path: adapterPath, version: 'codex-acp 1.1.4' }
+    })
+    await repository.setCodexInfo({ resolvedPath: adapterPath, version: '1.1.4' })
+    await repository.setAgentFramework('codex')
+    const provider = (
+      await service.upsertProvider({
+        type: 'official',
+        name: 'MiniMax',
+        vendorId: 'minimax',
+        region: 'global',
+        key: 'mm-secret'
+      })
+    ).providers[0]
+    const storedProvider = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({ ...storedProvider, lastValidatedAt: Date.now() })
+    await service.setActiveProvider(provider.id)
+
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
+    const backend = await service.resolveActiveAgentBackend()
+
+    // No bridge: no local provider-configuration, no bridge session model.
+    expect(backend.providerConfiguration).toBeUndefined()
+    expect(backend.sessionModel).toBe('MiniMax-M3')
+    // Codex posts native Responses to the vendor's own /v1 base with the vendor key.
+    const codexConfig = JSON.parse(backend.env.CODEX_CONFIG ?? '{}')
+    expect(codexConfig.model_providers['open-science']).toMatchObject({
+      base_url: 'https://api.minimax.io/v1',
+      wire_api: 'responses',
+      requires_openai_auth: true
+    })
+    expect(backend.authentication).toEqual({
+      methodId: 'api-key',
+      _meta: { 'api-key': { apiKey: 'mm-secret' } }
+    })
+    expect(backend.env.CODEX_CONFIG).not.toContain('127.0.0.1')
+    expect(backend.env.CODEX_CONFIG).not.toContain('mm-secret')
+  })
+
   it('builds spawn env from the active provider with the decrypted key', async () => {
     const service = createService()
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2169,8 +2169,14 @@ class SettingsService {
     if (!(framework.id === 'codex' && provider.type === 'codex-shared')) {
       await this.materializeAgentSkills(settings, skillsRoot)
     }
+    // The Chat Completions bridge only exists to let Codex (a Responses-only client) drive an
+    // OpenAI Chat provider. A provider that also speaks native Responses is driven directly, so
+    // starting the bridge for it would be dead weight — and worse, Codex would post to the bridge's
+    // local URL with the provider key instead of the bridge token. Bridge openai-only providers.
     const needsResponsesBridge =
-      framework.id === 'codex' && (provider.apiEndpoints?.includes('openai') ?? false)
+      framework.id === 'codex' &&
+      (provider.apiEndpoints?.includes('openai') ?? false) &&
+      !(provider.apiEndpoints?.includes('responses') ?? false)
     const enabledConnectorIds = this.enabledConnectorIds(settings.connectors)
     const responsesBridge = needsResponsesBridge
       ? await this.ensureResponsesBridge(provider, enabledConnectorIds, sessionEffort !== undefined)


### PR DESCRIPTION
## Summary

Follow-up to #290 (MiniMax `openai` + `responses` endpoints). Addresses the P1 review finding: a vendor advertising **both** `openai` and `responses` broke Codex sessions.

### Root cause

- `service.ts` started the Chat Completions bridge whenever `apiEndpoints` included `openai` — true for MiniMax (and StepFun).
- `codex.ts` correctly declines the bridge for a provider that speaks native Responses (`useBridge = false`), but still passed `bridge?.baseUrl ?? provider.baseUrl` as the base URL. With the bridge object present, Codex received the **bridge's local URL** while authenticating with the **vendor key** (not the bridge token) → native Responses requests fail.
- Validation still succeeded against the vendor's real `/v1/responses`, masking the runtime failure.

### Fix

- **service.ts** — only start the bridge for `openai`-only providers (`includes('openai') && !includes('responses')`). Native-Responses vendors are driven directly, so the bridge would be dead weight (and the source of the misroute).
- **codex.ts** — for native Responses, post to the vendor's own OpenAI `/v1` base (`openaiBaseUrl`, falling back to `baseUrl` for Responses-only providers like OpenAI) with the vendor key. The bridge URL is used only when actually bridging.

This also fixes the same latent bug for StepFun, the other 3-endpoint vendor.

## Testing

- `npm run typecheck` — clean.
- `npm run lint` — 0 errors.
- `npm run test` — targeted suites green (`codex.test.ts`, `service.test.ts`, `provider-registry.test.ts`).
- Added a codex-framework unit test (native vendor with a bridge present → posts to its `/v1` base, vendor-key auth, no bridge provider-config) and the service-level test the reviewer requested (official provider offering all three protocols → bridge not started).