### PR TITLE
fix(notebook): shorten Windows default runtime prefixes

### DIFF
--- a/src/main/notebook/environment-discovery.test.ts
+++ b/src/main/notebook/environment-discovery.test.ts
@@ -117,6 +117,18 @@ describe('discoverInterpreters', () => {
     expect(notPy3[0].detail).toMatch(/Python 3/)
   })
 
+  it('keeps the logical default name when discovery sees a short physical directory', async () => {
+    const path = '/rt/envs/.p/bin/python'
+    const [found] = await discoverInterpreters(
+      'python',
+      makeDeps([path], { versions: { [path]: '3.12.4' } })
+    )
+
+    expect(found.provenance).toBe('app-managed')
+    expect(found.condaEnv).toBe('default-python')
+    expect(found.label).toBe('conda: default-python')
+  })
+
   it('flags an agent-created named env and marks a conda R needing jsonlite', async () => {
     const deps = makeDeps(['/rt/envs/my-analysis/bin/R', '/opt/miniconda3/envs/bio/bin/R'], {
       versions: {

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -9,7 +9,15 @@ import type { NotebookLanguage } from '../../shared/notebook'
 import type { DiscoveredInterpreter, EnvProvenance } from '../../shared/notebook-runtime'
 import { probeInterpreterVersion } from './python-command'
 import { parseRVersion, rHasJsonlite } from './r-command'
-import { condaActivatedPath, DEFAULT_PY_ENV, DEFAULT_R_ENV, pythonBin, rBin } from './runtime-paths'
+import {
+  condaActivatedPath,
+  DEFAULT_PY_ENV,
+  DEFAULT_R_ENV,
+  envPrefix,
+  logicalEnvNameFromDirectory,
+  pythonBin,
+  rBin
+} from './runtime-paths'
 
 export type { DiscoveredInterpreter, EnvProvenance }
 
@@ -296,8 +304,10 @@ export const defaultCandidatePaths =
     // agent-created.
     const appEnvsDir = join(runtimeRoot, 'envs')
     try {
-      for (const name of readdirSync(appEnvsDir)) {
-        const prefix = join(appEnvsDir, name)
+      for (const directory of readdirSync(appEnvsDir)) {
+        const name = logicalEnvNameFromDirectory(directory)
+        const prefix = join(appEnvsDir, directory)
+        if (prefix !== envPrefix(runtimeRoot, name)) continue
         const p = language === 'python' ? pythonBin(prefix) : rBin(prefix)
         if (existsSync(p)) found.add(p)
       }
@@ -333,7 +343,7 @@ const classify = (interpreterPath: string, runtimeRoot: string): EnvProvenance =
   const real = safeRealpath(interpreterPath)
   if (!real.startsWith(envsRoot + '/') && !real.startsWith(envsRoot + '\\')) return 'user-own'
   const rest = real.slice(envsRoot.length + 1)
-  const envName = rest.split(/[/\\]/)[0]
+  const envName = logicalEnvNameFromDirectory(rest.split(/[/\\]/)[0])
   return envName === DEFAULT_PY_ENV ||
     envName === DEFAULT_R_ENV ||
     envName.startsWith(`${DEFAULT_PY_ENV}-`) ||
@@ -345,7 +355,9 @@ const classify = (interpreterPath: string, runtimeRoot: string): EnvProvenance =
 const condaEnvName = (interpreterPath: string): string | undefined => {
   const parts = safeRealpath(interpreterPath).split(/[/\\]/)
   const idx = parts.lastIndexOf('envs')
-  return idx >= 0 && idx + 1 < parts.length ? parts[idx + 1] : undefined
+  return idx >= 0 && idx + 1 < parts.length
+    ? logicalEnvNameFromDirectory(parts[idx + 1])
+    : undefined
 }
 
 // Discovers every interpreter for a language, deduped by real path, each probed for version +

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -16,6 +16,7 @@ import {
   readRReadyMarker,
   readReadyMarker,
   readyMarkerPath,
+  writeRReadyMarker,
   writeReadyMarker
 } from './runtime-paths'
 import {
@@ -702,7 +703,7 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
 })
 
 describe('DefaultRuntimeProvisioner Windows default-prefix compatibility', () => {
-  it('keeps a committed legacy default so an update does not drop user-installed packages', async () => {
+  it('keeps a committed legacy default beside a partial short prefix', async () => {
     const originalPlatform = process.platform
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
     const root = makeRoot()
@@ -710,6 +711,8 @@ describe('DefaultRuntimeProvisioner Windows default-prefix compatibility', () =>
       const legacy = legacyDefaultEnvPrefix(root, DEFAULT_PY_ENV)
       mkdirSync(dirname(pythonBin(legacy)), { recursive: true })
       writeFileSync(pythonBin(legacy), 'legacy')
+      const short = join(root, 'envs', '.p')
+      mkdirSync(short, { recursive: true })
       writeReadyMarker(root, DEFAULT_ENV_VERSION, 'legacy-ready')
       const runArgv = vi.fn(async () => undefined)
 
@@ -719,8 +722,69 @@ describe('DefaultRuntimeProvisioner Windows default-prefix compatibility', () =>
 
       expect(envPrefix(root, DEFAULT_PY_ENV, 'win32')).toBe(legacy)
       expect(existsSync(pythonBin(legacy))).toBe(true)
+      expect(existsSync(short)).toBe(true)
       expect(runArgv).not.toHaveBeenCalled()
-      expect(readReadyMarker(root)).toMatchObject({ defaultEnvVersion: DEFAULT_ENV_VERSION })
+      expect(readReadyMarker(root)).toMatchObject({
+        defaultEnvVersion: DEFAULT_ENV_VERSION,
+        prefixDirectory: DEFAULT_PY_ENV
+      })
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    }
+  })
+
+  it('keeps a materialized legacy R prefix beside a partial short prefix', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const root = makeRoot()
+    try {
+      const legacy = legacyDefaultEnvPrefix(root, DEFAULT_R_ENV)
+      mkdirSync(dirname(rBin(legacy)), { recursive: true })
+      writeFileSync(rBin(legacy), 'legacy')
+      const short = join(root, 'envs', '.r')
+      mkdirSync(short, { recursive: true })
+      writeRReadyMarker(root, DEFAULT_ENV_VERSION, 'legacy-ready')
+      const runArgv = vi.fn(async () => undefined)
+
+      await new DefaultRuntimeProvisioner(
+        makeDeps(root, { platform: 'win32', runArgv })
+      ).provisionR(() => {})
+
+      expect(envPrefix(root, DEFAULT_R_ENV, 'win32')).toBe(legacy)
+      expect(existsSync(rBin(legacy))).toBe(true)
+      expect(existsSync(short)).toBe(true)
+      expect(runArgv).not.toHaveBeenCalled()
+      expect(readRReadyMarker(root)).toMatchObject({
+        defaultEnvVersion: DEFAULT_ENV_VERSION,
+        prefixDirectory: DEFAULT_R_ENV
+      })
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    }
+  })
+
+  it('removes legacy residue only when the ready marker commits the short prefix', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const root = makeRoot()
+    try {
+      const short = join(root, 'envs', '.p')
+      mkdirSync(dirname(pythonBin(short)), { recursive: true })
+      writeFileSync(pythonBin(short), 'short')
+      const legacy = legacyDefaultEnvPrefix(root, DEFAULT_PY_ENV)
+      mkdirSync(dirname(pythonBin(legacy)), { recursive: true })
+      writeFileSync(pythonBin(legacy), 'legacy')
+      writeReadyMarker(root, DEFAULT_ENV_VERSION, 'short-ready', '.p')
+      const runArgv = vi.fn(async () => undefined)
+
+      await new DefaultRuntimeProvisioner(
+        makeDeps(root, { platform: 'win32', runArgv })
+      ).provisionPython(() => {})
+
+      expect(envPrefix(root, DEFAULT_PY_ENV, 'win32')).toBe(short)
+      expect(existsSync(pythonBin(short))).toBe(true)
+      expect(existsSync(legacy)).toBe(false)
+      expect(runArgv).not.toHaveBeenCalled()
     } finally {
       Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
     }

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
   envPrefix,
+  legacyDefaultEnvPrefix,
   pkgsCache,
   pythonBin,
   rBin,
@@ -57,7 +58,8 @@ const makeDeps = (root: string, overrides: Partial<ProvisionerDeps> = {}): Provi
       // argv[3] is --prefix / -p value depending on form; find the prefix and drop a bin file.
       const pIdx = argv.findIndex((a) => a === '--prefix' || a === '-p')
       const prefix = argv[pIdx + 1]
-      const isPython = prefix.endsWith(DEFAULT_PY_ENV)
+      const isPython =
+        prefix === envPrefix(root, DEFAULT_PY_ENV, overrides.platform ?? process.platform)
       const bin = isPython ? pythonBin(prefix) : rBin(prefix)
       mkdirSync(join(bin, '..'), { recursive: true })
       writeFileSync(bin, 'x')
@@ -699,6 +701,57 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
   })
 })
 
+describe('DefaultRuntimeProvisioner Windows default-prefix compatibility', () => {
+  it('keeps a committed legacy default so an update does not drop user-installed packages', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const root = makeRoot()
+    try {
+      const legacy = legacyDefaultEnvPrefix(root, DEFAULT_PY_ENV)
+      mkdirSync(dirname(pythonBin(legacy)), { recursive: true })
+      writeFileSync(pythonBin(legacy), 'legacy')
+      writeReadyMarker(root, DEFAULT_ENV_VERSION, 'legacy-ready')
+      const runArgv = vi.fn(async () => undefined)
+
+      await new DefaultRuntimeProvisioner(
+        makeDeps(root, { platform: 'win32', runArgv })
+      ).provisionPython(() => {})
+
+      expect(envPrefix(root, DEFAULT_PY_ENV, 'win32')).toBe(legacy)
+      expect(existsSync(pythonBin(legacy))).toBe(true)
+      expect(runArgv).not.toHaveBeenCalled()
+      expect(readReadyMarker(root)).toMatchObject({ defaultEnvVersion: DEFAULT_ENV_VERSION })
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    }
+  })
+
+  it('rebuilds an uncommitted legacy failure at the short prefix before removing the residue', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const root = makeRoot()
+    try {
+      const legacy = legacyDefaultEnvPrefix(root, DEFAULT_PY_ENV)
+      mkdirSync(dirname(pythonBin(legacy)), { recursive: true })
+      writeFileSync(pythonBin(legacy), 'legacy')
+      const short = envPrefix(root, DEFAULT_PY_ENV, 'win32')
+
+      await new DefaultRuntimeProvisioner(
+        makeDeps(root, {
+          platform: 'win32',
+          cache: { path: 'C:\\osp-cache', lockKey: 'c:\\osp-cache' }
+        })
+      ).provisionPython(() => {})
+
+      expect(existsSync(pythonBin(short))).toBe(true)
+      expect(existsSync(legacy)).toBe(false)
+      expect(readReadyMarker(root)).toMatchObject({ defaultEnvVersion: DEFAULT_ENV_VERSION })
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    }
+  })
+})
+
 // The real production pairing: serializeProvisioner (owns the queue) + DefaultRuntimeProvisioner (owns
 // running/skip). These drive an ACTUAL queue — python running while R waits behind it — so they verify
 // the queued-vs-idle cancel contract end-to-end rather than poking the primitive directly.
@@ -1210,6 +1263,27 @@ describe('DefaultRuntimeProvisioner.listEnvironments', () => {
       isDefault: false
     })
     expect(byName['r-stats']).toMatchObject({ language: 'r', ready: true, isDefault: false })
+  })
+
+  it('maps short Windows default directories to logical names and ignores legacy duplicates', () => {
+    const root = makeRoot()
+    const shortPrefix = join(root, 'envs', '.p')
+    mkdirSync(join(pythonBin(shortPrefix), '..'), { recursive: true })
+    writeFileSync(pythonBin(shortPrefix), 'short')
+    const legacyPrefix = join(root, 'envs', DEFAULT_PY_ENV)
+    mkdirSync(join(pythonBin(legacyPrefix), '..'), { recursive: true })
+    writeFileSync(pythonBin(legacyPrefix), 'legacy')
+
+    const infos = new DefaultRuntimeProvisioner(
+      makeDeps(root, { platform: 'win32' })
+    ).listEnvironments()
+
+    expect(infos).toHaveLength(1)
+    expect(infos[0]).toMatchObject({
+      name: DEFAULT_PY_ENV,
+      language: 'python',
+      isDefault: true
+    })
   })
 })
 
@@ -2032,7 +2106,11 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
     // detection is process.platform, so we can't mock it in the test, but we can verify the error message
     // contains appropriate guidance: on the real test platform (likely darwin/win32), it should mention
     // manual cleanup; on Linux CI, it should mention reboot.
-    const deps = makeDeps(root, { runArgv, isPrefixBlocked: () => true, readBootToken: () => BOOT_A })
+    const deps = makeDeps(root, {
+      runArgv,
+      isPrefixBlocked: () => true,
+      readBootToken: () => BOOT_A
+    })
     const error = await new DefaultRuntimeProvisioner(deps)
       .repair('python', () => {}, { force: true })
       .catch((e) => e)

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -57,6 +57,8 @@ import {
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
   envPrefix,
+  legacyDefaultEnvPrefix,
+  logicalEnvNameFromDirectory,
   needsRepair,
   pkgsCache,
   pythonBin,
@@ -724,6 +726,20 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     return this.deps.withPrefixLock ? this.deps.withPrefixLock(envName, fn) : fn()
   }
 
+  private cleanupLegacyDefaultPrefix(name: string): void {
+    if ((this.deps.platform ?? process.platform) !== 'win32') return
+    if (name !== DEFAULT_PY_ENV && name !== DEFAULT_R_ENV) return
+    const legacy = legacyDefaultEnvPrefix(this.deps.root, name)
+    if (envPrefix(this.deps.root, name, 'win32') === legacy) return
+    if (this.deps.isPrefixBlocked?.(legacy)) return
+    try {
+      rmSync(legacy, { recursive: true, force: true })
+    } catch {
+      // The short prefix is already verified and authoritative. A locked legacy directory is inert
+      // residue and can be retried by a later startup or removed by storage cleanup.
+    }
+  }
+
   // Wraps a language run so a QUEUED cancel is consumed (beginLanguageRun throws) BEFORE the run does
   // any work, and the provisioning flag + abort controller cover the whole run. repair uses this too, so
   // a cancel that arrived while the Reset was queued aborts BEFORE the destructive rm — never leaving a
@@ -752,6 +768,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     await this.materialize(DEFAULT_PYTHON_SPEC, onProgress)
     // Python is the app gate: stamp the ready marker only after create+verify succeed.
     writeReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
+    this.cleanupLegacyDefaultPrefix(DEFAULT_PY_ENV)
     onProgress({ phase: 'done', message: 'Python environment ready', progress: 1 })
   }
 
