### PR TITLE
fix(main): re-enable Cmd/Ctrl zoom in/out and actual-size shortcuts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,7 +37,7 @@ if (shouldRunArtifactMcpServer) {
 async function startElectronApp(mainEntryPath: string): Promise<void> {
   const [
     { app, BrowserWindow, ipcMain, nativeImage, protocol },
-    { electronApp, optimizer },
+    { electronApp },
     { default: icon },
     { acquireSingleInstanceLock },
     { orchestrateAppStartup }
@@ -70,7 +70,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { parseWebModeOptions, createWebServiceController, buildAuthenticatedWebUrl },
         { routeSecondInstance },
         { detectActiveSessions: computeActiveSessions },
-        { createElectronCloseConfirm }
+        { createElectronCloseConfirm },
+        { installWindowShortcuts }
       ] = await Promise.all([
         import('./ipc'),
         import('./windows'),
@@ -82,7 +83,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./web-service'),
         import('./second-instance-router'),
         import('./storage/detect-active'),
-        import('./window-close-confirm')
+        import('./window-close-confirm'),
+        import('./window-shortcuts')
       ])
 
       // Dev runs get a "(DEV)" suffix so the app name, macOS menu, and per-app paths (logs, userData)
@@ -116,6 +118,13 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       // Set app user model id for windows
       electronApp.setAppUserModelId(APP_USER_MODEL_ID)
 
+      // Forward F12 / Cmd-R blocking from `@electron-toolkit/utils`' `optimizer.watchWindowShortcuts`
+      // to every window (main + future preview windows). The helper is invoked with `zoom: true` so
+      // Cmd/Ctrl+=, Cmd/Ctrl+-, and Cmd/Ctrl+0 reach Electron's built-in zoomIn / zoomOut /
+      // resetZoom menu accelerators — without that, its before-input-event listener calls
+      // preventDefault() on Cmd+- and Cmd+= and silently disables zoom out / reset (issue #336).
+      installWindowShortcuts(app)
+
       // Dev builds use the app icon for the macOS dock.
       if (process.platform === 'darwin') {
         const dockIcon = nativeImage.createFromPath(icon)
@@ -123,13 +132,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           app.dock?.setIcon(dockIcon)
         }
       }
-
-      // Default open or close DevTools by F12 in development
-      // and ignore CommandOrControl + R in production.
-      // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
-      app.on('browser-window-created', (_, window) => {
-        optimizer.watchWindowShortcuts(window)
-      })
 
       const webMode = parseWebModeOptions(process.argv)
       // Always install the capture layer BEFORE handlers register: it records ipcMain.handle handlers as

--- a/src/main/window-shortcuts.test.ts
+++ b/src/main/window-shortcuts.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { watchWindowShortcuts } = vi.hoisted(() => ({
+  watchWindowShortcuts: vi.fn()
+}))
+
+vi.mock('@electron-toolkit/utils', () => ({
+  optimizer: {
+    watchWindowShortcuts
+  }
+}))
+
+import type { App } from 'electron'
+import { installWindowShortcuts } from './window-shortcuts'
+
+// Regression guard for issue #336: without `zoom: true`, electron-toolkit's helper calls
+// `event.preventDefault()` on `Cmd+-` and `Cmd+=` in its `before-input-event` listener, which
+// silently blocks Electron's built-in zoomOut / zoomIn menu accelerators and leaves the user
+// stuck at whatever zoom level they last chose — no zoom out, no actual size.
+describe('installWindowShortcuts', () => {
+  let appOnSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    appOnSpy = vi.fn()
+    watchWindowShortcuts.mockReset()
+  })
+
+  it('registers a browser-window-created listener that forwards windows with zoom enabled', () => {
+    installWindowShortcuts({ on: appOnSpy } as unknown as App)
+
+    expect(appOnSpy).toHaveBeenCalledTimes(1)
+    expect(appOnSpy).toHaveBeenCalledWith('browser-window-created', expect.any(Function))
+
+    const handler = appOnSpy.mock.calls[0]![1] as (event: unknown, window: unknown) => void
+    const fakeWindow = { id: 42 }
+    handler(null, fakeWindow)
+
+    expect(watchWindowShortcuts).toHaveBeenCalledTimes(1)
+    expect(watchWindowShortcuts).toHaveBeenCalledWith(fakeWindow, { zoom: true })
+  })
+
+  it('preserves caller-supplied non-zoom options while still forcing zoom on', () => {
+    installWindowShortcuts({ on: appOnSpy } as unknown as App, { escToCloseWindow: true })
+
+    const handler = appOnSpy.mock.calls[0]![1] as (event: unknown, window: unknown) => void
+    handler(null, {})
+
+    expect(watchWindowShortcuts).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ escToCloseWindow: true, zoom: true })
+    )
+  })
+})

