### PR TITLE
fix(acp): restore Codex MCP permission identity

### DIFF
--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -129,6 +129,7 @@ class AcpPermissionBroker {
     policyContext?: PermissionPolicyContext
   ): Promise<RequestPermissionResponse> {
     const requestId = randomUUID()
+    const categoryKey = resolveCategoryKey(params, policyContext?.mcpServerNames)
     const request: AcpPermissionRequest = {
       requestId,
       sessionId: params.sessionId,
@@ -136,6 +137,7 @@ class AcpPermissionBroker {
       title: params.toolCall.title ?? params.toolCall.toolCallId,
       status: params.toolCall.status ?? undefined,
       providerToolName: extractProviderToolName(params.toolCall),
+      isMcp: categoryKey.startsWith('mcp:'),
       toolKind: params.toolCall.kind ?? undefined,
       toolLocations: params.toolCall.locations ?? undefined,
       rawInput: params.toolCall.rawInput,
@@ -146,8 +148,6 @@ class AcpPermissionBroker {
       })),
       raw: params
     }
-
-    const categoryKey = resolveCategoryKey(params, policyContext?.mcpServerNames)
 
     // A model-independent fallback auto-reviews only structured, workspace-contained low-risk tools.
     const automaticOptionId = resolveAutomaticPermission(params, policyContext)

