### PR TITLE
ci(review): restrict AI reviewers to static inspection

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -7,7 +7,8 @@ name: AI PR Review
 # ANTHROPIC_AUTH_TOKEN is also passed to the Claude action's required API-key input; do not add a
 # separate ANTHROPIC_API_KEY secret.
 # Set ENABLE_CLAUDE_REVIEW=false or ENABLE_CODEX_REVIEW=false to disable either reviewer.
-# Override the review models with CLAUDE_REVIEW_MODEL and CODEX_REVIEW_MODEL (optional).
+# Override the review models with CLAUDE_REVIEW_MODEL and CODEX_REVIEW_MODEL (optional), and their
+# reasoning effort with CLAUDE_REVIEW_EFFORT or CODEX_REVIEW_EFFORT (both default to high).
 # Set FORK_REVIEW_MODE to disabled, manual, or automatic (default: manual). Same-repository PRs
 # always run. Manual mode permits workflow_dispatch reviews of forks; automatic mode also reviews
 # fork PRs on opened, synchronize, and reopened events. Disabled mode blocks both fork paths.
@@ -18,11 +19,12 @@ name: AI PR Review
 # Neither reviewer agent posts comments directly. Each writes its verdict to a job output, and a
 # separate trusted post-job publishes the comment via the GitHub REST API.
 #
-# The Claude agent inspects the checked-out pull request with Read, Glob, Grep, and Bash. This means
-# the agent process can access its review credentials and other runner-local data; the repository
-# intentionally accepts that exposure in exchange for on-demand code exploration. --safe-mode still
-# disables project customisations (CLAUDE.md, skills, plugins, hooks, MCP servers), and
-# --strict-mcp-config prevents .mcp.json from loading additional servers.
+# The Claude agent inspects the checked-out pull request with Read, Glob, Grep, and Bash in dontAsk
+# mode. Claude Code's built-in read-only command classifier permits safe repository inspection,
+# while commands requiring approval are denied non-interactively. The process can still access its
+# review credentials and other runner-local data; the repository accepts that exposure in exchange
+# for on-demand code exploration. --safe-mode disables project customisations (CLAUDE.md, skills,
+# plugins, hooks, MCP servers), and --strict-mcp-config prevents .mcp.json from adding servers.
 on:
   pull_request_target:
     branches:
@@ -184,6 +186,9 @@ jobs:
               "$PR_DIFF_BASE" "$PR_DIFF_BASE"
             echo 'changed files, their callers, tests, configuration, and surrounding implementation.'
             echo 'Do not modify the checkout or post comments yourself.'
+            echo 'Perform static code inspection only. You may read test source files to understand'
+            echo 'expected behavior, but do not install dependencies or run lint, tests, typecheck,'
+            echo 'build, package-manager commands, repository scripts, or project executables.'
             echo
             echo 'The Codex review job performs a comprehensive correctness, security, and convention'
             echo 'review. Complement that review by focusing exclusively on architecture and integration:'
@@ -227,6 +232,7 @@ jobs:
           CLAUDE_CODE_DISABLE_1M_CONTEXT: '1'
           CLAUDE_PROMPT_FILE: ${{ steps.context.outputs.prompt_file }}
           CLAUDE_MODEL: ${{ vars.CLAUDE_REVIEW_MODEL || 'claude-sonnet-5' }}
+          CLAUDE_REVIEW_EFFORT: ${{ vars.CLAUDE_REVIEW_EFFORT || 'high' }}
           CLAUDE_REVIEW_SCHEMA: >-
             {"type":"object","properties":{"verdict":{"type":"string","enum":["mergeable","needs changes"]},"summary":{"type":"string"},"findings":{"type":"array","items":{"type":"object","properties":{"priority":{"type":"string","enum":["P0","P1","P2","P3"]},"title":{"type":"string"},"path":{"type":"string"},"line":{"type":"integer","minimum":1},"impact":{"type":"string"},"recommendation":{"type":"string"}},"required":["priority","title","path","line","impact","recommendation"],"additionalProperties":false}}},"required":["verdict","summary","findings"],"additionalProperties":false}
         shell: bash
@@ -235,8 +241,8 @@ jobs:
           execution_file="$RUNNER_TEMP/claude-execution.jsonl"
 
           # Safe mode disables project customisations, hooks, skills, and plugins; strict MCP
-          # prevents the checkout from adding servers. Bash runs without approval and can read or
-          # modify runner-local state; this is an intentional tradeoff for autonomous inspection.
+          # prevents the checkout from adding servers. dontAsk lets Claude Code's built-in
+          # read-only command classifier run inspections and denies commands that need approval.
           set +e
           claude \
             --print \
@@ -245,11 +251,13 @@ jobs:
             --verbose \
             --no-session-persistence \
             --model "$CLAUDE_MODEL" \
+            --effort "$CLAUDE_REVIEW_EFFORT" \
             --json-schema "$CLAUDE_REVIEW_SCHEMA" \
             --safe-mode \
             --strict-mcp-config \
-            --permission-mode bypassPermissions \
+            --permission-mode dontAsk \
             --tools "Read,Glob,Grep,Bash" \
+            --allowedTools "Read,Glob,Grep" \
             < "$CLAUDE_PROMPT_FILE" \
             > "$execution_file"
           claude_status=$?
@@ -550,6 +558,10 @@ jobs:
             echo 'rule. Report a project-standard finding when either result below is false.'
             echo "Branch name valid: ${branch_valid}"
             echo "Pull request title valid: ${title_valid}"
+            echo
+            echo 'Perform static code inspection only. Do not install dependencies or run lint,'
+            echo 'tests, typecheck, build, package-manager commands, repository scripts, or project'
+            echo 'executables. Read test source files when needed to understand expected behavior.'
           } > "$instructions_file"
 
           jq -n '
