### PR TITLE
fix(storage): reserve Windows path budget for the longest default env

### DIFF
--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -176,8 +176,26 @@ describe('classifyDataRoot', () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
 
     try {
-      // Derived target length is 99; the default env reserve is 161, totaling exactly 260.
-      const result = await classifyDataRoot(`/${'b'.repeat(86)}`, currentDataRoot)
+      // Derived target length is 94; the default env reserve is 166 (runtime\envs\default-python +
+      // the 138 conservative pack budget), totaling exactly 260 — one over the 259 usable limit.
+      const result = await classifyDataRoot(`/${'b'.repeat(81)}`, currentDataRoot)
+
+      expect(result.kind).toBe('invalid')
+      expect(result.error).toMatch(/too long|260/i)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  })
+
+  it('reserves for default-python, the longest managed env, not the shorter default-r', async () => {
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+
+    try {
+      // Derived target length is 96. Under the old default-r reserve (23 + 138 = 161) this totaled
+      // 257 and was accepted, yet default-python (28 + 138 = 166) pushes it to 262 — the exact case
+      // where the picker used to accept a root that then overflowed MAX_PATH provisioning python.
+      const result = await classifyDataRoot(`/${'b'.repeat(83)}`, currentDataRoot)
 
       expect(result.kind).toBe('invalid')
       expect(result.error).toMatch(/too long|260/i)

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -21,6 +21,7 @@ import {
 } from './migration-marker'
 import { waitForDataRootWriters } from './migration-state'
 import { DEFAULT_MAX_ENV_RELATIVE_PATH, PACK_PATH_BUDGET_FILE } from '../notebook/bundle-manifest'
+import { DEFAULT_PY_ENV, DEFAULT_R_ENV } from '../notebook/runtime-paths'
 import { RELOCATABLE_DATA_DIRS } from './data-directories'
 
 export { DATA_ROOT_DIRS } from './data-directories'
@@ -44,9 +45,15 @@ export type ClassifyResult = { kind: DataRootKind; error?: string }
 const WINDOWS_MAX_USABLE_PATH = 259
 // Headroom reserved for the app's deepest nested paths (artifacts/notebooks/runtime) under the root.
 // Keep the migration guard aligned with the current managed env's conservative pack metadata:
-// runtime\\envs\\default-r plus the longest linked package path. This is deliberately a budget, not a
-// universal package-path constant; newer manifests can tighten the release gate further.
-const WINDOWS_ENV_PREFIX_RESERVE = 'runtime\\envs\\default-r'.length + 1
+// runtime\\envs\\<longest default env name> plus the longest linked package path. Both defaults are
+// auto-provisioned at baseline, and `default-python` (28 chars with the separator) is longer than
+// `default-r` (23) — reserving for the shorter name let a root pass the picker yet overflow MAX_PATH
+// once default-python provisioned. This is deliberately a budget, not a universal package-path
+// constant; newer manifests can tighten the release gate further.
+const LONGEST_DEFAULT_ENV_NAME = [DEFAULT_PY_ENV, DEFAULT_R_ENV].reduce((a, b) =>
+  a.length >= b.length ? a : b
+)
+const WINDOWS_ENV_PREFIX_RESERVE = `runtime\\envs\\${LONGEST_DEFAULT_ENV_NAME}`.length + 1
 
 export const maxManagedEnvRelativePath = (dataRoot: string): number => {
   let maximum = DEFAULT_MAX_ENV_RELATIVE_PATH


### PR DESCRIPTION
## Problem

The data-root MAX_PATH picker guard hardcoded `WINDOWS_ENV_PREFIX_RESERVE` using the string `runtime\\envs\\default-r` (23 characters including the separator reserved by the guard). The other auto-provisioned baseline environment, `default-python`, requires a 28-character reserve and is 5 characters longer.

As a result, the picker could accept a data root that fit the managed pack's environment-prefix budget for `default-r` but not for `default-python`. Provisioning that root later failed the environment-prefix check with:

> Managed python 3.12 pack exceeds the Windows path budget for default-python; choose a shorter data-root path.

This is distinct from the short-cache selection failure:

> No trusted writable package cache fits the managed runtime path budget.

The cache error concerns the independent package-cache path chain and is not caused by the five-character difference between the default environment names.

## Proposed change

Derive the picker reserve from the longest managed default environment name instead of hardcoding `default-r`:

```ts
const LONGEST_DEFAULT_ENV_NAME = [DEFAULT_PY_ENV, DEFAULT_R_ENV].reduce((a, b) =>
  a.length >= b.length ? a : b
)
const WINDOWS_ENV_PREFIX_RESERVE = `runtime\\envs\\${LONGEST_DEFAULT_ENV_NAME}`.length + 1
```

The reserve increases from 23 to 28 characters. Future renames of either default environment constant keep this picker check aligned with the longer baseline name.

## Scope and non-goals

This PR closes the validation gap for data roots selected through onboarding or the storage-location picker.

It does not:

- validate the automatically derived default data root before provisioning;
- relocate or rebuild an already blocked user's runtime;
- change the physical names or location of managed environment prefixes;
- change micromamba's independent package-cache selection or URL-derived cache layout.

## Acceptance criteria and validation

- Reject a target at the exact 260-character deepest managed-environment boundary.
- Reject a target that fit the former `default-r` reserve but exceeds the `default-python` reserve.
- Preserve non-Windows behavior and normal short Windows targets.
- `migration-service.test.ts`: 60 passed.
- `npm run typecheck`: passed.
- ESLint on the touched files: passed.

## Review focus

- The picker reserve is derived from the same logical default-environment constants used by runtime provisioning.
- The change remains limited to preflight validation; broader runtime-layout and package-cache work is intentionally separate.
