### PR TITLE
fix(settings): probe provider connection over proxy-aware net.fetch

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -21,7 +21,9 @@ vi.mock('electron', () => ({
     }
   },
   app: { getPath: () => '/home', getAppPath: () => '/home/no-such-app-root', isPackaged: false },
-  net: { fetch: vi.fn() }
+  // The provider-validation probe fetches over net.fetch (proxy-aware in production). Delegate to the
+  // global fetch each test stubs, so the existing vi.stubGlobal('fetch', …) probe expectations hold.
+  net: { fetch: vi.fn((...args: Parameters<typeof fetch>) => globalThis.fetch(...args)) }
 }))
 
 const { SettingsService } = await import('./service')
@@ -31,6 +33,9 @@ const { SkillRegistry } = await import('../skills/registry')
 const { managedClaudeDir } = await import('./managed-claude')
 const { managedOpencodeDir } = await import('./managed-opencode')
 const { netFetch } = await import('../skills/net-fetch')
+const { net: mockedNet } = (await import('electron')) as unknown as {
+  net: { fetch: ReturnType<typeof vi.fn> }
+}
 
 let storageRoot: string
 let repository: InstanceType<typeof SettingsRepository>
@@ -593,6 +598,29 @@ describe('SettingsService: validation', () => {
 
     expect(result.ok).toBe(true)
     expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeGreaterThan(0)
+  })
+
+  it('probes over the proxy-aware net.fetch, not Node global fetch directly', async () => {
+    const service = createService()
+    // A direct undici fetch ignores the system proxy, so an official vendor reachable only through a
+    // proxy fails as a false network error. The probe must go through net.fetch (Chromium stack).
+    mockedNet.fetch.mockClear()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200 }))
+
+    const created = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'G',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+
+    await service.validateProvider({ providerId: created.id })
+
+    expect(mockedNet.fetch).toHaveBeenCalledTimes(1)
+    expect(mockedNet.fetch.mock.calls[0][0]).toContain('https://g')
   })
 
   it('records the failure (not lastValidatedAt) for a saved provider on failure', async () => {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -150,7 +150,7 @@ import { renderConnectorInstructions, renderSkillDoc } from '../connectors/skill
 import { syncConnectorSkillDocs } from '../connectors/provision'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { UserSkillRepository } from '../skills/user-skill-repository'
-import { netFetch } from '../skills/net-fetch'
+import { netFetch, netFetchStandard } from '../skills/net-fetch'
 import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limits'
 import { readSkillFile } from '../skills/skill-files'
 import { NOTEBOOK_MCP_SERVER_NAME, NOTEBOOK_RPC_TOOLS } from '../notebook/mcp-server'
@@ -1611,6 +1611,11 @@ class SettingsService {
             'Not signed in. Use Sign in to connect your ChatGPT account.'
           )
         : await validateProvider(resolved.provider, {
+            // Probe over Electron's network stack, which honors the system/VPN proxy. Node's global
+            // fetch (undici) takes a direct path and ignores that proxy, so an official vendor reachable
+            // only through a proxy (e.g. api.openai.com) would fail the probe as a false `network` error
+            // even with a valid key. The local Responses-bridge loopback stays on the direct fetch.
+            fetchImpl: netFetchStandard,
             runClaudeProbe:
               resolved.provider.type === 'claude-default'
                 ? () => this.runClaudeProbe(resolved.provider, settings)

--- a/src/main/skills/net-fetch.ts
+++ b/src/main/skills/net-fetch.ts
@@ -7,3 +7,8 @@ import type { FetchLike } from './github-import'
 // path, so in proxied environments GitHub returns 403 for the direct requests while net.fetch succeeds.
 export const netFetch: FetchLike = (url, init) =>
   net.fetch(url, init) as unknown as ReturnType<FetchLike>
+
+// A `typeof fetch`-shaped view of net.fetch for callers that need the full Response API (`.text()`,
+// AbortSignal, arbitrary headers) rather than the narrow FetchLike shape — e.g. the provider-validation
+// probe, which reads the error body and aborts on timeout. Same proxy-honoring Chromium stack.
+export const netFetchStandard = net.fetch as unknown as typeof fetch

--- a/src/main/skills/net-fetch.ts
+++ b/src/main/skills/net-fetch.ts
@@ -10,5 +10,7 @@ export const netFetch: FetchLike = (url, init) =>
 
 // A `typeof fetch`-shaped view of net.fetch for callers that need the full Response API (`.text()`,
 // AbortSignal, arbitrary headers) rather than the narrow FetchLike shape — e.g. the provider-validation
-// probe, which reads the error body and aborts on timeout. Same proxy-honoring Chromium stack.
-export const netFetchStandard = net.fetch as unknown as typeof fetch
+// probe, which reads the error body and aborts on timeout. Same proxy-honoring Chromium stack. Bound to
+// `net` so the receiver is preserved (mirrors netFetch's method-call form) rather than shipping a
+// detached reference that could break if a future Electron makes net.fetch receiver-dependent.
+export const netFetchStandard = net.fetch.bind(net) as unknown as typeof fetch

--- a/src/main/skills/net-fetch.ts
+++ b/src/main/skills/net-fetch.ts
@@ -10,7 +10,8 @@ export const netFetch: FetchLike = (url, init) =>
 
 // A `typeof fetch`-shaped view of net.fetch for callers that need the full Response API (`.text()`,
 // AbortSignal, arbitrary headers) rather than the narrow FetchLike shape — e.g. the provider-validation
-// probe, which reads the error body and aborts on timeout. Same proxy-honoring Chromium stack. Bound to
-// `net` so the receiver is preserved (mirrors netFetch's method-call form) rather than shipping a
-// detached reference that could break if a future Electron makes net.fetch receiver-dependent.
-export const netFetchStandard = net.fetch.bind(net) as unknown as typeof fetch
+// probe, which reads the error body and aborts on timeout. Same proxy-honoring Chromium stack. A lazy
+// arrow wrapper (like netFetch) so `net.fetch` is only read at call time — reading it eagerly at module
+// load crashes any test whose electron mock omits `net` — while the method call preserves the receiver.
+export const netFetchStandard = ((input, init) =>
+  net.fetch(input as string, init)) as typeof fetch


### PR DESCRIPTION
## Summary

The provider connection test issued its HTTP probe through Node's global `fetch` (undici), which **ignores the system/VPN proxy** and takes a direct path. An official vendor reachable only through a proxy — e.g. OpenAI's `api.openai.com`, whose registry entry drives `/v1/responses` directly — then failed the test as a false `network` error even with a valid key, while the spawned agent (Codex/Claude/opencode, which inherit the proxy env) would have connected fine.

This routes the probe through Electron's `net.fetch` (the same Chromium network stack the skill importer already uses for proxy-reachable GitHub), so the connection test honors the same system/VPN proxy the rest of the desktop app does.

## Changes

- `net-fetch.ts`: add `netFetchStandard` — a `typeof fetch`-shaped view of `net.fetch` exposing the full `Response` API (`.text()`, `AbortSignal`, arbitrary headers) the validator needs, alongside the existing narrow `netFetch` used by skill import. Implemented as a lazy arrow wrapper (like `netFetch`) so `net.fetch` is read only at call time — reading it eagerly at module load crashes suites whose electron mock omits `net`.
- `service.ts`: pass `fetchImpl: netFetchStandard` into `validateProvider`.
- `service.test.ts`: the mocked `net.fetch` now delegates to each test's stubbed global `fetch`, so existing probe expectations hold; added a test asserting the probe routes through `net.fetch` rather than direct fetch.

### Scope of the transport change

- **Direct probe (custom / official vendors):** now over `net.fetch`.
- **Responses-bridge providers:** `fetchImpl` flows into `ResponsesBridge`, so the bridge's **upstream** call is now proxy-routed too — this is intentional and consistent (the upstream leg should honor the same proxy as the direct probe). Only the local loopback hop to `127.0.0.1` stays on direct `fetch`.

## Testing

- `npx vitest run src/main/settings/service.test.ts` — 117 passed (incl. new test)
- `npx vitest run src/main/settings/service.connectors.test.ts src/main/settings/ipc.test.ts src/main/skills/net-fetch.test.ts` — pass (collection-crash regression fixed)
- `npx eslint` on changed files — clean

`npm run typecheck` was not run for this iteration per request.

## Note / follow-up

`net.fetch` honors the **system proxy**, whereas the spawned agents read the **`HTTP_PROXY`/`HTTPS_PROXY` env vars**. On a machine where those two sources agree (the common case), a green test predicts a working agent. Where they diverge (e.g. a Finder-launched app with a system proxy but no env vars), the test can pass while the agent still needs the proxy injected into its spawn env — a separate, larger change tracked as a follow-up (align agent spawn env with the system proxy, or narrow the test's success wording), not in scope here.