### PR TITLE
feat(window): remember close action preference

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -139,7 +139,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       // can reach them. It only wraps ipcMain.handle — no server, no cost until something serves.
       const rpcCapture = installRpcCapture(ipcMain)
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
-      const { runtime, notebook, shutdownCoordinator, taskNotifications } =
+      const { runtime, notebook, shutdownCoordinator, taskNotifications, settingsService } =
         await registerIpcHandlers({
           mainEntryPath,
           headless: webMode.headless
@@ -161,9 +161,16 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         routeSecondInstance,
         shutdownCoordinator,
         taskNotifications,
+        settingsService,
         // Running-work snapshot + confirm coordinator, bound here where runtime/notebook are in scope.
         detectActiveSessions: () => computeActiveSessions({ runtime, notebook }),
-        createConfirmClose: createElectronCloseConfirm,
+        createConfirmClose: (getWindow: () => InstanceType<typeof BrowserWindow> | undefined) =>
+          createElectronCloseConfirm(getWindow, {
+            get: () => settingsService.getClosePreference(),
+            set: async (preference) => {
+              await settingsService.setClosePreference(preference)
+            }
+          }),
         installAppLifecycle,
         log,
         webMode,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -152,6 +152,7 @@ const registerIpcHandlers = async ({
   notebook: ReturnType<typeof createDefaultNotebookRuntimeService>
   shutdownCoordinator: BackendShutdownCoordinator
   taskNotifications: TaskNotificationService
+  settingsService: SettingsService
 }> => {
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
   const settingsService = createDefaultSettingsService()
@@ -627,7 +628,13 @@ const registerIpcHandlers = async ({
 
   // Return the long-lived backend handles so the app lifecycle (before-quit) can shut them down
   // cleanly on quit — the agent process tree and every notebook kernel.
-  return { runtime, notebook: notebookService, shutdownCoordinator, taskNotifications }
+  return {
+    runtime,
+    notebook: notebookService,
+    shutdownCoordinator,
+    taskNotifications,
+    settingsService
+  }
 }
 
 export { registerIpcHandlers }

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -36,6 +36,7 @@ type FakeSettingsService = Record<
   | 'setAgentFramework'
   | 'setReasoningEffort'
   | 'setNotificationsEnabled'
+  | 'setClosePreference'
   | 'upsertProvider'
   | 'deleteProvider'
   | 'setActiveProvider'
@@ -92,6 +93,9 @@ const createFakeService = (): FakeSettingsService => ({
   setNotificationsEnabled: vi
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], notificationsEnabled: false }),
+  setClosePreference: vi
+    .fn()
+    .mockResolvedValue({ claude: {}, providers: [], closePreference: 'quit' }),
   upsertProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
   deleteProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
   setActiveProvider: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
@@ -660,6 +664,21 @@ describe('settings IPC handlers', () => {
       'Invalid notifications-enabled flag'
     )
     expect(service.setNotificationsEnabled).not.toHaveBeenCalled()
+  })
+
+  it('persists valid close preferences and rejects unknown values', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    registerSettingsIpcHandlers({ service: asService(service) })
+
+    await invoke('settings:set-close-preference', { preference: 'quit' })
+    await invoke('settings:set-close-preference', {})
+
+    expect(service.setClosePreference).toHaveBeenNthCalledWith(1, 'quit')
+    expect(service.setClosePreference).toHaveBeenNthCalledWith(2, undefined)
+    await expect(invoke('settings:set-close-preference', { preference: 'close' })).rejects.toThrow(
+      'Invalid close preference'
+    )
   })
 
   it('surfaces a service error thrown by install-opencode', async () => {

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -31,6 +31,7 @@ import {
   type SetConnectorEnabledRequest,
   type SetNcbiCredentialsRequest,
   type SetPackageMirrorRequest,
+  type SetClosePreferenceRequest,
   type SetNotificationsEnabledRequest,
   type SetReasoningEffortRequest,
   type SetSkillEnabledRequest,
@@ -221,6 +222,18 @@ const registerSettingsIpcHandlers = ({
 
       log.info('set notifications enabled requested', { enabled: request.enabled })
       return service.setNotificationsEnabled(request.enabled)
+    }
+  )
+  ipcMain.handle(
+    'settings:set-close-preference',
+    async (_event, request: SetClosePreferenceRequest) => {
+      const preference = request?.preference
+      if (preference !== undefined && preference !== 'minimize' && preference !== 'quit') {
+        throw new Error(`Invalid close preference: ${String(preference)}`)
+      }
+
+      log.info('set close preference requested', { preference: preference ?? 'ask' })
+      return service.setClosePreference(preference)
     }
   )
   ipcMain.handle('settings:validate-provider', (_event, request: ValidateProviderRequest) =>

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -156,6 +156,18 @@ describe('settings repository', () => {
     expect(sanitizeSettings({}).notificationsEnabled).toBeUndefined()
   })
 
+  it('persists, sanitizes, and clears the close action preference', async () => {
+    const root = await createStorageRoot()
+    const repository = new SettingsRepository(root)
+
+    await repository.setClosePreference('minimize')
+    expect((await new SettingsRepository(root).getSettings()).closePreference).toBe('minimize')
+    expect(sanitizeSettings({ closePreference: 'invalid' }).closePreference).toBeUndefined()
+
+    await repository.setClosePreference(undefined)
+    expect((await repository.getSettings()).closePreference).toBeUndefined()
+  })
+
   it('persists the Codex adapter and paired native runtime across a sanitized read', async () => {
     const repository = new SettingsRepository(await createStorageRoot())
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -24,6 +24,7 @@ import { isOfficialVendorId } from '../../shared/provider-registry'
 import type { PackageMirror } from '../../shared/mirror'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
+import type { CloseActionPreference } from '../../shared/window-controls'
 import { createLogger } from '../logger'
 import {
   createEmptySettings,
@@ -470,6 +471,12 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
     settings.notificationsEnabled = notificationsEnabled
   }
 
+  const closePreference = asString(value.closePreference)
+
+  if (closePreference === 'minimize' || closePreference === 'quit') {
+    settings.closePreference = closePreference
+  }
+
   const opencodePath = asString(value.opencodePath)
 
   if (opencodePath) {
@@ -748,6 +755,11 @@ class SettingsRepository {
   // immediately, without a restart.
   async setNotificationsEnabled(enabled: boolean): Promise<StoredSettings> {
     return this.mutate((settings) => ({ ...settings, notificationsEnabled: enabled }))
+  }
+
+  // Persists the Windows titlebar-close behavior; undefined restores the confirmation dialog.
+  async setClosePreference(preference: CloseActionPreference | undefined): Promise<StoredSettings> {
+    return this.mutate((settings) => ({ ...settings, closePreference: preference }))
   }
 
   // Records the detected opencode executable path + version for later spawns + the settings status card.

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3039,6 +3039,21 @@ describe('SettingsService: notifications preference', () => {
   })
 })
 
+describe('SettingsService: close preference', () => {
+  it('projects, persists, and resets the Windows titlebar-close behavior', async () => {
+    const service = createService()
+
+    expect(await service.getClosePreference()).toBeUndefined()
+
+    const saved = await service.setClosePreference('quit')
+    expect(saved.closePreference).toBe('quit')
+    expect(await service.getClosePreference()).toBe('quit')
+
+    const reset = await service.setClosePreference(undefined)
+    expect(reset.closePreference).toBeUndefined()
+  })
+})
+
 describe('SettingsService: listAgentHomeSkills framework routing', () => {
   // The agent-home skill import is framework-agnostic: claude-code scans `~/.claude/skills/`,
   // codex scans `~/.codex/skills/`, and opencode (which has no global skills convention) returns

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -8,6 +8,8 @@ import { promisify } from 'node:util'
 
 import { z } from 'zod'
 
+import type { CloseActionPreference } from '../../shared/window-controls'
+
 import type {
   ClaudeDetectResult,
   ClaudeInstallEvent,
@@ -553,6 +555,7 @@ class SettingsService {
       packageMirror: settings.packageMirror,
       reasoningEffort: settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
       notificationsEnabled: settings.notificationsEnabled ?? DEFAULT_NOTIFICATIONS_ENABLED,
+      closePreference: settings.closePreference,
       agentFrameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
       agentFrameworks: listAgentFrameworks().map((framework) => ({
         id: framework.id,
@@ -719,6 +722,18 @@ class SettingsService {
   // Sets the desktop-notification preference and returns the refreshed snapshot for the renderer.
   async setNotificationsEnabled(enabled: boolean): Promise<SettingsSnapshot> {
     await this.repository.setNotificationsEnabled(enabled)
+
+    return this.getSettingsView()
+  }
+
+  async getClosePreference(): Promise<CloseActionPreference | undefined> {
+    return (await this.repository.getSettings()).closePreference
+  }
+
+  async setClosePreference(
+    preference: CloseActionPreference | undefined
+  ): Promise<SettingsSnapshot> {
+    await this.repository.setClosePreference(preference)
 
     return this.getSettingsView()
   }

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -11,6 +11,7 @@ import type { OfficialVendorId } from '../../shared/provider-registry'
 import type { PackageMirror } from '../../shared/mirror'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
+import type { CloseActionPreference } from '../../shared/window-controls'
 import type { AgentFrameworkId } from '../agent-framework'
 
 // Main-process-only stored shapes for settings.json. These carry the encrypted key reference and a
@@ -106,6 +107,8 @@ export type StoredSettings = {
   reasoningEffort?: ReasoningEffort
   // Desktop-notification preference for finished/failed agent tasks. Absent means enabled.
   notificationsEnabled?: boolean
+  // Windows titlebar-close behavior. Absent means ask every time.
+  closePreference?: CloseActionPreference
   // Detected opencode executable path + reported version (for the status card). Absent = detect on PATH.
   opencodePath?: string
   opencodeVersion?: string

--- a/src/main/window-close-confirm.test.ts
+++ b/src/main/window-close-confirm.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ActiveSessionInfo } from '../shared/storage'
-import type {
-  CloseConfirmChoice,
-  CloseConfirmRequest,
-  CloseConfirmResponse
-} from '../shared/window-controls'
-import { createCloseConfirm, type CloseConfirmDeps } from './window-close-confirm'
+import type { CloseConfirmRequest, CloseConfirmResponse } from '../shared/window-controls'
+import {
+  createCloseConfirm,
+  type CloseConfirmDeps,
+  type NativeCloseConfirmResult
+} from './window-close-confirm'
 
 const session: ActiveSessionInfo = {
   projectId: 'my-analysis',
@@ -21,6 +21,7 @@ const makeHarness = (
   confirm: ReturnType<typeof createCloseConfirm>
   sent: CloseConfirmRequest[]
   nativeFallback: ReturnType<typeof vi.fn>
+  setClosePreference: ReturnType<typeof vi.fn>
   ack: () => void
   choose: (choice: CloseConfirmResponse['choice']) => void
   reply: (payload: CloseConfirmResponse) => void
@@ -32,7 +33,8 @@ const makeHarness = (
   let goneCb: (() => void) | undefined
   let hangCbs: { onHang: () => void; onRecover: () => void } | undefined
   const sent: CloseConfirmRequest[] = []
-  const nativeFallback = vi.fn(async (): Promise<CloseConfirmChoice> => 'quit')
+  const nativeFallback = vi.fn(async (): Promise<NativeCloseConfirmResult> => ({ choice: 'quit' }))
+  const setClosePreference = vi.fn(async () => undefined)
   const deps: CloseConfirmDeps = {
     send: (payload) => sent.push(payload),
     onResponse: (cb) => {
@@ -55,6 +57,8 @@ const makeHarness = (
       }
     },
     nativeFallback,
+    getClosePreference: async () => undefined,
+    setClosePreference,
     newRequestId: () => 'req-1',
     ackTimeoutMs: 10,
     hangGraceMs: 10,
@@ -64,6 +68,7 @@ const makeHarness = (
     confirm: createCloseConfirm(deps),
     sent,
     nativeFallback,
+    setClosePreference,
     ack: () => responder?.({ requestId: 'req-1', ack: true }),
     choose: (choice: CloseConfirmResponse['choice']) => responder?.({ requestId: 'req-1', choice }),
     reply: (payload: CloseConfirmResponse) => responder?.(payload),
@@ -75,6 +80,10 @@ const makeHarness = (
 
 // Resolves after `ms` real milliseconds so a test can outlast a short ackTimeoutMs/hangGraceMs timer.
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+const flushPreferenceRead = async (): Promise<void> => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
 
 describe('createCloseConfirm', () => {
   it('resolves quit immediately for the quit variant with no running work (no IPC)', async () => {
@@ -86,15 +95,60 @@ describe('createCloseConfirm', () => {
   it('sends a request and resolves the renderer choice', async () => {
     const h = makeHarness()
     const pending = h.confirm('close-to-tray', [session])
+    await flushPreferenceRead()
     h.ack()
     h.choose('minimize')
     await expect(pending).resolves.toBe('minimize')
     expect(h.sent[0]).toMatchObject({ variant: 'close-to-tray', sessions: [session] })
   })
 
+  it('persists a remembered close-to-tray choice before resolving it', async () => {
+    const h = makeHarness()
+    const pending = h.confirm('close-to-tray', [session])
+    await flushPreferenceRead()
+    h.ack()
+    h.reply({ requestId: 'req-1', choice: 'minimize', remember: true })
+
+    await expect(pending).resolves.toBe('minimize')
+    expect(h.setClosePreference).toHaveBeenCalledWith('minimize')
+  })
+
+  it('uses a saved close-to-tray preference without showing the dialog', async () => {
+    const h = makeHarness({ getClosePreference: async () => 'quit' })
+
+    await expect(h.confirm('close-to-tray', [session])).resolves.toBe('quit')
+    expect(h.sent).toHaveLength(0)
+  })
+
+  it('shows the dialog when reading the saved preference fails', async () => {
+    const h = makeHarness({
+      getClosePreference: async () => {
+        throw new Error('settings unavailable')
+      }
+    })
+    const pending = h.confirm('close-to-tray', [session])
+    await flushPreferenceRead()
+    h.ack()
+    h.choose('minimize')
+
+    await expect(pending).resolves.toBe('minimize')
+    expect(h.sent).toHaveLength(1)
+  })
+
+  it('still confirms an explicit quit with running work when a close preference is saved', async () => {
+    const h = makeHarness({ getClosePreference: async () => 'quit' })
+    const pending = h.confirm('quit', [session])
+    h.ack()
+    h.choose('cancel')
+
+    await expect(pending).resolves.toBe('cancel')
+    expect(h.sent[0]).toMatchObject({ variant: 'quit', sessions: [session] })
+  })
+
   it('ignores a stale response with a mismatched requestId', async () => {
     const h = makeHarness()
     const pending = h.confirm('close-to-tray', [session])
+    await flushPreferenceRead()
     h.ack()
     h.reply({ requestId: 'other', choice: 'quit' })
     h.choose('cancel')
@@ -114,9 +168,20 @@ describe('createCloseConfirm', () => {
     expect(h.nativeFallback).toHaveBeenCalledWith('close-to-tray')
   })
 
+  it('persists a remembered choice from the native fallback', async () => {
+    const h = makeHarness({
+      isRendererAvailable: () => false,
+      nativeFallback: async () => ({ choice: 'minimize', remember: true })
+    })
+
+    await expect(h.confirm('close-to-tray', [session])).resolves.toBe('minimize')
+    expect(h.setClosePreference).toHaveBeenCalledWith('minimize')
+  })
+
   it('falls back once when the render process dies mid-modal', async () => {
     const h = makeHarness({ ackTimeoutMs: 10_000 })
     const pending = h.confirm('quit', [session])
+    await flushPreferenceRead()
     h.ack()
     h.fireGone()
     await expect(pending).resolves.toBe('quit')
@@ -126,7 +191,7 @@ describe('createCloseConfirm', () => {
   it('still settles when the native fallback rejects (never strands the confirm)', async () => {
     // A stranded promise would pin the caller's in-flight guard forever and block quit. If the native
     // dialog rejects (e.g. the window was destroyed), quit proceeds and close-to-tray stays resident.
-    const rejecting = vi.fn(async (): Promise<CloseConfirmChoice> => {
+    const rejecting = vi.fn(async (): Promise<NativeCloseConfirmResult> => {
       throw new Error('dialog failed')
     })
     const quitHarness = makeHarness({ isRendererAvailable: () => false, nativeFallback: rejecting })
@@ -136,9 +201,24 @@ describe('createCloseConfirm', () => {
     await expect(trayHarness.confirm('close-to-tray', [session])).resolves.toBe('minimize')
   })
 
+  it('still resolves the choice when saving a remembered preference fails', async () => {
+    const setClosePreference = vi.fn(async () => {
+      throw new Error('settings unavailable')
+    })
+    const h = makeHarness({ setClosePreference })
+    const pending = h.confirm('close-to-tray', [session])
+    await flushPreferenceRead()
+    h.ack()
+    h.reply({ requestId: 'req-1', choice: 'quit', remember: true })
+
+    await expect(pending).resolves.toBe('quit')
+    expect(setClosePreference).toHaveBeenCalledWith('quit')
+  })
+
   it('falls back after the grace period when an ACKed modal stays unresponsive', async () => {
     const h = makeHarness({ ackTimeoutMs: 10_000, hangGraceMs: 10 })
     const pending = h.confirm('quit', [session])
+    await flushPreferenceRead()
     h.ack()
     h.fireHang()
     // The grace timer is armed but hasn't elapsed yet, so no fallback has fired.
@@ -150,6 +230,7 @@ describe('createCloseConfirm', () => {
   it('does not fall back when a hung modal becomes responsive again before the grace elapses', async () => {
     const h = makeHarness({ ackTimeoutMs: 10_000, hangGraceMs: 10 })
     const pending = h.confirm('quit', [session])
+    await flushPreferenceRead()
     h.ack()
     h.fireHang()
     h.fireRecover()
@@ -162,6 +243,7 @@ describe('createCloseConfirm', () => {
   it('ignores a hang before ack: the ack timer still owns the pre-ack window', async () => {
     const h = makeHarness({ ackTimeoutMs: 10, hangGraceMs: 10_000 })
     const pending = h.confirm('quit', [session])
+    await flushPreferenceRead()
     h.fireHang() // pre-ack: must not arm the (10s) hang timer
     await expect(pending).resolves.toBe('quit') // resolved by the 10ms ack timeout, not the hang path
     expect(h.nativeFallback).toHaveBeenCalledTimes(1)

--- a/src/main/window-close-confirm.ts
+++ b/src/main/window-close-confirm.ts
@@ -5,11 +5,17 @@ import type { ActiveSessionInfo } from '../shared/storage'
 import {
   WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL,
   WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL,
+  type CloseActionPreference,
   type CloseConfirmChoice,
   type CloseConfirmRequest,
   type CloseConfirmResponse,
   type CloseConfirmVariant
 } from '../shared/window-controls'
+
+export type NativeCloseConfirmResult = {
+  choice: CloseConfirmChoice
+  remember?: boolean
+}
 
 // Structural (Electron-free) plumbing so the coordinator is unit-testable; the Electron glue that
 // satisfies this is createElectronCloseConfirm below.
@@ -29,13 +35,21 @@ export type CloseConfirmDeps = {
   onRendererUnresponsive?: (cbs: { onHang: () => void; onRecover: () => void }) => () => void
   // Native fallback when the renderer can't answer (dead/hung, or no window at all). May reject;
   // the coordinator wraps it so a rejection never leaves the confirm unsettled.
-  nativeFallback: (variant: CloseConfirmVariant) => Promise<CloseConfirmChoice>
+  nativeFallback: (variant: CloseConfirmVariant) => Promise<NativeCloseConfirmResult>
+  // Read/write the saved Windows titlebar-close behavior. Persistence failures fall back to asking.
+  getClosePreference: () => Promise<CloseActionPreference | undefined>
+  setClosePreference: (preference: CloseActionPreference) => Promise<void>
   newRequestId: () => string
   // Grace period for the modal-mounted ack before falling back. Defaults to 500ms.
   ackTimeoutMs?: number
   // Grace period after an ACKed modal goes 'unresponsive' before falling back. Defaults to 10s so a
   // brief hang the renderer recovers from doesn't yank the modal out from under the user.
   hangGraceMs?: number
+}
+
+export type ClosePreferenceAccess = {
+  get: () => Promise<CloseActionPreference | undefined>
+  set: (preference: CloseActionPreference) => Promise<void>
 }
 
 const DEFAULT_ACK_TIMEOUT_MS = 500
@@ -53,14 +67,35 @@ export const createCloseConfirm = (
   const ackTimeoutMs = deps.ackTimeoutMs ?? DEFAULT_ACK_TIMEOUT_MS
   const hangGraceMs = deps.hangGraceMs ?? DEFAULT_HANG_GRACE_MS
 
-  return (variant, sessions) => {
-    if (variant === 'quit' && sessions.length === 0) return Promise.resolve('quit')
+  return async (variant, sessions) => {
+    if (variant === 'quit' && sessions.length === 0) return 'quit'
+
+    if (variant === 'close-to-tray') {
+      const preference = await deps.getClosePreference().catch(() => undefined)
+      if (preference) return preference
+    }
+
+    const persistPreference = async (
+      choice: CloseConfirmChoice,
+      remember = false
+    ): Promise<void> => {
+      if (variant === 'close-to-tray' && remember && (choice === 'minimize' || choice === 'quit')) {
+        await deps.setClosePreference(choice).catch(() => undefined)
+      }
+    }
 
     // Never let a fallback rejection leave the confirm unsettled: a stranded promise would pin the
     // caller's in-flight guard forever and permanently block quit. On failure, keep the app resident
     // for close-to-tray and proceed for quit.
-    const safeFallback = (): Promise<CloseConfirmChoice> =>
-      deps.nativeFallback(variant).catch(() => (variant === 'quit' ? 'quit' : 'minimize'))
+    const safeFallback = async (): Promise<CloseConfirmChoice> => {
+      try {
+        const result = await deps.nativeFallback(variant)
+        await persistPreference(result.choice, result.remember)
+        return result.choice
+      } catch {
+        return variant === 'quit' ? 'quit' : 'minimize'
+      }
+    }
 
     if (!deps.isRendererAvailable()) return safeFallback()
 
@@ -72,7 +107,7 @@ export const createCloseConfirm = (
       let fallbackStarted = false
       let hangTimer: ReturnType<typeof setTimeout> | undefined
 
-      const finish = (choice: CloseConfirmChoice): void => {
+      const finish = (choice: CloseConfirmChoice, remember = false): void => {
         if (settled) return
         settled = true
         clearTimeout(ackTimer)
@@ -80,7 +115,7 @@ export const createCloseConfirm = (
         offResponse()
         offGone()
         offHang?.()
-        resolve(choice)
+        void persistPreference(choice, remember).then(() => resolve(choice))
       }
 
       // Known limitation (cosmetic): when a fallback settles the confirm, a modal the renderer had
@@ -103,7 +138,7 @@ export const createCloseConfirm = (
           clearTimeout(ackTimer)
           return
         }
-        if (payload.choice) finish(payload.choice)
+        if (payload.choice) finish(payload.choice, payload.remember)
       })
 
       const offGone = deps.onRenderGone(startFallback)
@@ -138,7 +173,7 @@ export const createCloseConfirm = (
 const nativeFallback = async (
   getWindow: () => BrowserWindow | undefined,
   variant: CloseConfirmVariant
-): Promise<CloseConfirmChoice> => {
+): Promise<NativeCloseConfirmResult> => {
   const options =
     variant === 'quit'
       ? {
@@ -157,21 +192,27 @@ const nativeFallback = async (
           cancelId: 0,
           title: 'Open Science',
           message: 'Minimize to tray or quit?',
-          detail: 'Background work may still be running.'
+          detail: 'Background work may still be running.',
+          checkboxLabel: "Don't ask again",
+          checkboxChecked: true
         }
   const window = getWindow()
-  const { response } =
+  const { response, checkboxChecked } =
     window && !window.isDestroyed()
       ? await dialog.showMessageBox(window, options)
       : await dialog.showMessageBox(options)
-  if (variant === 'quit') return response === 1 ? 'quit' : 'cancel'
-  return response === 1 ? 'quit' : 'minimize'
+  if (variant === 'quit') return { choice: response === 1 ? 'quit' : 'cancel' }
+  return {
+    choice: response === 1 ? 'quit' : 'minimize',
+    remember: checkboxChecked
+  }
 }
 
 // Wires createCloseConfirm to Electron IPC + the current main window (via getWindow, since the window
 // can be recreated). Response listeners are per-confirm and removed when it settles.
 export const createElectronCloseConfirm = (
-  getWindow: () => BrowserWindow | undefined
+  getWindow: () => BrowserWindow | undefined,
+  preferences: ClosePreferenceAccess
 ): ((variant: CloseConfirmVariant, sessions: ActiveSessionInfo[]) => Promise<CloseConfirmChoice>) =>
   createCloseConfirm({
     // Reveal the window before asking: a tray/Ctrl+Q quit can arrive while the window is hidden
@@ -211,5 +252,7 @@ export const createElectronCloseConfirm = (
       }
     },
     nativeFallback: (variant) => nativeFallback(getWindow, variant),
+    getClosePreference: preferences.get,
+    setClosePreference: preferences.set,
     newRequestId: () => randomUUID()
   })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -121,6 +121,7 @@ import type {
   SetPackageMirrorRequest,
   SetAgentFrameworkRequest,
   SetNotificationsEnabledRequest,
+  SetClosePreferenceRequest,
   SetReasoningEffortRequest,
   SetSkillEnabledRequest,
   SettingsSnapshot,
@@ -242,6 +243,7 @@ interface OpenScienceAPI {
     setAgentFramework(request: SetAgentFrameworkRequest): Promise<SettingsSnapshot>
     setReasoningEffort(request: SetReasoningEffortRequest): Promise<SettingsSnapshot>
     setNotificationsEnabled(request: SetNotificationsEnabledRequest): Promise<SettingsSnapshot>
+    setClosePreference(request: SetClosePreferenceRequest): Promise<SettingsSnapshot>
     validateProvider(request: ValidateProviderRequest): Promise<ValidateProviderResult>
     cancelCodexLogin(): Promise<void>
     loginIsolatedCodex(): Promise<ValidateProviderResult>
@@ -521,9 +523,9 @@ interface OpenScienceAPI {
     // Fires when Cmd+W / Ctrl+W is pressed; the renderer decides pane-vs-window.
     onCloseActivePane(listener: () => void): RemoveListener
     // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
-    onCloseConfirmRequest(listener: (payload: CloseConfirmRequest) => void): RemoveListener
+    onCloseConfirmRequest?(listener: (payload: CloseConfirmRequest) => void): RemoveListener
     // Renderer -> main: modal-mounted ack, then the user's choice, keyed by requestId.
-    sendCloseConfirmResponse(payload: CloseConfirmResponse): void
+    sendCloseConfirmResponse?(payload: CloseConfirmResponse): void
   }
 }
 

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -44,6 +44,7 @@ type PreloadApi = {
     installCodex: (request: unknown) => unknown
     setAgentFramework: (request: unknown) => unknown
     setNotificationsEnabled: (request: unknown) => unknown
+    setClosePreference: (request: unknown) => unknown
     uninstallClaude: () => unknown
     uninstallOpencode: () => unknown
     uninstallCodex: () => unknown
@@ -167,6 +168,12 @@ const cases: ForwardingCase[] = [
     invoke: (a) => a.settings.setNotificationsEnabled({ enabled: false }),
     channel: 'settings:set-notifications-enabled',
     args: [{ enabled: false }]
+  },
+  {
+    name: 'settings.setClosePreference → settings:set-close-preference',
+    invoke: (a) => a.settings.setClosePreference({ preference: 'minimize' }),
+    channel: 'settings:set-close-preference',
+    args: [{ preference: 'minimize' }]
   },
   {
     name: 'settings.uninstallClaude → settings:uninstall-claude (no args)',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -123,6 +123,7 @@ import type {
   SetPackageMirrorRequest,
   SetAgentFrameworkRequest,
   SetNotificationsEnabledRequest,
+  SetClosePreferenceRequest,
   SetReasoningEffortRequest,
   SetSkillEnabledRequest,
   SettingsSnapshot,
@@ -267,6 +268,7 @@ type OpenScienceAPI = {
     setAgentFramework: (request: SetAgentFrameworkRequest) => Promise<SettingsSnapshot>
     setReasoningEffort: (request: SetReasoningEffortRequest) => Promise<SettingsSnapshot>
     setNotificationsEnabled: (request: SetNotificationsEnabledRequest) => Promise<SettingsSnapshot>
+    setClosePreference: (request: SetClosePreferenceRequest) => Promise<SettingsSnapshot>
     validateProvider: (request: ValidateProviderRequest) => Promise<ValidateProviderResult>
     cancelCodexLogin: () => Promise<void>
     loginIsolatedCodex: () => Promise<ValidateProviderResult>
@@ -561,9 +563,9 @@ type OpenScienceAPI = {
     // Fires when Cmd+W / Ctrl+W is pressed; the renderer decides pane-vs-window.
     onCloseActivePane: (listener: () => void) => RemoveListener
     // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
-    onCloseConfirmRequest: (listener: (payload: CloseConfirmRequest) => void) => RemoveListener
+    onCloseConfirmRequest?: (listener: (payload: CloseConfirmRequest) => void) => RemoveListener
     // Renderer -> main: modal-mounted ack, then the user's choice, keyed by requestId.
-    sendCloseConfirmResponse: (payload: CloseConfirmResponse) => void
+    sendCloseConfirmResponse?: (payload: CloseConfirmResponse) => void
   }
 }
 
@@ -663,6 +665,8 @@ const api: OpenScienceAPI = {
         'settings:set-notifications-enabled',
         request
       ) as Promise<SettingsSnapshot>,
+    setClosePreference: (request) =>
+      ipcRenderer.invoke('settings:set-close-preference', request) as Promise<SettingsSnapshot>,
     validateProvider: (request) =>
       ipcRenderer.invoke('settings:validate-provider', request) as Promise<ValidateProviderResult>,
     cancelCodexLogin: () => ipcRenderer.invoke('settings:cancel-codex-login') as Promise<void>,

--- a/src/renderer/src/components/CloseConfirmModal.render.test.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.render.test.tsx
@@ -126,14 +126,38 @@ describe('CloseConfirmModal', () => {
     expect(sendResponse).toHaveBeenCalledWith({ requestId: 'r4', choice: 'cancel' })
   })
 
-  it('replies quit / minimize from the close-to-tray buttons', async () => {
+  it('defaults to remembering the close-to-tray choice', async () => {
     render()
     act(() => {
       emit({ requestId: 'r2', variant: 'close-to-tray', sessions: [] })
     })
+    const remember = document.body.querySelector<HTMLInputElement>('input[type="checkbox"]')
+    expect(remember?.checked).toBe(true)
+
     const minimizeButton = await findButtonByName(/minimize to tray/i)
     act(() => minimizeButton.click())
-    expect(sendResponse).toHaveBeenCalledWith({ requestId: 'r2', choice: 'minimize' })
+    expect(sendResponse).toHaveBeenCalledWith({
+      requestId: 'r2',
+      choice: 'minimize',
+      remember: true
+    })
+  })
+
+  it('does not remember the choice after the checkbox is cleared', async () => {
+    render()
+    act(() => {
+      emit({ requestId: 'r5', variant: 'close-to-tray', sessions: [] })
+    })
+    const remember = document.body.querySelector<HTMLInputElement>('input[type="checkbox"]')
+    act(() => remember?.click())
+
+    const quitButton = await findButtonByName(/^quit$/i)
+    act(() => quitButton.click())
+    expect(sendResponse).toHaveBeenCalledWith({
+      requestId: 'r5',
+      choice: 'quit',
+      remember: false
+    })
   })
 
   it('replies quit / cancel from the quit variant buttons', async () => {

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -23,19 +23,25 @@ type ActiveRequest = {
 // only), so every call into window.api.window here must tolerate that absence.
 export const CloseConfirmModal = (): React.JSX.Element | null => {
   const [request, setRequest] = useState<ActiveRequest | undefined>(undefined)
+  const [remember, setRemember] = useState(true)
 
   useEffect(() => {
     const windowApi = window.api.window
     if (!windowApi.onCloseConfirmRequest) return undefined
     return windowApi.onCloseConfirmRequest((payload: CloseConfirmRequest) => {
       windowApi.sendCloseConfirmResponse?.({ requestId: payload.requestId, ack: true })
+      setRemember(true)
       setRequest(payload)
     })
   }, [])
 
   const reply = (choice: CloseConfirmChoice): void => {
     if (request) {
-      window.api.window.sendCloseConfirmResponse?.({ requestId: request.requestId, choice })
+      window.api.window.sendCloseConfirmResponse?.({
+        requestId: request.requestId,
+        choice,
+        ...(request.variant === 'close-to-tray' ? { remember } : {})
+      })
     }
     setRequest(undefined)
   }
@@ -93,6 +99,17 @@ export const CloseConfirmModal = (): React.JSX.Element | null => {
                 )
               })}
             </ul>
+          ) : null}
+          {!isQuitVariant ? (
+            <label className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={remember}
+                onChange={(event) => setRemember(event.target.checked)}
+                className="size-4 shrink-0 accent-primary"
+              />
+              <span>Don&apos;t ask again</span>
+            </label>
           ) : null}
           <div className="mt-4 flex justify-end gap-2">
             {isQuitVariant ? (

--- a/src/renderer/src/pages/settings/GeneralPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.render.test.tsx
@@ -9,6 +9,15 @@ import { GeneralPanel } from './GeneralPanel'
 
 vi.mock('@/assets/logo.png', () => ({ default: 'logo.png' }))
 
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = (): void => undefined
+}
+
 let container: HTMLDivElement
 let root: Root
 let cliApi: {
@@ -18,6 +27,7 @@ let cliApi: {
 }
 let settingsApi: {
   setNotificationsEnabled: ReturnType<typeof vi.fn>
+  setClosePreference: ReturnType<typeof vi.fn>
 }
 
 const findButton = (pattern: RegExp): HTMLButtonElement | undefined =>
@@ -63,15 +73,22 @@ beforeEach(() => {
       .fn()
       .mockImplementation((request: { enabled: boolean }) =>
         Promise.resolve({ notificationsEnabled: request.enabled })
+      ),
+    setClosePreference: vi
+      .fn()
+      .mockImplementation((request: { preference?: 'minimize' | 'quit' }) =>
+        Promise.resolve({ closePreference: request.preference })
       )
   }
-  useSettingsStore.setState({ notificationsEnabled: true })
+  useSettingsStore.setState({ notificationsEnabled: true, closePreference: undefined })
   ;(window as unknown as { api: unknown }).api = {
     logs: {
       getPath: vi.fn().mockResolvedValue('/logs/main.log'),
       openFile: vi.fn().mockResolvedValue({ opened: true }),
       revealInFolder: vi.fn().mockResolvedValue({ revealed: true })
     },
+    platform: 'win32',
+    window: { onCloseConfirmRequest: vi.fn() },
     cli: cliApi,
     github: { getStars: vi.fn().mockResolvedValue(1) },
     settings: settingsApi
@@ -153,5 +170,35 @@ describe('GeneralPanel notifications', () => {
 
     expect(settingsApi.setNotificationsEnabled).toHaveBeenCalledWith({ enabled: false })
     expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
+  })
+})
+
+describe('GeneralPanel close behavior', () => {
+  it('changes the Windows titlebar-close preference', async () => {
+    await act(async () => {
+      root.render(<GeneralPanel />)
+    })
+    await flush()
+
+    const trigger = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="When closing the window"]'
+    )
+    expect(trigger?.textContent).toContain('Ask every time')
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+      trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    const quit = Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).find(
+      (option) => option.textContent?.includes('Quit')
+    )
+    await act(async () => {
+      quit?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, button: 0 }))
+      quit?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await flush()
+
+    expect(settingsApi.setClosePreference).toHaveBeenCalledWith({ preference: 'quit' })
+    expect(useSettingsStore.getState().closePreference).toBe('quit')
   })
 })

--- a/src/renderer/src/pages/settings/GeneralPanel.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.tsx
@@ -4,7 +4,9 @@ import { useEffect, useState } from 'react'
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { GitHubStarBadge } from '@/components/GitHubStarBadge'
 import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 import { useSettingsStore } from '@/stores/settings-store'
+import type { CloseActionPreference } from '../../../../shared/window-controls'
 import type { CliLauncherStatus } from '../../../../shared/cli'
 import { APP } from '../../../../shared/app-config'
 import { AppVersionSection } from './AppVersionSection'
@@ -40,6 +42,8 @@ const GeneralPanel = (): React.JSX.Element => {
   const [cliError, setCliError] = useState<string | undefined>(undefined)
   const notificationsEnabled = useSettingsStore((state) => state.notificationsEnabled)
   const setNotificationsEnabled = useSettingsStore((state) => state.setNotificationsEnabled)
+  const closePreference = useSettingsStore((state) => state.closePreference)
+  const setClosePreference = useSettingsStore((state) => state.setClosePreference)
 
   useEffect(() => {
     void window.api.logs.getPath().then(setLogPath)
@@ -97,6 +101,45 @@ const GeneralPanel = (): React.JSX.Element => {
   return (
     <div className="space-y-5 p-5">
       <AppVersionSection />
+
+      {window.api.platform === 'win32' && window.api.window?.onCloseConfirmRequest ? (
+        <SettingsSection
+          title="Window behavior"
+          description="Choose what the titlebar close button does."
+          aria-label="Window behavior"
+          separated
+        >
+          <SettingsRow
+            label="When closing the window"
+            description="Ask each time, keep Open Science running in the tray, or quit the app."
+            className="pt-0"
+          >
+            <Select
+              value={closePreference ?? 'ask'}
+              onValueChange={(value) =>
+                void setClosePreference(
+                  value === 'ask' ? undefined : (value as CloseActionPreference)
+                )
+              }
+            >
+              <SelectTrigger aria-label="When closing the window">
+                <span>
+                  {closePreference === 'minimize'
+                    ? 'Minimize to tray'
+                    : closePreference === 'quit'
+                      ? 'Quit'
+                      : 'Ask every time'}
+                </span>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ask">Ask every time</SelectItem>
+                <SelectItem value="minimize">Minimize to tray</SelectItem>
+                <SelectItem value="quit">Quit</SelectItem>
+              </SelectContent>
+            </Select>
+          </SettingsRow>
+        </SettingsSection>
+      ) : null}
 
       <SettingsSection
         title="Notifications"

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -33,6 +33,7 @@ type SettingsApi = {
   setAgentFramework: ReturnType<typeof vi.fn>
   setReasoningEffort: ReturnType<typeof vi.fn>
   setNotificationsEnabled: ReturnType<typeof vi.fn>
+  setClosePreference: ReturnType<typeof vi.fn>
   upsertProvider: ReturnType<typeof vi.fn>
   validateProvider: ReturnType<typeof vi.fn>
   cancelCodexLogin: ReturnType<typeof vi.fn>
@@ -145,6 +146,11 @@ beforeEach(() => {
       .fn()
       .mockImplementation((request: { enabled: boolean }) =>
         Promise.resolve({ ...snapshot([]), notificationsEnabled: request.enabled })
+      ),
+    setClosePreference: vi
+      .fn()
+      .mockImplementation((request: { preference?: 'minimize' | 'quit' }) =>
+        Promise.resolve({ ...snapshot([]), closePreference: request.preference })
       ),
     upsertProvider: vi.fn(),
     validateProvider: vi.fn(),
@@ -1299,5 +1305,36 @@ describe('settings store: setNotificationsEnabled', () => {
     await useSettingsStore.getState().load()
 
     expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
+  })
+})
+
+describe('settings store: setClosePreference', () => {
+  it('forwards a saved action and can reset to ask every time', async () => {
+    await useSettingsStore.getState().setClosePreference('minimize')
+    expect(api.setClosePreference).toHaveBeenCalledWith({ preference: 'minimize' })
+    expect(useSettingsStore.getState().closePreference).toBe('minimize')
+
+    await useSettingsStore.getState().setClosePreference(undefined)
+    expect(api.setClosePreference).toHaveBeenLastCalledWith({ preference: undefined })
+    expect(useSettingsStore.getState().closePreference).toBeUndefined()
+  })
+
+  it('reverts to the previous preference when main rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    useSettingsStore.setState({ closePreference: 'quit' })
+    api.setClosePreference.mockRejectedValue(new Error('ipc down'))
+
+    await useSettingsStore.getState().setClosePreference(undefined)
+
+    expect(useSettingsStore.getState().closePreference).toBe('quit')
+    expect(consoleError).toHaveBeenCalledWith('Failed to set close preference', expect.any(Error))
+  })
+
+  it('load() picks up a saved preference from the settings snapshot', async () => {
+    api.getSettings.mockResolvedValue({ ...snapshot([]), closePreference: 'minimize' })
+
+    await useSettingsStore.getState().load()
+
+    expect(useSettingsStore.getState().closePreference).toBe('minimize')
   })
 })

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -9,6 +9,7 @@ import {
   providerValidationFailed
 } from '../../../shared/settings'
 import type { PackageMirror } from '../../../shared/mirror'
+import type { CloseActionPreference } from '../../../shared/window-controls'
 import { isMirrorConfigured } from '../pages/settings/mirror-view'
 import type {
   ClaudeDetectResult,
@@ -135,6 +136,8 @@ type SettingsStoreData = {
   reasoningEffort: ReasoningEffort
   // Whether the app posts an OS notification when an agent task finishes or fails while unfocused.
   notificationsEnabled: boolean
+  // Saved Windows titlebar-close behavior. Undefined means ask every time.
+  closePreference: CloseActionPreference | undefined
   // When true, the settings dialog opens directly to the Compute panel.
   pendingComputePanel?: boolean
 }
@@ -195,6 +198,7 @@ type SettingsStore = SettingsStoreData & {
   setReasoningEffort: (effort: ReasoningEffort) => Promise<void>
   // Toggles desktop notifications for finished/failed agent tasks; applies immediately.
   setNotificationsEnabled: (enabled: boolean) => Promise<void>
+  setClosePreference: (preference: CloseActionPreference | undefined) => Promise<void>
   deleteProvider: (providerId: string) => Promise<void>
   openSettings: () => void
   closeSettings: () => void
@@ -332,6 +336,7 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   packageMirror: undefined,
   reasoningEffort: DEFAULT_REASONING_EFFORT,
   notificationsEnabled: DEFAULT_NOTIFICATIONS_ENABLED,
+  closePreference: undefined,
   pendingComputePanel: undefined
 })
 
@@ -347,6 +352,7 @@ const applySnapshot = (snapshot: SettingsSnapshot): Partial<SettingsStoreData> =
   // Defensive: main always fills this, but an untyped snapshot (tests, older backends) must not
   // write undefined into the boolean preference.
   notificationsEnabled: snapshot.notificationsEnabled ?? DEFAULT_NOTIFICATIONS_ENABLED,
+  closePreference: snapshot.closePreference,
   agentFrameworkId: snapshot.agentFrameworkId,
   agentFrameworks: snapshot.agentFrameworks,
   opencode: snapshot.opencode,
@@ -878,6 +884,18 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     } catch (error) {
       set({ notificationsEnabled: previous })
       console.error('Failed to set notifications enabled', error)
+    }
+  },
+
+  setClosePreference: async (preference) => {
+    const previous = get().closePreference
+    set({ closePreference: preference })
+
+    try {
+      set(applySnapshot(await window.api.settings.setClosePreference({ preference })))
+    } catch (error) {
+      set({ closePreference: previous })
+      console.error('Failed to set close preference', error)
     }
   },
 

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -134,6 +134,7 @@ export const WEB_INVOKE_CHANNELS = {
   'settings.scanRepoSkills': 'settings:scan-repo-skills',
   'settings.setActiveProvider': 'settings:set-active-provider',
   'settings.setAgentFramework': 'settings:set-agent-framework',
+  'settings.setClosePreference': 'settings:set-close-preference',
   'settings.setConnectorAutoAllow': 'settings:set-connector-auto-allow',
   'settings.setConnectorEnabled': 'settings:set-connector-enabled',
   'settings.setCustomServerEnabled': 'settings:set-custom-server-enabled',

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -6,6 +6,7 @@
 
 import type { OfficialVendorId } from './provider-registry'
 import type { PackageMirror } from './mirror'
+import type { CloseActionPreference } from './window-controls'
 
 // Settings file schema version; bumped when the on-disk shape changes. v2 adds official-vendor
 // providers (vendorId/region) and a per-selection activeModel alongside activeProviderId.
@@ -271,6 +272,8 @@ export type SettingsSnapshot = {
   reasoningEffort: ReasoningEffort
   // Whether the app posts an OS notification when an agent task finishes or fails while unfocused.
   notificationsEnabled: boolean
+  // Saved Windows titlebar-close behavior. Undefined means ask every time.
+  closePreference?: CloseActionPreference
 }
 
 // Request to set (or clear, via omitted fields) the package-mirror configuration.
@@ -286,6 +289,10 @@ export type SetReasoningEffortRequest = {
 
 export type SetNotificationsEnabledRequest = {
   enabled: boolean
+}
+
+export type SetClosePreferenceRequest = {
+  preference?: CloseActionPreference
 }
 
 // The hard startup gates. Kept as plain booleans so the wizard can target the first unmet step.

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -89,6 +89,9 @@ export type CloseConfirmVariant = 'close-to-tray' | 'quit'
 // 'minimize' only occurs for the 'close-to-tray' variant; 'cancel' keeps the app/window as-is.
 export type CloseConfirmChoice = 'quit' | 'minimize' | 'cancel'
 
+// Saved behavior for the Windows titlebar close action. Undefined means ask every time.
+export type CloseActionPreference = Extract<CloseConfirmChoice, 'quit' | 'minimize'>
+
 export type CloseConfirmRequest = {
   requestId: string
   variant: CloseConfirmVariant
@@ -96,8 +99,10 @@ export type CloseConfirmRequest = {
 }
 
 // ack:true when the modal mounts (proves the renderer is alive); choice set when the user decides.
+// remember is only meaningful for close-to-tray choices.
 export type CloseConfirmResponse = {
   requestId: string
   ack?: boolean
   choice?: CloseConfirmChoice
+  remember?: boolean
 }


### PR DESCRIPTION
## Problem

The Windows close confirmation asks the same Minimize to tray or Quit question every time, even after the user has established a preference.

## Proposed change

- add a default-selected "Don't ask again" checkbox to both the renderer modal and native fallback
- persist remembered Minimize to tray or Quit choices and apply them on later titlebar closes without showing a dialog
- add a Windows-only General Settings selector for Ask every time, Minimize to tray, or Quit
- keep explicit Quit confirmation intact while work is running

## Scope and non-goals

This changes the Windows titlebar close-to-tray flow. It does not suppress the separate safety confirmation for an explicit quit with active work.

## Acceptance criteria and validation

- default-selected remember control covers renderer and native fallback paths
- saved Minimize/Quit choices bypass later close dialogs
- Settings can change the action or reset it to Ask every time
- preference read/write failures degrade safely and renderer state rolls back on failed writes
- npm run typecheck
- npm run lint (0 errors)
- npm run check:web-api-map
- npm test (5915 passed, 83 skipped)

## Review focus

Please focus on the close-confirm fallback semantics and the settings persistence path across main, preload, and renderer.

Closes #375