### PR TITLE
fix(packaging): use ${arch} instead of hardcoded amd64 in deb template

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -136,7 +136,7 @@ linux:
 appImage:
   artifactName: aipoch-${name}-${version}-linux-${arch}.${ext}
 deb:
-  artifactName: aipoch-${name}_${version}_amd64.${ext}
+  artifactName: aipoch-${name}_${version}_${arch}.${ext}
 npmRebuild: false
 # electron-updater feed. Win/Linux/macOS auto-update reads app-update.yml (generated from this block)
 # and fetches its feed from <url>. Win/Linux use the default `latest` channel (latest.yml /


### PR DESCRIPTION
## Problem

The previous fix (#368) hardcoded `amd64` in the deb `artifactName` to work around `${arch}` expanding to `x64`. But this was based on an incorrect assumption — electron-builder already handles the mapping correctly.

## Proposed change

Revert to `${arch}` in the deb template: `aipoch-${name}_${version}_${arch}.${ext}`

electron-builder's `getArtifactArchName()` (`builder-util/out/arch.js:58-67`) automatically maps `x64` → `amd64` when `ext === "deb"`. So `${arch}` expands to `amd64` for the current x64 build, and would correctly produce `arm64` for a future arm64 build — which the hardcoded version would not.

## Scope and non-goals

One-line change. Test fixtures stay as-is (`amd64` matches what `${arch}` expands to).

## Acceptance criteria and validation

- [x] 11 tests pass (`electron-builder-config.test.ts` + `generate-version-manifest.test.ts`)
- [x] Source: `builder-util/out/arch.js:65` confirms `ext === "deb"` → `archName = "amd64"`