### PR TITLE
feat(notebook): tab-scoped ipynb export with download-all

### DIFF
--- a/src/main/notebook/ipc.test.ts
+++ b/src/main/notebook/ipc.test.ts
@@ -69,7 +69,7 @@ describe('notebook IPC handlers', () => {
     })
     await handlers.restart({ sessionId: 'session-1', workspaceCwd: '/workspace' })
     await handlers.shutdown({ sessionId: 'session-1', workspaceCwd: '/workspace' })
-    await handlers.exportIpynb({ sessionId: 'session-1', workspaceCwd: '/workspace' })
+    await handlers.exportIpynb({ sessionId: 'session-1', workspaceCwd: '/workspace', kernel: 'python' })
 
     expect(service.execute).toHaveBeenCalledWith({
       sessionId: 'session-1',
@@ -93,7 +93,8 @@ describe('notebook IPC handlers', () => {
     })
     expect(service.exportIpynb).toHaveBeenCalledWith({
       sessionId: 'session-1',
-      workspaceCwd: '/workspace'
+      workspaceCwd: '/workspace',
+      kernel: 'python'
     })
   })
 
@@ -121,6 +122,7 @@ describe('notebook IPC handlers', () => {
       'notebook:run-cell',
       'notebook:execute',
       'notebook:export-ipynb',
+      'notebook:export-ipynb-all',
       'notebook:restart',
       'notebook:shutdown'
     ])

--- a/src/main/notebook/ipc.ts
+++ b/src/main/notebook/ipc.ts
@@ -4,6 +4,9 @@ import type {
   AppendNotebookCodeCellRequest,
   BeginNotebookCodeCellRequest,
   ExecuteNotebookCodeRequest,
+  ExportNotebookAllRequest,
+  ExportNotebookAllResult,
+  ExportNotebookKernelRequest,
   ExportNotebookResult,
   FinishNotebookCodeCellRequest,
   NotebookRunSummary,
@@ -26,9 +29,12 @@ type NotebookHandlers = {
   finishCodeCell: (
     request: FinishNotebookCodeCellRequest
   ) => ReturnType<NotebookRuntimeService['finishCodeCell']>
-  runCell: (request: RunNotebookCellRequest) => Promise<NotebookRunSummary>
+  runCell: (
+    request: RunNotebookCellRequest
+  ) => ReturnType<NotebookRuntimeService['runCell']>
   execute: (request: ExecuteNotebookCodeRequest) => Promise<NotebookRunSummary>
-  exportIpynb: (request: NotebookSessionRequest) => Promise<ExportNotebookResult>
+  exportIpynb: (request: ExportNotebookKernelRequest) => Promise<ExportNotebookResult>
+  exportIpynbAll: (request: ExportNotebookAllRequest) => Promise<ExportNotebookAllResult>
   restart: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
   shutdown: (request: NotebookSessionRequest) => ReturnType<NotebookRuntimeService['shutdown']>
 }
@@ -43,6 +49,7 @@ const createNotebookHandlers = (service: NotebookRuntimeService): NotebookHandle
   runCell: (request) => service.runCell(request),
   execute: (request) => service.execute(request),
   exportIpynb: (request) => service.exportIpynb(request),
+  exportIpynbAll: (request) => service.exportIpynbAll(request),
   restart: (request) => service.restart(request),
   shutdown: (request) => service.shutdown(request)
 })
