### PR TITLE
build(packaging): prefix artifact names with aipoch-

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -78,7 +78,7 @@ extraResources:
 # afterPack ad-hoc-sign hook is a no-op off macOS (it returns early), so it is safe on this target.
 win:
   executableName: open-science
-  artifactName: ${name}-${version}-win-${arch}.${ext}
+  artifactName: aipoch-${name}-${version}-win-${arch}.${ext}
   # nsis = the installer; zip = a portable, no-install build. Offer both, mirroring mac (dmg + zip).
   target:
     - nsis
@@ -91,7 +91,7 @@ win:
     - from: build/windows-runtime-cache-uninstall.ps1
       to: windows-runtime-cache-uninstall.ps1
 nsis:
-  artifactName: ${name}-${version}-win-${arch}-setup.${ext}
+  artifactName: aipoch-${name}-${version}-win-${arch}-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
@@ -99,7 +99,7 @@ nsis:
   allowToChangeInstallationDirectory: true
   include: build/installer.nsh
 mac:
-  artifactName: ${name}-${version}-mac-${arch}.${ext}
+  artifactName: aipoch-${name}-${version}-mac-${arch}.${ext}
   # Minimum macOS to run the app (written to Info.plist LSMinimumSystemVersion). macOS 12 (Monterey)
   # and up; below this the OS refuses to launch. Independent of the CI build runner's macOS version.
   minimumSystemVersion: '12.0.0'
@@ -119,7 +119,7 @@ mac:
     - from: resources/bin/mac/${arch}/micromamba
       to: micromamba
 dmg:
-  artifactName: ${name}-${version}-mac-${arch}.${ext}
+  artifactName: aipoch-${name}-${version}-mac-${arch}.${ext}
 linux:
   # snap is intentionally omitted: building it on a stock GitHub runner needs snapcraft + LXD and
   # is flaky in CI. AppImage (portable, runs anywhere) + deb (Debian/Ubuntu) cover the common cases.
@@ -134,7 +134,9 @@ linux:
     - from: resources/bin/linux/${arch}/micromamba
       to: micromamba
 appImage:
-  artifactName: ${name}-${version}-linux-${arch}.${ext}
+  artifactName: aipoch-${name}-${version}-linux-${arch}.${ext}
+deb:
+  artifactName: aipoch-${name}_${version}_${arch}.${ext}
 npmRebuild: false
 # electron-updater feed. Win/Linux/macOS auto-update reads app-update.yml (generated from this block)
 # and fetches its feed from <url>. Win/Linux use the default `latest` channel (latest.yml /


### PR DESCRIPTION
## Problem

Released installer filenames (e.g. `open-science-0.6.0-mac-arm64.dmg`) lack a brand prefix, making them indistinguishable from generic assets in download directories and CDN listings.

## Proposed change

Prefix all installer artifact names with `aipoch-` by updating the `artifactName` templates in `electron-builder.yml`:

| Platform | Before | After |
|----------|--------|-------|
| macOS dmg/zip | `open-science-0.6.0-mac-arm64.dmg` | `aipoch-open-science-0.6.0-mac-arm64.dmg` |
| Windows setup/zip | `open-science-0.6.0-win-x64-setup.exe` | `aipoch-open-science-0.6.0-win-x64-setup.exe` |
| Linux AppImage | `open-science-0.6.0-linux-x86_64.AppImage` | `aipoch-open-science-0.6.0-linux-x86_64.AppImage` |
| Linux deb | `open-science_0.6.0_amd64.deb` | `aipoch-open-science_0.6.0_amd64.deb` |

The deb package preserves dpkg naming convention (underscores + `amd64` arch) — only the prefix is added.

## Scope and non-goals

**In scope:** downloadable installer file names only.

**Not in scope** (all unchanged):
- `productName` (display name "Open Science")
- `executableName`, `appId`, App bundle name
- npm package name, CLI command (`open-science`)
- `package.json` `"name"` field

## Acceptance criteria and validation

- [x] `npm run test` passes (11 tests in `electron-builder-config.test.ts` + `generate-version-manifest.test.ts`)
- [x] Auto-update feed consistency verified: `latest-mac.yml` is regenerated post-notarize by scanning actual build output (`endsWith("-mac-${arch}.zip")`), not by hardcoded prefix — feed and artifacts stay in sync automatically
- [x] CI workflows use glob patterns (`*-mac-*.dmg`, `*.exe`, etc.), not hardcoded filenames
- [x] `generate-version-manifest.mjs` matches by suffix regex, not prefix
- [x] Local build scripts (`local/_lib.sh`) synced in the main working tree (gitignored, not part of this PR)

## Review focus

Confirm the deb `artifactName` format (`aipoch-${name}_${version}_${arch}.${ext}`) is acceptable — it keeps the dpkg convention but may look slightly inconsistent with the hyphenated names on other platforms.