### PR TITLE
fix(workspace): report only unknown run failures, not expected ones

### DIFF
--- a/src/main/acp/prompt-error.test.ts
+++ b/src/main/acp/prompt-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { describePromptError } from './prompt-error'
+import { describePromptError, isProviderPromptError } from './prompt-error'
 
 // Builds an ACP RequestError-shaped value: an Error carrying the JSON-RPC code + data the agent attaches.
 const agentError = (
@@ -104,5 +104,43 @@ describe('describePromptError', () => {
 
   it('accepts a plain string error', () => {
     expect(describePromptError('boom')).toBe('boom')
+  })
+})
+
+describe('isProviderPromptError', () => {
+  it('flags an upstream APIError (auth/rate/quota/5xx all share this tag)', () => {
+    expect(isProviderPromptError(agentError('Invalid API key'))).toBe(true)
+    expect(isProviderPromptError(agentError('429 Too Many Requests'))).toBe(true)
+    expect(isProviderPromptError(agentError('Internal error: Overloaded: service is busy'))).toBe(
+      true
+    )
+  })
+
+  it('flags a provider-relayed failure tagged with errorKind "provider-error"', () => {
+    const error = Object.assign(new Error('Internal error'), {
+      code: -32603,
+      data: { errorKind: 'provider-error' },
+      name: 'RequestError'
+    })
+
+    expect(isProviderPromptError(error)).toBe(true)
+  })
+
+  it('flags a provider resource-not-found (wrong model id / endpoint)', () => {
+    const error = agentError(
+      'Internal error: Not Found: {"error":{"message":"unknown model","type":"resource_not_found_error"}}'
+    )
+
+    expect(isProviderPromptError(error)).toBe(true)
+  })
+
+  it('does NOT flag an ACP-layer exception (no provider signal) — these stay reportable', () => {
+    // A protocol not-found the resume path owns.
+    expect(
+      isProviderPromptError(Object.assign(new Error('Resource not found'), { code: -32002 }))
+    ).toBe(false)
+    // An app-layer throw with no agent tag.
+    expect(isProviderPromptError(new Error('Agent session could not be created.'))).toBe(false)
+    expect(isProviderPromptError('boom')).toBe(false)
   })
 })

--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -1,3 +1,5 @@
+import { PROVIDER_RESOURCE_NOT_FOUND_PREFIX } from '../../shared/run-error-classification'
+
 // Turns an agent prompt failure into user-visible text. Agents (opencode) relay an upstream provider
 // HTTP error wrapped as a JSON-RPC failure like
 //   `Internal error: Not Found: {"error":{"message":"The requested resource was not found","type":"resource_not_found_error"}}`
@@ -144,5 +146,5 @@ export const describePromptError = (error: unknown, ctx: PromptErrorContext = {}
   const providerText = detail?.text ?? stripWrapperPrefixes(raw)
   const modelPart = ctx.model ? ` for model "${ctx.model}"` : ''
 
-  return `The model provider could not find the requested resource${modelPart}. The model name or endpoint is likely incorrect — check it in Settings → Model. Provider response: ${providerText}`
+  return `${PROVIDER_RESOURCE_NOT_FOUND_PREFIX}${modelPart}. The model name or endpoint is likely incorrect — check it in Settings → Model. Provider response: ${providerText}`
 }

--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -148,3 +148,41 @@ export const describePromptError = (error: unknown, ctx: PromptErrorContext = {}
 
   return `${PROVIDER_RESOURCE_NOT_FOUND_PREFIX}${modelPart}. The model name or endpoint is likely incorrect — check it in Settings → Model. Provider response: ${providerText}`
 }
+
+// The agent's structured tag for a failure it relayed from the upstream model provider (as opposed to
+// an ACP protocol/session error). The bridges attach `data.errorKind: 'provider-error'` for these.
+const isProviderErrorKind = (error: unknown): boolean => {
+  try {
+    const data = (error as { data?: unknown } | null)?.data
+    const kind = (data as { errorKind?: unknown } | null | undefined)?.errorKind
+
+    return (
+      typeof kind === 'string' &&
+      kind
+        .trim()
+        .toLowerCase()
+        .replace(/[\s_-]+/g, '-') === 'provider-error'
+    )
+  } catch {
+    return false
+  }
+}
+
+// Whether a failed prompt originates from the model provider (an upstream LLM/HTTP failure the agent
+// relayed) rather than from the app's own ACP layer. Provider failures are the user's/provider's to
+// resolve (wrong key, rate limit, quota, model id, a provider 5xx), so the renderer does NOT offer a
+// "Report error → GitHub issue" affordance for them — only genuinely unexpected ACP-layer exceptions
+// are worth a bug report. Determined structurally, from the signals the agent attaches, so it needs no
+// message-text pattern matching:
+//   - the agent tagged the failure as an upstream `APIError` (covers auth/rate/quota/5xx/etc.), or
+//   - the agent tagged `data.errorKind: 'provider-error'` (the bridges' machine-readable marker), or
+//   - it is a provider "resource not found" (wrong model id / endpoint), which requires the same
+//     upstream signal (see isProviderNotFound) and is never a bare ACP protocol not-found.
+export const isProviderPromptError = (error: unknown): boolean => {
+  if (isApiError(error)) return true
+  if (isProviderErrorKind(error)) return true
+
+  const raw = rawErrorMessage(error)
+
+  return isProviderNotFound(error, raw, extractUpstreamDetail(raw))
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -5082,6 +5082,61 @@ describe('ACP runtime session management', () => {
     expect(errorEvent?.recoverable).toBeUndefined()
   })
 
+  it('tags a provider-relayed prompt failure with providerError so the renderer hides Report', async () => {
+    const process = new FakeAgentProcess()
+    const events: Array<{ kind: string; providerError?: boolean }> = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: () => {
+        // An upstream provider rejection the agent relays as an APIError — the user's to fix, not a bug.
+        throw acp.RequestError.internalError({ errorName: 'APIError' }, 'Invalid API key')
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: {
+        onEvent: (event) => events.push({ kind: event.kind, providerError: event.providerError })
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await expect(
+      runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'hi' })
+    ).rejects.toThrow()
+
+    expect(events).toContainEqual({ kind: 'error', providerError: true })
+  })
+
+  it('does not tag an ACP-layer prompt failure as providerError (stays reportable)', async () => {
+    const process = new FakeAgentProcess()
+    const events: Array<{ kind: string; providerError?: boolean }> = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: () => {
+        // A protocol-level failure with no upstream provider signal is an app/ACP problem, not a
+        // provider one, so it must NOT be tagged (the renderer keeps the Report button).
+        throw acp.RequestError.internalError({ errorKind: 'invalid_request' }, 'malformed request')
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: {
+        onEvent: (event) => events.push({ kind: event.kind, providerError: event.providerError })
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await expect(
+      runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'hi' })
+    ).rejects.toThrow()
+
+    const errorEvent = events.find((event) => event.kind === 'error')
+    expect(errorEvent).toBeDefined()
+    expect(errorEvent?.providerError).toBeFalsy()
+  })
+
   it('logs the provider rejection reason (message/code/data) when a prompt fails', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['remote-session-1'], {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -65,7 +65,7 @@ import {
   resolveSessionEffortOption,
   type SessionModelSelection
 } from './session-config'
-import { describePromptError } from './prompt-error'
+import { describePromptError, isProviderPromptError } from './prompt-error'
 import {
   ATTACHMENT_PREVIEW_BYTES,
   MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
@@ -1967,6 +1967,10 @@ class AcpRuntime {
         kind: 'error',
         level: 'error',
         recoverable,
+        // Tag a model-provider failure (upstream LLM/HTTP error the agent relayed) so the renderer
+        // keeps the message but hides the "Report error" button — only ACP-layer exceptions are bugs
+        // worth a GitHub issue. Determined structurally from the agent's signals, not the message text.
+        providerError: isProviderPromptError(error),
         sessionId: request.sessionId,
         title: ACP_PROMPT_FAILED_EVENT_TITLE,
         text
@@ -3425,6 +3429,7 @@ class AcpRuntime {
       level: event.level ?? 'info',
       kind: event.kind,
       recoverable: event.recoverable,
+      providerError: event.providerError,
       sessionId: event.sessionId,
       messageId: event.messageId,
       role: event.role,

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -73,6 +73,12 @@ import {
   providerEndpoints
 } from '../../shared/settings'
 import type { PackageMirror } from '../../shared/mirror'
+import {
+  buildActiveModelIncompatibleMessage,
+  CODEX_BRIDGE_UNSUPPORTED_MESSAGE,
+  CLAUDE_EXECUTABLE_MISSING_MESSAGE,
+  NO_ACTIVE_PROVIDER_MESSAGE
+} from '../../shared/run-error-classification'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
 import {
@@ -2427,7 +2433,7 @@ class SettingsService {
     }
 
     if (!executablePath) {
-      throw new Error('Claude executable is not configured. Complete onboarding in settings.')
+      throw new Error(CLAUDE_EXECUTABLE_MISSING_MESSAGE)
     }
 
     const activeProvider = settings.activeProviderId
@@ -2435,7 +2441,7 @@ class SettingsService {
       : undefined
 
     if (!activeProvider) {
-      throw new Error('No active model provider is configured. Configure one in settings.')
+      throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
     }
 
     // Ensure the app-owned config dir exists (and app assets are injected) before the agent spawns. The
@@ -2496,7 +2502,7 @@ class SettingsService {
       : undefined
 
     if (!activeProvider) {
-      throw new Error('No active model provider is configured. Configure one in settings.')
+      throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
     }
 
     if (
@@ -2508,9 +2514,7 @@ class SettingsService {
         framework
       )
     ) {
-      throw new Error(
-        `The active model isn't compatible with ${framework.displayName}. Open Settings → Model to pick a compatible model or switch the agent framework.`
-      )
+      throw new Error(buildActiveModelIncompatibleMessage(framework.displayName))
     }
 
     if (
@@ -2520,9 +2524,7 @@ class SettingsService {
         this.resolveActiveModel(activeProvider, settings.activeModel)
       )
     ) {
-      throw new Error(
-        'The active model is not supported over the Codex Chat Completions bridge. Pick another model in Settings → Model.'
-      )
+      throw new Error(CODEX_BRIDGE_UNSUPPORTED_MESSAGE)
     }
 
     if (framework.id === 'claude-code') {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -446,6 +446,9 @@ class HeadlessTaskApi {
       status: 'error',
       activeRun: undefined,
       error: message,
+      // A model-provider failure (tagged on the error event at the ACP layer) is not a reportable bug;
+      // persist that so a reloaded headless session hides the report button, matching the desktop path.
+      ...(runtimeError?.providerError ? { errorReportable: false } : {}),
       updatedAt: this.dependencies.now()
     }
     run.status = 'failed'

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -416,6 +416,41 @@ describe('workspace agent message sending', () => {
     })
   })
 
+  it('unwraps an IPC-wrapped config failure at session start and marks it non-reportable', async () => {
+    // resolveActiveAgentBackend throws app-authored setup guidance at spawn time; it crosses IPC wrapped
+    // as "Error invoking remote method '…': Error: <msg>". The createSession path must unwrap it so the
+    // persisted text matches the classifier's prefix and the report button is hidden (wrong-config, not
+    // a bug). Uses the framework-specific wording service.ts actually builds (not the resume rewording).
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            "Error invoking remote method 'acp:create-session': Error: The active model isn't compatible with Codex. Open Settings → Model to pick a compatible model or switch the agent framework."
+          )
+        ),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      text: 'Start a new analysis',
+      cwd: '/workspace/project',
+      agentFrameworkId: 'codex'
+    })
+    await flushRuntimeTasks()
+
+    const session = useSessionStore.getState().sessions[0]
+    // The IPC wrapper is stripped, leaving the app's own setup guidance verbatim.
+    expect(session.error).toBe(
+      "The active model isn't compatible with Codex. Open Settings → Model to pick a compatible model or switch the agent framework."
+    )
+    // A wrong-config start failure hides the report button.
+    expect(session.errorReportable).toBe(false)
+  })
+
   it('sends attachments when creating a new runtime session', async () => {
     const attachment = createAttachment()
     const finalizedAttachment = createAttachment({

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -788,6 +788,108 @@ describe('workspace agent message sending', () => {
     expect(session.error).toBe('Invalid API key')
   })
 
+  it('marks a model-provider prompt failure non-reportable from the run error event', async () => {
+    // The runtime pushes a providerError-tagged error event before rejecting; the rejection path reads
+    // it from the snapshot so the failure is recorded non-reportable (no "Report error" button) without
+    // guessing from the message text.
+    const providerErrorEvent: AcpRuntimeEvent = {
+      id: 'error-provider-1',
+      timestamp: Date.now(),
+      kind: 'error',
+      level: 'error',
+      sessionId: 'session-1',
+      providerError: true,
+      title: 'Prompt failed',
+      text: 'Invalid API key'
+    }
+    vi.stubGlobal('window', {
+      api: {
+        acp: {
+          getState: vi
+            .fn()
+            .mockResolvedValue({ ...createSnapshot(['session-1']), events: [providerErrorEvent] })
+        }
+      }
+    })
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockRejectedValue(new Error('Invalid API key'))
+    }
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'earlier turn',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'hello',
+      cwd: '/workspace/project'
+    })
+    await flushRuntimeTasks()
+    await flushRuntimeTasks()
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.status).toBe('error')
+    expect(session.errorReportable).toBe(false)
+  })
+
+  it('marks an untagged (ACP-layer) prompt failure reportable', async () => {
+    // No providerError tag on the run's error event → an app-layer failure the user should be able to
+    // report as a bug.
+    const acpErrorEvent: AcpRuntimeEvent = {
+      id: 'error-acp-1',
+      timestamp: Date.now(),
+      kind: 'error',
+      level: 'error',
+      sessionId: 'session-1',
+      title: 'Prompt failed',
+      text: 'Something unexpected broke'
+    }
+    vi.stubGlobal('window', {
+      api: {
+        acp: {
+          getState: vi
+            .fn()
+            .mockResolvedValue({ ...createSnapshot(['session-1']), events: [acpErrorEvent] })
+        }
+      }
+    })
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockRejectedValue(new Error('Something unexpected broke'))
+    }
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'earlier turn',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'hello',
+      cwd: '/workspace/project'
+    })
+    await flushRuntimeTasks()
+    await flushRuntimeTasks()
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.status).toBe('error')
+    expect(session.errorReportable).toBe(true)
+  })
+
   it('uses fallback message when error is empty or whitespace-only', async () => {
     vi.stubGlobal('window', {
       api: {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -17,6 +17,14 @@ import type { ArtifactReference } from '../../../../shared/artifacts'
 import type { MessagePart } from '../../../../shared/session-persistence'
 import type { AgentFrameworkId } from '../../../../shared/settings'
 import { isMediaOverflowError } from '../../../../shared/media-overflow'
+import {
+  IMAGE_REPLAY_UNSUPPORTED_MESSAGE,
+  RESUME_MODEL_INCOMPATIBLE_MESSAGE,
+  RESUME_RECONNECT_FAILED_MESSAGE,
+  RESUME_TIMED_OUT_MESSAGE,
+  RESUME_UNSUPPORTED_MESSAGE,
+  RESUME_WORKSPACE_MISSING_MESSAGE
+} from '../../../../shared/run-error-classification'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { useSessionStore, type ChatMessage } from '../../stores/session-store'
 import { useSettingsStore } from '../../stores/settings-store'
@@ -106,19 +114,19 @@ const getResumeFailureMessage = (error: unknown): string => {
   const message = error instanceof Error ? error.message : String(error)
 
   if (/cwd does not exist/i.test(message)) {
-    return 'Session workspace is missing; start a new conversation.'
+    return RESUME_WORKSPACE_MISSING_MESSAGE
   }
 
   if (/timed out/i.test(message)) {
-    return 'Agent session resume timed out; click Resume to try again.'
+    return RESUME_TIMED_OUT_MESSAGE
   }
 
   if (/does not support session resume/i.test(message)) {
-    return 'This agent build cannot resume sessions; start a new conversation.'
+    return RESUME_UNSUPPORTED_MESSAGE
   }
 
   if (/connection (failed|was superseded)|ACP connection/i.test(message)) {
-    return 'Could not reconnect to the agent; check it is installed, then click Resume to retry.'
+    return RESUME_RECONNECT_FAILED_MESSAGE
   }
 
   // Model↔framework mismatch is now flagged proactively in Settings → Model, so keep this soft and
@@ -127,7 +135,7 @@ const getResumeFailureMessage = (error: unknown): string => {
   // compatible with <framework>…") so unrelated "not compatible with" errors — notably an ACP
   // protocol-version mismatch — fall through to the default message instead of being mislabeled.
   if (/active model isn'?t compatible with/i.test(message)) {
-    return "The active model isn't compatible with this agent framework. Open Settings → Model to pick a compatible model or switch frameworks."
+    return RESUME_MODEL_INCOMPATIBLE_MESSAGE
   }
 
   const detail = unwrapResumeErrorDetail(message)
@@ -348,12 +356,6 @@ const startPendingSessionPrompt = (
   })()
 }
 
-// Records the user's prompt before slow runtime work continues.
-// Shared by the send path and the edit-resend pre-check so both reject incompatible image replays
-// with the same wording.
-const IMAGE_REPLAY_UNSUPPORTED_MESSAGE =
-  'This conversation needs image replay, but the selected model does not support image input.'
-
 const sendWorkspaceMessage = async (
   runtime: WorkspaceMessageRuntime,
   {
@@ -438,9 +440,7 @@ const sendWorkspaceMessage = async (
       const effectiveCwd = targetCwd || runtime.state.cwd
 
       if (!effectiveCwd) {
-        useSessionStore
-          .getState()
-          .failRun(targetSessionId, 'Session workspace is missing; start a new conversation.')
+        useSessionStore.getState().failRun(targetSessionId, RESUME_WORKSPACE_MISSING_MESSAGE)
         return undefined
       }
 
@@ -644,9 +644,7 @@ const resumeInterruptedWorkspaceSession = async (
   const resumeCwd = session.cwd || runtime.state.cwd
 
   if (!resumeCwd) {
-    useSessionStore
-      .getState()
-      .failRun(sessionId, 'Session workspace is missing; start a new conversation.')
+    useSessionStore.getState().failRun(sessionId, RESUME_WORKSPACE_MISSING_MESSAGE)
     return
   }
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -147,11 +147,32 @@ const getResumeFailureMessage = (error: unknown): string => {
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
 
+// The id of the most recent prompt-failure error event for a session, or undefined if none. Captured
+// before a prompt is dispatched so the rejection path can tell a NEW failure event (this turn) from a
+// stale one left by an earlier turn, and never inherit the earlier turn's providerError tag.
+const latestPromptFailureEventId = (
+  events: AcpRuntimeEvent[],
+  sessionId: string
+): string | undefined => {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]
+    if (event.kind === 'error' && event.sessionId === sessionId) return event.id
+  }
+  return undefined
+}
+
 // Classifies a failed prompt against the live connection status: an abnormal drop (status 'closed'/
 // 'error') shows the Resume banner so the user can reconnect and continue, while a turn-level error
 // (connection still up, e.g. a gateway 5xx) surfaces as a normal session error. Reading the status at
 // failure time avoids the race where failRun would flip the session out of 'running' first.
-const failOrMarkDisconnected = async (sessionId: string, message: string): Promise<void> => {
+//
+// priorErrorEventId is the newest prompt-failure event id observed BEFORE this prompt was dispatched;
+// it lets the reportability read below ignore a stale event from an earlier turn.
+const failOrMarkDisconnected = async (
+  sessionId: string,
+  message: string,
+  priorErrorEventId?: string
+): Promise<void> => {
   // A conversation being auto-compacted after a request-size overflow owns its own outcome (reset +
   // retry). Don't overwrite the neutral compacting state with a dead-end error from the rejected
   // sendPrompt call.
@@ -159,6 +180,13 @@ const failOrMarkDisconnected = async (sessionId: string, message: string): Promi
     return
   }
 
+  // The rejection carries no structural tag (IPC strips the Error's data), so read THIS turn's error
+  // event from the snapshot to learn whether it was a model-provider failure. The runtime pushes that
+  // event (tagged providerError) synchronously before rejecting, so by the time this getState resolves
+  // it is already present. Deriving `reportable = !providerError` here converges with the event path
+  // (workspace-events), so whichever path writes last agrees. Undefined (no NEW event — should not
+  // happen, but a stale prior-turn event is ignored) leaves failRun to fall back to text classification.
+  let reportable: boolean | undefined
   try {
     const snapshot = await window.api.acp.getState()
 
@@ -167,11 +195,18 @@ const failOrMarkDisconnected = async (sessionId: string, message: string): Promi
       useSessionStore.getState().markDisconnected(sessionId, message)
       return
     }
+
+    const runError = [...snapshot.events]
+      .reverse()
+      .find((event) => event.kind === 'error' && event.sessionId === sessionId)
+    // Only trust an event that is NEW for this turn, so a provider-error tag from an earlier turn can
+    // neither hide this failure's report button nor mislabel it.
+    if (runError && runError.id !== priorErrorEventId) reportable = !runError.providerError
   } catch {
     // Fall back to a plain error if the live status read fails.
   }
 
-  useSessionStore.getState().failRun(sessionId, message)
+  useSessionStore.getState().failRun(sessionId, message, { reportable })
 }
 
 // Moves staged uploads into the session directory and updates the already-visible user message.
@@ -344,6 +379,9 @@ const startPendingSessionPrompt = (
       return
     }
 
+    // Baseline the newest prompt-failure event before dispatch so the rejection path can tell this
+    // turn's error event from a stale one when it derives the report affordance.
+    const priorErrorEventId = latestPromptFailureEventId(runtime.state.events, runtimeSessionId)
     void runtime
       .sendPrompt(runtimeSessionId, content, promptAttachments, forcedSkillIds, referencedArtifacts)
       .catch((error) => {
@@ -351,7 +389,7 @@ const startPendingSessionPrompt = (
         // visible session error, instead of being swallowed as an unhandled rejection.
         // Ensure non-empty message to avoid being silently dropped by failRun's empty check.
         const errorMessage = getErrorMessage(error).trim() || 'Agent run failed'
-        void failOrMarkDisconnected(runtimeSessionId, errorMessage)
+        void failOrMarkDisconnected(runtimeSessionId, errorMessage, priorErrorEventId)
       })
   })()
 }
@@ -548,6 +586,10 @@ const sendWorkspaceMessage = async (
       return appended
     }
 
+    // Baseline the newest prior failure event so the rejection path can tell this turn's error event
+    // (carrying the providerError tag) from a stale one left by an earlier turn.
+    const priorErrorEventId = latestPromptFailureEventId(runtime.state.events, targetSessionId)
+
     // The hook returns after local state is updated; event listeners handle the streamed result.
     void runtime
       .sendPrompt(
@@ -566,7 +608,7 @@ const sendWorkspaceMessage = async (
         // visible session error, instead of being swallowed as an unhandled rejection.
         // Ensure non-empty message to avoid being silently dropped by failRun's empty check.
         const errorMessage = getErrorMessage(error).trim() || 'Agent run failed'
-        void failOrMarkDisconnected(targetSessionId, errorMessage)
+        void failOrMarkDisconnected(targetSessionId, errorMessage, priorErrorEventId)
       })
 
     return appended

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -195,9 +195,10 @@ const failOrMarkDisconnected = async (
   // The rejection carries no structural tag (IPC strips the Error's data), so read THIS turn's error
   // event from the snapshot to learn whether it was a model-provider failure. The runtime pushes that
   // event (tagged providerError) synchronously before rejecting, so by the time this getState resolves
-  // it is already present. Deriving `reportable = !providerError` here converges with the event path
-  // (workspace-events), so whichever path writes last agrees. Undefined (no NEW event — should not
-  // happen, but a stale prior-turn event is ignored) leaves failRun to fall back to text classification.
+  // it is already present. Only a provider-tagged event forces reportable=false; everything else is left
+  // undefined so failRun's text tier decides — this converges with the event path (workspace-events) and
+  // keeps a non-recovered overflow (providerError=false) non-reportable via the text tier instead of
+  // being mislabeled reportable. Undefined also covers no NEW event (a stale prior-turn event is ignored).
   let reportable: boolean | undefined
   try {
     const snapshot = await window.api.acp.getState()
@@ -213,7 +214,7 @@ const failOrMarkDisconnected = async (
       .find((event) => event.kind === 'error' && event.sessionId === sessionId)
     // Only trust an event that is NEW for this turn, so a provider-error tag from an earlier turn can
     // neither hide this failure's report button nor mislabel it.
-    if (runError && runError.id !== priorErrorEventId) reportable = !runError.providerError
+    if (runError && runError.id !== priorErrorEventId && runError.providerError) reportable = false
   } catch {
     // Fall back to a plain error if the live status read fails.
   }

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -97,12 +97,24 @@ type WorkspaceRuntimeEventProcessor = {
 }
 
 // Strips the Electron IPC wrapper ("Error invoking remote method '…': Error: <cause>") and any
-// leading "Error:" so the underlying agent message can be shown to the user on its own.
-const unwrapResumeErrorDetail = (message: string): string =>
+// leading "Error:" so the underlying agent message can be shown to the user on its own. Used by both
+// the resume and createSession failure paths, since either crosses IPC and arrives wrapped.
+const unwrapIpcErrorDetail = (message: string): string =>
   message
     .replace(/^Error invoking remote method '[^']*':\s*/i, '')
     .replace(/^Error:\s*/i, '')
     .trim()
+
+// Turns a createSession (conversation-start) failure into the message persisted on the session. The
+// error crosses IPC wrapped, so it is unwrapped first — this keeps the app-authored setup guidance
+// (settings/service.ts: model-incompat, no provider, Codex bridge, missing Claude executable) matching
+// the classifier's prefixes/constants, so a wrong-config start failure hides the report button instead
+// of masquerading as a reportable bug behind the "Error invoking remote method" wrapper.
+const getCreateSessionFailureMessage = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return unwrapIpcErrorDetail(message) || message.trim() || 'Agent session could not be created.'
+}
 
 // Turns a resume failure into an actionable message. Each branch matches one distinct cause thrown
 // along the runtime resume path (runtime.ts): a deleted/moved workspace folder ("cwd does not exist"),
@@ -138,7 +150,7 @@ const getResumeFailureMessage = (error: unknown): string => {
     return RESUME_MODEL_INCOMPATIBLE_MESSAGE
   }
 
-  const detail = unwrapResumeErrorDetail(message)
+  const detail = unwrapIpcErrorDetail(message)
 
   return detail ? `Agent session resume failed: ${detail}` : 'Agent session resume failed'
 }
@@ -334,7 +346,9 @@ const startPendingSessionPrompt = (
     try {
       createdSession = await runtime.createSession(cwd, projectName, permissionProfile)
     } catch (error) {
-      useSessionStore.getState().failRun(pending.sessionId, getErrorMessage(error))
+      // Unwrap the IPC wrapper so an app-authored setup failure (model-incompat / no provider / Codex
+      // bridge / missing executable) is recognized by the classifier and hides the report button.
+      useSessionStore.getState().failRun(pending.sessionId, getCreateSessionFailureMessage(error))
       return
     }
 

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -166,6 +166,9 @@ describe('workspace runtime events', () => {
       status: 'error',
       error: 'Network failed'
     })
+    // An opaque ACP-layer failure (no providerError tag, not app-crafted) stays reportable: the event
+    // path defers to the text tier rather than suppressing the button.
+    expect(useSessionStore.getState().sessions[0].errorReportable).toBe(true)
   })
 
   const overflowEvent = (): AcpRuntimeEvent =>
@@ -210,6 +213,34 @@ describe('workspace runtime events', () => {
     expect(session.status).toBe('error')
     expect(session.compacting).toBeFalsy()
     expect(session.error).toContain('Request too large')
+    // A non-recovered overflow (providerError=false) is a client-side/size failure the text tier
+    // recognizes as expected — it must NOT be forced reportable by the event path.
+    expect(session.errorReportable).toBe(false)
+  })
+
+  it('hides the report button for a provider-tagged error even when its text looks reportable', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'run the analysis'
+    })
+
+    // providerError=true forces reportable=false regardless of the (opaque) message — the structural
+    // tag, not the text, decides for a model/provider failure.
+    const applied = await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'event-provider',
+        kind: 'error',
+        level: 'error',
+        providerError: true,
+        title: 'Prompt failed',
+        text: 'Internal error: upstream exploded'
+      })
+    )
+
+    expect(applied).toBe(true)
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.status).toBe('error')
+    expect(session.errorReportable).toBe(false)
   })
 
   it('surfaces a session-scoped agent warning as the waiting-indicator status, cleared on stop', async () => {

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -310,7 +310,10 @@ const applyWorkspaceRuntimeEvent = async (
       return true
     }
 
-    store.failRun(event.sessionId, getEventErrorText(event))
+    // A model-provider failure (upstream LLM/HTTP error the agent relayed, tagged structurally in the
+    // runtime) keeps its message but is not a bug worth a GitHub issue — hide the report button. An
+    // ACP-layer failure stays reportable. providerError is absent on non-provider events (→ reportable).
+    store.failRun(event.sessionId, getEventErrorText(event), { reportable: !event.providerError })
     return true
   }
 

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -311,9 +311,15 @@ const applyWorkspaceRuntimeEvent = async (
     }
 
     // A model-provider failure (upstream LLM/HTTP error the agent relayed, tagged structurally in the
-    // runtime) keeps its message but is not a bug worth a GitHub issue — hide the report button. An
-    // ACP-layer failure stays reportable. providerError is absent on non-provider events (→ reportable).
-    store.failRun(event.sessionId, getEventErrorText(event), { reportable: !event.providerError })
+    // runtime) keeps its message but is not a bug worth a GitHub issue — hide the report button. For
+    // everything else, defer to failRun's text tier (undefined) rather than forcing reportable=true: a
+    // non-recovered overflow reaches here (repeat inside cooldown, nothing to replay, detached session)
+    // with providerError=false but IS a client-side/size failure the text tier recognizes as expected —
+    // forcing true here would wrongly show and persist the report button over it. Opaque ACP-layer
+    // failures still fall through the text tier to reportable.
+    store.failRun(event.sessionId, getEventErrorText(event), {
+      reportable: event.providerError ? false : undefined
+    })
     return true
   }
 

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -699,11 +699,30 @@ describe('ConversationPanel error box + report affordance', () => {
     expect(reportButton()).toBeNull()
   })
 
