### PR TITLE
fix(notebook): fit managed cache under long Windows profiles

### DIFF
--- a/build/windows-runtime-cache-uninstall.ps1
+++ b/build/windows-runtime-cache-uninstall.ps1
@@ -21,6 +21,32 @@ function Get-CacheLeaf([string]$RuntimeRoot, [string]$UserIdentity) {
   }
 }
 
+function Get-CompactCacheLeaf([string]$RuntimeRoot, [string]$UserIdentity) {
+  $key = $UserIdentity.ToLowerInvariant() + [char]0 + $RuntimeRoot.ToLowerInvariant()
+  $sha = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($key)
+    $digest = $sha.ComputeHash($bytes)
+    $alphabet = '0123456789abcdefghjkmnpqrstvwxyz'
+    $encoded = ''
+    $value = 0
+    $bits = 0
+    foreach ($byte in $digest[0..4]) {
+      $value = ($value -shl 8) -bor $byte
+      $bits += 8
+      while ($bits -ge 5) {
+        $bits -= 5
+        $encoded += $alphabet[($value -shr $bits) -band 31]
+        $value = $value -band ((1 -shl $bits) - 1)
+      }
+    }
+    return 'os' + $encoded
+  }
+  finally {
+    $sha.Dispose()
+  }
+}
+
 function Test-TrustedCache([string]$Path, [string]$CanonicalRoot, [string]$UserIdentity) {
   $item = Get-Item -LiteralPath $Path -Force
   if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { return $false }
@@ -84,9 +110,11 @@ foreach ($root in $roots) {
   try {
     $canonicalRoot = Get-CanonicalPath $root
     $leaf = Get-CacheLeaf $canonicalRoot $userIdentity
+    $compactLeaf = Get-CompactCacheLeaf $canonicalRoot $userIdentity
     $candidates = @(
       (Join-Path ([System.IO.Path]::GetPathRoot($canonicalRoot)) $leaf),
-      (Join-Path $env:USERPROFILE $leaf)
+      (Join-Path $env:USERPROFILE $leaf),
+      (Join-Path $env:USERPROFILE $compactLeaf)
     ) | Select-Object -Unique
     foreach ($candidate in $candidates) {
       try {

--- a/scripts/electron-builder-config.test.ts
+++ b/scripts/electron-builder-config.test.ts
@@ -28,6 +28,9 @@ describe('electron-builder Windows targets', () => {
     expect(config).toContain('include: build/installer.nsh')
     expect(include).toContain('windows-runtime-cache-uninstall.ps1')
     expect(cleanup).toContain('.open-science-cache.json')
+    expect(cleanup).toContain('Get-CompactCacheLeaf')
+    expect(cleanup).toContain('$compactLeaf = Get-CompactCacheLeaf $canonicalRoot $userIdentity')
+    expect(cleanup).toContain('(Join-Path $env:USERPROFILE $compactLeaf)')
     expect(cleanup).toContain('S-1-5-32-544')
     expect(cleanup).toContain('$trustedWriteSids -notcontains $sid')
     for (const right of WINDOWS_CACHE_DANGEROUS_RIGHT_NAMES) {

--- a/src/main/notebook/env-ipc.test.ts
+++ b/src/main/notebook/env-ipc.test.ts
@@ -7,6 +7,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // Capture ipcMain.handle registrations so registerNotebookEnvIpcHandlers can be exercised headless.
 const registered = new Map<string, (event: unknown, ...args: unknown[]) => unknown>()
 const sentProgress: ProvisionProgress[] = []
+const loggerSpies = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn()
+}))
 vi.mock('electron', () => ({
   ipcMain: { handle: (channel: string, handler: never) => registered.set(channel, handler) },
   BrowserWindow: {
@@ -20,6 +24,18 @@ vi.mock('electron', () => ({
     ]
   }
 }))
+vi.mock('../logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logger')>()
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: loggerSpies.info,
+      warn: vi.fn(),
+      error: loggerSpies.error
+    })
+  }
+})
 
 import type { ProvisionProgress, RuntimeProvisioner } from './provisioner'
 import {
@@ -291,6 +307,8 @@ describe('registerNotebookEnvIpcHandlers', () => {
   beforeEach(() => {
     registered.clear()
     sentProgress.length = 0
+    loggerSpies.info.mockReset()
+    loggerSpies.error.mockReset()
   })
   afterEach(() => {
     registered.clear()
@@ -337,6 +355,126 @@ describe('registerNotebookEnvIpcHandlers', () => {
       { phase: 'fetch-r', message: 'Downloading R', progress: 0.4, scope: 'r' },
       { phase: 'repair', message: 'Repairing Python', progress: 0.2, scope: 'python' }
     ])
+  })
+
+  it('logs a provision failure with diagnostics and rethrows the original error', async () => {
+    const failure = Object.assign(new Error('micromamba timed out after 600000ms'), {
+      code: 'MICROMAMBA_TIMEOUT',
+      data: { timeoutMs: 600_000, offline: true }
+    })
+    const provisioner = fakeProvisioner({
+      provisionPython: vi.fn().mockRejectedValue(failure)
+    })
+    registerNotebookEnvIpcHandlers(provisioner, 'F:\\openScience\\data\\OpenScience\\runtime')
+
+    await expect(registered.get('notebook-env:provision')?.({}, 'python')).rejects.toBe(failure)
+
+    expect(loggerSpies.error).toHaveBeenCalledOnce()
+    const [message, fields] = loggerSpies.error.mock.calls[0] as [string, Record<string, unknown>]
+    expect(message).toBe('runtime operation failed')
+    expect(fields).toMatchObject({
+      operation: 'provision',
+      language: 'python',
+      root: 'F:\\openScience\\data\\OpenScience\\runtime',
+      error: 'micromamba timed out after 600000ms',
+      code: 'MICROMAMBA_TIMEOUT',
+      data: { timeoutMs: 600_000, offline: true }
+    })
+    expect(fields.operationId).toEqual(expect.any(String))
+    expect(fields.durationMs).toEqual(expect.any(Number))
+  })
+
+  it('redacts credentials from persisted runtime diagnostics without changing the thrown error', async () => {
+    const channel = 'https://user:basic-secret@example.com/t/path-secret/conda?token=query-secret'
+    const failure = Object.assign(new Error(`micromamba timed out (${channel})`), {
+      code: 'MICROMAMBA_TIMEOUT',
+      data: {
+        argv: ['micromamba', '-c', channel],
+        stderrTail: 'api_key=stderr-secret',
+        stdoutTail: 'Bearer stdout-secret'
+      }
+    })
+    const provisioner = fakeProvisioner({
+      provisionPython: vi
+        .fn()
+        .mockImplementation(async (report: (p: ProvisionProgress) => void) => {
+          report({ phase: 'fetch-python', message: `Retrying ${channel}`, progress: 0.1 })
+          throw failure
+        })
+    })
+    registerNotebookEnvIpcHandlers(provisioner, '/runtime')
+
+    await expect(registered.get('notebook-env:provision')?.({}, 'python')).rejects.toBe(failure)
+
+    const persisted = JSON.stringify({
+      info: loggerSpies.info.mock.calls,
+      error: loggerSpies.error.mock.calls
+    })
+    for (const secret of [
+      'basic-secret',
+      'path-secret',
+      'query-secret',
+      'stderr-secret',
+      'stdout-secret'
+    ]) {
+      expect(persisted).not.toContain(secret)
+    }
+    expect(persisted).toContain('[redacted]')
+    expect(failure.message).toContain('basic-secret')
+  })
+
+  it('logs operation lifecycle and phase changes without logging every download chunk', async () => {
+    const provisioner = fakeProvisioner({
+      provisionPython: vi
+        .fn()
+        .mockImplementation(async (report: (p: ProvisionProgress) => void) => {
+          report({ phase: 'fetch-python', message: 'Downloading Python (10%)', progress: 0.1 })
+          report({ phase: 'fetch-python', message: 'Downloading Python (20%)', progress: 0.2 })
+          report({
+            phase: 'fetch-python',
+            message: 'Downloading Python (resuming…)',
+            progress: 0.2,
+            download: {
+              phase: 'reconnecting',
+              transferred: 20,
+              total: 100,
+              percent: 20,
+              bytesPerSecond: 0,
+              attempt: 1
+            }
+          })
+          report({ phase: 'create-python', message: 'Creating Python', progress: 0.45 })
+        })
+    })
+    registerNotebookEnvIpcHandlers(provisioner, '/runtime')
+
+    await registered.get('notebook-env:provision')?.({}, 'python')
+
+    expect(loggerSpies.info.mock.calls.map(([message]) => message)).toEqual([
+      'runtime operation started',
+      'runtime operation progress',
+      'runtime operation progress',
+      'runtime operation progress',
+      'runtime operation completed'
+    ])
+    const progressFields = loggerSpies.info.mock.calls
+      .filter(([message]) => message === 'runtime operation progress')
+      .map(([, fields]) => fields as Record<string, unknown>)
+    expect(progressFields).toMatchObject([
+      { phase: 'fetch-python', message: 'Downloading Python (10%)' },
+      {
+        phase: 'fetch-python',
+        message: 'Downloading Python (resuming…)',
+        download: { phase: 'reconnecting', attempt: 1, transferred: 20, total: 100 }
+      },
+      { phase: 'create-python', message: 'Creating Python' }
+    ])
+    const operationIds = new Set(
+      loggerSpies.info.mock.calls.map(
+        ([, fields]) => (fields as { operationId: string }).operationId
+      )
+    )
+    expect(operationIds.size).toBe(1)
   })
 })
 

--- a/src/main/notebook/env-ipc.ts
+++ b/src/main/notebook/env-ipc.ts
@@ -1,6 +1,10 @@
+import { randomUUID } from 'node:crypto'
+import { existsSync } from 'node:fs'
+
 import { BrowserWindow, ipcMain } from 'electron'
 
 import type { NotebookLanguage } from '../../shared/notebook'
+import { createLogger, errorLogFields } from '../logger'
 import {
   planStartupAction,
   type ProvisionProgress,
@@ -13,7 +17,117 @@ import {
 // through). Sourcing it from its actual home, runtime-paths.ts, instead of touching provisioner.ts
 // (out of this task's scope).
 import { DEFAULT_ENV_VERSION, DEFAULT_PY_ENV, envPrefix, readReadyMarker } from './runtime-paths'
-import { existsSync } from 'node:fs'
+
+const log = createLogger('notebook-env')
+
+type LoggedRuntimeOperation = 'provision' | 'repair'
+
+type RuntimeLogContext = {
+  operation: LoggedRuntimeOperation
+  language: NotebookLanguage
+  root: string
+  operationId: string
+}
+
+const redactRuntimeLogText = (value: string): string =>
+  value
+    .replace(/https?:\/\/[^\s"'<>]+/gi, (rawUrl) => {
+      try {
+        const url = new URL(rawUrl)
+        url.username = ''
+        url.password = ''
+        url.pathname = url.pathname.replace(
+          /\/(t|token|auth|api[_-]?key|secret|password)\/[^/]+/gi,
+          '/$1/[redacted]'
+        )
+        for (const key of [...url.searchParams.keys()]) url.searchParams.set(key, '[redacted]')
+        url.hash = ''
+        return url.toString()
+      } catch {
+        return rawUrl
+      }
+    })
+    .replace(/\bBearer\s+[^\s"']+/gi, 'Bearer [redacted]')
+    .replace(/\b(api[_-]?key|token|secret|password)\b(\s*[:=]\s*)[^\s,"'&]+/gi, '$1$2[redacted]')
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[redacted]')
+
+const redactRuntimeLogValue = (value: unknown): unknown => {
+  if (typeof value === 'string') return redactRuntimeLogText(value)
+  if (Array.isArray(value)) return value.map(redactRuntimeLogValue)
+  if (value === null || typeof value !== 'object') return value
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [key, redactRuntimeLogValue(nested)])
+  )
+}
+
+const runtimeErrorLogFields = (error: unknown): Record<string, unknown> =>
+  redactRuntimeLogValue(errorLogFields(error)) as Record<string, unknown>
+
+const logRuntimeInfo = (message: string, fields: Record<string, unknown>): void => {
+  try {
+    log.info(message, redactRuntimeLogValue(fields) as Record<string, unknown>)
+  } catch {
+    // Diagnostics are best-effort and must not interrupt provisioning or progress delivery.
+  }
+}
+
+const logRuntimeFailure = (context: RuntimeLogContext, startedAt: number, error: unknown): void => {
+  try {
+    log.error('runtime operation failed', {
+      ...runtimeErrorLogFields(error),
+      ...context,
+      durationMs: Date.now() - startedAt
+    })
+  } catch {
+    // Diagnostics must never replace the provisioning error returned to the renderer.
+  }
+}
+
+const runLoggedRuntimeOperation = async (
+  operation: LoggedRuntimeOperation,
+  language: NotebookLanguage,
+  root: string,
+  run: (onProgress: (progress: ProvisionProgress) => void) => Promise<void>,
+  broadcast: (progress: ProvisionProgress) => void
+): Promise<void> => {
+  const context: RuntimeLogContext = { operation, language, root, operationId: randomUUID() }
+  const startedAt = Date.now()
+  let lastPhase: string | undefined
+  let lastReconnectAttempt: number | undefined
+  logRuntimeInfo('runtime operation started', context)
+
+  const onProgress = (progress: ProvisionProgress): void => {
+    broadcast(progress)
+    const reconnectAttempt =
+      progress.download?.phase === 'reconnecting' ? progress.download.attempt : undefined
+    const phaseChanged = progress.phase !== lastPhase
+    const reconnectChanged =
+      reconnectAttempt !== undefined && reconnectAttempt !== lastReconnectAttempt
+    lastPhase = progress.phase
+    if (reconnectAttempt !== undefined) lastReconnectAttempt = reconnectAttempt
+    if (!phaseChanged && !reconnectChanged) return
+
+    logRuntimeInfo('runtime operation progress', {
+      ...context,
+      phase: progress.phase,
+      message: progress.message,
+      progress: progress.progress,
+      ...(progress.download ? { download: progress.download } : {})
+    })
+  }
+
+  try {
+    await run(onProgress)
+    logRuntimeInfo('runtime operation completed', {
+      ...context,
+      durationMs: Date.now() - startedAt,
+      lastPhase
+    })
+  } catch (error) {
+    logRuntimeFailure(context, startedAt, error)
+    throw error
+  }
+}
 
 // A small delegating surface so IPC behavior tests run without Electron wiring.
 export type NotebookEnvHandlers = {
@@ -248,12 +362,22 @@ export const registerNotebookEnvIpcHandlers = (
     : createUnavailableHandlers()
   ipcMain.handle('notebook-env:status', () => handlers.status())
   ipcMain.handle('notebook-env:provision', (_event, lang: NotebookLanguage) =>
-    handlers.provision(lang, (progress) =>
-      broadcastNotebookEnvProgress({ ...progress, scope: lang })
+    runLoggedRuntimeOperation(
+      'provision',
+      lang,
+      root,
+      (onProgress) => handlers.provision(lang, onProgress),
+      (progress) => broadcastNotebookEnvProgress({ ...progress, scope: lang })
     )
   )
   ipcMain.handle('notebook-env:repair', (_event, lang: NotebookLanguage) =>
-    handlers.repair(lang, (progress) => broadcastNotebookEnvProgress({ ...progress, scope: lang }))
+    runLoggedRuntimeOperation(
+      'repair',
+      lang,
+      root,
+      (onProgress) => handlers.repair(lang, onProgress),
+      (progress) => broadcastNotebookEnvProgress({ ...progress, scope: lang })
+    )
   )
   // Synchronous best-effort abort of an in-flight provision; returns immediately (the aborted run
   // settles on its own and broadcasts its terminal progress).

--- a/src/main/notebook/micromamba-cache.test.ts
+++ b/src/main/notebook/micromamba-cache.test.ts
@@ -11,6 +11,7 @@ import {
   removeMicromambaCacheForRoot,
   selectMicromambaCache,
   WINDOWS_CACHE_DANGEROUS_RIGHT_NAMES,
+  WINDOWS_MAX_USABLE_PATH,
   type MicromambaCacheDeps
 } from './micromamba-cache'
 
@@ -75,6 +76,27 @@ describe('selectMicromambaCache', () => {
     expect(prepare).toHaveBeenCalledTimes(2)
   })
 
+  it('uses a compact profile cache when the volume root is untrusted and the legacy leaf is too long', () => {
+    const prepare = vi.fn((path: string) =>
+      path.startsWith('E:\\') ? undefined : win32.normalize(path)
+    )
+    const selected = selectMicromambaCache(
+      'E:\\open science\\OpenScience\\runtime',
+      DEFAULT_MAX_CACHE_RELATIVE_PATH,
+      windowsDeps({
+        env: {
+          USERNAME: 'peipeidamowang',
+          USERPROFILE: 'C:\\Users\\peipeidamowang'
+        },
+        prepare
+      })
+    )
+
+    expect(selected.path).toMatch(/^C:\\Users\\peipeidamowang\\os[0-9a-hjkmnp-tv-z]{8}$/)
+    expect(selected.path.length + DEFAULT_MAX_CACHE_RELATIVE_PATH).toBe(WINDOWS_MAX_USABLE_PATH)
+    expect(prepare).toHaveBeenCalledTimes(2)
+  })
+
   it('rejects candidates that are writable but do not fit the actual pack budget', () => {
     expect(() =>
       selectMicromambaCache(
@@ -82,7 +104,7 @@ describe('selectMicromambaCache', () => {
         250,
         windowsDeps({ env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\a-very-long-profile' } })
       )
-    ).toThrow(/shorter (?:Windows user profile|data-root)/i)
+    ).toThrow(/Candidate diagnostics:/i)
     expect(() =>
       selectMicromambaCache(
         'D:\\OpenScience\\runtime',
@@ -90,6 +112,39 @@ describe('selectMicromambaCache', () => {
         windowsDeps({ env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\a-very-long-profile' } })
       )
     ).not.toThrow(/LongPathsEnabled|administrator/i)
+  })
+
+  it('reports why every Windows cache candidate was rejected', () => {
+    const profile = 'C:\\Users\\peipeidamowang-with-a-long-profile'
+    let message = ''
+    try {
+      selectMicromambaCache(
+        'E:\\open science\\OpenScience\\runtime',
+        DEFAULT_MAX_CACHE_RELATIVE_PATH,
+        windowsDeps({
+          env: { USERNAME: 'peipeidamowang', USERPROFILE: profile },
+          prepare: (path) => ({
+            rejection: path.startsWith('E:\\')
+              ? 'ownership or permissions are not trusted'
+              : 'cache marker is missing or unreadable'
+          })
+        })
+      )
+    } catch (error) {
+      message = (error as Error).message
+    }
+
+    expect(message).toContain('Candidate diagnostics:')
+    expect(message).toMatch(/E:\\osp[0-9a-f]{10}: ownership or permissions are not trusted/)
+    expect(message).toMatch(
+      /C:\\Users\\peipeidamowang-with-a-long-profile\\osp[0-9a-f]{10}: exceeds the Windows path budget/
+    )
+    expect(message).toMatch(
+      /C:\\Users\\peipeidamowang-with-a-long-profile\\os[0-9a-hjkmnp-tv-z]{8}: exceeds the Windows path budget/
+    )
+    expect(message).not.toContain('unavailable, untrusted, or not writable')
+    expect(message).not.toContain('restrict write access')
+    expect(message).not.toMatch(/shorter data-root/i)
   })
 
   it('rejects an untrusted candidate and tries the profile location', () => {
@@ -187,6 +242,23 @@ describe('removeMicromambaCacheForRoot', () => {
     })
 
     expect(remove).not.toHaveBeenCalled()
+  })
+
+  it('removes a correctly marked compact profile cache', () => {
+    const removed: string[] = []
+    removeMicromambaCacheForRoot(root, {
+      platform: 'win32',
+      env,
+      canonicalize: (path) => win32.normalize(path),
+      verifyOwnership: () => true,
+      inspect: () => ({ directory: true, symbolicLink: false, marker }),
+      remove: (path) => removed.push(path)
+    })
+
+    expect(removed).toHaveLength(3)
+    expect(removed).toContainEqual(
+      expect.stringMatching(/^C:\\Users\\alice\\os[0-9a-hjkmnp-tv-z]{8}$/)
+    )
   })
 })
 

--- a/src/main/notebook/micromamba-cache.ts
+++ b/src/main/notebook/micromamba-cache.ts
@@ -13,6 +13,11 @@ export type MicromambaCache = {
   lockKey: string
 }
 
+export type MicromambaCachePreparation = {
+  path?: string
+  rejection?: string
+}
+
 type CacheOwnership = {
   canonicalRoot: string
   userIdentity: string
@@ -24,7 +29,10 @@ export type MicromambaCacheDeps = {
   platform?: NodeJS.Platform
   env?: NodeJS.ProcessEnv
   canonicalize?: (path: string) => string
-  prepare?: (path: string, ownership: CacheOwnership) => string | undefined
+  prepare?: (
+    path: string,
+    ownership: CacheOwnership
+  ) => string | MicromambaCachePreparation | undefined
   verifyOwnership?: (path: string, userIdentity: string) => boolean
 }
 
@@ -154,14 +162,32 @@ const defaultPrepare = (
   path: string,
   ownership: CacheOwnership,
   verifyOwnership: (path: string, userIdentity: string) => boolean
-): string | undefined => {
+): MicromambaCachePreparation => {
   let created = false
+  const reject = (rejection: string): MicromambaCachePreparation => {
+    if (created) {
+      try {
+        rmSync(path, { recursive: true, force: true })
+      } catch {
+        // Preserve the original rejection; cleanup is best-effort for a directory this call created.
+      }
+    }
+    return { rejection }
+  }
+  const errorDetail = (error: unknown): string => {
+    if (!(error instanceof Error)) return 'unknown error'
+    const code = (error as NodeJS.ErrnoException).code
+    return code ? `${code}: ${error.message}` : error.message
+  }
   try {
     try {
       const stat = lstatSync(path)
-      if (!stat.isDirectory() || stat.isSymbolicLink()) return undefined
+      if (!stat.isDirectory()) return reject('path exists but is not a directory')
+      if (stat.isSymbolicLink()) return reject('path is a symbolic link or reparse point')
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return undefined
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        return reject(`path could not be inspected (${errorDetail(error)})`)
+      }
       mkdirSync(path, { mode: 0o700 })
       created = true
     }
@@ -175,68 +201,102 @@ const defaultPrepare = (
     if (created) {
       writeFileSync(markerPath, `${JSON.stringify(expected)}\n`, { encoding: 'utf8', mode: 0o600 })
     } else {
-      const marker = JSON.parse(readFileSync(markerPath, 'utf8')) as typeof expected
+      let marker: typeof expected
+      try {
+        marker = JSON.parse(readFileSync(markerPath, 'utf8')) as typeof expected
+      } catch (error) {
+        return reject(`cache marker is missing or unreadable (${errorDetail(error)})`)
+      }
       if (
         marker.schema !== expected.schema ||
         marker.canonicalRoot !== expected.canonicalRoot ||
         marker.userIdentity !== expected.userIdentity
       ) {
-        return undefined
+        return reject('cache marker does not match the current runtime root and Windows user')
       }
     }
 
     const physical = realpathSync.native(path)
-    if (windowsKey(physical) !== windowsKey(path)) return undefined
+    if (windowsKey(physical) !== windowsKey(path)) {
+      return reject(`path resolves to an unexpected physical location (${physical})`)
+    }
     if (
       ownership.profileBoundary &&
       !isInside(realpathSync.native(ownership.profileBoundary), physical)
     ) {
-      return undefined
+      return reject('path resolves outside the Windows user profile')
     }
     if (!verifyOwnership(physical, ownership.userIdentity)) {
-      throw new Error('Managed runtime cache ownership is not trusted.')
+      return reject('ownership or permissions are not trusted')
     }
 
     const probe = win32.join(physical, `.write-test-${randomUUID()}`)
     writeFileSync(probe, '')
     rmSync(probe, { force: true })
-    return physical
-  } catch {
-    if (created) rmSync(path, { recursive: true, force: true })
-    return undefined
+    return { path: physical }
+  } catch (error) {
+    return reject(`cache preparation failed (${errorDetail(error)})`)
   }
 }
 
 const fitsBudget = (cacheRoot: string, maxCacheRelativePath: number): boolean =>
   cacheRoot.length + maxCacheRelativePath <= WINDOWS_MAX_USABLE_PATH
 
+const BASE32_ALPHABET = '0123456789abcdefghjkmnpqrstvwxyz'
+
+const compactCacheHash = (digest: Buffer): string => {
+  let value = 0
+  let bits = 0
+  let encoded = ''
+  for (const byte of digest.subarray(0, 5)) {
+    value = (value << 8) | byte
+    bits += 8
+    while (bits >= 5) {
+      bits -= 5
+      encoded += BASE32_ALPHABET[(value >>> bits) & 31]
+      value &= (1 << bits) - 1
+    }
+  }
+  return encoded
+}
+
 const cacheIdentity = (
   root: string,
   env: NodeJS.ProcessEnv,
   canonicalize: (path: string) => string
-): { canonicalRoot: string; userIdentity: string; leaf: string } => {
+): { canonicalRoot: string; userIdentity: string; leaf: string; compactLeaf: string } => {
   const userIdentity = [env.USERDOMAIN, env.USERNAME].filter(Boolean).join('\\')
   if (!userIdentity) {
     throw new Error('Cannot determine the Windows user identity for the managed runtime cache.')
   }
   const canonicalRoot = win32.normalize(canonicalize(root))
-  const hash = createHash('sha256')
+  const digest = createHash('sha256')
     .update(`${userIdentity.toLowerCase()}\0${windowsKey(canonicalRoot)}`)
-    .digest('hex')
-    .slice(0, 10)
-  return { canonicalRoot, userIdentity, leaf: `osp${hash}` }
+    .digest()
+  return {
+    canonicalRoot,
+    userIdentity,
+    leaf: `osp${digest.toString('hex').slice(0, 10)}`,
+    compactLeaf: `os${compactCacheHash(digest)}`
+  }
 }
 
 const candidatePaths = (
   canonicalRoot: string,
   leaf: string,
+  compactLeaf: string,
   env: NodeJS.ProcessEnv,
   canonicalize: (path: string) => string
 ): Array<{ path: string; profileBoundary?: string }> => {
   const profile = env.USERPROFILE ? win32.normalize(canonicalize(env.USERPROFILE)) : undefined
   return [
     { path: win32.join(win32.parse(canonicalRoot).root, leaf) },
-    ...(profile ? [{ path: win32.join(profile, leaf), profileBoundary: profile }] : [])
+    ...(profile
+      ? [
+          { path: win32.join(profile, leaf), profileBoundary: profile },
+          { path: win32.join(profile, compactLeaf), profileBoundary: profile }
+        ]
+      : [])
   ]
 }
 
@@ -256,33 +316,51 @@ export const selectMicromambaCache = (
 
   const env = deps.env ?? process.env
   const canonicalize = deps.canonicalize ?? canonicalizeExisting
-  const { canonicalRoot, userIdentity, leaf } = cacheIdentity(root, env, canonicalize)
+  const { canonicalRoot, userIdentity, leaf, compactLeaf } = cacheIdentity(root, env, canonicalize)
   const verifyOwnership = deps.verifyOwnership ?? defaultVerifyOwnership
   const prepare =
     deps.prepare ??
     ((path: string, ownership: CacheOwnership) => defaultPrepare(path, ownership, verifyOwnership))
-  const candidates = candidatePaths(canonicalRoot, leaf, env, canonicalize)
+  const candidates = candidatePaths(canonicalRoot, leaf, compactLeaf, env, canonicalize)
+  const rejections: string[] = []
 
   for (const candidate of candidates) {
-    if (!fitsBudget(candidate.path, maxCacheRelativePath)) continue
-    const physical = prepare(candidate.path, {
+    if (!fitsBudget(candidate.path, maxCacheRelativePath)) {
+      const excess = candidate.path.length + maxCacheRelativePath - WINDOWS_MAX_USABLE_PATH
+      rejections.push(`${candidate.path}: exceeds the Windows path budget by ${excess} characters`)
+      continue
+    }
+    const prepared = prepare(candidate.path, {
       canonicalRoot,
       userIdentity,
       profileBoundary: candidate.profileBoundary,
       platform
     })
-    if (
-      !physical ||
-      !fitsBudget(physical, maxCacheRelativePath) ||
-      (deps.prepare !== undefined && !verifyOwnership(physical, userIdentity))
-    )
+    const preparation = typeof prepared === 'string' ? { path: prepared } : prepared
+    const physical = preparation?.path
+    if (!physical) {
+      rejections.push(
+        `${candidate.path}: ${preparation?.rejection ?? 'cache preparation returned no usable path'}`
+      )
       continue
+    }
+    if (!fitsBudget(physical, maxCacheRelativePath)) {
+      const excess = physical.length + maxCacheRelativePath - WINDOWS_MAX_USABLE_PATH
+      rejections.push(
+        `${physical}: physical path exceeds the Windows path budget by ${excess} characters`
+      )
+      continue
+    }
+    if (deps.prepare !== undefined && !verifyOwnership(physical, userIdentity)) {
+      rejections.push(`${physical}: ownership or permissions are not trusted`)
+      continue
+    }
     return { path: physical, lockKey: micromambaCacheLockKey(physical, { platform, canonicalize }) }
   }
 
   throw new Error(
     'No trusted writable package cache fits the managed runtime path budget. ' +
-      'Choose a shorter Windows user profile or data-root path.'
+      `Candidate diagnostics: ${rejections.join('; ')}.`
   )
 }
 
@@ -320,6 +398,7 @@ export const removeMicromambaCacheForRoot = (
   for (const candidate of candidatePaths(
     identity.canonicalRoot,
     identity.leaf,
+    identity.compactLeaf,
     env,
     canonicalize
   )) {

--- a/src/main/notebook/provisioner-runtime.test.ts
+++ b/src/main/notebook/provisioner-runtime.test.ts
@@ -89,6 +89,42 @@ describe('runMicromamba', () => {
     ).rejects.toThrow(/timed out[^]*timeout-stderr-token/i)
   })
 
+  it('attaches structured offline-create diagnostics to a timeout', async () => {
+    const argv = [
+      process.execPath,
+      '-e',
+      'process.stdout.write(process.env.MM_TIMEOUT_TOKEN); setInterval(() => {}, 1000)',
+      '--',
+      '--offline'
+    ]
+
+    await expect(
+      runMicromamba(
+        argv,
+        {
+          MM_TIMEOUT_TOKEN: 'timeout-stdout-token',
+          CONDA_PKGS_DIRS: 'C:\\Users\\test\\os12345678'
+        },
+        undefined,
+        undefined,
+        undefined,
+        200
+      )
+    ).rejects.toMatchObject({
+      code: 'MICROMAMBA_TIMEOUT',
+      data: {
+        argv,
+        cachePath: 'C:\\Users\\test\\os12345678',
+        durationMs: expect.any(Number),
+        offline: true,
+        pid: expect.any(Number),
+        stderrTail: '',
+        stdoutTail: 'timeout-stdout-token',
+        timeoutMs: 200
+      }
+    })
+  })
+
   it('distinguishes user cancellation from timeout and non-zero exit', async () => {
     const abort = new AbortController()
     const running = runMicromamba(

--- a/src/main/notebook/provisioner-runtime.ts
+++ b/src/main/notebook/provisioner-runtime.ts
@@ -139,6 +139,7 @@ export const runMicromamba = (
     let timedOut = false
     let cancelled = false
     let settled = false
+    const startedAt = Date.now()
     const appendTail = (current: string, chunk: unknown): string =>
       `${current}${String(chunk)}`.slice(-maxTail)
     child.stdout.on('data', (chunk) => {
@@ -217,11 +218,25 @@ export const runMicromamba = (
       }
       const tails = output()
       if (timedOut) {
-        reject(
+        const timeoutError = Object.assign(
           new Error(
             `micromamba timed out after ${timeoutMs}ms (${argv.join(' ')})${tails ? `:\n${tails}` : ''}`
-          )
+          ),
+          {
+            code: 'MICROMAMBA_TIMEOUT',
+            data: {
+              argv,
+              cachePath: env?.CONDA_PKGS_DIRS,
+              durationMs: Date.now() - startedAt,
+              offline: argv.includes('--offline'),
+              pid: child.pid,
+              stderrTail: stderr,
+              stdoutTail: stdout,
+              timeoutMs
+            }
+          }
         )
+        reject(timeoutError)
         return
       }
       if (code === 0) {


### PR DESCRIPTION
## Problem

On Windows, managed runtime provisioning can fail when no package-cache candidate is both trusted and short enough for the runtime's path budget. A drive-root candidate may be rejected because inherited ACLs allow broader writes, while the user-profile candidate can exceed the fixed 259-character limit under a long profile path. This affects both Python and R app-managed environments and is independent of system Python or R installations.

When provisioning later times out inside an offline `micromamba create`, the renderer only reports the ten-minute timeout. The existing app log does not retain enough lifecycle or subprocess context to distinguish slow extraction, cache I/O, antivirus interference, or a stalled child process from a download problem.

## Proposed change

- Preserve the existing `osp<10 hex>` cache candidates as the first choices.
- Add a compact user-profile candidate, `os<8 Crockford Base32>`, derived from the same first 40 bits of the SHA-256 identity.
- Report the exact rejection reason for every candidate, including path-budget, marker, reparse-point, ACL-trust, write, and inspection failures.
- Include the compact candidate in data-root migration cleanup and NSIS uninstall cleanup.
- Record provision and repair lifecycle diagnostics in the existing rotating `main.log`, including operation ID, language, runtime root, phase changes, reconnect attempts, duration, completion, and failure.
- Attach structured `MICROMAMBA_TIMEOUT` metadata: argv, cache path, elapsed time, offline mode, PID, timeout, and bounded stdout/stderr tails.
- Redact URL credentials, query values, token-bearing path segments, bearer tokens, API keys, secrets, and passwords before info or error fields are persisted.
- Sample phase transitions and reconnect attempts instead of logging every download progress chunk.

The original provisioning error object is still rethrown unchanged to the renderer.

## Scope and non-goals

This change remains fail-closed for cache markers and Windows ACL validation. It does not modify system Python or R installations, global or user `PATH`, `LongPathsEnabled`, global ACLs, Conda, or Mamba configuration. It does not change the ten-minute micromamba timeout or add a new log destination; diagnostics use the app's existing log and reveal workflow.

## Acceptance criteria and validation

For the reported path-budget case, the profile candidate changes from `37 + 225 = 262` characters to `34 + 225 = 259`, fitting the managed runtime path budget while retaining deterministic per-user identity.

For a later timeout, `main.log` now shows where provisioning stopped and records bounded subprocess evidence without exposing common credential forms or changing the error shown to the user.

- `npm run typecheck`: passed
- `npm run lint`: passed with 0 errors (56 pre-existing warnings)
- `npm run test`: 450 files passed, 9 skipped; 5,998 tests passed, 83 skipped
- Targeted managed-runtime tests: 161 passed
- Prettier check for touched files: passed

## Review focus

- TypeScript and PowerShell hash/encoding parity
- Legacy candidate priority and compatibility
- Fail-closed marker, reparse-point, and ACL checks
- Cleanup coverage for migration and uninstall
- Runtime lifecycle sampling and correlation IDs
- Timeout metadata bounds and renderer error compatibility
- Credential redaction across info and error logs
