### PR TITLE
fix(acp): nudge skills by slug id so the agent can resolve them

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -97,7 +97,7 @@ const createRuntime = ({
       needForceLoad: (ids) => settingsService.skillsNeedingForceLoad(ids),
       setTurnForced: (ids) => settingsService.setTurnForcedSkillIds(ids),
       clearTurnForced: () => settingsService.clearTurnForcedSkillIds(),
-      namesForIds: (ids) => settingsService.skillNamesForIds(ids)
+      namesForIds: (ids) => settingsService.skillNudgeNamesForIds(ids)
     },
     artifacts: {
       // Reuse the session persistence root so chat state and generated files move together.

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -17,6 +17,7 @@ import { AcpRuntime } from './runtime'
 import type { ReasoningEffort } from '../../shared/settings'
 import { terminateProcessTree } from '../process-tree'
 import { AgentMcpHttpHost } from './mcp-http-host'
+import { SkillRegistry } from '../skills/registry'
 import { claudeCodeFramework, codexFramework, opencodeFramework } from '../agent-framework'
 import { ArtifactRepository } from '../artifacts/repository'
 import { writeArtifactFileForCurrentRun } from '../artifacts/mcp-server'
@@ -5279,7 +5280,7 @@ describe('ACP runtime skill force-load + nudge', () => {
   // A stub of the settings-service skill hooks with per-call spies for assertions.
   const createSkillsHooks = (options: {
     needForceLoad: string[]
-    names: Record<string, string>
+    nudgeNames?: Record<string, string>
   }): {
     needForceLoad: ReturnType<typeof vi.fn<(ids: string[]) => Promise<string[]>>>
     setTurnForced: ReturnType<typeof vi.fn<(ids: string[]) => void>>
@@ -5290,16 +5291,13 @@ describe('ACP runtime skill force-load + nudge', () => {
     setTurnForced: vi.fn<(ids: string[]) => void>(),
     clearTurnForced: vi.fn<() => void>(),
     namesForIds: vi.fn<(ids: string[]) => Promise<string[]>>(async (ids: string[]) =>
-      ids.map((id) => options.names[id]).filter((name): name is string => name !== undefined)
+      ids.map((id) => options.nudgeNames?.[id] ?? id)
     )
   })
 
   it('respawns and nudges when a picked skill is disabled, then restores after the turn', async () => {
     const spawner = createFreshAgentSpawner()
-    const hooks = createSkillsHooks({
-      needForceLoad: ['research'],
-      names: { research: 'Deep Research' }
-    })
+    const hooks = createSkillsHooks({ needForceLoad: ['research'] })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
@@ -5321,11 +5319,12 @@ describe('ACP runtime skill force-load + nudge', () => {
     expect(spawner.spawnCount()).toBe(2)
     expect(spawner.agents[1].resumedSessions).toHaveLength(1)
 
-    // The nudge is prepended to the text the agent receives (on the respawned agent).
+    // The nudge names the skill by its slug id (the identifier the agent's Skill tool resolves),
+    // NOT its human display name — a display name like "Deep Research" is unknown to the tool.
     expect(spawner.agents[1].prompts).toEqual([
       {
         sessionId: 'remote-session-1',
-        text: 'Use the following skill(s) for this task: Deep Research.\n\nsummarize the paper'
+        text: 'Use the following skill(s) for this task: research.\n\nsummarize the paper'
       }
     ])
 
@@ -5337,10 +5336,7 @@ describe('ACP runtime skill force-load + nudge', () => {
 
   it('nudges without any reconnect when every picked skill is already enabled', async () => {
     const spawner = createFreshAgentSpawner()
-    const hooks = createSkillsHooks({
-      needForceLoad: [],
-      names: { research: 'Deep Research' }
-    })
+    const hooks = createSkillsHooks({ needForceLoad: [] })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
@@ -5362,17 +5358,43 @@ describe('ACP runtime skill force-load + nudge', () => {
     expect(spawner.agents[0].prompts).toEqual([
       {
         sessionId: 'remote-session-1',
-        text: 'Use the following skill(s) for this task: Deep Research.\n\nsummarize the paper'
+        text: 'Use the following skill(s) for this task: research.\n\nsummarize the paper'
       }
     ])
   })
 
-  it('leaves the prompt untouched when no skills are picked', async () => {
+  it('nudges a personal skill by its agent-resolvable frontmatter name', async () => {
     const spawner = createFreshAgentSpawner()
     const hooks = createSkillsHooks({
-      needForceLoad: ['research'],
-      names: { research: 'Deep Research' }
+      needForceLoad: [],
+      nudgeNames: { 'personal-my-skill': 'My Skill' }
     })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: spawner.spawn,
+      skills: hooks
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: 'remote-session-1',
+      text: 'summarize the paper',
+      forcedSkillIds: ['personal-my-skill']
+    })
+
+    expect(spawner.agents[0].prompts).toEqual([
+      {
+        sessionId: 'remote-session-1',
+        text: 'Use the following skill(s) for this task: My Skill.\n\nsummarize the paper'
+      }
+    ])
+    expect(hooks.namesForIds).toHaveBeenCalledWith(['personal-my-skill'])
+  })
+
+  it('leaves the prompt untouched when no skills are picked', async () => {
+    const spawner = createFreshAgentSpawner()
+    const hooks = createSkillsHooks({ needForceLoad: ['research'] })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
@@ -5385,12 +5407,48 @@ describe('ACP runtime skill force-load + nudge', () => {
 
     // With no forcedSkillIds, none of the skill hooks run and the text is unchanged.
     expect(hooks.needForceLoad).not.toHaveBeenCalled()
-    expect(hooks.namesForIds).not.toHaveBeenCalled()
     expect(hooks.setTurnForced).not.toHaveBeenCalled()
     expect(spawner.spawnCount()).toBe(1)
     expect(spawner.agents[0].prompts).toEqual([
       { sessionId: 'remote-session-1', text: 'plain prompt' }
     ])
+  })
+
+  // End-to-end guard over the whole bundled set: for EVERY real bundled skill, the nudge the agent
+  // receives must name it by the exact id the agent's Skill tool resolves (its frontmatter name), and
+  // must NOT leak the human display name. This is the regression that "any / skill errors" reduces to.
+  it('nudges every bundled skill by its resolvable id, never its display name', async () => {
+    const bundled = await new SkillRegistry(
+      join(__dirname, '..', '..', '..', 'resources', 'skills')
+    ).list()
+    expect(bundled.length).toBeGreaterThan(0)
+
+    for (const skill of bundled) {
+      const spawner = createFreshAgentSpawner()
+      const hooks = createSkillsHooks({ needForceLoad: [] })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: spawner.spawn,
+        skills: hooks
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+      await runtime.sendPrompt({
+        sessionId: 'remote-session-1',
+        text: 'do the task',
+        forcedSkillIds: [skill.id]
+      })
+
+      const prompt = spawner.agents[0].prompts[0]?.text ?? ''
+      expect(prompt, `nudge for "${skill.id}"`).toBe(
+        `Use the following skill(s) for this task: ${skill.id}.\n\ndo the task`
+      )
+      // A display name that differs from the id (16 of 18 bundled skills) must never reach the agent.
+      if (skill.name !== skill.id) {
+        expect(prompt, `display name for "${skill.id}"`).not.toContain(skill.name)
+      }
+    }
   })
 })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -159,7 +159,7 @@ type AcpRuntimeSkillsOptions = {
   setTurnForced: (ids: string[]) => void
   // Clears the turn-scoped force-load set so later spawns use the normal enabled set.
   clearTurnForced: () => void
-  // Resolves picked ids to display names for the steering nudge.
+  // Resolves picker ids to the names accepted by the agent's Skill tool.
   namesForIds: (ids: string[]) => Promise<string[]>
 }
 
@@ -2166,6 +2166,10 @@ class AcpRuntime {
 
   // Prepends a one-line steering nudge naming the picked skills to the prompt text. No-op when no skills
   // were picked or no hooks are wired. It is prompt text, not a system directive, per the design.
+  //
+  // Featured skill ids equal their frontmatter names, while personal/imported ids include an app-owned
+  // source prefix. Resolve the picker ids through settings so every nudge uses the name the agent's
+  // Skill tool accepts.
   private async applySkillNudge(text: string, forcedSkillIds: string[]): Promise<string> {
     if (!this.skillsHooks || forcedSkillIds.length === 0) return text
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { CODEX_SUBSCRIPTION_PROVIDER_ID, type ClaudeDetectResult } from '../../shared/settings'
 import type { CodexAuthControllerPort } from './codex-auth'
 import type { ClaudeIsolatedAuthControllerPort } from './claude-isolated-auth'
+import type { UserSkillRepository } from '../skills/user-skill-repository'
 
 // Reversible fake safeStorage so provider keys can be encrypted/decrypted without an OS keychain.
 vi.mock('electron', () => ({
@@ -2100,7 +2101,7 @@ describe('SettingsService: skills', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('reports only disabled picks as needing force-load and maps ids to names', async () => {
+  it('reports disabled picks and resolves agent-readable skill nudge names', async () => {
     const service = await createSkillService()
 
     await service.createSkill({ name: 'My Skill', description: 'Mine.', body: '# Mine' })
@@ -2110,10 +2111,35 @@ describe('SettingsService: skills', () => {
     expect(await service.skillsNeedingForceLoad(['demo', 'personal-my-skill'])).toEqual(['demo'])
     expect(await service.skillsNeedingForceLoad(['personal-my-skill'])).toEqual([])
 
-    // Names resolve in the given id order, skipping unknown ids.
-    expect(await service.skillNamesForIds(['personal-my-skill', 'demo', 'nope'])).toEqual([
-      'My Skill',
-      'Demo'
+    // Featured ids are the agent-facing frontmatter names, but user-skill ids carry an app prefix.
+    expect(await service.skillNudgeNamesForIds(['demo', 'personal-my-skill', 'nope'])).toEqual([
+      'demo',
+      'My Skill'
+    ])
+  })
+
+  it('uses the frontmatter name when nudging an imported skill', async () => {
+    const service = new SettingsService({
+      repository,
+      storageRoot,
+      skillRegistry: new SkillRegistry(await seedBundle()),
+      userSkills: {
+        list: () =>
+          Promise.resolve([
+            {
+              id: 'imported-data-explorer',
+              name: 'Data Explorer',
+              description: 'Explore imported data.',
+              source: 'imported' as const,
+              updatedAt: '2026-07-23T00:00:00.000Z',
+              sourceDir: join(storageRoot, 'skills', 'imported', 'data-explorer')
+            }
+          ])
+      } as unknown as UserSkillRepository
+    })
+
+    expect(await service.skillNudgeNamesForIds(['imported-data-explorer'])).toEqual([
+      'Data Explorer'
     ])
   })
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -775,10 +775,14 @@ class SettingsService {
     return forcedIds.filter((id) => disabled.has(id))
   }
 
-  // Maps skill ids to their display names in the given order, skipping unknown ids. Used for the nudge.
-  async skillNamesForIds(ids: string[]): Promise<string[]> {
+  // Resolves picker ids to the names the agent's Skill tool accepts. Bundled skills use their
+  // manifest id as frontmatter name, while personal/imported ids have an app-owned source prefix and
+  // must use the frontmatter name kept in the user skill catalog.
+  async skillNudgeNamesForIds(ids: string[]): Promise<string[]> {
     const skills = await this.skillCatalog()
-    const nameById = new Map(skills.map((skill) => [skill.id, skill.name]))
+    const nameById = new Map(
+      skills.map((skill) => [skill.id, skill.source === 'featured' ? skill.id : skill.name])
+    )
 
     return ids.map((id) => nameById.get(id)).filter((name): name is string => name !== undefined)
   }

--- a/src/main/skills/skill-nudge-identity.test.ts
+++ b/src/main/skills/skill-nudge-identity.test.ts
@@ -1,0 +1,29 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { parseFrontmatter } from './frontmatter'
+import { SkillRegistry } from './registry'
+
+// The real bundled-skills root shipped with the app.
+const skillsRoot = join(__dirname, '..', '..', '..', 'resources', 'skills')
+
+// The `/` skill picker stores each pick's manifest id, and the runtime nudge names skills to the agent
+// by that id (see AcpRuntime.applySkillNudge). The agent's Skill tool resolves a skill by the slug in
+// its SKILL.md frontmatter `name`. So for every bundled skill the nudge id MUST equal the frontmatter
+// name, or the agent fails the pick with "Unknown skill: <id>". This guards that contract for the whole
+// bundled set — a new skill whose manifest id drifts from its frontmatter name breaks the picker.
+describe('bundled skill nudge identity', () => {
+  it('has manifest id === SKILL.md frontmatter name for every bundled skill', async () => {
+    const skills = await new SkillRegistry(skillsRoot).list()
+    expect(skills.length).toBeGreaterThan(0)
+
+    for (const skill of skills) {
+      const raw = await readFile(join(skill.sourceDir, 'SKILL.md'), 'utf8')
+      const frontmatterName = parseFrontmatter(raw).fields.name
+
+      expect(frontmatterName, `skill "${skill.id}" frontmatter name`).toBe(skill.id)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

When a user picks skills from the `/` picker, the picker stores each pick's
**manifest id** and the runtime prepends a one-line "steering nudge" to the
prompt naming those skills to the agent. The nudge resolved the ids to **human
display names** (e.g. `Remote Compute (SSH)`) before naming them.

The agent's `Skill` tool resolves a skill by the slug in its `SKILL.md`
frontmatter `name`. For bundled skills that slug equals the manifest id. So
nudging by display name made the agent try `Skill("Remote Compute (SSH)")`,
which fails with `Unknown skill: <name>` — every pick from the picker was
broken.

## Proposed change

Name skills in the nudge by the name the agent's `Skill` tool actually accepts:

- **Bundled (`featured`) skills** — use the manifest `id` (which equals the
  frontmatter `name`).
- **Personal/imported skills** — their ids carry an app-owned source prefix, so
  use the frontmatter `name` kept in the user skill catalog.

Concretely, rename `SettingsService.skillNamesForIds` →
`skillNudgeNamesForIds` and resolve `featured` ids to their id rather than
their display name. The runtime hook stays `namesForIds` but now returns
agent-resolvable names.

## Scope and non-goals

- **Scope:** the steering nudge for picker-selected skills
  (`AcpRuntime.applySkillNudge`) and its id→name resolution in
  `SettingsService`.
- **Non-goals:** no change to which skills are force-loaded, to the picker UI,
  or to how skills are labelled elsewhere in the UI. Force-load behavior is
  untouched.

## Acceptance criteria and validation

- Every bundled skill's manifest `id` equals its `SKILL.md` frontmatter `name`
  (new invariant test `skill-nudge-identity.test.ts` guards the whole bundled
  set).
- The runtime nudge names skills by the resolvable id/name, never the display
  name (updated `runtime.test.ts`).
- `service.test.ts` covers `featured` (id) vs personal/imported (name)
  resolution.
- Required checks: `npm run typecheck`, `npm run lint`, `npm run test`.

## Review focus

The one behavior change is the `featured ? skill.id : skill.name` resolution in
`skillNudgeNamesForIds` (`service.ts`) plus the new bundled-set invariant. The
rest is the rename and test updates.
