### PR TITLE
fix(packaging): hardcode amd64 arch in deb artifactName

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -136,7 +136,7 @@ linux:
 appImage:
   artifactName: aipoch-${name}-${version}-linux-${arch}.${ext}
 deb:
-  artifactName: aipoch-${name}_${version}_${arch}.${ext}
+  artifactName: aipoch-${name}_${version}_amd64.${ext}
 npmRebuild: false
 # electron-updater feed. Win/Linux/macOS auto-update reads app-update.yml (generated from this block)
 # and fetches its feed from <url>. Win/Linux use the default `latest` channel (latest.yml /

--- a/scripts/generate-version-manifest.test.ts
+++ b/scripts/generate-version-manifest.test.ts
@@ -10,13 +10,14 @@ const VERSION = '0.1.2'
 const CDN = 'https://cdn.example.com'
 const PREFIX = 'open-science'
 
-// The full set of installer filenames a complete release produces (matches release.yml output).
+// The full set of installer filenames a complete release produces (matches electron-builder.yml
+// artifactName templates with the aipoch- prefix).
 const INSTALLERS = {
-  'mac-arm64': `open-science-${VERSION}-mac-arm64.dmg`,
-  'mac-x64': `open-science-${VERSION}-mac-x64.dmg`,
-  'win-x64': `open-science-${VERSION}-win-x64-setup.exe`,
-  'linux-x64-appimage': `open-science-${VERSION}-linux-x64.AppImage`,
-  'linux-x64-deb': `open-science_${VERSION}_amd64.deb`
+  'mac-arm64': `aipoch-open-science-${VERSION}-mac-arm64.dmg`,
+  'mac-x64': `aipoch-open-science-${VERSION}-mac-x64.dmg`,
+  'win-x64': `aipoch-open-science-${VERSION}-win-x64-setup.exe`,
+  'linux-x64-appimage': `aipoch-open-science-${VERSION}-linux-x64.AppImage`,
+  'linux-x64-deb': `aipoch-open-science_${VERSION}_amd64.deb`
 }
 
 // One line of SHA256SUMS.txt worth of file: content is hashed by `sha` (or omitted when sha is null).
@@ -154,7 +155,7 @@ describe('buildManifest', () => {
     )
     // deb keeps the underscore/amd64 convention in its url.
     expect(manifest.downloads['linux-x64-deb'].url).toBe(
-      `${CDN}/${PREFIX}/releases/${VERSION}/open-science_${VERSION}_amd64.deb`
+      `${CDN}/${PREFIX}/releases/${VERSION}/aipoch-open-science_${VERSION}_amd64.deb`
     )
 
     // sha256 comes from SHA256SUMS.txt (entry #2 -> content length 12, sha of '2').
@@ -203,7 +204,7 @@ describe('buildManifest', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     dir = makeReleaseDir([
       entry('mac-arm64', 1),
-      { name: 'open-science-0.1.2-mac-arm64.zip', content: 'zip', sha: HEX('9') },
+      { name: 'aipoch-open-science-0.1.2-mac-arm64.zip', content: 'zip', sha: HEX('9') },
       { name: 'mystery-artifact.bin', content: 'bin', sha: HEX('8') }
     ])
 


### PR DESCRIPTION
## Problem

PR #367 added an `aipoch-` prefix to all artifact names, but the deb `artifactName` used `${arch}`, which electron-builder expands to `x64` — not dpkg convention `amd64`. The manifest generator (`generate-version-manifest.mjs`) matches `_amd64.deb`, so the deb would silently drop out of `version.json` and Linux users would get no deb download link.

The test fixtures in `generate-version-manifest.test.ts` were also still using the old un-prefixed filenames.

## Proposed change

- `electron-builder.yml`: hardcode `amd64` in deb `artifactName` → `aipoch-${name}_${version}_amd64.${ext}`
- `generate-version-manifest.test.ts`: update all fixture filenames to use `aipoch-` prefix

## Scope and non-goals

Follow-up fix to #367. No new behavior beyond what that PR intended.

## Acceptance criteria and validation

- [x] 11 tests pass (`electron-builder-config.test.ts` + `generate-version-manifest.test.ts`)
- [x] deb produces `aipoch-open-science_0.6.0_amd64.deb` (matches `_amd64.deb` manifest regex)
- [x] All test fixture filenames aligned with prefixed artifact names