@@ -771,6 +788,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       await this.materialize(DEFAULT_R_SPEC, onProgress)
     }
     writeRReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
+    this.cleanupLegacyDefaultPrefix(DEFAULT_R_ENV)
     onProgress({ phase: 'done', message: 'R environment ready', progress: 1 })
   }
 
@@ -926,6 +944,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
               try {
                 stampDefaultMarkerBeforeLock(name) // marker BEFORE lock delete (no data-loss window)
                 rmSync(join(dir, file), { force: true })
+                this.cleanupLegacyDefaultPrefix(name)
               } catch {
                 // Marker/lock write failed — leave the working env and its lock intact for a later launch.
               }
@@ -971,6 +990,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
             await this.deps.verify(bin, prefix)
             stampDefaultMarkerBeforeLock(name) // marker BEFORE lock delete (no data-loss window)
             rmSync(join(dir, file), { force: true })
+            this.cleanupLegacyDefaultPrefix(name)
           } catch {
             // Leave the lock in place: retried next launch; the readiness gate re-provisions defaults
             // in the meantime so the app stays usable.
@@ -1056,9 +1076,8 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     }
   }
 
-  // Scans <root>/envs/ and classifies each subdirectory by interpreter-bin presence. Dirs with
-  // neither a python nor an R bin (e.g. a mid-creation leftover) are skipped — language can't be
-  // determined for them. Tolerant of a missing envs dir (fresh root, no env ever created) -> [].
+  // Scans the physical env directory and maps reserved Windows default directories back to their
+  // logical names. Dirs with neither interpreter are skipped. Tolerant of a missing envs dir.
   listEnvironments(): EnvironmentInfo[] {
     const envsDir = join(this.deps.root, 'envs')
     let entries: Dirent[]
@@ -1070,15 +1089,18 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     const infos: EnvironmentInfo[] = []
     for (const entry of entries) {
       if (!entry.isDirectory()) continue
-      const prefix = envPrefix(this.deps.root, entry.name)
+      const platform = this.deps.platform ?? process.platform
+      const name = logicalEnvNameFromDirectory(entry.name)
+      const prefix = join(envsDir, entry.name)
+      if (prefix !== envPrefix(this.deps.root, name, platform)) continue
       const isPython = existsSync(pythonBin(prefix))
       const isR = !isPython && existsSync(rBin(prefix))
       if (!isPython && !isR) continue
       infos.push({
-        name: entry.name,
+        name,
         language: isPython ? 'python' : 'r',
         ready: true,
-        isDefault: entry.name === DEFAULT_PY_ENV || entry.name === DEFAULT_R_ENV,
+        isDefault: name === DEFAULT_PY_ENV || name === DEFAULT_R_ENV,
         sizeBytes: dirSizeBytes(prefix)
       })
     }

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1,6 +1,6 @@
 import { type Dirent, existsSync, readdirSync, rmSync, statSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import type { NotebookLanguage } from '../../shared/notebook'
 import {
@@ -740,6 +740,13 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     }
   }
 
+  private markerPrefixDirectory(
+    name: typeof DEFAULT_PY_ENV | typeof DEFAULT_R_ENV
+  ): string | undefined {
+    const platform = this.deps.platform ?? process.platform
+    return platform === 'win32' ? basename(envPrefix(this.deps.root, name, platform)) : undefined
+  }
+
   // Wraps a language run so a QUEUED cancel is consumed (beginLanguageRun throws) BEFORE the run does
   // any work, and the provisioning flag + abort controller cover the whole run. repair uses this too, so
   // a cancel that arrived while the Reset was queued aborts BEFORE the destructive rm — never leaving a
@@ -767,7 +774,12 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     const onProgress = withLanguage(rawProgress, 'python')
     await this.materialize(DEFAULT_PYTHON_SPEC, onProgress)
     // Python is the app gate: stamp the ready marker only after create+verify succeed.
-    writeReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
+    writeReadyMarker(
+      this.deps.root,
+      DEFAULT_ENV_VERSION,
+      (this.deps.now ?? defaultNow)(),
+      this.markerPrefixDirectory(DEFAULT_PY_ENV)
+    )
     this.cleanupLegacyDefaultPrefix(DEFAULT_PY_ENV)
     onProgress({ phase: 'done', message: 'Python environment ready', progress: 1 })
   }
