### PR TITLE
fix(acp): recover from cross-framework and opencode session resume failures

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -121,6 +121,9 @@ const startFakeAgent = (
     // Some agents preserve a machine-readable reason in the Internal error data instead of relying on
     // the human-facing detail string.
     resumeInternalErrorData?: unknown
+    // opencode rejects a lost session with an Internal error tagged by the failing service and a
+    // descriptive message suffix (e.g. `{ service: 'session' }` + "OpenCode service failure").
+    resumeServiceFailure?: { service: string; message: string }
     // When true, the agent does NOT advertise session/close capability, so the runtime must fall back to
     // the session/cancel notification on delete instead of a close request.
     supportsClose?: boolean
@@ -212,6 +215,13 @@ const startFakeAgent = (
 
       if (options.resumeInternalErrorData !== undefined) {
         throw acp.RequestError.internalError(options.resumeInternalErrorData)
+      }
+
+      if (options.resumeServiceFailure) {
+        throw acp.RequestError.internalError(
+          { service: options.resumeServiceFailure.service },
+          options.resumeServiceFailure.message
+        )
       }
 
       resumedSessions.push({
@@ -3295,6 +3305,43 @@ describe('ACP runtime session management', () => {
     await expect(
       runtime.resumeSession({ sessionId: 'restarted-session', cwd: '/workspace' })
     ).rejects.toMatchObject({ code: -32603, data: { errorKind: 'provider-error' } })
+    expect(fakeAgent.newSessions).toEqual([])
+  })
+
+  it('adopts a fresh session when opencode tags a lost session with its failing service', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['adopted-session-1'], {
+      resumeServiceFailure: { service: 'session', message: 'OpenCode service failure' }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await expect(
+      runtime.resumeSession({ sessionId: 'restarted-session', cwd: '/workspace' })
+    ).resolves.toMatchObject({ sessionId: 'restarted-session', contextReset: true })
+    expect(fakeAgent.newSessions).toHaveLength(1)
+
+    await runtime.sendPrompt({ sessionId: 'restarted-session', text: 'keep going' })
+    expect(fakeAgent.prompts).toEqual([{ sessionId: 'adopted-session-1', text: 'keep going' }])
+  })
+
+  it('keeps an Internal error from a non-session service visible', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, [], {
+      resumeServiceFailure: { service: 'provider', message: 'OpenCode service failure' }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await expect(
+      runtime.resumeSession({ sessionId: 'restarted-session', cwd: '/workspace' })
+    ).rejects.toMatchObject({ code: -32603, data: { service: 'provider' } })
     expect(fakeAgent.newSessions).toEqual([])
   })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -115,6 +115,9 @@ const startFakeAgent = (
     // When true, the resume handler rejects with a generic "Internal error" (-32603) — what some
     // agents return instead of a clean not-found after their process was replaced by an app restart.
     resumeInternalError?: boolean
+    // A plain handler error is serialized by the ACP SDK as -32603 with the original message in
+    // data.details. This mirrors agents that do not translate their resume failure to resourceNotFound.
+    resumeInternalErrorDetails?: string
     // When true, the agent does NOT advertise session/close capability, so the runtime must fall back to
     // the session/cancel notification on delete instead of a close request.
     supportsClose?: boolean
@@ -198,6 +201,10 @@ const startFakeAgent = (
 
       if (options.resumeInternalError) {
         throw acp.RequestError.internalError()
+      }
+
+      if (options.resumeInternalErrorDetails) {
+        throw new Error(options.resumeInternalErrorDetails)
       }
 
       resumedSessions.push({
@@ -3182,6 +3189,63 @@ describe('ACP runtime session management', () => {
         { sessionId: 'restarted-session', text: 'reply for adopted-session-1' }
       ])
     )
+  })
+
+  it('adopts a fresh session when the ACP agent wraps a resume failure in Internal error details', async () => {
+    infoLogSpy.mockClear()
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['adopted-session-1'], {
+      resumeInternalErrorDetails: 'Failed to restore the previous conversation'
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const resumed = await runtime.resumeSession({
+      sessionId: 'restarted-session',
+      cwd: '/workspace'
+    })
+    expect(resumed).toMatchObject({
+      sessionId: 'restarted-session',
+      contextReset: true
+    })
+    expect(
+      infoLogSpy.mock.calls.find(
+        ([message]) => message === 'resumed session adopted after unrecoverable resume error'
+      )?.[1]
+    ).toMatchObject({
+      sessionId: 'restarted-session',
+      error: 'Internal error',
+      code: -32603,
+      data: { details: 'Failed to restore the previous conversation' }
+    })
+
+    await runtime.sendPrompt({ sessionId: 'restarted-session', text: 'keep going' })
+
+    expect(fakeAgent.prompts).toEqual([{ sessionId: 'adopted-session-1', text: 'keep going' }])
+  })
+
+  it('keeps an unrelated detailed Internal error visible instead of adopting a fresh session', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, [], {
+      resumeInternalErrorDetails: 'Authentication failed while configuring the provider'
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await expect(
+      runtime.resumeSession({ sessionId: 'restarted-session', cwd: '/workspace' })
+    ).rejects.toMatchObject({
+      code: -32603,
+      message: 'Internal error',
+      data: { details: 'Authentication failed while configuring the provider' }
+    })
+    expect(fakeAgent.newSessions).toEqual([])
   })
 
   it('skips resume entirely for a session that last ran under a different framework', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -118,6 +118,9 @@ const startFakeAgent = (
     // A plain handler error is serialized by the ACP SDK as -32603 with the original message in
     // data.details. This mirrors agents that do not translate their resume failure to resourceNotFound.
     resumeInternalErrorDetails?: string
+    // Some agents preserve a machine-readable reason in the Internal error data instead of relying on
+    // the human-facing detail string.
+    resumeInternalErrorData?: unknown
     // When true, the agent does NOT advertise session/close capability, so the runtime must fall back to
     // the session/cancel notification on delete instead of a close request.
     supportsClose?: boolean
@@ -205,6 +208,10 @@ const startFakeAgent = (
 
       if (options.resumeInternalErrorDetails) {
         throw new Error(options.resumeInternalErrorDetails)
+      }
+
+      if (options.resumeInternalErrorData !== undefined) {
+        throw acp.RequestError.internalError(options.resumeInternalErrorData)
       }
 
       resumedSessions.push({
@@ -3227,11 +3234,34 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.prompts).toEqual([{ sessionId: 'adopted-session-1', text: 'keep going' }])
   })
 
-  it('keeps an unrelated detailed Internal error visible instead of adopting a fresh session', async () => {
+  it('adopts a fresh session from a language-independent session-loss reason', async () => {
     const process = new FakeAgentProcess()
-    const fakeAgent = startFakeAgent(process, [], {
-      resumeInternalErrorDetails: 'Authentication failed while configuring the provider'
+    const fakeAgent = startFakeAgent(process, ['adopted-session-1'], {
+      resumeInternalErrorData: {
+        errorKind: 'session-not-found',
+        details: 'The agent supplied a localized diagnostic'
+      }
     })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await expect(
+      runtime.resumeSession({ sessionId: 'restarted-session', cwd: '/workspace' })
+    ).resolves.toMatchObject({ sessionId: 'restarted-session', contextReset: true })
+    expect(fakeAgent.newSessions).toHaveLength(1)
+  })
+
+  it.each([
+    'Authentication failed while configuring the provider',
+    'Failed to load session provider credentials',
+    'Unable to load Model Context Protocol server for this session',
+    'Unknown model context for this conversation'
+  ])('keeps unrelated Internal error details visible: %s', async (details) => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, [], { resumeInternalErrorDetails: details })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
@@ -3243,8 +3273,28 @@ describe('ACP runtime session management', () => {
     ).rejects.toMatchObject({
       code: -32603,
       message: 'Internal error',
-      data: { details: 'Authentication failed while configuring the provider' }
+      data: { details }
     })
+    expect(fakeAgent.newSessions).toEqual([])
+  })
+
+  it('trusts an unrelated structured reason over a session-like detail', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, [], {
+      resumeInternalErrorData: {
+        errorKind: 'provider-error',
+        details: 'Failed to restore the previous conversation'
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await expect(
+      runtime.resumeSession({ sessionId: 'restarted-session', cwd: '/workspace' })
+    ).rejects.toMatchObject({ code: -32603, data: { errorKind: 'provider-error' } })
     expect(fakeAgent.newSessions).toEqual([])
   })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -298,6 +298,22 @@ const safeLogError = (message: string, data?: unknown): void => {
   }
 }
 
+const describesUnresumableSession = (details: unknown): boolean => {
+  if (typeof details !== 'string') return false
+
+  const mentionsSession = /\b(?:session|conversation|context)\b/i.test(details)
+  if (!mentionsSession) return false
+
+  const describesMissingSession =
+    /\b(?:not found|does not exist|unknown|missing)\b/i.test(details) ||
+    /\bno\s+(?:saved\s+)?(?:session|conversation|context)\b/i.test(details)
+  const describesFailedResume =
+    /\b(?:failed|unable|cannot|can't|could not)\b/i.test(details) &&
+    /\b(?:resume|restore|load|reopen|reattach)\w*\b/i.test(details)
+
+  return describesMissingSession || describesFailedResume
+}
+
 // Detects an agent-side resume failure that means the session cannot be reattached, so the thread
 // should adopt a fresh agent session instead of dead-ending. A spec-compliant agent returns
 // "Resource not found" (-32002) for a session id it no longer holds (e.g. after a provider switch);
@@ -313,13 +329,14 @@ const isUnresumableSessionError = (error: unknown): boolean => {
   if (candidate.code === -32002 || /resource not found|session not found/i.test(message))
     return true
 
-  // Some restarted agents return a bare JSON-RPC Internal error for a lost session. Treat only that
-  // exact detail-free shape as unresumable; richer -32603 errors carry the real auth/MCP/provider
-  // failure in data.details and must propagate rather than being hidden by a fresh-session fallback.
+  // The ACP SDK wraps a plain agent exception as a generic Internal error and stores its message in
+  // data.details. Recover that shape only when the detail identifies a missing/unrestorable session;
+  // unrelated auth, MCP, and provider failures must remain visible. Detail-free Internal errors keep the
+  // existing fallback because some agents discard the cause entirely.
   return (
     candidate.code === -32603 &&
     /^internal error\.?$/i.test(message.trim()) &&
-    candidate.data?.details === undefined
+    (candidate.data?.details === undefined || describesUnresumableSession(candidate.data.details))
   )
 }
 
@@ -1211,7 +1228,7 @@ class AcpRuntime {
       // than dead-end the thread, adopt a brand-new agent session under the SAME app id.
       log.info('resumed session adopted after unrecoverable resume error', {
         sessionId: request.sessionId,
-        reason: error instanceof Error ? error.message : String(error)
+        ...errorLogFields(error)
       })
 
       return this.adoptFreshSession(connection, request, sessionCwd, projectName)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -361,14 +361,23 @@ const isUnresumableSessionError = (error: unknown): boolean => {
   const candidate = error as {
     code?: number
     message?: string
-    data?: { details?: unknown; errorKind?: unknown }
+    data?: { details?: unknown; errorKind?: unknown; service?: unknown }
   }
   const message = candidate.message ?? ''
 
   if (candidate.code === -32002 || /resource not found|session not found/i.test(message))
     return true
 
-  if (candidate.code !== -32603 || !/^internal error\.?$/i.test(message.trim())) return false
+  if (candidate.code !== -32603) return false
+
+  // opencode reports a lost session as an Internal error tagged with the failing service
+  // (`{ service: 'session' }`) and a descriptive message suffix, rather than the bare message or the
+  // details string the fallbacks below expect. This marker is machine-readable and language-
+  // independent, so a session-service failure is authoritative — adopt a fresh session regardless of
+  // the suffix. A non-session service (provider, mcp, …) still propagates as a genuine failure.
+  if (candidate.data?.service === 'session') return true
+
+  if (!/^internal error\.?$/i.test(message.trim())) return false
 
   // A structured reason is authoritative and language-independent. Unknown reasons propagate even when
   // their detail happens to look session-related, preventing provider/MCP errors from being swallowed.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -298,18 +298,53 @@ const safeLogError = (message: string, data?: unknown): void => {
   }
 }
 
+const UNRESUMABLE_SESSION_ERROR_KINDS = new Set([
+  'session_not_found',
+  'conversation_not_found',
+  'session_missing',
+  'conversation_missing',
+  'session_resume_failed',
+  'conversation_restore_failed'
+])
+
+const isUnresumableSessionErrorKind = (errorKind: unknown): boolean =>
+  typeof errorKind === 'string' &&
+  UNRESUMABLE_SESSION_ERROR_KINDS.has(
+    errorKind
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_|_$/g, '')
+  )
+
+// Legacy agents may expose only an English diagnostic. Keep this fallback deliberately narrow: a
+// false positive silently resets agent-side context, while a false negative leaves the real error
+// visible and can be fixed by teaching the backend to emit a machine-readable errorKind.
 const describesUnresumableSession = (details: unknown): boolean => {
   if (typeof details !== 'string') return false
-
-  const mentionsSession = /\b(?:session|conversation|context)\b/i.test(details)
-  if (!mentionsSession) return false
+  if (
+    /\b(?:auth|authentication|authorization|credential|provider|mcp|model|tool|server)\b/i.test(
+      details
+    )
+  )
+    return false
 
   const describesMissingSession =
-    /\b(?:not found|does not exist|unknown|missing)\b/i.test(details) ||
-    /\bno\s+(?:saved\s+)?(?:session|conversation|context)\b/i.test(details)
+    /\b(?:session|conversation)(?:\s+(?:id|identifier))?\s+(?:(?:was|is)\s+)?(?:not found|missing|unknown)\b/i.test(
+      details
+    ) ||
+    /\b(?:session|conversation)(?:\s+(?:id|identifier))?\s+does not exist\b/i.test(details) ||
+    /\b(?:no|missing|unknown)\s+(?:saved\s+|previous\s+)?(?:session|conversation)\b/i.test(details)
   const describesFailedResume =
-    /\b(?:failed|unable|cannot|can't|could not)\b/i.test(details) &&
-    /\b(?:resume|restore|load|reopen|reattach)\w*\b/i.test(details)
+    /\b(?:failed|unable|cannot|can't|could not)\s+to\s+(?:resume|restore|reopen|reattach)\b.{0,80}\b(?:session|conversation)\b/i.test(
+      details
+    ) ||
+    /\b(?:session|conversation)\b.{0,40}\b(?:failed|was unable)\s+to\s+(?:resume|restore|reopen|reattach)\b/i.test(
+      details
+    ) ||
+    /\b(?:session|conversation)\b.{0,40}\b(?:could not|cannot|can't)\s+be\s+(?:resumed|restored|reopened|reattached)\b/i.test(
+      details
+    )
 
   return describesMissingSession || describesFailedResume
 }
@@ -323,20 +358,27 @@ const describesUnresumableSession = (details: unknown): boolean => {
 const isUnresumableSessionError = (error: unknown): boolean => {
   if (typeof error !== 'object' || error === null) return false
 
-  const candidate = error as { code?: number; message?: string; data?: { details?: unknown } }
+  const candidate = error as {
+    code?: number
+    message?: string
+    data?: { details?: unknown; errorKind?: unknown }
+  }
   const message = candidate.message ?? ''
 
   if (candidate.code === -32002 || /resource not found|session not found/i.test(message))
     return true
 
-  // The ACP SDK wraps a plain agent exception as a generic Internal error and stores its message in
-  // data.details. Recover that shape only when the detail identifies a missing/unrestorable session;
-  // unrelated auth, MCP, and provider failures must remain visible. Detail-free Internal errors keep the
-  // existing fallback because some agents discard the cause entirely.
+  if (candidate.code !== -32603 || !/^internal error\.?$/i.test(message.trim())) return false
+
+  // A structured reason is authoritative and language-independent. Unknown reasons propagate even when
+  // their detail happens to look session-related, preventing provider/MCP errors from being swallowed.
+  if (candidate.data?.errorKind !== undefined) {
+    return isUnresumableSessionErrorKind(candidate.data.errorKind)
+  }
+
+  // Detail-free Internal errors keep the existing fallback because some agents discard the cause.
   return (
-    candidate.code === -32603 &&
-    /^internal error\.?$/i.test(message.trim()) &&
-    (candidate.data?.details === undefined || describesUnresumableSession(candidate.data.details))
+    candidate.data?.details === undefined || describesUnresumableSession(candidate.data.details)
   )
 }
 


### PR DESCRIPTION
## Problem
Switching agent framework (e.g. claude-code → opencode) and then resuming a
session created under the other framework surfaced `RequestError: Internal
error` in the UI. opencode rejects the lost session with a JSON-RPC Internal
error (-32603) tagged `{"service":"session"}` and a "OpenCode service failure"
message suffix; the resume-failure detector only matched a bare `Internal
error` message, so the error propagated instead of falling back to a fresh
session.

## Proposed change
- Recognize opencode's machine-readable `data.service === 'session'` marker as
  an authoritative, language-independent unresumable-session signal.
- Prefer structured `errorKind`, and constrain the English detail matcher so
  provider/credential/MCP/model/tool failures stay visible.

## Scope and non-goals
Resume-failure classification only. No change to the cross-framework skip path
or to genuine (non-session) failure propagation.

## Acceptance criteria and validation
- New tests: session-service failure adopts a fresh session; non-session
  service (`provider`) stays visible. `vitest` runtime suite: 146 passed.
- eslint clean on changed files.

## Review focus
`isUnresumableSessionError` — that `service === 'session'` cannot swallow real
provider/MCP failures.