### PR TITLE
fix(workspace): restore behavior lost in permission update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "react-resizable-panels": "^4.12.0",
+        "react-zoom-pan-pinch": "^4.0.3",
         "shadcn": "^4.12.0",
         "streamdown": "^2.5.0",
         "tailwind-merge": "^3.6.0",
@@ -17995,7 +17996,6 @@
       "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-4.0.3.tgz",
       "integrity": "sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8",
         "npm": ">=5"

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-resizable-panels": "^4.12.0",
+    "react-zoom-pan-pinch": "^4.0.3",
     "shadcn": "^4.12.0",
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.6.0",

--- a/src/main/acp/mcp-http-host.test.ts
+++ b/src/main/acp/mcp-http-host.test.ts
@@ -74,6 +74,51 @@ describe('AgentMcpHttpHost', () => {
     expect(files.map((file) => file.name)).toContain('note.txt')
   })
 
+  it('accepts a JSON-stringified artifact source from an MCP model call', async () => {
+    root = await mkdtemp(join(tmpdir(), 'mcp-http-host-'))
+    const projectName = 'default-project'
+    const artifactSessionId = 'artifact-session-1'
+    const runId = 'artifact-run-1'
+    const currentRunFile = join(root, 'current-run.json')
+    await writeFile(currentRunFile, JSON.stringify({ runId }), 'utf8')
+
+    host = new AgentMcpHttpHost()
+    const { token } = await host.ensureStarted()
+    host.registerArtifact(artifactSessionId, {
+      storageRoot: root,
+      projectName,
+      sessionId: artifactSessionId,
+      currentRunFile,
+      allowedImportRoots: [root]
+    })
+
+    const client = new Client({ name: 'test-client', version: '0.0.0' })
+    const transport = new StreamableHTTPClientTransport(
+      new URL(host.urlFor('artifact', artifactSessionId)),
+      { requestInit: { headers: { authorization: `Bearer ${token}` } } }
+    )
+    await client.connect(transport)
+
+    const result = await client.callTool({
+      name: 'write_artifact_file',
+      arguments: {
+        filename: 'report.md',
+        mimeType: 'text/markdown',
+        source: JSON.stringify({ kind: 'inline', content: '# Report' })
+      }
+    })
+    expect(JSON.stringify(result.content)).toContain('report.md')
+
+    await client.close()
+
+    const files = await new ArtifactRepository(root).listPendingRunFiles({
+      projectName,
+      sessionId: artifactSessionId,
+      runId
+    })
+    expect(files.map((file) => file.name)).toContain('report.md')
+  })
+
   it('rejects requests without the bearer token', async () => {
     host = new AgentMcpHttpHost()
     const { endpoint } = await host.ensureStarted()

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -45,6 +45,18 @@ type ArtifactToolWriteInput = {
   encoding?: ArtifactWriteEncoding
 }
 
+// Some MCP clients serialize nested tool arguments before sending them. Accept a valid JSON string
+// here while leaving non-JSON strings for Zod to reject with its normal schema error.
+const parseJsonString = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value
+
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return value
+  }
+}
+
 const writeArtifactFileToolSchema = {
   filename: z
     .string()
@@ -52,26 +64,29 @@ const writeArtifactFileToolSchema = {
     .describe('Display filename for the artifact, e.g. "sine_wave.png" or "report.pdf".'),
   mimeType: z.string().min(1).optional(),
   source: z
-    .union([
-      z.object({
-        kind: z.literal('inline'),
-        content: z
-          .string()
-          .describe(
-            'Small in-memory text to write directly. Use localPath for files already on disk.'
-          ),
-        encoding: z.enum(['utf8', 'base64']).default('utf8')
-      }),
-      z.object({
-        kind: z.literal('localPath'),
-        path: z
-          .string()
-          .min(1)
-          .describe(
-            'Path to an ALREADY-SAVED file. A bare filename or relative path (e.g. "plot.png") resolves against the notebook session data dir (the kernel cwd), or the session workspace when there is no notebook data dir this turn — pass the same name you saved with. An absolute path also works. Do NOT rebuild a path from an env var; the kernel cwd already IS the data dir. The file must exist before you call this — the app copies it.'
-          )
-      })
-    ])
+    .preprocess(
+      parseJsonString,
+      z.union([
+        z.object({
+          kind: z.literal('inline'),
+          content: z
+            .string()
+            .describe(
+              'Small in-memory text to write directly. Use localPath for files already on disk.'
+            ),
+          encoding: z.enum(['utf8', 'base64']).default('utf8')
+        }),
+        z.object({
+          kind: z.literal('localPath'),
+          path: z
+            .string()
+            .min(1)
+            .describe(
+              'Path to an ALREADY-SAVED file. A bare filename or relative path (e.g. "plot.png") resolves against the notebook session data dir (the kernel cwd), or the session workspace when there is no notebook data dir this turn — pass the same name you saved with. An absolute path also works. Do NOT rebuild a path from an env var; the kernel cwd already IS the data dir. The file must exist before you call this — the app copies it.'
+            )
+        })
+      ])
+    )
     .optional(),
   content: z.string().optional(),
   encoding: z.enum(['utf8', 'base64']).default('utf8')

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
@@ -184,6 +184,41 @@ describe('PermissionApprovalControls interactions', () => {
     expect(container.querySelector('[role="menuitemradio"]')).toBeNull()
   })
 
+  it('focuses and navigates scope choices from the keyboard', async () => {
+    act(() => {
+      root.render(<PermissionApprovalControls requests={[baseRequest]} onRespond={vi.fn()} />)
+    })
+    const chevron = container.querySelector('[data-testid="scope-chevron"]') as HTMLButtonElement
+
+    await act(async () => {
+      chevron.click()
+    })
+    const items = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')
+    )
+    expect(document.activeElement).toBe(items[0])
+
+    act(() => {
+      items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    })
+    expect(document.activeElement).toBe(items[1])
+
+    act(() => {
+      items[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    expect(container.textContent).toContain('this conversation')
+    expect(container.querySelector('[role="menuitemradio"]')).toBeNull()
+
+    act(() => chevron.click())
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(document.activeElement).toBe(chevron)
+  })
+
   it('Deny calls onRespond with reject optionId', () => {
     const onRespond = vi.fn()
     act(() => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { AcpPermissionRequest } from '../../../../shared/acp'
 import { cn } from '@/lib/utils'
-import { isNotebookExecuteToolName, resolveNotebookLanguage } from './notebook-tool-names'
+import { resolveNotebookLanguage, resolveNotebookRunToolName } from './notebook-tool-names'
 import { WorkspaceToolCodeBlock } from './WorkspaceToolCodeBlock'
 
 type PermissionApprovalControlsProps = {
@@ -102,22 +102,17 @@ type PermissionCode = { code: string; language?: string }
 // code. Requiring the notebook server segment (not just the suffix) keeps a lookalike tool from
 // another MCP server — e.g. a `notebook_execute` that takes a production target — on the generic
 // JSON path so all its arguments stay reviewable. Shared with the transcript renderer.
-const isNotebookExecuteTool = isNotebookExecuteToolName
-
 // Resolves a request's notebook tool name from EITHER identity field. The broker can send a
 // namespaced title (mcp.open-science-notebook.notebook_execute) alongside a bare leaf
 // providerToolName (notebook_execute); only the namespaced field carries the server segment the
 // identity check needs, so we return whichever field matches (or undefined for non-notebook tools).
-const resolveNotebookToolName = (request: AcpPermissionRequest): string | undefined => {
-  if (isNotebookExecuteTool(request.providerToolName)) return request.providerToolName ?? undefined
-  if (isNotebookExecuteTool(request.title)) return request.title ?? undefined
-  return undefined
-}
+const resolveNotebookToolName = (request: AcpPermissionRequest): string | undefined =>
+  resolveNotebookRunToolName(request.providerToolName, request.title)
 
 // Derives displayable code and language from the tool's raw input.
 const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | undefined => {
   const raw = request.rawInput
-  const input =
+  const rawInput =
     raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {}
 
   const isExecute = request.toolKind === 'execute' || request.providerToolName === 'Bash'
@@ -128,6 +123,12 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
   // runs also report kind:execute, and their namespaced identity may live only in `title`.
   const notebookToolName = resolveNotebookToolName(request)
   if (notebookToolName) {
+    const input =
+      rawInput.arguments &&
+      typeof rawInput.arguments === 'object' &&
+      !Array.isArray(rawInput.arguments)
+        ? (rawInput.arguments as Record<string, unknown>)
+        : rawInput
     for (const key of ['code', 'command', 'script'] as const) {
       const v = input[key]
       if (typeof v === 'string' && v.trim()) {
@@ -143,7 +144,7 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
   // command may live only in title). Only trust title-as-bash for providerToolName === 'Bash';
   // other MCP execute tools (arbitrary servers, diverse semantics) must not assume shell syntax.
   if (isExecute) {
-    const cmd = input.command
+    const cmd = rawInput.command
     if (typeof cmd === 'string' && cmd.trim()) return { code: cmd, language: 'bash' }
     if (request.providerToolName === 'Bash' && request.title?.trim()) {
       return { code: request.title, language: 'bash' }
@@ -152,7 +153,7 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
 
   // All other tools: pretty-print input as JSON.
   try {
-    const serialized = JSON.stringify(input, null, 2)
+    const serialized = JSON.stringify(rawInput, null, 2)
     if (serialized && serialized !== '{}') return { code: serialized, language: 'json' }
   } catch {
     /* non-serializable */
@@ -243,9 +244,15 @@ const ScopeDropdown = ({
   selected: PermissionScope
   available: Set<PermissionScope>
   onSelect: (scope: PermissionScope) => void
-  onClose: () => void
+  onClose: (restoreTriggerFocus?: boolean) => void
 }): React.JSX.Element => {
   const ref = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const options = SCOPE_OPTIONS.filter(({ scope }) => available.has(scope))
+
+  useEffect(() => {
+    itemRefs.current[options.findIndex(({ scope }) => scope === selected)]?.focus()
+  }, [options, selected])
 
   useEffect(() => {
     // Listen on `click` (not `mousedown`) so it pairs with the chevron's onClick toggle: the
@@ -255,7 +262,10 @@ const ScopeDropdown = ({
     }
     // Escape dismisses the menu, matching the keyboard affordance implied by aria-haspopup.
     const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose(true)
+      }
     }
     document.addEventListener('click', onDocClick)
     document.addEventListener('keydown', onKeyDown)
@@ -272,34 +282,55 @@ const ScopeDropdown = ({
       aria-label="Authorization scope"
       className="absolute bottom-full right-0 z-10 mb-1 min-w-[216px] rounded-lg border border-border-200 bg-bg-000 p-1 shadow-md"
     >
-      {SCOPE_OPTIONS.filter(({ scope }) => available.has(scope)).map(
-        ({ scope, label, subtitle }) => (
-          <button
-            key={scope}
-            type="button"
-            role="menuitemradio"
-            aria-checked={selected === scope}
-            className={cn(
-              'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-bg-200',
-              selected === scope && 'bg-bg-100'
-            )}
-            onClick={() => {
+      {options.map(({ scope, label, subtitle }, index) => (
+        <button
+          key={scope}
+          ref={(item) => {
+            itemRefs.current[index] = item
+          }}
+          type="button"
+          role="menuitemradio"
+          aria-checked={selected === scope}
+          className={cn(
+            'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-bg-200',
+            selected === scope && 'bg-bg-100'
+          )}
+          onClick={() => {
+            onSelect(scope)
+            onClose()
+          }}
+          onKeyDown={(event) => {
+            const lastIndex = options.length - 1
+            let nextIndex: number | undefined
+
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault()
               onSelect(scope)
               onClose()
-            }}
-          >
-            {/* Label column: left-aligned flush to padding so both rows line up */}
-            <div className="flex min-w-0 flex-1 flex-col">
-              <span className="text-[12px] font-medium text-text-000">{label}</span>
-              <span className="text-[11px] leading-tight text-text-300">{subtitle}</span>
-            </div>
-            {/* Check column: right side, fixed slot so selection never shifts the label */}
-            <span className="flex w-3.5 shrink-0 justify-center text-primary">
-              {selected === scope ? <Check className="size-3.5" strokeWidth={2.5} /> : null}
-            </span>
-          </button>
-        )
-      )}
+              return
+            }
+            if (event.key === 'ArrowDown') nextIndex = index === lastIndex ? 0 : index + 1
+            if (event.key === 'ArrowUp') nextIndex = index === 0 ? lastIndex : index - 1
+            if (event.key === 'Home') nextIndex = 0
+            if (event.key === 'End') nextIndex = lastIndex
+
+            if (nextIndex !== undefined) {
+              event.preventDefault()
+              itemRefs.current[nextIndex]?.focus()
+            }
+          }}
+        >
+          {/* Label column: left-aligned flush to padding so both rows line up */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-[12px] font-medium text-text-000">{label}</span>
+            <span className="text-[11px] leading-tight text-text-300">{subtitle}</span>
+          </div>
+          {/* Check column: right side, fixed slot so selection never shifts the label */}
+          <span className="flex w-3.5 shrink-0 justify-center text-primary">
+            {selected === scope ? <Check className="size-3.5" strokeWidth={2.5} /> : null}
+          </span>
+        </button>
+      ))}
     </div>
   )
 }
@@ -310,7 +341,11 @@ const PermissionApprovalControls = ({
 }: PermissionApprovalControlsProps): React.JSX.Element | null => {
   const [scope, setScope] = useState<PermissionScope>('once')
   const [scopeOpen, setScopeOpen] = useState(false)
-  const closeScopeMenu = useCallback(() => setScopeOpen(false), [])
+  const scopeTriggerRef = useRef<HTMLButtonElement>(null)
+  const closeScopeMenu = useCallback((restoreTriggerFocus = false) => {
+    setScopeOpen(false)
+    if (restoreTriggerFocus) queueMicrotask(() => scopeTriggerRef.current?.focus())
+  }, [])
 
   // Show only the oldest pending request; the rest stay queued.
   const request = requests[0]
@@ -424,6 +459,7 @@ const PermissionApprovalControls = ({
             </button>
             <div className="w-px bg-primary/30" />
             <button
+              ref={scopeTriggerRef}
               type="button"
               data-testid="scope-chevron"
               aria-label="Choose authorization scope"

--- a/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.test.tsx
@@ -27,10 +27,16 @@ const { WorkspaceToolCodeBlock } = await import('./WorkspaceToolCodeBlock')
 describe('WorkspaceToolCodeBlock', () => {
   let container: HTMLDivElement
   let root: Root
+  const writeText = vi.fn<() => Promise<void>>()
 
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    writeText.mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true
+    })
   })
 
   afterEach(() => {
@@ -51,5 +57,22 @@ describe('WorkspaceToolCodeBlock', () => {
     // The htmlStyle color must reach the DOM; jsdom normalizes the hex to rgb.
     expect((token as HTMLElement | null)?.style.color).toBe('rgb(215, 58, 73)')
     expect((token as HTMLElement | null)?.style.getPropertyValue('--shiki-dark')).toBe('#F97583')
+  })
+
+  it('does not report a successful copy when the Clipboard API rejects the request', async () => {
+    writeText.mockRejectedValueOnce(new DOMException('Denied', 'NotAllowedError'))
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<WorkspaceToolCodeBlock code="import" language="python" copyable />)
+    })
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="code-copy-button"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(writeText).toHaveBeenCalledWith('import')
+    expect(container.querySelector('[aria-label="Copied"]')).toBeNull()
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.tsx
@@ -48,9 +48,15 @@ const WorkspaceToolCodeBlock = ({
   const highlightKey = createHighlightKey(source, language)
 
   const copyCode = useCallback(async () => {
-    await navigator.clipboard.writeText(source)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    if (!navigator.clipboard) return
+
+    try {
+      await navigator.clipboard.writeText(source)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard access can be denied outside a trusted user gesture; leave the control usable.
+    }
   }, [source])
 
   useEffect(() => {

--- a/src/renderer/src/pages/workspace/notebook-tool-names.ts
+++ b/src/renderer/src/pages/workspace/notebook-tool-names.ts
@@ -52,6 +52,12 @@ const matchNotebookRunTool = (toolName: string | undefined | null): string | und
 const isNotebookExecuteToolName = (toolName: string | undefined | null): boolean =>
   matchNotebookRunTool(toolName) !== undefined
 
+// Resolves the namespaced tool identity from the optional fields ACP providers expose. Codex keeps
+// it in the dotted title while other providers commonly use providerToolName.
+const resolveNotebookRunToolName = (
+  ...toolNames: Array<string | undefined | null>
+): string | undefined => toolNames.find((toolName) => isNotebookExecuteToolName(toolName))?.trim()
+
 // Canonical kernel kinds, shared with the main process. 'repl' is JavaScript.
 type NotebookKernelKind = 'python' | 'r' | 'repl' | 'bash'
 
@@ -117,6 +123,7 @@ export {
   NOTEBOOK_SERVER_SEGMENT,
   matchNotebookRunTool,
   isNotebookExecuteToolName,
+  resolveNotebookRunToolName,
   resolveNotebookLanguage,
   type NotebookKernelKind
 }

--- a/src/renderer/src/pages/workspace/preview-image-content.test.tsx
+++ b/src/renderer/src/pages/workspace/preview-image-content.test.tsx
@@ -196,4 +196,91 @@ describe('PreviewImageContent', () => {
     expect(container.textContent).toContain("isn't in your current storage location")
     expect(container.textContent).not.toContain('no longer available')
   })
+
+  it('renders accessible zoom controls alongside the image', async () => {
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<PreviewImageContent path="/workspace/photo.png" name="photo.png" />)
+    })
+
+    expect(container.querySelector('[aria-label="Zoom in"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="Zoom out"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="Reset zoom"]')).not.toBeNull()
+  })
+
+  it('scales the transformed content when zooming in', async () => {
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<PreviewImageContent path="/workspace/photo.png" name="photo.png" />)
+    })
+
+    const transformed = container.querySelector<HTMLElement>('.react-transform-component')
+    const readScale = (): number =>
+      Number.parseFloat(/scale\(([\d.]+)\)/.exec(transformed?.style.transform ?? '')?.[1] ?? 'NaN')
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {
+      const deadline = Date.now() + 2000
+      let previous = Number.NaN
+      while (Date.now() < deadline && !(readScale() > 1 && readScale() === previous)) {
+        previous = readScale()
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      }
+    })
+
+    expect(readScale()).toBeGreaterThan(1.2)
+  })
+
+  it('applies zoom instantly when the user prefers reduced motion', async () => {
+    const matchMedia = vi.fn((query: string) => ({
+      matches: query.includes('prefers-reduced-motion'),
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }))
+    vi.stubGlobal('matchMedia', matchMedia)
+
+    try {
+      root = createRoot(container)
+      await act(async () => {
+        root.render(<PreviewImageContent path="/workspace/photo.png" name="photo.png" />)
+      })
+
+      const transformed = container.querySelector<HTMLElement>('.react-transform-component')
+      const readScale = (): number =>
+        Number.parseFloat(
+          /scale\(([\d.]+)\)/.exec(transformed?.style.transform ?? '')?.[1] ?? 'NaN'
+        )
+
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')
+          ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      })
+
+      expect(readScale()).toBeGreaterThan(1.6)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('preserves the decode-failure fallback behind the zoom wrapper', async () => {
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<PreviewImageContent path="/workspace/photo.png" name="photo.png" />)
+    })
+
+    await act(async () => {
+      container.querySelector('img')?.dispatchEvent(new Event('error'))
+    })
+
+    expect(container.querySelector('[aria-label="Zoom in"]')).toBeNull()
+    expect(container.textContent).toContain("Image couldn't be loaded for preview")
+    expect(window.api.previewResources.release).toHaveBeenCalledWith({ resourceId: 'resource-1' })
+  })
 })

--- a/src/renderer/src/pages/workspace/previews/renderers/ImagePreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/ImagePreview.tsx
@@ -1,12 +1,96 @@
-import { ImageOff } from 'lucide-react'
+import { ImageOff, Maximize2, ZoomIn, ZoomOut } from 'lucide-react'
 import { useState } from 'react'
+import { TransformComponent, TransformWrapper, useControls } from 'react-zoom-pan-pinch'
 
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { PreviewFileSource } from '@/stores/preview-workbench-store'
 
 import { PreviewErrorCard, PreviewFallbackCard, PreviewLoadingContent } from '../PreviewFallback'
 import { createPreviewResourceKey } from '../preview-resource-key'
 import type { PreviewFileRendererProps } from '../preview-types'
 import { useManagedPreviewResource } from '../useManagedPreviewResource'
+
+const prefersReducedMotion = (): boolean =>
+  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
+
+const ImageZoomControls = ({ reduceMotion }: { reduceMotion: boolean }): React.JSX.Element => {
+  const { zoomIn, zoomOut, resetTransform } = useControls()
+  const actions = [
+    { label: 'Zoom in', icon: ZoomIn, onClick: () => zoomIn() },
+    { label: 'Zoom out', icon: ZoomOut, onClick: () => zoomOut() },
+    {
+      label: 'Reset zoom',
+      icon: Maximize2,
+      onClick: () => resetTransform(reduceMotion ? 0 : undefined)
+    }
+  ]
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="absolute bottom-3 right-3 z-10 flex gap-1 rounded-md border border-border-300/50 bg-bg-000/90 p-1 shadow-sm backdrop-blur">
+        {actions.map(({ label, icon: Icon, onClick }) => (
+          <Tooltip key={label}>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="text-text-100 hover:text-text-000"
+                aria-label={label}
+                onClick={onClick}
+              >
+                <Icon aria-hidden="true" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{label}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </TooltipProvider>
+  )
+}
+
+const ZoomableImage = ({
+  url,
+  name,
+  onError
+}: {
+  url: string
+  name: string
+  onError: () => void
+}): React.JSX.Element => {
+  const reduceMotion = prefersReducedMotion()
+
+  return (
+    <TransformWrapper
+      minScale={1}
+      maxScale={8}
+      centerOnInit
+      zoomAnimation={{ disabled: reduceMotion }}
+      doubleClick={reduceMotion ? { mode: 'reset', animationTime: 0 } : { mode: 'reset' }}
+      wheel={{
+        step: 0.2,
+        activationKeys: (keys) => keys.includes('Control') || keys.includes('Meta')
+      }}
+      panning={{ velocityDisabled: true }}
+    >
+      <ImageZoomControls reduceMotion={reduceMotion} />
+      <TransformComponent
+        wrapperClass="!size-full cursor-grab active:cursor-grabbing"
+        contentClass="!size-full"
+      >
+        <img
+          src={url}
+          alt={name}
+          className="size-full object-contain"
+          draggable={false}
+          onError={onError}
+        />
+      </TransformComponent>
+    </TransformWrapper>
+  )
+}
 
 export const PreviewImageContent = ({
   path,
@@ -57,12 +141,10 @@ export const PreviewImageContent = ({
   }
 
   return (
-    <div className="flex size-full items-center justify-center overflow-auto p-4">
-      <img
-        src={state.resource.url}
-        alt={name}
-        className="max-h-full max-w-full object-contain"
-        draggable={false}
+    <div className="relative size-full overflow-hidden p-4">
+      <ZoomableImage
+        url={state.resource.url}
+        name={name}
         onError={() => setFailedRequestKey(requestKey)}
       />
     </div>

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
@@ -161,6 +161,19 @@ describe('workspace conversation items', () => {
     ).toBe('Used tool: Notebook cell')
   })
 
+  it('detects a Codex notebook activity whose MCP identity is only in the title', () => {
+    expect(
+      formatActivityTitle(
+        createActivity({
+          id: 'tool-codex-notebook',
+          title: 'mcp.open-science-notebook.notebook_execute',
+          status: 'completed',
+          toolKind: 'execute'
+        })
+      )
+    ).toBe('Used tool: Notebook cell')
+  })
+
   it('falls back to readable tool kind names for unnamed tools', () => {
     expect(
       formatActivityTitle(

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.ts
@@ -20,20 +20,20 @@ type ConversationItem = ConversationMessageItem | ConversationActivityItem
 
 const KNOWN_TITLE_TOOL_NAMES = new Set(['ToolSearch'])
 
-// MCP tools are namespaced as mcp__<server>__<tool>. Claude Code keeps the hyphenated server name
-// (open-science-notebook); the Codex/gpt bridge sanitizes hyphens to underscores
-// (open_science_notebook). Match both forms so notebook rows are detected regardless of framework.
-const NOTEBOOK_PROVIDER_TOOL_PATTERN = /^mcp__open[-_]science[-_]notebook__(.+)$/iu
+// Claude Code namespaces MCP tools with `mcp__`; Codex records completed tools as dotted titles.
+// Both preserve the notebook server name, with Codex occasionally sanitizing its hyphens.
+const NOTEBOOK_PROVIDER_TOOL_PATTERN =
+  /^(?:mcp__|mcp\.)?open[-_]science[-_]notebook(?:__|\.)([^.]+)$/iu
 
 // Returns the notebook tool suffix (e.g. "notebook_execute") for a notebook MCP tool identity, or
 // undefined when the name is not a notebook tool. Framework-agnostic across the two server-name forms.
-const getNotebookToolSuffix = (providerToolName: string | undefined): string | undefined =>
-  NOTEBOOK_PROVIDER_TOOL_PATTERN.exec(providerToolName?.trim() ?? '')?.[1]
+const getNotebookToolSuffix = (toolName: string | undefined): string | undefined =>
+  NOTEBOOK_PROVIDER_TOOL_PATTERN.exec(toolName?.trim() ?? '')?.[1]
 
 // Maps a notebook MCP tool to a clean human label so rows read as notebook actions, not raw
 // mcp__…__* names. Returns undefined for non-notebook tools.
-const formatNotebookToolName = (providerToolName: string): string | undefined => {
-  const suffix = getNotebookToolSuffix(providerToolName)
+const formatNotebookToolName = (toolName: string): string | undefined => {
+  const suffix = getNotebookToolSuffix(toolName)
 
   if (!suffix) return undefined
 
@@ -85,7 +85,12 @@ const formatActivityToolName = (activity: ToolActivity): string => {
   const providerToolName = trimDetail(activity.providerToolName)
   const title = trimDetail(activity.title)
 
-  if (providerToolName) return formatNotebookToolName(providerToolName) ?? providerToolName
+  const notebookToolName =
+    (providerToolName && formatNotebookToolName(providerToolName)) ??
+    (title && formatNotebookToolName(title))
+
+  if (notebookToolName) return notebookToolName
+  if (providerToolName) return providerToolName
   if (title && KNOWN_TITLE_TOOL_NAMES.has(title)) return title
 
   return formatToolKindName(activity.toolKind)

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
@@ -197,6 +197,36 @@ describe('workspace tool activity details', () => {
     expect((details?.sections[0] as { collapsible?: boolean }).collapsible).toBeFalsy()
   })
 
+  it('renders a Codex notebook activity from its dotted title and MCP arguments envelope', () => {
+    const runSummary = {
+      status: 'completed',
+      text: { stdout: '42\n', stderr: '', traceback: '' },
+      outputs: []
+    }
+    const activity = createActivity({
+      title: 'mcp.open-science-notebook.notebook_execute',
+      toolKind: 'execute',
+      rawInput: {
+        server: 'open-science-notebook',
+        tool: 'notebook_execute',
+        arguments: { kernelKind: 'python', code: 'print(42)' }
+      },
+      toolContent: [
+        { type: 'content', content: { type: 'text', text: JSON.stringify(runSummary) } }
+      ]
+    })
+    const details = buildToolActivityDetails(activity)
+
+    expect(details?.displayName).toBe('Notebook cell')
+    expect(details?.sections[0]).toMatchObject({
+      kind: 'code',
+      label: 'Code',
+      language: 'python',
+      text: 'print(42)'
+    })
+    expect(details?.sections[1]).toMatchObject({ kind: 'code', label: 'Output', text: '42' })
+  })
+
   it('renders an opencode single-underscore notebook tool as code, not raw JSON', () => {
     // opencode names the tool <server>_<tool> (no mcp__ prefix); the activity must still render as
     // a notebook cell rather than falling back to the run-summary envelope.

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
@@ -2,7 +2,7 @@ import type { ContentBlock, ToolCallContent, ToolKind } from '@agentclientprotoc
 
 import { formatByteSize } from '@/lib/utils'
 import type { ToolActivity } from '@/stores/session-store'
-import { isNotebookExecuteToolName, resolveNotebookLanguage } from './notebook-tool-names'
+import { resolveNotebookLanguage, resolveNotebookRunToolName } from './notebook-tool-names'
 
 type ToolCodeSection = {
   kind: 'code'
@@ -495,8 +495,19 @@ const toNotebookKernelKind = (value: unknown): NotebookKernelKindLike | undefine
 // Matches both server-name forms (Claude Code's hyphenated open-science-notebook and the
 // responses bridge's underscore-sanitized open_science_notebook) via the shared matcher, which
 // also requires the server segment to match exactly so lookalike server names are excluded.
+const getNotebookRunToolName = (activity: ToolActivity): string | undefined =>
+  resolveNotebookRunToolName(trimDetail(activity.providerToolName), trimDetail(activity.title))
+
+const getNotebookInput = (activity: ToolActivity): Record<string, unknown> => {
+  if (!isRecord(activity.rawInput)) return {}
+
+  // Codex preserves the MCP envelope on completed activities. The actual notebook input lives in
+  // `arguments`, while other providers expose those arguments directly.
+  return isRecord(activity.rawInput.arguments) ? activity.rawInput.arguments : activity.rawInput
+}
+
 const isNotebookKernelRunActivity = (activity: ToolActivity): boolean =>
-  isNotebookExecuteToolName(trimDetail(activity.providerToolName))
+  getNotebookRunToolName(activity) !== undefined
 
 // Resolves the kernel's Shiki language from input, run summary, tool name, and code heuristics.
 // Returns the language string directly (no intermediate NotebookKernelKindLike round-trip).
@@ -505,11 +516,7 @@ const getNotebookLanguage = (
   activity: ToolActivity,
   summary: Record<string, unknown> | undefined
 ): string => {
-  const rawInput = activity.rawInput
-  const input =
-    rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput)
-      ? (rawInput as Record<string, unknown>)
-      : {}
+  const input = getNotebookInput(activity)
   const inputKernel = ['kernelKind', 'kernel', 'language'].reduce<
     NotebookKernelKindLike | undefined
   >((found, key) => found ?? toNotebookKernelKind(input[key]), undefined)
@@ -522,7 +529,7 @@ const getNotebookLanguage = (
       : typeof summary?.script === 'string'
         ? summary.script
         : undefined
-  return resolveNotebookLanguage(activity.providerToolName, resolvedInput, code)
+  return resolveNotebookLanguage(getNotebookRunToolName(activity), resolvedInput, code)
 }
 
 // Reads the notebook run summary the execute tool returns as JSON content (or raw output).
@@ -546,9 +553,10 @@ const getNotebookCode = (
   activity: ToolActivity,
   summary: Record<string, unknown> | undefined
 ): string | undefined => {
-  if (isRecord(activity.rawInput)) {
+  const input = getNotebookInput(activity)
+  if (Object.keys(input).length > 0) {
     for (const key of ['code', 'command', 'script'] as const) {
-      const value = activity.rawInput[key]
+      const value = input[key]
 
       if (typeof value === 'string') {
         const trimmed = trimDetail(value)
@@ -646,11 +654,7 @@ const buildNotebookDetails = (activity: ToolActivity): ToolActivityDetails | und
 
   // Derive display name from language: python/r are cells, javascript (repl) is Agent SDK, bash is shell.
   const displayName =
-    language === 'javascript'
-      ? 'Agent SDK'
-      : language === 'bash'
-        ? 'Shell'
-        : 'Notebook cell'
+    language === 'javascript' ? 'Agent SDK' : language === 'bash' ? 'Shell' : 'Notebook cell'
 
   return {
     displayName,

--- a/test/setup-jsdom-polyfills.ts
+++ b/test/setup-jsdom-polyfills.ts
@@ -1,0 +1,14 @@
+// jsdom doesn't implement ResizeObserver, but react-zoom-pan-pinch constructs one on mount.
+if (!(globalThis as { ResizeObserver?: unknown }).ResizeObserver) {
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe(): void {
+      /* no-op: layout measurement isn't meaningful in jsdom */
+    }
+    unobserve(): void {
+      /* no-op */
+    }
+    disconnect(): void {
+      /* no-op */
+    }
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     // Loads .env into process.env before tests run. Integration tests gated on RUN_COMPUTE_JOBS=1
     // read their target alias from COMPUTE_TEST_SSH_ALIAS. The file is gitignored; .env.example
     // documents the supported variables.
-    setupFiles: ['./test/setup-dotenv.ts'],
+    setupFiles: ['./test/setup-dotenv.ts', './test/setup-jsdom-polyfills.ts'],
     // Keep vitest's defaults (node_modules, dist, .git, ...) and also ignore git worktrees created
     // under .claude/worktrees — those hold full source + node_modules copies that would otherwise be
     // discovered and run as duplicate (and often stale) suites during local runs.


### PR DESCRIPTION
## Problem

The squash merge of #381 included unrelated reversions in image preview and artifact handling, and the new permission UI missed keyboard focus/navigation. Codex notebook activities also use a dotted title plus an MCP arguments envelope, so completed runs were rendered as generic execute tools.

## Proposed change

- restore image zoom/pan controls, dependency, reduced-motion behavior, and managed-resource fallback coverage
- restore JSON-stringified artifact `source` compatibility and its HTTP MCP integration test
- resolve notebook run identity from either provider name or title and unwrap Codex MCP arguments for transcript/code rendering
- add keyboard focus, arrow navigation, selection, and Escape focus restoration to the authorization scope menu
- tolerate unavailable or rejected Clipboard API writes without reporting a successful copy

## Scope and non-goals

This keeps the permission-dialog feature introduced by #381 and only repairs regressions and cross-framework behavior around it. It does not redesign permission policy or change artifact storage semantics.

## Acceptance criteria and validation

- `npm run typecheck`
- `npm run lint` (passes with 56 pre-existing warnings, 0 errors)
- `npm run test` (5991 passed, 83 skipped)

## Review focus

- restored image preview behavior and accessibility
- Codex notebook activity identity/input normalization
- scope-menu keyboard interaction and least-privilege selection
- artifact MCP compatibility with JSON-stringified nested arguments

Follow-up to #381.