--- a/src/main/acp/permission-policy.test.ts
+++ b/src/main/acp/permission-policy.test.ts
@@ -97,6 +97,10 @@ describe('permission policy', () => {
     // opencode joins them <server>_<tool> — matched only against the session's known server names.
     expect(isMcpToolName('open-science-artifacts_write_artifact_file', servers)).toBe(true)
     expect(isMcpToolName('open-science-notebook', servers)).toBe(true)
+    // Codex uses mcp.<server>.<tool> — the generic mcp. prefix is not trusted without a known server.
+    expect(isMcpToolName('mcp.open-science-notebook.notebook_execute', servers)).toBe(true)
+    expect(isMcpToolName('mcp.unconfigured-server.execute', servers)).toBe(false)
+    expect(isMcpToolName('mcp.unconfigured-server.execute', [])).toBe(false)
     // Built-in framework tools never collide with a server name.
     expect(isMcpToolName('edit', servers)).toBe(false)
     expect(isMcpToolName('write_artifact_file', servers)).toBe(false)

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -15,10 +15,11 @@ type PermissionPolicyContext = {
   mcpServerNames?: readonly string[]
 }
 
-// MCP tool naming differs per framework: Claude Code namespaces them mcp__<server>__<tool>, while
-// opencode joins them <server>_<tool>. The mcp__ prefix identifies Claude's regardless of server;
-// opencode's are recognized against the session's known MCP server names.
+// MCP tool naming differs per framework: Claude Code namespaces them mcp__<server>__<tool>, Codex
+// reports mcp.<server>.<tool>, and opencode joins them <server>_<tool>. The explicit mcp prefixes
+// identify Claude/Codex regardless of server; opencode's are checked against known session servers.
 const MCP_TOOL_PREFIX = 'mcp__'
+const CODEX_MCP_TOOL_PREFIX = 'mcp.'
 const MCP_PROVIDER_LEAF_NAMES: Record<string, readonly string[]> = {
   'open-science-notebook': ['execute'],
   'open-science-artifacts': ['write']
@@ -32,6 +33,7 @@ const isMcpToolName = (
 ): boolean =>
   name != null &&
   (name.startsWith(MCP_TOOL_PREFIX) ||
+    name.startsWith(CODEX_MCP_TOOL_PREFIX) ||
     mcpServerNames.some(
       (server) =>
         name === server ||

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -16,8 +16,8 @@ type PermissionPolicyContext = {
 }
 
 // MCP tool naming differs per framework: Claude Code namespaces them mcp__<server>__<tool>, Codex
-// reports mcp.<server>.<tool>, and opencode joins them <server>_<tool>. The explicit mcp prefixes
-// identify Claude/Codex regardless of server; opencode's are checked against known session servers.
+// reports mcp.<server>.<tool>, and opencode joins them <server>_<tool>. Claude's distinctive prefix is
+// self-identifying; the shorter Codex/opencode forms are checked against known session servers.
 const MCP_TOOL_PREFIX = 'mcp__'
 const CODEX_MCP_TOOL_PREFIX = 'mcp.'
 const MCP_PROVIDER_LEAF_NAMES: Record<string, readonly string[]> = {
@@ -33,10 +33,10 @@ const isMcpToolName = (
 ): boolean =>
   name != null &&
   (name.startsWith(MCP_TOOL_PREFIX) ||
-    name.startsWith(CODEX_MCP_TOOL_PREFIX) ||
     mcpServerNames.some(
       (server) =>
         name === server ||
+        name.startsWith(`${CODEX_MCP_TOOL_PREFIX}${server}.`) ||
         name.startsWith(`${server}_`) ||
         MCP_PROVIDER_LEAF_NAMES[server]?.includes(name)
     ))

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2462,6 +2462,134 @@ describe('ACP runtime session management', () => {
     }
   })
 
+  it('restores Codex MCP identity before prompting and remembers a session grant across call ids', async () => {
+    const process = new FakeAgentProcess()
+    const permissionRequests: Array<{
+      title: string
+      providerToolName?: string
+      rawInput?: unknown
+      requestId: string
+      isMcp?: boolean
+    }> = []
+    const permissionResponses: unknown[] = []
+
+    acp
+      .agent({ name: 'codex-mcp-permission-agent' })
+      .onRequest(acp.methods.agent.initialize, () => ({
+        protocolVersion: acp.PROTOCOL_VERSION,
+        agentCapabilities: {
+          loadSession: false,
+          sessionCapabilities: { close: {} }
+        },
+        authMethods: []
+      }))
+      .onRequest(acp.methods.agent.session.new, () => ({
+        sessionId: 'codex-mcp-session',
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+      }))
+      .onRequest(acp.methods.agent.session.setMode, () => ({}))
+      .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+        for (const toolCallId of ['call-notebook-1', 'call-notebook-2']) {
+          await ctx.client.notify(acp.methods.client.session.update, {
+            sessionId: ctx.params.sessionId,
+            update: {
+              sessionUpdate: 'tool_call',
+              toolCallId,
+              kind: 'execute',
+              title: 'mcp.open-science-notebook.notebook_execute',
+              status: 'pending',
+              rawInput: {
+                server: 'open-science-notebook',
+                tool: 'notebook_execute',
+                arguments: { code: 'print(1)', language: 'python' }
+              },
+              _meta: { is_mcp_tool_call: true }
+            }
+          })
+
+          const response = await ctx.client.request(acp.methods.client.session.requestPermission, {
+            sessionId: ctx.params.sessionId,
+            toolCall: {
+              toolCallId,
+              kind: 'execute',
+              status: 'pending'
+            },
+            options: [
+              { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+              {
+                optionId: 'allow-session',
+                name: 'Allow for This Session',
+                kind: 'allow_always'
+              },
+              {
+                optionId: 'allow-always',
+                name: "Allow and Don't Ask Again",
+                kind: 'allow_always'
+              },
+              { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
+            ],
+            _meta: { is_mcp_tool_approval: true }
+          })
+          permissionResponses.push(response)
+        }
+
+        return { stopReason: 'end_turn' }
+      })
+      .onRequest(acp.methods.agent.session.close, () => ({}))
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: codexFramework,
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' })
+      },
+      callbacks: {
+        onPermissionRequest: (request) => {
+          permissionRequests.push(request)
+          runtime.respondToPermission({
+            requestId: request.requestId,
+            optionId: 'allow-session'
+          })
+        }
+      }
+    })
+    const session = await runtime.createSession({
+      cwd: '/workspace',
+      permissionProfile: 'auto'
+    })
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'run two notebook cells' })
+
+    expect(permissionRequests).toHaveLength(1)
+    expect(permissionRequests[0]).toMatchObject({
+      title: 'mcp.open-science-notebook.notebook_execute',
+      providerToolName: 'notebook_execute',
+      isMcp: true,
+      rawInput: { code: 'print(1)', language: 'python' }
+    })
+    expect(permissionResponses).toEqual([
+      { outcome: { outcome: 'selected', optionId: 'allow-session' } },
+      { outcome: { outcome: 'selected', optionId: 'allow-once' } }
+    ])
+    expect(runtime.getSnapshot().permissionGrants[session.sessionId]).toEqual([
+      {
+        categoryKey: 'mcp:mcp.open-science-notebook.notebook_execute',
+        kind: 'mcp',
+        label: 'mcp.open-science-notebook.notebook_execute'
+      }
+    ])
+  })
+
   it('records MCP server names on resume so a resumed session audits its MCP tool calls as MCP', async () => {
     infoLogSpy.mockClear()
     const process = new FakeAgentProcess()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1,5 +1,10 @@
 import * as acp from '@agentclientprotocol/sdk'
-import type { ContentBlock, SessionConfigOption, SessionModeState } from '@agentclientprotocol/sdk'
+import type {
+  ContentBlock,
+  SessionConfigOption,
+  SessionModeState,
+  SessionNotification
+} from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
@@ -351,6 +356,13 @@ const startPermissionProbeAgent = (
     toolTitle: string
     toolKind?: 'other' | 'execute' | 'read' | null
     providerToolName?: string
+    codexMcpIdentity?: {
+      server: string
+      tool: string
+      arguments?: Record<string, unknown>
+    }
+    sparseCodexMcpApproval?: boolean
+    modes?: SessionModeState
     permissionOptions?: Array<{
       optionId: string
       name: string
@@ -370,7 +382,11 @@ const startPermissionProbeAgent = (
       },
       authMethods: []
     }))
-    .onRequest(acp.methods.agent.session.new, () => ({ sessionId: options.newSessionId }))
+    .onRequest(acp.methods.agent.session.new, () => ({
+      sessionId: options.newSessionId,
+      modes: options.modes
+    }))
+    .onRequest(acp.methods.agent.session.setMode, () => ({}))
     .onRequest(acp.methods.agent.session.resume, (ctx) => {
       if (options.resume === 'notFound') {
         throw acp.RequestError.resourceNotFound(ctx.params.sessionId)
@@ -379,22 +395,44 @@ const startPermissionProbeAgent = (
       return {}
     })
     .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+      if (options.codexMcpIdentity) {
+        await ctx.client.notify(acp.methods.client.session.update, {
+          sessionId: ctx.params.sessionId,
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: options.toolCallId,
+            kind: 'execute',
+            title: `mcp.${options.codexMcpIdentity.server}.${options.codexMcpIdentity.tool}`,
+            status: 'pending',
+            rawInput: {
+              server: options.codexMcpIdentity.server,
+              tool: options.codexMcpIdentity.tool,
+              arguments: options.codexMcpIdentity.arguments ?? {}
+            },
+            _meta: { is_mcp_tool_call: true }
+          }
+        })
+      }
+
       // opencode renames MCP tools <server>_<tool>; classification must come from the session's
       // recorded MCP server names, so this exercises the sessionMcpServerNames map end to end.
       const response = await ctx.client.request(acp.methods.client.session.requestPermission, {
         sessionId: ctx.params.sessionId,
         toolCall: {
           toolCallId: options.toolCallId,
-          title: options.toolTitle,
+          ...(options.sparseCodexMcpApproval ? {} : { title: options.toolTitle }),
           status: 'pending',
-          ...(options.toolKind === null ? {} : { kind: options.toolKind ?? 'other' }),
-          ...(options.providerToolName
+          ...(options.toolKind === null
+            ? {}
+            : { kind: options.toolKind ?? (options.sparseCodexMcpApproval ? 'execute' : 'other') }),
+          ...(!options.sparseCodexMcpApproval && options.providerToolName
             ? { _meta: { claudeCode: { toolName: options.providerToolName } } }
             : {})
         },
         options: options.permissionOptions ?? [
           { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }
-        ]
+        ],
+        ...(options.sparseCodexMcpApproval ? { _meta: { is_mcp_tool_approval: true } } : {})
       })
       options.onPermissionResponse?.(response)
 
@@ -423,6 +461,20 @@ const sessionFrameworksMap = (runtime: AcpRuntime): Map<string, string> =>
 
 const reviewerSessionIds = (runtime: AcpRuntime): Set<string> =>
   (runtime as unknown as { reviewerSessionIds: Set<string> }).reviewerSessionIds
+
+const codexMcpToolIdentitiesMap = (runtime: AcpRuntime): Map<string, Map<string, unknown>> =>
+  (runtime as unknown as { codexMcpToolIdentities: Map<string, Map<string, unknown>> })
+    .codexMcpToolIdentities
+
+const observeCodexMcpToolIdentity = (
+  runtime: AcpRuntime,
+  notification: SessionNotification
+): void =>
+  (
+    runtime as unknown as {
+      observeCodexMcpToolIdentity: (value: SessionNotification) => void
+    }
+  ).observeCodexMcpToolIdentity(notification)
 
 // Finds the isMcp flag the runtime logged for a given permission request (identified by toolCallId).
 const auditedIsMcp = (toolCallId: string): boolean | undefined => {
@@ -2590,6 +2642,60 @@ describe('ACP runtime session management', () => {
     ])
   })
 
+  it('bounds pending Codex MCP identities and clears unmatched entries when the turn stops', async () => {
+    const process = new FakeAgentProcess()
+    const promptStarted = createDeferred()
+    const promptCanStop = createDeferred()
+    startFakeAgent(process, ['codex-bounded-session'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onPrompt: async () => {
+        promptStarted.resolve()
+        await promptCanStop.promise
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: codexFramework,
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' })
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'auto' })
+    const prompt = runtime.sendPrompt({ sessionId: session.sessionId, text: 'start a turn' })
+    await promptStarted.promise
+
+    for (let index = 0; index < 40; index += 1) {
+      observeCodexMcpToolIdentity(runtime, {
+        sessionId: session.sessionId,
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: `pending-mcp-${index}`,
+          kind: 'execute',
+          title: 'mcp.open-science-notebook.notebook_execute',
+          status: 'pending',
+          rawInput: {
+            server: 'open-science-notebook',
+            tool: 'notebook_execute',
+            arguments: { code: `print(${index})` }
+          }
+        }
+      })
+    }
+
+    const pendingIdentities = codexMcpToolIdentitiesMap(runtime).get(session.sessionId)
+    expect(pendingIdentities?.size).toBe(32)
+    expect(pendingIdentities?.has('pending-mcp-0')).toBe(false)
+    expect(pendingIdentities?.has('pending-mcp-39')).toBe(true)
+
+    promptCanStop.resolve()
+    await prompt
+    expect(codexMcpToolIdentitiesMap(runtime).has(session.sessionId)).toBe(false)
+  })
+
   it('records MCP server names on resume so a resumed session audits its MCP tool calls as MCP', async () => {
     infoLogSpy.mockClear()
     const process = new FakeAgentProcess()
@@ -2713,6 +2819,61 @@ describe('ACP runtime session management', () => {
     expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(false)
     expect(sessionFrameworksMap(runtime).has('reviewer-session-1')).toBe(false)
   })
+
+  it.each([
+    { tool: 'submit_findings', expectedOptionId: 'allow-once' },
+    { tool: 'run_shell', expectedOptionId: 'reject-once' }
+  ])(
+    'handles sparse Codex reviewer MCP tool $tool through the strict allowlist',
+    async ({ tool, expectedOptionId }) => {
+      const process = new FakeAgentProcess()
+      let permissionResponse: unknown
+      startPermissionProbeAgent(process, {
+        newSessionId: 'codex-reviewer-session',
+        toolCallId: `codex-reviewer-${tool}`,
+        toolTitle: 'unused by sparse approval',
+        codexMcpIdentity: {
+          server: 'open-science-reviewer',
+          tool,
+          arguments: { checks: [] }
+        },
+        sparseCodexMcpApproval: true,
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+        permissionOptions: [
+          { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+          { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+        ],
+        onPermissionResponse: (response) => {
+          permissionResponse = response
+        }
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        framework: codexFramework
+      })
+
+      const { session } = await runtime.buildReviewerSession({
+        cwd: '/workspace',
+        mcpServers: [
+          {
+            type: 'http',
+            name: 'open-science-reviewer',
+            url: 'http://127.0.0.1:1/mcp',
+            headers: []
+          }
+        ]
+      })
+      await session.prompt([{ type: 'text', text: 'submit the reviewer findings' }])
+
+      expect(auditedIsMcp(`codex-reviewer-${tool}`)).toBe(true)
+      expect(permissionResponse).toEqual({
+        outcome: { outcome: 'selected', optionId: expectedOptionId }
+      })
+      runtime.disposeReviewerSession(session)
+    }
+  )
 
   it.each([null, 'read'] as const)(
     'auto-approves an exact reviewer provider tool identity with kind %s',

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -199,6 +199,48 @@ type ClientContextSessionAttacher = {
   attachSession: (response: SessionAttachmentResponse) => ActiveSession
 }
 
+type CodexMcpToolIdentity = {
+  title: string
+  providerToolName: string
+  rawInput: unknown
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isCodexMcpApproval = (params: RequestPermissionRequest): boolean => {
+  const meta = (params as RequestPermissionRequest & { _meta?: unknown })._meta
+
+  return isRecord(meta) && meta.is_mcp_tool_approval === true
+}
+
+// Codex emits the full MCP identity in tool_call immediately before a sparse permission request.
+// Trust it only when the reported server is one this session was actually configured to use.
+const codexMcpToolIdentity = (
+  event: AcpRuntimeEvent,
+  mcpServerNames: readonly string[]
+): CodexMcpToolIdentity | undefined => {
+  if (!isRecord(event.rawInput)) return undefined
+
+  const server = event.rawInput.server
+  const tool = event.rawInput.tool
+
+  if (
+    typeof server !== 'string' ||
+    !mcpServerNames.includes(server) ||
+    typeof tool !== 'string' ||
+    !tool.trim()
+  ) {
+    return undefined
+  }
+
+  return {
+    title: event.title ?? `mcp.${server}.${tool}`,
+    providerToolName: tool,
+    rawInput: event.rawInput.arguments
+  }
+}
+
 // Keeps runtime snapshots bounded so long conversations do not grow renderer payloads forever.
 const MAX_EVENTS = 500
 // Appends artifact tool guidance as system prompt metadata so user prompts stay untouched.
@@ -425,6 +467,9 @@ class AcpRuntime {
   // opencode's <server>_<tool>) and never conservatively auto-approved. Derived per session rather
   // than hardcoded so it can't drift from what createMcpServers wires up.
   private readonly sessionMcpServerNames = new Map<string, string[]>()
+  // Codex splits an MCP approval across two ACP messages: tool_call carries the identity/arguments,
+  // then request_permission carries only the call id. Retain only pending identities until consumed.
+  private readonly codexMcpToolIdentities = new Map<string, Map<string, CodexMcpToolIdentity>>()
   // Ephemeral background reviewer sessions (built via buildReviewerSession). They are deliberately kept
   // out of `this.sessions` — not tracked in the snapshot, not user-facing. Their permission requests are
   // handled by a strict allowlist: only the scope-bounded reviewer MCP is approved; every built-in tool is
@@ -1558,6 +1603,7 @@ class AcpRuntime {
     this.currentPromptTurnBySession.clear()
     this.latestSessionConfigOptions.clear()
     this.sessionMcpServerNames.clear()
+    this.codexMcpToolIdentities.clear()
     this.sessionProjectNames.clear()
     this.permissionProfiles.clear()
     this.artifactSessionIds.clear()
@@ -1991,6 +2037,7 @@ class AcpRuntime {
     this.currentPromptTurnBySession.delete(request.sessionId)
     this.latestSessionConfigOptions.delete(request.sessionId)
     this.sessionMcpServerNames.delete(request.sessionId)
+    this.codexMcpToolIdentities.delete(request.sessionId)
     this.sessionProjectNames.delete(request.sessionId)
     this.sessionFrameworks.delete(request.sessionId)
     this.sessionBackendIds.delete(request.sessionId)
@@ -2855,14 +2902,19 @@ class AcpRuntime {
     // full URL with query params, i.e. user data).
     const appSessionId = this.agentToAppSessionId.get(params.sessionId) ?? params.sessionId
     const mcpServerNames = this.sessionMcpServerNames.get(appSessionId) ?? []
-    const toolName = extractProviderToolName(params.toolCall)
+    const normalizedParams = this.restoreCodexMcpPermissionIdentity(
+      params,
+      appSessionId,
+      mcpServerNames
+    )
+    const toolName = extractProviderToolName(normalizedParams.toolCall)
     const isMcp =
-      isMcpToolName(params.toolCall?.title, mcpServerNames) ||
+      isMcpToolName(normalizedParams.toolCall?.title, mcpServerNames) ||
       isMcpToolName(toolName, mcpServerNames)
     log.info('permission request received', {
-      tool: toolName ?? params.toolCall?.kind,
+      tool: toolName ?? normalizedParams.toolCall?.kind,
       isMcp,
-      toolCallId: params.toolCall?.toolCallId,
+      toolCallId: normalizedParams.toolCall?.toolCallId,
       sessionId: params.sessionId,
       optionCount: params.options?.length
     })
@@ -2886,7 +2938,9 @@ class AcpRuntime {
       const profileState = this.permissionProfiles.get(appSessionId)
 
       return await this.permissionBroker.requestPermission(
-        appSessionId === params.sessionId ? params : { ...params, sessionId: appSessionId },
+        appSessionId === normalizedParams.sessionId
+          ? normalizedParams
+          : { ...normalizedParams, sessionId: appSessionId },
         {
           profile: profileState?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE,
           autoReviewStrategy: profileState?.autoReviewStrategy,
@@ -2902,6 +2956,36 @@ class AcpRuntime {
         sessionId: params.sessionId
       })
       throw error
+    }
+  }
+
+  private restoreCodexMcpPermissionIdentity(
+    params: RequestPermissionRequest,
+    appSessionId: string,
+    mcpServerNames: readonly string[]
+  ): RequestPermissionRequest {
+    if (this.sessionFrameworks.get(appSessionId) !== 'codex' || !isCodexMcpApproval(params)) {
+      return params
+    }
+
+    const identities = this.codexMcpToolIdentities.get(appSessionId)
+    const identity = identities?.get(params.toolCall.toolCallId)
+
+    if (!identity || !isMcpToolName(identity.title, mcpServerNames)) return params
+
+    identities?.delete(params.toolCall.toolCallId)
+    if (identities?.size === 0) this.codexMcpToolIdentities.delete(appSessionId)
+
+    const toolMeta = isRecord(params.toolCall._meta) ? params.toolCall._meta : {}
+
+    return {
+      ...params,
+      toolCall: {
+        ...params.toolCall,
+        title: params.toolCall.title ?? identity.title,
+        rawInput: params.toolCall.rawInput ?? identity.rawInput,
+        _meta: { ...toolMeta, toolName: identity.providerToolName }
+      }
     }
   }
 
@@ -2987,6 +3071,27 @@ class AcpRuntime {
     }
 
     const event = toAcpRuntimeEvent(routed, this.nextEventId())
+
+    if (
+      event.kind === 'tool' &&
+      event.sessionId &&
+      event.toolCallId &&
+      this.sessionFrameworks.get(event.sessionId) === 'codex'
+    ) {
+      const identities = this.codexMcpToolIdentities.get(event.sessionId) ?? new Map()
+      const identity = codexMcpToolIdentity(
+        event,
+        this.sessionMcpServerNames.get(event.sessionId) ?? []
+      )
+
+      if (identity && event.status !== 'completed' && event.status !== 'failed') {
+        identities.set(event.toolCallId, identity)
+        this.codexMcpToolIdentities.set(event.sessionId, identities)
+      } else if (event.status === 'completed' || event.status === 'failed') {
+        identities.delete(event.toolCallId)
+        if (identities.size === 0) this.codexMcpToolIdentities.delete(event.sessionId)
+      }
+    }
 
     // Tool results (e.g. WebFetch's claude.ai domain-safety preflight, a failed Bash command) stream as
     // tool_call_update content, which the session-update log omits — so a tool that runs and fails leaves
@@ -3113,6 +3218,7 @@ class AcpRuntime {
     this.currentPromptTurnBySession.clear()
     this.latestSessionConfigOptions.clear()
     this.sessionMcpServerNames.clear()
+    this.codexMcpToolIdentities.clear()
     this.sessionProjectNames.clear()
     this.artifactSessionIds.clear()
     this.notebookRoutingIds.clear()
@@ -3321,6 +3427,7 @@ class AcpRuntime {
   disposeReviewerSession(session: import('@agentclientprotocol/sdk').ActiveSession): void {
     this.reviewerSessionIds.delete(session.sessionId)
     this.sessionMcpServerNames.delete(session.sessionId)
+    this.codexMcpToolIdentities.delete(session.sessionId)
     this.sessionFrameworks.delete(session.sessionId)
     const reviewerCwd = this.reviewerSessionDirectories.get(session.sessionId)
     this.reviewerSessionDirectories.delete(session.sessionId)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -243,6 +243,8 @@ const codexMcpToolIdentity = (
 
 // Keeps runtime snapshots bounded so long conversations do not grow renderer payloads forever.
 const MAX_EVENTS = 500
+// Bounds pending Codex MCP identities even if an agent never emits terminal tool updates.
+const MAX_CODEX_MCP_TOOL_IDENTITIES_PER_SESSION = 32
 // Appends artifact tool guidance as system prompt metadata so user prompts stay untouched.
 const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '<open_science_artifact_instructions>',
@@ -323,6 +325,7 @@ const log = createLogger('acp')
 const REVIEWER_MCP_OPENCODE_TOOL_NAMES = new Set(
   Object.values(REVIEWER_MCP_TOOLS).map((toolName) => `${REVIEWER_MCP_SERVER_NAME}_${toolName}`)
 )
+const REVIEWER_MCP_LEAF_TOOL_NAMES = new Set<string>(Object.values(REVIEWER_MCP_TOOLS))
 const REVIEWER_MCP_PROVIDER_TOOL_NAMES = new Set([
   ...REVIEWER_MCP_OPENCODE_TOOL_NAMES,
   ...Object.values(REVIEWER_MCP_TOOLS).map(
@@ -1932,6 +1935,7 @@ class AcpRuntime {
         const cancelTimer = this.cancelTimers.get(request.sessionId)
         if (cancelTimer) this.clearTimer(cancelTimer)
         this.cancelTimers.delete(request.sessionId)
+        this.codexMcpToolIdentities.delete(request.sessionId)
         this.currentPromptTurnBySession.delete(request.sessionId)
         this.promptInFlightSessionIds.delete(request.sessionId)
       }
@@ -2401,6 +2405,9 @@ class AcpRuntime {
       .client({ name: 'open-science' })
       .onRequest(acp.methods.client.session.requestPermission, (ctx) =>
         this.handlePermissionRequest(ctx.params)
+      )
+      .onNotification(acp.methods.client.session.update, (ctx) =>
+        this.observeCodexMcpToolIdentity(ctx.params)
       )
       .onRequest(acp.methods.client.fs.readTextFile, (ctx) =>
         readWorkspaceTextFile(
@@ -2925,7 +2932,7 @@ class AcpRuntime {
       // and unknown tools are rejected without involving the renderer.
       if (this.reviewerSessionIds.has(params.sessionId)) {
         return this.resolveReviewerPermission(
-          params,
+          normalizedParams,
           mcpServerNames,
           this.sessionFrameworks.get(params.sessionId)
         )
@@ -2957,6 +2964,40 @@ class AcpRuntime {
       })
       throw error
     }
+  }
+
+  // Observes every ACP update before framework-specific consumers drain their ActiveSession queue.
+  // Reviewer updates are consumed outside handleSessionUpdate, so this shared boundary is the only
+  // place where a preceding Codex tool_call can reliably enrich its later sparse permission request.
+  private observeCodexMcpToolIdentity(notification: SessionNotification): void {
+    const sessionId = this.agentToAppSessionId.get(notification.sessionId) ?? notification.sessionId
+    if (this.sessionFrameworks.get(sessionId) !== 'codex') return
+
+    const routed =
+      sessionId === notification.sessionId ? notification : { ...notification, sessionId }
+    const event = toAcpRuntimeEvent(routed, 'codex-mcp-identity')
+    if (event.kind !== 'tool' || !event.toolCallId) return
+
+    const identities = this.codexMcpToolIdentities.get(sessionId) ?? new Map()
+    if (event.status === 'completed' || event.status === 'failed') {
+      identities.delete(event.toolCallId)
+      if (identities.size === 0) this.codexMcpToolIdentities.delete(sessionId)
+      return
+    }
+
+    const identity = codexMcpToolIdentity(event, this.sessionMcpServerNames.get(sessionId) ?? [])
+    if (!identity) return
+
+    if (
+      !identities.has(event.toolCallId) &&
+      identities.size >= MAX_CODEX_MCP_TOOL_IDENTITIES_PER_SESSION
+    ) {
+      const oldestToolCallId = identities.keys().next().value
+      if (oldestToolCallId) identities.delete(oldestToolCallId)
+    }
+
+    identities.set(event.toolCallId, identity)
+    this.codexMcpToolIdentities.set(sessionId, identities)
   }
 
   private restoreCodexMcpPermissionIdentity(
@@ -3006,11 +3047,19 @@ class AcpRuntime {
       REVIEWER_MCP_OPENCODE_TOOL_NAMES.has(reportedTitle)
         ? reportedTitle
         : undefined
+    const codexToolName =
+      frameworkId === 'codex' &&
+      toolName != null &&
+      REVIEWER_MCP_LEAF_TOOL_NAMES.has(toolName) &&
+      reportedTitle === `mcp.${REVIEWER_MCP_SERVER_NAME}.${toolName}`
+        ? toolName
+        : undefined
     const isReviewerMcp =
       mcpServerNames.length === 1 &&
       mcpServerNames[0] === REVIEWER_MCP_SERVER_NAME &&
       ((toolName != null && REVIEWER_MCP_PROVIDER_TOOL_NAMES.has(toolName)) ||
-        opencodeToolName != null)
+        opencodeToolName != null ||
+        codexToolName != null)
 
     if (!isReviewerMcp) {
       const rejectOption =
@@ -3071,27 +3120,6 @@ class AcpRuntime {
     }
 
     const event = toAcpRuntimeEvent(routed, this.nextEventId())
-
-    if (
-      event.kind === 'tool' &&
-      event.sessionId &&
-      event.toolCallId &&
-      this.sessionFrameworks.get(event.sessionId) === 'codex'
-    ) {
-      const identities = this.codexMcpToolIdentities.get(event.sessionId) ?? new Map()
-      const identity = codexMcpToolIdentity(
-        event,
-        this.sessionMcpServerNames.get(event.sessionId) ?? []
-      )
-
-      if (identity && event.status !== 'completed' && event.status !== 'failed') {
-        identities.set(event.toolCallId, identity)
-        this.codexMcpToolIdentities.set(event.sessionId, identities)
-      } else if (event.status === 'completed' || event.status === 'failed') {
-        identities.delete(event.toolCallId)
-        if (identities.size === 0) this.codexMcpToolIdentities.delete(event.sessionId)
-      }
-    }
 
     // Tool results (e.g. WebFetch's claude.ai domain-safety preflight, a failed Bash command) stream as
     // tool_call_update content, which the session-update log omits — so a tool that runs and fails leaves
@@ -3304,6 +3332,7 @@ class AcpRuntime {
   private clearReviewerSessionState(): void {
     for (const [sessionId, reviewerCwd] of this.reviewerSessionDirectories) {
       this.removeReviewerDirectory(reviewerCwd)
+      this.codexMcpToolIdentities.delete(sessionId)
       this.sessionFrameworks.delete(sessionId)
     }
     this.reviewerSessionDirectories.clear()

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -94,6 +94,57 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('flex flex-wrap items-center justify-end gap-1 w-full overflow-hidden')
   })
 
+  it('keeps multiple always-allow scopes distinguishable', () => {
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[
+          {
+            ...permissionRequest,
+            options: [
+              {
+                optionId: 'allow-session',
+                name: 'Allow for This Session',
+                kind: 'allow_always'
+              },
+              {
+                optionId: 'allow-always',
+                name: "Allow and Don't Ask Again",
+                kind: 'allow_always'
+              },
+              { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+              { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
+            ]
+          }
+        ]}
+        onRespond={() => undefined}
+      />
+    )
+
+    expect(html).toContain('Allow for This Session</span>')
+    expect(html).toContain('Allow and Don&#x27;t Ask Again</span>')
+    expect(html.match(/>Always<\/span>/g)).toBeNull()
+  })
+
+  it('labels non-notebook MCP approvals as MCP instead of command execution', () => {
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[
+          {
+            ...permissionRequest,
+            title: 'mcp.open-science-artifacts.write_artifact_file',
+            providerToolName: 'write_artifact_file',
+            isMcp: true,
+            toolKind: 'execute'
+          }
+        ]}
+        onRespond={() => undefined}
+      />
+    )
+
+    expect(html).toContain('MCP tool access</span>')
+    expect(html).not.toContain('Command execution</span>')
+  })
+
   it('serializes prompts by rendering only the first pending request', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -120,9 +120,31 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('Allow for This Session</span>')
-    expect(html).toContain('Allow and Don&#x27;t Ask Again</span>')
+    expect(html).toContain('Always - Allow for This Session</span>')
+    expect(html).toContain('Always - Allow and Don&#x27;t Ask Again</span>')
     expect(html.match(/>Always<\/span>/g)).toBeNull()
+  })
+
+  it('keeps canonical semantics when provider scope names look like other actions', () => {
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[
+          {
+            ...permissionRequest,
+            options: [
+              { optionId: 'malicious-always', name: 'Reject', kind: 'allow_always' },
+              { optionId: 'session-always', name: 'Allow once', kind: 'allow_always' }
+            ]
+          }
+        ]}
+        onRespond={() => undefined}
+      />
+    )
+
+    expect(html).toContain('Always - Reject</span>')
+    expect(html).toContain('Always - Allow once</span>')
+    expect(html.match(/>Reject<\/span>/g)).toBeNull()
+    expect(html.match(/>Allow once<\/span>/g)).toBeNull()
   })
 
   it('labels non-notebook MCP approvals as MCP instead of command execution', () => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -37,15 +37,29 @@ const getPermissionActionLabel = (
   actionKind: PermissionActionKind,
   hasMultipleOptionsForAction: boolean
 ): string => {
-  // Providers may offer multiple scopes with the same ACP kind (for example, session-only and
-  // persistent allow_always). Preserve their display names only when the canonical label would make
-  // distinct decisions indistinguishable; the common one-option case stays compact.
-  if (hasMultipleOptionsForAction) return option.name
-  if (actionKind === 'always') return 'Always'
-  if (actionKind === 'allow-once') return 'Allow once'
-  if (actionKind === 'reject') return 'Reject'
+  const canonicalLabel =
+    actionKind === 'always'
+      ? 'Always'
+      : actionKind === 'allow-once'
+        ? 'Allow once'
+        : actionKind === 'reject'
+          ? 'Reject'
+          : undefined
 
-  return option.name
+  if (!canonicalLabel) return option.name
+
+  // Provider names distinguish multiple scopes, but never replace the protocol-derived semantic
+  // label: an untrusted allow_always name such as "Reject" must still render as an Always action.
+  const providerLabel = option.name.trim()
+  if (
+    hasMultipleOptionsForAction &&
+    providerLabel &&
+    providerLabel.toLowerCase() !== canonicalLabel.toLowerCase()
+  ) {
+    return `${canonicalLabel} - ${providerLabel}`
+  }
+
+  return canonicalLabel
 }
 
 const getOrderedPermissionOptions = (options: PermissionOption[]): PermissionOption[] =>

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -34,8 +34,13 @@ const getPermissionActionKind = (option: PermissionOption): PermissionActionKind
 
 const getPermissionActionLabel = (
   option: PermissionOption,
-  actionKind: PermissionActionKind
+  actionKind: PermissionActionKind,
+  hasMultipleOptionsForAction: boolean
 ): string => {
+  // Providers may offer multiple scopes with the same ACP kind (for example, session-only and
+  // persistent allow_always). Preserve their display names only when the canonical label would make
+  // distinct decisions indistinguishable; the common one-option case stays compact.
+  if (hasMultipleOptionsForAction) return option.name
   if (actionKind === 'always') return 'Always'
   if (actionKind === 'allow-once') return 'Allow once'
   if (actionKind === 'reject') return 'Reject'
@@ -91,6 +96,7 @@ const PermissionCommandBlock = ({ command }: { command: string }): React.JSX.Ele
 
 const getPermissionRiskLabel = (request: AcpPermissionRequest): string => {
   if (request.providerToolName === 'notebook_execute') return 'Notebook execution'
+  if (request.isMcp) return 'MCP tool access'
 
   switch (request.toolKind) {
     case 'execute':
@@ -129,6 +135,14 @@ const PermissionApprovalControls = ({
   if (!request) return null
 
   const notebookCode = getNotebookCode(request)
+  const actionCounts = request.options.reduce<Map<PermissionActionKind, number>>(
+    (counts, option) => {
+      const actionKind = getPermissionActionKind(option)
+      counts.set(actionKind, (counts.get(actionKind) ?? 0) + 1)
+      return counts
+    },
+    new Map()
+  )
 
   return (
     <div className="mb-2 w-full max-w-full space-y-2 overflow-hidden rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] leading-5 text-amber-900">
@@ -146,7 +160,11 @@ const PermissionApprovalControls = ({
         <span className="flex flex-wrap items-center justify-end gap-1 w-full overflow-hidden">
           {getOrderedPermissionOptions(request.options).map((option) => {
             const actionKind = getPermissionActionKind(option)
-            const actionLabel = getPermissionActionLabel(option, actionKind)
+            const actionLabel = getPermissionActionLabel(
+              option,
+              actionKind,
+              (actionCounts.get(actionKind) ?? 0) > 1
+            )
 
             return (
               <button

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -157,6 +157,9 @@ export type AcpPermissionRequest = {
   title: string
   status?: string
   providerToolName?: string
+  // Set by the permission broker after framework-aware classification so the renderer never has to
+  // infer MCP origin from provider-specific titles or tool kinds.
+  isMcp?: boolean
   toolKind?: ToolKind
   toolLocations?: ToolCallLocation[]
   rawInput?: unknown


### PR DESCRIPTION
## Problem

Codex ACP emits MCP tool details in a `tool_call` before sending a sparse permission request. Open Science therefore fell back to the unique call id, rendered Notebook/MCP approvals as command execution, and keyed session grants by an id that changes on every call.

The same split message shape broke background Reviewer sessions in #302. Reviewer updates were consumed outside the foreground session path, so the strict Reviewer allowlist saw only an `execute` request and automatically rejected `read_turn`, `query_execution_log`, and `submit_findings`.

Codex can also offer session and persistent choices with the same ACP `allow_always` kind, which the UI collapsed into duplicate `Always` buttons.

## Proposed change

- Observe Codex MCP identities at the shared ACP `session/update` boundary so foreground and Reviewer sessions use the same correlation path.
- Restore the stable MCP title, provider tool name, and raw arguments before broker and Reviewer permission classification.
- Approve a Codex Reviewer tool only when its framework, configured loopback server, canonical title, and known tool leaf all match; unrelated and unknown tools remain rejected.
- Bound pending identity caches to 32 entries per session and clear unmatched entries at turn/session teardown.
- Carry explicit MCP origin to the renderer so Notebook and other MCP approvals have accurate risk labels.
- Keep canonical permission semantics visible when provider-specific options share one ACP action kind.
- Recognize the Codex `mcp.<server>.<tool>` form only for MCP servers configured on that session.

## Scope and non-goals

- Auto permission semantics for user sessions are unchanged: an MCP tool still asks on its first call.
- Background Reviewer auto-approval remains limited to the single configured loopback `open-science-reviewer` MCP server.
- This change does not approve arbitrary MCP, shell, filesystem, or network tools.
- No changes are made to the installed `codex-acp` dependency.

## Acceptance criteria and validation

- Sparse Codex Reviewer permission requests reach `submit_findings` instead of being rejected as `execute`.
- Unknown methods in the Reviewer MCP namespace remain rejected.
- The first Codex Notebook/MCP approval shows the real tool identity and arguments instead of a call id.
- A session grant suppresses later prompts for the same MCP tool even when the call id changes.
- Session and persistent allow options remain distinguishable without allowing provider labels to spoof their semantics.

Validation performed:

- `npx vitest run src/main/acp/runtime.test.ts src/main/acp/permission-policy.test.ts src/main/acp/permission-broker.test.ts src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx src/main/notebook/ipynb-export.test.ts` - 195 tests passed.
- `npm run lint` - 0 errors; 6 pre-existing formatting warnings in unrelated files.
- `npm run test` - 389 files passed, 7 skipped; 4,844 tests passed, 66 skipped. Two unrelated timing-sensitive tests failed only under full-suite contention and passed in isolation (97/97).
- `npm run typecheck` was intentionally not run per request.

## Review focus

- Shared notification-time identity correlation and cleanup paths.
- Reviewer permission matching remaining fail-closed for unknown or unconfigured tools.
- Canonical permission action labels staying visible when provider names distinguish scopes.

Fixes #302
