### PR TITLE
fix(codex): seed isolated subscription model into CODEX_CONFIG

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -526,6 +526,55 @@ describe('ACP runtime migration write-gate', () => {
     )
   })
 
+  it('skips set_config_option when a required subscription model already matches currentValue', async () => {
+    // codex-acp reloads on every session/set_config_option call, which would stall the first prompt
+    // of a new session for ~2 min when the model was already seeded via CODEX_CONFIG (issue #277).
+    // When the agent reflects that seeded model as its option's currentValue, applySessionModel must
+    // treat it as a successful no-op instead of (a) re-applying the same value or (b) collapsing it
+    // into the required-model "not available" failure path. Verified end-to-end here.
+    const process = new FakeAgentProcess()
+    const configOptions = [
+      {
+        type: 'select',
+        id: 'model',
+        name: 'Model',
+        category: 'model',
+        currentValue: 'gpt-5.6-terra',
+        options: [
+          { value: 'gpt-5', name: 'GPT-5' },
+          { value: 'gpt-5.6-terra', name: 'GPT-5.6 Terra' }
+        ]
+      } as SessionConfigOption
+    ]
+    const fakeAgent = startFakeAgent(process, ['subscription-session'], {
+      modes: {
+        currentModeId: 'agent',
+        availableModes: ['read-only', 'agent', 'agent-full-access'].map((id) => ({ id, name: id }))
+      },
+      configOptions
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {},
+        sessionModel: 'gpt-5.6-terra',
+        sessionModelRequired: true
+      }),
+      framework: codexFramework
+    })
+
+    // createSession must succeed: the model is required, but it is already current — the runtime
+    // must not mistake that for an unavailable model.
+    const created = await runtime.createSession({ cwd: '/workspace' })
+    expect(created.sessionId).toBe('subscription-session')
+    // And it must NOT re-send set_config_option: that is exactly the round-trip we are trying to
+    // avoid for codex-isolated subscriptions whose model is already seeded via CODEX_CONFIG.
+    expect(fakeAgent.configChanges).toEqual([])
+  })
+
   it('rejects sendPrompt while a data-root migration is pending, then resumes once cleared', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['gated-session'])

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -574,6 +574,18 @@ class AcpRuntime {
       return undefined
     }
 
