### PR TITLE
fix(notebook): harden the ipynb export against the nbformat spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@vitejs/plugin-react": "^5.1.1",
         "@vitest/coverage-v8": "^4.1.10",
         "3dmol": "^2.5.5",
+        "ajv": "^8.20.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "electron": "^39.2.6",
@@ -6158,6 +6159,8 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^4.1.10",
     "3dmol": "^2.5.5",
+    "ajv": "^8.20.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "electron": "^39.2.6",

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -209,7 +209,12 @@ const createDefaultNotebookRuntimeService = (): NotebookRuntimeService => {
     // wired in main/ipc.ts via setPackageMirrorResolver once the settings service is constructed.
     locale: app.getLocale(),
     appVersion: app.getVersion(),
-    resolveArtifactPath: (path) => artifactRepository.resolveManagedFilePath({ path }),
+    resolveArtifactPath: (request) =>
+      artifactRepository.resolveSessionArtifactFilePath(
+        request.projectName,
+        request.sessionId,
+        request.path
+      ),
     callbacks: {
       onNotebookAvailable: (event) => broadcast('notebook:available', event),
       onNotebookChanged: (event) => broadcast('notebook:changed', event)

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -6,6 +6,7 @@ import {
   realpath,
   rename,
   rm,
+  symlink,
   writeFile
 } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
@@ -1042,6 +1043,94 @@ describe('artifact repository', () => {
     // Build the expectation with join() so the separator matches the host the test runs on.
     expect(getProjectArtifactDir('/Users/example/.open-science', 'default-project')).toBe(
       join('/Users/example/.open-science', 'artifacts', 'default-project')
+    )
+  })
+
+  describe('resolveSessionArtifactFilePath', () => {
+    const pendingPlotPath = (root: string, project: string, session: string): string =>
+      join(root, 'artifacts', project, session, '.pending', 'run-1', 'plot.png')
+
+    const writePendingPlot = (
+      repository: ArtifactRepository,
+      project: string,
+      session: string
+    ): Promise<unknown> =>
+      repository.writePendingFile({
+        projectName: project,
+        sessionId: session,
+        runId: 'run-1',
+        filename: 'plot.png',
+        source: createInlineSource(`${project}/${session} bytes`)
+      })
+
+    it('resolves a file inside the declaring session subtree', async () => {
+      const root = await createStorageRoot()
+      const repository = new ArtifactRepository(root)
+      await writePendingPlot(repository, 'default-project', 'session-1')
+
+      const resolved = await repository.resolveSessionArtifactFilePath(
+        'default-project',
+        'session-1',
+        pendingPlotPath(root, 'default-project', 'session-1')
+      )
+
+      expect(resolved).toBe(await realpath(pendingPlotPath(root, 'default-project', 'session-1')))
+    })
+
+    it('rejects a file from another session of the same project', async () => {
+      const root = await createStorageRoot()
+      const repository = new ArtifactRepository(root)
+      await writePendingPlot(repository, 'default-project', 'session-1')
+      // The declaring session exists too, so the rejection comes from the subtree comparison.
+      await writePendingPlot(repository, 'default-project', 'session-2')
+
+      await expect(
+        repository.resolveSessionArtifactFilePath(
+          'default-project',
+          'session-2',
+          pendingPlotPath(root, 'default-project', 'session-1')
+        )
+      ).rejects.toThrow('Artifact file is outside the declaring session.')
+    })
+
+    it('rejects a file from another project', async () => {
+      const root = await createStorageRoot()
+      const repository = new ArtifactRepository(root)
+      await writePendingPlot(repository, 'default-project', 'session-1')
+      await writePendingPlot(repository, 'other-project', 'session-1')
+
+      await expect(
+        repository.resolveSessionArtifactFilePath(
+          'default-project',
+          'session-1',
+          pendingPlotPath(root, 'other-project', 'session-1')
+        )
+      ).rejects.toThrow('Artifact file is outside the declaring session.')
+    })
+
+    // File symlinks need elevated privileges on Windows; covered on POSIX CI.
+    it.skipIf(process.platform === 'win32')(
+      'rejects a symlink inside the session subtree that points into another session',
+      async () => {
+        const root = await createStorageRoot()
+        const repository = new ArtifactRepository(root)
+        await writePendingPlot(repository, 'default-project', 'session-1')
+        await writePendingPlot(repository, 'default-project', 'session-2')
+        const linkPath = join(
+          root,
+          'artifacts',
+          'default-project',
+          'session-1',
+          '.pending',
+          'run-1',
+          'link.png'
+        )
+        await symlink(pendingPlotPath(root, 'default-project', 'session-2'), linkPath)
+
+        await expect(
+          repository.resolveSessionArtifactFilePath('default-project', 'session-1', linkPath)
+        ).rejects.toThrow('Artifact file is outside the declaring session.')
+      }
     )
   })
 })

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -530,6 +530,32 @@ class ArtifactRepository {
     return resolvedFilePath
   }
 
+  // resolveManagedFilePath additionally bound to one project/session subtree: an artifact record
+  // may only resolve to a file under its own declaring session, so a stale or crafted record (or a
+  // symlink inside the artifact root) cannot pull another session's or project's files into an
+  // export. Throws when the real path escapes that subtree.
+  async resolveSessionArtifactFilePath(
+    projectName: string,
+    sessionId: string,
+    path: string
+  ): Promise<string> {
+    const resolvedFilePath = await this.resolveManagedFilePath({ path })
+    const sessionRoot = join(getProjectArtifactDir(this.storageRoot, projectName), sessionId)
+
+    let resolvedSessionRoot: string
+    try {
+      resolvedSessionRoot = await realpath(sessionRoot)
+    } catch {
+      throw new Error('Artifact file is outside the declaring session.')
+    }
+
+    if (!isPathInsideRoot(resolvedSessionRoot, resolvedFilePath)) {
+      throw new Error('Artifact file is outside the declaring session.')
+    }
+
+    return resolvedFilePath
+  }
+
   // Given a now-missing `.pending/<run>/<file>` artifact path, finds the same file after finalize moved
   // it, using ONLY the run marker written at finalize (`.runs/<run>.json`), which pins the exact app
   // session + message the run produced. An unmarked run is never recovered by guessing among same-named

--- a/src/main/notebook/ipynb-export.test.ts
+++ b/src/main/notebook/ipynb-export.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
+import { readFile } from 'node:fs/promises'
+
+import Ajv from 'ajv'
+import { describe, expect, it } from 'vitest'
 
 import type { NotebookRunDocument, NotebookRunRecord } from '../../shared/notebook'