@@ -608,7 +620,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           responses-api-endpoint: ${{ steps.responses_endpoint.outputs.url }}
           model: ${{ vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol' }}
-          effort: high
+          effort: ${{ vars.CODEX_REVIEW_EFFORT || 'high' }}
           permission-profile: ':read-only'
           codex-home: ${{ runner.temp }}/codex-home
           codex-args: ${{ steps.codex_args.outputs.value }}
@@ -617,6 +629,10 @@ jobs:
             Review only the changes introduced by this pull request. Inspect the checked-out
             repository, diff, callers, tests, and configuration as needed. Focus on actionable
             correctness, security, regression, and repository-standard defects.
+
+            Perform static code inspection only. Do not install dependencies or run lint, tests,
+            typecheck, build, package-manager commands, repository scripts, or project executables.
+            Reading test source files is encouraged when it clarifies expected behavior.
 
             The exact pull request changes are between these commits:
               base: ${{ steps.diff_base.outputs.sha }}

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -394,20 +394,35 @@ describe('AI review workflow contract', () => {
     expect(reviewWorkflow).toContain('--repo "${{ github.repository }}"')
   })
 
-  it('lets Claude inspect the checked-out pull request with an explicit local tool set', () => {
+  it('lets Claude use Bash only through its built-in read-only command classifier', () => {
     const step = getNamedStep('claude_review', 'Run Claude architecture review')
     const command = step.run
 
     expect(command).toContain('--tools "Read,Glob,Grep,Bash"')
+    expect(command).toContain('--effort "$CLAUDE_REVIEW_EFFORT"')
+    expect(step.env?.CLAUDE_REVIEW_EFFORT).toBe("${{ vars.CLAUDE_REVIEW_EFFORT || 'high' }}")
+    expect(command).toContain('--permission-mode dontAsk')
+    expect(command).toContain('--allowedTools "Read,Glob,Grep"')
+    expect(command).not.toContain('--permission-mode bypassPermissions')
     expect(command).not.toContain('--max-turns')
     expect(parsedWorkflow.jobs.claude_review['timeout-minutes']).toBe(30)
-    expect(command).toContain('--permission-mode bypassPermissions')
     // --safe-mode disables all project customisations (hooks, MCP servers, .claude/settings.json).
     expect(command).toContain('--safe-mode')
     expect(command).toContain('--strict-mcp-config')
-    expect(reviewWorkflow).not.toContain('--allowedTools')
+    expect(command).not.toMatch(/--allowedTools[^\n]*Bash/)
     expect(reviewWorkflow).toContain('Build Claude review prompt')
     expect(reviewWorkflow).toContain('post_claude_feedback')
+  })
+
+  it('keeps both reviewers on static code inspection instead of running project checks', () => {
+    const claudePrompt = getRunStep('claude_review', 'context')
+    const codexStep = getNamedStep('codex_review', 'Run Codex correctness review')
+    const prohibitedChecks = ['install dependencies', 'lint', 'tests', 'typecheck', 'build']
+
+    for (const check of prohibitedChecks) {
+      expect(claudePrompt).toContain(check)
+      expect(codexStep.with?.prompt).toContain(check)
+    }
   })
 
   it('runs Claude with an explicit Sonnet model and endpoint-compatible output framing', () => {
@@ -451,6 +466,7 @@ exit 1
         RUNNER_TEMP: root,
         CLAUDE_PROMPT_FILE: promptFile,
         CLAUDE_MODEL: 'claude-sonnet-5',
+        CLAUDE_REVIEW_EFFORT: 'high',
         CLAUDE_REVIEW_SCHEMA: '{}',
         GITHUB_OUTPUT: runOutput
       }
@@ -733,7 +749,7 @@ exit 1
       'openai-api-key': '${{ secrets.OPENAI_API_KEY }}',
       'responses-api-endpoint': '${{ steps.responses_endpoint.outputs.url }}',
       model: "${{ vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol' }}",
-      effort: 'high',
+      effort: "${{ vars.CODEX_REVIEW_EFFORT || 'high' }}",
       'permission-profile': ':read-only',
       'codex-args': '${{ steps.codex_args.outputs.value }}',
       'output-schema-file': '${{ steps.codex_args.outputs.schema_file }}'


### PR DESCRIPTION
## Problem

The Claude review on #377 installed repository dependencies and ran thousands of tests even though the pull request already has dedicated lint, test, and type-check jobs. The review CLI exposed Bash under bypassPermissions, so the prompt's request to inspect tests could expand into executing the full project validation suite.

## Proposed change

- Run Claude Code with dontAsk instead of bypassPermissions. Read, Glob, and Grep remain pre-approved, while Bash is limited to commands Claude Code classifies as read-only; commands that require approval are denied in the non-interactive review.
- Tell both Claude and Codex to perform static source inspection only. They may read test code, but must not install dependencies or run lint, tests, typecheck, build, package-manager commands, repository scripts, or project executables.
- Add configurable CLAUDE_REVIEW_EFFORT and CODEX_REVIEW_EFFORT repository variables. Both default to high.

## Scope and non-goals

This does not change review output schemas, comment publishing, review limits, or ready-to-merge labeling. It also does not replace the repository's existing validation jobs.

## Acceptance criteria and validation

- Claude can still inspect the local checkout and PR diff with read-only tools.
- Dependency installation and project check commands are denied or explicitly out of scope for both reviewers.
- Claude and Codex effort remain high by default and can be overridden independently.
- Focused workflow tests: 57 passed.
- git diff --check passed.
- actionlint reports only the pre-existing SC2016 informational finding in the prompt-builder shell block.

## Review focus

Please focus on the Claude Code permission-mode interaction and whether the static-inspection constraints still leave enough access for useful review.
