### PR TITLE
feat(updater): show download size and transferred bytes during update

### DIFF
--- a/src/main/update/downloader.test.ts
+++ b/src/main/update/downloader.test.ts
@@ -20,7 +20,7 @@ describe('downloadInstaller', () => {
     dir = await mkdtemp(join(tmpdir(), 'upd-'))
     const target = join(dir, 'open-science-0.3.0-mac-arm64.dmg')
     const body = Buffer.from('installer-bytes')
-    const percents: number[] = []
+    const progresses: { percent: number; transferred: number; total: number }[] = []
     const fetchImpl = (() =>
       Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
 
@@ -31,12 +31,16 @@ describe('downloadInstaller', () => {
         sha256: sha256(body)
       },
       target,
-      { fetchImpl, onProgress: (p) => percents.push(p) }
+      { fetchImpl, onProgress: (p) => progresses.push(p) }
     )
 
     expect(path).toBe(target)
     expect(await readFile(path)).toEqual(body)
-    expect(percents.at(-1)).toBe(100)
+    expect(progresses.at(-1)).toEqual({
+      percent: 100,
+      transferred: body.byteLength,
+      total: body.byteLength
+    })
   })
 
   it('deletes the file and throws on checksum mismatch', async () => {

--- a/src/main/update/downloader.ts
+++ b/src/main/update/downloader.ts
@@ -2,11 +2,11 @@ import { createHash } from 'node:crypto'
 import { createWriteStream } from 'node:fs'
 import { rm } from 'node:fs/promises'
 
-import type { PlatformDownload } from '../../shared/update'
+import type { DownloadProgress, PlatformDownload } from '../../shared/update'
 
 export type DownloadDeps = {
   fetchImpl?: typeof fetch
-  onProgress?: (percent: number) => void
+  onProgress?: (progress: DownloadProgress) => void
   // Aborts the request/stream when signalled; the reader rejects and the partial file is cleaned up.
   signal?: AbortSignal
 }
@@ -47,7 +47,13 @@ export const downloadInstaller = async (
       hash.update(chunk)
       await writeChunk(chunk)
       received += chunk.byteLength
-      if (download.size > 0) deps.onProgress?.(Math.round((received / download.size) * 100))
+      if (download.size > 0) {
+        deps.onProgress?.({
+          percent: Math.round((received / download.size) * 100),
+          transferred: received,
+          total: download.size
+        })
+      }
     }
     if (streamError) throw streamError
 
@@ -60,7 +66,7 @@ export const downloadInstaller = async (
       await rm(targetPath, { force: true })
       throw new Error('Checksum mismatch')
     }
-    deps.onProgress?.(100)
+    deps.onProgress?.({ percent: 100, transferred: download.size, total: download.size })
     return targetPath
   } catch (error) {
     // Wait for the underlying fd to actually close before unlinking: createWriteStream opens

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -345,4 +345,22 @@ describe('ElectronUpdaterStrategy', () => {
     const status = await strategy.check()
     expect(status.notes).toBe('')
   })
+
+  it('hydrates totalBytes from the CDN manifest when the version matches', async () => {
+    const updater = new FakeUpdater()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      platform: 'darwin',
+      arch: 'arm64',
+      broadcast: vi.fn(),
+      fetchImpl: manifestFetch({
+        version: '0.3.0',
+        downloads: { 'mac-arm64': { url: 'https://cdn/x.dmg', size: 99000, sha256: 'a' } },
+        notes: 'notes'
+      })
+    })
+    const status = await strategy.check()
+    expect(status.totalBytes).toBe(99000)
+  })
 })

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -39,7 +39,7 @@ class FakeUpdater extends EventEmitter {
     this.emit('update-available', {
       version: '0.3.0',
       releaseNotes: 'notes',
-      files: [{ size: 10000 }]
+      files: [{ url: 'https://cdn/Open-Science-0.3.0.zip', size: 10000 }]
     })
   })
   downloadUpdate = vi.fn((token?: FakeToken): Promise<void> => {
@@ -355,7 +355,10 @@ describe('ElectronUpdaterStrategy', () => {
     updater.checkForUpdates = vi.fn(async () => {
       updater.emit('update-available', {
         version: '0.3.0',
-        files: [{ size: 99000 }, { size: 12000 }]
+        files: [
+          { url: 'https://cdn/app-0.3.0.zip', size: 99000 },
+          { url: 'https://cdn/app-0.3.0.dmg', size: 12000 }
+        ]
       })
     })
     const strategy = new ElectronUpdaterStrategy({
@@ -365,6 +368,7 @@ describe('ElectronUpdaterStrategy', () => {
       fetchImpl: offlineFetch()
     })
     const status = await strategy.check()
+    // darwin (the test default via process.platform mock) should match the .zip, not the .dmg.
     expect(status.totalBytes).toBe(99000)
   })
 
@@ -444,5 +448,29 @@ describe('ElectronUpdaterStrategy', () => {
     // The retry's progress event should report fresh transferred, not stale bytes.
     expect(retry.downloadedBytes).toBe(5500)
     await first
+  })
+
+  it('picks the platform-matching artifact over the first entry in a multi-file feed', async () => {
+    // A macOS feed lists both DMG (for manual download) and ZIP (for auto-update). The strategy
+    // must pick the ZIP size (what electron-updater downloads), not the DMG.
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', {
+        version: '0.3.0',
+        files: [
+          { url: 'https://cdn/app-0.3.0.dmg', size: 80000 },
+          { url: 'https://cdn/app-0.3.0.zip', size: 60000 }
+        ]
+      })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    const status = await strategy.check()
+    // darwin → .zip (60000), not .dmg (80000) which is listed first.
+    expect(status.totalBytes).toBe(60000)
   })
 })

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -422,6 +422,59 @@ describe('ElectronUpdaterStrategy', () => {
     expect(status.totalBytes).toBeUndefined()
   })
 