-  it('hides the Report button for a recognized provider-side error', () => {
+  it('hides the Report button for a model-provider error (tagged non-reportable at the ACP layer)', () => {
+    // A provider/model failure is tagged structurally (errorReportable: false), not by its text —
+    // the raw provider message is kept visible but is not a bug worth a GitHub issue.
     renderPanel({
-      activeSession: { ...errorSession, error: '429 Too Many Requests: rate_limit_error' }
+      activeSession: {
+        ...errorSession,
+        error: 'Invalid API key',
+        errorReportable: false
+      }
     })
-    expect(errorBoxText()).toContain('429 Too Many Requests')
+    expect(errorBoxText()).toContain('Invalid API key')
     expect(reportButton()).toBeNull()
+  })
+
+  it('shows the Report button when a persisted error predates the reportable flag (undefined)', () => {
+    // Old sessions have no errorReportable; fall back to classifying the text — an opaque failure
+    // stays reportable, an app-crafted reminder does not.
+    renderPanel({
+      activeSession: {
+        ...errorSession,
+        error: 'Run failed: connection reset',
+        errorReportable: undefined
+      }
+    })
+    expect(reportButton()).not.toBeNull()
   })
 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -686,4 +686,24 @@ describe('ConversationPanel error box + report affordance', () => {
     ) as HTMLTextAreaElement | null
     expect(textarea?.value).toBe('The run failed with no error message.')
   })
+
+  it('hides the Report button for an app-crafted, actionable failure', () => {
+    // A recognized failure keeps its message but is not a bug worth a GitHub issue.
+    renderPanel({
+      activeSession: {
+        ...errorSession,
+        error: 'Session workspace is missing; start a new conversation.'
+      }
+    })
+    expect(errorBoxText()).toContain('Session workspace is missing')
+    expect(reportButton()).toBeNull()
+  })
+
+  it('hides the Report button for a recognized provider-side error', () => {
+    renderPanel({
+      activeSession: { ...errorSession, error: '429 Too Many Requests: rate_limit_error' }
+    })
+    expect(errorBoxText()).toContain('429 Too Many Requests')
+    expect(reportButton()).toBeNull()
+  })
 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -174,11 +174,12 @@ const ConversationPanel = ({
   const allJobsForSession = useSessionJobStore((s) => s.allJobsForSession)
   const hasAnyJobs = activeSession !== undefined && allJobsForSession(activeSession.id).length > 0
   const resolvedRunError = normalizeRunFailureError(activeSession?.error)
-  // Only unknown/opaque failures offer the "Report error → GitHub issue" affordance. Failures the app
-  // already recognizes (its own actionable guidance, or a known provider error) keep their message but
-  // hide the button, so the issue tracker is not flooded with wrong-config / provider-side problems.
-  // Classify the raw persisted error (not the fallback) so a failure with no message stays reportable.
-  const isRunErrorReportable = isReportableRunFailure(activeSession?.error)
+  // Only unknown/opaque ACP-layer failures offer the "Report error → GitHub issue" affordance. The
+  // reportability is resolved at failure time and persisted on the session: a model-provider error is
+  // tagged non-reportable at the ACP layer, and an app-crafted reminder is recognized by its own text.
+  // Fall back to classifying the raw error for sessions persisted before the flag existed (undefined).
+  const isRunErrorReportable =
+    activeSession?.errorReportable ?? isReportableRunFailure(activeSession?.error)
 
   // Re-attaches the interrupted session; on success the banner unmounts, so guard the state update.
   const handleResume = async (): Promise<void> => {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -5,6 +5,7 @@ import type {
   SessionPermissionProfileState
 } from '../../../../shared/permission-profiles'
 import type { UploadedAttachment } from '../../../../shared/uploads'
+import { isReportableRunFailure } from '../../../../shared/run-error-classification'
 import {
   ArrowUp,
   BookOpen,
@@ -40,7 +41,6 @@ import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
 import { ComposerAgentControlsMenu } from './ComposerAgentControlsMenu'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
-import { isReportableRunFailure } from '../../../../shared/run-error-classification'
 import { normalizeRunFailureError } from './error-report'
 import { ReportErrorDialog } from './ReportErrorDialog'
 import { SessionInterruptedBanner } from './SessionInterruptedBanner'

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -40,6 +40,7 @@ import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
 import { ComposerAgentControlsMenu } from './ComposerAgentControlsMenu'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
+import { isReportableRunFailure } from '../../../../shared/run-error-classification'
 import { normalizeRunFailureError } from './error-report'
 import { ReportErrorDialog } from './ReportErrorDialog'
 import { SessionInterruptedBanner } from './SessionInterruptedBanner'
@@ -173,6 +174,11 @@ const ConversationPanel = ({
   const allJobsForSession = useSessionJobStore((s) => s.allJobsForSession)
   const hasAnyJobs = activeSession !== undefined && allJobsForSession(activeSession.id).length > 0
   const resolvedRunError = normalizeRunFailureError(activeSession?.error)
+  // Only unknown/opaque failures offer the "Report error → GitHub issue" affordance. Failures the app
+  // already recognizes (its own actionable guidance, or a known provider error) keep their message but
+  // hide the button, so the issue tracker is not flooded with wrong-config / provider-side problems.
+  // Classify the raw persisted error (not the fallback) so a failure with no message stays reportable.
+  const isRunErrorReportable = isReportableRunFailure(activeSession?.error)
 
   // Re-attaches the interrupted session; on success the banner unmounts, so guard the state update.
   const handleResume = async (): Promise<void> => {
@@ -290,16 +296,20 @@ const ConversationPanel = ({
                       <div className="flex items-start gap-2">
                         <span className="min-w-0 flex-1 break-words">{resolvedRunError}</span>
                         {/* The button sits on the failure row beside the run's own error, so the shown
-                            text and the reported text are always the same error. */}
-                        <button
-                          type="button"
-                          onClick={() => setIsReportOpen(true)}
-                          className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-red-200 bg-red-100/60 px-2 font-medium text-red-700 hover:bg-red-100"
-                          aria-label="Report this error"
-                        >
-                          <Flag className="size-3" strokeWidth={2.2} aria-hidden="true" />
-                          Report error
-                        </button>
+                            text and the reported text are always the same error. Shown only for an
+                            unknown failure — a recognized one (app guidance or a known provider error)
+                            keeps its message but is not a bug worth a GitHub issue. */}
+                        {isRunErrorReportable ? (
+                          <button
+                            type="button"
+                            onClick={() => setIsReportOpen(true)}
+                            className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-red-200 bg-red-100/60 px-2 font-medium text-red-700 hover:bg-red-100"
+                            aria-label="Report this error"
+                          >
+                            <Flag className="size-3" strokeWidth={2.2} aria-hidden="true" />
+                            Report error
+                          </button>
+                        ) : null}
                       </div>
                     ) : null}
                   </div>

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -465,6 +465,77 @@ describe('session store', () => {
     })
   })
 
+  it('derives errorReportable from the message when no explicit flag is passed', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Read the files'
+    })
+
+    // An opaque/internal failure with no crafted-message match stays reportable.
+    useSessionStore.getState().failRun('transport-session-1', 'Agent session could not be created.')
+    expect(useSessionStore.getState().sessions[0].errorReportable).toBe(true)
+
+    // An app-crafted reminder is recognized by its exact text and is not reportable.
+    useSessionStore
+      .getState()
+      .failRun('transport-session-1', 'Session workspace is missing; start a new conversation.')
+    expect(useSessionStore.getState().sessions[0].errorReportable).toBe(false)
+  })
+
+  it('honors an explicit reportable flag (the runtime tags a model-provider failure)', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Read the files'
+    })
+
+    // A model-provider failure: opaque text that WOULD derive reportable=true, but the ACP layer
+    // structurally tagged it non-reportable, and the explicit flag wins.
+    useSessionStore.getState().failRun('transport-session-1', 'Invalid API key', {
+      reportable: false
+    })
+    expect(useSessionStore.getState().sessions[0].errorReportable).toBe(false)
+  })
+
+  it('clears errorReportable when a new run starts, so a later error cannot inherit it', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'first turn'
+    })
+    // A model-provider failure hides the report button.
+    useSessionStore.getState().failRun('transport-session-1', 'Invalid API key', {
+      reportable: false
+    })
+    expect(useSessionStore.getState().sessions[0].errorReportable).toBe(false)
+
+    // A new turn clears the prior error + flag.
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'second turn'
+    })
+    expect(useSessionStore.getState().sessions[0].errorReportable).toBeUndefined()
+
+    // A later ACP-layer failure with no explicit flag derives reportable=true — it never inherits the
+    // earlier provider error's false.
+    useSessionStore.getState().failRun('transport-session-1', 'Agent cancellation failed')
+    expect(useSessionStore.getState().sessions[0].errorReportable).toBe(true)
+  })
+
+  it('records an artifact finalization error as reportable (an app-layer failure)', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Create a report'
+    })
+    // Simulate a prior provider error's flag lingering, then an artifact error overwriting it.
+    useSessionStore.getState().failRun('transport-session-1', 'Invalid API key', {
+      reportable: false
+    })
+    useSessionStore.getState().recordArtifactError('transport-session-1', 'disk full')
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.error).toContain('disk full')
+    expect(session.errorReportable).toBe(true)
+  })
+
   it('keeps artifact finalization errors visible when the run later stops', () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -32,6 +32,7 @@ import {
   type PersistedSessionStatus,
   type PersistedToolActivity
 } from '../../../shared/session-persistence'
+import { isReportableRunFailure } from '../../../shared/run-error-classification'
 
 export type SessionStatus = PersistedSessionStatus
 export type ChatMessageRole = PersistedMessageRole
@@ -186,7 +187,10 @@ type SessionStore = SessionStoreData & {
   hydrateSessions: (sessions: PersistedChatSession[], manifest?: PersistedSessionManifest) => void
   upsertPersistedSession: (session: PersistedChatSession) => void
   finishRun: (sessionId: string) => void
-  failRun: (sessionId: string, error: string) => void
+  // opts.reportable overrides the report-affordance decision: pass false for a model-provider failure
+  // (the agent relayed an upstream LLM/HTTP error), true to force it, or omit to let the store derive it
+  // from the message (an app-crafted reminder → not reportable; anything else → reportable).
+  failRun: (sessionId: string, error: string, opts?: { reportable?: boolean }) => void
   // Sets the transient agent status line shown in the waiting indicator; only applies while running.
   setAgentStatus: (sessionId: string, text: string) => void
   // Enters the auto-recovery "compacting" state after a request-size overflow: clears the error so the
@@ -625,6 +629,9 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
                 agentModel: normalizedAgentModel,
                 agentStatus: undefined,
                 error: undefined,
+                // Clear the prior failure's report flag alongside its text so a later internal error
+                // cannot inherit a stale `false` and wrongly hide its Report button.
+                errorReportable: undefined,
                 compacting: undefined,
                 messages: [...session.messages, userMessage],
                 updatedAt: now
@@ -1034,6 +1041,9 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               ...session,
               status: 'error',
               error: `${ARTIFACT_ERROR_PREFIX}: ${message}`,
+              // An app-layer finalization failure IS a reportable bug; set it explicitly so it never
+              // inherits a stale `false` from a prior provider error on the same session.
+              errorReportable: true,
               updatedAt: Date.now()
             }
           : session
@@ -1055,6 +1065,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           ...session,
           status: session.activeRun ? 'running' : 'idle',
           error: undefined,
+          errorReportable: undefined,
           updatedAt: Date.now()
         }
       })
