### PR TITLE
fix(compute): address remote SSH compute review items

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,10 +9,10 @@ security of that surface seriously and appreciate reports that help us keep it s
 This project is pre-1.0 and moving fast. Only the latest `0.x` release (and the
 `main` branch) receives security fixes.
 
-| Version | Supported |
-|---------|-----------|
-| latest `0.x` / `main` | ✅ |
-| older releases | ❌ |
+| Version               | Supported |
+| --------------------- | --------- |
+| latest `0.x` / `main` | ✅        |
+| older releases        | ❌        |
 
 The **Nightly (latest main)** pre-release tracks unreviewed commits and is provided
 as-is for testing — treat it as less hardened than tagged releases.
@@ -100,9 +100,19 @@ Some behavior is intentional by design and is **not** a vulnerability on its own
 - **The notebook kernel and the agent's tool calls execute code and shell commands
   by design.** Running local code is the product's purpose. A tool-call approval gate
   is the current control in front of higher-risk actions.
+- **Remote-compute downloads gate on approval by _initiator_, not by destination.**
+  A remote file pulled to the OS Downloads folder or published as a project artifact is
+  a **UI-initiated** action — the user clicked the button, and that click _is_ the
+  authorization, so no separate approval card is shown. Only **session-cache** downloads
+  (the agent pulling a remote file into the session workspace via its Python/tool API)
+  are agent-initiated and therefore go through the `ComputeApprovalBroker` before any
+  `scp` runs. This is intentional: prompting a user to approve the download they just
+  clicked would be noise, whereas an agent reaching for remote data is exactly what the
+  gate exists to surface. All destinations still validate the remote path (absolute, no
+  glob, no shell metacharacters) and enforce size caps regardless of initiator.
 - **Sandboxing is still on the roadmap.** Network allowlisting, a credential vault,
   directory-scoped file access, and per-scope permission tiers are **not implemented