+    // The agent already has the desired model — typically because the framework seeded it via
+    // CODEX_CONFIG (codex-isolated subscription) or because the previous call landed on it. Skip the
+    // redundant session/set_config_option round-trip: codex-acp reloads on every call, and even
+    // sending the same value back stalled the first prompt of a new session for ~2 min (issue #277).
+    if (selection.alreadyCurrent) {
+      log.info('session model already current', {
+        sessionId: session.sessionId,
+        model: selection.value
+      })
+      return configOptions ?? null
+    }
+
     try {
       const response = (await this.connection.agent.request(
         acp.methods.agent.session.setConfigOption,

--- a/src/main/acp/session-config.test.ts
+++ b/src/main/acp/session-config.test.ts
@@ -20,7 +20,11 @@ const modelOption = (
 
 describe('matchSessionModelOption', () => {
   it('matches an opencode provider/model value by its bare-model suffix', () => {
-    const options = [modelOption(['anthropic/claude-sonnet-4-5', 'openai/gpt-5'])]
+    // currentValue is pinned to a different option so the desired value still needs to be applied
+    // and we can verify the bare-model suffix match on its own.
+    const options = [
+      modelOption(['anthropic/claude-sonnet-4-5', 'openai/gpt-5'], { currentValue: 'openai/gpt-5' })
+    ]
 
     expect(matchSessionModelOption(options, 'claude-sonnet-4-5')).toEqual({
       configId: 'model',
@@ -46,7 +50,7 @@ describe('matchSessionModelOption', () => {
       id: 'model',
       name: 'Model',
       category: 'model',
-      currentValue: 'anthropic/claude-opus-4-8',
+      currentValue: 'openai/gpt-5',
       options: [
         { name: 'Anthropic', options: [{ value: 'anthropic/claude-opus-4-8', name: 'Opus' }] }
       ]
@@ -68,7 +72,9 @@ describe('matchSessionModelOption', () => {
   })
 
   it('identifies the model option by category even when its id differs', () => {
-    const options = [modelOption(['x/y-model'], { id: 'primary_model' })]
+    const options = [
+      modelOption(['x/y-model'], { id: 'primary_model', currentValue: 'openai/gpt-5' })
+    ]
 
     expect(matchSessionModelOption(options, 'y-model')).toEqual({
       configId: 'primary_model',
@@ -76,20 +82,37 @@ describe('matchSessionModelOption', () => {
     })
   })
 
-  it("skips the round-trip when the desired model is already the option's current value", () => {
+  it("returns alreadyCurrent when the desired model already matches the option's current value", () => {
     // codex-acp treats every session/set_config_option as a model reload, so re-sending the same
-    // value stalls the first prompt of a freshly created session (issue #277). When the option is
-    // already at the desired value there is nothing to apply — return undefined and let the runtime
-    // skip the call.
+    // value stalls the first prompt of a freshly created session (issue #277). The selection carries
+    // alreadyCurrent=true so the runtime can skip the round-trip — this MUST stay distinct from the
+    // undefined "no match" return so a required-model guard does not misfire on a successful seed.
     const options = [modelOption(['gpt-5.6-terra', 'gpt-5', 'gpt-5-mini'])]
 
-    expect(matchSessionModelOption(options, 'gpt-5.6-terra')).toBeUndefined()
+    expect(matchSessionModelOption(options, 'gpt-5.6-terra')).toEqual({
+      configId: 'model',
+      value: 'gpt-5.6-terra',
+      alreadyCurrent: true
+    })
+  })
+
+  it('returns alreadyCurrent when opencode surfaces a prefixed currentValue and the app stores the bare model', () => {
+    // opencode advertises model ids as `<provider>/<model>` while the app stores the bare model.
+    // The skip must compare names rather than raw strings, otherwise every session creation re-applies
+    // the same selection for free. (Claude review Low finding on PR #301.)
+    const options = [modelOption(['openai/gpt-5', 'anthropic/claude-sonnet-4-5'])]
+
+    expect(matchSessionModelOption(options, 'gpt-5')).toEqual({
+      configId: 'model',
+      value: 'openai/gpt-5',
+      alreadyCurrent: true
+    })
   })
 
   it('still applies when currentValue differs from the desired model even if a value matches', () => {
-    // Sanity check that the skip is gated on currentValue === desiredModel and not on any value
-    // match within the option: currentValue is pinned to a different model so the desired one
-    // genuinely needs to be applied.
+    // Sanity check that the skip is gated on currentValue matching the desired model (with
+    // suffix-equivalence), not on any value match within the option. Pin currentValue to a different
+    // model so the desired one genuinely needs to be applied.
     const options = [
       modelOption(['gpt-5', 'gpt-5.6-terra', 'gpt-5-mini'], { currentValue: 'gpt-5' })
     ]

--- a/src/main/acp/session-config.test.ts
+++ b/src/main/acp/session-config.test.ts
@@ -29,7 +29,10 @@ describe('matchSessionModelOption', () => {
   })
 
   it('prefers an exact value match over a suffix match', () => {
-    const options = [modelOption(['claude-sonnet-4-5', 'anthropic/claude-sonnet-4-5'])]
+    // currentValue is pinned to a different option so the desired value actually needs to be applied.
+    const options = [
+      modelOption(['openai/gpt-5', 'claude-sonnet-4-5', 'anthropic/claude-sonnet-4-5'])
+    ]
 
     expect(matchSessionModelOption(options, 'claude-sonnet-4-5')).toEqual({
       configId: 'model',
@@ -70,6 +73,30 @@ describe('matchSessionModelOption', () => {
     expect(matchSessionModelOption(options, 'y-model')).toEqual({
       configId: 'primary_model',
       value: 'x/y-model'
+    })
+  })
+
+  it("skips the round-trip when the desired model is already the option's current value", () => {
+    // codex-acp treats every session/set_config_option as a model reload, so re-sending the same
+    // value stalls the first prompt of a freshly created session (issue #277). When the option is
+    // already at the desired value there is nothing to apply — return undefined and let the runtime
+    // skip the call.
+    const options = [modelOption(['gpt-5.6-terra', 'gpt-5', 'gpt-5-mini'])]
+
+    expect(matchSessionModelOption(options, 'gpt-5.6-terra')).toBeUndefined()
+  })
+
+  it('still applies when currentValue differs from the desired model even if a value matches', () => {
+    // Sanity check that the skip is gated on currentValue === desiredModel and not on any value
+    // match within the option: currentValue is pinned to a different model so the desired one
+    // genuinely needs to be applied.
+    const options = [
+      modelOption(['gpt-5', 'gpt-5.6-terra', 'gpt-5-mini'], { currentValue: 'gpt-5' })
+    ]
+
+    expect(matchSessionModelOption(options, 'gpt-5.6-terra')).toEqual({
+      configId: 'model',
+      value: 'gpt-5.6-terra'
     })
   })
 })

--- a/src/main/acp/session-config.ts
+++ b/src/main/acp/session-config.ts
@@ -34,7 +34,9 @@ const collectSelectValues = (options: unknown): string[] => {
 // drive an agent's per-session model (opencode surfaces model as a `model` configOption). Matches the
 // desired model against option values exactly, else by the segment after the last '/', since opencode
 // ids are `<provider>/<model>` while the app stores the bare model. Returns undefined when there is no
-// model option or no matching value, so the agent keeps its own default rather than erroring.
+// model option, no matching value, or the desired value already matches the option's current value —
+// the last case avoids a redundant session/set_config_option round-trip that, on codex-acp, looks like
+// a model reload and stalls the first prompt of a new session (issue #277).
 export const matchSessionModelOption = (
   configOptions: readonly SessionConfigOption[] | null | undefined,
   desiredModel: string | undefined
@@ -47,6 +49,11 @@ export const matchSessionModelOption = (
   )
 
   if (!option || option.type !== 'select') return undefined
+
+  // Skip the round-trip when the desired model is already the option's current selection. codex-acp
+  // treats set_config_option as a model switch and reloads on every call, so even sending the same
+  // value back would make the first prompt of a freshly created session wait ~2 min for nothing.
+  if (option.currentValue === desiredModel) return undefined
 
   const values = collectSelectValues(option.options)
   const match =

--- a/src/main/acp/session-config.ts
+++ b/src/main/acp/session-config.ts
@@ -1,9 +1,14 @@
 import type { SessionConfigOption } from '@agentclientprotocol/sdk'
 
-// The config option id + value to apply via session/set_config_option.
+// The config option id + value to apply via session/set_config_option. `alreadyCurrent` flags the
+// case where the option's currentValue already equals the desired model — the caller should treat
+// that as a successful no-op instead of re-sending set_config_option, which on codex-acp triggers a
+// model reload and stalls the first prompt of a new session (issue #277). It must NOT collapse into
+// "no match": the runtime's required-model guard treats that as a hard failure.
 export type SessionModelSelection = {
   configId: string
   value: string
+  alreadyCurrent?: boolean
 }
 
 // Flattens a select option's values, tolerating both the flat and grouped option shapes.
@@ -30,13 +35,28 @@ const collectSelectValues = (options: unknown): string[] => {
   return values
 }
 
+// True when `a` and `b` denote the same model under either spelling — exact or `<provider>/<bare>`
+// suffix. opencode advertises model ids as `<provider>/<model>` while the app stores the bare model,
+// so a strict `===` check would miss the no-op case across the two namespaces.
+const sameModel = (a: string, b: string): boolean =>
+  a === b || a.split('/').pop() === b || a === b.split('/').pop()
+
 // Finds the session's model select option and the value id matching the desired model, so the app can
 // drive an agent's per-session model (opencode surfaces model as a `model` configOption). Matches the
 // desired model against option values exactly, else by the segment after the last '/', since opencode
-// ids are `<provider>/<model>` while the app stores the bare model. Returns undefined when there is no
-// model option, no matching value, or the desired value already matches the option's current value —
-// the last case avoids a redundant session/set_config_option round-trip that, on codex-acp, looks like
-// a model reload and stalls the first prompt of a new session (issue #277).
+// ids are `<provider>/<model>` while the app stores the bare model.
+//
+// Returns:
+// - `{ alreadyCurrent: true, ... }` when the option's `currentValue` already equals the desired
+//   model. The caller should treat this as a successful no-op (skip session/set_config_option) —
+//   codex-acp reloads on every set_config_option call, and even sending the same value back stalled
+//   the first prompt of a new session for ~2 min (issue #277). Suffix normalization matches the
+//   opencode `<provider>/<bare>` form, so a currentValue like `openai/gpt-5` against the bare
+//   `gpt-5` still short-circuits instead of re-applying.
+// - `{ alreadyCurrent: undefined, ... }` when the desired model matches an option value but is not
+//   currently selected. Caller sends session/set_config_option.
+// - `undefined` when there is no model option or no matching value. The runtime treats this as a
+//   hard failure when the model is required (subscription-backed Codex).
 export const matchSessionModelOption = (
   configOptions: readonly SessionConfigOption[] | null | undefined,
   desiredModel: string | undefined
@@ -50,10 +70,9 @@ export const matchSessionModelOption = (
 
   if (!option || option.type !== 'select') return undefined
 
-  // Skip the round-trip when the desired model is already the option's current selection. codex-acp
-  // treats set_config_option as a model switch and reloads on every call, so even sending the same
-  // value back would make the first prompt of a freshly created session wait ~2 min for nothing.
-  if (option.currentValue === desiredModel) return undefined
+  if (option.currentValue && sameModel(option.currentValue, desiredModel)) {
+    return { configId: option.id, value: option.currentValue, alreadyCurrent: true }
+  }
 
   const values = collectSelectValues(option.options)
   const match =

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -161,6 +161,81 @@ describe('codexFramework', () => {
     expect(config).toEqual({ env: { CODEX_HOME: join('/data', 'codex-subscription') } })
   })
 
+  it('seeds the selected model into CODEX_CONFIG for an isolated Codex subscription', () => {
+    // Without a model here, codex-acp falls back to its account default and we have to switch the
+    // model via session/set_config_option after session creation. The late switch makes the first
+    // prompt of every new session wait ~2 min for the new model to come online (issue #277).
+    const framework = createCodexFramework()
+    const config = framework.prepareModelConfig(
+      {
+        type: 'codex-isolated',
+        apiEndpoints: ['responses'],
+        model: 'gpt-5.6-terra'
+      },
+      { storageRoot: '/data', executablePath: '/runtime/codex-acp' }
+    )
+
+    expect(config.env?.CODEX_HOME).toBe(join('/data', 'codex-subscription'))
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).toEqual({ model: 'gpt-5.6-terra' })
+  })
+
+  it('seeds reasoning effort alongside the model for an isolated Codex subscription', () => {
+    const framework = createCodexFramework()
+    const config = framework.prepareModelConfig(
+      {
+        type: 'codex-isolated',
+        apiEndpoints: ['responses'],
+        model: 'gpt-5.6-terra'
+      },
+      {
+        storageRoot: '/data',
+        executablePath: '/runtime/codex-acp',
+        reasoningEffort: 'high'
+      }
+    )
+
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).toEqual({
+      model: 'gpt-5.6-terra',
+      model_reasoning_effort: 'high'
+    })
+  })
+
+  it('seeds reasoning effort without a model for an isolated Codex subscription', () => {
+    // No model picked but the user set an effort: still worth seeding so codex-acp does not have
+    // to apply it via session/set_config_option (issue #277, same root cause as the model case).
+    const framework = createCodexFramework()
+    const config = framework.prepareModelConfig(
+      { type: 'codex-isolated', apiEndpoints: ['responses'] },
+      {
+        storageRoot: '/data',
+        executablePath: '/runtime/codex-acp',
+        reasoningEffort: 'high'
+      }
+    )
+
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).toEqual({
+      model_reasoning_effort: 'high'
+    })
+  })
+
+  it('does not add a custom model_provider for an isolated Codex subscription', () => {
+    // The ChatGPT subscription is codex-acp's default provider; layering an open-science custom
+    // provider on top would route the request through a gateway the user did not configure.
+    const framework = createCodexFramework()
+    const config = framework.prepareModelConfig(
+      {
+        type: 'codex-isolated',
+        apiEndpoints: ['responses'],
+        model: 'gpt-5.6-terra'
+      },
+      { storageRoot: '/data', executablePath: '/runtime/codex-acp' }
+    )
+
+    const parsed = JSON.parse(config.env?.CODEX_CONFIG ?? '{}')
+    expect(parsed).not.toHaveProperty('model_provider')
+    expect(parsed).not.toHaveProperty('model_providers')
+  })
+
   it.each([
     // Bare origins gain the `/v1` version segment Codex needs before `/responses`.
     ['https://api.openai.com', 'https://api.openai.com/v1'],

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -90,6 +90,30 @@ const normalizeResponsesBaseUrl = (value: string | undefined): string | undefine
   return normalized
 }
 
+// Codex config takes low|medium|high|xhigh; the app's top level 'max' maps onto 'xhigh'.
+// 'default' is filtered upstream (never reaches here), but stay defensive and omit it too.
+const codexReasoningEffortFor = (effort: ReasoningEffort | undefined): string | undefined =>
+  effort === 'max'
+    ? 'xhigh'
+    : effort === 'low' || effort === 'medium' || effort === 'high'
+      ? effort
+      : undefined
+
+// Just the model + reasoning-effort fields a Codex config can carry, with no provider plumbing.
+// The bridge path layers the open-science custom provider on top of this; the codex-isolated path
+// uses it on its own so codex-acp can drive the ChatGPT subscription with the user's selected
+// model from session start (issue #277).
+const buildCodexModelOptions = (input: {
+  model?: string
+  reasoningEffort?: ReasoningEffort
+}): Record<string, unknown> => {
+  const codexEffort = codexReasoningEffortFor(input.reasoningEffort)
+  return {
+    ...(input.model ? { model: input.model } : {}),
+    ...(codexEffort ? { model_reasoning_effort: codexEffort } : {})
+  }
+}
+
 const buildCodexConfig = (provider: {
   baseUrl?: string
   model?: string
@@ -97,20 +121,9 @@ const buildCodexConfig = (provider: {
   reasoningEffort?: ReasoningEffort
 }): Record<string, unknown> => {
   const baseUrl = normalizeResponsesBaseUrl(provider.baseUrl)
-  // Codex config takes low|medium|high|xhigh; the app's top level 'max' maps onto 'xhigh'.
-  // 'default' is filtered upstream (never reaches here), but stay defensive and omit it too.
-  const codexEffort =
-    provider.reasoningEffort === 'max'
-      ? 'xhigh'
-      : provider.reasoningEffort === 'low' ||
-          provider.reasoningEffort === 'medium' ||
-          provider.reasoningEffort === 'high'
-        ? provider.reasoningEffort
-        : undefined
 
   return {
-    ...(provider.model ? { model: provider.model } : {}),
-    ...(codexEffort ? { model_reasoning_effort: codexEffort } : {}),
+    ...buildCodexModelOptions(provider),
     model_provider: CODEX_PROVIDER_ID,
     model_providers: {
       [CODEX_PROVIDER_ID]: {
@@ -219,12 +232,28 @@ export const createCodexFramework = ({
 
   prepareModelConfig(provider, ctx: ModelConfigContext): AgentModelConfig {
     if (isCodexSubscriptionProvider(provider.type)) {
-      return {
-        env:
-          provider.type === 'codex-isolated'
-            ? { CODEX_HOME: codexSubscriptionStorageDir(ctx.storageRoot) }
-            : {}
+      if (provider.type === 'codex-isolated') {
+        // The isolated home has no pre-existing config.toml and no CODEX_CONFIG of its own, so without
+        // a model here codex-acp falls back to its account default and we have to switch models via
+        // session/set_config_option AFTER session creation. That late switch makes the first prompt of
+        // every new session wait ~2 min for the new model to come online (issue #277). Seed the model
+        // + reasoning effort into CODEX_CONFIG so codex-acp uses the right model from session start
+        // and the first prompt is fast. No model_provider/model_providers override here — the ChatGPT
+        // subscription is codex-acp's default provider, configured by the user's stored credentials.
+        const modelOptions = buildCodexModelOptions({
+          model: provider.model,
+          reasoningEffort: ctx.reasoningEffort
+        })
+        const codexConfigJson =
+          Object.keys(modelOptions).length > 0 ? JSON.stringify(modelOptions) : undefined
+        return {
+          env: {
+            CODEX_HOME: codexSubscriptionStorageDir(ctx.storageRoot),
+            ...(codexConfigJson ? { CODEX_CONFIG: codexConfigJson } : {})
+          }
+        }
       }
+      return { env: {} }
     }
 
     const bridge = ctx.responsesBridge

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1207,8 +1207,16 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(backend.authentication).toBeUndefined()
     expect(backend.providerConfiguration).toBeUndefined()
     expect(backend.env.CODEX_API_KEY).toBeUndefined()
-    expect(backend.env.CODEX_CONFIG).toBeUndefined()
-    expect(backend.env.MODEL_PROVIDER).toBeUndefined()
+    if (type === 'codex-isolated') {
+      // Seed the selected model into CODEX_CONFIG so codex-acp uses it from session start and the
+      // first prompt doesn't wait for the late session/set_config_option model switch (issue #277).
+      // The ChatGPT subscription is codex-acp's default provider, so no model_provider override.
+      expect(JSON.parse(backend.env.CODEX_CONFIG ?? '{}')).toEqual({ model: 'gpt-5.6-terra' })
+      expect(backend.env.MODEL_PROVIDER).toBeUndefined()
+    } else {
+      expect(backend.env.CODEX_CONFIG).toBeUndefined()
+      expect(backend.env.MODEL_PROVIDER).toBeUndefined()
+    }
     expect(backend.env.NO_BROWSER).toBeUndefined()
     expect(backend.env.CODEX_PATH).toBe('/data/codex-managed/native/codex')
     expect(backend.env.CODEX_HOME).toBe(


### PR DESCRIPTION
## Problem

A Codex-isolated subscription (Sign in with ChatGPT inside Open Science) made the **first** prompt of every newly created session take about two minutes, even for `hi`. Subsequent prompts in the same session were fast, and creating another new session brought the delay back. The existing Codex process was reused across runs, so it wasn't a per-process cold start. Reproduced on 0.5.1 with `codex-acp` 1.1.4 and `gpt-5.6-terra` (#277).

The log showed a clean `prompt start` followed ~113 s later by `prompt stopped` (`end_turn`). No errors, no permission requests, no tool calls during the gap — the agent was just thinking for two minutes on the first turn of every new session.

## Root cause

For a `codex-isolated` provider, `prepareModelConfig` in `src/main/agent-framework/codex.ts` seeded only `CODEX_HOME` into the spawn env and **deliberately left `CODEX_CONFIG` unset**. So `codex-acp` came up with no model and we had to switch the model via `session/set_config_option` **after** session creation. `codex-acp` 1.1.4 treats that late switch as a full model load, which stalls the first prompt for as long as it takes the new model to come online — and that was ~2 minutes for `gpt-5.6-terra`.

The bridge / custom-gateway path already sets `CODEX_CONFIG` with the model + reasoning effort at spawn time, which is why it didn't exhibit the same delay.

## Proposed change

Seed the selected model (and reasoning effort, when set) into `CODEX_CONFIG` for `codex-isolated`, the same way the bridge path already does, so `codex-acp` uses the right model from session start and the first prompt is fast. `model_provider` / `model_providers` stay unset — the ChatGPT subscription is `codex-acp`'s default provider, configured by the user's stored credentials, and layering the open-science custom provider on top would route the request through a gateway the user never configured.

As a defensive belt for any adapter that would still reload on a redundant `session/set_config_option` call, also short-circuit `matchSessionModelOption` when the option's `currentValue` already equals the desired model. `opencode` also benefits — it stops re-applying the same selection at every session creation.

A new `buildCodexModelOptions` helper extracts the model + effort fields out of `buildCodexConfig` so the bridge path and the codex-isolated path share one source of truth for the effort mapping.

## Scope and non-goals

- Scope: the `codex-isolated` first-prompt delay for users who pick a model in the UI.
- Non-goals: the bridge / custom-gateway path is unchanged; effort application for opencode is unchanged; the user-managed `~/.codex/config.toml` for `codex-shared` is not touched.
- The fix does **not** modify `codex-acp` itself — it works around a behavioural quirk in 1.1.4 by making the model available at session start instead of switching it later.

## Acceptance criteria and validation

- `npm run lint` — 0 errors.
- `npm run test` — `codex.test.ts` (31, incl. 3 new), `session-config.test.ts` (16, incl. 2 new), `service.test.ts` (116), `runtime.test.ts` (≈130) all green; full suite `4765 passed | 66 skipped` (skipped are pre-existing integration tests).
- A new codex-framework unit test asserts the seed JSON for `codex-isolated` carries only `model` / `model_reasoning_effort`, never `model_provider` / `model_providers`.
- A new session-config unit test asserts `matchSessionModelOption` returns `undefined` when the desired model already equals the option's `currentValue`.
- A new service-level test replaces the previous `CODEX_CONFIG is undefined` expectation for `codex-isolated` with the new seeded payload, so a regression of the behaviour is caught at the resolution boundary.
- `npm run typecheck` was skipped per request; happy to add it on the PR if reviewers want it.

## Review focus

- `src/main/agent-framework/codex.ts` — `prepareModelConfig` codex-isolated branch + the new `buildCodexModelOptions` / `codexReasoningEffortFor` helpers. Confirm the ChatGPT-subscription default-provider reasoning is correct and that `codex-shared` is unaffected.
- `src/main/acp/session-config.ts` — the `currentValue === desiredModel` short-circuit. Confirm it doesn't accidentally mask a real model mismatch (e.g. when the agent advertises the model under a prefixed id).
- Live verification on the exact 0.5.1 + codex-acp 1.1.4 + gpt-5.6-terra combo from #277 would be the definitive validation — not possible from this environment.

Closes #277