### PR TITLE
fix(acp): keep Codex grants session-scoped

### DIFF
--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -191,6 +191,40 @@ describe('ACP permission broker', () => {
     await expect(otherSessionResponse).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
   })
 
+  it('removes Codex policy amendments when execute metadata is absent', () => {
+    const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const request = createCodexCommandPermissionRequest()
+    request.toolCall.kind = undefined
+
+    void broker.requestPermission(request, { profile: 'ask', frameworkId: 'codex' })
+
+    expect(emitted[0].options.map((option) => option.optionId)).toEqual([
+      'allow_once',
+      'allow_always',
+      'reject_once'
+    ])
+  })
+
+  it('fails closed when a Codex command omits canonical session actions', () => {
+    const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const request = createCodexCommandPermissionRequest()
+    request.options = request.options.filter((option) => option.optionId !== 'allow_always')
+    request.options.splice(2, 0, {
+      optionId: 'accept_networkpolicy_amendment',
+      name: 'Allow network access persistently',
+      kind: 'allow_always'
+    })
+
+    void broker.requestPermission(request, { profile: 'ask', frameworkId: 'codex' })
+
+    expect(emitted[0].options.map((option) => option.optionId)).toEqual([
+      'allow_once',
+      'reject_once'
+    ])
+  })
+
   it('cancels a Codex policy amendment response that was not exposed', async () => {
     const emittedRequests: string[] = []
     const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -63,6 +63,28 @@ const createToolPermissionRequest = (
   }
 }
 
+const createCodexCommandPermissionRequest = (
+  sessionId = 'session-1'
+): RequestPermissionRequest => ({
+  sessionId,
+  toolCall: {
+    toolCallId: `tool-${Math.random()}`,
+    title: 'git worktree add -b fix/example ../example main',
+    status: 'pending',
+    kind: 'execute'
+  },
+  options: [
+    { optionId: 'allow_once', name: 'Allow Once', kind: 'allow_once' },
+    { optionId: 'allow_always', name: 'Allow for Session', kind: 'allow_always' },
+    {
+      optionId: 'accept_execpolicy_amendment',
+      name: 'Allow Commands Starting With `git worktree add`',
+      kind: 'allow_always'
+    },
+    { optionId: 'reject_once', name: 'Reject', kind: 'reject_once' }
+  ]
+})
+
 describe('ACP permission broker', () => {
   it('preserves structured tool metadata for risk-aware approval UI', () => {
     const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
@@ -136,6 +158,54 @@ describe('ACP permission broker', () => {
         optionId: 'allow-once'
       }
     })
+  })
+
+  it('projects Codex commands to one session-scoped Always action', async () => {
+    const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const context = { profile: 'ask' as const, frameworkId: 'codex' as const }
+
+    const firstResponse = broker.requestPermission(createCodexCommandPermissionRequest(), context)
+
+    expect(emitted[0].options).toEqual([
+      { optionId: 'allow_once', name: 'Allow Once', kind: 'allow_once' },
+      { optionId: 'allow_always', name: 'Allow for Session', kind: 'allow_always' },
+      { optionId: 'reject_once', name: 'Reject', kind: 'reject_once' }
+    ])
+
+    broker.respond({ requestId: emitted[0].requestId, optionId: 'allow_always' })
+    await expect(firstResponse).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow_always' }
+    })
+
+    await expect(
+      broker.requestPermission(createCodexCommandPermissionRequest(), context)
+    ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow_once' } })
+
+    const otherSessionResponse = broker.requestPermission(
+      createCodexCommandPermissionRequest('session-2'),
+      context
+    )
+    expect(emitted).toHaveLength(2)
+    broker.cancelForSession('session-2')
+    await expect(otherSessionResponse).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+  })
+
+  it('cancels a Codex policy amendment response that was not exposed', async () => {
+    const emittedRequests: string[] = []
+    const broker = new AcpPermissionBroker((request) => emittedRequests.push(request.requestId))
+    const response = broker.requestPermission(createCodexCommandPermissionRequest(), {
+      profile: 'ask',
+      frameworkId: 'codex'
+    })
+
+    broker.respond({
+      requestId: emittedRequests[0],
+      optionId: 'accept_execpolicy_amendment'
+    })
+
+    await expect(response).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+    expect(broker.listGrants('session-1')).toEqual([])
   })
 
   it('resolves pending requests as cancelled when all permissions are cancelled', async () => {

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -206,7 +206,7 @@ describe('ACP permission broker', () => {
     ])
   })
 
-  it('fails closed when a Codex command omits canonical session actions', () => {
+  it('removes policy amendments when a Codex command omits canonical session actions', () => {
     const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
     const broker = new AcpPermissionBroker((request) => emitted.push(request))
     const request = createCodexCommandPermissionRequest()

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -23,6 +23,7 @@ type EmitPermissionRequest = (request: AcpPermissionRequest) => void
 
 const ALLOW_ALWAYS_OPTION_KIND = 'allow_always'
 const ALLOW_ONCE_OPTION_KIND = 'allow_once'
+const CODEX_SESSION_COMMAND_OPTION_IDS = new Set(['allow_once', 'allow_always', 'reject_once'])
 
 const commandFromRawInput = (rawInput: unknown): string | undefined => {
   if (!rawInput || typeof rawInput !== 'object' || Array.isArray(rawInput)) return undefined
@@ -66,6 +67,27 @@ const commandSignature = (command: string): string => {
   const rest = tokens.slice(index)
 
   return rest.length > 0 ? rest.join(' ') : command.trim()
+}
+
+// Open Science owns per-session grants, so Codex command approvals expose the same three actions as
+// Claude Code. Native exec/network policy amendments persist outside the app's visible, revocable
+// session grant model and are intentionally omitted when Codex supplies the canonical session choices.
+const projectPermissionOptions = (
+  params: RequestPermissionRequest,
+  policyContext: PermissionPolicyContext | undefined
+): RequestPermissionRequest['options'] => {
+  if (policyContext?.frameworkId !== 'codex' || params.toolCall.kind !== 'execute') {
+    return params.options
+  }
+
+  const optionIds = new Set(params.options.map((option) => option.optionId))
+  const hasCanonicalSessionActions = Array.from(CODEX_SESSION_COMMAND_OPTION_IDS).every(
+    (optionId) => optionIds.has(optionId)
+  )
+
+  return hasCanonicalSessionActions
+    ? params.options.filter((option) => CODEX_SESSION_COMMAND_OPTION_IDS.has(option.optionId))
+    : params.options
 }
 
 // Derives a session-scoped "Always" category key from a permission request (first match wins):
@@ -156,6 +178,7 @@ class AcpPermissionBroker {
     const requestId = randomUUID()
     const categoryKey = resolveCategoryKey(params, policyContext?.mcpServerNames)
     const isMcp = categoryKey.startsWith('mcp:')
+    const permissionOptions = projectPermissionOptions(params, policyContext)
     const request: AcpPermissionRequest = {
       requestId,
       sessionId: params.sessionId,
@@ -167,7 +190,7 @@ class AcpPermissionBroker {
       toolKind: params.toolCall.kind ?? undefined,
       toolLocations: params.toolCall.locations ?? undefined,
       rawInput: params.toolCall.rawInput,
-      options: params.options.map((option) => ({
+      options: permissionOptions.map((option) => ({
         optionId: option.optionId,
         name: option.name,
         kind: option.kind
@@ -211,6 +234,13 @@ class AcpPermissionBroker {
     this.pendingRequests.delete(response.requestId)
 
     if (response.cancelled || !response.optionId) {
+      pending.resolve({ outcome: { outcome: 'cancelled' } })
+      return true
+    }
+
+    // Only options projected to the renderer are valid responses. This keeps provider-specific
+    // persistent policy actions hidden at the protocol boundary as well as in the UI.
+    if (!pending.request.options.some((option) => option.optionId === response.optionId)) {
       pending.resolve({ outcome: { outcome: 'cancelled' } })
       return true
     }

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -23,7 +23,6 @@ type EmitPermissionRequest = (request: AcpPermissionRequest) => void
 
 const ALLOW_ALWAYS_OPTION_KIND = 'allow_always'
 const ALLOW_ONCE_OPTION_KIND = 'allow_once'
-const CODEX_SESSION_COMMAND_OPTION_IDS = new Set(['allow_once', 'allow_always', 'reject_once'])
 const CODEX_POLICY_AMENDMENT_OPTION_ID_PATTERN = /^accept_.*policy_amendment$/
 
 const commandFromRawInput = (rawInput: unknown): string | undefined => {
@@ -70,9 +69,9 @@ const commandSignature = (command: string): string => {
   return rest.length > 0 ? rest.join(' ') : command.trim()
 }
 
-// Open Science owns per-session grants, so Codex command approvals expose only its canonical session
-// actions. Native exec/network policy amendments persist outside the app's visible, revocable grant
-// model. Their presence also identifies command requests when optional execute metadata is absent.
+// Open Science owns per-session grants, so Codex command approvals omit native exec/network policy
+// amendments that persist outside the app's visible, revocable grant model. Their presence also
+// identifies command requests when optional execute metadata is absent.
 const projectPermissionOptions = (
   params: RequestPermissionRequest,
   policyContext: PermissionPolicyContext | undefined,
@@ -90,7 +89,9 @@ const projectPermissionOptions = (
     return params.options
   }
 
-  return params.options.filter((option) => CODEX_SESSION_COMMAND_OPTION_IDS.has(option.optionId))
+  return params.options.filter(
+    (option) => !CODEX_POLICY_AMENDMENT_OPTION_ID_PATTERN.test(option.optionId)
+  )
 }
 
 // Derives a session-scoped "Always" category key from a permission request (first match wins):

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -24,6 +24,7 @@ type EmitPermissionRequest = (request: AcpPermissionRequest) => void
 const ALLOW_ALWAYS_OPTION_KIND = 'allow_always'
 const ALLOW_ONCE_OPTION_KIND = 'allow_once'
 const CODEX_SESSION_COMMAND_OPTION_IDS = new Set(['allow_once', 'allow_always', 'reject_once'])
+const CODEX_POLICY_AMENDMENT_OPTION_ID_PATTERN = /^accept_.*policy_amendment$/
 
 const commandFromRawInput = (rawInput: unknown): string | undefined => {
   if (!rawInput || typeof rawInput !== 'object' || Array.isArray(rawInput)) return undefined
@@ -69,25 +70,27 @@ const commandSignature = (command: string): string => {
   return rest.length > 0 ? rest.join(' ') : command.trim()
 }
 
-// Open Science owns per-session grants, so Codex command approvals expose the same three actions as
-// Claude Code. Native exec/network policy amendments persist outside the app's visible, revocable
-// session grant model and are intentionally omitted when Codex supplies the canonical session choices.
+// Open Science owns per-session grants, so Codex command approvals expose only its canonical session
+// actions. Native exec/network policy amendments persist outside the app's visible, revocable grant
+// model. Their presence also identifies command requests when optional execute metadata is absent.
 const projectPermissionOptions = (
   params: RequestPermissionRequest,
-  policyContext: PermissionPolicyContext | undefined
+  policyContext: PermissionPolicyContext | undefined,
+  isMcp: boolean
 ): RequestPermissionRequest['options'] => {
-  if (policyContext?.frameworkId !== 'codex' || params.toolCall.kind !== 'execute') {
+  const hasPolicyAmendment = params.options.some((option) =>
+    CODEX_POLICY_AMENDMENT_OPTION_ID_PATTERN.test(option.optionId)
+  )
+
+  if (
+    policyContext?.frameworkId !== 'codex' ||
+    isMcp ||
+    (params.toolCall.kind !== 'execute' && !hasPolicyAmendment)
+  ) {
     return params.options
   }
 
-  const optionIds = new Set(params.options.map((option) => option.optionId))
-  const hasCanonicalSessionActions = Array.from(CODEX_SESSION_COMMAND_OPTION_IDS).every(
-    (optionId) => optionIds.has(optionId)
-  )
-
-  return hasCanonicalSessionActions
-    ? params.options.filter((option) => CODEX_SESSION_COMMAND_OPTION_IDS.has(option.optionId))
-    : params.options
+  return params.options.filter((option) => CODEX_SESSION_COMMAND_OPTION_IDS.has(option.optionId))
 }
 
 // Derives a session-scoped "Always" category key from a permission request (first match wins):
@@ -178,7 +181,7 @@ class AcpPermissionBroker {
     const requestId = randomUUID()
     const categoryKey = resolveCategoryKey(params, policyContext?.mcpServerNames)
     const isMcp = categoryKey.startsWith('mcp:')
-    const permissionOptions = projectPermissionOptions(params, policyContext)
+    const permissionOptions = projectPermissionOptions(params, policyContext, isMcp)
     const request: AcpPermissionRequest = {
       requestId,
       sessionId: params.sessionId,

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -5,10 +5,12 @@ import type {
   PermissionAutoReviewStrategy,
   PermissionProfileId
 } from '../../shared/permission-profiles'
+import type { AgentFrameworkId } from '../../shared/settings'
 import { extractProviderToolName } from './runtime-events'
 
 type PermissionPolicyContext = {
   profile: PermissionProfileId
+  frameworkId?: AgentFrameworkId
   autoReviewStrategy?: PermissionAutoReviewStrategy
   cwd?: string
   // Agent-visible MCP server names, so MCP tools can be recognized across frameworks (see isMcpToolName).

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -41,7 +41,11 @@ import {
   type PermissionProfileId,
   type SessionPermissionProfileState
 } from '../../shared/permission-profiles'
-import { DEFAULT_REASONING_EFFORT, type ReasoningEffort } from '../../shared/settings'
+import {
+  DEFAULT_REASONING_EFFORT,
+  type AgentFrameworkId,
+  type ReasoningEffort
+} from '../../shared/settings'
 import {
   claudeCodeFramework,
   type AgentFramework,
@@ -487,7 +491,7 @@ class AcpRuntime {
   // The framework each session last ran under. Deliberately NOT cleared on disconnect so a framework
   // switch (which disconnects) can still tell that an existing session belongs to the other framework
   // and skip a doomed resume. Cleaned per-session on delete.
-  private readonly sessionFrameworks = new Map<string, string>()
+  private readonly sessionFrameworks = new Map<string, AgentFrameworkId>()
   // Like sessionFrameworks, retained across disconnects. A provider/profile switch can keep the same
   // framework while moving to a different on-disk session store, where the old id is not resumable.
   private readonly sessionBackendIds = new Map<string, string>()
@@ -2950,6 +2954,7 @@ class AcpRuntime {
           : { ...normalizedParams, sessionId: appSessionId },
         {
           profile: profileState?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE,
+          frameworkId: this.sessionFrameworks.get(appSessionId) ?? this.framework.id,
           autoReviewStrategy: profileState?.autoReviewStrategy,
           cwd: this.sessionCwds.get(appSessionId),
           mcpServerNames

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -123,6 +123,8 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('Always - Allow for This Session</span>')
     expect(html).toContain('Always - Allow and Don&#x27;t Ask Again</span>')
     expect(html.match(/>Always<\/span>/g)).toBeNull()
+    expect(html).toContain('inline-flex min-w-0 max-w-full items-center')
+    expect(html).toContain('min-w-0 whitespace-normal break-words text-left')
   })
 
   it('keeps canonical semantics when provider scope names look like other actions', () => {
@@ -165,31 +167,6 @@ describe('PermissionApprovalControls', () => {
 
     expect(html).toContain('MCP tool access</span>')
     expect(html).not.toContain('Command execution</span>')
-  })
-
-  it('distinguishes Codex session approval from an exec-policy amendment', () => {
-    const codexRequest: AcpPermissionRequest = {
-      ...permissionRequest,
-      options: [
-        { optionId: 'allow_always', name: 'Allow for Session', kind: 'allow_always' },
-        {
-          optionId: 'accept_execpolicy_amendment',
-          name: 'Allow Commands Starting With `git worktree`',
-          kind: 'allow_always'
-        },
-        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
-        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
-      ]
-    }
-    const html = renderToStaticMarkup(
-      <PermissionApprovalControls requests={[codexRequest]} onRespond={() => undefined} />
-    )
-
-    expect(html).toContain('Always - Allow for Session</span>')
-    expect(html).toContain('Always - Allow Commands Starting With `git worktree`</span>')
-    expect(html.match(/>Always<\/span>/g)).toBeNull()
-    expect(html).toContain('inline-flex min-w-0 max-w-full items-center')
-    expect(html).toContain('min-w-0 whitespace-normal break-words text-left')
   })
 
   it('serializes prompts by rendering only the first pending request', () => {


### PR DESCRIPTION
## Problem

Open Science owns visible, revocable permission grants per conversation session. Codex command approvals can additionally advertise a native policy amendment as a second `allow_always` option, even though Open Science intends grants to last only for the current conversation session.

Showing both exposes a persistence model that the app does not display or revoke and diverges from the single session-scoped `Always` action used with Claude Code.

## Proposed change

- Pass the active session framework into permission projection.
- For Codex command requests, remove native `*policy_amendment` actions while preserving the provider's one-shot, session, and reject option IDs.
- Recognize command requests from `kind: execute` or a native `*policy_amendment` option, so missing optional tool metadata cannot expose persistent policy actions.
- Remove policy amendments independently of whether the full canonical Codex action set is present.
- Keep Claude Code, OpenCode, Codex MCP requests, and non-command tools unchanged.
- Reject renderer responses for options that were not exposed.

## User-facing behavior

Codex command approvals now show:

```text
Always
Allow once
Reject
Cancel
```

`Always` selects Codex `allow_always` and records the existing Open Science grant for the current conversation session. Later matching commands in that session auto-approve through `allow_once`. A different session prompts again.

Native policy amendment options such as `accept_execpolicy_amendment` are not shown and cannot be submitted through the broker.

## Scope and non-goals

This is narrowly scoped to Codex command permissions. It does not globally deduplicate ACP option kinds or change other frameworks and tool types. Codex MCP permissions keep their existing provider actions and session-grant behavior even when the MCP call reports `kind: execute`.

## Acceptance criteria and validation

- Codex command requests expose one session-scoped `Always`.
- The same session reuses the grant; another session prompts independently.
- Hidden policy-amendment responses are cancelled and create no grant.
- Missing `kind` and incomplete canonical action sets cannot expose policy amendments.
- Alternative provider session option IDs continue to establish and reuse the Open Science session grant.
- Codex MCP permissions remain unchanged.
- Passed after rebasing onto PR #315: broker, policy, and renderer regression suites (42/42), plus the sparse Codex command and Codex MCP runtime regressions (2/2).
- Passed: ESLint, Prettier, and `git diff --check`.
- The broader local runtime run passed 150/151; the unrelated HTTP-host test errored during teardown with `ERR_SERVER_NOT_RUNNING`.
- Passed on final head `88d97bd`: Ubuntu, macOS, and Windows Verify; CodeQL; commit validation; static analysis; and Claude architecture review.
- Not run locally: `npm run typecheck`, per request.

## Review focus

Please review the framework-aware projection boundary, independent filtering of native policy amendments, preservation of provider session and Codex MCP options, and response validation for projected-out options.
