### PR TITLE
feat(net): add resilient downloads with range resume, speed display, and retry

### DIFF
--- a/src/main/net/download-speed.test.ts
+++ b/src/main/net/download-speed.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { SpeedMeter } from './download-speed'
 
 describe('SpeedMeter', () => {
-  const clock = (start = 0) => {
+  const clock = (start = 0): { now: () => number; advance: (ms: number) => number } => {
     let t = start
     return { now: () => t, advance: (ms: number) => (t += ms) }
   }

--- a/src/main/net/download-speed.test.ts
+++ b/src/main/net/download-speed.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { SpeedMeter } from './download-speed'
+
+describe('SpeedMeter', () => {
+  const clock = (start = 0) => {
+    let t = start
+    return { now: () => t, advance: (ms: number) => (t += ms) }
+  }
+
+  it('returns 0 before two samples', () => {
+    const c = clock()
+    const m = new SpeedMeter({ now: c.now })
+    m.record(0)
+    expect(m.bytesPerSecond()).toBe(0)
+  })
+
+  it('averages bytes over the sliding window', () => {
+    const c = clock()
+    const m = new SpeedMeter({ windowMs: 3000, now: c.now })
+    m.record(0)
+    c.advance(1000)
+    m.record(1_000_000) // 1 MB in 1s
+    expect(m.bytesPerSecond()).toBeCloseTo(1_000_000, -3)
+  })
+
+  it('drops samples older than the window', () => {
+    const c = clock()
+    const m = new SpeedMeter({ windowMs: 2000, now: c.now })
+    m.record(0)
+    c.advance(5000)
+    m.record(5_000_000) // old sample evicted — only this one remains
+    c.advance(1000)
+    m.record(6_000_000) // 1 MB in last 1s
+    expect(m.bytesPerSecond()).toBeCloseTo(1_000_000, -3)
+  })
+
+  it('computes ETA from remaining bytes and speed', () => {
+    const c = clock()
+    const m = new SpeedMeter({ now: c.now })
+    m.record(0)
+    c.advance(1000)
+    m.record(1_000_000) // 1 MB/s
+    expect(m.etaSeconds(5_000_000)).toBe(4) // 4 MB remaining
+  })
+
+  it('returns undefined ETA when total unknown or speed zero', () => {
+    const c = clock()
+    const m = new SpeedMeter({ now: c.now })
+    m.record(0)
+    expect(m.etaSeconds(5_000_000)).toBeUndefined() // speed 0
+    c.advance(1000)
+    m.record(1_000_000)
+    expect(m.etaSeconds(undefined)).toBeUndefined()
+  })
+})

--- a/src/main/net/download-speed.ts
+++ b/src/main/net/download-speed.ts
@@ -1,0 +1,42 @@
+// Sliding-window download speed + ETA. Pure and clock-injectable so it unit-tests without wall time
+// and stays usable in sandboxes that restrict Date.now.
+type Sample = { t: number; bytes: number }
+
+export class SpeedMeter {
+  private readonly windowMs: number
+  private readonly now: () => number
+  private readonly samples: Sample[] = []
+
+  constructor(opts: { windowMs?: number; now?: () => number } = {}) {
+    this.windowMs = opts.windowMs ?? 3000
+    this.now = opts.now ?? (() => Date.now())
+  }
+
+  // Record a cumulative byte count at the current time, evicting samples outside the window.
+  record(cumulativeBytes: number): void {
+    const t = this.now()
+    this.samples.push({ t, bytes: cumulativeBytes })
+    const cutoff = t - this.windowMs
+    while (this.samples.length > 2 && this.samples[0].t < cutoff) this.samples.shift()
+  }
+
+  // Average bytes/s across the retained window; 0 until two samples span a non-zero interval.
+  bytesPerSecond(): number {
+    if (this.samples.length < 2) return 0
+    const first = this.samples[0]
+    const last = this.samples[this.samples.length - 1]
+    const elapsedMs = last.t - first.t
+    if (elapsedMs <= 0) return 0
+    return ((last.bytes - first.bytes) / elapsedMs) * 1000
+  }
+
+  // Seconds until `total` at the current speed; undefined when total unknown or speed is 0.
+  etaSeconds(totalBytes?: number): number | undefined {
+    if (totalBytes == null) return undefined
+    const speed = this.bytesPerSecond()
+    if (speed <= 0) return undefined
+    const last = this.samples[this.samples.length - 1]
+    const remaining = Math.max(0, totalBytes - (last?.bytes ?? 0))
+    return Math.ceil(remaining / speed)
+  }
+}

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -1,14 +1,14 @@
 import { createHash } from 'node:crypto'
-import { posix as posixPath } from 'node:path'
+import { join } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
 import { describe, expect, it, vi, type MockedFunction } from 'vitest'
 
 import { DownloadChecksumError, resilientDownload } from './resilient-download'
 
-// The memFs doubles key files by the exact string passed as destPath — they never touch the host
-// filesystem or path separators — so a stable posix join keeps the destPath host-agnostic (the plan's
-// Windows-safe join/sep rule) without changing behavior.
-const OUT_PATH = posixPath.join('downloads', 'out.bin')
+// Build the destPath with the host's own join/sep (the plan's Windows-safe path rule) rather than a
+// hardcoded literal. The memFs doubles key files by this exact string and never touch the real
+// filesystem, so the separator the host produces is what round-trips through the download.
+const OUT_PATH = join('downloads', 'out.bin')
 
 // Builds a fake fetch honoring Range header; `cutAfter` truncates the body to simulate a drop.
 const sha = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
@@ -292,10 +292,11 @@ describe('resilientDownload', () => {
     expect(created?.destroyed).toBe(true) // cleanup path destroyed the failed stream
   })
 
-  it('destroys the failed write stream before opening a new one on a network retry', async () => {
-    // A retryable NETWORK fault (short read), not a disk fault. Records create/destroy order across
-    // streams and asserts the first stream was destroyed before the second was created — the actual
-    // "clean up before retry" guarantee the earlier emit-only test could not prove.
+  it('destroys the still-open write stream in the catch path when the body errors mid-stream', async () => {
+    // The response body delivers a few bytes then THROWS mid-stream (a dropped socket) — so the file
+    // is still open when the error propagates, unlike a clean short read that ends() first. This is
+    // the path where the retry catch must proactively destroy() the open handle. Assert the first
+    // stream is destroyed before the retry opens the second, then the retry resumes and completes.
     const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
     const fs = memFs()
     const events: string[] = []
@@ -314,13 +315,25 @@ describe('resilientDownload', () => {
       pt.on('close', () => events.push(`destroy:${id}`))
       return pt as unknown as import('node:fs').WriteStream
     }
-    // First fetch delivers a short body (retryable), second completes.
-    const first = fakeFetch(body, { cutAfter: 10 })
-    const rest = fakeFetch(body)
+    // First response: a body stream that yields the first 8 bytes, then errors (socket drop) while the
+    // write stream is still open. Content-length announces the full size so it is not a clean short read.
+    const firstFetch = vi.fn(async () => {
+      const gen = (async function* () {
+        yield body.subarray(0, 8)
+        throw new Error('ECONNRESET socket hang up')
+      })()
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: (h: string) => (h.toLowerCase() === 'content-length' ? '26' : null) },
+        body: Readable.toWeb(Readable.from(gen))
+      } as unknown as Response
+    })
+    const rest = fakeFetch(body) // resumes from the persisted 8 bytes via Range
     let call = 0
     const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
       call++
-      return call === 1 ? first(input, init) : rest(input, init)
+      return call === 1 ? firstFetch() : rest(input, init)
     })
     const out = await resilientDownload('https://cdn/file', OUT_PATH, {
       expectedSha256: sha(body),
@@ -335,7 +348,8 @@ describe('resilientDownload', () => {
     })
     expect(out).toBe(OUT_PATH)
     expect(fs.files.get(OUT_PATH)?.toString()).toBe(body.toString())
-    // The first stream is destroyed before the second is created.
+    expect(call).toBe(2) // it did retry after the mid-stream error
+    // The open handle from attempt 1 was destroyed (in the catch) before attempt 2 opened its stream.
     expect(events.indexOf('destroy:0')).toBeLessThan(events.indexOf('create:1'))
   })
 

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -30,8 +30,7 @@ const fakeFetch = (
       ok: status < 400,
       status,
       headers: {
-        get: (h: string) =>
-          h.toLowerCase() === 'content-length' ? String(slice.length) : null
+        get: (h: string) => (h.toLowerCase() === 'content-length' ? String(slice.length) : null)
       },
       body: Readable.toWeb(stream)
     } as unknown as Response
@@ -135,7 +134,11 @@ describe('resilientDownload', () => {
       resilientDownload('https://cdn/file', '/tmp/out.bin', {
         expectedSha256: 'deadbeef',
         maxRetries: 0,
-        deps: { fetchImpl: fakeFetch(body) as unknown as typeof fetch, ...fs, sleep: async () => {} }
+        deps: {
+          fetchImpl: fakeFetch(body) as unknown as typeof fetch,
+          ...fs,
+          sleep: async () => {}
+        }
       })
     ).rejects.toBeInstanceOf(DownloadChecksumError)
     expect(fs.files.has('/tmp/out.bin.part')).toBe(false)
@@ -143,12 +146,15 @@ describe('resilientDownload', () => {
 
   it('keeps .part after exhausting retries on 5xx', async () => {
     const fs = memFs()
-    const failing = vi.fn(async () => ({
-      ok: false,
-      status: 503,
-      headers: { get: () => null },
-      body: Readable.toWeb(Readable.from([Buffer.alloc(0)]))
-    }) as unknown as Response)
+    const failing = vi.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 503,
+          headers: { get: () => null },
+          body: Readable.toWeb(Readable.from([Buffer.alloc(0)]))
+        }) as unknown as Response
+    )
     await expect(
       resilientDownload('https://cdn/file', '/tmp/out.bin', {
         maxRetries: 2,
@@ -175,7 +181,12 @@ describe('resilientDownload', () => {
       expectedSha256: sha(body),
       stallTimeoutMs: 20,
       onProgress: (p) => phases.push(`${p.phase}:${p.attempt}`),
-      deps: { fetchImpl: fetchImpl as unknown as typeof fetch, ...fs, sleep: async () => {}, now: () => 0 }
+      deps: {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        ...fs,
+        sleep: async () => {},
+        now: () => 0
+      }
     })
     expect(phases).toContain('reconnecting:1')
   })
@@ -239,5 +250,74 @@ describe('resilientDownload', () => {
     // The download must have been aborted during backoff — not after the full sleep completes.
     expect(sleepCallCount).toBe(1)
     expect(call).toBe(1) // second fetch was never started
+  })
+
+  it('closes the failed write stream before retry and keeps the hash consistent', async () => {
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const fs = memFs()
+    // Track every write stream so we can assert the failed one was destroyed before the retry.
+    const streams: Array<{ destroyed: boolean }> = []
+    let failNextWrite = true
+    const createWriteStreamImpl = (
+      path: string,
+      o?: { flags?: string }
+    ): import('node:fs').WriteStream => {
+      if (!o || o.flags !== 'a') fs.files.set(path, Buffer.alloc(0))
+      const pt = new PassThrough()
+      const rec = pt as unknown as { destroyed: boolean }
+      streams.push(rec)
+      pt.on('data', (c: Buffer) => {
+        // Fail the very first write to exercise the write-error path with the hash mid-stream.
+        if (failNextWrite) {
+          failNextWrite = false
+          pt.emit('error', new Error('EIO write failed'))
+          return
+        }
+        fs.files.set(path, Buffer.concat([fs.files.get(path) ?? Buffer.alloc(0), c]))
+      })
+      return pt as unknown as import('node:fs').WriteStream
+    }
+    const out = await resilientDownload('https://cdn/file', '/tmp/out.bin', {
+      expectedSha256: sha(body),
+      stallTimeoutMs: 50,
+      deps: {
+        fetchImpl: fakeFetch(body) as unknown as typeof fetch,
+        ...fs,
+        createWriteStreamImpl,
+        sleep: async () => {},
+        now: () => 0
+      }
+    })
+    expect(out).toBe('/tmp/out.bin')
+    // The download still succeeds with the correct digest — proof the hash did not run ahead of the
+    // bytes that actually reached disk when the first write failed.
+    expect(fs.files.get('/tmp/out.bin')?.toString()).toBe(body.toString())
+    // The first (failed) write stream was destroyed before the retry opened a new one.
+    expect(streams.length).toBeGreaterThanOrEqual(2)
+    expect(streams[0].destroyed).toBe(true)
+  })
+
+  it('does not retry when the final rename fails (terminal)', async () => {
+    const body = Buffer.from('payload-bytes')
+    const fs = memFs()
+    const fetchImpl = fakeFetch(body)
+    const renameImpl = vi.fn(async () => {
+      throw Object.assign(new Error('EXDEV cross-device rename'), { code: 'EXDEV' })
+    })
+    await expect(
+      resilientDownload('https://cdn/file', '/tmp/out.bin', {
+        expectedSha256: sha(body),
+        deps: {
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...fs,
+          renameImpl,
+          sleep: async () => {},
+          now: () => 0
+        }
+      })
+    ).rejects.toThrow(/EXDEV/)
+    // A rename failure is terminal: exactly one fetch and one rename attempt, no retry spin.
+    expect(fetchImpl.mock.calls.length).toBe(1)
+    expect(renameImpl.mock.calls.length).toBe(1)
   })
 })

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -1,8 +1,14 @@
 import { createHash } from 'node:crypto'
-import { PassThrough, Readable } from 'node:stream'
+import { posix as posixPath } from 'node:path'
+import { PassThrough, Readable, Writable } from 'node:stream'
 import { describe, expect, it, vi, type MockedFunction } from 'vitest'
 
 import { DownloadChecksumError, resilientDownload } from './resilient-download'
+
+// The memFs doubles key files by the exact string passed as destPath — they never touch the host
+// filesystem or path separators — so a stable posix join keeps the destPath host-agnostic (the plan's
+// Windows-safe join/sep rule) without changing behavior.
+const OUT_PATH = posixPath.join('downloads', 'out.bin')
 
 // Builds a fake fetch honoring Range header; `cutAfter` truncates the body to simulate a drop.
 const sha = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
@@ -75,13 +81,13 @@ describe('resilientDownload', () => {
   it('downloads and verifies a clean file', async () => {
     const body = Buffer.from('hello world payload')
     const fs = memFs()
-    const out = await resilientDownload('https://cdn/file', '/tmp/out.bin', {
+    const out = await resilientDownload('https://cdn/file', OUT_PATH, {
       expectedSha256: sha(body),
       deps: { fetchImpl: fakeFetch(body) as unknown as typeof fetch, ...fs, sleep: async () => {} }
     })
-    expect(out).toBe('/tmp/out.bin')
-    expect(fs.files.get('/tmp/out.bin')?.toString()).toBe('hello world payload')
-    expect(fs.files.has('/tmp/out.bin.part')).toBe(false)
+    expect(out).toBe(OUT_PATH)
+    expect(fs.files.get(OUT_PATH)?.toString()).toBe('hello world payload')
+    expect(fs.files.has(`${OUT_PATH}.part`)).toBe(false)
   })
 
   it('resumes with a Range request after a mid-stream cut', async () => {
@@ -96,7 +102,7 @@ describe('resilientDownload', () => {
       call++
       return call === 1 ? first(input, init) : rest(input, init)
     })
-    const out = await resilientDownload('https://cdn/file', '/tmp/out.bin', {
+    const out = await resilientDownload('https://cdn/file', OUT_PATH, {
       expectedSha256: sha(body),
       stallTimeoutMs: 20,
       deps: {
@@ -107,8 +113,8 @@ describe('resilientDownload', () => {
         now: () => 0
       }
     })
-    expect(out).toBe('/tmp/out.bin')
-    expect(fs.files.get('/tmp/out.bin')?.toString()).toBe(body.toString())
+    expect(out).toBe(OUT_PATH)
+    expect(fs.files.get(OUT_PATH)?.toString()).toBe(body.toString())
     const secondInit = rest.mock.calls[0][1] as { headers: Record<string, string> }
     expect(secondInit.headers['Range']).toBe('bytes=10-')
     // The 10 already-downloaded bytes stay in the hoisted hash — no .part re-read on resume.
@@ -118,20 +124,20 @@ describe('resilientDownload', () => {
   it('restarts from zero when server ignores Range (200 on resume)', async () => {
     const body = Buffer.from('0123456789')
     const fs = memFs()
-    fs.files.set('/tmp/out.bin.part', Buffer.from('GARBAGE'))
-    const out = await resilientDownload('https://cdn/file', '/tmp/out.bin', {
+    fs.files.set(`${OUT_PATH}.part`, Buffer.from('GARBAGE'))
+    const out = await resilientDownload('https://cdn/file', OUT_PATH, {
       expectedSha256: sha(body),
       deps: { fetchImpl: fakeFetch(body, { status: 200 }), ...fs, sleep: async () => {} }
     })
-    expect(fs.files.get('/tmp/out.bin')?.toString()).toBe('0123456789')
-    expect(out).toBe('/tmp/out.bin')
+    expect(fs.files.get(OUT_PATH)?.toString()).toBe('0123456789')
+    expect(out).toBe(OUT_PATH)
   })
 
   it('throws DownloadChecksumError and deletes .part on mismatch', async () => {
     const body = Buffer.from('payload')
     const fs = memFs()
     await expect(
-      resilientDownload('https://cdn/file', '/tmp/out.bin', {
+      resilientDownload('https://cdn/file', OUT_PATH, {
         expectedSha256: 'deadbeef',
         maxRetries: 0,
         deps: {
@@ -141,7 +147,7 @@ describe('resilientDownload', () => {
         }
       })
     ).rejects.toBeInstanceOf(DownloadChecksumError)
-    expect(fs.files.has('/tmp/out.bin.part')).toBe(false)
+    expect(fs.files.has(`${OUT_PATH}.part`)).toBe(false)
   })
 
   it('keeps .part after exhausting retries on 5xx', async () => {
@@ -156,7 +162,7 @@ describe('resilientDownload', () => {
         }) as unknown as Response
     )
     await expect(
-      resilientDownload('https://cdn/file', '/tmp/out.bin', {
+      resilientDownload('https://cdn/file', OUT_PATH, {
         maxRetries: 2,
         deps: { fetchImpl: failing as unknown as typeof fetch, ...fs, sleep: async () => {} }
       })
@@ -177,7 +183,7 @@ describe('resilientDownload', () => {
       return call === 1 ? first(input, init) : rest(input, init)
     })
     const phases: string[] = []
-    await resilientDownload('https://cdn/file', '/tmp/out.bin', {
+    await resilientDownload('https://cdn/file', OUT_PATH, {
       expectedSha256: sha(body),
       stallTimeoutMs: 20,
       onProgress: (p) => phases.push(`${p.phase}:${p.attempt}`),
@@ -201,7 +207,7 @@ describe('resilientDownload', () => {
       throw err
     })
     await expect(
-      resilientDownload('https://cdn/file', '/tmp/out.bin', {
+      resilientDownload('https://cdn/file', OUT_PATH, {
         signal: controller.signal,
         deps: { fetchImpl: fetchImpl as unknown as typeof fetch, ...fs, sleep: async () => {} }
       })
@@ -235,7 +241,7 @@ describe('resilientDownload', () => {
       return new Promise((resolve) => setTimeout(resolve, ms))
     })
     await expect(
-      resilientDownload('https://cdn/file', '/tmp/out.bin', {
+      resilientDownload('https://cdn/file', OUT_PATH, {
         expectedSha256: sha(body),
         stallTimeoutMs: 20,
         signal: controller.signal,
@@ -252,49 +258,85 @@ describe('resilientDownload', () => {
     expect(call).toBe(1) // second fetch was never started
   })
 
-  it('closes the failed write stream before retry and keeps the hash consistent', async () => {
+  it('fails terminally and destroys the stream when a write callback rejects', async () => {
+    // The write callback itself rejects (a real disk fault: ENOSPC/EIO), NOT merely a stream 'error'
+    // event with a still-succeeding write. A disk fault is terminal — retrying the download cannot fix
+    // a full/unwritable disk, and a partial write may already have hit disk. Assert: rejects, exactly
+    // one fetch (no retry), and the failed stream was destroyed by the cleanup path.
     const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
     const fs = memFs()
-    // Track every write stream so we can assert the failed one was destroyed before the retry.
-    const streams: Array<{ destroyed: boolean }> = []
-    let failNextWrite = true
+    const fetchImpl = fakeFetch(body)
+    let created: Writable | undefined
+    const createWriteStreamImpl = (): import('node:fs').WriteStream => {
+      const w = new Writable({
+        write(_chunk, _enc, cb) {
+          cb(new Error('ENOSPC no space left on device'))
+        }
+      })
+      created = w
+      return w as unknown as import('node:fs').WriteStream
+    }
+    await expect(
+      resilientDownload('https://cdn/file', OUT_PATH, {
+        expectedSha256: sha(body),
+        deps: {
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...fs,
+          createWriteStreamImpl,
+          sleep: async () => {},
+          now: () => 0
+        }
+      })
+    ).rejects.toThrow(/ENOSPC/)
+    expect(fetchImpl.mock.calls.length).toBe(1) // terminal — never retried
+    expect(created?.destroyed).toBe(true) // cleanup path destroyed the failed stream
+  })
+
+  it('destroys the failed write stream before opening a new one on a network retry', async () => {
+    // A retryable NETWORK fault (short read), not a disk fault. Records create/destroy order across
+    // streams and asserts the first stream was destroyed before the second was created — the actual
+    // "clean up before retry" guarantee the earlier emit-only test could not prove.
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const fs = memFs()
+    const events: string[] = []
+    let idx = 0
     const createWriteStreamImpl = (
       path: string,
       o?: { flags?: string }
     ): import('node:fs').WriteStream => {
       if (!o || o.flags !== 'a') fs.files.set(path, Buffer.alloc(0))
+      const id = idx++
+      events.push(`create:${id}`)
       const pt = new PassThrough()
-      const rec = pt as unknown as { destroyed: boolean }
-      streams.push(rec)
-      pt.on('data', (c: Buffer) => {
-        // Fail the very first write to exercise the write-error path with the hash mid-stream.
-        if (failNextWrite) {
-          failNextWrite = false
-          pt.emit('error', new Error('EIO write failed'))
-          return
-        }
+      pt.on('data', (c: Buffer) =>
         fs.files.set(path, Buffer.concat([fs.files.get(path) ?? Buffer.alloc(0), c]))
-      })
+      )
+      pt.on('close', () => events.push(`destroy:${id}`))
       return pt as unknown as import('node:fs').WriteStream
     }
-    const out = await resilientDownload('https://cdn/file', '/tmp/out.bin', {
+    // First fetch delivers a short body (retryable), second completes.
+    const first = fakeFetch(body, { cutAfter: 10 })
+    const rest = fakeFetch(body)
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : rest(input, init)
+    })
+    const out = await resilientDownload('https://cdn/file', OUT_PATH, {
       expectedSha256: sha(body),
       stallTimeoutMs: 50,
       deps: {
-        fetchImpl: fakeFetch(body) as unknown as typeof fetch,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
         ...fs,
         createWriteStreamImpl,
         sleep: async () => {},
         now: () => 0
       }
     })
-    expect(out).toBe('/tmp/out.bin')
-    // The download still succeeds with the correct digest — proof the hash did not run ahead of the
-    // bytes that actually reached disk when the first write failed.
-    expect(fs.files.get('/tmp/out.bin')?.toString()).toBe(body.toString())
-    // The first (failed) write stream was destroyed before the retry opened a new one.
-    expect(streams.length).toBeGreaterThanOrEqual(2)
-    expect(streams[0].destroyed).toBe(true)
+    expect(out).toBe(OUT_PATH)
+    expect(fs.files.get(OUT_PATH)?.toString()).toBe(body.toString())
+    // The first stream is destroyed before the second is created.
+    expect(events.indexOf('destroy:0')).toBeLessThan(events.indexOf('create:1'))
   })
 
   it('does not retry when the final rename fails (terminal)', async () => {
@@ -305,7 +347,7 @@ describe('resilientDownload', () => {
       throw Object.assign(new Error('EXDEV cross-device rename'), { code: 'EXDEV' })
     })
     await expect(
-      resilientDownload('https://cdn/file', '/tmp/out.bin', {
+      resilientDownload('https://cdn/file', OUT_PATH, {
         expectedSha256: sha(body),
         deps: {
           fetchImpl: fetchImpl as unknown as typeof fetch,

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -88,6 +88,8 @@ describe('resilientDownload', () => {
   it('resumes with a Range request after a mid-stream cut', async () => {
     const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
     const fs = memFs()
+    // Count .part reads to prove the hoisted hash is not re-read from disk on the Range resume.
+    const openReadSpy = vi.fn(fs.openReadStreamImpl)
     const first = fakeFetch(body, { cutAfter: 10 })
     const rest = fakeFetch(body)
     let call = 0
@@ -98,12 +100,20 @@ describe('resilientDownload', () => {
     const out = await resilientDownload('https://cdn/file', '/tmp/out.bin', {
       expectedSha256: sha(body),
       stallTimeoutMs: 20,
-      deps: { fetchImpl: fetchImpl as unknown as typeof fetch, ...fs, sleep: async () => {}, now: () => 0 }
+      deps: {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        ...fs,
+        openReadStreamImpl: openReadSpy,
+        sleep: async () => {},
+        now: () => 0
+      }
     })
     expect(out).toBe('/tmp/out.bin')
     expect(fs.files.get('/tmp/out.bin')?.toString()).toBe(body.toString())
     const secondInit = rest.mock.calls[0][1] as { headers: Record<string, string> }
     expect(secondInit.headers['Range']).toBe('bytes=10-')
+    // The 10 already-downloaded bytes stay in the hoisted hash — no .part re-read on resume.
+    expect(openReadSpy).not.toHaveBeenCalled()
   })
 
   it('restarts from zero when server ignores Range (200 on resume)', async () => {

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -1,18 +1,21 @@
 import { createHash } from 'node:crypto'
 import { PassThrough, Readable } from 'node:stream'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, type MockedFunction } from 'vitest'
 
 import { DownloadChecksumError, resilientDownload } from './resilient-download'
 
 // Builds a fake fetch honoring Range header; `cutAfter` truncates the body to simulate a drop.
-const sha = (buf: Buffer) => createHash('sha256').update(buf).digest('hex')
+const sha = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
 
 // Builds a fake fetch that honors Range for resume assertions. When `cutAfter` is set, it reports
 // the FULL remaining content-length (simulating a real mid-stream drop where the server announced
 // the size but closed the socket early) but only delivers `cutAfter` bytes of payload.
 // When `opts.status` is explicitly 200, the Range header is ignored and the full body is served
 // (simulates a server that does not support Range requests).
-const fakeFetch = (body: Buffer, opts: { cutAfter?: number; status?: number } = {}) =>
+const fakeFetch = (
+  body: Buffer,
+  opts: { cutAfter?: number; status?: number } = {}
+): MockedFunction<typeof fetch> =>
   vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
     const headers = (init?.headers ?? {}) as Record<string, string>
     const range = headers['Range'] ?? headers['range']
@@ -35,7 +38,14 @@ const fakeFetch = (body: Buffer, opts: { cutAfter?: number; status?: number } = 
   })
 
 // In-memory fs doubles keyed by path with append/truncate semantics.
-const memFs = () => {
+const memFs = (): {
+  files: Map<string, Buffer>
+  createWriteStreamImpl: (path: string, o?: { flags?: string }) => import('node:fs').WriteStream
+  statImpl: (path: string) => Promise<{ size: number }>
+  rmImpl: (path: string) => Promise<void>
+  renameImpl: (from: string, to: string) => Promise<void>
+  openReadStreamImpl: (path: string) => import('node:fs').ReadStream
+} => {
   const files = new Map<string, Buffer>()
   return {
     files,

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -187,4 +187,47 @@ describe('resilientDownload', () => {
     ).rejects.toThrow()
     expect(fetchImpl.mock.calls.length).toBe(1)
   })
+
+  it('cancels the retry backoff immediately when the signal fires mid-sleep', async () => {
+    const body = Buffer.from('data')
+    const fs = memFs()
+    const controller = new AbortController()
+    let sleepCallCount = 0
+    // First fetch succeeds with a short body so the core detects an incomplete read and schedules
+    // a retry with backoff. The signal is fired just as the backoff sleep starts; the sleep should
+    // resolve immediately rather than waiting the full delay.
+    const first = fakeFetch(body, { cutAfter: 2 }) // short read → retryable
+    const rest = fakeFetch(body)
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : rest(input, init)
+    })
+    const abortAfterFirstFetch = vi.fn(async (ms: number): Promise<void> => {
+      sleepCallCount++
+      if (sleepCallCount === 1) {
+        // Defer the abort to a microtask so sleepOrAbort's Promise.race has already attached the
+        // abort-event listener by the time the signal fires. Aborting synchronously inside the
+        // sleep mock would fire the event before the listener is registered.
+        void Promise.resolve().then(() => controller.abort())
+      }
+      return new Promise((resolve) => setTimeout(resolve, ms))
+    })
+    await expect(
+      resilientDownload('https://cdn/file', '/tmp/out.bin', {
+        expectedSha256: sha(body),
+        stallTimeoutMs: 20,
+        signal: controller.signal,
+        deps: {
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...fs,
+          sleep: abortAfterFirstFetch,
+          now: () => 0
+        }
+      })
+    ).rejects.toThrow()
+    // The download must have been aborted during backoff — not after the full sleep completes.
+    expect(sleepCallCount).toBe(1)
+    expect(call).toBe(1) // second fetch was never started
+  })
 })

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -1,0 +1,180 @@
+import { createHash } from 'node:crypto'
+import { PassThrough, Readable } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DownloadChecksumError, resilientDownload } from './resilient-download'
+
+// Builds a fake fetch honoring Range header; `cutAfter` truncates the body to simulate a drop.
+const sha = (buf: Buffer) => createHash('sha256').update(buf).digest('hex')
+
+// Builds a fake fetch that honors Range for resume assertions. When `cutAfter` is set, it reports
+// the FULL remaining content-length (simulating a real mid-stream drop where the server announced
+// the size but closed the socket early) but only delivers `cutAfter` bytes of payload.
+// When `opts.status` is explicitly 200, the Range header is ignored and the full body is served
+// (simulates a server that does not support Range requests).
+const fakeFetch = (body: Buffer, opts: { cutAfter?: number; status?: number } = {}) =>
+  vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    const headers = (init?.headers ?? {}) as Record<string, string>
+    const range = headers['Range'] ?? headers['range']
+    const rangeStart = range ? Number(/bytes=(\d+)-/.exec(range)?.[1] ?? 0) : 0
+    // A forced status:200 means "server ignored Range" → always serve from 0.
+    const start = opts.status === 200 ? 0 : rangeStart
+    const status = opts.status ?? (rangeStart > 0 ? 206 : 200)
+    const slice = body.subarray(start)
+    const served = opts.cutAfter != null ? slice.subarray(0, opts.cutAfter) : slice
+    const stream = Readable.from([served])
+    return {
+      ok: status < 400,
+      status,
+      headers: {
+        get: (h: string) =>
+          h.toLowerCase() === 'content-length' ? String(slice.length) : null
+      },
+      body: Readable.toWeb(stream)
+    } as unknown as Response
+  })
+
+// In-memory fs doubles keyed by path with append/truncate semantics.
+const memFs = () => {
+  const files = new Map<string, Buffer>()
+  return {
+    files,
+    createWriteStreamImpl: (path: string, o?: { flags?: string }) => {
+      if (!o || o.flags !== 'a') files.set(path, Buffer.alloc(0))
+      const pt = new PassThrough()
+      pt.on('data', (c: Buffer) =>
+        files.set(path, Buffer.concat([files.get(path) ?? Buffer.alloc(0), c]))
+      )
+      return pt as unknown as import('node:fs').WriteStream
+    },
+    statImpl: async (path: string) => {
+      const f = files.get(path)
+      if (!f) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      return { size: f.length }
+    },
+    rmImpl: async (path: string) => void files.delete(path),
+    renameImpl: async (from: string, to: string) => {
+      files.set(to, files.get(from) ?? Buffer.alloc(0))
+      files.delete(from)
+    },
+    openReadStreamImpl: (path: string) =>
+      Readable.from([files.get(path) ?? Buffer.alloc(0)]) as unknown as import('node:fs').ReadStream
+  }
+}
+
+describe('resilientDownload', () => {
+  it('downloads and verifies a clean file', async () => {
+    const body = Buffer.from('hello world payload')
+    const fs = memFs()
+    const out = await resilientDownload('https://cdn/file', '/tmp/out.bin', {
+      expectedSha256: sha(body),
+      deps: { fetchImpl: fakeFetch(body) as unknown as typeof fetch, ...fs, sleep: async () => {} }
+    })
+    expect(out).toBe('/tmp/out.bin')
+    expect(fs.files.get('/tmp/out.bin')?.toString()).toBe('hello world payload')
+    expect(fs.files.has('/tmp/out.bin.part')).toBe(false)
+  })
+
+  it('resumes with a Range request after a mid-stream cut', async () => {
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const fs = memFs()
+    const first = fakeFetch(body, { cutAfter: 10 })
+    const rest = fakeFetch(body)
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : rest(input, init)
+    })
+    const out = await resilientDownload('https://cdn/file', '/tmp/out.bin', {
+      expectedSha256: sha(body),
+      stallTimeoutMs: 20,
+      deps: { fetchImpl: fetchImpl as unknown as typeof fetch, ...fs, sleep: async () => {}, now: () => 0 }
+    })
+    expect(out).toBe('/tmp/out.bin')
+    expect(fs.files.get('/tmp/out.bin')?.toString()).toBe(body.toString())
+    const secondInit = rest.mock.calls[0][1] as { headers: Record<string, string> }
+    expect(secondInit.headers['Range']).toBe('bytes=10-')
+  })
+
+  it('restarts from zero when server ignores Range (200 on resume)', async () => {
+    const body = Buffer.from('0123456789')
+    const fs = memFs()
+    fs.files.set('/tmp/out.bin.part', Buffer.from('GARBAGE'))
+    const out = await resilientDownload('https://cdn/file', '/tmp/out.bin', {
+      expectedSha256: sha(body),
+      deps: { fetchImpl: fakeFetch(body, { status: 200 }), ...fs, sleep: async () => {} }
+    })
+    expect(fs.files.get('/tmp/out.bin')?.toString()).toBe('0123456789')
+    expect(out).toBe('/tmp/out.bin')
+  })
+
+  it('throws DownloadChecksumError and deletes .part on mismatch', async () => {
+    const body = Buffer.from('payload')
+    const fs = memFs()
+    await expect(
+      resilientDownload('https://cdn/file', '/tmp/out.bin', {
+        expectedSha256: 'deadbeef',
+        maxRetries: 0,
+        deps: { fetchImpl: fakeFetch(body) as unknown as typeof fetch, ...fs, sleep: async () => {} }
+      })
+    ).rejects.toBeInstanceOf(DownloadChecksumError)
+    expect(fs.files.has('/tmp/out.bin.part')).toBe(false)
+  })
+
+  it('keeps .part after exhausting retries on 5xx', async () => {
+    const fs = memFs()
+    const failing = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      headers: { get: () => null },
+      body: Readable.toWeb(Readable.from([Buffer.alloc(0)]))
+    }) as unknown as Response)
+    await expect(
+      resilientDownload('https://cdn/file', '/tmp/out.bin', {
+        maxRetries: 2,
+        deps: { fetchImpl: failing as unknown as typeof fetch, ...fs, sleep: async () => {} }
+      })
+    ).rejects.toThrow()
+    expect(failing.mock.calls.length).toBe(3) // initial + 2 retries
+    // .part may or may not exist (503 = no bytes written), but we verify it did NOT get deleted
+    // after-attempts cleanup — only sha256 mismatch deletes it
+  })
+
+  it('emits a reconnecting progress event before a retry', async () => {
+    const body = Buffer.from('abcdefghij')
+    const fs = memFs()
+    const first = fakeFetch(body, { cutAfter: 4 })
+    const rest = fakeFetch(body)
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : rest(input, init)
+    })
+    const phases: string[] = []
+    await resilientDownload('https://cdn/file', '/tmp/out.bin', {
+      expectedSha256: sha(body),
+      stallTimeoutMs: 20,
+      onProgress: (p) => phases.push(`${p.phase}:${p.attempt}`),
+      deps: { fetchImpl: fetchImpl as unknown as typeof fetch, ...fs, sleep: async () => {}, now: () => 0 }
+    })
+    expect(phases).toContain('reconnecting:1')
+  })
+
+  it('aborts via external signal and does not retry', async () => {
+    const fs = memFs()
+    const controller = new AbortController()
+    const fetchImpl = vi.fn(async () => {
+      controller.abort()
+      const err = new Error('aborted')
+      ;(err as { name: string }).name = 'AbortError'
+      throw err
+    })
+    await expect(
+      resilientDownload('https://cdn/file', '/tmp/out.bin', {
+        signal: controller.signal,
+        deps: { fetchImpl: fetchImpl as unknown as typeof fetch, ...fs, sleep: async () => {} }
+      })
+    ).rejects.toThrow()
+    expect(fetchImpl.mock.calls.length).toBe(1)
+  })
+})

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -1,0 +1,226 @@
+import { createHash } from 'node:crypto'
+import { createReadStream, createWriteStream, type WriteStream } from 'node:fs'
+import { rename, rm, stat } from 'node:fs/promises'
+import { Readable } from 'node:stream'
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
+
+import type { DownloadProgress } from '../../shared/download-progress'
+import { SpeedMeter } from './download-speed'
+
+export class DownloadChecksumError extends Error {
+  constructor(message = 'Checksum mismatch') {
+    super(message)
+    this.name = 'DownloadChecksumError'
+  }
+}
+
+export type ResilientDownloadDeps = {
+  fetchImpl?: typeof fetch
+  createWriteStreamImpl?: (path: string, opts?: { flags?: string }) => WriteStream
+  statImpl?: (path: string) => Promise<{ size: number }>
+  rmImpl?: (path: string) => Promise<void>
+  renameImpl?: (from: string, to: string) => Promise<void>
+  openReadStreamImpl?: (path: string) => NodeJS.ReadableStream
+  sleep?: (ms: number) => Promise<void>
+  now?: () => number
+}
+
+export type ResilientDownloadOpts = {
+  expectedSha256?: string
+  expectedSize?: number
+  maxRetries?: number
+  stallTimeoutMs?: number
+  signal?: AbortSignal
+  onProgress?: (p: DownloadProgress) => void
+  deps?: ResilientDownloadDeps
+}
+
+const DEFAULT_MAX_RETRIES = 5
+const DEFAULT_STALL_MS = 60_000
+const BASE_BACKOFF_MS = 1_000
+const MAX_BACKOFF_MS = 30_000
+
+// Signals that a server closed the stream before delivering all expected bytes (short read).
+class IncompleteStreamError extends Error {}
+
+const isAbortError = (e: unknown): boolean =>
+  e instanceof Error && (e.name === 'AbortError' || e.name === 'TimeoutError')
+
+export const resilientDownload = async (
+  url: string,
+  destPath: string,
+  opts: ResilientDownloadOpts = {}
+): Promise<string> => {
+  const d = opts.deps ?? {}
+  const fetchImpl = d.fetchImpl ?? fetch
+  const mkWrite = d.createWriteStreamImpl ?? ((p, o) => createWriteStream(p, o))
+  const statFile = d.statImpl ?? ((p) => stat(p))
+  const removeFile = d.rmImpl ?? ((p) => rm(p, { force: true }))
+  const renameFile = d.renameImpl ?? rename
+  const openRead = d.openReadStreamImpl ?? ((p) => createReadStream(p))
+  const sleep = d.sleep ?? ((ms) => new Promise<void>((r) => setTimeout(r, ms)))
+  const now = d.now ?? (() => Date.now())
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES
+  const stallMs = opts.stallTimeoutMs ?? DEFAULT_STALL_MS
+  const partPath = `${destPath}.part`
+
+  const partSize = async (): Promise<number> => {
+    try {
+      return (await statFile(partPath)).size
+    } catch {
+      return 0
+    }
+  }
+
+  // Re-feed the existing .part into the hash so a resumed download's digest covers the whole file.
+  const seedHash = async (
+    hash: ReturnType<typeof createHash>,
+    bytes: number
+  ): Promise<void> => {
+    if (bytes <= 0) return
+    await new Promise<void>((resolve, reject) => {
+      const rs = openRead(partPath)
+      ;(rs as NodeJS.ReadableStream).on('data', (c: Buffer) => hash.update(c))
+      ;(rs as NodeJS.ReadableStream).on('end', () => resolve())
+      ;(rs as NodeJS.ReadableStream).on('error', reject)
+    })
+  }
+
+  let lastError: unknown
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (opts.signal?.aborted) throw opts.signal.reason ?? new Error('aborted')
+
+    if (attempt > 0) {
+      const offset = await partSize()
+      opts.onProgress?.({ phase: 'reconnecting', transferred: offset, bytesPerSecond: 0, attempt })
+      const backoff = Math.min(BASE_BACKOFF_MS * 2 ** (attempt - 1), MAX_BACKOFF_MS)
+      await sleep(backoff + Math.floor((now() % 1000) / 4))
+    }
+
+    const controller = new AbortController()
+    let stallTimer: ReturnType<typeof setTimeout> | undefined
+    const armStall = (): void => {
+      if (stallTimer) clearTimeout(stallTimer)
+      stallTimer = setTimeout(
+        () => controller.abort(new Error(`stalled >${stallMs}ms`)),
+        stallMs
+      )
+    }
+    const combined = opts.signal
+      ? AbortSignal.any([controller.signal, opts.signal])
+      : controller.signal
+
+    try {
+      let offset = await partSize()
+      const headers: Record<string, string> = {}
+      if (offset > 0) headers['Range'] = `bytes=${offset}-`
+
+      armStall()
+      const res = await fetchImpl(url, { headers, signal: combined })
+
+      if (res.status >= 500) throw new Error(`server error ${res.status}`)
+      if (res.status >= 400 && res.status < 500) {
+        // Terminal: 4xx errors are not transient network problems.
+        const err = new Error(`request failed (${res.status})`)
+        ;(err as { terminal?: boolean }).terminal = true
+        throw err
+      }
+      if (res.status !== 200 && res.status !== 206) {
+        throw new Error(`unexpected status ${res.status}`)
+      }
+      if (!res.body) throw new Error('response had no body')
+
+      // Server returned 200 while we had a partial — it ignored Range, so discard and restart.
+      const resuming = res.status === 206 && offset > 0
+      if (!resuming && offset > 0) {
+        await removeFile(partPath)
+        offset = 0
+      }
+
+      const hash = createHash('sha256')
+      await seedHash(hash, offset)
+
+      const rawContentLength = Number(res.headers.get('content-length'))
+      const total =
+        rawContentLength > 0
+          ? offset + rawContentLength
+          : opts.expectedSize
+      const meter = new SpeedMeter({ now })
+      let transferred = offset
+      meter.record(transferred)
+      opts.onProgress?.({
+        phase: 'downloading',
+        transferred,
+        total,
+        percent: total ? Math.round((transferred / total) * 100) : undefined,
+        bytesPerSecond: 0,
+        attempt
+      })
+
+      const file: WriteStream = mkWrite(partPath, offset > 0 ? { flags: 'a' } : undefined)
+      let fileError: Error | null = null
+      file.on('error', (e) => (fileError = e))
+
+      const nodeStream = Readable.fromWeb(
+        res.body as unknown as NodeReadableStream<Uint8Array>
+      )
+      for await (const chunk of nodeStream) {
+        if (fileError) throw fileError
+        const buf = Buffer.from(chunk as Uint8Array)
+        hash.update(buf)
+        await new Promise<void>((resolve, reject) =>
+          file.write(buf, (e) => (e ? reject(e) : resolve()))
+        )
+        transferred += buf.length
+        meter.record(transferred)
+        armStall()
+        const bps = meter.bytesPerSecond()
+        opts.onProgress?.({
+          phase: 'downloading',
+          transferred,
+          total,
+          percent: total ? Math.round((transferred / total) * 100) : undefined,
+          bytesPerSecond: bps,
+          etaSeconds: meter.etaSeconds(total),
+          attempt
+        })
+      }
+
+      await new Promise<void>((resolve, reject) =>
+        file.end((e?: Error | null) => (e ? reject(e) : resolve()))
+      )
+      if (stallTimer) clearTimeout(stallTimer)
+      if (fileError) throw fileError
+
+      // A short read (stream closed before content-length) — retry with Range.
+      if (total != null && transferred < total) throw new IncompleteStreamError('short read')
+
+      if (opts.expectedSha256 && hash.digest('hex') !== opts.expectedSha256) {
+        await removeFile(partPath)
+        throw new DownloadChecksumError()
+      }
+
+      await renameFile(partPath, destPath)
+      opts.onProgress?.({
+        phase: 'downloading',
+        transferred,
+        total: total ?? transferred,
+        percent: 100,
+        bytesPerSecond: 0,
+        etaSeconds: 0,
+        attempt
+      })
+      return destPath
+    } catch (error) {
+      if (stallTimer) clearTimeout(stallTimer)
+      // Terminal errors: never retry.
+      if (error instanceof DownloadChecksumError) throw error
+      if ((error as { terminal?: boolean }).terminal) throw error
+      if (opts.signal?.aborted) throw opts.signal.reason ?? error
+      if (isAbortError(error) && !controller.signal.aborted) throw error
+      lastError = error
+      // Retryable (network/stall/5xx/incomplete) — continue to next attempt.
+    }
+  }
+  throw lastError ?? new Error('download failed after retries')
+}

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -27,6 +27,10 @@ export type ResilientDownloadDeps = {
 
 export type ResilientDownloadOpts = {
   expectedSha256?: string
+  // Expected total byte size, normally from a manifest. Short-read detection (retry a stream that
+  // closes early) needs a known total: it comes from the response Content-Length OR this field. If
+  // both are absent, a silently truncated stream is accepted without retry — callers that may hit a
+  // server or CDN redirect that strips Content-Length should always supply this from their manifest.
   expectedSize?: number
   maxRetries?: number
   stallTimeoutMs?: number
@@ -103,6 +107,22 @@ export const resilientDownload = async (
     ])
   }
 
+  // Hoist the hash above the retry loop. The hash is fed bytes incrementally chunk-by-chunk during
+  // each attempt; hoisting avoids re-reading the entire .part from disk on every retry (for a 200 MB
+  // pack that drops at 150 MB and retries 5× that saves 5 × 150 MB = 750 MB of extra disk I/O).
+  // `hashSeededTo` tracks how many bytes are accounted for in the hash so the catch path can
+  // reconcile when the .part is behind the hash (partial OS flush after destroy).
+  let hash = createHash('sha256')
+  let hashSeededTo = 0
+
+  // Seed from any .part that already exists before the first attempt (e.g. a manual retry after the
+  // app was restarted; within a session this is usually 0 and is a no-op).
+  {
+    const initial = await partSize()
+    await seedHash(hash, initial)
+    hashSeededTo = initial
+  }
+
   let lastError: unknown
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     if (opts.signal?.aborted) throw opts.signal.reason ?? new Error('aborted')
@@ -159,10 +179,17 @@ export const resilientDownload = async (
       if (!resuming && offset > 0) {
         await removeFile(partPath)
         offset = 0
+        // Reset the hoisted hash since we are restarting from byte 0.
+        hash = createHash('sha256')
+        hashSeededTo = 0
+      } else if (offset < hashSeededTo) {
+        // The .part was truncated below the hash cursor (OS did not flush all writes before destroy).
+        // Re-seed the hash from disk to bring it back in sync.
+        hash = createHash('sha256')
+        await seedHash(hash, offset)
+        hashSeededTo = offset
       }
-
-      const hash = createHash('sha256')
-      await seedHash(hash, offset)
+      // else: hash already covers [0, offset) — no I/O needed.
 
       const rawContentLength = Number(res.headers.get('content-length'))
       const total =
@@ -195,6 +222,9 @@ export const resilientDownload = async (
           file!.write(buf, (e) => (e ? reject(e) : resolve()))
         )
         transferred += buf.length
+        // The hash now covers every byte up to `transferred`. Track it so a failed attempt leaves
+        // hashSeededTo accurate; the next attempt only re-seeds if the .part flushed fewer bytes.
+        hashSeededTo = transferred
         meter.record(transferred)
         armStall()
         const bps = meter.bytesPerSecond()

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -77,10 +77,7 @@ export const resilientDownload = async (
   }
 
   // Re-feed the existing .part into the hash so a resumed download's digest covers the whole file.
-  const seedHash = async (
-    hash: ReturnType<typeof createHash>,
-    bytes: number
-  ): Promise<void> => {
+  const seedHash = async (hash: ReturnType<typeof createHash>, bytes: number): Promise<void> => {
     if (bytes <= 0) return
     await new Promise<void>((resolve, reject) => {
       const rs = openRead(partPath)
@@ -98,11 +95,9 @@ export const resilientDownload = async (
     return Promise.race([
       sleepFn(ms),
       new Promise<never>((_, reject) => {
-        signal.addEventListener(
-          'abort',
-          () => reject(signal.reason ?? new Error('aborted')),
-          { once: true }
-        )
+        signal.addEventListener('abort', () => reject(signal.reason ?? new Error('aborted')), {
+          once: true
+        })
       })
     ])
   }
@@ -129,7 +124,20 @@ export const resilientDownload = async (
 
     if (attempt > 0) {
       const offset = await partSize()
-      opts.onProgress?.({ phase: 'reconnecting', transferred: offset, bytesPerSecond: 0, attempt })
+      // Carry the known total/percent (from the manifest expectedSize) through the reconnect so the
+      // UI holds the resume position instead of collapsing to an indeterminate bar mid-retry.
+      const reconnectTotal = opts.expectedSize
+      opts.onProgress?.({
+        phase: 'reconnecting',
+        transferred: offset,
+        total: reconnectTotal,
+        percent:
+          reconnectTotal && reconnectTotal > 0
+            ? Math.round((offset / reconnectTotal) * 100)
+            : undefined,
+        bytesPerSecond: 0,
+        attempt
+      })
       const backoff = Math.min(BASE_BACKOFF_MS * 2 ** (attempt - 1), MAX_BACKOFF_MS)
       // Race the backoff sleep against the external abort signal so a user cancel does not wait up
       // to MAX_BACKOFF_MS before taking effect.
@@ -140,10 +148,7 @@ export const resilientDownload = async (
     let stallTimer: ReturnType<typeof setTimeout> | undefined
     const armStall = (): void => {
       if (stallTimer) clearTimeout(stallTimer)
-      stallTimer = setTimeout(
-        () => controller.abort(new Error(`stalled >${stallMs}ms`)),
-        stallMs
-      )
+      stallTimer = setTimeout(() => controller.abort(new Error(`stalled >${stallMs}ms`)), stallMs)
     }
     const combined = opts.signal
       ? AbortSignal.any([controller.signal, opts.signal])
@@ -192,10 +197,7 @@ export const resilientDownload = async (
       // else: hash already covers [0, offset) — no I/O needed.
 
       const rawContentLength = Number(res.headers.get('content-length'))
-      const total =
-        rawContentLength > 0
-          ? offset + rawContentLength
-          : opts.expectedSize
+      const total = rawContentLength > 0 ? offset + rawContentLength : opts.expectedSize
       const meter = new SpeedMeter({ now })
       let transferred = offset
       meter.record(transferred)
@@ -211,19 +213,20 @@ export const resilientDownload = async (
       file = mkWrite(partPath, offset > 0 ? { flags: 'a' } : undefined)
       file.on('error', (e) => (fileError = e))
 
-      const nodeStream = Readable.fromWeb(
-        res.body as unknown as NodeReadableStream<Uint8Array>
-      )
+      const nodeStream = Readable.fromWeb(res.body as unknown as NodeReadableStream<Uint8Array>)
       for await (const chunk of nodeStream) {
         if (fileError) throw fileError
         const buf = Buffer.from(chunk as Uint8Array)
-        hash.update(buf)
+        // Update the hash only AFTER the write is confirmed. If the write callback rejects, the hash
+        // must NOT have consumed these bytes — otherwise it runs ahead of the persisted .part and,
+        // when the next attempt resumes at the same offset (no re-seed), the digest is corrupted.
+        // hash, transferred, and hashSeededTo advance together in lockstep, with no await between
+        // them, so a failed attempt always leaves the three consistent.
         await new Promise<void>((resolve, reject) =>
           file!.write(buf, (e) => (e ? reject(e) : resolve()))
         )
+        hash.update(buf)
         transferred += buf.length
-        // The hash now covers every byte up to `transferred`. Track it so a failed attempt leaves
-        // hashSeededTo accurate; the next attempt only re-seeds if the .part flushed fewer bytes.
         hashSeededTo = transferred
         meter.record(transferred)
         armStall()
@@ -254,7 +257,15 @@ export const resilientDownload = async (
         throw new DownloadChecksumError()
       }
 
-      await renameFile(partPath, destPath)
+      // Finalization. digest() above consumed the hash, so it cannot be reused; and a rename failure
+      // (EXDEV, EPERM, disk full) is not a transient network fault. Mark any error here terminal so
+      // the retry loop does not spin on a dead hash or a rename that will never succeed.
+      try {
+        await renameFile(partPath, destPath)
+      } catch (renameError) {
+        ;(renameError as { terminal?: boolean }).terminal = true
+        throw renameError
+      }
       opts.onProgress?.({
         phase: 'downloading',
         transferred,
@@ -273,7 +284,10 @@ export const resilientDownload = async (
         const f = file
         file = undefined
         await new Promise<void>((resolve) => {
-          if (f.destroyed) { resolve(); return }
+          if (f.destroyed) {
+            resolve()
+            return
+          }
           f.once('close', resolve)
           f.destroy()
         })

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -86,6 +86,23 @@ export const resilientDownload = async (
     })
   }
 
+  // Resolves after `ms` ms but rejects early when the external abort signal fires, so a user
+  // cancel during exponential backoff does not wait up to MAX_BACKOFF_MS before taking effect.
+  const sleepOrAbort = (sleepFn: typeof sleep, ms: number, signal?: AbortSignal): Promise<void> => {
+    if (!signal) return sleepFn(ms)
+    if (signal.aborted) return Promise.reject(signal.reason ?? new Error('aborted'))
+    return Promise.race([
+      sleepFn(ms),
+      new Promise<never>((_, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => reject(signal.reason ?? new Error('aborted')),
+          { once: true }
+        )
+      })
+    ])
+  }
+
   let lastError: unknown
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     if (opts.signal?.aborted) throw opts.signal.reason ?? new Error('aborted')
@@ -94,7 +111,9 @@ export const resilientDownload = async (
       const offset = await partSize()
       opts.onProgress?.({ phase: 'reconnecting', transferred: offset, bytesPerSecond: 0, attempt })
       const backoff = Math.min(BASE_BACKOFF_MS * 2 ** (attempt - 1), MAX_BACKOFF_MS)
-      await sleep(backoff + Math.floor((now() % 1000) / 4))
+      // Race the backoff sleep against the external abort signal so a user cancel does not wait up
+      // to MAX_BACKOFF_MS before taking effect.
+      await sleepOrAbort(sleep, backoff + Math.floor((now() % 1000) / 4), opts.signal)
     }
 
     const controller = new AbortController()
@@ -109,6 +128,11 @@ export const resilientDownload = async (
     const combined = opts.signal
       ? AbortSignal.any([controller.signal, opts.signal])
       : controller.signal
+
+    // Hoisted so the catch path can destroy the descriptor before the next retry attempt,
+    // preventing descriptor leaks and Windows rename/append failures on a retried .part file.
+    let file: WriteStream | undefined
+    let fileError: Error | null = null
 
     try {
       let offset = await partSize()
@@ -157,8 +181,7 @@ export const resilientDownload = async (
         attempt
       })
 
-      const file: WriteStream = mkWrite(partPath, offset > 0 ? { flags: 'a' } : undefined)
-      let fileError: Error | null = null
+      file = mkWrite(partPath, offset > 0 ? { flags: 'a' } : undefined)
       file.on('error', (e) => (fileError = e))
 
       const nodeStream = Readable.fromWeb(
@@ -169,7 +192,7 @@ export const resilientDownload = async (
         const buf = Buffer.from(chunk as Uint8Array)
         hash.update(buf)
         await new Promise<void>((resolve, reject) =>
-          file.write(buf, (e) => (e ? reject(e) : resolve()))
+          file!.write(buf, (e) => (e ? reject(e) : resolve()))
         )
         transferred += buf.length
         meter.record(transferred)
@@ -187,8 +210,9 @@ export const resilientDownload = async (
       }
 
       await new Promise<void>((resolve, reject) =>
-        file.end((e?: Error | null) => (e ? reject(e) : resolve()))
+        file!.end((e?: Error | null) => (e ? reject(e) : resolve()))
       )
+      file = undefined // fd closed cleanly — no cleanup needed in catch
       if (stallTimer) clearTimeout(stallTimer)
       if (fileError) throw fileError
 
@@ -213,12 +237,24 @@ export const resilientDownload = async (
       return destPath
     } catch (error) {
       if (stallTimer) clearTimeout(stallTimer)
+      // Close any open write descriptor before the next retry so the .part file is not held open
+      // across attempts (prevents descriptor leaks and Windows rename/append failures).
+      if (file !== undefined) {
+        const f = file
+        file = undefined
+        await new Promise<void>((resolve) => {
+          if (f.destroyed) { resolve(); return }
+          f.once('close', resolve)
+          f.destroy()
+        })
+      }
       // Terminal errors: never retry.
       if (error instanceof DownloadChecksumError) throw error
       if ((error as { terminal?: boolean }).terminal) throw error
       if (opts.signal?.aborted) throw opts.signal.reason ?? error
       if (isAbortError(error) && !controller.signal.aborted) throw error
       lastError = error
+      fileError = null // reset per-attempt error tracker
       // Retryable (network/stall/5xx/incomplete) — continue to next attempt.
     }
   }

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -269,7 +269,11 @@ export const resilientDownload = async (
       if (total != null && transferred < total) throw new IncompleteStreamError('short read')
 
       if (opts.expectedSha256 && hash.digest('hex') !== opts.expectedSha256) {
-        await removeFile(partPath)
+        // digest() has finalized the hash, so it can never be reused on a retry. Guarantee the
+        // DownloadChecksumError is what propagates: if the .part cleanup itself fails (EACCES/EIO),
+        // swallow that error rather than let it escape — otherwise the loop would retry with a dead
+        // hash. A leftover .part is harmless (the next run re-checks or overwrites it).
+        await removeFile(partPath).catch(() => undefined)
         throw new DownloadChecksumError()
       }
 

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -47,6 +47,15 @@ const MAX_BACKOFF_MS = 30_000
 // Signals that a server closed the stream before delivering all expected bytes (short read).
 class IncompleteStreamError extends Error {}
 
+// Marks an error terminal so the retry loop rethrows instead of retrying. Local filesystem faults
+// (open/write/end failing with ENOSPC, EIO, EACCES, …) and rename failures are not transient network
+// problems — re-downloading will not fix a full or unwritable disk, and after a partial write the
+// on-disk .part can be left in a state the resume math should not paper over. Fail fast and loud.
+const markTerminal = <E>(error: E): E => {
+  ;(error as { terminal?: boolean }).terminal = true
+  return error
+}
+
 const isAbortError = (e: unknown): boolean =>
   e instanceof Error && (e.name === 'AbortError' || e.name === 'TimeoutError')
 
@@ -187,9 +196,13 @@ export const resilientDownload = async (
         // Reset the hoisted hash since we are restarting from byte 0.
         hash = createHash('sha256')
         hashSeededTo = 0
-      } else if (offset < hashSeededTo) {
-        // The .part was truncated below the hash cursor (OS did not flush all writes before destroy).
-        // Re-seed the hash from disk to bring it back in sync.
+      } else if (offset !== hashSeededTo) {
+        // The hash cursor and the on-disk .part disagree, so re-seed the hash from disk to match the
+        // exact bytes we are about to resume after. This covers both directions:
+        //  - offset < hashSeededTo: the .part was truncated below the cursor (partial OS flush).
+        //  - offset > hashSeededTo: bytes reached disk that the hash never consumed. File writes are
+        //    terminal now, so this should be unreachable — but re-seeding keeps the digest correct
+        //    rather than silently skipping the gap and later failing checksum.
         hash = createHash('sha256')
         await seedHash(hash, offset)
         hashSeededTo = offset
@@ -211,7 +224,8 @@ export const resilientDownload = async (
       })
 
       file = mkWrite(partPath, offset > 0 ? { flags: 'a' } : undefined)
-      file.on('error', (e) => (fileError = e))
+      // A stream 'error' is a local disk fault (ENOSPC/EIO/…), not a network problem — terminal.
+      file.on('error', (e) => (fileError = markTerminal(e)))
 
       const nodeStream = Readable.fromWeb(res.body as unknown as NodeReadableStream<Uint8Array>)
       for await (const chunk of nodeStream) {
@@ -221,9 +235,10 @@ export const resilientDownload = async (
         // must NOT have consumed these bytes — otherwise it runs ahead of the persisted .part and,
         // when the next attempt resumes at the same offset (no re-seed), the digest is corrupted.
         // hash, transferred, and hashSeededTo advance together in lockstep, with no await between
-        // them, so a failed attempt always leaves the three consistent.
+        // them, so a failed attempt always leaves the three consistent. A write fault is terminal:
+        // a partial write may have reached disk, and re-downloading will not fix a bad disk.
         await new Promise<void>((resolve, reject) =>
-          file!.write(buf, (e) => (e ? reject(e) : resolve()))
+          file!.write(buf, (e) => (e ? reject(markTerminal(e)) : resolve()))
         )
         hash.update(buf)
         transferred += buf.length
@@ -242,8 +257,9 @@ export const resilientDownload = async (
         })
       }
 
+      // Flushing/closing the fd failed — a local disk fault, terminal like the per-chunk writes.
       await new Promise<void>((resolve, reject) =>
-        file!.end((e?: Error | null) => (e ? reject(e) : resolve()))
+        file!.end((e?: Error | null) => (e ? reject(markTerminal(e)) : resolve()))
       )
       file = undefined // fd closed cleanly — no cleanup needed in catch
       if (stallTimer) clearTimeout(stallTimer)
@@ -263,8 +279,7 @@ export const resilientDownload = async (
       try {
         await renameFile(partPath, destPath)
       } catch (renameError) {
-        ;(renameError as { terminal?: boolean }).terminal = true
-        throw renameError
+        throw markTerminal(renameError)
       }
       opts.onProgress?.({
         phase: 'downloading',

--- a/src/main/notebook/bundle-manifest.ts
+++ b/src/main/notebook/bundle-manifest.ts
@@ -222,16 +222,16 @@ export const sha256File = (path: string): Promise<string> =>
 // the whole file through sha256 and compares. Throws on any mismatch so the caller drops the partial
 // pack and reports an actionable provisioning error.
 //
-// `opts.skipHash` runs the size check only, skipping the full-file sha256 pass. Use it when the file
-// was just streamed and sha256-verified inline by the resilient download core (which renames into
-// place only after the digest matches) — re-hashing hundreds of MB a second time is pure waste on the
-// provisioning hot path. Local bundled packs (bundle-local) are NOT inline-verified, so they must keep
-// the full hash and leave skipHash unset.
+// Defense-in-depth (INTENTIONAL — do not "optimize" into a size-only check): the resilient download
+// core already verifies sha256 inline while streaming, but this independent post-download re-hash is a
+// required, separate integrity gate per the plan. It catches corruption that inline hashing cannot —
+// a bad disk sector or another process mutating the file between the core's rename and extraction —
+// on a runtime the app will execute. The extra full-file read is a deliberate correctness/perf
+// tradeoff for a large, long-lived, executed artifact, not redundant work.
 export const verifyPackChecksum = async (
   filePath: string,
   expected: { sha256: string; size?: number },
-  deps: VerifyDeps = {},
-  opts: { skipHash?: boolean } = {}
+  deps: VerifyDeps = {}
 ): Promise<void> => {
   if (typeof expected.size === 'number') {
     const actualSize = statSync(filePath).size
@@ -239,7 +239,6 @@ export const verifyPackChecksum = async (
       throw new Error(`size mismatch for ${filePath}: expected ${expected.size}, got ${actualSize}`)
     }
   }
-  if (opts.skipHash) return
   const sha256Of = deps.sha256 ?? sha256File
   const actual = await sha256Of(filePath)
   if (actual.toLowerCase() !== expected.sha256.toLowerCase()) {

--- a/src/main/notebook/bundle-manifest.ts
+++ b/src/main/notebook/bundle-manifest.ts
@@ -221,10 +221,17 @@ export const sha256File = (path: string): Promise<string> =>
 // `size` is given (a cheap pre-check that catches a truncated download without hashing), then streams
 // the whole file through sha256 and compares. Throws on any mismatch so the caller drops the partial
 // pack and reports an actionable provisioning error.
+//
+// `opts.skipHash` runs the size check only, skipping the full-file sha256 pass. Use it when the file
+// was just streamed and sha256-verified inline by the resilient download core (which renames into
+// place only after the digest matches) — re-hashing hundreds of MB a second time is pure waste on the
+// provisioning hot path. Local bundled packs (bundle-local) are NOT inline-verified, so they must keep
+// the full hash and leave skipHash unset.
 export const verifyPackChecksum = async (
   filePath: string,
   expected: { sha256: string; size?: number },
-  deps: VerifyDeps = {}
+  deps: VerifyDeps = {},
+  opts: { skipHash?: boolean } = {}
 ): Promise<void> => {
   if (typeof expected.size === 'number') {
     const actualSize = statSync(filePath).size
@@ -232,6 +239,7 @@ export const verifyPackChecksum = async (
       throw new Error(`size mismatch for ${filePath}: expected ${expected.size}, got ${actualSize}`)
     }
   }
+  if (opts.skipHash) return
   const sha256Of = deps.sha256 ?? sha256File
   const actual = await sha256Of(filePath)
   if (actual.toLowerCase() !== expected.sha256.toLowerCase()) {

--- a/src/main/notebook/language-pack-fetch.test.ts
+++ b/src/main/notebook/language-pack-fetch.test.ts
@@ -17,6 +17,7 @@ import {
   fetchLanguagePack,
   type LanguagePackFetchDeps
 } from './language-pack-fetch'
+import type { ProvisionProgress } from './provisioner'
 
 const makeDestDir = (): string => mkdtempSync(join(tmpdir(), 'os-pack-'))
 
@@ -167,9 +168,23 @@ describe('createFetchBundleAdapter', () => {
     const deps = makeDeps({}, m)
     const writeDownload = deps.download
     deps.download = vi.fn(async (url, destPath, onProgress) => {
-      onProgress?.(50, 200)
+      onProgress?.({
+        phase: 'downloading',
+        transferred: 50,
+        total: 200,
+        percent: 25,
+        bytesPerSecond: 1000,
+        attempt: 0
+      })
       await writeDownload(url, destPath)
-      onProgress?.(200, 200)
+      onProgress?.({
+        phase: 'downloading',
+        transferred: 200,
+        total: 200,
+        percent: 100,
+        bytesPerSecond: 1000,
+        attempt: 0
+      })
     })
     const extract = vi.fn(async (_archivePath: string, destDir: string) => {
       await mkdir(destDir, { recursive: true })
@@ -179,7 +194,7 @@ describe('createFetchBundleAdapter', () => {
       )
       await writeFile(join(destDir, 'package-1.conda'), packageBytes)
     })
-    const progress: Array<{ message: string; progress: number }> = []
+    const progress: ProvisionProgress[] = []
     const adapter = createFetchBundleAdapter(root, 'https://cdn/envs', {
       ...deps,
       subdir: 'osx-arm64',
@@ -209,6 +224,9 @@ describe('createFetchBundleAdapter', () => {
       'Downloading managed python runtime (100%)'
     )
     expect(progress.map((event) => event.message)).toContain('Downloaded python-3.12.tar.zst')
+    // A download-phase event carries the nested DownloadProgress detail for the UI speed line.
+    const withDownload = progress.find((event) => event.download)
+    expect(withDownload?.download).toMatchObject({ phase: 'downloading', attempt: 0 })
     await rm(root, { recursive: true, force: true })
   })
 

--- a/src/main/notebook/language-pack-fetch.test.ts
+++ b/src/main/notebook/language-pack-fetch.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -336,4 +336,37 @@ describe('createFetchBundleAdapter', () => {
       )
     }
   )
+
+  it('preserves a partial .part in the stable cache when a download fails, for resume', async () => {
+    // Simulate an interrupted download: write a .part next to the archive destPath, then throw. The
+    // adapter must wipe the disposable .incoming-* staging in its finally, but LEAVE the .part so a
+    // manual retry resumes via Range instead of restarting the whole pack.
+    const root = makeDestDir()
+    const deps = makeDeps()
+    let partPath = ''
+    deps.download = vi.fn(async (_url: string, destPath: string) => {
+      partPath = `${destPath}.part`
+      writeFileSync(partPath, Buffer.from('partial-bytes'))
+      throw new Error('ECONNRESET mid-download')
+    })
+    const adapter = createFetchBundleAdapter(root, 'https://cdn/envs', {
+      ...deps,
+      subdir: 'osx-arm64'
+    })
+    await expect(
+      adapter(
+        { name: 'default-python', language: 'python', version: '3.12', packages: [] },
+        1,
+        () => {}
+      )
+    ).rejects.toThrow(/Managed runtime pack unavailable/)
+
+    // The .part survived in the stable .cache dir…
+    expect(partPath).toContain(join('packs', '.cache'))
+    expect(existsSync(partPath)).toBe(true)
+    // …while no .incoming-* staging dir was left behind.
+    const leftovers = readdirSync(join(root, 'packs')).filter((n) => n.startsWith('.incoming-'))
+    expect(leftovers).toEqual([])
+    await rm(root, { recursive: true, force: true })
+  })
 })

--- a/src/main/notebook/language-pack-fetch.test.ts
+++ b/src/main/notebook/language-pack-fetch.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import { describe, expect, it, vi } from 'vitest'
 
@@ -380,7 +380,7 @@ describe('createFetchBundleAdapter', () => {
       const deps = makeDeps()
       let dir = ''
       deps.download = vi.fn(async (_url: string, destPath: string) => {
-        dir = destPath.slice(0, destPath.lastIndexOf('/'))
+        dir = dirname(destPath) // dirname, not lastIndexOf('/'), so the dir is correct on Windows too
         throw new Error('stop after capturing the path')
       })
       return { deps, dirOf: () => dir }

--- a/src/main/notebook/language-pack-fetch.test.ts
+++ b/src/main/notebook/language-pack-fetch.test.ts
@@ -111,16 +111,15 @@ describe('fetchLanguagePack', () => {
     ).rejects.toThrow(/sha256 mismatch/)
   })
 
-  it('skips the post-download re-hash when the downloader verified inline', async () => {
-    // downloadVerifiesInline signals the pack was already sha256-verified by the resilient core, so
-    // verifyPackChecksum should NOT re-hash — a deliberately wrong sha256 hasher must not be consulted.
+  it('runs an independent post-download sha256 verification (defense-in-depth)', async () => {
+    // Even though the production download verifies inline, fetchLanguagePack must still run its own
+    // post-download hash as a separate integrity gate. A wrong hasher here must fail the fetch.
     const sha256 = vi.fn(async () => 'f'.repeat(64))
-    const deps = makeDeps({ sha256, downloadVerifiesInline: true })
-    const result = await fetchLanguagePack(
-      makeDestDir(), 'https://cdn/envs', 1, 'osx-arm64', 'python', '3.11', deps
-    )
-    expect(result.id).toBe('python-3.11')
-    expect(sha256).not.toHaveBeenCalled()
+    const deps = makeDeps({ sha256 })
+    await expect(
+      fetchLanguagePack(makeDestDir(), 'https://cdn/envs', 1, 'osx-arm64', 'python', '3.11', deps)
+    ).rejects.toThrow(/sha256 mismatch/)
+    expect(sha256).toHaveBeenCalled()
   })
 
   it('rejects a version that was not published', async () => {

--- a/src/main/notebook/language-pack-fetch.test.ts
+++ b/src/main/notebook/language-pack-fetch.test.ts
@@ -361,8 +361,8 @@ describe('createFetchBundleAdapter', () => {
       )
     ).rejects.toThrow(/Managed runtime pack unavailable/)
 
-    // The .part survived in the stable .cache dir…
-    expect(partPath).toContain(join('packs', '.cache'))
+    // The .part survived in the stable, version/subdir-keyed .cache dir…
+    expect(partPath).toContain(join('packs', '.cache', '1', 'osx-arm64'))
     expect(existsSync(partPath)).toBe(true)
     // …while no .incoming-* staging dir was left behind.
     const leftovers = readdirSync(join(root, 'packs')).filter((n) => n.startsWith('.incoming-'))

--- a/src/main/notebook/language-pack-fetch.test.ts
+++ b/src/main/notebook/language-pack-fetch.test.ts
@@ -361,12 +361,53 @@ describe('createFetchBundleAdapter', () => {
       )
     ).rejects.toThrow(/Managed runtime pack unavailable/)
 
-    // The .part survived in the stable, version/subdir-keyed .cache dir…
-    expect(partPath).toContain(join('packs', '.cache', '1', 'osx-arm64'))
+    // The .part survived, under a per-session cache key then the version/subdir segments.
+    expect(partPath).toContain(join('packs', '.cache'))
+    expect(partPath.endsWith(join('1', 'osx-arm64', 'python-3.12.tar.zst.part'))).toBe(true)
     expect(existsSync(partPath)).toBe(true)
     // …while no .incoming-* staging dir was left behind.
     const leftovers = readdirSync(join(root, 'packs')).filter((n) => n.startsWith('.incoming-'))
     expect(leftovers).toEqual([])
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('uses a distinct cache dir per adapter instance so a prior session cannot resume', async () => {
+    // Two adapters model two app sessions. Each must download under its OWN cache key, so one
+    // session's leftover .part is invisible to the other — the "start from scratch" guarantee holds
+    // by construction, independent of the startup wipe. Capture each session's archive dir.
+    const root = makeDestDir()
+    const capture = (): { deps: ReturnType<typeof makeDeps>; dirOf: () => string } => {
+      const deps = makeDeps()
+      let dir = ''
+      deps.download = vi.fn(async (_url: string, destPath: string) => {
+        dir = destPath.slice(0, destPath.lastIndexOf('/'))
+        throw new Error('stop after capturing the path')
+      })
+      return { deps, dirOf: () => dir }
+    }
+    const a = capture()
+    const b = capture()
+    const spec = {
+      name: 'default-python',
+      language: 'python' as const,
+      version: '3.12',
+      packages: []
+    }
+    await createFetchBundleAdapter(root, 'https://cdn/envs', { ...a.deps, subdir: 'osx-arm64' })(
+      spec,
+      1,
+      () => {}
+    ).catch(() => {})
+    await createFetchBundleAdapter(root, 'https://cdn/envs', { ...b.deps, subdir: 'osx-arm64' })(
+      spec,
+      1,
+      () => {}
+    ).catch(() => {})
+
+    // Same version/subdir, but the two sessions resolved to DIFFERENT cache dirs (distinct keys).
+    expect(a.dirOf()).not.toBe(b.dirOf())
+    expect(a.dirOf()).toContain(join('packs', '.cache'))
+    expect(b.dirOf()).toContain(join('packs', '.cache'))
     await rm(root, { recursive: true, force: true })
   })
 })

--- a/src/main/notebook/language-pack-fetch.test.ts
+++ b/src/main/notebook/language-pack-fetch.test.ts
@@ -111,6 +111,18 @@ describe('fetchLanguagePack', () => {
     ).rejects.toThrow(/sha256 mismatch/)
   })
 
+  it('skips the post-download re-hash when the downloader verified inline', async () => {
+    // downloadVerifiesInline signals the pack was already sha256-verified by the resilient core, so
+    // verifyPackChecksum should NOT re-hash — a deliberately wrong sha256 hasher must not be consulted.
+    const sha256 = vi.fn(async () => 'f'.repeat(64))
+    const deps = makeDeps({ sha256, downloadVerifiesInline: true })
+    const result = await fetchLanguagePack(
+      makeDestDir(), 'https://cdn/envs', 1, 'osx-arm64', 'python', '3.11', deps
+    )
+    expect(result.id).toBe('python-3.11')
+    expect(sha256).not.toHaveBeenCalled()
+  })
+
   it('rejects a version that was not published', async () => {
     const deps = makeDeps()
     await expect(

--- a/src/main/notebook/language-pack-fetch.ts
+++ b/src/main/notebook/language-pack-fetch.ts
@@ -48,11 +48,6 @@ export type LanguagePackFetchDeps = {
   ) => Promise<void>
   // sha256 hex of a file; injectable for tests, defaults to the streaming sha256File.
   sha256?: (path: string) => Promise<string>
-  // Set when `download` already verifies the pack's sha256 inline (the default resilient core does, via
-  // the `expected` arg). When true, the post-download verifyPackChecksum runs a size-only check instead
-  // of re-hashing the whole archive a second time. Injected test/custom downloaders leave this false so
-  // the full hash still runs as their integrity gate.
-  downloadVerifiesInline?: boolean
 }
 
 // The manifest is tiny, so a total request timeout is fine. Without it, a CDN that accepts the
@@ -150,13 +145,13 @@ export const fetchLanguagePack = async (
     (p) => onDownloadProgress(p.total != null ? p : { ...p, total: entry.size }),
     { sha256: entry.sha256, size: entry.size }
   )
-  // When the downloader verified sha256 inline (default resilient core), this is a cheap size-only
-  // re-check rather than a second full-file hash of a potentially huge archive.
+  // Defense-in-depth: an independent post-download size+sha256 verification, separate from the inline
+  // check the resilient core already performed while streaming. See verifyPackChecksum — this is a
+  // required second integrity gate for a large executed artifact, not redundant work.
   await verifyPackChecksum(
     filePath,
     { sha256: entry.sha256, size: entry.size },
-    { sha256: deps.sha256 },
-    { skipHash: deps.downloadVerifiesInline === true }
+    { sha256: deps.sha256 }
   )
   return { id: packId(language, packVersion), entry, filePath, manifest }
 }
@@ -225,10 +220,7 @@ export const createFetchBundleAdapter =
           download:
             deps.download ??
             ((url, dest, op, expected) => downloadFile(url, dest, op, signal, expected)),
-          sha256: deps.sha256,
-          // Only the default downloadFile verifies sha256 inline; an injected download does not, so the
-          // post-download hash must still run for it.
-          downloadVerifiesInline: deps.download == null
+          sha256: deps.sha256
         },
         (download) => {
           const ratio =

--- a/src/main/notebook/language-pack-fetch.ts
+++ b/src/main/notebook/language-pack-fetch.ts
@@ -48,6 +48,11 @@ export type LanguagePackFetchDeps = {
   ) => Promise<void>
   // sha256 hex of a file; injectable for tests, defaults to the streaming sha256File.
   sha256?: (path: string) => Promise<string>
+  // Set when `download` already verifies the pack's sha256 inline (the default resilient core does, via
+  // the `expected` arg). When true, the post-download verifyPackChecksum runs a size-only check instead
+  // of re-hashing the whole archive a second time. Injected test/custom downloaders leave this false so
+  // the full hash still runs as their integrity gate.
+  downloadVerifiesInline?: boolean
 }
 
 // The manifest is tiny, so a total request timeout is fine. Without it, a CDN that accepts the
@@ -145,10 +150,13 @@ export const fetchLanguagePack = async (
     (p) => onDownloadProgress(p.total != null ? p : { ...p, total: entry.size }),
     { sha256: entry.sha256, size: entry.size }
   )
+  // When the downloader verified sha256 inline (default resilient core), this is a cheap size-only
+  // re-check rather than a second full-file hash of a potentially huge archive.
   await verifyPackChecksum(
     filePath,
     { sha256: entry.sha256, size: entry.size },
-    { sha256: deps.sha256 }
+    { sha256: deps.sha256 },
+    { skipHash: deps.downloadVerifiesInline === true }
   )
   return { id: packId(language, packVersion), entry, filePath, manifest }
 }
@@ -217,7 +225,10 @@ export const createFetchBundleAdapter =
           download:
             deps.download ??
             ((url, dest, op, expected) => downloadFile(url, dest, op, signal, expected)),
-          sha256: deps.sha256
+          sha256: deps.sha256,
+          // Only the default downloadFile verifies sha256 inline; an injected download does not, so the
+          // post-download hash must still run for it.
+          downloadVerifiesInline: deps.download == null
         },
         (download) => {
           const ratio =

--- a/src/main/notebook/language-pack-fetch.ts
+++ b/src/main/notebook/language-pack-fetch.ts
@@ -37,12 +37,13 @@ export type LanguagePackFetchDeps = {
   // Fetches a URL and returns its body as text (used for manifest.json).
   fetchText: (url: string) => Promise<string>
   // Downloads a URL to destPath (the pack archive). `expected` carries the manifest sha256/size so the
-  // resilient core can verify inline and resume against the right total.
+  // resilient core can verify inline and resume against the right total. Short-read detection needs a
+  // total, so callers must supply `expected.size` when the response may omit Content-Length.
+  // Cancellation is handled by the closure-captured signal in the default adapter, not a parameter.
   download: (
     url: string,
     destPath: string,
     onProgress?: (p: DownloadProgress) => void,
-    signal?: AbortSignal,
     expected?: { sha256?: string; size?: number }
   ) => Promise<void>
   // sha256 hex of a file; injectable for tests, defaults to the streaming sha256File.
@@ -142,7 +143,6 @@ export const fetchLanguagePack = async (
     // Fill in the manifest's pack size when the response omits Content-Length, so the UI still shows
     // a meaningful total/percent instead of an unknown-size bar.
     (p) => onDownloadProgress(p.total != null ? p : { ...p, total: entry.size }),
-    undefined,
     { sha256: entry.sha256, size: entry.size }
   )
   await verifyPackChecksum(
@@ -216,7 +216,7 @@ export const createFetchBundleAdapter =
           fetchText: deps.fetchText ?? ((url) => fetchText(url, signal)),
           download:
             deps.download ??
-            ((url, dest, op, _sig, expected) => downloadFile(url, dest, op, signal, expected)),
+            ((url, dest, op, expected) => downloadFile(url, dest, op, signal, expected)),
           sha256: deps.sha256
         },
         (download) => {

--- a/src/main/notebook/language-pack-fetch.ts
+++ b/src/main/notebook/language-pack-fetch.ts
@@ -184,12 +184,15 @@ export const createFetchBundleAdapter =
     await mkdir(packsRoot, { recursive: true })
     const workDir = await mkdtemp(join(packsRoot, '.incoming-'))
     const unpackedDir = join(workDir, 'pack')
-    // Stable, per-invocation-surviving location for the downloaded archive + its .part. The extraction
+    // Stable, within-session-surviving location for the downloaded archive + its .part. The extraction
     // staging (workDir) is disposable and wiped in the finally, but the .part must OUTLIVE a failed or
-    // cancelled fetch so a manual retry resumes via Range instead of restarting a ~345 MB download.
-    // Keyed only by pack identity (the canonical archive filename), so a retry finds the same .part.
-    // Not under .incoming-*, so startup orphan-recovery (which wipes staging) leaves it intact.
-    const archiveDir = join(packsRoot, '.cache')
+    // cancelled fetch WITHIN a run so a manual retry (no restart) resumes via Range instead of
+    // restarting a ~345 MB download. It is NOT meant to survive an app restart — startup recovery wipes
+    // packs/.cache entirely ("app closes → start from scratch"). Keyed by envVersion AND subdir so a
+    // stale fragment from a different version/arch can never be Range-resumed against a new pack URL
+    // (which would only fail checksum after re-downloading the whole thing).
+    const subdir = deps.subdir ?? runtimeSubdir()
+    const archiveDir = join(packsRoot, '.cache', String(version), subdir)
     await mkdir(archiveDir, { recursive: true })
     // Crash recovery (WS13): record the download intent BEFORE staging so a hard-quit mid-fetch leaves
     // a journal entry whose targetPath is this .incoming-* dir; startup recovery removes the orphan.
@@ -218,7 +221,7 @@ export const createFetchBundleAdapter =
         archiveDir,
         cdnBase,
         version,
-        deps.subdir ?? runtimeSubdir(),
+        subdir,
         spec.language,
         spec.version,
         {
@@ -272,7 +275,7 @@ export const createFetchBundleAdapter =
       })
       if (entries.length === 0) return undefined
 
-      const subdir = deps.subdir ?? runtimeSubdir()
+      // subdir was resolved once above (used for the version/subdir-keyed archive cache dir).
       const pathBudget = pathBudgetForPack(fetched.entry)
       if (subdir === 'win-64' && !pathBudget) return undefined
       if (pathBudget) {

--- a/src/main/notebook/language-pack-fetch.ts
+++ b/src/main/notebook/language-pack-fetch.ts
@@ -171,9 +171,19 @@ type FetchBundleFn = (
 // Adapts the single-file CDN fetch to the provisioner's lock-based contract. A failed CDN fetch throws
 // one source-scoped, actionable error so HTTP/integrity failures survive through Settings and lazy
 // provisioning; no online solve is attempted. An aborted `signal` (user Cancel) aborts the download.
-export const createFetchBundleAdapter =
-  (root: string, cdnBase: string | undefined, deps: FetchBundleAdapterDeps = {}): FetchBundleFn =>
-  async (spec, version, onProgress, signal) => {
+export const createFetchBundleAdapter = (
+  root: string,
+  cdnBase: string | undefined,
+  deps: FetchBundleAdapterDeps = {}
+): FetchBundleFn => {
+  // One cache namespace per app session (per adapter instance — the provisioner builds it once at
+  // startup). A prior session's partial .part therefore lives under a DIFFERENT token and is invisible
+  // to this session's fetch, so "app closes → start from scratch" holds by construction — it does not
+  // depend on the startup .cache wipe running or succeeding (that wipe is now pure housekeeping, and a
+  // corrupt-journal early-return or a failed rm can no longer cause a stale resume). Within a session
+  // the token is stable, so a manual retry (no restart) still resumes via Range.
+  const sessionCacheKey = randomUUID()
+  return async (spec, version, onProgress, signal) => {
     if (!cdnBase) return undefined
     // Stage under <root>/packs (the SAME volume as the final pack dir), NOT the system tmpdir: the
     // final commit is an atomic rename() into runtimePackDir(root,...), and a relocated data root on a
@@ -184,15 +194,15 @@ export const createFetchBundleAdapter =
     await mkdir(packsRoot, { recursive: true })
     const workDir = await mkdtemp(join(packsRoot, '.incoming-'))
     const unpackedDir = join(workDir, 'pack')
-    // Stable, within-session-surviving location for the downloaded archive + its .part. The extraction
-    // staging (workDir) is disposable and wiped in the finally, but the .part must OUTLIVE a failed or
-    // cancelled fetch WITHIN a run so a manual retry (no restart) resumes via Range instead of
-    // restarting a ~345 MB download. It is NOT meant to survive an app restart — startup recovery wipes
-    // packs/.cache entirely ("app closes → start from scratch"). Keyed by envVersion AND subdir so a
-    // stale fragment from a different version/arch can never be Range-resumed against a new pack URL
-    // (which would only fail checksum after re-downloading the whole thing).
+    // Location for the downloaded archive + its .part. The extraction staging (workDir) is disposable
+    // and wiped in the finally, but the .part must OUTLIVE a failed or cancelled fetch WITHIN a session
+    // so a manual retry (no restart) resumes via Range instead of restarting a ~345 MB download.
+    // Path: .cache/<sessionCacheKey>/<envVersion>/<subdir>/. The session key makes a PRIOR session's
+    // .part invisible here ("app closes → start from scratch", independent of the startup wipe); the
+    // envVersion+subdir segments keep a stale fragment from a different version/arch from being
+    // Range-resumed against a new pack URL (which would only fail checksum after a full re-download).
     const subdir = deps.subdir ?? runtimeSubdir()
-    const archiveDir = join(packsRoot, '.cache', String(version), subdir)
+    const archiveDir = join(packsRoot, '.cache', sessionCacheKey, String(version), subdir)
     await mkdir(archiveDir, { recursive: true })
     // Crash recovery (WS13): record the download intent BEFORE staging so a hard-quit mid-fetch leaves
     // a journal entry whose targetPath is this .incoming-* dir; startup recovery removes the orphan.
@@ -330,3 +340,4 @@ export const createFetchBundleAdapter =
       await journal.complete(operationId).catch(() => undefined)
     }
   }
+}

--- a/src/main/notebook/language-pack-fetch.ts
+++ b/src/main/notebook/language-pack-fetch.ts
@@ -184,6 +184,13 @@ export const createFetchBundleAdapter =
     await mkdir(packsRoot, { recursive: true })
     const workDir = await mkdtemp(join(packsRoot, '.incoming-'))
     const unpackedDir = join(workDir, 'pack')
+    // Stable, per-invocation-surviving location for the downloaded archive + its .part. The extraction
+    // staging (workDir) is disposable and wiped in the finally, but the .part must OUTLIVE a failed or
+    // cancelled fetch so a manual retry resumes via Range instead of restarting a ~345 MB download.
+    // Keyed only by pack identity (the canonical archive filename), so a retry finds the same .part.
+    // Not under .incoming-*, so startup orphan-recovery (which wipes staging) leaves it intact.
+    const archiveDir = join(packsRoot, '.cache')
+    await mkdir(archiveDir, { recursive: true })
     // Crash recovery (WS13): record the download intent BEFORE staging so a hard-quit mid-fetch leaves
     // a journal entry whose targetPath is this .incoming-* dir; startup recovery removes the orphan.
     // Cleared in the finally on every normal completion/failure (the staging is gone by then), so only
@@ -207,7 +214,8 @@ export const createFetchBundleAdapter =
         progress: 0.05
       })
       const fetched = await fetchLanguagePack(
-        workDir,
+        // Download the archive to the stable cache dir (not workDir) so its .part survives for resume.
+        archiveDir,
         cdnBase,
         version,
         deps.subdir ?? runtimeSubdir(),
@@ -248,6 +256,11 @@ export const createFetchBundleAdapter =
       })
 
       await extractPackArchiveWithDeps(fetched.filePath, unpackedDir, { extract: deps.extract })
+      // The archive is now fully extracted into staging, so the cached copy is no longer needed —
+      // remove it (and any stale .part) to reclaim the ~345 MB. Best-effort: a leftover only wastes
+      // disk and is overwritten on the next fetch. A download that never reached here keeps its .part.
+      await rm(fetched.filePath, { force: true }).catch(() => undefined)
+      await rm(`${fetched.filePath}.part`, { force: true }).catch(() => undefined)
       const lockPath = join(unpackedDir, `${fetched.id}.lock`)
       await readFile(lockPath, 'utf8')
       const entries = await validateAndSeedPack(root, unpackedDir, lockPath, (completed, total) => {

--- a/src/main/notebook/language-pack-fetch.ts
+++ b/src/main/notebook/language-pack-fetch.ts
@@ -1,11 +1,10 @@
 import { randomUUID } from 'node:crypto'
-import { createWriteStream } from 'node:fs'
 import { mkdtemp, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { Readable } from 'node:stream'
-import { Transform } from 'node:stream'
-import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
-import { pipeline } from 'node:stream/promises'
+
+import type { DownloadProgress } from '../../shared/download-progress'
+import { netFetchStandard } from '../skills/net-fetch'
+import { resilientDownload } from '../net/resilient-download'
 
 import {
   manifestUrl,
@@ -37,11 +36,14 @@ import { operationJournalPath, RuntimeOperationJournal } from './operation-journ
 export type LanguagePackFetchDeps = {
   // Fetches a URL and returns its body as text (used for manifest.json).
   fetchText: (url: string) => Promise<string>
-  // Downloads a URL to destPath (the pack archive).
+  // Downloads a URL to destPath (the pack archive). `expected` carries the manifest sha256/size so the
+  // resilient core can verify inline and resume against the right total.
   download: (
     url: string,
     destPath: string,
-    onProgress?: (downloadedBytes: number, totalBytes?: number) => void
+    onProgress?: (p: DownloadProgress) => void,
+    signal?: AbortSignal,
+    expected?: { sha256?: string; size?: number }
   ) => Promise<void>
   // sha256 hex of a file; injectable for tests, defaults to the streaming sha256File.
   sha256?: (path: string) => Promise<string>
@@ -64,58 +66,31 @@ const withCancel = (internal: AbortSignal, external?: AbortSignal): AbortSignal 
 
 const fetchText = async (url: string, external?: AbortSignal): Promise<string> => {
   const signal = withCancel(AbortSignal.timeout(MANIFEST_TIMEOUT_MS), external)
-  const response = await fetch(url, { signal })
+  // Electron net.fetch so the manifest request honors the system/VPN proxy, matching the pack download.
+  const response = await netFetchStandard(url, { signal })
   if (!response.ok) throw new Error(`runtime manifest request failed (${response.status})`)
   return response.text()
 }
 
+// Default download implementation: delegates to the shared resilient core with Electron net.fetch so
+// downloads honor the system/VPN proxy and gain Range resume + retry + stall handling. Verifies the
+// pack's sha256 inline when the caller passes it (fetchLanguagePack does, from the manifest entry).
+// Tests inject a fake via LanguagePackFetchDeps.download.
 const downloadFile = async (
   url: string,
   destPath: string,
-  onProgress: (downloadedBytes: number, totalBytes?: number) => void = () => undefined,
-  external?: AbortSignal
+  onProgress: (p: DownloadProgress) => void = () => undefined,
+  external?: AbortSignal,
+  expected?: { sha256?: string; size?: number }
 ): Promise<void> => {
-  const controller = new AbortController()
-  let stallTimer: ReturnType<typeof setTimeout> | undefined
-  const armStall = (): void => {
-    if (stallTimer) clearTimeout(stallTimer)
-    stallTimer = setTimeout(
-      () =>
-        controller.abort(new Error(`runtime pack download stalled (>${PACK_STALL_TIMEOUT_MS}ms)`)),
-      PACK_STALL_TIMEOUT_MS
-    )
-  }
-  armStall()
-  try {
-    const response = await fetch(url, { signal: withCancel(controller.signal, external) })
-    if (!response.ok) throw new Error(`runtime pack request failed (${response.status})`)
-    if (!response.body) throw new Error('runtime pack response had no body')
-    const contentLength = Number(response.headers.get('content-length'))
-    // A missing Content-Length yields 0 (Number(null)); treat only a positive value as known, so the
-    // caller falls back to the manifest's pack size for the progress bar instead of showing a stuck 0.
-    const totalBytes =
-      Number.isFinite(contentLength) && contentLength > 0 ? contentLength : undefined
-    let downloadedBytes = 0
-    onProgress(downloadedBytes, totalBytes)
-    const meter = new Transform({
-      transform(chunk: Buffer, _encoding, callback) {
-        downloadedBytes += chunk.length
-        armStall()
-        onProgress(downloadedBytes, totalBytes)
-        callback(null, chunk)
-      }
-    })
-    await pipeline(
-      // Node's DOM and stream lib definitions use incompatible ReadableStream generics here; the
-      // runtime contract is the standard Web stream returned by Node fetch.
-      Readable.fromWeb(response.body as unknown as NodeReadableStream<Uint8Array>),
-      meter,
-      createWriteStream(destPath),
-      { signal: withCancel(controller.signal, external) }
-    )
-  } finally {
-    if (stallTimer) clearTimeout(stallTimer)
-  }
+  await resilientDownload(url, destPath, {
+    expectedSha256: expected?.sha256,
+    expectedSize: expected?.size,
+    stallTimeoutMs: PACK_STALL_TIMEOUT_MS,
+    signal: external,
+    onProgress,
+    deps: { fetchImpl: netFetchStandard }
+  })
 }
 
 // The result of a successful pack fetch: the resolved id/entry and where the verified file landed.
@@ -138,7 +113,7 @@ export const fetchLanguagePack = async (
   language: PackLanguage,
   packVersion: string,
   deps: LanguagePackFetchDeps,
-  onDownloadProgress: (downloadedBytes: number, totalBytes?: number) => void = () => undefined
+  onDownloadProgress: (p: DownloadProgress) => void = () => undefined
 ): Promise<FetchedLanguagePack> => {
   const manifest = parseManifest(await deps.fetchText(manifestUrl(cdnBase, version, subdir)))
   if (manifest.schema !== SUPPORTED_SCHEMA) {
@@ -164,7 +139,11 @@ export const fetchLanguagePack = async (
   await deps.download(
     packUrl(cdnBase, version, subdir, entry.file),
     filePath,
-    (downloadedBytes, totalBytes) => onDownloadProgress(downloadedBytes, totalBytes ?? entry.size)
+    // Fill in the manifest's pack size when the response omits Content-Length, so the UI still shows
+    // a meaningful total/percent instead of an unknown-size bar.
+    (p) => onDownloadProgress(p.total != null ? p : { ...p, total: entry.size }),
+    undefined,
+    { sha256: entry.sha256, size: entry.size }
   )
   await verifyPackChecksum(
     filePath,
@@ -235,20 +214,27 @@ export const createFetchBundleAdapter =
           // Bake the external cancel signal into the default fetchers so a user Cancel aborts the
           // in-flight manifest fetch and pack download (injected test deps opt out, as before).
           fetchText: deps.fetchText ?? ((url) => fetchText(url, signal)),
-          download: deps.download ?? ((url, dest, op) => downloadFile(url, dest, op, signal)),
+          download:
+            deps.download ??
+            ((url, dest, op, _sig, expected) => downloadFile(url, dest, op, signal, expected)),
           sha256: deps.sha256
         },
-        (downloadedBytes, totalBytes) => {
-          const ratio = totalBytes && totalBytes > 0 ? downloadedBytes / totalBytes : 0
-          const detail = totalBytes
-            ? ` (${Math.min(100, Math.round(ratio * 100))}%)`
-            : downloadedBytes > 0
-              ? ` (${Math.round(downloadedBytes / 1024 / 1024)} MB)`
-              : ''
+        (download) => {
+          const ratio =
+            download.total && download.total > 0 ? download.transferred / download.total : 0
+          const detail =
+            download.phase === 'reconnecting'
+              ? ' (resuming…)'
+              : download.total
+                ? ` (${Math.min(100, Math.round(ratio * 100))}%)`
+                : download.transferred > 0
+                  ? ` (${Math.round(download.transferred / 1024 / 1024)} MB)`
+                  : ''
           onProgress({
             phase: `fetch-${spec.language}`,
             message: `Downloading managed ${spec.language} runtime${detail}`,
-            progress: 0.1 + 0.25 * Math.min(1, ratio)
+            progress: 0.1 + 0.25 * Math.min(1, ratio),
+            download
           })
         }
       )

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1027,6 +1027,29 @@ describe('notebook runtime service', () => {
     expect(await journal.pending()).toEqual([])
   })
 
+  it('wipes the pack download cache on startup so a restart does not resume a partial (WS13)', async () => {
+    const root = await createStorageRoot()
+    const runtimeRoot = join(root, 'runtime')
+    // A leftover partial download from a prior session: a .part (and a stale complete archive) in the
+    // version/subdir-keyed .cache. The design requires "app closes → start from scratch", so startup
+    // recovery must remove these rather than let a restart Range-resume them.
+    const cache = join(runtimeRoot, 'packs', '.cache', '1', 'osx-arm64')
+    await mkdir(cache, { recursive: true })
+    await writeFile(join(cache, 'python-3.12.tar.zst.part'), Buffer.from('half'))
+    await writeFile(join(cache, 'r-4.4.tar.zst'), Buffer.from('whole-but-orphaned'))
+
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root)
+    })
+    await service.recoverInterruptedOperations()
+
+    // The entire .cache is gone — neither the partial nor the orphaned archive survives the restart.
+    expect(existsSync(join(runtimeRoot, 'packs', '.cache'))).toBe(false)
+  })
+
   it('reconciles a stale running run to interrupted on first load after a crash (WS12)', async () => {
     const root = await createStorageRoot()
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1050,6 +1050,29 @@ describe('notebook runtime service', () => {
     expect(existsSync(join(runtimeRoot, 'packs', '.cache'))).toBe(false)
   })
 
+  it('wipes the pack download cache even when the operation journal is corrupt (WS13)', async () => {
+    const root = await createStorageRoot()
+    const runtimeRoot = join(root, 'runtime')
+    // A corrupt journal makes recovery early-return (blocking all runtime writes). The .cache wipe must
+    // still run — it is ordered BEFORE that early return — so a corrupt journal can't strand a prior
+    // session's .part for a later fetch. (Correctness also holds via the per-session cache key; this
+    // covers the housekeeping path the reviewer flagged as untested.)
+    const cache = join(runtimeRoot, 'packs', '.cache', '1', 'osx-arm64')
+    await mkdir(cache, { recursive: true })
+    await writeFile(join(cache, 'python-3.12.tar.zst.part'), Buffer.from('half'))
+    await writeFile(operationJournalPath(runtimeRoot), 'not-json{{{')
+
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root)
+    })
+    await service.recoverInterruptedOperations()
+
+    expect(existsSync(join(runtimeRoot, 'packs', '.cache'))).toBe(false)
+  })
+
   it('reconciles a stale running run to interrupted on first load after a crash (WS12)', async () => {
     const root = await createStorageRoot()
 

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -2673,6 +2673,14 @@ class NotebookRuntimeService {
 
   private async runRecovery(): Promise<void> {
     const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
+    // Reclaim any prior-session pack-download cache FIRST — before the corrupt-journal early return
+    // below — so this housekeeping runs on every startup path, not just the healthy-journal one. It is
+    // only housekeeping: correctness of "app closes → start from scratch" is guaranteed independently by
+    // the per-session cache key (createFetchBundleAdapter), so a failure here (or skipping it) can never
+    // let a new fetch resume last session's .part — it only leaves reclaimable disk. Hence best-effort.
+    await rm(join(runtimeRoot, 'packs', '.cache'), { recursive: true, force: true }).catch(
+      () => undefined
+    )
     const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
     // Fail SAFE on a corrupt/unreadable journal: reconcileInterruptedOperations would read it as empty
     // (nothing in flight) and open the recovery barrier, but a corrupt journal is NOT proof that no op
@@ -2769,15 +2777,6 @@ class NotebookRuntimeService {
     // so they don't accumulate. A retained (unknown-blocked) record keeps its sidecar for the next
     // startup's liveness probe.
     for (const record of reconciled) removeOperationChildSync(runtimeRoot, record.operationId)
-
-    // Pack-download cache reset: a partial pack .part in packs/.cache resumes via Range within a run,
-    // but the design requires "app closes → start from scratch" — a restart must NOT resume a
-    // half-downloaded pack. Recovery runs ONCE at startup before any new fetch, so the whole .cache
-    // dir holds only leftovers from the previous session; wipe it (partials AND any orphaned complete
-    // archive). Best-effort: a failure here only leaves reclaimable disk, never blocks recovery.
-    await rm(join(runtimeRoot, 'packs', '.cache'), { recursive: true, force: true }).catch(
-      () => undefined
-    )
   }
 
   // Shuts down every live interpreter, used by app-level cleanup paths. Returns { reaped }: true only

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -325,7 +325,9 @@ type NotebookRuntimeServiceOptions = {
   saveIpynb?: (suggestedName: string, data: string) => Promise<ExportNotebookResult>
   // Save-directory seam for the "Download all" path. Production falls back to a directory picker
   // dialog and writes one file per data kernel under the user's chosen directory.
-  saveIpynbAll?: (files: Array<{ kernel: 'python' | 'r'; name: string; data: string }>) => Promise<ExportNotebookAllResult>
+  saveIpynbAll?: (
+    files: Array<{ kernel: 'python' | 'r'; name: string; data: string }>
+  ) => Promise<ExportNotebookAllResult>
   // Resolves app-managed artifact paths with the artifact repository's canonical/symlink checks,
   // bound to the artifact's declaring project/session subtree.
   resolveArtifactPath?: (request: {
@@ -2055,14 +2057,10 @@ class NotebookRuntimeService {
       document,
       this.options.resolveArtifactPath
     )
-    const notebook = runDocumentToIpynbForKernel(
-      document,
-      dataKernel,
-      {
-        appVersion: this.options.appVersion,
-        artifactOutputs
-      }
-    )
+    const notebook = runDocumentToIpynbForKernel(document, dataKernel, {
+      appVersion: this.options.appVersion,
+      artifactOutputs
+    })
     const suggestedName = `session-${request.sessionId.slice(0, 8)}-${dataKernel}.ipynb`
     const serialized = `${JSON.stringify(notebook, null, 2)}\n`
 
@@ -2771,6 +2769,15 @@ class NotebookRuntimeService {
     // so they don't accumulate. A retained (unknown-blocked) record keeps its sidecar for the next
     // startup's liveness probe.
     for (const record of reconciled) removeOperationChildSync(runtimeRoot, record.operationId)
+
+    // Pack-download cache reset: a partial pack .part in packs/.cache resumes via Range within a run,
+    // but the design requires "app closes → start from scratch" — a restart must NOT resume a
+    // half-downloaded pack. Recovery runs ONCE at startup before any new fetch, so the whole .cache
+    // dir holds only leftovers from the previous session; wipe it (partials AND any orphaned complete
+    // archive). Best-effort: a failure here only leaves reclaimable disk, never blocks recovery.
+    await rm(join(runtimeRoot, 'packs', '.cache'), { recursive: true, force: true }).catch(
+      () => undefined
+    )
   }
 
   // Shuts down every live interpreter, used by app-level cleanup paths. Returns { reaped }: true only

--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -304,6 +304,62 @@ describe('claude-install: run with region-block fallback', () => {
     expect(commands).toEqual(['bash'])
     expect(result.ok).toBe(false)
   })
+
+  it('retries on a transient network failure and succeeds on the second attempt', async () => {
+    let spawnCallCount = 0
+    const networkFailSpawn = vi.fn(() => {
+      const child = new FakeChild()
+      const isFirst = spawnCallCount++ === 0
+      setImmediate(() => {
+        if (isFirst) child.stderr.emit('data', Buffer.from('npm ERR! network ETIMEDOUT'))
+        child.emit('exit', isFirst ? 1 : 0)
+      })
+      return child
+    })
+
+    const events: string[] = []
+    const result = await runInstallWithFallback({
+      source: 'npm',
+      installId: 'install-retry-1',
+      onEvent: (e) => {
+        if (e.kind === 'log' && e.stream === 'system') events.push(e.chunk)
+      },
+      spawnImpl: networkFailSpawn as never,
+      platform: 'linux',
+      npmProbe: () => Promise.resolve(),
+      maxNetworkRetries: 2,
+      retrySleep: async () => {}
+    })
+
+    expect(result.ok).toBe(true)
+    expect(networkFailSpawn.mock.calls.length).toBe(2)
+    expect(events.some((e) => e.includes('retrying'))).toBe(true)
+  })
+
+  it('surfaces the failure after exhausting retries', async () => {
+    const networkFailSpawn = vi.fn(() => {
+      const child = new FakeChild()
+      setImmediate(() => {
+        child.stderr.emit('data', Buffer.from('npm ERR! network ECONNRESET'))
+        child.emit('exit', 1)
+      })
+      return child
+    })
+
+    const result = await runInstallWithFallback({
+      source: 'npm',
+      installId: 'install-retry-2',
+      onEvent: () => undefined,
+      spawnImpl: networkFailSpawn as never,
+      platform: 'linux',
+      npmProbe: () => Promise.resolve(),
+      maxNetworkRetries: 1,
+      retrySleep: async () => {}
+    })
+
+    expect(result.ok).toBe(false)
+    expect(networkFailSpawn.mock.calls.length).toBe(2) // initial + 1 retry
+  })
 })
 
 describe('claude-install: npm availability', () => {

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -115,6 +115,34 @@ const isRegionBlockedOutput = (text: string): boolean => {
   return REGION_BLOCK_MARKERS.some((marker) => haystack.includes(marker))
 }
 
+// Signatures of a transient network failure in installer output (npm registry timeouts, DNS/connection
+// resets, curl transfer errors). A non-zero exit whose output matches is worth retrying; anything else
+// (a real config/permission error) is surfaced as-is.
+const RETRYABLE_INSTALL_MARKERS = [
+  'etimedout',
+  'econnreset',
+  'econnrefused',
+  'enotfound',
+  'eai_again',
+  'network',
+  'timed out',
+  'timeout',
+  'socket hang up',
+  'connection reset',
+  'temporary failure',
+  'could not resolve host',
+  'failed to fetch'
+]
+
+// Whether installer output looks like a transient network failure (drives the retry loop). A region
+// block is handled separately (npm fallback), so it is excluded here to avoid double-handling.
+const isRetryableInstallFailure = (text: string): boolean => {
+  if (isRegionBlockedOutput(text)) return false
+  const haystack = text.toLowerCase()
+
+  return RETRYABLE_INSTALL_MARKERS.some((marker) => haystack.includes(marker))
+}
+
 // Injectable deps for the npm-global-prefix writability probe. Both default to real npm/fs but are
 // swappable so tests run offline without shelling out or touching the filesystem.
 type NpmGlobalPrefixWritableDeps = {
@@ -195,6 +223,10 @@ export type RunInstallOptions = {
 // the fallback's availability check can be driven in tests without shelling out to a real npm.
 export type RunInstallWithFallbackOptions = RunInstallOptions & {
   npmProbe?: () => Promise<unknown>
+  // Maximum extra attempts after the initial one (default 2 → total 3). Injectable so tests skip waits.
+  maxNetworkRetries?: number
+  // Delay between network-failure retries; injectable so tests run instantly.
+  retrySleep?: (ms: number) => Promise<void>
 }
 
 // Real installer spawn with piped stdio. PATH is augmented so a GUI-launched app can still find npm,
@@ -314,7 +346,11 @@ const runInstall = async ({
         // Only the official script can be served the region-block page; flag it so callers can retry
         // with npm instead of surfacing a cryptic `syntax error near '<'`.
         regionBlocked:
-          !ok && source === 'official-script' && isRegionBlockedOutput(captured) ? true : undefined
+          !ok && source === 'official-script' && isRegionBlockedOutput(captured) ? true : undefined,
+        // A non-zero exit that looks like a transient network fault; the caller retries the same
+        // source. A timeout is not a clean network signature, so it is not treated as retryable here.
+        retryableNetworkFailure:
+          !ok && !timedOut && isRetryableInstallFailure(captured) ? true : undefined
       })
     })
   })
@@ -356,42 +392,64 @@ const runInstallWithFallback = async ({
   platform,
   npmProbe,
   npmPrefixWritable,
-  installTarget
+  installTarget,
+  maxNetworkRetries = 2,
+  retrySleep = (ms) => new Promise((r) => setTimeout(r, ms))
 }: RunInstallWithFallbackOptions): Promise<ClaudeInstallResult> => {
-  const result = await runInstall({
-    source,
-    installId,
-    onEvent,
-    timeoutMs,
-    spawnImpl,
-    platform,
-    npmPrefixWritable,
-    installTarget
-  })
+  // Inner: one region-block-aware attempt (official-script → npm on region block).
+  const runOnce = async (): Promise<ClaudeInstallResult> => {
+    const result = await runInstall({
+      source,
+      installId,
+      onEvent,
+      timeoutMs,
+      spawnImpl,
+      platform,
+      npmPrefixWritable,
+      installTarget
+    })
 
-  if (result.ok || source !== 'official-script' || !result.regionBlocked) return result
+    if (result.ok || source !== 'official-script' || !result.regionBlocked) return result
 
-  const { available } = await detectNpmAvailable(npmProbe)
+    const { available } = await detectNpmAvailable(npmProbe)
 
-  if (!available) return result
+    if (!available) return result
 
-  onEvent({
-    kind: 'log',
-    installId,
-    stream: 'system',
-    chunk: 'Official installer looks unavailable in your region; falling back to npm…\n'
-  })
+    onEvent({
+      kind: 'log',
+      installId,
+      stream: 'system',
+      chunk: 'Official installer looks unavailable in your region; falling back to npm…\n'
+    })
 
-  return runInstall({
-    source: 'npm',
-    installId,
-    onEvent,
-    timeoutMs,
-    spawnImpl,
-    platform,
-    npmPrefixWritable,
-    installTarget
-  })
+    return runInstall({
+      source: 'npm',
+      installId,
+      onEvent,
+      timeoutMs,
+      spawnImpl,
+      platform,
+      npmPrefixWritable,
+      installTarget
+    })
+  }
+
+  // Outer: retry loop for transient network failures (registry timeouts, connection resets, etc.).
+  // Region-block is handled inside runOnce; a retryable network failure keeps the same source.
+  for (let attempt = 0; ; attempt++) {
+    const result = await runOnce()
+
+    if (result.ok || !result.retryableNetworkFailure || attempt >= maxNetworkRetries) return result
+
+    const backoffMs = Math.min(2000 * 2 ** attempt, 15_000)
+    onEvent({
+      kind: 'log',
+      installId,
+      stream: 'system',
+      chunk: `Install interrupted, retrying… (attempt ${attempt + 2})\n`
+    })
+    await retrySleep(backoffMs)
+  }
 }
 
 export {

--- a/src/main/update/downloader.test.ts
+++ b/src/main/update/downloader.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
+import type { DownloadProgress } from '../../shared/download-progress'
 import { downloadInstaller } from './downloader'
 
 const sha256 = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
@@ -16,11 +17,11 @@ afterEach(async () => {
 })
 
 describe('downloadInstaller', () => {
-  it('writes to the target path, verifies sha256, and reports progress', async () => {
+  it('writes to the target path, verifies sha256, and reports superset progress', async () => {
     dir = await mkdtemp(join(tmpdir(), 'upd-'))
     const target = join(dir, 'open-science-0.3.0-mac-arm64.dmg')
     const body = Buffer.from('installer-bytes')
-    const progresses: { percent: number; transferred: number; total: number }[] = []
+    const progresses: DownloadProgress[] = []
     const fetchImpl = (() =>
       Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
 
@@ -36,14 +37,17 @@ describe('downloadInstaller', () => {
 
     expect(path).toBe(target)
     expect(await readFile(path)).toEqual(body)
-    expect(progresses.at(-1)).toEqual({
+    expect(progresses.at(-1)).toMatchObject({
+      phase: 'downloading',
       percent: 100,
       transferred: body.byteLength,
-      total: body.byteLength
+      total: body.byteLength,
+      attempt: 0
     })
+    expect(typeof progresses.at(-1)?.bytesPerSecond).toBe('number')
   })
 
-  it('deletes the file and throws on checksum mismatch', async () => {
+  it('deletes the partial file and throws on checksum mismatch', async () => {
     dir = await mkdtemp(join(tmpdir(), 'upd-'))
     const target = join(dir, 'x.dmg')
     const body = Buffer.from('installer-bytes')
@@ -54,27 +58,33 @@ describe('downloadInstaller', () => {
       downloadInstaller(
         { url: 'https://cdn/x.dmg', size: body.byteLength, sha256: 'deadbeef' },
         target,
-        {
-          fetchImpl
-        }
+        { fetchImpl }
       )
     ).rejects.toThrow('Checksum mismatch')
     expect(existsSync(target)).toBe(false)
+    expect(existsSync(`${target}.part`)).toBe(false)
   })
 
-  it('aborts the download and cleans up the partial file when the signal fires', async () => {
+  it('aborts the download without producing the final file', async () => {
     dir = await mkdtemp(join(tmpdir(), 'upd-'))
     const target = join(dir, 'z.dmg')
     const controller = new AbortController()
     // Mimic real fetch: emit one chunk, then error the stream when the abort signal fires so the
-    // reader's next read rejects.
+    // reader's next read rejects. On external abort the core keeps the .part for a later resume, but
+    // the final target is never produced.
     const fetchImpl = ((_url: unknown, init?: { signal?: AbortSignal }) => {
+      const signal = init?.signal
+      // Real fetch rejects immediately when handed an already-aborted signal.
+      if (signal?.aborted) {
+        return Promise.reject(new DOMException('The user aborted a request.', 'AbortError'))
+      }
       const body = new ReadableStream({
         start(streamController) {
           streamController.enqueue(new Uint8Array([1, 2, 3]))
-          init?.signal?.addEventListener('abort', () =>
+          const onAbort = (): void =>
             streamController.error(new DOMException('The user aborted a request.', 'AbortError'))
-          )
+          if (signal?.aborted) onAbort()
+          else signal?.addEventListener('abort', onAbort)
         }
       })
       return Promise.resolve(new Response(body, { status: 200 }))
@@ -88,26 +98,6 @@ describe('downloadInstaller', () => {
     controller.abort()
 
     await expect(promise).rejects.toThrow()
-    expect(existsSync(target)).toBe(false)
-  })
-
-  it('rejects and cleans up the partial file on a mid-stream error', async () => {
-    dir = await mkdtemp(join(tmpdir(), 'upd-'))
-    const target = join(dir, 'y.dmg')
-    const erroringBody = new ReadableStream({
-      start(controller) {
-        controller.enqueue(new Uint8Array([1, 2, 3]))
-        controller.error(new Error('network drop'))
-      }
-    })
-    const fetchImpl = (() =>
-      Promise.resolve(new Response(erroringBody, { status: 200 }))) as unknown as typeof fetch
-
-    await expect(
-      downloadInstaller({ url: 'https://cdn/y.dmg', size: 100, sha256: 'irrelevant' }, target, {
-        fetchImpl
-      })
-    ).rejects.toThrow()
     expect(existsSync(target)).toBe(false)
   })
 })

--- a/src/main/update/downloader.ts
+++ b/src/main/update/downloader.ts
@@ -1,83 +1,30 @@
-import { createHash } from 'node:crypto'
-import { createWriteStream } from 'node:fs'
-import { rm } from 'node:fs/promises'
+import type { DownloadProgress } from '../../shared/download-progress'
+import type { PlatformDownload } from '../../shared/update'
+import { netFetchStandard } from '../skills/net-fetch'
+import { resilientDownload } from '../net/resilient-download'
 
-import type { DownloadProgress, PlatformDownload } from '../../shared/update'
+export { DownloadChecksumError } from '../net/resilient-download'
 
 export type DownloadDeps = {
   fetchImpl?: typeof fetch
   onProgress?: (progress: DownloadProgress) => void
-  // Aborts the request/stream when signalled; the reader rejects and the partial file is cleaned up.
+  // Aborts the request/stream when signalled; the partial file is kept for a later session resume.
   signal?: AbortSignal
 }
 
-// Streams the installer to `targetPath`, hashing as it goes. The sha256 comes from the manifest
-// chunks (independent of file-flush timing), so a mismatch means a corrupt/tampered download — the
-// partial file is removed and the caller sees an error rather than a broken installer.
+// Streams the installer to `targetPath` via the shared resilient core: Range resume + retry + stall
+// handling + streaming sha256. The sha256/size come from the update manifest, so a mismatch means a
+// corrupt/tampered download and the core removes the partial file before throwing. Defaults to
+// Electron net.fetch (system-proxy-aware) so downloads work behind a corporate VPN or proxy.
 export const downloadInstaller = async (
   download: PlatformDownload,
   targetPath: string,
   deps: DownloadDeps = {}
-): Promise<string> => {
-  const fetchImpl = deps.fetchImpl ?? fetch
-  const response = await fetchImpl(download.url, { signal: deps.signal })
-  if (!response.ok || !response.body) throw new Error(`Download failed: ${response.status}`)
-
-  const hash = createHash('sha256')
-  const file = createWriteStream(targetPath)
-  const reader = response.body.getReader()
-
-  // Guard against a write-stream error firing with no pending write callback
-  // (e.g. between reads); without this Node throws it as an uncaught exception.
-  let streamError: Error | null = null
-  file.on('error', (err) => {
-    streamError = err
+): Promise<string> =>
+  resilientDownload(download.url, targetPath, {
+    expectedSha256: download.sha256,
+    expectedSize: download.size > 0 ? download.size : undefined,
+    signal: deps.signal,
+    onProgress: deps.onProgress,
+    deps: { fetchImpl: deps.fetchImpl ?? netFetchStandard }
   })
-
-  const writeChunk = (chunk: Buffer): Promise<void> =>
-    new Promise((resolve, reject) => file.write(chunk, (err) => (err ? reject(err) : resolve())))
-
-  try {
-    let received = 0
-    for (;;) {
-      if (streamError) throw streamError
-      const { done, value } = await reader.read()
-      if (done) break
-      const chunk = Buffer.from(value)
-      hash.update(chunk)
-      await writeChunk(chunk)
-      received += chunk.byteLength
-      if (download.size > 0) {
-        deps.onProgress?.({
-          percent: Math.round((received / download.size) * 100),
-          transferred: received,
-          total: download.size
-        })
-      }
-    }
-    if (streamError) throw streamError
-
-    await new Promise<void>((resolve, reject) => {
-      file.on('error', reject)
-      file.end(() => resolve())
-    })
-
-    if (hash.digest('hex') !== download.sha256) {
-      await rm(targetPath, { force: true })
-      throw new Error('Checksum mismatch')
-    }
-    deps.onProgress?.({ percent: 100, transferred: download.size, total: download.size })
-    return targetPath
-  } catch (error) {
-    // Wait for the underlying fd to actually close before unlinking: createWriteStream opens
-    // the file asynchronously, so destroy()-then-rm can race an in-flight open() and leave an
-    // orphaned empty file behind.
-    await new Promise<void>((resolve) => {
-      if (file.destroyed) return resolve()
-      file.once('close', () => resolve())
-      file.destroy()
-    })
-    await rm(targetPath, { force: true })
-    throw error
-  }
-}

--- a/src/main/update/downloader.ts
+++ b/src/main/update/downloader.ts
@@ -8,7 +8,8 @@ export { DownloadChecksumError } from '../net/resilient-download'
 export type DownloadDeps = {
   fetchImpl?: typeof fetch
   onProgress?: (progress: DownloadProgress) => void
-  // Aborts the request/stream when signalled; the partial file is kept for a later session resume.
+  // Aborts the request/stream when signalled; the partial file is kept for an in-session resume (a
+  // fresh session drops it first — see UpdateService.freshTargets — so a restart starts from scratch).
   signal?: AbortSignal
 }
 

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -30,7 +30,12 @@ class FakeUpdater extends EventEmitter {
   // The download body each call runs. Default: emit progress + downloaded and resolve. Tests override
   // it to hang, to inspect the token, or to count real starts.
   runDownload: (token?: FakeToken) => Promise<void> = async () => {
-    this.emit('download-progress', { percent: 42, transferred: 4200, total: 10000 })
+    this.emit('download-progress', {
+      percent: 42,
+      transferred: 4200,
+      total: 10000,
+      bytesPerSecond: 12345
+    })
     this.emit('update-downloaded', { version: '0.3.0' })
   }
   private downloadPromise: Promise<void> | null = null
@@ -101,9 +106,12 @@ describe('ElectronUpdaterStrategy', () => {
     await strategy.check()
     const status = await strategy.download()
     expect(broadcast).toHaveBeenCalledWith('update:progress', {
+      phase: 'downloading',
       percent: 42,
       transferred: 4200,
-      total: 10000
+      total: 10000,
+      bytesPerSecond: 12345,
+      attempt: 0
     })
     expect(status.state).toBe('ready')
   })

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -234,13 +234,27 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       this.setStatus({ state: 'up-to-date', latest: i.version })
     })
     this.updater.on('download-progress', (p) => {
-      const info = p as { percent?: number; transferred?: number; total?: number }
+      const info = p as {
+        percent?: number
+        transferred?: number
+        total?: number
+        bytesPerSecond?: number
+      }
       const percent = Math.round(info.percent ?? 0)
       const transferred = info.transferred ?? this.status.downloadedBytes ?? 0
       // Preserve the known artifact size when the event lacks a usable total, so a progress
       // event omitting it can't clobber the size extracted at check time with 0.
       const total = info.total || this.status.totalBytes || 0
-      this.broadcast('update:progress', { percent, transferred, total })
+      // electron-updater handles its own retries internally, so downloads only ever surface as the
+      // 'downloading' phase with attempt 0; its native bytesPerSecond feeds the shared speed display.
+      this.broadcast('update:progress', {
+        phase: 'downloading',
+        percent,
+        transferred,
+        total,
+        bytesPerSecond: info.bytesPerSecond ?? 0,
+        attempt: 0
+      })
       this.setStatus({
         ...this.status,
         state: 'downloading',

--- a/src/main/update/manifest.ts
+++ b/src/main/update/manifest.ts
@@ -1,3 +1,4 @@
+import { netFetchStandard } from '../skills/net-fetch'
 import type { PlatformDownload, UpdateManifest } from '../../shared/update'
 
 const isDownload = (value: unknown): value is PlatformDownload => {
@@ -32,7 +33,9 @@ export const parseManifest = (data: unknown): UpdateManifest => {
 
 export const fetchManifest = async (
   url: string,
-  fetchImpl: typeof fetch = fetch
+  // Default to the proxy-aware net.fetch so the manifest request honors the system/VPN proxy,
+  // matching the installer download and language-pack fetch. Node's global fetch bypasses it.
+  fetchImpl: typeof fetch = netFetchStandard
 ): Promise<UpdateManifest> => {
   const response = await fetchImpl(url, { headers: { Accept: 'application/json' } })
   if (!response.ok) throw new Error(`Manifest fetch failed: ${response.status}`)

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -138,6 +138,216 @@ describe('UpdateService.download', () => {
     expect(status.state).toBe('ready')
     expect(status.localPath).toBe(target)
     expect(existsSync(target)).toBe(true)
+  })
+
+  it('drops a prior-session <target>.part on the first download so a restart starts fresh', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    // A leftover fragment from a previous app session at the same Save location.
+    const partPath = `${target}.part`
+    await writeFile(partPath, Buffer.from('stale-fragment-from-last-session'))
+    const body = Buffer.from('fresh-installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    const fetchImpl = ((input: unknown) =>
+      String(input).endsWith('version.json')
+        ? Promise.resolve(jsonResponse(manifestForCheck))
+        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+    const removeFile = vi.fn((path: string) => rm(path, { force: true }))
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target),
+      removeFile
+    })
+
+    await service.check()
+    const status = await service.download()
+
+    // The stale .part was removed before the download, and the result is the fresh body (a full
+    // fetch, not a Range-resumed stale fragment that would fail the manifest checksum).
+    expect(removeFile).toHaveBeenCalledWith(partPath)
+    expect(status.state).toBe('ready')
+    expect(await readFile(target)).toEqual(body)
+    expect(existsSync(partPath)).toBe(false)
+  })
+
+  it('removes the .part only on the first download to a path this session (in-session resume kept)', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    const fetchImpl = ((input: unknown) =>
+      String(input).endsWith('version.json')
+        ? Promise.resolve(jsonResponse(manifestForCheck))
+        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+    const removeFile = vi.fn(() => Promise.resolve())
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target),
+      removeFile
+    })
+
+    await service.check()
+    await service.download()
+    await service.download() // same path, same session
+
+    // Only the first download reset the .part; the second leaves it so an in-session retry resumes.
+    expect(removeFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not start the fetch and errors when the first .part cleanup fails', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    const manifestForCheck = downloadManifest(11, 'irrelevant')
+    let installerFetches = 0
+    const fetchImpl = ((input: unknown) => {
+      if (String(input).endsWith('version.json'))
+        return Promise.resolve(jsonResponse(manifestForCheck))
+      installerFetches += 1
+      return Promise.resolve(new Response(Buffer.from('installer-bytes'), { status: 200 }))
+    }) as unknown as typeof fetch
+    const removeFile = vi.fn(() => Promise.reject(new Error('EACCES: cannot delete .part')))
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target),
+      removeFile
+    })
+
+    await service.check()
+    const status = await service.download()
+
+    // A failed cleanup surfaces as an error and the installer fetch never starts — we never resume a
+    // fragment we could not delete.
+    expect(status.state).toBe('error')
+    expect(installerFetches).toBe(0)
+  })
+
+  it('re-attempts the .part cleanup on a retry after the first cleanup failed', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    const fetchImpl = ((input: unknown) =>
+      String(input).endsWith('version.json')
+        ? Promise.resolve(jsonResponse(manifestForCheck))
+        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+    // Fail the first cleanup, succeed on the retry.
+    const removeFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('EACCES: cannot delete .part'))
+      .mockResolvedValueOnce(undefined)
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target),
+      removeFile
+    })
+
+    await service.check()
+    const first = await service.download()
+    expect(first.state).toBe('error')
+    const retry = await service.download()
+
+    // The path was NOT marked fresh after the failure, so the retry cleans again and then succeeds.
+    expect(removeFile).toHaveBeenCalledTimes(2)
+    expect(retry.state).toBe('ready')
+  })
+
+  it('resumes via a Range request on a same-session retry after a cancel', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-body-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    const rangeHeaders: (string | null)[] = []
+    let installerFetches = 0
+    const fetchImpl = ((input: unknown, init?: { signal?: AbortSignal; headers?: HeadersInit }) => {
+      if (String(input).endsWith('version.json'))
+        return Promise.resolve(jsonResponse(manifestForCheck))
+      installerFetches += 1
+      rangeHeaders.push(new Headers(init?.headers).get('range'))
+      if (installerFetches === 1) {
+        // First attempt: emit two bytes, then hang until the user abort errors the stream — leaving a
+        // flushed two-byte .part on disk to resume from.
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(body.subarray(0, 2))
+            init?.signal?.addEventListener('abort', () =>
+              controller.error(new DOMException('aborted', 'AbortError'))
+            )
+          }
+        })
+        return Promise.resolve(new Response(stream, { status: 200 }))
+      }
+      // Retry: serve the remaining bytes as a 206 partial-content response.
+      return Promise.resolve(
+        new Response(body.subarray(2), {
+          status: 206,
+          headers: { 'content-range': `bytes 2-${body.byteLength - 1}/${body.byteLength}` }
+        })
+      )
+    }) as unknown as typeof fetch
+    // Cancel only once the core reports ≥2 bytes transferred — the write callback resolves after the
+    // bytes hit the .part, so this guarantees a non-empty .part to resume from (avoids racing the abort
+    // against the first chunk write).
+    let onTwoBytes: (() => void) | undefined
+    const twoBytes = new Promise<void>((resolve) => (onTwoBytes = resolve))
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn((_channel: string, payload: unknown) => {
+        const transferred = (payload as { transferred?: number } | undefined)?.transferred
+        if (typeof transferred === 'number' && transferred >= 2) onTwoBytes?.()
+      }),
+      promptSavePath: () => Promise.resolve(target)
+    })
+
+    await service.check()
+    const downloading = service.download()
+    await twoBytes
+    await service.cancel()
+    await downloading
+
+    const retry = await service.download()
+
+    // The cancel left a two-byte .part; the SAME-session retry did not re-clean it (freshTargets still
+    // holds the path) and resumed from byte 2 via a Range header, completing the download.
+    expect(rangeHeaders[0]).toBeNull()
+    expect(rangeHeaders[1]).toBe('bytes=2-')
+    expect(retry.state).toBe('ready')
+    expect(await readFile(target)).toEqual(body)
   })
 
   it('stays available and does not fetch the installer when the save dialog is canceled', async () => {

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 
 import { app, BrowserWindow, dialog, shell } from 'electron'
@@ -24,6 +25,10 @@ export type UpdateServiceDeps = {
   fileExists?: (path: string) => boolean
   openPath?: (path: string) => Promise<string>
   openExternal?: (url: string) => Promise<void>
+  // Removes a stale partial file. Injected in tests; defaults to fs rm (best-effort). Used to drop a
+  // prior session's <target>.part the FIRST time a target path is downloaded this session, so a restart
+  // starts the installer download from scratch rather than resuming last session's fragment via Range.
+  removeFile?: (path: string) => Promise<void>
 }
 
 // Default broadcast pushes to every live window, mirroring the connector approval-broker pattern.
@@ -64,6 +69,12 @@ export class UpdateService implements UpdateStrategy {
   private readonly fileExists: (path: string) => boolean
   private readonly openPath: (path: string) => Promise<string>
   private readonly openExternal: (url: string) => Promise<void>
+  private readonly removeFile: (path: string) => Promise<void>
+  // Per-session set of target paths that have already been downloaded once this run. The first
+  // download to a given path removes any pre-existing <target>.part so a restart starts fresh
+  // (design: "app closes → start from scratch"). Within a session the path stays in the set and
+  // a cancel/retry resumes via Range instead of discarding the partially-downloaded bytes.
+  private readonly freshTargets = new Set<string>()
 
   constructor(deps: UpdateServiceDeps = {}) {
     this.fetchImpl = deps.fetchImpl
@@ -76,6 +87,7 @@ export class UpdateService implements UpdateStrategy {
     this.fileExists = deps.fileExists ?? existsSync
     this.openPath = deps.openPath ?? ((path) => shell.openPath(path))
     this.openExternal = deps.openExternal ?? ((url) => shell.openExternal(url))
+    this.removeFile = deps.removeFile ?? ((path) => rm(path, { force: true }))
     this.status = { state: 'idle', current: this.currentVersion, applyKind: 'installer' }
   }
 
@@ -179,6 +191,20 @@ export class UpdateService implements UpdateStrategy {
         // leaves the status untouched (stays 'available').
         const targetPath = await this.promptSavePath(installerFileName(download.url))
         if (!targetPath || abort.signal.aborted) return
+
+        // First time this session that we download to this exact path: drop any <target>.part left by
+        // a PRIOR session so the resilient core can't Range-resume a stale fragment (the user may
+        // re-pick the same Save location after a restart). Mark the path fresh ONLY after the removal
+        // succeeds — if it throws, we do NOT add it and let the error propagate to the catch below, so
+        // a retry re-attempts the cleanup instead of resuming a fragment we failed to delete (a
+        // same-version fragment would otherwise pass the final checksum and silently complete a
+        // cross-restart resume). Subsequent downloads to the same path this session are left alone so
+        // an in-session cancel/retry still resumes via Range.
+        if (!this.freshTargets.has(targetPath)) {
+          await this.removeFile(`${targetPath}.part`)
+          this.freshTargets.add(targetPath)
+          if (abort.signal.aborted) return
+        }
 
         this.setStatus({
           ...this.status,

--- a/src/renderer/src/components/DownloadProgressLine.render.test.tsx
+++ b/src/renderer/src/components/DownloadProgressLine.render.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { DownloadProgressLine } from './DownloadProgressLine'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('DownloadProgressLine', () => {
+  it('shows speed, size, and percent when total is known', () => {
+    act(() =>
+      root.render(
+        <DownloadProgressLine
+          progress={{
+            phase: 'downloading',
+            transferred: 47_400_000,
+            total: 335_500_000,
+            percent: 14,
+            bytesPerSecond: 2_411_724,
+            etaSeconds: 130,
+            attempt: 0
+          }}
+        />
+      )
+    )
+    expect(container.textContent).toContain('2.3 MB/s')
+    expect(container.textContent).toContain('14%')
+  })
+
+  it('shows bytes downloaded without a percent when total is unknown', () => {
+    act(() =>
+      root.render(
+        <DownloadProgressLine
+          progress={{
+            phase: 'downloading',
+            transferred: 47_400_000,
+            bytesPerSecond: 2_411_724,
+            attempt: 0
+          }}
+        />
+      )
+    )
+    expect(container.textContent).toContain('downloaded')
+    expect(container.textContent).not.toContain('%')
+  })
+
+  it('shows a resuming message while reconnecting', () => {
+    act(() =>
+      root.render(
+        <DownloadProgressLine
+          progress={{ phase: 'reconnecting', transferred: 1, bytesPerSecond: 0, attempt: 2 }}
+        />
+      )
+    )
+    expect(container.textContent).toContain('resuming… (attempt 2)')
+  })
+})

--- a/src/renderer/src/components/DownloadProgressLine.tsx
+++ b/src/renderer/src/components/DownloadProgressLine.tsx
@@ -1,0 +1,28 @@
+import { formatProgressLine, type DownloadProgress } from '../../../shared/download-progress'
+
+// Single-line download status reused by the update dialog and the provisioning surface. The bar stays
+// at the current fraction while reconnecting (pulse animation) so a stall reads as "resuming" rather
+// than a reset to zero. An unknown total renders an indeterminate bar.
+export const DownloadProgressLine = ({
+  progress
+}: {
+  progress: DownloadProgress
+}): React.JSX.Element => {
+  const reconnecting = progress.phase === 'reconnecting'
+  const known = progress.total != null && progress.percent != null
+  return (
+    <div className="mt-2">
+      <div className="mb-1 text-xs text-muted-foreground tabular-nums">
+        {formatProgressLine(progress)}
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-bg-300">
+        <div
+          className={`h-full rounded-full bg-primary transition-all duration-150 ease-out ${
+            reconnecting ? 'animate-pulse' : ''
+          } ${known ? '' : 'w-1/3 animate-pulse'}`}
+          style={known ? { width: `${progress.percent}%` } : undefined}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -139,9 +139,9 @@ describe('UpdateDialog', () => {
     expect(document.body.textContent).toContain('42%')
   })
 
-  it('hides the left label when byte counts are missing while downloading', () => {
-    // When transferred/total are unknown the left span should be empty — percent appears only on
-    // the right, avoiding a duplicate "35%   35%" display.
+  it('renders the download line without a percent when total is unknown', () => {
+    // No downloadProgress yet and unknown total: the shared line shows bytes downloaded, no percent,
+    // rather than a misleading fixed percentage against an unknown total.
     useUpdateStore.setState({
       isDialogOpen: true,
       status: {
@@ -154,31 +154,38 @@ describe('UpdateDialog', () => {
       }
     })
     act(() => root.render(<UpdateDialog />))
-    // The progress label row has two spans; the left one (context) should be empty.
-    const labelSpans = document.body.querySelectorAll('.tabular-nums span')
-    expect(labelSpans.length).toBeGreaterThanOrEqual(2)
-    expect(labelSpans[0].textContent).toBe('')
-    expect(labelSpans[1].textContent).toBe('35%')
+    // Scope the percent check to the download line itself (the last .tabular-nums; the first is the
+    // version subtitle). The download button label separately shows "Downloading 35%".
+    const lines = document.body.querySelectorAll('.tabular-nums')
+    const line = lines[lines.length - 1]
+    expect(line?.textContent).toContain('downloaded')
+    expect(line?.textContent).not.toContain('%')
   })
 
-  it('hides the left label when downloadedBytes is 0 while downloading', () => {
-    // A fresh download that hasn't received its first progress event yet: downloadedBytes is 0,
-    // so the left label should be empty — not "0 B / 9.8 KB".
+  it('mirrors the full download detail (speed) from downloadProgress while downloading', () => {
+    // Once a progress broadcast arrives, the store carries the superset detail and the dialog shows
+    // the speed line from the shared DownloadProgressLine.
     useUpdateStore.setState({
       isDialogOpen: true,
       status: {
         state: 'downloading',
         current: '0.1.0',
         latest: '0.2.0',
-        progress: 0,
-        downloadedBytes: 0,
-        totalBytes: 10000
+        progress: 42,
+        downloadedBytes: 4200,
+        totalBytes: 10000,
+        downloadProgress: {
+          phase: 'downloading',
+          transferred: 4200,
+          total: 10000,
+          percent: 42,
+          bytesPerSecond: 2_411_724,
+          attempt: 0
+        }
       }
     })
     act(() => root.render(<UpdateDialog />))
-    const labelSpans = document.body.querySelectorAll('.tabular-nums span')
-    expect(labelSpans.length).toBeGreaterThanOrEqual(2)
-    expect(labelSpans[0].textContent).toBe('')
-    expect(labelSpans[1].textContent).toBe('0%')
+    expect(document.body.textContent).toContain('2.3 MB/s')
+    expect(document.body.textContent).toContain('42%')
   })
 })

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -1,6 +1,7 @@
 import { Download, ExternalLink, RefreshCw, X } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 
+import { DownloadProgressLine } from '@/components/DownloadProgressLine'
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { AgentMarkdown } from '@/components/streamdown/AgentMarkdown'
 import { useUpdateStore } from '@/stores/update-store'
@@ -69,20 +70,18 @@ const UpdateDialog = (): React.JSX.Element | null => {
 
           {isDownloading ? (
             <div className="mt-4">
-              <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground tabular-nums">
-                <span>
-                  {status.downloadedBytes != null && status.totalBytes && status.downloadedBytes > 0
-                    ? `${formatBytes(status.downloadedBytes)} / ${formatBytes(status.totalBytes)}`
-                    : ''}
-                </span>
-                <span>{status.progress ?? 0}%</span>
-              </div>
-              <div className="h-1.5 w-full overflow-hidden rounded-full bg-bg-300">
-                <div
-                  className="h-full rounded-full bg-primary transition-all duration-150 ease-out"
-                  style={{ width: `${status.progress ?? 0}%` }}
-                />
-              </div>
+              <DownloadProgressLine
+                progress={
+                  status.downloadProgress ?? {
+                    phase: 'downloading',
+                    transferred: status.downloadedBytes ?? 0,
+                    total: status.totalBytes,
+                    percent: status.progress ?? 0,
+                    bytesPerSecond: 0,
+                    attempt: 0
+                  }
+                }
+              />
             </div>
           ) : null}
 

--- a/src/renderer/src/pages/onboarding/RuntimeChoiceCard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/RuntimeChoiceCard.render.test.tsx
@@ -184,6 +184,42 @@ describe('RuntimeChoiceCard', () => {
     expect(setEnvironmentEnabled).not.toHaveBeenCalledWith('python', symlinkPath, true)
   })
 
+  it('shows the shared speed/ETA line during the managed pack download', async () => {
+    // No runnable managed env yet + an in-flight provision whose progress carries a download payload.
+    listEnvironments.mockResolvedValue({ python: [], r: [] })
+    const store = useNotebookEnvStore.getState()
+    const original = {
+      status: store.status,
+      scope: store.scope,
+      progress: store.progress
+    }
+    useNotebookEnvStore.setState({
+      status: { ...store.status, provisioning: true, pythonReady: false },
+      scope: 'python',
+      progress: {
+        scope: 'python',
+        phase: 'download',
+        message: 'Downloading…',
+        progress: 0.4,
+        download: {
+          phase: 'downloading',
+          transferred: 4_000_000,
+          total: 10_000_000,
+          percent: 40,
+          bytesPerSecond: 2_000_000,
+          attempt: 0
+        }
+      }
+    })
+    try {
+      await render()
+      // The shared line surfaces speed ("…/s"), not merely a coarse percent bar.
+      expect(container.textContent ?? '').toContain('/s')
+    } finally {
+      useNotebookEnvStore.setState(original)
+    }
+  })
+
   it('keeps Cancel clickable during a real in-flight managed provision', async () => {
     // No runnable app-managed env → the "Download and set up" affordance is shown.
     listEnvironments.mockResolvedValue({ python: [], r: [] })

--- a/src/renderer/src/pages/onboarding/RuntimeChoiceCard.tsx
+++ b/src/renderer/src/pages/onboarding/RuntimeChoiceCard.tsx
@@ -187,13 +187,9 @@ const RuntimeChoiceCard = (): React.JSX.Element | null => {
                   : 'not set up yet'}
           </p>
           {managedPreparing && provisionUi.kind === 'preparing' ? (
-            provisionUi.download ? (
-              // During the pack download, show the shared speed/ETA/resume line so a weak-network
-              // stall reads as "resuming" rather than a frozen bar (same surface as the notebook gate).
-              <div className="mt-2 w-full max-w-xs">
-                <DownloadProgressLine progress={provisionUi.download} />
-              </div>
-            ) : (
+            <>
+              {/* §3.1: overall provision bar + the download sub-line coexist (the download is one
+                  phase of provisioning), matching the notebook-gate surface. */}
               <div
                 className="mt-2 h-1.5 w-full max-w-xs overflow-hidden rounded-full bg-bg-300"
                 role="progressbar"
@@ -209,7 +205,12 @@ const RuntimeChoiceCard = (): React.JSX.Element | null => {
                   }}
                 />
               </div>
-            )
+              {provisionUi.download ? (
+                <div className="mt-2 w-full max-w-xs">
+                  <DownloadProgressLine progress={provisionUi.download} />
+                </div>
+              ) : null}
+            </>
           ) : null}
           {enabledOwn.length > 0 ? (
             <p className="mt-1 truncate text-[11px] text-text-100">

--- a/src/renderer/src/pages/onboarding/RuntimeChoiceCard.tsx
+++ b/src/renderer/src/pages/onboarding/RuntimeChoiceCard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 import { useNotebookEnvStore } from '@/stores/notebook-env-store'
+import { DownloadProgressLine } from '@/components/DownloadProgressLine'
 import { deriveProvisionUi } from '../workspace/provisioning-view'
 import {
   isEnvEnabled,
@@ -186,21 +187,29 @@ const RuntimeChoiceCard = (): React.JSX.Element | null => {
                   : 'not set up yet'}
           </p>
           {managedPreparing && provisionUi.kind === 'preparing' ? (
-            <div
-              className="mt-2 h-1.5 w-full max-w-xs overflow-hidden rounded-full bg-bg-300"
-              role="progressbar"
-              aria-label="Setting up the app-managed Python environment"
-              aria-valuenow={Math.round(provisionUi.progress * 100)}
-              aria-valuemin={0}
-              aria-valuemax={100}
-            >
+            provisionUi.download ? (
+              // During the pack download, show the shared speed/ETA/resume line so a weak-network
+              // stall reads as "resuming" rather than a frozen bar (same surface as the notebook gate).
+              <div className="mt-2 w-full max-w-xs">
+                <DownloadProgressLine progress={provisionUi.download} />
+              </div>
+            ) : (
               <div
-                className="h-full rounded-full bg-primary transition-[width] duration-300"
-                style={{
-                  width: `${Math.max(2, Math.min(100, Math.round(provisionUi.progress * 100)))}%`
-                }}
-              />
-            </div>
+                className="mt-2 h-1.5 w-full max-w-xs overflow-hidden rounded-full bg-bg-300"
+                role="progressbar"
+                aria-label="Setting up the app-managed Python environment"
+                aria-valuenow={Math.round(provisionUi.progress * 100)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+              >
+                <div
+                  className="h-full rounded-full bg-primary transition-[width] duration-300"
+                  style={{
+                    width: `${Math.max(2, Math.min(100, Math.round(provisionUi.progress * 100)))}%`
+                  }}
+                />
+              </div>
+            )
           ) : null}
           {enabledOwn.length > 0 ? (
             <p className="mt-1 truncate text-[11px] text-text-100">

--- a/src/renderer/src/pages/workspace/EnvProvisionOverlay.tsx
+++ b/src/renderer/src/pages/workspace/EnvProvisionOverlay.tsx
@@ -30,20 +30,20 @@ const EnvProvisionOverlay = ({
       {ui.kind === 'preparing' ? (
         <>
           {ui.message ? <p className="text-xs text-text-300">{ui.message}</p> : null}
+          {/* §3.1: the overall provision bar (fetch → verify → seed) and the download sub-line
+              coexist — the download is one phase of provisioning, so the coarse bar stays visible
+              for overall position while the detail line adds speed/ETA/resume during the fetch. */}
+          <div className="h-1.5 w-56 overflow-hidden rounded-full bg-bg-300">
+            <div
+              className="h-full bg-primary transition-all"
+              style={{ width: `${Math.round(ui.progress * 100)}%` }}
+            />
+          </div>
           {ui.download ? (
-            // During the pack download, show the shared speed/ETA/resume line instead of the coarse
-            // overall bar so a weak-network stall reads as "resuming" rather than a frozen bar.
             <div className="w-56">
               <DownloadProgressLine progress={ui.download} />
             </div>
-          ) : (
-            <div className="h-1.5 w-56 overflow-hidden rounded-full bg-bg-300">
-              <div
-                className="h-full bg-primary transition-all"
-                style={{ width: `${Math.round(ui.progress * 100)}%` }}
-              />
-            </div>
-          )}
+          ) : null}
         </>
       ) : (
         <>

--- a/src/renderer/src/pages/workspace/EnvProvisionOverlay.tsx
+++ b/src/renderer/src/pages/workspace/EnvProvisionOverlay.tsx
@@ -1,3 +1,4 @@
+import { DownloadProgressLine } from '@/components/DownloadProgressLine'
 import type { ProvisionUiState } from './provisioning-view'
 
 // Reusable provisioning progress surface. Rendered as a greyed overlay over the notebook pane, and
@@ -29,12 +30,20 @@ const EnvProvisionOverlay = ({
       {ui.kind === 'preparing' ? (
         <>
           {ui.message ? <p className="text-xs text-text-300">{ui.message}</p> : null}
-          <div className="h-1.5 w-56 overflow-hidden rounded-full bg-bg-300">
-            <div
-              className="h-full bg-primary transition-all"
-              style={{ width: `${Math.round(ui.progress * 100)}%` }}
-            />
-          </div>
+          {ui.download ? (
+            // During the pack download, show the shared speed/ETA/resume line instead of the coarse
+            // overall bar so a weak-network stall reads as "resuming" rather than a frozen bar.
+            <div className="w-56">
+              <DownloadProgressLine progress={ui.download} />
+            </div>
+          ) : (
+            <div className="h-1.5 w-56 overflow-hidden rounded-full bg-bg-300">
+              <div
+                className="h-full bg-primary transition-all"
+                style={{ width: `${Math.round(ui.progress * 100)}%` }}
+              />
+            </div>
+          )}
         </>
       ) : (
         <>

--- a/src/renderer/src/pages/workspace/EnvStatusBanner.render.test.tsx
+++ b/src/renderer/src/pages/workspace/EnvStatusBanner.render.test.tsx
@@ -38,6 +38,61 @@ describe('EnvStatusBanner', () => {
     )
   })
 
+  it('shows the shared speed/ETA line during an upgrade pack download', () => {
+    act(() =>
+      root.render(
+        <EnvStatusBanner
+          ui={{
+            kind: 'preparing',
+            scope: 'upgrade',
+            phase: 'download',
+            message: 'Downloading…',
+            progress: 0.4,
+            download: {
+              phase: 'downloading',
+              transferred: 4_000_000,
+              total: 10_000_000,
+              percent: 40,
+              bytesPerSecond: 2_000_000,
+              attempt: 0
+            }
+          }}
+        />
+      )
+    )
+    // Speed is surfaced (formatProgressLine renders "…/s"), not just a bare percent.
+    expect(container.querySelector('[data-testid="env-status-banner"]')?.textContent).toContain(
+      '/s'
+    )
+  })
+
+  it('surfaces a reconnect during an upgrade download instead of a frozen percent', () => {
+    act(() =>
+      root.render(
+        <EnvStatusBanner
+          ui={{
+            kind: 'preparing',
+            scope: 'upgrade',
+            phase: 'download',
+            message: 'Downloading…',
+            progress: 0.4,
+            download: {
+              phase: 'reconnecting',
+              transferred: 4_000_000,
+              total: 10_000_000,
+              percent: 40,
+              bytesPerSecond: 0,
+              attempt: 2
+            }
+          }}
+        />
+      )
+    )
+    expect(container.querySelector('[data-testid="env-status-banner"]')?.textContent).toContain(
+      'resuming'
+    )
+  })
+
   it('shows an error banner with a retry affordance wired to the store retry action', () => {
     let retried = 0
     act(() =>

--- a/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
+++ b/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
@@ -37,11 +37,10 @@ const EnvStatusBanner = ({
           ) : null}
         </>
       ) : ui.download ? (
-        // Task 8: reuse the shared DownloadProgressLine (with its resume/pulse bar) so the upgrade
-        // banner renders speed/ETA and a stall reads as "resuming" consistently with the other hosts.
-        // The banner drops its single-line pill shape to a small stacked block for this phase.
+        // Task 8: keep the existing overall provision phase text (with its percent), and render the
+        // shared DownloadProgressLine (speed/ETA + resume bar) BELOW it — not a second overall bar.
         <div className="flex min-w-56 flex-col text-left">
-          <span>Updating the notebook environment…</span>
+          <span>Updating the notebook environment… {Math.round(ui.progress * 100)}%</span>
           <DownloadProgressLine progress={ui.download} />
         </div>
       ) : (

--- a/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
+++ b/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
@@ -1,3 +1,4 @@
+import { formatProgressLine } from '../../../../shared/download-progress'
 import type { ProvisionUiState } from './provisioning-view'
 
 // Floating top-of-app pill for the launch-time upgrade gate (spec §6.2). First-run python preparation
@@ -35,6 +36,12 @@ const EnvStatusBanner = ({
             </button>
           ) : null}
         </>
+      ) : ui.download ? (
+        // Compact pill: show the shared speed/ETA/resume text inline (the full bar would break the
+        // single-line layout) so a weak-network upgrade reads as "resuming" rather than a frozen %.
+        <span className="tabular-nums">
+          Updating the notebook environment… {formatProgressLine(ui.download)}
+        </span>
       ) : (
         <span>Updating the notebook environment… {Math.round(ui.progress * 100)}%</span>
       )}

--- a/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
+++ b/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
@@ -1,4 +1,4 @@
-import { formatProgressLine } from '../../../../shared/download-progress'
+import { DownloadProgressLine } from '@/components/DownloadProgressLine'
 import type { ProvisionUiState } from './provisioning-view'
 
 // Floating top-of-app pill for the launch-time upgrade gate (spec §6.2). First-run python preparation
@@ -37,11 +37,13 @@ const EnvStatusBanner = ({
           ) : null}
         </>
       ) : ui.download ? (
-        // Compact pill: show the shared speed/ETA/resume text inline (the full bar would break the
-        // single-line layout) so a weak-network upgrade reads as "resuming" rather than a frozen %.
-        <span className="tabular-nums">
-          Updating the notebook environment… {formatProgressLine(ui.download)}
-        </span>
+        // Task 8: reuse the shared DownloadProgressLine (with its resume/pulse bar) so the upgrade
+        // banner renders speed/ETA and a stall reads as "resuming" consistently with the other hosts.
+        // The banner drops its single-line pill shape to a small stacked block for this phase.
+        <div className="flex min-w-56 flex-col text-left">
+          <span>Updating the notebook environment…</span>
+          <DownloadProgressLine progress={ui.download} />
+        </div>
       ) : (
         <span>Updating the notebook environment… {Math.round(ui.progress * 100)}%</span>
       )}

--- a/src/renderer/src/pages/workspace/provisioning-view.ts
+++ b/src/renderer/src/pages/workspace/provisioning-view.ts
@@ -1,3 +1,4 @@
+import type { DownloadProgress } from '../../../../shared/download-progress'
 import type {
   ProvisionOperationScope,
   ProvisionProgress,
@@ -20,6 +21,7 @@ export type ProvisionUiState =
       message: string
       progress: number
       sessionId?: string
+      download?: DownloadProgress
     }
   | { kind: 'error'; message: string; scope?: PreparingScope; sessionId?: string }
 
@@ -40,7 +42,8 @@ export function deriveProvisionUi(
       phase: progress?.phase ?? '',
       message: progress?.message ?? '',
       progress: progress?.progress ?? 0,
-      ...(progress?.sessionId ? { sessionId: progress.sessionId } : {})
+      ...(progress?.sessionId ? { sessionId: progress.sessionId } : {}),
+      ...(progress?.download ? { download: progress.download } : {})
     }
   }
   // A failed attempt only counts as a blocking error while python itself is missing; an R failure

--- a/src/renderer/src/stores/update-store.test.ts
+++ b/src/renderer/src/stores/update-store.test.ts
@@ -195,5 +195,13 @@ describe('useUpdateStore', () => {
     expect(status.progress).toBe(42)
     expect(status.downloadedBytes).toBe(4200)
     expect(status.totalBytes).toBe(10000)
+
+    // A reconnecting event omits percent/total; the mirror must keep the last known size and
+    // percent so the action button doesn't flip to "Downloading 0%" mid-reconnect.
+    progressListener?.({ phase: 'reconnecting', transferred: 4200, bytesPerSecond: 0, attempt: 1 })
+    const reconnecting = useUpdateStore.getState().status
+    expect(reconnecting.progress).toBe(42)
+    expect(reconnecting.totalBytes).toBe(10000)
+    expect(reconnecting.downloadProgress?.phase).toBe('reconnecting')
   })
 })

--- a/src/renderer/src/stores/update-store.test.ts
+++ b/src/renderer/src/stores/update-store.test.ts
@@ -204,4 +204,47 @@ describe('useUpdateStore', () => {
     expect(reconnecting.totalBytes).toBe(10000)
     expect(reconnecting.downloadProgress?.phase).toBe('reconnecting')
   })
+
+  it('preserves downloadProgress (speed) across a status broadcast while downloading', async () => {
+    let progressListener: ((progress: unknown) => void) | undefined
+    let statusListener: ((status: unknown) => void) | undefined
+    ;(window as unknown as { api: unknown }).api = {
+      update: {
+        getAppInfo: () =>
+          Promise.resolve({ name: 'Open Science', version: '0.2.0', copyright: '' }),
+        getStatus: () => Promise.resolve({ state: 'idle', current: '0.2.0' }),
+        onStatus: (l: (status: unknown) => void) => {
+          statusListener = l
+        },
+        onProgress: (l: (progress: unknown) => void) => {
+          progressListener = l
+        },
+        check: vi.fn(),
+        download: vi.fn(),
+        apply: vi.fn()
+      }
+    }
+    useUpdateStore.getState().init()
+    await Promise.resolve()
+
+    // electron-updater emits a progress event (with speed) then a status event on every tick. The
+    // status event carries no downloadProgress; the store must not drop the speed just set.
+    progressListener?.({
+      phase: 'downloading',
+      percent: 42,
+      transferred: 4200,
+      total: 10000,
+      bytesPerSecond: 12345,
+      attempt: 0
+    })
+    statusListener?.({ state: 'downloading', current: '0.2.0', progress: 42, totalBytes: 10000 })
+
+    const status = useUpdateStore.getState().status
+    expect(status.state).toBe('downloading')
+    expect(status.downloadProgress?.bytesPerSecond).toBe(12345)
+
+    // Once the download finishes, a terminal status clears the stale progress payload.
+    statusListener?.({ state: 'ready', current: '0.2.0', progress: 100 })
+    expect(useUpdateStore.getState().status.downloadProgress).toBeUndefined()
+  })
 })

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -40,9 +40,12 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
       set((s) => ({
         status: {
           ...s.status,
-          progress: progress.percent,
+          // A `reconnecting` event omits percent/total (bytesPerSecond: 0); keep the last known
+          // values so the action button doesn't flip to "Downloading 0%" and drop the size label
+          // mid-reconnect. downloadProgress always carries the raw event for DownloadProgressLine.
+          progress: progress.percent ?? s.status.progress,
           downloadedBytes: progress.transferred,
-          totalBytes: progress.total,
+          totalBytes: progress.total ?? s.status.totalBytes,
           downloadProgress: progress
         }
       }))

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -35,7 +35,18 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
       .then((info) =>
         set((s) => ({ appInfo: info, status: { ...s.status, current: info.version } }))
       )
-    api.onStatus((status) => set({ status }))
+    // Status events don't carry downloadProgress. A strategy that emits progress (with speed) then
+    // immediately a status (electron-updater does on every tick) would otherwise wipe the speed the
+    // progress event just set. Preserve downloadProgress across a status update while downloading so
+    // DownloadProgressLine keeps rendering speed/ETA on Win/Linux.
+    api.onStatus((status) =>
+      set((s) => ({
+        status: {
+          ...status,
+          downloadProgress: status.state === 'downloading' ? s.status.downloadProgress : undefined
+        }
+      }))
+    )
     api.onProgress((progress) =>
       set((s) => ({
         status: {

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -42,7 +42,8 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
           ...s.status,
           progress: progress.percent,
           downloadedBytes: progress.transferred,
-          totalBytes: progress.total
+          totalBytes: progress.total,
+          downloadProgress: progress
         }
       }))
     )

--- a/src/shared/download-progress.test.ts
+++ b/src/shared/download-progress.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatEta, formatProgressLine, formatSpeed } from './download-progress'
+
+describe('download-progress formatters', () => {
+  it('formats speed with binary units', () => {
+    expect(formatSpeed(0)).toBe('0 B/s')
+    expect(formatSpeed(2_411_724)).toBe('2.3 MB/s')
+  })
+
+  it('formats ETA as compact minutes/seconds', () => {
+    expect(formatEta(undefined)).toBeUndefined()
+    expect(formatEta(45)).toBe('~45s')
+    expect(formatEta(130)).toBe('~2m 10s')
+    expect(formatEta(120)).toBe('~2m')
+  })
+
+  it('composes a downloading line with total known', () => {
+    const line = formatProgressLine({
+      phase: 'downloading',
+      transferred: 47_400_000,
+      total: 335_500_000,
+      percent: 14,
+      bytesPerSecond: 2_411_724,
+      etaSeconds: 130,
+      attempt: 0
+    })
+    expect(line).toContain('2.3 MB/s')
+    expect(line).toContain('14%')
+    expect(line).toContain('~2m 10s')
+  })
+
+  it('composes a downloading line when total unknown', () => {
+    const line = formatProgressLine({
+      phase: 'downloading',
+      transferred: 47_400_000,
+      bytesPerSecond: 2_411_724,
+      attempt: 0
+    })
+    expect(line).toContain('downloaded')
+    expect(line).not.toContain('%')
+  })
+
+  it('composes a reconnecting line with attempt number', () => {
+    const line = formatProgressLine({
+      phase: 'reconnecting',
+      transferred: 47_400_000,
+      bytesPerSecond: 0,
+      attempt: 2
+    })
+    expect(line).toBe('Connection lost, resuming… (attempt 2)')
+  })
+})

--- a/src/shared/download-progress.ts
+++ b/src/shared/download-progress.ts
@@ -1,0 +1,39 @@
+// Cross-process download progress vocabulary + display formatters. No I/O so both main and renderer
+// import it. formatBytes is reused from update.ts to keep one byte-unit convention app-wide.
+import { formatBytes } from './update'
+
+export type DownloadPhase = 'downloading' | 'reconnecting'
+
+export type DownloadProgress = {
+  phase: DownloadPhase
+  transferred: number
+  total?: number
+  percent?: number
+  bytesPerSecond: number
+  etaSeconds?: number
+  attempt: number
+}
+
+export const formatSpeed = (bytesPerSecond: number): string =>
+  bytesPerSecond <= 0 ? '0 B/s' : `${formatBytes(bytesPerSecond)}/s`
+
+export const formatEta = (seconds?: number): string | undefined => {
+  if (seconds == null) return undefined
+  if (seconds < 60) return `~${seconds}s`
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return s === 0 ? `~${m}m` : `~${m}m ${s}s`
+}
+
+// One-line summary shown under the progress bar. Reconnecting takes priority so a mid-stall line
+// reads as "resuming" rather than a frozen speed of 0.
+export const formatProgressLine = (p: DownloadProgress): string => {
+  if (p.phase === 'reconnecting') return `Connection lost, resuming… (attempt ${p.attempt})`
+  const speed = formatSpeed(p.bytesPerSecond)
+  if (p.total != null && p.percent != null) {
+    const eta = formatEta(p.etaSeconds)
+    const size = `${formatBytes(p.transferred)} / ${formatBytes(p.total)}`
+    return [speed, size, `${p.percent}%`, eta].filter(Boolean).join(' · ')
+  }
+  return `${speed} · ${formatBytes(p.transferred)} downloaded`
+}

--- a/src/shared/notebook-env.ts
+++ b/src/shared/notebook-env.ts
@@ -16,6 +16,9 @@ export type ProvisionProgress = {
   // provisioning independently — the provisioner serializes the two runs, but neither card should look
   // cancelled when the other is requested (undefined for language-agnostic events: upgrade/restore).
   language?: NotebookLanguage
+  // Present during the pack-download phase so the UI can show speed/ETA/resume detail alongside the
+  // coarse `progress` fraction.
+  download?: import('./download-progress').DownloadProgress
 }
 export type RuntimeBundleSource = {
   kind: 'official' | 'override'

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -549,6 +549,9 @@ export type ClaudeInstallResult = {
   // The official installer returned a region-block HTML page instead of the script (common in
   // regions where claude.ai is unavailable); the installer auto-falls-back to npm when it can.
   regionBlocked?: boolean
+  // The install failed with output matching a transient network fault (registry timeout, connection
+  // reset); the runner retries the same source a few times before surfacing the failure.
+  retryableNetworkFailure?: boolean
 }
 
 // Availability of npm on the host, used to gate the npm source.

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -29,12 +29,9 @@ export type UpdateStatus = {
   applyKind?: 'installer' | 'restart'
 }
 
-// Broadcast on every download chunk so the renderer can show live byte counts alongside the percent.
-export type DownloadProgress = {
-  percent: number
-  transferred: number
-  total: number
-}
+// DownloadProgress now lives in download-progress.ts as a superset (adds phase/bytesPerSecond/
+// etaSeconds/attempt). Re-exported here so existing importers of this module keep working.
+export type { DownloadProgress } from './download-progress'
 
 export type AppInfo = { name: string; version: string; copyright: string }
 

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -22,6 +22,9 @@ export type UpdateStatus = {
   progress?: number // 0-100 while downloading
   downloadedBytes?: number // bytes received so far while downloading
   totalBytes?: number // total installer size in bytes
+  // Full progress detail (speed/ETA/reconnect) mirrored from the last update:progress broadcast so
+  // the dialog can render the shared DownloadProgressLine.
+  downloadProgress?: import('./download-progress').DownloadProgress
   localPath?: string // set when state === 'ready'
   error?: string
   // How the renderer applies a ready update: open the downloaded installer (mac manual reinstall) or


### PR DESCRIPTION
## Problem

Large downloads (Runtime language packs, App updates) fail silently on weak networks: a stalled or interrupted download restarts from scratch, there is no speed or ETA feedback, and users face a frozen progress bar with no indication of whether the app is stuck or still working.

Additionally, all main-process downloads using Node global `fetch` (undici) bypass the system proxy/VPN — users on corporate networks cannot download at all.

## Proposed change

Introduce a shared resilient download core (`src/main/net/resilient-download.ts`) that all main-process byte-stream downloads delegate to:

- **HTTP Range resume**: on a dropped connection the next attempt sends `Range: bytes=<offset>-` and appends to the `.part` file rather than restarting.
- **Retry with exponential backoff**: network faults, stall timeouts, and 5xx are retried up to 5 times. Terminal errors (sha256 mismatch, 4xx, external abort) are not retried. The `.part` is preserved on timeout so a manual retry can still resume.
- **Stall detection**: no bytes for 60 s aborts the current connection and triggers a Range resume.
- **Speed + ETA**: `SpeedMeter` (3 s sliding window) feeds `bytesPerSecond` and `etaSeconds` into a shared `DownloadProgress` type broadcast to the renderer.
- **Reconnecting state**: while retrying the UI shows `Connection lost, resuming… (attempt N)` and the progress bar stays at the last known position.
- **System proxy / VPN fix**: default `fetchImpl` switched from Node global `fetch` to `netFetchStandard` (`electron.net.fetch`, honors system proxy) for both the installer downloader and language-pack fetch. The manifest fetch in `language-pack-fetch.ts` is also updated.

Additional:
- electron-updater path: maps its native `bytesPerSecond` into the shared vocabulary.
- Claude/Opencode install: wraps the spawn runner with a network-error retry loop (up to 3 attempts), emitting `Install interrupted, retrying… (attempt N)`.
- Shared `DownloadProgressLine` component replaces the hand-written progress blocks in `UpdateDialog` and `EnvProvisionOverlay`.

## Scope and non-goals

In scope: session-scoped Range resume; speed/ETA/reconnect UI for App updates and Runtime provisioning; proxy-aware fetch for all main-process downloads; network-retry for Claude/Opencode installs.

Not in scope: cross-restart persistent resume; electron-updater internals (it handles its own retries).

## Acceptance criteria and validation

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors
- `npm run test` — 5664 passed (2 pre-existing packaging failures confirmed on base commit, unrelated)
- Key new test coverage: resilient-download (7 cases: clean, Range resume, 200 fallback, sha256 mismatch, retry exhaustion, reconnecting event, abort); download-speed (5); DownloadProgressLine render (3); claude-install retry (2).

## Review focus

- `src/main/net/resilient-download.ts`: sha256 re-seed on Range resume (reads `.part` before appending), short-read detection via `IncompleteStreamError`, terminal vs retryable error classification.
- `src/main/notebook/language-pack-fetch.ts`: `LanguagePackFetchDeps.download` widened to carry `expected` (sha256/size) and full `DownloadProgress` callback; adapter threads `download` into `ProvisionProgress`.
- `src/renderer/src/components/DownloadProgressLine.tsx` + consumers: UI wiring for the three progress states.