### PR TITLE
feat(notebook): split ipynb exports by kernel

### DIFF
--- a/src/main/notebook/ipc.test.ts
+++ b/src/main/notebook/ipc.test.ts
@@ -31,6 +31,7 @@ describe('notebook IPC handlers', () => {
       }),
       runCell: vi.fn().mockResolvedValue({ runId: 'run-2', status: 'completed' }),
       exportIpynb: vi.fn().mockResolvedValue({ saved: true, filePath: '/tmp/session.ipynb' }),
+      exportIpynbByKernel: vi.fn().mockResolvedValue({ saved: true, filePaths: [] }),
       beginCodeCell: vi.fn().mockResolvedValue({ cellId: 'cell-1', writeId: 'write-1' }),
       appendCodeCell: vi.fn().mockResolvedValue({ receivedBytes: 5 }),
       finishCodeCell: vi.fn().mockResolvedValue({ status: 'idle' }),
@@ -70,6 +71,7 @@ describe('notebook IPC handlers', () => {
     await handlers.restart({ sessionId: 'session-1', workspaceCwd: '/workspace' })
     await handlers.shutdown({ sessionId: 'session-1', workspaceCwd: '/workspace' })
     await handlers.exportIpynb({ sessionId: 'session-1', workspaceCwd: '/workspace' })
+    await handlers.exportIpynbByKernel({ sessionId: 'session-1', workspaceCwd: '/workspace' })
 
     expect(service.execute).toHaveBeenCalledWith({
       sessionId: 'session-1',
@@ -95,6 +97,10 @@ describe('notebook IPC handlers', () => {
       sessionId: 'session-1',
       workspaceCwd: '/workspace'
     })
+    expect(service.exportIpynbByKernel).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace'
+    })
   })
 
   it('registers every notebook channel and forwards the renderer payload unchanged', async () => {
@@ -107,6 +113,7 @@ describe('notebook IPC handlers', () => {
       runCell: vi.fn().mockResolvedValue({ runId: 'run-1', status: 'completed' }),
       execute: vi.fn().mockResolvedValue({ runId: 'run-2', status: 'completed' }),
       exportIpynb: vi.fn().mockResolvedValue({ saved: false }),
+      exportIpynbByKernel: vi.fn().mockResolvedValue({ saved: false }),
       restart: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
       shutdown: vi.fn().mockResolvedValue({ sessionId: 'session-1', status: 'shutdown' })
     } as unknown as NotebookRuntimeService
@@ -121,6 +128,7 @@ describe('notebook IPC handlers', () => {
       'notebook:run-cell',
       'notebook:execute',
       'notebook:export-ipynb',
+      'notebook:export-ipynb-by-kernel',
       'notebook:restart',
       'notebook:shutdown'
     ])
@@ -140,6 +148,7 @@ describe('notebook IPC handlers', () => {
     await ipcHandlers.get('notebook:run-cell')?.(undefined, run)
     await ipcHandlers.get('notebook:execute')?.(undefined, execute)
     await ipcHandlers.get('notebook:export-ipynb')?.(undefined, session)
+    await ipcHandlers.get('notebook:export-ipynb-by-kernel')?.(undefined, session)
     await ipcHandlers.get('notebook:restart')?.(undefined, session)
     await ipcHandlers.get('notebook:shutdown')?.(undefined, session)
 
@@ -151,6 +160,7 @@ describe('notebook IPC handlers', () => {
     expect(service.runCell).toHaveBeenCalledWith(run)
     expect(service.execute).toHaveBeenCalledWith(execute)
     expect(service.exportIpynb).toHaveBeenCalledWith(session)
+    expect(service.exportIpynbByKernel).toHaveBeenCalledWith(session)
     expect(service.restart).toHaveBeenCalledWith(session)
     expect(service.shutdown).toHaveBeenCalledWith(session)
   })

--- a/src/main/notebook/ipc.ts
+++ b/src/main/notebook/ipc.ts
@@ -5,6 +5,7 @@ import type {
   BeginNotebookCodeCellRequest,
   ExecuteNotebookCodeRequest,
   ExportNotebookResult,
+  ExportNotebookSplitResult,
   FinishNotebookCodeCellRequest,
   NotebookRunSummary,
   NotebookSessionReference,
@@ -29,6 +30,7 @@ type NotebookHandlers = {
   runCell: (request: RunNotebookCellRequest) => Promise<NotebookRunSummary>
   execute: (request: ExecuteNotebookCodeRequest) => Promise<NotebookRunSummary>
   exportIpynb: (request: NotebookSessionRequest) => Promise<ExportNotebookResult>
+  exportIpynbByKernel: (request: NotebookSessionRequest) => Promise<ExportNotebookSplitResult>
   restart: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
   shutdown: (request: NotebookSessionRequest) => ReturnType<NotebookRuntimeService['shutdown']>
 }
@@ -43,6 +45,7 @@ const createNotebookHandlers = (service: NotebookRuntimeService): NotebookHandle
   runCell: (request) => service.runCell(request),
   execute: (request) => service.execute(request),
   exportIpynb: (request) => service.exportIpynb(request),
+  exportIpynbByKernel: (request) => service.exportIpynbByKernel(request),
   restart: (request) => service.restart(request),
   shutdown: (request) => service.shutdown(request)
 })
@@ -74,6 +77,9 @@ const registerNotebookIpcHandlers = (service: NotebookRuntimeService): void => {
   )
   ipcMain.handle('notebook:export-ipynb', (_event, request: NotebookSessionRequest) =>
     handlers.exportIpynb(request)
+  )
+  ipcMain.handle('notebook:export-ipynb-by-kernel', (_event, request: NotebookSessionRequest) =>
+    handlers.exportIpynbByKernel(request)
   )
   ipcMain.handle('notebook:restart', (_event, request: NotebookSessionRequest) =>
     handlers.restart(request)

--- a/src/main/notebook/ipynb-export.test.ts
+++ b/src/main/notebook/ipynb-export.test.ts
@@ -4,7 +4,11 @@ import Ajv from 'ajv'
 import { describe, expect, it } from 'vitest'
 
 import type { NotebookRunDocument, NotebookRunRecord } from '../../shared/notebook'
-import { runDocumentToIpynb, type NbformatOutput } from './ipynb-export'
+import {
+  runDocumentToIpynb,
+  runDocumentToIpynbByKernel,
+  type NbformatOutput
+} from './ipynb-export'
 
 const makeRun = (overrides: Partial<NotebookRunRecord> = {}): NotebookRunRecord => ({
   runId: 'run-1',
@@ -294,5 +298,28 @@ describe('runDocumentToIpynb', () => {
     const notebook = runDocumentToIpynb(document, { appVersion: '1.2.3', artifactOutputs })
 
     await validateAgainstNbformatSchema(notebook)
+  })
+})
+
+describe('runDocumentToIpynbByKernel', () => {
+  it('preserves order and assigns control runs to the most recently active data kernel', async () => {
+    const split = await runDocumentToIpynbByKernel(
+      makeDocument([
+        makeRun({ runId: 'leading-shell', kernelKind: 'bash', script: 'pwd' }),
+        makeRun({ runId: 'python', kernelKind: 'python', script: 'print(1)' }),
+        makeRun({ runId: 'python-repl', kernelKind: 'repl', script: 'await host.mcp()' }),
+        makeRun({ runId: 'r', kernelKind: 'r', script: 'print(2)' }),
+        makeRun({ runId: 'r-shell', kernelKind: 'bash', script: 'ls' })
+      ])
+    )
+
+    expect(split.python?.metadata.kernelspec.name).toBe('python3')
+    expect(split.r?.metadata.kernelspec.name).toBe('ir')
+    expect(split.python?.cells.map((cell) => cell.id)).toEqual([
+      'leading-shell',
+      'python',
+      'python-repl'
+    ])
+    expect(split.r?.cells.map((cell) => cell.id)).toEqual(['r', 'r-shell'])
   })
 })

--- a/src/main/notebook/ipynb-export.ts
+++ b/src/main/notebook/ipynb-export.ts
@@ -85,6 +85,8 @@ type RunDocumentToIpynbOptions = {
   artifactOutputs?: ReadonlyMap<string, NbformatOutput[]>
 }
 
+type KernelSplitIpynb = Partial<Record<'python' | 'r', IpynbNotebook>>
+
 // nbformat accepts either one string or an array of lines. Arrays make generated notebooks stable and
 // easy to diff, while preserving every original newline.
 const splitLines = (value: string): string[] => {
@@ -296,5 +298,35 @@ const runDocumentToIpynb = (
   }
 }
 
-export { runDocumentToIpynb }
-export type { IpynbNotebook, NbformatOutput, ResolvedArtifact, RunDocumentToIpynbOptions }
+// Splits a mixed history into chronological per-data-kernel projections. Control-plane runs follow
+// the most recently active data kernel (or the dominant kernel before the first data cell), preserving
+// their local context without duplicating them across notebooks.
+const runDocumentToIpynbByKernel = async (
+  document: NotebookRunDocument,
+  options: RunDocumentToIpynbOptions = {}
+): Promise<KernelSplitIpynb> => {
+  const groups: Record<'python' | 'r', NotebookRunRecord[]> = { python: [], r: [] }
+  let activeKernel = dominantKernel(document.runs)
+  for (const run of document.runs) {
+    if (run.kernelKind === 'python' || run.kernelKind === 'r') {
+      activeKernel = run.kernelKind
+    }
+    groups[activeKernel].push(run)
+  }
+
+  const result: KernelSplitIpynb = {}
+  for (const kernel of ['python', 'r'] as const) {
+    if (groups[kernel].length === 0) continue
+    result[kernel] = await runDocumentToIpynb({ ...document, runs: groups[kernel] }, options)
+  }
+  return result
+}
+
+export { runDocumentToIpynb, runDocumentToIpynbByKernel }
+export type {
+  IpynbNotebook,
+  KernelSplitIpynb,
+  NbformatOutput,
+  ResolvedArtifact,
+  RunDocumentToIpynbOptions
+}

--- a/src/main/notebook/runtime-service.export.test.ts
+++ b/src/main/notebook/runtime-service.export.test.ts
@@ -77,6 +77,60 @@ describe('NotebookRuntimeService exportIpynb', () => {
     expect(result).toEqual({ saved: true, filePath: '/downloads/session.ipynb' })
   })
 
+  it('saves mixed sessions as separate per-kernel notebooks', async () => {
+    const mixedDocument: NotebookRunDocument = {
+      ...document,
+      runs: [
+        document.runs[0],
+        {
+          ...document.runs[0],
+          runId: 'run-r',
+          cellId: 'cell-r',
+          kernelKind: 'r',
+          script: 'print(2)',
+          environment: 'default-r'
+        }
+      ]
+    }
+    const repository = {
+      findExisting: vi.fn().mockResolvedValue(mixedDocument)
+    } as unknown as NotebookRunRepository
+    const saveSplitIpynb = vi.fn().mockResolvedValue({
+      saved: true,
+      filePaths: ['/downloads/python.ipynb', '/downloads/r.ipynb']
+    })
+    const service = new NotebookRuntimeService({
+      configRoot: '/config',
+      dataRoot: '/storage',
+      projectName: 'default-project',
+      repository,
+      saveSplitIpynb
+    })
+
+    const result = await service.exportIpynbByKernel({
+      sessionId: '12345678-abcd',
+      workspaceCwd: '/workspace'
+    })
+
+    expect(saveSplitIpynb).toHaveBeenCalledOnce()
+    const files = saveSplitIpynb.mock.calls[0][0] as Array<{ name: string; data: string }>
+    expect(files.map(({ name }) => name)).toEqual([
+      'session-12345678-python.ipynb',
+      'session-12345678-r.ipynb'
+    ])
+    expect(
+      files.map(
+        ({ data }) =>
+          (JSON.parse(data) as { metadata: { kernelspec: { name: string } } }).metadata.kernelspec
+            .name
+      )
+    ).toEqual(['python3', 'ir'])
+    expect(result).toEqual({
+      saved: true,
+      filePaths: ['/downloads/python.ipynb', '/downloads/r.ipynb']
+    })
+  })
+
   it('rejects an unknown session before opening the save dialog', async () => {
     const repository = {
       findExisting: vi.fn().mockResolvedValue(null)

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -12,6 +12,7 @@ import type {
   ExecuteNotebookControlRequest,
   ExecuteShellRequest,
   ExportNotebookResult,
+  ExportNotebookSplitResult,
   FinishNotebookCodeCellRequest,
   NotebookEnvironmentStatus,
   NotebookKernelMetadata,
@@ -36,7 +37,12 @@ import type {
   ProvisionProgress
 } from '../../shared/notebook-env'
 import type { PackageMirror } from '../../shared/mirror'
-import { runDocumentToIpynb, type NbformatOutput, type ResolvedArtifact } from './ipynb-export'
+import {
+  runDocumentToIpynb,
+  runDocumentToIpynbByKernel,
+  type NbformatOutput,
+  type ResolvedArtifact
+} from './ipynb-export'
 import { NotebookKernelExecutor, type NotebookKernelExecutorOptions } from './kernel-executor'
 import type { KernelProcessKind } from './kernel-executor'
 import { effectiveMirrorAsync, type ProbeDeps } from './mirror-probe'
@@ -308,6 +314,9 @@ type NotebookRuntimeServiceOptions = {
   appVersion?: string
   // Save-dialog seam for notebook export tests. Production falls back to Electron's native dialog.
   saveIpynb?: (suggestedName: string, data: string) => Promise<ExportNotebookResult>
+  saveSplitIpynb?: (
+    files: Array<{ name: string; data: string }>
+  ) => Promise<ExportNotebookSplitResult>
   // Resolves app-managed artifact paths with the artifact repository's canonical/symlink checks,
   // bound to the artifact's declaring project/session subtree.
   resolveArtifactPath?: (request: {
@@ -383,6 +392,27 @@ const saveIpynbWithDialog = async (
   if (canceled || !filePath) return { saved: false }
   await writeFile(filePath, data, 'utf8')
   return { saved: true, filePath }
+}
+
+const saveSplitIpynbWithDialog = async (
+  files: Array<{ name: string; data: string }>
+): Promise<ExportNotebookSplitResult> => {
+  const { dialog } = await import('electron')
+  const { canceled, filePaths } = await dialog.showOpenDialog({
+    title: 'Export notebooks by kernel',
+    properties: ['openDirectory', 'createDirectory']
+  })
+  const directory = filePaths[0]
+  if (canceled || !directory) return { saved: false }
+
+  const savedPaths = await Promise.all(
+    files.map(async (file) => {
+      const filePath = join(directory, file.name)
+      await writeFile(filePath, file.data, 'utf8')
+      return filePath
+    })
+  )
+  return { saved: true, filePaths: savedPaths }
 }
 
 const isPathInside = (root: string, candidate: string): boolean => {
@@ -2025,6 +2055,34 @@ class NotebookRuntimeService {
     const serialized = `${JSON.stringify(notebook, null, 2)}\n`
 
     return (this.options.saveIpynb ?? saveIpynbWithDialog)(suggestedName, serialized)
+  }
+
+  // Exports mixed histories as one notebook per data kernel, assigning each control run to the most
+  // recently active data kernel so shell/repl context remains adjacent to the cells it supported.
+  async exportIpynbByKernel(request: NotebookSessionRequest): Promise<ExportNotebookSplitResult> {
+    const projectName = request.projectName ?? this.options.projectName
+    const document = await this.repository.findExisting(projectName, request.sessionId)
+    if (!document) {
+      throw new Error(`Notebook session not found: ${request.sessionId}`)
+    }
+
+    const artifactOutputs = await resolveNotebookArtifactOutputs(
+      document,
+      this.options.resolveArtifactPath
+    )
+    const notebooks = await runDocumentToIpynbByKernel(document, {
+      appVersion: this.options.appVersion,
+      artifactOutputs
+    })
+    const prefix = `session-${request.sessionId.slice(0, 8)}`
+    const files = (['python', 'r'] as const)
+      .filter((kernel) => notebooks[kernel] !== undefined)
+      .map((kernel) => ({
+        name: `${prefix}-${kernel}.ipynb`,
+        data: `${JSON.stringify(notebooks[kernel], null, 2)}\n`
+      }))
+
+    return (this.options.saveSplitIpynb ?? saveSplitIpynbWithDialog)(files)
   }
 
   // Replaces the interpreter process while preserving cells and durable run history. Prefers the

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -36,6 +36,7 @@ import type {
   NotebookChangedEvent,
   ExecuteNotebookCodeRequest,
   ExportNotebookResult,
+  ExportNotebookSplitResult,
   FinishNotebookCodeCellRequest,
   NotebookLanguage,
   NotebookRunSummary,
@@ -337,6 +338,7 @@ interface OpenScienceAPI {
     runCell(request: RunNotebookCellRequest): Promise<NotebookRunSummary>
     execute(request: ExecuteNotebookCodeRequest): Promise<NotebookRunSummary>
     exportIpynb(request: NotebookSessionRequest): Promise<ExportNotebookResult>
+    exportIpynbByKernel(request: NotebookSessionRequest): Promise<ExportNotebookSplitResult>
     restart(request: NotebookSessionRequest): Promise<NotebookSessionState>
     shutdown(request: NotebookSessionRequest): Promise<{ sessionId: string; status: 'shutdown' }>
     onAvailable(listener: AcpListener<NotebookAvailableEvent>): RemoveListener

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -38,6 +38,7 @@ import type {
   NotebookChangedEvent,
   ExecuteNotebookCodeRequest,
   ExportNotebookResult,
+  ExportNotebookSplitResult,
   FinishNotebookCodeCellRequest,
   NotebookLanguage,
   NotebookRunSummary,
@@ -370,6 +371,7 @@ type OpenScienceAPI = {
     runCell: (request: RunNotebookCellRequest) => Promise<NotebookRunSummary>
     execute: (request: ExecuteNotebookCodeRequest) => Promise<NotebookRunSummary>
     exportIpynb: (request: NotebookSessionRequest) => Promise<ExportNotebookResult>
+    exportIpynbByKernel: (request: NotebookSessionRequest) => Promise<ExportNotebookSplitResult>
     restart: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
     shutdown: (
       request: NotebookSessionRequest
@@ -758,6 +760,11 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('notebook:execute', request) as Promise<NotebookRunSummary>,
     exportIpynb: (request) =>
       ipcRenderer.invoke('notebook:export-ipynb', request) as Promise<ExportNotebookResult>,
+    exportIpynbByKernel: (request) =>
+      ipcRenderer.invoke(
+        'notebook:export-ipynb-by-kernel',
+        request
+      ) as Promise<ExportNotebookSplitResult>,
     restart: (request) =>
       ipcRenderer.invoke('notebook:restart', request) as Promise<NotebookSessionState>,
     shutdown: (request) =>

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx
@@ -50,6 +50,7 @@ describe('SessionNotebookContent export', () => {
           status="ready"
           onClose={vi.fn()}
           onExport={onExport}
+          onExportByKernel={vi.fn()}
         />
       )
     })
@@ -77,6 +78,7 @@ describe('SessionNotebookContent export', () => {
           status="ready"
           onClose={vi.fn()}
           onExport={onExport}
+          onExportByKernel={vi.fn()}
         />
       )
     })
@@ -104,6 +106,7 @@ describe('SessionNotebookContent export', () => {
           status="ready"
           onClose={vi.fn()}
           onExport={onExport}
+          onExportByKernel={vi.fn()}
         />
       )
     })
@@ -127,6 +130,7 @@ describe('SessionNotebookContent export', () => {
           status="ready"
           onClose={vi.fn()}
           onExport={failingExport}
+          onExportByKernel={vi.fn()}
         />
       )
     })
@@ -147,10 +151,37 @@ describe('SessionNotebookContent export', () => {
           status="ready"
           onClose={vi.fn()}
           onExport={vi.fn()}
+          onExportByKernel={vi.fn()}
         />
       )
     })
 
     expect(container.querySelector('[role="alert"]')?.textContent).toBe('')
+  })
+
+  it('invokes split export for mixed data kernels', async () => {
+    const onExportByKernel = vi.fn().mockResolvedValue(undefined)
+    await act(async () => {
+      root.render(
+        <SessionNotebookContent
+          sessionId="session-1"
+          runs={[run, { ...run, runId: 'run-r', cellId: 'cell-r', kernelKind: 'r' }]}
+          status="ready"
+          onClose={vi.fn()}
+          onExport={vi.fn()}
+          onExportByKernel={onExportByKernel}
+        />
+      )
+    })
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Download separate notebooks by kernel"]'
+    )
+    await act(async () => {
+      button?.click()
+      await Promise.resolve()
+    })
+
+    expect(onExportByKernel).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
@@ -26,7 +26,14 @@ const renderContent = (props: {
   status: 'loading' | 'error' | 'ready'
   error?: string
 }): string =>
-  renderToStaticMarkup(<SessionNotebookContent onClose={vi.fn()} onExport={vi.fn()} {...props} />)
+  renderToStaticMarkup(
+    <SessionNotebookContent
+      onClose={vi.fn()}
+      onExport={vi.fn()}
+      onExportByKernel={vi.fn()}
+      {...props}
+    />
+  )
 
 describe('SessionNotebookContent', () => {
   it('shows the empty state when there are no runs', () => {
@@ -70,6 +77,22 @@ describe('SessionNotebookContent', () => {
     const emptyButton = empty.match(/<button[^>]*aria-label="Download as \.ipynb"[^>]*>/)?.[0]
     expect(populatedButton).not.toMatch(/\sdisabled(?:=|\s|>)/)
     expect(emptyButton).toMatch(/\sdisabled(?:=|\s|>)/)
+  })
+
+  it('offers split export only for mixed Python/R sessions', () => {
+    const mixed = renderContent({
+      sessionId: 's1',
+      runs: [makeRun(), makeRun({ runId: 'r1', kernelKind: 'r' })],
+      status: 'ready'
+    })
+    const pythonOnly = renderContent({
+      sessionId: 's1',
+      runs: [makeRun()],
+      status: 'ready'
+    })
+
+    expect(mixed).toContain('aria-label="Download separate notebooks by kernel"')
+    expect(pythonOnly).not.toContain('aria-label="Download separate notebooks by kernel"')
   })
 })
 

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
@@ -80,6 +80,7 @@ type SessionNotebookContentProps = {
   error?: string
   onClose: () => void
   onExport: () => Promise<void>
+  onExportByKernel: () => Promise<void>
 }
 
 // Pure presentational body of the dialog: header summary, empty/loading/error/populated states,
@@ -91,10 +92,12 @@ const SessionNotebookContent = ({
   status,
   error,
   onClose,
-  onExport
+  onExport,
+  onExportByKernel
 }: SessionNotebookContentProps): React.JSX.Element => {
   const [activeKind, setActiveKind] = useState<NotebookKernelKind>('python')
   const [exporting, setExporting] = useState(false)
+  const [splitExporting, setSplitExporting] = useState(false)
   const [exportError, setExportError] = useState<string>()
   const shortId = sessionId.slice(0, 8)
   const agents = runs.some((run) => run.source === 'agent') ? 1 : 0
@@ -119,7 +122,8 @@ const SessionNotebookContent = ({
     ? activeKind
     : (KERNEL_KIND_ORDER.find((kind) => kindsWithRuns.has(kind)) ?? visibleKinds[0] ?? 'python')
   const visibleRuns = runs.filter((run) => resolveRunKernelKind(run) === effectiveActiveKind)
-  const exportDisabled = status !== 'ready' || runs.length === 0 || exporting
+  const mixedDataKernels = kindsWithRuns.has('python') && kindsWithRuns.has('r')
+  const exportDisabled = status !== 'ready' || runs.length === 0 || exporting || splitExporting
 
   const handleExport = async (): Promise<void> => {
     setExporting(true)
@@ -133,6 +137,18 @@ const SessionNotebookContent = ({
       setExportError(getErrorMessage(exportFailure))
     } finally {
       setExporting(false)
+    }
+  }
+
+  const handleSplitExport = async (): Promise<void> => {
+    setSplitExporting(true)
+    setExportError(undefined)
+    try {
+      await onExportByKernel()
+    } catch (exportFailure) {
+      setExportError(getErrorMessage(exportFailure))
+    } finally {
+      setSplitExporting(false)
     }
   }
 
@@ -215,32 +231,50 @@ const SessionNotebookContent = ({
         <p className="min-w-0 truncate text-xs text-danger-000" role="alert">
           {exportError}
         </p>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {/* Wrapper span keeps the tooltip reachable while the button is disabled. */}
-              <span>
-                <button
-                  type="button"
-                  disabled={exportDisabled}
-                  onClick={() => void handleExport()}
-                  className="flex shrink-0 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label="Download as .ipynb"
-                >
-                  {exporting ? (
-                    <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
-                  ) : (
-                    <Download className="size-3.5" aria-hidden="true" />
-                  )}
-                  {exporting ? 'Exporting…' : '.ipynb'}
-                </button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>
-              {runs.length === 0 ? 'No runs to export' : 'Download as .ipynb'}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <div className="flex shrink-0 items-center gap-2">
+          {mixedDataKernels ? (
+            <button
+              type="button"
+              disabled={exportDisabled}
+              onClick={() => void handleSplitExport()}
+              className="flex items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Download separate notebooks by kernel"
+            >
+              {splitExporting ? (
+                <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+              ) : (
+                <Download className="size-3.5" aria-hidden="true" />
+              )}
+              {splitExporting ? 'Exporting…' : 'Split by kernel'}
+            </button>
+          ) : null}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {/* Wrapper span keeps the tooltip reachable while the button is disabled. */}
+                <span>
+                  <button
+                    type="button"
+                    disabled={exportDisabled}
+                    onClick={() => void handleExport()}
+                    className="flex items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label="Download as .ipynb"
+                  >
+                    {exporting ? (
+                      <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+                    ) : (
+                      <Download className="size-3.5" aria-hidden="true" />
+                    )}
+                    {exporting ? 'Exporting…' : '.ipynb'}
+                  </button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {runs.length === 0 ? 'No runs to export' : 'Download as .ipynb'}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
       </div>
     </>
   )
@@ -327,6 +361,13 @@ const SessionNotebookDialog = ({
               onClose={onClose}
               onExport={async () => {
                 await window.api.notebook.exportIpynb({
+                  sessionId: session.id,
+                  projectName: session.projectId,
+                  workspaceCwd: session.cwd ?? ''
+                })
+              }}
+              onExportByKernel={async () => {
+                await window.api.notebook.exportIpynbByKernel({
                   sessionId: session.id,
                   projectName: session.projectId,
                   workspaceCwd: session.cwd ?? ''

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -28,6 +28,7 @@ export const WEB_INVOKE_CHANNELS = {
   'notebook.beginCodeCell': 'notebook:begin-code-cell',
   'notebook.execute': 'notebook:execute',
   'notebook.exportIpynb': 'notebook:export-ipynb',
+  'notebook.exportIpynbByKernel': 'notebook:export-ipynb-by-kernel',
   'notebook.finishCodeCell': 'notebook:finish-code-cell',
   'notebook.getReference': 'notebook:reference',
   'notebook.restart': 'notebook:restart',

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -231,6 +231,13 @@ export type ExportNotebookResult =
       filePath: string
     }
 
+export type ExportNotebookSplitResult =
+  | { saved: false }
+  | {
+      saved: true
+      filePaths: string[]
+    }
+
 // Starts a streamed code write into a notebook cell.
 export type BeginNotebookCodeCellRequest = NotebookSessionRequest & {
   cellId?: string


### PR DESCRIPTION
## Summary
- partition mixed notebook histories into per-Python/R nbformat projections while preserving run order
- associate shell/REPL control runs with the most recently active data kernel without duplicating them
- add a mixed-session “Split by kernel” export action that writes both notebooks to a chosen directory

Part of #293

## Test plan
- [x] `npm run typecheck`
- [x] changed-file ESLint
- [x] `npm test -- src/main/notebook/ipynb-export.test.ts src/main/notebook/runtime-service.export.test.ts src/main/notebook/ipc.test.ts src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx src/renderer/web/api-map.generated.test.ts`
- [x] `npm run check:web-api-map`