### PR TITLE
feat(workspace): add Report error button for failed runs

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -292,7 +292,8 @@ describe('workspace agent message sending', () => {
 
     const sent = await sendWorkspaceMessage(runtime, {
       text: 'Help me inspect this notebook',
-      cwd: '/workspace/project'
+      cwd: '/workspace/project',
+      agentModel: 'model-used-by-run'
     })
 
     expect(runtime.createSession).toHaveBeenCalledWith('/workspace/project', undefined, 'ask')
@@ -300,6 +301,7 @@ describe('workspace agent message sending', () => {
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       id: sent?.sessionId,
       isPending: true,
+      agentModel: 'model-used-by-run',
       status: 'running',
       messages: [
         expect.objectContaining({
@@ -321,6 +323,7 @@ describe('workspace agent message sending', () => {
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       id: 'transport-session-1',
       isPending: false,
+      agentModel: 'model-used-by-run',
       messages: [
         expect.objectContaining({
           id: sent?.messageId,
@@ -381,6 +384,35 @@ describe('workspace agent message sending', () => {
       cwd: '',
       status: 'error',
       error: 'Agent session did not return a workspace.'
+    })
+  })
+
+  it('keeps the selected run subject when initial session creation rejects', async () => {
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn().mockRejectedValue(new Error('Authentication failed')),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    const sent = await sendWorkspaceMessage(runtime, {
+      text: 'Start a new analysis',
+      cwd: '/workspace/project',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:builtin-codex-subscription',
+      agentModel: 'gpt-5.6-sol'
+    })
+    await flushRuntimeTasks()
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      id: sent?.sessionId,
+      isPending: true,
+      status: 'error',
+      error: 'Authentication failed',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:builtin-codex-subscription',
+      agentModel: 'gpt-5.6-sol'
     })
   })
 
@@ -560,6 +592,68 @@ describe('workspace agent message sending', () => {
         })
       ]
     })
+  })
+
+  it('refreshes the run subject when a pending session retry also fails', async () => {
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('First provider failed'))
+        .mockRejectedValueOnce(new Error('Second provider failed'))
+        .mockRejectedValueOnce(new Error('No provider selected')),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    const first = await sendWorkspaceMessage(runtime, {
+      text: 'Start with Claude',
+      cwd: '/workspace/project',
+      agentFrameworkId: 'claude-code',
+      agentBackendId: 'claude-code:anthropic',
+      agentModel: 'claude-opus-4'
+    })
+    await flushRuntimeTasks()
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: first?.sessionId,
+      text: 'Retry with Codex',
+      cwd: '/workspace/project',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:builtin-codex-subscription',
+      agentModel: 'gpt-5.6-sol'
+    })
+    await flushRuntimeTasks()
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      id: first?.sessionId,
+      isPending: true,
+      status: 'error',
+      error: 'Second provider failed',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:builtin-codex-subscription',
+      agentModel: 'gpt-5.6-sol'
+    })
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: first?.sessionId,
+      text: 'Retry without a provider',
+      cwd: '/workspace/project',
+      agentFrameworkId: 'codex'
+    })
+    await flushRuntimeTasks()
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session).toMatchObject({
+      id: first?.sessionId,
+      isPending: true,
+      status: 'error',
+      error: 'No provider selected',
+      agentFrameworkId: 'codex'
+    })
+    expect(session.agentBackendId).toBeUndefined()
+    expect(session.agentModel).toBeUndefined()
   })
 
   it('does not fall back to the runtime home directory when retrying managed workspace creation', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -15,6 +15,7 @@ import {
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import type { ArtifactReference } from '../../../../shared/artifacts'
 import type { MessagePart } from '../../../../shared/session-persistence'
+import type { AgentFrameworkId } from '../../../../shared/settings'
 import { isMediaOverflowError } from '../../../../shared/media-overflow'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { useSessionStore, type ChatMessage } from '../../stores/session-store'
@@ -33,6 +34,11 @@ type SendWorkspaceMessageInput = {
   // Storage project the artifact/notebook MCP servers write under (usually the same value).
   projectName?: string
   permissionProfile?: PermissionProfileId
+  // Snapshot of the selected agent configuration for this run; persisted for failure diagnostics
+  // even when the initial ACP session handshake never completes.
+  agentFrameworkId?: AgentFrameworkId
+  agentBackendId?: string
+  agentModel?: string
   // Skills the user picked in the composer; force-loaded and nudged for this turn only.
   forcedSkillIds?: string[]
   // Existing files referenced via `@` mentions; attached to the prompt as content blocks.
@@ -358,6 +364,9 @@ const sendWorkspaceMessage = async (
     projectId,
     projectName,
     permissionProfile,
+    agentFrameworkId,
+    agentBackendId,
+    agentModel,
     forcedSkillIds,
     referencedArtifacts,
     parts,
@@ -399,7 +408,10 @@ const sendWorkspaceMessage = async (
         attachments,
         parts,
         cwd: retryCwd,
-        projectId: projectId ?? currentSession.projectId
+        projectId: projectId ?? currentSession.projectId,
+        agentFrameworkId,
+        agentBackendId,
+        agentModel
       })
 
       if (!appended) return undefined
@@ -443,7 +455,8 @@ const sendWorkspaceMessage = async (
           attachments,
           parts,
           cwd: targetCwd,
-          projectId: projectId ?? currentSession?.projectId
+          projectId: projectId ?? currentSession?.projectId,
+          agentModel
         })
 
     // appendUserMessage can reject stale session ids after local deletion or hydration changes.
@@ -565,7 +578,10 @@ const sendWorkspaceMessage = async (
     parts,
     cwd: targetCwd,
     projectId,
-    permissionProfile
+    permissionProfile,
+    agentFrameworkId,
+    agentBackendId,
+    agentModel
   })
 
   if (!pending) return undefined
@@ -611,7 +627,8 @@ const findInterruptedUserTurn = (messages: ChatMessage[]): ChatMessage | undefin
 const resumeInterruptedWorkspaceSession = async (
   runtime: WorkspaceMessageRuntime,
   sessionId: string,
-  supportsImageInput?: boolean
+  supportsImageInput?: boolean,
+  agentModel?: string
 ): Promise<void> => {
   const session = useSessionStore.getState().sessions.find((item) => item.id === sessionId)
 
@@ -674,7 +691,8 @@ const resumeInterruptedWorkspaceSession = async (
     permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
     // Replay the prior conversation when this resume adopted a fresh agent session.
     forceHistoryReplay: contextReset,
-    supportsImageInput
+    supportsImageInput,
+    agentModel
   })
 }
 
@@ -737,7 +755,8 @@ const recoverContextOverflowWorkspaceSession = async (
     projectId: session.projectId,
     permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
     // A fresh agent session lost the prior context, so replay the transcript on this first prompt.
-    forceHistoryReplay: true
+    forceHistoryReplay: true,
+    agentModel: session.agentModel
   })
 
   return true
@@ -752,7 +771,8 @@ const recoverContextOverflowWorkspaceSession = async (
 const resendEditedWorkspaceMessage = async (
   runtime: WorkspaceMessageRuntime,
   input: ResendEditedMessageInput & { sessionId: string; messageId: string },
-  supportsImageInput?: boolean
+  supportsImageInput?: boolean,
+  agentModel?: string
 ): Promise<boolean> => {
   const session = useSessionStore.getState().sessions.find((item) => item.id === input.sessionId)
 
@@ -787,7 +807,8 @@ const resendEditedWorkspaceMessage = async (
     attachments: [],
     parts: input.parts,
     cwd: resumeCwd,
-    projectId: session.projectId
+    projectId: session.projectId,
+    agentModel
   })
 
   if (!appended) return false
@@ -822,7 +843,8 @@ const resendEditedWorkspaceMessage = async (
     // The fresh agent session lost the prior context, so replay the truncated transcript.
     forceHistoryReplay: true,
     preAppendedMessageId: appended.messageId,
-    supportsImageInput
+    supportsImageInput,
+    agentModel
   })
 
   return true
@@ -955,6 +977,9 @@ const useWorkspaceAgentRuntime = (): {
     const provider = state.providers.find((candidate) => candidate.id === state.activeProviderId)
     return provider?.supportsImageInput ?? false
   })
+  const activeModel = useSettingsStore((state) => state.activeModel)
+  const activeProviderId = useSettingsStore((state) => state.activeProviderId)
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const eventProcessor = useRef(createWorkspaceRuntimeEventProcessor())
   // Tracks the last connection status so the disconnect effect fires only on a transition, not on
   // every unrelated snapshot re-render.