@@ -787,7 +799,12 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     } else {
       await this.materialize(DEFAULT_R_SPEC, onProgress)
     }
-    writeRReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
+    writeRReadyMarker(
+      this.deps.root,
+      DEFAULT_ENV_VERSION,
+      (this.deps.now ?? defaultNow)(),
+      this.markerPrefixDirectory(DEFAULT_R_ENV)
+    )
     this.cleanupLegacyDefaultPrefix(DEFAULT_R_ENV)
     onProgress({ phase: 'done', message: 'R environment ready', progress: 1 })
   }
@@ -816,9 +833,19 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       ) {
         onProgress({ phase: 'upgrade-r', message: 'Updating R packages…', progress: 0.6 })
         await this.withEnvPrefixLock(DEFAULT_R_ENV, () => this.upgradeOrRebuildR(onProgress))
-        writeRReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
+        writeRReadyMarker(
+          this.deps.root,
+          DEFAULT_ENV_VERSION,
+          (this.deps.now ?? defaultNow)(),
+          this.markerPrefixDirectory(DEFAULT_R_ENV)
+        )
       }
-      writeReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, (this.deps.now ?? defaultNow)())
+      writeReadyMarker(
+        this.deps.root,
+        DEFAULT_ENV_VERSION,
+        (this.deps.now ?? defaultNow)(),
+        this.markerPrefixDirectory(DEFAULT_PY_ENV)
+      )
       onProgress({ phase: 'done', message: 'Default environments updated', progress: 1 })
     } finally {
       this.provisioning = false
@@ -906,9 +933,20 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       // idempotently.
       const stampDefaultMarkerBeforeLock = (envName: string): void => {
         const now = (this.deps.now ?? defaultNow)()
-        if (envName === DEFAULT_PY_ENV) writeReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, now)
+        if (envName === DEFAULT_PY_ENV)
+          writeReadyMarker(
+            this.deps.root,
+            DEFAULT_ENV_VERSION,
+            now,
+            this.markerPrefixDirectory(DEFAULT_PY_ENV)
+          )
         else if (envName === DEFAULT_R_ENV)
-          writeRReadyMarker(this.deps.root, DEFAULT_ENV_VERSION, now)
+          writeRReadyMarker(
+            this.deps.root,
+            DEFAULT_ENV_VERSION,
+            now,
+            this.markerPrefixDirectory(DEFAULT_R_ENV)
+          )
       }
       for (const file of files) {
         const name = file.slice(0, -'.lock'.length)

--- a/src/main/notebook/runtime-paths.test.ts
+++ b/src/main/notebook/runtime-paths.test.ts
@@ -11,6 +11,10 @@ import {
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
   envPrefix,
+  envDirectoryName,
+  legacyDefaultEnvPrefix,
+  logicalEnvNameFromDirectory,
+  windowsDefaultEnvPrefixReserve,
   needsRepair,
   pkgsCache,
   pipBin,
@@ -84,6 +88,35 @@ describe('runtime-paths layout', () => {
     expect(readyMarkerPath('/r')).toBe(join('/r', '.env-ready'))
     expect(DEFAULT_ENV_VERSION).toBe(1)
     expect(DEFAULT_R_ENV).toBe('default-r')
+  })
+
+  it('uses short reserved physical directories for Windows defaults', () => {
+    expect(envDirectoryName(DEFAULT_PY_ENV, 'win32')).toBe('.p')
+    expect(envDirectoryName(DEFAULT_R_ENV, 'win32')).toBe('.r')
+    expect(envDirectoryName('my-analysis', 'win32')).toBe('my-analysis')
+    expect(logicalEnvNameFromDirectory('.p')).toBe(DEFAULT_PY_ENV)
+    expect(logicalEnvNameFromDirectory('.R')).toBe(DEFAULT_R_ENV)
+    expect(logicalEnvNameFromDirectory('my-analysis')).toBe('my-analysis')
+    expect(envPrefix('/runtime', DEFAULT_PY_ENV, 'win32')).toBe(join('/runtime', 'envs', '.p'))
+    expect(envPrefix('/runtime', DEFAULT_R_ENV, 'win32')).toBe(join('/runtime', 'envs', '.r'))
+    expect(windowsDefaultEnvPrefixReserve()).toBe('runtime\\envs\\.p'.length + 1)
+  })
+
+  it('keeps a committed legacy Windows prefix but sends failed and fresh installs to the short path', () => {
+    const root = makeRoot()
+    const short = join(root, 'envs', '.p')
+    const legacy = legacyDefaultEnvPrefix(root, DEFAULT_PY_ENV)
+
+    expect(envPrefix(root, DEFAULT_PY_ENV, 'win32')).toBe(short)
+    mkdirSync(legacy, { recursive: true })
+    writeFileSync(join(legacy, 'python.exe'), 'partial')
+    expect(envPrefix(root, DEFAULT_PY_ENV, 'win32')).toBe(short)
+
+    writeReadyMarker(root, DEFAULT_ENV_VERSION, 'ready')
+    expect(envPrefix(root, DEFAULT_PY_ENV, 'win32')).toBe(legacy)
+
+    mkdirSync(short, { recursive: true })
+    expect(envPrefix(root, DEFAULT_PY_ENV, 'win32')).toBe(short)
   })
 
   it('builds the complete Windows conda DLL search path ahead of the inherited PATH', () => {

--- a/src/main/notebook/runtime-paths.test.ts
+++ b/src/main/notebook/runtime-paths.test.ts
@@ -25,6 +25,7 @@ import {
   rLibraryDir,
   resolveEnvName,
   rReady,
+  readRReadyMarker,
   readReadyMarker,
   readyMarkerPath,
   rScriptBin,
@@ -102,7 +103,7 @@ describe('runtime-paths layout', () => {
     expect(windowsDefaultEnvPrefixReserve()).toBe('runtime\\envs\\.p'.length + 1)
   })
 
-  it('keeps a committed legacy Windows prefix but sends failed and fresh installs to the short path', () => {
+  it('uses marker provenance to distinguish committed legacy and short Windows prefixes', () => {
     const root = makeRoot()
     const short = join(root, 'envs', '.p')
     const legacy = legacyDefaultEnvPrefix(root, DEFAULT_PY_ENV)
@@ -116,7 +117,23 @@ describe('runtime-paths layout', () => {
     expect(envPrefix(root, DEFAULT_PY_ENV, 'win32')).toBe(legacy)
 
     mkdirSync(short, { recursive: true })
+    expect(envPrefix(root, DEFAULT_PY_ENV, 'win32')).toBe(legacy)
+
+    writeReadyMarker(root, DEFAULT_ENV_VERSION, 'short-ready', '.p')
     expect(envPrefix(root, DEFAULT_PY_ENV, 'win32')).toBe(short)
+  })
+
+  it('preserves a legacy R prefix beside a partial short directory until .r is committed', () => {
+    const root = makeRoot()
+    const short = join(root, 'envs', '.r')
+    const legacy = legacyDefaultEnvPrefix(root, DEFAULT_R_ENV)
+    touchBin(join(legacy, 'Lib', 'R', 'bin', 'R.exe'))
+    mkdirSync(short, { recursive: true })
+
+    expect(envPrefix(root, DEFAULT_R_ENV, 'win32')).toBe(legacy)
+
+    writeRReadyMarker(root, DEFAULT_ENV_VERSION, 'short-ready', '.r')
+    expect(envPrefix(root, DEFAULT_R_ENV, 'win32')).toBe(short)
   })
 
   it('builds the complete Windows conda DLL search path ahead of the inherited PATH', () => {
@@ -183,6 +200,23 @@ describe('.env-ready marker', () => {
     expect(body).toContain('"preparedAt"')
     const marker = readReadyMarker(root)
     expect(marker).toEqual({ defaultEnvVersion: 3, preparedAt: '1720000000000' })
+  })
+
+  it('roundtrips optional Windows prefix provenance', () => {
+    const root = makeRoot()
+    writeReadyMarker(root, 3, '1720000000000', '.p')
+    writeRReadyMarker(root, 3, '1720000000001', '.r')
+
+    expect(readReadyMarker(root)).toEqual({
+      defaultEnvVersion: 3,
+      preparedAt: '1720000000000',
+      prefixDirectory: '.p'
+    })
+    expect(readRReadyMarker(root)).toEqual({
+      defaultEnvVersion: 3,
+      preparedAt: '1720000000001',
+      prefixDirectory: '.r'
+    })
   })
 
   it('returns undefined when absent or corrupt', () => {

--- a/src/main/notebook/runtime-paths.ts
+++ b/src/main/notebook/runtime-paths.ts
@@ -44,6 +44,27 @@ export const resolveRuntimeCdnBase = (override?: string): string => {
 export const DEFAULT_PY_ENV = 'default-python'
 export const DEFAULT_R_ENV = 'default-r'
 
+const WINDOWS_DEFAULT_ENV_DIRECTORIES: Readonly<Record<string, string>> = {
+  [DEFAULT_PY_ENV]: '.p',
+  [DEFAULT_R_ENV]: '.r'
+}
+
+const windowsDefaultEnvNamesByDirectory = new Map(
+  Object.entries(WINDOWS_DEFAULT_ENV_DIRECTORIES).map(([name, directory]) => [directory, name])
+)
+
+// Logical environment names are part of notebook state and the tool interface. On Windows the two
+// app-managed defaults use short, reserved physical directory names so their descriptive logical
+// names do not consume the environment's MAX_PATH budget. User-created names cannot start with a
+// dot, so these directories cannot collide with a named environment.
+export const envDirectoryName = (
+  name: string,
+  platform: NodeJS.Platform = process.platform
+): string => (platform === 'win32' ? (WINDOWS_DEFAULT_ENV_DIRECTORIES[name] ?? name) : name)
+
+export const logicalEnvNameFromDirectory = (directory: string): string =>
+  windowsDefaultEnvNamesByDirectory.get(directory.toLowerCase()) ?? directory
+
 export const runtimePackDir = (
   root: string,
   envVersion: number,
@@ -108,8 +129,49 @@ export const assertSafeEnvName = (name: string | undefined): string => {
 // <storageRoot>/runtime — the shared runtime root holding envs, the pkgs cache and the ready marker.
 export const runtimeRoot = (storageRoot: string): string => join(storageRoot, 'runtime')
 
-// <root>/envs/<name> — a single conda env prefix under the runtime root.
-export const envPrefix = (root: string, name: string): string => join(root, 'envs', name)
+// A conda environment prefix under the runtime root. Callers use logical names; this is the sole seam
+// that maps them to physical directories. The platform argument keeps the Windows mapping directly
+// testable on non-Windows hosts.
+export const envPrefix = (
+  root: string,
+  name: string,
+  platform: NodeJS.Platform = process.platform
+): string => {
+  const physical = join(root, 'envs', envDirectoryName(name, platform))
+  if (platform !== 'win32' || (name !== DEFAULT_PY_ENV && name !== DEFAULT_R_ENV)) return physical
+  // A short prefix, including a partial one, is authoritative so repair resumes in the new layout.
+  if (existsSync(physical)) return physical
+
+  const legacy = join(root, 'envs', name)
+  // Preserve a committed Python environment so an app update never drops pip/conda additions merely
+  // to shorten its path. A failed create has no marker and therefore retries at the short prefix.
+  if (
+    name === DEFAULT_PY_ENV &&
+    existsSync(join(root, '.env-ready')) &&
+    existsSync(join(legacy, 'python.exe'))
+  )
+    return legacy
+  // Legacy R predates its dedicated marker. Keep any materialized prefix and let the existing
+  // activated verify/upgrade-or-rebuild path decide whether it is healthy.
+  if (name === DEFAULT_R_ENV && existsSync(join(legacy, 'Lib', 'R', 'bin', 'R.exe'))) return legacy
+  return physical
+}
+
+// The pre-shortening prefix is used only for best-effort migration cleanup/export. Never provision a
+// new default into this location.
+export const legacyDefaultEnvPrefix = (
+  root: string,
+  name: typeof DEFAULT_PY_ENV | typeof DEFAULT_R_ENV
+): string => join(root, 'envs', name)
+
+// Relative reserve from the data root through the deepest default prefix, including the separator
+// before a package-relative path. The picker and provisioner share envPrefix(), so this helper keeps
+// preflight arithmetic aligned with the physical Windows layout.
+export const windowsDefaultEnvPrefixReserve = (): number =>
+  Math.max(
+    win32.join('runtime', 'envs', envDirectoryName(DEFAULT_PY_ENV, 'win32')).length,
+    win32.join('runtime', 'envs', envDirectoryName(DEFAULT_R_ENV, 'win32')).length
+  ) + 1
 
 // <root>/pkgs — the shared micromamba package cache (offline seed target; $MAMBA_ROOT_PREFIX/pkgs).
 export const pkgsCache = (root: string): string => join(root, 'pkgs')

--- a/src/main/notebook/runtime-paths.ts
+++ b/src/main/notebook/runtime-paths.ts
@@ -139,21 +139,36 @@ export const envPrefix = (
 ): string => {
   const physical = join(root, 'envs', envDirectoryName(name, platform))
   if (platform !== 'win32' || (name !== DEFAULT_PY_ENV && name !== DEFAULT_R_ENV)) return physical
-  // A short prefix, including a partial one, is authoritative so repair resumes in the new layout.
-  if (existsSync(physical)) return physical
 
   const legacy = join(root, 'envs', name)
+  const marker = name === DEFAULT_PY_ENV ? readReadyMarker(root) : readRReadyMarker(root)
+  const committedDirectory = marker?.prefixDirectory?.toLowerCase()
+  const shortDirectory = envDirectoryName(name, 'win32')
+  // Marker provenance distinguishes a committed short prefix from a partial short directory left
+  // beside a committed legacy environment. Markers written before provenance was introduced belong
+  // to the legacy layout, because no released build could have committed the reserved short names.
+  if (existsSync(physical) && committedDirectory === shortDirectory) return physical
+
   // Preserve a committed Python environment so an app update never drops pip/conda additions merely
-  // to shorten its path. A failed create has no marker and therefore retries at the short prefix.
+  // to shorten its path. A failed create has no marker and therefore retries at the short prefix. This
+  // function reads live filesystem state; callers must not cache its result across provisioning steps.
   if (
     name === DEFAULT_PY_ENV &&
-    existsSync(join(root, '.env-ready')) &&
+    marker !== undefined &&
+    (committedDirectory === undefined || committedDirectory === name) &&
     existsSync(join(legacy, 'python.exe'))
   )
     return legacy
   // Legacy R predates its dedicated marker. Keep any materialized prefix and let the existing
   // activated verify/upgrade-or-rebuild path decide whether it is healthy.
-  if (name === DEFAULT_R_ENV && existsSync(join(legacy, 'Lib', 'R', 'bin', 'R.exe'))) return legacy
+  if (
+    name === DEFAULT_R_ENV &&
+    (committedDirectory === undefined || committedDirectory === name) &&
+    existsSync(join(legacy, 'Lib', 'R', 'bin', 'R.exe'))
+  )
+    return legacy
+  // With no committed legacy environment, an existing partial short prefix remains authoritative so
+  // repair resumes in the new layout instead of creating a second prefix.
   return physical
 }
 
@@ -231,8 +246,13 @@ export const condaActivatedPath = (
 export const readyMarkerPath = (root: string): string => join(root, '.env-ready')
 export const rReadyMarkerPath = (root: string): string => join(root, '.r-env-ready')
 
-// Readiness marker persisted as camelCase JSON (contract §2).
-export type EnvReadyMarker = { defaultEnvVersion: number; preparedAt: string }
+// Readiness marker persisted as camelCase JSON (contract §2). prefixDirectory is optional for backward
+// compatibility; on Windows, an absent value denotes a marker from the legacy default directory.
+export type EnvReadyMarker = {
+  defaultEnvVersion: number
+  preparedAt: string
+  prefixDirectory?: string
+}
 
 // Reads .env-ready; returns undefined when missing or corrupt (never throws).
 export const readReadyMarker = (root: string): EnvReadyMarker | undefined => {
@@ -243,7 +263,13 @@ export const readReadyMarker = (root: string): EnvReadyMarker | undefined => {
     if (typeof parsed.defaultEnvVersion !== 'number' || typeof parsed.preparedAt !== 'string') {
       return undefined
     }
-    return { defaultEnvVersion: parsed.defaultEnvVersion, preparedAt: parsed.preparedAt }
+    return {
+      defaultEnvVersion: parsed.defaultEnvVersion,
+      preparedAt: parsed.preparedAt,
+      ...(typeof parsed.prefixDirectory === 'string'
+        ? { prefixDirectory: parsed.prefixDirectory }
+        : {})
+    }
   } catch {
     return undefined
   }
@@ -261,8 +287,17 @@ const writeMarkerAtomic = (path: string, marker: EnvReadyMarker): void => {
 }
 
 // Writes .env-ready as pretty camelCase JSON, creating the runtime root if needed.
-export const writeReadyMarker = (root: string, version: number, preparedAt: string): void => {
-  writeMarkerAtomic(readyMarkerPath(root), { defaultEnvVersion: version, preparedAt })
+export const writeReadyMarker = (
+  root: string,
+  version: number,
+  preparedAt: string,
+  prefixDirectory?: string
+): void => {
+  writeMarkerAtomic(readyMarkerPath(root), {
+    defaultEnvVersion: version,
+    preparedAt,
+    ...(prefixDirectory === undefined ? {} : { prefixDirectory })
+  })
 }
 
 export const readRReadyMarker = (root: string): EnvReadyMarker | undefined => {
@@ -273,14 +308,29 @@ export const readRReadyMarker = (root: string): EnvReadyMarker | undefined => {
     if (typeof parsed.defaultEnvVersion !== 'number' || typeof parsed.preparedAt !== 'string') {
       return undefined
     }
-    return { defaultEnvVersion: parsed.defaultEnvVersion, preparedAt: parsed.preparedAt }
+    return {
+      defaultEnvVersion: parsed.defaultEnvVersion,
+      preparedAt: parsed.preparedAt,
+      ...(typeof parsed.prefixDirectory === 'string'
+        ? { prefixDirectory: parsed.prefixDirectory }
+        : {})
+    }
   } catch {
     return undefined
   }
 }
 
-export const writeRReadyMarker = (root: string, version: number, preparedAt: string): void => {
-  writeMarkerAtomic(rReadyMarkerPath(root), { defaultEnvVersion: version, preparedAt })
+export const writeRReadyMarker = (
+  root: string,
+  version: number,
+  preparedAt: string,
+  prefixDirectory?: string
+): void => {
+  writeMarkerAtomic(rReadyMarkerPath(root), {
+    defaultEnvVersion: version,
+    preparedAt,
+    ...(prefixDirectory === undefined ? {} : { prefixDirectory })
+  })
 }
 
 // True when a regular file exists at the path (mirrors Rust is_file()).

--- a/src/main/notebook/runtime-relocation.test.ts
+++ b/src/main/notebook/runtime-relocation.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { envsLockDir, exportRuntimeLocks } from './runtime-relocation'
-import { envPrefix, pythonBin, rBin, runtimeRoot } from './runtime-paths'
+import { DEFAULT_PY_ENV, envPrefix, pythonBin, rBin, runtimeRoot } from './runtime-paths'
 
 const roots: string[] = []
 const makeRoot = async (): Promise<string> => {
@@ -60,6 +60,31 @@ describe('exportRuntimeLocks', () => {
       '--explicit',
       '--md5'
     ])
+  })
+
+  it('exports the short Windows default under its logical lock name and ignores a legacy duplicate', async () => {
+    const from = await makeRoot()
+    const to = await makeRoot()
+    const envsDir = join(runtimeRoot(from), 'envs')
+    const shortPrefix = join(envsDir, '.p')
+    const legacyPrefix = join(envsDir, DEFAULT_PY_ENV)
+    for (const prefix of [shortPrefix, legacyPrefix]) {
+      const bin = pythonBin(prefix)
+      await mkdir(dirname(bin), { recursive: true })
+      await writeFile(bin, '')
+    }
+
+    const capture = vi.fn().mockResolvedValue(LOCK_STDOUT)
+    const exported = await exportRuntimeLocks(from, to, {
+      mm: '/mm',
+      capture,
+      platform: 'win32'
+    })
+
+    expect(exported).toEqual([DEFAULT_PY_ENV])
+    expect(capture).toHaveBeenCalledOnce()
+    expect(capture.mock.calls[0]?.[0]).toContain(shortPrefix)
+    expect(await readdir(envsLockDir(runtimeRoot(to)))).toEqual([`${DEFAULT_PY_ENV}.lock`])
   })
 
   it('returns [] and writes nothing when micromamba is unavailable', async () => {

--- a/src/main/notebook/runtime-relocation.ts
+++ b/src/main/notebook/runtime-relocation.ts
@@ -2,7 +2,13 @@ import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { normalizeExplicitLock } from './micromamba'
-import { envPrefix, pythonBin, rBin, runtimeRoot } from './runtime-paths'
+import {
+  envPrefix,
+  logicalEnvNameFromDirectory,
+  pythonBin,
+  rBin,
+  runtimeRoot
+} from './runtime-paths'
 
 // <root>/envs.lock — per-env @EXPLICIT locks captured for offline reconstruction after a data-root
 // relocation. The provisioner's startup restore consumes and then removes this directory.
@@ -13,6 +19,7 @@ export type ExportRuntimeLocksDeps = {
   mm: string | undefined
   // Runs a micromamba argv and returns stdout (for `list --explicit --md5`).
   capture: (argv: string[]) => Promise<string>
+  platform?: NodeJS.Platform
 }
 
 // Exports every conda env under <fromDataRoot>/runtime/envs to an @EXPLICIT lock at
@@ -31,20 +38,34 @@ export const exportRuntimeLocks = async (
 
   const fromRuntime = runtimeRoot(fromDataRoot)
   const envsDir = join(fromRuntime, 'envs')
-  let names: string[]
+  let entries: Array<{ name: string; prefix: string; canonical: boolean }>
   try {
-    names = readdirSync(envsDir, { withFileTypes: true })
+    entries = readdirSync(envsDir, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name)
+      .map((entry) => {
+        const name = logicalEnvNameFromDirectory(entry.name)
+        return {
+          name,
+          prefix: join(envsDir, entry.name),
+          canonical: join(envsDir, entry.name) === envPrefix(fromRuntime, name, deps.platform)
+        }
+      })
   } catch {
     return []
   }
-  if (names.length === 0) return []
+  if (entries.length === 0) return []
+
+  // If a short Windows default and its legacy directory both exist, export only the active short
+  // prefix. A legacy-only install is still exported so the new layout can rebuild it without losing
+  // user-added conda packages.
+  entries.sort((a, b) => Number(b.canonical) - Number(a.canonical))
+  const seen = new Set<string>()
 
   const outDir = envsLockDir(runtimeRoot(toDataRoot))
   const exported: string[] = []
-  for (const name of names) {
-    const prefix = envPrefix(fromRuntime, name)
+  for (const { name, prefix } of entries) {
+    if (seen.has(name)) continue
+    seen.add(name)
     // Skip mid-creation leftovers with no interpreter — nothing to reconstruct.
     if (!existsSync(pythonBin(prefix)) && !existsSync(rBin(prefix))) continue
     try {

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -176,9 +176,9 @@ describe('classifyDataRoot', () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
 
     try {
-      // Derived target length is 94; the default env reserve is 166 (runtime\envs\default-python +
-      // the 138 conservative pack budget), totaling exactly 260 — one over the 259 usable limit.
-      const result = await classifyDataRoot(`/${'b'.repeat(81)}`, currentDataRoot)
+      // Derived target length is 106; the short default env reserve is 154
+      // (runtime\envs\.p + separator + the 138 conservative pack budget), totaling exactly 260.
+      const result = await classifyDataRoot(`/${'b'.repeat(93)}`, currentDataRoot)
 
       expect(result.kind).toBe('invalid')
       expect(result.error).toMatch(/too long|260/i)
@@ -187,18 +187,18 @@ describe('classifyDataRoot', () => {
     }
   })
 
-  it('reserves for default-python, the longest managed env, not the shorter default-r', async () => {
+  it('uses the short physical default prefix rather than either logical default name', async () => {
     const original = process.platform
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
 
     try {
-      // Derived target length is 96. Under the old default-r reserve (23 + 138 = 161) this totaled
-      // 257 and was accepted, yet default-python (28 + 138 = 166) pushes it to 262 — the exact case
-      // where the picker used to accept a root that then overflowed MAX_PATH provisioning python.
+      // Derived target length is 96. The logical default-python reserve would total 262 and reject
+      // this target, while the physical .p reserve totals 250 and fits. The synthetic directory does
+      // not exist, but it must get past the path-budget check.
       const result = await classifyDataRoot(`/${'b'.repeat(83)}`, currentDataRoot)
 
       expect(result.kind).toBe('invalid')
-      expect(result.error).toMatch(/too long|260/i)
+      expect(result.error).not.toMatch(/too long|260/i)
     } finally {
       Object.defineProperty(process, 'platform', { value: original, configurable: true })
     }

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -21,7 +21,7 @@ import {
 } from './migration-marker'
 import { waitForDataRootWriters } from './migration-state'
 import { DEFAULT_MAX_ENV_RELATIVE_PATH, PACK_PATH_BUDGET_FILE } from '../notebook/bundle-manifest'
-import { DEFAULT_PY_ENV, DEFAULT_R_ENV } from '../notebook/runtime-paths'
+import { windowsDefaultEnvPrefixReserve } from '../notebook/runtime-paths'
 import { RELOCATABLE_DATA_DIRS } from './data-directories'
 
 export { DATA_ROOT_DIRS } from './data-directories'
@@ -44,16 +44,9 @@ export type ClassifyResult = { kind: DataRootKind; error?: string }
 // every tool a user's Python/R environment might shell out to, so the app guards against it directly.
 const WINDOWS_MAX_USABLE_PATH = 259
 // Headroom reserved for the app's deepest nested paths (artifacts/notebooks/runtime) under the root.
-// Keep the migration guard aligned with the current managed env's conservative pack metadata:
-// runtime\\envs\\<longest default env name> plus the longest linked package path. Both defaults are
-// auto-provisioned at baseline, and `default-python` (28 chars with the separator) is longer than
-// `default-r` (23) — reserving for the shorter name let a root pass the picker yet overflow MAX_PATH
-// once default-python provisioned. This is deliberately a budget, not a universal package-path
-// constant; newer manifests can tighten the release gate further.
-const LONGEST_DEFAULT_ENV_NAME = [DEFAULT_PY_ENV, DEFAULT_R_ENV].reduce((a, b) =>
-  a.length >= b.length ? a : b
-)
-const WINDOWS_ENV_PREFIX_RESERVE = `runtime\\envs\\${LONGEST_DEFAULT_ENV_NAME}`.length + 1
+// Keep the migration guard aligned with the physical default prefix selected by runtime-paths plus
+// the longest linked package path. Logical names deliberately do not participate in this budget.
+const WINDOWS_ENV_PREFIX_RESERVE = windowsDefaultEnvPrefixReserve()
 
 export const maxManagedEnvRelativePath = (dataRoot: string): number => {
   let maximum = DEFAULT_MAX_ENV_RELATIVE_PATH

--- a/src/main/storage/usage.test.ts
+++ b/src/main/storage/usage.test.ts
@@ -70,6 +70,29 @@ describe('computeStorageUsage', () => {
     })
   })
 
+  it('labels reserved short default directories by their logical environment', async () => {
+    await writeSized(join(dataRoot, 'runtime', 'envs', '.p', 'p.bin'), 200)
+    await writeSized(join(dataRoot, 'runtime', 'envs', '.r', 'r.bin'), 300)
+
+    const usage = await computeStorageUsage(dataRoot)
+    const runtime = usage.categories.find((category) => category.key === 'runtime')
+
+    expect(runtime?.children).toEqual([
+      { name: 'r', bytes: 300 },
+      { name: 'python', bytes: 200 }
+    ])
+  })
+
+  it('combines inert legacy residue with the active short default in one usage row', async () => {
+    await writeSized(join(dataRoot, 'runtime', 'envs', '.p', 'short.bin'), 200)
+    await writeSized(join(dataRoot, 'runtime', 'envs', 'default-python', 'legacy.bin'), 50)
+
+    const usage = await computeStorageUsage(dataRoot)
+    const runtime = usage.categories.find((category) => category.key === 'runtime')
+
+    expect(runtime?.children).toEqual([{ name: 'python', bytes: 250 }])
+  })
+
   it('counts envs.lock toward the runtime total but does not show it as its own row', async () => {
     await writeSized(join(dataRoot, 'runtime', 'envs', 'default-python', 'p.bin'), 200)
     await writeSized(join(dataRoot, 'runtime', 'envs.lock', 'default-r.lock'), 10)

--- a/src/main/storage/usage.ts
+++ b/src/main/storage/usage.ts
@@ -1,6 +1,8 @@
 import { readdir, stat, statfs } from 'node:fs/promises'
 import { join } from 'node:path'
 
+import { logicalEnvNameFromDirectory } from '../notebook/runtime-paths'
+
 export type UsageCategoryKey = 'artifacts' | 'uploads' | 'runtime' | 'notebooks' | 'workspaces'
 export type UsageChild = { name: string; bytes: number }
 export type UsageCategory = { key: UsageCategoryKey; bytes: number; children?: UsageChild[] }
@@ -82,13 +84,15 @@ const runtimeUsage = async (dir: string): Promise<{ bytes: number; children: Usa
   } catch {
     envEntries = []
   }
+  const envBytes = new Map<string, number>()
   for (const entry of envEntries) {
     if (entry.isSymbolicLink() || !entry.isDirectory()) continue
-    children.push({
-      name: ENV_LABELS[entry.name] ?? entry.name,
-      bytes: await dirSize(join(dir, 'envs', entry.name), seen)
-    })
+    const logicalName = logicalEnvNameFromDirectory(entry.name)
+    const label = ENV_LABELS[logicalName] ?? logicalName
+    const bytes = await dirSize(join(dir, 'envs', entry.name), seen)
+    envBytes.set(label, (envBytes.get(label) ?? 0) + bytes)
   }
+  for (const [name, bytes] of envBytes) children.push({ name, bytes })
 
   // loose top-level files (e.g. .env-ready) and any other top-level dirs, so the total stays exact.
   let topEntries


### PR DESCRIPTION
## Problem

PR #330 aligned the data-root picker with the longer logical name `default-python`, but the logical name still consumed 14 characters in every Windows environment prefix. A root in the five-character R/Python gap was rejected or failed provisioning even though the app controls the physical directory name.

The package-cache path chain is independent. This change must not claim that shortening environment prefixes fixes `No trusted writable package cache fits...`.

## Proposed change

- Keep `default-python` and `default-r` as the logical names used by tools, notebook state, process keys, lock files, and UI.
- On Windows, place fresh or previously failed defaults at reserved physical directories `runtime\\envs\\.p` and `.r`, saving 12 characters for Python and 7 for R.
- Record the committed physical directory in the existing ready marker. Old markers without provenance are treated as legacy because no released build could have committed `.p` / `.r`.
- Preserve a committed legacy Python prefix and a materialized legacy R prefix, even when a partial short directory also exists.
- Clean legacy residue only after the short prefix verifies and its ready marker explicitly commits `.p` / `.r`.
- Map physical directories back to logical names in discovery, environment listing, relocation export, and storage usage.
- Derive the picker reserve from the same physical layout seam used by provisioning.

```mermaid
flowchart TD
    A[Resolve a Windows default environment] --> B{Ready marker commits .p or .r<br/>and short prefix exists?}
    B -- Yes --> C[Use committed short prefix]
    B -- No --> D{Committed/materialized<br/>legacy prefix exists?}
    D -- Yes --> E[Keep legacy prefix]
    D -- No --> F[Use fresh or partial short prefix]
    C --> G[Verify and write marker provenance]
    E --> G
    F --> G
    G --> H{Marker commits short prefix?}
    H -- Yes --> I[Best-effort cleanup of legacy residue]
    H -- No --> J[Retain legacy and any short partial]
```

## Compatibility and trade-offs

- The reduction is bounded: 12 characters for Python and 7 for R. This fixes the R/Python name gap and gives fresh defaults more room, but it is not a general solution for arbitrarily long data roots.
- Healthy legacy environments stay at their longer paths and receive no path-budget improvement. They are not automatically rebuilt because an `@EXPLICIT` export cannot preserve all user-installed pip/CRAN additions.
- `envPrefix` is intentionally filesystem-state-dependent for the two Windows defaults. It performs synchronous marker and interpreter checks, so callers must not cache its result across provisioning or repair steps.
- Coexisting short and legacy directories require commit provenance. Directory existence alone is insufficient because a partial `.p` / `.r` must not displace a committed legacy environment.
- The reverse directory mapping is platform-independent. App-created named environments cannot collide because user environment names must start with an alphanumeric character.

## Scope and non-goals

This PR fixes the managed environment-prefix chain only.

It does not change micromamba's package-cache candidates, URL-derived cache layout, ACL policy, or the independent cache-selection error. That work has a different rollback surface and should remain separate.

Named environments retain their current physical names and existing create-time budget check.

## Acceptance criteria and validation

- Fresh and uncommitted Windows defaults resolve to `.p` / `.r`.
- An old committed legacy marker remains authoritative beside a partial short prefix.
- A marker that explicitly commits `.p` / `.r` makes the short prefix authoritative and permits legacy cleanup.
- A failed legacy Python install rebuilds at `.p`, then removes the old residue.
- Logical names survive discovery, relocation lock export, environment listing, and storage reporting.
- The picker accepts paths made safe by the physical-prefix reduction and rejects an exact 260-character path.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors (19 pre-existing warnings).
- Affected tests: 8 files passed, 226 tests passed.
- Full suite with `--maxWorkers=4`: 429 files passed, 9 skipped; one unrelated renderer interaction file was flaky under the full run and passed 4/4 in isolation.

## Review focus

- `envPrefix` is the sole logical-to-physical seam; callers do not duplicate the mapping.
- Marker provenance protects a committed legacy prefix from a partial short-prefix residue.
- Cleanup occurs only after verification and marker commit.
- Reverse scanners never expose `.p` / `.r` as logical environment names.
- Cache-chain behavior remains unchanged.
