### PR TITLE
fix(acp): block session creation on stale connection during deferred reconnect

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4124,6 +4124,108 @@ describe('ACP runtime session management', () => {
     expect(process.killed).toBe(true)
   })
 
+  it('createSession waits for a pending provider reconnect before using the new connection', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    const gate = createDeferred()
+    // Old process: one session, prompt gated so it stays in-flight.
+    startFakeAgent(oldProcess, ['s1'], { onPrompt: () => gate.promise })
+    // New process: serves sessions after the reconnect.
+    startFakeAgent(newProcess, ['s2'])
+
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: async () => {
+        spawnCount += 1
+        return {
+          framework: {
+            ...claudeCodeFramework,
+            spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/agent',
+          env: {},
+          args: []
+        }
+      }
+    })
+
+    // Establish the initial connection and start an in-flight prompt.
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+
+    // Request a provider reconnect while the prompt is running — arms the barrier.
+    await runtime.requestProviderReconnect()
+
+    // A concurrent createSession must NOT complete before the barrier resolves.
+    let secondSessionDone = false
+    const secondSession = runtime.createSession({ cwd: '/workspace' }).then((r) => {
+      secondSessionDone = true
+      return r
+    })
+
+    // Yield so any eager resolution would be observable, then assert still blocked.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(secondSessionDone).toBe(false)
+
+    // Release the gate → prompt finishes → deferred reconnect fires → barrier resolves.
+    gate.resolve()
+    await prompt
+    const result = await secondSession
+
+    // The second session must have landed on the new connection (second spawn).
+    expect(result.sessionId).toBe('s2')
+    expect(spawnCount).toBe(2)
+  })
+
+  it('createSession proceeds immediately when an unexpected connection close resolves the barrier', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    const gate = createDeferred()
+    startFakeAgent(oldProcess, ['s1'], { onPrompt: () => gate.promise })
+    startFakeAgent(newProcess, ['s2'])
+
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: async () => {
+        spawnCount += 1
+        return {
+          framework: {
+            ...claudeCodeFramework,
+            spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/agent',
+          env: {},
+          args: []
+        }
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+
+    // Arm the barrier with a deferred reconnect while the prompt is running.
+    await runtime.requestProviderReconnect()
+
+    // createSession blocks on the barrier.
+    const secondSession = runtime.createSession({ cwd: '/workspace' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Simulate an unexpected connection close — handleConnectionClosed resolves the barrier.
+    oldProcess.stdout.end()
+
+    // createSession must unblock and connect fresh (the close cleared the stale connection).
+    const result = await secondSession
+    expect(result.sessionId).toBe('s2')
+
+    // Clean up the in-flight prompt gate so the test can exit cleanly.
+    gate.resolve()
+    await prompt.catch(() => undefined)
+  })
+
   it('reconnects immediately when a provider switch happens with no prompt in flight', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['s1'])

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4226,14 +4226,29 @@ describe('ACP runtime session management', () => {
     await prompt.catch(() => undefined)
   })
 
-  it('does not strand the reconnect barrier when the deferred disconnect rejects', async () => {
-    const process = new FakeAgentProcess()
+  it('reconnects on a fresh backend when the deferred disconnect rejects', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
     const gate = createDeferred()
-    startFakeAgent(process, ['s1'], { onPrompt: () => gate.promise })
+    startFakeAgent(oldProcess, ['s1'], { onPrompt: () => gate.promise })
+    startFakeAgent(newProcess, ['s2'])
+
+    let spawnCount = 0
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
+      resolveBackend: async () => {
+        spawnCount += 1
+        return {
+          framework: {
+            ...claudeCodeFramework,
+            spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/agent',
+          env: {},
+          args: []
+        }
+      }
     })
 
     await runtime.createSession({ cwd: '/workspace' })
@@ -4242,8 +4257,9 @@ describe('ACP runtime session management', () => {
     // Arm the barrier with a deferred reconnect while the prompt is running.
     await runtime.requestProviderReconnect()
 
-    // The deferred disconnect (fired when the turn settles) rejects. The barrier must still
-    // resolve — otherwise every later createSession would await it forever.
+    // The deferred disconnect (fired when the turn settles) rejects before it can clear the stale
+    // connection. The barrier must still resolve AND the stale connection must be invalidated, so a
+    // blocked createSession reconnects on a fresh backend instead of reusing the old one.
     const disconnectSpy = vi
       .spyOn(runtime, 'disconnect')
       .mockRejectedValueOnce(new Error('teardown failed'))
@@ -4252,13 +4268,15 @@ describe('ACP runtime session management', () => {
     const secondSession = runtime.createSession({ cwd: '/workspace' })
 
     // Release the gate → turn settles → maybeApplyPendingProviderReconnect calls the rejecting
-    // disconnect → finally() still resolves the barrier.
+    // disconnect → catch invalidates the connection → finally() resolves the barrier.
     gate.resolve()
     await prompt
 
-    // The blocked createSession must complete rather than hang. A real timeout here would fail
-    // the suite; resolving proves the barrier was released on the rejection path.
-    await expect(secondSession).resolves.toBeDefined()
+    // Must complete (no deadlock) AND land on the second spawn — proof the stale connection was not
+    // reused after the teardown failure.
+    const result = await secondSession
+    expect(result.sessionId).toBe('s2')
+    expect(spawnCount).toBe(2)
     disconnectSpy.mockRestore()
   })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4280,6 +4280,90 @@ describe('ACP runtime session management', () => {
     disconnectSpy.mockRestore()
   })
 
+  it('broadcasts closed and releases the barrier when a failed deferred disconnect has no follow-up', async () => {
+    const process = new FakeAgentProcess()
+    const gate = createDeferred()
+    startFakeAgent(process, ['s1'], { onPrompt: () => gate.promise })
+    const states: string[] = []
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onStateChanged: (s) => states.push(s.status) }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+    await runtime.requestProviderReconnect()
+
+    const disconnectSpy = vi
+      .spyOn(runtime, 'disconnect')
+      .mockRejectedValueOnce(new Error('teardown failed'))
+
+    // Turn settles → deferred disconnect rejects → no createSession follows. The catch must still
+    // broadcast 'closed' so the renderer doesn't stay on the stale 'connected' snapshot.
+    states.length = 0
+    gate.resolve()
+    await prompt
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(states).toContain('closed')
+    expect(runtime.getSnapshot().status).toBe('closed')
+    disconnectSpy.mockRestore()
+  })
+
+  it('still releases the barrier when the closed broadcast on a failed disconnect throws', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    const gate = createDeferred()
+    startFakeAgent(oldProcess, ['s1'], { onPrompt: () => gate.promise })
+    startFakeAgent(newProcess, ['s2'])
+
+    let spawnCount = 0
+    // Throw from onStateChanged only on the post-failure broadcast (the one emitted while status is
+    // 'closed' with no connection), so the barrier must survive an emitState that itself throws.
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      callbacks: {
+        onStateChanged: (s) => {
+          if (s.status === 'closed') throw new Error('renderer broadcast blew up')
+        }
+      },
+      resolveBackend: async () => {
+        spawnCount += 1
+        return {
+          framework: {
+            ...claudeCodeFramework,
+            spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/agent',
+          env: {},
+          args: []
+        }
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+    await runtime.requestProviderReconnect()
+
+    const disconnectSpy = vi
+      .spyOn(runtime, 'disconnect')
+      .mockRejectedValueOnce(new Error('teardown failed'))
+
+    const secondSession = runtime.createSession({ cwd: '/workspace' })
+    gate.resolve()
+    await prompt
+
+    // The guarded emitState swallows its own throw, so the barrier still resolves and the blocked
+    // createSession reconnects on a fresh backend rather than hanging.
+    const result = await secondSession
+    expect(result.sessionId).toBe('s2')
+    expect(spawnCount).toBe(2)
+    disconnectSpy.mockRestore()
+  })
+
   it('reconnects immediately when a provider switch happens with no prompt in flight', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['s1'])

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4226,6 +4226,42 @@ describe('ACP runtime session management', () => {
     await prompt.catch(() => undefined)
   })
 
+  it('does not strand the reconnect barrier when the deferred disconnect rejects', async () => {
+    const process = new FakeAgentProcess()
+    const gate = createDeferred()
+    startFakeAgent(process, ['s1'], { onPrompt: () => gate.promise })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+
+    // Arm the barrier with a deferred reconnect while the prompt is running.
+    await runtime.requestProviderReconnect()
+
+    // The deferred disconnect (fired when the turn settles) rejects. The barrier must still
+    // resolve — otherwise every later createSession would await it forever.
+    const disconnectSpy = vi
+      .spyOn(runtime, 'disconnect')
+      .mockRejectedValueOnce(new Error('teardown failed'))
+
+    // A createSession issued during the deferred window blocks on the barrier.
+    const secondSession = runtime.createSession({ cwd: '/workspace' })
+
+    // Release the gate → turn settles → maybeApplyPendingProviderReconnect calls the rejecting
+    // disconnect → finally() still resolves the barrier.
+    gate.resolve()
+    await prompt
+
+    // The blocked createSession must complete rather than hang. A real timeout here would fail
+    // the suite; resolving proves the barrier was released on the rejection path.
+    await expect(secondSession).resolves.toBeDefined()
+    disconnectSpy.mockRestore()
+  })
+
   it('reconnects immediately when a provider switch happens with no prompt in flight', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['s1'])

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4317,6 +4317,52 @@ describe('ACP runtime session management', () => {
     expect(process.killed).toBe(true)
   })
 
+  it('applies a provider reconnect and a skills reload deferred in the same turn with one disconnect', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    const gate = createDeferred()
+    startFakeAgent(oldProcess, ['s1'], { onPrompt: () => gate.promise })
+    startFakeAgent(newProcess, ['s2'])
+
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: async () => {
+        spawnCount += 1
+        return {
+          framework: {
+            ...claudeCodeFramework,
+            spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/agent',
+          env: {},
+          args: []
+        }
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+
+    // Both a provider switch and a skill toggle arrive during the same in-flight prompt.
+    await runtime.requestProviderReconnect()
+    await runtime.requestSkillsReload()
+    expect(oldProcess.killed).toBe(false)
+
+    // Turn finishes → a SINGLE deferred disconnect satisfies both (spawnCount 1 → 2). A second,
+    // redundant disconnect would spawn a third process on the next createSession.
+    gate.resolve()
+    await prompt
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(oldProcess.killed).toBe(true)
+
+    // The next session lands on the second spawn — proof no extra reconnect churned the process.
+    const next = await runtime.createSession({ cwd: '/workspace' })
+    expect(next.sessionId).toBe('s2')
+    expect(spawnCount).toBe(2)
+  })
+
   it('passes the artifact MCP server to new and resumed sessions', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['remote-session-1'])

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1590,19 +1590,17 @@ class AcpRuntime {
   private maybeApplyPendingProviderReconnect(): void {
     if (this.promptInFlightSessionIds.size > 0) return
 
-    if (this.pendingProviderReconnect) {
+    // A single reconnect satisfies both a pending provider switch and a pending skills reload: the
+    // fresh spawn picks up the new backend AND re-provisions the current skill set. So clear both
+    // flags before tearing down — leaving one set would fire a second, redundant disconnect on the
+    // next idle turn, needlessly killing the just-established connection.
+    if (this.pendingProviderReconnect || this.pendingSkillsReload) {
       this.pendingProviderReconnect = false
-      // Resolve the barrier once teardown settles so ensureConnected falls through to a fresh
-      // connect with the new backend, not back onto the stale connection. catch-then-finally
-      // (not a bare then): a rejected disconnect must still release the barrier — otherwise it
-      // strands and every later createSession hangs forever — and the rejection must be swallowed
-      // so it doesn't surface as an unhandled promise rejection.
-      void this.disconnectForDeferredReconnect()
-      return
-    }
-
-    if (this.pendingSkillsReload) {
       this.pendingSkillsReload = false
+      // Resolve the barrier once teardown settles so ensureConnected falls through to a fresh
+      // connect with the new backend, not back onto the stale connection. disconnectForDeferredReconnect
+      // resolves the barrier even if disconnect() rejects — otherwise it strands and every later
+      // createSession hangs forever — and swallows the rejection so it never surfaces as unhandled.
       void this.disconnectForDeferredReconnect()
     }
   }
@@ -2001,7 +1999,14 @@ class AcpRuntime {
         this.currentPromptTurnBySession.delete(request.sessionId)
         this.promptInFlightSessionIds.delete(request.sessionId)
       }
-      this.emitState()
+      // emitState invokes the renderer onStateChanged callback; guard it so a throw there cannot skip
+      // the reconnect below. maybeApplyPendingProviderReconnect is what resolves an armed reconnect
+      // barrier, so skipping it would strand the barrier and hang every later createSession.
+      try {
+        this.emitState()
+      } catch (error) {
+        safeLogError('emitState after prompt turn failed', errorLogFields(error))
+      }
       // A disabled skill forced for this turn is restored now: clear the force set, then schedule a
       // reconnect so the NEXT prompt respawns with the normal enabled set. Ordering matters — the clear
       // must happen before the reconnect is applied so the fresh spawn no longer sees the forced ids.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -521,6 +521,10 @@ class AcpRuntime {
   // A provider change requested while a prompt was running, applied when the session next goes idle.
   private pendingProviderReconnect = false
   private pendingSkillsReload = false
+  // Barrier awaited by ensureConnected so a createSession called while a deferred reconnect is
+  // queued blocks until the reconnect completes rather than reusing the stale connection.
+  private reconnectBarrier: Promise<void> | undefined
+  private reconnectBarrierResolve: (() => void) | undefined
   private expectedProcessExits = new WeakSet<ChildProcessWithoutNullStreams>()
   private readonly permissionBroker: AcpPermissionBroker
   private readonly callbacks: AcpRuntimeCallbacks
@@ -1572,6 +1576,9 @@ class AcpRuntime {
   async requestProviderReconnect(): Promise<void> {
     if (this.promptInFlightSessionIds.size > 0) {
       this.pendingProviderReconnect = true
+      // Arm the barrier so any concurrent createSession waits for the reconnect
+      // rather than reusing the stale connection with the old backend.
+      this.armReconnectBarrier()
       return
     }
 
@@ -1585,13 +1592,15 @@ class AcpRuntime {
 
     if (this.pendingProviderReconnect) {
       this.pendingProviderReconnect = false
-      void this.disconnect()
+      // Resolve the barrier after disconnect so ensureConnected falls through to
+      // a fresh connect with the new backend, not back onto the stale connection.
+      void this.disconnect().then(() => this.resolveReconnectBarrier())
       return
     }
 
     if (this.pendingSkillsReload) {
       this.pendingSkillsReload = false
-      void this.disconnect()
+      void this.disconnect().then(() => this.resolveReconnectBarrier())
     }
   }
 
@@ -1602,11 +1611,29 @@ class AcpRuntime {
   async requestSkillsReload(): Promise<void> {
     if (this.promptInFlightSessionIds.size > 0) {
       this.pendingSkillsReload = true
+      this.armReconnectBarrier()
       return
     }
 
     this.pendingSkillsReload = false
     await this.disconnect()
+  }
+
+  // Creates the reconnect barrier promise if one is not already pending.
+  private armReconnectBarrier(): void {
+    if (!this.reconnectBarrier) {
+      this.reconnectBarrier = new Promise<void>((resolve) => {
+        this.reconnectBarrierResolve = resolve
+      })
+    }
+  }
+
+  // Resolves and clears the reconnect barrier, unblocking any ensureConnected callers.
+  private resolveReconnectBarrier(): void {
+    const resolve = this.reconnectBarrierResolve
+    this.reconnectBarrier = undefined
+    this.reconnectBarrierResolve = undefined
+    resolve?.()
   }
 
   private async disconnectCurrent(emitClosedStatus = true): Promise<AcpStateSnapshot> {
@@ -2394,6 +2421,14 @@ class AcpRuntime {
 
   // Lazily initializes the process connection before session creation.
   private async ensureConnected(cwd: string): Promise<ClientConnection> {
+    // A deferred provider/framework/skills reconnect is pending: wait for it to
+    // complete before reusing (or opening) a connection. Without this guard a
+    // createSession called while a prompt is still running would piggy-back onto
+    // the stale connection and land on the old backend.
+    if (this.reconnectBarrier) {
+      await this.reconnectBarrier
+    }
+
     if (this.connection && this.status === 'connected') {
       return this.connection
     }
@@ -3310,6 +3345,11 @@ class AcpRuntime {
     this.connection = undefined
     this.agentProcess = undefined
     this.promptInFlightSessionIds.clear()
+    // The connection is already gone, so any ensureConnected caller waiting on
+    // the reconnect barrier must unblock now — it will fall through to connect()
+    // and pick up the new backend from resolveBackend.
+    this.pendingProviderReconnect = false
+    this.resolveReconnectBarrier()
     this.setStatus('closed')
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1592,15 +1592,30 @@ class AcpRuntime {
 
     if (this.pendingProviderReconnect) {
       this.pendingProviderReconnect = false
-      // Resolve the barrier after disconnect so ensureConnected falls through to
-      // a fresh connect with the new backend, not back onto the stale connection.
-      void this.disconnect().then(() => this.resolveReconnectBarrier())
+      // Resolve the barrier once teardown settles so ensureConnected falls through to a fresh
+      // connect with the new backend, not back onto the stale connection. catch-then-finally
+      // (not a bare then): a rejected disconnect must still release the barrier — otherwise it
+      // strands and every later createSession hangs forever — and the rejection must be swallowed
+      // so it doesn't surface as an unhandled promise rejection.
+      void this.disconnectForDeferredReconnect()
       return
     }
 
     if (this.pendingSkillsReload) {
       this.pendingSkillsReload = false
-      void this.disconnect().then(() => this.resolveReconnectBarrier())
+      void this.disconnectForDeferredReconnect()
+    }
+  }
+
+  // Tears down the connection for a deferred provider/skills reconnect, always releasing the
+  // reconnect barrier — even if the disconnect rejects — and never leaking an unhandled rejection.
+  private async disconnectForDeferredReconnect(): Promise<void> {
+    try {
+      await this.disconnect()
+    } catch (error) {
+      safeLogError('deferred reconnect disconnect failed', errorLogFields(error))
+    } finally {
+      this.resolveReconnectBarrier()
     }
   }
 
@@ -3347,8 +3362,10 @@ class AcpRuntime {
     this.promptInFlightSessionIds.clear()
     // The connection is already gone, so any ensureConnected caller waiting on
     // the reconnect barrier must unblock now — it will fall through to connect()
-    // and pick up the new backend from resolveBackend.
+    // and pick up the new backend from resolveBackend. A fresh spawn re-provisions
+    // skills too, so clear both pending flags to avoid a spurious later reconnect.
     this.pendingProviderReconnect = false
+    this.pendingSkillsReload = false
     this.resolveReconnectBarrier()
     this.setStatus('closed')
   }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1612,6 +1612,14 @@ class AcpRuntime {
       await this.disconnect()
     } catch (error) {
       safeLogError('deferred reconnect disconnect failed', errorLogFields(error))
+      // disconnect() rejected — its synchronous teardown may have thrown before clearing the
+      // connection (e.g. session.dispose or connection.close). Force the connection invalid so the
+      // barrier-release below cannot let a blocked ensureConnected reuse the STALE connection on the
+      // old backend; the re-check there will fall through to a fresh connect(). Set status directly
+      // rather than via setStatus/emitState — the throw may have come from emitState itself, and the
+      // next connect() emits fresh state anyway.
+      this.connection = undefined
+      this.status = 'closed'
     } finally {
       this.resolveReconnectBarrier()
     }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1616,10 +1616,17 @@ class AcpRuntime {
       // connection (e.g. session.dispose or connection.close). Force the connection invalid so the
       // barrier-release below cannot let a blocked ensureConnected reuse the STALE connection on the
       // old backend; the re-check there will fall through to a fresh connect(). Set status directly
-      // rather than via setStatus/emitState — the throw may have come from emitState itself, and the
-      // next connect() emits fresh state anyway.
+      // rather than via setStatus — the throw may have come from emitState itself.
       this.connection = undefined
       this.status = 'closed'
+      // Broadcast the closed status defensively so the renderer doesn't keep showing the prior
+      // 'connected' state when no createSession follows to re-emit it. Guarded because emitState may
+      // be the very thing that threw — the barrier release below must still run.
+      try {
+        this.emitState()
+      } catch (emitError) {
+        safeLogError('emitState after failed deferred disconnect failed', errorLogFields(emitError))
+      }
     } finally {
       this.resolveReconnectBarrier()
     }

--- a/src/renderer/src/pages/settings/AgentFrameworkCard.tsx
+++ b/src/renderer/src/pages/settings/AgentFrameworkCard.tsx
@@ -48,6 +48,8 @@ type AgentFrameworkCardProps = {
   isUninstalling: boolean
   // A detect run is in flight (the section-level Re-detect triggers all frameworks at once).
   isDetecting: boolean
+  // Whether an ACP prompt is currently running; forwarded to RuntimeUninstallControl.
+  promptInFlight?: boolean
   onUninstall: () => void
   // Install menu + progress wiring (only meaningful on not-ready cards).
   installSources: ClaudeInstallSourceInfo[]
@@ -160,6 +162,7 @@ const AgentFrameworkCard = ({
   managed,
   isUninstalling,
   isDetecting,
+  promptInFlight,
   onUninstall,
   installSources,
   install,
@@ -303,6 +306,7 @@ const AgentFrameworkCard = ({
                 isDetecting={isDetecting}
                 // Global by contract: an install of ANY framework locks every card's Uninstall.
                 isInstalling={installRunning}
+                promptInFlight={promptInFlight}
                 onUninstall={onUninstall}
               />
             ) : (

--- a/src/renderer/src/pages/settings/AgentPanel.tsx
+++ b/src/renderer/src/pages/settings/AgentPanel.tsx
@@ -67,16 +67,21 @@ const AgentPanel = (): React.JSX.Element => {
   // Track whether an ACP prompt is currently running so the uninstall (a destructive teardown) can be
   // blocked while a task uses the runtime. Fail closed: default to true (treated as busy) until the
   // first snapshot arrives, so the button is never briefly enabled during the getState() round-trip.
-  // Subscribe FIRST, then load the initial snapshot, both gated by a mounted flag — mirrors
-  // useAcpRuntime so a broadcast arriving mid-load can't be overwritten by a stale initial read.
   const [promptInFlight, setPromptInFlight] = useState(true)
   useEffect(() => {
     let mounted = true
+    // A live onState broadcast is always fresher than the initial getState() read. Subscribing first
+    // is NOT enough — getState() is async, so a live event can arrive before the snapshot resolves and
+    // then be clobbered by the stale snapshot when it lands. Latch the first live event and drop any
+    // getState() result that arrives after it, so live state always wins the race.
+    let liveEventSeen = false
     const removeListener = window.api.acp.onState((s) => {
-      if (mounted) setPromptInFlight(s.promptInFlight)
+      if (!mounted) return
+      liveEventSeen = true
+      setPromptInFlight(s.promptInFlight)
     })
     void window.api.acp.getState().then((s) => {
-      if (mounted) setPromptInFlight(s.promptInFlight)
+      if (mounted && !liveEventSeen) setPromptInFlight(s.promptInFlight)
     })
     return () => {
       mounted = false

--- a/src/renderer/src/pages/settings/AgentPanel.tsx
+++ b/src/renderer/src/pages/settings/AgentPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { RefreshCw } from 'lucide-react'
 
 // Import the bare Mono/Color components straight from their modules: each icon's entry point
@@ -63,6 +63,13 @@ const AgentPanel = (): React.JSX.Element => {
   const uninstallCodex = useSettingsStore((state) => state.uninstallCodex)
   const detectClaude = useSettingsStore((state) => state.detectClaude)
   const installClaude = useSettingsStore((state) => state.installClaude)
+
+  // Track whether an ACP prompt is currently running so the uninstall button can be disabled.
+  const [promptInFlight, setPromptInFlight] = useState(false)
+  useEffect(() => {
+    void window.api.acp.getState().then((s) => setPromptInFlight(s.promptInFlight))
+    return window.api.acp.onState((s) => setPromptInFlight(s.promptInFlight))
+  }, [])
 
   // The app-managed runtime pending an uninstall confirmation (null = dialog closed), plus the
   // in-flight flag so the dialog and status cards can show progress and stay locked during removal.
@@ -233,6 +240,7 @@ const AgentPanel = (): React.JSX.Element => {
       managed={card.managed}
       isUninstalling={isUninstalling && pendingUninstall === card.key}
       isDetecting={isDetectingAnyFramework}
+      promptInFlight={promptInFlight}
       onUninstall={() => setPendingUninstall(card.key)}
       installSources={card.installSources}
       install={card.install}

--- a/src/renderer/src/pages/settings/AgentPanel.tsx
+++ b/src/renderer/src/pages/settings/AgentPanel.tsx
@@ -64,11 +64,24 @@ const AgentPanel = (): React.JSX.Element => {
   const detectClaude = useSettingsStore((state) => state.detectClaude)
   const installClaude = useSettingsStore((state) => state.installClaude)
 
-  // Track whether an ACP prompt is currently running so the uninstall button can be disabled.
-  const [promptInFlight, setPromptInFlight] = useState(false)
+  // Track whether an ACP prompt is currently running so the uninstall (a destructive teardown) can be
+  // blocked while a task uses the runtime. Fail closed: default to true (treated as busy) until the
+  // first snapshot arrives, so the button is never briefly enabled during the getState() round-trip.
+  // Subscribe FIRST, then load the initial snapshot, both gated by a mounted flag — mirrors
+  // useAcpRuntime so a broadcast arriving mid-load can't be overwritten by a stale initial read.
+  const [promptInFlight, setPromptInFlight] = useState(true)
   useEffect(() => {
-    void window.api.acp.getState().then((s) => setPromptInFlight(s.promptInFlight))
-    return window.api.acp.onState((s) => setPromptInFlight(s.promptInFlight))
+    let mounted = true
+    const removeListener = window.api.acp.onState((s) => {
+      if (mounted) setPromptInFlight(s.promptInFlight)
+    })
+    void window.api.acp.getState().then((s) => {
+      if (mounted) setPromptInFlight(s.promptInFlight)
+    })
+    return () => {
+      mounted = false
+      removeListener()
+    }
   }, [])
 
   // The app-managed runtime pending an uninstall confirmation (null = dialog closed), plus the
@@ -83,6 +96,13 @@ const AgentPanel = (): React.JSX.Element => {
   // reconnects the agent, so the cards and readiness gate update without a manual re-detect.
   const handleConfirmUninstall = async (): Promise<void> => {
     if (!pendingUninstall) return
+    // Revalidate at confirm time: a prompt may have started after the dialog opened (the card control
+    // disables live, but an already-open dialog wouldn't). Uninstalling the runtime out from under a
+    // running task is exactly what the guard prevents, so close the dialog instead of proceeding.
+    if (promptInFlight) {
+      setPendingUninstall(null)
+      return
+    }
 
     setIsUninstalling(true)
 

--- a/src/renderer/src/pages/settings/RuntimeUninstallControl.tsx
+++ b/src/renderer/src/pages/settings/RuntimeUninstallControl.tsx
@@ -19,6 +19,8 @@ type RuntimeUninstallControlProps = {
   isUninstalling: boolean
   isDetecting: boolean
   isInstalling: boolean
+  // Whether an ACP prompt is currently running; while true the uninstall button shows a standing hint.
+  promptInFlight?: boolean
   onUninstall: () => void
 }
 
@@ -36,12 +38,15 @@ const RuntimeUninstallControl = ({
   isUninstalling,
   isDetecting,
   isInstalling,
+  promptInFlight,
   onUninstall
 }: RuntimeUninstallControlProps): React.JSX.Element => {
   const busy = isUninstalling || isDetecting || isInstalling
   // Busy takes priority: during detect/uninstall the button is natively disabled with no explainer, even
   // if a standing reason (non-managed / active) also applies — that reason is stale mid-operation.
-  const hint = busy ? null : uninstallDisabledHint(label, uninstallCommand, { managed, active })
+  const hint = busy
+    ? null
+    : uninstallDisabledHint(label, uninstallCommand, { managed, active, promptInFlight })
 
   const button = (
     <Button

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -82,7 +82,9 @@ const installApi = (): void => {
       setPackageMirror: vi.fn().mockResolvedValue({})
     },
     acp: {
-      getState: vi.fn().mockResolvedValue({ promptInFlightSessionIds: [] }),
+      getState: vi.fn().mockResolvedValue({ promptInFlight: false, promptInFlightSessionIds: [] }),
+      // AgentPanel subscribes to live prompt-in-flight state; the mock returns a no-op unsubscribe.
+      onState: vi.fn().mockReturnValue(() => {}),
       cancel: vi.fn()
     },
     logs: {

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -757,6 +757,105 @@ describe('SettingsPage uninstall confirmation', () => {
     })
     expect(setAgentFramework).toHaveBeenCalledWith({ id: 'opencode' })
   })
+
+  // An inactive but managed Claude (OpenCode active) whose Uninstall would otherwise be enabled.
+  const inactiveManagedClaudeSnapshot = {
+    claude: { resolvedPath: '/data/claude-code/bin/claude', version: '2.1.0' },
+    opencode: { resolvedPath: '/usr/local/bin/opencode', version: '1.18.3' },
+    providers: [],
+    agentFrameworkId: 'opencode',
+    agentFrameworks: bothFrameworks,
+    claudeManaged: true,
+    opencodeManaged: false
+  }
+
+  it('disables uninstall while a prompt is in flight and blocks confirming a dialog opened before it', async () => {
+    const api = (
+      window as unknown as {
+        api: { settings: Record<string, unknown>; acp: Record<string, unknown> }
+      }
+    ).api
+    api.settings.getSettings = vi.fn().mockResolvedValue(inactiveManagedClaudeSnapshot)
+    const uninstallClaude = vi.fn().mockResolvedValue(inactiveManagedClaudeSnapshot)
+    api.settings.uninstallClaude = uninstallClaude
+
+    // Capture the live listener; start idle so the dialog can be opened.
+    let emitAcp:
+      ((s: { promptInFlight: boolean; promptInFlightSessionIds: string[] }) => void) | undefined
+    api.acp.getState = vi
+      .fn()
+      .mockResolvedValue({ promptInFlight: false, promptInFlightSessionIds: [] })
+    api.acp.onState = vi.fn().mockImplementation((cb: typeof emitAcp) => {
+      emitAcp = cb
+      return () => {}
+    })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await openAgentPanel()
+
+    // Idle → the card Uninstall is enabled and opens the confirmation.
+    const cardUninstall = findButton(document.body, 'Uninstall')
+    expect(cardUninstall?.disabled).toBe(false)
+    await act(async () => {
+      cardUninstall?.click()
+    })
+    expect(document.body.querySelector('[role="alertdialog"]')).not.toBeNull()
+
+    // A prompt starts while the dialog is open — the card control disables live, but confirming must
+    // also be intercepted so the busy runtime isn't torn down out from under the task.
+    await act(async () => {
+      emitAcp?.({ promptInFlight: true, promptInFlightSessionIds: ['s1'] })
+    })
+    const confirmDialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')
+    const confirm = confirmDialog ? findButton(confirmDialog, 'Uninstall') : undefined
+    await act(async () => {
+      confirm?.click()
+    })
+    expect(uninstallClaude).not.toHaveBeenCalled()
+    // Revalidation closes the dialog instead of proceeding.
+    expect(document.body.querySelector('[role="alertdialog"]')).toBeNull()
+  })
+
+  it('lets a live in-flight event win the race against a later idle initial snapshot', async () => {
+    const api = (
+      window as unknown as {
+        api: { settings: Record<string, unknown>; acp: Record<string, unknown> }
+      }
+    ).api
+    api.settings.getSettings = vi.fn().mockResolvedValue(inactiveManagedClaudeSnapshot)
+
+    // getState resolves LATE with a stale idle snapshot; a live in-flight event fires first. The
+    // effect must keep the button disabled — the stale snapshot must not clobber the live state.
+    let resolveGetState:
+      ((s: { promptInFlight: boolean; promptInFlightSessionIds: string[] }) => void) | undefined
+    api.acp.getState = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveGetState = resolve
+      })
+    )
+    let emitAcp:
+      ((s: { promptInFlight: boolean; promptInFlightSessionIds: string[] }) => void) | undefined
+    api.acp.onState = vi.fn().mockImplementation((cb: typeof emitAcp) => {
+      emitAcp = cb
+      return () => {}
+    })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await openAgentPanel()
+
+    // Live event arrives first (prompt in flight), then the stale idle getState resolves last.
+    await act(async () => {
+      emitAcp?.({ promptInFlight: true, promptInFlightSessionIds: ['s1'] })
+      resolveGetState?.({ promptInFlight: false, promptInFlightSessionIds: [] })
+    })
+
+    const cardUninstall = findButton(document.body, 'Uninstall')
+    expect(cardUninstall?.getAttribute('aria-disabled')).toBe('true')
+  })
 })
 
 describe('SettingsPage Codex framework', () => {

--- a/src/renderer/src/pages/settings/runtime-uninstall-hint.test.ts
+++ b/src/renderer/src/pages/settings/runtime-uninstall-hint.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { uninstallDisabledHint } from './runtime-uninstall-hint'
+
+describe('uninstallDisabledHint', () => {
+  const base = { managed: true, active: false }
+
+  it('returns null for an actionable non-active managed runtime', () => {
+    expect(uninstallDisabledHint('Codex', 'npm rm -g codex', base)).toBeNull()
+  })
+
+  it('explains that an unmanaged runtime cannot be uninstalled from the app', () => {
+    const hint = uninstallDisabledHint('Codex', 'npm rm -g codex', { ...base, managed: false })
+    expect(hint).toContain("isn't managed by the app")
+    expect(hint).toContain('npm rm -g codex')
+  })
+
+  it('explains that the active framework must be switched away first', () => {
+    expect(uninstallDisabledHint('Claude', 'x', { ...base, active: true })).toContain(
+      'active agent framework'
+    )
+  })
+
+  it('blocks uninstall with a wait-for-task hint while a prompt is in flight', () => {
+    expect(uninstallDisabledHint('Codex', 'x', { ...base, promptInFlight: true })).toBe(
+      'A task is running — wait for it to finish before uninstalling.'
+    )
+  })
+
+  it('prioritizes the unmanaged and active reasons over the prompt-in-flight reason', () => {
+    // Precedence matters: an unmanaged or active runtime has a standing reason (gets a tooltip),
+    // whereas prompt-in-flight is only a transient block.
+    expect(
+      uninstallDisabledHint('Codex', 'x', { managed: false, active: false, promptInFlight: true })
+    ).toContain("isn't managed by the app")
+    expect(
+      uninstallDisabledHint('Claude', 'x', { managed: true, active: true, promptInFlight: true })
+    ).toContain('active agent framework')
+  })
+})

--- a/src/renderer/src/pages/settings/runtime-uninstall-hint.ts
+++ b/src/renderer/src/pages/settings/runtime-uninstall-hint.ts
@@ -5,7 +5,11 @@
 export const uninstallDisabledHint = (
   label: string,
   uninstallCommand: string,
-  { managed, active }: { managed: boolean; active: boolean }
+  {
+    managed,
+    active,
+    promptInFlight
+  }: { managed: boolean; active: boolean; promptInFlight?: boolean }
 ): string | null => {
   if (!managed) {
     return `${label} was found on your system but isn't managed by the app, so it can't be uninstalled from here. Remove it with the tool you used to install it — for example \`${uninstallCommand}\`, your package manager, or by deleting it from your PATH — then re-detect.`
@@ -13,6 +17,10 @@ export const uninstallDisabledHint = (
 
   if (active) {
     return `${label} is the active agent framework and can't be uninstalled. Switch to another framework first, then uninstall.`
+  }
+
+  if (promptInFlight) {
+    return 'A task is running — wait for it to finish before uninstalling.'
   }
 
   return null

--- a/src/renderer/src/pages/settings/runtime-uninstall-hint.ts
+++ b/src/renderer/src/pages/settings/runtime-uninstall-hint.ts
@@ -19,6 +19,12 @@ export const uninstallDisabledHint = (
     return `${label} is the active agent framework and can't be uninstalled. Switch to another framework first, then uninstall.`
   }
 
+  // Intentionally keyed on the runtime-wide promptInFlight, not on `active`: during a deferred
+  // reconnect the framework serving the in-flight prompt is already non-active (the user switched
+  // away, but its process keeps running until the turn settles). Gating this on `active` would let
+  // that still-busy framework be uninstalled mid-task — exactly the hazard this guard exists to
+  // prevent. The cost is a conservative over-block: an unrelated idle managed framework also can't be
+  // uninstalled while a task runs elsewhere. That errs safe (blocks more, never less), so it stays.
   if (promptInFlight) {
     return 'A task is running — wait for it to finish before uninstalling.'
   }


### PR DESCRIPTION
## Summary

Fixes a class of "switch landed on the wrong backend" bugs during the ACP runtime's *deferred reconnect* window. When a provider, framework, model, or skills change arrives while a prompt is in-flight, the runtime defers the disconnect until the turn finishes. Before this PR, a `createSession` issued during that window called `ensureConnected`, found the old connection still alive, and reused it — the new session started on the **old** backend.

Fix: a `reconnectBarrier` promise armed when a reconnect is deferred. `ensureConnected` awaits it before reusing/opening a connection, so concurrent session creation blocks until the pending teardown completes and `resolveBackend` picks up the new backend.

This path is shared by framework / provider / model switches and the opencode reasoning-effort fallback. (Claude/Codex effort changes live-apply via `setConfigOption` and never hit this path — unchanged.)

## What changed

- **`reconnectBarrier` in `runtime.ts`** — armed in `requestProviderReconnect` / `requestSkillsReload` when deferring; awaited at the top of `ensureConnected`; resolved after the deferred `disconnect()` settles, and eagerly in `handleConnectionClosed` so an agent crash never deadlocks callers.
- **Uninstall guard** — the Agent settings Uninstall button is disabled with an explanatory tooltip while a prompt is in-flight (`AgentPanel` subscribes to live `promptInFlight`).

## Hardening from adversarial review

An adversarial review pass found and this PR fixes:

- **BLOCKER** — a rejected `disconnect()` on the deferred path would strand the barrier (`.then` skips its callback on rejection) → permanent deadlock of all session creation. Routed through `disconnectForDeferredReconnect()` which resolves the barrier in a `finally` and swallows+logs the rejection.
- **MAJOR** — `handleConnectionClosed` cleared `pendingProviderReconnect` but not `pendingSkillsReload`, causing a spurious post-recovery teardown. Both flags now cleared.
- **minor** — dual provider+skills reconnect deferred in one turn fired two disconnects; coalesced into one.
- **minor** — `emitState()` throwing before `maybeApplyPendingProviderReconnect()` was a second, narrower deadlock route; now guarded.

## Testing

- `runtime.test.ts`: added regression tests — barrier blocks `createSession` until reconnect completes; unexpected close unblocks it; rejected disconnect still releases the barrier; dual-deferred provider+skills reconnect tears down exactly once.
- `SettingsPage.render.test.tsx`: added the now-required `window.api.acp.onState` mock.
- Full `src/main` suite: 3833 passed, 0 failed. Renderer settings suite green. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
