### PR TITLE
ci(review): allow selecting a dispatched reviewer

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -10,8 +10,8 @@ name: AI PR Review
 # Override the review models with CLAUDE_REVIEW_MODEL and CODEX_REVIEW_MODEL (optional).
 # Uses pull_request_target so secrets are reachable for fork pull requests as well. Fork PRs are
 # skipped unless ENABLE_FORK_REVIEW=true; same-repository PRs always run. workflow_dispatch with a
-# pull request number re-runs either review on demand and bypasses the fork gate (the secret and
-# workflow code are already trusted under a manual dispatch).
+# pull request number re-runs either or both reviewers on demand and bypasses the fork gate (the
+# secret and workflow code are already trusted under a manual dispatch).
 # Codex reviews each opened, synchronized, or reopened PR state until the PR has accumulated 10
 # successful Codex review comments. Rapid updates still use concurrency cancellation so only the
 # latest surviving run publishes a review and consumes a round.
@@ -35,6 +35,15 @@ on:
       pull_request_number:
         description: Pull request number to review
         required: true
+      reviewer:
+        description: Reviewer to run
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - claude
+          - codex
 
 concurrency:
   group: ai-pr-review-${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}
@@ -46,7 +55,8 @@ jobs:
     name: Claude architecture review
     if: >-
       ${{ vars.ENABLE_CLAUDE_REVIEW != 'false' &&
-          ( github.event_name == 'workflow_dispatch' ||
+          ( ( github.event_name == 'workflow_dispatch' &&
+              ( inputs.reviewer == 'both' || inputs.reviewer == 'claude' ) ) ||
             github.event.pull_request.head.repo.full_name == github.repository ||
             vars.ENABLE_FORK_REVIEW == 'true' ) }}
     runs-on: ubuntu-latest
@@ -265,7 +275,8 @@ jobs:
     name: Check Codex review limit
     if: >-
       ${{ vars.ENABLE_CODEX_REVIEW != 'false' &&
-          ( github.event_name == 'workflow_dispatch' ||
+          ( ( github.event_name == 'workflow_dispatch' &&
+              ( inputs.reviewer == 'both' || inputs.reviewer == 'codex' ) ) ||
             github.event.pull_request.head.repo.full_name == github.repository ||
             vars.ENABLE_FORK_REVIEW == 'true' ) }}
     runs-on: ubuntu-latest

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -285,18 +285,23 @@ describe('AI review workflow contract', () => {
     expect(reviewWorkflow).toContain("vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol'")
   })
 
-  it('exposes a workflow_dispatch trigger with a pull request number input', () => {
+  it('exposes workflow_dispatch inputs for the pull request and selected reviewer', () => {
     expect(reviewWorkflow).toContain('workflow_dispatch:')
     expect(reviewWorkflow).toContain('pull_request_number')
+    expect(reviewWorkflow).toMatch(/reviewer:\n\s+description: Reviewer to run/)
+    expect(reviewWorkflow).toMatch(/options:\n\s+- both\n\s+- claude\n\s+- codex/)
   })
 
   it('runs again when a pull request receives new commits', () => {
     expect(reviewWorkflow).toContain('types: [opened, synchronize, reopened]')
   })
 
-  it('lets both review jobs run on manual dispatch by bypassing the fork gate', () => {
+  it('lets manual dispatch select either reviewer while bypassing the fork gate', () => {
     const dispatchGuards = reviewWorkflow.match(/github\.event_name == 'workflow_dispatch'/g)
     expect(dispatchGuards?.length).toBe(2)
+    expect(reviewWorkflow.match(/inputs\.reviewer == 'both'/g)?.length).toBe(2)
+    expect(reviewWorkflow.match(/inputs\.reviewer == 'claude'/g)?.length).toBe(1)
+    expect(reviewWorkflow.match(/inputs\.reviewer == 'codex'/g)?.length).toBe(1)
   })
 
   it('passes --repo to gh pr view so it works before checkout on a clean runner', () => {


### PR DESCRIPTION
## Summary

- add a `reviewer` choice to manual AI review dispatches
- allow `claude`, `codex`, or `both` without merging workflow changes first
- keep automatic PR reviews unchanged

## Validation

- `vitest run scripts/ai-review-workflows.test.ts` (31 tests passed)
- Claude and Codex will be dispatched separately from this PR branch before merge