### PR TITLE
fix(acp): use Codex MCP permission option IDs

### DIFF
--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -94,9 +94,9 @@ const createCodexMcpPermissionRequest = (sessionId = 'session-1'): RequestPermis
     status: 'pending'
   },
   options: [
-    { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
-    { optionId: 'allow-always', name: "Allow and Don't Ask Again", kind: 'allow_always' },
-    { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+    { optionId: 'allow_session', name: 'Allow for This Session', kind: 'allow_always' },
+    { optionId: 'allow_always', name: "Allow and Don't Ask Again", kind: 'allow_always' },
+    { optionId: 'allow_once', name: 'Allow', kind: 'allow_once' },
     { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
   ]
 })
@@ -251,10 +251,10 @@ describe('ACP permission broker', () => {
       mcpServerNames: ['open-science-notebook']
     })
 
-    // The persistent allow-always option is stripped by ID; session-scoped allow-session survives.
+    // The persistent allow_always option is stripped by ID; session-scoped allow_session survives.
     expect(emitted[0].options).toEqual([
-      { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
-      { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+      { optionId: 'allow_session', name: 'Allow for This Session', kind: 'allow_always' },
+      { optionId: 'allow_once', name: 'Allow', kind: 'allow_once' },
       { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
     ])
   })
@@ -265,9 +265,9 @@ describe('ACP permission broker', () => {
     const request = createCodexMcpPermissionRequest()
     // Reverse the option order to verify the filter is ID-based, not position-based.
     request.options = [
-      { optionId: 'allow-always', name: "Allow and Don't Ask Again", kind: 'allow_always' },
-      { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
-      { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+      { optionId: 'allow_always', name: "Allow and Don't Ask Again", kind: 'allow_always' },
+      { optionId: 'allow_session', name: 'Allow for This Session', kind: 'allow_always' },
+      { optionId: 'allow_once', name: 'Allow', kind: 'allow_once' },
       { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
     ]
 
@@ -278,8 +278,8 @@ describe('ACP permission broker', () => {
     })
 
     expect(emitted[0].options).toEqual([
-      { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
-      { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+      { optionId: 'allow_session', name: 'Allow for This Session', kind: 'allow_always' },
+      { optionId: 'allow_once', name: 'Allow', kind: 'allow_once' },
       { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
     ])
   })
@@ -289,8 +289,8 @@ describe('ACP permission broker', () => {
     const broker = new AcpPermissionBroker((request) => emitted.push(request))
     const request = createCodexMcpPermissionRequest()
     request.options = [
-      { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
-      { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+      { optionId: 'allow_session', name: 'Allow for This Session', kind: 'allow_always' },
+      { optionId: 'allow_once', name: 'Allow', kind: 'allow_once' },
       { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
     ]
 
@@ -301,8 +301,8 @@ describe('ACP permission broker', () => {
     })
 
     expect(emitted[0].options).toEqual([
-      { optionId: 'allow-session', name: 'Allow for This Session', kind: 'allow_always' },
-      { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+      { optionId: 'allow_session', name: 'Allow for This Session', kind: 'allow_always' },
+      { optionId: 'allow_once', name: 'Allow', kind: 'allow_once' },
       { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
     ])
   })

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -28,9 +28,9 @@ const ALLOW_ONCE_OPTION_KIND = 'allow_once'
 // projection tests (permission-broker.test.ts) pin this contract and would fail on such a drift.
 const CODEX_POLICY_AMENDMENT_OPTION_ID_PATTERN = /^accept_.*policy_amendment$/
 // Codex sends two allow_always options for MCP tool requests. The persistent cross-session one uses
-// this option ID; the session-scoped one uses 'allow-session'. Keying on the persistent ID (not
+// this option ID; the session-scoped one uses 'allow_session'. Keying on the persistent ID (not
 // position) is robust to option reordering — tests pin this contract.
-const CODEX_MCP_PERSISTENT_ALLOW_OPTION_ID = 'allow-always'
+const CODEX_MCP_PERSISTENT_ALLOW_OPTION_ID = 'allow_always'
 
 const commandFromRawInput = (rawInput: unknown): string | undefined => {
   if (!rawInput || typeof rawInput !== 'object' || Array.isArray(rawInput)) return undefined
@@ -87,8 +87,8 @@ const projectPermissionOptions = (
     return params.options
   }
 
-  // Codex MCP tools send two allow_always variants: a session-scoped one ('allow-session') and
-  // a persistent cross-session one ('allow-always'). Strip the persistent one by its known
+  // Codex MCP tools send two allow_always variants: a session-scoped one ('allow_session') and
+  // a persistent cross-session one ('allow_always'). Strip the persistent one by its known
   // option ID so the app's session-only, revocable grant model is never bypassed.
   if (isMcp) {
     return params.options.filter(

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2523,6 +2523,7 @@ describe('ACP runtime session management', () => {
       rawInput?: unknown
       requestId: string
       isMcp?: boolean
+      options: Array<{ optionId: string }>
     }> = []
     const permissionResponses: unknown[] = []
 
@@ -2568,14 +2569,14 @@ describe('ACP runtime session management', () => {
               status: 'pending'
             },
             options: [
-              { optionId: 'allow-once', name: 'Allow', kind: 'allow_once' },
+              { optionId: 'allow_once', name: 'Allow', kind: 'allow_once' },
               {
-                optionId: 'allow-session',
+                optionId: 'allow_session',
                 name: 'Allow for This Session',
                 kind: 'allow_always'
               },
               {
-                optionId: 'allow-always',
+                optionId: 'allow_always',
                 name: "Allow and Don't Ask Again",
                 kind: 'allow_always'
               },
@@ -2611,7 +2612,7 @@ describe('ACP runtime session management', () => {
           permissionRequests.push(request)
           runtime.respondToPermission({
             requestId: request.requestId,
-            optionId: 'allow-session'
+            optionId: 'allow_session'
           })
         }
       }
@@ -2628,11 +2629,12 @@ describe('ACP runtime session management', () => {
       title: 'mcp.open-science-notebook.notebook_execute',
       providerToolName: 'notebook_execute',
       isMcp: true,
-      rawInput: { code: 'print(1)', language: 'python' }
+      rawInput: { code: 'print(1)', language: 'python' },
+      options: [{ optionId: 'allow_once' }, { optionId: 'allow_session' }, { optionId: 'decline' }]
     })
     expect(permissionResponses).toEqual([
-      { outcome: { outcome: 'selected', optionId: 'allow-session' } },
-      { outcome: { outcome: 'selected', optionId: 'allow-once' } }
+      { outcome: { outcome: 'selected', optionId: 'allow_session' } },
+      { outcome: { outcome: 'selected', optionId: 'allow_once' } }
     ])
     expect(runtime.getSnapshot().permissionGrants[session.sessionId]).toEqual([
       {


### PR DESCRIPTION
## Problem

Codex MCP approval prompts still showed four choices after #342 because the broker filtered `allow-always`, while codex-acp 1.1.4 sends the persistent option as `allow_always`. The unit and runtime fixtures repeated the same hyphenated IDs, so they passed without exercising the real protocol contract.

## Proposed change

Use codex-acp's underscore-delimited MCP option IDs (`allow_once`, `allow_session`, `allow_always`, and `decline`) in the broker filter and test fixtures. Extend the runtime test to assert that the renderer-facing request contains only the one-shot allow, session allow, and decline options.

## Scope and non-goals

This only corrects Codex MCP permission projection. It does not change non-MCP Codex approvals, other agent frameworks, or the renderer layout.

## Acceptance criteria and validation

- Codex MCP approval requests expose three choices instead of four.
- The persistent cross-session `allow_always` option never reaches the renderer.
- The session-scoped `allow_session` option remains available and keeps working with per-session grants.
- `npm run typecheck`
- `npm run lint` (passes with existing repository warnings)
- `npm run test` (5837 passed, 82 skipped)

## Review focus

Please verify the codex-acp option-ID contract and the runtime assertion over the renderer-facing option list.
