### PR TITLE
fix(reviewer): accept hyphenated Claude MCP titles

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3186,6 +3186,50 @@ describe('ACP runtime session management', () => {
     runtime.disposeReviewerSession(session)
   })
 
+  // Claude Code preserves hyphens in MCP server names in real tool traces, so the permission title
+  // can use mcp__<hyphenated-server>__<tool> instead of the sanitized underscore form.
+  it('auto-approves a claude-code reviewer MCP tool identified by its hyphenated title', async () => {
+    const process = new FakeAgentProcess()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'reviewer-session-1',
+      toolCallId: 'reviewer-hyphenated-title',
+      toolTitle: 'mcp__open-science-reviewer__read_turn',
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework
+    })
+
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    await session.prompt([{ type: 'text', text: 'read the audited turn' }])
+
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(0)
+    runtime.disposeReviewerSession(session)
+  })
+
   // Security: the toolCallId is agent-controlled, so a reviewer-shaped id must NOT authorize a call
   // whose title/kind are a genuinely disallowed tool. Only the title carries the trusted MCP identity.
   it('rejects a Bash call that carries a reviewer-shaped toolCallId', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -331,22 +331,20 @@ const REVIEWER_MCP_OPENCODE_TOOL_NAMES = new Set(
   Object.values(REVIEWER_MCP_TOOLS).map((toolName) => `${REVIEWER_MCP_SERVER_NAME}_${toolName}`)
 )
 const REVIEWER_MCP_LEAF_TOOL_NAMES = new Set<string>(Object.values(REVIEWER_MCP_TOOLS))
-// claude-code namespaces MCP tools as mcp__<server>__<tool> and sanitizes the server name by replacing
-// every non-alphanumeric char with an underscore, so "open-science-reviewer" becomes
-// "open_science_reviewer". Match that sanitized identity, which appears in the tool call title and
-// carries no provider _meta tool name.
+// claude-code namespaces MCP tools as mcp__<server>__<tool>. Depending on the provider path, the
+// server segment either preserves hyphens or replaces them with underscores. Match both exact forms:
+// the tool call title can be the only identity available to a permission request.
 const REVIEWER_MCP_SERVER_NAME_SANITIZED = REVIEWER_MCP_SERVER_NAME.replace(/[^a-zA-Z0-9]/g, '_')
 const REVIEWER_MCP_CLAUDE_TOOL_NAMES = new Set(
-  Object.values(REVIEWER_MCP_TOOLS).map(
-    (toolName) => `mcp__${REVIEWER_MCP_SERVER_NAME_SANITIZED}__${toolName}`
+  Object.values(REVIEWER_MCP_TOOLS).flatMap((toolName) =>
+    [REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_SERVER_NAME_SANITIZED].map(
+      (serverName) => `mcp__${serverName}__${toolName}`
+    )
   )
 )
 const REVIEWER_MCP_PROVIDER_TOOL_NAMES = new Set([
   ...REVIEWER_MCP_OPENCODE_TOOL_NAMES,
-  ...REVIEWER_MCP_CLAUDE_TOOL_NAMES,
-  ...Object.values(REVIEWER_MCP_TOOLS).map(
-    (toolName) => `mcp__${REVIEWER_MCP_SERVER_NAME}__${toolName}`
-  )
+  ...REVIEWER_MCP_CLAUDE_TOOL_NAMES
 ])
 
 // Logs an error without ever throwing back into the caller. Used on failure paths where a throwing
@@ -3060,8 +3058,8 @@ class AcpRuntime {
   // identity must come from the title (the same field the generic MCP classifier trusts), never the
   // toolCallId: a tool call id is an opaque, agent-chosen string, so matching it would let a Bash call
   // carrying a reviewer-shaped id (e.g. mcp__open_science_reviewer__read_turn_0) slip past the gate.
-  // claude-code sanitizes server names (hyphens → underscores) and emits the exact mcp__<server>__<tool>
-  // form as the title with no numeric suffix, so an exact set membership check is sufficient.
+  // claude-code emits the exact mcp__<server>__<tool> form as the title with no numeric suffix, so an
+  // exact set membership check across its preserved and sanitized server-name forms is sufficient.
   private matchReviewerClaudeToolName(title: string | null | undefined): string | undefined {
     if (typeof title !== 'string') return undefined
     return REVIEWER_MCP_CLAUDE_TOOL_NAMES.has(title) ? title : undefined


### PR DESCRIPTION
## Problem

Claude reviewer MCP calls can preserve hyphens in the permission title, for example `mcp__open-science-reviewer__read_turn`. The strict reviewer gate only recognized the sanitized underscore form as a title, so it rejected the scope-bounded evidence and `submit_findings` calls. The reviewer then stopped with an incomplete-protocol error.

This is a follow-up to #333 and the original #329 report.

## Proposed change

Derive both exact Claude title forms from the configured reviewer MCP server name: the hyphen-preserving form emitted by real traces and the sanitized underscore form already covered. Reuse that exact set for provider identities and title matching, and add regression coverage for the real trace shape.

## Scope and non-goals

This only changes the unattended reviewer permission allowlist. It does not approve prefixes, suffixes, arbitrary MCP servers, or reviewer-shaped tool call IDs; the existing Bash spoofing regression remains green.

## Acceptance criteria and validation

- Regression test fails before the fix with `reject-once` and passes after the fix with `allow-once`.
- `npm run typecheck` passes.
- `npm run lint` passes with 0 errors (33 pre-existing warnings outside the changed files).
- `npm test` passes: 435 files passed, 9 skipped; 5651 tests passed, 82 skipped.

## Review focus

Please verify that both accepted title forms remain exact members derived from `open-science-reviewer`, preserving the strict rejection path for built-in tools and spoofed call IDs.