### PR TITLE
fix(compute): pass ssh alias (not resolved IP) as connection target

### DIFF
--- a/src/main/compute/scp-runner.test.ts
+++ b/src/main/compute/scp-runner.test.ts
@@ -191,6 +191,34 @@ describe('buildScpArgs', () => {
 })
 
 // ---------------------------------------------------------------------------
+// resolveSshTarget → buildScpArgs integration
+// Locks the contract that the alias (not the resolved IP) flows into the scp
+// remote spec and that ControlMaster args from resolveSshTarget are preserved.
+// ---------------------------------------------------------------------------
+
+describe('resolveSshTarget → buildScpArgs integration', () => {
+  it('passes the alias as the scp remote spec and preserves ControlMaster', async () => {
+    const { resolveSshTarget } = await import('./ssh-runner')
+    const target = await resolveSshTarget('aliyun-xt-test', undefined, async () => ({
+      user: 'ewen',
+      hostname: '47.98.96.100',
+      port: '22',
+      identityfile: '~/.ssh/aliyun-xt-test.pem'
+    }))
+    const args = buildScpArgs(target, '/remote/data.csv', '/local/data.csv')
+
+    // The remote spec must use the alias, NOT the resolved IP — scp matches the
+    // ~/.ssh/config "Host" block on the alias to apply IdentityFile etc.
+    expect(args).toContain('aliyun-xt-test:/remote/data.csv')
+    expect(args).not.toContain('47.98.96.100:/remote/data.csv')
+
+    // ControlMaster args from resolveSshTarget must survive the -p → Port translation.
+    expect(args).toContain('ControlMaster=auto')
+    expect(args.some((a) => a.startsWith('ControlPath='))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // inferMimeType
 // ---------------------------------------------------------------------------
 

--- a/src/main/compute/ssh-runner.test.ts
+++ b/src/main/compute/ssh-runner.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { parseProbeOutput } from './compute-service'
-import { CappedOutput, controlMasterArgs, resolveSshBinary } from './ssh-runner'
+import { CappedOutput, controlMasterArgs, resolveSshBinary, resolveSshTarget } from './ssh-runner'
 
 // Mock only mkdirSync so we can assert the ~/.ssh/ctrl dir is created; everything else stays real.
 vi.mock('node:fs', async (importOriginal) => ({
@@ -157,5 +157,58 @@ describe('parseProbeOutput probe output contract', () => {
     expect(result.detectedScheduler).toBe('none')
     expect(result.gpus).toEqual([])
     expect(result.scratchEnv).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveSshTarget — host must be the alias (not the resolved IP) so that the
+// ~/.ssh/config "Host <alias>" block is applied by ssh/scp, including a
+// non-default IdentityFile. Regression guard for the "Permission denied
+// (publickey,password)" bug where the resolved hostname was passed instead,
+// silently dropping the IdentityFile directive.
+// ---------------------------------------------------------------------------
+
+describe('resolveSshTarget', () => {
+  // Pretend `ssh -G aliyun-xt-test` output — non-default identityfile is the key detail.
+  const fakeSshG = () => ({
+    user: 'ewen',
+    hostname: '47.98.96.100',
+    port: '22',
+    identityfile: '~/.ssh/aliyun-xt-test.pem'
+  })
+
+  it('returns the alias as host, NOT the resolved hostname', async () => {
+    const target = await resolveSshTarget('aliyun-xt-test', undefined, async () => fakeSshG())
+    expect(target.host).toBe('aliyun-xt-test')
+    expect(target.host).not.toBe('47.98.96.100')
+  })
+
+  it('does not pass -i when identityFile override is absent (config handles it via alias)', async () => {
+    const target = await resolveSshTarget('aliyun-xt-test', undefined, async () => fakeSshG())
+    expect(target.extraArgs).not.toContain('-i')
+  })
+
+  it('passes -i <path> when an explicit identityFile override is provided', async () => {
+    const target = await resolveSshTarget('aliyun-xt-test', { identityFile: '/keys/custom.pem' }, async () => fakeSshG())
+    const iIdx = target.extraArgs.indexOf('-i')
+    expect(iIdx).toBeGreaterThan(-1)
+    expect(target.extraArgs[iIdx + 1]).toBe('/keys/custom.pem')
+  })
+
+  it('always sets BatchMode and ConnectTimeout', async () => {
+    const target = await resolveSshTarget('aliyun-xt-test', undefined, async () => fakeSshG())
+    expect(target.extraArgs).toContain('BatchMode=yes')
+    expect(target.extraArgs).toContain('ConnectTimeout=10')
+  })
+
+  it('applies user override from ssh -G', async () => {
+    const target = await resolveSshTarget('aliyun-xt-test', undefined, async () => fakeSshG())
+    expect(target.extraArgs).toContain('User=ewen')
+  })
+
+  it('falls back to the bare alias when ssh -G fails (no ~/.ssh/config)', async () => {
+    const target = await resolveSshTarget('bare-host', undefined, async () => ({}))
+    expect(target.host).toBe('bare-host')
+    expect(target.extraArgs).toContain('BatchMode=yes')
   })
 })

--- a/src/main/compute/ssh-runner.test.ts
+++ b/src/main/compute/ssh-runner.test.ts
@@ -210,8 +210,30 @@ describe('resolveSshTarget', () => {
     expect(target.extraArgs).toContain('User=ewen')
   })
 
-  it('falls back to the bare alias when ssh -G fails (no ~/.ssh/config)', async () => {
+  it('passes non-default port from ssh -G', async () => {
+    const target = await resolveSshTarget('aliyun-xt-test', undefined, async () => ({
+      ...fakeSshG(),
+      port: '2222'
+    }))
+    expect(target.extraArgs).toContain('-p')
+    expect(target.extraArgs).toContain('2222')
+  })
+
+  it('does not pass -p when port is the default 22', async () => {
+    const target = await resolveSshTarget('aliyun-xt-test', undefined, async () => fakeSshG())
+    expect(target.extraArgs).not.toContain('-p')
+  })
+
+  it('falls back to the bare alias when ssh -G returns empty config', async () => {
     const target = await resolveSshTarget('bare-host', undefined, async () => ({}))
+    expect(target.host).toBe('bare-host')
+    expect(target.extraArgs).toContain('BatchMode=yes')
+  })
+
+  it('falls back to the bare alias when ssh -G process rejects', async () => {
+    const target = await resolveSshTarget('bare-host', undefined, async () => {
+      throw new Error('Command failed: ssh -G bare-host')
+    })
     expect(target.host).toBe('bare-host')
     expect(target.extraArgs).toContain('BatchMode=yes')
   })

--- a/src/main/compute/ssh-runner.test.ts
+++ b/src/main/compute/ssh-runner.test.ts
@@ -170,7 +170,7 @@ describe('parseProbeOutput probe output contract', () => {
 
 describe('resolveSshTarget', () => {
   // Pretend `ssh -G aliyun-xt-test` output — non-default identityfile is the key detail.
-  const fakeSshG = () => ({
+  const fakeSshG = (): Record<string, string> => ({
     user: 'ewen',
     hostname: '47.98.96.100',
     port: '22',
@@ -189,7 +189,11 @@ describe('resolveSshTarget', () => {
   })
 
   it('passes -i <path> when an explicit identityFile override is provided', async () => {
-    const target = await resolveSshTarget('aliyun-xt-test', { identityFile: '/keys/custom.pem' }, async () => fakeSshG())
+    const target = await resolveSshTarget(
+      'aliyun-xt-test',
+      { identityFile: '/keys/custom.pem' },
+      async () => fakeSshG()
+    )
     const iIdx = target.extraArgs.indexOf('-i')
     expect(iIdx).toBeGreaterThan(-1)
     expect(target.extraArgs[iIdx + 1]).toBe('/keys/custom.pem')

--- a/src/main/compute/ssh-runner.ts
+++ b/src/main/compute/ssh-runner.ts
@@ -17,7 +17,8 @@ const DEFAULT_CONNECT_TIMEOUT_SECS = 10
 export type ResolvedSshTarget = {
   // Full path to the ssh binary (e.g. /usr/bin/ssh, C:\Windows\System32\OpenSSH\ssh.exe).
   sshBinary: string
-  // Hostname or alias to pass to ssh.
+  // The ssh target to pass to ssh/scp. This is the ~/.ssh/config alias (not the resolved IP) so the
+  // "Host <alias>" block and all its directives (HostName, IdentityFile, ProxyJump, …) are applied.
   host: string
   // Connection flags resolved from `ssh -G <alias>` plus overrides: -p, -l/-o User, -i, control args.
   extraArgs: string[]
@@ -98,24 +99,45 @@ const parseSshG = (output: string): Record<string, string> => {
   return result
 }
 
+// Reads the effective ~/.ssh/config for `alias` by running `ssh -G <alias>`. Returns a lowercased
+// key→value map. Returns an empty map on failure (e.g. no ~/.ssh/config) so the caller can still
+// build a usable connection from overrides and defaults. Extracted so resolveSshTarget can inject a
+// fake in tests without spawning ssh.
+const readEffectiveConfig = async (
+  alias: string,
+  sshBinary: string
+): Promise<Record<string, string>> => {
+  const execFileAsync = promisify(execFile)
+  try {
+    const { stdout } = await execFileAsync(sshBinary, ['-G', alias], { timeout: 5000 })
+    return parseSshG(stdout)
+  } catch {
+    return {}
+  }
+}
+
 // Resolves a ResolvedSshTarget for the given alias + optional overrides. Runs `ssh -G <alias>` to
 // read the effective config, then layers the overrides on top. BatchMode=yes and ConnectTimeout are
 // always set so the process never hangs on passphrase or slow networks.
+//
+// The returned `host` is the alias itself — NOT the hostname resolved by ssh -G. This is deliberate:
+// passing the alias makes ssh/scp match the user's ~/.ssh/config "Host" block and apply every
+// directive there (HostName, User, Port, IdentityFile, ProxyJump, HostKeyAlias, …) exactly like the
+// CLI. Returning the resolved IP instead made ssh skip Host-alias matching, silently dropping a
+// non-default IdentityFile and causing "Permission denied (publickey,password)" even though
+// `ssh <alias>` on the CLI works. ssh -G is still consulted only to surface explicit overrides
+// (user/port) on top of whatever config the alias resolves.
 export const resolveSshTarget = async (
   alias: string,
-  overrides: SshOverrides | undefined
+  overrides: SshOverrides | undefined,
+  // Test seam: inject the ssh -G config reader so resolveSshTarget is unit-testable without
+  // spawning ssh. Production callers omit it and get the real readEffectiveConfig.
+  readConfig: (alias: string, sshBinary: string) => Promise<Record<string, string>> = readEffectiveConfig
 ): Promise<ResolvedSshTarget> => {
   const sshBinary = resolveSshBinary()
-  const execFileAsync = promisify(execFile)
 
   // Read the effective connection config from ~/.ssh/config for this alias.
-  let sshGConfig: Record<string, string> = {}
-  try {
-    const { stdout } = await execFileAsync(sshBinary, ['-G', alias], { timeout: 5000 })
-    sshGConfig = parseSshG(stdout)
-  } catch {
-    // ssh -G failed (e.g. no ~/.ssh/config) — proceed with overrides and defaults only.
-  }
+  const sshGConfig = await readConfig(alias, sshBinary)
 
   const extraArgs: string[] = []
 
@@ -132,7 +154,9 @@ export const resolveSshTarget = async (
     extraArgs.push('-p', sshGConfig['port'])
   }
 
-  // Identity file: override only (ssh -G resolves it for us when not overriding).
+  // Identity file: explicit override only. When no override is given, the alias (returned as
+  // `host` below) makes ssh/scp read IdentityFile straight from ~/.ssh/config — the same way the
+  // CLI does — so non-default key paths (e.g. ~/.ssh/myhost.pem) work without the app touching keys.
   if (overrides?.identityFile?.trim()) {
     extraArgs.push('-i', overrides.identityFile.trim())
   }
@@ -147,8 +171,10 @@ export const resolveSshTarget = async (
   // ControlMaster on mac/linux for connection reuse across the probe bundle.
   extraArgs.push(...controlMasterArgs(alias))
 
-  // Resolve the hostname from ssh -G (may differ from the alias due to HostName directives).
-  const host = sshGConfig['hostname'] ?? alias
+  // Pass the alias — NOT the resolved hostname — as the connection target (see the function
+  // docstring above). ControlMaster's ControlPath uses %h, which ssh expands to the real HostName,
+  // so the mux socket is identical whether the alias or the IP is the target.
+  const host = alias
 
   return { sshBinary, host, extraArgs }
 }

--- a/src/main/compute/ssh-runner.ts
+++ b/src/main/compute/ssh-runner.ts
@@ -132,7 +132,10 @@ export const resolveSshTarget = async (
   overrides: SshOverrides | undefined,
   // Test seam: inject the ssh -G config reader so resolveSshTarget is unit-testable without
   // spawning ssh. Production callers omit it and get the real readEffectiveConfig.
-  readConfig: (alias: string, sshBinary: string) => Promise<Record<string, string>> = readEffectiveConfig
+  readConfig: (
+    alias: string,
+    sshBinary: string
+  ) => Promise<Record<string, string>> = readEffectiveConfig
 ): Promise<ResolvedSshTarget> => {
   const sshBinary = resolveSshBinary()
 
@@ -141,7 +144,10 @@ export const resolveSshTarget = async (
 
   const extraArgs: string[] = []
 
-  // User: override > ssh -G user > alias itself.
+  // User/Port: explicit override, or the value ssh -G resolves for this alias. Passing the alias as
+  // `host` below already makes ssh apply these from config, so these flags are technically redundant
+  // when no override is set — but harmless (values match) and kept for clarity. IdentityFile, by
+  // contrast, is override-only because ssh picks it up from config via the alias.
   const resolvedUser = overrides?.user?.trim() ?? sshGConfig['user']
   if (resolvedUser && resolvedUser !== alias) {
     extraArgs.push('-o', `User=${resolvedUser}`)

--- a/src/main/compute/ssh-runner.ts
+++ b/src/main/compute/ssh-runner.ts
@@ -139,8 +139,15 @@ export const resolveSshTarget = async (
 ): Promise<ResolvedSshTarget> => {
   const sshBinary = resolveSshBinary()
 
-  // Read the effective connection config from ~/.ssh/config for this alias.
-  const sshGConfig = await readConfig(alias, sshBinary)
+  // Read the effective connection config from ~/.ssh/config for this alias. Wrapped in try/catch so
+  // a failing readConfig (e.g. ssh -G process error) never breaks connection resolution — the
+  // caller falls back to the bare alias + defaults.
+  let sshGConfig: Record<string, string> = {}
+  try {
+    sshGConfig = await readConfig(alias, sshBinary)
+  } catch {
+    // readConfig failed — proceed with overrides and defaults only.
+  }
 
   const extraArgs: string[] = []
 


### PR DESCRIPTION
## Problem

SSH host probes (and all ssh/scp operations) fail with `Permission denied (publickey,password)` for any host that uses a non-default `IdentityFile` in `~/.ssh/config`, even though `ssh <alias>` works fine from the terminal.

## Root Cause

`resolveSshTarget` ran `ssh -G <alias>` to read the effective config, then returned the **resolved hostname** (e.g. `47.98.96.100`) as the connection target instead of the **alias** (e.g. `aliyun-xt-test`).

When ssh/scp receives a bare IP, it does **not** match the `Host <alias>` block in `~/.ssh/config`, so directives like `IdentityFile` are silently dropped. ssh then only tries default key names (`id_rsa` / `id_ed25519`), finds nothing, and fails.

This affected **both ssh and scp** — `scp-runner` builds its remote spec from the same `target.host` (`scp-runner.ts:114/130`).

## Fix

Return the **alias** as `host` instead of the resolved IP. This makes ssh/scp match the config block and apply all directives (`HostName`, `User`, `Port`, `IdentityFile`, `ProxyJump`, …) exactly like the CLI.

```diff
- const host = sshGConfig["hostname"] ?? alias
+ const host = alias
```

- `ssh -G` is still consulted to surface explicit `User`/`Port` overrides on top of what the alias resolves.
- `ControlMaster` ControlPath uses `%h`, which ssh expands to the real hostname — so the mux socket is identical whether the alias or the IP is the target.
- Extracted `readEffectiveConfig` as an injectable test seam so `resolveSshTarget` is unit-testable without spawning ssh.
- Added 6 regression tests locking the new behavior.

## Verification

- All 1936 existing compute tests pass (1911 passed, 25 skipped).
- Confirmed the exact error is reproducible locally: `ssh -o BatchMode=yes ewen@47.98.96.100` → `Permission denied (publickey,password)`, while `ssh aliyun-xt-test` succeeds.
- scp-runner needs no changes — it already consumes `target.host`, so the fix applies transparently.