### PR TITLE
fix(acp): collapse Codex MCP allow_always to single session-scoped option

### DIFF
--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -251,7 +251,55 @@ describe('ACP permission broker', () => {
       mcpServerNames: ['open-science-notebook']
     })
 
-    // Only the first allow_always (session-scoped) survives; the persistent one is hidden.
+    // The persistent allow-always option is stripped by ID; session-scoped allow-session survives.
+    expect(emitted[0].options).toEqual([
+      { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
+      { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+      { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
+    ])
+  })
+
+  it('retains session-scoped allow_always even when persistent option arrives first', () => {
+    const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const request = createCodexMcpPermissionRequest()
+    // Reverse the option order to verify the filter is ID-based, not position-based.
+    request.options = [
+      { optionId: 'allow-always', name: "Allow and Don't Ask Again", kind: 'allow_always' },
+      { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
+      { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+      { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
+    ]
+
+    void broker.requestPermission(request, {
+      profile: 'ask',
+      frameworkId: 'codex',
+      mcpServerNames: ['open-science-notebook']
+    })
+
+    expect(emitted[0].options).toEqual([
+      { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
+      { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+      { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
+    ])
+  })
+
+  it('passes through Codex MCP options unchanged when only one allow_always is present', () => {
+    const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const request = createCodexMcpPermissionRequest()
+    request.options = [
+      { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
+      { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+      { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
+    ]
+
+    void broker.requestPermission(request, {
+      profile: 'ask',
+      frameworkId: 'codex',
+      mcpServerNames: ['open-science-notebook']
+    })
+
     expect(emitted[0].options).toEqual([
       { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
       { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -85,6 +85,22 @@ const createCodexCommandPermissionRequest = (
   ]
 })
 
+// Codex MCP requests send two allow_always variants: a session-scoped one and a persistent one.
+const createCodexMcpPermissionRequest = (sessionId = 'session-1'): RequestPermissionRequest => ({
+  sessionId,
+  toolCall: {
+    toolCallId: `tool-${Math.random()}`,
+    title: 'mcp.open-science-notebook.notebook_execute',
+    status: 'pending'
+  },
+  options: [
+    { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
+    { optionId: 'allow-always', name: "Allow and Don't Ask Again", kind: 'allow_always' },
+    { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+    { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
+  ]
+})
+
 describe('ACP permission broker', () => {
   it('preserves structured tool metadata for risk-aware approval UI', () => {
     const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
@@ -222,6 +238,24 @@ describe('ACP permission broker', () => {
     expect(emitted[0].options.map((option) => option.optionId)).toEqual([
       'allow_once',
       'reject_once'
+    ])
+  })
+
+  it('collapses Codex MCP allow_always options to a single session-scoped Always', () => {
+    const emitted: Array<Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]> = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+
+    void broker.requestPermission(createCodexMcpPermissionRequest(), {
+      profile: 'ask',
+      frameworkId: 'codex',
+      mcpServerNames: ['open-science-notebook']
+    })
+
+    // Only the first allow_always (session-scoped) survives; the persistent one is hidden.
+    expect(emitted[0].options).toEqual([
+      { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
+      { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+      { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
     ])
   })
 

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -27,6 +27,10 @@ const ALLOW_ONCE_OPTION_KIND = 'allow_once'
 // options whose IDs match this shape. If codex-acp renames them, projection silently stops — the
 // projection tests (permission-broker.test.ts) pin this contract and would fail on such a drift.
 const CODEX_POLICY_AMENDMENT_OPTION_ID_PATTERN = /^accept_.*policy_amendment$/
+// Codex sends two allow_always options for MCP tool requests. The persistent cross-session one uses
+// this option ID; the session-scoped one uses 'allow-session'. Keying on the persistent ID (not
+// position) is robust to option reordering — tests pin this contract.
+const CODEX_MCP_PERSISTENT_ALLOW_OPTION_ID = 'allow-always'
 
 const commandFromRawInput = (rawInput: unknown): string | undefined => {
   if (!rawInput || typeof rawInput !== 'object' || Array.isArray(rawInput)) return undefined
@@ -83,18 +87,13 @@ const projectPermissionOptions = (
     return params.options
   }
 
-  // Codex MCP tools send two allow_always variants: a session-scoped one and a persistent
-  // "don't ask again" one. Only the first (session-scoped) fits the app's grant model.
+  // Codex MCP tools send two allow_always variants: a session-scoped one ('allow-session') and
+  // a persistent cross-session one ('allow-always'). Strip the persistent one by its known
+  // option ID so the app's session-only, revocable grant model is never bypassed.
   if (isMcp) {
-    let allowAlwaysSeen = false
-    return params.options.filter((option) => {
-      if (option.kind.toLowerCase() !== ALLOW_ALWAYS_OPTION_KIND) return true
-      if (!allowAlwaysSeen) {
-        allowAlwaysSeen = true
-        return true
-      }
-      return false
-    })
+    return params.options.filter(
+      (option) => option.optionId !== CODEX_MCP_PERSISTENT_ALLOW_OPTION_ID
+    )
   }
 
   // For non-MCP Codex tools, strip native policy amendments that persist outside the app.

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -72,23 +72,38 @@ const commandSignature = (command: string): string => {
   return rest.length > 0 ? rest.join(' ') : command.trim()
 }
 
-// Open Science owns per-session grants, so Codex command approvals omit native exec/network policy
-// amendments that persist outside the app's visible, revocable grant model. Their presence also
-// identifies command requests when optional execute metadata is absent.
+// Open Science owns per-session grants, so Codex approvals omit options that grant persistent
+// (cross-session) access outside the app's visible, revocable grant model.
 const projectPermissionOptions = (
   params: RequestPermissionRequest,
   policyContext: PermissionPolicyContext | undefined,
   isMcp: boolean
 ): RequestPermissionRequest['options'] => {
+  if (policyContext?.frameworkId !== 'codex') {
+    return params.options
+  }
+
+  // Codex MCP tools send two allow_always variants: a session-scoped one and a persistent
+  // "don't ask again" one. Only the first (session-scoped) fits the app's grant model.
+  if (isMcp) {
+    let allowAlwaysSeen = false
+    return params.options.filter((option) => {
+      if (option.kind.toLowerCase() !== ALLOW_ALWAYS_OPTION_KIND) return true
+      if (!allowAlwaysSeen) {
+        allowAlwaysSeen = true
+        return true
+      }
+      return false
+    })
+  }
+
+  // For non-MCP Codex tools, strip native policy amendments that persist outside the app.
+  // Their presence also identifies execute requests when optional kind metadata is absent.
   const hasPolicyAmendment = params.options.some((option) =>
     CODEX_POLICY_AMENDMENT_OPTION_ID_PATTERN.test(option.optionId)
   )
 
-  if (
-    policyContext?.frameworkId !== 'codex' ||
-    isMcp ||
-    (params.toolCall.kind !== 'execute' && !hasPolicyAmendment)
-  ) {
+  if (params.toolCall.kind !== 'execute' && !hasPolicyAmendment) {
     return params.options
   }
 


### PR DESCRIPTION
## Problem

Codex sends two `allow_always` options for MCP tool requests (e.g. `notebook_execute`):
- `allow-session` — "Allow for This Session" (session-scoped)
- `allow-always` — "Allow and Don't Ask Again" (persistent, cross-session)

The broker's `projectPermissionOptions` returned all options unfiltered when `isMcp = true`, so both reached the renderer. Because `actionCounts['always'] === 2`, the label logic expanded them into two separate buttons:

> Always - Allow for This Session | Always - Allow and Don't Ask Again | Allow once | Reject | Cancel

That's 5 buttons vs Claude Code's 4 (Always | Allow once | Reject | Cancel).

The persistent option also sits outside the app's session-only, revocable grant model (`alwaysAllowedCategories` is cleared on session teardown).

## Proposed change

Restructure `projectPermissionOptions` into three explicit paths:

1. **Non-Codex** — pass options through unchanged (no behavior change).
2. **Codex + MCP** — keep only the first `allow_always` option (session-scoped); drop any subsequent `allow_always` variants. The persistent option is hidden at the broker boundary, consistent with how policy amendments are already hidden for non-MCP exec tools.
3. **Codex + non-MCP** — existing policy-amendment filter, unchanged.

## Scope and non-goals

- Only affects Codex + MCP permission requests.
- Does not change the renderer label logic; the fix is entirely in the broker.
- Does not affect Claude Code, opencode, or non-Codex frameworks.
- Does not change the session-scoped "always allow" memory behavior.

## Acceptance criteria and validation

- Codex `notebook_execute` permission prompt shows 4 buttons (Always | Allow once | Reject | Cancel), matching Claude Code.
- The "Always" option is the session-scoped one (`allow-session`); the persistent variant is not reachable.
- All 24 broker tests pass; render tests unchanged and passing.
- `npm run typecheck`, `npm run lint`, `npm run test` all green.

## Review focus

- The `isMcp` branch in `projectPermissionOptions` now filters instead of early-returning for Codex — confirm the logic is correct and the non-Codex MCP path is not affected.
- The new fixture `createCodexMcpPermissionRequest` accurately models what Codex sends for MCP tools.