### PR TITLE
fix(artifacts): accept stringified source objects

### DIFF
--- a/src/main/acp/mcp-http-host.test.ts
+++ b/src/main/acp/mcp-http-host.test.ts
@@ -74,6 +74,58 @@ describe('AgentMcpHttpHost', () => {
     expect(files.map((file) => file.name)).toContain('note.txt')
   })
 
+  it('accepts a JSON-stringified artifact source from an MCP model call', async () => {
+    root = await mkdtemp(join(tmpdir(), 'mcp-http-host-'))
+    const projectName = 'default-project'
+    const artifactSessionId = 'artifact-session-1'
+    const runId = 'artifact-run-1'
+    const currentRunFile = join(root, 'current-run.json')
+    await writeFile(currentRunFile, JSON.stringify({ runId }), 'utf8')
+
+    host = new AgentMcpHttpHost()
+    const { token } = await host.ensureStarted()
+    host.registerArtifact(artifactSessionId, {
+      storageRoot: root,
+      projectName,
+      sessionId: artifactSessionId,
+      currentRunFile,
+      allowedImportRoots: [root]
+    })
+
+    const client = new Client({ name: 'test-client', version: '0.0.0' })
+    const transport = new StreamableHTTPClientTransport(
+      new URL(host.urlFor('artifact', artifactSessionId)),
+      { requestInit: { headers: { authorization: `Bearer ${token}` } } }
+    )
+    await client.connect(transport)
+
+    const tool = (await client.listTools()).tools.find(
+      (candidate) => candidate.name === 'write_artifact_file'
+    )
+    expect(tool?.inputSchema.properties?.source).toMatchObject({
+      anyOf: [{ type: 'object' }, { type: 'object' }]
+    })
+
+    const result = await client.callTool({
+      name: 'write_artifact_file',
+      arguments: {
+        filename: 'report.md',
+        mimeType: 'text/markdown',
+        source: JSON.stringify({ kind: 'inline', content: '# Report' })
+      }
+    })
+    expect(JSON.stringify(result.content)).toContain('report.md')
+
+    await client.close()
+
+    const files = await new ArtifactRepository(root).listPendingRunFiles({
+      projectName,
+      sessionId: artifactSessionId,
+      runId
+    })
+    expect(files.map((file) => file.name)).toContain('report.md')
+  })
+
   it('rejects requests without the bearer token', async () => {
     host = new AgentMcpHttpHost()
     const { endpoint } = await host.ensureStarted()

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -45,6 +45,16 @@ type ArtifactToolWriteInput = {
   encoding?: ArtifactWriteEncoding
 }
 
+const parseJsonString = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value
+
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return value
+  }
+}
+
 const writeArtifactFileToolSchema = {
   filename: z
     .string()
@@ -52,26 +62,29 @@ const writeArtifactFileToolSchema = {
     .describe('Display filename for the artifact, e.g. "sine_wave.png" or "report.pdf".'),
   mimeType: z.string().min(1).optional(),
   source: z
-    .union([
-      z.object({
-        kind: z.literal('inline'),
-        content: z
-          .string()
-          .describe(
-            'Small in-memory text to write directly. Use localPath for files already on disk.'
-          ),
-        encoding: z.enum(['utf8', 'base64']).default('utf8')
-      }),
-      z.object({
-        kind: z.literal('localPath'),
-        path: z
-          .string()
-          .min(1)
-          .describe(
-            'Path to an ALREADY-SAVED file. A bare filename or relative path (e.g. "plot.png") resolves against the notebook session data dir (the kernel cwd), or the session workspace when there is no notebook data dir this turn — pass the same name you saved with. An absolute path also works. Do NOT rebuild a path from an env var; the kernel cwd already IS the data dir. The file must exist before you call this — the app copies it.'
-          )
-      })
-    ])
+    .preprocess(
+      parseJsonString,
+      z.union([
+        z.object({
+          kind: z.literal('inline'),
+          content: z
+            .string()
+            .describe(
+              'Small in-memory text to write directly. Use localPath for files already on disk.'
+            ),
+          encoding: z.enum(['utf8', 'base64']).default('utf8')
+        }),
+        z.object({
+          kind: z.literal('localPath'),
+          path: z
+            .string()
+            .min(1)
+            .describe(
+              'Path to an ALREADY-SAVED file. A bare filename or relative path (e.g. "plot.png") resolves against the notebook session data dir (the kernel cwd), or the session workspace when there is no notebook data dir this turn — pass the same name you saved with. An absolute path also works. Do NOT rebuild a path from an env var; the kernel cwd already IS the data dir. The file must exist before you call this — the app copies it.'
+            )
+        })
+      ])
+    )
     .optional(),
   content: z.string().optional(),
   encoding: z.enum(['utf8', 'base64']).default('utf8')


### PR DESCRIPTION
## Problem

Some models serialize the nested `source` argument for `write_artifact_file` as a JSON string. The advertised MCP schema correctly requires an object, so the server rejects these calls with `-32602 invalid_union` even when the string contains a valid inline or local-path source.

## Proposed change

Parse JSON-string `source` values before applying the existing strict `inline` / `localPath` union validation. Keep the generated tool schema object-only so models continue receiving the preferred contract.

Add an MCP HTTP integration regression test that replays the observed stringified input, verifies the advertised schema remains object-based, and confirms the artifact is written.

## Scope and non-goals

- Only `source` receives compatibility parsing.
- Malformed JSON and parsed values outside the existing union remain rejected.
- No changes to artifact ownership, path authorization, or storage behavior.

## Acceptance criteria and validation

- `npm run typecheck`
- `npm run lint` (0 errors; existing repository warnings remain)
- `npm run test` (5920 passed, 83 skipped)
- Regression test reproduces the original `invalid_union` before the fix and passes after it.

## Review focus

Please confirm the preprocessing remains narrowly scoped and that the generated JSON Schema still advertises `source` as the two object variants.