@@ -999,24 +1024,35 @@ const useWorkspaceAgentRuntime = (): {
   // Creates a session if needed, records the user message, then starts the prompt in the background.
   const sendMessage = useCallback(
     (input: SendWorkspaceMessageInput): Promise<SendWorkspaceMessageResult | undefined> =>
-      sendWorkspaceMessage(runtime, { ...input, supportsImageInput }),
-    [runtime, supportsImageInput]
+      sendWorkspaceMessage(runtime, {
+        ...input,
+        supportsImageInput,
+        agentFrameworkId,
+        agentBackendId: activeProviderId ? `${agentFrameworkId}:${activeProviderId}` : undefined,
+        agentModel: activeModel
+      }),
+    [runtime, supportsImageInput, agentFrameworkId, activeProviderId, activeModel]
   )
 
   // Truncates the conversation at the edited message, then resends the adjusted prompt with the
   // kept history replayed into the reset agent context.
   const resendEditedMessage = useCallback(
     (sessionId: string, messageId: string, input: ResendEditedMessageInput): Promise<boolean> =>
-      resendEditedWorkspaceMessage(runtime, { sessionId, messageId, ...input }, supportsImageInput),
-    [runtime, supportsImageInput]
+      resendEditedWorkspaceMessage(
+        runtime,
+        { sessionId, messageId, ...input },
+        supportsImageInput,
+        activeModel
+      ),
+    [runtime, supportsImageInput, activeModel]
   )
 
   // Explicitly re-attaches an interrupted session's ACP runtime so the user can keep chatting. On
   // success the composer is unlocked; on failure the interrupted banner stays so a retry stays possible.
   const resumeInterruptedSession = useCallback(
     (sessionId: string): Promise<void> =>
-      resumeInterruptedWorkspaceSession(runtime, sessionId, supportsImageInput),
-    [runtime, supportsImageInput]
+      resumeInterruptedWorkspaceSession(runtime, sessionId, supportsImageInput, activeModel),
+    [runtime, supportsImageInput, activeModel]
   )
 
   // Sends a cancellation request while the runtime waits for the eventual stop event.

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -621,7 +621,9 @@ describe('ConversationPanel error box + report affordance', () => {
 
   it('renders the error box for a failed run even when it has no error text', () => {
     renderPanel({ activeSession: { ...errorSession, error: undefined } })
-    expect(errorBoxText()).toContain('The run failed.')
+    // The shown fallback equals the text seeded into the report (single RUN_FAILED_FALLBACK_ERROR),
+    // upholding the "shown == reported" invariant when a failed run carries no error message.
+    expect(errorBoxText()).toContain('The run failed with no error message.')
     // Still reportable — the affordance follows the failure status, not the presence of text.
     expect(reportButton()).not.toBeNull()
   })
@@ -655,5 +657,19 @@ describe('ConversationPanel error box + report affordance', () => {
       (el) => el.textContent === 'Report this error' && el.children.length === 0
     )
     expect(title).toBeTruthy()
+  })
+
+  it('seeds the dialog with the same fallback text the box shows when a run has no error', () => {
+    // shown == reported: the textarea the user reviews must carry the exact string shown in the box.
+    renderPanel({ activeSession: { ...errorSession, error: undefined } })
+    const shown = errorBoxText()
+    act(() => {
+      reportButton()?.click()
+    })
+    const textarea = document.body.querySelector(
+      'textarea[aria-label="Error details"]'
+    ) as HTMLTextAreaElement | null
+    expect(textarea?.value).toBe('The run failed with no error message.')
+    expect(shown).toContain(textarea?.value ?? ' ')
   })
 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -670,6 +670,20 @@ describe('ConversationPanel error box + report affordance', () => {
       'textarea[aria-label="Error details"]'
     ) as HTMLTextAreaElement | null
     expect(textarea?.value).toBe('The run failed with no error message.')
-    expect(shown).toContain(textarea?.value ?? ' ')
+    expect(shown).toContain(textarea?.value ?? '')
+  })
+
+  it('uses the shared fallback for a whitespace-only persisted error', () => {
+    renderPanel({ activeSession: { ...errorSession, error: '   ' } })
+    expect(errorBoxText()).toContain('The run failed with no error message.')
+
+    act(() => {
+      reportButton()?.click()
+    })
+
+    const textarea = document.body.querySelector(
+      'textarea[aria-label="Error details"]'
+    ) as HTMLTextAreaElement | null
+    expect(textarea?.value).toBe('The run failed with no error message.')
   })
 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -611,18 +611,17 @@ describe('ConversationPanel error box + report affordance', () => {
   const reportButton = (): HTMLElement | null =>
     container.querySelector('[aria-label="Report this error"]')
 
-  const errorText = (): string =>
-    container.querySelector('.border-red-200 .break-words')?.textContent ?? ''
+  const errorBoxText = (): string => container.querySelector('.border-red-200')?.textContent ?? ''
 
   it('shows the error and a Report button for a failed run (status === error)', () => {
     renderPanel({ activeSession: errorSession })
-    expect(errorText()).toBe('Run failed: connection reset')
+    expect(errorBoxText()).toContain('Run failed: connection reset')
     expect(reportButton()).not.toBeNull()
   })
 
   it('renders the error box for a failed run even when it has no error text', () => {
     renderPanel({ activeSession: { ...errorSession, error: undefined } })
-    expect(errorText()).toBe('The run failed.')
+    expect(errorBoxText()).toContain('The run failed.')
     // Still reportable — the affordance follows the failure status, not the presence of text.
     expect(reportButton()).not.toBeNull()
   })
@@ -632,16 +631,18 @@ describe('ConversationPanel error box + report affordance', () => {
       activeSession: { ...errorSession, status: 'idle', error: undefined },
       actionError: 'Could not send message'
     })
-    expect(errorText()).toBe('Could not send message')
+    expect(errorBoxText()).toContain('Could not send message')
     expect(reportButton()).toBeNull()
   })
 
-  it('prefers the transient actionError and hides Report so shown text matches reportable text', () => {
-    // Both present: the action error takes over the box; the run report is suppressed to avoid
-    // reporting an error different from the one displayed.
+  it('shows both a transient actionError and the run failure, keeping the Report button', () => {
+    // Both present: each error gets its own row, and the run failure keeps its report entry — a
+    // transient error must not suppress the ability to report the actual failure.
     renderPanel({ activeSession: errorSession, actionError: 'Could not send message' })
-    expect(errorText()).toBe('Could not send message')
-    expect(reportButton()).toBeNull()
+    const text = errorBoxText()
+    expect(text).toContain('Could not send message')
+    expect(text).toContain('Run failed: connection reset')
+    expect(reportButton()).not.toBeNull()
   })
 
   it('opens the report dialog when the Report button is clicked', () => {

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -594,3 +594,65 @@ describe('ConversationPanel notebook bar', () => {
     expect(handleOpenJobList).toHaveBeenCalledWith('session-bar')
   })
 })
+
+describe('ConversationPanel error box + report affordance', () => {
+  const errorSession: ChatSession = {
+    id: 'session-err',
+    projectId: 'project-a',
+    title: 'Error session',
+    cwd: '/workspace',
+    status: 'error',
+    error: 'Run failed: connection reset',
+    messages: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now()
+  }
+
+  const reportButton = (): HTMLElement | null =>
+    container.querySelector('[aria-label="Report this error"]')
+
+  const errorText = (): string =>
+    container.querySelector('.border-red-200 .break-words')?.textContent ?? ''
+
+  it('shows the error and a Report button for a failed run (status === error)', () => {
+    renderPanel({ activeSession: errorSession })
+    expect(errorText()).toBe('Run failed: connection reset')
+    expect(reportButton()).not.toBeNull()
+  })
+
+  it('renders the error box for a failed run even when it has no error text', () => {
+    renderPanel({ activeSession: { ...errorSession, error: undefined } })
+    expect(errorText()).toBe('The run failed.')
+    // Still reportable — the affordance follows the failure status, not the presence of text.
+    expect(reportButton()).not.toBeNull()
+  })
+
+  it('shows only the transient actionError, without a Report button, for a non-failed session', () => {
+    renderPanel({
+      activeSession: { ...errorSession, status: 'idle', error: undefined },
+      actionError: 'Could not send message'
+    })
+    expect(errorText()).toBe('Could not send message')
+    expect(reportButton()).toBeNull()
+  })
+
+  it('prefers the transient actionError and hides Report so shown text matches reportable text', () => {
+    // Both present: the action error takes over the box; the run report is suppressed to avoid
+    // reporting an error different from the one displayed.
+    renderPanel({ activeSession: errorSession, actionError: 'Could not send message' })
+    expect(errorText()).toBe('Could not send message')
+    expect(reportButton()).toBeNull()
+  })
+
+  it('opens the report dialog when the Report button is clicked', () => {
+    renderPanel({ activeSession: errorSession })
+    act(() => {
+      reportButton()?.click()
+    })
+    // Dialog renders into a portal on document.body.
+    const title = Array.from(document.body.querySelectorAll('*')).find(
+      (el) => el.textContent === 'Report this error' && el.children.length === 0
+    )
+    expect(title).toBeTruthy()
+  })
+})

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -40,7 +40,7 @@ import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
 import { ComposerAgentControlsMenu } from './ComposerAgentControlsMenu'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
-import { RUN_FAILED_FALLBACK_ERROR } from './error-report'
+import { normalizeRunFailureError } from './error-report'
 import { ReportErrorDialog } from './ReportErrorDialog'
 import { SessionInterruptedBanner } from './SessionInterruptedBanner'
 import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'
@@ -172,6 +172,7 @@ const ConversationPanel = ({
   // Unconditional hook: check if the active session has any jobs (running or finished).
   const allJobsForSession = useSessionJobStore((s) => s.allJobsForSession)
   const hasAnyJobs = activeSession !== undefined && allJobsForSession(activeSession.id).length > 0
+  const resolvedRunError = normalizeRunFailureError(activeSession?.error)
 
   // Re-attaches the interrupted session; on success the banner unmounts, so guard the state update.
   const handleResume = async (): Promise<void> => {
@@ -287,9 +288,7 @@ const ConversationPanel = ({
                     ) : null}
                     {activeSession?.status === 'error' ? (
                       <div className="flex items-start gap-2">
-                        <span className="min-w-0 flex-1 break-words">
-                          {activeSession.error ?? RUN_FAILED_FALLBACK_ERROR}
-                        </span>
+                        <span className="min-w-0 flex-1 break-words">{resolvedRunError}</span>
                         {/* The button sits on the failure row beside the run's own error, so the shown
                             text and the reported text are always the same error. */}
                         <button
@@ -514,10 +513,11 @@ const ConversationPanel = ({
         {isReportOpen ? (
           <ReportErrorDialog
             open
-            error={activeSession?.error ?? RUN_FAILED_FALLBACK_ERROR}
+            error={resolvedRunError}
             subject={{
               agentFrameworkId: activeSession?.agentFrameworkId,
-              agentBackendId: activeSession?.agentBackendId
+              agentBackendId: activeSession?.agentBackendId,
+              model: activeSession?.agentModel
             }}
             onClose={() => setIsReportOpen(false)}
           />

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -40,6 +40,7 @@ import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
 import { ComposerAgentControlsMenu } from './ComposerAgentControlsMenu'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
+import { RUN_FAILED_FALLBACK_ERROR } from './error-report'
 import { ReportErrorDialog } from './ReportErrorDialog'
 import { SessionInterruptedBanner } from './SessionInterruptedBanner'
 import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'
@@ -287,7 +288,7 @@ const ConversationPanel = ({
                     {activeSession?.status === 'error' ? (
                       <div className="flex items-start gap-2">
                         <span className="min-w-0 flex-1 break-words">
-                          {activeSession.error ?? 'The run failed.'}
+                          {activeSession.error ?? RUN_FAILED_FALLBACK_ERROR}
                         </span>
                         {/* The button sits on the failure row beside the run's own error, so the shown
                             text and the reported text are always the same error. */}
@@ -513,7 +514,11 @@ const ConversationPanel = ({
         {isReportOpen ? (
           <ReportErrorDialog
             open
-            error={activeSession?.error ?? 'The run failed with no error message.'}
+            error={activeSession?.error ?? RUN_FAILED_FALLBACK_ERROR}
+            subject={{
+              agentFrameworkId: activeSession?.agentFrameworkId,
+              agentBackendId: activeSession?.agentBackendId
+            }}
             onClose={() => setIsReportOpen(false)}
           />
         ) : null}

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -501,11 +501,15 @@ const ConversationPanel = ({
           </div>
         </div>
 
-        <ReportErrorDialog
-          open={isReportOpen}
-          error={activeSession?.error ?? ''}
-          onClose={() => setIsReportOpen(false)}
-        />
+        {/* Mounted only while open so the dialog seeds its editable report fresh from the current
+            error each time (lazy initial state), instead of syncing via an effect. */}
+        {isReportOpen ? (
+          <ReportErrorDialog
+            open
+            error={activeSession?.error ?? ''}
+            onClose={() => setIsReportOpen(false)}
+          />
+        ) : null}
       </section>
     </ResizablePanel>
   )

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -278,24 +278,29 @@ const ConversationPanel = ({
                     Compacting conversation to fit the context limit…
                   </div>
                 ) : actionError || activeSession?.status === 'error' ? (
-                  <div className="mb-2 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-700">
-                    <span className="min-w-0 flex-1 break-words">
-                      {actionError ?? activeSession?.error ?? 'The run failed.'}
-                    </span>
-                    {/* Report affordance only for a failed run (status === 'error'), and only when its
-                        own error is what's shown. A transient actionError takes over the box and has no
-                        run diagnostic to attach, so hiding the button keeps the shown text and the
-                        reported text identical — the user reports exactly what they see. */}
-                    {activeSession?.status === 'error' && !actionError ? (
-                      <button
-                        type="button"
-                        onClick={() => setIsReportOpen(true)}
-                        className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-red-200 bg-red-100/60 px-2 font-medium text-red-700 hover:bg-red-100"
-                        aria-label="Report this error"
-                      >
-                        <Flag className="size-3" strokeWidth={2.2} aria-hidden="true" />
-                        Report error
-                      </button>
+                  <div className="mb-2 flex flex-col gap-1.5 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-700">
+                    {/* Transient action errors and a run failure can coexist; show each on its own row
+                        so the run's report affordance is never suppressed by a transient error. */}
+                    {actionError ? (
+                      <span className="min-w-0 break-words">{actionError}</span>
+                    ) : null}
+                    {activeSession?.status === 'error' ? (
+                      <div className="flex items-start gap-2">
+                        <span className="min-w-0 flex-1 break-words">
+                          {activeSession.error ?? 'The run failed.'}
+                        </span>
+                        {/* The button sits on the failure row beside the run's own error, so the shown
+                            text and the reported text are always the same error. */}
+                        <button
+                          type="button"
+                          onClick={() => setIsReportOpen(true)}
+                          className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-red-200 bg-red-100/60 px-2 font-medium text-red-700 hover:bg-red-100"
+                          aria-label="Report this error"
+                        >
+                          <Flag className="size-3" strokeWidth={2.2} aria-hidden="true" />
+                          Report error
+                        </button>
+                      </div>
                     ) : null}
                   </div>
                 ) : null}

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -277,14 +277,16 @@ const ConversationPanel = ({
                     <Loader2 className="size-3.5 animate-spin" strokeWidth={2} aria-hidden="true" />
                     Compacting conversation to fit the context limit…
                   </div>
-                ) : actionError || activeSession?.error ? (
+                ) : actionError || activeSession?.status === 'error' ? (
                   <div className="mb-2 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-700">
                     <span className="min-w-0 flex-1 break-words">
-                      {actionError ?? activeSession?.error}
+                      {actionError ?? activeSession?.error ?? 'The run failed.'}
                     </span>
-                    {/* Failed runs get a report affordance; transient action errors do not, since there
-                        is no run diagnostic to attach. */}
-                    {activeSession?.error ? (
+                    {/* Report affordance only for a failed run (status === 'error'), and only when its
+                        own error is what's shown. A transient actionError takes over the box and has no
+                        run diagnostic to attach, so hiding the button keeps the shown text and the
+                        reported text identical — the user reports exactly what they see. */}
+                    {activeSession?.status === 'error' && !actionError ? (
                       <button
                         type="button"
                         onClick={() => setIsReportOpen(true)}
@@ -506,7 +508,7 @@ const ConversationPanel = ({
         {isReportOpen ? (
           <ReportErrorDialog
             open
-            error={activeSession?.error ?? ''}
+            error={activeSession?.error ?? 'The run failed with no error message.'}
             onClose={() => setIsReportOpen(false)}
           />
         ) : null}

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -9,6 +9,7 @@ import {
   ArrowUp,
   BookOpen,
   FileText,
+  Flag,
   Image as ImageIcon,
   Loader2,
   PanelRight,
@@ -39,6 +40,7 @@ import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
 import { ComposerAgentControlsMenu } from './ComposerAgentControlsMenu'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
+import { ReportErrorDialog } from './ReportErrorDialog'
 import { SessionInterruptedBanner } from './SessionInterruptedBanner'
 import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'
 
@@ -163,6 +165,8 @@ const ConversationPanel = ({
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   // Local so the interrupted banner can show a spinner and block a double-resume until the request settles.
   const [isResuming, setIsResuming] = useState(false)
+  // Opens the reviewable, consent-gated error report dialog for a failed run.
+  const [isReportOpen, setIsReportOpen] = useState(false)
 
   // Unconditional hook: check if the active session has any jobs (running or finished).
   const allJobsForSession = useSessionJobStore((s) => s.allJobsForSession)
@@ -274,8 +278,23 @@ const ConversationPanel = ({
                     Compacting conversation to fit the context limit…
                   </div>
                 ) : actionError || activeSession?.error ? (
-                  <div className="mb-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-700">
-                    {actionError ?? activeSession?.error}
+                  <div className="mb-2 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-700">
+                    <span className="min-w-0 flex-1 break-words">
+                      {actionError ?? activeSession?.error}
+                    </span>
+                    {/* Failed runs get a report affordance; transient action errors do not, since there
+                        is no run diagnostic to attach. */}
+                    {activeSession?.error ? (
+                      <button
+                        type="button"
+                        onClick={() => setIsReportOpen(true)}
+                        className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-red-200 bg-red-100/60 px-2 font-medium text-red-700 hover:bg-red-100"
+                        aria-label="Report this error"
+                      >
+                        <Flag className="size-3" strokeWidth={2.2} aria-hidden="true" />
+                        Report error
+                      </button>
+                    ) : null}
                   </div>
                 ) : null}
 
@@ -481,6 +500,12 @@ const ConversationPanel = ({
             </div>
           </div>
         </div>
+
+        <ReportErrorDialog
+          open={isReportOpen}
+          error={activeSession?.error ?? ''}
+          onClose={() => setIsReportOpen(false)}
+        />
       </section>
     </ResizablePanel>
   )

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ReportErrorDialog } from './ReportErrorDialog'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Minimal store state the dialog reads through its selectors.
+const settingsState = {
+  providers: [{ id: 'p1', name: 'Anthropic' }],
+  activeProviderId: 'p1',
+  activeModel: 'claude-opus-4',
+  agentFrameworkId: 'claude-code',
+  agentFrameworks: [{ id: 'claude-code', displayName: 'Claude Code' }]
+}
+
+vi.mock('@/stores/settings-store', () => ({
+  useSettingsStore: (selector: (state: typeof settingsState) => unknown): unknown =>
+    selector(settingsState)
+}))
+
+vi.mock('@/stores/update-store', () => ({
+  useUpdateStore: (selector: (state: { appInfo: { version: string } }) => unknown): unknown =>
+    selector({ appInfo: { version: '0.5.1' } })
+}))
+
+let container: HTMLElement
+let root: Root
+
+beforeEach(() => {
+  ;(window as unknown as { api: unknown }).api = {
+    platform: 'win32',
+    getRuntimeVersions: () => ({ electron: '30.0.0', chrome: '124', node: '20.11' }),
+    logs: { revealInFolder: vi.fn().mockResolvedValue({ revealed: true }) }
+  }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+const renderDialog = (): void => {
+  act(() => {
+    root.render(<ReportErrorDialog open error="Run failed: connection reset" onClose={() => {}} />)
+  })
+}
+
+// Radix renders the dialog into document.body via a portal, so query the whole document.
+const issueLink = (): HTMLAnchorElement | null =>
+  document.body.querySelector('a[aria-disabled]') as HTMLAnchorElement | null
+
+const consentCheckbox = (): HTMLInputElement =>
+  document.body.querySelector('input[type="checkbox"]') as HTMLInputElement
+
+describe('ReportErrorDialog', () => {
+  it('previews the error and environment, prefilled from the stores and bridge', () => {
+    renderDialog()
+    const preview = document.body.querySelector('[aria-label="Error report preview"]')
+    expect(preview?.textContent).toContain('Run failed: connection reset')
+    expect(preview?.textContent).toContain('App version: 0.5.1')
+    expect(preview?.textContent).toContain('Provider / model: Anthropic · claude-opus-4')
+    expect(preview?.textContent).toContain('Operating system: Windows')
+  })
+
+  it('gates the GitHub issue action behind the consent checkbox', () => {
+    renderDialog()
+    expect(issueLink()?.getAttribute('aria-disabled')).toBe('true')
+    expect(issueLink()?.getAttribute('href')).toBeNull()
+
+    act(() => {
+      consentCheckbox().click()
+    })
+
+    expect(issueLink()?.getAttribute('aria-disabled')).toBe('false')
+    expect(issueLink()?.getAttribute('href')).toContain('/issues/new?')
+    expect(issueLink()?.getAttribute('href')).toContain('template=bug_report.yml')
+  })
+})

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
@@ -140,4 +140,24 @@ describe('ReportErrorDialog', () => {
     const alert = document.body.querySelector('[role="alert"]')
     expect(alert?.textContent).toContain('not available')
   })
+
+  it('surfaces an inline message when the reveal IPC call rejects', async () => {
+    ;(window as unknown as { api: { logs: { revealInFolder: () => Promise<unknown> } } }).api = {
+      logs: { revealInFolder: vi.fn().mockRejectedValue(new Error('IPC channel closed')) }
+    } as never
+
+    renderDialog()
+
+    await act(async () => {
+      const revealBtn = Array.from(document.body.querySelectorAll('button')).find((b) =>
+        b.textContent?.includes('Reveal log file')
+      )
+      revealBtn?.click()
+      // Let the rejected promise settle before assertions.
+      await Promise.resolve()
+    })
+
+    const alert = document.body.querySelector('[role="alert"]')
+    expect(alert?.textContent).toContain('IPC channel closed')
+  })
 })

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
@@ -20,17 +20,22 @@ vi.mock('@/stores/settings-store', () => ({
     selector(settingsState)
 }))
 
+// Mutable so tests can simulate getAppInfo() resolving after the dialog has opened (appInfo starts
+// undefined during early boot). Reset in beforeEach.
+const updateState: { appInfo: { version: string } | undefined } = { appInfo: { version: '0.5.1' } }
+
 vi.mock('@/stores/update-store', () => ({
-  useUpdateStore: (selector: (state: { appInfo: { version: string } }) => unknown): unknown =>
-    selector({ appInfo: { version: '0.5.1' } })
+  useUpdateStore: (selector: (state: typeof updateState) => unknown): unknown =>
+    selector(updateState)
 }))
 
 let container: HTMLElement
 let root: Root
 
 beforeEach(() => {
-  // Reset the mutable mock state so a test that mutates it (e.g. the snapshot-freeze test) can't leak.
+  // Reset the mutable mock state so a test that mutates it (e.g. the consent-lapse tests) can't leak.
   settingsState.activeModel = 'claude-opus-4'
+  updateState.appInfo = { version: '0.5.1' }
   ;(window as unknown as { api: unknown }).api = {
     platform: 'win32',
     getRuntimeVersions: () => ({ electron: '30.0.0', chrome: '124', node: '20.11' }),
@@ -163,25 +168,44 @@ describe('ReportErrorDialog', () => {
     expect(alert?.textContent).toContain('IPC channel closed')
   })
 
-  it('freezes the context at open so a later store change cannot alter the consented report', () => {
+  it('revokes consent when a store field changes after consent, and reflects the new field', () => {
     renderDialog()
     act(() => {
       consentCheckbox().click()
     })
-    const before = issueLink()?.getAttribute('href') ?? ''
-    expect(before).toContain('claude-opus-4')
+    expect(consentCheckbox().checked).toBe(true)
+    expect(issueLink()?.getAttribute('href') ?? '').toContain('claude-opus-4')
 
-    // Simulate an async store update landing after the user consented (e.g. getAppInfo resolving),
-    // then a re-render. The mounted dialog must keep its snapshot: no new field enters the shared
-    // URL, and consent is not silently carried onto content the user never reviewed.
+    // A store field changing after consent (async update, or a swap) must both surface in the URL and
+    // drop consent, so the user never shares a payload they didn't confirm.
     act(() => {
-      settingsState.activeModel = 'claude-sneaky-swap'
+      settingsState.activeModel = 'claude-model-2'
       renderDialog()
     })
 
-    const after = issueLink()?.getAttribute('href') ?? ''
-    expect(after).toBe(before)
-    expect(after).not.toContain('claude-sneaky-swap')
-    expect(consentCheckbox().checked).toBe(true)
+    expect(consentCheckbox().checked).toBe(false)
+    const href = issueLink()?.getAttribute('href')
+    expect(href === null || href === undefined).toBe(true) // link disabled again
+  })
+
+  it('picks up an app version that resolves after the dialog opened (no permanent Unknown)', () => {
+    // Simulate opening during early boot: getAppInfo() has not resolved yet.
+    updateState.appInfo = undefined
+    renderDialog()
+    expect(environmentBlock()).toContain('App version: Unknown')
+    expect(issueLink()?.getAttribute('href') ?? '').not.toContain('app-version')
+
+    // getAppInfo() resolves and the store updates while the dialog is still open.
+    act(() => {
+      updateState.appInfo = { version: '0.5.1' }
+      renderDialog()
+    })
+
+    // The live-derived context must reflect the now-known version, not a frozen Unknown.
+    expect(environmentBlock()).toContain('App version: 0.5.1')
+    act(() => {
+      consentCheckbox().click()
+    })
+    expect(issueLink()?.getAttribute('href') ?? '').toContain('app-version=0.5.1')
   })
 })

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
@@ -7,7 +7,6 @@ import { ReportErrorDialog } from './ReportErrorDialog'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
-// Minimal store state the dialog reads through its selectors.
 const settingsState = {
   providers: [{ id: 'p1', name: 'Anthropic' }],
   activeProviderId: 'p1',
@@ -59,14 +58,17 @@ const issueLink = (): HTMLAnchorElement | null =>
 const consentCheckbox = (): HTMLInputElement =>
   document.body.querySelector('input[type="checkbox"]') as HTMLInputElement
 
+const textarea = (): HTMLTextAreaElement =>
+  document.body.querySelector('textarea[aria-label="Error report preview"]') as HTMLTextAreaElement
+
 describe('ReportErrorDialog', () => {
-  it('previews the error and environment, prefilled from the stores and bridge', () => {
+  it('seeds the editable textarea with error and environment on open', () => {
     renderDialog()
-    const preview = document.body.querySelector('[aria-label="Error report preview"]')
-    expect(preview?.textContent).toContain('Run failed: connection reset')
-    expect(preview?.textContent).toContain('App version: 0.5.1')
-    expect(preview?.textContent).toContain('Provider / model: Anthropic · claude-opus-4')
-    expect(preview?.textContent).toContain('Operating system: Windows')
+    const value = textarea()?.value ?? ''
+    expect(value).toContain('Run failed: connection reset')
+    expect(value).toContain('App version: 0.5.1')
+    expect(value).toContain('Provider / model: Anthropic · claude-opus-4')
+    expect(value).toContain('Operating system: Windows')
   })
 
   it('gates the GitHub issue action behind the consent checkbox', () => {
@@ -81,5 +83,52 @@ describe('ReportErrorDialog', () => {
     expect(issueLink()?.getAttribute('aria-disabled')).toBe('false')
     expect(issueLink()?.getAttribute('href')).toContain('/issues/new?')
     expect(issueLink()?.getAttribute('href')).toContain('template=bug_report.yml')
+  })
+
+  it('resets consent when the user edits the textarea', () => {
+    renderDialog()
+    act(() => {
+      consentCheckbox().click()
+    })
+    expect(issueLink()?.getAttribute('aria-disabled')).toBe('false')
+
+    act(() => {
+      const ta = textarea()
+      // React tracks the controlled value internally; set via the native setter so onChange fires.
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        'value'
+      )?.set
+      setter?.call(ta, 'redacted content')
+      ta.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(issueLink()?.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('includes environment block in the GitHub issue URL logs field', () => {
+    renderDialog()
+    act(() => {
+      consentCheckbox().click()
+    })
+    const href = issueLink()?.getAttribute('href') ?? ''
+    const params = new URL(href).searchParams
+    expect(params.get('logs')).toContain('Environment')
+    expect(params.get('logs')).toContain('Claude Code')
+  })
+
+  it('surfaces an error message when the preload bridge is missing', async () => {
+    ;(window as unknown as { api: unknown }).api = undefined
+    renderDialog()
+
+    await act(async () => {
+      const revealBtn = Array.from(document.body.querySelectorAll('button')).find((b) =>
+        b.textContent?.includes('Reveal log file')
+      )
+      revealBtn?.click()
+    })
+
+    const alert = document.body.querySelector('[role="alert"]')
+    expect(alert?.textContent).toContain('not available')
   })
 })

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
@@ -59,16 +59,25 @@ const consentCheckbox = (): HTMLInputElement =>
   document.body.querySelector('input[type="checkbox"]') as HTMLInputElement
 
 const textarea = (): HTMLTextAreaElement =>
-  document.body.querySelector('textarea[aria-label="Error report preview"]') as HTMLTextAreaElement
+  document.body.querySelector('textarea[aria-label="Error details"]') as HTMLTextAreaElement
+
+const environmentBlock = (): string =>
+  document.body.querySelector('[aria-label="Report environment"]')?.textContent ?? ''
 
 describe('ReportErrorDialog', () => {
-  it('seeds the editable textarea with error and environment on open', () => {
+  it('seeds the editable textarea with only the error text', () => {
     renderDialog()
-    const value = textarea()?.value ?? ''
-    expect(value).toContain('Run failed: connection reset')
-    expect(value).toContain('App version: 0.5.1')
-    expect(value).toContain('Provider / model: Anthropic · claude-opus-4')
-    expect(value).toContain('Operating system: Windows')
+    expect(textarea()?.value).toBe('Run failed: connection reset')
+  })
+
+  it('shows environment facts read-only, outside the editable field', () => {
+    renderDialog()
+    const env = environmentBlock()
+    expect(env).toContain('App version: 0.5.1')
+    expect(env).toContain('Provider / model: Anthropic · claude-opus-4')
+    expect(env).toContain('Operating system: Windows')
+    // Environment must not be duplicated inside the editable error field.
+    expect(textarea()?.value).not.toContain('App version')
   })
 
   it('gates the GitHub issue action behind the consent checkbox', () => {
@@ -106,15 +115,15 @@ describe('ReportErrorDialog', () => {
     expect(issueLink()?.getAttribute('aria-disabled')).toBe('true')
   })
 
-  it('includes environment block in the GitHub issue URL logs field', () => {
+  it('carries framework/runtime into the logs field without duplicating structured fields', () => {
     renderDialog()
     act(() => {
       consentCheckbox().click()
     })
-    const href = issueLink()?.getAttribute('href') ?? ''
-    const params = new URL(href).searchParams
-    expect(params.get('logs')).toContain('Environment')
+    const params = new URL(issueLink()?.getAttribute('href') ?? '').searchParams
     expect(params.get('logs')).toContain('Claude Code')
+    expect(params.get('logs')).not.toContain('App version')
+    expect(params.get('what-happened')).toBe('Run failed: connection reset')
   })
 
   it('surfaces an error message when the preload bridge is missing', async () => {

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
@@ -29,6 +29,8 @@ let container: HTMLElement
 let root: Root
 
 beforeEach(() => {
+  // Reset the mutable mock state so a test that mutates it (e.g. the snapshot-freeze test) can't leak.
+  settingsState.activeModel = 'claude-opus-4'
   ;(window as unknown as { api: unknown }).api = {
     platform: 'win32',
     getRuntimeVersions: () => ({ electron: '30.0.0', chrome: '124', node: '20.11' }),
@@ -159,5 +161,27 @@ describe('ReportErrorDialog', () => {
 
     const alert = document.body.querySelector('[role="alert"]')
     expect(alert?.textContent).toContain('IPC channel closed')
+  })
+
+  it('freezes the context at open so a later store change cannot alter the consented report', () => {
+    renderDialog()
+    act(() => {
+      consentCheckbox().click()
+    })
+    const before = issueLink()?.getAttribute('href') ?? ''
+    expect(before).toContain('claude-opus-4')
+
+    // Simulate an async store update landing after the user consented (e.g. getAppInfo resolving),
+    // then a re-render. The mounted dialog must keep its snapshot: no new field enters the shared
+    // URL, and consent is not silently carried onto content the user never reviewed.
+    act(() => {
+      settingsState.activeModel = 'claude-sneaky-swap'
+      renderDialog()
+    })
+
+    const after = issueLink()?.getAttribute('href') ?? ''
+    expect(after).toBe(before)
+    expect(after).not.toContain('claude-sneaky-swap')
+    expect(consentCheckbox().checked).toBe(true)
   })
 })

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
@@ -55,9 +55,10 @@ afterEach(() => {
 // Default subject matches the active config (framework claude-code, provider p1) so the environment
 // preview shows the same "Anthropic · claude-opus-4" the existing assertions expect.
 const renderDialog = (
-  subject: { agentFrameworkId?: string; agentBackendId?: string } = {
+  subject: { agentFrameworkId?: string; agentBackendId?: string; model?: string } = {
     agentFrameworkId: 'claude-code',
-    agentBackendId: 'claude-code:p1'
+    agentBackendId: 'claude-code:p1',
+    model: 'claude-opus-4'
   }
 ): void => {
   act(() => {
@@ -182,24 +183,34 @@ describe('ReportErrorDialog', () => {
     expect(alert?.textContent).toContain('IPC channel closed')
   })
 
-  it('revokes consent when a store field changes after consent, and reflects the new field', () => {
+  it('revokes consent when a payload store field changes after consent', () => {
     renderDialog()
     act(() => {
       consentCheckbox().click()
     })
     expect(consentCheckbox().checked).toBe(true)
-    expect(issueLink()?.getAttribute('href') ?? '').toContain('claude-opus-4')
+    expect(issueLink()?.getAttribute('href') ?? '').toContain('app-version=0.5.1')
 
-    // A store field changing after consent (async update, or a swap) must both surface in the URL and
-    // drop consent, so the user never shares a payload they didn't confirm.
+    // A payload field changing after consent must drop consent so the user never shares data they did
+    // not confirm. The model is session-scoped and intentionally unaffected by active-model changes.
     act(() => {
-      settingsState.activeModel = 'claude-model-2'
+      updateState.appInfo = { version: '0.5.2' }
       renderDialog()
     })
 
     expect(consentCheckbox().checked).toBe(false)
     const href = issueLink()?.getAttribute('href')
     expect(href === null || href === undefined).toBe(true) // link disabled again
+  })
+
+  it('keeps the failed session model when the active model changes later', () => {
+    renderDialog()
+    settingsState.activeModel = 'model-selected-after-failure'
+
+    act(() => renderDialog())
+
+    expect(environmentBlock()).toContain('Provider / model: Anthropic · claude-opus-4')
+    expect(environmentBlock()).not.toContain('model-selected-after-failure')
   })
 
   it('picks up an app version that resolves after the dialog opened (no permanent Unknown)', () => {
@@ -262,5 +273,11 @@ describe('ReportErrorDialog', () => {
     const whatHappened = new URL(href).searchParams.get('what-happened') ?? ''
     expect(whatHappened.length).toBeLessThan(20000)
     expect(whatHappened).toContain('truncated')
+
+    const submittedPreview = document.body.querySelector(
+      '[aria-label="GitHub issue prefill"]'
+    )?.textContent
+    expect(submittedPreview).toContain(whatHappened)
+    expect(submittedPreview).toContain('Copy details')
   })
 })

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
@@ -52,9 +52,23 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-const renderDialog = (): void => {
+// Default subject matches the active config (framework claude-code, provider p1) so the environment
+// preview shows the same "Anthropic · claude-opus-4" the existing assertions expect.
+const renderDialog = (
+  subject: { agentFrameworkId?: string; agentBackendId?: string } = {
+    agentFrameworkId: 'claude-code',
+    agentBackendId: 'claude-code:p1'
+  }
+): void => {
   act(() => {
-    root.render(<ReportErrorDialog open error="Run failed: connection reset" onClose={() => {}} />)
+    root.render(
+      <ReportErrorDialog
+        open
+        error="Run failed: connection reset"
+        subject={subject}
+        onClose={() => {}}
+      />
+    )
   })
 }
 
@@ -207,5 +221,46 @@ describe('ReportErrorDialog', () => {
       consentCheckbox().click()
     })
     expect(issueLink()?.getAttribute('href') ?? '').toContain('app-version=0.5.1')
+  })
+
+  it('attributes framework/provider to the failed session, not the current active config', () => {
+    // The session failed under provider p1; the user has since switched the active provider away to a
+    // provider not even in the list. The report must still name the session's provider (Anthropic), and
+    // must omit the model because the active provider no longer matches the session's.
+    settingsState.activeProviderId = 'p2-switched-later'
+    settingsState.activeModel = 'some-other-model'
+    renderDialog({ agentFrameworkId: 'claude-code', agentBackendId: 'claude-code:p1' })
+
+    const env = environmentBlock()
+    expect(env).toContain('Agent framework: Claude Code')
+    // Provider from the session (p1 → Anthropic), model dropped (active provider differs now).
+    expect(env).toContain('Provider / model: Anthropic')
+    expect(env).not.toContain('some-other-model')
+
+    // Restore for later tests (beforeEach also resets, but keep the mutation local in spirit).
+    settingsState.activeProviderId = 'p1'
+  })
+
+  it('truncates a very long error so the GitHub URL cannot 414, keeping Copy details full', () => {
+    const longError = 'x'.repeat(20000)
+    act(() => {
+      root.render(
+        <ReportErrorDialog
+          open
+          error={longError}
+          subject={{ agentFrameworkId: 'claude-code', agentBackendId: 'claude-code:p1' }}
+          onClose={() => {}}
+        />
+      )
+    })
+    act(() => {
+      consentCheckbox().click()
+    })
+
+    const href = issueLink()?.getAttribute('href') ?? ''
+    // The what-happened param is bounded well under the raw 20k error length, with a visible marker.
+    const whatHappened = new URL(href).searchParams.get('what-happened') ?? ''
+    expect(whatHappened.length).toBeLessThan(20000)
+    expect(whatHappened).toContain('truncated')
   })
 })

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
@@ -24,10 +24,6 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
 
-  const [consented, setConsented] = useState(false)
-  const [copied, setCopied] = useState(false)
-  const [revealMessage, setRevealMessage] = useState<string | null>(null)
-
   // Recompute the bundle only when an input changes; the picker and preview share one source of truth.
   const context = useMemo<ErrorReportContext>(() => {
     const provider = providers.find((candidate) => candidate.id === activeProviderId)
@@ -35,8 +31,8 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
       (framework) => framework.id === agentFrameworkId
     )?.displayName
 
-    // The bridge is read defensively so the always-mounted dialog renders even where the preload
-    // surface is absent (tests, early boot); the report helpers tolerate every missing field.
+    // The bridge is read defensively so the dialog renders even where the preload surface is absent
+    // (tests, early boot); the report helpers tolerate every missing field.
     return {
       error,
       appVersion,
@@ -57,30 +53,44 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
   ])
 
   const reportText = useMemo(() => buildErrorReportText(context), [context])
-  const issueUrl = useMemo(() => buildGithubIssueUrl(context), [context])
 
-  // Copies the reviewed bundle and briefly confirms; the write stays local (no network).
+  const [consented, setConsented] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [revealMessage, setRevealMessage] = useState<string | null>(null)
+  // Editable copy of the report text so users can redact sensitive content before consenting. Seeded
+  // lazily from the current report; the parent remounts this dialog on each open, so it stays fresh.
+  const [editedText, setEditedText] = useState(reportText)
+
+  // URL uses the user-edited body so any sensitive-data redactions made in the textarea are reflected.
+  const issueUrl = useMemo(() => buildGithubIssueUrl(context, editedText), [context, editedText])
+
+  // Copies the edited bundle and briefly confirms; the write stays local (no network).
   const handleCopy = (): void => {
-    void navigator.clipboard.writeText(reportText).then(() => {
-      setCopied(true)
-      window.setTimeout(() => setCopied(false), 1500)
-    })
+    void navigator.clipboard
+      .writeText(editedText)
+      .then(() => {
+        setCopied(true)
+        window.setTimeout(() => setCopied(false), 1500)
+      })
+      .catch(() => {
+        setRevealMessage('Could not write to clipboard.')
+      })
   }
 
   // Reveals the on-device log so the user can attach it themselves; the log is never sent for them.
+  // Defensive: `window.api` may be absent in tests or early boot (mirrors the useMemo guard above).
   const handleRevealLog = async (): Promise<void> => {
+    if (!window.api?.logs?.revealInFolder) {
+      setRevealMessage('Log reveal is not available in this environment.')
+      return
+    }
     const result = await window.api.logs.revealInFolder()
     if (!result.revealed) setRevealMessage(result.error ?? 'Could not reveal the log file.')
   }
 
-  // Reset transient state whenever the dialog closes so a re-open starts from a clean, unconsented view.
+  // Reset transient state whenever the dialog closes so a re-open starts from a clean view.
   const handleOpenChange = (next: boolean): void => {
-    if (!next) {
-      setConsented(false)
-      setCopied(false)
-      setRevealMessage(null)
-      onClose()
-    }
+    if (!next) onClose()
   }
 
   return (
@@ -97,12 +107,16 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
             attached automatically.
           </Dialog.Description>
 
-          <pre
-            className="mt-4 min-h-0 flex-1 overflow-auto whitespace-pre-wrap rounded-lg border border-border-200 bg-bg-100 px-3 py-2.5 font-mono text-[12px] leading-5 text-text-100"
+          <textarea
+            className="mt-4 min-h-0 flex-1 resize-none overflow-auto rounded-lg border border-border-200 bg-bg-100 px-3 py-2.5 font-mono text-[12px] leading-5 text-text-100 focus:outline-none focus:ring-1 focus:ring-primary/50"
             aria-label="Error report preview"
-          >
-            {reportText}
-          </pre>
+            value={editedText}
+            onChange={(event) => {
+              setEditedText(event.target.value)
+              // Require re-consent whenever the user edits the content being shared.
+              setConsented(false)
+            }}
+          />
 
           <label className="mt-4 flex items-start gap-2 text-[13px] leading-5 text-text-100">
             <input

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
@@ -8,12 +8,17 @@ import {
   buildEnvironmentBlock,
   buildErrorReportText,
   buildGithubIssueUrl,
-  type ErrorReportContext
+  resolveSessionSubject,
+  type ErrorReportContext,
+  type SessionReportSubject
 } from './error-report'
 
 type ReportErrorDialogProps = {
   open: boolean
   error: string
+  // Session-level identifiers used to attribute the report to the configuration that was active when
+  // the run failed, rather than the current global settings.
+  subject: SessionReportSubject
   onClose: () => void
 }
 
@@ -21,29 +26,51 @@ type ReportErrorDialogProps = {
 // update stores plus the preload bridge, shows the user exactly what it contains, and only unlocks the
 // public "Open GitHub issue" action once they agree. Nothing is transmitted automatically; the local
 // runtime log is never inlined (the user attaches it themselves after reviewing it).
-const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): React.JSX.Element => {
+const ReportErrorDialog = ({
+  open,
+  error,
+  subject,
+  onClose
+}: ReportErrorDialogProps): React.JSX.Element => {
   const appVersion = useUpdateStore((state) => state.appInfo?.version)
   const providers = useSettingsStore((state) => state.providers)
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
   const activeModel = useSettingsStore((state) => state.activeModel)
-  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
 
-  // Derive the bundle live from the stores. The bridge is read defensively so the dialog renders where
+  // Derive the bundle live from the stores. Framework/provider/model come from the failed session's own
+  // identifiers (via resolveSessionSubject), not the current active selection, so switching config after
+  // a failure never misattributes the report. The bridge is read defensively so the dialog renders where
   // the preload surface is absent (tests, early boot); the helpers tolerate every missing field.
-  const context = useMemo<ErrorReportContext>(
-    () => ({
+  const context = useMemo<ErrorReportContext>(() => {
+    const resolved = resolveSessionSubject(
+      subject,
+      providers,
+      activeProviderId,
+      activeModel,
+      agentFrameworks
+    )
+    return {
       error,
       appVersion,
       platform: window.api?.platform,
-      frameworkName: agentFrameworks.find((framework) => framework.id === agentFrameworkId)
-        ?.displayName,
-      providerName: providers.find((candidate) => candidate.id === activeProviderId)?.name,
-      model: activeModel,
+      frameworkName: resolved.frameworkName,
+      providerName: resolved.providerName,
+      model: resolved.model,
       runtimeVersions: window.api?.getRuntimeVersions?.()
-    }),
-    [error, appVersion, providers, activeProviderId, activeModel, agentFrameworkId, agentFrameworks]
-  )
+    }
+    // Depend on the primitive subject fields, not the object identity (a fresh literal each render).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    error,
+    appVersion,
+    providers,
+    activeProviderId,
+    activeModel,
+    agentFrameworks,
+    subject.agentFrameworkId,
+    subject.agentBackendId
+  ])
 
   const [copied, setCopied] = useState(false)
   const [revealMessage, setRevealMessage] = useState<string | null>(null)

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
@@ -29,24 +29,22 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
 
-  // Freeze the bundle at mount into a snapshot. These stores update asynchronously (e.g. getAppInfo()
-  // resolves after open), and re-deriving live would let new fields enter the reviewed preview and the
-  // GitHub URL *after* the user has consented — sharing data they never saw. The parent remounts this
-  // dialog on each open, so a lazy initializer captures a fresh, consistent snapshot every time and it
-  // stays stable for the lifetime of the open dialog. The bridge is read defensively so the dialog
-  // renders where the preload surface is absent (tests, early boot); the helpers tolerate missing fields.
-  const [context] = useState<ErrorReportContext>(() => ({
-    error,
-    appVersion,
-    platform: window.api?.platform,
-    frameworkName: agentFrameworks.find((framework) => framework.id === agentFrameworkId)
-      ?.displayName,
-    providerName: providers.find((candidate) => candidate.id === activeProviderId)?.name,
-    model: activeModel,
-    runtimeVersions: window.api?.getRuntimeVersions?.()
-  }))
+  // Derive the bundle live from the stores. The bridge is read defensively so the dialog renders where
+  // the preload surface is absent (tests, early boot); the helpers tolerate every missing field.
+  const context = useMemo<ErrorReportContext>(
+    () => ({
+      error,
+      appVersion,
+      platform: window.api?.platform,
+      frameworkName: agentFrameworks.find((framework) => framework.id === agentFrameworkId)
+        ?.displayName,
+      providerName: providers.find((candidate) => candidate.id === activeProviderId)?.name,
+      model: activeModel,
+      runtimeVersions: window.api?.getRuntimeVersions?.()
+    }),
+    [error, appVersion, providers, activeProviderId, activeModel, agentFrameworkId, agentFrameworks]
+  )
 
-  const [consented, setConsented] = useState(false)
   const [copied, setCopied] = useState(false)
   const [revealMessage, setRevealMessage] = useState<string | null>(null)
   // Only the error text is editable — it is the unpredictable, possibly-sensitive part users may need
@@ -61,6 +59,15 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
   )
   const environmentBlock = useMemo(() => buildEnvironmentBlock(context), [context])
   const issueUrl = useMemo(() => buildGithubIssueUrl(editedContext), [editedContext])
+
+  // Consent is tied to the exact payload it was given for, not a bare flag. We record the URL the user
+  // consented to; consent holds only while that still equals the current URL. So if a store field lands
+  // late (e.g. getAppInfo() resolving after an early open) or the user edits the error, issueUrl changes
+  // and consent lapses in the SAME render — the user re-confirms the complete bundle, and a late field
+  // can never ride into an already-consented URL. Deriving (not an effect) closes the one-frame gap
+  // where the link could be clicked with stale consent.
+  const [consentedUrl, setConsentedUrl] = useState<string | null>(null)
+  const consented = consentedUrl === issueUrl
 
   // Copies the full bundle (error + environment) with the redacted error; the write stays local.
   const handleCopy = (): void => {
@@ -118,9 +125,8 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
             aria-label="Error details"
             value={editedError}
             onChange={(event) => {
+              // Editing changes issueUrl, so consent lapses automatically via consentedUrl !== issueUrl.
               setEditedError(event.target.value)
-              // Require re-consent whenever the user edits the content being shared.
-              setConsented(false)
             }}
           />
 
@@ -139,7 +145,8 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
               type="checkbox"
               className="mt-0.5 size-4 shrink-0 accent-primary"
               checked={consented}
-              onChange={(event) => setConsented(event.target.checked)}
+              // Consent is granted for the payload on screen now; bind it to that exact URL.
+              onChange={(event) => setConsentedUrl(event.target.checked ? issueUrl : null)}
             />
             <span>
               I&apos;ve reviewed the details above and agree to share them in a public GitHub issue,

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
@@ -29,33 +29,22 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
 
-  // Recompute the bundle only when an input changes; the picker and preview share one source of truth.
-  const context = useMemo<ErrorReportContext>(() => {
-    const provider = providers.find((candidate) => candidate.id === activeProviderId)
-    const frameworkName = agentFrameworks.find(
-      (framework) => framework.id === agentFrameworkId
-    )?.displayName
-
-    // The bridge is read defensively so the dialog renders even where the preload surface is absent
-    // (tests, early boot); the report helpers tolerate every missing field.
-    return {
-      error,
-      appVersion,
-      platform: window.api?.platform,
-      frameworkName,
-      providerName: provider?.name,
-      model: activeModel,
-      runtimeVersions: window.api?.getRuntimeVersions?.()
-    }
-  }, [
+  // Freeze the bundle at mount into a snapshot. These stores update asynchronously (e.g. getAppInfo()
+  // resolves after open), and re-deriving live would let new fields enter the reviewed preview and the
+  // GitHub URL *after* the user has consented — sharing data they never saw. The parent remounts this
+  // dialog on each open, so a lazy initializer captures a fresh, consistent snapshot every time and it
+  // stays stable for the lifetime of the open dialog. The bridge is read defensively so the dialog
+  // renders where the preload surface is absent (tests, early boot); the helpers tolerate missing fields.
+  const [context] = useState<ErrorReportContext>(() => ({
     error,
     appVersion,
-    providers,
-    activeProviderId,
-    activeModel,
-    agentFrameworkId,
-    agentFrameworks
-  ])
+    platform: window.api?.platform,
+    frameworkName: agentFrameworks.find((framework) => framework.id === agentFrameworkId)
+      ?.displayName,
+    providerName: providers.find((candidate) => candidate.id === activeProviderId)?.name,
+    model: activeModel,
+    runtimeVersions: window.api?.getRuntimeVersions?.()
+  }))
 
   const [consented, setConsented] = useState(false)
   const [copied, setCopied] = useState(false)

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
@@ -87,14 +87,19 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
   }
 
   // Reveals the on-device log so the user can attach it themselves; the log is never sent for them.
-  // Defensive: `window.api` may be absent in tests or early boot (mirrors the useMemo guard above).
+  // Defensive: `window.api` may be absent in tests or early boot (mirrors the useMemo guard above),
+  // and the IPC call itself can reject — both surface inline rather than throwing (matches GeneralPanel).
   const handleRevealLog = async (): Promise<void> => {
     if (!window.api?.logs?.revealInFolder) {
       setRevealMessage('Log reveal is not available in this environment.')
       return
     }
-    const result = await window.api.logs.revealInFolder()
-    if (!result.revealed) setRevealMessage(result.error ?? 'Could not reveal the log file.')
+    try {
+      const result = await window.api.logs.revealInFolder()
+      if (!result.revealed) setRevealMessage(result.error ?? 'Could not reveal the log file.')
+    } catch (error) {
+      setRevealMessage(error instanceof Error ? error.message : 'Could not reveal the log file.')
+    }
   }
 
   // Reset transient state whenever the dialog closes so a re-open starts from a clean view.
@@ -148,7 +153,18 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
               onChange={(event) => setConsented(event.target.checked)}
             />
             <span>
-              I&apos;ve reviewed the details above and agree to share them in a public GitHub issue.
+              I&apos;ve reviewed the details above and agree to share them in a public GitHub issue,
+              subject to GitHub&apos;s{' '}
+              <a
+                href="https://docs.github.com/site-policy/privacy-policies/github-privacy-statement"
+                target="_blank"
+                rel="noreferrer"
+                className="underline hover:text-text-000"
+                onClick={(event) => event.stopPropagation()}
+              >
+                Privacy Statement
+              </a>
+              .
             </span>
           </label>
 

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
@@ -1,0 +1,170 @@
+import { Dialog } from 'radix-ui'
+import { Check, Copy, ExternalLink, FolderOpen } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import { useSettingsStore } from '@/stores/settings-store'
+import { useUpdateStore } from '@/stores/update-store'
+import { buildErrorReportText, buildGithubIssueUrl, type ErrorReportContext } from './error-report'
+
+type ReportErrorDialogProps = {
+  open: boolean
+  error: string
+  onClose: () => void
+}
+
+// Reviewable, consent-gated error report. Assembles a diagnostic bundle locally from the settings and
+// update stores plus the preload bridge, shows the user exactly what it contains, and only unlocks the
+// public "Open GitHub issue" action once they agree. Nothing is transmitted automatically; the local
+// runtime log is never inlined (the user attaches it themselves after reviewing it).
+const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): React.JSX.Element => {
+  const appVersion = useUpdateStore((state) => state.appInfo?.version)
+  const providers = useSettingsStore((state) => state.providers)
+  const activeProviderId = useSettingsStore((state) => state.activeProviderId)
+  const activeModel = useSettingsStore((state) => state.activeModel)
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
+
+  const [consented, setConsented] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [revealMessage, setRevealMessage] = useState<string | null>(null)
+
+  // Recompute the bundle only when an input changes; the picker and preview share one source of truth.
+  const context = useMemo<ErrorReportContext>(() => {
+    const provider = providers.find((candidate) => candidate.id === activeProviderId)
+    const frameworkName = agentFrameworks.find(
+      (framework) => framework.id === agentFrameworkId
+    )?.displayName
+
+    // The bridge is read defensively so the always-mounted dialog renders even where the preload
+    // surface is absent (tests, early boot); the report helpers tolerate every missing field.
+    return {
+      error,
+      appVersion,
+      platform: window.api?.platform,
+      frameworkName,
+      providerName: provider?.name,
+      model: activeModel,
+      runtimeVersions: window.api?.getRuntimeVersions?.()
+    }
+  }, [
+    error,
+    appVersion,
+    providers,
+    activeProviderId,
+    activeModel,
+    agentFrameworkId,
+    agentFrameworks
+  ])
+
+  const reportText = useMemo(() => buildErrorReportText(context), [context])
+  const issueUrl = useMemo(() => buildGithubIssueUrl(context), [context])
+
+  // Copies the reviewed bundle and briefly confirms; the write stays local (no network).
+  const handleCopy = (): void => {
+    void navigator.clipboard.writeText(reportText).then(() => {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  // Reveals the on-device log so the user can attach it themselves; the log is never sent for them.
+  const handleRevealLog = async (): Promise<void> => {
+    const result = await window.api.logs.revealInFolder()
+    if (!result.revealed) setRevealMessage(result.error ?? 'Could not reveal the log file.')
+  }
+
+  // Reset transient state whenever the dialog closes so a re-open starts from a clean, unconsented view.
+  const handleOpenChange = (next: boolean): void => {
+    if (!next) {
+      setConsented(false)
+      setCopied(false)
+      setRevealMessage(null)
+      onClose()
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/25 backdrop-blur-[2px]" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[min(640px,calc(100vh-2rem))] w-[min(560px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 flex-col rounded-2xl bg-bg-000 p-6 text-text-000 shadow-dialog">
+          <Dialog.Title className="text-base font-semibold text-text-000">
+            Report this error
+          </Dialog.Title>
+          <Dialog.Description className="mt-2 text-sm leading-relaxed text-text-100">
+            Review what will be included below. This report is posted publicly on GitHub — remove
+            anything sensitive before sharing. Your runtime log stays on this device and is never
+            attached automatically.
+          </Dialog.Description>
+
+          <pre
+            className="mt-4 min-h-0 flex-1 overflow-auto whitespace-pre-wrap rounded-lg border border-border-200 bg-bg-100 px-3 py-2.5 font-mono text-[12px] leading-5 text-text-100"
+            aria-label="Error report preview"
+          >
+            {reportText}
+          </pre>
+
+          <label className="mt-4 flex items-start gap-2 text-[13px] leading-5 text-text-100">
+            <input
+              type="checkbox"
+              className="mt-0.5 size-4 shrink-0 accent-primary"
+              checked={consented}
+              onChange={(event) => setConsented(event.target.checked)}
+            />
+            <span>
+              I&apos;ve reviewed the details above and agree to share them in a public GitHub issue.
+            </span>
+          </label>
+
+          {revealMessage ? (
+            <p className="mt-2 text-xs text-red-700" role="alert">
+              {revealMessage}
+            </p>
+          ) : null}
+
+          <div className="mt-6 flex flex-wrap items-center justify-end gap-2">
+            <button
+              type="button"
+              className="mr-auto inline-flex h-8 items-center gap-1.5 rounded-lg border border-border-200 bg-bg-000 px-2.5 text-sm font-medium text-text-100 hover:bg-bg-200 hover:text-text-000"
+              onClick={() => void handleRevealLog()}
+            >
+              <FolderOpen className="size-4" aria-hidden="true" />
+              Reveal log file
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border-200 bg-bg-000 px-2.5 text-sm font-medium text-text-100 hover:bg-bg-200 hover:text-text-000"
+              onClick={handleCopy}
+            >
+              {copied ? (
+                <Check className="size-4" aria-hidden="true" />
+              ) : (
+                <Copy className="size-4" aria-hidden="true" />
+              )}
+              {copied ? 'Copied' : 'Copy details'}
+            </button>
+            <a
+              href={consented ? issueUrl : undefined}
+              target="_blank"
+              rel="noreferrer"
+              aria-disabled={!consented}
+              tabIndex={consented ? undefined : -1}
+              onClick={(event) => {
+                if (!consented) event.preventDefault()
+                else handleOpenChange(false)
+              }}
+              className={`inline-flex h-8 items-center gap-1.5 rounded-lg border border-transparent bg-primary px-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/80 ${
+                consented ? '' : 'pointer-events-none opacity-50'
+              }`}
+            >
+              <ExternalLink className="size-4" aria-hidden="true" />
+              Open GitHub issue
+            </a>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+export { ReportErrorDialog }

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
@@ -4,7 +4,12 @@ import { useMemo, useState } from 'react'
 
 import { useSettingsStore } from '@/stores/settings-store'
 import { useUpdateStore } from '@/stores/update-store'
-import { buildErrorReportText, buildGithubIssueUrl, type ErrorReportContext } from './error-report'
+import {
+  buildEnvironmentBlock,
+  buildErrorReportText,
+  buildGithubIssueUrl,
+  type ErrorReportContext
+} from './error-report'
 
 type ReportErrorDialogProps = {
   open: boolean
@@ -52,22 +57,26 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
     agentFrameworks
   ])
 
-  const reportText = useMemo(() => buildErrorReportText(context), [context])
-
   const [consented, setConsented] = useState(false)
   const [copied, setCopied] = useState(false)
   const [revealMessage, setRevealMessage] = useState<string | null>(null)
-  // Editable copy of the report text so users can redact sensitive content before consenting. Seeded
-  // lazily from the current report; the parent remounts this dialog on each open, so it stays fresh.
-  const [editedText, setEditedText] = useState(reportText)
+  // Only the error text is editable — it is the unpredictable, possibly-sensitive part users may need
+  // to redact. Environment facts are non-sensitive and shown read-only below. Seeded lazily from the
+  // current error; the parent remounts this dialog on each open, so it stays fresh.
+  const [editedError, setEditedError] = useState(error)
 
-  // URL uses the user-edited body so any sensitive-data redactions made in the textarea are reflected.
-  const issueUrl = useMemo(() => buildGithubIssueUrl(context, editedText), [context, editedText])
+  // The edited error flows into every output so redactions are reflected everywhere it is shared.
+  const editedContext = useMemo<ErrorReportContext>(
+    () => ({ ...context, error: editedError }),
+    [context, editedError]
+  )
+  const environmentBlock = useMemo(() => buildEnvironmentBlock(context), [context])
+  const issueUrl = useMemo(() => buildGithubIssueUrl(editedContext), [editedContext])
 
-  // Copies the edited bundle and briefly confirms; the write stays local (no network).
+  // Copies the full bundle (error + environment) with the redacted error; the write stays local.
   const handleCopy = (): void => {
     void navigator.clipboard
-      .writeText(editedText)
+      .writeText(buildErrorReportText(editedContext))
       .then(() => {
         setCopied(true)
         window.setTimeout(() => setCopied(false), 1500)
@@ -102,21 +111,34 @@ const ReportErrorDialog = ({ open, error, onClose }: ReportErrorDialogProps): Re
             Report this error
           </Dialog.Title>
           <Dialog.Description className="mt-2 text-sm leading-relaxed text-text-100">
-            Review what will be included below. This report is posted publicly on GitHub — remove
-            anything sensitive before sharing. Your runtime log stays on this device and is never
-            attached automatically.
+            This report is posted publicly on GitHub. Edit the error text below to remove anything
+            sensitive before sharing. Your runtime log stays on this device and is never attached
+            automatically.
           </Dialog.Description>
 
+          <label className="mt-4 text-[11px] font-medium uppercase tracking-wide text-text-300">
+            Error details
+          </label>
           <textarea
-            className="mt-4 min-h-0 flex-1 resize-none overflow-auto rounded-lg border border-border-200 bg-bg-100 px-3 py-2.5 font-mono text-[12px] leading-5 text-text-100 focus:outline-none focus:ring-1 focus:ring-primary/50"
-            aria-label="Error report preview"
-            value={editedText}
+            className="mt-1 min-h-0 flex-1 resize-none overflow-auto rounded-lg border border-border-200 bg-bg-100 px-3 py-2.5 font-mono text-[12px] leading-5 text-text-100 focus:outline-none focus:ring-1 focus:ring-primary/50"
+            aria-label="Error details"
+            value={editedError}
             onChange={(event) => {
-              setEditedText(event.target.value)
+              setEditedError(event.target.value)
               // Require re-consent whenever the user edits the content being shared.
               setConsented(false)
             }}
           />
+
+          <p className="mt-3 text-[11px] font-medium uppercase tracking-wide text-text-300">
+            Also included
+          </p>
+          <pre
+            className="mt-1 max-h-28 shrink-0 overflow-auto whitespace-pre-wrap rounded-lg border border-border-200 bg-bg-100 px-3 py-2 font-mono text-[11px] leading-5 text-text-200"
+            aria-label="Report environment"
+          >
+            {environmentBlock}
+          </pre>
 
           <label className="mt-4 flex items-start gap-2 text-[13px] leading-5 text-text-100">
             <input

--- a/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
+++ b/src/renderer/src/pages/workspace/ReportErrorDialog.tsx
@@ -7,7 +7,7 @@ import { useUpdateStore } from '@/stores/update-store'
 import {
   buildEnvironmentBlock,
   buildErrorReportText,
-  buildGithubIssueUrl,
+  buildGithubIssuePrefill,
   resolveSessionSubject,
   type ErrorReportContext,
   type SessionReportSubject
@@ -16,8 +16,8 @@ import {
 type ReportErrorDialogProps = {
   open: boolean
   error: string
-  // Session-level identifiers used to attribute the report to the configuration that was active when
-  // the run failed, rather than the current global settings.
+  // Session-level identifiers and run model snapshot used to attribute the report to the configuration
+  // that was active when the run failed, rather than the current global settings.
   subject: SessionReportSubject
   onClose: () => void
 }
@@ -34,22 +34,13 @@ const ReportErrorDialog = ({
 }: ReportErrorDialogProps): React.JSX.Element => {
   const appVersion = useUpdateStore((state) => state.appInfo?.version)
   const providers = useSettingsStore((state) => state.providers)
-  const activeProviderId = useSettingsStore((state) => state.activeProviderId)
-  const activeModel = useSettingsStore((state) => state.activeModel)
   const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
 
-  // Derive the bundle live from the stores. Framework/provider/model come from the failed session's own
-  // identifiers (via resolveSessionSubject), not the current active selection, so switching config after
-  // a failure never misattributes the report. The bridge is read defensively so the dialog renders where
-  // the preload surface is absent (tests, early boot); the helpers tolerate every missing field.
+  // Derive environment facts live, while the failed session supplies framework/backend identifiers and
+  // its run model snapshot. The bridge is read defensively so the dialog renders where the preload
+  // surface is absent (tests, early boot); the helpers tolerate every missing field.
   const context = useMemo<ErrorReportContext>(() => {
-    const resolved = resolveSessionSubject(
-      subject,
-      providers,
-      activeProviderId,
-      activeModel,
-      agentFrameworks
-    )
+    const resolved = resolveSessionSubject(subject, providers, agentFrameworks)
     return {
       error,
       appVersion,
@@ -65,11 +56,10 @@ const ReportErrorDialog = ({
     error,
     appVersion,
     providers,
-    activeProviderId,
-    activeModel,
     agentFrameworks,
     subject.agentFrameworkId,
-    subject.agentBackendId
+    subject.agentBackendId,
+    subject.model
   ])
 
   const [copied, setCopied] = useState(false)
@@ -85,7 +75,25 @@ const ReportErrorDialog = ({
     [context, editedError]
   )
   const environmentBlock = useMemo(() => buildEnvironmentBlock(context), [context])
-  const issueUrl = useMemo(() => buildGithubIssueUrl(editedContext), [editedContext])
+  const issuePrefill = useMemo(() => buildGithubIssuePrefill(editedContext), [editedContext])
+  const issueUrl = issuePrefill.url
+  const issuePrefillPreview = useMemo(
+    () =>
+      [
+        'What happened',
+        issuePrefill.fields['what-happened'] ?? '(not prefilled)',
+        '',
+        'App version',
+        issuePrefill.fields['app-version'] ?? '(not prefilled)',
+        '',
+        'Provider / model',
+        issuePrefill.fields['provider-model'] ?? '(not prefilled)',
+        '',
+        'Relevant logs',
+        issuePrefill.fields.logs ?? '(not prefilled)'
+      ].join('\n'),
+    [issuePrefill]
+  )
 
   // Consent is tied to the exact payload it was given for, not a bare flag. We record the URL the user
   // consented to; consent holds only while that still equals the current URL. So if a store field lands
@@ -166,6 +174,20 @@ const ReportErrorDialog = ({
           >
             {environmentBlock}
           </pre>
+
+          {issuePrefill.truncatedFields.length > 0 ? (
+            <>
+              <p className="mt-3 text-[11px] font-medium uppercase tracking-wide text-text-300">
+                GitHub issue prefill
+              </p>
+              <pre
+                className="mt-1 max-h-28 shrink-0 overflow-auto whitespace-pre-wrap rounded-lg border border-border-200 bg-bg-100 px-3 py-2 font-mono text-[11px] leading-5 text-text-200"
+                aria-label="GitHub issue prefill"
+              >
+                {issuePrefillPreview}
+              </pre>
+            </>
+          ) : null}
 
           <label className="mt-4 flex items-start gap-2 text-[13px] leading-5 text-text-100">
             <input

--- a/src/renderer/src/pages/workspace/error-report.test.ts
+++ b/src/renderer/src/pages/workspace/error-report.test.ts
@@ -5,7 +5,9 @@ import {
   buildErrorReportText,
   buildGithubIssueUrl,
   formatProviderModel,
+  MAX_WHAT_HAPPENED_LENGTH,
   osLabelForPlatform,
+  resolveSessionSubject,
   type ErrorReportContext
 } from './error-report'
 
@@ -123,5 +125,105 @@ describe('buildGithubIssueUrl', () => {
     expect(url.searchParams.get('app-version')).toBeNull()
     expect(url.searchParams.get('provider-model')).toBeNull()
     expect(url.searchParams.get('what-happened')).toBe('boom')
+  })
+
+  it('bounds a very long error with a visible truncation marker so the URL cannot 414', () => {
+    const longError = 'x'.repeat(MAX_WHAT_HAPPENED_LENGTH + 5000)
+    const whatHappened =
+      new URL(buildGithubIssueUrl({ error: longError })).searchParams.get('what-happened') ?? ''
+    // Kept at/under the cap plus the short marker — never the full 11k+ characters.
+    expect(whatHappened.length).toBeLessThanOrEqual(MAX_WHAT_HAPPENED_LENGTH + 120)
+    expect(whatHappened).toContain('truncated')
+    expect(whatHappened).toContain('Copy details')
+  })
+
+  it('does not truncate an error at or below the cap', () => {
+    const exact = 'y'.repeat(MAX_WHAT_HAPPENED_LENGTH)
+    const whatHappened =
+      new URL(buildGithubIssueUrl({ error: exact })).searchParams.get('what-happened') ?? ''
+    expect(whatHappened).toBe(exact)
+  })
+})
+
+describe('buildErrorReportText (Copy details) fallback', () => {
+  it('always carries the full, untruncated error even when the URL is capped', () => {
+    const longError = 'z'.repeat(MAX_WHAT_HAPPENED_LENGTH + 5000)
+    const text = buildErrorReportText({ ...baseContext, error: longError })
+    // Copy details is the full-fidelity fallback: it must contain the entire error, untruncated.
+    expect(text).toContain(longError)
+  })
+})
+
+describe('resolveSessionSubject', () => {
+  const providers = [
+    { id: 'p1', name: 'Anthropic' },
+    { id: 'ssh:box', name: 'Remote Box' }
+  ]
+  const frameworks = [
+    { id: 'claude-code', displayName: 'Claude Code' },
+    { id: 'codex', displayName: 'Codex' }
+  ]
+
+  it('resolves framework and provider from the session ids, including the active model', () => {
+    const resolved = resolveSessionSubject(
+      { agentFrameworkId: 'claude-code', agentBackendId: 'claude-code:p1' },
+      providers,
+      'p1',
+      'claude-opus-4',
+      frameworks
+    )
+    expect(resolved).toEqual({
+      frameworkName: 'Claude Code',
+      providerName: 'Anthropic',
+      model: 'claude-opus-4'
+    })
+  })
+
+  it('splits backendId on the first colon so provider ids containing colons survive', () => {
+    const resolved = resolveSessionSubject(
+      { agentFrameworkId: 'codex', agentBackendId: 'codex:ssh:box' },
+      providers,
+      'ssh:box',
+      'gpt-x',
+      frameworks
+    )
+    expect(resolved.providerName).toBe('Remote Box')
+    expect(resolved.model).toBe('gpt-x')
+  })
+
+  it('omits the model when the active provider no longer matches the session provider', () => {
+    const resolved = resolveSessionSubject(
+      { agentFrameworkId: 'claude-code', agentBackendId: 'claude-code:p1' },
+      providers,
+      'p2-switched', // user switched provider after the failure
+      'a-newer-model',
+      frameworks
+    )
+    expect(resolved.providerName).toBe('Anthropic') // still the session's provider
+    expect(resolved.model).toBeUndefined() // but not the newer, unrelated model
+  })
+
+  it('falls back to the raw framework id when it is unknown, and tolerates missing ids', () => {
+    expect(
+      resolveSessionSubject({ agentFrameworkId: 'mystery' }, providers, undefined, undefined, [])
+    ).toEqual({
+      frameworkName: 'mystery'
+    })
+    expect(resolveSessionSubject({}, providers, undefined, undefined, frameworks)).toEqual({
+      frameworkName: undefined
+    })
+  })
+
+  it('yields no provider name when the session provider is gone from the list', () => {
+    const resolved = resolveSessionSubject(
+      { agentFrameworkId: 'claude-code', agentBackendId: 'claude-code:deleted' },
+      providers,
+      'deleted',
+      'm',
+      frameworks
+    )
+    expect(resolved.providerName).toBeUndefined()
+    // Provider matches active id, so model is still allowed even though the provider record is gone.
+    expect(resolved.model).toBe('m')
   })
 })

--- a/src/renderer/src/pages/workspace/error-report.test.ts
+++ b/src/renderer/src/pages/workspace/error-report.test.ts
@@ -81,7 +81,19 @@ describe('buildGithubIssueUrl', () => {
     expect(url.searchParams.get('what-happened')).toBe('Run failed: connection reset')
     expect(url.searchParams.get('app-version')).toBe('0.5.1')
     expect(url.searchParams.get('provider-model')).toBe('Anthropic · claude-opus-4')
-    expect(url.searchParams.get('logs')).toContain('not attached automatically')
+    expect(url.searchParams.get('logs')).toContain('Not attached automatically')
+  })
+
+  it('carries the environment block (framework + runtime) into the logs field', () => {
+    const logs = new URL(buildGithubIssueUrl(baseContext)).searchParams.get('logs') ?? ''
+    expect(logs).toContain('Environment')
+    expect(logs).toContain('Agent framework: Claude Code')
+    expect(logs).toContain('Electron 30.0.0, Chrome 124, Node 20.11')
+  })
+
+  it('uses the edited report body for what-happened when provided', () => {
+    const url = new URL(buildGithubIssueUrl(baseContext, 'redacted summary'))
+    expect(url.searchParams.get('what-happened')).toBe('redacted summary')
   })
 
   it('sets the os field only for platforms the dropdown can match', () => {

--- a/src/renderer/src/pages/workspace/error-report.test.ts
+++ b/src/renderer/src/pages/workspace/error-report.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  CODEX_SHARED_PROVIDER_ID,
+  CODEX_SUBSCRIPTION_PROVIDER_ID
+} from '../../../../shared/settings'
+import {
   buildEnvironmentBlock,
   buildErrorReportText,
+  buildGithubIssuePrefill,
   buildGithubIssueUrl,
   formatProviderModel,
-  MAX_WHAT_HAPPENED_LENGTH,
+  MAX_GITHUB_ISSUE_URL_LENGTH,
   osLabelForPlatform,
   resolveSessionSubject,
   type ErrorReportContext
@@ -128,26 +133,57 @@ describe('buildGithubIssueUrl', () => {
   })
 
   it('bounds a very long error with a visible truncation marker so the URL cannot 414', () => {
-    const longError = 'x'.repeat(MAX_WHAT_HAPPENED_LENGTH + 5000)
+    const longError = 'x'.repeat(MAX_GITHUB_ISSUE_URL_LENGTH + 5000)
     const whatHappened =
       new URL(buildGithubIssueUrl({ error: longError })).searchParams.get('what-happened') ?? ''
     // Kept at/under the cap plus the short marker — never the full 11k+ characters.
-    expect(whatHappened.length).toBeLessThanOrEqual(MAX_WHAT_HAPPENED_LENGTH + 120)
+    expect(whatHappened.length).toBeLessThanOrEqual(MAX_GITHUB_ISSUE_URL_LENGTH)
     expect(whatHappened).toContain('truncated')
     expect(whatHappened).toContain('Copy details')
   })
 
-  it('does not truncate an error at or below the cap', () => {
-    const exact = 'y'.repeat(MAX_WHAT_HAPPENED_LENGTH)
+  it('does not truncate an error when the serialized issue URL fits', () => {
+    const exact = 'y'.repeat(1000)
     const whatHappened =
       new URL(buildGithubIssueUrl({ error: exact })).searchParams.get('what-happened') ?? ''
     expect(whatHappened).toBe(exact)
+  })
+
+  it('bounds the final serialized URL after non-ASCII percent encoding', () => {
+    const url = buildGithubIssueUrl({
+      ...baseContext,
+      error: '中'.repeat(MAX_GITHUB_ISSUE_URL_LENGTH)
+    })
+
+    expect(url.length).toBeLessThanOrEqual(MAX_GITHUB_ISSUE_URL_LENGTH)
+  })
+
+  it('bounds every dynamic field and exposes the exact outgoing values', () => {
+    const oversized = '界'.repeat(4000)
+    const prefill = buildGithubIssuePrefill({
+      error: oversized,
+      appVersion: oversized,
+      platform: 'darwin',
+      frameworkName: oversized,
+      providerName: oversized,
+      model: oversized,
+      runtimeVersions: { electron: oversized, chrome: oversized, node: oversized }
+    })
+    const params = new URL(prefill.url).searchParams
+
+    expect(prefill.url.length).toBeLessThanOrEqual(MAX_GITHUB_ISSUE_URL_LENGTH)
+    expect(prefill.truncatedFields).toEqual(
+      expect.arrayContaining(['what-happened', 'app-version', 'provider-model', 'logs'])
+    )
+    for (const field of ['what-happened', 'app-version', 'provider-model', 'logs'] as const) {
+      expect(prefill.fields[field]).toBe(params.get(field))
+    }
   })
 })
 
 describe('buildErrorReportText (Copy details) fallback', () => {
   it('always carries the full, untruncated error even when the URL is capped', () => {
-    const longError = 'z'.repeat(MAX_WHAT_HAPPENED_LENGTH + 5000)
+    const longError = 'z'.repeat(MAX_GITHUB_ISSUE_URL_LENGTH + 5000)
     const text = buildErrorReportText({ ...baseContext, error: longError })
     // Copy details is the full-fidelity fallback: it must contain the entire error, untruncated.
     expect(text).toContain(longError)
@@ -164,12 +200,14 @@ describe('resolveSessionSubject', () => {
     { id: 'codex', displayName: 'Codex' }
   ]
 
-  it('resolves framework and provider from the session ids, including the active model', () => {
+  it('resolves framework, provider, and model from the failed session', () => {
     const resolved = resolveSessionSubject(
-      { agentFrameworkId: 'claude-code', agentBackendId: 'claude-code:p1' },
+      {
+        agentFrameworkId: 'claude-code',
+        agentBackendId: 'claude-code:p1',
+        model: 'claude-opus-4'
+      },
       providers,
-      'p1',
-      'claude-opus-4',
       frameworks
     )
     expect(resolved).toEqual({
@@ -181,49 +219,87 @@ describe('resolveSessionSubject', () => {
 
   it('splits backendId on the first colon so provider ids containing colons survive', () => {
     const resolved = resolveSessionSubject(
-      { agentFrameworkId: 'codex', agentBackendId: 'codex:ssh:box' },
+      { agentFrameworkId: 'codex', agentBackendId: 'codex:ssh:box', model: 'gpt-x' },
       providers,
-      'ssh:box',
-      'gpt-x',
       frameworks
     )
     expect(resolved.providerName).toBe('Remote Box')
     expect(resolved.model).toBe('gpt-x')
   })
 
-  it('omits the model when the active provider no longer matches the session provider', () => {
+  it('maps a Codex subscription backend id to the consolidated renderer provider', () => {
+    const resolved = resolveSessionSubject(
+      {
+        agentFrameworkId: 'codex',
+        agentBackendId: `codex:${CODEX_SHARED_PROVIDER_ID}`,
+        model: 'gpt-5.6-sol'
+      },
+      [{ id: CODEX_SUBSCRIPTION_PROVIDER_ID, name: 'Codex subscription' }],
+      frameworks
+    )
+
+    expect(resolved).toEqual({
+      frameworkName: 'Codex',
+      providerName: 'Codex subscription',
+      model: 'gpt-5.6-sol'
+    })
+  })
+
+  it('omits the model when the failed session has no model snapshot', () => {
     const resolved = resolveSessionSubject(
       { agentFrameworkId: 'claude-code', agentBackendId: 'claude-code:p1' },
       providers,
-      'p2-switched', // user switched provider after the failure
-      'a-newer-model',
       frameworks
     )
-    expect(resolved.providerName).toBe('Anthropic') // still the session's provider
-    expect(resolved.model).toBeUndefined() // but not the newer, unrelated model
+    expect(resolved.providerName).toBe('Anthropic')
+    expect(resolved.model).toBeUndefined()
+  })
+
+  it('keeps the run model when the backend snapshot is unavailable', () => {
+    const resolved = resolveSessionSubject(
+      { agentFrameworkId: 'codex', model: 'gpt-5.6-sol' },
+      providers,
+      frameworks
+    )
+
+    expect(resolved).toEqual({ frameworkName: 'Codex', model: 'gpt-5.6-sol' })
+  })
+
+  it('uses the failed session model instead of the current model selection', () => {
+    const resolved = resolveSessionSubject(
+      {
+        agentFrameworkId: 'claude-code',
+        agentBackendId: 'claude-code:p1',
+        model: 'model-used-by-failed-run'
+      },
+      providers,
+      frameworks
+    )
+
+    expect(resolved.model).toBe('model-used-by-failed-run')
   })
 
   it('falls back to the raw framework id when it is unknown, and tolerates missing ids', () => {
-    expect(
-      resolveSessionSubject({ agentFrameworkId: 'mystery' }, providers, undefined, undefined, [])
-    ).toEqual({
+    expect(resolveSessionSubject({ agentFrameworkId: 'mystery' }, providers, [])).toEqual({
       frameworkName: 'mystery'
     })
-    expect(resolveSessionSubject({}, providers, undefined, undefined, frameworks)).toEqual({
+    expect(resolveSessionSubject({}, providers, frameworks)).toEqual({
       frameworkName: undefined
     })
   })
 
   it('yields no provider name when the session provider is gone from the list', () => {
     const resolved = resolveSessionSubject(
-      { agentFrameworkId: 'claude-code', agentBackendId: 'claude-code:deleted' },
+      {
+        agentFrameworkId: 'claude-code',
+        agentBackendId: 'claude-code:deleted',
+        model: 'm'
+      },
       providers,
-      'deleted',
-      'm',
       frameworks
     )
     expect(resolved.providerName).toBeUndefined()
-    // Provider matches active id, so model is still allowed even though the provider record is gone.
+    // The session's model remains accurate even when its provider record was later deleted.
     expect(resolved.model).toBe('m')
   })
 })

--- a/src/renderer/src/pages/workspace/error-report.test.ts
+++ b/src/renderer/src/pages/workspace/error-report.test.ts
@@ -81,18 +81,29 @@ describe('buildGithubIssueUrl', () => {
     expect(url.searchParams.get('what-happened')).toBe('Run failed: connection reset')
     expect(url.searchParams.get('app-version')).toBe('0.5.1')
     expect(url.searchParams.get('provider-model')).toBe('Anthropic · claude-opus-4')
-    expect(url.searchParams.get('logs')).toContain('Not attached automatically')
+    expect(url.searchParams.get('logs')).toContain('Runtime log not attached automatically')
   })
 
-  it('carries the environment block (framework + runtime) into the logs field', () => {
+  it('puts only non-structured environment facts (framework + runtime) in the logs field', () => {
     const logs = new URL(buildGithubIssueUrl(baseContext)).searchParams.get('logs') ?? ''
-    expect(logs).toContain('Environment')
     expect(logs).toContain('Agent framework: Claude Code')
     expect(logs).toContain('Electron 30.0.0, Chrome 124, Node 20.11')
+    // App version / provider-model / OS have their own form fields — must not be duplicated here,
+    // and the shell-rendered field must stay plain (no Markdown emphasis).
+    expect(logs).not.toContain('App version')
+    expect(logs).not.toContain('**')
   })
 
-  it('uses the edited report body for what-happened when provided', () => {
-    const url = new URL(buildGithubIssueUrl(baseContext, 'redacted summary'))
+  it('keeps what-happened to the error alone, without the environment block', () => {
+    const whatHappened =
+      new URL(buildGithubIssueUrl(baseContext)).searchParams.get('what-happened') ?? ''
+    expect(whatHappened).toBe('Run failed: connection reset')
+    expect(whatHappened).not.toContain('Environment')
+    expect(whatHappened).not.toContain('App version')
+  })
+
+  it('reflects a redacted error passed via context', () => {
+    const url = new URL(buildGithubIssueUrl({ ...baseContext, error: 'redacted summary' }))
     expect(url.searchParams.get('what-happened')).toBe('redacted summary')
   })
 

--- a/src/renderer/src/pages/workspace/error-report.test.ts
+++ b/src/renderer/src/pages/workspace/error-report.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildEnvironmentBlock,
+  buildErrorReportText,
+  buildGithubIssueUrl,
+  formatProviderModel,
+  osLabelForPlatform,
+  type ErrorReportContext
+} from './error-report'
+
+const baseContext: ErrorReportContext = {
+  error: 'Run failed: connection reset',
+  appVersion: '0.5.1',
+  platform: 'darwin',
+  frameworkName: 'Claude Code',
+  providerName: 'Anthropic',
+  model: 'claude-opus-4',
+  runtimeVersions: { electron: '30.0.0', chrome: '124', node: '20.11' }
+}
+
+describe('osLabelForPlatform', () => {
+  it('maps windows and linux to template labels', () => {
+    expect(osLabelForPlatform('win32')).toBe('Windows')
+    expect(osLabelForPlatform('linux')).toBe('Linux')
+  })
+
+  it('leaves macOS unresolved so the user picks Apple Silicon vs Intel', () => {
+    expect(osLabelForPlatform('darwin')).toBeUndefined()
+    expect(osLabelForPlatform(undefined)).toBeUndefined()
+  })
+})
+
+describe('formatProviderModel', () => {
+  it('joins provider and model when both are present', () => {
+    expect(formatProviderModel(baseContext)).toBe('Anthropic · claude-opus-4')
+  })
+
+  it('falls back to provider name, then model, then Unknown', () => {
+    expect(formatProviderModel({ error: 'x', providerName: 'Anthropic' })).toBe('Anthropic')
+    expect(formatProviderModel({ error: 'x', model: 'gpt-4o' })).toBe('gpt-4o')
+    expect(formatProviderModel({ error: 'x' })).toBe('Unknown')
+  })
+})
+
+describe('buildEnvironmentBlock', () => {
+  it('renders every known field as a labelled line', () => {
+    const block = buildEnvironmentBlock(baseContext)
+    expect(block).toContain('- App version: 0.5.1')
+    expect(block).toContain('- Agent framework: Claude Code')
+    expect(block).toContain('- Provider / model: Anthropic · claude-opus-4')
+    expect(block).toContain('- Runtime: Electron 30.0.0, Chrome 124, Node 20.11')
+  })
+
+  it('omits the runtime line when no versions are known', () => {
+    const block = buildEnvironmentBlock({ error: 'x', appVersion: '1.0.0' })
+    expect(block).not.toContain('- Runtime:')
+    expect(block).toContain('- App version: 1.0.0')
+    expect(block).toContain('- Operating system: Unknown')
+  })
+})
+
+describe('buildErrorReportText', () => {
+  it('includes the error, environment, and a local-log note', () => {
+    const text = buildErrorReportText(baseContext)
+    expect(text).toContain('Run failed: connection reset')
+    expect(text).toContain('## Environment')
+    expect(text).toContain('The runtime log is not included automatically')
+  })
+
+  it('degrades to a placeholder when the error string is blank', () => {
+    expect(buildErrorReportText({ error: '   ' })).toContain('A run failed with no error message.')
+  })
+})
+
+describe('buildGithubIssueUrl', () => {
+  it('targets the bug report template with prefilled, decodable fields', () => {
+    const url = new URL(buildGithubIssueUrl(baseContext))
+    expect(url.pathname).toBe('/aipoch/open-science/issues/new')
+    expect(url.searchParams.get('template')).toBe('bug_report.yml')
+    expect(url.searchParams.get('what-happened')).toBe('Run failed: connection reset')
+    expect(url.searchParams.get('app-version')).toBe('0.5.1')
+    expect(url.searchParams.get('provider-model')).toBe('Anthropic · claude-opus-4')
+    expect(url.searchParams.get('logs')).toContain('not attached automatically')
+  })
+
+  it('sets the os field only for platforms the dropdown can match', () => {
+    expect(new URL(buildGithubIssueUrl(baseContext)).searchParams.get('os')).toBeNull()
+    expect(
+      new URL(buildGithubIssueUrl({ ...baseContext, platform: 'win32' })).searchParams.get('os')
+    ).toBe('Windows')
+  })
+
+  it('omits fields that are unknown rather than sending empty values', () => {
+    const url = new URL(buildGithubIssueUrl({ error: 'boom' }))
+    expect(url.searchParams.get('app-version')).toBeNull()
+    expect(url.searchParams.get('provider-model')).toBeNull()
+    expect(url.searchParams.get('what-happened')).toBe('boom')
+  })
+})

--- a/src/renderer/src/pages/workspace/error-report.test.ts
+++ b/src/renderer/src/pages/workspace/error-report.test.ts
@@ -20,14 +20,15 @@ const baseContext: ErrorReportContext = {
 }
 
 describe('osLabelForPlatform', () => {
-  it('maps windows and linux to template labels', () => {
+  it('maps known platforms to human-readable names', () => {
     expect(osLabelForPlatform('win32')).toBe('Windows')
     expect(osLabelForPlatform('linux')).toBe('Linux')
+    expect(osLabelForPlatform('darwin')).toBe('macOS')
   })
 
-  it('leaves macOS unresolved so the user picks Apple Silicon vs Intel', () => {
-    expect(osLabelForPlatform('darwin')).toBeUndefined()
+  it('returns undefined for an unknown platform', () => {
     expect(osLabelForPlatform(undefined)).toBeUndefined()
+    expect(osLabelForPlatform('sunos')).toBeUndefined()
   })
 })
 
@@ -84,11 +85,13 @@ describe('buildGithubIssueUrl', () => {
     expect(url.searchParams.get('logs')).toContain('Runtime log not attached automatically')
   })
 
-  it('puts only non-structured environment facts (framework + runtime) in the logs field', () => {
+  it('carries framework, runtime, and detected OS in the logs field', () => {
     const logs = new URL(buildGithubIssueUrl(baseContext)).searchParams.get('logs') ?? ''
     expect(logs).toContain('Agent framework: Claude Code')
     expect(logs).toContain('Electron 30.0.0, Chrome 124, Node 20.11')
-    // App version / provider-model / OS have their own form fields — must not be duplicated here,
+    // OS is a dropdown GitHub won't prefill, so its detected value is surfaced here instead.
+    expect(logs).toContain('Detected OS: macOS')
+    // App version / provider-model have their own prefilled inputs — must not be duplicated here,
     // and the shell-rendered field must stay plain (no Markdown emphasis).
     expect(logs).not.toContain('App version')
     expect(logs).not.toContain('**')
@@ -107,11 +110,12 @@ describe('buildGithubIssueUrl', () => {
     expect(url.searchParams.get('what-happened')).toBe('redacted summary')
   })
 
-  it('sets the os field only for platforms the dropdown can match', () => {
-    expect(new URL(buildGithubIssueUrl(baseContext)).searchParams.get('os')).toBeNull()
-    expect(
-      new URL(buildGithubIssueUrl({ ...baseContext, platform: 'win32' })).searchParams.get('os')
-    ).toBe('Windows')
+  it('never sets the os query param (GitHub ignores dropdown prefill) and uses logs instead', () => {
+    // Regression guard for the empirically-confirmed limitation: prefilling a dropdown via query
+    // string does not work, so the param must not be sent and the value must live in logs.
+    const url = new URL(buildGithubIssueUrl({ ...baseContext, platform: 'win32' }))
+    expect(url.searchParams.get('os')).toBeNull()
+    expect(url.searchParams.get('logs')).toContain('Detected OS: Windows')
   })
 
   it('omits fields that are unknown rather than sending empty values', () => {

--- a/src/renderer/src/pages/workspace/error-report.ts
+++ b/src/renderer/src/pages/workspace/error-report.ts
@@ -1,0 +1,121 @@
+import { APP } from '../../../../shared/app-config'
+
+// Assembles a failed-run diagnostic report locally. Nothing here transmits anything: the helpers only
+// build human-readable text and a pre-filled GitHub "new issue" URL, so the user reviews every field
+// before deciding to open a public issue. The runtime log stays on the device and is never inlined.
+
+// Runtime versions the preload bridge exposes; kept loose so callers can pass a partial snapshot.
+export type ReportRuntimeVersions = {
+  electron?: string
+  chrome?: string
+  node?: string
+}
+
+// Everything the dialog knows about a failed run at report time. All optional but `error` so the
+// bundle degrades gracefully when a field (provider, version) has not loaded yet.
+export type ErrorReportContext = {
+  error: string
+  appVersion?: string
+  platform?: string
+  frameworkName?: string
+  providerName?: string
+  model?: string
+  runtimeVersions?: ReportRuntimeVersions
+}
+
+// The exact option labels in .github/ISSUE_TEMPLATE/bug_report.yml's "Operating system" dropdown.
+// GitHub matches a prefilled dropdown by label, so these must stay in sync with the template.
+const OS_LABEL_WINDOWS = 'Windows'
+const OS_LABEL_LINUX = 'Linux'
+
+// Maps process.platform to the template's OS label. macOS is intentionally left unresolved: the
+// dropdown splits Apple Silicon vs Intel, which the platform string alone cannot tell apart, so the
+// user picks the right one rather than us guessing wrong.
+export const osLabelForPlatform = (platform: string | undefined): string | undefined => {
+  switch (platform) {
+    case 'win32':
+      return OS_LABEL_WINDOWS
+    case 'linux':
+      return OS_LABEL_LINUX
+    default:
+      return undefined
+  }
+}
+
+// Formats the provider/model line, tolerating a provider with no concrete model selected.
+export const formatProviderModel = (context: ErrorReportContext): string => {
+  if (context.providerName && context.model) return `${context.providerName} · ${context.model}`
+  if (context.providerName) return context.providerName
+  if (context.model) return context.model
+  return 'Unknown'
+}
+
+// Renders the "Environment" section shared by the on-screen preview and the GitHub issue body. Kept
+// as a labelled list so a maintainer can read it at a glance and a user can scan it before sharing.
+export const buildEnvironmentBlock = (context: ErrorReportContext): string => {
+  const runtime = context.runtimeVersions
+  const runtimeLine = runtime
+    ? [
+        runtime.electron ? `Electron ${runtime.electron}` : undefined,
+        runtime.chrome ? `Chrome ${runtime.chrome}` : undefined,
+        runtime.node ? `Node ${runtime.node}` : undefined
+      ]
+        .filter(Boolean)
+        .join(', ')
+    : ''
+
+  return [
+    `- App version: ${context.appVersion ?? 'Unknown'}`,
+    `- Operating system: ${osLabelForPlatform(context.platform) ?? context.platform ?? 'Unknown'}`,
+    `- Agent framework: ${context.frameworkName ?? 'Unknown'}`,
+    `- Provider / model: ${formatProviderModel(context)}`,
+    runtimeLine ? `- Runtime: ${runtimeLine}` : undefined
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+// Builds the full copy-to-clipboard report: the error, the environment block, and an explicit note
+// that the local log is not included so the user knows to attach it themselves if they want to.
+export const buildErrorReportText = (context: ErrorReportContext): string =>
+  [
+    '## What happened',
+    '',
+    context.error.trim() || 'A run failed with no error message.',
+    '',
+    '## Environment',
+    '',
+    buildEnvironmentBlock(context),
+    '',
+    '## Logs',
+    '',
+    'The runtime log is not included automatically. It stays on this device; attach it from',
+    'Settings → General → Diagnostics if you want to share it.'
+  ].join('\n')
+
+// Builds a pre-filled "new issue" URL against the Bug report form. GitHub's issue-form prefill reads
+// query params keyed by each field's `id` in bug_report.yml; the dropdown (`os`) is matched by option
+// label. Only fields we can fill accurately are set — Steps to reproduce is left for the user, and the
+// preflight checkboxes cannot be prefilled, so the user still confirms them in the browser.
+export const buildGithubIssueUrl = (context: ErrorReportContext): string => {
+  const params = new URLSearchParams({ template: 'bug_report.yml' })
+
+  const whatHappened = context.error.trim()
+  if (whatHappened) params.set('what-happened', whatHappened)
+
+  if (context.appVersion) params.set('app-version', context.appVersion)
+
+  const providerModel = formatProviderModel(context)
+  if (providerModel !== 'Unknown') params.set('provider-model', providerModel)
+
+  const osLabel = osLabelForPlatform(context.platform)
+  if (osLabel) params.set('os', osLabel)
+
+  params.set(
+    'logs',
+    'The runtime log is not attached automatically (it can contain local paths and prompts). ' +
+      'Attach it from Settings → General → Diagnostics after reviewing it.'
+  )
+
+  return `${APP.links.githubRepo}/issues/new?${params.toString()}`
+}

--- a/src/renderer/src/pages/workspace/error-report.ts
+++ b/src/renderer/src/pages/workspace/error-report.ts
@@ -97,10 +97,14 @@ export const buildErrorReportText = (context: ErrorReportContext): string =>
 // query params keyed by each field's `id` in bug_report.yml; the dropdown (`os`) is matched by option
 // label. Only fields we can fill accurately are set — Steps to reproduce is left for the user, and the
 // preflight checkboxes cannot be prefilled, so the user still confirms them in the browser.
-export const buildGithubIssueUrl = (context: ErrorReportContext): string => {
+//
+// `reportBody` overrides the `what-happened` field with user-edited content (the dialog's textarea
+// value), so the submitted issue reflects any sensitive-data redactions made before consent.
+export const buildGithubIssueUrl = (context: ErrorReportContext, reportBody?: string): string => {
   const params = new URLSearchParams({ template: 'bug_report.yml' })
 
-  const whatHappened = context.error.trim()
+  // Prefer the user-edited body; fall back to the raw error string.
+  const whatHappened = (reportBody ?? context.error).trim()
   if (whatHappened) params.set('what-happened', whatHappened)
 
   if (context.appVersion) params.set('app-version', context.appVersion)
@@ -111,10 +115,14 @@ export const buildGithubIssueUrl = (context: ErrorReportContext): string => {
   const osLabel = osLabelForPlatform(context.platform)
   if (osLabel) params.set('os', osLabel)
 
+  // Include the full environment block (framework, runtime versions) so the issue captures what the
+  // dialog preview shows — previously only the error text and structured fields were sent.
   params.set(
     'logs',
-    'The runtime log is not attached automatically (it can contain local paths and prompts). ' +
-      'Attach it from Settings → General → Diagnostics after reviewing it.'
+    `**Environment**\n${buildEnvironmentBlock(context)}\n\n` +
+      '**Runtime log**\n' +
+      'Not attached automatically (may contain local paths and prompts). ' +
+      'Reveal it from Settings → General → Diagnostics and attach after reviewing.'
   )
 
   return `${APP.links.githubRepo}/issues/new?${params.toString()}`

--- a/src/renderer/src/pages/workspace/error-report.ts
+++ b/src/renderer/src/pages/workspace/error-report.ts
@@ -4,6 +4,20 @@ import { APP } from '../../../../shared/app-config'
 // build human-readable text and a pre-filled GitHub "new issue" URL, so the user reviews every field
 // before deciding to open a public issue. The runtime log stays on the device and is never inlined.
 
+// Shown in the failure row AND seeded into the report when a failed run carries no error text. Defined
+// once so the text the user sees always equals the text they report ("shown == reported").
+export const RUN_FAILED_FALLBACK_ERROR = 'The run failed with no error message.'
+
+// Upper bound for the error text placed in the `what-happened` query param. GitHub's issue-form prefill
+// (and browsers) reject over-long request URIs with a 414, which would drop the user on an error page
+// instead of the prefilled form — a regression in the very failure-reporting path this feature adds. A
+// long stack trace is truncated with a visible marker; the full text is always available via Copy
+// details (buildErrorReportText is never truncated). Chosen conservatively: query values are percent-
+// encoded, so a char of stack trace can cost ~3 bytes in the URL.
+export const MAX_WHAT_HAPPENED_LENGTH = 6000
+const TRUNCATION_MARKER =
+  '\n\n…(truncated — use “Copy details” for the full error and attach the log)'
+
 // Runtime versions the preload bridge exposes; kept loose so callers can pass a partial snapshot.
 export type ReportRuntimeVersions = {
   electron?: string
@@ -43,7 +57,54 @@ export const osLabelForPlatform = (platform: string | undefined): string | undef
   }
 }
 
-// Formats the provider/model line, tolerating a provider with no concrete model selected.
+// Holds the session-level identifiers that tell us which framework and backend were active when the
+// run failed. Both are optional because older sessions were persisted before these fields were added.
+export type SessionReportSubject = {
+  agentFrameworkId?: string
+  agentBackendId?: string
+}
+
+// The framework/provider/model the report should attribute the failure to, resolved from the session's
+// own stored identifiers so a config change after the failure doesn't misattribute it.
+export type ResolvedSubject = {
+  frameworkName?: string
+  providerName?: string
+  model?: string
+}
+
+// Resolves the framework name and provider from the session's own stored identifiers. backendId is
+// encoded as "${frameworkId}:${providerId}" (see service.ts) — we split on the first colon because
+// provider ids can themselves contain colons (e.g. "ssh:alias"). The model is included only when the
+// session's provider still matches the currently active one; otherwise omitting it avoids reporting a
+// model that belonged to a later config switch.
+export const resolveSessionSubject = (
+  subject: SessionReportSubject,
+  providers: Array<{ id: string; name: string }>,
+  activeProviderId: string | undefined,
+  activeModel: string | undefined,
+  agentFrameworks: Array<{ id: string; displayName: string }>
+): ResolvedSubject => {
+  const frameworkName = subject.agentFrameworkId
+    ? (agentFrameworks.find((f) => f.id === subject.agentFrameworkId)?.displayName ??
+      subject.agentFrameworkId)
+    : undefined
+
+  if (!subject.agentBackendId) return { frameworkName }
+
+  // backendId format: "{frameworkId}:{providerId}" — split on first colon only.
+  const colonIdx = subject.agentBackendId.indexOf(':')
+  const providerId = colonIdx !== -1 ? subject.agentBackendId.slice(colonIdx + 1) : undefined
+
+  const provider = providerId ? providers.find((p) => p.id === providerId) : undefined
+  const providerName = provider?.name
+
+  // Only include the active model when the session's provider is still the active one; a config
+  // switch after the failure would make the model misleading.
+  const model =
+    providerId && activeProviderId === providerId && activeModel ? activeModel : undefined
+
+  return { frameworkName, providerName, model }
+}
 export const formatProviderModel = (context: ErrorReportContext): string => {
   if (context.providerName && context.model) return `${context.providerName} · ${context.model}`
   if (context.providerName) return context.providerName
@@ -132,7 +193,14 @@ export const buildGithubIssueUrl = (context: ErrorReportContext): string => {
   const params = new URLSearchParams({ template: 'bug_report.yml' })
 
   const whatHappened = context.error.trim()
-  if (whatHappened) params.set('what-happened', whatHappened)
+  if (whatHappened) {
+    // Bound the error text so a long stack trace can't push the URL past GitHub's URI limit (414).
+    const bounded =
+      whatHappened.length > MAX_WHAT_HAPPENED_LENGTH
+        ? whatHappened.slice(0, MAX_WHAT_HAPPENED_LENGTH) + TRUNCATION_MARKER
+        : whatHappened
+    params.set('what-happened', bounded)
+  }
 
   if (context.appVersion) params.set('app-version', context.appVersion)
 

--- a/src/renderer/src/pages/workspace/error-report.ts
+++ b/src/renderer/src/pages/workspace/error-report.ts
@@ -1,4 +1,8 @@
 import { APP } from '../../../../shared/app-config'
+import {
+  CODEX_SUBSCRIPTION_PROVIDER_ID,
+  isCodexSubscriptionProviderId
+} from '../../../../shared/settings'
 
 // Assembles a failed-run diagnostic report locally. Nothing here transmits anything: the helpers only
 // build human-readable text and a pre-filled GitHub "new issue" URL, so the user reviews every field
@@ -7,16 +11,29 @@ import { APP } from '../../../../shared/app-config'
 // Shown in the failure row AND seeded into the report when a failed run carries no error text. Defined
 // once so the text the user sees always equals the text they report ("shown == reported").
 export const RUN_FAILED_FALLBACK_ERROR = 'The run failed with no error message.'
+export const normalizeRunFailureError = (error: string | null | undefined): string =>
+  error?.trim() || RUN_FAILED_FALLBACK_ERROR
 
-// Upper bound for the error text placed in the `what-happened` query param. GitHub's issue-form prefill
-// (and browsers) reject over-long request URIs with a 414, which would drop the user on an error page
-// instead of the prefilled form — a regression in the very failure-reporting path this feature adds. A
-// long stack trace is truncated with a visible marker; the full text is always available via Copy
-// details (buildErrorReportText is never truncated). Chosen conservatively: query values are percent-
-// encoded, so a char of stack trace can cost ~3 bytes in the URL.
-export const MAX_WHAT_HAPPENED_LENGTH = 6000
-const TRUNCATION_MARKER =
+// Bound the serialized request URI, not decoded field lengths: URLSearchParams can expand one Unicode
+// code point into several percent-encoded bytes. Copy details remains full-fidelity when prefill fields
+// must be shortened to stay within this conservative request-line budget.
+export const MAX_GITHUB_ISSUE_URL_LENGTH = 7000
+const ERROR_TRUNCATION_MARKER =
   '\n\n…(truncated — use “Copy details” for the full error and attach the log)'
+const FIELD_TRUNCATION_MARKER = '…(truncated; full value is in Copy details)'
+const ENCODED_FIELD_BUDGETS = {
+  'app-version': 128,
+  'provider-model': 512,
+  logs: 1500
+} as const
+
+type GithubIssueFieldId = 'what-happened' | 'app-version' | 'provider-model' | 'logs'
+
+export type GithubIssuePrefill = {
+  url: string
+  fields: Partial<Record<GithubIssueFieldId, string>>
+  truncatedFields: GithubIssueFieldId[]
+}
 
 // Runtime versions the preload bridge exposes; kept loose so callers can pass a partial snapshot.
 export type ReportRuntimeVersions = {
@@ -62,26 +79,34 @@ export const osLabelForPlatform = (platform: string | undefined): string | undef
 export type SessionReportSubject = {
   agentFrameworkId?: string
   agentBackendId?: string
+  model?: string
 }
 
 // The framework/provider/model the report should attribute the failure to, resolved from the session's
-// own stored identifiers so a config change after the failure doesn't misattribute it.
+// stored subject and run-time model snapshot so later settings changes cannot misattribute it.
 export type ResolvedSubject = {
   frameworkName?: string
   providerName?: string
   model?: string
 }
 
+const normalizeSessionProviderId = (providerId: string | undefined): string | undefined => {
+  if (!providerId) return undefined
+
+  return isCodexSubscriptionProviderId(providerId) ||
+    providerId === 'codex-shared' ||
+    providerId === 'codex-isolated'
+    ? CODEX_SUBSCRIPTION_PROVIDER_ID
+    : providerId
+}
+
 // Resolves the framework name and provider from the session's own stored identifiers. backendId is
 // encoded as "${frameworkId}:${providerId}" (see service.ts) — we split on the first colon because
-// provider ids can themselves contain colons (e.g. "ssh:alias"). The model is included only when the
-// session's provider still matches the currently active one; otherwise omitting it avoids reporting a
-// model that belonged to a later config switch.
+// provider ids can themselves contain colons (e.g. "ssh:alias"). Codex subscription sessions retain
+// mode-specific backend ids, which normalize to the single provider card exposed in renderer settings.
 export const resolveSessionSubject = (
   subject: SessionReportSubject,
   providers: Array<{ id: string; name: string }>,
-  activeProviderId: string | undefined,
-  activeModel: string | undefined,
   agentFrameworks: Array<{ id: string; displayName: string }>
 ): ResolvedSubject => {
   const frameworkName = subject.agentFrameworkId
@@ -89,21 +114,18 @@ export const resolveSessionSubject = (
       subject.agentFrameworkId)
     : undefined
 
-  if (!subject.agentBackendId) return { frameworkName }
+  if (!subject.agentBackendId) return { frameworkName, model: subject.model }
 
   // backendId format: "{frameworkId}:{providerId}" — split on first colon only.
   const colonIdx = subject.agentBackendId.indexOf(':')
-  const providerId = colonIdx !== -1 ? subject.agentBackendId.slice(colonIdx + 1) : undefined
+  const providerId = normalizeSessionProviderId(
+    colonIdx !== -1 ? subject.agentBackendId.slice(colonIdx + 1) : undefined
+  )
 
   const provider = providerId ? providers.find((p) => p.id === providerId) : undefined
   const providerName = provider?.name
 
-  // Only include the active model when the session's provider is still the active one; a config
-  // switch after the failure would make the model misleading.
-  const model =
-    providerId && activeProviderId === providerId && activeModel ? activeModel : undefined
-
-  return { frameworkName, providerName, model }
+  return { frameworkName, providerName, model: subject.model }
 }
 export const formatProviderModel = (context: ErrorReportContext): string => {
   if (context.providerName && context.model) return `${context.providerName} · ${context.model}`
@@ -180,6 +202,64 @@ const buildLogsFieldText = (context: ErrorReportContext): string => {
   ].join('\n')
 }
 
+const issueUrlFromParams = (params: URLSearchParams): string =>
+  `${APP.links.githubRepo}/issues/new?${params.toString()}`
+
+const encodedParamValueLength = (key: string, value: string): number => {
+  const serialized = new URLSearchParams([[key, value]]).toString()
+  return serialized.length - key.length - 1
+}
+
+const truncateToEncodedBudget = (
+  key: string,
+  value: string,
+  budget: number,
+  marker: string
+): { value: string; truncated: boolean } => {
+  if (encodedParamValueLength(key, value) <= budget) return { value, truncated: false }
+
+  const characters = Array.from(value)
+  let low = 0
+  let high = characters.length
+
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2)
+    const candidate = `${characters.slice(0, mid).join('')}${marker}`
+
+    if (encodedParamValueLength(key, candidate) <= budget) low = mid
+    else high = mid - 1
+  }
+
+  return { value: `${characters.slice(0, low).join('')}${marker}`, truncated: true }
+}
+
+const fitErrorToUrlBudget = (
+  params: URLSearchParams,
+  value: string
+): { value: string; truncated: boolean } => {
+  params.set('what-happened', value)
+  if (issueUrlFromParams(params).length <= MAX_GITHUB_ISSUE_URL_LENGTH) {
+    return { value, truncated: false }
+  }
+
+  const characters = Array.from(value)
+  let low = 0
+  let high = characters.length
+
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2)
+    const candidate = `${characters.slice(0, mid).join('')}${ERROR_TRUNCATION_MARKER}`
+    params.set('what-happened', candidate)
+
+    if (issueUrlFromParams(params).length <= MAX_GITHUB_ISSUE_URL_LENGTH) low = mid
+    else high = mid - 1
+  }
+
+  const bounded = `${characters.slice(0, low).join('')}${ERROR_TRUNCATION_MARKER}`
+  params.set('what-happened', bounded)
+  return { value: bounded, truncated: true }
+}
+
 // Builds a pre-filled "new issue" URL against the Bug report form. GitHub's issue-form prefill reads
 // query params keyed by each field's `id` in bug_report.yml, but ONLY for `input`/`textarea` fields —
 // `dropdown` and `checkboxes` fields ignore query values. So we prefill what-happened / app-version /
@@ -189,18 +269,12 @@ const buildLogsFieldText = (context: ErrorReportContext): string => {
 // `what-happened` carries only the error/description (from `context.error`); the caller redacts it by
 // passing an edited context. Structured fields and `logs` carry the environment, so nothing is
 // duplicated across fields.
-export const buildGithubIssueUrl = (context: ErrorReportContext): string => {
+export const buildGithubIssuePrefill = (context: ErrorReportContext): GithubIssuePrefill => {
   const params = new URLSearchParams({ template: 'bug_report.yml' })
+  const truncatedFields: GithubIssueFieldId[] = []
 
   const whatHappened = context.error.trim()
-  if (whatHappened) {
-    // Bound the error text so a long stack trace can't push the URL past GitHub's URI limit (414).
-    const bounded =
-      whatHappened.length > MAX_WHAT_HAPPENED_LENGTH
-        ? whatHappened.slice(0, MAX_WHAT_HAPPENED_LENGTH) + TRUNCATION_MARKER
-        : whatHappened
-    params.set('what-happened', bounded)
-  }
+  if (whatHappened) params.set('what-happened', whatHappened)
 
   if (context.appVersion) params.set('app-version', context.appVersion)
 
@@ -209,5 +283,32 @@ export const buildGithubIssueUrl = (context: ErrorReportContext): string => {
 
   params.set('logs', buildLogsFieldText(context))
 
-  return `${APP.links.githubRepo}/issues/new?${params.toString()}`
+  if (issueUrlFromParams(params).length > MAX_GITHUB_ISSUE_URL_LENGTH) {
+    for (const [field, budget] of Object.entries(ENCODED_FIELD_BUDGETS) as Array<
+      [keyof typeof ENCODED_FIELD_BUDGETS, number]
+    >) {
+      const value = params.get(field)
+      if (!value) continue
+
+      const bounded = truncateToEncodedBudget(field, value, budget, FIELD_TRUNCATION_MARKER)
+      params.set(field, bounded.value)
+      if (bounded.truncated) truncatedFields.push(field)
+    }
+
+    if (whatHappened) {
+      const bounded = fitErrorToUrlBudget(params, whatHappened)
+      if (bounded.truncated) truncatedFields.push('what-happened')
+    }
+  }
+
+  const fields: GithubIssuePrefill['fields'] = {}
+  for (const field of ['what-happened', 'app-version', 'provider-model', 'logs'] as const) {
+    const value = params.get(field)
+    if (value !== null) fields[field] = value
+  }
+
+  return { url: issueUrlFromParams(params), fields, truncatedFields }
 }
+
+export const buildGithubIssueUrl = (context: ErrorReportContext): string =>
+  buildGithubIssuePrefill(context).url

--- a/src/renderer/src/pages/workspace/error-report.ts
+++ b/src/renderer/src/pages/workspace/error-report.ts
@@ -23,20 +23,21 @@ export type ErrorReportContext = {
   runtimeVersions?: ReportRuntimeVersions
 }
 
-// The exact option labels in .github/ISSUE_TEMPLATE/bug_report.yml's "Operating system" dropdown.
-// GitHub matches a prefilled dropdown by label, so these must stay in sync with the template.
-const OS_LABEL_WINDOWS = 'Windows'
-const OS_LABEL_LINUX = 'Linux'
-
-// Maps process.platform to the template's OS label. macOS is intentionally left unresolved: the
-// dropdown splits Apple Silicon vs Intel, which the platform string alone cannot tell apart, so the
-// user picks the right one rather than us guessing wrong.
+// Maps process.platform to a human-readable OS name for the preview and the `logs` field. macOS is
+// not split into Apple Silicon vs Intel here — the platform string alone can't tell them apart, and
+// the user selects the exact variant in the required dropdown themselves.
+//
+// Note: the bug_report.yml "Operating system" field is a `dropdown`, and GitHub's issue-form prefill
+// does NOT support dropdowns (only `input`/`textarea` accept query values). So we don't try to prefill
+// it — the detected OS is carried in the `logs` field instead, and the user picks the dropdown value.
 export const osLabelForPlatform = (platform: string | undefined): string | undefined => {
   switch (platform) {
     case 'win32':
-      return OS_LABEL_WINDOWS
+      return 'Windows'
     case 'linux':
-      return OS_LABEL_LINUX
+      return 'Linux'
+    case 'darwin':
+      return 'macOS'
     default:
       return undefined
   }
@@ -96,13 +97,16 @@ export const buildErrorReportText = (context: ErrorReportContext): string =>
     'Settings → General → Diagnostics if you want to share it.'
   ].join('\n')
 
-// Builds the `logs` field text: only the environment facts that have no dedicated bug_report.yml
-// field (agent framework, runtime versions). App version / provider-model / OS are omitted here
-// because the form has structured inputs for them — repeating them would clutter the issue. The
-// field is `render: shell`, so this stays plain text (no Markdown).
+// Builds the `logs` field text: the environment facts that either have no dedicated bug_report.yml
+// field (agent framework, runtime versions) or cannot be prefilled (OS — a dropdown GitHub won't
+// prefill, so we surface it here so maintainers still see the detected value even if the user's
+// dropdown pick differs). App version / provider-model are omitted — they prefill into their own
+// inputs. The field is `render: shell`, so this stays plain text (no Markdown).
 const buildLogsFieldText = (context: ErrorReportContext): string => {
+  const osLabel = osLabelForPlatform(context.platform)
   const runtimeLine = formatRuntimeVersions(context)
   const envLines = [
+    osLabel ? `Detected OS: ${osLabel}` : undefined,
     `Agent framework: ${context.frameworkName ?? 'Unknown'}`,
     runtimeLine ? `Runtime: ${runtimeLine}` : undefined
   ].filter(Boolean)
@@ -116,9 +120,10 @@ const buildLogsFieldText = (context: ErrorReportContext): string => {
 }
 
 // Builds a pre-filled "new issue" URL against the Bug report form. GitHub's issue-form prefill reads
-// query params keyed by each field's `id` in bug_report.yml; the dropdown (`os`) is matched by option
-// label. Only fields we can fill accurately are set — Steps to reproduce is left for the user, and the
-// preflight checkboxes cannot be prefilled, so the user still confirms them in the browser.
+// query params keyed by each field's `id` in bug_report.yml, but ONLY for `input`/`textarea` fields —
+// `dropdown` and `checkboxes` fields ignore query values. So we prefill what-happened / app-version /
+// provider-model / logs (the OS dropdown and preflight checkboxes are left for the user; the detected
+// OS is included in `logs` so it isn't lost). Steps to reproduce is intentionally left blank.
 //
 // `what-happened` carries only the error/description (from `context.error`); the caller redacts it by
 // passing an edited context. Structured fields and `logs` carry the environment, so nothing is
@@ -133,9 +138,6 @@ export const buildGithubIssueUrl = (context: ErrorReportContext): string => {
 
   const providerModel = formatProviderModel(context)
   if (providerModel !== 'Unknown') params.set('provider-model', providerModel)
-
-  const osLabel = osLabelForPlatform(context.platform)
-  if (osLabel) params.set('os', osLabel)
 
   params.set('logs', buildLogsFieldText(context))
 

--- a/src/renderer/src/pages/workspace/error-report.ts
+++ b/src/renderer/src/pages/workspace/error-report.ts
@@ -50,20 +50,23 @@ export const formatProviderModel = (context: ErrorReportContext): string => {
   return 'Unknown'
 }
 
-// Renders the "Environment" section shared by the on-screen preview and the GitHub issue body. Kept
-// as a labelled list so a maintainer can read it at a glance and a user can scan it before sharing.
-export const buildEnvironmentBlock = (context: ErrorReportContext): string => {
+// Joins the runtime versions into one line, e.g. "Electron 30.0.0, Chrome 124, Node 20.11".
+const formatRuntimeVersions = (context: ErrorReportContext): string => {
   const runtime = context.runtimeVersions
-  const runtimeLine = runtime
-    ? [
-        runtime.electron ? `Electron ${runtime.electron}` : undefined,
-        runtime.chrome ? `Chrome ${runtime.chrome}` : undefined,
-        runtime.node ? `Node ${runtime.node}` : undefined
-      ]
-        .filter(Boolean)
-        .join(', ')
-    : ''
+  if (!runtime) return ''
+  return [
+    runtime.electron ? `Electron ${runtime.electron}` : undefined,
+    runtime.chrome ? `Chrome ${runtime.chrome}` : undefined,
+    runtime.node ? `Node ${runtime.node}` : undefined
+  ]
+    .filter(Boolean)
+    .join(', ')
+}
 
+// Renders the full "Environment" section for the copy-to-clipboard bundle. Kept as a labelled list so
+// a maintainer can read it at a glance and a user can scan it before sharing.
+export const buildEnvironmentBlock = (context: ErrorReportContext): string => {
+  const runtimeLine = formatRuntimeVersions(context)
   return [
     `- App version: ${context.appVersion ?? 'Unknown'}`,
     `- Operating system: ${osLabelForPlatform(context.platform) ?? context.platform ?? 'Unknown'}`,
@@ -93,18 +96,37 @@ export const buildErrorReportText = (context: ErrorReportContext): string =>
     'Settings → General → Diagnostics if you want to share it.'
   ].join('\n')
 
+// Builds the `logs` field text: only the environment facts that have no dedicated bug_report.yml
+// field (agent framework, runtime versions). App version / provider-model / OS are omitted here
+// because the form has structured inputs for them — repeating them would clutter the issue. The
+// field is `render: shell`, so this stays plain text (no Markdown).
+const buildLogsFieldText = (context: ErrorReportContext): string => {
+  const runtimeLine = formatRuntimeVersions(context)
+  const envLines = [
+    `Agent framework: ${context.frameworkName ?? 'Unknown'}`,
+    runtimeLine ? `Runtime: ${runtimeLine}` : undefined
+  ].filter(Boolean)
+
+  return [
+    ...envLines,
+    '',
+    'Runtime log not attached automatically (it can contain local paths and prompts).',
+    'Reveal it from Settings → General → Diagnostics and attach after reviewing.'
+  ].join('\n')
+}
+
 // Builds a pre-filled "new issue" URL against the Bug report form. GitHub's issue-form prefill reads
 // query params keyed by each field's `id` in bug_report.yml; the dropdown (`os`) is matched by option
 // label. Only fields we can fill accurately are set — Steps to reproduce is left for the user, and the
 // preflight checkboxes cannot be prefilled, so the user still confirms them in the browser.
 //
-// `reportBody` overrides the `what-happened` field with user-edited content (the dialog's textarea
-// value), so the submitted issue reflects any sensitive-data redactions made before consent.
-export const buildGithubIssueUrl = (context: ErrorReportContext, reportBody?: string): string => {
+// `what-happened` carries only the error/description (from `context.error`); the caller redacts it by
+// passing an edited context. Structured fields and `logs` carry the environment, so nothing is
+// duplicated across fields.
+export const buildGithubIssueUrl = (context: ErrorReportContext): string => {
   const params = new URLSearchParams({ template: 'bug_report.yml' })
 
-  // Prefer the user-edited body; fall back to the raw error string.
-  const whatHappened = (reportBody ?? context.error).trim()
+  const whatHappened = context.error.trim()
   if (whatHappened) params.set('what-happened', whatHappened)
 
   if (context.appVersion) params.set('app-version', context.appVersion)
@@ -115,15 +137,7 @@ export const buildGithubIssueUrl = (context: ErrorReportContext, reportBody?: st
   const osLabel = osLabelForPlatform(context.platform)
   if (osLabel) params.set('os', osLabel)
 
-  // Include the full environment block (framework, runtime versions) so the issue captures what the
-  // dialog preview shows — previously only the error text and structured fields were sent.
-  params.set(
-    'logs',
-    `**Environment**\n${buildEnvironmentBlock(context)}\n\n` +
-      '**Runtime log**\n' +
-      'Not attached automatically (may contain local paths and prompts). ' +
-      'Reveal it from Settings → General → Diagnostics and attach after reviewing.'
-  )
+  params.set('logs', buildLogsFieldText(context))
 
   return `${APP.links.githubRepo}/issues/new?${params.toString()}`
 }

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -285,6 +285,25 @@ describe('session store', () => {
     ])
   })
 
+  it('persists the model selected when each run starts', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'First run',
+      agentModel: 'model-a'
+    })
+    useSessionStore.getState().finishRun('transport-session-1')
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Second run',
+      agentModel: 'model-b'
+    })
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.agentModel).toBe('model-b')
+    expect(toPersistedSession(session).agentModel).toBe('model-b')
+  })
+
   it('merges streamed agent chunks by stream id and completes them when the run stops', () => {
     const result = useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -95,6 +95,9 @@ type AppendUserMessageInput = {
   cwd?: string
   projectId?: string
   permissionProfile?: PermissionProfileId
+  agentFrameworkId?: PersistedChatSession['agentFrameworkId']
+  agentBackendId?: PersistedChatSession['agentBackendId']
+  agentModel?: string
   isPending?: boolean
 }
 
@@ -105,6 +108,9 @@ type AppendPendingUserMessageInput = {
   cwd?: string
   projectId?: string
   permissionProfile?: PermissionProfileId
+  agentFrameworkId?: PersistedChatSession['agentFrameworkId']
+  agentBackendId?: PersistedChatSession['agentBackendId']
+  agentModel?: string
 }
 
 type BindPendingSessionInput = {
@@ -567,9 +573,14 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     cwd,
     projectId,
     permissionProfile,
+    agentFrameworkId,
+    agentBackendId,
+    agentModel,
     isPending
   }) => {
     const trimmedContent = content.trim()
+    const normalizedAgentBackendId = agentBackendId?.trim() || undefined
+    const normalizedAgentModel = agentModel?.trim() || undefined
     const uploads = attachments.map(createPersistedUpload)
 
     if (!sessionId || (!trimmedContent && uploads.length === 0)) return undefined
@@ -601,6 +612,13 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
                 ...session,
                 status: 'running',
                 activeRun,
+                ...(session.isPending
+                  ? {
+                      agentFrameworkId,
+                      agentBackendId: normalizedAgentBackendId
+                    }
+                  : {}),
+                agentModel: normalizedAgentModel,
                 agentStatus: undefined,
                 error: undefined,
                 compacting: undefined,
@@ -620,6 +638,9 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         cwd: cwd ?? '',
         status: 'running',
         permissionProfile: permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+        agentFrameworkId,
+        agentBackendId: normalizedAgentBackendId,
+        agentModel: normalizedAgentModel,
         messages: [userMessage],
         activeRun,
         createdAt: now,
@@ -642,7 +663,10 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     parts,
     cwd,
     projectId,
-    permissionProfile
+    permissionProfile,
+    agentFrameworkId,
+    agentBackendId,
+    agentModel
   }) => {
     return get().appendUserMessage({
       sessionId: createPendingSessionId(),
@@ -652,6 +676,9 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       cwd,
       projectId,
       permissionProfile,
+      agentFrameworkId,
+      agentBackendId,
+      agentModel,
       isPending: true
     })
   },

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -249,16 +249,18 @@ describe('normalizeSessionFile with activities', () => {
     expect(malformed?.filesRevision).toBeUndefined()
   })
 
-  it('round-trips the agent backend identity used to resume a session', () => {
+  it('round-trips the agent backend identity and run model used for diagnostics', () => {
     const session = normalizeSessionFile({
       ...createSessionWithActivity(undefined),
       activities: undefined,
       agentFrameworkId: 'codex',
-      agentBackendId: 'codex:codex-isolated'
+      agentBackendId: 'codex:codex-isolated',
+      agentModel: 'gpt-5.6-sol'
     })
 
     expect(session?.agentFrameworkId).toBe('codex')
     expect(session?.agentBackendId).toBe('codex:codex-isolated')
+    expect(session?.agentModel).toBe('gpt-5.6-sol')
   })
 
   it('keeps known approval profiles and safely defaults unknown values', () => {

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -124,6 +124,9 @@ export type PersistedChatSession = {
   // Identifies the provider/profile session store within a framework so a restored session is never
   // resumed against an incompatible backend (for example Codex shared profile vs isolated login).
   agentBackendId?: string
+  // Model selected when the latest run started. Kept with the session so a later settings change
+  // cannot misattribute a failed run's diagnostic report.
+  agentModel?: string
   // Per-conversation approval posture. Older session files omit it and safely restore to Ask.
   permissionProfile?: PermissionProfileId
   // Per-conversation auto-review toggle. Absent (older files) or non-true is treated as disabled;
@@ -669,6 +672,7 @@ const sanitizeSession = (session: unknown): PersistedChatSession | undefined => 
   const error = asString(session.error)
   const agentFrameworkId = asString(session.agentFrameworkId) as AgentFrameworkId | undefined
   const agentBackendId = asString(session.agentBackendId)
+  const agentModel = asString(session.agentModel)
   const enabledComputeHosts = Array.isArray(session.enabledComputeHosts)
     ? session.enabledComputeHosts.filter(
         (item): item is string => typeof item === 'string' && item.startsWith('ssh:')
@@ -681,6 +685,7 @@ const sanitizeSession = (session: unknown): PersistedChatSession | undefined => 
     sanitized.agentFrameworkId = agentFrameworkId
   }
   if (agentBackendId) sanitized.agentBackendId = agentBackendId
+  if (agentModel) sanitized.agentModel = agentModel
   if (artifacts.length > 0) sanitized.artifacts = artifacts
   const filesRevision = asNumber(session.filesRevision)
   if (filesRevision !== undefined && Number.isInteger(filesRevision) && filesRevision >= 0) {


### PR DESCRIPTION
## Problem

When a run fails, users have no convenient path from the error message to a bug report. Collecting app version, OS, provider/model, and logs by hand is friction that causes most errors to go unreported.

## Proposed change

Add a **Report error** button inline in the failed-run error box. Clicking it opens a reviewable, consent-gated dialog that:

- Assembles a diagnostic bundle locally from the failed run's error, app/runtime information, framework/backend identifiers, and the model snapshot recorded when that run started.
- Resolves framework/provider/model from the failed session rather than current global settings. Codex shared and isolated backend IDs map to the consolidated Codex subscription provider shown in settings.
- Binds consent to the exact generated GitHub issue URL. Editing the error or receiving late app information invalidates prior consent.
- Shows the full report locally. If any GitHub prefill field must be shortened, the dialog also shows the exact outgoing prefill values before consent.
- Opens the existing `bug_report.yml` issue form only after explicit consent, and provides **Copy details** and **Reveal log file** alternatives. Nothing is transmitted automatically and the runtime log is never inlined.

## Scope and behavior

- The button appears for actual run failures (`activeSession.status === 'error'`) and remains separate from transient action errors.
- Missing, empty, and whitespace-only run errors use one shared fallback in both the failure row and report.
- The model selected for each run is persisted on the session. New sends, edited-message resends, interrupted-session resumes, and context-overflow recovery preserve the correct run model attribution.
- GitHub issue prefill is limited by the final percent-encoded URL length (`7000` characters), not decoded error length. Every dynamic field is bounded and truncated values carry a visible marker.
- **Copy details** always retains the complete, untruncated report.
- GitHub issue-form dropdowns and checkboxes cannot be prefilled. The detected OS is included in `logs`; the user still selects the required OS and preflight checkboxes in GitHub.

## Acceptance criteria

- [x] Failed-run row shows **Report error** without being hidden by a concurrent transient error.
- [x] Dialog attributes framework, provider, and model to the failed run, including Codex subscription backend variants.
- [x] Empty or whitespace-only failures show and report the same fallback message.
- [x] Consent is revoked whenever the generated issue payload changes.
- [x] The final issue URL stays within the configured serialized-length budget for ASCII and percent-encoded Unicode input.
- [x] When prefill values are truncated, the exact outgoing values are visible in the dialog before consent.
- [x] **Copy details** contains the full report; **Reveal log file** surfaces IPC failures inline.
- [x] Closing and reopening resets consent and copied state.

## Validation

- `npm run typecheck`
- ESLint on all changed files
- Prettier check on all changed files
- 197 focused tests across the six affected suites
- Previously timing-sensitive `ProjectFilesView`, logger, and notebook runtime suites pass when run individually

Closes #286