-import { runDocumentToIpynb } from './ipynb-export'
+import { runDocumentToIpynb, type NbformatOutput } from './ipynb-export'
 
 const makeRun = (overrides: Partial<NotebookRunRecord> = {}): NotebookRunRecord => ({
   runId: 'run-1',
@@ -38,8 +41,23 @@ const makeDocument = (runs: NotebookRunRecord[]): NotebookRunDocument => ({
   updatedAt: 300
 })
 
+// The vendored nbformat schema declares draft-04, which ajv 8 no longer loads; it only uses
+// draft-07-compatible keywords (verified when vendoring), so it is validated as draft-07 here.
+const validateAgainstNbformatSchema = async (notebook: unknown): Promise<void> => {
+  const schemaUrl = new URL('../../../test/fixtures/nbformat.v4.5.schema.json', import.meta.url)
+  const schema = JSON.parse(await readFile(schemaUrl, 'utf8')) as Record<string, unknown>
+  schema.$schema = 'http://json-schema.org/draft-07/schema#'
+
+  const ajv = new Ajv({ strict: false })
+  const validate = ajv.compile(schema)
+  const valid = validate(notebook)
+
+  expect(validate.errors).toBeNull()
+  expect(valid).toBe(true)
+}
+
 describe('runDocumentToIpynb', () => {
-  it('projects source, provenance, execution count, and every structured output kind', async () => {
+  it('projects source, provenance, execution count, and every structured output kind', () => {
     const run = makeRun({
       outputs: [
         { type: 'stream', name: 'stdout', text: 'hello\nworld' },
@@ -51,7 +69,7 @@ describe('runDocumentToIpynb', () => {
       ]
     })
 
-    const notebook = await runDocumentToIpynb(makeDocument([run]), { appVersion: '1.2.3' })
+    const notebook = runDocumentToIpynb(makeDocument([run]), { appVersion: '1.2.3' })
 
     expect(notebook).toMatchObject({
       nbformat: 4,
@@ -61,7 +79,8 @@ describe('runDocumentToIpynb', () => {
         open_science: {
           sessionId: 'session-123',
           projectName: 'default-project',
-          appVersion: '1.2.3'
+          appVersion: '1.2.3',
+          environment: 'default-python'
         }
       }
     })
@@ -73,7 +92,10 @@ describe('runDocumentToIpynb', () => {
       metadata: {
         open_science: {
           runId: 'run-1',
+          cellId: 'cell-1',
+          source: 'agent',
           startedAt: 100,
+          endedAt: 200,
           status: 'completed',
           kernel: 'python',
           environment: 'default-python'
@@ -104,7 +126,7 @@ describe('runDocumentToIpynb', () => {
     ])
   })
 
-  it('uses flattened text only as a legacy fallback, without duplicating structured streams', async () => {
+  it('uses flattened text only as a legacy fallback, without duplicating structured streams', () => {
     const fallback = makeRun({
       runId: 'fallback',
       text: { stdout: 'out', stderr: 'err', traceback: 'boom', plain: [] }
@@ -115,7 +137,7 @@ describe('runDocumentToIpynb', () => {
       outputs: [{ type: 'stream', name: 'stdout', text: 'canonical' }]
     })
 
-    const notebook = await runDocumentToIpynb(makeDocument([fallback, structured]))
+    const notebook = runDocumentToIpynb(makeDocument([fallback, structured]))
 
     expect(notebook.cells[0].outputs).toHaveLength(3)
     expect(notebook.cells[1].outputs).toEqual([
@@ -123,11 +145,11 @@ describe('runDocumentToIpynb', () => {
     ])
   })
 
-  it('chooses the dominant data kernel and marks downgraded bash and repl cells', async () => {
-    const notebook = await runDocumentToIpynb(
+  it('chooses the dominant data kernel and marks downgraded bash and repl cells', () => {
+    const notebook = runDocumentToIpynb(
       makeDocument([
-        makeRun({ runId: 'r-1', kernelKind: 'r', script: 'print(1)' }),
-        makeRun({ runId: 'r-2', kernelKind: 'r', script: 'print(2)' }),
+        makeRun({ runId: 'r-1', kernelKind: 'r', script: 'print(1)', environment: 'default-r' }),
+        makeRun({ runId: 'r-2', kernelKind: 'r', script: 'print(2)', environment: 'default-r' }),
         makeRun({ runId: 'py', kernelKind: 'python' }),
         makeRun({ runId: 'bash', kernelKind: 'bash', script: 'pwd', environment: undefined }),
         makeRun({
@@ -144,6 +166,8 @@ describe('runDocumentToIpynb', () => {
       language: 'R',
       name: 'ir'
     })
+    // Notebook-level environment follows the dominant (r) kernel's runs, not the python minority.
+    expect(notebook.metadata.open_science.environment).toBe('default-r')
     expect(notebook.cells[3]).toMatchObject({
       source: ['%%bash\n', 'pwd'],
       metadata: { tags: ['open-science-bash'], open_science: { kernel: 'bash' } }
@@ -154,69 +178,121 @@ describe('runDocumentToIpynb', () => {
     })
   })
 
-  it('sets unfinished execution counts to null and emits valid unique run-based cell ids', async () => {
-    const notebook = await runDocumentToIpynb(
+  it('passes execution counts through for every run status, including interrupted', () => {
+    const notebook = runDocumentToIpynb(
       makeDocument([
         makeRun({ runId: 'run.with invalid spaces', cellId: 'same', status: 'running' }),
-        makeRun({ runId: 'run-2', cellId: 'same', status: 'interrupted' })
+        makeRun({ runId: 'run-2', cellId: 'same', status: 'interrupted' }),
+        makeRun({ runId: 'run-3', cellId: 'other', status: 'cancelled', executionCount: undefined })
       ])
     )
 
-    expect(notebook.cells.map((cell) => cell.id)).toEqual(['run-with-invalid-spaces', 'run-2'])
-    expect(notebook.cells.map((cell) => cell.execution_count)).toEqual([null, null])
+    expect(notebook.cells.map((cell) => cell.id)).toEqual([
+      'run-with-invalid-spaces',
+      'run-2',
+      'run-3'
+    ])
+    expect(notebook.cells.map((cell) => cell.execution_count)).toEqual([1, 1, null])
   })
 
-  it('inlines resolved artifacts and degrades resolver failures to stderr', async () => {
-    const run = makeRun({
-      artifacts: [
-        {
-          id: 'a1',
-          projectName: 'default-project',
-          sessionId: 'session-123',
-          runId: 'run-1',
-          name: 'plot.png',
-          path: '/data/plot.png',
-          fileUrl: 'artifact://plot.png',
-          mimeType: 'image/png',
-          size: 3,
-          mtimeMs: 1
-        },
-        {
-          id: 'a2',
-          projectName: 'default-project',
-          sessionId: 'session-123',
-          runId: 'run-1',
-          name: 'missing.txt',
-          path: '/data/missing.txt',
-          fileUrl: 'artifact://missing.txt',
-          mimeType: 'text/plain',
-          size: 0,
-          mtimeMs: 1
-        }
-      ]
-    })
-    const resolveArtifact = vi.fn(async (artifact: NotebookRunRecord['artifacts'][number]) => {
-      if (artifact.id === 'a2') throw new Error('missing')
-      return { mimeType: 'image/png', data: 'cG5n' }
-    })
+  it('keeps cell ids unique and within nbformat’s 64-character budget', () => {
+    const oversized = `run-${'x'.repeat(100)}`
+    const notebook = runDocumentToIpynb(
+      makeDocument([
+        makeRun({ runId: oversized }),
+        makeRun({ runId: `${oversized}-different-tail` }),
+        makeRun({ runId: '!!!' })
+      ])
+    )
 
-    const notebook = await runDocumentToIpynb(makeDocument([run]), { resolveArtifact })
+    const ids = notebook.cells.map((cell) => cell.id)
+    expect(ids[0]).toBe(oversized.slice(0, 64))
+    // The second runId truncates to the same 64 chars, so the dedup suffix kicks in.
+    expect(ids[1]).toBe(`${oversized.slice(0, 62)}-2`)
+    expect(ids[2]).toBe('open-science-cell')
+    expect(new Set(ids).size).toBe(3)
+    for (const id of ids) {
+      expect(id).toMatch(/^[A-Za-z0-9-_]{1,64}$/)
+    }
+  })
+
+  it('appends pre-resolved artifact outputs without doing any IO itself', () => {
+    const artifactOutputs = new Map<string, NbformatOutput[]>([
+      [
+        'run-1',
+        [
+          {
+            output_type: 'display_data',
+            data: { 'image/svg+xml': '<svg xmlns="http://www.w3.org/2000/svg"/>' },
+            metadata: {}
+          }
+        ]
+      ]
+    ])
+
+    const notebook = runDocumentToIpynb(makeDocument([makeRun()]), { artifactOutputs })
 
     expect(notebook.cells[0].outputs).toEqual([
-      { output_type: 'display_data', data: { 'image/png': 'cG5n' }, metadata: {} },
       {
-        output_type: 'stream',
-        name: 'stderr',
-        text: ['[Open Science] Could not inline artifact: missing.txt\n']
+        output_type: 'display_data',
+        data: { 'image/svg+xml': '<svg xmlns="http://www.w3.org/2000/svg"/>' },
+        metadata: {}
       }
     ])
   })
 
-  it('is idempotent for the same document and deterministic resolver', async () => {
-    const document = makeDocument([makeRun()])
-    const first = await runDocumentToIpynb(document)
-    const second = await runDocumentToIpynb(document)
+  it('is byte-identical for the same document and embeds no absolute paths', () => {
+    const document = makeDocument([
+      makeRun({ outputs: [{ type: 'display', data: { 'image/png': 'aW1hZ2U=' } }] })
+    ])
+    const artifactOutputs = new Map<string, NbformatOutput[]>([
+      ['run-1', [{ output_type: 'display_data', data: { 'image/png': 'cG5n' }, metadata: {} }]]
+    ])
 
-    expect(second).toEqual(first)
+    const first = `${JSON.stringify(runDocumentToIpynb(document, { appVersion: '1.2.3', artifactOutputs }), null, 2)}\n`
+    const second = `${JSON.stringify(runDocumentToIpynb(document, { appVersion: '1.2.3', artifactOutputs }), null, 2)}\n`
+
+    expect(first).toBe(second)
+    expect(first).not.toContain('/workspace')
+    expect(first).not.toContain('/data/notebooks')
+    expect(first).not.toContain('/data/runtime')
+  })
+
+  it('validates against the nbformat 4.5 JSON schema', async () => {
+    const document = makeDocument([
+      makeRun({
+        outputs: [
+          { type: 'stream', name: 'stdout', text: 'hello\n' },
+          { type: 'display', data: { 'image/png': 'aW1hZ2U=' } },
+          { type: 'json', data: { answer: 42 } },
+          { type: 'text', text: '4' },
+          { type: 'error', name: 'ValueError', message: 'bad value', traceback: 'line 1\nline 2' }
+        ]
+      }),
+      makeRun({ runId: 'bash-1', kernelKind: 'bash', script: 'pwd', environment: undefined }),
+      makeRun({
+        runId: 'repl-1',
+        kernelKind: 'repl',
+        script: 'await host.mcp()',
+        environment: undefined
+      }),
+      makeRun({ runId: 'r-1', kernelKind: 'r', script: 'print(1)', environment: 'default-r' })
+    ])
+    const artifactOutputs = new Map<string, NbformatOutput[]>([
+      [
+        'run-1',
+        [
+          {
+            output_type: 'display_data',
+            data: { 'image/svg+xml': '<svg xmlns="http://www.w3.org/2000/svg"/>' },
+            metadata: {}
+          }
+        ]
+      ]
+    ])
+
+    const notebook = runDocumentToIpynb(document, { appVersion: '1.2.3', artifactOutputs })
+
+    await validateAgainstNbformatSchema(notebook)
   })
 })

--- a/src/main/notebook/ipynb-export.ts
+++ b/src/main/notebook/ipynb-export.ts
@@ -26,7 +26,10 @@ type NbformatOutput =
 
 type OpenScienceCellMetadata = {
   runId: string
+  cellId: string
+  source: NotebookRunRecord['source']
   startedAt: number
+  endedAt?: number
   status: NotebookRunRecord['status']
   kernel: NotebookKernelKind
   environment?: string
@@ -58,7 +61,11 @@ type IpynbNotebook = {
     open_science: {
       sessionId: string
       projectName: string
+      artifactSessionId?: string
       appVersion?: string
+      // The dominant analysis kernel's env (see dominantEnvironment), per issue #293's
+      // notebook-level metadata; omitted when no analysis run recorded one.
+      environment?: string
     }
   }
   nbformat: 4
@@ -72,10 +79,10 @@ type ResolvedArtifact = {
 
 type RunDocumentToIpynbOptions = {
   appVersion?: string
-  resolveArtifact?: (
-    artifact: NotebookRunRecord['artifacts'][number],
-    run: NotebookRunRecord
-  ) => Promise<ResolvedArtifact | null>
+  // Per-run artifact outputs keyed by runId, produced by the caller's async IO phase (artifact
+  // file reads) BEFORE this projection runs — keeping this module a pure function of
+  // (document, artifactOutputs, appVersion) whose result never depends on filesystem state.
+  artifactOutputs?: ReadonlyMap<string, NbformatOutput[]>
 }
 
 // nbformat accepts either one string or an array of lines. Arrays make generated notebooks stable and
@@ -86,9 +93,28 @@ const splitLines = (value: string): string[] => {
   return lines ?? []
 }
 
-const nbformatCellId = (runId: string): string => {
-  const safe = runId.replace(/[^A-Za-z0-9_-]/g, '-').slice(0, 64)
-  return safe || 'open-science-cell'
+// nbformat 4.5 cell ids are 1-64 chars of [A-Za-z0-9-_] and must be unique per notebook. runIds
+// already satisfy that almost always, so sanitize rather than generate; dedup suffixes (only
+// reachable via truncation collisions or empty ids) reserve room from the same 64-char budget.
+const MAX_CELL_ID_LENGTH = 64
+
+const nbformatCellId = (runId: string, seen: Set<string>): string => {
+  const base =
+    runId
+      .replace(/[^A-Za-z0-9_-]/g, '-')
+      .slice(0, MAX_CELL_ID_LENGTH)
+      .replace(/^-+|-+$/g, '') || 'open-science-cell'
+
+  let candidate = base
+  let suffix = 2
+  while (seen.has(candidate)) {
+    const suffixText = `-${suffix}`
+    candidate = `${base.slice(0, MAX_CELL_ID_LENGTH - suffixText.length)}${suffixText}`
+    suffix += 1
+  }
+  seen.add(candidate)
+
+  return candidate
 }
 
 const shellSource = (run: NotebookRunRecord): string => {
@@ -159,10 +185,9 @@ const fallbackTextOutputs = (run: NotebookRunRecord): NbformatOutput[] => {
   return outputs
 }
 
-const executionCountFor = (run: NotebookRunRecord): number | null =>
-  run.status === 'completed' || run.status === 'failed' || run.status === 'timeout'
-    ? (run.executionCount ?? null)
-    : null
+// Direct field mapping per issue #293: run.json's executionCount passes through for every status —
+// including interrupted/cancelled runs, which still executed (partially) under that count.
+const executionCountFor = (run: NotebookRunRecord): number | null => run.executionCount ?? null
 
 const dominantKernel = (runs: NotebookRunRecord[]): 'python' | 'r' => {
   let python = 0
@@ -179,38 +204,35 @@ const kernelspecFor = (kernel: 'python' | 'r'): IpynbNotebook['metadata']['kerne
     ? { display_name: 'R', language: 'R', name: 'ir' }
     : { display_name: 'Python 3', language: 'python', name: 'python3' }
 
-const artifactOutputs = async (
-  run: NotebookRunRecord,
-  resolver: RunDocumentToIpynbOptions['resolveArtifact']
-): Promise<NbformatOutput[]> => {
-  if (!resolver) return []
+// The notebook-level environment name (#293): the dominant analysis kernel's most frequent run
+// environment. Ties resolve to first-seen (Map insertion order), keeping the pick deterministic.
+const dominantEnvironment = (
+  runs: NotebookRunRecord[],
+  kernel: 'python' | 'r'
+): string | undefined => {
+  const counts = new Map<string, number>()
+  for (const run of runs) {
+    if (run.kernelKind !== kernel || !run.environment) continue
+    counts.set(run.environment, (counts.get(run.environment) ?? 0) + 1)
+  }
 
-  const outputs: NbformatOutput[] = []
-  for (const artifact of run.artifacts) {
-    try {
-      const resolved = await resolver(artifact, run)
-      if (resolved) {
-        outputs.push({
-          output_type: 'display_data',
-          data: { [resolved.mimeType]: resolved.data },
-          metadata: {}
-        })
-      }
-    } catch {
-      outputs.push({
-        output_type: 'stream',
-        name: 'stderr',
-        text: [`[Open Science] Could not inline artifact: ${artifact.name}\n`]
-      })
+  let best: string | undefined
+  let bestCount = 0
+  for (const [environment, count] of counts) {
+    if (count > bestCount) {
+      best = environment
+      bestCount = count
     }
   }
-  return outputs
+
+  return best
 }
 
-const runToCell = async (
+const runToCell = (
   run: NotebookRunRecord,
-  options: RunDocumentToIpynbOptions
-): Promise<NbformatCodeCell> => {
+  options: RunDocumentToIpynbOptions,
+  seen: Set<string>
+): NbformatCodeCell => {
   const executionCount = executionCountFor(run)
   const structuredOutputs =
     run.outputs.length > 0
@@ -219,7 +241,10 @@ const runToCell = async (
   const metadata: NbformatCodeCell['metadata'] = {
     open_science: {
       runId: run.runId,
+      cellId: run.cellId,
+      source: run.source,
       startedAt: run.startedAt,
+      ...(run.endedAt === undefined ? {} : { endedAt: run.endedAt }),
       status: run.status,
       kernel: run.kernelKind,
       ...(run.environment ? { environment: run.environment } : {})
@@ -233,31 +258,37 @@ const runToCell = async (
   return {
     cell_type: 'code',
     execution_count: executionCount,
-    id: nbformatCellId(run.runId),
+    id: nbformatCellId(run.runId, seen),
     metadata,
-    outputs: [...structuredOutputs, ...(await artifactOutputs(run, options.resolveArtifact))],
+    outputs: [...structuredOutputs, ...(options.artifactOutputs?.get(run.runId) ?? [])],
     source: splitLines(shellSource(run))
   }
 }
 
-// Projects the append-only run document into a standards-compliant nbformat 4.5 notebook without
-// changing run.json. Artifact IO is injected so the mapping stays deterministic and unit-testable.
-const runDocumentToIpynb = async (
+// Pure, synchronous projection of the append-only run document into a standards-compliant nbformat
+// 4.5 notebook, without changing run.json. All IO (artifact file reads) happens in the caller
+// beforehand and arrives via options.artifactOutputs, so the output is byte-identical for the same
+// (document, artifactOutputs, appVersion) inputs and never depends on filesystem state.
+const runDocumentToIpynb = (
   document: NotebookRunDocument,
   options: RunDocumentToIpynbOptions = {}
-): Promise<IpynbNotebook> => {
+): IpynbNotebook => {
   const kernel = dominantKernel(document.runs)
   const kernelspec = kernelspecFor(kernel)
+  const environment = dominantEnvironment(document.runs, kernel)
+  const seen = new Set<string>()
 
   return {
-    cells: await Promise.all(document.runs.map((run) => runToCell(run, options))),
+    cells: document.runs.map((run) => runToCell(run, options, seen)),
     metadata: {
       kernelspec,
       language_info: { name: kernelspec.language },
       open_science: {
         sessionId: document.sessionId,
         projectName: document.projectName,
-        ...(options.appVersion ? { appVersion: options.appVersion } : {})
+        ...(document.artifactSessionId ? { artifactSessionId: document.artifactSessionId } : {}),
+        ...(options.appVersion ? { appVersion: options.appVersion } : {}),
+        ...(environment ? { environment } : {})
       }
     },
     nbformat: 4,
@@ -266,4 +297,4 @@ const runDocumentToIpynb = async (
 }
 
 export { runDocumentToIpynb }
-export type { IpynbNotebook, ResolvedArtifact, RunDocumentToIpynbOptions }
+export type { IpynbNotebook, NbformatOutput, ResolvedArtifact, RunDocumentToIpynbOptions }

--- a/src/main/notebook/runtime-service.export.test.ts
+++ b/src/main/notebook/runtime-service.export.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { NotebookRunDocument } from '../../shared/notebook'
 import type { NotebookRunRepository } from './repository'
@@ -91,5 +94,97 @@ describe('NotebookRuntimeService exportIpynb', () => {
       service.exportIpynb({ sessionId: 'missing', workspaceCwd: '/workspace' })
     ).rejects.toThrow('Notebook session not found: missing')
     expect(saveIpynb).not.toHaveBeenCalled()
+  })
+
+  describe('artifact inlining', () => {
+    let sessionRoot: string | undefined
+
+    afterEach(async () => {
+      if (sessionRoot) {
+        await rm(sessionRoot, { recursive: true, force: true })
+        sessionRoot = undefined
+      }
+    })
+
+    const createSessionRoot = async (): Promise<string> => {
+      sessionRoot = await mkdtemp(join(tmpdir(), 'open-science-ipynb-artifacts-'))
+      return sessionRoot
+    }
+
+    const exportWithArtifact = async (
+      root: string,
+      artifact: NotebookRunDocument['runs'][number]['artifacts'][number]
+    ): Promise<Record<string, unknown>> => {
+      const documentWithArtifact: NotebookRunDocument = {
+        ...document,
+        notebookSessionRoot: root,
+        runs: [{ ...document.runs[0], artifacts: [artifact] }]
+      }
+      const repository = {
+        findExisting: vi.fn().mockResolvedValue(documentWithArtifact)
+      } as unknown as NotebookRunRepository
+      const saveIpynb = vi.fn().mockResolvedValue({ saved: true, filePath: '/out/session.ipynb' })
+      const service = new NotebookRuntimeService({
+        configRoot: '/config',
+        dataRoot: '/storage',
+        projectName: 'default-project',
+        repository,
+        saveIpynb
+      })
+
+      await service.exportIpynb({ sessionId: '12345678-abcd', workspaceCwd: '/workspace' })
+
+      const notebook = JSON.parse(saveIpynb.mock.calls[0][1]) as {
+        cells: Array<{ outputs: Array<{ output_type: string; data?: Record<string, unknown> }> }>
+      }
+      // The run's own stream fallback comes first; the artifact display output follows it.
+      const display = notebook.cells[0].outputs.find(
+        (output) => output.output_type === 'display_data'
+      )
+      return display?.data ?? {}
+    }
+
+    it('inlines SVG artifacts as raw text, not base64', async () => {
+      const root = await createSessionRoot()
+      const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1"/></svg>'
+      const svgPath = join(root, 'plot.svg')
+      await writeFile(svgPath, svg)
+
+      const data = await exportWithArtifact(root, {
+        id: 'a1',
+        projectName: 'default-project',
+        sessionId: '12345678-abcd',
+        runId: 'run-1',
+        name: 'plot.svg',
+        path: svgPath,
+        fileUrl: 'artifact://plot.svg',
+        mimeType: 'image/svg+xml',
+        size: svg.length,
+        mtimeMs: 1
+      })
+
+      expect(data['image/svg+xml']).toBe(svg)
+    })
+
+    it('inlines binary image artifacts as base64', async () => {
+      const root = await createSessionRoot()
+      const pngPath = join(root, 'plot.png')
+      await writeFile(pngPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+
+      const data = await exportWithArtifact(root, {
+        id: 'a2',
+        projectName: 'default-project',
+        sessionId: '12345678-abcd',
+        runId: 'run-1',
+        name: 'plot.png',
+        path: pngPath,
+        fileUrl: 'artifact://plot.png',
+        mimeType: 'image/png',
+        size: 4,
+        mtimeMs: 1
+      })
+
+      expect(data['image/png']).toBe(Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'))
+    })
   })
 })

--- a/src/main/notebook/runtime-service.export.test.ts
+++ b/src/main/notebook/runtime-service.export.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -111,10 +111,38 @@ describe('NotebookRuntimeService exportIpynb', () => {
       return sessionRoot
     }
 
+    type ArtifactRecord = NotebookRunDocument['runs'][number]['artifacts'][number]
+
+    const makeArtifact = (overrides: Partial<ArtifactRecord> = {}): ArtifactRecord => ({
+      id: 'a1',
+      projectName: 'default-project',
+      sessionId: '12345678-abcd',
+      runId: 'run-1',
+      name: 'plot.png',
+      path: '',
+      fileUrl: 'artifact://plot.png',
+      mimeType: 'image/png',
+      size: 0,
+      mtimeMs: 1,
+      ...overrides
+    })
+
+    type ExportResult = {
+      outputs: Array<{ output_type: string; data?: Record<string, unknown>; text?: string[] }>
+      json: string
+    }
+
     const exportWithArtifact = async (
       root: string,
-      artifact: NotebookRunDocument['runs'][number]['artifacts'][number]
-    ): Promise<Record<string, unknown>> => {
+      artifact: ArtifactRecord,
+      options: {
+        resolveArtifactPath?: (request: {
+          path: string
+          projectName: string
+          sessionId: string
+        }) => Promise<string>
+      } = {}
+    ): Promise<ExportResult> => {
       const documentWithArtifact: NotebookRunDocument = {
         ...document,
         notebookSessionRoot: root,
@@ -129,20 +157,22 @@ describe('NotebookRuntimeService exportIpynb', () => {
         dataRoot: '/storage',
         projectName: 'default-project',
         repository,
-        saveIpynb
+        saveIpynb,
+        ...(options.resolveArtifactPath ? { resolveArtifactPath: options.resolveArtifactPath } : {})
       })
 
       await service.exportIpynb({ sessionId: '12345678-abcd', workspaceCwd: '/workspace' })
 
-      const notebook = JSON.parse(saveIpynb.mock.calls[0][1]) as {
-        cells: Array<{ outputs: Array<{ output_type: string; data?: Record<string, unknown> }> }>
+      const json = saveIpynb.mock.calls[0][1] as string
+      const notebook = JSON.parse(json) as {
+        cells: Array<{ outputs: ExportResult['outputs'] }>
       }
-      // The run's own stream fallback comes first; the artifact display output follows it.
-      const display = notebook.cells[0].outputs.find(
-        (output) => output.output_type === 'display_data'
-      )
-      return display?.data ?? {}
+      return { outputs: notebook.cells[0].outputs, json }
     }
+
+    // The run's own stream fallback comes first; the artifact display output follows it.
+    const displayData = (result: ExportResult): Record<string, unknown> =>
+      result.outputs.find((output) => output.output_type === 'display_data')?.data ?? {}
 
     it('inlines SVG artifacts as raw text, not base64', async () => {
       const root = await createSessionRoot()
@@ -150,20 +180,17 @@ describe('NotebookRuntimeService exportIpynb', () => {
       const svgPath = join(root, 'plot.svg')
       await writeFile(svgPath, svg)
 
-      const data = await exportWithArtifact(root, {
-        id: 'a1',
-        projectName: 'default-project',
-        sessionId: '12345678-abcd',
-        runId: 'run-1',
-        name: 'plot.svg',
-        path: svgPath,
-        fileUrl: 'artifact://plot.svg',
-        mimeType: 'image/svg+xml',
-        size: svg.length,
-        mtimeMs: 1
-      })
+      const result = await exportWithArtifact(
+        root,
+        makeArtifact({
+          name: 'plot.svg',
+          path: svgPath,
+          mimeType: 'image/svg+xml',
+          size: svg.length
+        })
+      )
 
-      expect(data['image/svg+xml']).toBe(svg)
+      expect(displayData(result)['image/svg+xml']).toBe(svg)
     })
 
     it('inlines binary image artifacts as base64', async () => {
@@ -171,20 +198,95 @@ describe('NotebookRuntimeService exportIpynb', () => {
       const pngPath = join(root, 'plot.png')
       await writeFile(pngPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
 
-      const data = await exportWithArtifact(root, {
-        id: 'a2',
-        projectName: 'default-project',
-        sessionId: '12345678-abcd',
-        runId: 'run-1',
-        name: 'plot.png',
-        path: pngPath,
-        fileUrl: 'artifact://plot.png',
-        mimeType: 'image/png',
-        size: 4,
-        mtimeMs: 1
+      const result = await exportWithArtifact(root, makeArtifact({ path: pngPath, size: 4 }))
+
+      expect(displayData(result)['image/png']).toBe(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64')
+      )
+    })
+
+    // File symlinks need elevated privileges on Windows; covered on POSIX CI.
+    it.skipIf(process.platform === 'win32')(
+      'refuses to inline a notebook-root symlink that escapes the session root',
+      async () => {
+        const root = await createSessionRoot()
+        const outsideDir = await mkdtemp(join(tmpdir(), 'open-science-ipynb-outside-'))
+        try {
+          const secretPath = join(outsideDir, 'secret.png')
+          await writeFile(secretPath, 'secret-png-bytes')
+          const linkPath = join(root, 'link.png')
+          await symlink(secretPath, linkPath)
+
+          const result = await exportWithArtifact(
+            root,
+            makeArtifact({ name: 'link.png', path: linkPath })
+          )
+
+          expect(result.outputs.some((output) => output.output_type === 'display_data')).toBe(false)
+          expect(result.outputs.some((output) => output.output_type === 'stream')).toBe(true)
+          expect(result.json).not.toContain('secret-png-bytes')
+        } finally {
+          await rm(outsideDir, { recursive: true, force: true })
+        }
+      }
+    )
+
+    it('inlines a managed artifact resolved inside the declaring session subtree', async () => {
+      const root = await createSessionRoot()
+      // The managed artifact tree lives outside the notebook session root, so resolution goes
+      // through the session-scoped resolver rather than the notebook-root branch.
+      const managedRoot = await mkdtemp(join(tmpdir(), 'open-science-ipynb-managed-'))
+      try {
+        const managedDir = join(managedRoot, 'artifacts', 'default-project', '12345678-abcd')
+        await mkdir(managedDir, { recursive: true })
+        const managedPath = join(managedDir, 'plot.png')
+        await writeFile(managedPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+        const resolveArtifactPath = vi.fn(
+          async (request: { path: string; projectName: string; sessionId: string }) => request.path
+        )
+
+        const result = await exportWithArtifact(
+          root,
+          makeArtifact({ path: managedPath, size: 4 }),
+          { resolveArtifactPath }
+        )
+
+        expect(resolveArtifactPath).toHaveBeenCalledWith({
+          path: managedPath,
+          projectName: 'default-project',
+          sessionId: '12345678-abcd'
+        })
+        expect(displayData(result)['image/png']).toBe(
+          Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64')
+        )
+      } finally {
+        await rm(managedRoot, { recursive: true, force: true })
+      }
+    })
+
+    it('degrades a managed artifact the session-scoped resolver rejects to a stderr marker', async () => {
+      const root = await createSessionRoot()
+      const outsidePath = join(
+        tmpdir(),
+        'artifacts',
+        'default-project',
+        'other-session',
+        'plot.png'
+      )
+      const resolveArtifactPath = vi.fn(async () => {
+        throw new Error('Artifact file is outside the declaring session.')
       })
 
-      expect(data['image/png']).toBe(Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'))
+      const result = await exportWithArtifact(root, makeArtifact({ path: outsidePath }), {
+        resolveArtifactPath
+      })
+
+      expect(result.outputs.some((output) => output.output_type === 'display_data')).toBe(false)
+      expect(result.outputs).toContainEqual({
+        output_type: 'stream',
+        name: 'stderr',
+        text: ['[Open Science] Could not inline artifact: plot.png\n']
+      })
     })
   })
 })

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { existsSync, realpathSync } from 'node:fs'
-import { readFile, rm, writeFile } from 'node:fs/promises'
+import { readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type {
@@ -308,8 +308,13 @@ type NotebookRuntimeServiceOptions = {
   appVersion?: string
   // Save-dialog seam for notebook export tests. Production falls back to Electron's native dialog.
   saveIpynb?: (suggestedName: string, data: string) => Promise<ExportNotebookResult>
-  // Resolves app-managed artifact paths with the artifact repository's canonical/symlink checks.
-  resolveArtifactPath?: (path: string) => Promise<string>
+  // Resolves app-managed artifact paths with the artifact repository's canonical/symlink checks,
+  // bound to the artifact's declaring project/session subtree.
+  resolveArtifactPath?: (request: {
+    path: string
+    projectName: string
+    sessionId: string
+  }) => Promise<string>
 }
 
 // The wire binding plus the interpreter override the executor needs. `resolvedInterpreter` is set only
@@ -393,13 +398,31 @@ const isPathInside = (root: string, candidate: string): boolean => {
 const artifactMimeData = async (
   root: string,
   artifact: NotebookRunRecord['artifacts'][number],
-  resolveManagedPath?: (path: string) => Promise<string>
+  resolveManagedPath?: (request: {
+    path: string
+    projectName: string
+    sessionId: string
+  }) => Promise<string>
 ): Promise<ResolvedArtifact | null> => {
   const mimeType = artifact.mimeType
   if (!mimeType) return null
-  const filePath = isPathInside(root, artifact.path)
-    ? artifact.path
-    : await resolveManagedPath?.(artifact.path)
+
+  let filePath: string | undefined
+  if (isPathInside(root, artifact.path)) {
+    // Lexical containment is not enough — a symlink inside the notebook root can point anywhere.
+    // Canonicalize both sides and require the real path to stay inside the real notebook root.
+    const [realRoot, realFilePath] = await Promise.all([realpath(root), realpath(artifact.path)])
+    if (!isPathInside(realRoot, realFilePath)) {
+      throw new Error(`Artifact escapes the notebook session root: ${artifact.name}`)
+    }
+    filePath = realFilePath
+  } else {
+    filePath = await resolveManagedPath?.({
+      path: artifact.path,
+      projectName: artifact.projectName,
+      sessionId: artifact.sessionId
+    })
+  }
   if (!filePath) return null
 
   const binary = await readFile(filePath)
@@ -425,7 +448,11 @@ const artifactMimeData = async (
 // to a stderr marker output rather than aborting the export.
 const resolveNotebookArtifactOutputs = async (
   document: NotebookRunDocument,
-  resolveManagedPath?: (path: string) => Promise<string>
+  resolveManagedPath?: (request: {
+    path: string
+    projectName: string
+    sessionId: string
+  }) => Promise<string>
 ): Promise<Map<string, NbformatOutput[]>> => {
   const outputsByRun = new Map<string, NbformatOutput[]>()
   const artifactSessionId = document.artifactSessionId ?? document.sessionId

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -17,6 +17,7 @@ import type {
   NotebookKernelMetadata,
   NotebookLanguage,
   NotebookOutput,
+  NotebookRunDocument,
   NotebookRunRecord,
   NotebookRunSource,
   NotebookRunStatus,
@@ -35,7 +36,7 @@ import type {
   ProvisionProgress
 } from '../../shared/notebook-env'
 import type { PackageMirror } from '../../shared/mirror'
-import { runDocumentToIpynb, type ResolvedArtifact } from './ipynb-export'
+import { runDocumentToIpynb, type NbformatOutput, type ResolvedArtifact } from './ipynb-export'
 import { NotebookKernelExecutor, type NotebookKernelExecutorOptions } from './kernel-executor'
 import type { KernelProcessKind } from './kernel-executor'
 import { effectiveMirrorAsync, type ProbeDeps } from './mirror-probe'
@@ -402,6 +403,10 @@ const artifactMimeData = async (
   if (!filePath) return null
 
   const binary = await readFile(filePath)
+  // nbformat stores SVG as raw text; only binary images (png/jpeg/…) are base64-encoded.
+  if (mimeType === 'image/svg+xml') {
+    return { mimeType, data: binary.toString('utf8') }
+  }
   if (mimeType.startsWith('image/')) {
     return { mimeType, data: binary.toString('base64') }
   }
@@ -412,6 +417,49 @@ const artifactMimeData = async (
     return { mimeType, data: binary.toString('utf8') }
   }
   return null
+}
+
+// The IO phase of an ipynb export: resolves every run's artifacts into nbformat outputs up front,
+// so the projection itself (runDocumentToIpynb) is a pure function that never touches the
+// filesystem. Only artifacts belonging to this document are inlined; read/parse failures degrade
+// to a stderr marker output rather than aborting the export.
+const resolveNotebookArtifactOutputs = async (
+  document: NotebookRunDocument,
+  resolveManagedPath?: (path: string) => Promise<string>
+): Promise<Map<string, NbformatOutput[]>> => {
+  const outputsByRun = new Map<string, NbformatOutput[]>()
+  const artifactSessionId = document.artifactSessionId ?? document.sessionId
+
+  for (const run of document.runs) {
+    if (run.artifacts.length === 0) continue
+
+    const outputs: NbformatOutput[] = []
+    for (const artifact of run.artifacts) {
+      try {
+        const belongsToDocument =
+          artifact.projectName === document.projectName && artifact.sessionId === artifactSessionId
+        const resolved = belongsToDocument
+          ? await artifactMimeData(document.notebookSessionRoot, artifact, resolveManagedPath)
+          : null
+        if (resolved) {
+          outputs.push({
+            output_type: 'display_data',
+            data: { [resolved.mimeType]: resolved.data },
+            metadata: {}
+          })
+        }
+      } catch {
+        outputs.push({
+          output_type: 'stream',
+          name: 'stderr',
+          text: [`[Open Science] Could not inline artifact: ${artifact.name}\n`]
+        })
+      }
+    }
+    outputsByRun.set(run.runId, outputs)
+  }
+
+  return outputsByRun
 }
 
 // Builds the compact plain text output list shown in the preview panel.
@@ -1930,6 +1978,7 @@ class NotebookRuntimeService {
   }
 
   // Exports the durable history as an nbformat projection; run.json remains the source of truth.
+  // Artifact IO is resolved first, then the projection runs as a pure function over the result.
   async exportIpynb(request: NotebookSessionRequest): Promise<ExportNotebookResult> {
     const projectName = request.projectName ?? this.options.projectName
     const document = await this.repository.findExisting(projectName, request.sessionId)
@@ -1937,22 +1986,13 @@ class NotebookRuntimeService {
       throw new Error(`Notebook session not found: ${request.sessionId}`)
     }
 
-    const notebook = await runDocumentToIpynb(document, {
+    const artifactOutputs = await resolveNotebookArtifactOutputs(
+      document,
+      this.options.resolveArtifactPath
+    )
+    const notebook = runDocumentToIpynb(document, {
       appVersion: this.options.appVersion,
-      resolveArtifact: (artifact) => {
-        const artifactSessionId = document.artifactSessionId ?? document.sessionId
-        if (
-          artifact.projectName !== document.projectName ||
-          artifact.sessionId !== artifactSessionId
-        ) {
-          return Promise.resolve(null)
-        }
-        return artifactMimeData(
-          document.notebookSessionRoot,
-          artifact,
-          this.options.resolveArtifactPath
-        )
-      }
+      artifactOutputs
     })
     const suggestedName = `session-${request.sessionId.slice(0, 8)}.ipynb`
     const serialized = `${JSON.stringify(notebook, null, 2)}\n`

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx
@@ -27,6 +27,7 @@ let container: HTMLDivElement
 let root: Root
 
 beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -35,6 +36,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount())
   container.remove()
+  vi.restoreAllMocks()
 })
 
 describe('SessionNotebookContent export', () => {
@@ -89,5 +91,66 @@ describe('SessionNotebookContent export', () => {
 
     expect(container.querySelector('[role="alert"]')?.textContent).toBe('Disk is full')
     expect(button?.disabled).toBe(false)
+  })
+
+  it('logs export failures for diagnostics, not just the footer banner', async () => {
+    const failure = new Error('Disk is full')
+    const onExport = vi.fn().mockRejectedValue(failure)
+    await act(async () => {
+      root.render(
+        <SessionNotebookContent
+          sessionId="session-1"
+          runs={[run]}
+          status="ready"
+          onClose={vi.fn()}
+          onExport={onExport}
+        />
+      )
+    })
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button[aria-label="Download as .ipynb"]')?.click()
+      await Promise.resolve()
+    })
+
+    expect(console.error).toHaveBeenCalledWith('Failed to export notebook as .ipynb:', failure)
+  })
+
+  it('discards a failed export state when the content remounts for another session', async () => {
+    const failingExport = vi.fn().mockRejectedValue(new Error('Disk is full'))
+    await act(async () => {
+      root.render(
+        <SessionNotebookContent
+          key="session-a"
+          sessionId="session-a"
+          runs={[run]}
+          status="ready"
+          onClose={vi.fn()}
+          onExport={failingExport}
+        />
+      )
+    })
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button[aria-label="Download as .ipynb"]')?.click()
+      await Promise.resolve()
+    })
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe('Disk is full')
+
+    // The container remounts SessionNotebookContent with key={session.id} on session switch.
+    await act(async () => {
+      root.render(
+        <SessionNotebookContent
+          key="session-b"
+          sessionId="session-b"
+          runs={[run]}
+          status="ready"
+          onClose={vi.fn()}
+          onExport={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe('')
   })
 })

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Download, LoaderCircle, X } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { ChatSession } from '@/stores/session-store'
 
@@ -126,6 +127,9 @@ const SessionNotebookContent = ({
     try {
       await onExport()
     } catch (exportFailure) {
+      // A canceled Save As resolves rather than throws, so reaching here is a real failure —
+      // keep a diagnostic trail in addition to the footer banner.
+      console.error('Failed to export notebook as .ipynb:', exportFailure)
       setExportError(getErrorMessage(exportFailure))
     } finally {
       setExporting(false)
@@ -211,20 +215,32 @@ const SessionNotebookContent = ({
         <p className="min-w-0 truncate text-xs text-danger-000" role="alert">
           {exportError}
         </p>
-        <button
-          type="button"
-          disabled={exportDisabled}
-          onClick={() => void handleExport()}
-          className="flex shrink-0 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
-          aria-label="Download as .ipynb"
-        >
-          {exporting ? (
-            <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
-          ) : (
-            <Download className="size-3.5" aria-hidden="true" />
-          )}
-          {exporting ? 'Exporting…' : '.ipynb'}
-        </button>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* Wrapper span keeps the tooltip reachable while the button is disabled. */}
+              <span>
+                <button
+                  type="button"
+                  disabled={exportDisabled}
+                  onClick={() => void handleExport()}
+                  className="flex shrink-0 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label="Download as .ipynb"
+                >
+                  {exporting ? (
+                    <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <Download className="size-3.5" aria-hidden="true" />
+                  )}
+                  {exporting ? 'Exporting…' : '.ipynb'}
+                </button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {runs.length === 0 ? 'No runs to export' : 'Download as .ipynb'}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
     </>
   )
@@ -300,6 +316,10 @@ const SessionNotebookDialog = ({
           <Dialog.Title className="sr-only">Session notebook</Dialog.Title>
           {session ? (
             <SessionNotebookContent
+              // Remount per session: the dialog is mounted once and the session prop swaps in
+              // place, so per-session export state (a failure banner, an in-flight setState from
+              // a superseded export) must be discarded rather than leak into the next session.
+              key={session.id}
               sessionId={session.id}
               runs={runs}
               status={status}

--- a/test/fixtures/nbformat.v4.5.schema.json
+++ b/test/fixtures/nbformat.v4.5.schema.json
@@ -1,0 +1,471 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Jupyter Notebook v4.5 JSON schema.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["metadata", "nbformat_minor", "nbformat", "cells"],
+  "properties": {
+    "metadata": {
+      "description": "Notebook root-level metadata.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "kernelspec": {
+          "description": "Kernel information.",
+          "type": "object",
+          "required": ["name", "display_name"],
+          "properties": {
+            "name": {
+              "description": "Name of the kernel specification.",
+              "type": "string"
+            },
+            "display_name": {
+              "description": "Name to display in UI.",
+              "type": "string"
+            }
+          }
+        },
+        "language_info": {
+          "description": "Kernel information.",
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "description": "The programming language which this kernel runs.",
+              "type": "string"
+            },
+            "codemirror_mode": {
+              "description": "The codemirror mode to use for code in this language.",
+              "oneOf": [{ "type": "string" }, { "type": "object" }]
+            },
+            "file_extension": {
+              "description": "The file extension for files in this language.",
+              "type": "string"
+            },
+            "mimetype": {
+              "description": "The mimetype corresponding to files in this language.",
+              "type": "string"
+            },
+            "pygments_lexer": {
+              "description": "The pygments lexer to use for code in this language.",
+              "type": "string"
+            }
+          }
+        },
+        "orig_nbformat": {
+          "description": "Original notebook format (major number) before converting the notebook between versions. This should never be written to a file.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "title": {
+          "description": "The title of the notebook document",
+          "type": "string"
+        },
+        "authors": {
+          "description": "The author(s) of the notebook document",
+          "type": "array",
+          "item": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "nbformat_minor": {
+      "description": "Notebook format (minor number). Incremented for backward compatible changes to the notebook format.",
+      "type": "integer",
+      "minimum": 5
+    },
+    "nbformat": {
+      "description": "Notebook format (major number). Incremented between backwards incompatible changes to the notebook format.",
+      "type": "integer",
+      "minimum": 4,
+      "maximum": 4
+    },
+    "cells": {
+      "description": "Array of cells of the current notebook.",
+      "type": "array",
+      "items": { "$ref": "#/definitions/cell" }
+    }
+  },
+
+  "definitions": {
+    "cell_id": {
+      "description": "A string field representing the identifier of this particular cell.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9-_]+$",
+      "minLength": 1,
+      "maxLength": 64
+    },
+
+    "cell": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/raw_cell" },
+        { "$ref": "#/definitions/markdown_cell" },
+        { "$ref": "#/definitions/code_cell" }
+      ]
+    },
+
+    "raw_cell": {
+      "description": "Notebook raw nbconvert cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "cell_type", "metadata", "source"],
+      "properties": {
+        "id": { "$ref": "#/definitions/cell_id" },
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["raw"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "format": {
+              "description": "Raw cell metadata format for nbconvert.",
+              "type": "string"
+            },
+            "jupyter": {
+              "description": "Official Jupyter Metadata for Raw Cells",
+              "type": "object",
+              "additionalProperties": true,
+              "source_hidden": {
+                "description": "Whether the source is hidden.",
+                "type": "boolean"
+              }
+            },
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          }
+        },
+        "attachments": { "$ref": "#/definitions/misc/attachments" },
+        "source": { "$ref": "#/definitions/misc/source" }
+      }
+    },
+
+    "markdown_cell": {
+      "description": "Notebook markdown cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "cell_type", "metadata", "source"],
+      "properties": {
+        "id": { "$ref": "#/definitions/cell_id" },
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["markdown"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "properties": {
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" },
+            "jupyter": {
+              "description": "Official Jupyter Metadata for Markdown Cells",
+              "type": "object",
+              "additionalProperties": true,
+              "source_hidden": {
+                "description": "Whether the source is hidden.",
+                "type": "boolean"
+              }
+            }
+          },
+          "additionalProperties": true
+        },
+        "attachments": { "$ref": "#/definitions/misc/attachments" },
+        "source": { "$ref": "#/definitions/misc/source" }
+      }
+    },
+
+    "code_cell": {
+      "description": "Notebook code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "cell_type",
+        "metadata",
+        "source",
+        "outputs",
+        "execution_count"
+      ],
+      "properties": {
+        "id": { "$ref": "#/definitions/cell_id" },
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["code"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "jupyter": {
+              "description": "Official Jupyter Metadata for Code Cells",
+              "type": "object",
+              "additionalProperties": true,
+              "source_hidden": {
+                "description": "Whether the source is hidden.",
+                "type": "boolean"
+              },
+              "outputs_hidden": {
+                "description": "Whether the outputs are hidden.",
+                "type": "boolean"
+              }
+            },
+            "execution": {
+              "description": "Execution time for the code in the cell. This tracks time at which messages are received from iopub or shell channels",
+              "type": "object",
+              "properties": {
+                "iopub.execute_input": {
+                  "description": "header.date (in ISO 8601 format) of iopub channel's execute_input message. It indicates the time at which the kernel broadcasts an execute_input message to connected frontends",
+                  "type": "string"
+                },
+                "iopub.status.busy": {
+                  "description": "header.date (in ISO 8601 format) of iopub channel's kernel status message when the status is 'busy'",
+                  "type": "string"
+                },
+                "shell.execute_reply": {
+                  "description": "header.date (in ISO 8601 format) of the shell channel's execute_reply message. It indicates the time at which the execute_reply message was created",
+                  "type": "string"
+                },
+                "iopub.status.idle": {
+                  "description": "header.date (in ISO 8601 format) of iopub channel's kernel status message when the status is 'idle'. It indicates the time at which kernel finished processing the associated request",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true,
+              "patternProperties": {
+                "^.*$": {
+                  "type": "string"
+                }
+              }
+            },
+            "collapsed": {
+              "description": "Whether the cell's output is collapsed/expanded.",
+              "type": "boolean"
+            },
+            "scrolled": {
+              "description": "Whether the cell's output is scrolled, unscrolled, or autoscrolled.",
+              "enum": [true, false, "auto"]
+            },
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          }
+        },
+        "source": { "$ref": "#/definitions/misc/source" },
+        "outputs": {
+          "description": "Execution, display, or stream outputs.",
+          "type": "array",
+          "items": { "$ref": "#/definitions/output" }
+        },
+        "execution_count": {
+          "description": "The code cell's prompt number. Will be null if the cell has not been run.",
+          "type": ["integer", "null"],
+          "minimum": 0
+        }
+      }
+    },
+
+    "unrecognized_cell": {
+      "description": "Unrecognized cell from a future minor-revision to the notebook format.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["cell_type", "metadata"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "not": {
+            "enum": ["markdown", "code", "raw"]
+          }
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "properties": {
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          },
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "output": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/execute_result" },
+        { "$ref": "#/definitions/display_data" },
+        { "$ref": "#/definitions/stream" },
+        { "$ref": "#/definitions/error" }
+      ]
+    },
+
+    "execute_result": {
+      "description": "Result of executing a code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "data", "metadata", "execution_count"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["execute_result"]
+        },
+        "execution_count": {
+          "description": "A result's prompt number.",
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "data": { "$ref": "#/definitions/misc/mimebundle" },
+        "metadata": { "$ref": "#/definitions/misc/output_metadata" }
+      }
+    },
+
+    "display_data": {
+      "description": "Data displayed as a result of code cell execution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "data", "metadata"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["display_data"]
+        },
+        "data": { "$ref": "#/definitions/misc/mimebundle" },
+        "metadata": { "$ref": "#/definitions/misc/output_metadata" }
+      }
+    },
+
+    "stream": {
+      "description": "Stream output from a code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "name", "text"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["stream"]
+        },
+        "name": {
+          "description": "The name of the stream (stdout, stderr).",
+          "type": "string"
+        },
+        "text": {
+          "description": "The stream's text output, represented as an array of strings.",
+          "$ref": "#/definitions/misc/multiline_string"
+        }
+      }
+    },
+
+    "error": {
+      "description": "Output of an error that occurred during code cell execution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "ename", "evalue", "traceback"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["error"]
+        },
+        "ename": {
+          "description": "The name of the error.",
+          "type": "string"
+        },
+        "evalue": {
+          "description": "The value, or message, of the error.",
+          "type": "string"
+        },
+        "traceback": {
+          "description": "The error's traceback, represented as an array of strings.",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+
+    "unrecognized_output": {
+      "description": "Unrecognized output from a future minor-revision to the notebook format.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["output_type"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "not": {
+            "enum": ["execute_result", "display_data", "stream", "error"]
+          }
+        }
+      }
+    },
+
+    "misc": {
+      "metadata_name": {
+        "description": "The cell's name. If present, must be a non-empty string. Cell names are expected to be unique across all the cells in a given notebook. This criterion cannot be checked by the json schema and must be established by an additional check.",
+        "type": "string",
+        "pattern": "^.+$"
+      },
+      "metadata_tags": {
+        "description": "The cell's tags. Tags must be unique, and must not contain commas.",
+        "type": "array",
+        "uniqueItems": true,
+        "items": {
+          "type": "string",
+          "pattern": "^[^,]+$"
+        }
+      },
+      "attachments": {
+        "description": "Media attachments (e.g. inline images), stored as mimebundle keyed by filename.",
+        "type": "object",
+        "patternProperties": {
+          ".*": {
+            "description": "The attachment's data stored as a mimebundle.",
+            "$ref": "#/definitions/misc/mimebundle"
+          }
+        }
+      },
+      "source": {
+        "description": "Contents of the cell, represented as an array of lines.",
+        "$ref": "#/definitions/misc/multiline_string"
+      },
+      "execution_count": {
+        "description": "The code cell's prompt number. Will be null if the cell has not been run.",
+        "type": ["integer", "null"],
+        "minimum": 0
+      },
+      "mimebundle": {
+        "description": "A mime-type keyed dictionary of data",
+        "type": "object",
+        "additionalProperties": {
+          "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
+          "$ref": "#/definitions/misc/multiline_string"
+        },
+        "patternProperties": {
+          "^application/(.*\\+)?json$": {
+            "description": "Mimetypes with JSON output, can be any type"
+          }
+        }
+      },
+      "output_metadata": {
+        "description": "Cell output metadata.",
+        "type": "object",
+        "additionalProperties": true
+      },
+      "multiline_string": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #296 (merged), refining the Stage-1 `.ipynb` export against the spec in #293. Supersedes the now-closed #297, whose review findings are carried over here.

## Problem

The merged export works, but diverges from the nbformat spec and #293's mapping in a few observable ways, and keeps some rough edges found during review of #297:

- SVG artifacts are base64-encoded like binary images, but nbformat stores `image/svg+xml` as raw text — exported SVGs can render blank or corrupt in Jupyter tooling.
- `execution_count` is forced to `null` for `interrupted`/`cancelled` runs even when `run.json` retains the count, breaking the direct `executionCount ≈ execution_count` mapping.
- Notebook-level metadata omits the environment name #293 calls for.
- The projection calls an async artifact resolver mid-mapping, so its result depends on filesystem state — it is not the pure function the design intends.
- Cell ids are truncated at 64 chars without dedup, so pathological runIds can violate nbformat's uniqueness requirement.
- The dialog keeps per-session export state across session switches (mounted once, `session` prop swapped in place), leaking failure banners and in-flight `setState` into the next session.
- Artifact ownership was checked by comparing record strings only: notebook-root paths were read through out-of-root symlinks, and the managed resolver validated only the global artifact root — a stale or crafted record could inline another session's or project's files into a shareable `.ipynb`.

## Proposed change

```mermaid
flowchart LR
    A["SessionNotebookDialog<br/>(key=session.id)"] -->|"notebook:export-ipynb"| B["NotebookRuntimeService<br/>.exportIpynb"]
    B -->|"findExisting (read-only)"| C["NotebookRunRepository<br/>run.json"]
    B --> D["resolveNotebookArtifactOutputs<br/>(async IO: read + validate artifacts)"]
    D --> E["runDocumentToIpynb<br/>(pure, synchronous)"]
    E -->|"serialized notebook"| F["saveIpynb seam<br/>(native Save As)"]
```

Main process:

- **Two-phase boundary**: `resolveNotebookArtifactOutputs` does all artifact IO up front (session/project match, path validation, mime dispatch); `runDocumentToIpynb` is now a pure, synchronous function of `(document, artifactOutputs, appVersion)` — byte-identical output for identical inputs, never touching the filesystem.
- **Artifact path binding**: notebook-root candidates are canonicalized with `realpath` on both sides and must stay inside the real session root (symlink escapes degrade to the stderr marker); managed artifacts resolve through a new `ArtifactRepository.resolveSessionArtifactFilePath`, which keeps the canonical/symlink checks and additionally binds the real path to the declaring project/session subtree. Covered by symlink-escape, cross-session, and cross-project tests (symlink cases skip on Windows).
- **SVG as text**: `image/svg+xml` inlines as raw SVG text; only binary images (`image/png`, `image/jpeg`, …) use base64.
- **Direct execution-count mapping**: `executionCount ?? null` for every status, including `interrupted`/`cancelled`.
- **Metadata**: notebook-level `open_science` gains `environment` (the dominant analysis kernel's most frequent env, deterministic tie-break) and `artifactSessionId`; cell-level gains `cellId`, `source`, `endedAt`.
- **Cell ids**: dedup within the 64-char nbformat budget — truncation collisions get a suffix that fits the same budget.

Renderer:

- `SessionNotebookContent` remounts via `key={session.id}` — per-session export state (failure banner, superseded in-flight `setState`) is discarded on session switch instead of leaking.
- Export failures log via `console.error` in addition to the footer banner; the disabled empty state explains itself ("No runs to export" tooltip).

## Scope and non-goals

- No change to #296's main-owned save flow (save seam + native dialog) — that trade-off is accepted, not re-litigated.
- Round-trip (`export(import(nb))`) tests wait for the Stage-2 importer, per the issue's staging.
- Display-path (kernel `outputs`) SVG is out of scope: the driver contract produces `image/png` base64 there today.

## Acceptance criteria and validation

- [x] Exported notebooks validate against the vendored nbformat 4.5 JSON Schema (`test/fixtures/nbformat.v4.5.schema.json`, ajv; the draft-04 schema uses only draft-07-compatible keywords and is validated as such).
- [x] SVG artifacts export as raw text; binary images stay base64 (service-level tests with real files).
- [x] Projection is byte-identical for fixed inputs and embeds no absolute paths.
- [x] `npm run typecheck` — green.
- [x] `npm run lint` — green.
- [x] `npm run test` — green (4806 passed, 66 skipped; skips are the pre-existing opt-in integration/smoke suites).

Note: adds `ajv` (^8.20.0) as a **devDependency** (already in the tree transitively) for schema validation in tests.

## Review focus

- The two-phase split: `resolveNotebookArtifactOutputs` (IO) in `runtime-service.ts` vs the pure `runDocumentToIpynb`.
- `dominantEnvironment` semantics for the notebook-level env name (dominant kernel's most frequent env, first-seen tie-break).
- The `key={session.id}` remount choice over an in-component reset effect.