+  it('resolves x64 under Rosetta to arm64 for artifact size selection', async () => {
+    // An x64 app running under Rosetta 2 on Apple Silicon downloads the arm64 ZIP (electron-updater's
+    // MacUpdater.filterFilesForArch does the same via sysctl.proc_translated). The pre-download size
+    // must match the arm64 entry, not the x64 one.
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', {
+        version: '0.3.0',
+        files: [
+          { url: 'https://cdn/app-0.3.0-arm64.zip', size: 95000 },
+          { url: 'https://cdn/app-0.3.0-x64.zip', size: 105000 }
+        ]
+      })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      platform: 'darwin',
+      arch: 'x64',
+      isRosetta: () => true,
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    const status = await strategy.check()
+    // x64 + Rosetta → effective arm64 → picks 95000, not 105000.
+    expect(status.totalBytes).toBe(95000)
+  })
+
+  it('keeps x64 arch when not under Rosetta', async () => {
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', {
+        version: '0.3.0',
+        files: [
+          { url: 'https://cdn/app-0.3.0-arm64.zip', size: 95000 },
+          { url: 'https://cdn/app-0.3.0-x64.zip', size: 105000 }
+        ]
+      })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      platform: 'darwin',
+      arch: 'x64',
+      isRosetta: () => false,
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    const status = await strategy.check()
+    // Native Intel x64 → picks 105000.
+    expect(status.totalBytes).toBe(105000)
+  })
+
   it('preserves check-time totalBytes when download-progress omits total', async () => {
     // Artifacts published with a size in the feed should keep that size even if a progress event
     // arrives without a total field.

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -350,13 +350,13 @@ describe('ElectronUpdaterStrategy', () => {
     expect(status.notes).toBe('')
   })
 
-  it('extracts totalBytes from the updater feed artifact files at check time', async () => {
+  it('extracts totalBytes from the updater feed artifact for the current platform', async () => {
     const updater = new FakeUpdater()
     updater.checkForUpdates = vi.fn(async () => {
       updater.emit('update-available', {
         version: '0.3.0',
         files: [
-          { url: 'https://cdn/app-0.3.0.zip', size: 99000 },
+          { url: 'https://cdn/app-0.3.0-arm64.zip', size: 99000 },
           { url: 'https://cdn/app-0.3.0.dmg', size: 12000 }
         ]
       })
@@ -364,12 +364,62 @@ describe('ElectronUpdaterStrategy', () => {
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
+      platform: 'darwin',
+      arch: 'arm64',
       broadcast: vi.fn(),
       fetchImpl: offlineFetch()
     })
     const status = await strategy.check()
-    // darwin (the test default via process.platform mock) should match the .zip, not the .dmg.
+    // darwin/arm64 → the arm64 ZIP (99000), not the DMG (12000).
     expect(status.totalBytes).toBe(99000)
+  })
+
+  it('matches the correct architecture in a multi-arch macOS feed', async () => {
+    // Real latest-mac.yml carries both arm64 and x64 ZIPs; x64 must not pick arm64's size.
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', {
+        version: '0.3.0',
+        files: [
+          { url: 'https://cdn/app-0.3.0-arm64.zip', size: 95000 },
+          { url: 'https://cdn/app-0.3.0-x64.zip', size: 105000 }
+        ]
+      })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      platform: 'darwin',
+      arch: 'x64',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    const status = await strategy.check()
+    expect(status.totalBytes).toBe(105000)
+  })
+
+  it('omits totalBytes when multiple files match the platform and arch ambiguously', async () => {
+    // If two files somehow match the same platform+arch+extension, don't guess.
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', {
+        version: '0.3.0',
+        files: [
+          { url: 'https://cdn/app-0.3.0-arm64.zip', size: 95000 },
+          { url: 'https://cdn/app-0.3.0-arm64.zip', size: 105000 }
+        ]
+      })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      platform: 'darwin',
+      arch: 'arm64',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    const status = await strategy.check()
+    expect(status.totalBytes).toBeUndefined()
   })
 
   it('preserves check-time totalBytes when download-progress omits total', async () => {
@@ -448,29 +498,5 @@ describe('ElectronUpdaterStrategy', () => {
     // The retry's progress event should report fresh transferred, not stale bytes.
     expect(retry.downloadedBytes).toBe(5500)
     await first
-  })
-
-  it('picks the platform-matching artifact over the first entry in a multi-file feed', async () => {
-    // A macOS feed lists both DMG (for manual download) and ZIP (for auto-update). The strategy
-    // must pick the ZIP size (what electron-updater downloads), not the DMG.
-    const updater = new FakeUpdater()
-    updater.checkForUpdates = vi.fn(async () => {
-      updater.emit('update-available', {
-        version: '0.3.0',
-        files: [
-          { url: 'https://cdn/app-0.3.0.dmg', size: 80000 },
-          { url: 'https://cdn/app-0.3.0.zip', size: 60000 }
-        ]
-      })
-    })
-    const strategy = new ElectronUpdaterStrategy({
-      updater,
-      currentVersion: '0.2.0',
-      broadcast: vi.fn(),
-      fetchImpl: offlineFetch()
-    })
-    const status = await strategy.check()
-    // darwin → .zip (60000), not .dmg (80000) which is listed first.
-    expect(status.totalBytes).toBe(60000)
   })
 })

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -36,7 +36,11 @@ class FakeUpdater extends EventEmitter {
   private downloadPromise: Promise<void> | null = null
   checkForUpdates = vi.fn(async () => {
     this.emit('checking-for-update')
-    this.emit('update-available', { version: '0.3.0', releaseNotes: 'notes' })
+    this.emit('update-available', {
+      version: '0.3.0',
+      releaseNotes: 'notes',
+      files: [{ size: 10000 }]
+    })
   })
   downloadUpdate = vi.fn((token?: FakeToken): Promise<void> => {
     if (this.downloadPromise != null) return this.downloadPromise
@@ -346,21 +350,99 @@ describe('ElectronUpdaterStrategy', () => {
     expect(status.notes).toBe('')
   })
 
-  it('hydrates totalBytes from the CDN manifest when the version matches', async () => {
+  it('extracts totalBytes from the updater feed artifact files at check time', async () => {
     const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', {
+        version: '0.3.0',
+        files: [{ size: 99000 }, { size: 12000 }]
+      })
+    })
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
-      platform: 'darwin',
-      arch: 'arm64',
       broadcast: vi.fn(),
-      fetchImpl: manifestFetch({
-        version: '0.3.0',
-        downloads: { 'mac-arm64': { url: 'https://cdn/x.dmg', size: 99000, sha256: 'a' } },
-        notes: 'notes'
-      })
+      fetchImpl: offlineFetch()
     })
     const status = await strategy.check()
     expect(status.totalBytes).toBe(99000)
+  })
+
+  it('preserves check-time totalBytes when download-progress omits total', async () => {
+    // Artifacts published with a size in the feed should keep that size even if a progress event
+    // arrives without a total field.
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', { version: '0.3.0', files: [{ size: 50000 }] })
+    })
+    updater.runDownload = async () => {
+      // Progress event intentionally omits total — must not clobber the known 50000.
+      updater.emit('download-progress', { percent: 10, transferred: 5000 })
+      updater.emit('update-downloaded', { version: '0.3.0' })
+    }
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    await strategy.check()
+    expect(strategy.getStatus().totalBytes).toBe(50000)
+
+    const status = await strategy.download()
+    expect(status.totalBytes).toBe(50000)
+    expect(status.downloadedBytes).toBe(5000)
+  })
+
+  it('omits totalBytes when the updater feed has no artifact size', async () => {
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', { version: '0.3.0' })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    const status = await strategy.check()
+    expect(status.totalBytes).toBeUndefined()
+  })
+
+  it('resets downloadedBytes to 0 when starting a new download', async () => {
+    // A retry after cancel must not carry over the previous download's transferred bytes.
+    const updater = new FakeUpdater()
+    let starts = 0
+    let release: (() => void) | undefined
+    updater.runDownload = async (token) => {
+      starts += 1
+      if (starts === 1) {
+        await new Promise<void>((resolve) => (release = resolve))
+        if (token?.cancelled) throw new Error('cancelled')
+      } else {
+        updater.emit('download-progress', { percent: 55, transferred: 5500, total: 10000 })
+        updater.emit('update-downloaded', { version: '0.3.0' })
+      }
+    }
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    await strategy.check()
+
+    const first = strategy.download()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(strategy.getStatus().downloadedBytes).toBe(0)
+
+    await strategy.cancel()
+    release?.()
+    const retry = await strategy.download()
+    expect(retry.state).toBe('ready')
+    expect(starts).toBe(2)
+    // The retry's progress event should report fresh transferred, not stale bytes.
+    expect(retry.downloadedBytes).toBe(5500)
+    await first
   })
 })

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -30,7 +30,7 @@ class FakeUpdater extends EventEmitter {
   // The download body each call runs. Default: emit progress + downloaded and resolve. Tests override
   // it to hang, to inspect the token, or to count real starts.
   runDownload: (token?: FakeToken) => Promise<void> = async () => {
-    this.emit('download-progress', { percent: 42 })
+    this.emit('download-progress', { percent: 42, transferred: 4200, total: 10000 })
     this.emit('update-downloaded', { version: '0.3.0' })
   }
   private downloadPromise: Promise<void> | null = null
@@ -96,7 +96,11 @@ describe('ElectronUpdaterStrategy', () => {
     })
     await strategy.check()
     const status = await strategy.download()
-    expect(broadcast).toHaveBeenCalledWith('update:progress', 42)
+    expect(broadcast).toHaveBeenCalledWith('update:progress', {
+      percent: 42,
+      transferred: 4200,
+      total: 10000
+    })
     expect(status.state).toBe('ready')
   })
 
