### PR TITLE
fix(acp): isolate sessions across framework switches

### DIFF
--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -45,7 +45,23 @@ const { createSession, resetSessionContext, resumeSession, sendPrompt, AcpRuntim
     const resumeSession = vi.fn().mockResolvedValue({ sessionId: 's-1', cwd: '/workspace' })
     const sendPrompt = vi.fn().mockResolvedValue(undefined)
     const AcpRuntimeMock = vi.fn().mockImplementation(function () {
-      return { createSession, resetSessionContext, resumeSession, sendPrompt, getSnapshot: vi.fn() }
+      return {
+        createSession,
+        resetSessionContext,
+        resumeSession,
+        sendPrompt,
+        getSnapshot: vi.fn().mockReturnValue({
+          status: 'idle',
+          cwd: '/workspace',
+          sessionIds: [],
+          events: [],
+          pendingPermissions: [],
+          permissionProfiles: {},
+          permissionGrants: {},
+          promptInFlight: false,
+          promptInFlightSessionIds: []
+        })
+      }
     })
     return { createSession, resetSessionContext, resumeSession, sendPrompt, AcpRuntimeMock }
   })
@@ -91,7 +107,10 @@ const registerWithFakes = (overrides?: {
     runRegistry: {} as never,
     uploadRepository: {} as never,
     notebookRpcServer: {} as never,
-    settingsService: {} as never,
+    settingsService: {
+      captureActiveAgentBackendSelection: vi.fn().mockResolvedValue({}),
+      resolveAgentBackend: vi.fn().mockResolvedValue({})
+    } as never,
     taskNotifications: taskNotifications as never
   })
 }

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -106,14 +106,13 @@ const createRuntime = ({
         appVersion: app.getVersion(),
         // Packaged macOS apps often start with cwd at "/" or the app bundle; use home instead.
         defaultCwd,
-        resolveBackend: async () => settingsService.resolveAgentBackend(await selection),
+        resolveBackend: async (context) =>
+          settingsService.resolveAgentBackend(await selection, context),
         // HTTP MCP registrations are runtime-owned. Sharing one host would let an old runtime teardown
         // clear routes belonging to sessions on the newly selected framework.
         mcpHttpHost: new AgentMcpHttpHost(),
         skills: {
           needForceLoad: (ids) => settingsService.skillsNeedingForceLoad(ids),
-          setTurnForced: (ids) => settingsService.setTurnForcedSkillIds(ids),
-          clearTurnForced: () => settingsService.clearTurnForcedSkillIds(),
           namesForIds: (ids) => settingsService.skillNudgeNamesForIds(ids)
         },
         artifacts: {

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -20,7 +20,8 @@ import type {
   AcpStateSnapshot
 } from '../../shared/acp'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
-import { AcpRuntime } from './runtime'
+import { AcpRuntime, type AcpRuntimeCallbacks } from './runtime'
+import { AcpRuntimeCoordinator } from './runtime-coordinator'
 import { installAgentShutdownGuard } from './shutdown-guard'
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { ArtifactRepository } from '../artifacts/repository'
@@ -68,7 +69,8 @@ const createManagedSessionWorkspace = async (): Promise<string> => {
   return workspace
 }
 
-// Creates the shared runtime instance used by all ACP IPC handlers and artifact claims.
+// Creates the runtime coordinator used by all ACP IPC handlers and artifact claims. Each child runtime
+// captures one framework generation so sessions on different frameworks can remain live concurrently.
 const createRuntime = ({
   mcpEntryPath,
   repository,
@@ -77,67 +79,70 @@ const createRuntime = ({
   notebookRpcServer,
   settingsService,
   taskNotifications
-}: AcpIpcOptions): AcpRuntime => {
+}: AcpIpcOptions): AcpRuntimeCoordinator => {
   const configRoot = resolveConfigRoot()
   const dataRoot = resolveDataRoot()
-
-  return new AcpRuntime({
-    appVersion: app.getVersion(),
-    // Packaged macOS apps often start with cwd at "/" or the app bundle; use home instead.
-    defaultCwd: homedir(),
-    // Resolve the active framework + provider credentials/model on every connect so framework and
-    // provider switches apply on reconnect.
-    resolveBackend: () => settingsService.resolveActiveAgentBackend(),
-    // Serves the artifact/notebook MCP over local http for frameworks that reject stdio MCP (opencode);
-    // Claude ignores it and keeps launching them over stdio.
-    mcpHttpHost: new AgentMcpHttpHost(),
-    // Turn-scoped skill force-load: the runtime uses these to respawn with a picked-but-disabled skill
-    // for one prompt and to build the steering nudge naming the picked skills.
-    skills: {
-      needForceLoad: (ids) => settingsService.skillsNeedingForceLoad(ids),
-      setTurnForced: (ids) => settingsService.setTurnForcedSkillIds(ids),
-      clearTurnForced: () => settingsService.clearTurnForcedSkillIds(),
-      namesForIds: (ids) => settingsService.skillNudgeNamesForIds(ids)
+  const defaultCwd = homedir()
+  const callbacks: AcpRuntimeCallbacks = {
+    onStateChanged: (state: AcpStateSnapshot) => broadcast('acp:state', state),
+    onEvent: (event: AcpRuntimeEvent) => {
+      broadcast('acp:event', event)
+      // Fire-and-forget: a notification hiccup must never stall the renderer event stream.
+      void taskNotifications?.handleRuntimeEvent(event)
     },
-    artifacts: {
-      // Reuse the session persistence root so chat state and generated files move together.
-      configRoot,
-      dataRoot,
-      projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
-      mcpEntryPath,
-      repository,
-      runRegistry
-    },
-    uploads: {
-      // Reuse the renderer upload repository so prompt content only references managed files.
-      repository: uploadRepository
-    },
-    notebook: {
-      projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
-      mcpEntryPath,
-      getRpcConnection: () => notebookRpcServer.ensureStarted(),
-      registerSessionAlias: (aliasSessionId, sessionId) =>
-        notebookRpcServer.registerSessionAlias(aliasSessionId, sessionId)
-    },
-    callbacks: {
-      onStateChanged: (state: AcpStateSnapshot) => broadcast('acp:state', state),
-      onEvent: (event: AcpRuntimeEvent) => {
-        broadcast('acp:event', event)
-        // Fire-and-forget: a notification hiccup must never stall the renderer event stream.
-        void taskNotifications?.handleRuntimeEvent(event)
-      },
-      onPermissionRequest: (request: AcpPermissionRequest) => {
-        broadcast('acp:permission-request', request)
-        // A pending approval parks the turn; an unfocused user gets a desktop nudge.
-        void taskNotifications?.handlePermissionRequest(request)
-      }
+    onPermissionRequest: (request: AcpPermissionRequest) => {
+      broadcast('acp:permission-request', request)
+      // A pending approval parks the turn; an unfocused user gets a desktop nudge.
+      void taskNotifications?.handlePermissionRequest(request)
     }
-  })
+  }
+
+  return new AcpRuntimeCoordinator(
+    (runtimeCallbacks) => {
+      // Capture only the non-secret selection per generation. Credentials are resolved fresh at spawn
+      // and released by AcpRuntime after authentication instead of living in this coordinator closure.
+      const selection = settingsService.captureActiveAgentBackendSelection()
+      return new AcpRuntime({
+        appVersion: app.getVersion(),
+        // Packaged macOS apps often start with cwd at "/" or the app bundle; use home instead.
+        defaultCwd,
+        resolveBackend: async () => settingsService.resolveAgentBackend(await selection),
+        // HTTP MCP registrations are runtime-owned. Sharing one host would let an old runtime teardown
+        // clear routes belonging to sessions on the newly selected framework.
+        mcpHttpHost: new AgentMcpHttpHost(),
+        skills: {
+          needForceLoad: (ids) => settingsService.skillsNeedingForceLoad(ids),
+          setTurnForced: (ids) => settingsService.setTurnForcedSkillIds(ids),
+          clearTurnForced: () => settingsService.clearTurnForcedSkillIds(),
+          namesForIds: (ids) => settingsService.skillNudgeNamesForIds(ids)
+        },
+        artifacts: {
+          configRoot,
+          dataRoot,
+          projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
+          mcpEntryPath,
+          repository,
+          runRegistry
+        },
+        uploads: { repository: uploadRepository },
+        notebook: {
+          projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
+          mcpEntryPath,
+          getRpcConnection: () => notebookRpcServer.ensureStarted(),
+          registerSessionAlias: (aliasSessionId, sessionId) =>
+            notebookRpcServer.registerSessionAlias(aliasSessionId, sessionId)
+        },
+        callbacks: runtimeCallbacks
+      })
+    },
+    callbacks,
+    defaultCwd
+  )
 }
 
-// Registers renderer-callable runtime commands on Electron IPC and returns the shared runtime so the
-// settings layer can drop the connection when the active provider changes.
-const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntime => {
+// Registers renderer-callable runtime commands on Electron IPC and returns the coordinator used by
+// settings, storage, reviewer, and shutdown integrations.
+const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator => {
   const runtime = createRuntime(options)
 
   ipcMain.handle('acp:get-state', () => runtime.getSnapshot())

--- a/src/main/acp/mcp-http-host.ts
+++ b/src/main/acp/mcp-http-host.ts
@@ -103,9 +103,11 @@ class AgentMcpHttpHost {
 
     if (!server) return
 
-    await new Promise<void>((resolve, reject) => {
+    const closing = new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()))
     })
+    server.closeAllConnections()
+    await closing
   }
 
   // Registers (or replaces) the artifact environment for one routing id; re-registration on resume

--- a/src/main/acp/runtime-activity.ts
+++ b/src/main/acp/runtime-activity.ts
@@ -1,0 +1,22 @@
+import type { AcpResumeSessionRequest } from '../../shared/acp'
+import type { AcpRuntime } from './runtime'
+
+// A background workflow uses one concrete runtime generation for its whole lifetime. Session metadata
+// is optional and consumed lazily only if that workflow later needs to prompt the main conversation.
+export type AcpRuntimeActivityOptions = {
+  session?: AcpResumeSessionRequest & {
+    historyPreamble?: string
+  }
+}
+
+export type AcpRuntimeActivity = Pick<
+  AcpRuntime,
+  'buildReviewerSession' | 'disposeReviewerSession' | 'sendPrompt'
+>
+
+export type AcpRuntimeActivityOwner = {
+  withActivity: <T>(
+    options: AcpRuntimeActivityOptions,
+    work: (runtime: AcpRuntimeActivity) => Promise<T>
+  ) => Promise<T>
+}

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpPermissionRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
+import { AcpRuntimeCoordinator } from './runtime-coordinator'
+import type { AcpRuntime, AcpRuntimeCallbacks } from './runtime'
+
+const createDeferred = <Value = void>(): {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+} => {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
+const emptySnapshot = (): AcpStateSnapshot => ({
+  status: 'connected',
+  cwd: '/workspace',
+  sessionIds: [],
+  events: [],
+  pendingPermissions: [],
+  permissionProfiles: {},
+  permissionGrants: {},
+  promptInFlight: false,
+  promptInFlightSessionIds: []
+})
+
+const createFakeRuntime = (options: {
+  frameworkId: 'claude-code' | 'codex'
+  sessionIds: string[]
+  callbacks: AcpRuntimeCallbacks
+  prompt?: (sessionId: string) => Promise<unknown>
+}): {
+  runtime: AcpRuntime
+  disconnect: ReturnType<typeof vi.fn>
+  requestRetirement: ReturnType<typeof vi.fn>
+  requestProviderReconnect: ReturnType<typeof vi.fn>
+  respondToPermission: ReturnType<typeof vi.fn>
+  emitEvent: (event: AcpRuntimeEvent) => void
+  emitPermission: (request: AcpPermissionRequest) => void
+  emitState: (overrides: Partial<AcpStateSnapshot>) => void
+} => {
+  let snapshot = emptySnapshot()
+  let sessionIndex = 0
+  const disconnect = vi.fn(async () => snapshot)
+  const requestRetirement = vi.fn(async () => undefined)
+  const requestProviderReconnect = vi.fn(async () => undefined)
+  const respondToPermission = vi.fn(() => snapshot)
+  const sendPrompt = vi.fn(async ({ sessionId }: { sessionId: string }) => {
+    snapshot = {
+      ...snapshot,
+      promptInFlight: true,
+      promptInFlightSessionIds: [...snapshot.promptInFlightSessionIds, sessionId]
+    }
+    options.callbacks.onStateChanged?.(snapshot)
+
+    try {
+      return await (options.prompt
+        ? options.prompt(sessionId)
+        : Promise.resolve({ stopReason: 'end_turn' }))
+    } finally {
+      snapshot = {
+        ...snapshot,
+        promptInFlight: false,
+        promptInFlightSessionIds: snapshot.promptInFlightSessionIds.filter(
+          (candidate) => candidate !== sessionId
+        )
+      }
+      options.callbacks.onStateChanged?.(snapshot)
+    }
+  })
+  const runtime = {
+    getSnapshot: () => snapshot,
+    getActivePromptSessions: () => [],
+    getActiveArtifactRunIds: () => [],
+    createSession: vi.fn(async () => {
+      const sessionId = options.sessionIds[sessionIndex]
+      sessionIndex += 1
+      snapshot = { ...snapshot, sessionId, sessionIds: [...snapshot.sessionIds, sessionId] }
+      options.callbacks.onStateChanged?.(snapshot)
+      return { sessionId, cwd: '/workspace', frameworkId: options.frameworkId }
+    }),
+    resumeSession: vi.fn(async ({ sessionId }: { sessionId: string }) => {
+      snapshot = {
+        ...snapshot,
+        sessionId,
+        sessionIds: snapshot.sessionIds.includes(sessionId)
+          ? snapshot.sessionIds
+          : [...snapshot.sessionIds, sessionId]
+      }
+      options.callbacks.onStateChanged?.(snapshot)
+      return { sessionId, cwd: '/workspace', frameworkId: options.frameworkId, contextReset: true }
+    }),
+    sendPrompt,
+    withActivity: vi.fn(
+      async (_activityOptions: unknown, work: (scopedRuntime: AcpRuntime) => Promise<unknown>) =>
+        work(runtime)
+    ),
+    buildReviewerSession: vi.fn(async () => ({
+      session: { sessionId: `reviewer-${options.frameworkId}` }
+    })),
+    disposeReviewerSession: vi.fn(() => 0),
+    disconnect,
+    requestRetirement,
+    requestProviderReconnect,
+    respondToPermission
+  } as unknown as AcpRuntime
+
+  return {
+    runtime,
+    disconnect,
+    requestRetirement,
+    requestProviderReconnect,
+    respondToPermission,
+    emitEvent: (event) => {
+      snapshot = { ...snapshot, events: [...snapshot.events, event] }
+      options.callbacks.onEvent?.(event)
+      options.callbacks.onStateChanged?.(snapshot)
+    },
+    emitPermission: (request) => {
+      snapshot = { ...snapshot, pendingPermissions: [...snapshot.pendingPermissions, request] }
+      options.callbacks.onPermissionRequest?.(request)
+      options.callbacks.onStateChanged?.(snapshot)
+    },
+    emitState: (overrides) => {
+      snapshot = { ...snapshot, ...overrides }
+      options.callbacks.onStateChanged?.(snapshot)
+    }
+  }
+}
+
+describe('AcpRuntimeCoordinator', () => {
+  it('runs new sessions immediately and moves the old session after its active turn', async () => {
+    const oldPrompt = createDeferred<{ stopReason: string }>()
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime(
+        created.length === 0
+          ? {
+              frameworkId: 'claude-code',
+              sessionIds: ['old-session'],
+              callbacks,
+              prompt: () => oldPrompt.promise
+            }
+          : { frameworkId: 'codex', sessionIds: ['new-session-1', 'new-session-2'], callbacks }
+      )
+      created.push(fake)
+      return fake.runtime
+    })
+
+    const oldSession = await coordinator.createSession({ cwd: '/workspace' })
+    const oldTurn = coordinator.sendPrompt({ sessionId: oldSession.sessionId, text: 'use a tool' })
+
+    await coordinator.requestAgentFrameworkSwitch()
+    const newSessions = await Promise.all([
+      coordinator.createSession({ cwd: '/workspace' }),
+      coordinator.createSession({ cwd: '/workspace' })
+    ])
+    await expect(
+      coordinator.sendPrompt({ sessionId: newSessions[0].sessionId, text: 'new conversation' })
+    ).resolves.toMatchObject({ stopReason: 'end_turn' })
+
+    expect(newSessions.map((session) => session.frameworkId)).toEqual(['codex', 'codex'])
+    expect(created).toHaveLength(2)
+    expect(created[0].requestRetirement).toHaveBeenCalledOnce()
+    expect(created[0].requestProviderReconnect).not.toHaveBeenCalled()
+    expect(created[0].disconnect).not.toHaveBeenCalled()
+    expect(coordinator.getSnapshot().sessionIds).toEqual([
+      'old-session',
+      'new-session-1',
+      'new-session-2'
+    ])
+
+    oldPrompt.resolve({ stopReason: 'end_turn' })
+    await expect(oldTurn).resolves.toMatchObject({ stopReason: 'end_turn' })
+
+    expect(coordinator.getSnapshot().sessionIds).toEqual(['new-session-1', 'new-session-2'])
+
+    await coordinator.resumeSession({
+      sessionId: oldSession.sessionId,
+      cwd: '/workspace',
+      previousFrameworkId: 'claude-code'
+    })
+    await expect(
+      coordinator.sendPrompt({ sessionId: oldSession.sessionId, text: 'continue on Codex' })
+    ).resolves.toMatchObject({ stopReason: 'end_turn' })
+
+    expect(vi.mocked(created[0].runtime.sendPrompt)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(created[1].runtime.resumeSession)).toHaveBeenCalledWith({
+      sessionId: 'old-session',
+      cwd: '/workspace',
+      previousFrameworkId: 'claude-code'
+    })
+    expect(vi.mocked(created[1].runtime.sendPrompt)).toHaveBeenCalledWith({
+      sessionId: 'old-session',
+      text: 'continue on Codex'
+    })
+  })
+
+  it('namespaces events and routes permission responses to their owning runtime', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const forwardedEvents: AcpRuntimeEvent[] = []
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+          sessionIds: [`session-${created.length + 1}`],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      { onEvent: (event) => forwardedEvents.push(event) }
+    )
+
+    await coordinator.createSession()
+    await coordinator.requestAgentFrameworkSwitch()
+    expect(coordinator.getSnapshot().sessionIds).toEqual([])
+    await coordinator.createSession()
+
+    const event = (sessionId: string): AcpRuntimeEvent => ({
+      id: 'acp-event-1',
+      timestamp: 1,
+      kind: 'system',
+      level: 'info',
+      sessionId,
+      title: 'event'
+    })
+    created[0].emitEvent(event('session-1'))
+    created[1].emitEvent(event('session-2'))
+
+    expect(forwardedEvents.map((item) => item.id)).toEqual([
+      'runtime-1:acp-event-1',
+      'runtime-2:acp-event-1'
+    ])
+    expect(coordinator.getSnapshot().events.map((item) => item.id)).toEqual([
+      'runtime-1:acp-event-1',
+      'runtime-2:acp-event-1'
+    ])
+
+    const permission: AcpPermissionRequest = {
+      requestId: 'permission-1',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Run tool',
+      options: [],
+      raw: {}
+    }
+    created[0].emitPermission(permission)
+    expect(coordinator.getSnapshot().sessionIds).toContain('session-1')
+    coordinator.respondToPermission({ requestId: permission.requestId, cancelled: true })
+
+    expect(created[0].respondToPermission).toHaveBeenCalledWith({
+      requestId: 'permission-1',
+      cancelled: true
+    })
+    expect(created[1].respondToPermission).not.toHaveBeenCalled()
+  })
+
+  it('pins each activity workflow to the runtime generation active when it starts', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: [`session-${created.length + 1}`],
+        callbacks
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+    const oldActivityStarted = createDeferred()
+    const releaseOldActivity = createDeferred()
+
+    const oldActivity = coordinator.withActivity({}, async (runtime) => {
+      oldActivityStarted.resolve()
+      await releaseOldActivity.promise
+      await runtime.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
+    })
+    await oldActivityStarted.promise
+
+    await coordinator.requestAgentFrameworkSwitch()
+    await coordinator.withActivity({}, (runtime) =>
+      runtime.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
+    )
+    releaseOldActivity.resolve()
+    await oldActivity
+
+    expect(vi.mocked(created[0].runtime.buildReviewerSession)).toHaveBeenCalledOnce()
+    expect(vi.mocked(created[1].runtime.buildReviewerSession)).toHaveBeenCalledOnce()
+  })
+
+  it('lazily adopts the main session on the pinned runtime only when an activity sends a prompt', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: created.length === 0 ? ['old-session'] : ['unused-session'],
+        callbacks
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+    await coordinator.createSession({ cwd: '/workspace' })
+    await coordinator.requestAgentFrameworkSwitch()
+
+    await coordinator.withActivity(
+      {
+        session: {
+          sessionId: 'old-session',
+          cwd: '/workspace',
+          projectName: 'project-1',
+          previousFrameworkId: 'claude-code',
+          historyPreamble: 'prior transcript'
+        }
+      },
+      async (runtime) => {
+        await runtime.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
+        expect(vi.mocked(created[1].runtime.resumeSession)).not.toHaveBeenCalled()
+        await runtime.sendPrompt({ sessionId: 'old-session', text: '[Auditor] fix this' })
+      }
+    )
+
+    expect(vi.mocked(created[1].runtime.resumeSession)).toHaveBeenCalledWith({
+      sessionId: 'old-session',
+      cwd: '/workspace',
+      projectName: 'project-1',
+      previousFrameworkId: 'claude-code'
+    })
+    expect(vi.mocked(created[1].runtime.sendPrompt)).toHaveBeenCalledWith({
+      sessionId: 'old-session',
+      text: '[Auditor] fix this',
+      historyPreamble: 'prior transcript'
+    })
+    expect(vi.mocked(created[0].runtime.sendPrompt)).not.toHaveBeenCalled()
+  })
+
+  it('removes a runtime from aggregation after its retirement completes', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: [`session-${created.length + 1}`],
+        callbacks
+      })
+      fake.requestRetirement.mockImplementation(async () => {
+        callbacks.onRetired?.()
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+
+    await coordinator.createSession()
+    created[0].emitEvent({
+      id: 'old-event',
+      timestamp: 1,
+      kind: 'system',
+      level: 'info',
+      sessionId: 'session-1',
+      title: 'old generation'
+    })
+    await coordinator.requestAgentFrameworkSwitch()
+
+    expect(coordinator.getSnapshot().events).toEqual([])
+    expect(coordinator.getSnapshot().sessionIds).toEqual([])
+  })
+
+  it('projects connection status from each session owning runtime', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: [`session-${created.length + 1}`],
+        callbacks
+      })
+      fake.requestRetirement.mockImplementation(async () => callbacks.onRetired?.())
+      created.push(fake)
+      return fake.runtime
+    })
+
+    await coordinator.createSession()
+    created[0].emitState({ status: 'error', error: 'old runtime failed' })
+    await coordinator.requestAgentFrameworkSwitch()
+    await coordinator.createSession()
+
+    expect(coordinator.getSnapshot()).toMatchObject({
+      status: 'connected',
+      sessionConnectionStatuses: {
+        'session-1': 'error',
+        'session-2': 'connected'
+      }
+    })
+  })
+})

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -140,7 +140,7 @@ const createFakeRuntime = (options: {
 }
 
 describe('AcpRuntimeCoordinator', () => {
-  it('applies live settings changes only to the active runtime generation', async () => {
+  it('keeps reconnecting settings on the active generation and fans out live effort', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const coordinator = new AcpRuntimeCoordinator((callbacks) => {
       const fake = createFakeRuntime({
@@ -154,6 +154,7 @@ describe('AcpRuntimeCoordinator', () => {
 
     await coordinator.createSession()
     await coordinator.requestAgentFrameworkSwitch()
+    created[0].applyReasoningEffortChange.mockResolvedValue(false)
     await coordinator.requestProviderReconnect()
     await coordinator.requestSkillsReload()
     await expect(coordinator.applyReasoningEffortChange('high')).resolves.toBe(true)
@@ -161,7 +162,7 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created).toHaveLength(2)
     expect(created[0].requestProviderReconnect).not.toHaveBeenCalled()
     expect(created[0].requestSkillsReload).not.toHaveBeenCalled()
-    expect(created[0].applyReasoningEffortChange).not.toHaveBeenCalled()
+    expect(created[0].applyReasoningEffortChange).toHaveBeenCalledWith('high')
     expect(created[1].requestProviderReconnect).toHaveBeenCalledOnce()
     expect(created[1].requestSkillsReload).toHaveBeenCalledOnce()
     expect(created[1].applyReasoningEffortChange).toHaveBeenCalledWith('high')

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -52,6 +52,8 @@ const createFakeRuntime = (options: {
   const requestSkillsReload = vi.fn(async () => undefined)
   const applyReasoningEffortChange = vi.fn(async () => true)
   const respondToPermission = vi.fn(() => snapshot)
+  const shutdownForQuit = vi.fn(async () => ({ reaped: true }))
+  const shutdownForUpdateGate = vi.fn(async () => ({ reaped: true }))
   const sendPrompt = vi.fn(async ({ sessionId }: { sessionId: string }) => {
     snapshot = {
       ...snapshot,
@@ -105,13 +107,18 @@ const createFakeRuntime = (options: {
     buildReviewerSession: vi.fn(async () => ({
       session: { sessionId: `reviewer-${options.frameworkId}` }
     })),
-    disposeReviewerSession: vi.fn(() => 0),
+    disposeReviewerSession: vi.fn(() => ({
+      rejectedToolCalls: 0,
+      reviewerBridgeScoped: undefined
+    })),
     disconnect,
     requestRetirement,
     requestProviderReconnect,
     requestSkillsReload,
     applyReasoningEffortChange,
-    respondToPermission
+    respondToPermission,
+    shutdownForQuit,
+    shutdownForUpdateGate
   } as unknown as AcpRuntime
 
   return {
@@ -166,6 +173,95 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created[1].requestProviderReconnect).toHaveBeenCalledOnce()
     expect(created[1].requestSkillsReload).toHaveBeenCalledOnce()
     expect(created[1].applyReasoningEffortChange).toHaveBeenCalledWith('high')
+  })
+
+  it('keeps the active effort result when a retiring generation rejects', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: [`session-${created.length + 1}`],
+        callbacks
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+
+    await coordinator.createSession()
+    await coordinator.requestAgentFrameworkSwitch()
+    await coordinator.createSession()
+    created[0].applyReasoningEffortChange.mockRejectedValue(new Error('old effort failed'))
+
+    await expect(coordinator.applyReasoningEffortChange('high')).resolves.toBe(true)
+    expect(created[1].applyReasoningEffortChange).toHaveBeenCalledWith('high')
+  })
+
+  it('attempts every runtime disconnect before surfacing a partial failure', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: [`session-${created.length + 1}`],
+        callbacks
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+
+    await coordinator.createSession()
+    await coordinator.requestAgentFrameworkSwitch()
+    await coordinator.createSession()
+    const activeDisconnect = createDeferred<AcpStateSnapshot>()
+    created[0].disconnect.mockRejectedValueOnce(new Error('old disconnect failed'))
+    created[1].disconnect.mockReturnValueOnce(activeDisconnect.promise)
+
+    let settled = false
+    const disconnecting = coordinator.disconnect().finally(() => {
+      settled = true
+    })
+    void disconnecting.catch(() => undefined)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(settled).toBe(false)
+    expect(created[0].disconnect).toHaveBeenCalledOnce()
+    expect(created[1].disconnect).toHaveBeenCalledOnce()
+    activeDisconnect.resolve(emptySnapshot())
+    await expect(disconnecting).rejects.toThrow('old disconnect failed')
+  })
+
+  it('attempts every runtime quit teardown before surfacing a partial failure', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: [`session-${created.length + 1}`],
+        callbacks
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+
+    await coordinator.createSession()
+    await coordinator.requestAgentFrameworkSwitch()
+    await coordinator.createSession()
+    const activeShutdown = createDeferred<{ reaped: boolean }>()
+    vi.mocked(created[0].runtime.shutdownForQuit).mockRejectedValueOnce(
+      new Error('old shutdown failed')
+    )
+    vi.mocked(created[1].runtime.shutdownForQuit).mockReturnValueOnce(activeShutdown.promise)
+
+    let settled = false
+    const shuttingDown = coordinator.shutdownForQuit().finally(() => {
+      settled = true
+    })
+    void shuttingDown.catch(() => undefined)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(settled).toBe(false)
+    expect(created[0].runtime.shutdownForQuit).toHaveBeenCalledOnce()
+    expect(created[1].runtime.shutdownForQuit).toHaveBeenCalledOnce()
+    activeShutdown.resolve({ reaped: true })
+    await expect(shuttingDown).rejects.toThrow('old shutdown failed')
   })
 
   it('runs new sessions immediately and moves the old session after its active turn', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -37,6 +37,8 @@ const createFakeRuntime = (options: {
   disconnect: ReturnType<typeof vi.fn>
   requestRetirement: ReturnType<typeof vi.fn>
   requestProviderReconnect: ReturnType<typeof vi.fn>
+  requestSkillsReload: ReturnType<typeof vi.fn>
+  applyReasoningEffortChange: ReturnType<typeof vi.fn>
   respondToPermission: ReturnType<typeof vi.fn>
   emitEvent: (event: AcpRuntimeEvent) => void
   emitPermission: (request: AcpPermissionRequest) => void
@@ -47,6 +49,8 @@ const createFakeRuntime = (options: {
   const disconnect = vi.fn(async () => snapshot)
   const requestRetirement = vi.fn(async () => undefined)
   const requestProviderReconnect = vi.fn(async () => undefined)
+  const requestSkillsReload = vi.fn(async () => undefined)
+  const applyReasoningEffortChange = vi.fn(async () => true)
   const respondToPermission = vi.fn(() => snapshot)
   const sendPrompt = vi.fn(async ({ sessionId }: { sessionId: string }) => {
     snapshot = {
@@ -105,6 +109,8 @@ const createFakeRuntime = (options: {
     disconnect,
     requestRetirement,
     requestProviderReconnect,
+    requestSkillsReload,
+    applyReasoningEffortChange,
     respondToPermission
   } as unknown as AcpRuntime
 
@@ -113,6 +119,8 @@ const createFakeRuntime = (options: {
     disconnect,
     requestRetirement,
     requestProviderReconnect,
+    requestSkillsReload,
+    applyReasoningEffortChange,
     respondToPermission,
     emitEvent: (event) => {
       snapshot = { ...snapshot, events: [...snapshot.events, event] }
@@ -132,6 +140,33 @@ const createFakeRuntime = (options: {
 }
 
 describe('AcpRuntimeCoordinator', () => {
+  it('applies live settings changes only to the active runtime generation', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: [`session-${created.length + 1}`],
+        callbacks
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+
+    await coordinator.createSession()
+    await coordinator.requestAgentFrameworkSwitch()
+    await coordinator.requestProviderReconnect()
+    await coordinator.requestSkillsReload()
+    await expect(coordinator.applyReasoningEffortChange('high')).resolves.toBe(true)
+
+    expect(created).toHaveLength(2)
+    expect(created[0].requestProviderReconnect).not.toHaveBeenCalled()
+    expect(created[0].requestSkillsReload).not.toHaveBeenCalled()
+    expect(created[0].applyReasoningEffortChange).not.toHaveBeenCalled()
+    expect(created[1].requestProviderReconnect).toHaveBeenCalledOnce()
+    expect(created[1].requestSkillsReload).toHaveBeenCalledOnce()
+    expect(created[1].applyReasoningEffortChange).toHaveBeenCalledWith('high')
+  })
+
   it('runs new sessions immediately and moves the old session after its active turn', async () => {
     const oldPrompt = createDeferred<{ stopReason: string }>()
     const created: ReturnType<typeof createFakeRuntime>[] = []

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -204,6 +204,9 @@ class AcpRuntimeCoordinator {
     await retiring.requestRetirement()
   }
 
+  // Settings changes target the generation that owns future turns. Retiring generations stay pinned
+  // to the configuration of the workflow they are finishing; reconnecting or mutating them here would
+  // break the framework-switch guarantee that an in-progress turn/reviewer loop completes atomically.
   requestProviderReconnect(): Promise<void> {
     return this.getActiveRuntime().requestProviderReconnect()
   }

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -204,9 +204,9 @@ class AcpRuntimeCoordinator {
     await retiring.requestRetirement()
   }
 
-  // Settings changes target the generation that owns future turns. Retiring generations stay pinned
-  // to the configuration of the workflow they are finishing; reconnecting or mutating them here would
-  // break the framework-switch guarantee that an in-progress turn/reviewer loop completes atomically.
+  // Reconnect-triggering settings target the generation that owns future turns. Retiring generations
+  // stay pinned to the backend of the workflow they are finishing; reconnecting them here can strand a
+  // later workflow operation behind a barrier that its own activity lease prevents from resolving.
   requestProviderReconnect(): Promise<void> {
     return this.getActiveRuntime().requestProviderReconnect()
   }
@@ -215,8 +215,18 @@ class AcpRuntimeCoordinator {
     return this.getActiveRuntime().requestSkillsReload()
   }
 
-  applyReasoningEffortChange(effort: ReasoningEffort): Promise<boolean> {
-    return this.getActiveRuntime().applyReasoningEffortChange(effort)
+  async applyReasoningEffortChange(effort: ReasoningEffort): Promise<boolean> {
+    const active = this.getActiveRuntime()
+    const activeResult = active.applyReasoningEffortChange(effort)
+    const otherResults = Array.from(this.runtimes)
+      .filter((runtime) => runtime !== active)
+      .map((runtime) => runtime.applyReasoningEffortChange(effort))
+
+    // Effort is a non-disruptive live session option, so every still-running generation receives the
+    // global preference. Only the active result controls reconnect fallback: an old generation that
+    // cannot apply effort must not force the selected generation to respawn unnecessarily.
+    const [appliedToActive] = await Promise.all([activeResult, Promise.all(otherResults)])
+    return appliedToActive
   }
 
   writeArtifactForCurrentRun(

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -109,7 +109,14 @@ class AcpRuntimeCoordinator {
 
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
     const runtimes = Array.from(this.runtimes)
-    await Promise.all(runtimes.map((runtime) => runtime.disconnect(emitClosedStatus)))
+    const results = await Promise.allSettled(
+      runtimes.map((runtime) => runtime.disconnect(emitClosedStatus))
+    )
+    const failure = results.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    )
+    // Keep ownership when any teardown fails so a later disconnect/shutdown can retry the runtime.
+    if (failure) throw failure.reason
     this.clearRuntimeOwnership()
     return this.getSnapshot()
   }
@@ -224,9 +231,11 @@ class AcpRuntimeCoordinator {
 
     // Effort is a non-disruptive live session option, so every still-running generation receives the
     // global preference. Only the active result controls reconnect fallback: an old generation that
-    // cannot apply effort must not force the selected generation to respawn unnecessarily.
-    const [appliedToActive] = await Promise.all([activeResult, Promise.all(otherResults)])
-    return appliedToActive
+    // cannot apply effort or rejects must not force the selected generation to respawn unnecessarily.
+    const results = await Promise.allSettled([activeResult, ...otherResults])
+    const activeOutcome = results[0]
+    if (activeOutcome.status === 'rejected') throw activeOutcome.reason
+    return activeOutcome.value
   }
 
   writeArtifactForCurrentRun(
@@ -255,7 +264,7 @@ class AcpRuntimeCoordinator {
     return built
   }
 
-  disposeReviewerSession(session: ActiveSession): number {
+  disposeReviewerSession(session: ActiveSession): ReturnType<AcpRuntime['disposeReviewerSession']> {
     const runtime = this.reviewerRuntimes.get(session) ?? this.getActiveRuntime()
     this.reviewerRuntimes.delete(session)
     return runtime.disposeReviewerSession(session)
@@ -412,8 +421,9 @@ class AcpRuntimeCoordinator {
   private visibleSessionIds(runtime: AcpRuntime, snapshot: AcpStateSnapshot): string[] {
     if (!this.retiredRuntimes.has(runtime)) return snapshot.sessionIds
 
-    // Keep a retiring session visible only while its current turn still needs routing. Once idle, hiding
-    // it makes every client use resumeSession, which adopts it under the selected framework.
+    // Keep a retiring session visible only while its current turn still needs routing. Once idle it
+    // deliberately disappears from coordinator aggregation; the next client turn uses resumeSession,
+    // which re-discovers and adopts it under the selected framework.
     const active = new Set([
       ...snapshot.promptInFlightSessionIds,
       ...snapshot.pendingPermissions.map((request) => request.sessionId)
@@ -433,9 +443,17 @@ class AcpRuntimeCoordinator {
   private async shutdownAll(
     shutdown: (runtime: AcpRuntime) => Promise<{ reaped: boolean }>
   ): Promise<{ reaped: boolean }> {
-    const results = await Promise.all(Array.from(this.runtimes, shutdown))
+    const runtimes = Array.from(this.runtimes)
+    const outcomes = await Promise.allSettled(runtimes.map(shutdown))
+    const failure = outcomes.find(
+      (outcome): outcome is PromiseRejectedResult => outcome.status === 'rejected'
+    )
+    // Preserve failed runtime ownership so a bounded caller can retry or use the synchronous guard.
+    if (failure) throw failure.reason
     this.clearRuntimeOwnership()
-    return { reaped: results.every((result) => result.reaped) }
+    return {
+      reaped: outcomes.every((outcome) => outcome.status === 'fulfilled' && outcome.value.reaped)
+    }
   }
 
   private clearRuntimeOwnership(): void {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1,0 +1,439 @@
+import type { ActiveSession } from '@agentclientprotocol/sdk'
+
+import type {
+  AcpCancelPromptRequest,
+  AcpConnectRequest,
+  AcpCreateSessionRequest,
+  AcpCreateSessionResponse,
+  AcpDeleteSessionRequest,
+  AcpPermissionResponse,
+  AcpPromptRequest,
+  AcpResumeSessionRequest,
+  AcpRevokePermissionGrantRequest,
+  AcpSetPermissionProfileRequest,
+  AcpStateSnapshot
+} from '../../shared/acp'
+import type { ReasoningEffort } from '../../shared/settings'
+import { AcpRuntime, type AcpRuntimeCallbacks } from './runtime'
+import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
+
+const MAX_EVENTS = 500
+
+type RuntimeFactory = (callbacks: AcpRuntimeCallbacks) => AcpRuntime
+
+// Keeps each framework generation in its own AcpRuntime. Framework changes preserve active turns, then
+// retire their runtime so every later turn resumes through the newly selected framework.
+class AcpRuntimeCoordinator {
+  private readonly runtimes = new Set<AcpRuntime>()
+  private readonly retiredRuntimes = new Set<AcpRuntime>()
+  private readonly sessionRuntimes = new Map<string, AcpRuntime>()
+  private readonly sessionConnectionStatuses = new Map<string, AcpStateSnapshot['status']>()
+  private readonly permissionRuntimes = new Map<string, AcpRuntime>()
+  private readonly reviewerRuntimes = new WeakMap<ActiveSession, AcpRuntime>()
+  private readonly runtimeIds = new WeakMap<AcpRuntime, string>()
+  private runtimeSequence = 0
+  private activeRuntime: AcpRuntime | undefined
+  private lastRuntime: AcpRuntime | undefined
+
+  constructor(
+    private readonly createRuntime: RuntimeFactory,
+    private readonly callbacks: AcpRuntimeCallbacks = {},
+    private readonly defaultCwd = ''
+  ) {
+    this.activeRuntime = this.addRuntime()
+    this.lastRuntime = this.activeRuntime
+  }
+
+  getSnapshot(): AcpStateSnapshot {
+    const snapshots = Array.from(this.runtimes, (runtime) => ({
+      runtime,
+      snapshot: runtime.getSnapshot()
+    }))
+    const primaryRuntime = this.activeRuntime ?? this.lastRuntime
+    const primary = snapshots.find(({ runtime }) => runtime === primaryRuntime)?.snapshot
+    const events = snapshots
+      .flatMap(({ runtime, snapshot }) =>
+        snapshot.events.map((event) => ({
+          ...event,
+          id: this.eventId(runtime, event.id)
+        }))
+      )
+      .sort((left, right) => left.timestamp - right.timestamp)
+      .slice(-MAX_EVENTS)
+    const sessionIds = Array.from(
+      new Set(
+        snapshots.flatMap(({ runtime, snapshot }) => this.visibleSessionIds(runtime, snapshot))
+      )
+    )
+    const promptInFlightSessionIds = snapshots.flatMap(
+      ({ snapshot }) => snapshot.promptInFlightSessionIds
+    )
+
+    return {
+      status: primary?.status ?? 'idle',
+      sessionConnectionStatuses: Object.fromEntries(this.sessionConnectionStatuses),
+      cwd: primary?.cwd ?? this.defaultCwd,
+      ...(primary?.sessionId && sessionIds.includes(primary.sessionId)
+        ? { sessionId: primary.sessionId }
+        : {}),
+      sessionIds,
+      ...(primary?.error ? { error: primary.error } : {}),
+      events,
+      pendingPermissions: snapshots.flatMap(({ snapshot }) => snapshot.pendingPermissions),
+      permissionProfiles: Object.assign(
+        {},
+        ...snapshots.map(({ snapshot }) => snapshot.permissionProfiles)
+      ),
+      permissionGrants: Object.assign(
+        {},
+        ...snapshots.map(({ snapshot }) => snapshot.permissionGrants)
+      ),
+      promptInFlight: promptInFlightSessionIds.length > 0,
+      promptInFlightSessionIds
+    }
+  }
+
+  getActivePromptSessions(): { projectName: string; sessionId: string }[] {
+    return Array.from(this.runtimes).flatMap((runtime) => runtime.getActivePromptSessions())
+  }
+
+  getActiveArtifactRunIds(): string[] {
+    return Array.from(this.runtimes).flatMap((runtime) => runtime.getActiveArtifactRunIds())
+  }
+
+  async connect(request: AcpConnectRequest = {}): Promise<AcpStateSnapshot> {
+    const runtime = this.getActiveRuntime()
+    await runtime.connect(request)
+    return this.getSnapshot()
+  }
+
+  async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
+    const runtimes = Array.from(this.runtimes)
+    await Promise.all(runtimes.map((runtime) => runtime.disconnect(emitClosedStatus)))
+    this.clearRuntimeOwnership()
+    return this.getSnapshot()
+  }
+
+  shutdown(): void {
+    for (const runtime of this.runtimes) runtime.shutdown()
+    this.clearRuntimeOwnership()
+  }
+
+  async shutdownForQuit(): Promise<{ reaped: boolean }> {
+    return this.shutdownAll((runtime) => runtime.shutdownForQuit())
+  }
+
+  async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
+    return this.shutdownAll((runtime) => runtime.shutdownForUpdateGate())
+  }
+
+  async createSession(request: AcpCreateSessionRequest = {}): Promise<AcpCreateSessionResponse> {
+    const runtime = this.getActiveRuntime()
+    const response = await runtime.createSession(request)
+    this.sessionRuntimes.set(response.sessionId, runtime)
+    this.lastRuntime = runtime
+    return response
+  }
+
+  async resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
+    const owner = this.findRuntimeForSession(request.sessionId)
+    const runtime = owner && !this.retiredRuntimes.has(owner) ? owner : this.getActiveRuntime()
+    const response = await runtime.resumeSession(request)
+    this.sessionRuntimes.set(response.sessionId, runtime)
+    this.lastRuntime = runtime
+    return response
+  }
+
+  async resetSessionContext(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
+    const runtime = this.runtimeForSession(request.sessionId)
+    const response = await runtime.resetSessionContext(request)
+    this.sessionRuntimes.set(response.sessionId, runtime)
+    this.lastRuntime = runtime
+    return response
+  }
+
+  sendPrompt(request: AcpPromptRequest): ReturnType<AcpRuntime['sendPrompt']> {
+    return this.runtimeForSession(request.sessionId).sendPrompt(request)
+  }
+
+  async cancelPrompt(request: AcpCancelPromptRequest): Promise<AcpStateSnapshot> {
+    await this.runtimeForSession(request.sessionId).cancelPrompt(request)
+    return this.getSnapshot()
+  }
+
+  async deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot> {
+    const runtime = this.runtimeForSession(request.sessionId)
+    await runtime.deleteSession(request)
+    this.sessionRuntimes.delete(request.sessionId)
+    this.sessionConnectionStatuses.delete(request.sessionId)
+    return this.getSnapshot()
+  }
+
+  respondToPermission(response: AcpPermissionResponse): AcpStateSnapshot {
+    const runtime =
+      this.permissionRuntimes.get(response.requestId) ??
+      Array.from(this.runtimes).find((candidate) =>
+        candidate
+          .getSnapshot()
+          .pendingPermissions.some((request) => request.requestId === response.requestId)
+      ) ??
+      this.getActiveRuntime()
+    runtime.respondToPermission(response)
+    this.permissionRuntimes.delete(response.requestId)
+    return this.getSnapshot()
+  }
+
+  async setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<AcpStateSnapshot> {
+    await this.runtimeForSession(request.sessionId).setPermissionProfile(request)
+    return this.getSnapshot()
+  }
+
+  revokePermissionGrant(request: AcpRevokePermissionGrantRequest): AcpStateSnapshot {
+    this.runtimeForSession(request.sessionId).revokePermissionGrant(request)
+    return this.getSnapshot()
+  }
+
+  // A framework change takes effect for every future turn and workflow. The old generation stays alive
+  // until its active prompts and workflow leases finish; idle sessions resume on demand.
+  async requestAgentFrameworkSwitch(): Promise<void> {
+    const retiring = this.activeRuntime
+    if (!retiring) return
+
+    this.retiredRuntimes.add(retiring)
+    this.rotateActiveRuntime()
+    await retiring.requestRetirement()
+  }
+
+  requestProviderReconnect(): Promise<void> {
+    return this.getActiveRuntime().requestProviderReconnect()
+  }
+
+  requestSkillsReload(): Promise<void> {
+    return this.getActiveRuntime().requestSkillsReload()
+  }
+
+  applyReasoningEffortChange(effort: ReasoningEffort): Promise<boolean> {
+    return this.getActiveRuntime().applyReasoningEffortChange(effort)
+  }
+
+  writeArtifactForCurrentRun(
+    sessionId: string,
+    input: Parameters<AcpRuntime['writeArtifactForCurrentRun']>[1]
+  ): ReturnType<AcpRuntime['writeArtifactForCurrentRun']> {
+    return this.runtimeForSession(sessionId).writeArtifactForCurrentRun(sessionId, input)
+  }
+
+  async withActivity<T>(
+    options: AcpRuntimeActivityOptions,
+    work: (runtime: AcpRuntimeActivity) => Promise<T>
+  ): Promise<T> {
+    const runtime = this.getActiveRuntime()
+    const scopedRuntime = this.createScopedActivityRuntime(runtime, options)
+
+    return runtime.withActivity(options, () => work(scopedRuntime))
+  }
+
+  async buildReviewerSession(
+    request: Parameters<AcpRuntime['buildReviewerSession']>[0]
+  ): ReturnType<AcpRuntime['buildReviewerSession']> {
+    const runtime = this.getActiveRuntime()
+    const built = await runtime.buildReviewerSession(request)
+    this.reviewerRuntimes.set(built.session, runtime)
+    return built
+  }
+
+  disposeReviewerSession(session: ActiveSession): number {
+    const runtime = this.reviewerRuntimes.get(session) ?? this.getActiveRuntime()
+    this.reviewerRuntimes.delete(session)
+    return runtime.disposeReviewerSession(session)
+  }
+
+  reviewerRejectedToolCallCount(sessionId: string): number {
+    return Array.from(this.runtimes).reduce(
+      (count, runtime) => count + runtime.reviewerRejectedToolCallCount(sessionId),
+      0
+    )
+  }
+
+  private createScopedActivityRuntime(
+    runtime: AcpRuntime,
+    options: AcpRuntimeActivityOptions
+  ): AcpRuntimeActivity {
+    let resumeInFlight: Promise<boolean> | undefined
+
+    const ensureActivitySession = async (sessionId: string): Promise<boolean> => {
+      const session = options.session
+      if (!session || session.sessionId !== sessionId) return false
+      if (runtime.getSnapshot().sessionIds.includes(sessionId)) return false
+
+      if (!resumeInFlight) {
+        const resumeRequest: AcpResumeSessionRequest = {
+          sessionId: session.sessionId,
+          cwd: session.cwd,
+          ...(session.projectName ? { projectName: session.projectName } : {}),
+          ...(session.permissionProfile ? { permissionProfile: session.permissionProfile } : {}),
+          ...(session.previousFrameworkId
+            ? { previousFrameworkId: session.previousFrameworkId }
+            : {}),
+          ...(session.previousBackendId ? { previousBackendId: session.previousBackendId } : {})
+        }
+        resumeInFlight = runtime.resumeSession(resumeRequest).then((response) => {
+          this.sessionRuntimes.set(response.sessionId, runtime)
+          this.lastRuntime = runtime
+          return Boolean(response.contextReset)
+        })
+      }
+
+      return resumeInFlight
+    }
+
+    return {
+      buildReviewerSession: async (request) => {
+        const built = await runtime.buildReviewerSession(request)
+        this.reviewerRuntimes.set(built.session, runtime)
+        return built
+      },
+      disposeReviewerSession: (session) => {
+        this.reviewerRuntimes.delete(session)
+        return runtime.disposeReviewerSession(session)
+      },
+      sendPrompt: async (request) => {
+        const contextReset = await ensureActivitySession(request.sessionId)
+        const historyPreamble = options.session?.historyPreamble
+        return runtime.sendPrompt(
+          contextReset && historyPreamble && !request.historyPreamble
+            ? { ...request, historyPreamble }
+            : request
+        )
+      }
+    }
+  }
+
+  private getActiveRuntime(): AcpRuntime {
+    if (!this.activeRuntime) this.activeRuntime = this.addRuntime()
+    this.lastRuntime = this.activeRuntime
+    return this.activeRuntime
+  }
+
+  private runtimeForSession(sessionId: string): AcpRuntime {
+    return this.findRuntimeForSession(sessionId) ?? this.getActiveRuntime()
+  }
+
+  private findRuntimeForSession(sessionId: string): AcpRuntime | undefined {
+    const owned = this.sessionRuntimes.get(sessionId)
+    if (owned) return owned
+
+    const discovered = Array.from(this.runtimes).find((runtime) =>
+      runtime.getSnapshot().sessionIds.includes(sessionId)
+    )
+    if (discovered) {
+      this.sessionRuntimes.set(sessionId, discovered)
+      return discovered
+    }
+
+    return undefined
+  }
+
+  private addRuntime(): AcpRuntime {
+    const runtime = this.createRuntime({
+      onStateChanged: (snapshot) => this.handleRuntimeState(runtime, snapshot),
+      onEvent: (event) =>
+        this.callbacks.onEvent?.({ ...event, id: this.eventId(runtime, event.id) }),
+      onPermissionRequest: (request) => {
+        this.permissionRuntimes.set(request.requestId, runtime)
+        this.callbacks.onPermissionRequest?.(request)
+      },
+      onRetired: () => this.handleRuntimeRetired(runtime)
+    })
+    this.runtimeSequence += 1
+    this.runtimeIds.set(runtime, `runtime-${this.runtimeSequence}`)
+    this.runtimes.add(runtime)
+    return runtime
+  }
+
+  private handleRuntimeState(runtime: AcpRuntime, snapshot: AcpStateSnapshot): void {
+    const attached = new Set(snapshot.sessionIds)
+    for (const [sessionId, owner] of this.sessionRuntimes) {
+      if (owner !== runtime || attached.has(sessionId)) continue
+
+      this.sessionRuntimes.delete(sessionId)
+      if (snapshot.status === 'closed' || snapshot.status === 'error') {
+        this.sessionConnectionStatuses.set(sessionId, snapshot.status)
+      } else {
+        this.sessionConnectionStatuses.delete(sessionId)
+      }
+    }
+    for (const sessionId of attached) {
+      const owner = this.sessionRuntimes.get(sessionId)
+      // A late state emission from a retiring runtime must not steal back a session already adopted by
+      // the current generation.
+      if (!owner || !this.retiredRuntimes.has(runtime) || this.retiredRuntimes.has(owner)) {
+        this.sessionRuntimes.set(sessionId, runtime)
+        this.sessionConnectionStatuses.set(sessionId, snapshot.status)
+      }
+    }
+    this.callbacks.onStateChanged?.(this.getSnapshot())
+  }
+
+  private handleRuntimeRetired(runtime: AcpRuntime): void {
+    const retiredStatus = runtime.getSnapshot().status
+    this.runtimes.delete(runtime)
+    this.retiredRuntimes.delete(runtime)
+    for (const [sessionId, owner] of this.sessionRuntimes) {
+      if (owner !== runtime) continue
+      this.sessionRuntimes.delete(sessionId)
+      if (retiredStatus === 'closed' || retiredStatus === 'error') {
+        this.sessionConnectionStatuses.set(sessionId, retiredStatus)
+      } else {
+        this.sessionConnectionStatuses.delete(sessionId)
+      }
+    }
+    for (const [requestId, owner] of this.permissionRuntimes) {
+      if (owner === runtime) this.permissionRuntimes.delete(requestId)
+    }
+    if (this.activeRuntime === runtime) this.activeRuntime = undefined
+    if (this.lastRuntime === runtime) this.lastRuntime = this.activeRuntime
+    this.callbacks.onStateChanged?.(this.getSnapshot())
+  }
+
+  private visibleSessionIds(runtime: AcpRuntime, snapshot: AcpStateSnapshot): string[] {
+    if (!this.retiredRuntimes.has(runtime)) return snapshot.sessionIds
+
+    // Keep a retiring session visible only while its current turn still needs routing. Once idle, hiding
+    // it makes every client use resumeSession, which adopts it under the selected framework.
+    const active = new Set([
+      ...snapshot.promptInFlightSessionIds,
+      ...snapshot.pendingPermissions.map((request) => request.sessionId)
+    ])
+    return snapshot.sessionIds.filter((sessionId) => active.has(sessionId))
+  }
+
+  private eventId(runtime: AcpRuntime, eventId: string): string {
+    return `${this.runtimeIds.get(runtime) ?? 'runtime'}:${eventId}`
+  }
+
+  private rotateActiveRuntime(): void {
+    if (this.activeRuntime) this.lastRuntime = this.activeRuntime
+    this.activeRuntime = undefined
+  }
+
+  private async shutdownAll(
+    shutdown: (runtime: AcpRuntime) => Promise<{ reaped: boolean }>
+  ): Promise<{ reaped: boolean }> {
+    const results = await Promise.all(Array.from(this.runtimes, shutdown))
+    this.clearRuntimeOwnership()
+    return { reaped: results.every((result) => result.reaped) }
+  }
+
+  private clearRuntimeOwnership(): void {
+    this.runtimes.clear()
+    this.retiredRuntimes.clear()
+    this.sessionRuntimes.clear()
+    this.sessionConnectionStatuses.clear()
+    this.permissionRuntimes.clear()
+    this.activeRuntime = undefined
+    this.lastRuntime = undefined
+  }
+}
+
+export { AcpRuntimeCoordinator }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3319,7 +3319,10 @@ describe('ACP runtime session management', () => {
 
     expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(1)
     // dispose returns the final count and clears it atomically — the orchestrator relies on this.
-    expect(runtime.disposeReviewerSession(session)).toBe(1)
+    expect(runtime.disposeReviewerSession(session)).toEqual({
+      rejectedToolCalls: 1,
+      reviewerBridgeScoped: undefined
+    })
     expect(runtime.reviewerRejectedToolCallCount('reviewer-session-1')).toBe(0)
   })
 
@@ -4439,6 +4442,36 @@ describe('ACP runtime session management', () => {
     })
     expect(process.killed).toBe(true)
     expect(releaseBridge).toHaveBeenCalledOnce()
+  })
+
+  it('finishes disconnect state cleanup when the responses bridge lease rejects release', async () => {
+    const process = new FakeAgentProcess()
+    const releaseBridge = vi.fn().mockRejectedValue(new Error('bridge close failed'))
+    startFakeAgent(process, ['s1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {},
+        responsesBridgeLease: {
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => true),
+          release: releaseBridge
+        }
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    await expect(runtime.disconnect()).resolves.toMatchObject({ status: 'closed' })
+
+    expect(releaseBridge).toHaveBeenCalledOnce()
+    expect(runtime.getSnapshot().status).toBe('closed')
+    expect(errorLogSpy).toHaveBeenCalledWith(
+      'responses bridge lease release failed',
+      expect.objectContaining({ error: 'bridge close failed' })
+    )
   })
 
   it('keeps a retiring runtime alive across gaps in an activity workflow', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4200,13 +4200,108 @@ describe('ACP runtime session management', () => {
     expect(onRetired).toHaveBeenCalledOnce()
   })
 
-  it('keeps a reviewer session alive until it is disposed before retiring', async () => {
+  it('does not retire while createSession is resolving its backend', async () => {
     const process = new FakeAgentProcess()
-    startFakeAgent(process, ['reviewer-session-1'])
+    const backendEntered = createDeferred()
+    const releaseBackend = createDeferred()
+    const onRetired = vi.fn()
+    startFakeAgent(process, ['s1'])
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
+      callbacks: { onRetired },
+      resolveBackend: async () => {
+        backendEntered.resolve()
+        await releaseBackend.promise
+        return {
+          framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+          executablePath: '/bin/agent',
+          env: {}
+        }
+      }
+    })
+
+    const creating = runtime.createSession({ cwd: '/workspace' })
+    await backendEntered.promise
+    await runtime.requestRetirement()
+
+    expect(process.killed).toBe(false)
+    expect(onRetired).not.toHaveBeenCalled()
+
+    releaseBackend.resolve()
+    await expect(creating).resolves.toMatchObject({ sessionId: 's1' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(process.killed).toBe(true)
+    expect(onRetired).toHaveBeenCalledOnce()
+  })
+
+  it('does not retire while a prompt checks whether disabled skills need force-loading', async () => {
+    const process = new FakeAgentProcess()
+    const skillCheckEntered = createDeferred()
+    const releaseSkillCheck = createDeferred()
+    const onRetired = vi.fn()
+    startFakeAgent(process, ['s1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onRetired },
+      skills: {
+        needForceLoad: async () => {
+          skillCheckEntered.resolve()
+          await releaseSkillCheck.promise
+          return []
+        },
+        namesForIds: async (ids) => ids
+      }
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const prompting = runtime.sendPrompt({
+      sessionId: 's1',
+      text: 'use the selected skill',
+      forcedSkillIds: ['research']
+    })
+    await skillCheckEntered.promise
+    await runtime.requestRetirement()
+
+    expect(process.killed).toBe(false)
+    expect(onRetired).not.toHaveBeenCalled()
+
+    releaseSkillCheck.resolve()
+    await expect(prompting).resolves.toMatchObject({ stopReason: 'end_turn' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(process.killed).toBe(true)
+    expect(onRetired).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a reviewer session alive until it is disposed before retiring', async () => {
+    const process = new FakeAgentProcess()
+    const registerReviewerSession = vi.fn()
+    const unregisterReviewerSession = vi.fn()
+    const releaseBridge = vi.fn(async () => undefined)
+    startFakeAgent(process, ['reviewer-session-1'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {},
+        providerConfiguration: {
+          providerId: 'custom-gateway',
+          apiType: 'openai',
+          baseUrl: 'http://127.0.0.1:1/v1',
+          headers: { authorization: 'Bearer bridge' }
+        },
+        responsesBridgeLease: {
+          registerReviewerSession,
+          unregisterReviewerSession,
+          release: releaseBridge
+        }
+      })
     })
 
     const { session } = await runtime.buildReviewerSession({
@@ -4220,14 +4315,18 @@ describe('ACP runtime session management', () => {
         }
       ]
     })
+    expect(registerReviewerSession).toHaveBeenCalledWith('reviewer-session-1')
 
     await runtime.requestRetirement()
     expect(process.killed).toBe(false)
+    expect(releaseBridge).not.toHaveBeenCalled()
 
     runtime.disposeReviewerSession(session)
     await new Promise((resolve) => setTimeout(resolve, 0))
 
+    expect(unregisterReviewerSession).toHaveBeenCalledWith('reviewer-session-1')
     expect(process.killed).toBe(true)
+    expect(releaseBridge).toHaveBeenCalledOnce()
   })
 
   it('keeps a retiring runtime alive across gaps in an activity workflow', async () => {
@@ -5427,16 +5526,63 @@ describe('ACP runtime skill force-load + nudge', () => {
     nudgeNames?: Record<string, string>
   }): {
     needForceLoad: ReturnType<typeof vi.fn<(ids: string[]) => Promise<string[]>>>
-    setTurnForced: ReturnType<typeof vi.fn<(ids: string[]) => void>>
-    clearTurnForced: ReturnType<typeof vi.fn<() => void>>
     namesForIds: ReturnType<typeof vi.fn<(ids: string[]) => Promise<string[]>>>
   } => ({
     needForceLoad: vi.fn<(ids: string[]) => Promise<string[]>>(async () => options.needForceLoad),
-    setTurnForced: vi.fn<(ids: string[]) => void>(),
-    clearTurnForced: vi.fn<() => void>(),
     namesForIds: vi.fn<(ids: string[]) => Promise<string[]>>(async (ids: string[]) =>
       ids.map((id) => options.nudgeNames?.[id] ?? id)
     )
+  })
+
+  it('passes turn-forced skill ids to backend resolution per runtime instance', async () => {
+    const firstSpawner = createFreshAgentSpawner()
+    const secondSpawner = createFreshAgentSpawner()
+    const firstContexts: Array<{ forcedSkillIds: string[] } | undefined> = []
+    const secondContexts: Array<{ forcedSkillIds: string[] } | undefined> = []
+    const createRuntime = (
+      spawner: ReturnType<typeof createFreshAgentSpawner>,
+      contexts: Array<{ forcedSkillIds: string[] } | undefined>
+    ): AcpRuntime =>
+      new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: (context?: { forcedSkillIds: string[] }) => {
+          contexts.push(context)
+          return {
+            framework: { ...claudeCodeFramework, spawn: spawner.spawn },
+            executablePath: '/bin/agent',
+            env: {}
+          }
+        },
+        skills: {
+          needForceLoad: async (ids) => ids,
+          namesForIds: async (ids) => ids
+        }
+      })
+
+    const first = createRuntime(firstSpawner, firstContexts)
+    const second = createRuntime(secondSpawner, secondContexts)
+    await Promise.all([
+      first.createSession({ cwd: '/workspace' }),
+      second.createSession({ cwd: '/workspace' })
+    ])
+    await Promise.all([
+      first.sendPrompt({
+        sessionId: 'remote-session-1',
+        text: 'first',
+        forcedSkillIds: ['skill-a']
+      }),
+      second.sendPrompt({
+        sessionId: 'remote-session-1',
+        text: 'second',
+        forcedSkillIds: ['skill-b']
+      })
+    ])
+
+    expect(firstContexts).toContainEqual({ forcedSkillIds: ['skill-a'] })
+    expect(secondContexts).toContainEqual({ forcedSkillIds: ['skill-b'] })
+    expect(firstContexts).not.toContainEqual({ forcedSkillIds: ['skill-b'] })
+    expect(secondContexts).not.toContainEqual({ forcedSkillIds: ['skill-a'] })
   })
 
   it('respawns and nudges when a picked skill is disabled, then restores after the turn', async () => {
@@ -5458,8 +5604,7 @@ describe('ACP runtime skill force-load + nudge', () => {
       forcedSkillIds: ['research']
     })
 
-    // The picked skill was marked forced and the agent respawned before the prompt (resume path).
-    expect(hooks.setTurnForced).toHaveBeenCalledWith(['research'])
+    // The picked skill was scoped to this runtime and the agent respawned before the prompt.
     expect(spawner.spawnCount()).toBe(2)
     expect(spawner.agents[1].resumedSessions).toHaveLength(1)
 
@@ -5473,7 +5618,6 @@ describe('ACP runtime skill force-load + nudge', () => {
     ])
 
     // After the turn the force set is cleared and a restore reconnect is scheduled (agent torn down).
-    expect(hooks.clearTurnForced).toHaveBeenCalledTimes(1)
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(runtime.getSnapshot().status).toBe('closed')
   })
@@ -5496,8 +5640,6 @@ describe('ACP runtime skill force-load + nudge', () => {
     })
 
     // No disabled picks → no respawn and no force set toggling, but the nudge is still prepended.
-    expect(hooks.setTurnForced).not.toHaveBeenCalled()
-    expect(hooks.clearTurnForced).not.toHaveBeenCalled()
     expect(spawner.spawnCount()).toBe(1)
     expect(spawner.agents[0].prompts).toEqual([
       {
@@ -5551,7 +5693,6 @@ describe('ACP runtime skill force-load + nudge', () => {
 
     // With no forcedSkillIds, none of the skill hooks run and the text is unchanged.
     expect(hooks.needForceLoad).not.toHaveBeenCalled()
-    expect(hooks.setTurnForced).not.toHaveBeenCalled()
     expect(spawner.spawnCount()).toBe(1)
     expect(spawner.agents[0].prompts).toEqual([
       { sessionId: 'remote-session-1', text: 'plain prompt' }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4279,10 +4279,35 @@ describe('ACP runtime session management', () => {
     expect(onRetired).toHaveBeenCalledOnce()
   })
 
+  it('completes retirement after an unexpected connection close drains the active operation', async () => {
+    const process = new FakeAgentProcess()
+    const gate = createDeferred()
+    const onRetired = vi.fn()
+    startFakeAgent(process, ['s1'], { onPrompt: () => gate.promise })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onRetired }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+    await runtime.requestRetirement()
+
+    process.stdout.end()
+    gate.resolve()
+    await prompt.catch(() => undefined)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(runtime.getSnapshot().status).toBe('closed')
+    expect(onRetired).toHaveBeenCalledOnce()
+  })
+
   it('keeps a reviewer session alive until it is disposed before retiring', async () => {
     const process = new FakeAgentProcess()
     const registerReviewerSession = vi.fn()
-    const unregisterReviewerSession = vi.fn()
+    const unregisterReviewerSession = vi.fn(() => false)
     const releaseBridge = vi.fn(async () => undefined)
     startFakeAgent(process, ['reviewer-session-1'], {
       modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
@@ -4329,6 +4354,9 @@ describe('ACP runtime session management', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(unregisterReviewerSession).toHaveBeenCalledWith('reviewer-session-1')
+    expect(errorLogSpy).toHaveBeenCalledWith('reviewer bridge request was never scoped', {
+      sessionId: 'reviewer-session-1'
+    })
     expect(process.killed).toBe(true)
     expect(releaseBridge).toHaveBeenCalledOnce()
   })

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -134,6 +134,8 @@ const startFakeAgent = (
     // the session/cancel notification on delete instead of a close request.
     supportsClose?: boolean
     rejectModeChange?: boolean
+    onSetMode?: (context: { sessionId: string; modeId: string }) => Promise<void> | void
+    onClose?: (sessionId: string) => Promise<void> | void
     onPrompt?: (context: {
       sessionId: string
       text: string
@@ -241,9 +243,16 @@ const startFakeAgent = (
     })
     .onRequest(acp.methods.agent.session.setMode, (ctx) => {
       if (options.rejectModeChange) throw new Error('set mode failed')
-      modeChanges.push({ sessionId: ctx.params.sessionId, modeId: ctx.params.modeId })
-      actions.push(`mode:${ctx.params.modeId}`)
-      return {}
+      const recordModeChange = (): Record<string, never> => {
+        modeChanges.push({ sessionId: ctx.params.sessionId, modeId: ctx.params.modeId })
+        actions.push(`mode:${ctx.params.modeId}`)
+        return {}
+      }
+      const pending = options.onSetMode?.({
+        sessionId: ctx.params.sessionId,
+        modeId: ctx.params.modeId
+      })
+      return pending ? pending.then(recordModeChange) : recordModeChange()
     })
     .onRequest(acp.methods.agent.session.setConfigOption, (ctx) => {
       if (options.rejectSetConfigOption) throw acp.RequestError.internalError()
@@ -285,8 +294,12 @@ const startFakeAgent = (
       return undefined
     })
     .onRequest(acp.methods.agent.session.close, (ctx) => {
-      closedSessions.push(ctx.params.sessionId)
-      return {}
+      const recordClose = (): Record<string, never> => {
+        closedSessions.push(ctx.params.sessionId)
+        return {}
+      }
+      const pending = options.onClose?.(ctx.params.sessionId)
+      return pending ? pending.then(recordClose) : recordClose()
     })
     .connect(
       acp.ndJsonStream(
@@ -4274,6 +4287,73 @@ describe('ACP runtime session management', () => {
 
     releaseSkillCheck.resolve()
     await expect(prompting).resolves.toMatchObject({ stopReason: 'end_turn' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(process.killed).toBe(true)
+    expect(onRetired).toHaveBeenCalledOnce()
+  })
+
+  it('does not retire while deleteSession awaits the agent close request', async () => {
+    const process = new FakeAgentProcess()
+    const closeEntered = createDeferred()
+    const releaseClose = createDeferred()
+    const onRetired = vi.fn()
+    startFakeAgent(process, ['s1'], {
+      onClose: async () => {
+        closeEntered.resolve()
+        await releaseClose.promise
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onRetired }
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const deleting = runtime.deleteSession({ sessionId: 's1' })
+    await closeEntered.promise
+    await runtime.requestRetirement()
+
+    expect(process.killed).toBe(false)
+    expect(onRetired).not.toHaveBeenCalled()
+
+    releaseClose.resolve()
+    await deleting
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(process.killed).toBe(true)
+    expect(onRetired).toHaveBeenCalledOnce()
+  })
+
+  it('does not retire while setPermissionProfile awaits the agent mode request', async () => {
+    const process = new FakeAgentProcess()
+    const modeEntered = createDeferred()
+    const releaseMode = createDeferred()
+    const onRetired = vi.fn()
+    startFakeAgent(process, ['s1'], {
+      modes: createModes(['default', 'bypassPermissions']),
+      onSetMode: async () => {
+        modeEntered.resolve()
+        await releaseMode.promise
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onRetired }
+    })
+    await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+
+    const changingProfile = runtime.setPermissionProfile({ sessionId: 's1', profile: 'full' })
+    await modeEntered.promise
+    await runtime.requestRetirement()
+
+    expect(process.killed).toBe(false)
+    expect(onRetired).not.toHaveBeenCalled()
+
+    releaseMode.resolve()
+    await changingProfile
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(process.killed).toBe(true)
     expect(onRetired).toHaveBeenCalledOnce()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4171,6 +4171,93 @@ describe('ACP runtime session management', () => {
     expect(process.killed).toBe(true)
   })
 
+  it('retires a framework runtime only after its in-flight prompt finishes', async () => {
+    const process = new FakeAgentProcess()
+    const gate = createDeferred()
+    const onRetired = vi.fn()
+    startFakeAgent(process, ['s1'], { onPrompt: () => gate.promise })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onRetired }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+
+    await runtime.requestRetirement()
+    expect(process.killed).toBe(false)
+    expect(onRetired).not.toHaveBeenCalled()
+    expect(runtime.getSnapshot().sessionIds).toEqual(['s1'])
+
+    gate.resolve()
+    await prompt
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(process.killed).toBe(true)
+    expect(runtime.getSnapshot().sessionIds).toEqual([])
+    expect(onRetired).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a reviewer session alive until it is disposed before retiring', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['reviewer-session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+
+    await runtime.requestRetirement()
+    expect(process.killed).toBe(false)
+
+    runtime.disposeReviewerSession(session)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(process.killed).toBe(true)
+  })
+
+  it('keeps a retiring runtime alive across gaps in an activity workflow', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['s1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    const activityStarted = createDeferred()
+    const releaseActivity = createDeferred()
+
+    const activity = runtime.withActivity({}, async () => {
+      activityStarted.resolve()
+      await releaseActivity.promise
+    })
+    await activityStarted.promise
+
+    await runtime.requestRetirement()
+    expect(process.killed).toBe(false)
+
+    releaseActivity.resolve()
+    await activity
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(process.killed).toBe(true)
+  })
+
   it('createSession waits for a pending provider reconnect before using the new connection', async () => {
     const oldProcess = new FakeAgentProcess()
     const newProcess = new FakeAgentProcess()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2016,6 +2016,7 @@ describe('ACP runtime session management', () => {
   it('serves artifact/notebook MCP over the http host for an http-only framework', async () => {
     const root = await createTemporaryRoot()
     const httpHost = new AgentMcpHttpHost()
+    const closeHttpHost = vi.spyOn(httpHost, 'close')
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['oc-session'])
     const runtime = new AcpRuntime({
@@ -2057,6 +2058,9 @@ describe('ACP runtime session management', () => {
       const artifactServer = servers.find((server) => server.name === 'open-science-artifacts')
       expect(artifactServer?.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp\/artifact\//)
       expect(artifactServer?.headers?.[0]).toMatchObject({ name: 'authorization' })
+
+      await runtime.requestRetirement()
+      expect(closeHttpHost).toHaveBeenCalledOnce()
     } finally {
       await httpHost.close()
     }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -130,7 +130,9 @@ type AcpRuntimeOptions = {
   // Resolves the active agent backend (framework + spawn inputs) at connect time so a framework or
   // provider switch takes effect on reconnect. Ignored when an explicit spawnAgent is provided (tests
   // inject that directly).
-  resolveBackend?: () => Promise<ResolvedAgentBackend> | ResolvedAgentBackend
+  resolveBackend?: (context: {
+    forcedSkillIds: string[]
+  }) => Promise<ResolvedAgentBackend> | ResolvedAgentBackend
   artifacts?: AcpRuntimeArtifactOptions
   uploads?: AcpRuntimeUploadOptions
   notebook?: AcpRuntimeNotebookOptions
@@ -157,12 +159,19 @@ type AcpRuntimeOptions = {
 type AcpRuntimeSkillsOptions = {
   // Returns the subset of forced ids that are currently disabled (i.e. need a respawn to materialize).
   needForceLoad: (ids: string[]) => Promise<string[]>
-  // Marks these ids force-loaded for the next spawn's provisioning.
-  setTurnForced: (ids: string[]) => void
-  // Clears the turn-scoped force-load set so later spawns use the normal enabled set.
-  clearTurnForced: () => void
   // Resolves picker ids to the names accepted by the agent's Skill tool.
   namesForIds: (ids: string[]) => Promise<string[]>
+}
+
+type ReviewerSessionRequest = {
+  cwd: string
+  mcpServers: McpServer[]
+  systemPromptAppend?: string
+}
+
+type ReviewerSessionResult = {
+  session: import('@agentclientprotocol/sdk').ActiveSession
+  promptPrefix?: string
 }
 
 type AcpRuntimeArtifactOptions = {
@@ -512,10 +521,17 @@ class AcpRuntime {
   // framework while moving to a different on-disk session store, where the old id is not resumable.
   private readonly sessionBackendIds = new Map<string, string>()
   private readonly promptInFlightSessionIds = new Set<string>()
+  // Public operations acquire this lease synchronously, before backend resolution, skill checks, or
+  // session handshakes can await. Retirement cannot remove a generation while one of those preflight
+  // phases is still capable of spawning or attaching a process/session.
+  private operationLeaseCount = 0
   // Workflow-scoped leases keep this generation alive across gaps between ephemeral sessions and main
   // prompts (for example reviewer -> correction -> re-review). A framework switch can retire the runtime
   // only after every lease and reviewer session has been released.
   private activityLeaseCount = 0
+  // Forced skill state belongs to this runtime generation. It is passed explicitly into backend
+  // provisioning so concurrent old/new generations cannot overwrite a SettingsService singleton.
+  private readonly turnForcedSkillIds = new Set<string>()
   // Monotonic per-turn token and the token of the turn that currently owns each app session id. When an
   // overflow-recovery replay reuses a session id, its start bumps the token; the abandoned turn's finally
   // then sees a newer owner and leaves the replay's shared state (lock, artifact run) untouched.
@@ -564,6 +580,7 @@ class AcpRuntime {
   // initialize so the decrypted key is not retained by the runtime longer than necessary.
   private pendingAuthentication: ResolvedAgentBackend['authentication']
   private pendingProviderConfiguration: ResolvedAgentBackend['providerConfiguration']
+  private responsesBridgeLease: ResolvedAgentBackend['responsesBridgeLease']
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
   private readonly cancelTimeoutMs: number
@@ -866,6 +883,10 @@ class AcpRuntime {
 
   // Starts a fresh agent process connection and initializes protocol capabilities.
   async connect(request: AcpConnectRequest = {}): Promise<AcpStateSnapshot> {
+    return this.withOperationLease(() => this.connectOperation(request))
+  }
+
+  private async connectOperation(request: AcpConnectRequest = {}): Promise<AcpStateSnapshot> {
     if (this.connectInFlight) {
       return this.connectInFlight
     }
@@ -925,8 +946,12 @@ class AcpRuntime {
       // on timeout. Awaited (not a bare kill) so a teardown that awaits this in-flight connect does not
       // resolve before the child's whole tree is reaped on Windows.
       if (this.shuttingDown || generation !== this.connectionGeneration) {
-        const result = await terminateProcessTree(agentProcess, undefined, log)
-        this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
+        try {
+          const result = await terminateProcessTree(agentProcess, undefined, log)
+          this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
+        } finally {
+          await spawned.backend.responsesBridgeLease?.release()
+        }
         throw new Error(
           this.shuttingDown
             ? 'ACP runtime is shutting down.'
@@ -934,6 +959,7 @@ class AcpRuntime {
         )
       }
 
+      this.applyResolvedBackend(spawned.backend)
       this.agentProcess = agentProcess
       this.attachAgentProcessEvents(this.agentProcess)
 
@@ -1101,6 +1127,12 @@ class AcpRuntime {
 
   // Creates a protocol session, injects artifact tooling, and uses the returned id as the app session id.
   async createSession(request: AcpCreateSessionRequest = {}): Promise<AcpCreateSessionResponse> {
+    return this.withOperationLease(() => this.createSessionOperation(request))
+  }
+
+  private async createSessionOperation(
+    request: AcpCreateSessionRequest = {}
+  ): Promise<AcpCreateSessionResponse> {
     try {
       log.info('createSession: starting', { request })
       const sessionCwd = resolve(request.cwd || this.cwd || this.options.defaultCwd)
@@ -1209,6 +1241,12 @@ class AcpRuntime {
 
   // Reattaches a persisted protocol session after an app restart so later prompts can stream.
   async resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
+    return this.withOperationLease(() => this.resumeSessionOperation(request))
+  }
+
+  private async resumeSessionOperation(
+    request: AcpResumeSessionRequest
+  ): Promise<AcpCreateSessionResponse> {
     const sessionCwd = resolve(request.cwd || this.cwd || this.options.defaultCwd)
     const projectName = this.normalizeProjectName(request.projectName)
 
@@ -1251,6 +1289,12 @@ class AcpRuntime {
   // transcript starts clean. Returns contextReset so the caller replays a bounded transcript into the
   // next prompt (the app-level equivalent of compaction, which — unlike the backend's — drops all media).
   async resetSessionContext(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
+    return this.withOperationLease(() => this.resetSessionContextOperation(request))
+  }
+
+  private async resetSessionContextOperation(
+    request: AcpResumeSessionRequest
+  ): Promise<AcpCreateSessionResponse> {
     const sessionCwd = resolve(request.cwd || this.cwd || this.options.defaultCwd)
     const projectName = this.normalizeProjectName(request.projectName)
     const connection = await this.ensureConnected(sessionCwd)
@@ -1532,6 +1576,7 @@ class AcpRuntime {
     this.connection?.close()
     this.connection = undefined
     this.killAgentProcess()
+    void this.releaseResponsesBridgeLease()
   }
 
   // Awaitable quit/relaunch teardown. Latches shuttingDown FIRST so a connect that is mid-spawn when
@@ -1581,7 +1626,7 @@ class AcpRuntime {
   // coordinator stops routing new work here immediately; teardown waits for every prompt and lease.
   async requestRetirement(): Promise<void> {
     this.pendingRetirement = true
-    if (this.hasBlockingActivity()) return
+    if (this.hasRetirementBlockingActivity()) return
 
     this.pendingRetirement = false
     this.pendingProviderReconnect = false
@@ -1608,15 +1653,17 @@ class AcpRuntime {
 
   // If a provider reconnect was deferred while a prompt ran, apply it once nothing is in flight.
   private maybeApplyPendingProviderReconnect(): void {
-    if (this.hasBlockingActivity()) return
-
     if (this.pendingRetirement) {
+      if (this.hasRetirementBlockingActivity()) return
+
       this.pendingRetirement = false
       this.pendingProviderReconnect = false
       this.pendingSkillsReload = false
       void this.disconnectForRetirement()
       return
     }
+
+    if (this.hasBlockingActivity()) return
 
     // A single reconnect satisfies both a pending provider switch and a pending skills reload: the
     // fresh spawn picks up the new backend AND re-provisions the current skill set. So clear both
@@ -1708,12 +1755,26 @@ class AcpRuntime {
     }
   }
 
+  private async withOperationLease<T>(work: () => Promise<T>): Promise<T> {
+    this.operationLeaseCount += 1
+    try {
+      return await work()
+    } finally {
+      this.operationLeaseCount = Math.max(0, this.operationLeaseCount - 1)
+      this.maybeApplyPendingProviderReconnect()
+    }
+  }
+
   private hasBlockingActivity(): boolean {
     return (
       this.promptInFlightSessionIds.size > 0 ||
       this.reviewerSessionIds.size > 0 ||
       this.activityLeaseCount > 0
     )
+  }
+
+  private hasRetirementBlockingActivity(): boolean {
+    return this.operationLeaseCount > 0 || this.hasBlockingActivity()
   }
 
   // Creates the reconnect barrier promise if one is not already pending.
@@ -1734,37 +1795,41 @@ class AcpRuntime {
   }
 
   private async disconnectCurrent(emitClosedStatus = true): Promise<AcpStateSnapshot> {
-    for (const timer of this.cancelTimers.values()) this.clearTimer(timer)
-    this.cancelTimers.clear()
-    this.permissionBroker.cancelAll()
-    this.clearReviewerSessionState()
-    this.promptInFlightSessionIds.clear()
+    try {
+      for (const timer of this.cancelTimers.values()) this.clearTimer(timer)
+      this.cancelTimers.clear()
+      this.permissionBroker.cancelAll()
+      this.clearReviewerSessionState()
+      this.promptInFlightSessionIds.clear()
 
-    for (const session of this.sessions.values()) {
-      session.dispose()
+      for (const session of this.sessions.values()) {
+        session.dispose()
+      }
+
+      this.sessions.clear()
+      this.sessionCwds.clear()
+      this.sessionInlineImageBytes.clear()
+      this.currentPromptTurnBySession.clear()
+      this.latestSessionConfigOptions.clear()
+      this.sessionMcpServerNames.clear()
+      this.codexMcpToolIdentities.clear()
+      this.sessionProjectNames.clear()
+      this.permissionProfiles.clear()
+      this.artifactSessionIds.clear()
+      this.notebookRoutingIds.clear()
+      this.mcpHttpHost?.clear()
+      this.agentToAppSessionId.clear()
+      this.currentSessionId = undefined
+      this.supportsSessionClose = false
+      this.supportsSessionDelete = false
+      this.supportsSessionResume = false
+      this.connection?.close()
+      this.connection = undefined
+
+      await this.killAgentProcessTree()
+    } finally {
+      await this.releaseResponsesBridgeLease()
     }
-
-    this.sessions.clear()
-    this.sessionCwds.clear()
-    this.sessionInlineImageBytes.clear()
-    this.currentPromptTurnBySession.clear()
-    this.latestSessionConfigOptions.clear()
-    this.sessionMcpServerNames.clear()
-    this.codexMcpToolIdentities.clear()
-    this.sessionProjectNames.clear()
-    this.permissionProfiles.clear()
-    this.artifactSessionIds.clear()
-    this.notebookRoutingIds.clear()
-    this.mcpHttpHost?.clear()
-    this.agentToAppSessionId.clear()
-    this.currentSessionId = undefined
-    this.supportsSessionClose = false
-    this.supportsSessionDelete = false
-    this.supportsSessionResume = false
-    this.connection?.close()
-    this.connection = undefined
-
-    await this.killAgentProcessTree()
 
     if (emitClosedStatus) {
       this.setStatus('closed')
@@ -1820,30 +1885,27 @@ class AcpRuntime {
   private async spawnAgentProcess(): Promise<{
     process: ChildProcessWithoutNullStreams
     framework: AgentFramework['id']
+    backend: ResolvedAgentBackend
   }> {
     if (this.spawnAgent) {
-      return { process: this.spawnAgent(), framework: this.framework.id }
+      return {
+        process: this.spawnAgent(),
+        framework: this.framework.id,
+        backend: {
+          framework: this.framework,
+          executablePath: '',
+          env: {}
+        }
+      }
     }
 
-    const backend = this.options.resolveBackend ? await this.options.resolveBackend() : undefined
+    const backend = this.options.resolveBackend
+      ? await this.options.resolveBackend({ forcedSkillIds: [...this.turnForcedSkillIds] })
+      : undefined
 
     if (!backend) {
       throw new Error('ACP agent spawn configuration is not available.')
     }
-
-    // Adopt the framework this reconnect resolved so session meta, permission mapping, and the spawn
-    // itself all agree with the current selection.
-    this.framework = backend.framework
-    this.backendId = backend.backendId
-    this.nativeMcpEnabled =
-      backend.framework.id !== 'codex' || backend.providerConfiguration === undefined
-    this.bridgeMcpAliasesEnabled =
-      backend.framework.id === 'codex' && backend.providerConfiguration !== undefined
-    this.pendingSessionModel = backend.sessionModel
-    this.pendingSessionModelRequired = backend.sessionModelRequired ?? false
-    this.pendingSessionEffort = backend.sessionEffort
-    this.pendingAuthentication = backend.authentication
-    this.pendingProviderConfiguration = backend.providerConfiguration
 
     // Surfaces which backend + model this connect uses, so a fallback to the framework's own default
     // model (e.g. opencode with no app model to inject) is diagnosable in the log rather than silent.
@@ -1860,7 +1922,7 @@ class AcpRuntime {
 
     let process: ChildProcessWithoutNullStreams
     try {
-      process = this.framework.spawn({
+      process = backend.framework.spawn({
         executablePath: backend.executablePath,
         env: backend.env,
         args: backend.args ?? []
@@ -1869,6 +1931,7 @@ class AcpRuntime {
       // Wrap (never mutate) the failure with the framework this spawn targeted: the connect-level catch
       // would otherwise fall back to this.framework.id, which an overlapping reconnect could move before
       // the log is written. connectFresh unwraps this and re-throws the original `error` value.
+      await backend.responsesBridgeLease?.release()
       throw new SpawnFailure(backend.framework.id, error)
     }
 
@@ -1877,12 +1940,33 @@ class AcpRuntime {
       pid: process.pid
     })
 
-    return { process, framework: backend.framework.id }
+    return { process, framework: backend.framework.id, backend }
+  }
+
+  private applyResolvedBackend(backend: ResolvedAgentBackend): void {
+    this.framework = backend.framework
+    this.backendId = backend.backendId
+    this.nativeMcpEnabled =
+      backend.framework.id !== 'codex' || backend.providerConfiguration === undefined
+    this.bridgeMcpAliasesEnabled =
+      backend.framework.id === 'codex' && backend.providerConfiguration !== undefined
+    this.pendingSessionModel = backend.sessionModel
+    this.pendingSessionModelRequired = backend.sessionModelRequired ?? false
+    this.pendingSessionEffort = backend.sessionEffort
+    this.pendingAuthentication = backend.authentication
+    this.pendingProviderConfiguration = backend.providerConfiguration
+    this.responsesBridgeLease = backend.responsesBridgeLease
+  }
+
+  private async releaseResponsesBridgeLease(): Promise<void> {
+    const lease = this.responsesBridgeLease
+    this.responsesBridgeLease = undefined
+    await lease?.release()
   }
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
   async sendPrompt(request: AcpPromptRequest): Promise<PromptResponse> {
-    return withDataRootWrite(() => this.sendPromptTurn(request))
+    return this.withOperationLease(() => withDataRootWrite(() => this.sendPromptTurn(request)))
   }
 
   private async sendPromptTurn(request: AcpPromptRequest): Promise<PromptResponse> {
@@ -1903,37 +1987,43 @@ class AcpRuntime {
     const forced = request.forcedSkillIds ?? []
     let didForceReload = false
 
-    if (this.skillsHooks && forced.length > 0) {
-      const toForce = await this.skillsHooks.needForceLoad(forced)
+    try {
+      if (this.skillsHooks && forced.length > 0) {
+        const toForce = await this.skillsHooks.needForceLoad(forced)
 
-      if (toForce.length > 0) {
-        // Capture routing before the disconnect clears it, so the resume lands on the same conversation.
-        const sessionCwd = this.sessionCwds.get(request.sessionId) ?? this.cwd
-        const projectName = this.resolveSessionProjectName(request.sessionId)
-        const permissionProfile =
-          this.permissionProfiles.get(request.sessionId)?.selectedProfile ??
-          DEFAULT_PERMISSION_PROFILE
-        this.skillsHooks.setTurnForced(forced)
-        didForceReload = true
-        await this.disconnect(false)
-        const reloadResume = await this.resumeSession({
-          sessionId: request.sessionId,
-          cwd: sessionCwd,
-          projectName,
-          permissionProfile
-        })
-        if (reloadResume.contextReset) {
-          request.historyPreamble = request.resumeFallback?.historyPreamble
-          request.historyAttachments = request.resumeFallback?.historyAttachments
-          request.historyImages = request.resumeFallback?.historyImages
-        }
+        if (toForce.length > 0) {
+          // Capture routing before disconnect clears it, so resume lands on the same conversation.
+          const sessionCwd = this.sessionCwds.get(request.sessionId) ?? this.cwd
+          const projectName = this.resolveSessionProjectName(request.sessionId)
+          const permissionProfile =
+            this.permissionProfiles.get(request.sessionId)?.selectedProfile ??
+            DEFAULT_PERMISSION_PROFILE
+          this.turnForcedSkillIds.clear()
+          for (const id of forced) this.turnForcedSkillIds.add(id)
+          didForceReload = true
+          await this.disconnect(false)
+          const reloadResume = await this.resumeSession({
+            sessionId: request.sessionId,
+            cwd: sessionCwd,
+            projectName,
+            permissionProfile
+          })
+          if (reloadResume.contextReset) {
+            request.historyPreamble = request.resumeFallback?.historyPreamble
+            request.historyAttachments = request.resumeFallback?.historyAttachments
+            request.historyImages = request.resumeFallback?.historyImages
+          }
 
-        const reloaded = this.sessions.get(request.sessionId)
-        if (!reloaded) {
-          throw new Error(`ACP session not found after force-load: ${request.sessionId}`)
+          const reloaded = this.sessions.get(request.sessionId)
+          if (!reloaded) {
+            throw new Error(`ACP session not found after force-load: ${request.sessionId}`)
+          }
+          activeSession = reloaded
         }
-        activeSession = reloaded
       }
+    } catch (error) {
+      if (didForceReload) this.turnForcedSkillIds.clear()
+      throw error
     }
 
     this.currentSessionId = request.sessionId
@@ -2098,8 +2188,8 @@ class AcpRuntime {
       // A disabled skill forced for this turn is restored now: clear the force set, then schedule a
       // reconnect so the NEXT prompt respawns with the normal enabled set. Ordering matters — the clear
       // must happen before the reconnect is applied so the fresh spawn no longer sees the forced ids.
-      if (didForceReload && this.skillsHooks) {
-        this.skillsHooks.clearTurnForced()
+      if (didForceReload) {
+        this.turnForcedSkillIds.clear()
         this.pendingSkillsReload = true
       }
       // A provider switch requested mid-turn is applied now that the session is idle.
@@ -3465,6 +3555,7 @@ class AcpRuntime {
     this.pendingSkillsReload = false
     this.pendingRetirement = false
     this.resolveReconnectBarrier()
+    void this.releaseResponsesBridgeLease()
     this.setStatus('closed')
   }
 
@@ -3539,6 +3630,7 @@ class AcpRuntime {
 
   private clearReviewerSessionState(): void {
     for (const [sessionId, reviewerCwd] of this.reviewerSessionDirectories) {
+      this.responsesBridgeLease?.unregisterReviewerSession(sessionId)
       this.removeReviewerDirectory(reviewerCwd)
       this.codexMcpToolIdentities.delete(sessionId)
       this.sessionFrameworks.delete(sessionId)
@@ -3562,18 +3654,15 @@ class AcpRuntime {
   // session is isolated from main agent sessions: it is not tracked in this.sessions, does not
   // appear in the snapshot, and callers are responsible for disposing it. This allows background
   // review to run in parallel with the main session without affecting the main state machine.
-  async buildReviewerSession(request: {
+  async buildReviewerSession(request: ReviewerSessionRequest): Promise<ReviewerSessionResult> {
+    return this.withOperationLease(() => this.buildReviewerSessionOperation(request))
+  }
+
+  private async buildReviewerSessionOperation(
+    request: ReviewerSessionRequest
+  ): Promise<ReviewerSessionResult> {
     // Used only to establish/reuse the shared agent connection. The reviewer session itself runs in an
     // app-created empty temporary directory so built-in read tools cannot see the audited workspace.
-    cwd: string
-    mcpServers: McpServer[]
-    systemPromptAppend?: string
-  }): Promise<{
-    session: import('@agentclientprotocol/sdk').ActiveSession
-    // Framework-neutral rubric delivery: Claude carries the append in session _meta (empty prefix),
-    // opencode has no preset so the rubric rides back as a prompt prefix the caller must prepend.
-    promptPrefix?: string
-  }> {
     const mcpServerNames = this.mcpServerNamesOf(request.mcpServers)
     const reviewerMcp = request.mcpServers[0]
     const reviewerMcpHttp =
@@ -3649,6 +3738,7 @@ class AcpRuntime {
       }
 
       this.reviewerSessionIds.add(session.sessionId)
+      this.responsesBridgeLease?.registerReviewerSession(session.sessionId)
       this.reviewerSessionDirectories.set(session.sessionId, reviewerCwd)
       this.sessionMcpServerNames.set(session.sessionId, mcpServerNames)
       this.sessionFrameworks.set(session.sessionId, this.framework.id)
@@ -3667,6 +3757,7 @@ class AcpRuntime {
   disposeReviewerSession(session: import('@agentclientprotocol/sdk').ActiveSession): number {
     const rejectedToolCalls = this.reviewerRejectedToolCalls.get(session.sessionId) ?? 0
     this.reviewerSessionIds.delete(session.sessionId)
+    this.responsesBridgeLease?.unregisterReviewerSession(session.sessionId)
     this.sessionMcpServerNames.delete(session.sessionId)
     this.codexMcpToolIdentities.delete(session.sessionId)
     this.sessionFrameworks.delete(session.sessionId)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1533,6 +1533,12 @@ class AcpRuntime {
   // Changes approval behavior only while the conversation is idle. Applying the ACP mode before the
   // next prompt guarantees Full access cannot show a first-tool permission race.
   async setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<AcpStateSnapshot> {
+    return this.withOperationLease(() => this.setPermissionProfileOperation(request))
+  }
+
+  private async setPermissionProfileOperation(
+    request: AcpSetPermissionProfileRequest
+  ): Promise<AcpStateSnapshot> {
     const session = this.sessions.get(request.sessionId)
 
     if (!session) throw new Error(`ACP session not found: ${request.sessionId}`)
@@ -2256,6 +2262,12 @@ class AcpRuntime {
 
   // Closes the agent-side session when supported, then removes local routing state.
   async deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot> {
+    return this.withOperationLease(() => this.deleteSessionOperation(request))
+  }
+
+  private async deleteSessionOperation(
+    request: AcpDeleteSessionRequest
+  ): Promise<AcpStateSnapshot> {
     const session = this.sessions.get(request.sessionId)
 
     if (session) {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -3566,11 +3566,16 @@ class AcpRuntime {
     // skills too, so clear both pending flags to avoid a spurious later reconnect.
     this.pendingProviderReconnect = false
     this.pendingSkillsReload = false
-    this.pendingRetirement = false
     this.resolveReconnectBarrier()
     void this.closeMcpHttpHost()
     void this.releaseResponsesBridgeLease()
-    this.setStatus('closed')
+    try {
+      this.setStatus('closed')
+    } finally {
+      // An unexpected close satisfies any pending reconnect, but retirement remains terminal. Re-run
+      // its evaluator now and again when outstanding operation/activity leases drain.
+      this.maybeApplyPendingProviderReconnect()
+    }
   }
 
   // Updates connection status and broadcasts the new snapshot.
@@ -3644,7 +3649,7 @@ class AcpRuntime {
 
   private clearReviewerSessionState(): void {
     for (const [sessionId, reviewerCwd] of this.reviewerSessionDirectories) {
-      this.responsesBridgeLease?.unregisterReviewerSession(sessionId)
+      this.unregisterReviewerBridgeSession(sessionId)
       this.removeReviewerDirectory(reviewerCwd)
       this.codexMcpToolIdentities.delete(sessionId)
       this.sessionFrameworks.delete(sessionId)
@@ -3771,7 +3776,7 @@ class AcpRuntime {
   disposeReviewerSession(session: import('@agentclientprotocol/sdk').ActiveSession): number {
     const rejectedToolCalls = this.reviewerRejectedToolCalls.get(session.sessionId) ?? 0
     this.reviewerSessionIds.delete(session.sessionId)
-    this.responsesBridgeLease?.unregisterReviewerSession(session.sessionId)
+    this.unregisterReviewerBridgeSession(session.sessionId)
     this.sessionMcpServerNames.delete(session.sessionId)
     this.codexMcpToolIdentities.delete(session.sessionId)
     this.sessionFrameworks.delete(session.sessionId)
@@ -3782,6 +3787,13 @@ class AcpRuntime {
     if (reviewerCwd) this.removeReviewerDirectory(reviewerCwd)
     this.maybeApplyPendingProviderReconnect()
     return rejectedToolCalls
+  }
+
+  private unregisterReviewerBridgeSession(sessionId: string): void {
+    const scoped = this.responsesBridgeLease?.unregisterReviewerSession(sessionId)
+    if (scoped === false) {
+      log.error('reviewer bridge request was never scoped', { sessionId })
+    }
   }
 
   // Returns how many permission requests the strict reviewer gate rejected for a given reviewer

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1562,7 +1562,11 @@ class AcpRuntime {
     this.nextConnectionGeneration()
     this.connectInFlight = undefined
 
-    return this.disconnectCurrent(emitClosedStatus)
+    try {
+      return await this.disconnectCurrent(emitClosedStatus)
+    } finally {
+      await this.closeMcpHttpHost()
+    }
   }
 
   // Synchronously terminates the agent child for app shutdown. Electron's `will-quit` cannot await, so
@@ -1576,6 +1580,7 @@ class AcpRuntime {
     this.connection?.close()
     this.connection = undefined
     this.killAgentProcess()
+    void this.closeMcpHttpHost()
     void this.releaseResponsesBridgeLease()
   }
 
@@ -1962,6 +1967,14 @@ class AcpRuntime {
     const lease = this.responsesBridgeLease
     this.responsesBridgeLease = undefined
     await lease?.release()
+  }
+
+  private async closeMcpHttpHost(): Promise<void> {
+    try {
+      await this.mcpHttpHost?.close()
+    } catch (error) {
+      safeLogError('MCP HTTP host close failed', errorLogFields(error))
+    }
   }
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
@@ -3555,6 +3568,7 @@ class AcpRuntime {
     this.pendingSkillsReload = false
     this.pendingRetirement = false
     this.resolveReconnectBarrier()
+    void this.closeMcpHttpHost()
     void this.releaseResponsesBridgeLease()
     this.setStatus('closed')
   }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -103,6 +103,7 @@ import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
 import { isMediaOverflowError } from '../../shared/media-overflow'
+import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
 import { REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_TOOLS } from '../../shared/reviewer'
 import {
   buildImageContentData,
@@ -114,10 +115,11 @@ import {
   type InlineImageBudget
 } from '../uploads/attachment-media'
 
-type AcpRuntimeCallbacks = {
+export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
   onEvent?: (event: AcpRuntimeEvent) => void
   onPermissionRequest?: (request: AcpPermissionRequest) => void
+  onRetired?: () => void
 }
 
 type AcpRuntimeOptions = {
@@ -510,6 +512,10 @@ class AcpRuntime {
   // framework while moving to a different on-disk session store, where the old id is not resumable.
   private readonly sessionBackendIds = new Map<string, string>()
   private readonly promptInFlightSessionIds = new Set<string>()
+  // Workflow-scoped leases keep this generation alive across gaps between ephemeral sessions and main
+  // prompts (for example reviewer -> correction -> re-review). A framework switch can retire the runtime
+  // only after every lease and reviewer session has been released.
+  private activityLeaseCount = 0
   // Monotonic per-turn token and the token of the turn that currently owns each app session id. When an
   // overflow-recovery replay reuses a session id, its start bumps the token; the abandoned turn's finally
   // then sees a newer owner and leaves the replay's shared state (lock, artifact run) untouched.
@@ -519,6 +525,10 @@ class AcpRuntime {
   // A provider change requested while a prompt was running, applied when the session next goes idle.
   private pendingProviderReconnect = false
   private pendingSkillsReload = false
+  // A coordinator-owned framework generation retires after its last active turn or background workflow.
+  // Unlike a provider reconnect, it must never spawn again: future work uses the coordinator's current
+  // runtime.
+  private pendingRetirement = false
   // Barrier awaited by ensureConnected so a createSession called while a deferred reconnect is
   // queued blocks until the reconnect completes rather than reusing the stale connection.
   private reconnectBarrier: Promise<void> | undefined
@@ -532,8 +542,8 @@ class AcpRuntime {
   private framework: AgentFramework
   private backendId: string | undefined
   private readonly mcpHttpHost: AgentMcpHttpHost | undefined
-  // A Chat Completions provider uses the local Responses bridge. The app-owned notebook MCP has an
-  // explicit namespaced bridge mapping; other app MCP tools still require native Responses.
+  // A Chat Completions provider uses the local Responses bridge. App-owned notebook, artifact, and
+  // reviewer MCPs have explicit namespaced bridge mappings; other MCP tools still require Responses.
   private nativeMcpEnabled = true
   private bridgeMcpAliasesEnabled = false
   // Model to apply per session via the ACP model configOption (opencode); undefined for env-driven
@@ -1567,12 +1577,24 @@ class AcpRuntime {
     return { reaped: this.lastTreeKillReaped }
   }
 
+  // Retires this framework generation without interrupting active turns or background workflows. The
+  // coordinator stops routing new work here immediately; teardown waits for every prompt and lease.
+  async requestRetirement(): Promise<void> {
+    this.pendingRetirement = true
+    if (this.hasBlockingActivity()) return
+
+    this.pendingRetirement = false
+    this.pendingProviderReconnect = false
+    this.pendingSkillsReload = false
+    await this.disconnectForRetirement()
+  }
+
   // Applies an active-provider change without interrupting the user. The agent bakes its provider env in
   // at spawn, so a new provider needs a reconnect — but if a prompt is running we defer the reconnect
   // until the session goes idle. Because every provider shares one config dir, the reconnect resumes the
   // conversation on the new provider with full context. Called when the active provider changes.
   async requestProviderReconnect(): Promise<void> {
-    if (this.promptInFlightSessionIds.size > 0) {
+    if (this.hasBlockingActivity()) {
       this.pendingProviderReconnect = true
       // Arm the barrier so any concurrent createSession waits for the reconnect
       // rather than reusing the stale connection with the old backend.
@@ -1586,7 +1608,15 @@ class AcpRuntime {
 
   // If a provider reconnect was deferred while a prompt ran, apply it once nothing is in flight.
   private maybeApplyPendingProviderReconnect(): void {
-    if (this.promptInFlightSessionIds.size > 0) return
+    if (this.hasBlockingActivity()) return
+
+    if (this.pendingRetirement) {
+      this.pendingRetirement = false
+      this.pendingProviderReconnect = false
+      this.pendingSkillsReload = false
+      void this.disconnectForRetirement()
+      return
+    }
 
     // A single reconnect satisfies both a pending provider switch and a pending skills reload: the
     // fresh spawn picks up the new backend AND re-provisions the current skill set. So clear both
@@ -1630,12 +1660,31 @@ class AcpRuntime {
     }
   }
 
+  // Retirement is terminal for this runtime generation. Swallow teardown failures just like deferred
+  // reconnect cleanup so a late dispose error cannot become an unhandled rejection after a prompt ends.
+  private async disconnectForRetirement(): Promise<void> {
+    try {
+      // Retirement is an intentional handoff after all blocking activity has finished. Suppress the
+      // abnormal-drop status so the renderer does not mark the just-completed turn as interrupted.
+      await this.disconnect(false)
+    } catch (error) {
+      safeLogError('retired runtime disconnect failed', errorLogFields(error))
+    } finally {
+      this.resolveReconnectBarrier()
+      try {
+        this.callbacks.onRetired?.()
+      } catch (error) {
+        safeLogError('retired runtime callback failed', errorLogFields(error))
+      }
+    }
+  }
+
   // Re-materializes the agent's skills on the next reconnect: a disconnect makes the next prompt spawn a
   // fresh agent, whose provisioning copies the current enabled set into the config dir before the session
   // resumes with full context. Defers past an in-flight prompt exactly like a provider switch. Called
   // when a skill is toggled in settings.
   async requestSkillsReload(): Promise<void> {
-    if (this.promptInFlightSessionIds.size > 0) {
+    if (this.hasBlockingActivity()) {
       this.pendingSkillsReload = true
       this.armReconnectBarrier()
       return
@@ -1643,6 +1692,28 @@ class AcpRuntime {
 
     this.pendingSkillsReload = false
     await this.disconnect()
+  }
+
+  // Holds this generation across a multi-step background workflow, including gaps with no live session.
+  async withActivity<T>(
+    _options: AcpRuntimeActivityOptions,
+    work: (runtime: AcpRuntimeActivity) => Promise<T>
+  ): Promise<T> {
+    this.activityLeaseCount += 1
+    try {
+      return await work(this)
+    } finally {
+      this.activityLeaseCount = Math.max(0, this.activityLeaseCount - 1)
+      this.maybeApplyPendingProviderReconnect()
+    }
+  }
+
+  private hasBlockingActivity(): boolean {
+    return (
+      this.promptInFlightSessionIds.size > 0 ||
+      this.reviewerSessionIds.size > 0 ||
+      this.activityLeaseCount > 0
+    )
   }
 
   // Creates the reconnect barrier promise if one is not already pending.
@@ -3392,6 +3463,7 @@ class AcpRuntime {
     // skills too, so clear both pending flags to avoid a spurious later reconnect.
     this.pendingProviderReconnect = false
     this.pendingSkillsReload = false
+    this.pendingRetirement = false
     this.resolveReconnectBarrier()
     this.setStatus('closed')
   }
@@ -3602,6 +3674,7 @@ class AcpRuntime {
     this.reviewerSessionDirectories.delete(session.sessionId)
     session.dispose()
     if (reviewerCwd) this.removeReviewerDirectory(reviewerCwd)
+    this.maybeApplyPendingProviderReconnect()
     return rejectedToolCalls
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -174,6 +174,12 @@ type ReviewerSessionResult = {
   promptPrefix?: string
 }
 
+export type ReviewerSessionDisposition = {
+  rejectedToolCalls: number
+  // Undefined for frameworks/providers that do not traverse the Responses bridge.
+  reviewerBridgeScoped: boolean | undefined
+}
+
 type AcpRuntimeArtifactOptions = {
   // Config root: where the app-owned claude config dir lives (never relocated).
   configRoot: string
@@ -1972,7 +1978,11 @@ class AcpRuntime {
   private async releaseResponsesBridgeLease(): Promise<void> {
     const lease = this.responsesBridgeLease
     this.responsesBridgeLease = undefined
-    await lease?.release()
+    try {
+      await lease?.release()
+    } catch (error) {
+      safeLogError('responses bridge lease release failed', errorLogFields(error))
+    }
   }
 
   private async closeMcpHttpHost(): Promise<void> {
@@ -3782,13 +3792,15 @@ class AcpRuntime {
   }
 
   // Disposes an ephemeral reviewer session and unregisters it from the auto-approve set. Safe to call
-  // even if the session was never registered (e.g. it failed before start). Returns the number of tool
-  // calls the gate rejected during the session: the read and the clear are atomic here so callers need
-  // no capture-before-dispose ordering — dispose deletes the counter, and this is its last observer.
-  disposeReviewerSession(session: import('@agentclientprotocol/sdk').ActiveSession): number {
+  // even if the session was never registered (e.g. it failed before start). Returns the gate rejection
+  // count plus whether a bridged reviewer request actually hit its trusted session scope. The reads and
+  // clears are atomic here so callers need no capture-before-dispose ordering.
+  disposeReviewerSession(
+    session: import('@agentclientprotocol/sdk').ActiveSession
+  ): ReviewerSessionDisposition {
     const rejectedToolCalls = this.reviewerRejectedToolCalls.get(session.sessionId) ?? 0
     this.reviewerSessionIds.delete(session.sessionId)
-    this.unregisterReviewerBridgeSession(session.sessionId)
+    const reviewerBridgeScoped = this.unregisterReviewerBridgeSession(session.sessionId)
     this.sessionMcpServerNames.delete(session.sessionId)
     this.codexMcpToolIdentities.delete(session.sessionId)
     this.sessionFrameworks.delete(session.sessionId)
@@ -3798,14 +3810,15 @@ class AcpRuntime {
     session.dispose()
     if (reviewerCwd) this.removeReviewerDirectory(reviewerCwd)
     this.maybeApplyPendingProviderReconnect()
-    return rejectedToolCalls
+    return { rejectedToolCalls, reviewerBridgeScoped }
   }
 
-  private unregisterReviewerBridgeSession(sessionId: string): void {
+  private unregisterReviewerBridgeSession(sessionId: string): boolean | undefined {
     const scoped = this.responsesBridgeLease?.unregisterReviewerSession(sessionId)
     if (scoped === false) {
       log.error('reviewer bridge request was never scoped', { sessionId })
     }
+    return scoped
   }
 
   // Returns how many permission requests the strict reviewer gate rejected for a given reviewer

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -3605,7 +3605,8 @@ class AcpRuntime {
     })
     const reviewerMeta: Record<string, unknown> = {
       ...(setup.meta ?? {}),
-      // claude-agent-acp's framework-neutral legacy switch; harmless to agents that ignore it.
+      // claude-agent-acp honors this legacy switch. codex-acp currently ignores it, so bridged
+      // Codex turns are independently restricted to reviewer MCP schemas at the bridge boundary.
       disableBuiltInTools: true
     }
     if (this.framework.id === 'claude-code') {

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -133,9 +133,8 @@ const buildCodexConfig = (provider: {
         ...(provider.key ? { requires_openai_auth: true } : {})
       }
     }
-    // Tool-search configuration is intentionally left at Codex defaults. The Chat bridge exposes the
-    // app-owned notebook tools through explicit namespaced aliases and does not depend on deferred
-    // tool_search behavior.
+    // Tool-search configuration is intentionally left at Codex defaults. The Chat bridge exposes its
+    // app-owned tools through explicit namespaced aliases and does not depend on deferred tool_search.
   }
 }
 

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -155,7 +155,7 @@ export type ResolvedAgentBackend = {
   // reviewer sessions register their Codex prompt_cache_key here so routing never depends on content.
   responsesBridgeLease?: {
     registerReviewerSession: (promptCacheKey: string) => void
-    unregisterReviewerSession: (promptCacheKey: string) => void
+    unregisterReviewerSession: (promptCacheKey: string) => boolean
     release: () => Promise<void>
   }
 }

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -151,4 +151,11 @@ export type ResolvedAgentBackend = {
   sessionEffort?: ReasoningEffort
   authentication?: AgentAuthentication
   providerConfiguration?: AgentProviderConfiguration
+  // A bridged backend owns one reference to its local loopback bridge. Runtime teardown releases it;
+  // reviewer sessions register their Codex prompt_cache_key here so routing never depends on content.
+  responsesBridgeLease?: {
+    registerReviewerSession: (promptCacheKey: string) => void
+    unregisterReviewerSession: (promptCacheKey: string) => void
+    release: () => Promise<void>
+  }
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -454,12 +454,12 @@ const registerIpcHandlers = async ({
   updateService.setInstallGate?.(() =>
     shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
   )
-  // Switching the active provider takes effect on the next reconnect. Defer that reconnect until any
-  // in-flight prompt finishes so switching never interrupts a running turn; the shared config dir keeps
-  // the conversation's context across the switch.
+  // Spawn-config changes rotate the coordinator's runtime for future sessions. Existing sessions retain
+  // their owning runtime, so a framework/provider switch cannot interrupt an in-flight turn.
   registerSettingsIpcHandlers({
     service: settingsService,
     onActiveProviderChanged: () => void runtime.requestProviderReconnect(),
+    onAgentFrameworkChanged: () => void runtime.requestAgentFrameworkSwitch(),
     onReasoningEffortChanged: (effort) => runtime.applyReasoningEffortChange(effort),
     onSkillsChanged: () => void runtime.requestSkillsReload(),
     // Re-sync bundled + custom skill docs and refresh the in-memory snapshot the connector

--- a/src/main/reviewer/acp-runtime.ts
+++ b/src/main/reviewer/acp-runtime.ts
@@ -1,0 +1,20 @@
+import type { AcpRuntime } from '../acp/runtime'
+import type {
+  AcpRuntimeActivity,
+  AcpRuntimeActivityOptions,
+  AcpRuntimeActivityOwner
+} from '../acp/runtime-activity'
+
+// Reviewer orchestration needs only this public runtime surface. Keeping it structural lets tests use
+// small stubs while production pins the whole review/fix-loop workflow to one runtime generation.
+export type ReviewerAcpRuntime = Pick<
+  AcpRuntime,
+  'buildReviewerSession' | 'disposeReviewerSession' | 'sendPrompt'
+> &
+  Partial<AcpRuntimeActivityOwner>
+
+export const withReviewerRuntimeActivity = <T>(
+  runtime: ReviewerAcpRuntime,
+  options: AcpRuntimeActivityOptions,
+  work: (runtime: AcpRuntimeActivity) => Promise<T>
+): Promise<T> => (runtime.withActivity ? runtime.withActivity(options, work) : work(runtime))

--- a/src/main/reviewer/bridge-tools.ts
+++ b/src/main/reviewer/bridge-tools.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+
+import { REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_TOOLS } from '../../shared/reviewer'
+import type { ResponsesBridgeNamespacedTool } from '../settings/responses-bridge'
+import { submitFindingsInputSchema } from './mcp-server'
+
+export const REVIEWER_BRIDGE_TOOL_NAMESPACE = `mcp__${REVIEWER_MCP_SERVER_NAME.replace(
+  /[^a-zA-Z0-9_]/g,
+  '_'
+)}`
+
+export const REVIEWER_BRIDGE_NAMESPACED_TOOLS: ResponsesBridgeNamespacedTool[] = [
+  {
+    namespace: REVIEWER_BRIDGE_TOOL_NAMESPACE,
+    name: REVIEWER_MCP_TOOLS.readTurn,
+    description: 'Return the ordered message and tool-activity blocks in the audited turn.',
+    parameters: z.toJSONSchema(z.object({}).strict(), { target: 'draft-7' })
+  },
+  {
+    namespace: REVIEWER_BRIDGE_TOOL_NAMESPACE,
+    name: REVIEWER_MCP_TOOLS.queryExecutionLog,
+    description: 'Return the execution log for the audited turn or one in-scope activity.',
+    parameters: z.toJSONSchema(
+      z
+        .object({ activityId: z.string().optional().describe('Optional in-scope activity id') })
+        .strict(),
+      { target: 'draft-7' }
+    )
+  },
+  {
+    namespace: REVIEWER_BRIDGE_TOOL_NAMESPACE,
+    name: REVIEWER_MCP_TOOLS.readArtifact,
+    description: 'Read one artifact attached to the audited turn.',
+    parameters: z.toJSONSchema(
+      z.object({ id: z.string().min(1).describe('In-scope artifact version id') }).strict(),
+      { target: 'draft-7' }
+    )
+  },
+  {
+    namespace: REVIEWER_BRIDGE_TOOL_NAMESPACE,
+    name: REVIEWER_MCP_TOOLS.submitFindings,
+    description:
+      'Submit structured review checks exactly once, then stop. Pass an empty checks array if no issues were found.',
+    parameters: z.toJSONSchema(submitFindingsInputSchema, {
+      target: 'draft-7'
+    }) as ResponsesBridgeNamespacedTool['parameters']
+  }
+]

--- a/src/main/reviewer/correction.ts
+++ b/src/main/reviewer/correction.ts
@@ -4,7 +4,7 @@
 // Phase 3: correction.ts no longer hardcodes unaddressed resolutions.
 // The fix loop in orchestrator.ts drives re-review and sets resolutions from those results.
 
-import type { AcpRuntime } from '../acp/runtime'
+import type { ReviewerAcpRuntime } from './acp-runtime'
 import { createLogger } from '../logger'
 import type { ReviewCheck } from '../../shared/reviewer'
 
@@ -41,7 +41,7 @@ export const injectAuditorMessage = async (options: {
   sessionId: string
   mainSessionId: string
   findings: ReviewCheck[] // the full checks list; only warn/fail are injected
-  acpRuntime: AcpRuntime
+  acpRuntime: ReviewerAcpRuntime
   // Optional hook for tests to capture the injected message text.
   onCorrectionPrompt?: (text: string) => void
   // Called if the correction sendPrompt fails, so the caller can undo pre-emptive suppression.

--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -449,6 +449,29 @@ describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
       spawnAgent: () => asAgentProcess(process)
     })
 
+    let activityActive = false
+    const originalWithActivity = runtime.withActivity.bind(runtime)
+    const originalBuildReviewerSession = runtime.buildReviewerSession.bind(runtime)
+    const originalSendPrompt = runtime.sendPrompt.bind(runtime)
+    const activitySpy = vi.spyOn(runtime, 'withActivity').mockImplementation((options, work) =>
+      originalWithActivity(options, async (scopedRuntime) => {
+        activityActive = true
+        try {
+          return await work(scopedRuntime)
+        } finally {
+          activityActive = false
+        }
+      })
+    )
+    vi.spyOn(runtime, 'buildReviewerSession').mockImplementation((request) => {
+      expect(activityActive).toBe(true)
+      return originalBuildReviewerSession(request)
+    })
+    vi.spyOn(runtime, 'sendPrompt').mockImplementation((request) => {
+      expect(activityActive).toBe(true)
+      return originalSendPrompt(request)
+    })
+
     await runtime.createSession({ cwd: '/workspace' })
 
     const client = createProjectDbClient(temporaryRoot!)
@@ -475,6 +498,7 @@ describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
       s.sessionId.startsWith('reviewer-session')
     )
     expect(reviewerSessions).toHaveLength(2)
+    expect(activitySpy).toHaveBeenCalledOnce()
 
     // The original review's warn/fail check must now be resolved.
     const reviews = await repository.getReviewsForSession('session-1')

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -16,7 +16,7 @@ import { createLogger } from '../logger'
 import { runReview } from './orchestrator'
 import { flagStaleReviews } from './stale-reviews'
 import { ReviewRepository } from './repository'
-import type { AcpRuntime } from '../acp/runtime'
+import type { ReviewerAcpRuntime } from './acp-runtime'
 import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { SessionRepository } from '../session-persistence/repository'
@@ -59,7 +59,7 @@ const createDefaultReviewRepository = (): ReviewRepository => {
 
 type ReviewerIpcOptions = {
   // The ACP runtime used to spawn reviewer sessions.
-  acpRuntime: AcpRuntime
+  acpRuntime: ReviewerAcpRuntime
   // Optional override for the config root (DB/sessions) (for testing).
   storageRoot?: string
   // Optional override for the data root (artifacts) (for testing).

--- a/src/main/reviewer/orchestrator-prompt-prefix.test.ts
+++ b/src/main/reviewer/orchestrator-prompt-prefix.test.ts
@@ -81,7 +81,7 @@ const makeFakeReviewerSession = (
 const makeStubRuntime = (session: unknown, promptPrefix: string | undefined): AcpRuntime =>
   ({
     buildReviewerSession: async () => ({ session, promptPrefix }),
-    disposeReviewerSession: () => 0
+    disposeReviewerSession: () => ({ rejectedToolCalls: 0, reviewerBridgeScoped: undefined })
   }) as unknown as AcpRuntime
 
 // --- Reviewer MCP submit helper (mirrors orchestrator.test.ts) ---
@@ -257,6 +257,52 @@ describe('runReview — framework-neutral rubric delivery (promptPrefix)', () =>
 
     await client.$disconnect()
   })
+
+  it('fails closed when a completed bridged reviewer request was never session-scoped', async () => {
+    const runtime = {
+      buildReviewerSession: async (request: { mcpServers: unknown[] }) => {
+        const mcp = extractReviewerMcp(request.mcpServers)
+        let submitDone: Promise<void> | null = null
+        return {
+          session: {
+            sessionId: 'reviewer-session-1',
+            prompt: () => {
+              submitDone = callSubmitFindings(mcp.url, mcp.token, [
+                { status: 'pass', claim: 'Scoped claim', evidence: 'Scoped evidence' }
+              ])
+            },
+            nextUpdate: async () => {
+              if (submitDone) await submitDone
+              return { kind: 'stop', stopReason: 'end_turn' }
+            },
+            dispose: () => {}
+          }
+        }
+      },
+      disposeReviewerSession: () => ({
+        rejectedToolCalls: 0,
+        reviewerBridgeScoped: false
+      })
+    } as unknown as AcpRuntime
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => makeSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    expect(review.lifecycle).toBe('error')
+    expect(review.errorMessage).toContain('reviewer-only tool scope')
+    expect(review.checks).toEqual([])
+    await client.$disconnect()
+  })
 })
 
 // The second promptPrefix concat site lives inside the module-local runScopedReview, reachable only
@@ -303,7 +349,7 @@ describe('runScopedReview — framework-neutral rubric delivery (fix-loop re-rev
         }
         return { session: makeFakeReviewerSession(scopedPromptSink), promptPrefix: scopedPrefix }
       },
-      disposeReviewerSession: () => 0,
+      disposeReviewerSession: () => ({ rejectedToolCalls: 0, reviewerBridgeScoped: undefined }),
       // The [Auditor] correction turn: append the auditor user turn + the agent's correction turn so
       // the fix loop resolves a new correctionTurnMessageId (msg-4-correction) for the scoped review.
       sendPrompt: async () => {

--- a/src/main/reviewer/orchestrator.start-contract.test.ts
+++ b/src/main/reviewer/orchestrator.start-contract.test.ts
@@ -60,7 +60,10 @@ const session = { id: 'session-1', cwd: '', messages: [] } as unknown as Persist
 // the test focused on the start-contract without needing a full reviewer drive.
 const acpRuntime = {
   buildReviewerSession: vi.fn().mockRejectedValue(new Error('build failed')),
-  disposeReviewerSession: vi.fn()
+  disposeReviewerSession: vi.fn(() => ({
+    rejectedToolCalls: 0,
+    reviewerBridgeScoped: undefined
+  }))
 } as unknown as AcpRuntime
 
 const makeRepo = (createReview: ReviewRepository['createReview']): ReviewRepository =>

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -116,6 +116,9 @@ const incompleteReviewMessage = (rejectedToolCalls: number): string =>
       `${rejectedToolCalls} tool call(s) were also rejected by the permission gate.`
     : 'Reviewer stopped without calling submit_findings.'
 
+const REVIEWER_BRIDGE_SCOPE_ERROR =
+  'Reviewer request was not constrained to the reviewer-only tool scope.'
+
 // Streaming content deltas are emitted one-per-chunk as the reviewer writes its message/thinking, so
 // their count tracks how much it *says*, not how much it *does*. Counting them toward the loop cap
 // made a normally-verbose review trip the guard mid-stream before it could call submit_findings. Only
@@ -748,6 +751,7 @@ const runScopedReview = async (options: {
   let checksReceived: NewCheck[] = []
   let checksSubmitted = false
   let rejectedToolCalls = 0
+  let reviewerBridgeScoped: boolean | undefined
   const capturedLog: ReviewerLogEntry[] = []
 
   try {
@@ -801,8 +805,24 @@ const runScopedReview = async (options: {
     return { review: errorWithChecks, submittedChecks: [] }
   } finally {
     // dispose returns the gate's rejection count and clears it atomically — no ordering hazard.
-    if (reviewerSession) rejectedToolCalls = acpRuntime.disposeReviewerSession(reviewerSession)
+    if (reviewerSession) {
+      const disposition = acpRuntime.disposeReviewerSession(reviewerSession)
+      rejectedToolCalls = disposition.rejectedToolCalls
+      reviewerBridgeScoped = disposition.reviewerBridgeScoped
+    }
     await mcpServer?.stop().catch(() => undefined)
+  }
+
+  if (reviewerBridgeScoped === false) {
+    log.error('scoped re-review bridge isolation failed', { reviewId: review.id })
+    review = await reviewRepository.updateReview(review.id, {
+      lifecycle: 'error',
+      errorMessage: REVIEWER_BRIDGE_SCOPE_ERROR,
+      reviewerLog: capturedLog
+    })
+    const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
+    onReviewUpdate?.(errorWithChecks)
+    return { review: errorWithChecks, submittedChecks: [] }
   }
 
   if (!checksSubmitted) {
@@ -929,6 +949,7 @@ const runReviewWithSession = async (
   let checksReceived: NewCheck[] = []
   let checksSubmitted = false
   let rejectedToolCalls = 0
+  let reviewerBridgeScoped: boolean | undefined
   const capturedLog: ReviewerLogEntry[] = []
 
   try {
@@ -1000,8 +1021,24 @@ const runReviewWithSession = async (
     // Always dispose the reviewer session and shut down the servers. dispose returns the gate's
     // rejection count and clears it atomically, so an incomplete review reports the real cause with
     // no capture-before-dispose ordering to get wrong.
-    if (reviewerSession) rejectedToolCalls = acpRuntime.disposeReviewerSession(reviewerSession)
+    if (reviewerSession) {
+      const disposition = acpRuntime.disposeReviewerSession(reviewerSession)
+      rejectedToolCalls = disposition.rejectedToolCalls
+      reviewerBridgeScoped = disposition.reviewerBridgeScoped
+    }
     await mcpServer?.stop().catch(() => undefined)
+  }
+
+  if (reviewerBridgeScoped === false) {
+    log.error('reviewer bridge isolation failed', { reviewId: review.id })
+    review = await reviewRepository.updateReview(review.id, {
+      lifecycle: 'error',
+      errorMessage: REVIEWER_BRIDGE_SCOPE_ERROR,
+      reviewerLog: capturedLog
+    })
+    const errorWithFindings: ReviewWithChecks = { ...review, checks: [] }
+    onReviewUpdate?.(errorWithFindings)
+    return errorWithFindings
   }
 
   if (!checksSubmitted) {

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -14,14 +14,13 @@ import type { ActiveSession } from '@agentclientprotocol/sdk'
 import { withReviewerRuntimeActivity, type ReviewerAcpRuntime } from './acp-runtime'
 import { createLogger } from '../logger'
 import { extractProviderToolName, extractTerminalMeta } from '../acp/runtime-events'
-import {
-  REVIEWER_BRIDGE_SESSION_MARKER,
-  type NewCheck,
-  type ReviewCheck,
-  type ReviewerLogEntry,
-  type ReviewOutcome,
-  type ReviewWithChecks,
-  type TurnScope
+import type {
+  NewCheck,
+  ReviewCheck,
+  ReviewerLogEntry,
+  ReviewOutcome,
+  ReviewWithChecks,
+  TurnScope
 } from '../../shared/reviewer'
 import type { ReviewRepository } from './repository'
 import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
@@ -1208,7 +1207,6 @@ export const buildReviewerPrompt = (
 
   return [
     `You are reviewing turn: ${scope.turnMessageId}`,
-    REVIEWER_BRIDGE_SESSION_MARKER,
     '',
     blockSummary,
     artifactSummary,

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -11,7 +11,7 @@ import { homedir } from 'node:os'
 
 import type { ActiveSession } from '@agentclientprotocol/sdk'
 
-import type { AcpRuntime } from '../acp/runtime'
+import { withReviewerRuntimeActivity, type ReviewerAcpRuntime } from './acp-runtime'
 import { createLogger } from '../logger'
 import { extractProviderToolName, extractTerminalMeta } from '../acp/runtime-events'
 import type {
@@ -29,6 +29,7 @@ import { ReviewerMcpServer } from './mcp-server'
 import { ReviewerHostServer } from './host-sdk'
 import { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } from './rubric'
 import { injectAuditorMessage } from './correction'
+import { buildHistoryPreamble } from '../../shared/history-preamble'
 
 const log = createLogger('reviewer:orchestrator')
 
@@ -57,7 +58,7 @@ export type RunReviewOptions = {
   // Repository for persisting review rows + checks.
   reviewRepository: ReviewRepository
   // The ACP runtime that owns the agent connection (used to spawn the reviewer session).
-  acpRuntime: AcpRuntime
+  acpRuntime: ReviewerAcpRuntime
   // Storage root for artifact reads (used by the scope-bounded evidence reader).
   artifactStorageRoot: string
   // The model/provider tag to record on the Review row.
@@ -363,7 +364,7 @@ type FixLoopOptions = {
   mainSessionId: string
   getSession: SessionProvider
   reviewRepository: ReviewRepository
-  acpRuntime: AcpRuntime
+  acpRuntime: ReviewerAcpRuntime
   artifactStorageRoot: string
   model: string
   onReviewUpdate?: (review: ReviewWithChecks) => void
@@ -674,7 +675,7 @@ const runScopedReview = async (options: {
   projectId: string
   getSession: SessionProvider
   reviewRepository: ReviewRepository
-  acpRuntime: AcpRuntime
+  acpRuntime: ReviewerAcpRuntime
   artifactStorageRoot: string
   model: string
   onReviewUpdate?: (review: ReviewWithChecks) => void
@@ -868,7 +869,10 @@ const runScopedReview = async (options: {
 // Drives one complete auto-review cycle: scope resolution → DB record → reviewer session →
 // submit_findings → lifecycle update. Returns the final review (with checks) for the caller
 // to broadcast. Never throws — errors are captured as lifecycle='error'.
-export const runReview = async (options: RunReviewOptions): Promise<ReviewWithChecks> => {
+const runReviewWithSession = async (
+  options: RunReviewOptions,
+  session: PersistedChatSession
+): Promise<ReviewWithChecks> => {
   const {
     sessionId,
     turnMessageId,
@@ -892,27 +896,6 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
     fixLoopAbortSignal,
     sessionRefreshTimeoutMs = DEFAULT_SESSION_REFRESH_TIMEOUT_MS
   } = options
-
-  log.info('runReview started', { sessionId, turnMessageId })
-
-  // Step 1: resolve the turn scope.
-  const session = await getSession(sessionId)
-
-  if (!session) {
-    log.warn('session not found for review', { sessionId })
-    const errorReview = await reviewRepository.createReview({
-      projectId,
-      sessionId,
-      turnMessageId,
-      scope: { turnMessageId, blocks: [], artifactVersionIds: [] },
-      lifecycle: 'error',
-      errorMessage: `Session ${sessionId} not found`,
-      model
-    })
-    const withFindings: ReviewWithChecks = { ...errorReview, checks: [] }
-    onReviewUpdate?.(withFindings)
-    return withFindings
-  }
 
   // Audit the scope turn (defaults to the grouping turn) but keep the row grouped under turnMessageId.
   const scope = await resolveTurnScopeWithArtifactDigests(
@@ -1127,6 +1110,59 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
 
   onReviewUpdate?.(finalReview)
   return finalReview
+}
+
+export const runReview = async (options: RunReviewOptions): Promise<ReviewWithChecks> => {
+  const {
+    sessionId,
+    turnMessageId,
+    projectId,
+    getSession,
+    reviewRepository,
+    acpRuntime,
+    onReviewUpdate,
+    mainSessionId,
+    model = ''
+  } = options
+
+  log.info('runReview started', { sessionId, turnMessageId })
+
+  const session = await getSession(sessionId)
+  if (!session) {
+    log.warn('session not found for review', { sessionId })
+    const errorReview = await reviewRepository.createReview({
+      projectId,
+      sessionId,
+      turnMessageId,
+      scope: { turnMessageId, blocks: [], artifactVersionIds: [] },
+      lifecycle: 'error',
+      errorMessage: `Session ${sessionId} not found`,
+      model
+    })
+    const withFindings: ReviewWithChecks = { ...errorReview, checks: [] }
+    onReviewUpdate?.(withFindings)
+    return withFindings
+  }
+
+  return withReviewerRuntimeActivity(
+    acpRuntime,
+    {
+      ...(mainSessionId
+        ? {
+            session: {
+              sessionId: mainSessionId,
+              cwd: session.cwd,
+              projectName: session.projectId,
+              permissionProfile: session.permissionProfile,
+              previousFrameworkId: session.agentFrameworkId,
+              previousBackendId: session.agentBackendId,
+              historyPreamble: buildHistoryPreamble(session.messages)
+            }
+          }
+        : {})
+    },
+    (scopedRuntime) => runReviewWithSession({ ...options, acpRuntime: scopedRuntime }, session)
+  )
 }
 
 // Builds the prompt sent to the isolated reviewer session. All evidence is available only through the

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -14,13 +14,14 @@ import type { ActiveSession } from '@agentclientprotocol/sdk'
 import { withReviewerRuntimeActivity, type ReviewerAcpRuntime } from './acp-runtime'
 import { createLogger } from '../logger'
 import { extractProviderToolName, extractTerminalMeta } from '../acp/runtime-events'
-import type {
-  NewCheck,
-  ReviewCheck,
-  ReviewerLogEntry,
-  ReviewOutcome,
-  ReviewWithChecks,
-  TurnScope
+import {
+  REVIEWER_BRIDGE_SESSION_MARKER,
+  type NewCheck,
+  type ReviewCheck,
+  type ReviewerLogEntry,
+  type ReviewOutcome,
+  type ReviewWithChecks,
+  type TurnScope
 } from '../../shared/reviewer'
 import type { ReviewRepository } from './repository'
 import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
@@ -1207,6 +1208,7 @@ export const buildReviewerPrompt = (
 
   return [
     `You are reviewing turn: ${scope.turnMessageId}`,
+    REVIEWER_BRIDGE_SESSION_MARKER,
     '',
     blockSummary,
     artifactSummary,

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -71,15 +71,18 @@ const createFakeService = (): FakeSettingsService => ({
   installClaude: vi.fn().mockResolvedValue({ installId: 'i', ok: true }),
   installOpencode: vi.fn().mockResolvedValue({ installId: 'oc', ok: true }),
   installCodex: vi.fn().mockResolvedValue({ installId: 'cx', ok: true }),
-  uninstallClaude: vi
-    .fn()
-    .mockResolvedValue({ snapshot: { claude: {}, providers: [] }, activeBackendAffected: true }),
-  uninstallOpencode: vi
-    .fn()
-    .mockResolvedValue({ snapshot: { claude: {}, providers: [] }, activeBackendAffected: true }),
-  uninstallCodex: vi
-    .fn()
-    .mockResolvedValue({ snapshot: { claude: {}, providers: [] }, activeBackendAffected: true }),
+  uninstallClaude: vi.fn().mockResolvedValue({
+    snapshot: { claude: {}, providers: [], agentFrameworkId: 'claude-code' },
+    activeBackendAffected: true
+  }),
+  uninstallOpencode: vi.fn().mockResolvedValue({
+    snapshot: { claude: {}, providers: [], agentFrameworkId: 'opencode' },
+    activeBackendAffected: true
+  }),
+  uninstallCodex: vi.fn().mockResolvedValue({
+    snapshot: { claude: {}, providers: [], agentFrameworkId: 'codex' },
+    activeBackendAffected: true
+  }),
   setAgentFramework: vi
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], agentFrameworkId: 'opencode' }),
@@ -332,20 +335,59 @@ describe('settings IPC handlers', () => {
     expect(onActiveProviderChanged).not.toHaveBeenCalled()
   })
 
-  it('reconnects after uninstall only when the removed runtime was the active backend', async () => {
+  it.each([
+    ['claude', 'opencode'],
+    ['opencode', 'codex'],
+    ['codex', 'claude-code']
+  ] as const)(
+    'rotates the runtime after uninstalling active %s auto-switches frameworks',
+    async (channel, fallbackFramework) => {
+      handlers.clear()
+      const service = createFakeService()
+      service[
+        channel === 'claude'
+          ? 'uninstallClaude'
+          : channel === 'opencode'
+            ? 'uninstallOpencode'
+            : 'uninstallCodex'
+      ].mockResolvedValue({
+        snapshot: { claude: {}, providers: [], agentFrameworkId: fallbackFramework },
+        activeBackendAffected: true
+      })
+      const onActiveProviderChanged = vi.fn()
+      const onAgentFrameworkChanged = vi.fn()
+      registerSettingsIpcHandlers({
+        service: asService(service),
+        onActiveProviderChanged,
+        onAgentFrameworkChanged
+      })
+
+      await invoke(`settings:uninstall-${channel}`)
+
+      expect(onAgentFrameworkChanged).toHaveBeenCalledOnce()
+      expect(onActiveProviderChanged).not.toHaveBeenCalled()
+    }
+  )
+
+  it('reconnects after uninstalling the active runtime when no fallback is ready', async () => {
     handlers.clear()
     const service = createFakeService()
     service.uninstallClaude.mockResolvedValue({
-      snapshot: { claude: {}, providers: [] },
+      snapshot: { claude: {}, providers: [], agentFrameworkId: 'claude-code' },
       activeBackendAffected: true
     })
     const onActiveProviderChanged = vi.fn()
-    registerSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+    const onAgentFrameworkChanged = vi.fn()
+    registerSettingsIpcHandlers({
+      service: asService(service),
+      onActiveProviderChanged,
+      onAgentFrameworkChanged
+    })
 
     await invoke('settings:uninstall-claude')
 
-    expect(service.uninstallClaude).toHaveBeenCalledTimes(1)
     expect(onActiveProviderChanged).toHaveBeenCalledOnce()
+    expect(onAgentFrameworkChanged).not.toHaveBeenCalled()
   })
 
   it('does not reconnect after uninstalling the inactive runtime', async () => {

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -505,20 +505,26 @@ describe('settings IPC handlers', () => {
     }
   })
 
-  it('persists the selected framework and respawns the agent on set-agent-framework', async () => {
+  it('persists the selected framework and rotates future sessions on set-agent-framework', async () => {
     handlers.clear()
     const service = createFakeService()
     const snapshot = { claude: {}, providers: [], agentFrameworkId: 'opencode' }
     service.setAgentFramework.mockResolvedValue(snapshot)
     const onActiveProviderChanged = vi.fn()
-    registerSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+    const onAgentFrameworkChanged = vi.fn()
+    registerSettingsIpcHandlers({
+      service: asService(service),
+      onActiveProviderChanged,
+      onAgentFrameworkChanged
+    })
 
     const result = await invoke('settings:set-agent-framework', { id: 'opencode' })
 
     // The handler unwraps the request to the bare framework id the service expects.
     expect(service.setAgentFramework).toHaveBeenCalledWith('opencode')
-    // Switching frameworks swaps the backend binary, so the live agent must be dropped like a provider switch.
-    expect(onActiveProviderChanged).toHaveBeenCalledOnce()
+    // Existing sessions keep their owning runtime; only future sessions rotate to the new framework.
+    expect(onAgentFrameworkChanged).toHaveBeenCalledOnce()
+    expect(onActiveProviderChanged).not.toHaveBeenCalled()
     expect(result).toBe(snapshot)
   })
 

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -4,7 +4,9 @@ import {
   CLAUDE_ISOLATED_PROVIDER_ID,
   CODEX_SUBSCRIPTION_PROVIDER_ID,
   isReasoningEffort,
+  type AgentFrameworkId,
   type ReasoningEffort,
+  type SettingsSnapshot,
   type CreateSkillRequest,
   type DeleteProviderRequest,
   type DeleteSkillRequest,
@@ -79,6 +81,21 @@ const registerSettingsIpcHandlers = ({
   onSkillsChanged,
   onConnectorsChanged
 }: SettingsIpcOptions = {}): void => {
+  const notifyAfterRuntimeUninstall = (
+    uninstalledFramework: AgentFrameworkId,
+    snapshot: SettingsSnapshot,
+    activeBackendAffected: boolean
+  ): void => {
+    if (!activeBackendAffected) return
+
+    if (snapshot.agentFrameworkId !== uninstalledFramework) {
+      onAgentFrameworkChanged?.()
+      return
+    }
+
+    onActiveProviderChanged?.()
+  }
+
   ipcMain.handle('settings:get-preflight', () => service.getPreflight())
   ipcMain.handle('settings:get-settings', () => service.getSettingsView())
   ipcMain.handle('settings:encryption-available', () => service.isEncryptionAvailable())
@@ -101,10 +118,10 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:uninstall-claude', async () => {
     const { snapshot, activeBackendAffected } = await service.uninstallClaude()
 
-    // Reconnect only when the removed runtime backed the active framework (its live agent is now stale,
-    // possibly auto-switched to the other). Uninstalling the inactive runtime touches nothing the live
-    // agent depends on, so it must not churn the connection.
-    if (activeBackendAffected) onActiveProviderChanged?.()
+    // Refresh only when the removed runtime backed the active framework. Rotate generations when the
+    // service selected a fallback framework; otherwise reconnect the now-stale current generation.
+    // Uninstalling an inactive runtime must not churn the live agent.
+    notifyAfterRuntimeUninstall('claude-code', snapshot, activeBackendAffected)
 
     return snapshot
   })
@@ -112,7 +129,7 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:uninstall-opencode', async () => {
     const { snapshot, activeBackendAffected } = await service.uninstallOpencode()
 
-    if (activeBackendAffected) onActiveProviderChanged?.()
+    notifyAfterRuntimeUninstall('opencode', snapshot, activeBackendAffected)
 
     return snapshot
   })
@@ -120,7 +137,7 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:uninstall-codex', async () => {
     const { snapshot, activeBackendAffected } = await service.uninstallCodex()
 
-    if (activeBackendAffected) onActiveProviderChanged?.()
+    notifyAfterRuntimeUninstall('codex', snapshot, activeBackendAffected)
 
     return snapshot
   })

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -49,8 +49,11 @@ const SETTINGS_INSTALL_LOG_CHANNEL = 'settings:install-log'
 
 export type SettingsIpcOptions = {
   service?: SettingsService
-  // Called after the active provider changes so the ACP runtime can drop its stale connection.
+  // Called after the active provider changes so the current framework runtime reconnects with it.
   onActiveProviderChanged?: () => void
+  // Called after the agent framework changes. Active turns finish on their prior framework; every later
+  // turn resumes through the newly selected framework.
+  onAgentFrameworkChanged?: () => void
   // Called after the reasoning effort changes so the ACP runtime can live-apply it to open sessions.
   // Returns true when the level was applied over ACP (no reconnect needed); false means the active
   // framework only carries effort in its spawn config and onActiveProviderChanged must fire instead.
@@ -71,6 +74,7 @@ const broadcastInstallEvent = (event: ClaudeInstallEvent): void => {
 const registerSettingsIpcHandlers = ({
   service = createDefaultSettingsService(),
   onActiveProviderChanged,
+  onAgentFrameworkChanged,
   onReasoningEffortChanged,
   onSkillsChanged,
   onConnectorsChanged
@@ -159,9 +163,9 @@ const registerSettingsIpcHandlers = ({
       log.info('set agent framework requested', { id: request.id })
       const snapshot = await service.setAgentFramework(request.id)
 
-      // Switching frameworks needs a fresh agent process, exactly like a provider switch — the live
-      // process is a different backend binary, so the choice only takes effect on reconnect.
-      onActiveProviderChanged?.()
+      // A framework uses a different backend binary. Preserve active turns, then resume every later turn
+      // through a runtime for the newly selected framework.
+      onAgentFrameworkChanged?.()
 
       return snapshot
     }

--- a/src/main/settings/responses-bridge.integration.test.ts
+++ b/src/main/settings/responses-bridge.integration.test.ts
@@ -5,8 +5,11 @@ import { join } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 
 import * as acp from '@agentclientprotocol/sdk'
-import { expect, it } from 'vitest'
+import { expect, it, vi } from 'vitest'
 
+import { REVIEWER_BRIDGE_SESSION_MARKER } from '../../shared/reviewer'
+import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
+import { ReviewerMcpServer, type SubmitFindingsHandler } from '../reviewer/mcp-server'
 import { ResponsesBridge } from './responses-bridge'
 
 const adapterPath = process.env.CODEX_ACP_PATH
@@ -237,6 +240,277 @@ it.runIf(runLiveContract)(
     } finally {
       await terminate(child)
       await bridge.close()
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  },
+  30_000
+)
+
+it.runIf(runLiveContract)(
+  'routes a reviewer read and submission through real Codex ACP without advertising built-ins',
+  async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'open-science-codex-reviewer-bridge-'))
+    const codexHome = join(tempRoot, 'codex-home')
+    const workspace = join(tempRoot, 'workspace')
+    await Promise.all([mkdir(codexHome), mkdir(workspace)])
+
+    const scope = { turnMessageId: 'turn-1', blocks: [], artifactVersionIds: [] }
+    const evidence = {
+      readTurn: vi.fn(() => [
+        {
+          id: 'block-1',
+          kind: 'message' as const,
+          sourceId: 'message-1',
+          blockIndex: 0,
+          contentHash: 'hash-1',
+          role: 'agent',
+          content: 'audited evidence'
+        }
+      ]),
+      queryExecutionLog: vi.fn(() => []),
+      readArtifact: vi.fn(async () => ({
+        id: 'artifact-1',
+        kind: 'raw' as const,
+        content: 'artifact evidence',
+        encoding: 'utf8' as const
+      }))
+    }
+    let submittedChecks: unknown
+    const submitFindings = vi.fn(async (checks: unknown) => {
+      submittedChecks = checks
+    })
+    const reviewerMcp = new ReviewerMcpServer(
+      scope,
+      submitFindings as SubmitFindingsHandler,
+      evidence
+    )
+    await reviewerMcp.start()
+
+    const chatRequests: Record<string, unknown>[] = []
+    const upstreamFetch = async (
+      _url: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1]
+    ): Promise<Response> => {
+      const request = JSON.parse(String(init?.body)) as Record<string, unknown>
+      chatRequests.push(request)
+
+      if (chatRequests.length === 1) {
+        return chatSse([
+          {
+            id: 'chat-reviewer-read',
+            model: 'probe-model',
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  role: 'assistant',
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call-reviewer-read',
+                      type: 'function',
+                      function: {
+                        name: 'mcp__open_science_reviewer__read_turn',
+                        arguments: '{}'
+                      }
+                    }
+                  ]
+                },
+                finish_reason: null
+              }
+            ]
+          },
+          {
+            id: 'chat-reviewer-read',
+            model: 'probe-model',
+            choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }]
+          }
+        ])
+      }
+
+      if (chatRequests.length === 2) {
+        return chatSse([
+          {
+            id: 'chat-reviewer-submit',
+            model: 'probe-model',
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  role: 'assistant',
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call-reviewer-submit',
+                      type: 'function',
+                      function: {
+                        name: 'mcp__open_science_reviewer__submit_findings',
+                        arguments: '{"checks":[]}'
+                      }
+                    }
+                  ]
+                },
+                finish_reason: null
+              }
+            ]
+          },
+          {
+            id: 'chat-reviewer-submit',
+            model: 'probe-model',
+            choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }]
+          }
+        ])
+      }
+
+      return chatSse([
+        {
+          id: 'chat-reviewer-complete',
+          model: 'probe-model',
+          choices: [
+            {
+              index: 0,
+              delta: { role: 'assistant', content: 'REVIEWER_BRIDGE_OK' },
+              finish_reason: null
+            }
+          ]
+        },
+        {
+          id: 'chat-reviewer-complete',
+          model: 'probe-model',
+          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }]
+        }
+      ])
+    }
+
+    const bridge = new ResponsesBridge(
+      {
+        baseUrl: 'https://vendor.invalid/v1',
+        model: 'probe-model',
+        namespacedTools: [
+          {
+            namespace: 'mcp__open_science_notebook',
+            name: 'notebook_execute',
+            parameters: { type: 'object' }
+          }
+        ],
+        reviewerScope: {
+          marker: REVIEWER_BRIDGE_SESSION_MARKER,
+          namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS
+        }
+      },
+      upstreamFetch
+    )
+    const connection = await bridge.start()
+    const child = spawn(adapterPath!, [], {
+      cwd: workspace,
+      env: {
+        ...process.env,
+        CODEX_HOME: codexHome,
+        CODEX_PATH: nativeCodexPath!,
+        MODEL_PROVIDER: 'probe',
+        NO_BROWSER: '1',
+        CODEX_CONFIG: JSON.stringify({
+          model: 'gpt-5.5',
+          model_provider: 'probe',
+          model_providers: {
+            probe: {
+              name: 'Bridge reviewer contract',
+              base_url: connection.baseUrl,
+              env_key: 'CODEX_API_KEY',
+              wire_api: 'responses'
+            }
+          }
+        })
+      },
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    const stderr: string[] = []
+    child.stderr.on('data', (chunk) => stderr.push(chunk.toString('utf8')))
+
+    try {
+      const stream = acp.ndJsonStream(
+        Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+        Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>
+      )
+      const permissionTools: string[] = []
+      const result = await acp
+        .client({ name: 'open-science-reviewer-bridge-contract' })
+        .onRequest(acp.methods.client.session.requestPermission, (ctx) => {
+          permissionTools.push(String(ctx.params.toolCall.title ?? ctx.params.toolCall.kind ?? ''))
+          return {
+            outcome: {
+              outcome: 'selected',
+              optionId:
+                ctx.params.options.find((option) => option.kind === 'allow_once')?.optionId ??
+                ctx.params.options[0].optionId
+            }
+          }
+        })
+        .onRequest(acp.methods.client.fs.readTextFile, () => ({ content: '' }))
+        .onRequest(acp.methods.client.fs.writeTextFile, () => ({}))
+        .connectWith(stream, async (ctx) => {
+          await ctx.request(acp.methods.agent.initialize, {
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientInfo: { name: 'open-science-reviewer-bridge-contract', version: '1.0.0' },
+            clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } }
+          })
+          await ctx.request(acp.methods.agent.providers.set, {
+            providerId: 'custom-gateway',
+            apiType: 'openai',
+            baseUrl: connection.baseUrl,
+            headers: { authorization: `Bearer ${connection.token}` }
+          })
+
+          return ctx
+            .buildSession({
+              cwd: workspace,
+              mcpServers: [reviewerMcp.toAcpMcpServerConfig()],
+              _meta: { disableBuiltInTools: true }
+            })
+            .withSession(async (session) => {
+              session.prompt(
+                `${REVIEWER_BRIDGE_SESSION_MARKER}\nUse read_turn, then call submit_findings.`
+              )
+              const updates: acp.SessionNotification[] = []
+              for (;;) {
+                const update = await session.nextUpdate()
+                if (update.kind === 'stop') {
+                  return { updates, stopReason: update.response.stopReason }
+                }
+                updates.push(update.notification)
+              }
+            })
+        })
+
+      const expectedReviewerTools = REVIEWER_BRIDGE_NAMESPACED_TOOLS.map(
+        (tool) => `${tool.namespace}__${tool.name}`
+      )
+      const upstreamToolNames = chatRequests.map((request) =>
+        ((request.tools ?? []) as Array<{ function?: { name?: string } }>).map(
+          (tool) => tool.function?.name
+        )
+      )
+      expect(chatRequests).toHaveLength(3)
+      expect(upstreamToolNames).toEqual([
+        expectedReviewerTools,
+        expectedReviewerTools,
+        expectedReviewerTools
+      ])
+      expect(JSON.stringify(chatRequests[1]?.messages)).toContain('audited evidence')
+      expect(evidence.readTurn).toHaveBeenCalledOnce()
+      expect(submitFindings).toHaveBeenCalledOnce()
+      expect(submittedChecks).toEqual([])
+      expect(permissionTools).toHaveLength(2)
+      expect(JSON.stringify(permissionTools)).not.toMatch(/exec_command|local_shell|shell_command/)
+      expect(JSON.stringify(result.updates)).not.toMatch(/exec_command|local_shell|shell_command/)
+      expect(JSON.stringify(result.updates)).toContain('REVIEWER_BRIDGE_OK')
+      expect(result.stopReason).toBe('end_turn')
+    } catch (error) {
+      throw new Error(`${String(error)}\n${stderr.join('')}`)
+    } finally {
+      await terminate(child)
+      await bridge.close()
+      await reviewerMcp.stop()
       await rm(tempRoot, { recursive: true, force: true })
     }
   },

--- a/src/main/settings/responses-bridge.integration.test.ts
+++ b/src/main/settings/responses-bridge.integration.test.ts
@@ -7,7 +7,6 @@ import { Readable, Writable } from 'node:stream'
 import * as acp from '@agentclientprotocol/sdk'
 import { expect, it, vi } from 'vitest'
 
-import { REVIEWER_BRIDGE_SESSION_MARKER } from '../../shared/reviewer'
 import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
 import { ReviewerMcpServer, type SubmitFindingsHandler } from '../reviewer/mcp-server'
 import { ResponsesBridge } from './responses-bridge'
@@ -394,7 +393,6 @@ it.runIf(runLiveContract)(
           }
         ],
         reviewerScope: {
-          marker: REVIEWER_BRIDGE_SESSION_MARKER,
           namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS
         }
       },
@@ -468,9 +466,8 @@ it.runIf(runLiveContract)(
               _meta: { disableBuiltInTools: true }
             })
             .withSession(async (session) => {
-              session.prompt(
-                `${REVIEWER_BRIDGE_SESSION_MARKER}\nUse read_turn, then call submit_findings.`
-              )
+              bridge.registerReviewerSession(session.sessionId)
+              session.prompt('Use read_turn, then call submit_findings.')
               const updates: acp.SessionNotification[] = []
               for (;;) {
                 const update = await session.nextUpdate()

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -3,7 +3,6 @@ import { createConnection } from 'node:net'
 
 import { describe, expect, it, vi } from 'vitest'
 
-import { REVIEWER_BRIDGE_SESSION_MARKER } from '../../shared/reviewer'
 import {
   ResponsesBridge,
   completionToResponse,
@@ -14,6 +13,7 @@ import {
 } from './responses-bridge'
 
 describe('Responses-compatible bridge conversion', () => {
+  const legacyReviewerMarker = '<open_science_reviewer_session>'
   it('maps instructions, messages, function calls, and tool results to Chat Completions', () => {
     const request = responsesToChatRequest({
       model: 'model-a',
@@ -981,7 +981,7 @@ describe('Responses-compatible bridge conversion', () => {
     }
   })
 
-  it('advertises only reviewer MCP functions for a marked reviewer session', async () => {
+  it('advertises reviewer MCP functions only for a trusted registered session key', async () => {
     const upstreamRequests: Array<Record<string, unknown>> = []
     const upstreamFetch = vi.fn(
       async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
@@ -1012,7 +1012,6 @@ describe('Responses-compatible bridge conversion', () => {
           }
         ],
         reviewerScope: {
-          marker: REVIEWER_BRIDGE_SESSION_MARKER,
           namespacedTools: [
             {
               namespace: 'mcp__open_science_reviewer',
@@ -1030,7 +1029,7 @@ describe('Responses-compatible bridge conversion', () => {
       upstreamFetch
     )
     const connection = await bridge.start()
-    const post = async (input: string): Promise<void> => {
+    const post = async (input: string, promptCacheKey: string): Promise<void> => {
       const response = await fetch(`${connection.baseUrl}/responses`, {
         method: 'POST',
         headers: {
@@ -1040,6 +1039,7 @@ describe('Responses-compatible bridge conversion', () => {
         body: JSON.stringify({
           model: 'model-a',
           input,
+          prompt_cache_key: promptCacheKey,
           stream: true,
           tools: [
             { type: 'function', name: 'exec_command', parameters: { type: 'object' } },
@@ -1053,8 +1053,9 @@ describe('Responses-compatible bridge conversion', () => {
     }
 
     try {
-      await post('normal session')
-      await post(`${REVIEWER_BRIDGE_SESSION_MARKER} review this turn`)
+      await post(`${legacyReviewerMarker} normal user content`, 'normal-session')
+      bridge.registerReviewerSession('reviewer-session')
+      await post('review this turn without a model-visible routing marker', 'reviewer-session')
 
       const toolNames = upstreamRequests.map((request) =>
         ((request.tools ?? []) as Array<{ function?: { name?: string } }>).map(

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -3,6 +3,7 @@ import { createConnection } from 'node:net'
 
 import { describe, expect, it, vi } from 'vitest'
 
+import { REVIEWER_BRIDGE_SESSION_MARKER } from '../../shared/reviewer'
 import {
   ResponsesBridge,
   completionToResponse,
@@ -975,6 +976,101 @@ describe('Responses-compatible bridge conversion', () => {
       expect(output).toContain('"name":"notebook_execute"')
       expect(output).toContain('"call_id":"call-notebook-1"')
       expect(output).not.toContain('"name":"mcp__open_science_notebook__notebook_execute"')
+    } finally {
+      await bridge.close()
+    }
+  })
+
+  it('advertises only reviewer MCP functions for a marked reviewer session', async () => {
+    const upstreamRequests: Array<Record<string, unknown>> = []
+    const upstreamFetch = vi.fn(
+      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        upstreamRequests.push(JSON.parse(String(init?.body)) as Record<string, unknown>)
+        return new Response(
+          [
+            `data: ${JSON.stringify({
+              id: 'chat-reviewer-scope',
+              model: 'model-a',
+              choices: [{ index: 0, delta: {}, finish_reason: 'stop' }]
+            })}`,
+            '',
+            'data: [DONE]',
+            ''
+          ].join('\n'),
+          { headers: { 'content-type': 'text/event-stream' } }
+        )
+      }
+    )
+    const bridge = new ResponsesBridge(
+      {
+        baseUrl: 'https://vendor.example/v1',
+        namespacedTools: [
+          {
+            namespace: 'mcp__open_science_notebook',
+            name: 'notebook_execute',
+            parameters: { type: 'object' }
+          }
+        ],
+        reviewerScope: {
+          marker: REVIEWER_BRIDGE_SESSION_MARKER,
+          namespacedTools: [
+            {
+              namespace: 'mcp__open_science_reviewer',
+              name: 'read_turn',
+              parameters: { type: 'object' }
+            },
+            {
+              namespace: 'mcp__open_science_reviewer',
+              name: 'submit_findings',
+              parameters: { type: 'object' }
+            }
+          ]
+        }
+      },
+      upstreamFetch
+    )
+    const connection = await bridge.start()
+    const post = async (input: string): Promise<void> => {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'model-a',
+          input,
+          stream: true,
+          tools: [
+            { type: 'function', name: 'exec_command', parameters: { type: 'object' } },
+            { type: 'local_shell' },
+            { type: 'tool_search' }
+          ],
+          tool_choice: { type: 'function', name: 'exec_command' }
+        })
+      })
+      await response.text()
+    }
+
+    try {
+      await post('normal session')
+      await post(`${REVIEWER_BRIDGE_SESSION_MARKER} review this turn`)
+
+      const toolNames = upstreamRequests.map((request) =>
+        ((request.tools ?? []) as Array<{ function?: { name?: string } }>).map(
+          (tool) => tool.function?.name
+        )
+      )
+      expect(toolNames[0]).toEqual(['exec_command', 'mcp__open_science_notebook__notebook_execute'])
+      expect(toolNames[1]).toEqual([
+        'mcp__open_science_reviewer__read_turn',
+        'mcp__open_science_reviewer__submit_findings'
+      ])
+      expect(upstreamRequests[0]?.tool_choice).toEqual({
+        type: 'function',
+        function: { name: 'exec_command' }
+      })
+      expect(upstreamRequests[1]?.tool_choice).toBe('auto')
     } finally {
       await bridge.close()
     }

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -1053,9 +1053,13 @@ describe('Responses-compatible bridge conversion', () => {
     }
 
     try {
+      bridge.registerReviewerSession('never-observed-reviewer-session')
+      expect(bridge.unregisterReviewerSession('never-observed-reviewer-session')).toBe(false)
+
       await post(`${legacyReviewerMarker} normal user content`, 'normal-session')
       bridge.registerReviewerSession('reviewer-session')
       await post('review this turn without a model-visible routing marker', 'reviewer-session')
+      expect(bridge.unregisterReviewerSession('reviewer-session')).toBe(true)
 
       const toolNames = upstreamRequests.map((request) =>
         ((request.tools ?? []) as Array<{ function?: { name?: string } }>).map(

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -29,7 +29,6 @@ export type ResponsesBridgeTarget = {
   // and gateways fronting non-OpenAI models often reject unknown parameters.
   forwardReasoningEffort?: boolean
   reviewerScope?: {
-    marker: string
     namespacedTools: ResponsesBridgeNamespacedTool[]
   }
 }
@@ -345,21 +344,6 @@ const withConnectorInstructions = (
     body: { ...body, instructions },
     selectedIds: selected.map((connector) => connector.id)
   }
-}
-
-const containsTextMarker = (value: unknown, marker: string): boolean => {
-  if (typeof value === 'string') return value.includes(marker)
-  if (Array.isArray(value)) return value.some((item) => containsTextMarker(item, marker))
-  if (!value || typeof value !== 'object') return false
-  return Object.values(value).some((item) => containsTextMarker(item, marker))
-}
-
-const isReviewerScopedRequest = (body: JsonObject, target: ResponsesBridgeTarget): boolean => {
-  const marker = target.reviewerScope?.marker
-  return Boolean(
-    marker &&
-    (containsTextMarker(body.instructions, marker) || containsTextMarker(body.input, marker))
-  )
 }
 
 const namespacedToolAlias = (
@@ -1059,6 +1043,7 @@ export class ResponsesBridge {
   // it back to thinking-mode providers that require it. Grows within a session; cleared on close (a
   // provider switch / disconnect). Keyed by call_id, which Codex round-trips, so lookups stay stable.
   private readonly reasoningByCallId = new Map<string, string>()
+  private readonly reviewerSessionKeys = new Set<string>()
 
   constructor(
     target: ResponsesBridgeTarget,
@@ -1085,6 +1070,14 @@ export class ResponsesBridge {
   // a setTarget: the upstream provider is unchanged, so the reasoning cache must be preserved.
   setForwardReasoningEffort(forward: boolean): void {
     this.target = { ...this.target, forwardReasoningEffort: forward }
+  }
+
+  registerReviewerSession(promptCacheKey: string): void {
+    this.reviewerSessionKeys.add(promptCacheKey)
+  }
+
+  unregisterReviewerSession(promptCacheKey: string): void {
+    this.reviewerSessionKeys.delete(promptCacheKey)
   }
 
   async start(): Promise<ResponsesBridgeConnection> {
@@ -1124,6 +1117,7 @@ export class ResponsesBridge {
     this.server = undefined
     this.connection = undefined
     this.reasoningByCallId.clear()
+    this.reviewerSessionKeys.clear()
     if (!server) return
     const closing = new Promise<void>((resolve, reject) =>
       server.close((error) => (error ? reject(error) : resolve()))
@@ -1162,7 +1156,9 @@ export class ResponsesBridge {
 
     try {
       const body = await readBody(request)
-      const reviewerScoped = isReviewerScopedRequest(body, this.target)
+      const reviewerScoped =
+        typeof body.prompt_cache_key === 'string' &&
+        this.reviewerSessionKeys.has(body.prompt_cache_key)
       const namespacedTools = reviewerScoped
         ? (this.target.reviewerScope?.namespacedTools ?? [])
         : (this.target.namespacedTools ?? [])

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -1102,17 +1102,23 @@ export class ResponsesBridge {
         }
       })
     })
-    await new Promise<void>((resolve, reject) => {
-      server.once('error', reject)
-      server.listen(0, '127.0.0.1', resolve)
-    })
-    server.unref()
-    const address = server.address()
-    if (!address || typeof address === 'string')
-      throw new Error('Responses bridge did not bind a port')
+    // Own the server before listen resolves so every partial-start failure remains closeable.
     this.server = server
-    this.connection = { baseUrl: `http://127.0.0.1:${address.port}/v1`, token }
-    return this.connection
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', resolve)
+      })
+      server.unref()
+      const address = server.address()
+      if (!address || typeof address === 'string')
+        throw new Error('Responses bridge did not bind a port')
+      this.connection = { baseUrl: `http://127.0.0.1:${address.port}/v1`, token }
+      return this.connection
+    } catch (error) {
+      await this.close().catch(() => undefined)
+      throw error
+    }
   }
 
   async close(): Promise<void> {

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -28,6 +28,10 @@ export type ResponsesBridgeTarget = {
   // unconditional forwarding would change what existing bridged users send to their gateway —
   // and gateways fronting non-OpenAI models often reject unknown parameters.
   forwardReasoningEffort?: boolean
+  reviewerScope?: {
+    marker: string
+    namespacedTools: ResponsesBridgeNamespacedTool[]
+  }
 }
 
 export type ResponsesBridgeNamespacedTool = {
@@ -341,6 +345,21 @@ const withConnectorInstructions = (
     body: { ...body, instructions },
     selectedIds: selected.map((connector) => connector.id)
   }
+}
+
+const containsTextMarker = (value: unknown, marker: string): boolean => {
+  if (typeof value === 'string') return value.includes(marker)
+  if (Array.isArray(value)) return value.some((item) => containsTextMarker(item, marker))
+  if (!value || typeof value !== 'object') return false
+  return Object.values(value).some((item) => containsTextMarker(item, marker))
+}
+
+const isReviewerScopedRequest = (body: JsonObject, target: ResponsesBridgeTarget): boolean => {
+  const marker = target.reviewerScope?.marker
+  return Boolean(
+    marker &&
+    (containsTextMarker(body.instructions, marker) || containsTextMarker(body.input, marker))
+  )
 }
 
 const namespacedToolAlias = (
@@ -1143,11 +1162,17 @@ export class ResponsesBridge {
 
     try {
       const body = await readBody(request)
-      const namespacedTools = this.target.namespacedTools ?? []
-      const connectorSelection = withConnectorInstructions(
-        body,
-        this.target.connectorInstructions ?? []
-      )
+      const reviewerScoped = isReviewerScopedRequest(body, this.target)
+      const namespacedTools = reviewerScoped
+        ? (this.target.reviewerScope?.namespacedTools ?? [])
+        : (this.target.namespacedTools ?? [])
+      // codex-acp ignores disableBuiltInTools metadata and still advertises shell/filesystem tools.
+      // For reviewer turns, replace the entire declaration set at the protocol boundary so the model
+      // can call only the scope-bounded reviewer HTTP MCP functions.
+      const scopedBody = reviewerScoped ? { ...body, tools: [], tool_choice: 'auto' } : body
+      const connectorSelection = reviewerScoped
+        ? { body: scopedBody, selectedIds: [] }
+        : withConnectorInstructions(scopedBody, this.target.connectorInstructions ?? [])
       const chatRequest = responsesToChatRequest(
         connectorSelection.body,
         this.target.model,
@@ -1176,6 +1201,7 @@ export class ResponsesBridge {
         incomingToolCount: incomingTools.length,
         outgoingToolNames,
         selectedConnectors: connectorSelection.selectedIds,
+        reviewerScoped,
         toolChoice: chatRequest.tool_choice ?? null
       })
 

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -1044,6 +1044,7 @@ export class ResponsesBridge {
   // provider switch / disconnect). Keyed by call_id, which Codex round-trips, so lookups stay stable.
   private readonly reasoningByCallId = new Map<string, string>()
   private readonly reviewerSessionKeys = new Set<string>()
+  private readonly scopedReviewerSessionKeys = new Set<string>()
 
   constructor(
     target: ResponsesBridgeTarget,
@@ -1074,10 +1075,12 @@ export class ResponsesBridge {
 
   registerReviewerSession(promptCacheKey: string): void {
     this.reviewerSessionKeys.add(promptCacheKey)
+    this.scopedReviewerSessionKeys.delete(promptCacheKey)
   }
 
-  unregisterReviewerSession(promptCacheKey: string): void {
+  unregisterReviewerSession(promptCacheKey: string): boolean {
     this.reviewerSessionKeys.delete(promptCacheKey)
+    return this.scopedReviewerSessionKeys.delete(promptCacheKey)
   }
 
   async start(): Promise<ResponsesBridgeConnection> {
@@ -1118,6 +1121,7 @@ export class ResponsesBridge {
     this.connection = undefined
     this.reasoningByCallId.clear()
     this.reviewerSessionKeys.clear()
+    this.scopedReviewerSessionKeys.clear()
     if (!server) return
     const closing = new Promise<void>((resolve, reject) =>
       server.close((error) => (error ? reject(error) : resolve()))
@@ -1156,9 +1160,11 @@ export class ResponsesBridge {
 
     try {
       const body = await readBody(request)
+      const promptCacheKey =
+        typeof body.prompt_cache_key === 'string' ? body.prompt_cache_key : undefined
       const reviewerScoped =
-        typeof body.prompt_cache_key === 'string' &&
-        this.reviewerSessionKeys.has(body.prompt_cache_key)
+        promptCacheKey !== undefined && this.reviewerSessionKeys.has(promptCacheKey)
+      if (reviewerScoped) this.scopedReviewerSessionKeys.add(promptCacheKey)
       const namespacedTools = reviewerScoped
         ? (this.target.reviewerScope?.namespacedTools ?? [])
         : (this.target.namespacedTools ?? [])

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1157,6 +1157,7 @@ describe('SettingsService: preflight & spawn config', () => {
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
 
     const backend = await service.resolveActiveAgentBackend()
+    const selection = await service.captureActiveAgentBackendSelection()
 
     expect(backend.framework.id).toBe('codex')
     expect(backend.executablePath).toBe(adapterPath)
@@ -1169,6 +1170,20 @@ describe('SettingsService: preflight & spawn config', () => {
     })
     expect(backend.env.CODEX_API_KEY).toBeUndefined()
     expect(backend.authentication).toEqual({
+      methodId: 'api-key',
+      _meta: { 'api-key': { apiKey: 'test-key' } }
+    })
+
+    expect(selection).toEqual({ frameworkId: 'codex' })
+    expect(selection).not.toHaveProperty('key')
+
+    // The generation stays on Codex after global framework settings move elsewhere; credentials are
+    // decrypted again from the active provider only when another spawn is actually needed.
+    await repository.setAgentFramework('claude-code')
+    const pinnedBackend = await service.resolveAgentBackend(selection)
+    expect(pinnedBackend.framework.id).toBe('codex')
+    expect(pinnedBackend.backendId).toBe(`codex:${provider.id}`)
+    expect(pinnedBackend.authentication).toEqual({
       methodId: 'api-key',
       _meta: { 'api-key': { apiKey: 'test-key' } }
     })
@@ -1409,6 +1424,119 @@ describe('SettingsService: preflight & spawn config', () => {
       'utf8'
     )
     expect(pubmedSkill).toContain('host.mcp')
+  })
+
+  it('keeps bridged Codex backends pinned to the provider target they were created for', async () => {
+    const localFetch = globalThis.fetch
+    const upstreamRequests: Array<{ url: string; authorization: string; model: unknown }> = []
+    const upstreamToolNames: string[][] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+        const tools = Array.isArray(body.tools) ? body.tools : []
+        upstreamToolNames.push(
+          tools.map((tool) =>
+            String((tool as { function?: { name?: unknown } }).function?.name ?? '')
+          )
+        )
+        upstreamRequests.push({
+          url: String(url),
+          authorization: String((init?.headers as Record<string, string>)?.authorization ?? ''),
+          model: body.model
+        })
+        return new Response(
+          [
+            `data: ${JSON.stringify({
+              id: `chat-${upstreamRequests.length}`,
+              model: body.model,
+              choices: [{ index: 0, delta: {}, finish_reason: 'stop' }]
+            })}`,
+            '',
+            'data: [DONE]',
+            ''
+          ].join('\n'),
+          { headers: { 'content-type': 'text/event-stream' } }
+        )
+      })
+    )
+    const adapterPath = join(storageRoot, 'bin', 'codex-acp')
+    await mkdir(dirname(adapterPath), { recursive: true })
+    await writeFile(adapterPath, '', 'utf8')
+    const service = createService(undefined, {
+      codexDetected: { path: adapterPath, version: 'codex-acp 1.1.4' }
+    })
+    await repository.setCodexInfo({ resolvedPath: adapterPath, version: '1.1.4' })
+    await repository.setAgentFramework('codex')
+    const first = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'Provider One',
+        apiEndpoints: ['openai'],
+        baseUrl: 'https://one.example/v1',
+        model: 'model-one',
+        key: 'key-one'
+      })
+    ).providers[0]
+    const second = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'Provider Two',
+        apiEndpoints: ['openai'],
+        baseUrl: 'https://two.example/v1',
+        model: 'model-two',
+        key: 'key-two'
+      })
+    ).providers.find((provider) => provider.name === 'Provider Two')!
+    for (const provider of (await repository.getSettings()).providers) {
+      await repository.upsertProvider({ ...provider, lastValidatedAt: Date.now() })
+    }
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
+
+    await service.setActiveProvider(first.id)
+    const firstBackend = await service.resolveActiveAgentBackend()
+    await service.setActiveProvider(second.id)
+    const secondBackend = await service.resolveActiveAgentBackend()
+
+    expect(firstBackend.providerConfiguration?.baseUrl).not.toBe(
+      secondBackend.providerConfiguration?.baseUrl
+    )
+
+    const send = async (backend: typeof firstBackend): Promise<void> => {
+      const response = await localFetch(`${backend.providerConfiguration?.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: backend.providerConfiguration?.headers.authorization ?? '',
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'gpt-5.5',
+          input: 'hello',
+          stream: true,
+          tools: [{ type: 'tool_search' }]
+        })
+      })
+      await response.text()
+    }
+    await send(firstBackend)
+    await send(secondBackend)
+
+    expect(upstreamRequests).toEqual([
+      {
+        url: 'https://one.example/v1/chat/completions',
+        authorization: 'Bearer key-one',
+        model: 'model-one'
+      },
+      {
+        url: 'https://two.example/v1/chat/completions',
+        authorization: 'Bearer key-two',
+        model: 'model-two'
+      }
+    ])
+    expect(upstreamToolNames).toEqual([
+      expect.arrayContaining(['mcp__open_science_reviewer__submit_findings']),
+      expect.arrayContaining(['mcp__open_science_reviewer__submit_findings'])
+    ])
   })
 
   it('drives a native-Responses official vendor directly, without starting the bridge', async () => {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -8,6 +8,7 @@ import { CODEX_SUBSCRIPTION_PROVIDER_ID, type ClaudeDetectResult } from '../../s
 import type { CodexAuthControllerPort } from './codex-auth'
 import type { ClaudeIsolatedAuthControllerPort } from './claude-isolated-auth'
 import type { UserSkillRepository } from '../skills/user-skill-repository'
+import type { ResponsesBridge } from './responses-bridge'
 
 // Reversible fake safeStorage so provider keys can be encrypted/decrypted without an OS keychain.
 vi.mock('electron', () => ({
@@ -1495,6 +1496,7 @@ describe('SettingsService: preflight & spawn config', () => {
 
     await service.setActiveProvider(first.id)
     const firstBackend = await service.resolveActiveAgentBackend()
+    const firstBackendPeer = await service.resolveActiveAgentBackend()
     await service.setActiveProvider(second.id)
     const secondBackend = await service.resolveActiveAgentBackend()
 
@@ -1502,7 +1504,18 @@ describe('SettingsService: preflight & spawn config', () => {
       secondBackend.providerConfiguration?.baseUrl
     )
 
-    const send = async (backend: typeof firstBackend): Promise<void> => {
+    const bridges = Array.from(
+      (
+        service as unknown as {
+          responsesBridges: Map<string, { bridge: ResponsesBridge }>
+        }
+      ).responsesBridges.values(),
+      (entry) => entry.bridge
+    )
+    bridges[0].registerReviewerSession('reviewer-one')
+    bridges[1].registerReviewerSession('reviewer-two')
+
+    const send = async (backend: typeof firstBackend, promptCacheKey: string): Promise<void> => {
       const response = await localFetch(`${backend.providerConfiguration?.baseUrl}/responses`, {
         method: 'POST',
         headers: {
@@ -1511,15 +1524,16 @@ describe('SettingsService: preflight & spawn config', () => {
         },
         body: JSON.stringify({
           model: 'gpt-5.5',
-          input: '<open_science_reviewer_session> hello',
+          input: 'hello',
+          prompt_cache_key: promptCacheKey,
           stream: true,
           tools: [{ type: 'tool_search' }]
         })
       })
       await response.text()
     }
-    await send(firstBackend)
-    await send(secondBackend)
+    await send(firstBackend, 'reviewer-one')
+    await send(secondBackend, 'reviewer-two')
 
     expect(upstreamRequests).toEqual([
       {
@@ -1537,6 +1551,19 @@ describe('SettingsService: preflight & spawn config', () => {
       expect.arrayContaining(['mcp__open_science_reviewer__submit_findings']),
       expect.arrayContaining(['mcp__open_science_reviewer__submit_findings'])
     ])
+
+    const bridgePool = (
+      service as unknown as {
+        responsesBridges: Map<string, unknown>
+      }
+    ).responsesBridges
+    expect(bridgePool.size).toBe(2)
+    await firstBackend.responsesBridgeLease?.release()
+    expect(bridgePool.size).toBe(2)
+    await firstBackendPeer.responsesBridgeLease?.release()
+    expect(bridgePool.size).toBe(1)
+    await secondBackend.responsesBridgeLease?.release()
+    expect(bridgePool.size).toBe(0)
   })
 
   it('drives a native-Responses official vendor directly, without starting the bridge', async () => {
@@ -2130,8 +2157,7 @@ describe('SettingsService: skills', () => {
     expect(await exists(skillDir)).toBe(false)
 
     // Turn-forced: the disabled skill is materialized for this spawn only.
-    service.setTurnForcedSkillIds(['demo'])
-    await service.resolveActiveSpawnConfig()
+    await service.resolveActiveSpawnConfig({ forcedSkillIds: ['demo'] })
     expect(await exists(skillDir)).toBe(true)
 
     // The stored disabled set is untouched, so the skill still lists as disabled.
@@ -2139,7 +2165,6 @@ describe('SettingsService: skills', () => {
     expect(skills.find((skill) => skill.id === 'demo')?.enabled).toBe(false)
 
     // Clearing the force set removes it again on the next spawn.
-    service.clearTurnForcedSkillIds()
     await service.resolveActiveSpawnConfig()
     expect(await exists(skillDir)).toBe(false)
   })
@@ -2992,7 +3017,7 @@ describe('SettingsService: listAgentHomeSkills framework routing', () => {
     )
   }
 
-  it("scans the user Claude home when the active framework is claude-code", async () => {
+  it('scans the user Claude home when the active framework is claude-code', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-'))
     const userCodexDir = await mkdtemp(join(tmpdir(), 'os-list-agent-codex-'))
     await seedSkill(userClaudeDir, 'alpha')
@@ -3007,7 +3032,7 @@ describe('SettingsService: listAgentHomeSkills framework routing', () => {
     expect(items[0].path).toBe(join(userClaudeDir, 'skills', 'alpha'))
   })
 
-  it("scans the user Codex home when the active framework is codex", async () => {
+  it('scans the user Codex home when the active framework is codex', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-'))
     const userCodexDir = await mkdtemp(join(tmpdir(), 'os-list-agent-codex-'))
     await seedSkill(userCodexDir, 'beta')
@@ -3174,9 +3199,7 @@ describe('SettingsService: importAgentHomeSkill path containment', () => {
 
     // Path-traversal payloads are caught by the SAFE_SLUG regex (no '/', '.', etc.), so the
     // containment check downstream is defense-in-depth and is not exercised by valid slugs.
-    await expect(service.importAgentHomeSkill({ slug: '../../etc' })).rejects.toThrow(
-      /unsafe slug/
-    )
+    await expect(service.importAgentHomeSkill({ slug: '../../etc' })).rejects.toThrow(/unsafe slug/)
     await expect(service.importAgentHomeSkill({ slug: '../sibling' })).rejects.toThrow(
       /unsafe slug/
     )
@@ -3582,10 +3605,7 @@ describe('SettingsService: importAgentHomeSkill realpath containment', () => {
   const seedSkill = async (agentHome: string, slug: string): Promise<string> => {
     const dir = join(agentHome, 'skills', slug)
     await mkdir(dir, { recursive: true })
-    await writeFile(
-      join(dir, 'SKILL.md'),
-      `---\nname: ${slug}\ndescription: Test\n---\nBody.\n`
-    )
+    await writeFile(join(dir, 'SKILL.md'), `---\nname: ${slug}\ndescription: Test\n---\nBody.\n`)
     return dir
   }
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1511,7 +1511,7 @@ describe('SettingsService: preflight & spawn config', () => {
         },
         body: JSON.stringify({
           model: 'gpt-5.5',
-          input: 'hello',
+          input: '<open_science_reviewer_session> hello',
           stream: true,
           tools: [{ type: 'tool_search' }]
         })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -30,6 +30,7 @@ vi.mock('electron', () => ({
 }))
 
 const { SettingsService } = await import('./service')
+const { ResponsesBridge: ResponsesBridgeClass } = await import('./responses-bridge')
 const { SettingsRepository } = await import('./repository')
 const { getAppClaudeConfigDir } = await import('./provider-env')
 const { SkillRegistry } = await import('../skills/registry')
@@ -1564,6 +1565,43 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(bridgePool.size).toBe(1)
     await secondBackend.responsesBridgeLease?.release()
     expect(bridgePool.size).toBe(0)
+  })
+
+  it('closes and evicts a responses bridge whose start fails', async () => {
+    const startError = new Error('bridge start failed')
+    const startSpy = vi.spyOn(ResponsesBridgeClass.prototype, 'start').mockRejectedValue(startError)
+    const closeSpy = vi.spyOn(ResponsesBridgeClass.prototype, 'close').mockResolvedValue(undefined)
+    const adapterPath = join(storageRoot, 'bin', 'codex-acp')
+    await mkdir(dirname(adapterPath), { recursive: true })
+    await writeFile(adapterPath, '', 'utf8')
+    const service = createService(undefined, {
+      codexDetected: { path: adapterPath, version: 'codex-acp 1.1.4' }
+    })
+    await repository.setCodexInfo({ resolvedPath: adapterPath, version: '1.1.4' })
+    await repository.setAgentFramework('codex')
+    const provider = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'Broken bridge provider',
+        apiEndpoints: ['openai'],
+        baseUrl: 'https://broken.example/v1',
+        model: 'model-one',
+        key: 'key-one'
+      })
+    ).providers[0]
+    const storedProvider = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({ ...storedProvider, lastValidatedAt: Date.now() })
+    await service.setActiveProvider(provider.id)
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
+
+    await expect(service.resolveActiveAgentBackend()).rejects.toBe(startError)
+
+    const bridgePool = (service as unknown as { responsesBridges: Map<string, unknown> })
+      .responsesBridges
+    expect(closeSpy).toHaveBeenCalledOnce()
+    expect(bridgePool.size).toBe(0)
+    startSpy.mockRestore()
+    closeSpy.mockRestore()
   })
 
   it('drives a native-Responses official vendor directly, without starting the bridge', async () => {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -81,7 +81,6 @@ import {
 } from '../../shared/run-error-classification'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
-import { REVIEWER_BRIDGE_SESSION_MARKER } from '../../shared/reviewer'
 import {
   defaultVendorModel,
   getOfficialVendor,
@@ -193,6 +192,20 @@ import {
 
 export type AgentBackendSelection = {
   frameworkId: AgentFrameworkId
+}
+
+export type AgentBackendResolutionContext = {
+  forcedSkillIds?: string[]
+}
+
+type ResponsesBridgePoolEntry = {
+  bridge: ResponsesBridge
+  connection: Promise<ResponsesBridgeConnection>
+  leaseCount: number
+}
+
+type LeasedResponsesBridgeConnection = ResponsesBridgeConnection & {
+  lease: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>
 }
 
 const execFileAsync = promisify(execFile)
@@ -398,12 +411,9 @@ class SettingsService {
   ) => Promise<ManagedCodexInstallOutcome>
   private readonly codexAuth: CodexAuthControllerPort
   private readonly claudeIsolatedAuth: ClaudeIsolatedAuthControllerPort
-  private readonly responsesBridges = new Map<string, ResponsesBridge>()
+  private readonly responsesBridges = new Map<string, ResponsesBridgePoolEntry>()
   private providerSequence = 0
   private readonly providerValidationGenerations = new Map<string, number>()
-  // Skills force-loaded for the current turn: subtracted from the stored disabled set at spawn time so
-  // a picked-but-disabled skill materializes for this prompt only, without mutating stored settings.
-  private turnForcedSkillIds = new Set<string>()
 
   constructor(options: SettingsServiceOptions = {}) {
     this.storageRoot = options.storageRoot ?? resolveStorageRoot()
@@ -691,7 +701,7 @@ class SettingsService {
     // A live bridge never sees resolveActiveAgentBackend again until the next provider switch, so its
     // forwarding policy must be updated in place: an explicit level forwards, 'default' restores
     // stripping so Codex's own default effort never leaks upstream.
-    for (const bridge of this.responsesBridges.values()) {
+    for (const { bridge } of this.responsesBridges.values()) {
       bridge.setForwardReasoningEffort(effort !== DEFAULT_REASONING_EFFORT)
     }
 
@@ -768,16 +778,6 @@ class SettingsService {
     const disabled = new Set(settings.disabledSkillIds ?? [])
 
     return skills.map((skill) => this.toSkillView(skill, disabled))
-  }
-
-  // Sets the skills to force-load for the current turn (picked in the composer). Cleared after the turn.
-  setTurnForcedSkillIds(ids: string[]): void {
-    this.turnForcedSkillIds = new Set(ids)
-  }
-
-  // Clears the turn-scoped force-load set so later spawns use the normal enabled set.
-  clearTurnForcedSkillIds(): void {
-    this.turnForcedSkillIds.clear()
   }
 
   // Returns the subset of forced ids that are currently disabled in settings — i.e. the picks that need
@@ -2177,10 +2177,11 @@ class SettingsService {
   // its disabled state, mirroring the Claude provisioning path.
   private async materializeAgentSkills(
     settings: StoredSettings,
-    configRoot: string
+    configRoot: string,
+    forcedSkillIds: ReadonlySet<string>
   ): Promise<void> {
     const disabled = new Set(
-      (settings.disabledSkillIds ?? []).filter((id) => !this.turnForcedSkillIds.has(id))
+      (settings.disabledSkillIds ?? []).filter((id) => !forcedSkillIds.has(id))
     )
     const enabled = (await this.skillCatalog()).filter((skill) => !disabled.has(skill.id))
 
@@ -2428,13 +2429,18 @@ class SettingsService {
   }
 
   // Builds the spawn env for the active provider, read fresh so switching takes effect on reconnect.
-  async resolveActiveSpawnConfig(): Promise<AgentSpawnConfig> {
+  async resolveActiveSpawnConfig(
+    context: AgentBackendResolutionContext = {}
+  ): Promise<AgentSpawnConfig> {
     const settings = await this.repository.getSettings()
 
-    return this.resolveSpawnConfig(settings)
+    return this.resolveSpawnConfig(settings, new Set(context.forcedSkillIds ?? []))
   }
 
-  private async resolveSpawnConfig(settings: StoredSettings): Promise<AgentSpawnConfig> {
+  private async resolveSpawnConfig(
+    settings: StoredSettings,
+    forcedSkillIds: ReadonlySet<string>
+  ): Promise<AgentSpawnConfig> {
     let executablePath = settings.claude?.resolvedPath
 
     // Trust the stored path only if it still exists. A user who uninstalled Claude leaves a stale path
@@ -2463,7 +2469,7 @@ class SettingsService {
     // disabled set so a picked-but-disabled skill materializes for this prompt without mutating settings.
     const appConfigDir = getAppClaudeConfigDir(this.storageRoot)
     const disabledSkillIds = (settings.disabledSkillIds ?? []).filter(
-      (id) => !this.turnForcedSkillIds.has(id)
+      (id) => !forcedSkillIds.has(id)
     )
     await provisionAppClaudeConfigDir(appConfigDir, {
       skills: await this.skillCatalog(),
@@ -2486,7 +2492,9 @@ class SettingsService {
   // provider to their own native config (a generated opencode.json) via the framework adapter and get
   // it written to disk before spawn. The framework can be forced with OPEN_SCIENCE_AGENT_FRAMEWORK for
   // the spike until the settings selector lands.
-  async resolveActiveAgentBackend(): Promise<ResolvedAgentBackend> {
+  async resolveActiveAgentBackend(
+    context: AgentBackendResolutionContext = {}
+  ): Promise<ResolvedAgentBackend> {
     const settings = await this.repository.getSettings()
     const forced = process.env.OPEN_SCIENCE_AGENT_FRAMEWORK
     const frameworkId: AgentFrameworkId =
@@ -2494,7 +2502,7 @@ class SettingsService {
         ? forced
         : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
 
-    return this.resolveAgentBackendFromSettings(settings, frameworkId)
+    return this.resolveAgentBackendFromSettings(settings, frameworkId, context)
   }
 
   // Captures only non-secret backend identity. Runtime generations resolve credentials again at spawn,
@@ -2510,20 +2518,25 @@ class SettingsService {
     return { frameworkId }
   }
 
-  async resolveAgentBackend(selection: AgentBackendSelection): Promise<ResolvedAgentBackend> {
+  async resolveAgentBackend(
+    selection: AgentBackendSelection,
+    context: AgentBackendResolutionContext = {}
+  ): Promise<ResolvedAgentBackend> {
     const stored = await this.repository.getSettings()
     const settings: StoredSettings = {
       ...stored,
       agentFrameworkId: selection.frameworkId
     }
 
-    return this.resolveAgentBackendFromSettings(settings, selection.frameworkId)
+    return this.resolveAgentBackendFromSettings(settings, selection.frameworkId, context)
   }
 
   private async resolveAgentBackendFromSettings(
     settings: StoredSettings,
-    frameworkId: AgentFrameworkId
+    frameworkId: AgentFrameworkId,
+    context: AgentBackendResolutionContext
   ): Promise<ResolvedAgentBackend> {
+    const forcedSkillIds = new Set(context.forcedSkillIds ?? [])
     const framework = getAgentFramework(frameworkId)
     // 'default' means "don't override": nothing is sent over ACP or framework config, so the agent
     // keeps its own default effort. A concrete level is delivered through two channels deliberately
@@ -2573,7 +2586,10 @@ class SettingsService {
 
     if (framework.id === 'claude-code') {
       // Unchanged Claude path: skills provisioning + Anthropic-shaped env + local-auth handling.
-      const { envOverrides, executablePath } = await this.resolveSpawnConfig(settings)
+      const { envOverrides, executablePath } = await this.resolveSpawnConfig(
+        settings,
+        forcedSkillIds
+      )
 
       return {
         framework,
@@ -2608,7 +2624,7 @@ class SettingsService {
     // Shared mode exposes the user's normal Codex profile exactly as they own it. The app's skill
     // synchronizer deliberately stays out of ~/.codex so same-named user skills are never replaced.
     if (!(framework.id === 'codex' && provider.type === 'codex-shared')) {
-      await this.materializeAgentSkills(settings, skillsRoot)
+      await this.materializeAgentSkills(settings, skillsRoot, forcedSkillIds)
     }
     // The Chat Completions bridge only exists to let Codex (a Responses-only client) drive an
     // OpenAI Chat provider. A provider that also speaks native Responses is driven directly, so
@@ -2624,38 +2640,44 @@ class SettingsService {
     const responsesBridge = needsResponsesBridge
       ? await this.ensureResponsesBridge(provider, enabledConnectorIds, sessionEffort !== undefined)
       : undefined
-    const modelConfig = framework.prepareModelConfig(provider, {
-      storageRoot: this.storageRoot,
-      executablePath,
-      responsesBridge,
-      reasoningEffort: sessionEffort,
-      // Connector conventions + tools, so opencode uses host.mcp instead of raw HTTP (it has no skill
-      // docs like Claude). Enabled bundled connectors only.
-      instructions: renderConnectorInstructions(enabledConnectorIds)
-    })
-    await this.writeAgentConfigFiles(modelConfig.configFiles)
+    try {
+      const modelConfig = framework.prepareModelConfig(provider, {
+        storageRoot: this.storageRoot,
+        executablePath,
+        responsesBridge,
+        reasoningEffort: sessionEffort,
+        // Connector conventions + tools, so opencode uses host.mcp instead of raw HTTP (it has no skill
+        // docs like Claude). Enabled bundled connectors only.
+        instructions: renderConnectorInstructions(enabledConnectorIds)
+      })
+      await this.writeAgentConfigFiles(modelConfig.configFiles)
 
-    // Protocol-driven frameworks apply an explicit model through the ACP session configOption. A Codex
-    // subscription with no explicit selection leaves this undefined so Codex uses the account default.
-    const sessionModel = modelConfig.sessionModel ?? provider.model
-    return {
-      framework,
-      backendId: `${framework.id}:${backendProviderId}`,
-      executablePath,
-      env: {
-        ...(modelConfig.env ?? {}),
-        ...(framework.id === 'codex' && settings.codex?.nativePath
-          ? { CODEX_PATH: settings.codex.nativePath }
-          : {})
-      },
-      args: modelConfig.args,
-      sessionModel,
-      ...(framework.id === 'codex' && isCodexSubscriptionProvider(provider.type) && sessionModel
-        ? { sessionModelRequired: true }
-        : {}),
-      sessionEffort,
-      authentication: modelConfig.authentication,
-      providerConfiguration: modelConfig.providerConfiguration
+      // Protocol-driven frameworks apply an explicit model through the ACP session configOption. A Codex
+      // subscription with no explicit selection leaves this undefined so Codex uses the account default.
+      const sessionModel = modelConfig.sessionModel ?? provider.model
+      return {
+        framework,
+        backendId: `${framework.id}:${backendProviderId}`,
+        executablePath,
+        env: {
+          ...(modelConfig.env ?? {}),
+          ...(framework.id === 'codex' && settings.codex?.nativePath
+            ? { CODEX_PATH: settings.codex.nativePath }
+            : {})
+        },
+        args: modelConfig.args,
+        sessionModel,
+        ...(framework.id === 'codex' && isCodexSubscriptionProvider(provider.type) && sessionModel
+          ? { sessionModelRequired: true }
+          : {}),
+        sessionEffort,
+        authentication: modelConfig.authentication,
+        providerConfiguration: modelConfig.providerConfiguration,
+        responsesBridgeLease: responsesBridge?.lease
+      }
+    } catch (error) {
+      await responsesBridge?.lease.release()
+      throw error
     }
   }
 
@@ -2663,7 +2685,7 @@ class SettingsService {
     provider: ResolvedProvider,
     enabledConnectorIds: string[],
     forwardReasoningEffort: boolean
-  ): Promise<ResponsesBridgeConnection> {
+  ): Promise<LeasedResponsesBridgeConnection> {
     // Resolve to the OpenAI base the bridge appends `/chat/completions` to: an official vendor's exact
     // versioned base, or a custom gateway root normalized to `<root>/v1`.
     const targetBaseUrl = openAiCompletionsBase(provider)
@@ -2676,7 +2698,6 @@ class SettingsService {
       forwardReasoningEffort,
       namespacedTools: [...CODEX_BRIDGE_NOTEBOOK_TOOLS, ...CODEX_BRIDGE_ARTIFACT_TOOLS],
       reviewerScope: {
-        marker: REVIEWER_BRIDGE_SESSION_MARKER,
         namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS
       },
       connectorInstructions: enabledConnectorIds.map((id) => {
@@ -2691,16 +2712,52 @@ class SettingsService {
       })
     }
     const fingerprint = this.responsesBridgeFingerprint(target)
-    let bridge = this.responsesBridges.get(fingerprint)
-    if (!bridge) {
-      bridge = new ResponsesBridge(target)
-      this.responsesBridges.set(fingerprint, bridge)
+    let entry = this.responsesBridges.get(fingerprint)
+    if (!entry) {
+      const bridge = new ResponsesBridge(target)
+      entry = { bridge, connection: bridge.start(), leaseCount: 0 }
+      this.responsesBridges.set(fingerprint, entry)
     } else {
       // Reasoning effort is a live global preference, not part of the bridge's pinned routing target.
-      bridge.setForwardReasoningEffort(forwardReasoningEffort)
+      entry.bridge.setForwardReasoningEffort(forwardReasoningEffort)
+    }
+    entry.leaseCount += 1
+
+    let connection: ResponsesBridgeConnection
+    try {
+      connection = await entry.connection
+    } catch (error) {
+      entry.leaseCount = Math.max(0, entry.leaseCount - 1)
+      if (entry.leaseCount === 0 && this.responsesBridges.get(fingerprint) === entry) {
+        this.responsesBridges.delete(fingerprint)
+      }
+      throw error
     }
 
-    return bridge.start()
+    let released = false
+    const leasedEntry = entry
+    return {
+      ...connection,
+      lease: {
+        registerReviewerSession: (promptCacheKey) =>
+          leasedEntry.bridge.registerReviewerSession(promptCacheKey),
+        unregisterReviewerSession: (promptCacheKey) =>
+          leasedEntry.bridge.unregisterReviewerSession(promptCacheKey),
+        release: async () => {
+          if (released) return
+          released = true
+          leasedEntry.leaseCount = Math.max(0, leasedEntry.leaseCount - 1)
+          if (
+            leasedEntry.leaseCount > 0 ||
+            this.responsesBridges.get(fingerprint) !== leasedEntry
+          ) {
+            return
+          }
+          this.responsesBridges.delete(fingerprint)
+          await leasedEntry.bridge.close()
+        }
+      }
+    }
   }
 
   private responsesBridgeFingerprint(target: ResponsesBridgeTarget): string {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2730,6 +2730,7 @@ class SettingsService {
       entry.leaseCount = Math.max(0, entry.leaseCount - 1)
       if (entry.leaseCount === 0 && this.responsesBridges.get(fingerprint) === entry) {
         this.responsesBridges.delete(fingerprint)
+        await entry.bridge.close().catch(() => undefined)
       }
       throw error
     }
@@ -2761,6 +2762,8 @@ class SettingsService {
   }
 
   private responsesBridgeFingerprint(target: ResponsesBridgeTarget): string {
+    // forwardReasoningEffort is intentionally live mutable and therefore excluded from the pinned
+    // routing identity. Including it would split leases and prevent effort fan-out to existing bridges.
     const pinnedTarget = {
       baseUrl: target.baseUrl,
       key: target.key,

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -81,7 +81,7 @@ import {
 } from '../../shared/run-error-classification'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
-import { REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_TOOLS } from '../../shared/reviewer'
+import { REVIEWER_BRIDGE_SESSION_MARKER } from '../../shared/reviewer'
 import {
   defaultVendorModel,
   getOfficialVendor,
@@ -170,7 +170,7 @@ import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limit
 import { readSkillFile } from '../skills/skill-files'
 import { NOTEBOOK_MCP_SERVER_NAME, NOTEBOOK_RPC_TOOLS } from '../notebook/mcp-server'
 import { ARTIFACT_MCP_SERVER_NAME, writeArtifactFileToolSchema } from '../artifacts/mcp-server'
-import { submitFindingsInputSchema } from '../reviewer/mcp-server'
+import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
 import type {
   StoredConnectors,
   StoredCodexInfo,
@@ -245,48 +245,6 @@ const CODEX_BRIDGE_ARTIFACT_TOOLS: ResponsesBridgeNamespacedTool[] = [
     }) as ResponsesBridgeNamespacedTool['parameters']
   }
 ]
-const CODEX_REVIEWER_TOOL_NAMESPACE = `mcp__${REVIEWER_MCP_SERVER_NAME.replace(
-  /[^a-zA-Z0-9_]/g,
-  '_'
-)}`
-const CODEX_BRIDGE_REVIEWER_TOOLS: ResponsesBridgeNamespacedTool[] = [
-  {
-    namespace: CODEX_REVIEWER_TOOL_NAMESPACE,
-    name: REVIEWER_MCP_TOOLS.readTurn,
-    description: 'Return the ordered message and tool-activity blocks in the audited turn.',
-    parameters: z.toJSONSchema(z.object({}).strict(), { target: 'draft-7' })
-  },
-  {
-    namespace: CODEX_REVIEWER_TOOL_NAMESPACE,
-    name: REVIEWER_MCP_TOOLS.queryExecutionLog,
-    description: 'Return the execution log for the audited turn or one in-scope activity.',
-    parameters: z.toJSONSchema(
-      z
-        .object({ activityId: z.string().optional().describe('Optional in-scope activity id') })
-        .strict(),
-      { target: 'draft-7' }
-    )
-  },
-  {
-    namespace: CODEX_REVIEWER_TOOL_NAMESPACE,
-    name: REVIEWER_MCP_TOOLS.readArtifact,
-    description: 'Read one artifact attached to the audited turn.',
-    parameters: z.toJSONSchema(
-      z.object({ id: z.string().min(1).describe('In-scope artifact version id') }).strict(),
-      { target: 'draft-7' }
-    )
-  },
-  {
-    namespace: CODEX_REVIEWER_TOOL_NAMESPACE,
-    name: REVIEWER_MCP_TOOLS.submitFindings,
-    description:
-      'Submit structured review checks exactly once, then stop. Pass an empty checks array if no issues were found.',
-    parameters: z.toJSONSchema(submitFindingsInputSchema, {
-      target: 'draft-7'
-    }) as ResponsesBridgeNamespacedTool['parameters']
-  }
-]
-
 const isManagedCodexPath = (adapterPath: string, storageRoot: string): boolean =>
   adapterPath === managedCodexAdapterEntry(storageRoot)
 
@@ -2716,11 +2674,11 @@ class SettingsService {
       key: provider.key,
       model: provider.model,
       forwardReasoningEffort,
-      namespacedTools: [
-        ...CODEX_BRIDGE_NOTEBOOK_TOOLS,
-        ...CODEX_BRIDGE_ARTIFACT_TOOLS,
-        ...CODEX_BRIDGE_REVIEWER_TOOLS
-      ],
+      namespacedTools: [...CODEX_BRIDGE_NOTEBOOK_TOOLS, ...CODEX_BRIDGE_ARTIFACT_TOOLS],
+      reviewerScope: {
+        marker: REVIEWER_BRIDGE_SESSION_MARKER,
+        namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS
+      },
       connectorInstructions: enabledConnectorIds.map((id) => {
         const metadata = CONNECTOR_CATALOG.find((connector) => connector.id === id)
         return {
@@ -2751,6 +2709,7 @@ class SettingsService {
       key: target.key,
       model: target.model,
       namespacedTools: target.namespacedTools,
+      reviewerScope: target.reviewerScope,
       connectorInstructions: target.connectorInstructions
     }
     return createHash('sha256').update(JSON.stringify(pinnedTarget)).digest('hex')

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -3,7 +3,7 @@ import { access, chmod, mkdir, readdir, realpath, writeFile } from 'node:fs/prom
 import { constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join, resolve, sep } from 'node:path'
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { promisify } from 'node:util'
 
 import { z } from 'zod'
@@ -81,6 +81,7 @@ import {
 } from '../../shared/run-error-classification'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
+import { REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_TOOLS } from '../../shared/reviewer'
 import {
   defaultVendorModel,
   getOfficialVendor,
@@ -153,7 +154,8 @@ import { buildProviderEnv, getAppClaudeConfigDir, type ResolvedProvider } from '
 import {
   ResponsesBridge,
   type ResponsesBridgeConnection,
-  type ResponsesBridgeNamespacedTool
+  type ResponsesBridgeNamespacedTool,
+  type ResponsesBridgeTarget
 } from './responses-bridge'
 import { SettingsRepository } from './repository'
 import { sanitizeCustomMcpServer } from './repository'
@@ -168,6 +170,7 @@ import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limit
 import { readSkillFile } from '../skills/skill-files'
 import { NOTEBOOK_MCP_SERVER_NAME, NOTEBOOK_RPC_TOOLS } from '../notebook/mcp-server'
 import { ARTIFACT_MCP_SERVER_NAME, writeArtifactFileToolSchema } from '../artifacts/mcp-server'
+import { submitFindingsInputSchema } from '../reviewer/mcp-server'
 import type {
   StoredConnectors,
   StoredCodexInfo,
@@ -187,6 +190,10 @@ import {
   type ClaudeIsolatedAuthControllerPort,
   type ClaudeIsolatedAuthStatus
 } from './claude-isolated-auth'
+
+export type AgentBackendSelection = {
+  frameworkId: AgentFrameworkId
+}
 
 const execFileAsync = promisify(execFile)
 
@@ -234,6 +241,47 @@ const CODEX_BRIDGE_ARTIFACT_TOOLS: ResponsesBridgeNamespacedTool[] = [
     description:
       'Attach a generated image, chart, report, data export, or archive to the current Open Science response. The file must already exist before using a localPath source.',
     parameters: z.toJSONSchema(z.object(writeArtifactFileToolSchema), {
+      target: 'draft-7'
+    }) as ResponsesBridgeNamespacedTool['parameters']
+  }
+]
+const CODEX_REVIEWER_TOOL_NAMESPACE = `mcp__${REVIEWER_MCP_SERVER_NAME.replace(
+  /[^a-zA-Z0-9_]/g,
+  '_'
+)}`
+const CODEX_BRIDGE_REVIEWER_TOOLS: ResponsesBridgeNamespacedTool[] = [
+  {
+    namespace: CODEX_REVIEWER_TOOL_NAMESPACE,
+    name: REVIEWER_MCP_TOOLS.readTurn,
+    description: 'Return the ordered message and tool-activity blocks in the audited turn.',
+    parameters: z.toJSONSchema(z.object({}).strict(), { target: 'draft-7' })
+  },
+  {
+    namespace: CODEX_REVIEWER_TOOL_NAMESPACE,
+    name: REVIEWER_MCP_TOOLS.queryExecutionLog,
+    description: 'Return the execution log for the audited turn or one in-scope activity.',
+    parameters: z.toJSONSchema(
+      z
+        .object({ activityId: z.string().optional().describe('Optional in-scope activity id') })
+        .strict(),
+      { target: 'draft-7' }
+    )
+  },
+  {
+    namespace: CODEX_REVIEWER_TOOL_NAMESPACE,
+    name: REVIEWER_MCP_TOOLS.readArtifact,
+    description: 'Read one artifact attached to the audited turn.',
+    parameters: z.toJSONSchema(
+      z.object({ id: z.string().min(1).describe('In-scope artifact version id') }).strict(),
+      { target: 'draft-7' }
+    )
+  },
+  {
+    namespace: CODEX_REVIEWER_TOOL_NAMESPACE,
+    name: REVIEWER_MCP_TOOLS.submitFindings,
+    description:
+      'Submit structured review checks exactly once, then stop. Pass an empty checks array if no issues were found.',
+    parameters: z.toJSONSchema(submitFindingsInputSchema, {
       target: 'draft-7'
     }) as ResponsesBridgeNamespacedTool['parameters']
   }
@@ -392,7 +440,7 @@ class SettingsService {
   ) => Promise<ManagedCodexInstallOutcome>
   private readonly codexAuth: CodexAuthControllerPort
   private readonly claudeIsolatedAuth: ClaudeIsolatedAuthControllerPort
-  private responsesBridge: ResponsesBridge | undefined
+  private readonly responsesBridges = new Map<string, ResponsesBridge>()
   private providerSequence = 0
   private readonly providerValidationGenerations = new Map<string, number>()
   // Skills force-loaded for the current turn: subtracted from the stored disabled set at spawn time so
@@ -685,7 +733,9 @@ class SettingsService {
     // A live bridge never sees resolveActiveAgentBackend again until the next provider switch, so its
     // forwarding policy must be updated in place: an explicit level forwards, 'default' restores
     // stripping so Codex's own default effort never leaks upstream.
-    this.responsesBridge?.setForwardReasoningEffort(effort !== DEFAULT_REASONING_EFFORT)
+    for (const bridge of this.responsesBridges.values()) {
+      bridge.setForwardReasoningEffort(effort !== DEFAULT_REASONING_EFFORT)
+    }
 
     return this.getSettingsView()
   }
@@ -2422,6 +2472,11 @@ class SettingsService {
   // Builds the spawn env for the active provider, read fresh so switching takes effect on reconnect.
   async resolveActiveSpawnConfig(): Promise<AgentSpawnConfig> {
     const settings = await this.repository.getSettings()
+
+    return this.resolveSpawnConfig(settings)
+  }
+
+  private async resolveSpawnConfig(settings: StoredSettings): Promise<AgentSpawnConfig> {
     let executablePath = settings.claude?.resolvedPath
 
     // Trust the stored path only if it still exists. A user who uninstalled Claude leaves a stale path
@@ -2480,6 +2535,37 @@ class SettingsService {
       forced === 'opencode' || forced === 'claude-code' || forced === 'codex'
         ? forced
         : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
+
+    return this.resolveAgentBackendFromSettings(settings, frameworkId)
+  }
+
+  // Captures only non-secret backend identity. Runtime generations resolve credentials again at spawn,
+  // so decrypted keys are not retained by the coordinator after AcpRuntime finishes authentication.
+  async captureActiveAgentBackendSelection(): Promise<AgentBackendSelection> {
+    const settings = await this.repository.getSettings()
+    const forced = process.env.OPEN_SCIENCE_AGENT_FRAMEWORK
+    const frameworkId: AgentFrameworkId =
+      forced === 'opencode' || forced === 'claude-code' || forced === 'codex'
+        ? forced
+        : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
+
+    return { frameworkId }
+  }
+
+  async resolveAgentBackend(selection: AgentBackendSelection): Promise<ResolvedAgentBackend> {
+    const stored = await this.repository.getSettings()
+    const settings: StoredSettings = {
+      ...stored,
+      agentFrameworkId: selection.frameworkId
+    }
+
+    return this.resolveAgentBackendFromSettings(settings, selection.frameworkId)
+  }
+
+  private async resolveAgentBackendFromSettings(
+    settings: StoredSettings,
+    frameworkId: AgentFrameworkId
+  ): Promise<ResolvedAgentBackend> {
     const framework = getAgentFramework(frameworkId)
     // 'default' means "don't override": nothing is sent over ACP or framework config, so the agent
     // keeps its own default effort. A concrete level is delivered through two channels deliberately
@@ -2528,9 +2614,8 @@ class SettingsService {
     }
 
     if (framework.id === 'claude-code') {
-      await this.disableResponsesBridge()
       // Unchanged Claude path: skills provisioning + Anthropic-shaped env + local-auth handling.
-      const { envOverrides, executablePath } = await this.resolveActiveSpawnConfig()
+      const { envOverrides, executablePath } = await this.resolveSpawnConfig(settings)
 
       return {
         framework,
@@ -2576,9 +2661,11 @@ class SettingsService {
       (provider.apiEndpoints?.includes('openai') ?? false) &&
       !(provider.apiEndpoints?.includes('responses') ?? false)
     const enabledConnectorIds = this.enabledConnectorIds(settings.connectors)
+    // A bridge may still serve a live Codex runtime from an earlier framework generation. Do not stop
+    // or retarget it merely because the newly selected framework/provider does not need one.
     const responsesBridge = needsResponsesBridge
       ? await this.ensureResponsesBridge(provider, enabledConnectorIds, sessionEffort !== undefined)
-      : await this.disableResponsesBridge()
+      : undefined
     const modelConfig = framework.prepareModelConfig(provider, {
       storageRoot: this.storageRoot,
       executablePath,
@@ -2629,7 +2716,11 @@ class SettingsService {
       key: provider.key,
       model: provider.model,
       forwardReasoningEffort,
-      namespacedTools: [...CODEX_BRIDGE_NOTEBOOK_TOOLS, ...CODEX_BRIDGE_ARTIFACT_TOOLS],
+      namespacedTools: [
+        ...CODEX_BRIDGE_NOTEBOOK_TOOLS,
+        ...CODEX_BRIDGE_ARTIFACT_TOOLS,
+        ...CODEX_BRIDGE_REVIEWER_TOOLS
+      ],
       connectorInstructions: enabledConnectorIds.map((id) => {
         const metadata = CONNECTOR_CATALOG.find((connector) => connector.id === id)
         return {
@@ -2641,19 +2732,28 @@ class SettingsService {
         }
       })
     }
-    if (!this.responsesBridge) {
-      this.responsesBridge = new ResponsesBridge(target)
+    const fingerprint = this.responsesBridgeFingerprint(target)
+    let bridge = this.responsesBridges.get(fingerprint)
+    if (!bridge) {
+      bridge = new ResponsesBridge(target)
+      this.responsesBridges.set(fingerprint, bridge)
     } else {
-      this.responsesBridge.setTarget(target)
+      // Reasoning effort is a live global preference, not part of the bridge's pinned routing target.
+      bridge.setForwardReasoningEffort(forwardReasoningEffort)
     }
 
-    return this.responsesBridge.start()
+    return bridge.start()
   }
 
-  private async disableResponsesBridge(): Promise<undefined> {
-    if (this.responsesBridge) await this.responsesBridge.close()
-    this.responsesBridge = undefined
-    return undefined
+  private responsesBridgeFingerprint(target: ResponsesBridgeTarget): string {
+    const pinnedTarget = {
+      baseUrl: target.baseUrl,
+      key: target.key,
+      model: target.model,
+      namespacedTools: target.namespacedTools,
+      connectorInstructions: target.connectorInstructions
+    }
+    return createHash('sha256').update(JSON.stringify(pinnedTarget)).digest('hex')
   }
 
   // Locates the opencode binary: an explicitly stored path wins, else a best-effort PATH lookup.

--- a/src/renderer/src/lib/acp/history-preamble.ts
+++ b/src/renderer/src/lib/acp/history-preamble.ts
@@ -5,64 +5,7 @@ import {
   type AcpMessageImage
 } from '../../../../shared/acp'
 import { MAX_COMPOSER_ATTACHMENTS, type UploadedAttachment } from '../../../../shared/uploads'
-
-// Character budget for the replayed transcript. Kept modest so a long conversation cannot blow the new
-// agent's context window on its very first turn; older turns past the budget are summarized as omitted.
-const DEFAULT_PREAMBLE_BUDGET = 12_000
-
-const HEADER =
-  'The conversation below happened earlier in this session, before you joined it. Treat it as prior' +
-  ' context — do not reply to it directly; continue from the user message that follows.'
-
-const OMISSION_NOTE = '[…earlier turns omitted for length…]'
-
-// Renders one message as a labelled transcript line, collapsing trailing whitespace.
-const formatMessage = (message: ChatMessage): string => {
-  const speaker = message.role === 'user' ? 'User' : 'Assistant'
-
-  return `**${speaker}:** ${message.content.trim()}`
-}
-
-// Builds a bounded transcript of prior turns to replay into the next prompt after an agent-side context
-// reset (framework switch or unresumable restart). Only completed text turns are included; tool activity
-// is intentionally omitted because its effects already live on disk. Keeps the most recent turns within a
-// character budget and prepends an omission marker when older turns are dropped. Returns undefined when
-// there is nothing meaningful to replay, so the caller can skip the field entirely.
-export const buildHistoryPreamble = (
-  messages: ChatMessage[],
-  budget: number = DEFAULT_PREAMBLE_BUDGET
-): string | undefined => {
-  const usable = messages.filter(
-    (message) => message.status !== 'error' && message.content.trim().length > 0
-  )
-
-  if (usable.length === 0) return undefined
-
-  // Walk newest-first, accepting turns until the budget is spent, then restore chronological order.
-  const kept: ChatMessage[] = []
-  let used = 0
-
-  for (let index = usable.length - 1; index >= 0; index -= 1) {
-    const line = formatMessage(usable[index])
-    const cost = line.length + 2 // account for the blank line joiner
-
-    if (kept.length > 0 && used + cost > budget) break
-
-    kept.unshift(usable[index])
-    used += cost
-  }
-
-  const omittedSome = kept.length < usable.length
-  const body = kept.map(formatMessage).join('\n\n')
-  const transcript = omittedSome ? `${OMISSION_NOTE}\n\n${body}` : body
-  const omissionPrefix = `${OMISSION_NOTE}\n\n`
-  const boundedTranscript =
-    transcript.length <= budget
-      ? transcript
-      : `${omissionPrefix}${transcript.slice(-Math.max(0, budget - omissionPrefix.length))}`
-
-  return `${HEADER}\n\n${boundedTranscript}`
-}
+export { buildHistoryPreamble } from '../../../../shared/history-preamble'
 
 export const buildHistoryReplayMedia = (
   messages: ChatMessage[]

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -823,6 +823,76 @@ describe('workspace agent message sending', () => {
     expect(session.error).toBe('Invalid API key')
   })
 
+  it('uses the session owner status when a prompt fails on an old runtime', async () => {
+    vi.stubGlobal('window', {
+      api: {
+        acp: {
+          getState: vi.fn().mockResolvedValue({
+            ...createSnapshot(['session-1']),
+            status: 'connected',
+            sessionConnectionStatuses: { 'session-1': 'closed' }
+          })
+        }
+      }
+    })
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockRejectedValue(new Error('Old runtime exited'))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'continue',
+      cwd: '/workspace/project'
+    })
+    await flushRuntimeTasks()
+    await flushRuntimeTasks()
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      interrupted: true,
+      error: 'Old runtime exited — Resume to reconnect and continue.'
+    })
+  })
+
+  it('does not treat a healthy old runtime failure as an active runtime disconnect', async () => {
+    vi.stubGlobal('window', {
+      api: {
+        acp: {
+          getState: vi.fn().mockResolvedValue({
+            ...createSnapshot(['session-1']),
+            status: 'closed',
+            sessionConnectionStatuses: { 'session-1': 'connected' }
+          })
+        }
+      }
+    })
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockRejectedValue(new Error('Invalid API key'))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'continue',
+      cwd: '/workspace/project'
+    })
+    await flushRuntimeTasks()
+    await flushRuntimeTasks()
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error: 'Invalid API key'
+    })
+    expect(useSessionStore.getState().sessions[0].interrupted).toBeFalsy()
+  })
+
   it('marks a model-provider prompt failure non-reportable from the run error event', async () => {
     // The runtime pushes a providerError-tagged error event before rejecting; the rejection path reads
     // it from the snapshot so the failure is recorded non-reportable (no "Report error" button) without
@@ -1291,6 +1361,45 @@ describe('resuming an interrupted session on demand', () => {
     expect(session.error).toBe('Connection lost — Resume to reconnect and continue.')
   })
 
+  it('uses the owning runtime status instead of another generation global status', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Keep working',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+
+    markRunningSessionsDisconnectedOnDrop(
+      'connected',
+      'connected',
+      { 'session-1': 'connected' },
+      { 'session-1': 'closed' }
+    )
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      interrupted: true
+    })
+  })
+
+  it('does not disconnect a running old-generation session when only the active runtime drops', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Keep working',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+
+    markRunningSessionsDisconnectedOnDrop(
+      'connected',
+      'closed',
+      { 'session-1': 'connected' },
+      { 'session-1': 'connected' }
+    )
+
+    expect(useSessionStore.getState().sessions[0].status).toBe('running')
+  })
+
   it('does not flag an idle session on drop so provider/skills reconnects stay silent', () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',
@@ -1491,6 +1600,65 @@ describe('resuming an interrupted session on demand', () => {
     expect(preamble).toContain('Done, saved chart.png')
     // The preamble carries prior turns only; the turn being sent is not folded into it.
     expect(preamble).not.toContain('now add a trend line')
+  })
+
+  it('moves the next turn to the selected framework after the prior framework turn ends', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Analyze the data with Claude',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      agentFrameworkId: 'claude-code',
+      agentBackendId: 'claude-code:anthropic'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'Claude finished the analysis'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    const runtime = {
+      // The retiring Claude runtime may still report the session until its deferred teardown finishes.
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        cwd: '/workspace/project',
+        contextReset: true,
+        frameworkId: 'codex',
+        backendId: 'codex:builtin-codex-subscription'
+      }),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'continue with Codex',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:builtin-codex-subscription'
+    })
+    await flushRuntimeTasks()
+
+    expect(runtime.resumeSession).toHaveBeenCalledWith(
+      'session-1',
+      '/workspace/project',
+      'default-project',
+      'ask',
+      'claude-code',
+      'claude-code:anthropic'
+    )
+    const preamble = runtime.sendPrompt.mock.calls[0]?.[5]
+    expect(preamble).toContain('Analyze the data with Claude')
+    expect(preamble).toContain('Claude finished the analysis')
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:builtin-codex-subscription'
+    })
   })
 
   it('does not replay a history preamble when the resume kept agent context', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -203,7 +203,8 @@ const failOrMarkDisconnected = async (
   try {
     const snapshot = await window.api.acp.getState()
 
-    if (snapshot.status === 'closed' || snapshot.status === 'error') {
+    const status = snapshot.sessionConnectionStatuses?.[sessionId] ?? snapshot.status
+    if (status === 'closed' || status === 'error') {
       // Keep the specific failure cause (e.g. "Connection timeout") in the Resume banner.
       useSessionStore.getState().markDisconnected(sessionId, message)
       return
@@ -485,7 +486,15 @@ const sendWorkspaceMessage = async (
       return appended
     }
 
-    const shouldResumeSession = !runtime.state.sessionIds.includes(targetSessionId)
+    // A framework switch applies at the next turn boundary. The retiring runtime may still expose the
+    // old session for a brief teardown window, so compare persisted ownership as well as the snapshot.
+    const frameworkChanged = Boolean(
+      agentFrameworkId &&
+      currentSession?.agentFrameworkId &&
+      agentFrameworkId !== currentSession.agentFrameworkId
+    )
+    const shouldResumeSession =
+      frameworkChanged || !runtime.state.sessionIds.includes(targetSessionId)
     let resumeCwd: string | undefined
 
     if (shouldResumeSession) {
@@ -961,21 +970,29 @@ const processContextOverflowRecovery = (
 // reconnects have no running session, so neither reaches markDisconnected here.
 const markRunningSessionsDisconnectedOnDrop = (
   previousStatus: AcpConnectionStatus,
-  currentStatus: AcpConnectionStatus
+  currentStatus: AcpConnectionStatus,
+  previousSessionStatuses: Partial<Record<string, AcpConnectionStatus>> = {},
+  currentSessionStatuses: Partial<Record<string, AcpConnectionStatus>> = {}
 ): void => {
-  const droppedNow =
-    (currentStatus === 'closed' || currentStatus === 'error') &&
-    previousStatus !== 'closed' &&
-    previousStatus !== 'error'
-
-  if (!droppedNow) return
-
   const { sessions, markDisconnected } = useSessionStore.getState()
 
   for (const session of sessions) {
-    if (session.status === 'running' || session.status === 'waiting-permission') {
-      markDisconnected(session.id)
-    }
+    if (session.status !== 'running' && session.status !== 'waiting-permission') continue
+
+    const previousOwnedStatus = previousSessionStatuses[session.id]
+    const currentOwnedStatus = currentSessionStatuses[session.id]
+    const hasOwningRuntimeStatus =
+      previousOwnedStatus !== undefined || currentOwnedStatus !== undefined
+    const previous = hasOwningRuntimeStatus
+      ? (previousOwnedStatus ?? currentOwnedStatus ?? previousStatus)
+      : previousStatus
+    const current = hasOwningRuntimeStatus
+      ? (currentOwnedStatus ?? previousOwnedStatus ?? currentStatus)
+      : currentStatus
+    const droppedNow =
+      (current === 'closed' || current === 'error') && previous !== 'closed' && previous !== 'error'
+
+    if (droppedNow) markDisconnected(session.id)
   }
 }
 
@@ -1039,6 +1056,7 @@ const useWorkspaceAgentRuntime = (): {
   // Tracks the last connection status so the disconnect effect fires only on a transition, not on
   // every unrelated snapshot re-render.
   const previousStatusRef = useRef(runtime.state.status)
+  const previousSessionStatusesRef = useRef(runtime.state.sessionConnectionStatuses)
   // Dedup + cooldown state for the request-size overflow auto-recovery, kept across re-renders.
   const handledOverflowEventIds = useRef(new Set<string>())
   const recoveringOverflowSessionIds = useRef(new Set<string>())
@@ -1072,9 +1090,16 @@ const useWorkspaceAgentRuntime = (): {
   // while a session is still running. Flag those sessions so the Resume banner appears.
   useEffect(() => {
     const previousStatus = previousStatusRef.current
+    const previousSessionStatuses = previousSessionStatusesRef.current
     previousStatusRef.current = runtime.state.status
-    markRunningSessionsDisconnectedOnDrop(previousStatus, runtime.state.status)
-  }, [runtime.state.status])
+    previousSessionStatusesRef.current = runtime.state.sessionConnectionStatuses
+    markRunningSessionsDisconnectedOnDrop(
+      previousStatus,
+      runtime.state.status,
+      previousSessionStatuses,
+      runtime.state.sessionConnectionStatuses
+    )
+  }, [runtime.state.status, runtime.state.sessionConnectionStatuses])
 
   // Creates a session if needed, records the user message, then starts the prompt in the background.
   const sendMessage = useCallback(

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -190,6 +190,9 @@ export type AcpPermissionGrant = {
 
 export type AcpStateSnapshot = {
   status: AcpConnectionStatus
+  // A coordinator may keep multiple framework generations alive. Callers handling one session should
+  // prefer its owning runtime status over the active generation's top-level compatibility status.
+  sessionConnectionStatuses?: Partial<Record<string, AcpConnectionStatus>>
   cwd: string
   sessionId?: string
   sessionIds: string[]

--- a/src/shared/history-preamble.ts
+++ b/src/shared/history-preamble.ts
@@ -1,0 +1,56 @@
+// Character budget for the replayed transcript. Kept modest so a long conversation cannot blow the new
+// agent's context window on its first turn after a framework switch or unresumable restart.
+const DEFAULT_PREAMBLE_BUDGET = 12_000
+
+const HEADER =
+  'The conversation below happened earlier in this session, before you joined it. Treat it as prior' +
+  ' context — do not reply to it directly; continue from the user message that follows.'
+
+const OMISSION_NOTE = '[…earlier turns omitted for length…]'
+
+type HistoryMessage = {
+  role: string
+  content: string
+  status?: string
+}
+
+const formatMessage = (message: HistoryMessage): string => {
+  const speaker = message.role === 'user' ? 'User' : 'Assistant'
+  return `**${speaker}:** ${message.content.trim()}`
+}
+
+// Builds a bounded text-only transcript. Tool effects already live on disk and are intentionally omitted.
+export const buildHistoryPreamble = (
+  messages: HistoryMessage[],
+  budget: number = DEFAULT_PREAMBLE_BUDGET
+): string | undefined => {
+  const usable = messages.filter(
+    (message) => message.status !== 'error' && message.content.trim().length > 0
+  )
+
+  if (usable.length === 0) return undefined
+
+  const kept: HistoryMessage[] = []
+  let used = 0
+
+  for (let index = usable.length - 1; index >= 0; index -= 1) {
+    const line = formatMessage(usable[index])
+    const cost = line.length + 2
+
+    if (kept.length > 0 && used + cost > budget) break
+
+    kept.unshift(usable[index])
+    used += cost
+  }
+
+  const omittedSome = kept.length < usable.length
+  const body = kept.map(formatMessage).join('\n\n')
+  const transcript = omittedSome ? `${OMISSION_NOTE}\n\n${body}` : body
+  const omissionPrefix = `${OMISSION_NOTE}\n\n`
+  const boundedTranscript =
+    transcript.length <= budget
+      ? transcript
+      : `${omissionPrefix}${transcript.slice(-Math.max(0, budget - omissionPrefix.length))}`
+
+  return `${HEADER}\n\n${boundedTranscript}`
+}

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -55,6 +55,10 @@ export type ReviewOutcome = 'pass' | 'flagged'
 // The only MCP server an unattended reviewer session may use. Keeping the name in shared code lets
 // the orchestrator and ACP permission gate enforce the same allowlist without importing each other.
 export const REVIEWER_MCP_SERVER_NAME = 'open-science-reviewer'
+// codex-acp does not forward session metadata to Responses requests. This marker lets the local
+// bridge recognize reviewer history and replace Codex's built-in tool declarations with the
+// reviewer-only schema set. It grants no access by itself; the ACP session still owns the MCP server.
+export const REVIEWER_BRIDGE_SESSION_MARKER = '<open_science_reviewer_session>'
 export const REVIEWER_MCP_TOOLS = {
   readTurn: 'read_turn',
   queryExecutionLog: 'query_execution_log',

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -55,10 +55,6 @@ export type ReviewOutcome = 'pass' | 'flagged'
 // The only MCP server an unattended reviewer session may use. Keeping the name in shared code lets
 // the orchestrator and ACP permission gate enforce the same allowlist without importing each other.
 export const REVIEWER_MCP_SERVER_NAME = 'open-science-reviewer'
-// codex-acp does not forward session metadata to Responses requests. This marker lets the local
-// bridge recognize reviewer history and replace Codex's built-in tool declarations with the
-// reviewer-only schema set. It grants no access by itself; the ACP session still owns the MCP server.
-export const REVIEWER_BRIDGE_SESSION_MARKER = '<open_science_reviewer_session>'
 export const REVIEWER_MCP_TOOLS = {
   readTurn: 'read_turn',
   queryExecutionLog: 'query_execution_log',


### PR DESCRIPTION
## Problem

A single `AcpRuntime` originally owned one mutable backend process and every active session. Deferring a framework reconnect blocked new sessions behind old work, while forcing it disposed the old session and failed its in-flight tools.

The first coordinator implementation isolated main-session turns, but several cross-generation gaps remained:

- reviewer sessions and fix-loop gaps were not part of the runtime lifetime;
- one mutable Chat Completions bridge could retarget an old Codex runtime to a new provider key/model;
- completed retired runtime objects remained in coordinator aggregation after their child process stopped;
- a single top-level connection status could misclassify failures belonging to another runtime generation;
- preflight create/connect/skill operations were not counted during retirement;
- forced-skill provisioning used one SettingsService-global mutable set across runtime generations;
- reviewer bridge isolation trusted a marker in model-visible conversation content;
- bridged providers retained listeners and decrypted credentials after their final runtime retired;
- per-generation MCP HTTP hosts had no terminal close path.

The reviewer combination let Codex advertise built-in shell/filesystem tools and could leave the review protocol incomplete without `submit_findings`.

## Proposed change

Keep one child runtime per framework generation, add workflow- and operation-scoped lifetime leases, and enforce reviewer-only tools through trusted session routing at the bridge boundary.

```mermaid
flowchart LR
  S[Framework selection changes] --> N[New active runtime generation]
  S --> R[Previous generation becomes retiring]
  R --> A{Active prompt, reviewer, workflow, or preflight operation?}
  A -->|yes| K[Finish on previous generation]
  K --> A
  A -->|no| D[Disconnect and remove previous generation]
  N --> NS[New sessions and reviewer workflows]
  N --> C[Next correction or user turn]
  C --> M[Resume or adopt lazily]
  M --> H[Replay transcript after context reset]
```

- A framework switch routes new sessions and reviewer workflows to the selected framework immediately.
- A main turn, reviewer session, reviewer/fix-loop workflow, or session preflight already in progress stays pinned to its original generation until it completes.
- An idle old main session is not proactively migrated. It moves only when a correction or later user turn actually prompts it.
- Each bridged Codex upstream target gets a SHA-256-keyed bridge instance. Provider URL, credentials, model, tools, and connector instructions remain pinned for older generations.
- Bridge instances are leased to runtime generations and close after their final owner releases them.
- Runtime-owned MCP HTTP hosts close their listener and active connections during disconnect, shutdown, retirement, or unexpected connection loss.
- Runtime retirement emits a completion callback after teardown, allowing the coordinator to remove completed generations and their event/permission aggregation.
- Forced-skill IDs belong to the runtime generation and are passed explicitly into backend provisioning.
- Provider/model and skill reconnects target only the active generation. Non-disruptive reasoning-effort changes live-apply to every tracked generation, while reconnect fallback is decided by the active generation only.
- Snapshots retain the top-level compatibility status and add optional per-session owner statuses. Prompt failure and disconnect handling prefer the owning runtime status.
- A Codex reviewer session registers its ACP session ID as a trusted bridge `prompt_cache_key`. Reviewer requests discard every Codex-provided tool declaration and explicit tool choice, then inject only the four namespaced reviewer HTTP MCP schemas. Conversation content cannot enable or disable reviewer mode.
- Uninstalling an active managed framework rotates runtime generations when settings auto-select a fallback; without a ready fallback, the stale current generation follows the existing reconnect path.
- Asynchronous session deletion and permission-profile changes hold operation leases so terminal retirement cannot close their ACP requests mid-flight.

## Scope and non-goals

- Reconnect-triggering provider/model/skill changes intentionally do not fan out to retiring generations. A retiring workflow is terminal and pinned; arming its reconnect barrier while it holds an activity lease can strand its next operation behind its own lease.
- Reasoning effort remains a global live preference because applying the ACP session option does not reconnect or replace a runtime.
- Operation leases block terminal runtime retirement but do not block deferred provider/skills reconnects, avoiding a reconnect-barrier deadlock.
- The tool-declaration enforcement applies to Chat-bridged Codex providers. Direct native Responses providers do not traverse this bridge; `codex-acp` currently exposes no ACP session-level built-in tool allowlist for that path, which retains the existing temporary-cwd and permission-gate containment.
- `getActiveRuntime()`/`lastRuntime` cleanup and hypothetical permission-map key collisions remain unchanged because there is no current incorrect behavior.

## Acceptance criteria and validation

- Framework switching does not interrupt main turns waiting on tools or user permission.
- New sessions converse immediately on the newly selected framework.
- Create/connect/resume/reviewer and disabled-skill preflight cannot be orphaned by retirement.
- Session deletion and permission-profile changes cannot be interrupted by retirement.
- An active-framework uninstall that selects a fallback rotates to that framework immediately.
- Reviewer/fix-loop work survives a switch and remains on one generation; later reviewer workflows use the new generation.
- Provider/model/skill reconnects do not mutate or deadlock a retiring workflow.
- Reasoning-effort changes reach active and retiring live generations without letting an unsupported old generation force an active reconnect.
- Old and new runtime generations cannot overwrite each other's forced-skill provisioning state.
- Old and new bridged Codex generations continue using their own provider URL, key, and model.
- A bridge stays alive while any runtime generation owns it and closes after its last lease is released.
- An HTTP-only framework's per-generation MCP host closes when its runtime retires.
- A completed retired runtime disappears from coordinator aggregation.
- A dropped old runtime marks only its sessions disconnected; a dropped active runtime does not mislabel healthy old sessions.
- Normal prompt text containing the legacy reviewer marker retains normal tools.
- Bridge-backed Codex reviewer requests advertise only `read_turn`, `query_execution_log`, `read_artifact`, and `submit_findings`; built-in shell/filesystem tools and connector tools are absent.
- The live Codex ACP contract drives `read_turn -> submit_findings` through the bridge and real reviewer HTTP MCP handler.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors and 56 pre-existing warnings.
- `npm run test`: 446 files passed, 5,892 tests passed; 9 files / 83 tests skipped.
- Live Codex ACP contract: 2 files passed, 41 tests passed, including both real bridge contracts.

## Review focus

Review runtime retirement around preflight and session-mutation operations, active-framework uninstall fallback, reconnecting-setting scope, live effort fan-out, forced-skill ownership, trusted reviewer session registration, bridge leases, MCP HTTP host teardown, and provider/framework generation handoff.
