### PR TITLE
fix(notebook): validate bioconda mirror availability

### DIFF
--- a/src/main/notebook/mirror-probe.test.ts
+++ b/src/main/notebook/mirror-probe.test.ts
@@ -8,18 +8,34 @@ import {
 } from './mirror-probe'
 
 const candidates: MirrorCandidate[] = [
-  { name: 'public', mirror: {}, probeUrl: 'https://public/repodata.json' },
+  {
+    name: 'public',
+    mirror: {},
+    probeUrl: 'https://public/conda-forge/repodata.json',
+    biocondaProbeUrl: 'https://public/bioconda/repodata.json'
+  },
   {
     name: 'tuna',
     mirror: { condaChannel: 'https://tuna/conda-forge/', pypiIndex: 'https://tuna/pypi' },
-    probeUrl: 'https://tuna/repodata.json'
+    probeUrl: 'https://tuna/conda-forge/repodata.json',
+    biocondaProbeUrl: 'https://tuna/bioconda/repodata.json'
   },
   {
     name: 'aliyun',
     mirror: { condaChannel: 'https://aliyun/conda-forge/' },
-    probeUrl: 'https://aliyun/repodata.json'
+    probeUrl: 'https://aliyun/conda-forge/repodata.json',
+    biocondaProbeUrl: 'https://aliyun/bioconda/repodata.json'
   }
 ]
+
+const reachableLatencies = {
+  'https://public/conda-forge/repodata.json': 300,
+  'https://public/bioconda/repodata.json': 320,
+  'https://tuna/conda-forge/repodata.json': 40,
+  'https://tuna/bioconda/repodata.json': 50,
+  'https://aliyun/conda-forge/repodata.json': 120,
+  'https://aliyun/bioconda/repodata.json': 130
+}
 
 // A probe that returns per-URL latencies from a table; a missing/`null` entry rejects (unreachable).
 const probeFrom =
