### PR TITLE
fix(db): regenerate Prisma client before dev and build to prevent stale delegates

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,15 @@
     "dev:web": "node scripts/dev-app-branding.cjs && node scripts/dev-web.cjs",
     "dev:headless": "node scripts/dev-app-branding.cjs && node scripts/dev-web.cjs --headless",
     "cli": "node cli/index.mjs",
-    "build": "npm run typecheck && electron-vite build && npm run build:web",
+    "gen:prisma": "prisma generate",
+    "build": "npm run gen:prisma && npm run typecheck && electron-vite build && npm run build:web",
     "postinstall": "prisma generate && electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",
-    "build:mac": "npm run build:web && electron-vite build && electron-builder --mac",
-    "build:linux": "npm run build:web && electron-vite build && electron-builder --linux",
-    "build:win": "npm run build:web && electron-vite build && electron-builder --win",
+    "build:mac": "npm run gen:prisma && npm run build:web && electron-vite build && electron-builder --mac",
+    "build:linux": "npm run gen:prisma && npm run build:web && electron-vite build && electron-builder --linux",
+    "build:win": "npm run gen:prisma && npm run build:web && electron-vite build && electron-builder --win",
     "stage-default-envs": "node scripts/stage-default-envs.mjs",
-    "predev": "node scripts/dev-app-branding.cjs"
+    "predev": "prisma generate && node scripts/dev-app-branding.cjs"
   },
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.60.0",

--- a/src/main/projects/prisma-schema-sync.test.ts
+++ b/src/main/projects/prisma-schema-sync.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { PrismaClient } from '@prisma/client'
+import { describe, expect, it } from 'vitest'
+
+// Guards against a stale generated Prisma client — the root cause of the "Cannot read properties of
+// undefined (reading 'findMany')" crash that occurs when prisma/schema.prisma gains a model but the
+// client is not regenerated. The postinstall hook runs `prisma generate`, but `npm run dev` and
+// `npm run build` no longer implicitly trigger it after a bare `git pull`, so a developer who pulls
+// a schema change without reinstalling gets a client that silently omits the new delegates.
+//
+// This test fails fast and with a clear message instead of letting the app crash at runtime with a
+// confusing TypeError from deep inside the repository/poller stack.
+
+const SCHEMA_PATH = join(process.cwd(), 'prisma', 'schema.prisma')
+
+/** Extracts model names (lowercased first letter = Prisma delegate key) from the schema source. */
+const readSchemaModelNames = (): string[] => {
+  const source = readFileSync(SCHEMA_PATH, 'utf-8')
+  const matches = source.matchAll(/^model\s+(\w+)\s*{/gm)
+  const names = [...matches].map((m) => m[1]!)
+  if (names.length === 0) {
+    throw new Error('No models found in prisma/schema.prisma — the test regex may be stale.')
+  }
+  return names
+}
+
+describe('prisma schema ↔ generated client sync', () => {
+  it('every model in prisma/schema.prisma has a delegate on the generated PrismaClient', () => {
+    const models = readSchemaModelNames()
+    const client = new PrismaClient()
+
+    const missing: string[] = []
+    for (const model of models) {
+      const delegate = model[0]!.toLowerCase() + model.slice(1)
+      if (!(delegate in client)) {
+        missing.push(model)
+      }
+    }
+
+    expect(
+      missing,
+      [
+        'Generated Prisma client is stale — run `npx prisma generate`.',
+        'Missing delegates for models: ' + missing.join(', '),
+        'This usually means prisma/schema.prisma changed but the client was not regenerated.'
+      ].join('\n')
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

The app crashes at startup with:
```
TypeError: Cannot read properties of undefined (reading 'findMany')
    at ComputeJobRepository.findTerminalUnharvested
    at JobPoller.tick
```
and the Compute SSH hosts panel fails to load:
```
Couldn't load hosts: Error invoking remote method 'compute:list': TypeError: Cannot read properties of undefined (reading 'findMany')
```

**Root cause:** the generated Prisma client (`node_modules/.prisma/client`) was stale — it was missing the `ComputeJob` and `ComputeHost` model delegates entirely. When `ComputeJobRepository.findTerminalUnharvested` calls `client.computeJob.findMany(...)`, `client.computeJob` is `undefined`, producing the crash.

The client is only regenerated by the `postinstall` hook (`prisma generate && electron-builder install-app-deps`). After a bare `git pull` that adds a schema change, neither `npm run dev` nor `npm run build` re-triggers generation, so a developer who pulls without reinstalling gets a silently stale client.

## Proposed change

1. Add `gen:prisma` (`prisma generate`) as an explicit npm script.
2. Wire it into the paths that currently skip it:
   - `predev` — runs before `electron-vite dev`
   - `build` — before `typecheck` and bundling
   - `build:mac` / `build:linux` / `build:win` — before packaging
3. Add a guard test (`prisma-schema-sync.test.ts`) that parses `prisma/schema.prisma`, extracts every `model` name, and asserts each one has a matching delegate on the generated `PrismaClient`. A stale client now fails CI with a clear message instead of crashing at runtime.

## Scope and non-goals

- **In scope:** prevent the stale-client class of bug; add a regression test.
- **Non-goals:** no schema changes, no repository logic changes, no migration changes. The runtime DDL and `ensureProjectSchema` are unaffected.

## Acceptance criteria and validation

- [x] `npx vitest run src/main/projects/prisma-schema-sync.test.ts` — passes against a freshly generated client.
- [x] `npx vitest run src/main/compute/prisma-client.test.ts src/main/projects/prisma-client.test.ts` — existing integration tests pass (6/6).
- [x] `npx vitest run src/main/compute/job-repository.test.ts src/main/compute/job-poller.test.ts` — tests from the stack trace pass (37/37).
- [x] `npm run typecheck` — passes.
- [x] `npm run lint` — no new warnings from the new file.

## Review focus

- The `predev` change adds ~1s to `npm run dev` startup. This is negligible and only runs once per dev session start.
- The guard test instantiates a `PrismaClient` (no DB connection) to check delegate keys — fast and side-effect-free.