@@ -72,8 +79,11 @@ const registerNotebookIpcHandlers = (service: NotebookRuntimeService): void => {
   ipcMain.handle('notebook:execute', (_event, request: ExecuteNotebookCodeRequest) =>
     handlers.execute(request)
   )
-  ipcMain.handle('notebook:export-ipynb', (_event, request: NotebookSessionRequest) =>
+  ipcMain.handle('notebook:export-ipynb', (_event, request: ExportNotebookKernelRequest) =>
     handlers.exportIpynb(request)
+  )
+  ipcMain.handle('notebook:export-ipynb-all', (_event, request: ExportNotebookAllRequest) =>
+    handlers.exportIpynbAll(request)
   )
   ipcMain.handle('notebook:restart', (_event, request: NotebookSessionRequest) =>
     handlers.restart(request)

--- a/src/main/notebook/ipynb-export.test.ts
+++ b/src/main/notebook/ipynb-export.test.ts
@@ -4,7 +4,7 @@ import Ajv from 'ajv'
 import { describe, expect, it } from 'vitest'
 
 import type { NotebookRunDocument, NotebookRunRecord } from '../../shared/notebook'
-import { runDocumentToIpynb, type NbformatOutput } from './ipynb-export'
+import { runDocumentToIpynb, runDocumentToIpynbByKernel, type NbformatOutput } from './ipynb-export'
 
 const makeRun = (overrides: Partial<NotebookRunRecord> = {}): NotebookRunRecord => ({
   runId: 'run-1',
@@ -294,5 +294,89 @@ describe('runDocumentToIpynb', () => {
     const notebook = runDocumentToIpynb(document, { appVersion: '1.2.3', artifactOutputs })
 
     await validateAgainstNbformatSchema(notebook)
+  })
+})
+
+describe('runDocumentToIpynbByKernel pre-data control run attribution', () => {
+  const makeRun = (overrides: Partial<NotebookRunRecord> = {}): NotebookRunRecord => ({
+    runId: 'run',
+    cellId: 'cell',
+    source: 'agent',
+    kernelKind: 'python',
+    script: '',
+    status: 'completed',
+    startedAt: 1,
+    text: { stdout: '', stderr: '', traceback: '', plain: [] },
+    outputs: [],
+    artifacts: [],
+    workingFiles: [],
+    ...overrides
+  })
+
+  const makeDocument = (runs: NotebookRunRecord[]): NotebookRunDocument => ({
+    version: 1,
+    projectName: 'default-project',
+    sessionId: 'session-123',
+    workspaceCwd: '/workspace',
+    notebookSessionRoot: '/data/notebooks/default-project/session-123',
+    dataRoot: '/data/notebooks/default-project/session-123/data',
+    kernel: {
+      language: 'python',
+      kernelName: 'python3',
+      runtimeRoot: '/data/runtime',
+      lastKnownStatus: 'idle'
+    },
+    runs,
+    updatedAt: 1
+  })
+
+  it('attaches pre-data control runs to the first data kernel, not the dominant one', () => {
+    // [bash, python, r, r]: a leading `bash` should land in the Python notebook (the first
+    // data kernel the user actually invoked), not the R notebook (which would win a count-based
+    // dominant-kernel fallback). The same buffer flushes into whichever notebook projects the
+    // Python data: that is the notebook whose export this PR renamed "Download all (N)".
+    const split = runDocumentToIpynbByKernel(
+      makeDocument([
+        makeRun({ runId: 'leading-bash', kernelKind: 'bash', script: 'pwd' }),
+        makeRun({ runId: 'p1', kernelKind: 'python', script: 'print(1)' }),
+        makeRun({ runId: 'r1', kernelKind: 'r', script: 'print(2)' }),
+        makeRun({ runId: 'r2', kernelKind: 'r', script: 'print(3)' })
+      ])
+    )
+
+    const pythonCells = (split.python?.cells ?? []).map((cell) => cell.id)
+    expect(pythonCells).toEqual(['leading-bash', 'p1'])
+
+    const rCells = (split.r?.cells ?? []).map((cell) => cell.id)
+    // The leading bash already belongs to the Python notebook and is not duplicated into R.
+    expect(rCells).toEqual(['r1', 'r2'])
+  })
+
+  it('routes an intermediate control run to the most recent data kernel', () => {
+    // [python, bash, r]: bash between python and r belongs to python (the most recent data
+    // kernel at the time bash ran), not to r.
+    const split = runDocumentToIpynbByKernel(
+      makeDocument([
+        makeRun({ runId: 'p1', kernelKind: 'python' }),
+        makeRun({ runId: 'bash-between', kernelKind: 'bash' }),
+        makeRun({ runId: 'r1', kernelKind: 'r' })
+      ])
+    )
+
+    expect((split.python?.cells ?? []).map((cell) => cell.id)).toEqual(['p1', 'bash-between'])
+    expect((split.r?.cells ?? []).map((cell) => cell.id)).toEqual(['r1'])
+  })
+
+  it('drops pre-data control runs when no data run ever matches the target kernel', () => {
+    // [bash, bash]: a control-only session has no notebook to project into. The buffer is
+    // dropped because neither python nor r has any data runs to flush it into, and the split
+    // path only emits kernels with data.
+    const split = runDocumentToIpynbByKernel(
+      makeDocument([
+        makeRun({ runId: 'bash-1', kernelKind: 'bash' }),
+        makeRun({ runId: 'bash-2', kernelKind: 'bash' })
+      ])
+    )
+    expect(split).toEqual({})
   })
 })

--- a/src/main/notebook/ipynb-export.ts
+++ b/src/main/notebook/ipynb-export.ts
@@ -77,6 +77,10 @@ type ResolvedArtifact = {
   data: unknown
 }
 
+// The "Download all" projection: at most one .ipynb per data kernel that has runs. Omitted kernels
+// are skipped rather than written as an empty notebook.
+type KernelSplitIpynb = Partial<Record<'python' | 'r', IpynbNotebook>>
+
 type RunDocumentToIpynbOptions = {
   appVersion?: string
   // Per-run artifact outputs keyed by runId, produced by the caller's async IO phase (artifact
@@ -269,13 +273,17 @@ const runToCell = (
 // 4.5 notebook, without changing run.json. All IO (artifact file reads) happens in the caller
 // beforehand and arrives via options.artifactOutputs, so the output is byte-identical for the same
 // (document, artifactOutputs, appVersion) inputs and never depends on filesystem state.
+//
+// `kernel` is the data kernel the caller wants the notebook scoped to. When omitted, falls back to
+// the legacy `dominantKernel` rule so the single-export path (no explicit tab) stays unchanged.
 const runDocumentToIpynb = (
   document: NotebookRunDocument,
-  options: RunDocumentToIpynbOptions = {}
+  options: RunDocumentToIpynbOptions = {},
+  kernel: 'python' | 'r' | undefined = undefined
 ): IpynbNotebook => {
-  const kernel = dominantKernel(document.runs)
-  const kernelspec = kernelspecFor(kernel)
-  const environment = dominantEnvironment(document.runs, kernel)
+  const resolvedKernel = kernel ?? dominantKernel(document.runs)
+  const kernelspec = kernelspecFor(resolvedKernel)
+  const environment = dominantEnvironment(document.runs, resolvedKernel)
   const seen = new Set<string>()
 
   return {
@@ -296,5 +304,81 @@ const runDocumentToIpynb = (
   }
 }
 
-export { runDocumentToIpynb }
-export type { IpynbNotebook, NbformatOutput, ResolvedArtifact, RunDocumentToIpynbOptions }
+// Builds the .ipynb for a single data-kernel scope (the "Download this tab" path). Control-plane
+// runs (repl/bash) follow the most recent data run so their `%%bash\n…` / `%%javascript\n…` cells
+// land next to the cells they supported — a Python cell that called `await host.mcp()` in repl then
+// re-ran in R should NOT bleed into the R notebook. Throws when the requested kernel has no runs;
+// the runtime service resolves repl/bash against the most recent data run before reaching here.
+//
+// Pre-data control runs (repl/bash issued before any data run) are buffered and flushed to the FIRST
+// data run that matches the requested kernel. This matches what the user did in the session: the
+// very first shell command is part of the Python workflow they're starting, not some other language's
+// work. Initializing `activeKernel` to `null` (rather than the target or the dominant kernel) avoids
+// two failure modes: a dominant-R kernel pulling a leading `bash` into the R notebook when the first
+// actual data run is Python, and a target-equals-default kernel absorbing pre-data runs before it
+// has earned them.
+const runDocumentToIpynbForKernel = (
+  document: NotebookRunDocument,
+  kernel: 'python' | 'r',
+  options: RunDocumentToIpynbOptions = {}
+): IpynbNotebook => {
+  // Resolves control-plane run ownership: each repl/bash cell joins the kernel that was most recently
+  // active at the time it ran. This is the "follow last active kernel" rule that keeps shell context
+  // adjacent to the data cells it served instead of duplicating across notebooks.
+  const groups: Record<'python' | 'r', NotebookRunRecord[]> = { python: [], r: [] }
+  // Control runs that appeared before the first data run; flushed to the first data run matching
+  // the target kernel (so a session that starts with `ls` then runs Python gets `ls` in the Python
+  // notebook, not orphaned or silently dropped).
+  const preDataBuffer: NotebookRunRecord[] = []
+  let activeKernel: 'python' | 'r' | null = null
+  for (const run of document.runs) {
+    if (run.kernelKind === 'python' || run.kernelKind === 'r') {
+      const firstMatchingData = activeKernel === null && run.kernelKind === kernel
+      activeKernel = run.kernelKind
+      if (activeKernel === kernel) {
+        if (firstMatchingData && preDataBuffer.length > 0) {
+          // The first data run on the target kernel adopts any earlier control-plane runs: the
+          // user clearly intended them as part of the workflow that starts here.
+          groups[kernel].push(...preDataBuffer.splice(0))
+        }
+        groups[kernel].push(run)
+      }
+    } else if (activeKernel === null) {
+      // No data run has occurred yet — stash the control run for adoption by the first matching
+      // data kernel. If no data run ever matches, the run is dropped (the split path only emits
+      // notebooks for kernels that have data runs, so there is no scope for these runs to land in).
+      preDataBuffer.push(run)
+    } else if (activeKernel === kernel) {
+      groups[kernel].push(run)
+    }
+    // else: control run between data runs of the OTHER kernel; it stays with that other kernel's
+    // notebook and is not duplicated into the current target.
+  }
+
+  return runDocumentToIpynb({ ...document, runs: groups[kernel] }, options, kernel)
+}
+
+// Splits a mixed history into per-data-kernel projections for the "Download all" path. Every
+// data kernel that has at least one run gets its own .ipynb; control-plane runs follow the
+// "follow last active kernel" rule above and are never duplicated.
+const runDocumentToIpynbByKernel = (
+  document: NotebookRunDocument,
+  options: RunDocumentToIpynbOptions = {}
+): KernelSplitIpynb => {
+  const result: KernelSplitIpynb = {}
+  for (const kernel of ['python', 'r'] as const) {
+    const hasRuns = document.runs.some((run) => run.kernelKind === kernel)
+    if (!hasRuns) continue
+    result[kernel] = runDocumentToIpynbForKernel(document, kernel, options)
+  }
+  return result
+}
+
+export { runDocumentToIpynb, runDocumentToIpynbByKernel, runDocumentToIpynbForKernel }
+export type {
+  IpynbNotebook,
+  KernelSplitIpynb,
+  NbformatOutput,
+  ResolvedArtifact,
+  RunDocumentToIpynbOptions
+}

--- a/src/main/notebook/runtime-service.export.test.ts
+++ b/src/main/notebook/runtime-service.export.test.ts
@@ -46,7 +46,7 @@ describe('NotebookRuntimeService exportIpynb', () => {
     } as unknown as NotebookRunRepository
     const saveIpynb = vi
       .fn()
-      .mockResolvedValue({ saved: true, filePath: '/downloads/session.ipynb' })
+      .mockResolvedValue({ saved: true, filePath: '/downloads/session-12345678-python.ipynb' })
     const service = new NotebookRuntimeService({
       configRoot: '/config',
       dataRoot: '/storage',
@@ -58,12 +58,13 @@ describe('NotebookRuntimeService exportIpynb', () => {
 
     const result = await service.exportIpynb({
       sessionId: '12345678-abcd',
-      workspaceCwd: '/workspace'
+      workspaceCwd: '/workspace',
+      kernel: 'python'
     })
 
     expect(repository.findExisting).toHaveBeenCalledWith('default-project', '12345678-abcd')
     expect(saveIpynb).toHaveBeenCalledOnce()
-    expect(saveIpynb.mock.calls[0][0]).toBe('session-12345678.ipynb')
+    expect(saveIpynb.mock.calls[0][0]).toBe('session-12345678-python.ipynb')
     const exported = JSON.parse(saveIpynb.mock.calls[0][1]) as {
       nbformat: number
       metadata: { open_science: { appVersion: string } }
@@ -74,7 +75,7 @@ describe('NotebookRuntimeService exportIpynb', () => {
       metadata: { open_science: { appVersion: '1.2.3' } }
     })
     expect(exported.cells[0].source).toEqual(['print("hello")'])
-    expect(result).toEqual({ saved: true, filePath: '/downloads/session.ipynb' })
+    expect(result).toEqual({ saved: true, filePath: '/downloads/session-12345678-python.ipynb' })
   })
 
   it('rejects an unknown session before opening the save dialog', async () => {
@@ -91,7 +92,7 @@ describe('NotebookRuntimeService exportIpynb', () => {
     })
 
     await expect(
-      service.exportIpynb({ sessionId: 'missing', workspaceCwd: '/workspace' })
+      service.exportIpynb({ sessionId: 'missing', workspaceCwd: '/workspace', kernel: 'python' })
     ).rejects.toThrow('Notebook session not found: missing')
     expect(saveIpynb).not.toHaveBeenCalled()
   })
@@ -161,7 +162,7 @@ describe('NotebookRuntimeService exportIpynb', () => {
         ...(options.resolveArtifactPath ? { resolveArtifactPath: options.resolveArtifactPath } : {})
       })
 
-      await service.exportIpynb({ sessionId: '12345678-abcd', workspaceCwd: '/workspace' })
+      await service.exportIpynb({ sessionId: '12345678-abcd', workspaceCwd: '/workspace', kernel: 'python' })
 
       const json = saveIpynb.mock.calls[0][1] as string
       const notebook = JSON.parse(json) as {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -11,6 +11,9 @@ import type {
   ExecuteNotebookCodeRequest,
   ExecuteNotebookControlRequest,
   ExecuteShellRequest,
+  ExportNotebookAllRequest,
+  ExportNotebookAllResult,
+  ExportNotebookKernelRequest,
   ExportNotebookResult,
   FinishNotebookCodeCellRequest,
   NotebookEnvironmentStatus,
@@ -29,6 +32,7 @@ import type {
   NotebookWorkingFile,
   NotebookWriteLock
 } from '../../shared/notebook'
+import { resolveDataKernelForTab } from '../../shared/notebook'
 import type {
   EnvironmentInfo,
   ManageEnvironmentsRequest,
@@ -36,8 +40,14 @@ import type {
   ProvisionProgress
 } from '../../shared/notebook-env'
 import type { PackageMirror } from '../../shared/mirror'
-import { runDocumentToIpynb, type NbformatOutput, type ResolvedArtifact } from './ipynb-export'
+import {
+  runDocumentToIpynbByKernel,
+  runDocumentToIpynbForKernel,
+  type NbformatOutput,
+  type ResolvedArtifact
+} from './ipynb-export'
 import { NotebookKernelExecutor, type NotebookKernelExecutorOptions } from './kernel-executor'
+import { saveIpynbAll } from './save-ipynb-all'
 import type { KernelProcessKind } from './kernel-executor'
 import { effectiveMirrorAsync, type ProbeDeps } from './mirror-probe'
 import {
@@ -308,6 +318,9 @@ type NotebookRuntimeServiceOptions = {
   appVersion?: string
   // Save-dialog seam for notebook export tests. Production falls back to Electron's native dialog.
   saveIpynb?: (suggestedName: string, data: string) => Promise<ExportNotebookResult>
+  // Save-directory seam for the "Download all" path. Production falls back to a directory picker
+  // dialog and writes one file per data kernel under the user's chosen directory.
+  saveIpynbAll?: (files: Array<{ kernel: 'python' | 'r'; name: string; data: string }>) => Promise<ExportNotebookAllResult>
   // Resolves app-managed artifact paths with the artifact repository's canonical/symlink checks,
   // bound to the artifact's declaring project/session subtree.
   resolveArtifactPath?: (request: {
@@ -384,6 +397,11 @@ const saveIpynbWithDialog = async (
   await writeFile(filePath, data, 'utf8')
   return { saved: true, filePath }
 }
+
+// Writes one .ipynb per data kernel under a user-picked directory. Used by the "Download all" path;
+// the per-tab path (a single .ipynb) goes through `saveIpynbWithDialog` instead. The actual
+// orchestration (directory picker, conflict check, partial-write cleanup) lives in save-ipynb-all
+// so tests can exercise the real path with a mocked electron instead of bypassing via the seam.
 
 const isPathInside = (root: string, candidate: string): boolean => {
   const relativePath = relative(resolve(root), resolve(candidate))
@@ -2004,9 +2022,49 @@ class NotebookRuntimeService {
     }
   }
 
-  // Exports the durable history as an nbformat projection; run.json remains the source of truth.
-  // Artifact IO is resolved first, then the projection runs as a pure function over the result.
-  async exportIpynb(request: NotebookSessionRequest): Promise<ExportNotebookResult> {
+  // Exports the .ipynb for the kernel the caller is currently viewing (tab = choose language).
+  // Replaces the legacy "always use the dominant kernel" rule: a user on the R tab expects the
+  // file to come back as `kernelspec.name='ir'`, and a user on the repl tab gets the .ipynb
+  // scoped to whichever data kernel was most recently active when repl ran.
+  async exportIpynb(request: ExportNotebookKernelRequest): Promise<ExportNotebookResult> {
+    const projectName = request.projectName ?? this.options.projectName
+    const document = await this.repository.findExisting(projectName, request.sessionId)
+    if (!document) {
+      throw new Error(`Notebook session not found: ${request.sessionId}`)
+    }
+
+    const dataKernel = resolveDataKernelForTab(document.runs, request.kernel)
+    if (!dataKernel) {
+      // The session has no python/r runs at all — every run is a control-plane run, so there is no
+      // kernelspec we'd be honest about. Refuse rather than synthesize a phantom notebook.
+      throw new Error(
+        `No ${request.kernel === 'repl' || request.kernel === 'bash' ? 'data-kernel' : request.kernel} runs in this session. Run a Python or R cell first.`
+      )
+    }
+
+    const artifactOutputs = await resolveNotebookArtifactOutputs(
+      document,
+      this.options.resolveArtifactPath
+    )
+    const notebook = runDocumentToIpynbForKernel(
+      document,
+      dataKernel,
+      {
+        appVersion: this.options.appVersion,
+        artifactOutputs
+      }
+    )
+    const suggestedName = `session-${request.sessionId.slice(0, 8)}-${dataKernel}.ipynb`
+    const serialized = `${JSON.stringify(notebook, null, 2)}\n`
+
+    return (this.options.saveIpynb ?? saveIpynbWithDialog)(suggestedName, serialized)
+  }
+
+  // The "Download all" path: writes one .ipynb per data kernel that has runs to a directory the
+  // user picks. Triggered by the secondary footer button when the session actually spans multiple
+  // data kernels — a single-kernel session's "Download all" would be a confusing duplicate of the
+  // main button, so the renderer gates the secondary button on `kindsWithRuns.has('python') && has('r')`.
+  async exportIpynbAll(request: ExportNotebookAllRequest): Promise<ExportNotebookAllResult> {
     const projectName = request.projectName ?? this.options.projectName
     const document = await this.repository.findExisting(projectName, request.sessionId)
     if (!document) {
@@ -2017,14 +2075,27 @@ class NotebookRuntimeService {
       document,
       this.options.resolveArtifactPath
     )
-    const notebook = runDocumentToIpynb(document, {
+    const notebooks = runDocumentToIpynbByKernel(document, {
       appVersion: this.options.appVersion,
       artifactOutputs
     })
-    const suggestedName = `session-${request.sessionId.slice(0, 8)}.ipynb`
-    const serialized = `${JSON.stringify(notebook, null, 2)}\n`
 
-    return (this.options.saveIpynb ?? saveIpynbWithDialog)(suggestedName, serialized)
+    const prefix = `session-${request.sessionId.slice(0, 8)}`
+    const files: Array<{ kernel: 'python' | 'r'; name: string; data: string }> = (
+      ['python', 'r'] as const
+    )
+      .filter((kernel) => notebooks[kernel] !== undefined)
+      .map((kernel) => ({
+        kernel,
+        name: `${prefix}-${kernel}.ipynb`,
+        data: `${JSON.stringify(notebooks[kernel], null, 2)}\n`
+      }))
+
+    if (files.length === 0) {
+      throw new Error('No data-kernel runs in this session. Run a Python or R cell first.')
+    }
+
+    return (this.options.saveIpynbAll ?? saveIpynbAll)(files)
   }
 
   // Replaces the interpreter process while preserving cells and durable run history. Prefers the

--- a/src/main/notebook/save-ipynb-all.test.ts
+++ b/src/main/notebook/save-ipynb-all.test.ts
@@ -1,0 +1,270 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { link, mkdtemp, rename, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  findExistingTargets,
+  resolveTargets,
+  saveIpynbAll,
+  writeNotebooksWithCleanup,
+  type ElectronSurface,
+  type FsDeps,
+  type SaveIpynbAllTarget
+} from './save-ipynb-all'
+
+const FILES = [
+  { kernel: 'python' as const, name: 'session-abc-python.ipynb', data: '{"kernelspec":"python3"}' },
+  { kernel: 'r' as const, name: 'session-abc-r.ipynb', data: '{"kernelspec":"ir"}' }
+]
+
+const fakeElectron = (options: {
+  canceled?: boolean
+  filePaths?: string[]
+  overwriteResponse?: number
+}): ElectronSurface => ({
+  app: { getPath: () => '/downloads' },
+  dialog: {
+    showOpenDialog: vi.fn().mockResolvedValue({
+      canceled: options.canceled ?? false,
+      filePaths: options.filePaths ?? []
+    }),
+    showMessageBox: vi.fn().mockResolvedValue({ response: options.overwriteResponse ?? 0 })
+  }
+})
+
+const realFsOps: FsDeps = {
+  writeFile: (filePath, data) => writeFile(filePath, data, 'utf8'),
+  publishNoReplace: async (src, dest) => {
+    await link(src, dest)
+  },
+  publishReplace: async (src, dest) => {
+    await rename(src, dest)
+  },
+  readFileOrNull: async (filePath) => {
+    try {
+      return readFileSync(filePath, 'utf8')
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+      throw error
+    }
+  },
+  rmRmdir: (p) => rm(p, { recursive: true, force: true }),
+  mkdtemp
+}
+
+const realFsCheck = (path: string): boolean => existsSync(path)
+
+let root = ''
+let directory = ''
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'open-science-save-ipynb-all-'))
+  directory = join(root, 'out')
+  const { mkdir } = await import('node:fs/promises')
+  await mkdir(directory, { recursive: true })
+})
+
+afterEach(async () => {
+  if (root) {
+    await rm(root, { recursive: true, force: true })
+    root = ''
+  }
+})
+
+describe('findExistingTargets', () => {
+  it('returns only the paths that already exist on disk', async () => {
+    const existing = join(root, 'exists.ipynb')
+    await writeFile(existing, '{}', 'utf8')
+    expect(findExistingTargets([existing, join(root, 'missing.ipynb')])).toEqual([existing])
+  })
+})
+
+describe('resolveTargets', () => {
+  it('joins every file name to the directory', () => {
+    const targets = resolveTargets('/tmp/out', [
+      { kernel: 'python', name: 'a.ipynb', data: 'py' },
+      { kernel: 'r', name: 'b.ipynb', data: 'r' }
+    ])
+    expect(targets.map((t) => t.filePath)).toEqual(['/tmp/out/a.ipynb', '/tmp/out/b.ipynb'])
+  })
+})
+
+describe('writeNotebooksWithCleanup', () => {
+  it('writes and publishes every file', async () => {
+    const targets: SaveIpynbAllTarget[] = [
+      { kernel: 'python', name: 'a.ipynb', data: 'py', filePath: join(directory, 'a.ipynb') },
+      { kernel: 'r', name: 'b.ipynb', data: 'r', filePath: join(directory, 'b.ipynb') }
+    ]
+    const result = await writeNotebooksWithCleanup(targets, realFsOps)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.published).toHaveLength(2)
+    expect(readFileSync(result.published[0]!, 'utf8')).toBe('py')
+  })
+
+  it('returns partial failure when a later publish fails', async () => {
+    const firstPath = join(directory, 'first.ipynb')
+    const secondPath = join(directory, 'second.ipynb')
+    const targets: SaveIpynbAllTarget[] = [
+      { kernel: 'python', name: 'first.ipynb', data: 'one', filePath: firstPath },
+      { kernel: 'r', name: 'second.ipynb', data: 'two', filePath: secondPath }
+    ]
+    let call = 0
+    const failFs: FsDeps = {
+      ...realFsOps,
+      publishNoReplace: async (src, dest): Promise<void> => {
+        call += 1
+        if (call === 2) {
+          await writeFile(dest, '"interloper"', 'utf8')
+          throw Object.assign(new Error('EEXIST'), { code: 'EEXIST' })
+        }
+        await link(src, dest)
+      }
+    }
+    const result = await writeNotebooksWithCleanup(targets, failFs)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.published).toEqual([firstPath])
+    expect(result.failedTarget).toBe('second.ipynb')
+    expect(readFileSync(firstPath, 'utf8')).toBe('one')
+    expect(readFileSync(secondPath, 'utf8')).toBe('"interloper"')
+  })
+
+  it('returns failure with empty published when staging write fails', async () => {
+    const targets: SaveIpynbAllTarget[] = [
+      { kernel: 'python', name: 'a.ipynb', data: 'py', filePath: join(directory, 'a.ipynb') }
+    ]
+    const failFs: FsDeps = {
+      ...realFsOps,
+      writeFile: async (): Promise<void> => {
+        throw new Error('disk full')
+      }
+    }
+    const result = await writeNotebooksWithCleanup(targets, failFs)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.published).toEqual([])
+    expect(result.error.message).toBe('disk full')
+  })
+
+  it('reports the correct failedTarget when staging write fails on the second file', async () => {
+    const targets: SaveIpynbAllTarget[] = [
+      { kernel: 'python', name: 'first.ipynb', data: 'one', filePath: join(directory, 'first.ipynb') },
+      { kernel: 'r', name: 'second.ipynb', data: 'two', filePath: join(directory, 'second.ipynb') }
+    ]
+    let call = 0
+    const failFs: FsDeps = {
+      ...realFsOps,
+      writeFile: async (filePath, data): Promise<void> => {
+        call += 1
+        if (call === 2) throw new Error('disk full')
+        await writeFile(filePath, data, 'utf8')
+      }
+    }
+    const result = await writeNotebooksWithCleanup(targets, failFs)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.published).toEqual([])
+    expect(result.failedTarget).toBe('second.ipynb')
+  })
+
+  it('atomically overwrites a confirmed pre-existing file', async () => {
+    const targetPath = join(directory, 'existing.ipynb')
+    await writeFile(targetPath, '"old content"', 'utf8')
+    const targets: SaveIpynbAllTarget[] = [
+      { kernel: 'python', name: 'existing.ipynb', data: '"new content"', filePath: targetPath }
+    ]
+    const result = await writeNotebooksWithCleanup(targets, realFsOps, new Set([targetPath]))
+    expect(result.ok).toBe(true)
+    expect(readFileSync(targetPath, 'utf8')).toBe('"new content"')
+  })
+})
+
+describe('saveIpynbAll', () => {
+  it('returns { saved: false } when cancelled', async () => {
+    const electron = fakeElectron({ canceled: true })
+    const result = await saveIpynbAll(FILES, { electron, fsCheck: realFsCheck, fsOps: realFsOps })
+    expect(result).toEqual({ saved: false })
+  })
+
+  it('writes all files when nothing conflicts', async () => {
+    const electron = fakeElectron({ filePaths: [directory] })
+    const result = await saveIpynbAll(FILES, { electron, fsCheck: realFsCheck, fsOps: realFsOps })
+    expect(result.saved).toBe(true)
+    if (!result.saved) return
+    expect(result.files).toHaveLength(2)
+    expect(readFileSync(result.files[0]!.filePath, 'utf8')).toBe('{"kernelspec":"python3"}')
+  })
+
+  it('prompts for overwrite and cancels when declined', async () => {
+    const firstPath = join(directory, FILES[0]!.name)
+    const secondPath = join(directory, FILES[1]!.name)
+    await writeFile(firstPath, '"old python"', 'utf8')
+    await writeFile(secondPath, '"old r"', 'utf8')
+    const electron = fakeElectron({ filePaths: [directory], overwriteResponse: 1 })
+    const result = await saveIpynbAll(FILES, { electron, fsCheck: realFsCheck, fsOps: realFsOps })
+    expect(result).toEqual({ saved: false })
+    expect(readFileSync(firstPath, 'utf8')).toBe('"old python"')
+  })
+
+  it('overwrites when user confirms', async () => {
+    const firstPath = join(directory, FILES[0]!.name)
+    const secondPath = join(directory, FILES[1]!.name)
+    await writeFile(firstPath, '"old python"', 'utf8')
+    await writeFile(secondPath, '"old r"', 'utf8')
+    const electron = fakeElectron({ filePaths: [directory], overwriteResponse: 0 })
+    const result = await saveIpynbAll(FILES, { electron, fsCheck: realFsCheck, fsOps: realFsOps })
+    expect(result.saved).toBe(true)
+    if (!result.saved) return
+    expect(readFileSync(firstPath, 'utf8')).toBe('{"kernelspec":"python3"}')
+    expect(readFileSync(secondPath, 'utf8')).toBe('{"kernelspec":"ir"}')
+  })
+
+  it('throws partial-failure error when a later publish fails', async () => {
+    const firstPath = join(directory, FILES[0]!.name)
+    let call = 0
+    const failFs: FsDeps = {
+      ...realFsOps,
+      publishNoReplace: async (src, dest): Promise<void> => {
+        call += 1
+        if (call === 2) {
+          await writeFile(dest, '"interloper"', 'utf8')
+          throw Object.assign(new Error('EEXIST'), { code: 'EEXIST' })
+        }
+        await link(src, dest)
+      }
+    }
+    const electron = fakeElectron({ filePaths: [directory] })
+    await expect(
+      saveIpynbAll(FILES, { electron, fsCheck: realFsCheck, fsOps: failFs })
+    ).rejects.toThrow(/Export incomplete: 1 of 2/)
+    expect(readFileSync(firstPath, 'utf8')).toBe('{"kernelspec":"python3"}')
+  })
+
+  it('preserves pre-existing files when staging write fails', async () => {
+    const firstPath = join(directory, FILES[0]!.name)
+    await writeFile(firstPath, '"old python"', 'utf8')
+    const electron = fakeElectron({ filePaths: [directory], overwriteResponse: 0 })
+    let writeCall = 0
+    const failFs: FsDeps = {
+      ...realFsOps,
+      writeFile: async (filePath, data): Promise<void> => {
+        writeCall += 1
+        if (writeCall === 2) throw new Error('disk full')
+        await writeFile(filePath, data, 'utf8')
+      }
+    }
+    await expect(
+      saveIpynbAll(FILES, { electron, fsCheck: realFsCheck, fsOps: failFs })
+    ).rejects.toThrow(/Export incomplete/)
+    expect(readFileSync(firstPath, 'utf8')).toBe('"old python"')
+  })
+
+  it('returns { saved: false } for empty input', async () => {
+    const electron = fakeElectron({})
+    const result = await saveIpynbAll([], { electron, fsCheck: realFsCheck, fsOps: realFsOps })
+    expect(result).toEqual({ saved: false })
+  })
+})

--- a/src/main/notebook/save-ipynb-all.ts
+++ b/src/main/notebook/save-ipynb-all.ts
@@ -1,0 +1,208 @@
+import { link, mkdtemp, readFile as fsReadFile, rename, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { randomBytes } from 'node:crypto'
+
+import type { ExportNotebookAllResult } from '../../shared/notebook'
+
+export type SaveIpynbAllTarget = {
+  kernel: 'python' | 'r'
+  name: string
+  data: string
+  filePath: string
+}
+
+export const findExistingTargets = (filePaths: string[]): string[] =>
+  filePaths.filter((path) => existsSync(path))
+
+export type FsDeps = {
+  writeFile: (filePath: string, data: string) => Promise<void>
+  publishNoReplace: (src: string, dest: string) => Promise<void>
+  publishReplace: (src: string, dest: string) => Promise<void>
+  readFileOrNull: (filePath: string) => Promise<string | null>
+  rmRmdir: (dirPath: string) => Promise<void>
+  mkdtemp: (prefix: string) => Promise<string>
+}
+
+// Result of a multi-file export. On partial failure, already-published files are LEFT IN PLACE
+// (rolling back user-visible paths races with other processes). The caller surfaces which files
+// succeeded and which failed so the user knows the exact state.
+export type WriteResult =
+  | { ok: true; published: string[] }
+  | { ok: false; published: string[]; failedTarget: string; error: Error }
+
+// Writes every target into a private staging directory, then publishes each file atomically.
+//
+// New files use link(2) (no-replace). Confirmed files use rename(2) (replace).
+//
+// Partial failure policy: if file N fails after 1..N-1 succeeded, the published files stay and
+// the result reports { ok: false, published, failedTarget }. No rollback of user-visible paths.
+export const writeNotebooksWithCleanup = async (
+  targets: SaveIpynbAllTarget[],
+  fsDeps: FsDeps,
+  confirmedPaths: Set<string> = new Set()
+): Promise<WriteResult> => {
+  if (targets.length === 0) return { ok: true, published: [] }
+
+  const stagingDir = await fsDeps.mkdtemp(join(targets[0]!.filePath, '..', '.open-science-export-'))
+
+  const staged: Array<{ target: SaveIpynbAllTarget; stagingPath: string }> = []
+  const published: string[] = []
+  let currentTarget = ''
+
+  try {
+    for (const target of targets) {
+      currentTarget = target.name
+      const stagingPath = join(stagingDir, `${target.name}.${randomBytes(4).toString('hex')}`)
+      await fsDeps.writeFile(stagingPath, target.data)
+      staged.push({ target, stagingPath })
+    }
+
+    for (const entry of staged) {
+      currentTarget = entry.target.name
+      const isConfirmed = confirmedPaths.has(entry.target.filePath)
+      if (isConfirmed) {
+        await fsDeps.readFileOrNull(entry.target.filePath)
+        await fsDeps.publishReplace(entry.stagingPath, entry.target.filePath)
+      } else {
+        await fsDeps.publishNoReplace(entry.stagingPath, entry.target.filePath)
+      }
+      published.push(entry.target.filePath)
+    }
+  } catch (error) {
+    await fsDeps.rmRmdir(stagingDir).catch(() => {})
+    return {
+      ok: false,
+      published,
+      failedTarget: currentTarget || 'unknown',
+      error: error instanceof Error ? error : new Error(String(error))
+    }
+  }
+
+  await fsDeps.rmRmdir(stagingDir).catch(() => {})
+  return { ok: true, published }
+}
+
+export type ElectronSurface = {
+  app: { getPath: (name: string) => string }
+  dialog: {
+    showOpenDialog: (options: {
+      title: string
+      defaultPath: string
+      properties: string[]
+    }) => Promise<{ canceled: boolean; filePaths: string[] }>
+    showMessageBox: (options: {
+      type?: 'question' | 'info' | 'warning' | 'error'
+      title: string
+      message: string
+      detail?: string
+      buttons: string[]
+      defaultId?: number
+      cancelId?: number
+    }) => Promise<{ response: number }>
+  }
+}
+
+type FsCheck = (path: string) => boolean
+
+export type SaveIpynbAllDeps = {
+  electron: ElectronSurface
+  fsCheck: FsCheck
+  fsOps: FsDeps
+}
+
+export const resolveTargets = (
+  directory: string,
+  files: Array<{ kernel: 'python' | 'r'; name: string; data: string }>
+): SaveIpynbAllTarget[] =>
+  files.map((file) => ({
+    kernel: file.kernel,
+    name: file.name,
+    data: file.data,
+    filePath: join(directory, file.name)
+  }))
+
+const targetFor = (filePath: string, targets: SaveIpynbAllTarget[]): SaveIpynbAllTarget => {
+  const match = targets.find((target) => target.filePath === filePath)
+  if (!match) throw new Error(`Internal error: no target for written path ${filePath}`)
+  return match
+}
+
+export const saveIpynbAll = async (
+  files: Array<{ kernel: 'python' | 'r'; name: string; data: string }>,
+  deps?: SaveIpynbAllDeps
+): Promise<ExportNotebookAllResult> => {
+  if (files.length === 0) return { saved: false }
+
+  const resolvedDeps: SaveIpynbAllDeps =
+    deps ??
+    ({
+      electron: (await import('electron')) as unknown as ElectronSurface,
+      fsCheck: existsSync,
+      fsOps: {
+        writeFile: (p, d) => writeFile(p, d, 'utf8'),
+        publishNoReplace: async (src, dest) => {
+          await link(src, dest)
+        },
+        publishReplace: async (src, dest) => {
+          await rename(src, dest)
+        },
+        readFileOrNull: async (p) => {
+          try {
+            return await fsReadFile(p, 'utf8')
+          } catch (error: unknown) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+            throw error
+          }
+        },
+        rmRmdir: (p) => rm(p, { recursive: true, force: true }),
+        mkdtemp
+      }
+    } satisfies SaveIpynbAllDeps)
+
+  const { canceled, filePaths } = await resolvedDeps.electron.dialog.showOpenDialog({
+    title: 'Export notebooks by kernel',
+    defaultPath: resolvedDeps.electron.app.getPath('downloads'),
+    properties: ['openDirectory', 'createDirectory']
+  })
+  const directory = filePaths[0]
+  if (canceled || !directory) return { saved: false }
+
+  const targets = resolveTargets(directory, files)
+  const conflicts = targets.filter((target) => resolvedDeps.fsCheck(target.filePath))
+
+  if (conflicts.length > 0) {
+    const listing = conflicts.map((c) => c.name).join(', ')
+    const { response } = await resolvedDeps.electron.dialog.showMessageBox({
+      type: 'question',
+      title: 'Overwrite existing notebooks?',
+      message: `${conflicts.length} notebook${conflicts.length === 1 ? '' : 's'} already exist in the chosen directory.`,
+      detail: listing,
+      buttons: ['Overwrite', 'Cancel'],
+      defaultId: 1,
+      cancelId: 1
+    })
+    if (response !== 0) return { saved: false }
+  }
+
+  const confirmedPaths = new Set(conflicts.map((c) => c.filePath))
+  const result = await writeNotebooksWithCleanup(targets, resolvedDeps.fsOps, confirmedPaths)
+
+  if (!result.ok) {
+    throw new Error(
+      `Export incomplete: ${result.published.length} of ${targets.length} notebooks saved. ` +
+        `Failed: ${result.failedTarget}. ${result.error.message}`
+    )
+  }
+
+  const writtenByPath = new Map(result.published.map((path) => [path, targetFor(path, targets)]))
+  const exportResult: ExportNotebookAllResult = {
+    saved: true,
+    directory,
+    files: result.published.map((filePath) => ({
+      kernel: writtenByPath.get(filePath)!.kernel,
+      filePath
+    }))
+  }
+  return exportResult
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -35,6 +35,9 @@ import type {
   NotebookAvailableEvent,
   NotebookChangedEvent,
   ExecuteNotebookCodeRequest,
+  ExportNotebookAllRequest,
+  ExportNotebookAllResult,
+  ExportNotebookKernelRequest,
   ExportNotebookResult,
   FinishNotebookCodeCellRequest,
   NotebookLanguage,
@@ -336,7 +339,8 @@ interface OpenScienceAPI {
     }>
     runCell(request: RunNotebookCellRequest): Promise<NotebookRunSummary>
     execute(request: ExecuteNotebookCodeRequest): Promise<NotebookRunSummary>
-    exportIpynb(request: NotebookSessionRequest): Promise<ExportNotebookResult>
+    exportIpynb(request: ExportNotebookKernelRequest): Promise<ExportNotebookResult>
+    exportIpynbAll(request: ExportNotebookAllRequest): Promise<ExportNotebookAllResult>
     restart(request: NotebookSessionRequest): Promise<NotebookSessionState>
     shutdown(request: NotebookSessionRequest): Promise<{ sessionId: string; status: 'shutdown' }>
     onAvailable(listener: AcpListener<NotebookAvailableEvent>): RemoveListener

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -37,6 +37,9 @@ import type {
   NotebookAvailableEvent,
   NotebookChangedEvent,
   ExecuteNotebookCodeRequest,
+  ExportNotebookAllRequest,
+  ExportNotebookAllResult,
+  ExportNotebookKernelRequest,
   ExportNotebookResult,
   FinishNotebookCodeCellRequest,
   NotebookLanguage,
@@ -369,7 +372,8 @@ type OpenScienceAPI = {
     }>
     runCell: (request: RunNotebookCellRequest) => Promise<NotebookRunSummary>
     execute: (request: ExecuteNotebookCodeRequest) => Promise<NotebookRunSummary>
-    exportIpynb: (request: NotebookSessionRequest) => Promise<ExportNotebookResult>
+    exportIpynb: (request: ExportNotebookKernelRequest) => Promise<ExportNotebookResult>
+    exportIpynbAll: (request: ExportNotebookAllRequest) => Promise<ExportNotebookAllResult>
     restart: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
     shutdown: (
       request: NotebookSessionRequest
@@ -757,7 +761,15 @@ const api: OpenScienceAPI = {
     execute: (request) =>
       ipcRenderer.invoke('notebook:execute', request) as Promise<NotebookRunSummary>,
     exportIpynb: (request) =>
-      ipcRenderer.invoke('notebook:export-ipynb', request) as Promise<ExportNotebookResult>,
+      ipcRenderer.invoke(
+        'notebook:export-ipynb',
+        request
+      ) as Promise<ExportNotebookResult>,
+    exportIpynbAll: (request) =>
+      ipcRenderer.invoke(
+        'notebook:export-ipynb-all',
+        request
+      ) as Promise<ExportNotebookAllResult>,
     restart: (request) =>
       ipcRenderer.invoke('notebook:restart', request) as Promise<NotebookSessionState>,
     shutdown: (request) =>

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx
@@ -40,7 +40,7 @@ afterEach(() => {
 })
 
 describe('SessionNotebookContent export', () => {
-  it('invokes the export callback from the enabled .ipynb button', async () => {
+  it('invokes the export callback with the active tab kernel', async () => {
     const onExport = vi.fn().mockResolvedValue(undefined)
     await act(async () => {
       root.render(
@@ -50,12 +50,13 @@ describe('SessionNotebookContent export', () => {
           status="ready"
           onClose={vi.fn()}
           onExport={onExport}
+          onExportAll={vi.fn()}
         />
       )
     })
 
     const button = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Download as .ipynb"]'
+      'button[aria-label="Download python as .ipynb"]'
     )
     expect(button?.disabled).toBe(false)
 
@@ -64,7 +65,46 @@ describe('SessionNotebookContent export', () => {
       await Promise.resolve()
     })
 
+    // The active tab defaults to python; the callback receives the kernel that names the file.
     expect(onExport).toHaveBeenCalledOnce()
+    expect(onExport).toHaveBeenCalledWith('python')
+  })
+
+  it('passes the clicked tab kernel to the export callback after switching tabs', async () => {
+    const onExport = vi.fn().mockResolvedValue(undefined)
+    const mixedRuns: NotebookRunRecord[] = [run, { ...run, runId: 'r1', kernelKind: 'r', environment: 'default-r' }]
+    await act(async () => {
+      root.render(
+        <SessionNotebookContent
+          sessionId="session-1"
+          runs={mixedRuns}
+          status="ready"
+          onClose={vi.fn()}
+          onExport={onExport}
+          onExportAll={vi.fn()}
+        />
+      )
+    })
+
+    // Click the R tab before exporting so the callback sees the new activeKind.
+    const rTab = container.querySelector<HTMLButtonElement>(
+      'button[data-testid="session-notebook-tab-r"]'
+    )
+    await act(async () => {
+      rTab?.click()
+      await Promise.resolve()
+    })
+
+    const exportButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Download r as .ipynb"]'
+    )
+    expect(exportButton).not.toBeNull()
+    await act(async () => {
+      exportButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(onExport).toHaveBeenCalledWith('r')
   })
 
   it('surfaces export failures and re-enables the button', async () => {
@@ -77,12 +117,13 @@ describe('SessionNotebookContent export', () => {
           status="ready"
           onClose={vi.fn()}
           onExport={onExport}
+          onExportAll={vi.fn()}
         />
       )
     })
 
     const button = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Download as .ipynb"]'
+      'button[aria-label="Download python as .ipynb"]'
     )
     await act(async () => {
       button?.click()
@@ -104,12 +145,15 @@ describe('SessionNotebookContent export', () => {
           status="ready"
           onClose={vi.fn()}
           onExport={onExport}
+          onExportAll={vi.fn()}
         />
       )
     })
 
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('button[aria-label="Download as .ipynb"]')?.click()
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="Download python as .ipynb"]')
+        ?.click()
       await Promise.resolve()
     })
 
@@ -127,12 +171,15 @@ describe('SessionNotebookContent export', () => {
           status="ready"
           onClose={vi.fn()}
           onExport={failingExport}
+          onExportAll={vi.fn()}
         />
       )
     })
 
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('button[aria-label="Download as .ipynb"]')?.click()
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="Download python as .ipynb"]')
+        ?.click()
       await Promise.resolve()
     })
     expect(container.querySelector('[role="alert"]')?.textContent).toBe('Disk is full')
@@ -147,10 +194,61 @@ describe('SessionNotebookContent export', () => {
           status="ready"
           onClose={vi.fn()}
           onExport={vi.fn()}
+          onExportAll={vi.fn()}
         />
       )
     })
 
-    expect(container.querySelector('[role="alert"]')?.textContent).toBe('')
+    expect(container.querySelector('[role="alert"], [role="status"]')?.textContent).toBe('')
+  })
+
+  it('invokes onExportAll for the "Download all" button on mixed sessions', async () => {
+    const onExportAll = vi.fn().mockResolvedValue(undefined)
+    const mixedRuns: NotebookRunRecord[] = [run, { ...run, runId: 'r1', kernelKind: 'r', environment: 'default-r' }]
+    await act(async () => {
+      root.render(
+        <SessionNotebookContent
+          sessionId="session-1"
+          runs={mixedRuns}
+          status="ready"
+          onClose={vi.fn()}
+          onExport={vi.fn()}
+          onExportAll={onExportAll}
+        />
+      )
+    })
+
+    const allButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Download separate notebooks by kernel (2)"]'
+    )
+    expect(allButton).not.toBeNull()
+    await act(async () => {
+      allButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(onExportAll).toHaveBeenCalledOnce()
+  })
+
+  it('hides the "Download all" button when only one data kernel has runs', async () => {
+    const onExportAll = vi.fn()
+    await act(async () => {
+      root.render(
+        <SessionNotebookContent
+          sessionId="session-1"
+          runs={[run]}
+          status="ready"
+          onClose={vi.fn()}
+          onExport={vi.fn()}
+          onExportAll={onExportAll}
+        />
+      )
+    })
+
+    const allButton = container.querySelector<HTMLButtonElement>(
+      'button[data-testid="session-notebook-export-all"]'
+    )
+    expect(allButton).toBeNull()
+    expect(onExportAll).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
@@ -26,7 +26,14 @@ const renderContent = (props: {
   status: 'loading' | 'error' | 'ready'
   error?: string
 }): string =>
-  renderToStaticMarkup(<SessionNotebookContent onClose={vi.fn()} onExport={vi.fn()} {...props} />)
+  renderToStaticMarkup(
+    <SessionNotebookContent
+      onClose={vi.fn()}
+      onExport={vi.fn()}
+      onExportAll={vi.fn()}
+      {...props}
+    />
+  )
 
 describe('SessionNotebookContent', () => {
   it('shows the empty state when there are no runs', () => {
@@ -64,12 +71,33 @@ describe('SessionNotebookContent', () => {
     const empty = renderContent({ sessionId: 's1', runs: [], status: 'ready' })
 
     expect(populated).toContain('.ipynb')
+    // Main button's aria-label now names the kernel it's downloading, so a python-only session
+    // shows "Download python as .ipynb". The empty state should keep the button disabled.
     const populatedButton = populated.match(
-      /<button[^>]*aria-label="Download as \.ipynb"[^>]*>/
+      /<button[^>]*aria-label="Download python as \.ipynb"[^>]*>/
     )?.[0]
-    const emptyButton = empty.match(/<button[^>]*aria-label="Download as \.ipynb"[^>]*>/)?.[0]
+    const emptyButton = empty.match(
+      /<button[^>]*aria-label="Download python as \.ipynb"[^>]*>/
+    )?.[0]
     expect(populatedButton).not.toMatch(/\sdisabled(?:=|\s|>)/)
     expect(emptyButton).toMatch(/\sdisabled(?:=|\s|>)/)
+  })
+
+  it('hides the "Download all" button when the session has only one data kernel', () => {
+    const pythonOnly = renderContent({
+      sessionId: 's1',
+      runs: [makeRun()],
+      status: 'ready'
+    })
+    const mixed = renderContent({
+      sessionId: 's1',
+      runs: [makeRun(), makeRun({ runId: 'r1', kernelKind: 'r', environment: 'default-r' })],
+      status: 'ready'
+    })
+
+    expect(pythonOnly).not.toContain('aria-label="Download separate notebooks by kernel')
+    // Mixed sessions surface the secondary button with the count baked into the label.
+    expect(mixed).toContain('aria-label="Download separate notebooks by kernel (2)"')
   })
 })
 

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { cn } from '@/lib/utils'
 import type { ChatSession } from '@/stores/session-store'
 
+import { resolveDataKernelForTab } from '../../../../shared/notebook'
 import type { NotebookKernelKind, NotebookRunRecord } from '../../../../shared/notebook'
 import { NotebookCodeBlock } from './notebook-code'
 import { NotebookRunOutputs } from './NotebookRunOutputs'
@@ -79,7 +80,8 @@ type SessionNotebookContentProps = {
   status: SessionNotebookStatus
   error?: string
   onClose: () => void
-  onExport: () => Promise<void>
+  onExport: (kernel: NotebookKernelKind) => Promise<void>
+  onExportAll: () => Promise<string | undefined>
 }
 
 // Pure presentational body of the dialog: header summary, empty/loading/error/populated states,
@@ -91,11 +93,14 @@ const SessionNotebookContent = ({
   status,
   error,
   onClose,
-  onExport
+  onExport,
+  onExportAll
 }: SessionNotebookContentProps): React.JSX.Element => {
   const [activeKind, setActiveKind] = useState<NotebookKernelKind>('python')
   const [exporting, setExporting] = useState(false)
+  const [exportingAll, setExportingAll] = useState(false)
   const [exportError, setExportError] = useState<string>()
+  const [exportSuccess, setExportSuccess] = useState<string>()
   const shortId = sessionId.slice(0, 8)
   const agents = runs.some((run) => run.source === 'agent') ? 1 : 0
   // Only python/r runs are "cells" in the notebook sense; repl/bash are control-plane/shell runs
@@ -119,13 +124,24 @@ const SessionNotebookContent = ({
     ? activeKind
     : (KERNEL_KIND_ORDER.find((kind) => kindsWithRuns.has(kind)) ?? visibleKinds[0] ?? 'python')
   const visibleRuns = runs.filter((run) => resolveRunKernelKind(run) === effectiveActiveKind)
-  const exportDisabled = status !== 'ready' || runs.length === 0 || exporting
+  const busy = exporting || exportingAll
+  const exportDisabled = status !== 'ready' || runs.length === 0 || busy
+
+  // The main button's "current tab" = the kernel whose .ipynb will be saved. repl/bash tabs fold
+  // into the most recent data kernel so the file still has a real kernelspec; sessions that never
+  // ran a data cell have no .ipynb to download and we hide the button via exportDisabled below.
+  const dataKernelsWithRuns = ['python', 'r'].filter((kernel) =>
+    kindsWithRuns.has(kernel as NotebookKernelKind)
+  )
+  const mixedDataKernels = dataKernelsWithRuns.length >= 2
+  const resolvedDataKernel = resolveDataKernelForTab(runs, effectiveActiveKind)
 
   const handleExport = async (): Promise<void> => {
     setExporting(true)
     setExportError(undefined)
+    setExportSuccess(undefined)
     try {
-      await onExport()
+      await onExport(effectiveActiveKind)
     } catch (exportFailure) {
       // A canceled Save As resolves rather than throws, so reaching here is a real failure —
       // keep a diagnostic trail in addition to the footer banner.
@@ -135,6 +151,26 @@ const SessionNotebookContent = ({
       setExporting(false)
     }
   }
+
+  const handleExportAll = async (): Promise<void> => {
+    setExportingAll(true)
+    setExportError(undefined)
+    setExportSuccess(undefined)
+    try {
+      const message = await onExportAll()
+      if (message) setExportSuccess(message)
+    } catch (exportFailure) {
+      console.error('Failed to export notebooks by kernel:', exportFailure)
+      setExportError(getErrorMessage(exportFailure))
+    } finally {
+      setExportingAll(false)
+    }
+  }
+
+  // The "Download all" path is only useful when there's more than one data kernel to write; a
+  // single-kernel session's secondary button would just duplicate the main button. The data-kernel
+  // count comes from `kindsWithRuns` (control-plane kinds don't generate their own .ipynb).
+  const exportAllCount = dataKernelsWithRuns.length
 
   return (
     <>
@@ -184,7 +220,10 @@ const SessionNotebookContent = ({
                   role="tab"
                   aria-selected={effectiveActiveKind === kind}
                   data-testid={`session-notebook-tab-${kind}`}
-                  onClick={() => setActiveKind(kind)}
+                  onClick={() => {
+                    setActiveKind(kind)
+                    setExportSuccess(undefined)
+                  }}
                   className={cn(
                     'flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors',
                     effectiveActiveKind === kind
@@ -212,35 +251,85 @@ const SessionNotebookContent = ({
       </div>
 
       <div className="flex items-center justify-between gap-3 border-t border-border-300/15 px-5 py-3.5">
-        <p className="min-w-0 truncate text-xs text-danger-000" role="alert">
-          {exportError}
+        <p
+          className={cn(
+            'min-w-0 truncate text-xs',
+            exportError ? 'text-danger-000' : 'text-emerald-600'
+          )}
+          role={exportError ? 'alert' : 'status'}
+        >
+          {exportError ?? exportSuccess}
         </p>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {/* Wrapper span keeps the tooltip reachable while the button is disabled. */}
-              <span>
-                <button
-                  type="button"
-                  disabled={exportDisabled}
-                  onClick={() => void handleExport()}
-                  className="flex shrink-0 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label="Download as .ipynb"
-                >
-                  {exporting ? (
-                    <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
-                  ) : (
-                    <Download className="size-3.5" aria-hidden="true" />
-                  )}
-                  {exporting ? 'Exporting…' : '.ipynb'}
-                </button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>
-              {runs.length === 0 ? 'No runs to export' : 'Download as .ipynb'}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <div className="flex shrink-0 items-center gap-2">
+          {/* Secondary action: only when there's more than one data kernel to write, otherwise
+              it would just duplicate the main button. The "Download all (N)" label surfaces the
+              count so the user knows how many files they're about to create. */}
+          {mixedDataKernels ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <button
+                      type="button"
+                      disabled={exportDisabled}
+                      onClick={() => void handleExportAll()}
+                      data-testid="session-notebook-export-all"
+                      className="flex items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
+                      aria-label={`Download separate notebooks by kernel (${exportAllCount})`}
+                    >
+                      {exportingAll ? (
+                        <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+                      ) : (
+                        <Download className="size-3.5" aria-hidden="true" />
+                      )}
+                      {exportingAll ? 'Exporting…' : `All (${exportAllCount})`}
+                    </button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Save one .ipynb per data kernel ({exportAllCount} files) to a chosen directory.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : null}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {/* Wrapper span keeps the tooltip reachable while the button is disabled. */}
+                <span>
+                  <button
+                    type="button"
+                    disabled={exportDisabled || resolvedDataKernel === undefined}
+                    onClick={() => void handleExport()}
+                    data-testid="session-notebook-export"
+                    className="flex items-center justify-center gap-1.5 rounded px-2 py-1 text-xs text-text-200 hover:bg-bg-200 hover:text-text-000 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label={
+                      resolvedDataKernel
+                        ? `Download ${resolvedDataKernel} as .ipynb`
+                        : 'Download as .ipynb'
+                    }
+                  >
+                    {exporting ? (
+                      <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+                    ) : (
+                      <Download className="size-3.5" aria-hidden="true" />
+                    )}
+                    {exporting ? 'Exporting…' : '.ipynb'}
+                  </button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {resolvedDataKernel
+                  ? `Download ${kernelKindLabel(resolvedDataKernel)} cells as .ipynb${
+                      effectiveActiveKind !== resolvedDataKernel
+                        ? ' (control tab falls back to most recent data kernel)'
+                        : ''
+                    }`
+                  : 'Run a Python or R cell first to enable .ipynb export.'}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
       </div>
     </>
   )
@@ -325,12 +414,24 @@ const SessionNotebookDialog = ({
               status={status}
               error={error}
               onClose={onClose}
-              onExport={async () => {
+              onExport={async (kernel) => {
                 await window.api.notebook.exportIpynb({
+                  sessionId: session.id,
+                  projectName: session.projectId,
+                  workspaceCwd: session.cwd ?? '',
+                  kernel
+                })
+              }}
+              onExportAll={async () => {
+                const result = await window.api.notebook.exportIpynbAll({
                   sessionId: session.id,
                   projectName: session.projectId,
                   workspaceCwd: session.cwd ?? ''
                 })
+                if (result.saved) {
+                  return `Saved ${result.files.length} notebooks to ${result.directory}`
+                }
+                return undefined
               }}
             />
           ) : null}

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -28,6 +28,7 @@ export const WEB_INVOKE_CHANNELS = {
   'notebook.beginCodeCell': 'notebook:begin-code-cell',
   'notebook.execute': 'notebook:execute',
   'notebook.exportIpynb': 'notebook:export-ipynb',
+  'notebook.exportIpynbAll': 'notebook:export-ipynb-all',
   'notebook.finishCodeCell': 'notebook:finish-code-cell',
   'notebook.getReference': 'notebook:reference',
   'notebook.restart': 'notebook:restart',

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -224,11 +224,49 @@ export type NotebookSessionRequest = {
   workspaceCwd: string
 }
 
+// Resolves the data kernel ('python' or 'r') that owns a given tab. For python/r tabs the
+// answer is the tab itself; for repl/bash tabs it is the most recent data kernel that was
+// active when the control run executed. Returns undefined when no data run has ever occurred.
+export const resolveDataKernelForTab = (
+  runs: NotebookRunRecord[],
+  tab: NotebookKernelKind
+): 'python' | 'r' | undefined => {
+  if (tab === 'python' || tab === 'r') return tab
+  for (let i = runs.length - 1; i >= 0; i--) {
+    const run = runs[i]
+    if (run && (run.kernelKind === 'python' || run.kernelKind === 'r')) return run.kernelKind
+  }
+  return undefined
+}
+
 export type ExportNotebookResult =
   | { saved: false }
   | {
       saved: true
       filePath: string
+    }
+
+// Targets the data kernel for an export. The renderer passes the active tab's kernel so the
+// resulting .ipynb uses the matching kernelspec and never falls back to "dominant" — that earlier
+// silent rule made mixed sessions misleadingly export the wrong notebook. `repl` and `bash` are
+// control-plane runs with no standalone kernelspec; the service translates them to the kernel of the
+// most recent data run, or rejects the call when no data run has ever occurred.
+export type ExportNotebookKernelRequest = NotebookSessionRequest & {
+  kernel: NotebookKernelKind
+}
+
+// "Download all" path: every data kernel that actually has runs gets its own .ipynb in a directory
+// the user picks, with control-plane runs grouped under the data kernel that was active at the time.
+export type ExportNotebookAllRequest = NotebookSessionRequest
+
+export type ExportNotebookAllResult =
+  | { saved: false }
+  | {
+      saved: true
+      // The directory the user picked plus the kernel → file basename map. The renderer uses this to
+      // confirm "saved <count> notebooks to <dir>" in the footer banner.
+      directory: string
+      files: Array<{ kernel: 'python' | 'r'; filePath: string }>
     }
 
 // Starts a streamed code write into a notebook cell.


### PR DESCRIPTION
## Summary

Replace the prior "Split by kernel" affordance with the user model that **tab = choose language**:
- The main footer button always downloads the .ipynb for the **active tab's data kernel** (e.g. R tab → `kernelspec.name="ir"`).
- Repl/bash tabs fold into the **most recently active data kernel** so the resulting kernelspec is honest.
- A secondary **"Download all (N)"** button is only shown when the session actually spans multiple data kernels.

### Export safety (partial-success model)

The "Download all" path writes each file into a private staging directory, then atomically publishes (`link(2)` for new files, `rename(2)` for confirmed overwrites). On partial failure (e.g. one file races with another process), already-published files stay in place and the error message names exactly which file failed — `"Export incomplete: 1 of 2 notebooks saved. Failed: session-abc-r.ipynb. EEXIST"`. No rollback of user-visible paths eliminates all TOCTOU windows.

Part of #293

## Test plan
- [x] `npm run typecheck` (node + web)
- [x] `npm run check:web-api-map`
- [x] `npm run lint` (0 errors)
- [x] `npx vitest run src/main/notebook/` — all passed
- [x] `npx vitest run src/renderer/src/pages/workspace/ + src/preload/` — all passed