### PR TITLE
feat(activity-groups): declare titles before tool groups

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -131,6 +131,7 @@ const createRuntime = ({
           registerSessionAlias: (aliasSessionId, sessionId) =>
             notebookRpcServer.registerSessionAlias(aliasSessionId, sessionId)
         },
+        activityGroups: { mcpEntryPath },
         callbacks: runtimeCallbacks
       })
     },

--- a/src/main/acp/permission-policy.test.ts
+++ b/src/main/acp/permission-policy.test.ts
@@ -151,6 +151,27 @@ describe('permission policy', () => {
     ).toBeUndefined()
   })
 
+  it('auto-approves the declaration-only activity group tool under Ask', () => {
+    const request = createPermissionRequest('other', undefined, {
+      title: 'mcp__open-science-activity__begin_activity_group'
+    })
+
+    expect(
+      resolveAutomaticPermission(request, {
+        profile: 'ask',
+        mcpServerNames: ['open-science-activity']
+      })
+    ).toBe('allow')
+    expect(isMcpToolName('begin_activity_group', ['open-science-activity'])).toBe(true)
+
+    expect(
+      resolveAutomaticPermission(
+        createPermissionRequest('other', undefined, { title: 'begin_activity_group' }),
+        { profile: 'ask', mcpServerNames: ['open-science-activity'] }
+      )
+    ).toBeUndefined()
+  })
+
   it('grants a single-use approval only, never escalating to allow_always', () => {
     const request = createPermissionRequest('read', [{ path: 'data/input.csv' }])
 

--- a/src/main/acp/permission-policy.test.ts
+++ b/src/main/acp/permission-policy.test.ts
@@ -15,6 +15,7 @@ const createPermissionRequest = (
   overrides?: {
     title?: string
     options?: RequestPermissionRequest['options']
+    rawInput?: unknown
   }
 ): RequestPermissionRequest => ({
   sessionId: 'session-1',
@@ -22,7 +23,8 @@ const createPermissionRequest = (
     toolCallId: 'tool-1',
     title: overrides?.title ?? 'Tool call',
     kind,
-    locations
+    locations,
+    rawInput: overrides?.rawInput
   },
   options: overrides?.options ?? [
     { optionId: 'allow', name: 'Allow once', kind: 'allow_once' },
@@ -172,6 +174,24 @@ describe('permission policy', () => {
     ).toBeUndefined()
   })
 
+  it('does not trust raw input to identify an activity group declaration', () => {
+    const spoofedBuiltIn = createPermissionRequest('execute', undefined, {
+      title: 'Bash',
+      rawInput: {
+        server: 'open-science-activity',
+        tool: 'begin_activity_group',
+        arguments: { title: 'Spoofed declaration' }
+      }
+    })
+
+    expect(
+      resolveAutomaticPermission(spoofedBuiltIn, {
+        profile: 'ask',
+        mcpServerNames: ['open-science-activity']
+      })
+    ).toBeUndefined()
+  })
+
   it('grants a single-use approval only, never escalating to allow_always', () => {
     const request = createPermissionRequest('read', [{ path: 'data/input.csv' }])
 
@@ -251,5 +271,22 @@ describe('permission policy', () => {
     })
 
     expect(resolveAutomaticPermission(onlyAlways, { profile: 'full' })).toBe('always')
+  })
+
+  it('preserves the Full access allow_always fallback for activity declarations', () => {
+    const onlyAlways = createPermissionRequest('other', undefined, {
+      title: 'mcp__open-science-activity__begin_activity_group',
+      options: [
+        { optionId: 'always', name: 'Allow always', kind: 'allow_always' },
+        { optionId: 'reject', name: 'Reject', kind: 'reject_once' }
+      ]
+    })
+
+    expect(
+      resolveAutomaticPermission(onlyAlways, {
+        profile: 'full',
+        mcpServerNames: ['open-science-activity']
+      })
+    ).toBe('always')
   })
 })

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -108,19 +108,20 @@ const resolveAutomaticPermission = (
   params: RequestPermissionRequest,
   context: PermissionPolicyContext | undefined
 ): string | undefined => {
+  if (context?.profile === 'full') {
+    return resolveFullAccessAllowOptionId(params)
+  }
+
+  // The declaration exception must be bound to a server-qualified tool identity. rawInput is
+  // agent-controlled arguments and cannot prove which tool the permission request will execute.
   if (
     context?.mcpServerNames?.includes(ACTIVITY_GROUP_MCP_SERVER_NAME) &&
     isActivityGroupToolEvent({
       title: params.toolCall.title ?? undefined,
-      providerToolName: extractProviderToolName(params.toolCall),
-      rawInput: params.toolCall.rawInput
+      providerToolName: extractProviderToolName(params.toolCall)
     })
   ) {
     return resolveAllowOptionId(params)
-  }
-
-  if (context?.profile === 'full') {
-    return resolveFullAccessAllowOptionId(params)
   }
 
   if (

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -6,6 +6,10 @@ import type {
   PermissionProfileId
 } from '../../shared/permission-profiles'
 import type { AgentFrameworkId } from '../../shared/settings'
+import {
+  ACTIVITY_GROUP_MCP_SERVER_NAME,
+  isActivityGroupToolEvent
+} from '../../shared/activity-groups'
 import { extractProviderToolName } from './runtime-events'
 
 type PermissionPolicyContext = {
@@ -24,7 +28,8 @@ const MCP_TOOL_PREFIX = 'mcp__'
 const CODEX_MCP_TOOL_PREFIX = 'mcp.'
 const MCP_PROVIDER_LEAF_NAMES: Record<string, readonly string[]> = {
   'open-science-notebook': ['execute'],
-  'open-science-artifacts': ['write']
+  'open-science-artifacts': ['write'],
+  'open-science-activity': ['begin_activity_group']
 }
 
 // Recognizes an MCP-originated tool name across frameworks (see MCP_TOOL_PREFIX): Claude's mcp__ prefix,
@@ -103,6 +108,17 @@ const resolveAutomaticPermission = (
   params: RequestPermissionRequest,
   context: PermissionPolicyContext | undefined
 ): string | undefined => {
+  if (
+    context?.mcpServerNames?.includes(ACTIVITY_GROUP_MCP_SERVER_NAME) &&
+    isActivityGroupToolEvent({
+      title: params.toolCall.title ?? undefined,
+      providerToolName: extractProviderToolName(params.toolCall),
+      rawInput: params.toolCall.rawInput
+    })
+  ) {
+    return resolveAllowOptionId(params)
+  }
+
   if (context?.profile === 'full') {
     return resolveFullAccessAllowOptionId(params)
   }

--- a/src/main/acp/runtime-events.test.ts
+++ b/src/main/acp/runtime-events.test.ts
@@ -203,6 +203,28 @@ describe('ACP runtime event normalization', () => {
     })
   })
 
+  it('drops oversized raw tool payloads before runtime snapshots are broadcast', () => {
+    const oversizedInput = { content: 'A'.repeat(10_000) }
+    const oversizedOutput = { result: 'B'.repeat(10_000) }
+    const notification: SessionNotification = {
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'tool-large',
+        kind: 'execute',
+        status: 'completed',
+        rawInput: oversizedInput,
+        rawOutput: oversizedOutput
+      }
+    }
+
+    const event = toAcpRuntimeEvent(notification, 'event-large-tool', 1710000000005)
+
+    expect(event.rawInput).toBeUndefined()
+    expect(event.rawOutput).toBeUndefined()
+    expect(event.raw).toBeUndefined()
+  })
+
   it('extracts streamed terminal output and exit code from tool metadata', () => {
     const notification: SessionNotification = {
       sessionId: 'session-1',

--- a/src/main/acp/runtime-events.ts
+++ b/src/main/acp/runtime-events.ts
@@ -9,6 +9,7 @@ import {
 // Bounds how much of a failed tool's result text reaches the log, so large or sensitive tool output
 // cannot flood it. Tuned to fit a typical error message (e.g. WebFetch's domain-safety preflight).
 const TOOL_FAILURE_TEXT_LIMIT = 300
+const MAX_RUNTIME_RAW_PAYLOAD_CHARS = 8_000
 
 // Narrows protocol extension values before reading provider-specific metadata.
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -21,6 +22,24 @@ const trimProviderValue = (value: unknown): string | undefined => {
   const trimmedValue = value.trim()
 
   return trimmedValue ? trimmedValue : undefined
+}
+
+// Keeps small JSON payloads for activity details while dropping values that would make runtime
+// snapshots expensive or impossible to structured-clone across IPC.
+const sanitizeRawToolPayload = (value: unknown): unknown | undefined => {
+  if (value === undefined || value === null) return undefined
+
+  try {
+    const serialized = JSON.stringify(value)
+
+    if (serialized === undefined || serialized.length > MAX_RUNTIME_RAW_PAYLOAD_CHARS) {
+      return undefined
+    }
+
+    return JSON.parse(serialized) as unknown
+  } catch {
+    return undefined
+  }
 }
 
 // Extracts a safe tool identity (e.g. "WebFetch") from ACP extension metadata without exposing
@@ -192,17 +211,19 @@ const toAcpRuntimeEvent = (
         text: contentToText(update.content)
       }
     case 'tool_call':
-      // Keep provider-specific tool metadata only in raw; preview behavior is file-only for now.
+      // Tool events expose only the bounded fields consumed by the UI. Do not retain the original
+      // notification because it duplicates the unbounded arguments and results inside `raw`.
       return {
         ...base,
+        raw: undefined,
         kind: 'tool',
         toolCallId: update.toolCallId,
         providerToolName: extractProviderToolName(update),
         toolKind: update.kind,
         toolContent: update.content,
         toolLocations: update.locations,
-        rawInput: update.rawInput,
-        rawOutput: update.rawOutput,
+        rawInput: sanitizeRawToolPayload(update.rawInput),
+        rawOutput: sanitizeRawToolPayload(update.rawOutput),
         ...extractTerminalMeta(update),
         title: update.title,
         status: update.status
@@ -211,14 +232,15 @@ const toAcpRuntimeEvent = (
       // Tool updates stay compact and do not expose future preview metadata assumptions.
       return {
         ...base,
+        raw: undefined,
         kind: 'tool',
         toolCallId: update.toolCallId,
         providerToolName: extractProviderToolName(update),
         toolKind: update.kind ?? undefined,
         toolContent: update.content ?? undefined,
         toolLocations: update.locations ?? undefined,
-        rawInput: update.rawInput,
-        rawOutput: update.rawOutput,
+        rawInput: sanitizeRawToolPayload(update.rawInput),
+        rawOutput: sanitizeRawToolPayload(update.rawOutput),
         ...extractTerminalMeta(update),
         title: update.title ?? undefined,
         status: update.status ?? undefined

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -744,6 +744,7 @@ describe('ACP runtime session management', () => {
     ])
     expect(JSON.stringify(fakeAgent.newSessions[0]._meta)).toContain(BEGIN_ACTIVITY_GROUP_TOOL_NAME)
     expect(fakeAgent.prompts[0].text).toContain('mcp__open-science-activity__begin_activity_group')
+    expect(fakeAgent.prompts[0].text).toContain('Before each coherent tool group this turn')
 
     const reviewerServer = {
       type: 'http' as const,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -733,7 +733,8 @@ describe('ACP runtime session management', () => {
       activityGroups: { mcpEntryPath: '/app/out/main/index.js' }
     })
 
-    await runtime.createSession({ cwd: '/workspace' })
+    const mainSession = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: mainSession.sessionId, text: 'Search PubMed' })
 
     expect(fakeAgent.newSessions[0].mcpServers).toEqual([
       expect.objectContaining({
@@ -742,6 +743,7 @@ describe('ACP runtime session management', () => {
       })
     ])
     expect(JSON.stringify(fakeAgent.newSessions[0]._meta)).toContain(BEGIN_ACTIVITY_GROUP_TOOL_NAME)
+    expect(fakeAgent.prompts[0].text).toContain('mcp__open-science-activity__begin_activity_group')
 
     const reviewerServer = {
       type: 'http' as const,
@@ -749,16 +751,18 @@ describe('ACP runtime session management', () => {
       url: 'http://127.0.0.1:1/mcp',
       headers: []
     }
-    await runtime.buildReviewerSession({
+    const { session: reviewerSession } = await runtime.buildReviewerSession({
       cwd: '/workspace',
       mcpServers: [reviewerServer],
       systemPromptAppend: 'Reviewer-only instructions'
     })
+    await reviewerSession.prompt([{ type: 'text', text: 'Review this turn' }])
 
     expect(fakeAgent.newSessions[1].mcpServers).toEqual([reviewerServer])
     expect(JSON.stringify(fakeAgent.newSessions[1]._meta)).not.toContain(
       BEGIN_ACTIVITY_GROUP_TOOL_NAME
     )
+    expect(fakeAgent.prompts[1].text).toBe('Review this turn')
   })
 
   it.each([

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -21,6 +21,10 @@ import { SkillRegistry } from '../skills/registry'
 import { claudeCodeFramework, codexFramework, opencodeFramework } from '../agent-framework'
 import { ArtifactRepository } from '../artifacts/repository'
 import { writeArtifactFileForCurrentRun } from '../artifacts/mcp-server'
+import {
+  ACTIVITY_GROUP_MCP_SERVER_NAME,
+  BEGIN_ACTIVITY_GROUP_TOOL_NAME
+} from '../activity-groups/mcp-server'
 import type { UploadedAttachment } from '../../shared/uploads'
 import { UploadRepository } from '../uploads/repository'
 import { MAX_INLINE_IMAGE_TOTAL_BASE64_BYTES } from '../uploads/attachment-media'
@@ -719,6 +723,74 @@ describe('ACP runtime migration write-gate', () => {
 })
 
 describe('ACP runtime session management', () => {
+  it('injects activity-group declarations into main sessions but not reviewer sessions', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['main-session', 'reviewer-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      activityGroups: { mcpEntryPath: '/app/out/main/index.js' }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    expect(fakeAgent.newSessions[0].mcpServers).toEqual([
+      expect.objectContaining({
+        name: ACTIVITY_GROUP_MCP_SERVER_NAME,
+        args: ['/app/out/main/index.js', '--open-science-activity-group-mcp']
+      })
+    ])
+    expect(JSON.stringify(fakeAgent.newSessions[0]._meta)).toContain(BEGIN_ACTIVITY_GROUP_TOOL_NAME)
+
+    const reviewerServer = {
+      type: 'http' as const,
+      name: 'open-science-reviewer',
+      url: 'http://127.0.0.1:1/mcp',
+      headers: []
+    }
+    await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [reviewerServer],
+      systemPromptAppend: 'Reviewer-only instructions'
+    })
+
+    expect(fakeAgent.newSessions[1].mcpServers).toEqual([reviewerServer])
+    expect(JSON.stringify(fakeAgent.newSessions[1]._meta)).not.toContain(
+      BEGIN_ACTIVITY_GROUP_TOOL_NAME
+    )
+  })
+
+  it.each([
+    ['opencode', opencodeFramework],
+    ['codex', codexFramework]
+  ] as const)(
+    'injects activity-group tooling and prompt guidance for %s',
+    async (_name, framework) => {
+      const process = new FakeAgentProcess()
+      const fakeAgent = startFakeAgent(process, ['main-session'], {
+        modes:
+          framework.id === 'codex'
+            ? createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+            : undefined
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.2.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        framework,
+        activityGroups: { mcpEntryPath: '/app/out/main/index.js' }
+      })
+
+      const session = await runtime.createSession({ cwd: '/workspace' })
+      await runtime.sendPrompt({ sessionId: session.sessionId, text: 'Inspect the project' })
+
+      expect(fakeAgent.newSessions[0].mcpServers).toEqual([
+        expect.objectContaining({ name: ACTIVITY_GROUP_MCP_SERVER_NAME })
+      ])
+      expect(fakeAgent.prompts[0].text).toContain(BEGIN_ACTIVITY_GROUP_TOOL_NAME)
+    }
+  )
   it('applies native Full access before the first prompt', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['full-session'], {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -286,6 +286,7 @@ const ACTIVITY_GROUP_SYSTEM_PROMPT_APPEND = [
   'The declaration is control metadata: it is not itself a visible step and does not replace the actual tool calls.',
   '</open_science_activity_group_instructions>'
 ].join('\n')
+const ACTIVITY_GROUP_TURN_PROMPT_REMINDER = `Before using any other tool this turn, first call \`${BEGIN_ACTIVITY_GROUP_TOOL_NAME}\` with one concise purpose title for the upcoming group. Call it once per coherent group, not once per tool.`
 // Appends artifact tool guidance as system prompt metadata so user prompts stay untouched.
 const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '<open_science_artifact_instructions>',
@@ -2100,11 +2101,12 @@ class AcpRuntime {
       }
       // Prepend a short steering nudge naming the picked skills. It goes only into the content sent to
       // the agent; the user-facing message event keeps the original text (which already shows /Name).
-      // Framework-neutral delivery of the system-prompt guidance: Claude carries it in session _meta so
-      // the prefix is empty and the prompt is unchanged; opencode has no preset, so its guidance rides as
-      // a prompt prefix here, ahead of the skill nudge and the user's text.
+      // Framework-neutral delivery of the system-prompt guidance: Claude carries the complete appends in
+      // session _meta but repeats the short activity declaration reminder here; frameworks without a
+      // session preset carry the complete guidance as a prompt prefix.
       const { promptPrefix } = this.framework.buildSessionSetup({
-        systemPromptAppends: this.getSystemPromptAppends()
+        systemPromptAppends: this.getSystemPromptAppends(),
+        turnPromptReminders: this.getTurnPromptReminders()
       })
       const nudgedText = await this.applySkillNudge(request.text, forced)
       // A history preamble (transcript replayed after a context reset) leads, then the framework guidance
@@ -3066,6 +3068,12 @@ class AcpRuntime {
       ...(this.artifactToolingAvailable() ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
       ...(this.notebookToolingAvailable() ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : [])
     ]
+  }
+
+  private getTurnPromptReminders(): string[] {
+    return this.activityGroupOptions && this.framework.acceptsStdioMcp
+      ? [ACTIVITY_GROUP_TURN_PROMPT_REMINDER]
+      : []
   }
 
   // Builds the ACP `_meta` argument for session/new and session/resume, delegating the framework-specific

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -84,6 +84,11 @@ import {
   type ArtifactMcpEnvironment,
   type ArtifactRunContext
 } from '../artifacts/mcp-server'
+import {
+  ACTIVITY_GROUP_MCP_SERVER_NAME,
+  BEGIN_ACTIVITY_GROUP_TOOL_NAME,
+  createActivityGroupMcpServerConfig
+} from '../activity-groups/mcp-server'
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { ArtifactRepository, getArtifactCurrentRunFilePath } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
@@ -136,6 +141,7 @@ type AcpRuntimeOptions = {
   artifacts?: AcpRuntimeArtifactOptions
   uploads?: AcpRuntimeUploadOptions
   notebook?: AcpRuntimeNotebookOptions
+  activityGroups?: AcpRuntimeActivityGroupOptions
   skills?: AcpRuntimeSkillsOptions
   // The agent backend to drive. Defaults to Claude Code; selecting another (opencode) swaps only the
   // framework-coupled behavior (spawn, session meta, permission-mode mapping) via AgentFramework.
@@ -210,6 +216,11 @@ type AcpRuntimeNotebookOptions = {
   registerSessionAlias?: (aliasSessionId: string, sessionId: string) => void
 }
 
+type AcpRuntimeActivityGroupOptions = {
+  mcpEntryPath: string
+  mcpCommand?: string
+}
+
 type SessionAttachmentResponse = {
   sessionId: string
   modes?: SessionModeState | null
@@ -267,6 +278,14 @@ const codexMcpToolIdentity = (
 const MAX_EVENTS = 500
 // Bounds pending Codex MCP identities even if an agent never emits terminal tool updates.
 const MAX_CODEX_MCP_TOOL_IDENTITIES_PER_SESSION = 32
+const ACTIVITY_GROUP_SYSTEM_PROMPT_APPEND = [
+  '<open_science_activity_group_instructions>',
+  `Before the first tool call in each coherent group of work, call the MCP tool \`${BEGIN_ACTIVITY_GROUP_TOOL_NAME}\` from the \`${ACTIVITY_GROUP_MCP_SERVER_NAME}\` server with a concise user-facing purpose title.`,
+  'Call it once for the group, not once per tool or step. A turn may contain multiple groups when the purpose changes.',
+  'Declare the group before doing its work. Do not call it when you will answer without using tools.',
+  'The declaration is control metadata: it is not itself a visible step and does not replace the actual tool calls.',
+  '</open_science_activity_group_instructions>'
+].join('\n')
 // Appends artifact tool guidance as system prompt metadata so user prompts stay untouched.
 const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '<open_science_artifact_instructions>',
@@ -596,6 +615,7 @@ class AcpRuntime {
   private readonly cancelTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly artifactOptions: AcpRuntimeArtifactOptions | undefined
   private readonly notebookOptions: AcpRuntimeNotebookOptions | undefined
+  private readonly activityGroupOptions: AcpRuntimeActivityGroupOptions | undefined
   private readonly artifactRepository: ArtifactRepository | undefined
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly uploadRepository: UploadRepository | undefined
@@ -627,6 +647,7 @@ class AcpRuntime {
     this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
     this.artifactOptions = options.artifacts
     this.notebookOptions = options.notebook
+    this.activityGroupOptions = options.activityGroups
     this.artifactRepository = options.artifacts
       ? (options.artifacts.repository ?? new ArtifactRepository(options.artifacts.dataRoot))
       : undefined
@@ -2817,6 +2838,17 @@ class AcpRuntime {
     this.notebookOptions.registerSessionAlias?.(notebookSessionId, sessionId)
   }
 
+  private createActivityGroupMcpServers(): McpServer[] {
+    if (!this.activityGroupOptions) return []
+
+    return [
+      createActivityGroupMcpServerConfig({
+        command: this.activityGroupOptions.mcpCommand ?? process.execPath,
+        entryPath: this.activityGroupOptions.mcpEntryPath
+      })
+    ]
+  }
+
   // Builds the notebook MCP environment for one session, shared by the stdio config and the http host.
   private async buildNotebookEnvironment(
     notebookSessionId: string,
@@ -2894,6 +2926,7 @@ class AcpRuntime {
     // runs instead of failing on an unsupported stdio server config.
     const servers = this.framework.acceptsStdioMcp
       ? [
+          ...this.createActivityGroupMcpServers(),
           ...(artifactEnabled
             ? this.createArtifactMcpServers(artifactSessionId, sessionCwd, projectName)
             : []),
@@ -3027,6 +3060,9 @@ class AcpRuntime {
     return [
       SKILLS_READ_GUARD_SYSTEM_PROMPT_APPEND,
       LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND,
+      ...(this.activityGroupOptions && this.framework.acceptsStdioMcp
+        ? [ACTIVITY_GROUP_SYSTEM_PROMPT_APPEND]
+        : []),
       ...(this.artifactToolingAvailable() ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
       ...(this.notebookToolingAvailable() ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : [])
     ]
@@ -3646,6 +3682,8 @@ class AcpRuntime {
       toolKind: event.toolKind,
       toolContent: event.toolContent,
       toolLocations: event.toolLocations,
+      rawInput: event.rawInput,
+      rawOutput: event.rawOutput,
       runId: event.runId,
       artifactSessionId: event.artifactSessionId,
       artifactClaimId: event.artifactClaimId,

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -286,7 +286,7 @@ const ACTIVITY_GROUP_SYSTEM_PROMPT_APPEND = [
   'The declaration is control metadata: it is not itself a visible step and does not replace the actual tool calls.',
   '</open_science_activity_group_instructions>'
 ].join('\n')
-const ACTIVITY_GROUP_TURN_PROMPT_REMINDER = `Before using any other tool this turn, first call \`${BEGIN_ACTIVITY_GROUP_TOOL_NAME}\` with one concise purpose title for the upcoming group. Call it once per coherent group, not once per tool.`
+const ACTIVITY_GROUP_TURN_PROMPT_REMINDER = `Before each coherent tool group this turn, call \`${BEGIN_ACTIVITY_GROUP_TOOL_NAME}\` with one concise purpose title immediately before that group's first tool. Repeat the declaration whenever the purpose changes; do not reuse the previous group. Call it once per group, not once per tool.`
 // Appends artifact tool guidance as system prompt metadata so user prompts stay untouched.
 const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '<open_science_artifact_instructions>',

--- a/src/main/activity-groups/mcp-server.test.ts
+++ b/src/main/activity-groups/mcp-server.test.ts
@@ -1,0 +1,44 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { describe, expect, it } from 'vitest'
+
+import {
+  ACTIVITY_GROUP_MCP_SERVER_NAME,
+  BEGIN_ACTIVITY_GROUP_TOOL_NAME,
+  createActivityGroupMcpServer
+} from './mcp-server'
+
+describe('activity group MCP server', () => {
+  it('exposes a declaration-only begin_activity_group tool', async () => {
+    const server = createActivityGroupMcpServer()
+    const client = new Client({ name: 'activity-group-test', version: '1.0.0' })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+
+    const tools = await client.listTools()
+    expect(tools.tools).toEqual([
+      expect.objectContaining({
+        name: BEGIN_ACTIVITY_GROUP_TOOL_NAME,
+        inputSchema: expect.objectContaining({
+          properties: expect.objectContaining({ title: expect.any(Object) }),
+          required: ['title']
+        })
+      })
+    ])
+
+    await expect(
+      client.callTool({
+        name: BEGIN_ACTIVITY_GROUP_TOOL_NAME,
+        arguments: { title: 'Inspect files' }
+      })
+    ).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'Activity group declared: Inspect files' }]
+    })
+
+    expect(ACTIVITY_GROUP_MCP_SERVER_NAME).toBe('open-science-activity')
+
+    await client.close()
+    await server.close()
+  })
+})

--- a/src/main/activity-groups/mcp-server.test.ts
+++ b/src/main/activity-groups/mcp-server.test.ts
@@ -33,7 +33,12 @@ describe('activity group MCP server', () => {
         arguments: { title: 'Inspect files' }
       })
     ).resolves.toMatchObject({
-      content: [{ type: 'text', text: 'Activity group declared: Inspect files' }]
+      content: [
+        {
+          type: 'text',
+          text: 'Activity group declared: Inspect files. Before starting another coherent tool group this turn, call begin_activity_group again with its own purpose title.'
+        }
+      ]
     })
 
     expect(ACTIVITY_GROUP_MCP_SERVER_NAME).toBe('open-science-activity')

--- a/src/main/activity-groups/mcp-server.ts
+++ b/src/main/activity-groups/mcp-server.ts
@@ -1,0 +1,73 @@
+import type { McpServerStdio } from '@agentclientprotocol/sdk'
+import { McpServer as ModelContextProtocolServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+
+import { ACTIVITY_GROUP_MCP_SERVER_ARG } from '../mcp-server-args'
+import {
+  ACTIVITY_GROUP_MCP_SERVER_NAME,
+  BEGIN_ACTIVITY_GROUP_TOOL_NAME,
+  MAX_ACTIVITY_GROUP_TITLE_LENGTH
+} from '../../shared/activity-groups'
+
+const beginActivityGroupToolSchema = {
+  title: z
+    .string()
+    .trim()
+    .min(1)
+    .refine((value) => Array.from(value).length <= MAX_ACTIVITY_GROUP_TITLE_LENGTH, {
+      message: `Title must be at most ${MAX_ACTIVITY_GROUP_TITLE_LENGTH} characters.`
+    })
+    .describe('A concise user-facing title describing the purpose of the upcoming tool group.')
+}
+
+const createActivityGroupMcpServer = (): ModelContextProtocolServer => {
+  const server = new ModelContextProtocolServer({
+    name: ACTIVITY_GROUP_MCP_SERVER_NAME,
+    version: '1.0.0'
+  })
+
+  server.registerTool(
+    BEGIN_ACTIVITY_GROUP_TOOL_NAME,
+    {
+      title: 'Begin activity group',
+      description:
+        'Declare the concise purpose of the next coherent group of tool calls. Call once before the first tool in that group, not once per step.',
+      inputSchema: beginActivityGroupToolSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true }
+    },
+    async ({ title }) => ({
+      content: [{ type: 'text', text: `Activity group declared: ${title}` }]
+    })
+  )
+
+  return server
+}
+
+const createActivityGroupMcpServerConfig = ({
+  command,
+  entryPath
+}: {
+  command: string
+  entryPath: string
+}): McpServerStdio => ({
+  name: ACTIVITY_GROUP_MCP_SERVER_NAME,
+  command,
+  args: [entryPath, ACTIVITY_GROUP_MCP_SERVER_ARG],
+  env: [{ name: 'ELECTRON_RUN_AS_NODE', value: '1' }]
+})
+
+const runActivityGroupMcpServer = async (): Promise<void> => {
+  const server = createActivityGroupMcpServer()
+  await server.connect(new StdioServerTransport())
+}
+
+export {
+  ACTIVITY_GROUP_MCP_SERVER_ARG,
+  ACTIVITY_GROUP_MCP_SERVER_NAME,
+  BEGIN_ACTIVITY_GROUP_TOOL_NAME,
+  beginActivityGroupToolSchema,
+  createActivityGroupMcpServer,
+  createActivityGroupMcpServerConfig,
+  runActivityGroupMcpServer
+}

--- a/src/main/activity-groups/mcp-server.ts
+++ b/src/main/activity-groups/mcp-server.ts
@@ -37,7 +37,12 @@ const createActivityGroupMcpServer = (): ModelContextProtocolServer => {
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true }
     },
     async ({ title }) => ({
-      content: [{ type: 'text', text: `Activity group declared: ${title}` }]
+      content: [
+        {
+          type: 'text',
+          text: `Activity group declared: ${title}. Before starting another coherent tool group this turn, call ${BEGIN_ACTIVITY_GROUP_TOOL_NAME} again with its own purpose title.`
+        }
+      ]
     })
   )
 

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -39,4 +39,15 @@ describe('claudeCodeFramework', () => {
 
     expect(systemPrompt.append).toBe(callableName)
   })
+
+  it('renders per-turn reminders with Claude callable tool names', () => {
+    const setup = claudeCodeFramework.buildSessionSetup({
+      systemPromptAppends: ['Complete session guidance'],
+      turnPromptReminders: ['First call `begin_activity_group` with a purpose title.']
+    })
+
+    expect(setup.promptPrefix).toBe(
+      'First call `mcp__open-science-activity__begin_activity_group` with a purpose title.'
+    )
+  })
 })

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -19,6 +19,7 @@ import type {
 
 // Claude exposes ACP-provided MCP tools as mcp__<server>__<tool>; shared prompts stay framework-neutral.
 const CLAUDE_MCP_TOOL_NAMES = [
+  ['begin_activity_group', 'mcp__open-science-activity__begin_activity_group'],
   ['write_artifact_file', 'mcp__open-science-artifacts__write_artifact_file'],
   ['notebook_execute', 'mcp__open-science-notebook__notebook_execute'],
   ['repl_execute', 'mcp__open-science-notebook__repl_execute'],

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -88,7 +88,12 @@ export const claudeCodeFramework: AgentFramework = {
       }
     }
 
-    return { meta }
+    const promptPrefix = ctx.turnPromptReminders
+      ?.map(renderClaudeMcpToolNames)
+      .filter(Boolean)
+      .join('\n\n')
+
+    return { meta, ...(promptPrefix ? { promptPrefix } : {}) }
   },
 
   mapPermissionProfile(

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -69,11 +69,14 @@ export type ModelConfigContext = {
 // privacy). The framework decides HOW it is delivered — see SessionSetup.
 export type SessionSetupContext = {
   systemPromptAppends: string[]
+  // Short, high-priority reminders that must reach each turn when the framework carries the complete
+  // appends only in session metadata. Frameworks whose appends already ride each prompt may omit them.
+  turnPromptReminders?: string[]
 }
 
 // Framework-specific session configuration returned to the runtime. `meta` becomes the ACP `_meta`
 // on session/new and session/resume. `promptPrefix` is prepended to prompt content when the framework
-// cannot carry appends in session meta (opencode has no system-prompt preset).
+// cannot carry appends in session meta, or when a session-level append needs a per-turn reminder.
 export type SessionSetup = {
   meta?: Record<string, unknown>
   promptPrefix?: string

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,12 +3,17 @@ import { fileURLToPath } from 'node:url'
 // Only the lightweight argv flags are imported statically here. The MCP server modules (and their heavy
 // SDK graph) are imported lazily inside the matching branch, and the Electron backend is imported only
 // after the single-instance lock is held — so no backend module loads before the lock in UI mode.
-import { ARTIFACT_MCP_SERVER_ARG, NOTEBOOK_MCP_SERVER_ARG } from './mcp-server-args'
+import {
+  ACTIVITY_GROUP_MCP_SERVER_ARG,
+  ARTIFACT_MCP_SERVER_ARG,
+  NOTEBOOK_MCP_SERVER_ARG
+} from './mcp-server-args'
 
 const APP_NAME = 'Open Science'
 const APP_USER_MODEL_ID = 'com.aipoch.open-science'
 const shouldRunArtifactMcpServer = process.argv.includes(ARTIFACT_MCP_SERVER_ARG)
 const shouldRunNotebookMcpServer = process.argv.includes(NOTEBOOK_MCP_SERVER_ARG)
+const shouldRunActivityGroupMcpServer = process.argv.includes(ACTIVITY_GROUP_MCP_SERVER_ARG)
 
 if (shouldRunArtifactMcpServer) {
   // Reuse the packaged entry point as a Node stdio MCP server; import it only in this mode.
@@ -22,6 +27,13 @@ if (shouldRunArtifactMcpServer) {
   // Keep notebook MCP mode as a Node stdio process that proxies to the app-owned runtime.
   void import('./notebook/mcp-server')
     .then(({ runNotebookMcpServer }) => runNotebookMcpServer())
+    .catch((error: unknown) => {
+      console.error(error)
+      process.exitCode = 1
+    })
+} else if (shouldRunActivityGroupMcpServer) {
+  void import('./activity-groups/mcp-server')
+    .then(({ runActivityGroupMcpServer }) => runActivityGroupMcpServer())
     .catch((error: unknown) => {
       console.error(error)
       process.exitCode = 1

--- a/src/main/mcp-server-args.ts
+++ b/src/main/mcp-server-args.ts
@@ -5,3 +5,4 @@
 // backend module loads.
 export const ARTIFACT_MCP_SERVER_ARG = '--open-science-artifact-mcp'
 export const NOTEBOOK_MCP_SERVER_ARG = '--open-science-notebook-mcp'
+export const ACTIVITY_GROUP_MCP_SERVER_ARG = '--open-science-activity-group-mcp'

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1407,6 +1407,12 @@ describe('SettingsService: preflight & spawn config', () => {
           function: expect.objectContaining({
             name: 'mcp__open_science_artifacts__write_artifact_file'
           })
+        }),
+        expect.objectContaining({
+          type: 'function',
+          function: expect.objectContaining({
+            name: 'mcp__open_science_activity__begin_activity_group'
+          })
         })
       ])
     })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -171,6 +171,11 @@ import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limit
 import { readSkillFile } from '../skills/skill-files'
 import { NOTEBOOK_MCP_SERVER_NAME, NOTEBOOK_RPC_TOOLS } from '../notebook/mcp-server'
 import { ARTIFACT_MCP_SERVER_NAME, writeArtifactFileToolSchema } from '../artifacts/mcp-server'
+import { beginActivityGroupToolSchema } from '../activity-groups/mcp-server'
+import {
+  ACTIVITY_GROUP_MCP_SERVER_NAME,
+  BEGIN_ACTIVITY_GROUP_TOOL_NAME
+} from '../../shared/activity-groups'
 import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
 import type {
   StoredConnectors,
@@ -256,6 +261,21 @@ const CODEX_BRIDGE_ARTIFACT_TOOLS: ResponsesBridgeNamespacedTool[] = [
     description:
       'Attach a generated image, chart, report, data export, or archive to the current Open Science response. The file must already exist before using a localPath source.',
     parameters: z.toJSONSchema(z.object(writeArtifactFileToolSchema), {
+      target: 'draft-7'
+    }) as ResponsesBridgeNamespacedTool['parameters']
+  }
+]
+const CODEX_ACTIVITY_TOOL_NAMESPACE = `mcp__${ACTIVITY_GROUP_MCP_SERVER_NAME.replace(
+  /[^a-zA-Z0-9_]/g,
+  '_'
+)}`
+const CODEX_BRIDGE_ACTIVITY_TOOLS: ResponsesBridgeNamespacedTool[] = [
+  {
+    namespace: CODEX_ACTIVITY_TOOL_NAMESPACE,
+    name: BEGIN_ACTIVITY_GROUP_TOOL_NAME,
+    description:
+      'Declare the concise purpose of the next coherent group of tool calls. Call once before the first tool in that group, not once per step.',
+    parameters: z.toJSONSchema(z.object(beginActivityGroupToolSchema), {
       target: 'draft-7'
     }) as ResponsesBridgeNamespacedTool['parameters']
   }
@@ -2711,7 +2731,11 @@ class SettingsService {
       key: provider.key,
       model: provider.model,
       forwardReasoningEffort,
-      namespacedTools: [...CODEX_BRIDGE_NOTEBOOK_TOOLS, ...CODEX_BRIDGE_ARTIFACT_TOOLS],
+      namespacedTools: [
+        ...CODEX_BRIDGE_NOTEBOOK_TOOLS,
+        ...CODEX_BRIDGE_ARTIFACT_TOOLS,
+        ...CODEX_BRIDGE_ACTIVITY_TOOLS
+      ],
       reviewerScope: {
         namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS
       },

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -92,6 +92,57 @@ describe('workspace runtime events', () => {
     })
   })
 
+  it('consumes activity-group declarations without creating a visible tool step', async () => {
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'group-event-1',
+        kind: 'tool',
+        toolCallId: 'group-call-1',
+        providerToolName: 'mcp__open-science-activity__begin_activity_group',
+        rawInput: { title: 'Inspect the implementation' },
+        status: 'pending'
+      })
+    )
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'narration-event-1',
+        role: 'assistant',
+        messageId: 'assistant-message-1',
+        text: 'I will inspect the implementation first.'
+      })
+    )
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'group-event-2',
+        kind: 'tool',
+        toolCallId: 'group-call-1',
+        status: 'completed'
+      })
+    )
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'tool-event-1',
+        kind: 'tool',
+        toolCallId: 'tool-read-1',
+        providerToolName: 'Read',
+        toolKind: 'read',
+        status: 'completed'
+      })
+    )
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.activities).toEqual([
+      expect.objectContaining({ id: 'tool-read-1', activityGroupId: 'group-call-1' })
+    ])
+    expect(session.activityGroups).toEqual([
+      expect.objectContaining({
+        id: 'group-call-1',
+        title: 'Inspect the implementation',
+        activityIds: ['tool-read-1']
+      })
+    ])
+  })
+
   it('applies assistant image events without creating placeholder text', async () => {
     await applyWorkspaceRuntimeEvent(
       createEvent({

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -5,6 +5,10 @@ import { createPreviewFileItem } from '../../pages/workspace/preview-file-item'
 import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { isMediaOverflowError } from '../../../../shared/media-overflow'
+import {
+  getActivityGroupTitleFromToolEvent,
+  isActivityGroupToolEvent
+} from '../../../../shared/activity-groups'
 import { useSessionStore } from '../../stores/session-store'
 import { useSettingsStore } from '../../stores/settings-store'
 import {
@@ -22,6 +26,20 @@ const pendingPermissionSessionIds = new Set<string>()
 // the main process broadcasts reviewer:suppress-next-auto-review before sending the correction prompt;
 // the renderer calls suppressNextAutoReview(sessionId) so the correction turn's stop event is ignored.
 const suppressAutoReviewOnceFor = new Set<string>()
+const activityGroupToolCallIdsBySession = new Map<string, Set<string>>()
+
+const isActivityGroupControlEvent = (event: AcpRuntimeEvent): boolean => {
+  if (!event.sessionId || !event.toolCallId) return false
+
+  if (isActivityGroupToolEvent(event)) {
+    const toolCallIds = activityGroupToolCallIdsBySession.get(event.sessionId) ?? new Set<string>()
+    toolCallIds.add(event.toolCallId)
+    activityGroupToolCallIdsBySession.set(event.sessionId, toolCallIds)
+    return true
+  }
+
+  return activityGroupToolCallIdsBySession.get(event.sessionId)?.has(event.toolCallId) === true
+}
 
 // Marks the next triggerAutoReview call for a session as suppressed. Cleared on use (one-shot).
 const suppressNextAutoReview = (sessionId: string): void => {
@@ -205,6 +223,7 @@ const applyWorkspaceRuntimeEvent = async (
       return true
     }
 
+    store.completeActivityGroup(event.sessionId)
     store.appendAgentMessageChunk({
       sessionId: event.sessionId,
       streamId: createRuntimeStreamId(event),
@@ -217,6 +236,12 @@ const applyWorkspaceRuntimeEvent = async (
 
   // Tool calls become visible activity rows, including web-search query/result payloads.
   if (event.kind === 'tool' && event.sessionId && event.toolCallId) {
+    if (isActivityGroupControlEvent(event)) {
+      const title = getActivityGroupTitleFromToolEvent(event)
+      if (title) store.beginActivityGroup(event.sessionId, event.toolCallId, title)
+      return true
+    }
+
     store.upsertToolActivity({
       sessionId: event.sessionId,
       toolCallId: event.toolCallId,
@@ -236,6 +261,7 @@ const applyWorkspaceRuntimeEvent = async (
   }
 
   if (event.kind === 'stop' && event.sessionId) {
+    activityGroupToolCallIdsBySession.delete(event.sessionId)
     store.finishRun(event.sessionId)
 
     // Trigger a background review for the just-completed turn.
@@ -291,6 +317,7 @@ const applyWorkspaceRuntimeEvent = async (
   }
 
   if (event.kind === 'error' && event.sessionId) {
+    activityGroupToolCallIdsBySession.delete(event.sessionId)
     // A recoverable request-size overflow shows the neutral "compacting" note ONLY while a recovery is
     // actually in flight — the workspace runtime flips the session to `compacting` first (its recovery
     // effect runs before this event is applied). If the session is not compacting, no recovery started

--- a/src/renderer/src/pages/workspace/WorkspaceActivityGroup.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceActivityGroup.tsx
@@ -69,7 +69,7 @@ const WorkspaceActivityGroup = ({
               <ChevronRight className="size-3.5" strokeWidth={2.2} aria-hidden="true" />
             </span>
             <span className="min-w-0 truncate text-left font-medium text-text-000">
-              {formatActivityGroupTitle(group.activities)}
+              {formatActivityGroupTitle(group.activities, group.title)}
             </span>
             <span className="ml-auto shrink-0 whitespace-nowrap text-[12px] tabular-nums text-text-100">
               {formatStepCount(visibleActivities)}

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -179,7 +179,11 @@ const WorkspaceMessageScroller = ({
     activityExpansionOverrideState.sessionId === currentSessionId
       ? activityExpansionOverrideState.overrides
       : {}
-  const conversationItems = groupConversationItems(createConversationItems(activeSession))
+  const conversationItems = useMemo(
+    () =>
+      groupConversationItems(createConversationItems(activeSession), activeSession?.activityGroups),
+    [activeSession]
+  )
   const showAgentLoadingMessage = shouldShowAgentLoadingMessage(activeSession)
 
   // Counts the user turns after each message; the destructive-resend warning keys off turns, not

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -393,7 +393,9 @@ describe('conversation message scroller integration', () => {
     expect(workspaceActivityGroupSource).toContain('data-testid="tool-group"')
     expect(workspaceActivityGroupSource).toContain('data-testid="tool-group-header"')
     expect(workspaceActivityGroupSource).toContain('<WorkspaceWebSearchActivityRow')
-    expect(workspaceActivityGroupSource).toContain('formatActivityGroupTitle(group.activities)')
+    expect(workspaceActivityGroupSource).toContain(
+      'formatActivityGroupTitle(group.activities, group.title)'
+    )
     expect(workspaceActivityGroupSource).toContain('getRenderableActivityEntries(group.activities)')
     expect(workspaceWebSearchActivityRowSource).toContain('const WorkspaceWebSearchActivityRow')
     expect(workspaceWebSearchActivityRowSource).toContain('<WorkspaceToolActivityRowButton')

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
@@ -101,9 +101,46 @@ describe('groupConversationItems', () => {
       expect(secondGroup.activities.map((activity) => activity.id)).toEqual(['a2', 'a3'])
     }
   })
+
+  it('splits adjacent activities at declared group boundaries', () => {
+    const grouped = groupConversationItems(
+      [
+        activityItem(createActivity({ id: 'a1', activityGroupId: 'g1' })),
+        activityItem(createActivity({ id: 'a2', activityGroupId: 'g2' }))
+      ],
+      [
+        {
+          id: 'g1',
+          title: 'Inspect files',
+          sortIndex: 1,
+          activityIds: ['a1'],
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'g2',
+          title: 'Apply changes',
+          sortIndex: 2,
+          activityIds: ['a2'],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ]
+    )
+
+    expect(grouped).toEqual([
+      expect.objectContaining({ id: 'activity-group-g1', title: 'Inspect files' }),
+      expect.objectContaining({ id: 'activity-group-g2', title: 'Apply changes' })
+    ])
+  })
 })
 
 describe('formatActivityGroupTitle', () => {
+  it('uses the declared group title when one exists', () => {
+    expect(
+      formatActivityGroupTitle([createActivity({ id: 'a1' })], 'Inspect the implementation')
+    ).toBe('Inspect the implementation')
+  })
   it('emits ordered, pluralized clauses for a mixed group', () => {
     const activities = [
       createActivity({ id: 'edit-1', toolKind: 'edit' }),

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
@@ -1,3 +1,4 @@
+import type { PersistedActivityGroup } from '../../../../shared/session-persistence'
 import type { ToolActivity } from '@/stores/session-store'
 
 import {
@@ -14,6 +15,8 @@ type ConversationActivityGroupItem = {
   createdAt: number
   sortIndex: number
   activities: ToolActivity[]
+  activityGroupId?: string
+  title?: string
 }
 
 type GroupedConversationItem =
@@ -27,8 +30,12 @@ type RenderableActivityEntry = {
 const WEB_SEARCH_PROVIDER_TOOL_NAME = 'websearch'
 
 // Collapses consecutive activity items into one transcript group between chat messages.
-const groupConversationItems = (items: ConversationItem[]): GroupedConversationItem[] => {
+const groupConversationItems = (
+  items: ConversationItem[],
+  activityGroups: PersistedActivityGroup[] = []
+): GroupedConversationItem[] => {
   const groupedItems: GroupedConversationItem[] = []
+  const groupsById = new Map(activityGroups.map((group) => [group.id, group]))
 
   for (const item of items) {
     if (item.type === 'message') {
@@ -37,18 +44,27 @@ const groupConversationItems = (items: ConversationItem[]): GroupedConversationI
     }
 
     const previousItem = groupedItems[groupedItems.length - 1]
+    const activityGroupId = item.activity.activityGroupId
+    const declaredGroup = activityGroupId ? groupsById.get(activityGroupId) : undefined
 
-    if (previousItem?.type === 'activity-group') {
+    if (
+      previousItem?.type === 'activity-group' &&
+      previousItem.activityGroupId === activityGroupId
+    ) {
       previousItem.activities.push(item.activity)
       continue
     }
 
     groupedItems.push({
-      id: `activity-group-${item.activity.id}`,
+      id: activityGroupId
+        ? `activity-group-${activityGroupId}`
+        : `activity-group-${item.activity.id}`,
       type: 'activity-group',
       createdAt: item.createdAt,
       sortIndex: item.sortIndex,
-      activities: [item.activity]
+      activities: [item.activity],
+      activityGroupId,
+      title: declaredGroup?.title
     })
   }
 
@@ -220,7 +236,10 @@ const capitalizeFirst = (value: string): string =>
   value.length > 0 ? `${value.charAt(0).toUpperCase()}${value.slice(1)}` : value
 
 // Summarizes a group as "Ran 2 commands, loaded a skill, made a call" style category clauses.
-const formatActivityGroupTitle = (activities: ToolActivity[]): string => {
+const formatActivityGroupTitle = (activities: ToolActivity[], declaredTitle?: string): string => {
+  const groupTitle = declaredTitle?.trim()
+  if (groupTitle) return groupTitle
+
   const hasSearchActivities = countSearchActivities(activities) > 0
   const categoryCounts = new Map<ActivityCategory, number>()
 

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -619,6 +619,76 @@ describe('session store', () => {
     ])
   })
 
+  it('assigns real tool activities to the declared activity group and persists the group', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Inspect and update the app'
+    })
+
+    useSessionStore
+      .getState()
+      .beginActivityGroup(
+        'transport-session-1',
+        'group-call-1',
+        'Inspect the current implementation'
+      )
+    useSessionStore.getState().upsertToolActivity({
+      sessionId: 'transport-session-1',
+      toolCallId: 'tool-read-1',
+      eventId: 'event-read-1',
+      toolKind: 'read',
+      status: 'completed'
+    })
+    useSessionStore
+      .getState()
+      .beginActivityGroup('transport-session-1', 'group-call-2', 'Apply the focused change')
+    useSessionStore.getState().upsertToolActivity({
+      sessionId: 'transport-session-1',
+      toolCallId: 'tool-edit-1',
+      eventId: 'event-edit-1',
+      toolKind: 'edit',
+      status: 'completed'
+    })
+    useSessionStore.getState().completeActivityGroup('transport-session-1')
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.activities).toEqual([
+      expect.objectContaining({ id: 'tool-read-1', activityGroupId: 'group-call-1' }),
+      expect.objectContaining({ id: 'tool-edit-1', activityGroupId: 'group-call-2' })
+    ])
+    expect(session.activityGroups).toEqual([
+      expect.objectContaining({
+        id: 'group-call-1',
+        title: 'Inspect the current implementation',
+        activityIds: ['tool-read-1'],
+        completedAt: expect.any(Number)
+      }),
+      expect.objectContaining({
+        id: 'group-call-2',
+        title: 'Apply the focused change',
+        activityIds: ['tool-edit-1'],
+        completedAt: expect.any(Number)
+      })
+    ])
+    expect(toPersistedSession(session).activityGroups).toEqual(session.activityGroups)
+  })
+
+  it('does not notify the store when no started activity group can be completed', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Answer without tools'
+    })
+    const before = useSessionStore.getState()
+    const listener = vi.fn()
+    const unsubscribe = useSessionStore.subscribe(listener)
+
+    useSessionStore.getState().completeActivityGroup('transport-session-1')
+
+    expect(useSessionStore.getState()).toBe(before)
+    expect(listener).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
   it('preserves tool activity content and locations across updates', () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',
@@ -1663,6 +1733,42 @@ describe('truncateSessionFromMessage', () => {
     expect(
       useSessionStore.getState().sessions[0].activities?.map((activity) => activity.id)
     ).toEqual(['act-1'])
+  })
+
+  it('prunes activity group references when edited resend removes their activities', () => {
+    seedSession({
+      activities: [
+        { ...createActivity('act-1', baseTime + 150), activityGroupId: 'group-1' },
+        { ...createActivity('act-2', baseTime + 250), activityGroupId: 'group-1' },
+        { ...createActivity('act-3', baseTime + 350), activityGroupId: 'group-2' }
+      ],
+      activityGroups: [
+        {
+          id: 'group-1',
+          title: 'First group',
+          sortIndex: 1,
+          activityIds: ['act-1', 'act-2'],
+          createdAt: baseTime + 140,
+          updatedAt: baseTime + 250,
+          completedAt: baseTime + 260
+        },
+        {
+          id: 'group-2',
+          title: 'Second group',
+          sortIndex: 2,
+          activityIds: ['act-3'],
+          createdAt: baseTime + 340,
+          updatedAt: baseTime + 350,
+          completedAt: baseTime + 360
+        }
+      ]
+    })
+
+    useSessionStore.getState().truncateSessionFromMessage('session-1', 'user-2')
+
+    expect(useSessionStore.getState().sessions[0].activityGroups).toEqual([
+      expect.objectContaining({ id: 'group-1', activityIds: ['act-1'] })
+    ])
   })
 
   it('advances filesRevision only when removed messages carry file references', () => {

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -7,6 +7,7 @@ import type {
 } from '@agentclientprotocol/sdk'
 
 import type { ArtifactFile } from '../../../shared/artifacts'
+import { sanitizeActivityGroupTitle } from '../../../shared/activity-groups'
 import {
   MAX_ACP_SESSION_IMAGE_BYTES,
   sanitizeAcpMessageImage,
@@ -20,8 +21,10 @@ import {
   INTERRUPTED_SESSION_ERROR,
   sanitizeMessageImages,
   sanitizeToolActivity,
+  sanitizeActivityGroup,
   type MessagePart,
   type PersistedActiveRun,
+  type PersistedActivityGroup,
   type PersistedArtifact,
   type PersistedChatMessage,
   type PersistedChatSession,
@@ -46,6 +49,7 @@ export type ToolActivity = {
   id: string
   kind: 'tool'
   title: string
+  activityGroupId?: string
   status: ToolActivityStatus
   eventIds: string[]
   sortIndex: number
@@ -205,6 +209,8 @@ type SessionStore = SessionStoreData & {
   removeMessage: (sessionId: string, messageId: string) => void
   truncateSessionFromMessage: (sessionId: string, messageId: string) => void
   upsertToolActivity: (input: UpsertToolActivityInput) => void
+  beginActivityGroup: (sessionId: string, groupId: string, title: string) => void
+  completeActivityGroup: (sessionId: string) => void
   setPermissionPending: (sessionId: string) => void
   clearPermissionPending: (sessionId: string) => void
   setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => void
@@ -246,6 +252,7 @@ const stripTransientMessageState = (message: ChatMessage): PersistedChatMessage 
 const stripTransientSessionState = (session: ChatSession): PersistedChatSession => {
   const {
     activities,
+    activityGroups,
     isPending,
     interrupted,
     fixLoopActive,
@@ -265,12 +272,18 @@ const stripTransientSessionState = (session: ChatSession): PersistedChatSession 
   const persistedActivities = activities
     ?.map(sanitizeToolActivity)
     .filter((activity): activity is PersistedToolActivity => !!activity)
+  const persistedActivityGroups = activityGroups
+    ?.map(sanitizeActivityGroup)
+    .filter((group): group is PersistedActivityGroup => !!group)
 
   return {
     ...persistedSession,
     messages: messages.map(stripTransientMessageState),
     ...(persistedActivities && persistedActivities.length > 0
       ? { activities: persistedActivities }
+      : {}),
+    ...(persistedActivityGroups && persistedActivityGroups.length > 0
+      ? { activityGroups: persistedActivityGroups }
       : {})
   }
 }
@@ -311,6 +324,19 @@ const createPendingSessionId = (): string => {
 const createSortIndex = (): number => {
   timelineSequence += 1
   return timelineSequence
+}
+
+const completeOpenActivityGroups = (
+  groups: PersistedActivityGroup[] | undefined,
+  now: number
+): PersistedActivityGroup[] | undefined => {
+  const completed = groups
+    ?.filter((group) => group.completedAt !== undefined || group.activityIds.length > 0)
+    .map((group) =>
+      group.completedAt === undefined ? { ...group, completedAt: now, updatedAt: now } : group
+    )
+
+  return completed && completed.length > 0 ? completed : undefined
 }
 
 // Derives a compact default title from the first user message.
@@ -1136,6 +1162,10 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           return session
         }
 
+        const activeGroup = session.activityGroups?.findLast(
+          (group) => group.completedAt === undefined
+        )
+
         // New tool calls are transient activity rows, not persisted chat messages.
         const activity: ToolActivity = {
           id: toolCallId,
@@ -1144,6 +1174,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           status: nextStatus ?? 'pending',
           eventIds: [eventId],
           sortIndex: createSortIndex(),
+          activityGroupId: activeGroup?.id,
           providerToolName,
           toolKind,
           toolContent,
@@ -1160,10 +1191,77 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           ...session,
           status: getToolActivitySessionStatus(session),
           activities: [...activities, activity],
+          activityGroups: activeGroup
+            ? session.activityGroups?.map((group) =>
+                group.id === activeGroup.id
+                  ? {
+                      ...group,
+                      activityIds: [...group.activityIds, activity.id],
+                      updatedAt: now
+                    }
+                  : group
+              )
+            : session.activityGroups,
           updatedAt: now
         }
       })
     }))
+  },
+
+  beginActivityGroup: (sessionId, groupId, title) => {
+    const groupTitle = sanitizeActivityGroupTitle(title)
+    if (!sessionId || !groupId || !groupTitle) return
+
+    set((state) => ({
+      sessions: state.sessions.map((session) => {
+        if (session.id !== sessionId || !session.activeRun) return session
+        if (session.activityGroups?.some((group) => group.id === groupId)) return session
+
+        const now = Date.now()
+        const completedGroups = completeOpenActivityGroups(session.activityGroups, now) ?? []
+
+        return {
+          ...session,
+          activityGroups: [
+            ...completedGroups,
+            {
+              id: groupId,
+              title: groupTitle,
+              sortIndex: createSortIndex(),
+              activityIds: [],
+              createdAt: now,
+              updatedAt: now
+            }
+          ],
+          updatedAt: now
+        }
+      })
+    }))
+  },
+
+  completeActivityGroup: (sessionId) => {
+    if (!sessionId) return
+
+    const now = Date.now()
+    set((state) => {
+      const target = state.sessions.find((session) => session.id === sessionId)
+      const hasStartedOpenGroup = target?.activityGroups?.some(
+        (group) => group.completedAt === undefined && group.activityIds.length > 0
+      )
+      if (!hasStartedOpenGroup) return state
+
+      return {
+        sessions: state.sessions.map((session) =>
+          session.id === sessionId
+            ? {
+                ...session,
+                activityGroups: completeOpenActivityGroups(session.activityGroups, now),
+                updatedAt: now
+              }
+            : session
+        )
+      }
+    })
   },
 
   // Completes the active run and any streamed messages for the session.
@@ -1184,6 +1282,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           errorReportable: keepArtifactError ? session.errorReportable : undefined,
           messages: completeStreamingMessages(session.messages),
           activities: completeOpenActivities(session.activities),
+          activityGroups: completeOpenActivityGroups(session.activityGroups, Date.now()),
           updatedAt: Date.now()
         }
       })
@@ -1214,6 +1313,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               errorReportable,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
+              activityGroups: completeOpenActivityGroups(session.activityGroups, Date.now()),
               updatedAt: Date.now()
             }
           : session
@@ -1254,6 +1354,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               compacting: true,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
+              activityGroups: completeOpenActivityGroups(session.activityGroups, Date.now()),
               updatedAt: Date.now()
             }
           : session
@@ -1306,6 +1407,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               errorReportable: undefined,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
+              activityGroups: completeOpenActivityGroups(session.activityGroups, Date.now()),
               updatedAt: Date.now()
             }
           : session
@@ -1353,14 +1455,23 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         const hasFiles = removed.some(
           (message) => (message.uploads?.length ?? 0) > 0 || (message.artifactIds?.length ?? 0) > 0
         )
+        const activities = session.activities?.filter(
+          (activity) => activity.createdAt < cutMessage.createdAt
+        )
+        const retainedActivityIds = new Set(activities?.map((activity) => activity.id) ?? [])
+        const activityGroups = session.activityGroups
+          ?.map((group) => ({
+            ...group,
+            activityIds: group.activityIds.filter((id) => retainedActivityIds.has(id))
+          }))
+          .filter((group) => group.activityIds.length > 0)
 
         return {
           ...session,
           status: 'idle',
           messages: session.messages.slice(0, cutIndex),
-          activities: session.activities?.filter(
-            (activity) => activity.createdAt < cutMessage.createdAt
-          ),
+          activities,
+          activityGroups,
           activeRun: undefined,
           agentStatus: undefined,
           error: undefined,

--- a/src/shared/activity-groups.test.ts
+++ b/src/shared/activity-groups.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getActivityGroupTitleFromToolEvent,
+  isActivityGroupToolEvent,
+  sanitizeActivityGroupTitle
+} from './activity-groups'
+
+describe('activity group tool events', () => {
+  it.each([
+    'mcp__open-science-activity__begin_activity_group',
+    'open-science-activity_begin_activity_group',
+    'mcp__open_science_activity__begin_activity_group'
+  ])('recognizes framework tool identity %s', (providerToolName) => {
+    expect(isActivityGroupToolEvent({ providerToolName })).toBe(true)
+  })
+
+  it('extracts native and Codex-wrapped arguments', () => {
+    expect(
+      getActivityGroupTitleFromToolEvent({
+        providerToolName: 'mcp__open-science-activity__begin_activity_group',
+        rawInput: { title: 'Inspect the implementation.' }
+      })
+    ).toBe('Inspect the implementation')
+    expect(
+      getActivityGroupTitleFromToolEvent({
+        rawInput: {
+          server: 'open-science-activity',
+          tool: 'begin_activity_group',
+          arguments: { title: 'Apply the focused change' }
+        }
+      })
+    ).toBe('Apply the focused change')
+  })
+
+  it('does not trust a bare leaf name without a server-qualified identity', () => {
+    expect(isActivityGroupToolEvent({ providerToolName: 'begin_activity_group' })).toBe(false)
+    expect(
+      isActivityGroupToolEvent({
+        providerToolName: 'mcp__open-science-activity__begin_activity_group'
+      })
+    ).toBe(true)
+  })
+
+  it('bounds and normalizes titles', () => {
+    expect(sanitizeActivityGroupTitle(`Title: "${'x'.repeat(100)}."`)?.length).toBe(80)
+  })
+})

--- a/src/shared/activity-groups.test.ts
+++ b/src/shared/activity-groups.test.ts
@@ -10,7 +10,9 @@ describe('activity group tool events', () => {
   it.each([
     'mcp__open-science-activity__begin_activity_group',
     'open-science-activity_begin_activity_group',
-    'mcp__open_science_activity__begin_activity_group'
+    'mcp__open_science_activity__begin_activity_group',
+    'mcp.open-science-activity.begin_activity_group',
+    'open_science_activity_begin_activity_group'
   ])('recognizes framework tool identity %s', (providerToolName) => {
     expect(isActivityGroupToolEvent({ providerToolName })).toBe(true)
   })
@@ -44,5 +46,9 @@ describe('activity group tool events', () => {
 
   it('bounds and normalizes titles', () => {
     expect(sanitizeActivityGroupTitle(`Title: "${'x'.repeat(100)}."`)?.length).toBe(80)
+
+    const unicodeTitle = sanitizeActivityGroupTitle(`Title: "${'🌟'.repeat(100)}."`)
+    expect(unicodeTitle).toBe('🌟'.repeat(80))
+    expect(Array.from(unicodeTitle ?? '')).toHaveLength(80)
   })
 })

--- a/src/shared/activity-groups.ts
+++ b/src/shared/activity-groups.ts
@@ -1,0 +1,63 @@
+export const ACTIVITY_GROUP_MCP_SERVER_NAME = 'open-science-activity'
+export const BEGIN_ACTIVITY_GROUP_TOOL_NAME = 'begin_activity_group'
+export const MAX_ACTIVITY_GROUP_TITLE_LENGTH = 80
+
+type ActivityGroupToolEvent = {
+  title?: string
+  providerToolName?: string
+  rawInput?: unknown
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const ACTIVITY_GROUP_TOOL_NAMES = new Set([
+  `mcp__${ACTIVITY_GROUP_MCP_SERVER_NAME}__${BEGIN_ACTIVITY_GROUP_TOOL_NAME}`,
+  `mcp__${ACTIVITY_GROUP_MCP_SERVER_NAME.replaceAll('-', '_')}__${BEGIN_ACTIVITY_GROUP_TOOL_NAME}`,
+  `mcp.${ACTIVITY_GROUP_MCP_SERVER_NAME}.${BEGIN_ACTIVITY_GROUP_TOOL_NAME}`,
+  `${ACTIVITY_GROUP_MCP_SERVER_NAME}_${BEGIN_ACTIVITY_GROUP_TOOL_NAME}`,
+  `${ACTIVITY_GROUP_MCP_SERVER_NAME.replaceAll('-', '_')}_${BEGIN_ACTIVITY_GROUP_TOOL_NAME}`
+])
+
+export const sanitizeActivityGroupTitle = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined
+
+  const collapsed = value.replace(/\s+/gu, ' ').trim()
+  const withoutPrefix = collapsed.replace(/^title\s*:\s*/iu, '')
+  const withoutWrappingQuotes = withoutPrefix.replace(/^["'`“”‘’]+|["'`“”‘’]+$/gu, '')
+  const withoutTrailingPunctuation = withoutWrappingQuotes.replace(/[.!?。！？]+$/u, '').trim()
+
+  if (!withoutTrailingPunctuation) return undefined
+
+  return Array.from(withoutTrailingPunctuation)
+    .slice(0, MAX_ACTIVITY_GROUP_TITLE_LENGTH)
+    .join('')
+    .trim()
+}
+
+export const isActivityGroupToolEvent = (event: ActivityGroupToolEvent): boolean => {
+  const names = [event.providerToolName, event.title]
+    .map((value) => value?.trim().toLowerCase())
+    .filter((value): value is string => Boolean(value))
+
+  if (names.some((name) => ACTIVITY_GROUP_TOOL_NAMES.has(name))) return true
+  if (!isRecord(event.rawInput)) return false
+
+  return (
+    event.rawInput.server === ACTIVITY_GROUP_MCP_SERVER_NAME &&
+    event.rawInput.tool === BEGIN_ACTIVITY_GROUP_TOOL_NAME
+  )
+}
+
+export const getActivityGroupTitleFromToolEvent = (
+  event: ActivityGroupToolEvent
+): string | undefined => {
+  if (!isActivityGroupToolEvent(event) || !isRecord(event.rawInput)) return undefined
+
+  const input =
+    isRecord(event.rawInput.arguments) && event.rawInput.server === ACTIVITY_GROUP_MCP_SERVER_NAME
+      ? event.rawInput.arguments
+      : event.rawInput
+
+  return sanitizeActivityGroupTitle(input.title)
+}

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { MAX_ACP_SESSION_IMAGE_BYTES } from './acp'
 
 import {
+  sanitizeActivityGroup,
   normalizeSessionFile,
   sanitizeMessageImages,
   sanitizeToolActivity,
@@ -115,6 +116,7 @@ describe('sanitizeToolActivity', () => {
       id: 'tool-1',
       kind: 'tool',
       title: 'Edit app.ts',
+      activityGroupId: 'group-1',
       status: 'completed',
       sortIndex: 3,
       eventIds: ['event-1'],
@@ -134,6 +136,7 @@ describe('sanitizeToolActivity', () => {
       id: 'tool-1',
       kind: 'tool',
       title: 'Edit app.ts',
+      activityGroupId: 'group-1',
       status: 'completed',
       providerToolName: 'Edit',
       toolKind: 'edit',
@@ -175,6 +178,28 @@ describe('sanitizeToolActivity', () => {
 
   it('rejects entries without an id', () => {
     expect(sanitizeToolActivity({ status: 'completed' })).toBeUndefined()
+  })
+})
+
+describe('sanitizeActivityGroup', () => {
+  it('keeps a valid group declaration bounded and structured', () => {
+    expect(
+      sanitizeActivityGroup({
+        id: 'group-1',
+        title: 'Inspect the implementation.',
+        sortIndex: 4,
+        activityIds: ['tool-1'],
+        createdAt: 5,
+        updatedAt: 6
+      })
+    ).toEqual({
+      id: 'group-1',
+      title: 'Inspect the implementation',
+      sortIndex: 4,
+      activityIds: ['tool-1'],
+      createdAt: 5,
+      updatedAt: 6
+    })
   })
 })
 

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -12,6 +12,7 @@ import {
   type PermissionProfileId
 } from './permission-profiles'
 import type { AgentFrameworkId } from './settings'
+import { sanitizeActivityGroupTitle } from './activity-groups'
 
 // One JSON file per session (sessions/<projectId>/<sessionId>.json) carries this envelope version.
 export const SESSION_FILE_VERSION = 1
@@ -97,6 +98,7 @@ export type PersistedToolActivity = {
   id: string
   kind: 'tool'
   title: string
+  activityGroupId?: string
   status: PersistedToolActivityStatus
   sortIndex: number
   eventIds: string[]
@@ -111,6 +113,16 @@ export type PersistedToolActivity = {
   terminalExitCode?: number | null
   createdAt: number
   updatedAt: number
+}
+
+export type PersistedActivityGroup = {
+  id: string
+  title: string
+  sortIndex: number
+  activityIds: string[]
+  createdAt: number
+  updatedAt: number
+  completedAt?: number
 }
 
 export type PersistedChatSession = {
@@ -141,6 +153,7 @@ export type PersistedChatSession = {
   pinned?: boolean
   messages: PersistedChatMessage[]
   activities?: PersistedToolActivity[]
+  activityGroups?: PersistedActivityGroup[]
   activeRun?: PersistedActiveRun
   error?: string
   // Whether a failed run's error is worth a GitHub issue. False for a recognized failure (a provider/
@@ -483,6 +496,7 @@ export const sanitizeToolActivity = (activity: unknown): PersistedToolActivity |
     updatedAt: asNumber(activity.updatedAt) ?? 0
   }
   const providerToolName = asString(activity.providerToolName)
+  const activityGroupId = asString(activity.activityGroupId)
   const toolKind = asString(activity.toolKind)
   const toolContent = sanitizeToolContent(activity.toolContent)
   const toolLocations = sanitizeToolLocations(activity.toolLocations)
@@ -492,6 +506,7 @@ export const sanitizeToolActivity = (activity: unknown): PersistedToolActivity |
   const terminalExitCode = asNumber(activity.terminalExitCode)
 
   if (providerToolName) sanitized.providerToolName = providerToolName
+  if (activityGroupId) sanitized.activityGroupId = activityGroupId
   if (toolKind) sanitized.toolKind = toolKind
   if (toolContent) sanitized.toolContent = toolContent
   if (toolLocations) sanitized.toolLocations = toolLocations
@@ -508,6 +523,31 @@ const normalizeActivityAfterRestore = (activity: PersistedToolActivity): Persist
   activity.status === 'pending' || activity.status === 'in_progress'
     ? { ...activity, status: 'failed' }
     : activity
+
+export const sanitizeActivityGroup = (group: unknown): PersistedActivityGroup | undefined => {
+  if (!isRecord(group)) return undefined
+
+  const id = asString(group.id)
+  const title = sanitizeActivityGroupTitle(group.title)
+  if (!id || !title) return undefined
+
+  const updatedAt = asNumber(group.updatedAt) ?? 0
+  const completedAt = asNumber(group.completedAt)
+  return {
+    id,
+    title,
+    sortIndex: asNumber(group.sortIndex) ?? 0,
+    activityIds: asStringArray(group.activityIds),
+    createdAt: asNumber(group.createdAt) ?? 0,
+    updatedAt,
+    ...(completedAt === undefined ? {} : { completedAt })
+  }
+}
+
+const normalizeActivityGroupAfterRestore = (
+  group: PersistedActivityGroup
+): PersistedActivityGroup =>
+  group.completedAt === undefined ? { ...group, completedAt: group.updatedAt } : group
 
 // Rebuilds one structured mention segment, dropping malformed entries so the bubble stays renderable.
 const sanitizeMessagePart = (part: unknown): MessagePart | undefined => {
@@ -656,6 +696,12 @@ const sanitizeSession = (session: unknown): PersistedChatSession | undefined => 
         .filter((item): item is PersistedToolActivity => !!item)
         .map(normalizeActivityAfterRestore)
     : []
+  const activityGroups = Array.isArray(session.activityGroups)
+    ? session.activityGroups
+        .map(sanitizeActivityGroup)
+        .filter((item): item is PersistedActivityGroup => !!item)
+        .map(normalizeActivityGroupAfterRestore)
+    : []
   const sanitized: PersistedChatSession = {
     id,
     // Content value is a hint; the repository overrides it with the session file's directory on load.
@@ -704,6 +750,7 @@ const sanitizeSession = (session: unknown): PersistedChatSession | undefined => 
     sanitized.filesRevision = filesRevision
   }
   if (activities.length > 0) sanitized.activities = activities
+  if (activityGroups.length > 0) sanitized.activityGroups = activityGroups
   if (enabledComputeHosts.length > 0) sanitized.enabledComputeHosts = enabledComputeHosts
 
   return sanitizeSessionMessageImages(normalizeSessionAfterRestore(sanitized))


### PR DESCRIPTION
## Problem

Tool activity groups were titled from the mechanics of their individual calls, such as "Ran a notebook cell" or "Saved a file". This made a coherent group of steps hard to scan because the UI could not show why the agent was doing the work.

Generating a title after the tools run would require a separate model request, add latency and provider-specific request handling, and still infer intent after the fact. The agent already knows the purpose before it starts the group.

## Proposed change

- Add a declaration-only `begin_activity_group({ title })` MCP tool. The main agent calls it once before the first tool in each coherent group, not once per tool or step.
- Treat the declaration as control metadata: hide its start and terminal events, exclude it from the visible step count, and attach subsequent real tool activities to the declared group.
- Persist groups independently as `PersistedActivityGroup` records and render their declared titles after reload.
- Close the current group when started work is followed by assistant output, a new declaration, run completion, or failure. Prune declarations that never receive a real tool activity.
- Preserve legacy adjacent-tool grouping for sessions that have no declared group metadata.
- Supply the activity-group tool and instruction only to mainline ACP sessions. Reviewer sessions retain only their reviewer MCP scope and prompt.
- Support Claude Code, OpenCode, Codex native ACP, and the Codex Chat Completions bridge without making a separate external model request.

### Architecture

```mermaid
flowchart LR
  subgraph Mainline["Mainline ACP session"]
    Agent["Claude Code / OpenCode / Codex"]
    Prompt["Activity-group instruction"]
    MCP["open-science-activity MCP"]
    Bridge["Codex Chat Completions bridge schema"]
  end

  subgraph Runtime["Open Science runtime"]
    Events["ACP runtime events"]
    Filter["Control-event detection"]
  end

  subgraph Renderer["Renderer"]
    Store["Session store"]
    Persist["Session persistence"]
    UI["Activity-group UI"]
  end

  Prompt --> Agent
  MCP --> Agent
  Bridge --> Agent
  Agent --> Events --> Filter --> Store
  Store <--> Persist
  Store --> UI

  Reviewer["Reviewer ACP session"] -. "reviewer MCP only; no injection" .-> Agent
```

### Data flow

```mermaid
flowchart TD
  Declare["begin_activity_group with title"] --> Detect["Recognize server-qualified control event"]
  Detect --> Sanitize["Normalize and cap title at 80 Unicode code points"]
  Sanitize --> Group["Create open PersistedActivityGroup"]
  Detect --> Hide["Cache toolCallId and hide declaration updates"]
  Tool["Subsequent real tool event"] --> Attach["Set activityGroupId"]
  Group --> Attach
  Attach --> Persist["Persist group and activity references"]
  Persist --> Render["Render one title with N real steps"]
  Boundary["Assistant output / new declaration / stop / failure"] --> Close["Complete started group and prune empty declarations"]
  Close --> Persist
```

### Interaction

```mermaid
sequenceDiagram
  participant U as User
  participant A as Main agent
  participant G as Activity-group MCP
  participant R as ACP runtime
  participant S as Session store
  participant V as Workspace UI

  U->>A: Send turn
  A->>G: begin_activity_group(title)
  G-->>R: Declaration tool events
  R->>S: Begin group; suppress control row
  A->>R: Real tool call 1
  R->>S: Add activity with activityGroupId
  A->>R: Real tool call 2
  R->>S: Add activity with same activityGroupId
  S-->>V: Show declared title and 2 steps
  A->>R: Assistant output or run stop
  R->>S: Complete group
```

## Scope and non-goals

- This names a coherent tool group, not every tool call or individual step.
- This does not generate titles after execution and does not add an external LLM request, provider setting, or background ACP session.
- This does not inject activity-group tooling or instructions into reviewer sessions.
- This does not change individual tool-row labels.
- This does not rewrite legacy sessions; they continue to use mechanical adjacent-tool grouping when group metadata is absent.

## Acceptance criteria and validation

- A valid declaration precedes each coherent tool group and can split multiple groups within one turn.
- Narration before the first real tool does not discard the declaration.
- Declaration events are invisible and do not count toward `N steps`, including sparse terminal updates that omit tool identity.
- Titles are normalized and capped at 80 Unicode code points.
- Groups and activity references survive save, hydration, edited-resend truncation, stop, and failure paths.
- Automatic permission approval requires server-qualified activity-tool identity; a bare `begin_activity_group` name is not trusted.
- Claude Code, OpenCode, Codex native ACP, and the Codex Chat Completions bridge expose the declaration path to mainline sessions.
- Reviewer sessions remain isolated from the activity tool and instruction.
- `npm run test` (5,933 passed, 83 skipped; 448 files passed, 9 skipped)
- `npm run typecheck`
- `npm run check:web-api-map`
- `npm run lint` (0 errors; 56 pre-existing warnings)
- `git diff --check`

## Review focus

- Mainline-versus-reviewer session scoping for MCP tools, prompt injection, and bridge schemas.
- Control-event identification, permission handling, and suppression of all declaration updates.
- Group lifecycle boundaries, empty-group pruning, persistence compatibility, and legacy fallback rendering.

Closes #384
