### PR TITLE
fix(reviewer): recognize claude-code reviewer MCP tool identity

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2961,6 +2961,94 @@ describe('ACP runtime session management', () => {
     runtime.disposeReviewerSession(session)
   })
 
+  // Regression: claude-code (and OpenAI-compatible providers routed through it) emit reviewer MCP calls
+  // with the sanitized mcp__<server>__<tool> identity in the title/toolCallId and no provider _meta tool
+  // name. The gate must recognize that form or every reviewer tool call is rejected (issue #329).
+  it.each([
+    { label: 'title', toolTitle: 'mcp__open_science_reviewer__read_turn', toolCallId: 'call-a' },
+    {
+      label: 'toolCallId suffix',
+      toolTitle: 'Read audited turn',
+      toolCallId: 'mcp__open_science_reviewer__read_turn_0'
+    }
+  ])(
+    'auto-approves a claude-code reviewer MCP tool identified by $label',
+    async ({ toolTitle, toolCallId }) => {
+      const process = new FakeAgentProcess()
+      let permissionResponse: unknown
+      startPermissionProbeAgent(process, {
+        newSessionId: 'reviewer-session-1',
+        toolCallId,
+        toolTitle,
+        permissionOptions: [
+          { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+          { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+        ],
+        onPermissionResponse: (response) => {
+          permissionResponse = response
+        }
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        framework: claudeCodeFramework
+      })
+
+      const { session } = await runtime.buildReviewerSession({
+        cwd: '/workspace',
+        mcpServers: [
+          {
+            type: 'http',
+            name: 'open-science-reviewer',
+            url: 'http://127.0.0.1:1/mcp',
+            headers: []
+          }
+        ]
+      })
+      await session.prompt([{ type: 'text', text: 'read the audited turn' }])
+
+      expect(permissionResponse).toEqual({
+        outcome: { outcome: 'selected', optionId: 'allow-once' }
+      })
+      expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(0)
+      runtime.disposeReviewerSession(session)
+    }
+  )
+
+  it('counts reviewer tool calls rejected by the strict gate', async () => {
+    const process = new FakeAgentProcess()
+    startPermissionProbeAgent(process, {
+      newSessionId: 'reviewer-session-1',
+      toolCallId: 'reviewer-blocked-bash',
+      toolTitle: 'Bash',
+      toolKind: 'execute',
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ]
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework
+    })
+
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        { type: 'http', name: 'open-science-reviewer', url: 'http://127.0.0.1:1/mcp', headers: [] }
+      ]
+    })
+    await session.prompt([{ type: 'text', text: 'run a shell command' }])
+
+    expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(1)
+    runtime.disposeReviewerSession(session)
+    // Dispose clears the counter so a later session under the same id starts fresh.
+    expect(runtime.reviewerRejectedToolCallCount('reviewer-session-1')).toBe(0)
+  })
+
   it('refuses a non-loopback reviewer MCP before starting an agent connection', async () => {
     const process = new FakeAgentProcess()
     const spawnAgent = vi.fn(() => asAgentProcess(process))

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2962,59 +2962,84 @@ describe('ACP runtime session management', () => {
   })
 
   // Regression: claude-code (and OpenAI-compatible providers routed through it) emit reviewer MCP calls
-  // with the sanitized mcp__<server>__<tool> identity in the title/toolCallId and no provider _meta tool
-  // name. The gate must recognize that form or every reviewer tool call is rejected (issue #329).
-  it.each([
-    { label: 'title', toolTitle: 'mcp__open_science_reviewer__read_turn', toolCallId: 'call-a' },
-    {
-      label: 'toolCallId suffix',
-      toolTitle: 'Read audited turn',
-      toolCallId: 'mcp__open_science_reviewer__read_turn_0'
-    }
-  ])(
-    'auto-approves a claude-code reviewer MCP tool identified by $label',
-    async ({ toolTitle, toolCallId }) => {
-      const process = new FakeAgentProcess()
-      let permissionResponse: unknown
-      startPermissionProbeAgent(process, {
-        newSessionId: 'reviewer-session-1',
-        toolCallId,
-        toolTitle,
-        permissionOptions: [
-          { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
-          { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
-        ],
-        onPermissionResponse: (response) => {
-          permissionResponse = response
-        }
-      })
-      const runtime = new AcpRuntime({
-        appVersion: '0.1.0',
-        defaultCwd: '/workspace',
-        spawnAgent: () => asAgentProcess(process),
-        framework: claudeCodeFramework
-      })
+  // with the sanitized mcp__<server>__<tool> identity in the title and no provider _meta tool name. The
+  // gate must recognize that title form or every reviewer tool call is rejected (issue #329).
+  it('auto-approves a claude-code reviewer MCP tool identified by its sanitized title', async () => {
+    const process = new FakeAgentProcess()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'reviewer-session-1',
+      toolCallId: 'mcp__open_science_reviewer__read_turn_0',
+      toolTitle: 'mcp__open_science_reviewer__read_turn',
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework
+    })
 
-      const { session } = await runtime.buildReviewerSession({
-        cwd: '/workspace',
-        mcpServers: [
-          {
-            type: 'http',
-            name: 'open-science-reviewer',
-            url: 'http://127.0.0.1:1/mcp',
-            headers: []
-          }
-        ]
-      })
-      await session.prompt([{ type: 'text', text: 'read the audited turn' }])
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        { type: 'http', name: 'open-science-reviewer', url: 'http://127.0.0.1:1/mcp', headers: [] }
+      ]
+    })
+    await session.prompt([{ type: 'text', text: 'read the audited turn' }])
 
-      expect(permissionResponse).toEqual({
-        outcome: { outcome: 'selected', optionId: 'allow-once' }
-      })
-      expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(0)
-      runtime.disposeReviewerSession(session)
-    }
-  )
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(0)
+    runtime.disposeReviewerSession(session)
+  })
+
+  // Security: the toolCallId is agent-controlled, so a reviewer-shaped id must NOT authorize a call
+  // whose title/kind are a genuinely disallowed tool. Only the title carries the trusted MCP identity.
+  it('rejects a Bash call that carries a reviewer-shaped toolCallId', async () => {
+    const process = new FakeAgentProcess()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'reviewer-session-1',
+      toolCallId: 'mcp__open_science_reviewer__read_turn_0',
+      toolTitle: 'Bash',
+      toolKind: 'execute',
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework
+    })
+
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        { type: 'http', name: 'open-science-reviewer', url: 'http://127.0.0.1:1/mcp', headers: [] }
+      ]
+    })
+    await session.prompt([{ type: 'text', text: 'run a shell command with a spoofed id' }])
+
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'reject-once' }
+    })
+    expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(1)
+    runtime.disposeReviewerSession(session)
+  })
 
   it('counts reviewer tool calls rejected by the strict gate', async () => {
     const process = new FakeAgentProcess()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3069,8 +3069,8 @@ describe('ACP runtime session management', () => {
     await session.prompt([{ type: 'text', text: 'run a shell command' }])
 
     expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(1)
-    runtime.disposeReviewerSession(session)
-    // Dispose clears the counter so a later session under the same id starts fresh.
+    // dispose returns the final count and clears it atomically — the orchestrator relies on this.
+    expect(runtime.disposeReviewerSession(session)).toBe(1)
     expect(runtime.reviewerRejectedToolCallCount('reviewer-session-1')).toBe(0)
   })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -327,8 +327,19 @@ const REVIEWER_MCP_OPENCODE_TOOL_NAMES = new Set(
   Object.values(REVIEWER_MCP_TOOLS).map((toolName) => `${REVIEWER_MCP_SERVER_NAME}_${toolName}`)
 )
 const REVIEWER_MCP_LEAF_TOOL_NAMES = new Set<string>(Object.values(REVIEWER_MCP_TOOLS))
+// claude-code namespaces MCP tools as mcp__<server>__<tool> and sanitizes the server name by replacing
+// every non-alphanumeric char with an underscore, so "open-science-reviewer" becomes
+// "open_science_reviewer". Match that sanitized identity, which appears in the tool call title/id and
+// carries no provider _meta tool name.
+const REVIEWER_MCP_SERVER_NAME_SANITIZED = REVIEWER_MCP_SERVER_NAME.replace(/[^a-zA-Z0-9]/g, '_')
+const REVIEWER_MCP_CLAUDE_TOOL_NAMES = new Set(
+  Object.values(REVIEWER_MCP_TOOLS).map(
+    (toolName) => `mcp__${REVIEWER_MCP_SERVER_NAME_SANITIZED}__${toolName}`
+  )
+)
 const REVIEWER_MCP_PROVIDER_TOOL_NAMES = new Set([
   ...REVIEWER_MCP_OPENCODE_TOOL_NAMES,
+  ...REVIEWER_MCP_CLAUDE_TOOL_NAMES,
   ...Object.values(REVIEWER_MCP_TOOLS).map(
     (toolName) => `mcp__${REVIEWER_MCP_SERVER_NAME}__${toolName}`
   )
@@ -480,6 +491,10 @@ class AcpRuntime {
   // rejected. Each session also gets an empty temporary cwd so ungated read-only tools see no project data.
   private readonly reviewerSessionIds = new Set<string>()
   private readonly reviewerSessionDirectories = new Map<string, string>()
+  // Per reviewer session: count of tool calls the strict allowlist rejected. Lets the orchestrator
+  // distinguish "reviewer never called its tools" from "the gate blocked them" when a review ends
+  // without submit_findings, so the reported cause is accurate instead of misleading.
+  private readonly reviewerRejectedToolCalls = new Map<string, number>()
   // A replaced agent's own session id -> the app-facing id it was adopted under (after a provider
   // switch), so agent-origin events/permissions relabel into the conversation the renderer tracks.
   private readonly agentToAppSessionId = new Map<string, string>()
@@ -3031,6 +3046,16 @@ class AcpRuntime {
     }
   }
 
+  // Returns the leaf reviewer tool name when a claude-code MCP identity string matches the reviewer.
+  // claude-code sanitizes server names (hyphens → underscores) and may append a _<n> disambiguator to
+  // the toolCallId; strip it before checking so both the title and toolCallId forms are recognized.
+  private matchReviewerClaudeToolName(candidate: string | null | undefined): string | undefined {
+    if (typeof candidate !== 'string') return undefined
+    const stripped = candidate.replace(/_\d+$/, '')
+    if (REVIEWER_MCP_CLAUDE_TOOL_NAMES.has(stripped)) return stripped
+    return undefined
+  }
+
   // Grants only the dedicated reviewer MCP. The old implementation selected the first available option
   // for every reviewer request, which effectively approved Bash/network/filesystem tools. A denied call
   // uses a one-shot reject when offered and otherwise cancels; it never falls through to an allow option.
@@ -3055,17 +3080,32 @@ class AcpRuntime {
       reportedTitle === `mcp.${REVIEWER_MCP_SERVER_NAME}.${toolName}`
         ? toolName
         : undefined
+    // claude-code (and the OpenAI-compatible providers routed through it) emit reviewer MCP calls with
+    // no provider _meta tool name; the mcp__<sanitized-server>__<tool> identity rides only in the tool
+    // call title or its toolCallId (the latter may carry a trailing _<n> disambiguator). Recognize it
+    // there so the strict allowlist does not reject the reviewer's own tools.
+    const claudeToolName =
+      toolName == null && frameworkId === 'claude-code'
+        ? (this.matchReviewerClaudeToolName(reportedTitle) ??
+          this.matchReviewerClaudeToolName(params.toolCall?.toolCallId))
+        : undefined
     const isReviewerMcp =
       mcpServerNames.length === 1 &&
       mcpServerNames[0] === REVIEWER_MCP_SERVER_NAME &&
       ((toolName != null && REVIEWER_MCP_PROVIDER_TOOL_NAMES.has(toolName)) ||
         opencodeToolName != null ||
-        codexToolName != null)
+        codexToolName != null ||
+        claudeToolName != null)
 
     if (!isReviewerMcp) {
       const rejectOption =
         params.options.find((option) => option.kind === 'reject_once') ??
         params.options.find((option) => option.kind === 'reject_always')
+
+      this.reviewerRejectedToolCalls.set(
+        params.sessionId,
+        (this.reviewerRejectedToolCalls.get(params.sessionId) ?? 0) + 1
+      )
 
       log.warn('rejecting non-reviewer tool requested by background reviewer', {
         sessionId: params.sessionId,
@@ -3459,10 +3499,17 @@ class AcpRuntime {
     this.sessionMcpServerNames.delete(session.sessionId)
     this.codexMcpToolIdentities.delete(session.sessionId)
     this.sessionFrameworks.delete(session.sessionId)
+    this.reviewerRejectedToolCalls.delete(session.sessionId)
     const reviewerCwd = this.reviewerSessionDirectories.get(session.sessionId)
     this.reviewerSessionDirectories.delete(session.sessionId)
     session.dispose()
     if (reviewerCwd) this.removeReviewerDirectory(reviewerCwd)
+  }
+
+  // Returns how many permission requests the strict reviewer gate rejected for a given reviewer
+  // session. Non-zero means the session was active but the gate blocked its tool calls.
+  reviewerRejectedToolCallCount(sessionId: string): number {
+    return this.reviewerRejectedToolCalls.get(sessionId) ?? 0
   }
 }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -3494,8 +3494,11 @@ class AcpRuntime {
   }
 
   // Disposes an ephemeral reviewer session and unregisters it from the auto-approve set. Safe to call
-  // even if the session was never registered (e.g. it failed before start).
-  disposeReviewerSession(session: import('@agentclientprotocol/sdk').ActiveSession): void {
+  // even if the session was never registered (e.g. it failed before start). Returns the number of tool
+  // calls the gate rejected during the session: the read and the clear are atomic here so callers need
+  // no capture-before-dispose ordering — dispose deletes the counter, and this is its last observer.
+  disposeReviewerSession(session: import('@agentclientprotocol/sdk').ActiveSession): number {
+    const rejectedToolCalls = this.reviewerRejectedToolCalls.get(session.sessionId) ?? 0
     this.reviewerSessionIds.delete(session.sessionId)
     this.sessionMcpServerNames.delete(session.sessionId)
     this.codexMcpToolIdentities.delete(session.sessionId)
@@ -3505,6 +3508,7 @@ class AcpRuntime {
     this.reviewerSessionDirectories.delete(session.sessionId)
     session.dispose()
     if (reviewerCwd) this.removeReviewerDirectory(reviewerCwd)
+    return rejectedToolCalls
   }
 
   // Returns how many permission requests the strict reviewer gate rejected for a given reviewer

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -329,7 +329,7 @@ const REVIEWER_MCP_OPENCODE_TOOL_NAMES = new Set(
 const REVIEWER_MCP_LEAF_TOOL_NAMES = new Set<string>(Object.values(REVIEWER_MCP_TOOLS))
 // claude-code namespaces MCP tools as mcp__<server>__<tool> and sanitizes the server name by replacing
 // every non-alphanumeric char with an underscore, so "open-science-reviewer" becomes
-// "open_science_reviewer". Match that sanitized identity, which appears in the tool call title/id and
+// "open_science_reviewer". Match that sanitized identity, which appears in the tool call title and
 // carries no provider _meta tool name.
 const REVIEWER_MCP_SERVER_NAME_SANITIZED = REVIEWER_MCP_SERVER_NAME.replace(/[^a-zA-Z0-9]/g, '_')
 const REVIEWER_MCP_CLAUDE_TOOL_NAMES = new Set(
@@ -3046,14 +3046,15 @@ class AcpRuntime {
     }
   }
 
-  // Returns the leaf reviewer tool name when a claude-code MCP identity string matches the reviewer.
-  // claude-code sanitizes server names (hyphens → underscores) and may append a _<n> disambiguator to
-  // the toolCallId; strip it before checking so both the title and toolCallId forms are recognized.
-  private matchReviewerClaudeToolName(candidate: string | null | undefined): string | undefined {
-    if (typeof candidate !== 'string') return undefined
-    const stripped = candidate.replace(/_\d+$/, '')
-    if (REVIEWER_MCP_CLAUDE_TOOL_NAMES.has(stripped)) return stripped
-    return undefined
+  // Returns the leaf reviewer tool name when a claude-code MCP *title* matches the reviewer. The
+  // identity must come from the title (the same field the generic MCP classifier trusts), never the
+  // toolCallId: a tool call id is an opaque, agent-chosen string, so matching it would let a Bash call
+  // carrying a reviewer-shaped id (e.g. mcp__open_science_reviewer__read_turn_0) slip past the gate.
+  // claude-code sanitizes server names (hyphens → underscores) and emits the exact mcp__<server>__<tool>
+  // form as the title with no numeric suffix, so an exact set membership check is sufficient.
+  private matchReviewerClaudeToolName(title: string | null | undefined): string | undefined {
+    if (typeof title !== 'string') return undefined
+    return REVIEWER_MCP_CLAUDE_TOOL_NAMES.has(title) ? title : undefined
   }
 
   // Grants only the dedicated reviewer MCP. The old implementation selected the first available option
@@ -3081,13 +3082,13 @@ class AcpRuntime {
         ? toolName
         : undefined
     // claude-code (and the OpenAI-compatible providers routed through it) emit reviewer MCP calls with
-    // no provider _meta tool name; the mcp__<sanitized-server>__<tool> identity rides only in the tool
-    // call title or its toolCallId (the latter may carry a trailing _<n> disambiguator). Recognize it
-    // there so the strict allowlist does not reject the reviewer's own tools.
+    // no provider _meta tool name; the sanitized mcp__<server>__<tool> identity rides in the tool call
+    // title. Recognize it there — the same field the generic MCP classifier trusts — so the strict
+    // allowlist does not reject the reviewer's own tools. The toolCallId is deliberately not consulted:
+    // it is agent-controlled, so trusting it would let a Bash call with a reviewer-shaped id slip past.
     const claudeToolName =
       toolName == null && frameworkId === 'claude-code'
-        ? (this.matchReviewerClaudeToolName(reportedTitle) ??
-          this.matchReviewerClaudeToolName(params.toolCall?.toolCallId))
+        ? this.matchReviewerClaudeToolName(reportedTitle)
         : undefined
     const isReviewerMcp =
       mcpServerNames.length === 1 &&

--- a/src/main/reviewer/orchestrator-prompt-prefix.test.ts
+++ b/src/main/reviewer/orchestrator-prompt-prefix.test.ts
@@ -81,8 +81,7 @@ const makeFakeReviewerSession = (
 const makeStubRuntime = (session: unknown, promptPrefix: string | undefined): AcpRuntime =>
   ({
     buildReviewerSession: async () => ({ session, promptPrefix }),
-    disposeReviewerSession: () => {},
-    reviewerRejectedToolCallCount: () => 0
+    disposeReviewerSession: () => 0
   }) as unknown as AcpRuntime
 
 // --- Reviewer MCP submit helper (mirrors orchestrator.test.ts) ---
@@ -304,8 +303,7 @@ describe('runScopedReview — framework-neutral rubric delivery (fix-loop re-rev
         }
         return { session: makeFakeReviewerSession(scopedPromptSink), promptPrefix: scopedPrefix }
       },
-      disposeReviewerSession: () => {},
-      reviewerRejectedToolCallCount: () => 0,
+      disposeReviewerSession: () => 0,
       // The [Auditor] correction turn: append the auditor user turn + the agent's correction turn so
       // the fix loop resolves a new correctionTurnMessageId (msg-4-correction) for the scoped review.
       sendPrompt: async () => {

--- a/src/main/reviewer/orchestrator-prompt-prefix.test.ts
+++ b/src/main/reviewer/orchestrator-prompt-prefix.test.ts
@@ -76,12 +76,13 @@ const makeFakeReviewerSession = (
   dispose: () => {}
 })
 
-// A stub runtime that returns the given promptPrefix from buildReviewerSession. Only the two methods
+// A stub runtime that returns the given promptPrefix from buildReviewerSession. Only the methods
 // runReview calls on the runtime are implemented.
 const makeStubRuntime = (session: unknown, promptPrefix: string | undefined): AcpRuntime =>
   ({
     buildReviewerSession: async () => ({ session, promptPrefix }),
-    disposeReviewerSession: () => {}
+    disposeReviewerSession: () => {},
+    reviewerRejectedToolCallCount: () => 0
   }) as unknown as AcpRuntime
 
 // --- Reviewer MCP submit helper (mirrors orchestrator.test.ts) ---
@@ -304,6 +305,7 @@ describe('runScopedReview — framework-neutral rubric delivery (fix-loop re-rev
         return { session: makeFakeReviewerSession(scopedPromptSink), promptPrefix: scopedPrefix }
       },
       disposeReviewerSession: () => {},
+      reviewerRejectedToolCallCount: () => 0,
       // The [Auditor] correction turn: append the auditor user turn + the agent's correction turn so
       // the fix loop resolves a new correctionTurnMessageId (msg-4-correction) for the scoped review.
       sendPrompt: async () => {

--- a/src/main/reviewer/orchestrator.test.ts
+++ b/src/main/reviewer/orchestrator.test.ts
@@ -83,6 +83,9 @@ const startFakeReviewerAgent = (
   options: {
     // When set, the agent simulates the reviewer calling submit_findings via the MCP server URL.
     simulateFindingsViaHttp?: boolean
+    // When set, the agent requests a non-reviewer tool the strict gate rejects, then ends its turn
+    // without submit_findings — exercising the gate-rejection incomplete-review path.
+    emitRejectedToolCall?: boolean
     // v3: checks[] only — reasoning removed from submit_findings
     checksToSubmit?: Array<{
       status: 'pass' | 'warn' | 'fail'
@@ -128,6 +131,24 @@ const startFakeReviewerAgent = (
         .join('')
 
       prompts.push({ sessionId: ctx.params.sessionId, text })
+
+      // If requested, ask for a tool outside the reviewer allowlist; the runtime gate rejects it and
+      // increments the session's rejected-tool-call counter.
+      if (options.emitRejectedToolCall) {
+        await ctx.client.request(acp.methods.client.session.requestPermission, {
+          sessionId: ctx.params.sessionId,
+          toolCall: {
+            toolCallId: 'reviewer-blocked-bash',
+            title: 'Bash',
+            kind: 'execute',
+            status: 'pending'
+          },
+          options: [
+            { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+            { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+          ]
+        })
+      }
 
       // If requested, simulate the reviewer calling submit_findings via the HTTP MCP server.
       if (options.simulateFindingsViaHttp && newSessions.length > 0) {
@@ -383,6 +404,38 @@ describe('reviewer orchestrator', () => {
     expect(review.lifecycle).toBe('error')
     expect(review.outcome).toBeNull()
     expect(review.errorMessage).toContain('without calling submit_findings')
+    expect(review.checks).toHaveLength(0)
+
+    await client.$disconnect()
+  })
+
+  it('reports the permission gate as the cause when it rejected the reviewer tool calls', async () => {
+    const process = new FakeAgentProcess()
+    startFakeReviewerAgent(process, 'reviewer-session-1', { emitRejectedToolCall: true })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => makeSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    expect(review.lifecycle).toBe('error')
+    expect(review.errorMessage).toContain('rejected by the permission gate')
+    expect(review.errorMessage).not.toContain('stopped without calling submit_findings')
     expect(review.checks).toHaveLength(0)
 
     await client.$disconnect()

--- a/src/main/reviewer/orchestrator.test.ts
+++ b/src/main/reviewer/orchestrator.test.ts
@@ -409,7 +409,7 @@ describe('reviewer orchestrator', () => {
     await client.$disconnect()
   })
 
-  it('reports the permission gate as the cause when it rejected the reviewer tool calls', async () => {
+  it('notes permission-gate rejections as context on an incomplete review', async () => {
     const process = new FakeAgentProcess()
     startFakeReviewerAgent(process, 'reviewer-session-1', { emitRejectedToolCall: true })
 
@@ -434,8 +434,9 @@ describe('reviewer orchestrator', () => {
     })
 
     expect(review.lifecycle).toBe('error')
+    // The message reports the rejection count as context without claiming it blocked submit_findings.
     expect(review.errorMessage).toContain('rejected by the permission gate')
-    expect(review.errorMessage).not.toContain('stopped without calling submit_findings')
+    expect(review.errorMessage).toContain('stopped without calling submit_findings')
     expect(review.checks).toHaveLength(0)
 
     await client.$disconnect()

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -799,10 +799,8 @@ const runScopedReview = async (options: {
     onReviewUpdate?.(errorWithChecks)
     return { review: errorWithChecks, submittedChecks: [] }
   } finally {
-    if (reviewerSession) {
-      rejectedToolCalls = acpRuntime.reviewerRejectedToolCallCount(reviewerSession.sessionId)
-      acpRuntime.disposeReviewerSession(reviewerSession)
-    }
+    // dispose returns the gate's rejection count and clears it atomically — no ordering hazard.
+    if (reviewerSession) rejectedToolCalls = acpRuntime.disposeReviewerSession(reviewerSession)
     await mcpServer?.stop().catch(() => undefined)
   }
 
@@ -1016,12 +1014,10 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
 
     return errorWithFindings
   } finally {
-    // Always dispose the reviewer session and shut down the servers. Capture the gate's rejection
-    // count first: dispose clears it, and an incomplete review needs it to report the real cause.
-    if (reviewerSession) {
-      rejectedToolCalls = acpRuntime.reviewerRejectedToolCallCount(reviewerSession.sessionId)
-      acpRuntime.disposeReviewerSession(reviewerSession)
-    }
+    // Always dispose the reviewer session and shut down the servers. dispose returns the gate's
+    // rejection count and clears it atomically, so an incomplete review reports the real cause with
+    // no capture-before-dispose ordering to get wrong.
+    if (reviewerSession) rejectedToolCalls = acpRuntime.disposeReviewerSession(reviewerSession)
     await mcpServer?.stop().catch(() => undefined)
   }
 

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -106,12 +106,13 @@ const DEFAULT_SESSION_REFRESH_TIMEOUT_MS = 10_000
 const SESSION_REFRESH_POLL_MS = 50
 
 // A review can end without submit_findings for two very different reasons: the reviewer genuinely
-// stalled, or the permission gate rejected its own tool calls (submit_findings included). Report the
-// gate case explicitly instead of the misleading "stopped without calling submit_findings".
+// stalled, or the permission gate rejected its tool calls. The rejection counter cannot tell these
+// apart — it counts every rejected call, including tools the gate is *meant* to block (Bash/network) —
+// so the message reports the count as context without asserting it blocked submit_findings.
 const incompleteReviewMessage = (rejectedToolCalls: number): string =>
   rejectedToolCalls > 0
-    ? `Reviewer tool calls were rejected by the permission gate (${rejectedToolCalls} blocked); ` +
-      'submit_findings never reached the orchestrator.'
+    ? 'Reviewer stopped without calling submit_findings; ' +
+      `${rejectedToolCalls} tool call(s) were also rejected by the permission gate.`
     : 'Reviewer stopped without calling submit_findings.'
 
 // Streaming content deltas are emitted one-per-chunk as the reviewer writes its message/thinking, so

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -105,6 +105,15 @@ const DEFAULT_REVIEWER_MAX_UPDATES = 1000
 const DEFAULT_SESSION_REFRESH_TIMEOUT_MS = 10_000
 const SESSION_REFRESH_POLL_MS = 50
 
+// A review can end without submit_findings for two very different reasons: the reviewer genuinely
+// stalled, or the permission gate rejected its own tool calls (submit_findings included). Report the
+// gate case explicitly instead of the misleading "stopped without calling submit_findings".
+const incompleteReviewMessage = (rejectedToolCalls: number): string =>
+  rejectedToolCalls > 0
+    ? `Reviewer tool calls were rejected by the permission gate (${rejectedToolCalls} blocked); ` +
+      'submit_findings never reached the orchestrator.'
+    : 'Reviewer stopped without calling submit_findings.'
+
 // Streaming content deltas are emitted one-per-chunk as the reviewer writes its message/thinking, so
 // their count tracks how much it *says*, not how much it *does*. Counting them toward the loop cap
 // made a normally-verbose review trip the guard mid-stream before it could call submit_findings. Only
@@ -736,6 +745,7 @@ const runScopedReview = async (options: {
   let mcpServer: ReviewerMcpServer | undefined
   let checksReceived: NewCheck[] = []
   let checksSubmitted = false
+  let rejectedToolCalls = 0
   const capturedLog: ReviewerLogEntry[] = []
 
   try {
@@ -788,12 +798,15 @@ const runScopedReview = async (options: {
     onReviewUpdate?.(errorWithChecks)
     return { review: errorWithChecks, submittedChecks: [] }
   } finally {
-    if (reviewerSession) acpRuntime.disposeReviewerSession(reviewerSession)
+    if (reviewerSession) {
+      rejectedToolCalls = acpRuntime.reviewerRejectedToolCallCount(reviewerSession.sessionId)
+      acpRuntime.disposeReviewerSession(reviewerSession)
+    }
     await mcpServer?.stop().catch(() => undefined)
   }
 
   if (!checksSubmitted) {
-    const errorMessage = 'Reviewer stopped without calling submit_findings.'
+    const errorMessage = incompleteReviewMessage(rejectedToolCalls)
     log.error('scoped re-review protocol incomplete', { reviewId: review.id, error: errorMessage })
     review = await reviewRepository.updateReview(review.id, {
       lifecycle: 'error',
@@ -933,6 +946,7 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
   let mcpServer: ReviewerMcpServer | undefined
   let checksReceived: NewCheck[] = []
   let checksSubmitted = false
+  let rejectedToolCalls = 0
   const capturedLog: ReviewerLogEntry[] = []
 
   try {
@@ -1001,13 +1015,17 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
 
     return errorWithFindings
   } finally {
-    // Always dispose the reviewer session and shut down the servers.
-    if (reviewerSession) acpRuntime.disposeReviewerSession(reviewerSession)
+    // Always dispose the reviewer session and shut down the servers. Capture the gate's rejection
+    // count first: dispose clears it, and an incomplete review needs it to report the real cause.
+    if (reviewerSession) {
+      rejectedToolCalls = acpRuntime.reviewerRejectedToolCallCount(reviewerSession.sessionId)
+      acpRuntime.disposeReviewerSession(reviewerSession)
+    }
     await mcpServer?.stop().catch(() => undefined)
   }
 
   if (!checksSubmitted) {
-    const errorMessage = 'Reviewer stopped without calling submit_findings.'
+    const errorMessage = incompleteReviewMessage(rejectedToolCalls)
     log.error('review protocol incomplete', { reviewId: review.id, error: errorMessage })
     review = await reviewRepository.updateReview(review.id, {
       lifecycle: 'error',


### PR DESCRIPTION
Fixes #329

## Problem

Background reviewer sessions failed on the built-in claude-code framework and on OpenAI-compatible providers (e.g. Kimi) routed through it: every reviewer MCP tool call was rejected, and the review ended with the misleading error "Reviewer stopped without calling submit_findings."

`resolveReviewerPermission` recognized a reviewer MCP call through three paths only: a provider tool name in `_meta`, an opencode-style title, or a codex-style title. A claude-code MCP tool call arrives with its identity in `toolCall.title` (the sanitized `mcp__open_science_reviewer__<tool>` form) and **no** `_meta` tool name, so none of the three matched and the gate rejected the reviewer's own tools. The reviewer had in fact called `submit_findings`; the call was blocked before it reached the orchestrator.

There was also a latent mismatch: the allowlist was built with the hyphenated server name (`mcp__open-science-reviewer__…`), while claude-code sanitizes it to underscores (`mcp__open_science_reviewer__…`).

## Proposed change

- Add a claude-code recognition path to `resolveReviewerPermission` that reads the identity from **`toolCall.title` only** — the same field the generic MCP classifier (`isMcpToolName`) trusts — when no `_meta` tool name is present and the framework is `claude-code`. The `toolCallId` is deliberately **not** consulted: it is agent-controlled, so trusting it would let a `Bash` call carrying a reviewer-shaped id slip past the gate.
- `REVIEWER_MCP_CLAUDE_TOOL_NAMES`: sanitize the server name the same way claude-code does (`[^a-zA-Z0-9]` → `_`) and merge it into `REVIEWER_MCP_PROVIDER_TOOL_NAMES` so the metadata path also works if a build populates `_meta` with the sanitized name.
- `matchReviewerClaudeToolName`: exact set-membership check on the title (claude-code emits the exact `mcp__<server>__<tool>` form as the title, with no numeric suffix).
- Count gate rejections per reviewer session; `disposeReviewerSession` returns that count and clears it atomically, and the orchestrator uses it so an incomplete review reports the rejection count as context rather than the misleading "stopped without calling submit_findings" alone. Wired into both the initial and scoped re-review paths.

## Scope and non-goals

- No change to **what** the gate approves — only how the reviewer's own MCP tools are **identified** across frameworks. The gate still requires exactly one MCP server named `open-science-reviewer` and only the four reviewer leaf tools.
- The sanitized `mcp__open_science_reviewer__` prefix can only originate from the isolated reviewer session's dedicated MCP, so recognizing it does not widen the trust boundary. Identity is taken from the trusted title, never the agent-controlled `toolCallId`.

## Acceptance criteria and validation

- `npm run typecheck` and `npm run lint` clean.
- New unit tests: claude-code reviewer auto-approval via the sanitized title; a **negative** test that a `Bash` title with a reviewer-shaped `toolCallId` is rejected and counted; the rejection-counter lifecycle (increments on a blocked call, returned and cleared by dispose); and the incomplete-review message wording.
- Existing reviewer permission tests continue to pass unchanged.

## Review focus

- `resolveReviewerPermission` in `src/main/acp/runtime.ts`: the claude-code branch matches the **title** by exact set membership and never consults the `toolCallId`, keeping the gate strict.
- Whether the `frameworkId === 'claude-code'` guard correctly covers the OpenAI-compatible provider case.