@@ -1170,6 +1181,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           agentStatus: undefined,
           compacting: undefined,
           error: keepArtifactError ? session.error : undefined,
+          errorReportable: keepArtifactError ? session.errorReportable : undefined,
           messages: completeStreamingMessages(session.messages),
           activities: completeOpenActivities(session.activities),
           updatedAt: Date.now()
@@ -1179,10 +1191,15 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   },
 
   // Fails the active run and records the visible session error.
-  failRun: (sessionId, error) => {
+  failRun: (sessionId, error, opts) => {
     const message = error.trim()
 
     if (!message) return
+
+    // Resolve the report affordance once and persist it (survives reload): an explicit opts.reportable
+    // wins (the runtime passes false for a model-provider failure); otherwise derive it from the message
+    // so an app-crafted reminder hides the button while an unknown/opaque failure keeps it.
+    const errorReportable = opts?.reportable ?? isReportableRunFailure(message)
 
     set((state) => ({
       sessions: state.sessions.map((session) =>
@@ -1194,6 +1211,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               agentStatus: undefined,
               compacting: undefined,
               error: message,
+              errorReportable,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
               updatedAt: Date.now()
@@ -1232,6 +1250,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               activeRun: undefined,
               agentStatus: undefined,
               error: undefined,
+              errorReportable: undefined,
               compacting: true,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
@@ -1251,6 +1270,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               ...session,
               status: 'idle',
               error: undefined,
+              errorReportable: undefined,
               interrupted: undefined,
               agentFrameworkId: agentFrameworkId ?? session.agentFrameworkId,
               agentBackendId: agentBackendId ?? session.agentBackendId,
@@ -1281,6 +1301,9 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               interrupted: true,
               compacting: undefined,
               error,
+              // Cleared so a prior run's report flag can't bleed onto this disconnect (the interrupted
+              // banner owns this path anyway; the report button never shows for it).
+              errorReportable: undefined,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
               updatedAt: Date.now()
@@ -1341,6 +1364,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           activeRun: undefined,
           agentStatus: undefined,
           error: undefined,
+          errorReportable: undefined,
           interrupted: undefined,
           filesRevision: hasFiles ? (session.filesRevision ?? 0) + 1 : session.filesRevision,
           updatedAt: Date.now()

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -104,6 +104,13 @@ export type AcpRuntimeEvent = {
   // Set on an error event the app can auto-recover from, so the renderer compacts-and-retries instead
   // of surfacing a dead-end error.
   recoverable?: AcpRecoverableFailure
+  // Set on an error event whose failure originates upstream of the app — the agent relayed a
+  // model/provider error (bad key, rate limit, quota, provider 5xx/overloaded, wrong model id). The
+  // renderer uses this to withhold the "Report error" affordance: a provider-side problem is the user's
+  // or provider's to resolve, not an app bug worth a GitHub issue. Absent (falsy) means the failure came
+  // from the ACP layer itself (our runtime) and stays reportable unless it is one of our own crafted,
+  // actionable reminder messages.
+  providerError?: boolean
   sessionId?: string
   messageId?: string
   role?: 'assistant' | 'user'

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -49,6 +49,8 @@ describe('isReportableRunFailure', () => {
     expect(isExpectedRunFailure('{"error":{"type":"authentication_error"}}')).toBe(true)
     expect(isExpectedRunFailure('invalid_api_key: check your key')).toBe(true)
     expect(isExpectedRunFailure('403 permission_denied')).toBe(true)
+    // The auth phrasing the runtime persists verbatim from a sendPrompt rejection.
+    expect(isExpectedRunFailure('Invalid API key')).toBe(true)
     // Rate limit
     expect(isExpectedRunFailure('429 Too Many Requests')).toBe(true)
     expect(isExpectedRunFailure('rate_limit_error: slow down')).toBe(true)
@@ -56,9 +58,10 @@ describe('isReportableRunFailure', () => {
     expect(isExpectedRunFailure('insufficient_quota')).toBe(true)
     expect(isExpectedRunFailure('{"error":{"type":"billing_hard_limit"}}')).toBe(true)
     expect(isExpectedRunFailure('Your billing plan has no remaining credit')).toBe(true)
-    // Overloaded / unavailable
+    // Overloaded / unavailable — incl. the describePromptError passthrough the runtime persists verbatim.
     expect(isExpectedRunFailure('overloaded_error')).toBe(true)
     expect(isExpectedRunFailure('503 Service Unavailable')).toBe(true)
+    expect(isExpectedRunFailure('Internal error: Overloaded: service is busy')).toBe(true)
   })
 
   it('recognizes every 5xx status with an HTTP/status marker (overloaded/unavailable family)', () => {
@@ -67,6 +70,11 @@ describe('isReportableRunFailure', () => {
     expect(isExpectedRunFailure('500 Internal Server Error')).toBe(true)
     expect(isExpectedRunFailure('status code: 502')).toBe(true)
     expect(isExpectedRunFailure('504 Gateway Timeout')).toBe(true)
+    // Real-world marker shapes: a word between marker and code, no separator, JSON, underscored marker.
+    expect(isExpectedRunFailure('HTTP Error 500')).toBe(true)
+    expect(isExpectedRunFailure('HTTPError: 503')).toBe(true)
+    expect(isExpectedRunFailure('{"status":500}')).toBe(true)
+    expect(isExpectedRunFailure('status_code: 504')).toBe(true)
   })
 
   it('does not swallow an ordinary app error that merely mentions a provider word', () => {
@@ -86,6 +94,12 @@ describe('isReportableRunFailure', () => {
       isReportableRunFailure('HTTP parser expected status 200 but received malformed headers')
     ).toBe(true)
     expect(isReportableRunFailure('expected status 404 but got none')).toBe(true)
+    // A billing/credit reason phrase is \b-bounded, so a longer word that merely starts with it
+    // ("planner", "accountant", "creditor", "creditworthiness") stays reportable.
+    expect(isReportableRunFailure('Billing planner initialization failed')).toBe(true)
+    expect(isReportableRunFailure('Billing accountant crashed')).toBe(true)
+    expect(isReportableRunFailure('No remaining creditor record found')).toBe(true)
+    expect(isReportableRunFailure('Insufficient creditworthiness score parsing failed')).toBe(true)
   })
 
   it('recognizes a request-size overflow (its own recovery path) as expected', () => {

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import { describePromptError } from '../main/acp/prompt-error'
 import {
+  buildActiveModelIncompatibleMessage,
+  CLAUDE_EXECUTABLE_MISSING_MESSAGE,
+  CODEX_BRIDGE_UNSUPPORTED_MESSAGE,
   IMAGE_REPLAY_UNSUPPORTED_MESSAGE,
+  NO_ACTIVE_PROVIDER_MESSAGE,
   PROVIDER_RESOURCE_NOT_FOUND_PREFIX,
   RESUME_MODEL_INCOMPATIBLE_MESSAGE,
   RESUME_RECONNECT_FAILED_MESSAGE,
@@ -91,5 +95,24 @@ describe('isReportableRunFailure (text tier)', () => {
     const produced = describePromptError(error, { model: 'xyz' })
     expect(produced.startsWith(PROVIDER_RESOURCE_NOT_FOUND_PREFIX)).toBe(true)
     expect(isReportableRunFailure(produced)).toBe(false)
+  })
+
+  it('does not report app-authored agent-setup guidance (createSession spawn failures)', () => {
+    // These are thrown by settings/service.ts:resolveActiveAgentBackend when a conversation fails to
+    // START — wrong-config the user fixes in Settings → Model, not app bugs, so no report button.
+    expect(isReportableRunFailure(NO_ACTIVE_PROVIDER_MESSAGE)).toBe(false)
+    expect(isReportableRunFailure(CODEX_BRIDGE_UNSUPPORTED_MESSAGE)).toBe(false)
+    expect(isReportableRunFailure(CLAUDE_EXECUTABLE_MISSING_MESSAGE)).toBe(false)
+  })
+
+  it('recognizes the framework-specific model-incompat message built by service.ts (prefix)', () => {
+    // Drift guard: the classifier matches ACTIVE_MODEL_INCOMPATIBLE_PREFIX, and service.ts builds its
+    // throw from the SAME builder, so the framework name can vary and both stay in sync. This is the
+    // createSession wording ("…compatible with Codex."), distinct from the reworded resume constant.
+    const codex = buildActiveModelIncompatibleMessage('Codex')
+    const claude = buildActiveModelIncompatibleMessage('Claude Code')
+    expect(codex).not.toBe(RESUME_MODEL_INCOMPATIBLE_MESSAGE)
+    expect(isReportableRunFailure(codex)).toBe(false)
+    expect(isReportableRunFailure(claude)).toBe(false)
   })
 })

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -9,11 +9,14 @@ import {
   RESUME_TIMED_OUT_MESSAGE,
   RESUME_UNSUPPORTED_MESSAGE,
   RESUME_WORKSPACE_MISSING_MESSAGE,
-  isExpectedRunFailure,
   isReportableRunFailure
 } from './run-error-classification'
 
-describe('isReportableRunFailure', () => {
+// This module is only the SECONDARY, text-based tier: it recognizes the app's OWN crafted strings so
+// their report button is hidden even without the structural `providerError` flag. Ordinary provider
+// errors are suppressed by that flag (set at the ACP layer), NOT here — so at this text tier they read
+// as reportable, and this suite asserts exactly that boundary.
+describe('isReportableRunFailure (text tier)', () => {
   it('reports an empty or whitespace-only failure (nothing explains it)', () => {
     expect(isReportableRunFailure(undefined)).toBe(true)
     expect(isReportableRunFailure(null)).toBe(true)
@@ -21,7 +24,7 @@ describe('isReportableRunFailure', () => {
     expect(isReportableRunFailure('   ')).toBe(true)
   })
 
-  it('reports an opaque / internal failure', () => {
+  it('reports an opaque / internal ACP-layer failure', () => {
     expect(isReportableRunFailure('Agent session could not be created.')).toBe(true)
     expect(isReportableRunFailure('Agent session did not return a workspace.')).toBe(true)
     expect(isReportableRunFailure('Permission response failed')).toBe(true)
@@ -30,7 +33,7 @@ describe('isReportableRunFailure', () => {
     expect(isReportableRunFailure('Agent session resume failed: something odd')).toBe(true)
   })
 
-  it('does not report an app-crafted, actionable failure', () => {
+  it('does not report an app-crafted, actionable failure (exact-match set)', () => {
     for (const message of [
       RESUME_WORKSPACE_MISSING_MESSAGE,
       RESUME_TIMED_OUT_MESSAGE,
@@ -43,73 +46,42 @@ describe('isReportableRunFailure', () => {
     }
   })
 
-  it('does not report a recognized provider-side error', () => {
-    // Auth
-    expect(isExpectedRunFailure('HTTP 401 Unauthorized')).toBe(true)
-    expect(isExpectedRunFailure('{"error":{"type":"authentication_error"}}')).toBe(true)
-    expect(isExpectedRunFailure('invalid_api_key: check your key')).toBe(true)
-    expect(isExpectedRunFailure('403 permission_denied')).toBe(true)
-    // The auth phrasing the runtime persists verbatim from a sendPrompt rejection.
-    expect(isExpectedRunFailure('Invalid API key')).toBe(true)
-    // Rate limit
-    expect(isExpectedRunFailure('429 Too Many Requests')).toBe(true)
-    expect(isExpectedRunFailure('rate_limit_error: slow down')).toBe(true)
-    // Quota / billing (structured slugs or a narrow billing reason phrase, not a bare "billing" word)
-    expect(isExpectedRunFailure('insufficient_quota')).toBe(true)
-    expect(isExpectedRunFailure('{"error":{"type":"billing_hard_limit"}}')).toBe(true)
-    expect(isExpectedRunFailure('Your billing plan has no remaining credit')).toBe(true)
-    // Overloaded / unavailable — incl. the describePromptError passthrough the runtime persists verbatim.
-    expect(isExpectedRunFailure('overloaded_error')).toBe(true)
-    expect(isExpectedRunFailure('503 Service Unavailable')).toBe(true)
-    expect(isExpectedRunFailure('Internal error: Overloaded: service is busy')).toBe(true)
-  })
-
-  it('recognizes every 5xx status with an HTTP/status marker (overloaded/unavailable family)', () => {
-    // The spec treats the whole overloaded/unavailable 5xx family as expected, not just 502/503/504.
-    expect(isExpectedRunFailure('HTTP 500 Internal Server Error')).toBe(true)
-    expect(isExpectedRunFailure('500 Internal Server Error')).toBe(true)
-    expect(isExpectedRunFailure('status code: 502')).toBe(true)
-    expect(isExpectedRunFailure('504 Gateway Timeout')).toBe(true)
-    // Real-world marker shapes: a word between marker and code, no separator, JSON, underscored marker.
-    expect(isExpectedRunFailure('HTTP Error 500')).toBe(true)
-    expect(isExpectedRunFailure('HTTPError: 503')).toBe(true)
-    expect(isExpectedRunFailure('{"status":500}')).toBe(true)
-    expect(isExpectedRunFailure('status_code: 504')).toBe(true)
+  it('does NOT recognize provider error TEXT at this tier — the structural flag suppresses those', () => {
+    // These come from the model/provider and are hidden by `providerError`/`errorReportable=false`, set
+    // structurally at the ACP layer. The text tier must NOT try to recognize them (that heuristic was
+    // fragile and swallowed genuine app errors), so here — text only — they read as reportable.
+    for (const providerText of [
+      'HTTP 401 Unauthorized',
+      '{"error":{"type":"authentication_error"}}',
+      'Invalid API key',
+      '429 Too Many Requests',
+      'insufficient_quota',
+      'Internal error: Overloaded: service is busy',
+      '503 Service Unavailable'
+    ]) {
+      expect(isReportableRunFailure(providerText)).toBe(true)
+    }
   })
 
   it('does not swallow an ordinary app error that merely mentions a provider word', () => {
-    // Regression: the classifier keys on structured slugs / HTTP-marked statuses / reason phrases, so
-    // an internal failure that happens to contain "permission denied", "rate limit", or a bare number
-    // stays reportable instead of being hidden as a provider problem.
+    // The text tier only matches the app's own exact strings, so an internal failure that happens to
+    // contain a provider-ish word or number is never mistaken for an expected failure.
     expect(isReportableRunFailure('EACCES: permission denied opening workspace')).toBe(true)
     expect(isReportableRunFailure('Failed to parse rate limit configuration')).toBe(true)
     expect(isReportableRunFailure('Record 503 could not be decoded')).toBe(true)
-    expect(isReportableRunFailure('Retrying after 429ms backoff')).toBe(true)
-    expect(isReportableRunFailure('Quota manager initialization failed')).toBe(true)
-    // A longer identifier that merely starts with a slug is not the slug (\b token boundary).
-    expect(isReportableRunFailure('rate_limiter initialization failed')).toBe(true)
-    expect(isReportableRunFailure('permission_denied_handler crashed')).toBe(true)
-    // A status marker followed by a non-provider code is not swallowed (codes restricted to 401|403|429|5xx).
-    expect(
-      isReportableRunFailure('HTTP parser expected status 200 but received malformed headers')
-    ).toBe(true)
-    expect(isReportableRunFailure('expected status 404 but got none')).toBe(true)
-    // A billing/credit reason phrase is \b-bounded, so a longer word that merely starts with it
-    // ("planner", "accountant", "creditor", "creditworthiness") stays reportable.
     expect(isReportableRunFailure('Billing planner initialization failed')).toBe(true)
-    expect(isReportableRunFailure('Billing accountant crashed')).toBe(true)
-    expect(isReportableRunFailure('No remaining creditor record found')).toBe(true)
-    expect(isReportableRunFailure('Insufficient creditworthiness score parsing failed')).toBe(true)
+    expect(isReportableRunFailure('Scheduler crashed while overloaded with tasks')).toBe(true)
   })
 
   it('recognizes a request-size overflow (its own recovery path) as expected', () => {
-    expect(isExpectedRunFailure('Request too large (max 32MB)')).toBe(true)
-    expect(isExpectedRunFailure('maximum context length exceeded')).toBe(true)
+    expect(isReportableRunFailure('Request too large (max 32MB)')).toBe(false)
+    expect(isReportableRunFailure('maximum context length exceeded')).toBe(false)
   })
 
   it('recognizes the provider resource-not-found message built by describePromptError', () => {
     // Drift guard: feed describePromptError's REAL output through the classifier so the shared prefix
-    // constant and the produced message can never diverge silently.
+    // constant and the produced message can never diverge silently. This one IS text-recognized because
+    // it is the app's OWN reworded string (a model-config problem the user fixes in Settings).
     const error = Object.assign(
       new Error(
         'Internal error: Not Found: {"error":{"message":"model xyz not found","type":"resource_not_found"}}'
@@ -119,10 +91,5 @@ describe('isReportableRunFailure', () => {
     const produced = describePromptError(error, { model: 'xyz' })
     expect(produced.startsWith(PROVIDER_RESOURCE_NOT_FOUND_PREFIX)).toBe(true)
     expect(isReportableRunFailure(produced)).toBe(false)
-  })
-
-  it('does not misclassify an ordinary failure that lacks any recognized signal', () => {
-    expect(isExpectedRunFailure('TypeError: cannot read property foo of undefined')).toBe(false)
-    expect(isExpectedRunFailure('Unexpected token < in JSON at position 0')).toBe(false)
   })
 })

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -52,12 +52,31 @@ describe('isReportableRunFailure', () => {
     // Rate limit
     expect(isExpectedRunFailure('429 Too Many Requests')).toBe(true)
     expect(isExpectedRunFailure('rate_limit_error: slow down')).toBe(true)
-    // Quota / billing
+    // Quota / billing (structured slugs only — a bare "billing" word is not a provider signal)
     expect(isExpectedRunFailure('insufficient_quota')).toBe(true)
-    expect(isExpectedRunFailure('Your billing plan has no remaining credit')).toBe(true)
+    expect(isExpectedRunFailure('{"error":{"type":"billing_hard_limit"}}')).toBe(true)
     // Overloaded / unavailable
     expect(isExpectedRunFailure('overloaded_error')).toBe(true)
     expect(isExpectedRunFailure('503 Service Unavailable')).toBe(true)
+  })
+
+  it('recognizes every 5xx status with an HTTP/status marker (overloaded/unavailable family)', () => {
+    // The spec treats the whole overloaded/unavailable 5xx family as expected, not just 502/503/504.
+    expect(isExpectedRunFailure('HTTP 500 Internal Server Error')).toBe(true)
+    expect(isExpectedRunFailure('500 Internal Server Error')).toBe(true)
+    expect(isExpectedRunFailure('status code: 502')).toBe(true)
+    expect(isExpectedRunFailure('504 Gateway Timeout')).toBe(true)
+  })
+
+  it('does not swallow an ordinary app error that merely mentions a provider word', () => {
+    // Regression: the classifier keys on structured slugs / HTTP-marked statuses / reason phrases, so
+    // an internal failure that happens to contain "permission denied", "rate limit", or a bare number
+    // stays reportable instead of being hidden as a provider problem.
+    expect(isReportableRunFailure('EACCES: permission denied opening workspace')).toBe(true)
+    expect(isReportableRunFailure('Failed to parse rate limit configuration')).toBe(true)
+    expect(isReportableRunFailure('Record 503 could not be decoded')).toBe(true)
+    expect(isReportableRunFailure('Retrying after 429ms backoff')).toBe(true)
+    expect(isReportableRunFailure('Quota manager initialization failed')).toBe(true)
   })
 
   it('recognizes a request-size overflow (its own recovery path) as expected', () => {

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -52,9 +52,10 @@ describe('isReportableRunFailure', () => {
     // Rate limit
     expect(isExpectedRunFailure('429 Too Many Requests')).toBe(true)
     expect(isExpectedRunFailure('rate_limit_error: slow down')).toBe(true)
-    // Quota / billing (structured slugs only — a bare "billing" word is not a provider signal)
+    // Quota / billing (structured slugs or a narrow billing reason phrase, not a bare "billing" word)
     expect(isExpectedRunFailure('insufficient_quota')).toBe(true)
     expect(isExpectedRunFailure('{"error":{"type":"billing_hard_limit"}}')).toBe(true)
+    expect(isExpectedRunFailure('Your billing plan has no remaining credit')).toBe(true)
     // Overloaded / unavailable
     expect(isExpectedRunFailure('overloaded_error')).toBe(true)
     expect(isExpectedRunFailure('503 Service Unavailable')).toBe(true)
@@ -77,6 +78,14 @@ describe('isReportableRunFailure', () => {
     expect(isReportableRunFailure('Record 503 could not be decoded')).toBe(true)
     expect(isReportableRunFailure('Retrying after 429ms backoff')).toBe(true)
     expect(isReportableRunFailure('Quota manager initialization failed')).toBe(true)
+    // A longer identifier that merely starts with a slug is not the slug (\b token boundary).
+    expect(isReportableRunFailure('rate_limiter initialization failed')).toBe(true)
+    expect(isReportableRunFailure('permission_denied_handler crashed')).toBe(true)
+    // A status marker followed by a non-provider code is not swallowed (codes restricted to 401|403|429|5xx).
+    expect(
+      isReportableRunFailure('HTTP parser expected status 200 but received malformed headers')
+    ).toBe(true)
+    expect(isReportableRunFailure('expected status 404 but got none')).toBe(true)
   })
 
   it('recognizes a request-size overflow (its own recovery path) as expected', () => {

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { describePromptError } from '../main/acp/prompt-error'
+import {
+  IMAGE_REPLAY_UNSUPPORTED_MESSAGE,
+  PROVIDER_RESOURCE_NOT_FOUND_PREFIX,
+  RESUME_MODEL_INCOMPATIBLE_MESSAGE,
+  RESUME_RECONNECT_FAILED_MESSAGE,
+  RESUME_TIMED_OUT_MESSAGE,
+  RESUME_UNSUPPORTED_MESSAGE,
+  RESUME_WORKSPACE_MISSING_MESSAGE,
+  isExpectedRunFailure,
+  isReportableRunFailure
+} from './run-error-classification'
+
+describe('isReportableRunFailure', () => {
+  it('reports an empty or whitespace-only failure (nothing explains it)', () => {
+    expect(isReportableRunFailure(undefined)).toBe(true)
+    expect(isReportableRunFailure(null)).toBe(true)
+    expect(isReportableRunFailure('')).toBe(true)
+    expect(isReportableRunFailure('   ')).toBe(true)
+  })
+
+  it('reports an opaque / internal failure', () => {
+    expect(isReportableRunFailure('Agent session could not be created.')).toBe(true)
+    expect(isReportableRunFailure('Agent session did not return a workspace.')).toBe(true)
+    expect(isReportableRunFailure('Permission response failed')).toBe(true)
+    expect(isReportableRunFailure('Run failed: connection reset')).toBe(true)
+    // An unrecognized resume cause keeps the generic fallback and stays reportable.
+    expect(isReportableRunFailure('Agent session resume failed: something odd')).toBe(true)
+  })
+
+  it('does not report an app-crafted, actionable failure', () => {
+    for (const message of [
+      RESUME_WORKSPACE_MISSING_MESSAGE,
+      RESUME_TIMED_OUT_MESSAGE,
+      RESUME_UNSUPPORTED_MESSAGE,
+      RESUME_RECONNECT_FAILED_MESSAGE,
+      RESUME_MODEL_INCOMPATIBLE_MESSAGE,
+      IMAGE_REPLAY_UNSUPPORTED_MESSAGE
+    ]) {
+      expect(isReportableRunFailure(message)).toBe(false)
+    }
+  })
+
+  it('does not report a recognized provider-side error', () => {
+    // Auth
+    expect(isExpectedRunFailure('HTTP 401 Unauthorized')).toBe(true)
+    expect(isExpectedRunFailure('{"error":{"type":"authentication_error"}}')).toBe(true)
+    expect(isExpectedRunFailure('invalid_api_key: check your key')).toBe(true)
+    expect(isExpectedRunFailure('403 permission_denied')).toBe(true)
+    // Rate limit
+    expect(isExpectedRunFailure('429 Too Many Requests')).toBe(true)
+    expect(isExpectedRunFailure('rate_limit_error: slow down')).toBe(true)
+    // Quota / billing
+    expect(isExpectedRunFailure('insufficient_quota')).toBe(true)
+    expect(isExpectedRunFailure('Your billing plan has no remaining credit')).toBe(true)
+    // Overloaded / unavailable
+    expect(isExpectedRunFailure('overloaded_error')).toBe(true)
+    expect(isExpectedRunFailure('503 Service Unavailable')).toBe(true)
+  })
+
+  it('recognizes a request-size overflow (its own recovery path) as expected', () => {
+    expect(isExpectedRunFailure('Request too large (max 32MB)')).toBe(true)
+    expect(isExpectedRunFailure('maximum context length exceeded')).toBe(true)
+  })
+
+  it('recognizes the provider resource-not-found message built by describePromptError', () => {
+    // Drift guard: feed describePromptError's REAL output through the classifier so the shared prefix
+    // constant and the produced message can never diverge silently.
+    const error = Object.assign(
+      new Error(
+        'Internal error: Not Found: {"error":{"message":"model xyz not found","type":"resource_not_found"}}'
+      ),
+      { code: -32603, data: { errorName: 'APIError' }, name: 'RequestError' }
+    )
+    const produced = describePromptError(error, { model: 'xyz' })
+    expect(produced.startsWith(PROVIDER_RESOURCE_NOT_FOUND_PREFIX)).toBe(true)
+    expect(isReportableRunFailure(produced)).toBe(false)
+  })
+
+  it('does not misclassify an ordinary failure that lacks any recognized signal', () => {
+    expect(isExpectedRunFailure('TypeError: cannot read property foo of undefined')).toBe(false)
+    expect(isExpectedRunFailure('Unexpected token < in JSON at position 0')).toBe(false)
+  })
+})

--- a/src/shared/run-error-classification.ts
+++ b/src/shared/run-error-classification.ts
@@ -49,17 +49,39 @@ const EXPECTED_RUN_FAILURE_MESSAGES = new Set<string>([
 
 // Recognizes provider-side API errors that are the user's or provider's to resolve, not app bugs:
 // bad/absent credentials, rate limits, exhausted quota or billing, and provider "overloaded/
-// unavailable" responses. The passed-through provider text carries an ASCII error-type slug
-// (`authentication_error`), an HTTP status label (`401`/`429`/`503`), or a plain-English phrase, so
-// matching stays language-agnostic without pattern-matching localized message bodies. Kept narrow so
-// a genuine app failure that merely mentions one of these words is not silently swallowed:
-//   - auth:      401/403, authentication_error, invalid_api_key, permission_denied, "invalid api key"
-//   - rate:      429, rate_limit(_error/_exceeded), "rate limit"
-//   - quota:     insufficient_quota, "quota", billing_(hard_limit|not_active), "billing"
-//   - overload:  overloaded_error, 502/503/504, "overloaded", "service unavailable"
+// unavailable" responses. Matching stays language-agnostic (no localized message bodies) but is
+// deliberately anchored to signals that DO NOT occur in ordinary app-error prose, so a genuine app
+// failure that merely mentions one of these words ("EACCES: permission denied", "Failed to parse rate
+// limit configuration", "Record 503 could not be decoded") is never swallowed:
+//   - Structured error-type slugs in their exact underscore form (a provider payload field, e.g.
+//     `authentication_error`) — a bare "permission denied"/"rate limit" with spaces is NOT a slug.
+//   - An HTTP status code that carries an explicit `HTTP`/`status` marker (covers every 3-digit code,
+//     so all 5xx qualify), or a status code immediately followed by its canonical reason phrase.
+//   - A few multi-word HTTP reason phrases that are unmistakable on their own.
 // Resource-not-found and request-size overflow are recognized separately (their own dedicated paths).
-const PROVIDER_ERROR_PATTERN =
-  /\b(?:401|403|429|502|503|504)\b|authentication[_\s-]?error|invalid[_\s-]?api[_\s-]?key|permission[_\s-]?denied|rate[_\s-]?limit|insufficient[_\s-]?quota|\bquota\b|billing|overloaded|service[_\s-]?unavailable/i
+const PROVIDER_ERROR_PATTERN = new RegExp(
+  [
+    // Structured provider error-type slugs (underscore form — absent from app-error prose).
+    'authentication_error',
+    'invalid_api_key',
+    'permission_denied',
+    'rate_limit(?:ed|_error|_exceeded)?',
+    'insufficient_quota',
+    'quota_exceeded',
+    'billing_(?:hard_limit|not_active)',
+    'overloaded_error',
+    // A 3-digit status code carrying an explicit HTTP/status marker (any code, so every 5xx matches).
+    '(?:\\bhttp\\b|\\bstatus(?:\\s*code)?\\b)[\\s:]*\\d{3}',
+    // A status code immediately followed by its canonical reason phrase.
+    '\\b(?:401|403|429|500|502|503|504)\\s+(?:unauthorized|forbidden|too\\s+many\\s+requests|internal\\s+server\\s+error|bad\\s+gateway|service\\s+unavailable|gateway\\s+time-?out)\\b',
+    // Unmistakable multi-word HTTP reason phrases on their own.
+    'too\\s+many\\s+requests',
+    'service\\s+unavailable',
+    'bad\\s+gateway',
+    'gateway\\s+time-?out'
+  ].join('|'),
+  'i'
+)
 
 // Whether a run failure is one the app already recognizes — either app-crafted actionable guidance or
 // a well-understood provider error. These keep their message but hide the "Report error" button.

--- a/src/shared/run-error-classification.ts
+++ b/src/shared/run-error-classification.ts
@@ -1,0 +1,82 @@
+import { isMediaOverflowError } from './media-overflow'
+
+// Classifies a failed run's error text into "expected" (the app already recognized the failure and
+// showed actionable guidance, or the provider returned a well-understood error) vs "unknown" (an
+// opaque or internal failure worth a GitHub issue). Only unknown failures get the "Report error"
+// affordance; expected ones keep their message but drop the report button, so the issue tracker is
+// not flooded with wrong-config / provider-side problems the user is meant to fix themselves.
+//
+// Kept as a pure, dependency-light leaf module (like media-overflow.ts) so both the main process
+// (the error producers) and the renderer (the report gate) reference the SAME constants and patterns,
+// and the branch matrix is unit-testable. The persisted `session.error` string is classified at
+// display time, so recognition survives a reload without a schema change.
+
+// App-crafted resume-failure messages (useWorkspaceAgentRuntime.getResumeFailureMessage). Each is the
+// actionable text the app writes when it recognizes a specific resume cause. The generic
+// "Agent session resume failed: …" fallback is deliberately NOT here — an unrecognized resume cause
+// stays reportable.
+export const RESUME_WORKSPACE_MISSING_MESSAGE =
+  'Session workspace is missing; start a new conversation.'
+export const RESUME_TIMED_OUT_MESSAGE = 'Agent session resume timed out; click Resume to try again.'
+export const RESUME_UNSUPPORTED_MESSAGE =
+  'This agent build cannot resume sessions; start a new conversation.'
+export const RESUME_RECONNECT_FAILED_MESSAGE =
+  'Could not reconnect to the agent; check it is installed, then click Resume to retry.'
+export const RESUME_MODEL_INCOMPATIBLE_MESSAGE =
+  "The active model isn't compatible with this agent framework. Open Settings → Model to pick a compatible model or switch frameworks."
+
+// A conversation that needs image replay on a text-only model (useWorkspaceAgentRuntime).
+export const IMAGE_REPLAY_UNSUPPORTED_MESSAGE =
+  'This conversation needs image replay, but the selected model does not support image input.'
+
+// Stable prefix of the provider "resource not found" message produced by main's describePromptError.
+// That message interpolates the model name and the provider's own response, so the classifier matches
+// on this leading, model-independent phrase. prompt-error.ts builds its message from the SAME constant
+// so the two can never drift (a drift-guard test feeds describePromptError's real output through the
+// classifier).
+export const PROVIDER_RESOURCE_NOT_FOUND_PREFIX =
+  'The model provider could not find the requested resource'
+
+// The exact app-crafted messages an equality check recognizes as expected.
+const EXPECTED_RUN_FAILURE_MESSAGES = new Set<string>([
+  RESUME_WORKSPACE_MISSING_MESSAGE,
+  RESUME_TIMED_OUT_MESSAGE,
+  RESUME_UNSUPPORTED_MESSAGE,
+  RESUME_RECONNECT_FAILED_MESSAGE,
+  RESUME_MODEL_INCOMPATIBLE_MESSAGE,
+  IMAGE_REPLAY_UNSUPPORTED_MESSAGE
+])
+
+// Recognizes provider-side API errors that are the user's or provider's to resolve, not app bugs:
+// bad/absent credentials, rate limits, exhausted quota or billing, and provider "overloaded/
+// unavailable" responses. The passed-through provider text carries an ASCII error-type slug
+// (`authentication_error`), an HTTP status label (`401`/`429`/`503`), or a plain-English phrase, so
+// matching stays language-agnostic without pattern-matching localized message bodies. Kept narrow so
+// a genuine app failure that merely mentions one of these words is not silently swallowed:
+//   - auth:      401/403, authentication_error, invalid_api_key, permission_denied, "invalid api key"
+//   - rate:      429, rate_limit(_error/_exceeded), "rate limit"
+//   - quota:     insufficient_quota, "quota", billing_(hard_limit|not_active), "billing"
+//   - overload:  overloaded_error, 502/503/504, "overloaded", "service unavailable"
+// Resource-not-found and request-size overflow are recognized separately (their own dedicated paths).
+const PROVIDER_ERROR_PATTERN =
+  /\b(?:401|403|429|502|503|504)\b|authentication[_\s-]?error|invalid[_\s-]?api[_\s-]?key|permission[_\s-]?denied|rate[_\s-]?limit|insufficient[_\s-]?quota|\bquota\b|billing|overloaded|service[_\s-]?unavailable/i
+
+// Whether a run failure is one the app already recognizes — either app-crafted actionable guidance or
+// a well-understood provider error. These keep their message but hide the "Report error" button.
+export const isExpectedRunFailure = (error: string | null | undefined): boolean => {
+  const message = error?.trim()
+
+  // An empty message is itself an unknown failure (a run failed with nothing to explain it).
+  if (!message) return false
+
+  if (EXPECTED_RUN_FAILURE_MESSAGES.has(message)) return true
+  if (message.startsWith(PROVIDER_RESOURCE_NOT_FOUND_PREFIX)) return true
+  if (isMediaOverflowError(message)) return true
+
+  return PROVIDER_ERROR_PATTERN.test(message)
+}
+
+// Whether a run failure should offer the "Report error → open a GitHub issue" affordance. True only for
+// unknown/opaque failures; recognized (expected) ones return false so they are not reported as bugs.
+export const isReportableRunFailure = (error: string | null | undefined): boolean =>
+  !isExpectedRunFailure(error)

--- a/src/shared/run-error-classification.ts
+++ b/src/shared/run-error-classification.ts
@@ -57,8 +57,10 @@ const EXPECTED_RUN_FAILURE_MESSAGES = new Set<string>([
 //     field, e.g. `authentication_error`) — a bare "permission denied"/"rate limit" with spaces is NOT
 //     a slug, and a longer identifier like `rate_limiter`/`permission_denied_handler` does not match.
 //   - An auth/rate/5xx status code (401|403|429|5xx, not any 3-digit number) carrying an explicit
-//     `HTTP`/`status` marker, or a status code immediately followed by its canonical reason phrase.
-//   - A few multi-word HTTP reason phrases, and narrow billing/quota phrases, unmistakable on their own.
+//     `HTTP`/`status` marker (tolerant of `HTTP Error 500`/`HTTPError: 503`/`status_code: 504`/
+//     `{"status":500}`), or a status code immediately followed by its canonical reason phrase.
+//   - A few multi-word HTTP reason phrases, the auth/overload phrasings the runtime persists verbatim
+//     ("Invalid API key", "Overloaded: …"), and narrow billing/quota phrases — unmistakable on their own.
 // Resource-not-found and request-size overflow are recognized separately (their own dedicated paths).
 const PROVIDER_ERROR_PATTERN = new RegExp(
   [
@@ -76,8 +78,10 @@ const PROVIDER_ERROR_PATTERN = new RegExp(
     '\\boverloaded_error\\b',
     // A provider auth/rate/5xx status code carrying an explicit HTTP/status marker. Restricted to those
     // families (not any 3-digit number) so an incidental "status 200"/"expected status 404" in an app
-    // error is not swallowed. 5\d\d covers every 5xx.
-    '(?:\\bhttp\\b|\\bstatus(?:\\s*code)?\\b)[\\s:]*(?:401|403|429|5\\d\\d)\\b',
+    // error is not swallowed; 5\d\d covers every 5xx. The marker word may carry a suffix and up to two
+    // connective tokens before the code, so real-world shapes match: "HTTP 500", "HTTP Error 500",
+    // "HTTPError: 503", "status code: 502", "status_code: 504", and JSON "{"status":500}".
+    '(?:https?|status)[a-z]*(?:[\\s:"_-]+[a-z]*){0,2}[\\s:"_-]*(?:401|403|429|5\\d\\d)\\b',
     // A status code immediately followed by its canonical reason phrase.
     '\\b(?:401|403|429|500|502|503|504)\\s+(?:unauthorized|forbidden|too\\s+many\\s+requests|internal\\s+server\\s+error|bad\\s+gateway|service\\s+unavailable|gateway\\s+time-?out)\\b',
     // Unmistakable multi-word HTTP reason phrases on their own.
@@ -85,10 +89,16 @@ const PROVIDER_ERROR_PATTERN = new RegExp(
     'service\\s+unavailable',
     'bad\\s+gateway',
     'gateway\\s+time-?out',
-    // Narrow billing/quota reason phrases (a bare "billing" is too broad — it recurs in app prose).
-    'billing\\s+(?:plan|account|period|issue|hard[_\\s-]?limit)',
-    'no\\s+remaining\\s+credit',
-    'insufficient\\s+(?:credit|balance|funds)'
+    // Common provider auth/overload phrasings the runtime persists verbatim (sendPrompt rejection text /
+    // describePromptError passthrough): "Invalid API key", "Overloaded: service is busy".
+    '\\binvalid\\s+api\\s+key\\b',
+    '\\boverloaded\\b',
+    // Narrow billing/quota reason phrases, each fully \b-bounded so a prefix ("Billing planner", "No
+    // remaining creditor", "Insufficient creditworthiness") is NOT mistaken for the phrase. A bare
+    // "billing" is deliberately excluded — it recurs in ordinary app prose.
+    'billing\\s+(?:plan|account|period|issue|hard[_\\s-]?limit)\\b',
+    'no\\s+remaining\\s+credit\\b',
+    'insufficient\\s+(?:credit|balance|funds)\\b'
   ].join('|'),
   'i'
 )

--- a/src/shared/run-error-classification.ts
+++ b/src/shared/run-error-classification.ts
@@ -1,15 +1,18 @@
 import { isMediaOverflowError } from './media-overflow'
 
-// Classifies a failed run's error text into "expected" (the app already recognized the failure and
-// showed actionable guidance, or the provider returned a well-understood error) vs "unknown" (an
-// opaque or internal failure worth a GitHub issue). Only unknown failures get the "Report error"
-// affordance; expected ones keep their message but drop the report button, so the issue tracker is
-// not flooded with wrong-config / provider-side problems the user is meant to fix themselves.
+// Classifies a failed run into "expected" (keep the message, no report button) vs "unknown/reportable"
+// (an opaque or internal failure worth a GitHub issue). The primary signal is STRUCTURAL, not textual:
+// a model/provider failure is tagged `providerError` on the error event at the ACP layer (runtime.ts,
+// via isProviderPromptError) and persisted as `session.errorReportable = false`. Text is NEVER used to
+// guess whether a failure came from the provider — that was fragile and repeatedly swallowed genuine
+// app errors that merely mentioned a provider word.
 //
-// Kept as a pure, dependency-light leaf module (like media-overflow.ts) so both the main process
-// (the error producers) and the renderer (the report gate) reference the SAME constants and patterns,
-// and the branch matrix is unit-testable. The persisted `session.error` string is classified at
-// display time, so recognition survives a reload without a schema change.
+// This module owns only the SECONDARY, text-based tier: recognizing the app's OWN crafted reminder
+// strings (which we author, so an exact-match set is reliable) so their report button is hidden even
+// on the paths that don't carry the structural flag (a persisted pre-flag session, or a renderer-side
+// failRun call). It is a pure, dependency-light leaf module (like media-overflow.ts) usable from both
+// processes. Anything it does not recognize stays reportable — including opaque provider text — so the
+// structural flag, not this text tier, is what suppresses ordinary provider errors.
 
 // App-crafted resume-failure messages (useWorkspaceAgentRuntime.getResumeFailureMessage). Each is the
 // actionable text the app writes when it recognizes a specific resume cause. The generic
@@ -47,64 +50,12 @@ const EXPECTED_RUN_FAILURE_MESSAGES = new Set<string>([
   IMAGE_REPLAY_UNSUPPORTED_MESSAGE
 ])
 
-// Recognizes provider-side API errors that are the user's or provider's to resolve, not app bugs:
-// bad/absent credentials, rate limits, exhausted quota or billing, and provider "overloaded/
-// unavailable" responses. Matching stays language-agnostic (no localized message bodies) but is
-// deliberately anchored to signals that DO NOT occur in ordinary app-error prose, so a genuine app
-// failure that merely mentions one of these words ("EACCES: permission denied", "Failed to parse rate
-// limit configuration", "Record 503 could not be decoded") is never swallowed:
-//   - Structured error-type slugs in their exact underscore form, each \b-bounded (a provider payload
-//     field, e.g. `authentication_error`) — a bare "permission denied"/"rate limit" with spaces is NOT
-//     a slug, and a longer identifier like `rate_limiter`/`permission_denied_handler` does not match.
-//   - An auth/rate/5xx status code (401|403|429|5xx, not any 3-digit number) carrying an explicit
-//     `HTTP`/`status` marker (tolerant of `HTTP Error 500`/`HTTPError: 503`/`status_code: 504`/
-//     `{"status":500}`), or a status code immediately followed by its canonical reason phrase.
-//   - A few multi-word HTTP reason phrases, the auth/overload phrasings the runtime persists verbatim
-//     ("Invalid API key", "Overloaded: …"), and narrow billing/quota phrases — unmistakable on their own.
-// Resource-not-found and request-size overflow are recognized separately (their own dedicated paths).
-const PROVIDER_ERROR_PATTERN = new RegExp(
-  [
-    // Structured provider error-type slugs, each bounded by \b so a longer identifier that merely
-    // starts with one (e.g. `rate_limiter`, `permission_denied_handler`) is NOT matched. The trailing
-    // \b sits at the end of the slug's own word chars — `_` is a word char, so `permission_denied\b`
-    // cannot fire inside `permission_denied_handler`.
-    '\\bauthentication_error\\b',
-    '\\binvalid_api_key\\b',
-    '\\bpermission_denied\\b',
-    '\\brate_limit(?:ed|_error|_exceeded)?\\b',
-    '\\binsufficient_quota\\b',
-    '\\bquota_exceeded\\b',
-    '\\bbilling_(?:hard_limit|not_active)\\b',
-    '\\boverloaded_error\\b',
-    // A provider auth/rate/5xx status code carrying an explicit HTTP/status marker. Restricted to those
-    // families (not any 3-digit number) so an incidental "status 200"/"expected status 404" in an app
-    // error is not swallowed; 5\d\d covers every 5xx. The marker word may carry a suffix and up to two
-    // connective tokens before the code, so real-world shapes match: "HTTP 500", "HTTP Error 500",
-    // "HTTPError: 503", "status code: 502", "status_code: 504", and JSON "{"status":500}".
-    '(?:https?|status)[a-z]*(?:[\\s:"_-]+[a-z]*){0,2}[\\s:"_-]*(?:401|403|429|5\\d\\d)\\b',
-    // A status code immediately followed by its canonical reason phrase.
-    '\\b(?:401|403|429|500|502|503|504)\\s+(?:unauthorized|forbidden|too\\s+many\\s+requests|internal\\s+server\\s+error|bad\\s+gateway|service\\s+unavailable|gateway\\s+time-?out)\\b',
-    // Unmistakable multi-word HTTP reason phrases on their own.
-    'too\\s+many\\s+requests',
-    'service\\s+unavailable',
-    'bad\\s+gateway',
-    'gateway\\s+time-?out',
-    // Common provider auth/overload phrasings the runtime persists verbatim (sendPrompt rejection text /
-    // describePromptError passthrough): "Invalid API key", "Overloaded: service is busy".
-    '\\binvalid\\s+api\\s+key\\b',
-    '\\boverloaded\\b',
-    // Narrow billing/quota reason phrases, each fully \b-bounded so a prefix ("Billing planner", "No
-    // remaining creditor", "Insufficient creditworthiness") is NOT mistaken for the phrase. A bare
-    // "billing" is deliberately excluded — it recurs in ordinary app prose.
-    'billing\\s+(?:plan|account|period|issue|hard[_\\s-]?limit)\\b',
-    'no\\s+remaining\\s+credit\\b',
-    'insufficient\\s+(?:credit|balance|funds)\\b'
-  ].join('|'),
-  'i'
-)
-
-// Whether a run failure is one the app already recognizes — either app-crafted actionable guidance or
-// a well-understood provider error. These keep their message but hide the "Report error" button.
+// Whether a run failure is one the app itself already surfaced with a purpose — an app-crafted
+// actionable reminder, the reworded provider not-found, or a request-size overflow the app auto-
+// recovers — so the report button is hidden even without the structural `providerError` flag (an old
+// persisted session, or a renderer-side failRun). Recognition is by EXACT crafted string / known
+// prefix only; it deliberately does NOT try to recognize arbitrary provider error text (that is the
+// structural flag's job), so an unknown/opaque failure it doesn't author stays reportable.
 export const isExpectedRunFailure = (error: string | null | undefined): boolean => {
   const message = error?.trim()
 
@@ -112,10 +63,10 @@ export const isExpectedRunFailure = (error: string | null | undefined): boolean 
   if (!message) return false
 
   if (EXPECTED_RUN_FAILURE_MESSAGES.has(message)) return true
+  // The reworded provider not-found (a model-config problem the user fixes in Settings, not a bug).
   if (message.startsWith(PROVIDER_RESOURCE_NOT_FOUND_PREFIX)) return true
-  if (isMediaOverflowError(message)) return true
-
-  return PROVIDER_ERROR_PATTERN.test(message)
+  // A request-size overflow the app auto-recovers from — never a reportable bug.
+  return isMediaOverflowError(message)
 }
 
 // Whether a run failure should offer the "Report error → open a GitHub issue" affordance. True only for

--- a/src/shared/run-error-classification.ts
+++ b/src/shared/run-error-classification.ts
@@ -32,6 +32,24 @@ export const RESUME_MODEL_INCOMPATIBLE_MESSAGE =
 export const IMAGE_REPLAY_UNSUPPORTED_MESSAGE =
   'This conversation needs image replay, but the selected model does not support image input.'
 
+// App-authored agent-setup guidance thrown by settings/service.ts:resolveActiveAgentBackend at spawn
+// time — surfaced when a conversation FAILS TO START (createSession), which does not route through the
+// resume-path softener. All three are wrong-config the user fixes in Settings → Model, not app bugs, so
+// they must hide the report button. service.ts builds its throws from these SAME constants/builder so
+// the text can never drift from what the classifier recognizes.
+export const NO_ACTIVE_PROVIDER_MESSAGE =
+  'No active model provider is configured. Configure one in settings.'
+export const CLAUDE_EXECUTABLE_MISSING_MESSAGE =
+  'Claude executable is not configured. Complete onboarding in settings.'
+export const CODEX_BRIDGE_UNSUPPORTED_MESSAGE =
+  'The active model is not supported over the Codex Chat Completions bridge. Pick another model in Settings → Model.'
+// The model↔framework mismatch message interpolates the framework name, so the classifier matches on
+// this leading, framework-independent phrase. It also covers the resume-path RESUME_MODEL_INCOMPATIBLE
+// wording (both begin here), so either surfacing is recognized.
+export const ACTIVE_MODEL_INCOMPATIBLE_PREFIX = "The active model isn't compatible with"
+export const buildActiveModelIncompatibleMessage = (frameworkDisplayName: string): string =>
+  `${ACTIVE_MODEL_INCOMPATIBLE_PREFIX} ${frameworkDisplayName}. Open Settings → Model to pick a compatible model or switch the agent framework.`
+
 // Stable prefix of the provider "resource not found" message produced by main's describePromptError.
 // That message interpolates the model name and the provider's own response, so the classifier matches
 // on this leading, model-independent phrase. prompt-error.ts builds its message from the SAME constant
@@ -47,7 +65,10 @@ const EXPECTED_RUN_FAILURE_MESSAGES = new Set<string>([
   RESUME_UNSUPPORTED_MESSAGE,
   RESUME_RECONNECT_FAILED_MESSAGE,
   RESUME_MODEL_INCOMPATIBLE_MESSAGE,
-  IMAGE_REPLAY_UNSUPPORTED_MESSAGE
+  IMAGE_REPLAY_UNSUPPORTED_MESSAGE,
+  NO_ACTIVE_PROVIDER_MESSAGE,
+  CLAUDE_EXECUTABLE_MISSING_MESSAGE,
+  CODEX_BRIDGE_UNSUPPORTED_MESSAGE
 ])
 
 // Whether a run failure is one the app itself already surfaced with a purpose — an app-crafted
@@ -65,6 +86,11 @@ export const isExpectedRunFailure = (error: string | null | undefined): boolean 
   if (EXPECTED_RUN_FAILURE_MESSAGES.has(message)) return true
   // The reworded provider not-found (a model-config problem the user fixes in Settings, not a bug).
   if (message.startsWith(PROVIDER_RESOURCE_NOT_FOUND_PREFIX)) return true
+  // Model↔framework incompatibility raised at spawn/createSession. The main-side message names the
+  // framework (`…compatible with Codex.`) while the resume path rewords it to a generic form; both
+  // share this leading phrase, so one prefix covers the createSession path (which is not reworded) and
+  // any framework name. It is app-authored setup guidance ("Open Settings → Model"), not a bug.
+  if (message.startsWith(ACTIVE_MODEL_INCOMPATIBLE_PREFIX)) return true
   // A request-size overflow the app auto-recovers from — never a reportable bug.
   return isMediaOverflowError(message)
 }

--- a/src/shared/run-error-classification.ts
+++ b/src/shared/run-error-classification.ts
@@ -53,32 +53,42 @@ const EXPECTED_RUN_FAILURE_MESSAGES = new Set<string>([
 // deliberately anchored to signals that DO NOT occur in ordinary app-error prose, so a genuine app
 // failure that merely mentions one of these words ("EACCES: permission denied", "Failed to parse rate
 // limit configuration", "Record 503 could not be decoded") is never swallowed:
-//   - Structured error-type slugs in their exact underscore form (a provider payload field, e.g.
-//     `authentication_error`) — a bare "permission denied"/"rate limit" with spaces is NOT a slug.
-//   - An HTTP status code that carries an explicit `HTTP`/`status` marker (covers every 3-digit code,
-//     so all 5xx qualify), or a status code immediately followed by its canonical reason phrase.
-//   - A few multi-word HTTP reason phrases that are unmistakable on their own.
+//   - Structured error-type slugs in their exact underscore form, each \b-bounded (a provider payload
+//     field, e.g. `authentication_error`) — a bare "permission denied"/"rate limit" with spaces is NOT
+//     a slug, and a longer identifier like `rate_limiter`/`permission_denied_handler` does not match.
+//   - An auth/rate/5xx status code (401|403|429|5xx, not any 3-digit number) carrying an explicit
+//     `HTTP`/`status` marker, or a status code immediately followed by its canonical reason phrase.
+//   - A few multi-word HTTP reason phrases, and narrow billing/quota phrases, unmistakable on their own.
 // Resource-not-found and request-size overflow are recognized separately (their own dedicated paths).
 const PROVIDER_ERROR_PATTERN = new RegExp(
   [
-    // Structured provider error-type slugs (underscore form — absent from app-error prose).
-    'authentication_error',
-    'invalid_api_key',
-    'permission_denied',
-    'rate_limit(?:ed|_error|_exceeded)?',
-    'insufficient_quota',
-    'quota_exceeded',
-    'billing_(?:hard_limit|not_active)',
-    'overloaded_error',
-    // A 3-digit status code carrying an explicit HTTP/status marker (any code, so every 5xx matches).
-    '(?:\\bhttp\\b|\\bstatus(?:\\s*code)?\\b)[\\s:]*\\d{3}',
+    // Structured provider error-type slugs, each bounded by \b so a longer identifier that merely
+    // starts with one (e.g. `rate_limiter`, `permission_denied_handler`) is NOT matched. The trailing
+    // \b sits at the end of the slug's own word chars — `_` is a word char, so `permission_denied\b`
+    // cannot fire inside `permission_denied_handler`.
+    '\\bauthentication_error\\b',
+    '\\binvalid_api_key\\b',
+    '\\bpermission_denied\\b',
+    '\\brate_limit(?:ed|_error|_exceeded)?\\b',
+    '\\binsufficient_quota\\b',
+    '\\bquota_exceeded\\b',
+    '\\bbilling_(?:hard_limit|not_active)\\b',
+    '\\boverloaded_error\\b',
+    // A provider auth/rate/5xx status code carrying an explicit HTTP/status marker. Restricted to those
+    // families (not any 3-digit number) so an incidental "status 200"/"expected status 404" in an app
+    // error is not swallowed. 5\d\d covers every 5xx.
+    '(?:\\bhttp\\b|\\bstatus(?:\\s*code)?\\b)[\\s:]*(?:401|403|429|5\\d\\d)\\b',
     // A status code immediately followed by its canonical reason phrase.
     '\\b(?:401|403|429|500|502|503|504)\\s+(?:unauthorized|forbidden|too\\s+many\\s+requests|internal\\s+server\\s+error|bad\\s+gateway|service\\s+unavailable|gateway\\s+time-?out)\\b',
     // Unmistakable multi-word HTTP reason phrases on their own.
     'too\\s+many\\s+requests',
     'service\\s+unavailable',
     'bad\\s+gateway',
-    'gateway\\s+time-?out'
+    'gateway\\s+time-?out',
+    // Narrow billing/quota reason phrases (a bare "billing" is too broad — it recurs in app prose).
+    'billing\\s+(?:plan|account|period|issue|hard[_\\s-]?limit)',
+    'no\\s+remaining\\s+credit',
+    'insufficient\\s+(?:credit|balance|funds)'
   ].join('|'),
   'i'
 )

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -334,4 +334,35 @@ describe('normalizeSessionFile with activities', () => {
     expect(mixedValid?.enabledComputeHosts).toEqual(['ssh:valid'])
     expect(allInvalid?.enabledComputeHosts).toBeUndefined()
   })
+
+  it('persists errorReportable only when a model-provider error marked it false', () => {
+    const base = { ...createSessionWithActivity(undefined), activities: undefined, status: 'error' }
+
+    // A provider error tagged non-reportable at the ACP layer round-trips as false so the reloaded
+    // session keeps the report button hidden.
+    const providerFailure = normalizeSessionFile({
+      ...base,
+      error: 'Invalid API key',
+      errorReportable: false
+    })
+    // A reportable failure does not persist the field (default is reportable — no need to store true).
+    const reportableFailure = normalizeSessionFile({
+      ...base,
+      error: 'Agent session could not be created.',
+      errorReportable: true
+    })
+    // An older session file, written before the flag existed, has no field and defaults to reportable.
+    const legacy = normalizeSessionFile({ ...base, error: 'Some old failure' })
+    // The flag is meaningless without an error and is dropped.
+    const noError = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined,
+      errorReportable: false
+    })
+
+    expect(providerFailure?.errorReportable).toBe(false)
+    expect(reportableFailure?.errorReportable).toBeUndefined()
+    expect(legacy?.errorReportable).toBeUndefined()
+    expect(noError?.errorReportable).toBeUndefined()
+  })
 })

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -143,6 +143,11 @@ export type PersistedChatSession = {
   activities?: PersistedToolActivity[]
   activeRun?: PersistedActiveRun
   error?: string
+  // Whether a failed run's error is worth a GitHub issue. False for a recognized failure (a provider/
+  // model error the agent relayed, or one of the app's own actionable reminders); true/absent for an
+  // unknown ACP-layer failure. Resolved once when the run fails and persisted so the "Report error"
+  // gate survives a reload. Absent on older files — treated as reportable (the prior behavior).
+  errorReportable?: boolean
   artifacts?: PersistedArtifact[]
   // Incremented only when finalized file metadata changes; text streaming leaves it untouched.
   filesRevision?: number
@@ -684,6 +689,8 @@ const sanitizeSession = (session: unknown): PersistedChatSession | undefined => 
 
   if (activeRun) sanitized.activeRun = activeRun
   if (error) sanitized.error = error
+  // Only meaningful alongside an error; persisted only when explicitly false (absent = reportable).
+  if (error && session.errorReportable === false) sanitized.errorReportable = false
   if (agentFrameworkId && AGENT_FRAMEWORK_IDS.has(agentFrameworkId)) {
     sanitized.agentFrameworkId = agentFrameworkId
   }


### PR DESCRIPTION
## Problem

When a run fails, the inline error box always shows a "Report error" button that opens a pre-filled GitHub issue (added in #286). But not every run failure is a bug. Many are relayed model/provider errors — a wrong API key, a rate limit, an exhausted quota, a provider 5xx, a wrong model id — that the user or provider resolves, not the app. Others are failures the app already recognized and gave actionable guidance for (a missing workspace, an incompatible model, a resume timeout). Offering "Report error" on these floods the issue tracker with wrong-config and provider-side problems and drowns the genuinely unknown app failures a maintainer should see.

## Proposed change

Decide reportability by **where the failure originated**, not by pattern-matching the error text (which proved fragile and repeatedly swallowed genuine app errors that merely mentioned a provider word):

- **Model/provider failures** — the agent relays an upstream LLM/HTTP error. Tagged **structurally** at the ACP layer: the error event carries `providerError`, set from `isProviderPromptError` (the agent's own `APIError` tag / `errorKind: 'provider-error'` / a provider resource-not-found). → **not reportable**.
- **ACP-layer failures** — our own runtime threw (handshake, connection, protocol, operational). → **reportable**, unless the message is one of *our own crafted reminder strings* (workspace-missing, resume-timeout/unsupported/reconnect, incompatible-model, image-replay, the reworded provider not-found), which we recognize by **exact match** because we author those literals.
- A failure with **no message** stays reportable — nothing explains it.

The resolved reportability is persisted on the session (`errorReportable`) so it survives a reload; the rejection path reads the same structural flag from the run's error event (correlated to the current turn), so the event path and the promise-rejection path always agree.

## Scope and non-goals

- Adds one optional persisted field (`errorReportable`) and one optional event field (`providerError`). This supersedes the earlier draft's "no schema change" note: classifying purely on persisted text can't distinguish a relayed provider error from an app bug, which is exactly the distinction requested. Sessions persisted before the field default to reportable (fail-safe — never wrongly hides the button).
- No change to which failures reach the error box, to the box styling, or to the report dialog itself — only whether the button is offered.
- The text tier no longer tries to recognize arbitrary provider error text; that is the structural flag's job. It only recognizes the app's own crafted strings.

## Acceptance criteria and validation

- Model/provider failure (event tagged `providerError`, or headless run's error event tagged) → message shown, **no** Report button, and it stays hidden after reload.
- ACP-layer failure (incl. empty message) → message shown **and** the Report button.
- App-crafted reminder → message shown, **no** Report button (exact-match tier, works even on a pre-flag persisted session).
- `errorReportable` is cleared wherever `error` is cleared/replaced, so a later internal error never inherits a stale non-reportable flag.

Validation — tests across every layer of the new chain:
- `prompt-error.test.ts` — `isProviderPromptError` (APIError / `provider-error` errorKind / resource-not-found true; ACP protocol not-found and app throws false).
- `runtime.test.ts` — the error event is tagged `providerError` for a relayed provider rejection and untagged otherwise.
- `session-store.test.ts` — `failRun` resolves + persists `errorReportable` from `opts.reportable` and from text; clear-sites reset it.
- `session-persistence.test.ts` — `errorReportable: false` round-trips; older sessions omit it.
- `useWorkspaceAgentRuntime.test.ts` — the rejection path reads the run's error event and records provider vs ACP failures correctly.
- `ConversationPanel.interaction.test.tsx` + `run-error-classification.test.ts` updated to the structural design.
- `npm run typecheck` (node + web), `npm run lint` (0 errors), `npm run test` across the affected files (354 tests) all green.

## Review focus

- The origin split: is `isProviderPromptError` the right structural signal, and is defaulting pre-flag sessions to reportable the right fail-safe?
- The event-path vs rejection-path convergence in `failOrMarkDisconnected` (reading the current turn's error event rather than guessing from text).

Relates to #286.
