### PR TITLE
fix(agent-framework): render Claude MCP tool names

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3776,6 +3776,9 @@ describe('ACP runtime session management', () => {
         append: expect.stringContaining('writable session workspace')
       }
     })
+    const createdSessionMeta = JSON.stringify(fakeAgent.newSessions[0]._meta)
+    expect(createdSessionMeta).toContain('mcp__open-science-notebook__notebook_execute')
+    expect(createdSessionMeta).not.toContain('`notebook_execute`')
   })
 
   it('passes only the workspace as a static allowed import root, not the pre-start notebook alias', async () => {

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { NOTEBOOK_SYSTEM_PROMPT_APPEND } from '../notebook/mcp-server'
+import { claudeCodeFramework } from './claude-code'
+import { codexFramework } from './codex'
+import { opencodeFramework } from './opencode'
+
+describe('claudeCodeFramework', () => {
+  it('renders Open Science MCP tool references as Claude callable names', () => {
+    const setup = claudeCodeFramework.buildSessionSetup({
+      systemPromptAppends: [
+        NOTEBOOK_SYSTEM_PROMPT_APPEND,
+        'Save final files with `write_artifact_file` from `open-science-artifacts`.'
+      ]
+    })
+    const systemPrompt = setup.meta?.systemPrompt as { append: string }
+
+    expect(systemPrompt.append).toContain('`mcp__open-science-notebook__notebook_execute`')
+    expect(systemPrompt.append).toContain('`mcp__open-science-notebook__repl_execute`')
+    expect(systemPrompt.append).toContain('`mcp__open-science-notebook__manage_packages`')
+    expect(systemPrompt.append).toContain('`mcp__open-science-artifacts__write_artifact_file`')
+    expect(systemPrompt.append).not.toMatch(/`notebook_execute`/)
+    expect(systemPrompt.append).not.toMatch(/`write_artifact_file`/)
+  })
+
+  it.each([
+    ['Codex', codexFramework],
+    ['OpenCode', opencodeFramework]
+  ])('keeps generic MCP tool references unchanged for %s', (_name, framework) => {
+    const append = 'Use `notebook_execute` and then `write_artifact_file`.'
+
+    expect(framework.buildSessionSetup({ systemPromptAppends: [append] }).promptPrefix).toBe(append)
+  })
+
+  it('keeps already-namespaced Claude MCP tool references unchanged', () => {
+    const callableName = 'mcp__open-science-notebook__notebook_execute'
+    const setup = claudeCodeFramework.buildSessionSetup({ systemPromptAppends: [callableName] })
+    const systemPrompt = setup.meta?.systemPrompt as { append: string }
+
+    expect(systemPrompt.append).toBe(callableName)
+  })
+})

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -17,6 +17,29 @@ import type {
   SessionSetupContext
 } from './types'
 
+// Claude exposes ACP-provided MCP tools as mcp__<server>__<tool>; shared prompts stay framework-neutral.
+const CLAUDE_MCP_TOOL_NAMES = [
+  ['write_artifact_file', 'mcp__open-science-artifacts__write_artifact_file'],
+  ['notebook_execute', 'mcp__open-science-notebook__notebook_execute'],
+  ['repl_execute', 'mcp__open-science-notebook__repl_execute'],
+  ['bash_execute', 'mcp__open-science-notebook__bash_execute'],
+  ['notebook_state', 'mcp__open-science-notebook__notebook_state'],
+  ['list_notebook_runtimes', 'mcp__open-science-notebook__list_notebook_runtimes'],
+  ['notebook_bind_runtime', 'mcp__open-science-notebook__notebook_bind_runtime'],
+  ['notebook_switch_runtime', 'mcp__open-science-notebook__notebook_switch_runtime'],
+  ['notebook_restart', 'mcp__open-science-notebook__notebook_restart'],
+  ['notebook_shutdown', 'mcp__open-science-notebook__notebook_shutdown'],
+  ['manage_packages', 'mcp__open-science-notebook__manage_packages'],
+  ['manage_environments', 'mcp__open-science-notebook__manage_environments']
+] as const
+
+const renderClaudeMcpToolNames = (append: string): string =>
+  CLAUDE_MCP_TOOL_NAMES.reduce(
+    (rendered, [toolName, callableName]) =>
+      rendered.replace(new RegExp(`\\b${toolName}\\b`, 'g'), callableName),
+    append
+  )
+
 // Claude Code adapter. A faithful extraction of behavior currently inline in AcpRuntime /
 // agent-process / provider-env — moving the runtime onto AgentFramework must not change it.
 export const claudeCodeFramework: AgentFramework = {
@@ -60,7 +83,7 @@ export const claudeCodeFramework: AgentFramework = {
       meta.systemPrompt = {
         type: 'preset',
         preset: 'claude_code',
-        append: ctx.systemPromptAppends.join('\n\n')
+        append: ctx.systemPromptAppends.map(renderClaudeMcpToolNames).join('\n\n')
       }
     }
 


### PR DESCRIPTION
## Problem

Open Science supplies framework-neutral notebook and artifact guidance with bare MCP tool names such as `notebook_execute`. Claude Code exposes those tools as namespaced callable names, so models can first call a nonexistent bare tool before recovering.

## Proposed change

Render built-in Open Science MCP tool references into Claude Code callable names when the Claude adapter builds session metadata. Keep the shared guidance unchanged, and leave Codex and OpenCode prompt delivery unchanged.

Add adapter and ACP runtime regression coverage for namespaced notebook, REPL, package-management, and artifact calls, bare-name removal, and idempotent rendering.

## Scope and non-goals

This change only affects Claude Code system-prompt rendering. It does not change MCP registration, permission handling, or the separate auto-approve / `permissionProfile: ask` issue.

## Acceptance criteria and validation

- [x] Claude session guidance uses `mcp__open-science-notebook__notebook_execute` and other namespaced callable names.
- [x] Claude guidance no longer instructs a bare `notebook_execute` call.
- [x] Codex and OpenCode preserve their existing prompt behavior.
- [x] Relevant Vitest suites pass: 5 files, 247 tests.
- [x] `npm run lint` completes with 0 errors. Six existing formatting warnings remain in files outside this diff.
- [ ] Full `npm run test`: 4,795 tests pass and 66 skip; three environment/dependency-layout failures remain because this worktree has no installed `app-builder-lib` templates and the shared dependency tree lacks the new `@lobehub/icons` path. All 147 ACP runtime tests pass outside the localhost-restricted sandbox.
- [ ] `npm run typecheck` was intentionally not run per request.

## Review focus

Please review the Claude-only tool-name mapping and its token-boundary behavior, especially that generic prompts remain reusable and already-namespaced tool names remain unchanged.