### PR TITLE
style(permission): align approval card with dialog chrome

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -326,6 +326,15 @@ const ConversationPanel = ({
                 <PermissionApprovalControls
                   requests={pendingPermissions}
                   onRespond={onRespondToPermission}
+                  notebookLookup={
+                    activeSession
+                      ? {
+                          sessionId: activeSession.id,
+                          workspaceCwd: activeSession.cwd ?? '',
+                          projectName: activeSession.projectId
+                        }
+                      : undefined
+                  }
                 />
 
                 {notebookReference || hasAnyJobs ? (

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
@@ -38,23 +38,24 @@ afterEach(() => {
 })
 
 describe('PermissionApprovalControls interactions', () => {
-  it('default Allow button uses the narrowest scope (this call only), not the standing grant', () => {
-    // Least-privilege: the easiest click must be the one-time approval, not a persistent grant.
+  it('default Allow button uses the conversation scope so a repeated tool does not re-prompt', () => {
+    // The easiest click approves for the whole conversation; narrowing to a one-time
+    // approval is an explicit choice via the scope menu.
     act(() => {
       root.render(<PermissionApprovalControls requests={[baseRequest]} onRespond={vi.fn()} />)
     })
-    expect(container.textContent).toContain('this call only')
-    expect(container.textContent).not.toContain('this conversation')
+    expect(container.textContent).toContain('this conversation')
+    expect(container.textContent).not.toContain('this call only')
   })
 
-  it('Allow with default scope calls onRespond with the allow_once optionId', () => {
+  it('Allow with default scope calls onRespond with the allow_always optionId', () => {
     const onRespond = vi.fn()
     act(() => {
       root.render(<PermissionApprovalControls requests={[baseRequest]} onRespond={onRespond} />)
     })
     const allowBtn = container.querySelector('[data-testid="allow-primary"]') as HTMLButtonElement
     act(() => allowBtn.click())
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'opt-once')
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'opt-always')
   })
 
   it('switching to Once updates button label and calls allow_once optionId', () => {
@@ -196,17 +197,19 @@ describe('PermissionApprovalControls interactions', () => {
     const items = Array.from(
       container.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')
     )
+    // The menu opens with focus on the currently selected scope (conversation by default).
+    expect(document.activeElement).toBe(items[1])
+
+    // ArrowDown wraps from the last item back to the first.
+    act(() => {
+      items[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    })
     expect(document.activeElement).toBe(items[0])
 
     act(() => {
-      items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
     })
-    expect(document.activeElement).toBe(items[1])
-
-    act(() => {
-      items[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
-    })
-    expect(container.textContent).toContain('this conversation')
+    expect(container.textContent).toContain('this call only')
     expect(container.querySelector('[role="menuitemradio"]')).toBeNull()
 
     act(() => chevron.click())
@@ -260,23 +263,23 @@ describe('PermissionApprovalControls interactions', () => {
   })
 
   it('resets scope, open menu, and expand state when the next request is shown', () => {
-    // Switch req-1 to Conversation (away from the default Once) and leave the menu open, then swap
+    // Switch req-1 to Once (away from the default Conversation) and leave the menu open, then swap
     // to a fresh request to verify all state resets.
     act(() => {
       root.render(<PermissionApprovalControls requests={[baseRequest]} onRespond={vi.fn()} />)
     })
     const chevron = container.querySelector('[data-testid="scope-chevron"]') as HTMLButtonElement
     act(() => chevron.click())
-    const convItem = Array.from(container.querySelectorAll('[role="menuitemradio"]')).find((el) =>
-      el.textContent?.includes('This conversation')
+    const onceItem = Array.from(container.querySelectorAll('[role="menuitemradio"]')).find(
+      (el) => el.textContent?.includes('Once') && !el.textContent?.includes('conversation')
     ) as HTMLElement
-    act(() => convItem.click())
+    act(() => onceItem.click())
     // Collapse the code card so we can prove it re-expands for the next request.
     const toggle = container.querySelector(
       '[data-testid="permission-code-toggle"]'
     ) as HTMLButtonElement
     act(() => toggle.click())
-    expect(container.textContent).toContain('this conversation')
+    expect(container.textContent).toContain('this call only')
     expect(container.querySelector('[data-testid="tool-code-block"]')).toBeNull()
 
     // Rerender with a different request as the head of the queue.
@@ -289,9 +292,9 @@ describe('PermissionApprovalControls interactions', () => {
     act(() => {
       root.render(<PermissionApprovalControls requests={[nextRequest]} onRespond={vi.fn()} />)
     })
-    // Scope reset to the default (once), menu closed, card re-expanded.
-    expect(container.textContent).toContain('this call only')
-    expect(container.textContent).not.toContain('this conversation')
+    // Scope reset to the default (conversation), menu closed, card re-expanded.
+    expect(container.textContent).toContain('this conversation')
+    expect(container.textContent).not.toContain('this call only')
     expect(container.querySelector('[role="menuitemradio"]')).toBeNull()
     const nextToggle = container.querySelector(
       '[data-testid="permission-code-toggle"]'

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
@@ -316,4 +316,62 @@ describe('PermissionApprovalControls interactions', () => {
     expect(container.querySelector('[role="menuitemradio"]')).not.toBeNull()
     expect(chevron.getAttribute('aria-expanded')).toBe('true')
   })
+
+  it('falls back to the Settings runtime name for the env badge before any kernel ran', async () => {
+    // No live kernel and no run history: the badge must still name the enabled runtime from
+    // Settings → Runtimes (the app-managed default wins over user-registered envs).
+    const notebookRequest: AcpPermissionRequest = {
+      requestId: 'req-env',
+      sessionId: 'session-env-fallback',
+      toolCallId: 'tool-env',
+      title: 'mcp__open-science-notebook__notebook_execute',
+      providerToolName: 'mcp__open-science-notebook__notebook_execute',
+      rawInput: { kernelKind: 'python', code: 'print(1)' },
+      options: [{ optionId: 'opt-once', name: 'Allow once', kind: 'allow_once' }],
+      raw: {}
+    }
+    ;(window as { api?: unknown }).api = {
+      notebook: {
+        state: async () => ({ environments: [], runs: [] })
+      },
+      runtime: {
+        listEnvironments: async () => ({
+          python: [
+            {
+              language: 'python',
+              provenance: 'app-managed',
+              envId: '/envs/default-python',
+              interpreterPath: '/envs/default-python/bin/python',
+              label: 'default-python',
+              runnable: true
+            }
+          ],
+          r: []
+        }),
+        getEnablement: async () => ({ enabled: {}, installAuthorized: {} })
+      }
+    }
+    try {
+      act(() => {
+        root.render(
+          <PermissionApprovalControls
+            requests={[notebookRequest]}
+            onRespond={vi.fn()}
+            notebookLookup={{ sessionId: 'session-env-fallback', workspaceCwd: '' }}
+          />
+        )
+      })
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      expect(container.querySelector('[data-testid="permission-env-badge"]')?.textContent).toBe(
+        'default-python'
+      )
+      expect(
+        container.querySelector('[data-testid="permission-language-badge"]')?.textContent
+      ).toBe('python')
+    } finally {
+      delete (window as { api?: unknown }).api
+    }
+  })
 })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -317,7 +317,7 @@ describe('PermissionApprovalControls', () => {
       <PermissionApprovalControls requests={[brokerShape]} onRespond={() => undefined} />
     )
     expect(html).toContain('Run notebook cell')
-    expect(html).toContain('Notebook execution</span>')
+    expect(html).toContain('data-testid="permission-tool-info"')
     expect(html).toContain('data-language="python"')
     expect(html).toContain('print(&quot;hi&quot;)')
     // Must not misclassify as a shell command showing the namespaced title.
@@ -341,22 +341,45 @@ describe('PermissionApprovalControls', () => {
       <PermissionApprovalControls requests={[opencodeShape]} onRespond={() => undefined} />
     )
     expect(html).toContain('Run notebook cell')
-    expect(html).toContain('Notebook execution</span>')
+    expect(html).toContain('data-testid="permission-tool-info"')
     expect(html).toContain('data-language="python"')
     expect(html).not.toContain('data-language="bash"')
   })
 
-  it('labels a fully-namespaced notebook request as Notebook execution', () => {
-    // The risk badge must agree with the code-card header for real mcp__<server>__notebook_execute
-    // names, not fall through to the generic MCP label.
+  it('labels a fully-namespaced notebook request with the notebook badge cluster, not MCP', () => {
+    // The header cluster must agree with the code-card header for real
+    // mcp__<server>__notebook_execute names, not fall through to the generic MCP label.
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[{ ...notebookPermissionRequest, isMcp: true }]}
         onRespond={() => undefined}
       />
     )
-    expect(html).toContain('Notebook execution</span>')
+    expect(html).toContain('data-testid="permission-language-badge"')
+    expect(html).toContain('data-testid="permission-tool-info"')
     expect(html).not.toContain('MCP tool access</span>')
+  })
+
+  it('shows the kernel language badge for notebook prompts, matching the code highlight', () => {
+    const pythonHtml = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[notebookPermissionRequest]}
+        onRespond={() => undefined}
+      />
+    )
+    expect(pythonHtml).toContain('>python</span>')
+
+    // The badge follows the inferred code language even without an explicit kernel field.
+    const rHtml = renderToStaticMarkup(
+      <PermissionApprovalControls requests={[rNotebookRequest]} onRespond={() => undefined} />
+    )
+    expect(rHtml).toContain('>r</span>')
+
+    // repl_execute pins JavaScript even though its code looks generic.
+    const replHtml = renderToStaticMarkup(
+      <PermissionApprovalControls requests={[replRequest]} onRespond={() => undefined} />
+    )
+    expect(replHtml).toContain('>javascript</span>')
   })
 
   it('renders no code block when rawInput is absent', () => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -200,6 +200,26 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('Run command?')
   })
 
+  it('shows the title for a non-Bash execute request with no command preview', () => {
+    // A non-Bash execute request whose command lives only in the title: extractPermissionCode
+    // has no Bash fallback here, so the title is the only place the command can appear — the
+    // generic "Run command?" header must not leave the prompt opaque.
+    const executeTitleOnly: AcpPermissionRequest = {
+      requestId: 'exec-title-1',
+      sessionId: 'session-1',
+      toolCallId: 'tool-exec-title',
+      title: 'python scripts/run_pipeline.py --full',
+      toolKind: 'execute',
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }],
+      raw: {}
+    }
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls requests={[executeTitleOnly]} onRespond={() => undefined} />
+    )
+    expect(html).toContain('Run command?')
+    expect(html).toContain('python scripts/run_pipeline.py --full')
+  })
+
   it('serializes prompts by rendering only the first pending request', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -137,10 +137,10 @@ const secondPermissionRequest: AcpPermissionRequest = {
 }
 
 describe('PermissionApprovalControls', () => {
-  it('renders the Allow button with the narrowest default scope (once), not standing access', () => {
+  it('renders the Allow button with the conversation scope by default', () => {
     const html = renderControls()
-    expect(html).toContain('for this call only')
-    expect(html).not.toContain('for this conversation')
+    expect(html).toContain('for this conversation')
+    expect(html).not.toContain('for this call only')
     expect(html).toContain('data-testid="allow-primary"')
     expect(html).toContain('data-testid="deny-button"')
     expect(html).toContain('data-testid="scope-chevron"')

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -176,6 +176,30 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('Command execution</span>')
   })
 
+  it('keeps the tool identity visible for execute-kind MCP requests', () => {
+    // An MCP tool reporting kind:'execute' (write_artifact_file) must not collapse into the
+    // generic "Run command?" shell wording — the provider name is the only identity left when
+    // the request carries no previewable command payload.
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[
+          {
+            ...permissionRequest,
+            title: 'mcp.open-science-artifacts.write_artifact_file',
+            providerToolName: 'write_artifact_file',
+            isMcp: true,
+            toolKind: 'execute',
+            rawInput: undefined
+          }
+        ]}
+        onRespond={() => undefined}
+      />
+    )
+
+    expect(html).toContain('Run write_artifact_file?')
+    expect(html).not.toContain('Run command?')
+  })
+
   it('serializes prompts by rendering only the first pending request', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -181,12 +181,12 @@ const PermissionCodeSection = ({
   const [expanded, setExpanded] = useState(true)
 
   return (
-    <div className="w-full overflow-hidden rounded-lg bg-muted/60 px-1.5 py-1">
+    <div className="w-full overflow-hidden rounded-lg bg-muted/60 px-2 py-1.5">
       <button
         type="button"
         data-testid="permission-code-toggle"
         aria-expanded={expanded}
-        className="flex w-full items-center gap-2 rounded-lg py-[5px] pl-1.5 pr-2.5 text-[13px] transition-colors hover:bg-muted"
+        className="flex w-full items-center gap-2 rounded-lg px-1.5 py-1.5 text-[13px] transition-colors hover:bg-muted"
         onClick={() => setExpanded((e) => !e)}
       >
         <span
@@ -283,7 +283,7 @@ const ScopeDropdown = ({
       ref={ref}
       role="menu"
       aria-label="Authorization scope"
-      className="absolute bottom-full left-0 z-10 mb-1 min-w-44 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-menu outline-none"
+      className="absolute bottom-full right-0 z-10 mb-1.5 min-w-44 rounded-lg border border-border bg-popover p-1.5 text-popover-foreground shadow-menu outline-none"
     >
       {options.map(({ scope, label, subtitle }, index) => (
         <button
@@ -295,7 +295,7 @@ const ScopeDropdown = ({
           role="menuitemradio"
           aria-checked={selected === scope}
           className={cn(
-            'flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-muted',
+            'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted',
             selected === scope && 'bg-muted'
           )}
           onClick={() => {
@@ -323,15 +323,15 @@ const ScopeDropdown = ({
             }
           }}
         >
-          {/* Check column: left side, fixed slot so selection never shifts the label */}
-          <span className="flex w-3.5 shrink-0 justify-center text-primary">
-            {selected === scope ? <Check className="size-3.5" strokeWidth={2.5} /> : null}
-          </span>
-          {/* Label column: left-aligned flush to the check slot so both rows line up */}
+          {/* Label column: left-aligned flush to padding so both rows line up */}
           <div className="flex min-w-0 flex-1 flex-col">
             <span className="text-xs font-medium text-foreground">{label}</span>
             <span className="text-[11px] leading-tight text-muted-foreground">{subtitle}</span>
           </div>
+          {/* Check column: right side, fixed slot so selection never shifts the label */}
+          <span className="flex w-3.5 shrink-0 justify-center text-primary">
+            {selected === scope ? <Check className="size-3.5" strokeWidth={2.5} /> : null}
+          </span>
         </button>
       ))}
     </div>
@@ -414,7 +414,7 @@ const PermissionApprovalControls = ({
       : undefined
 
   return (
-    <div className="mb-2 flex w-full max-w-full flex-col gap-3 rounded-xl border border-border bg-card p-4 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
+    <div className="mb-2 flex w-full max-w-full flex-col gap-4 rounded-xl border border-border bg-card p-5 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
       {/* Header: action question + risk label */}
       <div className="flex min-w-0 items-center gap-2">
         <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>{headerTitle}</span>
@@ -449,13 +449,13 @@ const PermissionApprovalControls = ({
         />
       )}
 
-      {/* Allow / Deny button row, left-aligned like the reference approval prompts */}
-      <div className="flex items-center gap-2">
-        {/* Split Allow button: main action + scope chevron; the menu anchors to this group's left edge.
-            Styled like the shared Button (size sm, including flex centering so the label baseline
+      {/* Allow / Deny button row */}
+      <div className="flex items-center justify-end gap-2">
+        {/* Split Allow button: main action + scope chevron; the menu anchors to this group's right edge.
+            Styled like the shared Button (default size, including flex centering so the label baseline
             matches the neighboring Button primitives) but kept as two segments so the chevron
             stays a separate tab stop with its own aria-haspopup semantics. */}
-        <div className="relative flex items-stretch overflow-visible rounded-[min(var(--radius-md),12px)]">
+        <div className="relative flex items-stretch overflow-visible rounded-lg">
           {scopeOpen && (
             <ScopeDropdown
               selected={effectiveScope}
@@ -464,11 +464,11 @@ const PermissionApprovalControls = ({
               onClose={closeScopeMenu}
             />
           )}
-          <div className="flex items-stretch overflow-hidden rounded-[min(var(--radius-md),12px)]">
+          <div className="flex items-stretch overflow-hidden rounded-lg">
             <button
               type="button"
               data-testid="allow-primary"
-              className="inline-flex h-7 select-none items-center justify-center whitespace-nowrap bg-primary px-2.5 text-[0.8rem] font-medium text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50 disabled:opacity-50"
+              className="inline-flex h-8 select-none items-center justify-center whitespace-nowrap bg-primary px-3 text-sm font-medium text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50 disabled:opacity-50"
               disabled={!allowOptionId}
               onClick={() => {
                 if (allowOptionId) onRespond(request.requestId, allowOptionId)
@@ -484,7 +484,7 @@ const PermissionApprovalControls = ({
               aria-label="Choose authorization scope"
               aria-expanded={scopeOpen}
               aria-haspopup="menu"
-              className="inline-flex h-7 select-none items-center justify-center bg-primary px-1.5 text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50"
+              className="inline-flex h-8 select-none items-center justify-center bg-primary px-2 text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50"
               onClick={(e) => {
                 // Stop propagation so this click doesn't reach the dropdown's document
                 // click-listener and immediately re-close the menu it just opened.
@@ -492,7 +492,7 @@ const PermissionApprovalControls = ({
                 setScopeOpen((o) => !o)
               }}
             >
-              <ChevronDown className="size-3.5" />
+              <ChevronDown className="size-4" />
             </button>
           </div>
         </div>
@@ -503,7 +503,6 @@ const PermissionApprovalControls = ({
             key={option.optionId}
             type="button"
             variant="outline"
-            size="sm"
             data-testid="extra-option"
             onClick={() => onRespond(request.requestId, option.optionId)}
           >
@@ -513,7 +512,6 @@ const PermissionApprovalControls = ({
         <Button
           type="button"
           variant="outline"
-          size="sm"
           data-testid="deny-button"
           onClick={() => onRespond(request.requestId, denyOptionId)}
         >

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -392,9 +392,14 @@ const PermissionApprovalControls = ({
   // Header asks a friendly action question; raw tool identifiers (namespaced MCP names like
   // mcp__open-science-notebook__notebook_execute) are illegible in a sentence, so notebook and
   // shell runs get plain-language phrasing. The provider name only heads the prompt for other
-  // tools, where it is typically a short readable name (Write, Edit).
+  // tools, where it is typically a short readable name (Write, Edit). MCP requests are never
+  // collapsed into the shell wording: the broker preserves MCP identity even for kind:'execute'
+  // tools (e.g. open-science-artifacts_write_artifact_file), and the provider/title is the only
+  // place that identity stays visible when there is no code preview.
   const isNotebook = resolveNotebookToolName(request) !== undefined
-  const isShell = request.toolKind === 'execute' || request.providerToolName === 'Bash'
+  const isShell =
+    request.isMcp !== true &&
+    (request.toolKind === 'execute' || request.providerToolName === 'Bash')
   const headerTitle = isNotebook
     ? 'Run notebook code?'
     : isShell
@@ -451,8 +456,9 @@ const PermissionApprovalControls = ({
         />
       )}
 
-      {/* Allow / Deny button row */}
-      <div className="flex items-center justify-end gap-2">
+      {/* Allow / Deny button row; wraps so long provider-supplied option labels can never
+          push the primary Allow/Deny controls out of view. */}
+      <div className="flex flex-wrap items-center justify-end gap-2">
         {/* Split Allow button: main action + scope chevron; the menu anchors to this group's right edge.
             Styled like the shared Button (default size, including flex centering so the label baseline
             matches the neighboring Button primitives) but kept as two segments so the chevron
@@ -499,13 +505,16 @@ const PermissionApprovalControls = ({
           </div>
         </div>
         {/* Fallback buttons for any protocol option the Allow/Deny controls can't reach, so an
-            unrecognized or ambiguous same-kind option stays selectable rather than disappearing. */}
+            unrecognized or ambiguous same-kind option stays selectable rather than disappearing.
+            Provider-controlled labels can be long: override the Button's shrink-0/whitespace-nowrap
+            so the label wraps inside the card instead of overflowing it. */}
         {extraOptions.map((option) => (
           <Button
             key={option.optionId}
             type="button"
             variant="outline"
             data-testid="extra-option"
+            className="h-auto min-h-8 min-w-0 max-w-full shrink whitespace-normal break-words py-1"
             onClick={() => onRespond(request.requestId, option.optionId)}
           >
             {getExtraOptionLabel(option)}

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -300,21 +300,20 @@ const useNotebookEnvironment = (
 
 // Header cluster for notebook prompts: kernel-language badge, the session's bound environment
 // (once the runtime has spawned or recorded one), and an info tooltip explaining where the code
-// runs and what an approval covers, with the raw tool identity kept reachable now that the header
-// shows a friendly question instead of the tool name.
+// runs and what an approval covers, phrased for the current kernel language.
 const NotebookHeaderBadges = ({
   lookup,
   language,
-  riskLabel,
   rawIdentity
 }: {
   lookup: NotebookSessionRequest | undefined
   language: string
-  riskLabel: string
   rawIdentity: string | undefined
 }): React.JSX.Element => {
   const kernelKind = language === 'python' ? 'python' : language === 'r' ? 'r' : undefined
   const envName = useNotebookEnvironment(lookup, kernelKind)
+  // Display form for the tooltip sentence: javascript/r read better capitalized.
+  const languageLabel = language === 'javascript' ? 'JavaScript' : language === 'r' ? 'R' : language
 
   return (
     <span className="ml-auto flex shrink-0 items-center gap-1.5">
@@ -340,12 +339,7 @@ const NotebookHeaderBadges = ({
               </button>
             </TooltipTrigger>
             <TooltipContent className="max-w-72 whitespace-normal">
-              <span className="block">
-                {riskLabel}. Runs in this session&apos;s notebook runtime
-                {envName ? ` (${envName})` : ''}; allowing for this conversation auto-approves later
-                calls to this tool without asking again.
-              </span>
-              <span className="mt-0.5 block break-all opacity-70">{rawIdentity}</span>
+              {`Runs in this session's notebook environment${envName ? ` (${envName})` : ''}. Grants cover any ${languageLabel} call until this chat ends.`}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
@@ -557,7 +551,6 @@ const PermissionApprovalControls = ({
           <NotebookHeaderBadges
             lookup={notebookLookup}
             language={permLanguage}
-            riskLabel={getPermissionRiskLabel(request)}
             rawIdentity={request.providerToolName ?? request.title}
           />
         ) : (

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -342,7 +342,7 @@ const PermissionApprovalControls = ({
   requests,
   onRespond
 }: PermissionApprovalControlsProps): React.JSX.Element | null => {
-  const [scope, setScope] = useState<PermissionScope>('once')
+  const [scope, setScope] = useState<PermissionScope>('conversation')
   const [scopeOpen, setScopeOpen] = useState(false)
   const scopeTriggerRef = useRef<HTMLButtonElement>(null)
   const closeScopeMenu = useCallback((restoreTriggerFocus = false) => {
@@ -353,11 +353,13 @@ const PermissionApprovalControls = ({
   // Show only the oldest pending request; the rest stay queued.
   const request = requests[0]
 
-  // Default the primary Allow action to the NARROWEST scope the request offers, so the single
-  // easiest click grants the least standing access (a one-time approval). Widening to
-  // 'conversation' (allow_always) requires an explicit choice via the scope menu.
+  // Default the primary Allow action to the WIDEST in-session scope the request offers
+  // ('conversation', backed by allow_always), so a repeated tool doesn't re-prompt on every
+  // call. Narrowing to a one-time approval ('once') is an explicit choice via the scope menu.
   const availableScopes = request ? getAvailableScopes(request.options) : new Set<PermissionScope>()
-  const defaultScope: PermissionScope = availableScopes.has('once') ? 'once' : 'conversation'
+  const defaultScope: PermissionScope = availableScopes.has('conversation')
+    ? 'conversation'
+    : 'once'
 
   // Reset per-request UI state (scope + open menu) whenever the displayed request changes,
   // so nothing leaks from the previously answered prompt.

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -613,13 +613,14 @@ const PermissionApprovalControls = ({
             <button
               type="button"
               data-testid="allow-primary"
-              className="inline-flex h-8 select-none items-center justify-center whitespace-nowrap bg-primary px-3 text-sm font-medium text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50 disabled:opacity-50"
+              className="inline-flex h-8 select-none items-center justify-center whitespace-nowrap bg-primary px-3 text-sm text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50 disabled:opacity-50"
               disabled={!allowOptionId}
               onClick={() => {
                 if (allowOptionId) onRespond(request.requestId, allowOptionId)
               }}
             >
-              Allow {scopeLabel}
+              <span className="font-semibold">Allow</span>{' '}
+              <span className="font-normal">{scopeLabel}</span>
             </button>
             <div className="w-px bg-primary-foreground/25" />
             <button

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -299,8 +299,9 @@ const useNotebookEnvironment = (
 }
 
 // Header cluster for notebook prompts: kernel-language badge, the session's bound environment
-// (once the runtime has spawned or recorded one), and an info tooltip that keeps the raw tool
-// identity reachable now that the header shows a friendly question instead of the tool name.
+// (once the runtime has spawned or recorded one), and an info tooltip explaining where the code
+// runs and what an approval covers, with the raw tool identity kept reachable now that the header
+// shows a friendly question instead of the tool name.
 const NotebookHeaderBadges = ({
   lookup,
   language,
@@ -338,8 +339,13 @@ const NotebookHeaderBadges = ({
                 <Info className="size-3.5" aria-hidden="true" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>
-              {riskLabel} · {rawIdentity}
+            <TooltipContent className="max-w-72 whitespace-normal">
+              <span className="block">
+                {riskLabel}. Runs in this session&apos;s notebook runtime
+                {envName ? ` (${envName})` : ''}; allowing for this conversation auto-approves later
+                calls to this tool without asking again.
+              </span>
+              <span className="mt-0.5 block break-all opacity-70">{rawIdentity}</span>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -1,10 +1,12 @@
-import { Check, ChevronDown, ChevronRight } from 'lucide-react'
+import { Check, ChevronDown, ChevronRight, Info } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { AcpPermissionRequest } from '../../../../shared/acp'
+import type { NotebookSessionRequest } from '../../../../shared/notebook'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { dialogTitleClassName } from '@/components/ui/dialog-chrome'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { resolveNotebookLanguage, resolveNotebookRunToolName } from './notebook-tool-names'
 import { WorkspaceToolCodeBlock } from './WorkspaceToolCodeBlock'
@@ -12,6 +14,9 @@ import { WorkspaceToolCodeBlock } from './WorkspaceToolCodeBlock'
 type PermissionApprovalControlsProps = {
   requests: AcpPermissionRequest[]
   onRespond: (requestId: string, optionId?: string) => void
+  // Session locator for the notebook env badge; optional so the controls render standalone
+  // (isolation tests, sessions without notebook context).
+  notebookLookup?: NotebookSessionRequest
 }
 
 type PermissionOption = AcpPermissionRequest['options'][number]
@@ -237,6 +242,112 @@ const getPermissionRiskLabel = (request: AcpPermissionRequest): string => {
   }
 }
 
+// Per-session env-name lookups, cached so every prompt in the same chat reuses a single read.
+// Keyed by sessionId + kernel kind so a python badge and an R badge never share a stale answer.
+const notebookEnvCache = new Map<string, Promise<string | undefined>>()
+
+// Resolves the environment a session's notebook kernels run in: prefer the live kernel matching
+// the requested kind, then any live env, then the most recent run's recorded env. Sessions that
+// never touched the notebook (or have no bridge in tests) resolve to undefined — no badge.
+const lookupNotebookEnvironment = async (
+  request: NotebookSessionRequest,
+  kernelKind: 'python' | 'r'
+): Promise<string | undefined> => {
+  const api = window.api?.notebook
+  if (!api) return undefined
+  try {
+    const state = await api.state(request)
+    const live =
+      state.environments.find((e) => e.kind === kernelKind && e.environment)?.environment ??
+      state.environments.find((e) => e.environment)?.environment
+    if (live) return live
+    for (let i = state.runs.length - 1; i >= 0; i -= 1) {
+      const env = state.runs[i].environment
+      if (env) return env
+    }
+  } catch {
+    /* no notebook for this session yet */
+  }
+  return undefined
+}
+
+const useNotebookEnvironment = (
+  lookup: NotebookSessionRequest | undefined,
+  kernelKind: 'python' | 'r' | undefined
+): string | undefined => {
+  const [envName, setEnvName] = useState<string | undefined>()
+  const lookupKey = lookup ? `${lookup.projectName ?? ''}:${lookup.sessionId}` : undefined
+  useEffect(() => {
+    if (!lookup || !lookupKey || !kernelKind) return
+    let cancelled = false
+    const key = `${lookupKey}:${kernelKind}`
+    let cached = notebookEnvCache.get(key)
+    if (!cached) {
+      cached = lookupNotebookEnvironment(lookup, kernelKind)
+      notebookEnvCache.set(key, cached)
+    }
+    void cached.then((name) => {
+      if (!cancelled) setEnvName(name)
+    })
+    return () => {
+      cancelled = true
+    }
+    // lookup is a fresh object per render; the primitive key is the real dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lookupKey, kernelKind])
+  return kernelKind ? envName : undefined
+}
+
+// Header cluster for notebook prompts: kernel-language badge, the session's bound environment
+// (once the runtime has spawned or recorded one), and an info tooltip that keeps the raw tool
+// identity reachable now that the header shows a friendly question instead of the tool name.
+const NotebookHeaderBadges = ({
+  lookup,
+  language,
+  riskLabel,
+  rawIdentity
+}: {
+  lookup: NotebookSessionRequest | undefined
+  language: string
+  riskLabel: string
+  rawIdentity: string | undefined
+}): React.JSX.Element => {
+  const kernelKind = language === 'python' ? 'python' : language === 'r' ? 'r' : undefined
+  const envName = useNotebookEnvironment(lookup, kernelKind)
+
+  return (
+    <span className="ml-auto flex shrink-0 items-center gap-1.5">
+      <Badge variant="secondary" data-testid="permission-language-badge">
+        {language}
+      </Badge>
+      {envName ? (
+        <Badge variant="secondary" data-testid="permission-env-badge">
+          {envName}
+        </Badge>
+      ) : null}
+      {rawIdentity ? (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Tool details"
+                data-testid="permission-tool-info"
+                className="flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <Info className="size-3.5" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {riskLabel} · {rawIdentity}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+    </span>
+  )
+}
+
 // Popover listing the two available scope choices.
 const ScopeDropdown = ({
   selected,
@@ -340,7 +451,8 @@ const ScopeDropdown = ({
 
 const PermissionApprovalControls = ({
   requests,
-  onRespond
+  onRespond,
+  notebookLookup
 }: PermissionApprovalControlsProps): React.JSX.Element | null => {
   const [scope, setScope] = useState<PermissionScope>('conversation')
   const [scopeOpen, setScopeOpen] = useState(false)
@@ -396,7 +508,8 @@ const PermissionApprovalControls = ({
   // collapsed into the shell wording: the broker preserves MCP identity even for kind:'execute'
   // tools (e.g. open-science-artifacts_write_artifact_file), and the provider/title is the only
   // place that identity stays visible when there is no code preview.
-  const isNotebook = resolveNotebookToolName(request) !== undefined
+  const notebookToolName = resolveNotebookToolName(request)
+  const isNotebook = notebookToolName !== undefined
   const isShell =
     request.isMcp !== true &&
     (request.toolKind === 'execute' || request.providerToolName === 'Bash')
@@ -422,14 +535,30 @@ const PermissionApprovalControls = ({
     return request.title !== headerName ? request.title : undefined
   })()
 
+  // Kernel language for the notebook header badge: the code preview's language when there is one,
+  // otherwise resolved from the tool identity alone (repl/bash suffixes, python default), so the
+  // badge always agrees with what the code block would highlight.
+  const permLanguage = notebookToolName
+    ? (permCode?.language ?? resolveNotebookLanguage(notebookToolName, undefined, undefined))
+    : undefined
+
   return (
     <div className="mb-2 flex w-full max-w-full flex-col gap-4 rounded-xl border border-border bg-card p-5 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
-      {/* Header: action question + risk label */}
+      {/* Header: action question + risk label (notebook prompts get language/env badges + tooltip) */}
       <div className="flex min-w-0 items-center gap-2">
         <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>{headerTitle}</span>
-        <Badge variant="secondary" className="ml-auto">
-          {getPermissionRiskLabel(request)}
-        </Badge>
+        {notebookToolName && permLanguage ? (
+          <NotebookHeaderBadges
+            lookup={notebookLookup}
+            language={permLanguage}
+            riskLabel={getPermissionRiskLabel(request)}
+            rawIdentity={request.providerToolName ?? request.title}
+          />
+        ) : (
+          <Badge variant="secondary" className="ml-auto">
+            {getPermissionRiskLabel(request)}
+          </Badge>
+        )}
       </div>
 
       {/* Full request title (the target being authorized) when the header alone doesn't show it. */}
@@ -526,6 +655,7 @@ const PermissionApprovalControls = ({
           type="button"
           variant="outline"
           data-testid="deny-button"
+          className="px-4"
           onClick={() => onRespond(request.requestId, denyOptionId)}
         >
           Deny

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { AcpPermissionRequest } from '../../../../shared/acp'
 import type { NotebookSessionRequest } from '../../../../shared/notebook'
+import { isEnvEnabled } from '../../../../shared/notebook-runtime'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { dialogTitleClassName } from '@/components/ui/dialog-chrome'
@@ -246,29 +247,45 @@ const getPermissionRiskLabel = (request: AcpPermissionRequest): string => {
 // Keyed by sessionId + kernel kind so a python badge and an R badge never share a stale answer.
 const notebookEnvCache = new Map<string, Promise<string | undefined>>()
 
-// Resolves the environment a session's notebook kernels run in: prefer the live kernel matching
-// the requested kind, then any live env, then the most recent run's recorded env. Sessions that
-// never touched the notebook (or have no bridge in tests) resolve to undefined — no badge.
+// Resolves the environment a session's notebook kernels run in, best-known first: the live kernel
+// matching the requested kind, then any live env, then the most recent run's recorded env, and
+// finally the enabled runtime from Settings → Runtimes (what a kernel started now would bind).
+// Sessions with no notebook history and no bridge (tests) resolve to undefined — no badge.
 const lookupNotebookEnvironment = async (
   request: NotebookSessionRequest,
   kernelKind: 'python' | 'r'
 ): Promise<string | undefined> => {
-  const api = window.api?.notebook
-  if (!api) return undefined
-  try {
-    const state = await api.state(request)
-    const live =
-      state.environments.find((e) => e.kind === kernelKind && e.environment)?.environment ??
-      state.environments.find((e) => e.environment)?.environment
-    if (live) return live
-    for (let i = state.runs.length - 1; i >= 0; i -= 1) {
-      const env = state.runs[i].environment
-      if (env) return env
+  const notebookApi = window.api?.notebook
+  if (notebookApi) {
+    try {
+      const state = await notebookApi.state(request)
+      const live =
+        state.environments.find((e) => e.kind === kernelKind && e.environment)?.environment ??
+        state.environments.find((e) => e.environment)?.environment
+      if (live) return live
+      for (let i = state.runs.length - 1; i >= 0; i -= 1) {
+        const env = state.runs[i].environment
+        if (env) return env
+      }
+    } catch {
+      /* no notebook for this session yet — fall through to the Settings default */
     }
-  } catch {
-    /* no notebook for this session yet */
   }
-  return undefined
+
+  const runtimeApi = window.api?.runtime
+  if (!runtimeApi) return undefined
+  try {
+    const [lists, enablement] = await Promise.all([
+      runtimeApi.listEnvironments(),
+      runtimeApi.getEnablement(kernelKind)
+    ])
+    const enabled = lists[kernelKind].filter((env) => isEnvEnabled(env, enablement))
+    // Mirror the session's default binding: the app-managed env wins over user-registered ones.
+    const fallback = enabled.find((env) => env.provenance === 'app-managed') ?? enabled[0]
+    return fallback?.label
+  } catch {
+    return undefined
+  }
 }
 
 const useNotebookEnvironment = (

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -408,17 +408,19 @@ const PermissionApprovalControls = ({
 
   // The title often carries the actual target (e.g. provider "Write" with title
   // "Write report.md"). Surface it as a detail line when it adds information the header
-  // doesn't, and isn't already shown verbatim by the code card. Skipped for notebook and
-  // shell prompts: there the title is just the tool identifier or the command itself.
+  // doesn't, and isn't already shown verbatim by the code card. Skipped for notebook
+  // prompts: there the title is just the tool identifier. For shell prompts the header is
+  // generic ("Run command?"), so when no code preview renders the command — e.g. a non-Bash
+  // execute request whose command lives only in the title — the title must stay visible,
+  // otherwise the user approves an opaque execution request.
   const headerName = request.providerToolName ?? request.title
-  const titleDetail =
-    !isNotebook &&
-    !isShell &&
-    request.title &&
-    request.title !== headerName &&
-    request.title !== permCode?.code
-      ? request.title
-      : undefined
+  const titleDetail = ((): string | undefined => {
+    if (isNotebook || !request.title || request.title === permCode?.code) return undefined
+    if (isShell) {
+      return !permCode && request.title !== request.providerToolName ? request.title : undefined
+    }
+    return request.title !== headerName ? request.title : undefined
+  })()
 
   return (
     <div className="mb-2 flex w-full max-w-full flex-col gap-4 rounded-xl border border-border bg-card p-5 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -2,6 +2,9 @@ import { Check, ChevronDown, ChevronRight } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { AcpPermissionRequest } from '../../../../shared/acp'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { dialogTitleClassName } from '@/components/ui/dialog-chrome'
 import { cn } from '@/lib/utils'
 import { resolveNotebookLanguage, resolveNotebookRunToolName } from './notebook-tool-names'
 import { WorkspaceToolCodeBlock } from './WorkspaceToolCodeBlock'
@@ -178,25 +181,25 @@ const PermissionCodeSection = ({
   const [expanded, setExpanded] = useState(true)
 
   return (
-    <div className="w-full overflow-hidden rounded-[14px] bg-bg-200/70 px-1.5 py-1">
+    <div className="w-full overflow-hidden rounded-lg bg-muted/60 px-1.5 py-1">
       <button
         type="button"
         data-testid="permission-code-toggle"
         aria-expanded={expanded}
-        className="flex w-full items-center gap-2 rounded-lg py-[5px] pl-1.5 pr-2.5 text-[13px] transition-colors hover:bg-bg-300"
+        className="flex w-full items-center gap-2 rounded-lg py-[5px] pl-1.5 pr-2.5 text-[13px] transition-colors hover:bg-muted"
         onClick={() => setExpanded((e) => !e)}
       >
         <span
           className={cn(
-            'inline-flex w-4 shrink-0 items-center justify-center text-text-100 transition-transform duration-200',
+            'inline-flex w-4 shrink-0 items-center justify-center text-muted-foreground transition-transform duration-200',
             expanded && 'rotate-90'
           )}
         >
           <ChevronRight className="size-3.5" strokeWidth={2.2} aria-hidden="true" />
         </span>
-        <span className="min-w-0 truncate text-left font-medium text-text-000">{title}</span>
+        <span className="min-w-0 truncate text-left font-medium text-foreground">{title}</span>
         {language ? (
-          <span className="ml-auto shrink-0 whitespace-nowrap text-[12px] text-text-100">
+          <span className="ml-auto shrink-0 whitespace-nowrap text-xs text-muted-foreground">
             {language}
           </span>
         ) : null}
@@ -280,7 +283,7 @@ const ScopeDropdown = ({
       ref={ref}
       role="menu"
       aria-label="Authorization scope"
-      className="absolute bottom-full right-0 z-10 mb-1 min-w-[216px] rounded-lg border border-border-200 bg-bg-000 p-1 shadow-md"
+      className="absolute bottom-full right-0 z-10 mb-1 min-w-[216px] rounded-lg border border-border bg-popover p-1.5 text-popover-foreground shadow-menu outline-none"
     >
       {options.map(({ scope, label, subtitle }, index) => (
         <button
@@ -292,8 +295,8 @@ const ScopeDropdown = ({
           role="menuitemradio"
           aria-checked={selected === scope}
           className={cn(
-            'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-bg-200',
-            selected === scope && 'bg-bg-100'
+            'flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-muted',
+            selected === scope && 'bg-muted'
           )}
           onClick={() => {
             onSelect(scope)
@@ -322,8 +325,8 @@ const ScopeDropdown = ({
         >
           {/* Label column: left-aligned flush to padding so both rows line up */}
           <div className="flex min-w-0 flex-1 flex-col">
-            <span className="text-[12px] font-medium text-text-000">{label}</span>
-            <span className="text-[11px] leading-tight text-text-300">{subtitle}</span>
+            <span className="text-xs font-medium text-foreground">{label}</span>
+            <span className="text-[11px] leading-tight text-muted-foreground">{subtitle}</span>
           </div>
           {/* Check column: right side, fixed slot so selection never shifts the label */}
           <span className="flex w-3.5 shrink-0 justify-center text-primary">
@@ -394,26 +397,26 @@ const PermissionApprovalControls = ({
       : undefined
 
   return (
-    <div className="mb-2 w-full max-w-full rounded-lg border border-border-200 bg-bg-000 px-3 py-2 text-[12px] leading-5 text-text-000 shadow-sm">
+    <div className="mb-2 w-full max-w-full rounded-xl border border-border bg-card px-3 py-2.5 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
       {/* Header: tool name + risk label */}
       <div className="mb-2 flex min-w-0 items-center gap-2">
-        <span className="font-semibold truncate">
+        <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>
           Run {request.providerToolName ?? request.title}?
         </span>
-        <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[11px] bg-bg-100 text-text-300">
+        <Badge variant="secondary" className="ml-auto">
           {getPermissionRiskLabel(request)}
-        </span>
+        </Badge>
       </div>
 
       {/* Full request title (the target being authorized) when the header alone doesn't show it. */}
       {titleDetail ? (
-        <div className="mb-2 break-all text-[11px] text-text-300">{titleDetail}</div>
+        <div className="mb-2 break-all text-[11px] text-muted-foreground">{titleDetail}</div>
       ) : null}
 
       {/* Affected file targets — the canonical location field, shown so read/edit/delete
           prompts always reveal the path being authorized. Wraps to keep full values readable. */}
       {request.toolLocations?.length ? (
-        <div className="mb-2 flex flex-wrap gap-x-2 gap-y-0.5 break-all text-[11px] text-text-300">
+        <div className="mb-2 flex flex-wrap gap-x-2 gap-y-0.5 break-all text-[11px] text-muted-foreground">
           {request.toolLocations.map((location) => (
             <span key={location.path}>{location.path}</span>
           ))}
@@ -435,8 +438,10 @@ const PermissionApprovalControls = ({
 
       {/* Allow / Deny button row */}
       <div className="flex items-center justify-end gap-2">
-        {/* Split Allow button: main action + scope chevron; the menu anchors to this group's right edge */}
-        <div className="relative flex items-stretch overflow-visible rounded-md">
+        {/* Split Allow button: main action + scope chevron; the menu anchors to this group's right edge.
+            Styled like the shared Button (size sm) but kept as two segments so the chevron stays a
+            separate tab stop with its own aria-haspopup semantics. */}
+        <div className="relative flex items-stretch overflow-visible rounded-lg">
           {scopeOpen && (
             <ScopeDropdown
               selected={effectiveScope}
@@ -445,11 +450,11 @@ const PermissionApprovalControls = ({
               onClose={closeScopeMenu}
             />
           )}
-          <div className="flex items-stretch overflow-hidden rounded-md">
+          <div className="flex items-stretch overflow-hidden rounded-lg">
             <button
               type="button"
               data-testid="allow-primary"
-              className="bg-primary px-3 py-1.5 text-[12px] font-medium text-primary-foreground hover:bg-primary/80 disabled:opacity-40"
+              className="h-7 bg-primary px-2.5 text-[0.8rem] font-medium text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50 disabled:opacity-50"
               disabled={!allowOptionId}
               onClick={() => {
                 if (allowOptionId) onRespond(request.requestId, allowOptionId)
@@ -457,7 +462,7 @@ const PermissionApprovalControls = ({
             >
               Allow {scopeLabel}
             </button>
-            <div className="w-px bg-primary/30" />
+            <div className="w-px bg-primary-foreground/25" />
             <button
               ref={scopeTriggerRef}
               type="button"
@@ -465,7 +470,7 @@ const PermissionApprovalControls = ({
               aria-label="Choose authorization scope"
               aria-expanded={scopeOpen}
               aria-haspopup="menu"
-              className="bg-primary px-2 py-1.5 text-primary-foreground hover:bg-primary/80"
+              className="h-7 bg-primary px-1.5 text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50"
               onClick={(e) => {
                 // Stop propagation so this click doesn't reach the dropdown's document
                 // click-listener and immediately re-close the menu it just opened.
@@ -480,24 +485,26 @@ const PermissionApprovalControls = ({
         {/* Fallback buttons for any protocol option the Allow/Deny controls can't reach, so an
             unrecognized or ambiguous same-kind option stays selectable rather than disappearing. */}
         {extraOptions.map((option) => (
-          <button
+          <Button
             key={option.optionId}
             type="button"
+            variant="outline"
+            size="sm"
             data-testid="extra-option"
-            className="rounded-md border border-border-200 bg-bg-000 px-3 py-1.5 text-[12px] text-text-100 hover:bg-bg-100"
             onClick={() => onRespond(request.requestId, option.optionId)}
           >
             {getExtraOptionLabel(option)}
-          </button>
+          </Button>
         ))}
-        <button
+        <Button
           type="button"
+          variant="outline"
+          size="sm"
           data-testid="deny-button"
-          className="rounded-md border border-border-200 bg-bg-000 px-3 py-1.5 text-[12px] text-text-100 hover:bg-bg-100"
           onClick={() => onRespond(request.requestId, denyOptionId)}
         >
           Deny
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -613,7 +613,7 @@ const PermissionApprovalControls = ({
             <button
               type="button"
               data-testid="allow-primary"
-              className="inline-flex h-8 select-none items-center justify-center whitespace-nowrap bg-primary px-3 text-sm text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50 disabled:opacity-50"
+              className="inline-flex h-8 select-none items-center justify-center gap-1 whitespace-nowrap bg-primary px-3 text-sm text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50 disabled:opacity-50"
               disabled={!allowOptionId}
               onClick={() => {
                 if (allowOptionId) onRespond(request.requestId, allowOptionId)

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -283,7 +283,7 @@ const ScopeDropdown = ({
       ref={ref}
       role="menu"
       aria-label="Authorization scope"
-      className="absolute bottom-full right-0 z-10 mb-1 min-w-[216px] rounded-lg border border-border bg-popover p-1.5 text-popover-foreground shadow-menu outline-none"
+      className="absolute bottom-full left-0 z-10 mb-1 min-w-44 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-menu outline-none"
     >
       {options.map(({ scope, label, subtitle }, index) => (
         <button
@@ -323,15 +323,15 @@ const ScopeDropdown = ({
             }
           }}
         >
-          {/* Label column: left-aligned flush to padding so both rows line up */}
+          {/* Check column: left side, fixed slot so selection never shifts the label */}
+          <span className="flex w-3.5 shrink-0 justify-center text-primary">
+            {selected === scope ? <Check className="size-3.5" strokeWidth={2.5} /> : null}
+          </span>
+          {/* Label column: left-aligned flush to the check slot so both rows line up */}
           <div className="flex min-w-0 flex-1 flex-col">
             <span className="text-xs font-medium text-foreground">{label}</span>
             <span className="text-[11px] leading-tight text-muted-foreground">{subtitle}</span>
           </div>
-          {/* Check column: right side, fixed slot so selection never shifts the label */}
-          <span className="flex w-3.5 shrink-0 justify-center text-primary">
-            {selected === scope ? <Check className="size-3.5" strokeWidth={2.5} /> : null}
-          </span>
         </button>
       ))}
     </div>
@@ -387,22 +387,37 @@ const PermissionApprovalControls = ({
     denyOptionId
   )
 
-  // The header shows the provider name; the title often carries the actual target (e.g. provider
-  // "Write" with title "Write report.md"). Surface the title as a detail line when it adds
-  // information the header doesn't, and isn't already shown verbatim by the code card.
+  // Header asks a friendly action question; raw tool identifiers (namespaced MCP names like
+  // mcp__open-science-notebook__notebook_execute) are illegible in a sentence, so notebook and
+  // shell runs get plain-language phrasing. The provider name only heads the prompt for other
+  // tools, where it is typically a short readable name (Write, Edit).
+  const isNotebook = resolveNotebookToolName(request) !== undefined
+  const isShell = request.toolKind === 'execute' || request.providerToolName === 'Bash'
+  const headerTitle = isNotebook
+    ? 'Run notebook code?'
+    : isShell
+      ? 'Run command?'
+      : `Run ${request.providerToolName ?? request.title}?`
+
+  // The title often carries the actual target (e.g. provider "Write" with title
+  // "Write report.md"). Surface it as a detail line when it adds information the header
+  // doesn't, and isn't already shown verbatim by the code card. Skipped for notebook and
+  // shell prompts: there the title is just the tool identifier or the command itself.
   const headerName = request.providerToolName ?? request.title
   const titleDetail =
-    request.title && request.title !== headerName && request.title !== permCode?.code
+    !isNotebook &&
+    !isShell &&
+    request.title &&
+    request.title !== headerName &&
+    request.title !== permCode?.code
       ? request.title
       : undefined
 
   return (
-    <div className="mb-2 w-full max-w-full rounded-xl border border-border bg-card px-3 py-2.5 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
-      {/* Header: tool name + risk label */}
-      <div className="mb-2 flex min-w-0 items-center gap-2">
-        <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>
-          Run {request.providerToolName ?? request.title}?
-        </span>
+    <div className="mb-2 flex w-full max-w-full flex-col gap-3 rounded-xl border border-border bg-card p-4 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
+      {/* Header: action question + risk label */}
+      <div className="flex min-w-0 items-center gap-2">
+        <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>{headerTitle}</span>
         <Badge variant="secondary" className="ml-auto">
           {getPermissionRiskLabel(request)}
         </Badge>
@@ -410,38 +425,37 @@ const PermissionApprovalControls = ({
 
       {/* Full request title (the target being authorized) when the header alone doesn't show it. */}
       {titleDetail ? (
-        <div className="mb-2 break-all text-[11px] text-muted-foreground">{titleDetail}</div>
+        <div className="break-all text-xs text-muted-foreground">{titleDetail}</div>
       ) : null}
 
       {/* Affected file targets — the canonical location field, shown so read/edit/delete
           prompts always reveal the path being authorized. Wraps to keep full values readable. */}
       {request.toolLocations?.length ? (
-        <div className="mb-2 flex flex-wrap gap-x-2 gap-y-0.5 break-all text-[11px] text-muted-foreground">
+        <div className="flex flex-wrap gap-x-2 gap-y-0.5 break-all text-xs text-muted-foreground">
           {request.toolLocations.map((location) => (
             <span key={location.path}>{location.path}</span>
           ))}
         </div>
       ) : null}
 
-      {/* Activity-style card showing the code that will run */}
+      {/* Activity-style card showing the code that will run.
+          Keyed by requestId so the collapsed/expanded state never carries over between prompts. */}
       {permCode && (
-        <div className="mb-2">
-          {/* Keyed by requestId so the collapsed/expanded state never carries over between prompts. */}
-          <PermissionCodeSection
-            key={requestId}
-            title={getPermissionActionTitle(request)}
-            code={permCode.code}
-            language={permCode.language}
-          />
-        </div>
+        <PermissionCodeSection
+          key={requestId}
+          title={getPermissionActionTitle(request)}
+          code={permCode.code}
+          language={permCode.language}
+        />
       )}
 
-      {/* Allow / Deny button row */}
-      <div className="flex items-center justify-end gap-2">
-        {/* Split Allow button: main action + scope chevron; the menu anchors to this group's right edge.
-            Styled like the shared Button (size sm) but kept as two segments so the chevron stays a
-            separate tab stop with its own aria-haspopup semantics. */}
-        <div className="relative flex items-stretch overflow-visible rounded-lg">
+      {/* Allow / Deny button row, left-aligned like the reference approval prompts */}
+      <div className="flex items-center gap-2">
+        {/* Split Allow button: main action + scope chevron; the menu anchors to this group's left edge.
+            Styled like the shared Button (size sm, including flex centering so the label baseline
+            matches the neighboring Button primitives) but kept as two segments so the chevron
+            stays a separate tab stop with its own aria-haspopup semantics. */}
+        <div className="relative flex items-stretch overflow-visible rounded-[min(var(--radius-md),12px)]">
           {scopeOpen && (
             <ScopeDropdown
               selected={effectiveScope}
@@ -450,11 +464,11 @@ const PermissionApprovalControls = ({
               onClose={closeScopeMenu}
             />
           )}
-          <div className="flex items-stretch overflow-hidden rounded-lg">
+          <div className="flex items-stretch overflow-hidden rounded-[min(var(--radius-md),12px)]">
             <button
               type="button"
               data-testid="allow-primary"
-              className="h-7 bg-primary px-2.5 text-[0.8rem] font-medium text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50 disabled:opacity-50"
+              className="inline-flex h-7 select-none items-center justify-center whitespace-nowrap bg-primary px-2.5 text-[0.8rem] font-medium text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50 disabled:opacity-50"
               disabled={!allowOptionId}
               onClick={() => {
                 if (allowOptionId) onRespond(request.requestId, allowOptionId)
@@ -470,7 +484,7 @@ const PermissionApprovalControls = ({
               aria-label="Choose authorization scope"
               aria-expanded={scopeOpen}
               aria-haspopup="menu"
-              className="h-7 bg-primary px-1.5 text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50"
+              className="inline-flex h-7 select-none items-center justify-center bg-primary px-1.5 text-primary-foreground outline-none transition-colors hover:bg-primary/80 focus-visible:ring-3 focus-visible:ring-ring/50"
               onClick={(e) => {
                 // Stop propagation so this click doesn't reach the dropdown's document
                 // click-listener and immediately re-close the menu it just opened.

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -319,7 +319,7 @@ describe('conversation message scroller integration', () => {
 
     // Outer container maintains width constraints (overflow-visible so the scope dropdown is not clipped)
     expect(permissionApprovalControlsSource).toContain(
-      'className="mb-2 w-full max-w-full rounded-lg border border-border-200'
+      'className="mb-2 w-full max-w-full rounded-xl border border-border bg-card'
     )
     // Header maintains min-w-0 for text truncation
     expect(permissionApprovalControlsSource).toContain(

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -329,7 +329,7 @@ describe('conversation message scroller integration', () => {
     expect(permissionApprovalControlsSource).toContain('WorkspaceToolCodeBlock')
     // Button row maintains layout constraints
     expect(permissionApprovalControlsSource).toContain(
-      'className="flex items-center justify-end gap-2"'
+      'className="flex flex-wrap items-center justify-end gap-2"'
     )
   })
 

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -319,18 +319,16 @@ describe('conversation message scroller integration', () => {
 
     // Outer container maintains width constraints (overflow-visible so the scope dropdown is not clipped)
     expect(permissionApprovalControlsSource).toContain(
-      'className="mb-2 w-full max-w-full rounded-xl border border-border bg-card'
+      'className="mb-2 flex w-full max-w-full flex-col gap-3 rounded-xl border border-border bg-card'
     )
     // Header maintains min-w-0 for text truncation
     expect(permissionApprovalControlsSource).toContain(
-      'className="mb-2 flex min-w-0 items-center gap-2"'
+      'className="flex min-w-0 items-center gap-2"'
     )
     // Code block uses WorkspaceToolCodeBlock with max-height constraint
     expect(permissionApprovalControlsSource).toContain('WorkspaceToolCodeBlock')
     // Button row maintains layout constraints
-    expect(permissionApprovalControlsSource).toContain(
-      'className="flex items-center justify-end gap-2"'
-    )
+    expect(permissionApprovalControlsSource).toContain('className="flex items-center gap-2"')
   })
 
   it('keeps composer attachment UI inline with the composer', () => {

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -319,7 +319,7 @@ describe('conversation message scroller integration', () => {
 
     // Outer container maintains width constraints (overflow-visible so the scope dropdown is not clipped)
     expect(permissionApprovalControlsSource).toContain(
-      'className="mb-2 flex w-full max-w-full flex-col gap-3 rounded-xl border border-border bg-card'
+      'className="mb-2 flex w-full max-w-full flex-col gap-4 rounded-xl border border-border bg-card'
     )
     // Header maintains min-w-0 for text truncation
     expect(permissionApprovalControlsSource).toContain(
@@ -328,7 +328,9 @@ describe('conversation message scroller integration', () => {
     // Code block uses WorkspaceToolCodeBlock with max-height constraint
     expect(permissionApprovalControlsSource).toContain('WorkspaceToolCodeBlock')
     // Button row maintains layout constraints
-    expect(permissionApprovalControlsSource).toContain('className="flex items-center gap-2"')
+    expect(permissionApprovalControlsSource).toContain(
+      'className="flex items-center justify-end gap-2"'
+    )
   })
 
   it('keeps composer attachment UI inline with the composer', () => {


### PR DESCRIPTION
## Problem

The inline permission approval card in the workspace conversation still uses the legacy `bg-bg-000` / `text-text-000` / `border-border-200` palette, a hand-rolled `shadow-sm` card, and ad-hoc buttons. Every other surface in the app (project, session, settings, update, data migration, error report, file browser, job detail dialogs and the shared dropdown menus) has moved to the shared `dialog-chrome` tokens, so the approval prompt visually sticks out.

## Proposed change

Restyle `PermissionApprovalControls` to the shared dialog-chrome visual language — presentation only, no behavior change:

- Card shell: `rounded-xl border border-border bg-card text-card-foreground shadow-dialog`, plus a `motion-safe` fade/slide-in on mount (matching the dialog chrome's fade-in affordance)
- Header title uses `dialogTitleClassName`; the risk label becomes the shared `Badge` (`secondary`)
- Scope dropdown matches `DropdownMenuContent` (`bg-popover`, `border-border`, `shadow-menu`, `p-1.5`) and its items match `DropdownMenuItem` (`hover:bg-muted`, selected `bg-muted`)
- Code section and detail/location lines move from `bg-bg-*` / `text-text-*` to `bg-muted` / `text-foreground` / `text-muted-foreground`
- Deny and extra-option buttons use the shared `Button` (`outline`, `sm`); the Allow split button keeps its two-segment structure (chevron stays a separate tab stop with `aria-haspopup`) but adopts the same `sm` metrics, divider, and focus ring

## Scope and non-goals

- No behavioral changes: scope defaults, option-kind matching, keyboard navigation, focus restore, and testids are untouched
- The card stays an inline conversation element — it does not become a modal overlay
- Other legacy-palette surfaces in the workspace are not part of this change

## Acceptance criteria and validation

- `npm run typecheck` — green
- `npm run lint` — no new findings on the changed files
- `npm run test` — 460 files / 6057 tests green, including the 37 `PermissionApprovalControls` render/interaction tests; the source-string assertion in `workspace-components.test.tsx` is updated to the new container classes (the width-constraint intent it guards is preserved)

## Review focus

- Token choices for the inline card (`shadow-dialog` on a non-modal surface, `bg-muted/60` for the code section)
- The Allow split button remains hand-rolled (two segments, shared-button metrics) rather than the `Button` primitive — confirm the trade-off is acceptable
