### PR TITLE
fix(workspace): detect notebook cells across frameworks; collapse tool rows

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceActivityGroup.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceActivityGroup.tsx
@@ -8,10 +8,7 @@ import { extractJobIdFromActivity } from '@/components/job-binding-utils'
 import { WorkspaceToolActivityRow } from './WorkspaceToolActivityRow'
 import { WorkspaceToolDetailsRow } from './WorkspaceToolDetailsRow'
 import { WorkspaceWebSearchActivityRow } from './WorkspaceWebSearchActivityRow'
-import {
-  buildToolActivityDetails,
-  isNotebookExecuteActivity
-} from './workspace-tool-activity-details'
+import { buildToolActivityDetails } from './workspace-tool-activity-details'
 import {
   formatActivityGroupTitle,
   formatStepCount,
@@ -86,9 +83,9 @@ const WorkspaceActivityGroup = ({
                   const isSearch = isSearchActivity(activity, group.activities, activityIndex)
                   const searchDetails = isSearch ? formatWebSearchDetails(activity) : undefined
                   const toolDetails = isSearch ? undefined : buildToolActivityDetails(activity)
-                  // Notebook cells lead with their code, so show it unfolded unless the user collapsed it.
-                  const isRowExpanded =
-                    expansionOverrides[activity.id] ?? isNotebookExecuteActivity(activity)
+                  // All tool rows — notebook cells included — default collapsed (meaningful title
+                  // only); clicking the title reveals the code and output. A user toggle still wins.
+                  const isRowExpanded = expansionOverrides[activity.id] ?? false
 
                   return (
                     <div key={activity.id} className="w-full overflow-hidden">

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
@@ -147,6 +147,20 @@ describe('workspace conversation items', () => {
     ).toBe('Using tool: Notebook restart')
   })
 
+  it('detects notebook tools whose server name was underscore-sanitized (Codex/gpt bridge)', () => {
+    // The gpt/codex bridge rewrites the hyphenated server name to underscores; still a notebook cell.
+    expect(
+      formatActivityTitle(
+        createActivity({
+          id: 'tool-notebook-underscore',
+          status: 'completed',
+          providerToolName: 'mcp__open_science_notebook__notebook_execute',
+          toolKind: 'other'
+        })
+      )
+    ).toBe('Used tool: Notebook cell')
+  })
+
   it('falls back to readable tool kind names for unnamed tools', () => {
     expect(
       formatActivityTitle(

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.ts
@@ -20,15 +20,24 @@ type ConversationItem = ConversationMessageItem | ConversationActivityItem
 
 const KNOWN_TITLE_TOOL_NAMES = new Set(['ToolSearch'])
 
-// Claude Code namespaces MCP tools as mcp__<server>__<tool>; this is the notebook server's prefix.
-const NOTEBOOK_PROVIDER_TOOL_PREFIX = 'mcp__open-science-notebook__'
+// MCP tools are namespaced as mcp__<server>__<tool>. Claude Code keeps the hyphenated server name
+// (open-science-notebook); the Codex/gpt bridge sanitizes hyphens to underscores
+// (open_science_notebook). Match both forms so notebook rows are detected regardless of framework.
+const NOTEBOOK_PROVIDER_TOOL_PATTERN = /^mcp__open[-_]science[-_]notebook__(.+)$/iu
+
+// Returns the notebook tool suffix (e.g. "notebook_execute") for a notebook MCP tool identity, or
+// undefined when the name is not a notebook tool. Framework-agnostic across the two server-name forms.
+const getNotebookToolSuffix = (providerToolName: string | undefined): string | undefined =>
+  NOTEBOOK_PROVIDER_TOOL_PATTERN.exec(providerToolName?.trim() ?? '')?.[1]
 
 // Maps a notebook MCP tool to a clean human label so rows read as notebook actions, not raw
-// mcp__open-science-notebook__* names. Returns undefined for non-notebook tools.
+// mcp__…__* names. Returns undefined for non-notebook tools.
 const formatNotebookToolName = (providerToolName: string): string | undefined => {
-  if (!providerToolName.startsWith(NOTEBOOK_PROVIDER_TOOL_PREFIX)) return undefined
+  const suffix = getNotebookToolSuffix(providerToolName)
 
-  switch (providerToolName.slice(NOTEBOOK_PROVIDER_TOOL_PREFIX.length)) {
+  if (!suffix) return undefined
+
+  switch (suffix) {
     case 'notebook_execute':
       return 'Notebook cell'
     case 'notebook_state':
@@ -120,10 +129,10 @@ const createConversationItems = (session: ChatSession | undefined): Conversation
 }
 
 export {
-  NOTEBOOK_PROVIDER_TOOL_PREFIX,
   createConversationItems,
   formatActivityTitle,
   formatNotebookToolName,
+  getNotebookToolSuffix,
   isActivityActive
 }
 export type { ConversationItem }

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
@@ -5,8 +5,7 @@ import type { ToolActivity } from '@/stores/session-store'
 import {
   buildToolActivityDetails,
   getToolDisplayName,
-  isEditActivity,
-  isNotebookExecuteActivity
+  isEditActivity
 } from './workspace-tool-activity-details'
 
 const createActivity = (overrides: Partial<ToolActivity>): ToolActivity => ({
@@ -163,20 +162,6 @@ describe('workspace tool activity details', () => {
     expect(details?.sections[1]).toMatchObject({ label: 'Output', text: '5 rows returned' })
   })
 
-  it('detects the notebook execute tool so its row can default to expanded', () => {
-    expect(
-      isNotebookExecuteActivity(
-        createActivity({ providerToolName: 'mcp__open-science-notebook__notebook_execute' })
-      )
-    ).toBe(true)
-    expect(
-      isNotebookExecuteActivity(
-        createActivity({ providerToolName: 'mcp__open-science-notebook__notebook_state' })
-      )
-    ).toBe(false)
-    expect(isNotebookExecuteActivity(createActivity({ providerToolName: 'Bash' }))).toBe(false)
-  })
-
   it('renders a notebook cell as Python code plus output, not the raw run summary', () => {
     const runSummary = {
       runId: 'notebook-run-1',
@@ -210,6 +195,27 @@ describe('workspace tool activity details', () => {
     // The code section stays open; only the output collapses.
     expect(details?.sections[0]).toMatchObject({ label: 'Code' })
     expect((details?.sections[0] as { collapsible?: boolean }).collapsible).toBeFalsy()
+  })
+
+  it('labels a notebook cell with its clean kernel name, never the raw tool id', () => {
+    const runSummary = {
+      status: 'completed',
+      script: 'x = 1',
+      text: { stdout: '', stderr: '', traceback: '', plain: [] },
+      outputs: []
+    }
+    const activity = createActivity({
+      // The runtime may backfill an untitled call with the raw tool id; the row label ignores it.
+      title: 'mcp__open-science-notebook__notebook_execute',
+      providerToolName: 'mcp__open-science-notebook__notebook_execute',
+      rawInput: { code: 'x = 1' },
+      toolContent: [
+        { type: 'content', content: { type: 'text', text: JSON.stringify(runSummary) } }
+      ]
+    })
+    const details = buildToolActivityDetails(activity)
+
+    expect(details?.displayName).toBe('Notebook cell')
   })
 
   it('falls back to the run summary script when notebook input code is unavailable', () => {

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
@@ -474,13 +474,6 @@ const buildArtifactDetails = (activity: ToolActivity): ToolActivityDetails | und
   }
 }
 
-// Detects the notebook execute MCP tool so its cell can render as code plus output.
-const isNotebookExecuteActivity = (activity: ToolActivity): boolean => {
-  const providerName = trimDetail(activity.providerToolName)?.toLowerCase() ?? ''
-
-  return providerName.includes('open-science-notebook') && providerName.endsWith('notebook_execute')
-}
-
 // The kernel kinds a notebook run tool can produce; drives language, label, and display name.
 type NotebookKernelKindLike = 'python' | 'r' | 'repl' | 'bash'
 
@@ -508,9 +501,11 @@ const NOTEBOOK_KERNEL_DISPLAY: Record<NotebookKernelKindLike, string> = {
 // Detects any notebook kernel run (python/r cell, repl control-plane, or bash) so all three render
 // as code plus output rather than the raw run-summary JSON envelope.
 const isNotebookKernelRunActivity = (activity: ToolActivity): boolean => {
+  // Match both server-name forms: Claude Code's hyphenated open-science-notebook and the Codex/gpt
+  // bridge's underscore-sanitized open_science_notebook.
   const providerName = trimDetail(activity.providerToolName)?.toLowerCase() ?? ''
 
-  if (!providerName.includes('open-science-notebook')) return false
+  if (!/open[-_]science[-_]notebook/u.test(providerName)) return false
 
   return NOTEBOOK_RUN_TOOL_SUFFIXES.some((suffix) => providerName.endsWith(suffix))
 }
@@ -898,7 +893,7 @@ const buildToolActivityDetails = (activity: ToolActivity): ToolActivityDetails |
   return buildGenericDetails(activity)
 }
 
-export { buildToolActivityDetails, getToolDisplayName, isEditActivity, isNotebookExecuteActivity }
+export { buildToolActivityDetails, getToolDisplayName, isEditActivity }
 export type {
   ToolActivityDetails,
   ToolCodeSection,

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
@@ -135,6 +135,8 @@ describe('formatActivityGroupTitle', () => {
     const cases: Array<[Partial<ToolActivity>, string]> = [
       [{ providerToolName: 'websearch' }, 'Ran a search'],
       [{ providerToolName: 'mcp__open-science-notebook__notebook_execute' }, 'Ran a notebook cell'],
+      // Codex/gpt bridge underscore-sanitizes the server name; still categorized as a notebook cell.
+      [{ providerToolName: 'mcp__open_science_notebook__notebook_execute' }, 'Ran a notebook cell'],
       [{ providerToolName: 'skill' }, 'Loaded a skill'],
       [{ providerToolName: 'save_artifacts' }, 'Saved a file'],
       [{ providerToolName: 'manage_packages' }, 'Managed an environment'],

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
@@ -1,7 +1,7 @@
 import type { ToolActivity } from '@/stores/session-store'
 
 import {
-  NOTEBOOK_PROVIDER_TOOL_PREFIX,
+  getNotebookToolSuffix,
   isActivityActive,
   type ConversationItem
 } from './workspace-conversation-items'
@@ -168,7 +168,7 @@ const categorizeActivity = (
   const providerName = getNormalizedProviderName(activity)
 
   // A notebook_execute call is one cell run; summarize it as such instead of a generic tool.
-  if (providerName === `${NOTEBOOK_PROVIDER_TOOL_PREFIX}notebook_execute`) return 'notebook'
+  if (getNotebookToolSuffix(providerName) === 'notebook_execute') return 'notebook'
   if (providerName === 'skill') return 'skill'
   if (providerName === 'save_artifacts' || providerName.includes('artifact')) return 'artifact'
   if (providerName === 'manage_packages' || providerName.includes('package')) return 'environment'


### PR DESCRIPTION
## Summary

Notebook cells run through the Codex/gpt bridge rendered as generic **"Terminal"** commands instead of notebook cells, and tool rows auto-expanded in the transcript. This fixes both.

- **Cross-framework notebook detection.** Claude Code namespaces the notebook MCP server as `open-science-notebook` (hyphens); the Codex/gpt bridge sanitizes it to `open_science_notebook` (underscores). All three renderer detection sites hardcoded the hyphenated form, so gpt notebook cells fell through to the generic command/"Terminal" renderer. A single `getNotebookToolSuffix` matcher now accepts both forms, wired into row labeling, group categorization, and the notebook-run detail renderer.
- **Collapse tool rows by default.** Every tool row (notebook cells included) now starts collapsed, showing its clean kernel label (Notebook cell / Agent SDK / Shell); code + output reveal on click. A user's manual toggle still wins.

Card titles intentionally stay the mechanical category summary for now — an LLM-generated *purpose* title is tracked separately in #384.

## Testing

- `npm run typecheck` — clean
- `vitest run src/renderer/src/pages/workspace/` — 701 passed
- New regression tests: underscore-sanitized notebook tool name is detected as a notebook cell in both row labeling and group categorization.

## Related

- Follow-up: #384 (LLM-generated purpose title for tool-activity cards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)