--- a/src/main/window-shortcuts.ts
+++ b/src/main/window-shortcuts.ts
@@ -1,0 +1,15 @@
+import type { App, BrowserWindow } from 'electron'
+import { optimizer, type shortcutOptions } from '@electron-toolkit/utils'
+
+// Wraps `@electron-toolkit/utils`' `optimizer.watchWindowShortcuts` so it (a) tests cleanly with a
+// mocked `app`, and (b) gets `zoom: true` baked in — without that the helper `preventDefault`s
+// `Cmd/Ctrl+=` and `Cmd/Ctrl+-` in its `before-input-event` listener, silently disabling Electron's
+// built-in zoomIn/zoomOut menu accelerators (issue #336). Default DevTools / reload behavior from
+// electron-toolkit is preserved unchanged.
+const installWindowShortcuts = (app: App, options?: Omit<shortcutOptions, 'zoom'>): void => {
+  app.on('browser-window-created', (_event: unknown, window: BrowserWindow) => {
+    optimizer.watchWindowShortcuts(window, { ...options, zoom: true })
+  })
+}
+
+export { installWindowShortcuts }


### PR DESCRIPTION
## Problem

On macOS, `Cmd + +` zoomed the UI in but there was no way to zoom back out, and `Cmd + 0` only sometimes reset to 100%. Once zoomed in, the UI stayed enlarged with no escape. Same shape on Windows/Linux with `Ctrl`. Reported in #336.

The cause lives in the main process. Every `browser-window-created` registers `optimizer.watchWindowShortcuts(window)` from `@electron-toolkit/utils`. The helper's default options register a `before-input-event` listener that calls `event.preventDefault()` on `Cmd/Ctrl+=` and `Cmd/Ctrl+-`, silently blocking Electron's built-in `zoomIn` and `zoomOut` menu accelerators. `Cmd/Ctrl+0` was not on the block-list but only worked when the default view menu was actually registered, which has been inconsistent across Electron versions.

## Proposed change

Stop blocking the zoom chords in the first place. Electron's native `zoomIn` / `zoomOut` / `resetZoom` menu role accelerators already do the right thing — they call `webContents.setZoomLevel` per the standard macOS / Electron convention the issue asks for.

Extracted the `browser-window-created` registration into a small `installWindowShortcuts(app, options?)` helper in `src/main/window-shortcuts.ts`:

- Hard-codes `zoom: true` so the toolkit's two `preventDefault` branches are skipped.
- Forwards any other caller-supplied options (`escToCloseWindow`) unchanged.
- `src/main/index.ts` calls `installWindowShortcuts(app)` inside `prepare()` next to the existing `setAppUserModelId` wiring.

A regression test in `src/main/window-shortcuts.test.ts` asserts the helper forces `{ zoom: true }` and still honors caller-supplied flags, so this can't silently regress to the toolkit default again.

## Scope and non-goals

**In scope.** Restore `Cmd/Ctrl+=`, `Cmd/Ctrl+-`, `Cmd/Ctrl+0` to drive Electron's built-in zoom menu accelerators on every window (main + any future preview windows since the helper is registered globally on `browser-window-created`).

**Out of scope.** Not installing an explicit application menu — the default Electron view menu already carries the three Zoom items with the right accelerators. Build-side, packaging, and renderer-side concerns are untouched.

## Acceptance criteria and validation

- `npm run typecheck` — clean
- `npm run lint` — clean on changed files (`src/main/index.ts`, `src/main/window-shortcuts.ts`, `src/main/window-shortcuts.test.ts`); pre-existing `.worktrees/` lint errors unrelated to this change
- `npx vitest run src/main/` — 520 files / 7582 tests pass; the new 2-test `window-shortcuts.test.ts` covers the wiring
- Manual: after this change, on macOS `Cmd + =` zooms in, `Cmd + -` zooms out, `Cmd + 0` resets to 100%; on Windows/Linux the same three shortcuts work via `Ctrl` (Electron maps the modifier per platform automatically).

## Review focus

- `src/main/window-shortcuts.ts` and its test — confirm the helper preserves existing electron-toolkit behavior (F12 DevTools in dev, `Cmd/Ctrl+R` reload suppression in production) and only touches the two zoom preventDefault branches.
- `src/main/index.ts` — confirm the registration moved cleanly into `prepare()` and the import surface area did not grow net-new modules beyond `./window-shortcuts`.

Closes #336
