### PR TITLE
fix(acp): show Codex commands in permission approvals

### DIFF
--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -85,6 +85,26 @@ describe('ACP permission broker', () => {
     })
   })
 
+  it('preserves an explicit shell title when raw input also contains a command', async () => {
+    const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const request = createToolPermissionRequest({
+      title: 'Build project',
+      providerToolName: 'Bash',
+      kind: 'execute'
+    })
+    request.toolCall.rawInput = { command: './build.sh --verbose' }
+
+    const response = broker.requestPermission(request)
+
+    expect(emitted[0].title).toBe('Build project')
+    broker.respond({ requestId: emitted[0].requestId, optionId: 'allow-always' })
+    await response
+    expect(broker.listGrants('session-1')).toEqual([
+      { categoryKey: 'bash:Build project', kind: 'shell', label: 'Build project' }
+    ])
+  })
+
   it('auto-approves only conservative Auto operations accepted by policy', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -221,7 +221,7 @@ describe('ACP permission broker', () => {
     expect(emittedRequests).toHaveLength(2)
   })
 
-  it('remembers Always for shell by full command signature, not just the executable', async () => {
+  it('remembers Always for shell by leading executable', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
 
@@ -231,23 +231,23 @@ describe('ACP permission broker', () => {
     broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
     await firstBash
 
-    // The exact same command auto-approves.
-    const sameBash = broker.requestPermission(
-      createToolPermissionRequest({ title: 'python a.py', providerToolName: 'Bash' })
+    // The same executable with different arguments auto-approves.
+    const secondBash = broker.requestPermission(
+      createToolPermissionRequest({ title: 'python b.py', providerToolName: 'Bash' })
     )
-    await expect(sameBash).resolves.toEqual({
+    await expect(secondBash).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
     expect(emittedRequests).toHaveLength(1)
 
-    // Different arguments to the same executable are a distinct signature and still prompt.
+    // A different executable still prompts.
     broker.requestPermission(
-      createToolPermissionRequest({ title: 'python b.py', providerToolName: 'Bash' })
+      createToolPermissionRequest({ title: 'rm -rf x', providerToolName: 'Bash' })
     )
     expect(emittedRequests).toHaveLength(2)
   })
 
-  it('normalizes leading env assignments in the shell command signature', async () => {
+  it('normalizes leading env assignments in the shell executable category', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
 
@@ -257,18 +257,18 @@ describe('ACP permission broker', () => {
     broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
     await firstBash
 
-    // The same command without the leading env assignment shares the signature and auto-approves.
+    // The same executable without the leading env assignment shares the category and auto-approves.
     const secondBash = broker.requestPermission(
-      createToolPermissionRequest({ title: 'node build.js', kind: 'execute' })
+      createToolPermissionRequest({ title: 'node serve.js', kind: 'execute' })
     )
     await expect(secondBash).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
     expect(emittedRequests).toHaveLength(1)
 
-    // A different command still prompts.
+    // A different executable still prompts.
     broker.requestPermission(
-      createToolPermissionRequest({ title: 'node serve.js', kind: 'execute' })
+      createToolPermissionRequest({ title: 'python serve.py', kind: 'execute' })
     )
     expect(emittedRequests).toHaveLength(2)
   })
@@ -412,7 +412,7 @@ describe('ACP permission broker', () => {
     expect(broker.listGrants('session-1')).toEqual(
       expect.arrayContaining([
         { categoryKey: 'tool:Write', kind: 'tool', label: 'Write' },
-        { categoryKey: 'bash:python a.py', kind: 'shell', label: 'python a.py' },
+        { categoryKey: 'bash:python', kind: 'shell', label: 'python' },
         {
           categoryKey: 'mcp:mcp__open-science-notebook__notebook_execute',
           kind: 'mcp',
@@ -428,7 +428,7 @@ describe('ACP permission broker', () => {
         .listGrants('session-1')
         .map((grant) => grant.categoryKey)
         .sort()
-    ).toEqual(['bash:python a.py', 'mcp:mcp__open-science-notebook__notebook_execute'].sort())
+    ).toEqual(['bash:python', 'mcp:mcp__open-science-notebook__notebook_execute'].sort())
 
     const countBeforeWrite = emittedRequests.length
     broker.requestPermission(

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -221,7 +221,7 @@ describe('ACP permission broker', () => {
     expect(emittedRequests).toHaveLength(2)
   })
 
-  it('remembers Always for shell by leading executable', async () => {
+  it('remembers Always for shell by full command signature, not just the executable', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
 
@@ -231,23 +231,23 @@ describe('ACP permission broker', () => {
     broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
     await firstBash
 
-    // The same executable with different arguments auto-approves.
-    const secondBash = broker.requestPermission(
-      createToolPermissionRequest({ title: 'python b.py', providerToolName: 'Bash' })
+    // The exact same command auto-approves.
+    const sameBash = broker.requestPermission(
+      createToolPermissionRequest({ title: 'python a.py', providerToolName: 'Bash' })
     )
-    await expect(secondBash).resolves.toEqual({
+    await expect(sameBash).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
     expect(emittedRequests).toHaveLength(1)
 
-    // A different executable still prompts.
+    // Different arguments to the same executable are a distinct signature and still prompt.
     broker.requestPermission(
-      createToolPermissionRequest({ title: 'rm -rf x', providerToolName: 'Bash' })
+      createToolPermissionRequest({ title: 'python b.py', providerToolName: 'Bash' })
     )
     expect(emittedRequests).toHaveLength(2)
   })
 
-  it('normalizes leading env assignments in the shell executable category', async () => {
+  it('normalizes leading env assignments in the shell command signature', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
 
@@ -257,18 +257,18 @@ describe('ACP permission broker', () => {
     broker.respond({ requestId: emittedRequests[0], optionId: 'allow-always' })
     await firstBash
 
-    // The same executable without the leading env assignment shares the category and auto-approves.
+    // The same command without the leading env assignment shares the signature and auto-approves.
     const secondBash = broker.requestPermission(
-      createToolPermissionRequest({ title: 'node serve.js', kind: 'execute' })
+      createToolPermissionRequest({ title: 'node build.js', kind: 'execute' })
     )
     await expect(secondBash).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
     expect(emittedRequests).toHaveLength(1)
 
-    // A different executable still prompts.
+    // A different command still prompts.
     broker.requestPermission(
-      createToolPermissionRequest({ title: 'python serve.py', kind: 'execute' })
+      createToolPermissionRequest({ title: 'node serve.js', kind: 'execute' })
     )
     expect(emittedRequests).toHaveLength(2)
   })
@@ -370,6 +370,36 @@ describe('ACP permission broker', () => {
     expect(emittedRequests).toHaveLength(1)
   })
 
+  it('keeps MCP identity when raw input contains a command field', async () => {
+    const emittedRequests: Array<
+      Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]
+    > = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request))
+    const firstRequest = createToolPermissionRequest({
+      title: 'mcp__runner__execute',
+      kind: 'execute'
+    })
+    firstRequest.toolCall.rawInput = { command: 'npm publish' }
+
+    const firstResponse = broker.requestPermission(firstRequest)
+
+    expect(emittedRequests[0]).toMatchObject({
+      title: 'mcp__runner__execute',
+      isMcp: true
+    })
+    broker.respond({ requestId: emittedRequests[0].requestId, optionId: 'allow-always' })
+    await firstResponse
+
+    const secondRequest = createToolPermissionRequest({
+      title: 'mcp__other__execute',
+      kind: 'execute'
+    })
+    secondRequest.toolCall.rawInput = { command: 'npm publish' }
+    void broker.requestPermission(secondRequest)
+
+    expect(emittedRequests).toHaveLength(2)
+  })
+
   it('does not remember Always across sessions for built-in tools', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
@@ -412,7 +442,7 @@ describe('ACP permission broker', () => {
     expect(broker.listGrants('session-1')).toEqual(
       expect.arrayContaining([
         { categoryKey: 'tool:Write', kind: 'tool', label: 'Write' },
-        { categoryKey: 'bash:python', kind: 'shell', label: 'python' },
+        { categoryKey: 'bash:python a.py', kind: 'shell', label: 'python a.py' },
         {
           categoryKey: 'mcp:mcp__open-science-notebook__notebook_execute',
           kind: 'mcp',
@@ -428,7 +458,7 @@ describe('ACP permission broker', () => {
         .listGrants('session-1')
         .map((grant) => grant.categoryKey)
         .sort()
-    ).toEqual(['bash:python', 'mcp:mcp__open-science-notebook__notebook_execute'].sort())
+    ).toEqual(['bash:python a.py', 'mcp:mcp__open-science-notebook__notebook_execute'].sort())
 
     const countBeforeWrite = emittedRequests.length
     broker.requestPermission(

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -32,27 +32,29 @@ const commandFromRawInput = (rawInput: unknown): string | undefined => {
   return typeof command === 'string' && command.trim() ? command : undefined
 }
 
+const reportedPermissionTitle = (params: RequestPermissionRequest): string =>
+  params.toolCall.title ?? params.toolCall.toolCallId
+
 // codex-acp command approvals omit title but retain the exact command in rawInput. Prefer that
-// security-relevant value over opaque call ids and generic provider titles.
-const resolvePermissionTitle = (params: RequestPermissionRequest): string =>
-  commandFromRawInput(params.toolCall.rawInput) ??
-  params.toolCall.title ??
-  params.toolCall.toolCallId
+// security-relevant value only for confirmed non-MCP shell requests; MCP inputs are arbitrary and
+// may contain an unrelated `command` field.
+const resolvePermissionTitle = (params: RequestPermissionRequest, isMcp: boolean): string => {
+  const isShell =
+    extractProviderToolName(params.toolCall) === 'Bash' || params.toolCall.kind === 'execute'
+
+  return (
+    (!isMcp && isShell ? commandFromRawInput(params.toolCall.rawInput) : undefined) ??
+    reportedPermissionTitle(params)
+  )
+}
 
 // Trivial `KEY=VALUE` env assignment prefixing a shell command (e.g. `FOO=bar python a.py`). Values
 // containing whitespace/quotes are not covered (already split away) and fall back to the raw token.
 const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=[^\s]*$/
 
-// Strips a single matching pair of surrounding quotes from a shell token.
-const stripSurroundingQuotes = (token: string): string => {
-  const match = token.match(/^(["'])(.*)\1$/)
-
-  return match ? match[2] : token
-}
-
-// Derives the executable category used to group shell/execute permissions. Leading trivial env
-// assignments are skipped so `FOO=bar python a.py` still groups under `python`.
-const leadingExecutable = (command: string): string => {
+// Derives the normalized full-command signature used to group shell/execute permissions. Leading
+// trivial env assignments are skipped, but arguments remain part of the authorization boundary.
+const commandSignature = (command: string): string => {
   const tokens = command.trim().split(/\s+/)
   let index = 0
 
@@ -60,13 +62,15 @@ const leadingExecutable = (command: string): string => {
     index += 1
   }
 
-  return stripSurroundingQuotes(tokens[index] ?? command.trim())
+  const rest = tokens.slice(index)
+
+  return rest.length > 0 ? rest.join(' ') : command.trim()
 }
 
 // Derives a session-scoped "Always" category key from a permission request (first match wins):
 // 1. MCP tool (recognized across frameworks — Claude's mcp__ prefix or an opencode <server>_ name):
 //    keyed by the tool name, no args.
-// 2. Shell/execute tool (provider tool name Bash, or execute kind): keyed by leading executable.
+// 2. Shell/execute tool (provider tool name Bash, or execute kind): keyed by full command signature.
 // 3. Other built-ins (Write/Edit/WebFetch/…): keyed by provider tool name (falls back to title).
 // The MCP check runs before the execute branch so an opencode MCP tool reporting kind:execute (e.g. a
 // notebook execute-cell) is grouped as its own MCP tool, not misrouted to the shared Bash category.
@@ -75,18 +79,20 @@ const resolveCategoryKey = (
   mcpServerNames: readonly string[] = []
 ): string => {
   const { toolCall } = params
-  const title = resolvePermissionTitle(params)
+  const reportedTitle = reportedPermissionTitle(params)
   const providerToolName = extractProviderToolName(toolCall)
 
   if (
     isMcpToolName(toolCall.title, mcpServerNames) ||
     isMcpToolName(providerToolName, mcpServerNames)
   ) {
-    return `mcp:${title}`
+    return `mcp:${reportedTitle}`
   }
 
+  const title = resolvePermissionTitle(params, false)
+
   if (providerToolName === 'Bash' || toolCall.kind === 'execute') {
-    return `bash:${leadingExecutable(title)}`
+    return `bash:${commandSignature(title)}`
   }
 
   return `tool:${providerToolName ?? title}`
@@ -148,14 +154,15 @@ class AcpPermissionBroker {
   ): Promise<RequestPermissionResponse> {
     const requestId = randomUUID()
     const categoryKey = resolveCategoryKey(params, policyContext?.mcpServerNames)
+    const isMcp = categoryKey.startsWith('mcp:')
     const request: AcpPermissionRequest = {
       requestId,
       sessionId: params.sessionId,
       toolCallId: params.toolCall.toolCallId,
-      title: resolvePermissionTitle(params),
+      title: resolvePermissionTitle(params, isMcp),
       status: params.toolCall.status ?? undefined,
       providerToolName: extractProviderToolName(params.toolCall),
-      isMcp: categoryKey.startsWith('mcp:'),
+      isMcp,
       toolKind: params.toolCall.kind ?? undefined,
       toolLocations: params.toolCall.locations ?? undefined,
       rawInput: params.toolCall.rawInput,

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -41,9 +41,10 @@ const reportedPermissionTitle = (params: RequestPermissionRequest): string =>
 const resolvePermissionTitle = (params: RequestPermissionRequest, isMcp: boolean): string => {
   const isShell =
     extractProviderToolName(params.toolCall) === 'Bash' || params.toolCall.kind === 'execute'
+  const hasNoTitle = !params.toolCall.title?.trim()
 
   return (
-    (!isMcp && isShell ? commandFromRawInput(params.toolCall.rawInput) : undefined) ??
+    (!isMcp && isShell && hasNoTitle ? commandFromRawInput(params.toolCall.rawInput) : undefined) ??
     reportedPermissionTitle(params)
   )
 }

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -24,15 +24,35 @@ type EmitPermissionRequest = (request: AcpPermissionRequest) => void
 const ALLOW_ALWAYS_OPTION_KIND = 'allow_always'
 const ALLOW_ONCE_OPTION_KIND = 'allow_once'
 
+const commandFromRawInput = (rawInput: unknown): string | undefined => {
+  if (!rawInput || typeof rawInput !== 'object' || Array.isArray(rawInput)) return undefined
+
+  const command = (rawInput as Record<string, unknown>).command
+
+  return typeof command === 'string' && command.trim() ? command : undefined
+}
+
+// codex-acp command approvals omit title but retain the exact command in rawInput. Prefer that
+// security-relevant value over opaque call ids and generic provider titles.
+const resolvePermissionTitle = (params: RequestPermissionRequest): string =>
+  commandFromRawInput(params.toolCall.rawInput) ??
+  params.toolCall.title ??
+  params.toolCall.toolCallId
+
 // Trivial `KEY=VALUE` env assignment prefixing a shell command (e.g. `FOO=bar python a.py`). Values
 // containing whitespace/quotes are not covered (already split away) and fall back to the raw token.
 const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=[^\s]*$/
 
-// Derives the command signature used to group shell/execute permissions. Leading trivial env
-// assignments are dropped, then the remaining command (executable plus its arguments) is normalized
-// to single-spaced form. Keying on the full command — not just the executable — keeps "Always" on
-// `python a.py` from also allowing `python b.py`.
-const commandSignature = (command: string): string => {
+// Strips a single matching pair of surrounding quotes from a shell token.
+const stripSurroundingQuotes = (token: string): string => {
+  const match = token.match(/^(["'])(.*)\1$/)
+
+  return match ? match[2] : token
+}
+
+// Derives the executable category used to group shell/execute permissions. Leading trivial env
+// assignments are skipped so `FOO=bar python a.py` still groups under `python`.
+const leadingExecutable = (command: string): string => {
   const tokens = command.trim().split(/\s+/)
   let index = 0
 
@@ -40,15 +60,13 @@ const commandSignature = (command: string): string => {
     index += 1
   }
 
-  const rest = tokens.slice(index)
-
-  return rest.length > 0 ? rest.join(' ') : command.trim()
+  return stripSurroundingQuotes(tokens[index] ?? command.trim())
 }
 
 // Derives a session-scoped "Always" category key from a permission request (first match wins):
 // 1. MCP tool (recognized across frameworks — Claude's mcp__ prefix or an opencode <server>_ name):
 //    keyed by the tool name, no args.
-// 2. Shell/execute tool (provider tool name Bash, or execute kind): keyed by full command signature.
+// 2. Shell/execute tool (provider tool name Bash, or execute kind): keyed by leading executable.
 // 3. Other built-ins (Write/Edit/WebFetch/…): keyed by provider tool name (falls back to title).
 // The MCP check runs before the execute branch so an opencode MCP tool reporting kind:execute (e.g. a
 // notebook execute-cell) is grouped as its own MCP tool, not misrouted to the shared Bash category.
@@ -57,7 +75,7 @@ const resolveCategoryKey = (
   mcpServerNames: readonly string[] = []
 ): string => {
   const { toolCall } = params
-  const title = toolCall.title ?? toolCall.toolCallId
+  const title = resolvePermissionTitle(params)
   const providerToolName = extractProviderToolName(toolCall)
 
   if (
@@ -68,7 +86,7 @@ const resolveCategoryKey = (
   }
 
   if (providerToolName === 'Bash' || toolCall.kind === 'execute') {
-    return `bash:${commandSignature(title)}`
+    return `bash:${leadingExecutable(title)}`
   }
 
   return `tool:${providerToolName ?? title}`
@@ -134,7 +152,7 @@ class AcpPermissionBroker {
       requestId,
       sessionId: params.sessionId,
       toolCallId: params.toolCall.toolCallId,
-      title: params.toolCall.title ?? params.toolCall.toolCallId,
+      title: resolvePermissionTitle(params),
       status: params.toolCall.status ?? undefined,
       providerToolName: extractProviderToolName(params.toolCall),
       isMcp: categoryKey.startsWith('mcp:'),

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2642,6 +2642,107 @@ describe('ACP runtime session management', () => {
     ])
   })
 
+  it('shows sparse Codex command approvals and remembers Always by executable', async () => {
+    const process = new FakeAgentProcess()
+    const permissionRequests: Array<{
+      title: string
+      rawInput?: unknown
+      requestId: string
+    }> = []
+    const permissionResponses: unknown[] = []
+
+    acp
+      .agent({ name: 'codex-command-permission-agent' })
+      .onRequest(acp.methods.agent.initialize, () => ({
+        protocolVersion: acp.PROTOCOL_VERSION,
+        agentCapabilities: {
+          loadSession: false,
+          sessionCapabilities: { close: {} }
+        },
+        authMethods: []
+      }))
+      .onRequest(acp.methods.agent.session.new, () => ({
+        sessionId: 'codex-command-session',
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+      }))
+      .onRequest(acp.methods.agent.session.setMode, () => ({}))
+      .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+        for (const [toolCallId, command] of [
+          ['call-command-1', 'npm run lint'],
+          ['call-command-2', 'npm test']
+        ]) {
+          await ctx.client.notify(acp.methods.client.session.update, {
+            sessionId: ctx.params.sessionId,
+            update: {
+              sessionUpdate: 'tool_call',
+              toolCallId,
+              kind: 'execute',
+              title: command,
+              status: 'pending',
+              rawInput: { command }
+            }
+          })
+
+          const response = await ctx.client.request(acp.methods.client.session.requestPermission, {
+            sessionId: ctx.params.sessionId,
+            toolCall: {
+              toolCallId,
+              kind: 'execute',
+              status: 'pending',
+              rawInput: { command, cwd: '/workspace' }
+            },
+            options: [
+              { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+              { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
+              { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
+            ]
+          })
+          permissionResponses.push(response)
+        }
+
+        return { stopReason: 'end_turn' }
+      })
+      .onRequest(acp.methods.agent.session.close, () => ({}))
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: codexFramework,
+      callbacks: {
+        onPermissionRequest: (request) => {
+          permissionRequests.push(request)
+          runtime.respondToPermission({
+            requestId: request.requestId,
+            optionId: 'allow-session'
+          })
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'run two npm commands' })
+
+    expect(permissionRequests).toHaveLength(1)
+    expect(permissionRequests[0]).toMatchObject({
+      title: 'npm run lint',
+      rawInput: { command: 'npm run lint' }
+    })
+    expect(permissionResponses).toEqual([
+      { outcome: { outcome: 'selected', optionId: 'allow-session' } },
+      { outcome: { outcome: 'selected', optionId: 'allow-once' } }
+    ])
+    expect(runtime.getSnapshot().permissionGrants[session.sessionId]).toEqual([
+      { categoryKey: 'bash:npm', kind: 'shell', label: 'npm' }
+    ])
+  })
+
   it('bounds pending Codex MCP identities and clears unmatched entries when the turn stops', async () => {
     const process = new FakeAgentProcess()
     const promptStarted = createDeferred()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2642,7 +2642,7 @@ describe('ACP runtime session management', () => {
     ])
   })
 
-  it('shows sparse Codex command approvals and remembers Always by executable', async () => {
+  it('shows sparse Codex commands and remembers Always for the same command only', async () => {
     const process = new FakeAgentProcess()
     const permissionRequests: Array<{
       title: string
@@ -2669,7 +2669,8 @@ describe('ACP runtime session management', () => {
       .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
         for (const [toolCallId, command] of [
           ['call-command-1', 'npm run lint'],
-          ['call-command-2', 'npm test']
+          ['call-command-2', 'npm run lint'],
+          ['call-command-3', 'npm test']
         ]) {
           await ctx.client.notify(acp.methods.client.session.update, {
             sessionId: ctx.params.sessionId,
@@ -2720,7 +2721,7 @@ describe('ACP runtime session management', () => {
           permissionRequests.push(request)
           runtime.respondToPermission({
             requestId: request.requestId,
-            optionId: 'allow-session'
+            optionId: permissionRequests.length === 1 ? 'allow-session' : 'allow-once'
           })
         }
       }
@@ -2729,17 +2730,24 @@ describe('ACP runtime session management', () => {
 
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'run two npm commands' })
 
-    expect(permissionRequests).toHaveLength(1)
-    expect(permissionRequests[0]).toMatchObject({
-      title: 'npm run lint',
-      rawInput: { command: 'npm run lint' }
-    })
+    expect(permissionRequests).toHaveLength(2)
+    expect(permissionRequests).toMatchObject([
+      {
+        title: 'npm run lint',
+        rawInput: { command: 'npm run lint' }
+      },
+      {
+        title: 'npm test',
+        rawInput: { command: 'npm test' }
+      }
+    ])
     expect(permissionResponses).toEqual([
       { outcome: { outcome: 'selected', optionId: 'allow-session' } },
+      { outcome: { outcome: 'selected', optionId: 'allow-once' } },
       { outcome: { outcome: 'selected', optionId: 'allow-once' } }
     ])
     expect(runtime.getSnapshot().permissionGrants[session.sessionId]).toEqual([
-      { categoryKey: 'bash:npm', kind: 'shell', label: 'npm' }
+      { categoryKey: 'bash:npm run lint', kind: 'shell', label: 'npm run lint' }
     ])
   })
 


### PR DESCRIPTION
## Problem

Codex ACP command permission requests omit toolCall.title while retaining the exact command in rawInput.command. The broker fell back to the unique call id, so the approval UI displayed an opaque id and session Always grants could not match later calls for the same command.

## Proposed change

Prefer rawInput.command for confirmed non-MCP command approval titles. Keep shell Always grants scoped to the normalized full command so the same command is approved across changing call ids without authorizing different arguments.

Keep MCP category identity separate from display-title resolution so arbitrary MCP command inputs cannot collide across tools.

Add end-to-end Codex ACP regression coverage for visible command text, reuse across call ids, and a new prompt for a different command.

## Scope and non-goals

This change keeps grants session-scoped and preserves existing MCP and non-shell tool category behavior. It does not change permission profiles, broaden shell grants to an entire executable, or alter Codex ACP option selection semantics.

## Acceptance criteria and validation

- npm test: 391 files passed, 7 skipped; 4,848 tests passed, 66 skipped
- npm run lint: passed with 0 errors and 6 pre-existing Prettier warnings in unrelated files
- npm run typecheck: not run, per request
- Targeted regression: 169 affected tests passed

## Review focus

Please review rawInput.command precedence for non-MCP shell approvals, MCP identity isolation, and full-command grant scoping.