@@ -33,13 +49,49 @@ const probeFrom =
 afterEach(() => resetAutoMirrorCache())
 
 describe('pickFastestMirror', () => {
-  it('returns the mirror of the fastest reachable candidate', async () => {
+  it('returns the fastest candidate whose conda-forge and bioconda channels respond', async () => {
+    const result = await pickFastestMirror({
+      candidates,
+      probe: probeFrom(reachableLatencies)
+    })
+    expect(result).toEqual({
+      condaChannel: 'https://tuna/conda-forge/',
+      pypiIndex: 'https://tuna/pypi'
+    })
+  })
+
+  it('skips a candidate when its bioconda channel is unreachable', async () => {
     const result = await pickFastestMirror({
       candidates,
       probe: probeFrom({
-        'https://public/repodata.json': 300,
-        'https://tuna/repodata.json': 40,
-        'https://aliyun/repodata.json': 120
+        ...reachableLatencies,
+        'https://tuna/bioconda/repodata.json': null
+      })
+    })
+    expect(result).toEqual({ condaChannel: 'https://aliyun/conda-forge/' })
+  })
+
+  it('skips a candidate when its conda-forge channel is unreachable', async () => {
+    const result = await pickFastestMirror({
+      candidates,
+      probe: probeFrom({
+        ...reachableLatencies,
+        'https://tuna/conda-forge/repodata.json': null
+      })
+    })
+    expect(result).toEqual({ condaChannel: 'https://aliyun/conda-forge/' })
+  })
+
+  it('scores each candidate by its slower required channel', async () => {
+    const result = await pickFastestMirror({
+      candidates,
+      probe: probeFrom({
+        'https://public/conda-forge/repodata.json': 10,
+        'https://public/bioconda/repodata.json': 300,
+        'https://tuna/conda-forge/repodata.json': 100,
+        'https://tuna/bioconda/repodata.json': 100,
+        'https://aliyun/conda-forge/repodata.json': 120,
+        'https://aliyun/bioconda/repodata.json': 120
       })
     })
     expect(result).toEqual({
@@ -48,22 +100,14 @@ describe('pickFastestMirror', () => {
     })
   })
 
-  it('skips unreachable candidates and picks the fastest that responds', async () => {
+  it('returns undefined when no candidate has a reachable bioconda channel', async () => {
     const result = await pickFastestMirror({
       candidates,
       probe: probeFrom({
-        'https://public/repodata.json': null, // unreachable
-        'https://tuna/repodata.json': null, // unreachable
-        'https://aliyun/repodata.json': 120
+        'https://public/conda-forge/repodata.json': 300,
+        'https://tuna/conda-forge/repodata.json': 40,
+        'https://aliyun/conda-forge/repodata.json': 120
       })
-    })
-    expect(result).toEqual({ condaChannel: 'https://aliyun/conda-forge/' })
-  })
-
-  it('returns undefined when nothing responds', async () => {
-    const result = await pickFastestMirror({
-      candidates,
-      probe: probeFrom({})
     })
     expect(result).toBeUndefined()
   })
@@ -83,32 +127,28 @@ describe('effectiveMirrorAsync', () => {
   it('uses the fastest-probed mirror when there is no override', async () => {
     const result = await effectiveMirrorAsync(undefined, 'en-US', {
       candidates,
-      probe: probeFrom({
-        'https://public/repodata.json': 300,
-        'https://tuna/repodata.json': 40,
-        'https://aliyun/repodata.json': 120
-      })
+      probe: probeFrom(reachableLatencies)
     })
     expect(result.condaChannel).toBe('https://tuna/conda-forge/')
   })
 
-  it('falls back to the locale default when the probe finds nothing', async () => {
+  it('falls back to the locale default when no complete channel pair responds', async () => {
     const result = await effectiveMirrorAsync(undefined, 'zh-CN', {
       candidates,
-      probe: probeFrom({})
+      probe: probeFrom({
+        'https://public/conda-forge/repodata.json': 300,
+        'https://tuna/conda-forge/repodata.json': 40,
+        'https://aliyun/conda-forge/repodata.json': 120
+      })
     })
-    // No reachable mirror -> zh-CN locale default (TUNA) from the sync effectiveMirror.
+    // No candidate has a reachable bioconda channel -> zh-CN locale default (TUNA).
     expect(result.condaChannel).toContain('tuna')
   })
 
   it('preserves a caBundle-only config while still using the fastest-probed channel', async () => {
     const result = await effectiveMirrorAsync({ caBundle: '/etc/corp-ca.pem' }, 'en-US', {
       candidates,
-      probe: probeFrom({
-        'https://public/repodata.json': 300,
-        'https://tuna/repodata.json': 40,
-        'https://aliyun/repodata.json': 120
-      })
+      probe: probeFrom(reachableLatencies)
     })
     expect(result.condaChannel).toBe('https://tuna/conda-forge/')
     expect(result.caBundle).toBe('/etc/corp-ca.pem')

--- a/src/main/notebook/mirror-probe.ts
+++ b/src/main/notebook/mirror-probe.ts
@@ -1,23 +1,32 @@
 import type { PackageMirror } from '../../shared/mirror'
 import { CURATED_MIRRORS, effectiveMirror } from './mirror'
 
-// A candidate mirror bundle + a cheap URL to measure reachability/latency. Public endpoints only (no
-// secrets). probeUrl points at each mirror's conda-forge repodata, HEAD-ed so no body is downloaded.
-export type MirrorCandidate = { name: string; mirror: PackageMirror; probeUrl: string }
+// A candidate mirror bundle + cheap URLs to measure both required conda channels. Public endpoints
+// only (no secrets). The repodata URLs are HEAD-ed so no body is downloaded.
+export type MirrorCandidate = {
+  name: string
+  mirror: PackageMirror
+  probeUrl: string
+  biocondaProbeUrl: string
+}
 
 const condaRepodata = (base: string): string =>
   `${base}anaconda/cloud/conda-forge/noarch/repodata.json`
+const biocondaRepodata = (base: string): string =>
+  `${base}anaconda/cloud/bioconda/noarch/repodata.json`
 
 export const MIRROR_CANDIDATES: MirrorCandidate[] = [
   {
     name: 'public',
     mirror: {},
-    probeUrl: 'https://conda.anaconda.org/conda-forge/noarch/repodata.json'
+    probeUrl: 'https://conda.anaconda.org/conda-forge/noarch/repodata.json',
+    biocondaProbeUrl: 'https://conda.anaconda.org/bioconda/noarch/repodata.json'
   },
   {
     name: 'tuna',
     mirror: { ...CURATED_MIRRORS.cn },
-    probeUrl: condaRepodata('https://mirrors.tuna.tsinghua.edu.cn/')
+    probeUrl: condaRepodata('https://mirrors.tuna.tsinghua.edu.cn/'),
+    biocondaProbeUrl: biocondaRepodata('https://mirrors.tuna.tsinghua.edu.cn/')
   },
   {
     name: 'ustc',
@@ -26,7 +35,8 @@ export const MIRROR_CANDIDATES: MirrorCandidate[] = [
       pypiIndex: 'https://mirrors.ustc.edu.cn/pypi/web/simple',
       cranMirror: 'https://mirrors.ustc.edu.cn/CRAN/'
     },
-    probeUrl: condaRepodata('https://mirrors.ustc.edu.cn/')
+    probeUrl: condaRepodata('https://mirrors.ustc.edu.cn/'),
+    biocondaProbeUrl: biocondaRepodata('https://mirrors.ustc.edu.cn/')
   },
   {
     name: 'aliyun',
@@ -35,7 +45,8 @@ export const MIRROR_CANDIDATES: MirrorCandidate[] = [
       pypiIndex: 'https://mirrors.aliyun.com/pypi/simple',
       cranMirror: 'https://mirrors.aliyun.com/CRAN/'
     },
-    probeUrl: condaRepodata('https://mirrors.aliyun.com/')
+    probeUrl: condaRepodata('https://mirrors.aliyun.com/'),
+    biocondaProbeUrl: biocondaRepodata('https://mirrors.aliyun.com/')
   }
 ]
 
@@ -56,8 +67,9 @@ export type ProbeDeps = {
   timeoutMs?: number
 }
 
-// Probes every candidate in parallel and returns the mirror of the fastest that responds, or
-// undefined when none respond within the timeout (caller then falls back to the locale default).
+// Probes every candidate's conda-forge and bioconda channels in parallel. A candidate is reachable only
+// when both respond; its score is the slower response because both channels are required for installs.
+// Returns undefined when no complete candidate responds (caller then falls back to the locale default).
 export const pickFastestMirror = async (
   deps: ProbeDeps = {}
 ): Promise<PackageMirror | undefined> => {
@@ -68,7 +80,11 @@ export const pickFastestMirror = async (
   const timed = await Promise.all(
     candidates.map(async (candidate) => {
       try {
-        return { candidate, ms: await probe(candidate.probeUrl, timeoutMs) }
+        const [condaMs, biocondaMs] = await Promise.all([
+          probe(candidate.probeUrl, timeoutMs),
+          probe(candidate.biocondaProbeUrl, timeoutMs)
+        ])
+        return { candidate, ms: Math.max(condaMs, biocondaMs) }
       } catch {
         return undefined
       }


### PR DESCRIPTION
## Problem

Automatic package-mirror selection only probed each candidate’s conda-forge repodata. A mirror could therefore win even when its matching bioconda channel was unreachable, causing Bioconductor package installs to fail.

## Proposed change

Probe conda-forge and bioconda repodata concurrently for every mirror candidate. Keep only candidates where both channels respond, and rank each complete candidate by its slower response.

## Scope and non-goals

- Keep CRAN and PyPI bundled with the selected mirror; they are not independently probed.
- Keep the existing micromamba + bioconda installation path.
- Do not change package naming, CRAN fallback, settings, or the PackageMirror model.

## Acceptance criteria and validation

- Candidates with an unreachable conda-forge or bioconda endpoint are excluded.
- Complete channel pairs are ranked by their slower endpoint.
- Locale fallback and explicit mirror overrides remain unchanged.
- `npm run test -- src/main/notebook/mirror-probe.test.ts src/main/notebook/mirror.test.ts src/main/notebook/package-manager.test.ts src/main/notebook/runtime-service.test.ts` — passed (172 passed, 1 skipped).
- `npm run lint` — completed with no errors; 5 existing Prettier warnings remain in unrelated files.
- `npm run test` — passed (389 files, 4804 tests; 7 files and 66 tests skipped).
- `npm run typecheck` — not run per request.

## Review focus

Please review the paired endpoint URLs and the use of the slower response as the candidate score.