### PR TITLE
fix(workspace): wrap scoped permission labels

### DIFF
--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -167,6 +167,31 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('Command execution</span>')
   })
 
+  it('distinguishes Codex session approval from an exec-policy amendment', () => {
+    const codexRequest: AcpPermissionRequest = {
+      ...permissionRequest,
+      options: [
+        { optionId: 'allow_always', name: 'Allow for Session', kind: 'allow_always' },
+        {
+          optionId: 'accept_execpolicy_amendment',
+          name: 'Allow Commands Starting With `git worktree`',
+          kind: 'allow_always'
+        },
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ]
+    }
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls requests={[codexRequest]} onRespond={() => undefined} />
+    )
+
+    expect(html).toContain('Always - Allow for Session</span>')
+    expect(html).toContain('Always - Allow Commands Starting With `git worktree`</span>')
+    expect(html.match(/>Always<\/span>/g)).toBeNull()
+    expect(html).toContain('inline-flex min-w-0 max-w-full items-center')
+    expect(html).toContain('min-w-0 whitespace-normal break-words text-left')
+  })
+
   it('serializes prompts by rendering only the first pending request', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -174,21 +174,22 @@ const PermissionApprovalControls = ({
         <span className="flex flex-wrap items-center justify-end gap-1 w-full overflow-hidden">
           {getOrderedPermissionOptions(request.options).map((option) => {
             const actionKind = getPermissionActionKind(option)
+            const hasMultipleOptionsForAction = (actionCounts.get(actionKind) ?? 0) > 1
             const actionLabel = getPermissionActionLabel(
               option,
               actionKind,
-              (actionCounts.get(actionKind) ?? 0) > 1
+              hasMultipleOptionsForAction
             )
 
             return (
               <button
                 key={option.optionId}
                 type="button"
-                className="max-w-full break-words rounded-md border border-amber-300 bg-white px-2 py-1 text-[12px] hover:bg-amber-100"
+                className="inline-flex min-w-0 max-w-full items-center rounded-md border border-amber-300 bg-white px-2 py-1 text-[12px] hover:bg-amber-100"
                 aria-label={`${actionLabel}: ${request.title}`}
                 onClick={() => onRespond(request.requestId, option.optionId)}
               >
-                <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+                <span className="min-w-0 whitespace-normal break-words text-left">
                   {actionLabel}
                 </span>
               </button>


### PR DESCRIPTION
## Problem

Codex ACP can offer both session approval and an exec-policy amendment as separate `allow_always` options. PR #305 preserved their scopes as canonical labels, but a command-prefix label can be much longer than the permission card.

The existing inner label used `white-space: nowrap` on an inline element, so ellipsis was not a reliable containment mechanism and could also hide security-relevant scope details.

## Proposed change

- Keep the canonical scoped labels introduced by #305.
- Make permission action buttons shrink within the card.
- Allow long action labels and unbroken command fragments to wrap instead of overflowing or being hidden.
- Add an exact Codex regression fixture for `allow_always` and `accept_execpolicy_amendment`.

## User-facing behavior

The duplicate choices are displayed as:

```text
Always - Allow for Session
Always - Allow Commands Starting With <command prefix>
Allow once
Reject
Cancel
```

Short labels stay on one line. A long command-prefix label wraps onto additional lines inside the button and remains fully readable; it does not widen the permission card.

`Always - Allow for Session` approves matching commands for the current Codex session. `Always - Allow Commands Starting With <command prefix>` accepts the proposed exec-policy amendment and remembers that command pattern. A request with only one `allow_always` option keeps the concise `Always` label.

The submitted `optionId` and permission behavior are unchanged.

## Scope and non-goals

This is a renderer layout and regression-test change. It does not change permission option IDs, broker behavior, remembered grants, or Codex policy semantics.

## Acceptance criteria and validation

- The exact Codex session and exec-policy options display distinct canonical labels.
- Long scoped labels wrap within the permission card without truncating their meaning.
- A bare duplicate `Always` label is not rendered.
- Passed: `npm run test -- src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx` (7/7)
- Passed: ESLint and Prettier checks for changed files
- Passed: `git diff --check`
- Not run locally: `npm run typecheck`, per request

## Review focus

Please verify the flex min-width constraints and wrapping behavior, plus the Codex ACP 1.1.4 option IDs used by the regression fixture.