### PR TITLE
fix(review): restore AI review execution

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -141,14 +141,17 @@ jobs:
             done
           } > review_context_raw.txt
 
-          # Fail closed if the context exceeds the limit — a silent byte truncation could hide
-          # later changes from the no-tools agent that has no way to re-read them.
+          # Skip Claude if the context exceeds the limit — a silent byte truncation could hide
+          # later changes from the no-tools agent that has no way to re-read them. The outcome
+          # label workflow still fails closed because no Claude verdict is posted.
           actual_bytes="$(wc -c < review_context_raw.txt)"
           if (( actual_bytes > max_bytes )); then
-            echo "::error::Review context is ${actual_bytes} bytes (limit ${max_bytes}). " \
-              "The PR diff is too large for the no-tools review mode. Reduce the diff size." >&2
-            exit 1
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Claude review: context is ${actual_bytes} bytes " \
+              "(limit ${max_bytes}) for no-tools review mode."
+            exit 0
           fi
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
 
           # Use a random delimiter so a changed file cannot contain it as a line and break the
           # $GITHUB_OUTPUT heredoc.
@@ -161,6 +164,7 @@ jobs:
 
       - name: Run Claude architecture review
         id: run_claude
+        if: ${{ steps.context.outputs.should_run == 'true' }}
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
@@ -441,8 +445,8 @@ jobs:
           # Use the built-in 'codex exec review' subcommand which understands git diffs
           # natively (--base scopes the diff against the base branch) and performs a comprehensive
           # review (correctness, security, tests, type safety, etc.) using its own framing. The
-          # prompt argument adds only project-specific conventions the built-in review would not
-          # know about, keeping the prompt-injection surface minimal.
+          # developer instructions add only project-specific conventions the built-in review
+          # would not know about, keeping the prompt-injection surface minimal.
           review_prompt_file="$CODEX_HOME/review-prompt.txt"
           {
             echo 'This repository follows Conventional Commits. Verify that the branch name'
@@ -458,18 +462,19 @@ jobs:
             echo
             echo "Pull request branch: ${PR_BRANCH}"
           } > "$review_prompt_file"
+          review_instructions="$(jq -Rs . < "$review_prompt_file")"
 
           output_file="$CODEX_HOME/review-output.md"
 
           codex exec \
             --sandbox read-only \
             review \
+            --config "developer_instructions=${review_instructions}" \
             --skip-git-repo-check \
             --model "$CODEX_MODEL" \
             --base "$PR_BASE_SHA" \
             --title "$PR_TITLE" \
-            -o "$output_file" \
-            - < "$review_prompt_file"
+            -o "$output_file"
 
           # Publish the review as a step output for the post job.
           if [[ -s "$output_file" ]]; then

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -28,6 +28,7 @@ const headers = [...labelsWorkflow.matchAll(/header: '([^']+)'/g)].map(([, heade
 
 type WorkflowStep = {
   id?: string
+  if?: string
   name?: string
   run?: string
   'working-directory'?: string
@@ -429,11 +430,13 @@ describe('AI review workflow contract', () => {
     expect(readFileSync(githubOutput, 'utf8')).toContain('### outside-link (skipped: symlink)')
   })
 
-  it('fails closed when review context exceeds the size limit', () => {
-    expect(reviewWorkflow).toContain('exit 1')
-    expect(reviewWorkflow).not.toContain(
-      'head -c 393216 review_context_raw.txt > review_context.txt'
-    )
+  it('skips Claude without truncating review context when the size limit is exceeded', () => {
+    const contextStep = getNamedStep('claude_review', 'Generate review context')
+    const reviewStep = getNamedStep('claude_review', 'Run Claude architecture review')
+
+    expect(contextStep.run).toContain('should_run=false')
+    expect(contextStep.run).not.toContain('head -c 393216 review_context_raw.txt')
+    expect(reviewStep.if).toBe("${{ steps.context.outputs.should_run == 'true' }}")
   })
 
   it('uses codex exec review (built-in) instead of openai/codex-action with prompt injection', () => {
@@ -468,6 +471,7 @@ describe('AI review workflow contract', () => {
 
     expect(args.slice(0, 4)).toEqual(['exec', '--sandbox', 'read-only', 'review'])
     expect(args).not.toContain('--ignore-user-config')
+    expect(args).not.toContain('-')
   })
 
   it('does not expose upstream secrets to the codex process', () => {
@@ -477,12 +481,14 @@ describe('AI review workflow contract', () => {
     expect(readFileSync(join(captureDir, 'codex-base-url'), 'utf8')).toBe('unset')
   })
 
-  it('includes the pull request branch in the supplementary review instructions', () => {
+  it('passes the pull request branch through developer instructions, not a prompt', () => {
     const { captureDir } = runCodexReviewStep()
+    const args = readFileSync(join(captureDir, 'args'), 'utf8').trim().split('\n')
+    const configIndex = args.indexOf('--config')
 
-    expect(readFileSync(join(captureDir, 'stdin'), 'utf8')).toContain(
-      'Pull request branch: ci/test-workflow'
-    )
+    expect(args[configIndex + 1]).toContain('developer_instructions=')
+    expect(args[configIndex + 1]).toContain('Pull request branch: ci/test-workflow')
+    expect(readFileSync(join(captureDir, 'stdin'), 'utf8')).toBe('')
   })
 
   it('allows the first Codex review for a pull request', () => {


### PR DESCRIPTION
## Summary

- pass Codex project rules through developer instructions so they can coexist with --base
- remove the conflicting positional prompt argument
- skip oversized no-tools Claude reviews without failing the workflow
- keep outcome labeling fail-closed when Claude does not post a verdict

## Validation

Not run, per request.