-  yet** (tracked as 🟡 *Security & Permissions* in the [Roadmap](ROADMAP.md#capability-map)).
+  yet** (tracked as 🟡 _Security & Permissions_ in the [Roadmap](ROADMAP.md#capability-map)).
   The absence of these is a known limitation, not a defect to report — though ideas on
   how to build them are very welcome as Issues/Discussions.
 

--- a/src/main/compute/compute-service.ts
+++ b/src/main/compute/compute-service.ts
@@ -781,8 +781,11 @@ export class ComputeService {
   //                    Requires approval from the ComputeApprovalBroker BEFORE scp.
   //                    Optional context enables grant-aware approval (conversation/project scope).
   //
-  // Human-initiated downloads (os-downloads, artifact) do NOT trigger the approval gate.
-  // Only session-cache (agent) downloads go through approval (design §5).
+  // Approval gates by INITIATOR, not destination (see SECURITY.md "Scope and trust boundaries").
+  // os-downloads and artifact are UI-initiated — the user's click IS the authorization, so no
+  // approval card is shown. Only session-cache is agent-initiated and goes through the
+  // ComputeApprovalBroker before scp (design §5). All destinations still validate the remote path
+  // and enforce size caps below regardless of initiator.
   //
   // Throws an Error with .remoteFsError on any failure (too_large / not_a_file / connection /
   // outside_roots / permission / other).
@@ -1185,30 +1188,24 @@ export class ComputeService {
     const jobId = randomUUID()
     const remoteWorkdir = computeRemoteWorkdir(host.scratchRoot, jobId)
 
-    // ── CONCURRENCY CHECK (before approval gate) ──────────────────────────────────
-    let initialStatus: 'queued' | 'submitted' = 'submitted'
+    // ── EARLY QUEUE-FULL CHECK (before approval gate) ─────────────────────────────
+    // Advisory only: reject obviously-unacceptable jobs before prompting the user. The
+    // authoritative decision (and slot reservation) happens atomically in admit() below, after
+    // approval, so two concurrent submissions cannot both pass the same slot.
+    const queueFullError = (): Error & { computeCallError: ComputeCallError } => {
+      const message =
+        'Job queue is full (100 queued jobs). Wait for queued jobs to start running before submitting more.'
+      const err = new Error(message) as Error & { computeCallError: ComputeCallError }
+      err.computeCallError = { error_code: 'queue_full', message, retry_after_user_action: false }
+      return err
+    }
     if (this.concurrencyManager) {
-      const enqueueResult = await this.concurrencyManager.enqueue({
+      const preview = await this.concurrencyManager.enqueue({
         jobId,
         sessionId: context.sessionId,
         providerId
       })
-
-      if (enqueueResult === 'queue_full') {
-        const err = new Error(
-          `Job queue is full (100 queued jobs). Wait for queued jobs to start running before submitting more.`
-        ) as Error & { computeCallError: ComputeCallError }
-        err.computeCallError = {
-          error_code: 'queue_full',
-          message: 'Job queue is full (100 queued jobs). Wait for queued jobs to start running before submitting more.',
-          retry_after_user_action: false
-        }
-        throw err
-      }
-
-      if (enqueueResult === 'should_queue') {
-        initialStatus = 'queued'
-      }
+      if (preview === 'queue_full') throw queueFullError()
     }
 
     // ── APPROVAL GATE (must fire before any DB write or SSH) ──────────────────────
@@ -1254,25 +1251,41 @@ export class ComputeService {
     // ── WRITE JOB ROW ──────────────────────────────────────────────────────────────
     const commandHash = hashCommand(command)
     const inputManifest = stagedEntries.length > 0 ? JSON.stringify(stagedEntries) : undefined
+    const jobRepository = this.jobRepository
+    const createRow = async (initialStatus: 'submitted' | 'queued'): Promise<void> => {
+      await jobRepository.create({
+        id: jobId,
+        providerId: host.providerId,
+        shape: host.shape,
+        sessionId: context.sessionId,
+        projectId: context.projectId,
+        intent,
+        command,
+        commandHash,
+        environment: options.environment,
+        resourceRequest: options.resourceRequest,
+        inputManifest,
+        outputManifest: options.outputManifest,
+        harvestConfig: options.harvestConfig,
+        timeoutSeconds,
+        remoteWorkdir,
+        initialStatus
+      })
+    }
 
-    await this.jobRepository.create({
-      id: jobId,
-      providerId: host.providerId,
-      shape: host.shape,
-      sessionId: context.sessionId,
-      projectId: context.projectId,
-      intent,
-      command,
-      commandHash,
-      environment: options.environment,
-      resourceRequest: options.resourceRequest,
-      inputManifest,
-      outputManifest: options.outputManifest,
-      harvestConfig: options.harvestConfig,
-      timeoutSeconds,
-      remoteWorkdir,
-      initialStatus
-    })
+    // With a ConcurrencyManager, decide the status and commit the row atomically so concurrent
+    // submissions cannot both pass one slot. Without one, submit immediately (tests / no-limit mode).
+    let initialStatus: 'submitted' | 'queued' = 'submitted'
+    if (this.concurrencyManager) {
+      const admitted = await this.concurrencyManager.admit(
+        { sessionId: context.sessionId, providerId },
+        createRow
+      )
+      if (admitted === 'queue_full') throw queueFullError()
+      initialStatus = admitted
+    } else {
+      await createRow('submitted')
+    }
 
     // ── BACKGROUND DISPATCH (non-blocking, only for submitted jobs) ────────────────
     // Fire-and-forget. Errors are persisted to the job row by the dispatcher.
@@ -1424,7 +1437,9 @@ export class ComputeService {
     }
 
     if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
-      throw new Error(`Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`)
+      throw new Error(
+        `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
+      )
     }
 
     this.concurrencyManager.setSessionLimit(sessionId, limit)

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -607,4 +607,69 @@ describe('ConcurrencyManager', () => {
       expect(dispatchStarted).toBe(1)
     })
   })
+
+  describe('admit - atomic status decision + row commit', () => {
+    it('calls commit with submitted when limits are clear', async () => {
+      vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
+      vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(0)
+      vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(0)
+      vi.mocked(hostRepo.get).mockResolvedValue({ concurrencyLimit: 10 } as ComputeHost)
+      const commit = vi.fn().mockResolvedValue(undefined)
+
+      const result = await manager.admit({ sessionId: 's1', providerId: 'p1' }, commit)
+
+      expect(result).toBe('submitted')
+      expect(commit).toHaveBeenCalledWith('submitted')
+    })
+
+    it('calls commit with queued when session limit is reached', async () => {
+      manager.setSessionLimit('s1', 2)
+      vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
+      vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(2)
+      vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(0)
+      vi.mocked(hostRepo.get).mockResolvedValue({ concurrencyLimit: 10 } as ComputeHost)
+      const commit = vi.fn().mockResolvedValue(undefined)
+
+      const result = await manager.admit({ sessionId: 's1', providerId: 'p1' }, commit)
+
+      expect(result).toBe('queued')
+      expect(commit).toHaveBeenCalledWith('queued')
+    })
+
+    it('returns queue_full and does NOT call commit when global queue is at capacity', async () => {
+      vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(100)
+      const commit = vi.fn().mockResolvedValue(undefined)
+
+      const result = await manager.admit({ sessionId: 's1', providerId: 'p1' }, commit)
+
+      expect(result).toBe('queue_full')
+      expect(commit).not.toHaveBeenCalled()
+    })
+
+    it('serializes concurrent admits so both cannot pass the same slot', async () => {
+      // Two concurrent calls see activeByProvider=0 individually, but admit serializes them so
+      // the second sees activeByProvider=1 (as committed by the first).
+      manager.setSessionLimit('s1', 10)
+      vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
+      vi.mocked(hostRepo.get).mockResolvedValue({ concurrencyLimit: 1 } as ComputeHost)
+
+      // Simulate DB counts that reflect committed rows from the first admit
+      let committedCount = 0
+      vi.mocked(jobRepo.countActiveBySession).mockImplementation(async () => committedCount)
+      vi.mocked(jobRepo.countActiveByProvider).mockImplementation(async () => committedCount)
+
+      const commit = vi.fn().mockImplementation(async () => {
+        committedCount++
+      })
+
+      const [r1, r2] = await Promise.all([
+        manager.admit({ sessionId: 's1', providerId: 'p1' }, commit),
+        manager.admit({ sessionId: 's1', providerId: 'p1' }, commit)
+      ])
+
+      // First wins the slot, second sees the committed count and queues
+      expect([r1, r2].sort()).toEqual(['queued', 'submitted'])
+      expect(commit).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -671,5 +671,57 @@ describe('ConcurrencyManager', () => {
       expect([r1, r2].sort()).toEqual(['queued', 'submitted'])
       expect(commit).toHaveBeenCalledTimes(2)
     })
+
+    it('does not overrun a provider ceiling when admit() races queue promotion', async () => {
+      // Regression for the P1 race: a new submission (admit) and a queued-job promotion
+      // (onJobCompleted → tryDispatchNext) must not both claim the same free slot. With the reserve
+      // step of tryDispatchNext sharing admit()'s lock, only one row flips to 'submitted'.
+      const providerCeiling = 1
+      vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
+      vi.mocked(hostRepo.get).mockResolvedValue({
+        concurrencyLimit: providerCeiling
+      } as ComputeHost)
+
+      // Both paths read active from the same committed counter; each commit (admit's commit callback
+      // or the promotion's status update to 'submitted') increments it.
+      let active = 0
+      vi.mocked(jobRepo.countActiveBySession).mockImplementation(async () => active)
+      vi.mocked(jobRepo.countActiveByProvider).mockImplementation(async () => active)
+
+      // One queued job available for promotion.
+      vi.mocked(jobRepo.findQueuedJobs).mockResolvedValue([
+        {
+          job_id: 'queued-1',
+          session_id: 's1',
+          provider_id: 'p1',
+          created_at: 1000,
+          status: 'queued'
+        } as ComputeJob
+      ])
+      // The promotion's reserve commit (status → 'submitted') bumps the active counter.
+      vi.mocked(jobRepo.update).mockImplementation(async (_id, u) => {
+        if ((u as { status?: string }).status === 'submitted') active++
+        return {} as ComputeJob
+      })
+      vi.mocked(dispatchJob).mockResolvedValue(undefined)
+
+      // admit's commit callback also bumps the active counter when it writes a 'submitted' row.
+      const commit = vi.fn().mockImplementation(async (status: string) => {
+        if (status === 'submitted') active++
+      })
+
+      const [admitResult] = await Promise.all([
+        manager.admit({ sessionId: 's1', providerId: 'p1' }, commit),
+        manager.onJobCompleted()
+      ])
+
+      // Exactly one of the two paths won the single slot; active never exceeded the ceiling.
+      expect(active).toBe(providerCeiling)
+      const promotionSubmits = vi
+        .mocked(jobRepo.update)
+        .mock.calls.filter(([, u]) => (u as { status?: string }).status === 'submitted').length
+      const admitSubmits = admitResult === 'submitted' ? 1 : 0
+      expect(promotionSubmits + admitSubmits).toBe(1)
+    })
   })
 })

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -100,6 +100,12 @@ export class ConcurrencyManager {
   // - 'queue_full': global queue at capacity (100 jobs)
   // - 'should_queue': either session limit or provider ceiling reached
   // - 'can_dispatch': both limits allow, job can be dispatched immediately
+  //
+  // ADVISORY ONLY for the submit path. submitJob() calls this before the approval gate purely to
+  // reject early on a full global queue; its 'should_queue'/'can_dispatch' returns are NOT the
+  // authoritative admission decision, because reading the count here and committing the row later is
+  // not atomic (the race admit() closes). The binding decision + row commit is admit(). Do NOT route
+  // a real submit decision through enqueue() — use admit() so the read→decide→commit stays atomic.
   async enqueue(params: {
     jobId: string
     sessionId: string
@@ -166,35 +172,32 @@ export class ConcurrencyManager {
       const queuedJobs = await this.jobRepository.findQueuedJobs()
 
       for (const job of queuedJobs) {
-        // Re-check session limit for this job's session - only count active jobs
-        const sessionLimit = this.sessionLimits.get(job.session_id)
-        let sessionLimitOk = true
-        if (sessionLimit !== undefined) {
-          const activeInSession = await this.jobRepository.countActiveBySession(job.session_id)
-          sessionLimitOk = activeInSession < sessionLimit
-        }
+        // Reserve the slot atomically against admit() and other promotions: the re-check of both
+        // limits and the status flip to 'submitted' run inside the SAME admitLock as admit(), so a
+        // concurrent new submission cannot also claim this slot and overrun a provider ceiling /
+        // session limit. Without this shared lock the promotion and an admission each read the same
+        // active count and both become 'submitted' (the race admit() was added to close).
+        //
+        // The slow dispatchJob (SSH staging/launch) runs OUTSIDE the lock: once the row is
+        // 'submitted' it counts as active, so any later admit()/promotion sees it. Holding the lock
+        // across SSH work would serialize every submission behind network latency.
+        const reserved = await this.runExclusive(async () => {
+          if (await this.overActiveLimits(job.session_id, job.provider_id)) return false
+          await this.jobRepository.update(job.job_id, { status: 'submitted' })
+          return true
+        })
+        if (!reserved) continue // limits hit — leave queued for a future completion
 
-        // Re-check provider ceiling for this job's provider - only count active jobs
-        const host = await this.hostRepository.get(job.provider_id)
-        const providerCeiling = host?.concurrencyLimit ?? DEFAULT_PROVIDER_CEILING
-        const activeOnProvider = await this.jobRepository.countActiveByProvider(job.provider_id)
-        const providerCeilingOk = activeOnProvider < providerCeiling
-
-        // Dispatch if both limits allow
-        if (sessionLimitOk && providerCeilingOk) {
-          try {
-            await this.jobRepository.update(job.job_id, { status: 'submitted' })
-            await this.dispatchJob(job.job_id)
-          } catch {
-            // If dispatch fails, mark job as error and continue to next queued job
-            await this.jobRepository.update(job.job_id, {
-              status: 'error',
-              errorCode: 'dispatch_failed',
-              finishedAt: new Date()
-            })
-          }
+        try {
+          await this.dispatchJob(job.job_id)
+        } catch {
+          // If dispatch fails, mark job as error and continue to next queued job.
+          await this.jobRepository.update(job.job_id, {
+            status: 'error',
+            errorCode: 'dispatch_failed',
+            finishedAt: new Date()
+          })
         }
-        // Otherwise skip this job and continue to next
       }
     } finally {
       this.dispatching = false

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -24,6 +24,13 @@ export class ConcurrencyManager {
   // Flag to prevent concurrent execution of tryDispatchNext
   private dispatching: boolean = false
 
+  // In-process serialization lock for admit(). The decision (read counts → pick status) and the
+  // job-row commit must be atomic: without this, two concurrent submitJob calls could both read the
+  // same active count, both decide 'submitted', and overrun a provider ceiling or session limit.
+  // JS is single-threaded, so chaining commit work onto this promise fully serializes the critical
+  // section — the row written by one admit is visible to the DB counts read by the next.
+  private admitLock: Promise<unknown> = Promise.resolve()
+
   constructor(
     private readonly jobRepository: ComputeJobRepository,
     private readonly hostRepository: ComputeHostRepository,
@@ -33,6 +40,59 @@ export class ConcurrencyManager {
   // Set session-level concurrency limit (stored in memory, not persisted).
   setSessionLimit(sessionId: string, limit: number): void {
     this.sessionLimits.set(sessionId, limit)
+  }
+
+  // Runs `fn` while holding the admit lock, serializing it against every other runExclusive call.
+  // The lock is advanced regardless of whether `fn` resolves or rejects so one failure can't wedge
+  // the chain.
+  private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.admitLock.then(fn, fn)
+    this.admitLock = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
+  // Returns true when a new active job for this (session, provider) would exceed the session limit
+  // or the provider ceiling — i.e. the job should be queued rather than dispatched immediately.
+  // Only active jobs (submitted + running) count; queued jobs do not occupy a slot.
+  private async overActiveLimits(sessionId: string, providerId: string): Promise<boolean> {
+    const sessionLimit = this.sessionLimits.get(sessionId)
+    if (sessionLimit !== undefined) {
+      const activeInSession = await this.jobRepository.countActiveBySession(sessionId)
+      if (activeInSession >= sessionLimit) return true
+    }
+
+    const host = await this.hostRepository.get(providerId)
+    const providerCeiling = host?.concurrencyLimit ?? DEFAULT_PROVIDER_CEILING
+    const activeOnProvider = await this.jobRepository.countActiveByProvider(providerId)
+    return activeOnProvider >= providerCeiling
+  }
+
+  // Atomically decides the initial status and commits the job row inside one critical section.
+  // `commit` MUST perform the DB row create with the passed status; its write becomes visible to
+  // the counts read by the next admit before the lock releases, so concurrent callers cannot both
+  // pass the same slot. Returns the committed status, or 'queue_full' WITHOUT committing when the
+  // global queue is at capacity (the caller must not create a row in that case).
+  async admit(
+    params: { sessionId: string; providerId: string },
+    commit: (status: 'submitted' | 'queued') => Promise<void>
+  ): Promise<'submitted' | 'queued' | 'queue_full'> {
+    return this.runExclusive(async () => {
+      const globalQueuedCount = await this.jobRepository.countQueuedJobs()
+      if (globalQueuedCount >= GLOBAL_QUEUE_LIMIT) return 'queue_full'
+
+      const status: 'submitted' | 'queued' = (await this.overActiveLimits(
+        params.sessionId,
+        params.providerId
+      ))
+        ? 'queued'
+        : 'submitted'
+
+      await commit(status)
+      return status
+    })
   }
 
   // Check limits and decide: dispatch now, queue, or reject (queue full).
@@ -53,24 +113,8 @@ export class ConcurrencyManager {
       return 'queue_full'
     }
 
-    // 2. Check session limit (if set) - only count active jobs (submitted + running), not queued
-    const sessionLimit = this.sessionLimits.get(sessionId)
-    let sessionLimitViolated = false
-    if (sessionLimit !== undefined) {
-      const activeInSession = await this.jobRepository.countActiveBySession(sessionId)
-      if (activeInSession >= sessionLimit) {
-        sessionLimitViolated = true
-      }
-    }
-
-    // 3. Check provider ceiling - only count active jobs (submitted + running), not queued
-    const host = await this.hostRepository.get(providerId)
-    const providerCeiling = host?.concurrencyLimit ?? DEFAULT_PROVIDER_CEILING
-    const activeOnProvider = await this.jobRepository.countActiveByProvider(providerId)
-    const providerCeilingViolated = activeOnProvider >= providerCeiling
-
-    // 4. Determine result
-    if (sessionLimitViolated || providerCeilingViolated) {
+    // 2. Check session limit + provider ceiling (only active jobs count, not queued).
+    if (await this.overActiveLimits(sessionId, providerId)) {
       return 'should_queue'
     }
 

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -223,9 +223,14 @@ const createComputeHandlers = (
     const scpRunner = new SystemScpRunner()
 
     // Terminal transitions must both broadcast to the renderer AND wake the ConcurrencyManager so
-    // the next queued job dispatches. The dispatcher (submitted→running/error) and the JobPoller
-    // both flow through this hook, so an error during dispatch drains the queue too — not only
-    // poller-observed completions.
+    // the next queued job dispatches. The dispatcher (submitted→running/error) flows through this
+    // hook, so an error during dispatch drains the queue too.
+    //
+    // DRAIN CONTRACT (two sites, keep in sync): this hook covers dispatcher-observed transitions.
+    // Poller-observed terminal transitions (success/failed/timeout of a running job) are drained
+    // separately in src/main/ipc.ts, which composes the broadcaster with
+    // computeService.notifyJobCompleted(). The two paths cover disjoint transitions — do not remove
+    // either without moving its responsibility to the other, or queued jobs stop dispatching.
     let concurrencyManager: ConcurrencyManager | undefined
     const TERMINAL = new Set(['success', 'failed', 'timeout', 'error'])
     const onJobUpdatedWithDrain = (job: ComputeJob): void => {

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -28,10 +28,13 @@ import { SettingsRepository } from '../settings/repository'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { ComputeApprovalBroker } from './compute-approval-broker'
 import { ComputeService, type ArtifactResolver } from './compute-service'
+import { ConcurrencyManager } from './concurrency-manager'
 import { ComputeHostRepository } from './repository'
 import { ComputeJobRepository } from './job-repository'
 import { readSshConfigHostAliases } from './ssh-config'
 import { SystemSshRunner } from './ssh-runner'
+import { SystemScpRunner } from './scp-runner'
+import { dispatchJob } from './job-dispatcher'
 import { EnabledComputeHostsRegistry, enabledComputeHostsRegistry } from './enabled-hosts-registry'
 import { getJobHarvestDir } from './harvest-engine'
 
@@ -205,20 +208,56 @@ const createComputeHandlers = (
   // Construct the production service with the full job dependency set so agent submit_job works and
   // dispatcher status transitions (submitted→running/error) broadcast to the renderer. Positional
   // args match the ComputeService constructor: (runner, repository, broker, scpRunner,
-  // overrideDownloadsDir, jobRepository, onJobUpdated, artifactResolver, storageRoot).
-  const service =
-    injectedService ??
-    new ComputeService(
-      new SystemSshRunner(),
+  // overrideDownloadsDir, jobRepository, onJobUpdated, artifactResolver, storageRoot,
+  // concurrencyManager).
+  //
+  // The ConcurrencyManager enforces session limits + provider ceilings and auto-dispatches queued
+  // jobs when a slot frees up. It is wired here (not in ComputeService) because it needs a
+  // dispatchJob closure carrying the same runner/scp/repository deps the dispatcher uses. Only built
+  // for the production path — tests inject their own service and drive the manager directly.
+  let service: ComputeService
+  if (injectedService) {
+    service = injectedService
+  } else {
+    const sshRunner = new SystemSshRunner()
+    const scpRunner = new SystemScpRunner()
+
+    // Terminal transitions must both broadcast to the renderer AND wake the ConcurrencyManager so
+    // the next queued job dispatches. The dispatcher (submitted→running/error) and the JobPoller
+    // both flow through this hook, so an error during dispatch drains the queue too — not only
+    // poller-observed completions.
+    let concurrencyManager: ConcurrencyManager | undefined
+    const TERMINAL = new Set(['success', 'failed', 'timeout', 'error'])
+    const onJobUpdatedWithDrain = (job: ComputeJob): void => {
+      onJobUpdated?.(job)
+      if (TERMINAL.has(job.status)) void concurrencyManager?.onJobCompleted()
+    }
+
+    if (jobRepository) {
+      concurrencyManager = new ConcurrencyManager(jobRepository, repository, (queuedJobId) =>
+        dispatchJob(queuedJobId, {
+          runner: sshRunner,
+          scpRunner,
+          hostRepository: repository,
+          jobRepository,
+          onJobUpdated: onJobUpdatedWithDrain
+        })
+      )
+    }
+
+    service = new ComputeService(
+      sshRunner,
       repository,
       broker,
-      undefined,
+      scpRunner,
       undefined,
       jobRepository,
-      onJobUpdated,
+      onJobUpdatedWithDrain,
       artifactResolver,
-      storageRoot
+      storageRoot,
+      concurrencyManager
     )
+  }
 
   return {
     list: () => repository.list(),

--- a/src/main/compute/job-poller.test.ts
+++ b/src/main/compute/job-poller.test.ts
@@ -1290,6 +1290,67 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
     expect(broadcast).toHaveBeenCalledOnce()
     expect(broadcast.mock.calls[0][0].status).toBe('error')
   })
+
+  it('does not double-emit when two ticks overlap before notified_at commits', async () => {
+    // Ticks are not serialized (setInterval). The in-flight guard must stop a second overlapping
+    // tick from re-selecting the same error row and emitting a duplicate notification while the
+    // first tick's notified_at write is still pending.
+    const errorJob = makeJob({
+      status: 'error',
+      error_code: 'dispatch_failed',
+      remote_handle: undefined,
+      finished_at: Date.now(),
+      notified_at: undefined
+    })
+
+    // Gate the notified_at write so both ticks run while the first emit is still in flight.
+    let releaseUpdate: () => void = () => {}
+    const updateGate = new Promise<void>((resolve) => {
+      releaseUpdate = resolve
+    })
+    const update = vi.fn(async (id: string, u: unknown) => {
+      await updateGate
+      return { ...errorJob, job_id: id, ...(u as object) }
+    })
+
+    const jobRepo = {
+      findNonTerminal: vi.fn(() => Promise.resolve([])),
+      findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
+      // Both ticks see the row as still unnotified (write is gated).
+      findErrorUnnotified: vi.fn(() => Promise.resolve([errorJob])),
+      update
+    } as unknown as ComputeJobRepository
+    const hostRepo = {
+      get: vi.fn(() => Promise.resolve(sampleHost()))
+    } as unknown as ComputeHostRepository
+    const runner = makeSshRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const broadcast = vi.fn()
+
+    const poller = new JobPoller({
+      runner,
+      hostRepository: hostRepo,
+      jobRepository: jobRepo,
+      broadcast,
+      storageRoot: '/tmp/test-storage'
+    })
+
+    // Fire two overlapping ticks, then release the gated write.
+    const t1 = poller.tick()
+    const t2 = poller.tick()
+    releaseUpdate()
+    await Promise.all([t1, t2])
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // Only ONE emit despite two overlapping ticks selecting the same unnotified row.
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(broadcast).toHaveBeenCalledOnce()
+  })
 })
 
 describe('JobPoller sub-batching (per-job output budget)', () => {

--- a/src/main/compute/job-poller.test.ts
+++ b/src/main/compute/job-poller.test.ts
@@ -1151,6 +1151,7 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
+      findErrorUnnotified: vi.fn(() => Promise.resolve([])),
       update
     } as unknown as ComputeJobRepository
 
@@ -1235,5 +1236,138 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
     // Only one update call (the status=error write), no notifiedAt write
     expect(update).toHaveBeenCalledOnce()
     expect(update).toHaveBeenCalledWith('job-1', expect.objectContaining({ status: 'error' }))
+  })
+
+  it('emits notification for dispatcher-written error jobs via the recovery scan', async () => {
+    // The dispatcher writes status='error' directly (dispatch_failed / host_unreachable) without
+    // notifying. 'error' is excluded from findNonTerminal and findTerminalUnharvested, so only the
+    // findErrorUnnotified recovery scan surfaces it to notify→analyze.
+    const errorJob = makeJob({
+      status: 'error',
+      error_code: 'host_unreachable',
+      remote_handle: undefined,
+      finished_at: Date.now(),
+      notified_at: undefined
+    })
+    const notifiedJob = { ...errorJob, notified_at: Date.now() }
+    const update = vi.fn().mockResolvedValue(notifiedJob)
+
+    const jobRepo = {
+      // No non-terminal jobs and nothing to harvest — only the error job awaits notification.
+      findNonTerminal: vi.fn(() => Promise.resolve([])),
+      findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
+      findErrorUnnotified: vi.fn(() => Promise.resolve([errorJob])),
+      update
+    } as unknown as ComputeJobRepository
+    const hostRepo = {
+      get: vi.fn(() => Promise.resolve(sampleHost()))
+    } as unknown as ComputeHostRepository
+    const runner = makeSshRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const broadcast = vi.fn()
+
+    const poller = new JobPoller({
+      runner,
+      hostRepository: hostRepo,
+      jobRepository: jobRepo,
+      broadcast,
+      storageRoot: '/tmp/test-storage'
+    })
+
+    await poller.tick()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // notifiedAt written and broadcast fired for the error job
+    expect(update).toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({ notifiedAt: expect.any(Date) })
+    )
+    expect(broadcast).toHaveBeenCalledOnce()
+    expect(broadcast.mock.calls[0][0].status).toBe('error')
+  })
+})
+
+describe('JobPoller sub-batching (per-job output budget)', () => {
+  it('polls >8 jobs for one provider in size-bounded sub-batches, updating every job', async () => {
+    // 10 running jobs on one provider. Previously all 10 batched into ONE ssh call sized for a
+    // single job, so the trailing jobs' sections overflowed the cap and were silently dropped.
+    // Now they poll in sub-batches of ≤8, each with a cap sized to its batch.
+    const jobs = Array.from({ length: 10 }, (_, i) =>
+      makeJob({
+        job_id: `job-${i}`,
+        remote_handle: JSON.stringify({
+          pid: 1000 + i,
+          exit_code_path: `~/.openscience/jobs/job-${i}/exit_code`,
+          stdout_path: `~/.openscience/jobs/job-${i}/stdout`,
+          stderr_path: `~/.openscience/jobs/job-${i}/stderr`,
+          workdir: `~/.openscience/jobs/job-${i}`
+        })
+      })
+    )
+
+    const update = vi.fn((id: string, u: unknown) =>
+      Promise.resolve({ ...makeJob({ job_id: id }), ...(u as object) })
+    )
+    const jobRepo = {
+      findNonTerminal: vi.fn(() => Promise.resolve(jobs)),
+      findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
+      get: vi.fn((id: string) => Promise.resolve(makeJob({ job_id: id }))),
+      update
+    } as unknown as ComputeJobRepository
+    const hostRepo = {
+      get: vi.fn(() => Promise.resolve(sampleHost()))
+    } as unknown as ComputeHostRepository
+
+    // Runner synthesizes output for exactly the job IDs named in each poll command, so each
+    // sub-batch's reply covers only its own jobs. It also records the maxOutputBytes cap used.
+    const capsSeen: number[] = []
+    const runner: SshRunner = {
+      run: vi.fn((_target, cmd: string, opts?: { maxOutputBytes?: number }) => {
+        capsSeen.push(opts?.maxOutputBytes ?? 0)
+        const ids = [...cmd.matchAll(/JOB_START:(job-\d+)/g)].map((m) => m[1])
+        const lines: string[] = []
+        for (const id of ids) {
+          lines.push(
+            `JOB_START:${id}`,
+            'alive:1',
+            '', // no exit code — still running
+            'out',
+            `STDOUT_END:${id}`,
+            '',
+            `STDERR_END:${id}`
+          )
+        }
+        return Promise.resolve({
+          exitCode: 0,
+          stdout: withNonce(lines),
+          stderr: '',
+          truncated: false,
+          timedOut: false
+        })
+      })
+    }
+
+    const poller = new JobPoller({
+      runner,
+      hostRepository: hostRepo,
+      jobRepository: jobRepo,
+      makeNonce: () => NONCE
+    })
+
+    await poller.tick()
+
+    // Two sub-batches (8 + 2) → two ssh round-trips, each capped to its batch size.
+    expect(runner.run).toHaveBeenCalledTimes(2)
+    expect(capsSeen).toEqual([8 * (65536 * 2 + 1024), 2 * (65536 * 2 + 1024)])
+
+    // Every one of the 10 jobs got a status update (none silently dropped by truncation).
+    const updatedIds = new Set(update.mock.calls.map((c) => c[0]))
+    expect(updatedIds.size).toBe(10)
+    for (let i = 0; i < 10; i++) expect(updatedIds.has(`job-${i}`)).toBe(true)
   })
 })

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -107,6 +107,9 @@ export class JobPoller {
   private readonly inFlightHarvests = new Set<string>()
   private harvestSemaphore = HARVEST_CONCURRENCY_LIMIT
   private readonly harvestQueue: ComputeJob[] = []
+  //   inFlightErrorNotifs: jobIds whose error-notification emit is in progress — prevents a second
+  //   overlapping tick from re-emitting before notified_at is persisted (ticks are not serialized)
+  private readonly inFlightErrorNotifs = new Set<string>()
 
   constructor(private readonly deps: JobPollerDeps) {
     this.setIntervalFn = deps.setInterval ?? ((fn, ms) => setInterval(fn, ms))
@@ -150,16 +153,27 @@ export class JobPoller {
     // notify→analyze. emitJobNotification is idempotent (guards on notified_at), so a job already
     // notified via another path (e.g. the noHandle branch below) is skipped.
     if (this.deps.broadcast && this.deps.storageRoot) {
+      const { broadcast, storageRoot } = this.deps
       const errorUnnotified = await this.deps.jobRepository.findErrorUnnotified()
       for (const job of errorUnnotified) {
+        // emitJobNotification guards on notified_at (idempotent), but that is a check-then-act
+        // with a real window: ticks are not serialized, so a second tick could re-select this row
+        // before the notified_at write commits and emit a duplicate user-visible notification. The
+        // in-flight set closes that window (mirrors inFlightHarvests for the harvest scan).
+        if (this.inFlightErrorNotifs.has(job.job_id)) continue
+        this.inFlightErrorNotifs.add(job.job_id)
         void emitJobNotification(job, {
           jobRepository: this.deps.jobRepository,
           hostRepository: this.deps.hostRepository,
-          storageRoot: this.deps.storageRoot,
-          broadcast: this.deps.broadcast
-        }).catch(() => {
-          // Non-fatal: job status is already persisted; retry on the next tick.
+          storageRoot,
+          broadcast
         })
+          .catch(() => {
+            // Non-fatal: job status is already persisted; retry on the next tick.
+          })
+          .finally(() => {
+            this.inFlightErrorNotifs.delete(job.job_id)
+          })
       }
     }
 

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -21,8 +21,17 @@ const PROCESS_VANISHED_TICKS = 2
 // Timeout for the per-host poll SSH command.
 const POLL_TIMEOUT_MS = 30_000
 
-// Maximum output per poll (pid lines + exit codes + tails; bounded by TAIL_MAX_BYTES × 2 + overhead).
-const POLL_MAX_OUTPUT_BYTES = TAIL_MAX_BYTES * 2 + 4 * 1024
+// Per-job output budget for a poll: two tails (stdout+stderr) plus marker/pid/exit-code lines.
+// The 1 KiB pad covers the seven nonce-prefixed marker lines and the exit-code/alive output.
+const PER_JOB_POLL_BYTES = TAIL_MAX_BYTES * 2 + 1024
+
+// Maximum jobs polled in a single SSH round-trip. All non-terminal jobs for one provider used to be
+// batched into ONE ssh call sized for a single job, so a provider with N running jobs overflowed the
+// output cap and the trailing jobs' sections were silently dropped (truncation keeps the head). We
+// now poll in sub-batches of at most this many jobs, sizing the output cap to the sub-batch, which
+// bounds peak memory per call (~POLL_BATCH_MAX_JOBS × PER_JOB_POLL_BYTES ≈ 1 MiB) while guaranteeing
+// every job's section fits.
+const POLL_BATCH_MAX_JOBS = 8
 
 // Grace period added to timeout_seconds before the poller forcibly kills a still-running job
 // (design.md §10). This gives the remote `timeout` command time to deliver SIGTERM+SIGKILL
@@ -132,6 +141,25 @@ export class JobPoller {
       const unharvested = await this.deps.jobRepository.findTerminalUnharvested()
       for (const job of unharvested) {
         this._dispatchHarvest(job)
+      }
+    }
+
+    // Error-notification recovery scan: the dispatcher writes status='error' (dispatch_failed /
+    // host_unreachable) but never emits a compute_done notification, and 'error' is excluded from
+    // both the harvest scan and findNonTerminal. Without this, a dispatch failure would never reach
+    // notify→analyze. emitJobNotification is idempotent (guards on notified_at), so a job already
+    // notified via another path (e.g. the noHandle branch below) is skipped.
+    if (this.deps.broadcast && this.deps.storageRoot) {
+      const errorUnnotified = await this.deps.jobRepository.findErrorUnnotified()
+      for (const job of errorUnnotified) {
+        void emitJobNotification(job, {
+          jobRepository: this.deps.jobRepository,
+          hostRepository: this.deps.hostRepository,
+          storageRoot: this.deps.storageRoot,
+          broadcast: this.deps.broadcast
+        }).catch(() => {
+          // Non-fatal: job status is already persisted; retry on the next tick.
+        })
       }
     }
 
@@ -254,6 +282,21 @@ export class JobPoller {
       return
     }
 
+    // Poll in sub-batches so the SSH output cap always fits every job's section. Each sub-batch is
+    // one SSH round-trip; batches for the same provider run sequentially to reuse one connection and
+    // avoid a fan-out of concurrent ssh processes per provider.
+    for (let i = 0; i < withHandle.length; i += POLL_BATCH_MAX_JOBS) {
+      const batch = withHandle.slice(i, i + POLL_BATCH_MAX_JOBS)
+      await this._pollBatch(batch, target)
+    }
+  }
+
+  // Polls one sub-batch of jobs (all with handles) in a single SSH round-trip, sizing the output cap
+  // to the batch so no job's section is truncated away.
+  private async _pollBatch(
+    jobs: ComputeJob[],
+    target: import('./ssh-runner').ResolvedSshTarget
+  ): Promise<void> {
     // Per-tick random nonce prefixed onto every structural marker. Job stdout/stderr tails are
     // interleaved into the same stream, so bare markers (JOB_START:/alive:/STDOUT_END:/...) printed
     // by the job could otherwise hijack section splitting or field parsing. An unpredictable nonce
@@ -270,9 +313,11 @@ export class JobPoller {
     //   tail -c 65536 <stderr_path> 2>/dev/null || true
     //   echo "<nonce>STDERR_END:<jobId>"
     const parts: string[] = []
-    for (const job of withHandle) {
+    const batched: ComputeJob[] = []
+    for (const job of jobs) {
       const handle = this._parseHandle(job.remote_handle)
       if (!handle) continue
+      batched.push(job)
 
       parts.push(
         `echo "${nonce}JOB_START:${job.job_id}"`,
@@ -287,18 +332,20 @@ export class JobPoller {
 
     if (parts.length === 0) return
 
+    // Size the output cap to this batch: one PER_JOB_POLL_BYTES budget per job that emits a section.
+    const maxOutputBytes = batched.length * PER_JOB_POLL_BYTES
     const pollCmd = parts.join('\n')
     let runResult
     try {
       runResult = await this.deps.runner.run(target, pollCmd, {
         timeoutMs: POLL_TIMEOUT_MS,
         loginShell: false,
-        maxOutputBytes: POLL_MAX_OUTPUT_BYTES
+        maxOutputBytes
       })
     } catch (err) {
       // SSH threw — record lastPollError for each job but do NOT flip status (design.md §8 boundary 2).
       const msg = err instanceof Error ? err.message : String(err)
-      await this._recordPollError(withHandle, msg)
+      await this._recordPollError(batched, msg)
       return
     }
 
@@ -306,13 +353,15 @@ export class JobPoller {
       // Host unreachable — record error per job but do NOT flip status (design.md §8 boundary 2).
       const msg =
         runResult.stderr || (runResult.timedOut ? 'SSH connection timed out' : 'SSH exit 255')
-      await this._recordPollError(withHandle, msg)
+      await this._recordPollError(batched, msg)
       return
     }
 
     // Parse the batched output using nonce-prefixed markers. Pass target for poller fallback kill.
-    const output = runResult.stdout
-    await this._parsePollOutput(output, withHandle, nonce, target)
+    // A truncated result should be impossible now that the cap is sized to the batch, but if it ever
+    // happens the head is kept, so leading jobs still parse; any job whose section was dropped simply
+    // stays non-terminal and is re-polled next tick (its remote exit_code file persists).
+    await this._parsePollOutput(runResult.stdout, batched, nonce, target)
   }
 
   private _parseHandle(raw: string | undefined): RemoteHandle | null {

--- a/src/main/compute/job-repository.ts
+++ b/src/main/compute/job-repository.ts
@@ -158,6 +158,23 @@ export class ComputeJobRepository {
     return rows.map(toJob)
   }
 
+  // Returns error-state jobs that have not yet emitted a compute_done notification.
+  // 'error' is a terminal resting state written by the dispatcher (dispatch_failed / host_unreachable)
+  // and is excluded from both findNonTerminal and findTerminalUnharvested — so without this scan an
+  // error job would never reach the notify→analyze flow. The poller uses it as a recovery scan;
+  // emitJobNotification is idempotent (guards on notified_at), so re-scanning a row is a no-op.
+  async findErrorUnnotified(): Promise<ComputeJob[]> {
+    const client = await this.getClient()
+    const rows = await client.computeJob.findMany({
+      where: {
+        status: 'error',
+        notifiedAt: null
+      },
+      orderBy: { createdAt: 'asc' }
+    })
+    return rows.map(toJob)
+  }
+
   // Returns all non-terminal jobs for a given provider (used by per-host batch polling).
   async findNonTerminalByProvider(providerId: string): Promise<ComputeJob[]> {
     const client = await this.getClient()

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -345,11 +345,19 @@ const registerIpcHandlers = async ({
   // wire the compute_done notification emitter for all three terminal outcomes (issue 06).
   const sshRunner = new SystemSshRunner()
   const scpRunner = new SystemScpRunner()
+  // Poller-observed terminal transitions (success/failed/timeout of originally-submitted jobs) must
+  // both broadcast to the renderer AND wake the ConcurrencyManager so the next queued job dispatches
+  // when a slot frees. Compose the broadcaster with computeService.notifyJobCompleted (a no-op for
+  // non-terminal states and when no ConcurrencyManager is wired).
+  const broadcastJobUpdatedHook = createJobUpdatedBroadcaster(hostRepository, storageRoot)
   const jobPoller = new JobPoller({
     runner: sshRunner,
     hostRepository,
     jobRepository,
-    onJobUpdated: createJobUpdatedBroadcaster(hostRepository, storageRoot),
+    onJobUpdated: (job) => {
+      broadcastJobUpdatedHook(job)
+      computeService.notifyJobCompleted(job)
+    },
     broadcast: broadcastJobUpdated,
     storageRoot,
     harvestFn: (job) =>

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -349,6 +349,11 @@ const registerIpcHandlers = async ({
   // both broadcast to the renderer AND wake the ConcurrencyManager so the next queued job dispatches
   // when a slot frees. Compose the broadcaster with computeService.notifyJobCompleted (a no-op for
   // non-terminal states and when no ConcurrencyManager is wired).
+  //
+  // DRAIN CONTRACT (two sites, keep in sync): this covers poller-observed completions. Dispatcher-
+  // observed transitions (submitted→running/error) are drained inside registerComputeIpcHandlers via
+  // onJobUpdatedWithDrain (src/main/compute/ipc.ts). Dropping the notifyJobCompleted call below would
+  // silently stop queued jobs from dispatching on completion — with no test failure at this seam.
   const broadcastJobUpdatedHook = createJobUpdatedBroadcaster(hostRepository, storageRoot)
   const jobPoller = new JobPoller({
     runner: sshRunner,

--- a/src/renderer/src/components/JobDetailModal.tsx
+++ b/src/renderer/src/components/JobDetailModal.tsx
@@ -373,6 +373,7 @@ export function JobDetailModal({
           open={fileBrowserOpen}
           onClose={() => setFileBrowserOpen(false)}
           initialProviderId={fileBrowserState.providerId}
+          initialPath={fileBrowserState.path}
         />
       )}
     </>

--- a/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
@@ -107,6 +107,33 @@ describe('FileBrowserModal', () => {
     expect(document.body.textContent).toContain('biowulf')
   })
 
+  it('navigates to initialPath on open instead of scratchRoot', async () => {
+    const listDir = vi.fn().mockResolvedValue({ ...mockListing, resolvedPath: '/jobs/job-42' })
+    setComputeApi({
+      listDir,
+      bookmarksGet: vi.fn().mockResolvedValue([]),
+      bookmarksSet: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await act(async () => {
+      root.render(
+        <FileBrowserModal
+          open={true}
+          onClose={vi.fn()}
+          initialProviderId="ssh:biowulf"
+          initialPath="/jobs/job-42"
+        />
+      )
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // listDir should have been called with the initialPath, not with /scratch/user (scratchRoot)
+    expect(listDir).toHaveBeenCalledWith('ssh:biowulf', '/jobs/job-42')
+    expect(listDir).not.toHaveBeenCalledWith('ssh:biowulf', '/scratch/user')
+  })
+
   it('shows directory listing after load', async () => {
     await act(async () => {
       root.render(

--- a/src/renderer/src/pages/settings/FileBrowserModal.tsx
+++ b/src/renderer/src/pages/settings/FileBrowserModal.tsx
@@ -29,7 +29,11 @@ import { Dialog } from 'radix-ui'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { DirListing, RemoteDirEntry } from '../../../../shared/remote-fs'
-import { decodeRemoteFsError, resolveRemotePath, validateRemotePath } from '../../../../shared/remote-fs'
+import {
+  decodeRemoteFsError,
+  resolveRemotePath,
+  validateRemotePath
+} from '../../../../shared/remote-fs'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { useComputeStore } from '@/stores/compute-store'
@@ -314,12 +318,17 @@ type FileBrowserModalProps = {
   open: boolean
   onClose: () => void
   initialProviderId?: string
+  // Directory to open at (e.g. a job's remote_workdir). When omitted, the host's scratchRoot is
+  // used. Applied on the open edge and once the requested provider is active; a later manual host
+  // switch navigates to that host's scratchRoot instead.
+  initialPath?: string
 }
 
 export function FileBrowserModal({
   open,
   onClose,
-  initialProviderId
+  initialProviderId,
+  initialPath
 }: FileBrowserModalProps): React.JSX.Element | null {
   const hosts = useComputeStore((s) => s.hosts)
   const probeHost = useComputeStore((s) => s.probeHost)
@@ -351,6 +360,16 @@ export function FileBrowserModal({
   // Go-to dropdown open state
   const [gotoOpen, setGotoOpen] = useState(false)
 
+  // Open-edge detection + one-shot target directory for the current open session (e.g. a job's
+  // remote_workdir). Tracked as state (not refs) so it works with the "adjust state during render"
+  // pattern below without touching refs mid-render. `pending` is null when nothing is queued, or
+  // `{ path }` on the closed→open edge (path may be undefined → fall back to scratchRoot). It is
+  // consumed by the navigation effect so a later manual host switch goes to that host's scratchRoot.
+  const [prevOpen, setPrevOpen] = useState(open)
+  const [pending, setPending] = useState<{ path?: string } | null>(
+    open ? { path: initialPath } : null
+  )
+
   const navigate = useCallback(
     async (path: string, pushHistory = true) => {
       if (!host) return
@@ -381,14 +400,33 @@ export function FileBrowserModal({
     [host, cwd, probeHost]
   )
 
-  // Initial navigation when modal opens or host changes.
-  // All state resets happen inside the async navigate() call via a dedicated "reset" flag.
+  // Adjust state during render on the open edge (React's "adjust state when a prop changes" pattern
+  // — https://react.dev/learn/you-might-not-need-an-effect). The modal stays mounted across opens in
+  // JobDetailModal, so without this re-sync activeProviderId would stay stale for a different job's
+  // provider. Setting state during render (not in an effect) lets React re-render immediately with
+  // the correct provider before committing, avoiding a stale-host flash.
+  if (open !== prevOpen) {
+    setPrevOpen(open)
+    setPending(open ? { path: initialPath } : null)
+    if (open && initialProviderId && initialProviderId !== activeProviderId) {
+      setActiveProviderId(initialProviderId)
+    }
+  }
+
+  // Initial navigation when modal opens or host changes. Consuming `pending` (setPending(null))
+  // happens inside the async IIFE — the same place the other nav-state resets already run — so this
+  // effect never sets state synchronously in its body. `pending` is intentionally NOT in the deps:
+  // it is read once per open/host change; consuming it must not itself re-fire the effect.
   useEffect(() => {
     if (!open || !host) return
-    const startPath = host.scratchRoot ?? '~'
-    // Synchronously reset navigation state before the async navigate starts.
-    // React batches these updates together in the same render cycle.
+    // While the open-edge sync switches to the requested provider, `host` may lag by one render.
+    // Skip navigating the stale host so we don't flash its scratchRoot; the effect re-fires once
+    // activeProviderId (and thus host) catches up.
+    if (initialProviderId && host.providerId !== initialProviderId && pending) return
+    // Consume the one-shot target: use it on the open edge, else fall back to scratchRoot.
+    const startPath = pending?.path ?? host.scratchRoot ?? '~'
     void (async () => {
+      if (pending) setPending(null)
       setCwd(startPath)
       setHistory([])
       setSelected(null)


### PR DESCRIPTION
## Summary

Follow-ups to #326 (remote SSH compute host support), addressing review findings across concurrency, notifications, polling, the file browser, and docs.

- **Slot race fix.** `ConcurrencyManager.admit()` now decides the initial status *and* commits the job row inside one serialized critical section (`runExclusive` chains onto a promise lock). Without this, two concurrent `submitJob` calls could both read the same active count, both decide `submitted`, and overrun a provider ceiling or session limit. `submitJob` keeps an advisory `queue_full` pre-check before the approval gate, then commits atomically via `admit` after approval. The manager is now wired into the production `ComputeService`, with terminal transitions draining the queue via both the dispatcher and poller paths.
- **Dispatcher errors reach notify→analyze.** The dispatcher writes `status: 'error'` (dispatch_failed / host_unreachable) but never emitted a `compute_done` notification, and `error` is excluded from both the harvest scan and `findNonTerminal` — so a dispatch failure never reached the analysis turn. Added `findErrorUnnotified()` and a poller recovery scan (idempotent via `notified_at`).
- **Poll output budget.** All non-terminal jobs for a provider used to batch into one SSH call sized for a single job, so a provider with N running jobs overflowed the output cap and trailing jobs' sections were silently dropped (truncation keeps the head). Now polls run in sub-batches of ≤8 jobs, each with an output cap sized to its batch.
- **File browser workdir target.** Added an `initialPath` prop so opening the browser from a job's workdir link opens *at* that `remote_workdir` instead of `scratchRoot`, and re-syncs the active provider on the open edge (the modal stays mounted across opens). Implemented with the React "adjust state during render" pattern to satisfy the compiler lint rules.
- **Approval-scope docs.** Documented in `SECURITY.md` (and the code comment) that remote-compute download approval gates by *initiator* — agent session-cache pulls go through the approval broker; UI-initiated OS-downloads/artifacts do not, since the click is the authorization. All destinations still validate the remote path and enforce size caps.

## Testing

- `npm run typecheck` — clean
- `vitest run src/main/compute … FileBrowserModal … JobDetailModal` — **404 passed / 5 skipped** (skips are pre-existing, env-gated integration tests)
- eslint + prettier clean on all changed files

New coverage: `admit` serialization (concurrent callers can't share a slot), the error-notification recovery scan, sub-batch output sizing (10 jobs → 2 size-bounded round-trips, none dropped), and `FileBrowserModal` `initialPath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)