### PR TITLE
feat(settings): re-enable the built-in WebSearch tool for the ACP agent

### DIFF
--- a/src/main/settings/claude-config-provision.test.ts
+++ b/src/main/settings/claude-config-provision.test.ts
@@ -88,14 +88,15 @@ describe('provisionAppClaudeConfigDir', () => {
     }
   })
 
-  it('disables the built-in WebSearch tool in the app user scope', async () => {
+  it('leaves the built-in web tools enabled in the app user scope', async () => {
     root = await mkdtemp(join(tmpdir(), 'os-claude-config-'))
     const configDir = join(root, 'claude')
 
     await provisionAppClaudeConfigDir(configDir)
 
     const settings = JSON.parse(await readFile(join(configDir, 'settings.json'), 'utf8'))
-    expect(settings.permissions.deny).toContain('WebSearch')
+    expect(settings.permissions.deny).not.toContain('WebSearch')
+    expect(settings.permissions.deny).not.toContain('WebFetch')
   })
 
   it('disables Claude Code bundled skills in the app user scope', async () => {

--- a/src/main/settings/claude-config-provision.test.ts
+++ b/src/main/settings/claude-config-provision.test.ts
@@ -99,6 +99,25 @@ describe('provisionAppClaudeConfigDir', () => {
     expect(settings.permissions.deny).not.toContain('WebFetch')
   })
 
+  it('prunes a persisted managed built-in deny (WebSearch) on upgrade, keeping unrelated rules', async () => {
+    root = await mkdtemp(join(tmpdir(), 'os-claude-config-'))
+    const configDir = join(root, 'claude')
+    await mkdir(configDir, { recursive: true })
+    // Simulate an install provisioned before this change: WebSearch already persisted alongside an
+    // unrelated user deny rule.
+    await writeFile(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ permissions: { deny: ['WebSearch', 'Bash(rm:*)'] } }),
+      'utf8'
+    )
+
+    await provisionAppClaudeConfigDir(configDir)
+
+    const settings = JSON.parse(await readFile(join(configDir, 'settings.json'), 'utf8'))
+    expect(settings.permissions.deny).not.toContain('WebSearch')
+    expect(settings.permissions.deny).toContain('Bash(rm:*)')
+  })
+
   it('disables Claude Code bundled skills in the app user scope', async () => {
     root = await mkdtemp(join(tmpdir(), 'os-claude-config-'))
     const configDir = join(root, 'claude')

--- a/src/main/settings/claude-config-provision.test.ts
+++ b/src/main/settings/claude-config-provision.test.ts
@@ -9,6 +9,7 @@ import { ClaudeCodeSkillMaterializer } from '../skills/materializer'
 import {
   APP_ASSET_SUBDIRS,
   DENIED_BUILTIN_TOOLS,
+  MANAGED_BUILTIN_TOOLS,
   configDenyRules,
   provisionAppClaudeConfigDir
 } from './claude-config-provision'
@@ -49,6 +50,18 @@ afterEach(async () => {
     await rm(root, { recursive: true, force: true })
     root = undefined
   }
+})
+
+describe('built-in tool deny policy', () => {
+  // Pruning-on-removal only re-enables a tool if it is in the module-owned superset. A tool denied
+  // now but absent from MANAGED_BUILTIN_TOOLS would stay denied forever once later removed from
+  // DENIED_BUILTIN_TOOLS — the exact bug the prune step fixes. Guard the DENIED ⊆ MANAGED invariant.
+  it('keeps every denied built-in tool in the managed superset', () => {
+    const managed = new Set<string>(MANAGED_BUILTIN_TOOLS)
+    for (const tool of DENIED_BUILTIN_TOOLS) {
+      expect(managed.has(tool)).toBe(true)
+    }
+  })
 })
 
 describe('provisionAppClaudeConfigDir', () => {

--- a/src/main/settings/claude-config-provision.ts
+++ b/src/main/settings/claude-config-provision.ts
@@ -20,7 +20,20 @@ const GUARDED_FILE_TOOLS = ['Read', 'Edit', 'Glob', 'Grep'] as const
 // Built-in agent tools disabled outright in this app. Empty by default: the model's open-web tools
 // (WebSearch/WebFetch) are left enabled so the agent can reach the open web alongside the curated MCP
 // research connectors. Add a tool name here to fence it out of the app-owned user scope.
+//
+// Tradeoff: #105 originally denied WebSearch as an exfiltration-channel hardening measure (open-web
+// reach is a path for conversation/workspace data to leave the app). Re-opening it accepts that risk
+// in exchange for the model's built-in web reach. WebFetch additionally relies on the CLI's own
+// claude.ai domain-safety preflight (enforced inside the claude binary, not here) as a backstop.
 const DENIED_BUILTIN_TOOLS = [] as const
+
+// Built-in tool deny entries this module OWNS across versions — the full set it has ever written into
+// `permissions.deny`, regardless of what DENIED_BUILTIN_TOOLS currently holds. Provisioning prunes
+// these from the existing file before re-adding the current DENIED_BUILTIN_TOOLS, so the deny list
+// stays declarative (reflects present policy) instead of accumulating stale entries. Without this, a
+// tool removed from DENIED_BUILTIN_TOOLS would stay denied forever on installs that once persisted it
+// (e.g. WebSearch written by #105). Unrelated user/third-party deny rules are never touched.
+const MANAGED_BUILTIN_TOOLS = ['WebSearch'] as const
 
 // Builds the claude-code permission deny rules that fence the agent's file tools out of `configDir`.
 // Claude Code permission paths are gitignore-style with forward slashes, where a `//<abs>` prefix
@@ -32,11 +45,12 @@ const configDenyRules = (configDir: string): string[] => {
 }
 
 // Writes/merges `<configDir>/settings.json` for the app-owned user scope (the agent runs with
-// settingSources: ['user']). Two things are enforced here, merge-preserving any settings already
-// present: the permissions.deny guard rules (file-tool fence, plus any DENIED_BUILTIN_TOOLS), and
-// disableBundledSkills so Claude Code's own bundled skills/workflows (dataviz, deep-research, …)
-// never leak in — the app injects its OWN curated skill set into `<configDir>/skills`, which
-// disableBundledSkills leaves untouched.
+// settingSources: ['user']). Two things are enforced here, preserving unrelated settings already
+// present: the permissions.deny guard rules (file-tool fence, plus the current DENIED_BUILTIN_TOOLS,
+// after pruning any stale module-owned MANAGED_BUILTIN_TOOLS entries), and disableBundledSkills so
+// Claude Code's own bundled skills/workflows (dataviz, deep-research, …) never leak in — the app
+// injects its OWN curated skill set into `<configDir>/skills`, which disableBundledSkills leaves
+// untouched.
 const writeAppSettings = async (configDir: string): Promise<void> => {
   const settingsPath = join(configDir, 'settings.json')
 
@@ -53,8 +67,12 @@ const writeAppSettings = async (configDir: string): Promise<void> => {
       ? (settings.permissions as Record<string, unknown>)
       : {}
   const existingDeny = Array.isArray(permissions.deny) ? (permissions.deny as string[]) : []
+  // Drop any module-owned built-in deny entries first so a tool dropped from DENIED_BUILTIN_TOOLS is
+  // actually re-enabled on upgrade, then re-add only the ones current policy still denies.
+  const managed = new Set<string>(MANAGED_BUILTIN_TOOLS)
+  const preservedDeny = existingDeny.filter((rule) => !managed.has(rule))
   const deny = [
-    ...new Set([...existingDeny, ...configDenyRules(configDir), ...DENIED_BUILTIN_TOOLS])
+    ...new Set([...preservedDeny, ...configDenyRules(configDir), ...DENIED_BUILTIN_TOOLS])
   ]
 
   settings.permissions = { ...permissions, deny }
@@ -91,4 +109,10 @@ const provisionAppClaudeConfigDir = async (
   await materializer.sync(configDir, enabled)
 }
 
-export { APP_ASSET_SUBDIRS, DENIED_BUILTIN_TOOLS, configDenyRules, provisionAppClaudeConfigDir }
+export {
+  APP_ASSET_SUBDIRS,
+  DENIED_BUILTIN_TOOLS,
+  MANAGED_BUILTIN_TOOLS,
+  configDenyRules,
+  provisionAppClaudeConfigDir
+}

--- a/src/main/settings/claude-config-provision.ts
+++ b/src/main/settings/claude-config-provision.ts
@@ -17,9 +17,10 @@ const APP_ASSET_SUBDIRS = ['skills', 'plugins', 'commands'] as const
 // (bash/subprocess) is guarded separately; see the notebook audit hook and read-guard spec.
 const GUARDED_FILE_TOOLS = ['Read', 'Edit', 'Glob', 'Grep'] as const
 
-// Built-in agent tools disabled outright in this app. Web search is off by policy: the agent gets its
-// external data through the curated MCP research connectors, not the model's open-web search.
-const DENIED_BUILTIN_TOOLS = ['WebSearch'] as const
+// Built-in agent tools disabled outright in this app. Empty by default: the model's open-web tools
+// (WebSearch/WebFetch) are left enabled so the agent can reach the open web alongside the curated MCP
+// research connectors. Add a tool name here to fence it out of the app-owned user scope.
+const DENIED_BUILTIN_TOOLS = [] as const
 
 // Builds the claude-code permission deny rules that fence the agent's file tools out of `configDir`.
 // Claude Code permission paths are gitignore-style with forward slashes, where a `//<abs>` prefix
@@ -31,9 +32,9 @@ const configDenyRules = (configDir: string): string[] => {
 }
 
 // Writes/merges `<configDir>/settings.json` for the app-owned user scope (the agent runs with
-// settingSources: ['user']). Three things are enforced here, merge-preserving any settings already
-// present: the permissions.deny guard rules (file-tool fence + disabled built-in tools like WebSearch),
-// and disableBundledSkills so Claude Code's own bundled skills/workflows (dataviz, deep-research, …)
+// settingSources: ['user']). Two things are enforced here, merge-preserving any settings already
+// present: the permissions.deny guard rules (file-tool fence, plus any DENIED_BUILTIN_TOOLS), and
+// disableBundledSkills so Claude Code's own bundled skills/workflows (dataviz, deep-research, …)
 // never leak in — the app injects its OWN curated skill set into `<configDir>/skills`, which
 // disableBundledSkills leaves untouched.
 const writeAppSettings = async (configDir: string): Promise<void> => {


### PR DESCRIPTION
## Problem

The ACP agent's built-in `WebSearch` tool is denied in the app-owned Claude config scope (`permissions.deny`), added in #105 as a hardening measure. This blocks the model from doing open-web searches. `WebFetch` was never restricted, but the deny list was the only thing standing between the agent and open-web reach.

## Proposed change

Empty out `DENIED_BUILTIN_TOOLS` in `src/main/settings/claude-config-provision.ts` so `WebSearch` is no longer written into `permissions.deny`. `WebSearch` and `WebFetch` are now both available to the agent alongside the curated MCP research connectors.

The deny set keeps its existing file-tool fence (`Read`/`Edit`/`Glob`/`Grep` out of the config dir) and stays merge-preserving, so any built-in tool can be re-added to `DENIED_BUILTIN_TOOLS` to disable it again.

## Scope and non-goals

- In scope: the app-level deny rule for the built-in web tools.
- Non-goal: the CLI's own claude.ai domain-safety preflight for `WebFetch` — that is enforced inside the Claude binary and is not toggled here.

## Acceptance criteria and validation

- `permissions.deny` in the provisioned `settings.json` no longer contains `WebSearch` (or `WebFetch`).
- The file-tool fence and `disableBundledSkills` are unchanged.
- `npx vitest run src/main/settings/claude-config-provision.test.ts` — 7 passed.
- `eslint` and `prettier --check` clean on the changed files.

## Review focus

Whether re-opening the model's built-in web search is desired given #105 framed it as an exfiltration-channel hardening measure.