### PR TITLE
feat(notebook): export sessions as ipynb

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -23,7 +23,7 @@ import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
 import { AcpRuntime } from './runtime'
 import { installAgentShutdownGuard } from './shutdown-guard'
 import { AgentMcpHttpHost } from './mcp-http-host'
-import type { ArtifactRepository } from '../artifacts/repository'
+import { ArtifactRepository } from '../artifacts/repository'
 import type { ArtifactRunRegistry } from '../artifacts/run-registry'
 import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
 import { NotebookRunRepository } from '../notebook/repository'
@@ -198,6 +198,7 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntime => {
 // Creates the shared notebook runtime used by both renderer IPC and agent MCP calls.
 const createDefaultNotebookRuntimeService = (): NotebookRuntimeService => {
   const dataRoot = resolveDataRoot()
+  const artifactRepository = new ArtifactRepository(dataRoot)
 
   return new NotebookRuntimeService({
     configRoot: resolveConfigRoot(),
@@ -207,6 +208,8 @@ const createDefaultNotebookRuntimeService = (): NotebookRuntimeService => {
     // Region default for manage_packages when no mirror is configured; the configured override is
     // wired in main/ipc.ts via setPackageMirrorResolver once the settings service is constructed.
     locale: app.getLocale(),
+    appVersion: app.getVersion(),
+    resolveArtifactPath: (path) => artifactRepository.resolveManagedFilePath({ path }),
     callbacks: {
       onNotebookAvailable: (event) => broadcast('notebook:available', event),
       onNotebookChanged: (event) => broadcast('notebook:changed', event)

--- a/src/main/notebook/ipc.test.ts
+++ b/src/main/notebook/ipc.test.ts
@@ -30,6 +30,7 @@ describe('notebook IPC handlers', () => {
         text: { stdout: 'ok\n', stderr: '', traceback: '', plain: ['ok'] }
       }),
       runCell: vi.fn().mockResolvedValue({ runId: 'run-2', status: 'completed' }),
+      exportIpynb: vi.fn().mockResolvedValue({ saved: true, filePath: '/tmp/session.ipynb' }),
       beginCodeCell: vi.fn().mockResolvedValue({ cellId: 'cell-1', writeId: 'write-1' }),
       appendCodeCell: vi.fn().mockResolvedValue({ receivedBytes: 5 }),
       finishCodeCell: vi.fn().mockResolvedValue({ status: 'idle' }),
@@ -68,6 +69,7 @@ describe('notebook IPC handlers', () => {
     })
     await handlers.restart({ sessionId: 'session-1', workspaceCwd: '/workspace' })
     await handlers.shutdown({ sessionId: 'session-1', workspaceCwd: '/workspace' })
+    await handlers.exportIpynb({ sessionId: 'session-1', workspaceCwd: '/workspace' })
 
     expect(service.execute).toHaveBeenCalledWith({
       sessionId: 'session-1',
@@ -89,6 +91,10 @@ describe('notebook IPC handlers', () => {
       sessionId: 'session-1',
       workspaceCwd: '/workspace'
     })
+    expect(service.exportIpynb).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace'
+    })
   })
 
   it('registers every notebook channel and forwards the renderer payload unchanged', async () => {
@@ -100,6 +106,7 @@ describe('notebook IPC handlers', () => {
       finishCodeCell: vi.fn().mockResolvedValue({ status: 'idle' }),
       runCell: vi.fn().mockResolvedValue({ runId: 'run-1', status: 'completed' }),
       execute: vi.fn().mockResolvedValue({ runId: 'run-2', status: 'completed' }),
+      exportIpynb: vi.fn().mockResolvedValue({ saved: false }),
       restart: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
       shutdown: vi.fn().mockResolvedValue({ sessionId: 'session-1', status: 'shutdown' })
     } as unknown as NotebookRuntimeService
@@ -113,6 +120,7 @@ describe('notebook IPC handlers', () => {
       'notebook:finish-code-cell',
       'notebook:run-cell',
       'notebook:execute',
+      'notebook:export-ipynb',
       'notebook:restart',
       'notebook:shutdown'
     ])
@@ -131,6 +139,7 @@ describe('notebook IPC handlers', () => {
     await ipcHandlers.get('notebook:finish-code-cell')?.(undefined, finish)
     await ipcHandlers.get('notebook:run-cell')?.(undefined, run)
     await ipcHandlers.get('notebook:execute')?.(undefined, execute)
+    await ipcHandlers.get('notebook:export-ipynb')?.(undefined, session)
     await ipcHandlers.get('notebook:restart')?.(undefined, session)
     await ipcHandlers.get('notebook:shutdown')?.(undefined, session)
 
@@ -141,6 +150,7 @@ describe('notebook IPC handlers', () => {
     expect(service.finishCodeCell).toHaveBeenCalledWith(finish)
     expect(service.runCell).toHaveBeenCalledWith(run)
     expect(service.execute).toHaveBeenCalledWith(execute)
+    expect(service.exportIpynb).toHaveBeenCalledWith(session)
     expect(service.restart).toHaveBeenCalledWith(session)
     expect(service.shutdown).toHaveBeenCalledWith(session)
   })

--- a/src/main/notebook/ipc.ts
+++ b/src/main/notebook/ipc.ts
@@ -4,6 +4,7 @@ import type {
   AppendNotebookCodeCellRequest,
   BeginNotebookCodeCellRequest,
   ExecuteNotebookCodeRequest,
+  ExportNotebookResult,
   FinishNotebookCodeCellRequest,
   NotebookRunSummary,
   NotebookSessionReference,
@@ -27,6 +28,7 @@ type NotebookHandlers = {
   ) => ReturnType<NotebookRuntimeService['finishCodeCell']>
   runCell: (request: RunNotebookCellRequest) => Promise<NotebookRunSummary>
   execute: (request: ExecuteNotebookCodeRequest) => Promise<NotebookRunSummary>
+  exportIpynb: (request: NotebookSessionRequest) => Promise<ExportNotebookResult>
   restart: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
   shutdown: (request: NotebookSessionRequest) => ReturnType<NotebookRuntimeService['shutdown']>
 }
@@ -40,6 +42,7 @@ const createNotebookHandlers = (service: NotebookRuntimeService): NotebookHandle
   finishCodeCell: (request) => service.finishCodeCell(request),
   runCell: (request) => service.runCell(request),
   execute: (request) => service.execute(request),
+  exportIpynb: (request) => service.exportIpynb(request),
   restart: (request) => service.restart(request),
   shutdown: (request) => service.shutdown(request)
 })
@@ -68,6 +71,9 @@ const registerNotebookIpcHandlers = (service: NotebookRuntimeService): void => {
   )
   ipcMain.handle('notebook:execute', (_event, request: ExecuteNotebookCodeRequest) =>
     handlers.execute(request)
+  )
+  ipcMain.handle('notebook:export-ipynb', (_event, request: NotebookSessionRequest) =>
+    handlers.exportIpynb(request)
   )
   ipcMain.handle('notebook:restart', (_event, request: NotebookSessionRequest) =>
     handlers.restart(request)

--- a/src/main/notebook/ipynb-export.test.ts
+++ b/src/main/notebook/ipynb-export.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { NotebookRunDocument, NotebookRunRecord } from '../../shared/notebook'
+import { runDocumentToIpynb } from './ipynb-export'
+
+const makeRun = (overrides: Partial<NotebookRunRecord> = {}): NotebookRunRecord => ({
+  runId: 'run-1',
+  cellId: 'cell-1',
+  source: 'agent',
+  kernelKind: 'python',
+  script: 'print("hello")\n2 + 2',
+  status: 'completed',
+  startedAt: 100,
+  endedAt: 200,
+  executionCount: 1,
+  text: { stdout: '', stderr: '', traceback: '', plain: [] },
+  outputs: [],
+  artifacts: [],
+  workingFiles: [],
+  environment: 'default-python',
+  ...overrides
+})
+
+const makeDocument = (runs: NotebookRunRecord[]): NotebookRunDocument => ({
+  version: 1,
+  projectName: 'default-project',
+  sessionId: 'session-123',
+  workspaceCwd: '/workspace',
+  notebookSessionRoot: '/data/notebooks/default-project/session-123',
+  dataRoot: '/data/notebooks/default-project/session-123/data',
+  kernel: {
+    language: 'python',
+    kernelName: 'python3',
+    runtimeRoot: '/data/runtime',
+    lastKnownStatus: 'idle'
+  },
+  runs,
+  updatedAt: 300
+})
+
+describe('runDocumentToIpynb', () => {
+  it('projects source, provenance, execution count, and every structured output kind', async () => {
+    const run = makeRun({
+      outputs: [
+        { type: 'stream', name: 'stdout', text: 'hello\nworld' },
+        { type: 'stream', name: 'stderr', text: 'warning' },
+        { type: 'display', data: { 'image/png': 'aW1hZ2U=', 'text/plain': '<plot>' } },
+        { type: 'json', data: { answer: 42 } },
+        { type: 'text', text: '4' },
+        { type: 'error', name: 'ValueError', message: 'bad value', traceback: 'line 1\nline 2' }
+      ]
+    })
+
+    const notebook = await runDocumentToIpynb(makeDocument([run]), { appVersion: '1.2.3' })
+
+    expect(notebook).toMatchObject({
+      nbformat: 4,
+      nbformat_minor: 5,
+      metadata: {
+        kernelspec: { name: 'python3', language: 'python' },
+        open_science: {
+          sessionId: 'session-123',
+          projectName: 'default-project',
+          appVersion: '1.2.3'
+        }
+      }
+    })
+    expect(notebook.cells[0]).toMatchObject({
+      cell_type: 'code',
+      id: 'run-1',
+      execution_count: 1,
+      source: ['print("hello")\n', '2 + 2'],
+      metadata: {
+        open_science: {
+          runId: 'run-1',
+          startedAt: 100,
+          status: 'completed',
+          kernel: 'python',
+          environment: 'default-python'
+        }
+      }
+    })
+    expect(notebook.cells[0].outputs).toEqual([
+      { output_type: 'stream', name: 'stdout', text: ['hello\n', 'world'] },
+      { output_type: 'stream', name: 'stderr', text: ['warning'] },
+      {
+        output_type: 'display_data',
+        data: { 'image/png': 'aW1hZ2U=', 'text/plain': '<plot>' },
+        metadata: {}
+      },
+      { output_type: 'display_data', data: { 'application/json': { answer: 42 } }, metadata: {} },
+      {
+        output_type: 'execute_result',
+        data: { 'text/plain': '4' },
+        metadata: {},
+        execution_count: 1
+      },
+      {
+        output_type: 'error',
+        ename: 'ValueError',
+        evalue: 'bad value',
+        traceback: ['line 1\n', 'line 2']
+      }
+    ])
+  })
+
+  it('uses flattened text only as a legacy fallback, without duplicating structured streams', async () => {
+    const fallback = makeRun({
+      runId: 'fallback',
+      text: { stdout: 'out', stderr: 'err', traceback: 'boom', plain: [] }
+    })
+    const structured = makeRun({
+      runId: 'structured',
+      text: { stdout: 'duplicate', stderr: '', traceback: '', plain: [] },
+      outputs: [{ type: 'stream', name: 'stdout', text: 'canonical' }]
+    })
+
+    const notebook = await runDocumentToIpynb(makeDocument([fallback, structured]))
+
+    expect(notebook.cells[0].outputs).toHaveLength(3)
+    expect(notebook.cells[1].outputs).toEqual([
+      { output_type: 'stream', name: 'stdout', text: ['canonical'] }
+    ])
+  })
+
+  it('chooses the dominant data kernel and marks downgraded bash and repl cells', async () => {
+    const notebook = await runDocumentToIpynb(
+      makeDocument([
+        makeRun({ runId: 'r-1', kernelKind: 'r', script: 'print(1)' }),
+        makeRun({ runId: 'r-2', kernelKind: 'r', script: 'print(2)' }),
+        makeRun({ runId: 'py', kernelKind: 'python' }),
+        makeRun({ runId: 'bash', kernelKind: 'bash', script: 'pwd', environment: undefined }),
+        makeRun({
+          runId: 'repl',
+          kernelKind: 'repl',
+          script: 'await host.mcp()',
+          environment: undefined
+        })
+      ])
+    )
+
+    expect(notebook.metadata.kernelspec).toEqual({
+      display_name: 'R',
+      language: 'R',
+      name: 'ir'
+    })
+    expect(notebook.cells[3]).toMatchObject({
+      source: ['%%bash\n', 'pwd'],
+      metadata: { tags: ['open-science-bash'], open_science: { kernel: 'bash' } }
+    })
+    expect(notebook.cells[4]).toMatchObject({
+      source: ['%%javascript\n', 'await host.mcp()'],
+      metadata: { tags: ['open-science-repl'], open_science: { kernel: 'repl' } }
+    })
+  })
+
+  it('sets unfinished execution counts to null and emits valid unique run-based cell ids', async () => {
+    const notebook = await runDocumentToIpynb(
+      makeDocument([
+        makeRun({ runId: 'run.with invalid spaces', cellId: 'same', status: 'running' }),
+        makeRun({ runId: 'run-2', cellId: 'same', status: 'interrupted' })
+      ])
+    )
+
+    expect(notebook.cells.map((cell) => cell.id)).toEqual(['run-with-invalid-spaces', 'run-2'])
+    expect(notebook.cells.map((cell) => cell.execution_count)).toEqual([null, null])
+  })
+
+  it('inlines resolved artifacts and degrades resolver failures to stderr', async () => {
+    const run = makeRun({
+      artifacts: [
+        {
+          id: 'a1',
+          projectName: 'default-project',
+          sessionId: 'session-123',
+          runId: 'run-1',
+          name: 'plot.png',
+          path: '/data/plot.png',
+          fileUrl: 'artifact://plot.png',
+          mimeType: 'image/png',
+          size: 3,
+          mtimeMs: 1
+        },
+        {
+          id: 'a2',
+          projectName: 'default-project',
+          sessionId: 'session-123',
+          runId: 'run-1',
+          name: 'missing.txt',
+          path: '/data/missing.txt',
+          fileUrl: 'artifact://missing.txt',
+          mimeType: 'text/plain',
+          size: 0,
+          mtimeMs: 1
+        }
+      ]
+    })
+    const resolveArtifact = vi.fn(async (artifact: NotebookRunRecord['artifacts'][number]) => {
+      if (artifact.id === 'a2') throw new Error('missing')
+      return { mimeType: 'image/png', data: 'cG5n' }
+    })
+
+    const notebook = await runDocumentToIpynb(makeDocument([run]), { resolveArtifact })
+
+    expect(notebook.cells[0].outputs).toEqual([
+      { output_type: 'display_data', data: { 'image/png': 'cG5n' }, metadata: {} },
+      {
+        output_type: 'stream',
+        name: 'stderr',
+        text: ['[Open Science] Could not inline artifact: missing.txt\n']
+      }
+    ])
+  })
+
+  it('is idempotent for the same document and deterministic resolver', async () => {
+    const document = makeDocument([makeRun()])
+    const first = await runDocumentToIpynb(document)
+    const second = await runDocumentToIpynb(document)
+
+    expect(second).toEqual(first)
+  })
+})

--- a/src/main/notebook/ipynb-export.ts
+++ b/src/main/notebook/ipynb-export.ts
@@ -1,0 +1,269 @@
+import type {
+  NotebookKernelKind,
+  NotebookOutput,
+  NotebookRunDocument,
+  NotebookRunRecord
+} from '../../shared/notebook'
+
+type NbformatOutput =
+  | {
+      output_type: 'stream'
+      name: 'stdout' | 'stderr'
+      text: string[]
+    }
+  | {
+      output_type: 'error'
+      ename: string
+      evalue: string
+      traceback: string[]
+    }
+  | {
+      output_type: 'display_data' | 'execute_result'
+      data: Record<string, unknown>
+      metadata: Record<string, unknown>
+      execution_count?: number | null
+    }
+
+type OpenScienceCellMetadata = {
+  runId: string
+  startedAt: number
+  status: NotebookRunRecord['status']
+  kernel: NotebookKernelKind
+  environment?: string
+}
+
+type NbformatCodeCell = {
+  cell_type: 'code'
+  execution_count: number | null
+  id: string
+  metadata: {
+    open_science: OpenScienceCellMetadata
+    tags?: string[]
+  }
+  outputs: NbformatOutput[]
+  source: string[]
+}
+
+type IpynbNotebook = {
+  cells: NbformatCodeCell[]
+  metadata: {
+    kernelspec: {
+      display_name: string
+      language: string
+      name: string
+    }
+    language_info: {
+      name: string
+    }
+    open_science: {
+      sessionId: string
+      projectName: string
+      appVersion?: string
+    }
+  }
+  nbformat: 4
+  nbformat_minor: 5
+}
+
+type ResolvedArtifact = {
+  mimeType: string
+  data: unknown
+}
+
+type RunDocumentToIpynbOptions = {
+  appVersion?: string
+  resolveArtifact?: (
+    artifact: NotebookRunRecord['artifacts'][number],
+    run: NotebookRunRecord
+  ) => Promise<ResolvedArtifact | null>
+}
+
+// nbformat accepts either one string or an array of lines. Arrays make generated notebooks stable and
+// easy to diff, while preserving every original newline.
+const splitLines = (value: string): string[] => {
+  if (!value) return []
+  const lines = value.match(/[^\n]*\n|[^\n]+$/g)
+  return lines ?? []
+}
+
+const nbformatCellId = (runId: string): string => {
+  const safe = runId.replace(/[^A-Za-z0-9_-]/g, '-').slice(0, 64)
+  return safe || 'open-science-cell'
+}
+
+const shellSource = (run: NotebookRunRecord): string => {
+  if (run.kernelKind === 'bash') return `%%bash\n${run.script}`
+  if (run.kernelKind === 'repl') return `%%javascript\n${run.script}`
+  return run.script
+}
+
+const errorName = (output: Extract<NotebookOutput, { type: 'error' }>): string =>
+  output.name?.trim() || 'Error'
+
+const errorValue = (output: Extract<NotebookOutput, { type: 'error' }>): string =>
+  output.message?.trim() || output.traceback.split('\n')[0] || 'Notebook execution failed'
+
+const mapOutput = (output: NotebookOutput, executionCount: number | null): NbformatOutput => {
+  switch (output.type) {
+    case 'stream':
+      return {
+        output_type: 'stream',
+        name: output.name,
+        text: splitLines(output.text)
+      }
+    case 'error':
+      return {
+        output_type: 'error',
+        ename: errorName(output),
+        evalue: errorValue(output),
+        traceback: splitLines(output.traceback)
+      }
+    case 'text':
+      return {
+        output_type: 'execute_result',
+        data: { 'text/plain': output.text },
+        metadata: {},
+        execution_count: executionCount
+      }
+    case 'json':
+      return {
+        output_type: 'display_data',
+        data: { 'application/json': output.data },
+        metadata: {}
+      }
+    case 'display':
+      return {
+        output_type: 'display_data',
+        data: output.data,
+        metadata: {}
+      }
+  }
+}
+
+const fallbackTextOutputs = (run: NotebookRunRecord): NbformatOutput[] => {
+  const outputs: NbformatOutput[] = []
+  if (run.text.stdout) {
+    outputs.push({ output_type: 'stream', name: 'stdout', text: splitLines(run.text.stdout) })
+  }
+  if (run.text.stderr) {
+    outputs.push({ output_type: 'stream', name: 'stderr', text: splitLines(run.text.stderr) })
+  }
+  if (run.text.traceback) {
+    outputs.push({
+      output_type: 'error',
+      ename: 'Error',
+      evalue: run.text.traceback.split('\n')[0] || 'Notebook execution failed',
+      traceback: splitLines(run.text.traceback)
+    })
+  }
+  return outputs
+}
+
+const executionCountFor = (run: NotebookRunRecord): number | null =>
+  run.status === 'completed' || run.status === 'failed' || run.status === 'timeout'
+    ? (run.executionCount ?? null)
+    : null
+
+const dominantKernel = (runs: NotebookRunRecord[]): 'python' | 'r' => {
+  let python = 0
+  let r = 0
+  for (const run of runs) {
+    if (run.kernelKind === 'python') python += 1
+    if (run.kernelKind === 'r') r += 1
+  }
+  return r > python ? 'r' : 'python'
+}
+
+const kernelspecFor = (kernel: 'python' | 'r'): IpynbNotebook['metadata']['kernelspec'] =>
+  kernel === 'r'
+    ? { display_name: 'R', language: 'R', name: 'ir' }
+    : { display_name: 'Python 3', language: 'python', name: 'python3' }
+
+const artifactOutputs = async (
+  run: NotebookRunRecord,
+  resolver: RunDocumentToIpynbOptions['resolveArtifact']
+): Promise<NbformatOutput[]> => {
+  if (!resolver) return []
+
+  const outputs: NbformatOutput[] = []
+  for (const artifact of run.artifacts) {
+    try {
+      const resolved = await resolver(artifact, run)
+      if (resolved) {
+        outputs.push({
+          output_type: 'display_data',
+          data: { [resolved.mimeType]: resolved.data },
+          metadata: {}
+        })
+      }
+    } catch {
+      outputs.push({
+        output_type: 'stream',
+        name: 'stderr',
+        text: [`[Open Science] Could not inline artifact: ${artifact.name}\n`]
+      })
+    }
+  }
+  return outputs
+}
+
+const runToCell = async (
+  run: NotebookRunRecord,
+  options: RunDocumentToIpynbOptions
+): Promise<NbformatCodeCell> => {
+  const executionCount = executionCountFor(run)
+  const structuredOutputs =
+    run.outputs.length > 0
+      ? run.outputs.map((output) => mapOutput(output, executionCount))
+      : fallbackTextOutputs(run)
+  const metadata: NbformatCodeCell['metadata'] = {
+    open_science: {
+      runId: run.runId,
+      startedAt: run.startedAt,
+      status: run.status,
+      kernel: run.kernelKind,
+      ...(run.environment ? { environment: run.environment } : {})
+    }
+  }
+
+  if (run.kernelKind === 'bash' || run.kernelKind === 'repl') {
+    metadata.tags = [`open-science-${run.kernelKind}`]
+  }
+
+  return {
+    cell_type: 'code',
+    execution_count: executionCount,
+    id: nbformatCellId(run.runId),
+    metadata,
+    outputs: [...structuredOutputs, ...(await artifactOutputs(run, options.resolveArtifact))],
+    source: splitLines(shellSource(run))
+  }
+}
+
+// Projects the append-only run document into a standards-compliant nbformat 4.5 notebook without
+// changing run.json. Artifact IO is injected so the mapping stays deterministic and unit-testable.
+const runDocumentToIpynb = async (
+  document: NotebookRunDocument,
+  options: RunDocumentToIpynbOptions = {}
+): Promise<IpynbNotebook> => {
+  const kernel = dominantKernel(document.runs)
+  const kernelspec = kernelspecFor(kernel)
+
+  return {
+    cells: await Promise.all(document.runs.map((run) => runToCell(run, options))),
+    metadata: {
+      kernelspec,
+      language_info: { name: kernelspec.language },
+      open_science: {
+        sessionId: document.sessionId,
+        projectName: document.projectName,
+        ...(options.appVersion ? { appVersion: options.appVersion } : {})
+      }
+    },
+    nbformat: 4,
+    nbformat_minor: 5
+  }
+}
+
+export { runDocumentToIpynb }
+export type { IpynbNotebook, ResolvedArtifact, RunDocumentToIpynbOptions }

--- a/src/main/notebook/runtime-service.export.test.ts
+++ b/src/main/notebook/runtime-service.export.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { NotebookRunDocument } from '../../shared/notebook'
+import type { NotebookRunRepository } from './repository'
+import { NotebookRuntimeService } from './runtime-service'
+
+const document: NotebookRunDocument = {
+  version: 1,
+  projectName: 'default-project',
+  sessionId: '12345678-abcd',
+  workspaceCwd: '/workspace',
+  notebookSessionRoot: '/storage/notebooks/default-project/12345678-abcd',
+  dataRoot: '/storage/notebooks/default-project/12345678-abcd/data',
+  kernel: {
+    language: 'python',
+    kernelName: 'python3',
+    runtimeRoot: '/storage/runtime',
+    lastKnownStatus: 'idle'
+  },
+  runs: [
+    {
+      runId: 'run-1',
+      cellId: 'cell-1',
+      source: 'agent',
+      kernelKind: 'python',
+      script: 'print("hello")',
+      status: 'completed',
+      startedAt: 1,
+      executionCount: 1,
+      text: { stdout: 'hello', stderr: '', traceback: '', plain: ['hello'] },
+      outputs: [],
+      artifacts: [],
+      workingFiles: []
+    }
+  ],
+  updatedAt: 2
+}
+
+describe('NotebookRuntimeService exportIpynb', () => {
+  it('loads the durable document and sends a serialized nbformat notebook to the save seam', async () => {
+    const repository = {
+      findExisting: vi.fn().mockResolvedValue(document)
+    } as unknown as NotebookRunRepository
+    const saveIpynb = vi
+      .fn()
+      .mockResolvedValue({ saved: true, filePath: '/downloads/session.ipynb' })
+    const service = new NotebookRuntimeService({
+      configRoot: '/config',
+      dataRoot: '/storage',
+      projectName: 'default-project',
+      repository,
+      appVersion: '1.2.3',
+      saveIpynb
+    })
+
+    const result = await service.exportIpynb({
+      sessionId: '12345678-abcd',
+      workspaceCwd: '/workspace'
+    })
+
+    expect(repository.findExisting).toHaveBeenCalledWith('default-project', '12345678-abcd')
+    expect(saveIpynb).toHaveBeenCalledOnce()
+    expect(saveIpynb.mock.calls[0][0]).toBe('session-12345678.ipynb')
+    const exported = JSON.parse(saveIpynb.mock.calls[0][1]) as {
+      nbformat: number
+      metadata: { open_science: { appVersion: string } }
+      cells: Array<{ source: string[] }>
+    }
+    expect(exported).toMatchObject({
+      nbformat: 4,
+      metadata: { open_science: { appVersion: '1.2.3' } }
+    })
+    expect(exported.cells[0].source).toEqual(['print("hello")'])
+    expect(result).toEqual({ saved: true, filePath: '/downloads/session.ipynb' })
+  })
+
+  it('rejects an unknown session before opening the save dialog', async () => {
+    const repository = {
+      findExisting: vi.fn().mockResolvedValue(null)
+    } as unknown as NotebookRunRepository
+    const saveIpynb = vi.fn()
+    const service = new NotebookRuntimeService({
+      configRoot: '/config',
+      dataRoot: '/storage',
+      projectName: 'default-project',
+      repository,
+      saveIpynb
+    })
+
+    await expect(
+      service.exportIpynb({ sessionId: 'missing', workspaceCwd: '/workspace' })
+    ).rejects.toThrow('Notebook session not found: missing')
+    expect(saveIpynb).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -1,8 +1,8 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { existsSync, realpathSync } from 'node:fs'
-import { rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { readFile, rm, writeFile } from 'node:fs/promises'
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type {
   NotebookCell,
@@ -11,6 +11,7 @@ import type {
   ExecuteNotebookCodeRequest,
   ExecuteNotebookControlRequest,
   ExecuteShellRequest,
+  ExportNotebookResult,
   FinishNotebookCodeCellRequest,
   NotebookEnvironmentStatus,
   NotebookKernelMetadata,
@@ -34,6 +35,7 @@ import type {
   ProvisionProgress
 } from '../../shared/notebook-env'
 import type { PackageMirror } from '../../shared/mirror'
+import { runDocumentToIpynb, type ResolvedArtifact } from './ipynb-export'
 import { NotebookKernelExecutor, type NotebookKernelExecutorOptions } from './kernel-executor'
 import type { KernelProcessKind } from './kernel-executor'
 import { effectiveMirrorAsync, type ProbeDeps } from './mirror-probe'
@@ -301,6 +303,12 @@ type NotebookRuntimeServiceOptions = {
   // fake; the production instance (the DefaultRuntimeProvisioner) is wired after construction in
   // main/ipc.ts via setEnvironmentManager, mirroring the mcp/mirror resolvers.
   environmentManager?: NotebookEnvironmentManager
+  // Included in exported notebook provenance. Tests may omit it.
+  appVersion?: string
+  // Save-dialog seam for notebook export tests. Production falls back to Electron's native dialog.
+  saveIpynb?: (suggestedName: string, data: string) => Promise<ExportNotebookResult>
+  // Resolves app-managed artifact paths with the artifact repository's canonical/symlink checks.
+  resolveArtifactPath?: (path: string) => Promise<string>
 }
 
 // The wire binding plus the interpreter override the executor needs. `resolvedInterpreter` is set only
@@ -353,6 +361,57 @@ type RuntimeSession = {
   // Process keys whose in-flight run is being FORCE-STOPPED by a disable (kernel killed mid-run): the
   // run's kill is recorded 'cancelled' (not 'failed'), then the key is cleared. WS10 force-stop.
   forceStoppedKeys: Set<string>
+}
+
+const saveIpynbWithDialog = async (
+  suggestedName: string,
+  data: string
+): Promise<ExportNotebookResult> => {
+  const { app, dialog } = await import('electron')
+  const { canceled, filePath } = await dialog.showSaveDialog({
+    defaultPath: join(app.getPath('downloads'), suggestedName),
+    title: 'Export notebook',
+    filters: [{ name: 'Jupyter Notebook', extensions: ['ipynb'] }]
+  })
+
+  if (canceled || !filePath) return { saved: false }
+  await writeFile(filePath, data, 'utf8')
+  return { saved: true, filePath }
+}
+
+const isPathInside = (root: string, candidate: string): boolean => {
+  const relativePath = relative(resolve(root), resolve(candidate))
+  return (
+    relativePath !== '' &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${sep}`) &&
+    !isAbsolute(relativePath)
+  )
+}
+
+const artifactMimeData = async (
+  root: string,
+  artifact: NotebookRunRecord['artifacts'][number],
+  resolveManagedPath?: (path: string) => Promise<string>
+): Promise<ResolvedArtifact | null> => {
+  const mimeType = artifact.mimeType
+  if (!mimeType) return null
+  const filePath = isPathInside(root, artifact.path)
+    ? artifact.path
+    : await resolveManagedPath?.(artifact.path)
+  if (!filePath) return null
+
+  const binary = await readFile(filePath)
+  if (mimeType.startsWith('image/')) {
+    return { mimeType, data: binary.toString('base64') }
+  }
+  if (mimeType === 'application/json') {
+    return { mimeType, data: JSON.parse(binary.toString('utf8')) as unknown }
+  }
+  if (mimeType.startsWith('text/')) {
+    return { mimeType, data: binary.toString('utf8') }
+  }
+  return null
 }
 
 // Builds the compact plain text output list shown in the preview panel.
@@ -1868,6 +1927,37 @@ class NotebookRuntimeService {
       runtimeRoot: document.kernel.runtimeRoot,
       runJsonPath: getNotebookRunJsonPath(this.options.dataRoot, projectName, request.sessionId)
     }
+  }
+
+  // Exports the durable history as an nbformat projection; run.json remains the source of truth.
+  async exportIpynb(request: NotebookSessionRequest): Promise<ExportNotebookResult> {
+    const projectName = request.projectName ?? this.options.projectName
+    const document = await this.repository.findExisting(projectName, request.sessionId)
+    if (!document) {
+      throw new Error(`Notebook session not found: ${request.sessionId}`)
+    }
+
+    const notebook = await runDocumentToIpynb(document, {
+      appVersion: this.options.appVersion,
+      resolveArtifact: (artifact) => {
+        const artifactSessionId = document.artifactSessionId ?? document.sessionId
+        if (
+          artifact.projectName !== document.projectName ||
+          artifact.sessionId !== artifactSessionId
+        ) {
+          return Promise.resolve(null)
+        }
+        return artifactMimeData(
+          document.notebookSessionRoot,
+          artifact,
+          this.options.resolveArtifactPath
+        )
+      }
+    })
+    const suggestedName = `session-${request.sessionId.slice(0, 8)}.ipynb`
+    const serialized = `${JSON.stringify(notebook, null, 2)}\n`
+
+    return (this.options.saveIpynb ?? saveIpynbWithDialog)(suggestedName, serialized)
   }
 
   // Replaces the interpreter process while preserving cells and durable run history. Prefers the

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -35,6 +35,7 @@ import type {
   NotebookAvailableEvent,
   NotebookChangedEvent,
   ExecuteNotebookCodeRequest,
+  ExportNotebookResult,
   FinishNotebookCodeCellRequest,
   NotebookLanguage,
   NotebookRunSummary,
@@ -335,6 +336,7 @@ interface OpenScienceAPI {
     }>
     runCell(request: RunNotebookCellRequest): Promise<NotebookRunSummary>
     execute(request: ExecuteNotebookCodeRequest): Promise<NotebookRunSummary>
+    exportIpynb(request: NotebookSessionRequest): Promise<ExportNotebookResult>
     restart(request: NotebookSessionRequest): Promise<NotebookSessionState>
     shutdown(request: NotebookSessionRequest): Promise<{ sessionId: string; status: 'shutdown' }>
     onAvailable(listener: AcpListener<NotebookAvailableEvent>): RemoveListener

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -37,6 +37,7 @@ import type {
   NotebookAvailableEvent,
   NotebookChangedEvent,
   ExecuteNotebookCodeRequest,
+  ExportNotebookResult,
   FinishNotebookCodeCellRequest,
   NotebookLanguage,
   NotebookRunSummary,
@@ -368,6 +369,7 @@ type OpenScienceAPI = {
     }>
     runCell: (request: RunNotebookCellRequest) => Promise<NotebookRunSummary>
     execute: (request: ExecuteNotebookCodeRequest) => Promise<NotebookRunSummary>
+    exportIpynb: (request: NotebookSessionRequest) => Promise<ExportNotebookResult>
     restart: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
     shutdown: (
       request: NotebookSessionRequest
@@ -754,6 +756,8 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('notebook:run-cell', request) as Promise<NotebookRunSummary>,
     execute: (request) =>
       ipcRenderer.invoke('notebook:execute', request) as Promise<NotebookRunSummary>,
+    exportIpynb: (request) =>
+      ipcRenderer.invoke('notebook:export-ipynb', request) as Promise<ExportNotebookResult>,
     restart: (request) =>
       ipcRenderer.invoke('notebook:restart', request) as Promise<NotebookSessionState>,
     shutdown: (request) =>

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { NotebookRunRecord } from '../../../../shared/notebook'
+import { SessionNotebookContent } from './SessionNotebookDialog'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const run: NotebookRunRecord = {
+  runId: 'run-1',
+  cellId: 'cell-1',
+  source: 'agent',
+  kernelKind: 'python',
+  script: 'print("hello")',
+  status: 'completed',
+  startedAt: 1,
+  executionCount: 1,
+  text: { stdout: 'hello', stderr: '', traceback: '', plain: ['hello'] },
+  outputs: [],
+  artifacts: [],
+  workingFiles: []
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('SessionNotebookContent export', () => {
+  it('invokes the export callback from the enabled .ipynb button', async () => {
+    const onExport = vi.fn().mockResolvedValue(undefined)
+    await act(async () => {
+      root.render(
+        <SessionNotebookContent
+          sessionId="session-1"
+          runs={[run]}
+          status="ready"
+          onClose={vi.fn()}
+          onExport={onExport}
+        />
+      )
+    })
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Download as .ipynb"]'
+    )
+    expect(button?.disabled).toBe(false)
+
+    await act(async () => {
+      button?.click()
+      await Promise.resolve()
+    })
+
+    expect(onExport).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces export failures and re-enables the button', async () => {
+    const onExport = vi.fn().mockRejectedValue(new Error('Disk is full'))
+    await act(async () => {
+      root.render(
+        <SessionNotebookContent
+          sessionId="session-1"
+          runs={[run]}
+          status="ready"
+          onClose={vi.fn()}
+          onExport={onExport}
+        />
+      )
+    })
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Download as .ipynb"]'
+    )
+    await act(async () => {
+      button?.click()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe('Disk is full')
+    expect(button?.disabled).toBe(false)
+  })
+})

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
@@ -25,7 +25,8 @@ const renderContent = (props: {
   runs: NotebookRunRecord[]
   status: 'loading' | 'error' | 'ready'
   error?: string
-}): string => renderToStaticMarkup(<SessionNotebookContent onClose={vi.fn()} {...props} />)
+}): string =>
+  renderToStaticMarkup(<SessionNotebookContent onClose={vi.fn()} onExport={vi.fn()} {...props} />)
 
 describe('SessionNotebookContent', () => {
   it('shows the empty state when there are no runs', () => {
@@ -54,12 +55,21 @@ describe('SessionNotebookContent', () => {
     expect(html).toContain('ModuleNotFoundError')
   })
 
-  it('renders the .ipynb footer button as disabled', () => {
-    const html = renderContent({ sessionId: 's1', runs: [], status: 'ready' })
+  it('enables .ipynb export for a loaded notebook and disables it when empty', () => {
+    const populated = renderContent({
+      sessionId: 's1',
+      runs: [makeRun()],
+      status: 'ready'
+    })
+    const empty = renderContent({ sessionId: 's1', runs: [], status: 'ready' })
 
-    expect(html).toContain('.ipynb')
-    // The only disabled control in the content is the placeholder export button.
-    expect(html).toContain('disabled')
+    expect(populated).toContain('.ipynb')
+    const populatedButton = populated.match(
+      /<button[^>]*aria-label="Download as \.ipynb"[^>]*>/
+    )?.[0]
+    const emptyButton = empty.match(/<button[^>]*aria-label="Download as \.ipynb"[^>]*>/)?.[0]
+    expect(populatedButton).not.toMatch(/\sdisabled(?:=|\s|>)/)
+    expect(emptyButton).toMatch(/\sdisabled(?:=|\s|>)/)
   })
 })
 

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react'
-import { Download, X } from 'lucide-react'
+import { Download, LoaderCircle, X } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { ChatSession } from '@/stores/session-store'
 
@@ -79,19 +78,23 @@ type SessionNotebookContentProps = {
   status: SessionNotebookStatus
   error?: string
   onClose: () => void
+  onExport: () => Promise<void>
 }
 
 // Pure presentational body of the dialog: header summary, empty/loading/error/populated states,
-// and the disabled .ipynb footer. Kept free of data-loading hooks and Dialog context so it renders
+// and the .ipynb export footer. Kept free of data-loading hooks and Dialog context so it renders
 // standalone in tests; close is delegated through onClose.
 const SessionNotebookContent = ({
   sessionId,
   runs,
   status,
   error,
-  onClose
+  onClose,
+  onExport
 }: SessionNotebookContentProps): React.JSX.Element => {
   const [activeKind, setActiveKind] = useState<NotebookKernelKind>('python')
+  const [exporting, setExporting] = useState(false)
+  const [exportError, setExportError] = useState<string>()
   const shortId = sessionId.slice(0, 8)
   const agents = runs.some((run) => run.source === 'agent') ? 1 : 0
   // Only python/r runs are "cells" in the notebook sense; repl/bash are control-plane/shell runs
@@ -115,6 +118,19 @@ const SessionNotebookContent = ({
     ? activeKind
     : (KERNEL_KIND_ORDER.find((kind) => kindsWithRuns.has(kind)) ?? visibleKinds[0] ?? 'python')
   const visibleRuns = runs.filter((run) => resolveRunKernelKind(run) === effectiveActiveKind)
+  const exportDisabled = status !== 'ready' || runs.length === 0 || exporting
+
+  const handleExport = async (): Promise<void> => {
+    setExporting(true)
+    setExportError(undefined)
+    try {
+      await onExport()
+    } catch (exportFailure) {
+      setExportError(getErrorMessage(exportFailure))
+    } finally {
+      setExporting(false)
+    }
+  }
 
   return (
     <>
@@ -191,26 +207,24 @@ const SessionNotebookContent = ({
         )}
       </div>
 
-      <div className="flex justify-end gap-3 border-t border-border-300/15 px-5 py-3.5">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {/* Wrapper span keeps the tooltip reachable even though the button is disabled. */}
-              <span>
-                <button
-                  type="button"
-                  disabled
-                  className="flex items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label="Download as .ipynb"
-                >
-                  <Download className="size-3.5" aria-hidden="true" />
-                  .ipynb
-                </button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>Notebook export is coming soon</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+      <div className="flex items-center justify-between gap-3 border-t border-border-300/15 px-5 py-3.5">
+        <p className="min-w-0 truncate text-xs text-danger-000" role="alert">
+          {exportError}
+        </p>
+        <button
+          type="button"
+          disabled={exportDisabled}
+          onClick={() => void handleExport()}
+          className="flex shrink-0 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Download as .ipynb"
+        >
+          {exporting ? (
+            <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+          ) : (
+            <Download className="size-3.5" aria-hidden="true" />
+          )}
+          {exporting ? 'Exporting…' : '.ipynb'}
+        </button>
       </div>
     </>
   )
@@ -291,6 +305,13 @@ const SessionNotebookDialog = ({
               status={status}
               error={error}
               onClose={onClose}
+              onExport={async () => {
+                await window.api.notebook.exportIpynb({
+                  sessionId: session.id,
+                  projectName: session.projectId,
+                  workspaceCwd: session.cwd ?? ''
+                })
+              }}
             />
           ) : null}
         </Dialog.Content>

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -27,6 +27,7 @@ export const WEB_INVOKE_CHANNELS = {
   'notebook.appendCodeCell': 'notebook:append-code-cell',
   'notebook.beginCodeCell': 'notebook:begin-code-cell',
   'notebook.execute': 'notebook:execute',
+  'notebook.exportIpynb': 'notebook:export-ipynb',
   'notebook.finishCodeCell': 'notebook:finish-code-cell',
   'notebook.getReference': 'notebook:reference',
   'notebook.restart': 'notebook:restart',

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -224,6 +224,13 @@ export type NotebookSessionRequest = {
   workspaceCwd: string
 }
 
+export type ExportNotebookResult =
+  | { saved: false }
+  | {
+      saved: true
+      filePath: string
+    }
+
 // Starts a streamed code write into a notebook cell.
 export type BeginNotebookCodeCellRequest = NotebookSessionRequest & {
   cellId?: string


### PR DESCRIPTION
## Summary
- project persisted notebook runs into nbformat 4.5 code cells, outputs, kernelspec, and Open Science provenance metadata
- inline validated notebook/artifact outputs and export them through a typed main-process IPC save flow
- enable the Session Notebook `.ipynb` action with progress/error states and add projection, IPC, service, and UI coverage

Part of #293

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test -- src/main/notebook/ipynb-export.test.ts src/main/notebook/runtime-service.export.test.ts src/main/notebook/ipc.test.ts src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx src/renderer/web/api-map.generated.test.ts`
- [x] `npm run check:web-api-map`
- [ ] Full `npm test` currently has unrelated Windows/runtime-pack failures (370 test files passed; 15 failed)