@@ -183,7 +187,7 @@ describe('ElectronUpdaterStrategy', () => {
         await new Promise<void>((resolve) => (release = resolve))
         if (token?.cancelled) throw new Error('cancelled')
       } else {
-        updater.emit('download-progress', { percent: 55 })
+        updater.emit('download-progress', { percent: 55, transferred: 5500, total: 10000 })
         updater.emit('update-downloaded', { version: '0.3.0' })
       }
     }

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -475,6 +475,32 @@ describe('ElectronUpdaterStrategy', () => {
     expect(status.totalBytes).toBe(105000)
   })
 
+  it('omits totalBytes when Rosetta status is uncertain and feed has both arches', async () => {
+    // When the Rosetta probe returns undefined (e.g. sysctl failed), electron-updater might still
+    // pick arm64. Don't guess — omit the size so the user sees no pre-download size label.
+    const updater = new FakeUpdater()
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('update-available', {
+        version: '0.3.0',
+        files: [
+          { url: 'https://cdn/app-0.3.0-arm64.zip', size: 95000 },
+          { url: 'https://cdn/app-0.3.0-x64.zip', size: 105000 }
+        ]
+      })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      platform: 'darwin',
+      arch: 'x64',
+      isRosetta: () => undefined,
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    const status = await strategy.check()
+    expect(status.totalBytes).toBeUndefined()
+  })
+
   it('preserves check-time totalBytes when download-progress omits total', async () => {
     // Artifacts published with a size in the feed should keep that size even if a progress event
     // arrives without a total field.

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -391,6 +391,7 @@ describe('ElectronUpdaterStrategy', () => {
       currentVersion: '0.2.0',
       platform: 'darwin',
       arch: 'x64',
+      isRosetta: () => false,
       broadcast: vi.fn(),
       fetchImpl: offlineFetch()
     })

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -3,7 +3,6 @@ import { autoUpdater, CancellationToken } from 'electron-updater'
 
 import { APP } from '../../shared/app-config'
 import type { UpdateStatus } from '../../shared/update'
-import { selectDownload } from '../../shared/update'
 import { fetchManifest } from './manifest'
 import type { InstallGate, UpdateStrategy } from './strategy'
 import { broadcastToRenderers } from '../renderer-broadcast'
@@ -33,8 +32,6 @@ export interface MinimalAutoUpdater {
 export type ElectronUpdaterDeps = {
   updater?: MinimalAutoUpdater
   currentVersion?: string
-  platform?: NodeJS.Platform
-  arch?: string
   broadcast?: (channel: string, payload: unknown) => void
   // Factory for the per-download cancellation token; defaults to electron-updater's CancellationToken.
   // Injectable so tests can drive cancel() without the real class.
@@ -75,8 +72,6 @@ const notesToString = (notes: unknown): string => {
 export class ElectronUpdaterStrategy implements UpdateStrategy {
   private readonly updater: MinimalAutoUpdater
   private readonly currentVersion: string
-  private readonly platform: NodeJS.Platform
-  private readonly arch: string
   private readonly broadcast: (channel: string, payload: unknown) => void
   private readonly fetchImpl?: typeof fetch
   private readonly manifestUrl: string
@@ -101,8 +96,6 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   constructor(deps: ElectronUpdaterDeps = {}) {
     this.updater = deps.updater ?? (autoUpdater as unknown as MinimalAutoUpdater)
     this.currentVersion = deps.currentVersion ?? app?.getVersion?.() ?? '0.0.0'
-    this.platform = deps.platform ?? process.platform
-    this.arch = deps.arch ?? process.arch
     this.broadcast = deps.broadcast ?? defaultBroadcast
     this.fetchImpl = deps.fetchImpl
     this.manifestUrl = deps.manifestUrl ?? APP.update.manifestUrl
@@ -123,11 +116,16 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private subscribe(): void {
     this.updater.on('checking-for-update', () => this.setStatus({ state: 'checking' }))
     this.updater.on('update-available', (info) => {
-      const i = info as { version?: string; releaseNotes?: unknown }
+      const i = info as { version?: string; releaseNotes?: unknown; files?: { size?: number }[] }
+      // The size comes from electron-updater's own feed (the artifact it will actually download —
+      // e.g. a macOS ZIP or Linux AppImage), not the CDN manifest's installer entry (DMG/deb) which
+      // is a different file with a different size.
+      const totalBytes = i.files?.find((f) => f.size != null)?.size
       this.setStatus({
         state: 'available',
         latest: i.version,
-        notes: notesToString(i.releaseNotes)
+        notes: notesToString(i.releaseNotes),
+        ...(totalBytes != null ? { totalBytes } : {})
       })
       // electron-updater's *.yml feed carries no release notes, so the dialog would only get a
       // GitHub link. Hydrate the notes from the CDN manifest (the same version.json the installer
@@ -141,9 +139,9 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.updater.on('download-progress', (p) => {
       const info = p as { percent?: number; transferred?: number; total?: number }
       const percent = Math.round(info.percent ?? 0)
-      const transferred = info.transferred ?? 0
-      // Preserve the manifest-hydrated size when the event lacks a usable total, so a progress
-      // event omitting it can't clobber the known installer size with 0.
+      const transferred = info.transferred ?? this.status.downloadedBytes ?? 0
+      // Preserve the known artifact size when the event lacks a usable total, so a progress
+      // event omitting it can't clobber the size extracted at check time with 0.
       const total = info.total || this.status.totalBytes || 0
       this.broadcast('update:progress', { percent, transferred, total })
       this.setStatus({
@@ -178,22 +176,17 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     return this.status
   }
 
-  // Fetch the CDN manifest and, when it matches the offered update, merge in release notes and the
-  // download size. Any failure (network, parse, version drift) leaves the existing fallbacks in place —
-  // notes link to GitHub and totalBytes is absent until download-progress starts reporting.
+  // Fetch the CDN manifest and, when it matches the offered update and actually carries notes,
+  // merge them into the current status. Any failure (network, parse, version drift) leaves the
+  // GitHub-link fallback in place — notes are best-effort and never block the update.
   private async hydrateNotes(version: string): Promise<void> {
     try {
       const manifest = await fetchManifest(this.manifestUrl, this.fetchImpl)
-      if (manifest.version === version && this.status.latest === version) {
-        const download = selectDownload(manifest, this.platform, this.arch)
-        this.setStatus({
-          ...this.status,
-          notes: manifest.notes || this.status.notes,
-          totalBytes: download?.size ?? this.status.totalBytes
-        })
+      if (manifest.version === version && manifest.notes && this.status.latest === version) {
+        this.setStatus({ ...this.status, notes: manifest.notes })
       }
     } catch {
-      // Keep the fallbacks that link out to the GitHub release and omit totalBytes.
+      // Keep the fallback that links out to the GitHub release.
     }
   }
 
@@ -226,7 +219,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     const generation = ++this.downloadGeneration
     const token = this.createCancellationToken()
     this.downloadToken = token
-    this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
+    this.setStatus({ ...this.status, state: 'downloading', progress: 0, downloadedBytes: 0 })
 
     const lifecycle = (async () => {
       try {

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -47,30 +47,33 @@ export type ElectronUpdaterDeps = {
   installGate?: InstallGate
   // Diagnostics sink for the apply path; defaults to a no-op so unit tests stay quiet.
   log?: UpdaterLogger
-  // True when an x64 process is running under Rosetta 2 on Apple Silicon. Electron-updater detects
-  // this via sysctl.proc_translated and selects the arm64 artifact, so we must match that to show the
-  // correct pre-download size. Injectable for tests; defaults to app.runningUnderARM64Translation.
-  isRosetta?: () => boolean
+  // True when an x64 process is running under Rosetta 2 on Apple Silicon; false when definitively not;
+  // undefined when the probe could not determine it. Electron-updater detects this via
+  // sysctl.proc_translated and selects the arm64 artifact, so we must match that to show the correct
+  // pre-download size. When undefined, the strategy omits size rather than risking the wrong arch.
+  isRosetta?: () => boolean | undefined
 }
 
 // Detects whether an x64 process is running under Rosetta 2 on Apple Silicon. Electron-updater's
 // MacUpdater.filterFilesForArch uses the same sysctl key to pick the arm64 entry, so we must match
-// it to show the correct pre-download size. Prefers Electron's app.runningUnderARM64Translation
-// when available (the renderer-facing API), falls back to the raw sysctl probe.
-const defaultIsRosetta = (): boolean => {
+// it to show the correct pre-download size. Returns undefined when neither Electron's
+// runningUnderARM64Translation nor the sysctl probe could give a definitive answer — the caller then
+// omits size to avoid advertising the wrong arch's ZIP.
+const defaultIsRosetta = (): boolean | undefined => {
   try {
     if (app?.runningUnderARM64Translation) return true
   } catch {
     // app not available (test without Electron)
   }
   try {
-    return (
-      spawnSync('sysctl', ['-n', 'sysctl.proc_translated'], { encoding: 'utf8' }).stdout?.trim() ===
-      '1'
-    )
+    const result = spawnSync('sysctl', ['-n', 'sysctl.proc_translated'], { encoding: 'utf8' })
+    const value = result.stdout?.trim()
+    if (value === '1') return true
+    if (value === '0') return false
   } catch {
-    return false
+    // sysctl failed — can't determine
   }
+  return undefined
 }
 
 // Default broadcast pushes to every live window (mirrors service.ts). Never runs in unit tests, which
@@ -179,7 +182,16 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     // artifact (electron-updater does the same), so promote x64 → arm64 to match the correct size.
     const rawArch = deps.arch ?? process.arch
     const isRosetta = deps.isRosetta ?? defaultIsRosetta
-    this.arch = this.platform === 'darwin' && rawArch === 'x64' && isRosetta() ? 'arm64' : rawArch
+    let arch = rawArch
+    if (this.platform === 'darwin' && rawArch === 'x64') {
+      if (isRosetta() === true) arch = 'arm64'
+      else if (isRosetta() === undefined) {
+        // Can't determine Rosetta status — electron-updater might still pick arm64. Blank the arch
+        // token so extractArtifactSize sees a multi-arch feed as ambiguous and omits the size.
+        arch = ''
+      }
+    }
+    this.arch = arch
     this.broadcast = deps.broadcast ?? defaultBroadcast
     this.fetchImpl = deps.fetchImpl
     this.manifestUrl = deps.manifestUrl ?? APP.update.manifestUrl

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -132,9 +132,18 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       this.setStatus({ state: 'up-to-date', latest: i.version })
     })
     this.updater.on('download-progress', (p) => {
-      const percent = Math.round((p as { percent?: number }).percent ?? 0)
-      this.broadcast('update:progress', percent)
-      this.setStatus({ ...this.status, state: 'downloading', progress: percent })
+      const info = p as { percent?: number; transferred?: number; total?: number }
+      const percent = Math.round(info.percent ?? 0)
+      const transferred = info.transferred ?? 0
+      const total = info.total ?? 0
+      this.broadcast('update:progress', { percent, transferred, total })
+      this.setStatus({
+        ...this.status,
+        state: 'downloading',
+        progress: percent,
+        downloadedBytes: transferred,
+        totalBytes: total
+      })
     })
     this.updater.on('update-downloaded', () => {
       this.setStatus({ ...this.status, state: 'ready', progress: 100 })

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron'
+import { spawnSync } from 'node:child_process'
 import { autoUpdater, CancellationToken } from 'electron-updater'
 
 import { APP } from '../../shared/app-config'
@@ -44,8 +45,30 @@ export type ElectronUpdaterDeps = {
   manifestUrl?: string
   // Pre-install backend-shutdown gate; usually injected later via setInstallGate once the runtime exists.
   installGate?: InstallGate
-  // Diagnostics sink for the apply path; defaults to a no-op so unit tests stay quiet.
-  log?: UpdaterLogger
+  // True when an x64 process is running under Rosetta 2 on Apple Silicon. Electron-updater detects
+  // this via sysctl.proc_translated and selects the arm64 artifact, so we must match that to show the
+  // correct pre-download size. Injectable for tests; defaults to app.runningUnderARM64Translation.
+  isRosetta?: () => boolean
+}
+
+// Detects whether an x64 process is running under Rosetta 2 on Apple Silicon. Electron-updater's
+// MacUpdater.filterFilesForArch uses the same sysctl key to pick the arm64 entry, so we must match
+// it to show the correct pre-download size. Prefers Electron's app.runningUnderARM64Translation
+// when available (the renderer-facing API), falls back to the raw sysctl probe.
+const defaultIsRosetta = (): boolean => {
+  try {
+    if (app?.runningUnderARM64Translation) return true
+  } catch {
+    // app not available (test without Electron)
+  }
+  try {
+    return (
+      spawnSync('sysctl', ['-n', 'sysctl.proc_translated'], { encoding: 'utf8' }).stdout?.trim() ===
+      '1'
+    )
+  } catch {
+    return false
+  }
 }
 
 // Default broadcast pushes to every live window (mirrors service.ts). Never runs in unit tests, which
@@ -150,7 +173,11 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.updater = deps.updater ?? (autoUpdater as unknown as MinimalAutoUpdater)
     this.currentVersion = deps.currentVersion ?? app?.getVersion?.() ?? '0.0.0'
     this.platform = deps.platform ?? process.platform
-    this.arch = deps.arch ?? process.arch
+    // Resolve the effective arch: an x64 app under Rosetta on Apple Silicon downloads the arm64
+    // artifact (electron-updater does the same), so promote x64 → arm64 to match the correct size.
+    const rawArch = deps.arch ?? process.arch
+    const isRosetta = deps.isRosetta ?? defaultIsRosetta
+    this.arch = this.platform === 'darwin' && rawArch === 'x64' && isRosetta() ? 'arm64' : rawArch
     this.broadcast = deps.broadcast ?? defaultBroadcast
     this.fetchImpl = deps.fetchImpl
     this.manifestUrl = deps.manifestUrl ?? APP.update.manifestUrl

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -32,6 +32,8 @@ export interface MinimalAutoUpdater {
 export type ElectronUpdaterDeps = {
   updater?: MinimalAutoUpdater
   currentVersion?: string
+  platform?: NodeJS.Platform
+  arch?: string
   broadcast?: (channel: string, payload: unknown) => void
   // Factory for the per-download cancellation token; defaults to electron-updater's CancellationToken.
   // Injectable so tests can drive cancel() without the real class.
@@ -76,18 +78,42 @@ const PLATFORM_ARTIFACT_EXT: Record<string, string> = {
   linux: '.AppImage'
 }
 
-// Extracts the auto-update artifact size from the updater feed's files list. Prefers the file whose URL
-// matches the current platform's expected extension (the one electron-updater will actually download);
-// falls back to the first file with a size. This avoids advertising a DMG size when the updater actually
-// downloads a ZIP on macOS, or a deb size when it downloads an AppImage on Linux.
-const extractArtifactSize = (files?: UpdateFeedFile[]): number | undefined => {
+// Architecture tokens that appear in electron-updater artifact filenames for each platform.
+const PLATFORM_ARCH_TOKENS: Record<string, string[]> = {
+  darwin: ['arm64', 'x64'],
+  win32: ['x64', 'arm64'],
+  linux: ['x64', 'arm64']
+}
+
+// Extracts the auto-update artifact size from the updater feed's files list. Matches both the platform's
+// expected extension AND the current architecture token (e.g. `-arm64` or `-x64` in the URL), because
+// production feeds carry per-arch entries (macOS latest-mac.yml lists both arm64 and x64 ZIPs). When
+// multiple files match (ambiguous), returns undefined rather than risking the wrong size.
+const extractArtifactSize = (
+  files: UpdateFeedFile[] | undefined,
+  platform: NodeJS.Platform,
+  arch: string
+): number | undefined => {
   if (!files || files.length === 0) return undefined
-  const targetExt = PLATFORM_ARTIFACT_EXT[process.platform]
-  if (targetExt) {
-    const match = files.find((f) => f.size != null && f.url?.endsWith(targetExt))
-    if (match?.size != null) return match.size
+  const targetExt = PLATFORM_ARTIFACT_EXT[platform]
+  if (!targetExt) return files.find((f) => f.size != null)?.size
+  const archToken = PLATFORM_ARCH_TOKENS[platform]?.find((token) => arch.includes(token))
+  if (archToken) {
+    // Match both extension and arch token — the exact artifact electron-updater will download.
+    const matches = files.filter(
+      (f) => f.size != null && f.url?.endsWith(targetExt) && f.url?.includes(archToken)
+    )
+    if (matches.length === 1) return matches[0].size
+    // Ambiguous (0 or 2+ matches) — don't risk showing the wrong size.
+    if (matches.length > 1) return undefined
   }
-  return files.find((f) => f.size != null)?.size
+  // No arch token to disambiguate (or no matching file): fall back to a single unambiguous extension match.
+  const extMatches = files.filter((f) => f.size != null && f.url?.endsWith(targetExt))
+  if (extMatches.length === 1) return extMatches[0].size
+  // Still ambiguous or no extension match: try any file with a size, but only if there's exactly one.
+  const sized = files.filter((f) => f.size != null)
+  if (sized.length === 1) return sized[0].size
+  return undefined
 }
 
 // In-place auto-update strategy: wraps electron-updater for true download + restart on win/linux and
@@ -97,6 +123,8 @@ const extractArtifactSize = (files?: UpdateFeedFile[]): number | undefined => {
 export class ElectronUpdaterStrategy implements UpdateStrategy {
   private readonly updater: MinimalAutoUpdater
   private readonly currentVersion: string
+  private readonly platform: NodeJS.Platform
+  private readonly arch: string
   private readonly broadcast: (channel: string, payload: unknown) => void
   private readonly fetchImpl?: typeof fetch
   private readonly manifestUrl: string
@@ -121,6 +149,8 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   constructor(deps: ElectronUpdaterDeps = {}) {
     this.updater = deps.updater ?? (autoUpdater as unknown as MinimalAutoUpdater)
     this.currentVersion = deps.currentVersion ?? app?.getVersion?.() ?? '0.0.0'
+    this.platform = deps.platform ?? process.platform
+    this.arch = deps.arch ?? process.arch
     this.broadcast = deps.broadcast ?? defaultBroadcast
     this.fetchImpl = deps.fetchImpl
     this.manifestUrl = deps.manifestUrl ?? APP.update.manifestUrl
@@ -142,7 +172,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.updater.on('checking-for-update', () => this.setStatus({ state: 'checking' }))
     this.updater.on('update-available', (info) => {
       const i = info as { version?: string; releaseNotes?: unknown; files?: UpdateFeedFile[] }
-      const totalBytes = extractArtifactSize(i.files)
+      const totalBytes = extractArtifactSize(i.files, this.platform, this.arch)
       this.setStatus({
         state: 'available',
         latest: i.version,

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -56,12 +56,15 @@ export type ElectronUpdaterDeps = {
 
 // Detects whether an x64 process is running under Rosetta 2 on Apple Silicon. Electron-updater's
 // MacUpdater.filterFilesForArch uses the same sysctl key to pick the arm64 entry, so we must match
-// it to show the correct pre-download size. Returns undefined when neither Electron's
-// runningUnderARM64Translation nor the sysctl probe could give a definitive answer — the caller then
-// omits size to avoid advertising the wrong arch's ZIP.
+// it to show the correct pre-download size. Prefers Electron's app.runningUnderARM64Translation — a
+// definitive boolean — when available; falls back to sysctl only when the Electron property is absent
+// (e.g. test without Electron). Returns undefined only when the sysctl fallback is inconclusive.
 const defaultIsRosetta = (): boolean | undefined => {
   try {
-    if (app?.runningUnderARM64Translation) return true
+    // Electron's property is a definitive boolean — return it directly without falling through.
+    if (typeof app?.runningUnderARM64Translation === 'boolean') {
+      return app.runningUnderARM64Translation
+    }
   } catch {
     // app not available (test without Electron)
   }
@@ -181,11 +184,12 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     // Resolve the effective arch: an x64 app under Rosetta on Apple Silicon downloads the arm64
     // artifact (electron-updater does the same), so promote x64 → arm64 to match the correct size.
     const rawArch = deps.arch ?? process.arch
-    const isRosetta = deps.isRosetta ?? defaultIsRosetta
     let arch = rawArch
     if (this.platform === 'darwin' && rawArch === 'x64') {
-      if (isRosetta() === true) arch = 'arm64'
-      else if (isRosetta() === undefined) {
+      const rosetta = (deps.isRosetta ?? defaultIsRosetta)()
+      if (rosetta === true) {
+        arch = 'arm64'
+      } else if (rosetta === undefined) {
         // Can't determine Rosetta status — electron-updater might still pick arm64. Blank the arch
         // token so extractArtifactSize sees a multi-arch feed as ambiguous and omits the size.
         arch = ''

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -142,7 +142,9 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       const info = p as { percent?: number; transferred?: number; total?: number }
       const percent = Math.round(info.percent ?? 0)
       const transferred = info.transferred ?? 0
-      const total = info.total ?? 0
+      // Preserve the manifest-hydrated size when the event lacks a usable total, so a progress
+      // event omitting it can't clobber the known installer size with 0.
+      const total = info.total || this.status.totalBytes || 0
       this.broadcast('update:progress', { percent, transferred, total })
       this.setStatus({
         ...this.status,

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -45,6 +45,8 @@ export type ElectronUpdaterDeps = {
   manifestUrl?: string
   // Pre-install backend-shutdown gate; usually injected later via setInstallGate once the runtime exists.
   installGate?: InstallGate
+  // Diagnostics sink for the apply path; defaults to a no-op so unit tests stay quiet.
+  log?: UpdaterLogger
   // True when an x64 process is running under Rosetta 2 on Apple Silicon. Electron-updater detects
   // this via sysctl.proc_translated and selects the arm64 artifact, so we must match that to show the
   // correct pre-download size. Injectable for tests; defaults to app.runningUnderARM64Translation.

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -3,6 +3,7 @@ import { autoUpdater, CancellationToken } from 'electron-updater'
 
 import { APP } from '../../shared/app-config'
 import type { UpdateStatus } from '../../shared/update'
+import { selectDownload } from '../../shared/update'
 import { fetchManifest } from './manifest'
 import type { InstallGate, UpdateStrategy } from './strategy'
 import { broadcastToRenderers } from '../renderer-broadcast'
@@ -32,6 +33,8 @@ export interface MinimalAutoUpdater {
 export type ElectronUpdaterDeps = {
   updater?: MinimalAutoUpdater
   currentVersion?: string
+  platform?: NodeJS.Platform
+  arch?: string
   broadcast?: (channel: string, payload: unknown) => void
   // Factory for the per-download cancellation token; defaults to electron-updater's CancellationToken.
   // Injectable so tests can drive cancel() without the real class.
@@ -72,6 +75,8 @@ const notesToString = (notes: unknown): string => {
 export class ElectronUpdaterStrategy implements UpdateStrategy {
   private readonly updater: MinimalAutoUpdater
   private readonly currentVersion: string
+  private readonly platform: NodeJS.Platform
+  private readonly arch: string
   private readonly broadcast: (channel: string, payload: unknown) => void
   private readonly fetchImpl?: typeof fetch
   private readonly manifestUrl: string
@@ -96,6 +101,8 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   constructor(deps: ElectronUpdaterDeps = {}) {
     this.updater = deps.updater ?? (autoUpdater as unknown as MinimalAutoUpdater)
     this.currentVersion = deps.currentVersion ?? app?.getVersion?.() ?? '0.0.0'
+    this.platform = deps.platform ?? process.platform
+    this.arch = deps.arch ?? process.arch
     this.broadcast = deps.broadcast ?? defaultBroadcast
     this.fetchImpl = deps.fetchImpl
     this.manifestUrl = deps.manifestUrl ?? APP.update.manifestUrl
@@ -169,17 +176,22 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     return this.status
   }
 
-  // Fetch the CDN manifest and, when it matches the offered update and actually carries notes,
-  // merge them into the current status. Any failure (network, parse, version drift) leaves the
-  // GitHub-link fallback in place — notes are best-effort and never block the update.
+  // Fetch the CDN manifest and, when it matches the offered update, merge in release notes and the
+  // download size. Any failure (network, parse, version drift) leaves the existing fallbacks in place —
+  // notes link to GitHub and totalBytes is absent until download-progress starts reporting.
   private async hydrateNotes(version: string): Promise<void> {
     try {
       const manifest = await fetchManifest(this.manifestUrl, this.fetchImpl)
-      if (manifest.version === version && manifest.notes && this.status.latest === version) {
-        this.setStatus({ ...this.status, notes: manifest.notes })
+      if (manifest.version === version && this.status.latest === version) {
+        const download = selectDownload(manifest, this.platform, this.arch)
+        this.setStatus({
+          ...this.status,
+          notes: manifest.notes || this.status.notes,
+          totalBytes: download?.size ?? this.status.totalBytes
+        })
       }
     } catch {
-      // Keep the fallback that links out to the GitHub release.
+      // Keep the fallbacks that link out to the GitHub release and omit totalBytes.
     }
   }
 

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -65,6 +65,31 @@ const notesToString = (notes: unknown): string => {
   return ''
 }
 
+// A file entry in electron-updater's UpdateInfo.files array.
+type UpdateFeedFile = { url?: string; size?: number }
+
+// The file extension electron-updater downloads for each platform (the auto-update artifact, not the
+// CDN manifest's installer entry): ZIP on macOS, NSIS .exe on Windows, AppImage on Linux.
+const PLATFORM_ARTIFACT_EXT: Record<string, string> = {
+  darwin: '.zip',
+  win32: '.exe',
+  linux: '.AppImage'
+}
+
+// Extracts the auto-update artifact size from the updater feed's files list. Prefers the file whose URL
+// matches the current platform's expected extension (the one electron-updater will actually download);
+// falls back to the first file with a size. This avoids advertising a DMG size when the updater actually
+// downloads a ZIP on macOS, or a deb size when it downloads an AppImage on Linux.
+const extractArtifactSize = (files?: UpdateFeedFile[]): number | undefined => {
+  if (!files || files.length === 0) return undefined
+  const targetExt = PLATFORM_ARTIFACT_EXT[process.platform]
+  if (targetExt) {
+    const match = files.find((f) => f.size != null && f.url?.endsWith(targetExt))
+    if (match?.size != null) return match.size
+  }
+  return files.find((f) => f.size != null)?.size
+}
+
 // In-place auto-update strategy: wraps electron-updater for true download + restart on win/linux and
 // on signed stable macOS (Squirrel.Mac). Emits the same UpdateStatus shape as UpdateService, always
 // stamped applyKind:'restart'. Opt-in: autoDownload and autoInstallOnAppQuit are disabled so nothing
@@ -116,11 +141,8 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private subscribe(): void {
     this.updater.on('checking-for-update', () => this.setStatus({ state: 'checking' }))
     this.updater.on('update-available', (info) => {
-      const i = info as { version?: string; releaseNotes?: unknown; files?: { size?: number }[] }
-      // The size comes from electron-updater's own feed (the artifact it will actually download —
-      // e.g. a macOS ZIP or Linux AppImage), not the CDN manifest's installer entry (DMG/deb) which
-      // is a different file with a different size.
-      const totalBytes = i.files?.find((f) => f.size != null)?.size
+      const i = info as { version?: string; releaseNotes?: unknown; files?: UpdateFeedFile[] }
+      const totalBytes = extractArtifactSize(i.files)
       this.setStatus({
         state: 'available',
         latest: i.version,

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -78,6 +78,19 @@ describe('UpdateService.check', () => {
     const status = await service.check()
     expect(status.applyKind).toBe('installer')
   })
+
+  it('stamps totalBytes on the available status from the manifest download size', async () => {
+    const service = new UpdateService({
+      fetchImpl: (() => Promise.resolve(jsonResponse(manifest))) as unknown as typeof fetch,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      broadcast: vi.fn()
+    })
+    const status = await service.check()
+    expect(status.state).toBe('available')
+    expect(status.totalBytes).toBe(5)
+  })
 })
 
 describe('UpdateService.download', () => {

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -118,12 +118,14 @@ export class UpdateService implements UpdateStrategy {
         })
         return this.status
       }
+      const download = selectDownload(manifest, this.platform, this.arch) ?? undefined
       this.setStatus({
         state: 'available',
         current: this.currentVersion,
         latest: manifest.version,
         notes: manifest.notes,
-        download: selectDownload(manifest, this.platform, this.arch) ?? undefined
+        download,
+        totalBytes: download?.size
       })
     } catch (error) {
       this.setStatus({

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -178,13 +178,26 @@ export class UpdateService implements UpdateStrategy {
         const targetPath = await this.promptSavePath(installerFileName(download.url))
         if (!targetPath || abort.signal.aborted) return
 
-        this.setStatus({ ...this.status, state: 'downloading', progress: 0 })
+        this.setStatus({
+          ...this.status,
+          state: 'downloading',
+          progress: 0,
+          downloadedBytes: 0,
+          totalBytes: download.size
+        })
         const localPath = await downloadInstaller(download, targetPath, {
           fetchImpl: this.fetchImpl,
-          onProgress: (percent) => this.broadcast('update:progress', percent),
+          onProgress: (progress) => this.broadcast('update:progress', progress),
           signal: abort.signal
         })
-        this.setStatus({ ...this.status, state: 'ready', progress: 100, localPath })
+        this.setStatus({
+          ...this.status,
+          state: 'ready',
+          progress: 100,
+          downloadedBytes: download.size,
+          totalBytes: download.size,
+          localPath
+        })
       } catch (error) {
         // A user cancel aborts the fetch (rejects here); cancel() already reset the status to
         // 'available', so leave it. Any other failure — including a save-dialog rejection — surfaces as

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -143,7 +143,7 @@ import type {
   StorageInfo
 } from '../shared/storage'
 import type { CliLauncherStatus } from '../shared/cli'
-import type { AppInfo, UpdateStatus } from '../shared/update'
+import type { AppInfo, DownloadProgress, UpdateStatus } from '../shared/update'
 import type {
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
@@ -270,7 +270,7 @@ interface OpenScienceAPI {
     cancel(): Promise<UpdateStatus>
     apply(): Promise<UpdateStatus>
     onStatus(listener: (status: UpdateStatus) => void): RemoveListener
-    onProgress(listener: (percent: number) => void): RemoveListener
+    onProgress(listener: (progress: DownloadProgress) => void): RemoveListener
   }
   projects: {
     list(): Promise<Project[]>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -145,7 +145,7 @@ import type {
   StorageInfo
 } from '../shared/storage'
 import type { CliLauncherStatus } from '../shared/cli'
-import type { AppInfo, UpdateStatus } from '../shared/update'
+import type { AppInfo, DownloadProgress, UpdateStatus } from '../shared/update'
 import type {
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
@@ -295,7 +295,7 @@ type OpenScienceAPI = {
     cancel: () => Promise<UpdateStatus>
     apply: () => Promise<UpdateStatus>
     onStatus: (listener: (status: UpdateStatus) => void) => RemoveListener
-    onProgress: (listener: (percent: number) => void) => RemoveListener
+    onProgress: (listener: (progress: DownloadProgress) => void) => RemoveListener
   }
   projects: {
     list: () => Promise<Project[]>

--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -138,4 +138,40 @@ describe('UpdateDialog', () => {
     expect(document.body.textContent).toContain('9.8 KB')
     expect(document.body.textContent).toContain('42%')
   })
+
+  it('falls back to percent-only when byte counts are missing while downloading', () => {
+    // When transferred/total are unknown the label should show only the percent, not "0 B / 0 B".
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: {
+        state: 'downloading',
+        current: '0.1.0',
+        latest: '0.2.0',
+        progress: 35,
+        downloadedBytes: undefined,
+        totalBytes: undefined
+      }
+    })
+    act(() => root.render(<UpdateDialog />))
+    // Should NOT show byte formatting — just the percent.
+    expect(document.body.textContent).not.toContain('0 B')
+  })
+
+  it('falls back to percent-only when downloadedBytes is 0 while downloading', () => {
+    // A fresh download that hasn't received its first progress event yet: downloadedBytes is 0,
+    // so the label should show percent, not "0 B / 9.8 KB".
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: {
+        state: 'downloading',
+        current: '0.1.0',
+        latest: '0.2.0',
+        progress: 0,
+        downloadedBytes: 0,
+        totalBytes: 10000
+      }
+    })
+    act(() => root.render(<UpdateDialog />))
+    expect(document.body.textContent).not.toContain('0 B')
+  })
 })

--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -139,8 +139,9 @@ describe('UpdateDialog', () => {
     expect(document.body.textContent).toContain('42%')
   })
 
-  it('falls back to percent-only when byte counts are missing while downloading', () => {
-    // When transferred/total are unknown the label should show only the percent, not "0 B / 0 B".
+  it('hides the left label when byte counts are missing while downloading', () => {
+    // When transferred/total are unknown the left span should be empty — percent appears only on
+    // the right, avoiding a duplicate "35%   35%" display.
     useUpdateStore.setState({
       isDialogOpen: true,
       status: {
@@ -153,13 +154,16 @@ describe('UpdateDialog', () => {
       }
     })
     act(() => root.render(<UpdateDialog />))
-    // Should NOT show byte formatting — just the percent.
-    expect(document.body.textContent).not.toContain('0 B')
+    // The progress label row has two spans; the left one (context) should be empty.
+    const labelSpans = document.body.querySelectorAll('.tabular-nums span')
+    expect(labelSpans.length).toBeGreaterThanOrEqual(2)
+    expect(labelSpans[0].textContent).toBe('')
+    expect(labelSpans[1].textContent).toBe('35%')
   })
 
-  it('falls back to percent-only when downloadedBytes is 0 while downloading', () => {
+  it('hides the left label when downloadedBytes is 0 while downloading', () => {
     // A fresh download that hasn't received its first progress event yet: downloadedBytes is 0,
-    // so the label should show percent, not "0 B / 9.8 KB".
+    // so the left label should be empty — not "0 B / 9.8 KB".
     useUpdateStore.setState({
       isDialogOpen: true,
       status: {
@@ -172,6 +176,9 @@ describe('UpdateDialog', () => {
       }
     })
     act(() => root.render(<UpdateDialog />))
-    expect(document.body.textContent).not.toContain('0 B')
+    const labelSpans = document.body.querySelectorAll('.tabular-nums span')
+    expect(labelSpans.length).toBeGreaterThanOrEqual(2)
+    expect(labelSpans[0].textContent).toBe('')
+    expect(labelSpans[1].textContent).toBe('0%')
   })
 })

--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -106,4 +106,36 @@ describe('UpdateDialog', () => {
     expect(link).not.toBeNull()
     expect(link?.textContent).toContain('Download manually')
   })
+
+  it('shows download size on the download button when totalBytes is present', () => {
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: {
+        state: 'available',
+        current: '0.1.0',
+        latest: '0.2.0',
+        totalBytes: 12.5 * 1024 * 1024
+      }
+    })
+    act(() => root.render(<UpdateDialog />))
+    expect(document.body.textContent).toContain('Download update (12.5 MB)')
+  })
+
+  it('shows downloaded and total bytes alongside the progress bar while downloading', () => {
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: {
+        state: 'downloading',
+        current: '0.1.0',
+        latest: '0.2.0',
+        progress: 42,
+        downloadedBytes: 4200,
+        totalBytes: 10000
+      }
+    })
+    act(() => root.render(<UpdateDialog />))
+    expect(document.body.textContent).toContain('4.1 KB')
+    expect(document.body.textContent).toContain('9.8 KB')
+    expect(document.body.textContent).toContain('42%')
+  })
 })

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -71,7 +71,7 @@ const UpdateDialog = (): React.JSX.Element | null => {
             <div className="mt-4">
               <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground tabular-nums">
                 <span>
-                  {status.downloadedBytes != null && status.totalBytes
+                  {status.downloadedBytes != null && status.totalBytes && status.downloadedBytes > 0
                     ? `${formatBytes(status.downloadedBytes)} / ${formatBytes(status.totalBytes)}`
                     : `${status.progress ?? 0}%`}
                 </span>

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -73,7 +73,7 @@ const UpdateDialog = (): React.JSX.Element | null => {
                 <span>
                   {status.downloadedBytes != null && status.totalBytes && status.downloadedBytes > 0
                     ? `${formatBytes(status.downloadedBytes)} / ${formatBytes(status.totalBytes)}`
-                    : `${status.progress ?? 0}%`}
+                    : ''}
                 </span>
                 <span>{status.progress ?? 0}%</span>
               </div>

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -5,6 +5,7 @@ import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { AgentMarkdown } from '@/components/streamdown/AgentMarkdown'
 import { useUpdateStore } from '@/stores/update-store'
 import { APP } from '../../../shared/app-config'
+import { formatBytes } from '../../../shared/update'
 
 // Update confirmation dialog: shows the target version and release notes so the user can decide
 // before a large download. Opened from the external capsule and the settings About section. When the
@@ -67,11 +68,21 @@ const UpdateDialog = (): React.JSX.Element | null => {
           )}
 
           {isDownloading ? (
-            <div className="mt-4 h-1.5 w-full overflow-hidden rounded-full bg-bg-300">
-              <div
-                className="h-full rounded-full bg-primary transition-all duration-150 ease-out"
-                style={{ width: `${status.progress ?? 0}%` }}
-              />
+            <div className="mt-4">
+              <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground tabular-nums">
+                <span>
+                  {status.downloadedBytes != null && status.totalBytes
+                    ? `${formatBytes(status.downloadedBytes)} / ${formatBytes(status.totalBytes)}`
+                    : `${status.progress ?? 0}%`}
+                </span>
+                <span>{status.progress ?? 0}%</span>
+              </div>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-bg-300">
+                <div
+                  className="h-full rounded-full bg-primary transition-all duration-150 ease-out"
+                  style={{ width: `${status.progress ?? 0}%` }}
+                />
+              </div>
             </div>
           ) : null}
 
@@ -120,7 +131,11 @@ const UpdateDialog = (): React.JSX.Element | null => {
                 className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
               >
                 <Download className="size-4" aria-hidden="true" />
-                {isDownloading ? `Downloading ${status.progress ?? 0}%` : 'Download update'}
+                {isDownloading
+                  ? `Downloading ${status.progress ?? 0}%`
+                  : status.totalBytes
+                    ? `Download update (${formatBytes(status.totalBytes)})`
+                    : 'Download update'}
               </button>
             )}
           </div>

--- a/src/renderer/src/stores/update-store.test.ts
+++ b/src/renderer/src/stores/update-store.test.ts
@@ -168,4 +168,32 @@ describe('useUpdateStore', () => {
     expect(useUpdateStore.getState().status.state).toBe('available')
     expect(useUpdateStore.getState().status.latest).toBe('0.3.0')
   })
+
+  it('onProgress callback maps DownloadProgress payload into status fields', async () => {
+    let progressListener: ((progress: unknown) => void) | undefined
+    ;(window as unknown as { api: unknown }).api = {
+      update: {
+        getAppInfo: () =>
+          Promise.resolve({ name: 'Open Science', version: '0.2.0', copyright: '' }),
+        getStatus: () => Promise.resolve({ state: 'idle', current: '0.2.0' }),
+        onStatus: vi.fn(),
+        onProgress: (listener: (progress: unknown) => void) => {
+          progressListener = listener
+        },
+        check: vi.fn(),
+        download: vi.fn(),
+        apply: vi.fn()
+      }
+    }
+
+    useUpdateStore.getState().init()
+    await Promise.resolve()
+
+    progressListener?.({ percent: 42, transferred: 4200, total: 10000 })
+
+    const status = useUpdateStore.getState().status
+    expect(status.progress).toBe(42)
+    expect(status.downloadedBytes).toBe(4200)
+    expect(status.totalBytes).toBe(10000)
+  })
 })

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -36,7 +36,16 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
         set((s) => ({ appInfo: info, status: { ...s.status, current: info.version } }))
       )
     api.onStatus((status) => set({ status }))
-    api.onProgress((progress) => set((s) => ({ status: { ...s.status, progress } })))
+    api.onProgress((progress) =>
+      set((s) => ({
+        status: {
+          ...s.status,
+          progress: progress.percent,
+          downloadedBytes: progress.transferred,
+          totalBytes: progress.total
+        }
+      }))
+    )
     void api.getStatus().then((status) => {
       // Only apply the startup snapshot if no live broadcast has updated us yet.
       if (get().status.state === 'idle') set({ status })

--- a/src/shared/update.test.ts
+++ b/src/shared/update.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   compareVersions,
+  formatBytes,
   isNewer,
   platformDownloadKey,
   selectDownload,
@@ -56,5 +57,24 @@ describe('selectDownload', () => {
   })
   it('returns null when no entry matches', () => {
     expect(selectDownload(manifest, 'darwin', 'x64')).toBeNull()
+  })
+})
+
+describe('formatBytes', () => {
+  it('formats bytes below 1 KB as-is', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1023)).toBe('1023 B')
+  })
+  it('formats KB', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+  })
+  it('formats MB', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB')
+    expect(formatBytes(12.5 * 1024 * 1024)).toBe('12.5 MB')
+  })
+  it('formats GB', () => {
+    expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0 GB')
   })
 })

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -20,11 +20,20 @@ export type UpdateStatus = {
   notes?: string
   download?: PlatformDownload
   progress?: number // 0-100 while downloading
+  downloadedBytes?: number // bytes received so far while downloading
+  totalBytes?: number // total installer size in bytes
   localPath?: string // set when state === 'ready'
   error?: string
   // How the renderer applies a ready update: open the downloaded installer (mac manual reinstall) or
   // restart into an in-place electron-updater install (win/linux). Set by the active strategy.
   applyKind?: 'installer' | 'restart'
+}
+
+// Broadcast on every download chunk so the renderer can show live byte counts alongside the percent.
+export type DownloadProgress = {
+  percent: number
+  transferred: number
+  total: number
 }
 
 export type AppInfo = { name: string; version: string; copyright: string }
@@ -67,4 +76,18 @@ export const selectDownload = (
     return manifest.downloads['linux-x64-appimage']
   }
   return null
+}
+
+// Formats a byte count into a human-readable string (e.g. 1234567 → "1.2 MB"). Uses 1024-based
+// binary units, matching the convention most desktop OSes show for file/download sizes.
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB'] as const
+export const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`
+  let value = bytes
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < BYTE_UNITS.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+  return `${value.toFixed(1)} ${BYTE_UNITS[unitIndex]}`
 }


### PR DESCRIPTION
## Problem

The in-app update dialog only showed a percentage during download. Users had no way to see the installer size or how many bytes had actually transferred — making it hard to gauge whether a download was stalled or how large the update was before committing.

## Proposed change

Show the installer size on the **Download update** button and display a live `transferred / total` byte count above the progress bar during download. The percentage remains visible on the right side.

The change flows through the entire IPC chain:

- **`shared/update.ts`** — new `DownloadProgress` type `{ percent, transferred, total }`; new `downloadedBytes` / `totalBytes` fields on `UpdateStatus`; `formatBytes` helper for human-readable sizes (B / KB / MB / GB).
- **`downloader.ts`** — `onProgress` now receives `{ percent, transferred, total }` instead of a bare percent.
- **`service.ts`** — stamps `downloadedBytes` / `totalBytes` on the `downloading` and `ready` status; broadcasts the richer progress payload.
- **`electron-updater-strategy.ts`** — extracts `transferred` / `total` from electron-updater's `download-progress` event.
- **`preload/index.d.ts`** — `onProgress` typed as `(progress: DownloadProgress)`.
- **`update-store.ts`** — mirrors percent + bytes into `status`.
- **`UpdateDialog.tsx`** — renders byte count on the button and a `transferred / total` label beside the progress bar.

## Scope and non-goals

- Scope: the update dialog UI and its IPC data pipeline.
- Non-goals: download speed/ETA estimation, changes to the update capsule, or changes to the electron-updater version feed.

## Acceptance criteria and validation

- Download button shows installer size (e.g. `Download update (85.3 MB)`) when `totalBytes` is known.
- Progress bar label shows `transferred / total` (e.g. `4.1 KB / 9.8 KB`) and `42%` on the right while downloading.
- Falls back to percent-only when byte counts are unavailable.
- All existing update tests pass; new tests cover `formatBytes`, the downloader progress payload, the electron-updater byte extraction, and the dialog rendering.

```
npm run test    # 60/60 update-related tests pass
npm run lint    # clean
```

## Review focus

- The `DownloadProgress` payload shape and whether it should live in `shared/update.ts` (it does — shared by main + renderer).
- The `formatBytes` unit choice (1024-based binary, matching desktop OS conventions for file sizes).