### PR TITLE
feat(notebook): export session run history as .ipynb

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -207,6 +207,8 @@ const createDefaultNotebookRuntimeService = (): NotebookRuntimeService => {
     // Region default for manage_packages when no mirror is configured; the configured override is
     // wired in main/ipc.ts via setPackageMirrorResolver once the settings service is constructed.
     locale: app.getLocale(),
+    // Stamped into .ipynb exports so a shared notebook records which app version produced it.
+    appVersion: app.getVersion(),
     callbacks: {
       onNotebookAvailable: (event) => broadcast('notebook:available', event),
       onNotebookChanged: (event) => broadcast('notebook:changed', event)

--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -33,6 +33,35 @@ describe('file save IPC handlers', () => {
     expect(handlers.has('file:save-managed')).toBe(true)
   })
 
+  it('saves a blob with an .ipynb filter for the notebook mime type', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-blob-'))
+    const destinationPath = join(root, 'notebook-134d5d81.ipynb')
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: destinationPath })
+    registerFileSaveHandlers()
+
+    try {
+      const result = await handlers.get('file:save-blob')!(
+        { sender: {} },
+        {
+          suggestedName: 'notebook-134d5d81.ipynb',
+          mimeType: 'application/x-ipynb+json',
+          data: new TextEncoder().encode('{"nbformat":4}').buffer
+        }
+      )
+
+      expect(showSaveDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultPath: 'notebook-134d5d81.ipynb',
+          filters: [{ name: 'IPYNB', extensions: ['ipynb'] }]
+        })
+      )
+      expect(result).toEqual({ saved: true, filePath: destinationPath })
+      await expect(readFile(destinationPath, 'utf8')).resolves.toBe('{"nbformat":4}')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('opens a managed source once and copies that exact file to the selected destination', async () => {
     const resolveManagedFilePath = vi.fn().mockResolvedValue('/managed/canonical-report.csv')
     const copyTo = vi.fn().mockResolvedValue(undefined)

--- a/src/main/file-save.ts
+++ b/src/main/file-save.ts
@@ -85,6 +85,8 @@ const extensionForMime = (mimeType: string): string | undefined => {
       return 'tsv'
     case 'text/markdown':
       return 'md'
+    case 'application/x-ipynb+json':
+      return 'ipynb'
     default:
       return undefined
   }

--- a/src/main/notebook/ipc.test.ts
+++ b/src/main/notebook/ipc.test.ts
@@ -24,6 +24,7 @@ describe('notebook IPC handlers', () => {
     const service = {
       state: vi.fn().mockResolvedValue({ sessionId: 'session-1', cells: [] }),
       getSessionReference: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+      exportIpynb: vi.fn().mockResolvedValue({ suggestedName: 'notebook-s1.ipynb', json: '{}' }),
       execute: vi.fn().mockResolvedValue({
         runId: 'run-1',
         status: 'completed',
@@ -40,6 +41,7 @@ describe('notebook IPC handlers', () => {
 
     await handlers.state({ sessionId: 'session-1', workspaceCwd: '/workspace' })
     await handlers.reference({ sessionId: 'session-1', workspaceCwd: '/workspace' })
+    await handlers.exportIpynb({ sessionId: 'session-1', workspaceCwd: '/workspace' })
     await handlers.execute({
       sessionId: 'session-1',
       workspaceCwd: '/workspace',
@@ -89,12 +91,17 @@ describe('notebook IPC handlers', () => {
       sessionId: 'session-1',
       workspaceCwd: '/workspace'
     })
+    expect(service.exportIpynb).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace'
+    })
   })
 
   it('registers every notebook channel and forwards the renderer payload unchanged', async () => {
     const service = {
       state: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
       getSessionReference: vi.fn().mockResolvedValue(null),
+      exportIpynb: vi.fn().mockResolvedValue(null),
       beginCodeCell: vi.fn().mockResolvedValue({ cellId: 'cell-1', writeId: 'write-1' }),
       appendCodeCell: vi.fn().mockResolvedValue({ receivedBytes: 5 }),
       finishCodeCell: vi.fn().mockResolvedValue({ status: 'idle' }),
@@ -108,6 +115,7 @@ describe('notebook IPC handlers', () => {
     expect([...ipcHandlers.keys()]).toEqual([
       'notebook:state',
       'notebook:reference',
+      'notebook:export-ipynb',
       'notebook:begin-code-cell',
       'notebook:append-code-cell',
       'notebook:finish-code-cell',
@@ -126,6 +134,7 @@ describe('notebook IPC handlers', () => {
 
     await ipcHandlers.get('notebook:state')?.(undefined, session)
     await ipcHandlers.get('notebook:reference')?.(undefined, session)
+    await ipcHandlers.get('notebook:export-ipynb')?.(undefined, session)
     await ipcHandlers.get('notebook:begin-code-cell')?.(undefined, begin)
     await ipcHandlers.get('notebook:append-code-cell')?.(undefined, append)
     await ipcHandlers.get('notebook:finish-code-cell')?.(undefined, finish)
@@ -136,6 +145,7 @@ describe('notebook IPC handlers', () => {
 
     expect(service.state).toHaveBeenCalledWith(session)
     expect(service.getSessionReference).toHaveBeenCalledWith(session)
+    expect(service.exportIpynb).toHaveBeenCalledWith(session)
     expect(service.beginCodeCell).toHaveBeenCalledWith(begin)
     expect(service.appendCodeCell).toHaveBeenCalledWith(append)
     expect(service.finishCodeCell).toHaveBeenCalledWith(finish)

--- a/src/main/notebook/ipc.ts
+++ b/src/main/notebook/ipc.ts
@@ -5,6 +5,7 @@ import type {
   BeginNotebookCodeCellRequest,
   ExecuteNotebookCodeRequest,
   FinishNotebookCodeCellRequest,
+  NotebookIpynbExport,
   NotebookRunSummary,
   NotebookSessionReference,
   NotebookSessionRequest,
@@ -16,6 +17,7 @@ import type { NotebookRuntimeService } from './runtime-service'
 type NotebookHandlers = {
   state: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
   reference: (request: NotebookSessionRequest) => Promise<NotebookSessionReference | null>
+  exportIpynb: (request: NotebookSessionRequest) => Promise<NotebookIpynbExport | null>
   beginCodeCell: (
     request: BeginNotebookCodeCellRequest
   ) => ReturnType<NotebookRuntimeService['beginCodeCell']>
@@ -35,6 +37,7 @@ type NotebookHandlers = {
 const createNotebookHandlers = (service: NotebookRuntimeService): NotebookHandlers => ({
   state: (request) => service.state(request),
   reference: (request) => service.getSessionReference(request),
+  exportIpynb: (request) => service.exportIpynb(request),
   beginCodeCell: (request) => service.beginCodeCell(request),
   appendCodeCell: (request) => service.appendCodeCell(request),
   finishCodeCell: (request) => service.finishCodeCell(request),
@@ -53,6 +56,9 @@ const registerNotebookIpcHandlers = (service: NotebookRuntimeService): void => {
   )
   ipcMain.handle('notebook:reference', (_event, request: NotebookSessionRequest) =>
     handlers.reference(request)
+  )
+  ipcMain.handle('notebook:export-ipynb', (_event, request: NotebookSessionRequest) =>
+    handlers.exportIpynb(request)
   )
   ipcMain.handle('notebook:begin-code-cell', (_event, request: BeginNotebookCodeCellRequest) =>
     handlers.beginCodeCell(request)

--- a/src/main/notebook/ipynb-export.test.ts
+++ b/src/main/notebook/ipynb-export.test.ts
@@ -197,8 +197,26 @@ describe('projectRunDocumentToIpynb', () => {
     expect(cells[2].id).toBe('cell-2')
     expect(new Set(cells.map((cell) => cell.id)).size).toBe(3)
     for (const cell of cells) {
-      expect(cell.id).toMatch(/^[A-Za-z0-9-_]+$/)
+      expect(cell.id).toMatch(/^[A-Za-z0-9-_]{1,64}$/)
     }
+  })
+
+  it('keeps oversized cell ids within nbformat’s 64-character limit, dedup suffix included', () => {
+    const oversized = `cell-${'x'.repeat(100)}`
+    const runs = [
+      makeRun({ runId: 'a', cellId: oversized }),
+      makeRun({ runId: 'b', cellId: oversized }),
+      makeRun({ runId: 'c', cellId: oversized })
+    ]
+    const cells = projectRunDocumentToIpynb(makeDocument(runs)).cells
+
+    expect(cells[0].id).toBe(oversized.slice(0, 64))
+    expect(cells[1].id).toBe(`${oversized.slice(0, 62)}-2`)
+    expect(cells[2].id).toBe(`${oversized.slice(0, 62)}-3`)
+    for (const cell of cells) {
+      expect(cell.id).toMatch(/^[A-Za-z0-9-_]{1,64}$/)
+    }
+    expect(new Set(cells.map((cell) => cell.id)).size).toBe(3)
   })
 
   it('is deterministic and embeds no absolute paths', () => {

--- a/src/main/notebook/ipynb-export.test.ts
+++ b/src/main/notebook/ipynb-export.test.ts
@@ -1,0 +1,292 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { NotebookRunDocument, NotebookRunRecord } from '../../shared/notebook'
+import { projectRunDocumentToIpynb, stringifyIpynb } from './ipynb-export'
+import { NotebookRunRepository } from './repository'
+import { NotebookRuntimeService } from './runtime-service'
+
+const makeRun = (overrides: Partial<NotebookRunRecord> = {}): NotebookRunRecord => ({
+  runId: 'run-1',
+  cellId: 'cell-1',
+  source: 'agent',
+  kernelKind: 'python',
+  script: 'print("hello")',
+  status: 'completed',
+  startedAt: 1_700_000_000_000,
+  executionCount: 1,
+  text: { stdout: '', stderr: '', traceback: '', plain: [] },
+  outputs: [],
+  artifacts: [],
+  workingFiles: [],
+  ...overrides
+})
+
+const makeDocument = (runs: NotebookRunRecord[]): NotebookRunDocument => ({
+  version: 1,
+  projectName: 'project-a',
+  sessionId: 'session-1',
+  workspaceCwd: '/Users/example/workspace',
+  notebookSessionRoot: '/data/notebooks/project-a/session-1',
+  dataRoot: '/data/notebooks/project-a/session-1/data',
+  kernel: {
+    language: 'python',
+    kernelName: 'python3',
+    runtimeRoot: '/data/runtime',
+    lastKnownStatus: 'idle'
+  },
+  runs,
+  updatedAt: 1_700_000_100_000
+})
+
+describe('projectRunDocumentToIpynb', () => {
+  it('emits an nbformat 4.5 document with kernelspec and open_science metadata', () => {
+    const notebook = projectRunDocumentToIpynb(makeDocument([makeRun()]), { appVersion: '0.5.1' })
+
+    expect(notebook.nbformat).toBe(4)
+    expect(notebook.nbformat_minor).toBe(5)
+    expect(notebook.metadata.kernelspec).toEqual({
+      name: 'python3',
+      display_name: 'Python 3',
+      language: 'python'
+    })
+    expect(notebook.metadata.language_info).toEqual({ name: 'python' })
+    expect(notebook.metadata.open_science).toEqual({
+      sessionId: 'session-1',
+      projectName: 'project-a',
+      artifactSessionId: undefined,
+      appVersion: '0.5.1'
+    })
+  })
+
+  it('maps a run to a code cell preserving source lines, count, and provenance metadata', () => {
+    const run = makeRun({
+      runId: 'run-9',
+      cellId: 'cell-9',
+      script: 'import os\nimport requests\n',
+      executionCount: 7,
+      endedAt: 1_700_000_060_000,
+      environment: 'default-python'
+    })
+    const [cell] = projectRunDocumentToIpynb(makeDocument([run])).cells
+
+    expect(cell.cell_type).toBe('code')
+    expect(cell.id).toBe('cell-9')
+    expect(cell.source).toEqual(['import os\n', 'import requests\n'])
+    expect(cell.execution_count).toBe(7)
+    expect(cell.metadata.open_science).toEqual({
+      kernel: 'python',
+      runId: 'run-9',
+      cellId: 'cell-9',
+      source: 'agent',
+      status: 'completed',
+      startedAt: new Date(1_700_000_000_000).toISOString(),
+      endedAt: new Date(1_700_000_060_000).toISOString(),
+      environment: 'default-python'
+    })
+  })
+
+  it('maps stream, display, json, and error outputs to their nbformat counterparts', () => {
+    const run = makeRun({
+      outputs: [
+        { type: 'stream', name: 'stdout', text: 'first\nsecond\n' },
+        { type: 'stream', name: 'stderr', text: 'warn' },
+        { type: 'display', data: { 'image/png': 'aGVsbG8=' } },
+        { type: 'json', data: { answer: 42 } },
+        {
+          type: 'error',
+          message: 'ModuleNotFoundError: no module named requests',
+          traceback: 'Traceback...\nModuleNotFoundError: no module named requests'
+        }
+      ]
+    })
+    const [cell] = projectRunDocumentToIpynb(makeDocument([run])).cells
+
+    expect(cell.outputs).toEqual([
+      { output_type: 'stream', name: 'stdout', text: ['first\n', 'second\n'] },
+      { output_type: 'stream', name: 'stderr', text: ['warn'] },
+      { output_type: 'display_data', data: { 'image/png': 'aGVsbG8=' }, metadata: {} },
+      { output_type: 'display_data', data: { 'application/json': { answer: 42 } }, metadata: {} },
+      {
+        output_type: 'error',
+        ename: 'Error',
+        evalue: 'ModuleNotFoundError: no module named requests',
+        traceback: ['Traceback...', 'ModuleNotFoundError: no module named requests']
+      }
+    ])
+  })
+
+  it('falls back to the flattened text streams when a run has no structured outputs', () => {
+    const run = makeRun({
+      outputs: [],
+      text: {
+        stdout: 'ok\n',
+        stderr: 'careful\n',
+        traceback: 'line 1\nZeroDivisionError',
+        plain: []
+      }
+    })
+    const [cell] = projectRunDocumentToIpynb(makeDocument([run])).cells
+
+    expect(cell.outputs).toEqual([
+      { output_type: 'stream', name: 'stdout', text: ['ok\n'] },
+      { output_type: 'stream', name: 'stderr', text: ['careful\n'] },
+      {
+        output_type: 'error',
+        ename: 'Error',
+        evalue: '',
+        traceback: ['line 1', 'ZeroDivisionError']
+      }
+    ])
+  })
+
+  it('downgrades bash runs to %%bash cells and exports repl runs verbatim with kernel tags', () => {
+    const bash = makeRun({
+      runId: 'run-b',
+      cellId: 'bash-run-b',
+      kernelKind: 'bash',
+      script: 'ls -la'
+    })
+    const repl = makeRun({
+      runId: 'run-r',
+      cellId: 'repl-run-r',
+      kernelKind: 'repl',
+      script: 'await host.mcp()',
+      executionCount: undefined
+    })
+    const [bashCell, replCell] = projectRunDocumentToIpynb(makeDocument([bash, repl])).cells
+
+    expect(bashCell.source).toEqual(['%%bash\n', 'ls -la'])
+    expect(bashCell.metadata.open_science.kernel).toBe('bash')
+    expect(replCell.source).toEqual(['await host.mcp()'])
+    expect(replCell.metadata.open_science.kernel).toBe('repl')
+    expect(replCell.execution_count).toBeNull()
+  })
+
+  it('picks the dominant analysis kernel for the kernelspec', () => {
+    const python = makeRun({ runId: 'p1', cellId: 'p1' })
+    const r1 = makeRun({ runId: 'r1', cellId: 'r1', kernelKind: 'r' })
+    const r2 = makeRun({ runId: 'r2', cellId: 'r2', kernelKind: 'r' })
+
+    const rDominant = projectRunDocumentToIpynb(makeDocument([python, r1, r2]))
+    expect(rDominant.metadata.kernelspec).toEqual({ name: 'ir', display_name: 'R', language: 'R' })
+    expect(rDominant.metadata.language_info).toEqual({ name: 'R' })
+
+    // Ties (and control-plane-only sessions) resolve to python3.
+    const tied = projectRunDocumentToIpynb(makeDocument([python, r1]))
+    expect(tied.metadata.kernelspec.name).toBe('python3')
+
+    const shellOnly = projectRunDocumentToIpynb(
+      makeDocument([makeRun({ kernelKind: 'bash', script: 'ls' })])
+    )
+    expect(shellOnly.metadata.kernelspec.name).toBe('python3')
+  })
+
+  it('produces unique, tooling-safe cell ids even from unsanitary or duplicated cellIds', () => {
+    const runs = [
+      makeRun({ runId: 'a', cellId: 'cell 1.2' }),
+      makeRun({ runId: 'b', cellId: 'cell 1.2' }),
+      makeRun({ runId: 'c', cellId: '...' })
+    ]
+    const cells = projectRunDocumentToIpynb(makeDocument(runs)).cells
+
+    expect(cells[0].id).toBe('cell-1-2')
+    expect(cells[1].id).toBe('cell-1-2-2')
+    expect(cells[2].id).toBe('cell-2')
+    expect(new Set(cells.map((cell) => cell.id)).size).toBe(3)
+    for (const cell of cells) {
+      expect(cell.id).toMatch(/^[A-Za-z0-9-_]+$/)
+    }
+  })
+
+  it('is deterministic and embeds no absolute paths', () => {
+    const document = makeDocument([
+      makeRun({ outputs: [{ type: 'display', data: { 'image/png': 'aGVsbG8=' } }] })
+    ])
+
+    const first = stringifyIpynb(projectRunDocumentToIpynb(document, { appVersion: '0.5.1' }))
+    const second = stringifyIpynb(projectRunDocumentToIpynb(document, { appVersion: '0.5.1' }))
+
+    expect(first).toBe(second)
+    expect(first.endsWith('\n')).toBe(true)
+    expect(first).not.toContain('/Users/example/workspace')
+    expect(first).not.toContain('/data/notebooks')
+    // Round-trip: the serialized bytes parse back to the same projection.
+    expect(JSON.parse(first)).toEqual(projectRunDocumentToIpynb(document, { appVersion: '0.5.1' }))
+  })
+})
+
+describe('NotebookRuntimeService.exportIpynb', () => {
+  let storageRoot: string | undefined
+
+  const createStorageRoot = async (): Promise<string> => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-ipynb-export-'))
+    return storageRoot
+  }
+
+  afterEach(async () => {
+    if (storageRoot) {
+      await rm(storageRoot, { recursive: true, force: true })
+      storageRoot = undefined
+    }
+  })
+
+  it('returns null without creating run.json when the session has none', async () => {
+    const dataRoot = await createStorageRoot()
+    const service = new NotebookRuntimeService({
+      configRoot: join(dataRoot, 'config'),
+      dataRoot,
+      projectName: 'project-a'
+    })
+
+    await expect(
+      service.exportIpynb({ sessionId: 'missing', workspaceCwd: '/workspace' })
+    ).resolves.toBeNull()
+    await expect(
+      service.exportIpynb({ sessionId: 'missing', workspaceCwd: '/workspace' })
+    ).resolves.toBeNull()
+  })
+
+  it('projects the persisted run.json through the real repository path', async () => {
+    const dataRoot = await createStorageRoot()
+    const repository = new NotebookRunRepository(dataRoot)
+    await repository.loadOrCreate({
+      projectName: 'project-a',
+      sessionId: '134d5d81aa-bbbb',
+      workspaceCwd: '/workspace'
+    })
+    await repository.appendRun({
+      projectName: 'project-a',
+      sessionId: '134d5d81aa-bbbb',
+      run: makeRun({ outputs: [{ type: 'stream', name: 'stdout', text: 'ok\n' }] })
+    })
+    const service = new NotebookRuntimeService({
+      configRoot: join(dataRoot, 'config'),
+      dataRoot,
+      projectName: 'project-a',
+      repository,
+      appVersion: '0.5.1'
+    })
+
+    const exported = await service.exportIpynb({
+      sessionId: '134d5d81aa-bbbb',
+      workspaceCwd: '/workspace'
+    })
+
+    if (!exported) {
+      throw new Error('expected an export for a persisted session')
+    }
+
+    expect(exported.suggestedName).toBe('notebook-134d5d81.ipynb')
+    const notebook = JSON.parse(exported.json) as ReturnType<typeof projectRunDocumentToIpynb>
+    expect(notebook.nbformat).toBe(4)
+    expect(notebook.cells).toHaveLength(1)
+    expect(notebook.cells[0].source).toEqual(['print("hello")'])
+    expect(notebook.cells[0].outputs).toEqual([
+      { output_type: 'stream', name: 'stdout', text: ['ok\n'] }
+    ])
+    expect(notebook.metadata.open_science.appVersion).toBe('0.5.1')
+  })
+})

--- a/src/main/notebook/ipynb-export.ts
+++ b/src/main/notebook/ipynb-export.ts
@@ -1,0 +1,273 @@
+import type {
+  NotebookKernelKind,
+  NotebookOutput,
+  NotebookRunDocument,
+  NotebookRunRecord
+} from '../../shared/notebook'
+
+// Minimal nbformat 4.5 shapes — only the subset the export emits. nbformat is plain JSON, so the
+// projection is built by hand here: no Python / nbconvert dependency (issue #293, stage 1).
+type IpynbStreamOutput = {
+  output_type: 'stream'
+  name: 'stdout' | 'stderr'
+  text: string[]
+}
+
+type IpynbErrorOutput = {
+  output_type: 'error'
+  ename: string
+  evalue: string
+  traceback: string[]
+}
+
+type IpynbDisplayDataOutput = {
+  output_type: 'display_data'
+  data: Record<string, unknown>
+  metadata: Record<string, unknown>
+}
+
+type IpynbOutput = IpynbStreamOutput | IpynbErrorOutput | IpynbDisplayDataOutput
+
+type IpynbCellMetadata = {
+  // Custom namespace linking every cell back to its run record; Jupyter tools preserve unknown
+  // metadata, so this doubles as the provenance anchor for a future re-import / provenance chain.
+  open_science: {
+    kernel: NotebookKernelKind
+    runId: string
+    cellId: string
+    source: NotebookRunRecord['source']
+    status: NotebookRunRecord['status']
+    startedAt: string
+    endedAt?: string
+    environment?: string
+  }
+}
+
+type IpynbCodeCell = {
+  cell_type: 'code'
+  id: string
+  metadata: IpynbCellMetadata
+  source: string[]
+  outputs: IpynbOutput[]
+  execution_count: number | null
+}
+
+type IpynbKernelspec = {
+  name: string
+  display_name: string
+  language: string
+}
+
+type IpynbNotebookMetadata = {
+  kernelspec: IpynbKernelspec
+  language_info: { name: string }
+  open_science: {
+    sessionId: string
+    projectName: string
+    artifactSessionId?: string
+    appVersion?: string
+  }
+}
+
+type IpynbNotebook = {
+  cells: IpynbCodeCell[]
+  metadata: IpynbNotebookMetadata
+  nbformat: 4
+  nbformat_minor: 5
+}
+
+type ProjectIpynbOptions = {
+  appVersion?: string
+}
+
+const KERNELSPEC_BY_LANGUAGE: Record<
+  'python' | 'r',
+  { kernelspec: IpynbKernelspec; languageName: string }
+> = {
+  python: {
+    kernelspec: { name: 'python3', display_name: 'Python 3', language: 'python' },
+    languageName: 'python'
+  },
+  r: {
+    kernelspec: { name: 'ir', display_name: 'R', language: 'R' },
+    languageName: 'R'
+  }
+}
+
+// Splits text the nbformat way: lines keep their trailing newline, and a trailing newline does not
+// produce an empty final element (mirrors Python's splitlines(keepends=True)).
+const toMultilineString = (text: string): string[] => {
+  const lines: string[] = []
+  let start = 0
+
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] === '\n') {
+      lines.push(text.slice(start, index + 1))
+      start = index + 1
+    }
+  }
+
+  if (start < text.length) {
+    lines.push(text.slice(start))
+  }
+
+  return lines
+}
+
+// nbformat 4.5 requires a unique id per cell; tooling expects [A-Za-z0-9-_]. runIds/cellIds are
+// already close to that, so sanitize rather than generate — keeping the id traceable to the run.
+const toCellId = (run: NotebookRunRecord, index: number, seen: Set<string>): string => {
+  const sanitized = run.cellId.replace(/[^A-Za-z0-9-_]/g, '-').replace(/^-+|-+$/g, '')
+  const base = sanitized.length > 0 ? sanitized : `cell-${index}`
+
+  let candidate = base
+  let suffix = 2
+  while (seen.has(candidate)) {
+    candidate = `${base}-${suffix}`
+    suffix += 1
+  }
+  seen.add(candidate)
+
+  return candidate
+}
+
+const projectOutput = (output: NotebookOutput): IpynbOutput => {
+  switch (output.type) {
+    case 'stream':
+      return { output_type: 'stream', name: output.name, text: toMultilineString(output.text) }
+    case 'error':
+      return {
+        output_type: 'error',
+        ename: output.name ?? 'Error',
+        evalue: output.message ?? '',
+        traceback: output.traceback.split('\n')
+      }
+    case 'display':
+      // Text mimes are verbatim and image/png is already base64, so the bundle passes through.
+      return { output_type: 'display_data', data: { ...output.data }, metadata: {} }
+    case 'json':
+      return {
+        output_type: 'display_data',
+        data: { 'application/json': output.data },
+        metadata: {}
+      }
+    case 'text':
+      return { output_type: 'display_data', data: { 'text/plain': output.text }, metadata: {} }
+  }
+}
+
+// Structured outputs are the primary source; runs persisted before outputs existed (or by kernels
+// that only fill the flattened text) fall back to text.stdout/stderr/traceback.
+const projectOutputs = (run: NotebookRunRecord): IpynbOutput[] => {
+  if (run.outputs.length > 0) {
+    return run.outputs.map(projectOutput)
+  }
+
+  const fallback: IpynbOutput[] = []
+  if (run.text.stdout) {
+    fallback.push({
+      output_type: 'stream',
+      name: 'stdout',
+      text: toMultilineString(run.text.stdout)
+    })
+  }
+  if (run.text.stderr) {
+    fallback.push({
+      output_type: 'stream',
+      name: 'stderr',
+      text: toMultilineString(run.text.stderr)
+    })
+  }
+  if (run.text.traceback) {
+    fallback.push({
+      output_type: 'error',
+      ename: 'Error',
+      evalue: '',
+      traceback: run.text.traceback.split('\n')
+    })
+  }
+
+  return fallback
+}
+
+// Shell runs downgrade to a %%bash cell so they stay runnable in a Python kernel. repl runs are
+// JavaScript (the control-plane SDK), which no standard cell magic runs — they export verbatim and
+// rely on the metadata.open_science.kernel tag instead of a misleading %%bash marker.
+const projectSource = (run: NotebookRunRecord): string[] => {
+  const lines = toMultilineString(run.script)
+
+  if (run.kernelKind === 'bash') {
+    return ['%%bash\n', ...lines]
+  }
+
+  return lines
+}
+
+const projectRun = (run: NotebookRunRecord, index: number, seen: Set<string>): IpynbCodeCell => ({
+  cell_type: 'code',
+  id: toCellId(run, index, seen),
+  metadata: {
+    open_science: {
+      kernel: run.kernelKind,
+      runId: run.runId,
+      cellId: run.cellId,
+      source: run.source,
+      status: run.status,
+      startedAt: new Date(run.startedAt).toISOString(),
+      endedAt: run.endedAt === undefined ? undefined : new Date(run.endedAt).toISOString(),
+      environment: run.environment
+    }
+  },
+  source: projectSource(run),
+  outputs: projectOutputs(run),
+  execution_count: run.executionCount ?? null
+})
+
+// .ipynb allows exactly one kernelspec: the dominant analysis kernel wins (python on ties and when
+// a session has only control-plane runs). Foreign-kernel cells keep their identity in metadata.
+const resolveDominantLanguage = (runs: NotebookRunRecord[]): 'python' | 'r' => {
+  let pythonRuns = 0
+  let rRuns = 0
+
+  for (const run of runs) {
+    if (run.kernelKind === 'python') pythonRuns += 1
+    if (run.kernelKind === 'r') rRuns += 1
+  }
+
+  return rRuns > pythonRuns ? 'r' : 'python'
+}
+
+// Pure projection run.json -> .ipynb (nbformat 4.5). Deterministic: the same document always
+// produces byte-identical output, and no absolute paths or timestamps are embedded, so the exported
+// file is safe to share or publish.
+const projectRunDocumentToIpynb = (
+  document: NotebookRunDocument,
+  options: ProjectIpynbOptions = {}
+): IpynbNotebook => {
+  const language = resolveDominantLanguage(document.runs)
+  const { kernelspec, languageName } = KERNELSPEC_BY_LANGUAGE[language]
+  const seen = new Set<string>()
+
+  return {
+    cells: document.runs.map((run, index) => projectRun(run, index, seen)),
+    metadata: {
+      kernelspec,
+      language_info: { name: languageName },
+      open_science: {
+        sessionId: document.sessionId,
+        projectName: document.projectName,
+        artifactSessionId: document.artifactSessionId,
+        appVersion: options.appVersion
+      }
+    },
+    nbformat: 4,
+    nbformat_minor: 5
+  }
+}
+
+// Serializes the projection to the exact bytes to save: indent 1 (matching nbformat's own writer)
+// with a trailing newline.
+const stringifyIpynb = (notebook: IpynbNotebook): string => `${JSON.stringify(notebook, null, 1)}\n`
+
+export { projectRunDocumentToIpynb, stringifyIpynb }
+export type { IpynbNotebook, ProjectIpynbOptions }

--- a/src/main/notebook/ipynb-export.ts
+++ b/src/main/notebook/ipynb-export.ts
@@ -114,16 +114,20 @@ const toMultilineString = (text: string): string[] => {
   return lines
 }
 
-// nbformat 4.5 requires a unique id per cell; tooling expects [A-Za-z0-9-_]. runIds/cellIds are
-// already close to that, so sanitize rather than generate — keeping the id traceable to the run.
+// nbformat 4.5 requires a unique id per cell: 1-64 chars of [A-Za-z0-9-_] (JEP 62). runIds/cellIds
+// are already close to that, so sanitize rather than generate — keeping the id traceable to the
+// run. Dedup suffixes reserve room from the 64-char budget so ids never exceed it.
+const MAX_CELL_ID_LENGTH = 64
+
 const toCellId = (run: NotebookRunRecord, index: number, seen: Set<string>): string => {
   const sanitized = run.cellId.replace(/[^A-Za-z0-9-_]/g, '-').replace(/^-+|-+$/g, '')
-  const base = sanitized.length > 0 ? sanitized : `cell-${index}`
+  const base = (sanitized.length > 0 ? sanitized : `cell-${index}`).slice(0, MAX_CELL_ID_LENGTH)
 
   let candidate = base
   let suffix = 2
   while (seen.has(candidate)) {
-    candidate = `${base}-${suffix}`
+    const suffixText = `-${suffix}`
+    candidate = `${base.slice(0, MAX_CELL_ID_LENGTH - suffixText.length)}${suffixText}`
     suffix += 1
   }
   seen.add(candidate)
@@ -237,9 +241,10 @@ const resolveDominantLanguage = (runs: NotebookRunRecord[]): 'python' | 'r' => {
   return rRuns > pythonRuns ? 'r' : 'python'
 }
 
-// Pure projection run.json -> .ipynb (nbformat 4.5). Deterministic: the same document always
-// produces byte-identical output, and no absolute paths or timestamps are embedded, so the exported
-// file is safe to share or publish.
+// Pure projection run.json -> .ipynb (nbformat 4.5). Deterministic: the same document and options
+// always produce byte-identical output (appVersion is an explicit option, not read from the
+// environment), and no absolute paths or wall-clock timestamps are embedded, so the exported file
+// is safe to share or publish.
 const projectRunDocumentToIpynb = (
   document: NotebookRunDocument,
   options: ProjectIpynbOptions = {}

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -13,6 +13,7 @@ import type {
   ExecuteShellRequest,
   FinishNotebookCodeCellRequest,
   NotebookEnvironmentStatus,
+  NotebookIpynbExport,
   NotebookKernelMetadata,
   NotebookLanguage,
   NotebookOutput,
@@ -44,6 +45,7 @@ import {
   type InstallResult
 } from './package-manager'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
+import { projectRunDocumentToIpynb, stringifyIpynb } from './ipynb-export'
 import {
   addRepairRequired,
   assertSafeEnvName,
@@ -301,6 +303,8 @@ type NotebookRuntimeServiceOptions = {
   // fake; the production instance (the DefaultRuntimeProvisioner) is wired after construction in
   // main/ipc.ts via setEnvironmentManager, mirroring the mcp/mirror resolvers.
   environmentManager?: NotebookEnvironmentManager
+  // App version stamped into exported .ipynb metadata.open_science; optional so tests stay minimal.
+  appVersion?: string
 }
 
 // The wire binding plus the interpreter override the executor needs. `resolvedInterpreter` is set only
@@ -1867,6 +1871,24 @@ class NotebookRuntimeService {
       dataRoot: document.dataRoot,
       runtimeRoot: document.kernel.runtimeRoot,
       runJsonPath: getNotebookRunJsonPath(this.options.dataRoot, projectName, request.sessionId)
+    }
+  }
+
+  // Projects the persisted run history to an .ipynb (nbformat 4.5) document. Read-only like
+  // getSessionReference: a session without run.json returns null — export never creates one.
+  async exportIpynb(request: NotebookSessionRequest): Promise<NotebookIpynbExport | null> {
+    const projectName = request.projectName ?? this.options.projectName
+    const document = await this.repository.findExisting(projectName, request.sessionId)
+
+    if (!document) {
+      return null
+    }
+
+    const notebook = projectRunDocumentToIpynb(document, { appVersion: this.options.appVersion })
+
+    return {
+      suggestedName: `notebook-${request.sessionId.slice(0, 8)}.ipynb`,
+      json: stringifyIpynb(notebook)
     }
   }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -36,6 +36,7 @@ import type {
   NotebookChangedEvent,
   ExecuteNotebookCodeRequest,
   FinishNotebookCodeCellRequest,
+  NotebookIpynbExport,
   NotebookLanguage,
   NotebookRunSummary,
   NotebookSessionReference,
@@ -315,6 +316,8 @@ interface OpenScienceAPI {
   notebook: {
     state(request: NotebookSessionRequest): Promise<NotebookSessionState>
     getReference(request: NotebookSessionRequest): Promise<NotebookSessionReference | null>
+    // Projects the persisted run history to a save-ready .ipynb, or null when no run.json exists.
+    exportIpynb(request: NotebookSessionRequest): Promise<NotebookIpynbExport | null>
     beginCodeCell(request: BeginNotebookCodeCellRequest): Promise<{
       sessionId: string
       cellId: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -38,6 +38,7 @@ import type {
   NotebookChangedEvent,
   ExecuteNotebookCodeRequest,
   FinishNotebookCodeCellRequest,
+  NotebookIpynbExport,
   NotebookLanguage,
   NotebookRunSummary,
   NotebookSessionReference,
@@ -348,6 +349,8 @@ type OpenScienceAPI = {
     state: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
     // Resolves an existing notebook entry for a session without creating one, or null when absent.
     getReference: (request: NotebookSessionRequest) => Promise<NotebookSessionReference | null>
+    // Projects the persisted run history to a save-ready .ipynb, or null when no run.json exists.
+    exportIpynb: (request: NotebookSessionRequest) => Promise<NotebookIpynbExport | null>
     beginCodeCell: (request: BeginNotebookCodeCellRequest) => Promise<{
       sessionId: string
       cellId: string
@@ -729,6 +732,8 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('notebook:state', request) as Promise<NotebookSessionState>,
     getReference: (request) =>
       ipcRenderer.invoke('notebook:reference', request) as Promise<NotebookSessionReference | null>,
+    exportIpynb: (request) =>
+      ipcRenderer.invoke('notebook:export-ipynb', request) as Promise<NotebookIpynbExport | null>,
     beginCodeCell: (request) =>
       ipcRenderer.invoke('notebook:begin-code-cell', request) as Promise<{
         sessionId: string

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
@@ -25,6 +25,8 @@ const renderContent = (props: {
   runs: NotebookRunRecord[]
   status: 'loading' | 'error' | 'ready'
   error?: string
+  onExportIpynb?: () => void
+  ipynbExportStatus?: 'idle' | 'saving' | 'error'
 }): string => renderToStaticMarkup(<SessionNotebookContent onClose={vi.fn()} {...props} />)
 
 describe('SessionNotebookContent', () => {
@@ -54,12 +56,50 @@ describe('SessionNotebookContent', () => {
     expect(html).toContain('ModuleNotFoundError')
   })
 
-  it('renders the .ipynb footer button as disabled', () => {
-    const html = renderContent({ sessionId: 's1', runs: [], status: 'ready' })
+  it('enables the .ipynb export button when runs exist and an export handler is wired', () => {
+    const html = renderContent({
+      sessionId: 's1',
+      runs: [makeRun()],
+      status: 'ready',
+      onExportIpynb: vi.fn()
+    })
 
-    expect(html).toContain('.ipynb')
-    // The only disabled control in the content is the placeholder export button.
-    expect(html).toContain('disabled')
+    expect(html).toContain('aria-label="Download as .ipynb"')
+    // No control in the content is disabled once export is available.
+    expect(html).not.toContain('disabled=""')
+  })
+
+  it('keeps the .ipynb export button disabled when there are no runs to export', () => {
+    const html = renderContent({
+      sessionId: 's1',
+      runs: [],
+      status: 'ready',
+      onExportIpynb: vi.fn()
+    })
+
+    expect(html).toContain('aria-label="Download as .ipynb"')
+    expect(html).toContain('disabled=""')
+  })
+
+  it('shows export progress and failure feedback on the .ipynb footer', () => {
+    const saving = renderContent({
+      sessionId: 's1',
+      runs: [makeRun()],
+      status: 'ready',
+      onExportIpynb: vi.fn(),
+      ipynbExportStatus: 'saving'
+    })
+    expect(saving).toContain('Exporting…')
+    expect(saving).toContain('disabled=""')
+
+    const failed = renderContent({
+      sessionId: 's1',
+      runs: [makeRun()],
+      status: 'ready',
+      onExportIpynb: vi.fn(),
+      ipynbExportStatus: 'error'
+    })
+    expect(failed).toContain('Notebook export failed. Try again.')
   })
 })
 

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
@@ -278,7 +278,10 @@ const SessionNotebookDialog = ({
         data: new TextEncoder().encode(exported.json).buffer
       })
       setIpynbExportStatus('idle')
-    } catch {
+    } catch (exportError) {
+      // A canceled Save As resolves instead of throwing, so reaching here means a real failure —
+      // keep a diagnostic trail instead of collapsing it into the generic banner alone.
+      console.error('Failed to export notebook as .ipynb:', exportError)
       setIpynbExportStatus('error')
     }
   }
@@ -293,6 +296,9 @@ const SessionNotebookDialog = ({
       setStatus('loading')
       setError(undefined)
       setRuns([])
+      // The dialog is mounted once and the session prop swaps in place, so per-session export
+      // state (notably a prior failure banner) must not leak into the next session.
+      setIpynbExportStatus('idle')
 
       void loadSessionNotebookRuns(window.api.notebook, {
         sessionId,

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
@@ -20,6 +20,9 @@ import { loadSessionNotebookRuns } from './session-notebook-data'
 
 type SessionNotebookStatus = 'loading' | 'error' | 'ready'
 
+// Export lifecycle for the .ipynb footer button; 'error' surfaces inline until the next attempt.
+type IpynbExportStatus = 'idle' | 'saving' | 'error'
+
 // Fixed section order for the per-kernel grouping, mirroring NotebookPreview's tab order.
 const KERNEL_KIND_ORDER: NotebookKernelKind[] = ['python', 'r', 'repl', 'bash']
 
@@ -79,17 +82,22 @@ type SessionNotebookContentProps = {
   status: SessionNotebookStatus
   error?: string
   onClose: () => void
+  // Wired by the container; the button stays disabled when no handler or no runs are available.
+  onExportIpynb?: () => void
+  ipynbExportStatus?: IpynbExportStatus
 }
 
 // Pure presentational body of the dialog: header summary, empty/loading/error/populated states,
-// and the disabled .ipynb footer. Kept free of data-loading hooks and Dialog context so it renders
-// standalone in tests; close is delegated through onClose.
+// and the .ipynb export footer. Kept free of data-loading hooks and Dialog context so it renders
+// standalone in tests; close and export are delegated through props.
 const SessionNotebookContent = ({
   sessionId,
   runs,
   status,
   error,
-  onClose
+  onClose,
+  onExportIpynb,
+  ipynbExportStatus = 'idle'
 }: SessionNotebookContentProps): React.JSX.Element => {
   const [activeKind, setActiveKind] = useState<NotebookKernelKind>('python')
   const shortId = sessionId.slice(0, 8)
@@ -191,24 +199,35 @@ const SessionNotebookContent = ({
         )}
       </div>
 
-      <div className="flex justify-end gap-3 border-t border-border-300/15 px-5 py-3.5">
+      <div className="flex items-center justify-end gap-3 border-t border-border-300/15 px-5 py-3.5">
+        {ipynbExportStatus === 'error' ? (
+          <span className="text-xs text-danger-000">Notebook export failed. Try again.</span>
+        ) : null}
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              {/* Wrapper span keeps the tooltip reachable even though the button is disabled. */}
+              {/* Wrapper span keeps the tooltip reachable while the button is disabled. */}
               <span>
                 <button
                   type="button"
-                  disabled
+                  disabled={
+                    status !== 'ready' ||
+                    runs.length === 0 ||
+                    onExportIpynb === undefined ||
+                    ipynbExportStatus === 'saving'
+                  }
+                  onClick={onExportIpynb}
                   className="flex items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
                   aria-label="Download as .ipynb"
                 >
                   <Download className="size-3.5" aria-hidden="true" />
-                  .ipynb
+                  {ipynbExportStatus === 'saving' ? 'Exporting…' : '.ipynb'}
                 </button>
               </span>
             </TooltipTrigger>
-            <TooltipContent>Notebook export is coming soon</TooltipContent>
+            <TooltipContent>
+              {runs.length === 0 ? 'No runs to export' : 'Download as .ipynb'}
+            </TooltipContent>
           </Tooltip>
         </TooltipProvider>
       </div>
@@ -229,10 +248,40 @@ const SessionNotebookDialog = ({
   const [runs, setRuns] = useState<NotebookRunRecord[]>([])
   const [status, setStatus] = useState<SessionNotebookStatus>('loading')
   const [error, setError] = useState<string | undefined>(undefined)
+  const [ipynbExportStatus, setIpynbExportStatus] = useState<IpynbExportStatus>('idle')
 
   const sessionId = session?.id
   const projectId = session?.projectId
   const cwd = session?.cwd
+
+  // Reads the freshly projected .ipynb from main (run.json stays the source of truth there) and
+  // hands the exact bytes to the shared Save As flow. A canceled dialog is neutral, not an error.
+  const handleExportIpynb = async (): Promise<void> => {
+    if (!sessionId || ipynbExportStatus === 'saving') return
+
+    setIpynbExportStatus('saving')
+
+    try {
+      const exported = await window.api.notebook.exportIpynb({
+        sessionId,
+        projectName: projectId,
+        workspaceCwd: cwd ?? ''
+      })
+
+      if (!exported) {
+        throw new Error('No notebook found for this session.')
+      }
+
+      await window.api.saveBlobFile({
+        suggestedName: exported.suggestedName,
+        mimeType: 'application/x-ipynb+json',
+        data: new TextEncoder().encode(exported.json).buffer
+      })
+      setIpynbExportStatus('idle')
+    } catch {
+      setIpynbExportStatus('error')
+    }
+  }
 
   useEffect(() => {
     if (!sessionId) return
@@ -291,6 +340,10 @@ const SessionNotebookDialog = ({
               status={status}
               error={error}
               onClose={onClose}
+              onExportIpynb={() => {
+                void handleExportIpynb()
+              }}
+              ipynbExportStatus={ipynbExportStatus}
             />
           ) : null}
         </Dialog.Content>

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -27,6 +27,7 @@ export const WEB_INVOKE_CHANNELS = {
   'notebook.appendCodeCell': 'notebook:append-code-cell',
   'notebook.beginCodeCell': 'notebook:begin-code-cell',
   'notebook.execute': 'notebook:execute',
+  'notebook.exportIpynb': 'notebook:export-ipynb',
   'notebook.finishCodeCell': 'notebook:finish-code-cell',
   'notebook.getReference': 'notebook:reference',
   'notebook.restart': 'notebook:restart',

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -224,6 +224,13 @@ export type NotebookSessionRequest = {
   workspaceCwd: string
 }
 
+// One session's run history projected to an .ipynb (nbformat 4.5) document, ready to save.
+export type NotebookIpynbExport = {
+  suggestedName: string
+  // The exact file contents (JSON text), serialized in main so the renderer never re-shapes it.
+  json: string
+}
+
 // Starts a streamed code write into a notebook cell.
 export type BeginNotebookCodeCellRequest = NotebookSessionRequest & {
   cellId?: string


### PR DESCRIPTION
Refs #293 — implements **Stage 1 (one-way export, `run.json` → `.ipynb`)** of the three-stage plan proposed there. Stages 2 (import / "Open in JupyterLab") and 3 (mirror-on-run) are intentionally left for follow-ups.

## Problem

A finished notebook session is locked inside the app: `run.json` is durable but can't be handed to a JupyterLab/VS Code collaborator, pushed to a paper repository, or rendered on GitHub/nbviewer. The Session Notebook viewer has acknowledged this with a disabled "Download as .ipynb" button ("coming soon") since #130.

## Proposed change

A pure projection in the main process — `run.json` stays the single source of truth, no storage change, no Python/`nbconvert` dependency (nbformat is plain JSON, generated by hand):

```mermaid
flowchart LR
    A["SessionNotebookDialog<br/>.ipynb button"] -->|"notebook:export-ipynb"| B["NotebookRuntimeService<br/>.exportIpynb"]
    B -->|"findExisting (read-only)"| C["NotebookRunRepository<br/>run.json"]
    B --> D["projectRunDocumentToIpynb<br/>(pure, deterministic)"]
    D -->|"NotebookIpynbExport json"| A
    A -->|"file:save-blob"| E["Save As dialog<br/>(.ipynb filter)"]
```

- `src/main/notebook/ipynb-export.ts` (new): `projectRunDocumentToIpynb` maps each `NotebookRunRecord` to an nbformat 4.5 code cell — `script` → `source`, `outputs` → stream/error/display_data (images are already base64 inline), `executionCount` → `execution_count`, and every cell gets `metadata.open_science` (`runId`, kernel, status, ISO timestamps) as the provenance anchor anticipated by the roadmap. Structured `outputs` are primary; runs without them fall back to the flattened `text.stdout/stderr/traceback`.
- Kernelspec comes from the dominant analysis kernel (`python3` / `ir`); `.ipynb` allows only one, so foreign-kernel cells keep their identity in `metadata.open_science.kernel`.
- **Deliberate deviation from the issue's mapping table**: `bash` runs downgrade to `%%bash` cells, but `repl` runs are JavaScript (the control-plane SDK), so they export verbatim with the kernel metadata tag — a `%%bash` marker over JS would be wrong.
- The projection is deterministic and privacy-safe: no absolute paths (`workspaceCwd`, session roots) and no wall-clock export timestamp, so the same `run.json` yields byte-identical output.
- `NotebookRuntimeService.exportIpynb` reads via `repository.findExisting` — read-only, never creates `run.json` — exposed as the new `notebook:export-ipynb` IPC channel and `window.api.notebook.exportIpynb` bridge (also registered in the generated web API map).
- The footer button in `SessionNotebookDialog` is now active (disabled only when empty/loading/export-in-flight), and saves through the existing `file:save-blob` flow with a new `.ipynb` dialog filter; failures surface inline next to the button.

## Scope and non-goals

- One-way export only: no `.ipynb` import, no JupyterLab launcher, no mirror-on-run (stages 2–3).
- No split-by-kernel export mode; mixed sessions carry per-cell kernel tags instead.
- No nbformat JSON-Schema dependency added; the emitted subset is asserted structurally in tests.
- `run.json` format, kernels, and the run lifecycle are untouched.

## Acceptance criteria and validation

- [x] The previously disabled ".ipynb" button exports the session's run history to a valid nbformat 4.5 file chosen via Save As.
- [x] Exported notebooks render out of the box (kernelspec + language_info set) and trace every cell back to its `runId`.
- [x] Export is idempotent and free of absolute paths.
- [x] `npm run lint` — green (0 errors; prettier-clean for all touched files).
- [x] `npm run test` — green (4779 passed, 66 skipped; skips are the pre-existing opt-in integration/smoke suites).
- [ ] `npm run typecheck` — not run locally yet (deferred for now); will run and address anything that surfaces.

Tests added/updated:

- `src/main/notebook/ipynb-export.test.ts` (new): cell/output mapping, `%%bash` downgrade, repl handling, dominant-kernel kernelspec, cell-id sanitizing/uniqueness, determinism + no-path-leak, and a service-level test through the real `NotebookRunRepository` (incl. the null/no-creation path).
- `src/main/notebook/ipc.test.ts`: new channel in the exact-channel assertion + delegation.
- `src/main/file-save.test.ts`: `.ipynb` filter for the `application/x-ipynb+json` mime.
- `SessionNotebookDialog.render.test.tsx`: enabled/disabled/saving/error states of the export button.
- `src/renderer/web/api-map.generated.ts`: regenerated for the new `notebook:export-ipynb` channel.

## Review focus

- The repl-vs-`%%bash` deviation described above.
- The `metadata.open_science` field set — this is the contract a future import/provenance stage will hang off.
- Determinism choices (indent 1 + trailing newline, ISO timestamps only from run data).
