### PR TITLE
fix(notebook): harden managed cache ACLs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -74,6 +74,12 @@ jobs:
       - name: Check CLI package
         run: npm run check:cli-package
 
+      # This exercises the production DACL writer and verifier on a real Windows filesystem. Keep
+      # it hard-gated even while the general Windows suite remains advisory.
+      - name: Test Windows micromamba cache ACL
+        if: matrix.os == 'windows-latest'
+        run: npx vitest run src/main/notebook/micromamba-cache-acl.integration.test.ts
+
       # Full test suite + coverage gate on macOS (thresholds live in vitest.config.ts).
       - name: Test (with coverage)
         if: matrix.os == 'macos-14'

--- a/src/main/notebook/micromamba-cache-acl.integration.test.ts
+++ b/src/main/notebook/micromamba-cache-acl.integration.test.ts
@@ -1,0 +1,24 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  hardenWindowsCacheAcl,
+  isTrustedWindowsCacheAcl,
+  readWindowsCacheAcl
+} from './micromamba-cache'
+
+describe.runIf(process.platform === 'win32')('Windows micromamba cache ACL integration', () => {
+  it('applies an ACL accepted by the production trust verifier', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'os-cache-acl-'))
+    try {
+      hardenWindowsCacheAcl(directory)
+
+      expect(isTrustedWindowsCacheAcl(readWindowsCacheAcl(directory))).toBe(true)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/notebook/micromamba-cache-preparation.test.ts
+++ b/src/main/notebook/micromamba-cache-preparation.test.ts
@@ -1,0 +1,119 @@
+import { win32 } from 'node:path'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsMocks = vi.hoisted(() => {
+  const native = vi.fn((path: string) => path)
+  const realpathSync = Object.assign(
+    vi.fn((path: string) => path),
+    { native }
+  )
+  return {
+    lstatSync: vi.fn(() => {
+      throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+    }),
+    mkdirSync: vi.fn(),
+    readFileSync: vi.fn(),
+    realpathSync,
+    rmSync: vi.fn(),
+    writeFileSync: vi.fn()
+  }
+})
+
+vi.mock('node:fs', () => fsMocks)
+
+import {
+  DEFAULT_MAX_CACHE_RELATIVE_PATH,
+  selectMicromambaCache,
+  type MicromambaCacheDeps
+} from './micromamba-cache'
+
+describe('Windows micromamba cache preparation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('hardens a newly created candidate before verifying its ownership and permissions', () => {
+    const hardenOwnership = vi.fn()
+    const verifyOwnership = vi.fn(() => hardenOwnership.mock.calls.length > 0)
+    const deps = {
+      platform: 'win32',
+      env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' },
+      canonicalize: (path: string) => win32.normalize(path),
+      hardenOwnership,
+      verifyOwnership
+    } as MicromambaCacheDeps
+
+    const cache = selectMicromambaCache(
+      'D:\\OpenScience\\runtime',
+      DEFAULT_MAX_CACHE_RELATIVE_PATH,
+      deps
+    )
+
+    expect(cache.path).toMatch(/^D:\\osp[0-9a-f]{10}$/)
+    expect(hardenOwnership).toHaveBeenCalledOnce()
+    expect(hardenOwnership).toHaveBeenCalledWith(cache.path)
+    expect(hardenOwnership.mock.invocationCallOrder[0]).toBeLessThan(
+      fsMocks.writeFileSync.mock.invocationCallOrder[0]
+    )
+    expect(hardenOwnership.mock.invocationCallOrder[0]).toBeLessThan(
+      verifyOwnership.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('removes newly created candidates when ACL hardening fails', () => {
+    const hardenOwnership = vi.fn(() => {
+      throw new Error('Set-Acl denied')
+    })
+
+    expect(() =>
+      selectMicromambaCache('D:\\OpenScience\\runtime', DEFAULT_MAX_CACHE_RELATIVE_PATH, {
+        platform: 'win32',
+        env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' },
+        canonicalize: (path) => win32.normalize(path),
+        hardenOwnership,
+        verifyOwnership: () => true
+      })
+    ).toThrow(/cache ACL could not be hardened \(Set-Acl denied\)/)
+
+    expect(hardenOwnership).toHaveBeenCalledTimes(3)
+    expect(fsMocks.rmSync).toHaveBeenCalledTimes(3)
+    for (const [path, options] of fsMocks.rmSync.mock.calls) {
+      expect(path).toMatch(/^(D:\\|C:\\Users\\alice\\)os/)
+      expect(options).toEqual({ recursive: true, force: true })
+    }
+  })
+
+  it('does not harden or take over an existing marked candidate', () => {
+    fsMocks.lstatSync.mockImplementationOnce(
+      () =>
+        ({
+          isDirectory: () => true,
+          isSymbolicLink: () => false
+        }) as never
+    )
+    fsMocks.readFileSync.mockImplementationOnce(() =>
+      JSON.stringify({
+        schema: 1,
+        canonicalRoot: 'd:\\openscience\\runtime',
+        userIdentity: 'alice'
+      })
+    )
+    const hardenOwnership = vi.fn()
+
+    const cache = selectMicromambaCache(
+      'D:\\OpenScience\\runtime',
+      DEFAULT_MAX_CACHE_RELATIVE_PATH,
+      {
+        platform: 'win32',
+        env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' },
+        canonicalize: (path) => win32.normalize(path),
+        hardenOwnership,
+        verifyOwnership: () => true
+      }
+    )
+
+    expect(cache.path).toMatch(/^D:\\osp/)
+    expect(hardenOwnership).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/notebook/micromamba-cache.test.ts
+++ b/src/main/notebook/micromamba-cache.test.ts
@@ -12,6 +12,8 @@ import {
   selectMicromambaCache,
   WINDOWS_CACHE_DANGEROUS_RIGHT_NAMES,
   WINDOWS_MAX_USABLE_PATH,
+  windowsCacheAclHardeningScript,
+  windowsCacheAclReadScript,
   type MicromambaCacheDeps
 } from './micromamba-cache'
 
@@ -263,6 +265,31 @@ describe('removeMicromambaCacheForRoot', () => {
 })
 
 describe('isTrustedWindowsCacheAcl', () => {
+  it('builds a literal-safe least-privilege ACL hardening command', () => {
+    const script = windowsCacheAclHardeningScript("C:\\Users\\O'Brien\\cache")
+
+    expect(script).toContain("$path='C:\\Users\\O''Brien\\cache'")
+    expect(script).toContain('$acl.SetOwner($current)')
+    expect(script).toContain('$acl.SetAccessRuleProtection($true,$false)')
+    expect(script).toContain('S-1-5-18')
+    expect(script).toContain('S-1-5-32-544')
+    expect(script).toContain('FileSystemRights]::FullControl')
+    expect(script).toContain('[System.IO.Directory]::SetAccessControl($path,$acl)')
+    expect(script).not.toMatch(/Everyone|Authenticated Users|S-1-1-0|S-1-5-11/i)
+    expect(script).not.toMatch(/Set-Acl/i)
+  })
+
+  it('reads ACLs without relying on PowerShell security module autoloading', () => {
+    const script = windowsCacheAclReadScript("C:\\Users\\O'Brien\\cache")
+
+    expect(script).toContain(
+      "$acl=[System.IO.Directory]::GetAccessControl('C:\\Users\\O''Brien\\cache')"
+    )
+    expect(script).toContain('$acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value')
+    expect(script).toContain('$acl.GetAccessRules($true,$true,')
+    expect(script).not.toMatch(/Get-Acl/i)
+  })
+
   it('allows writes only for the current user and trusted system principals', () => {
     const current = 'S-1-5-21-1000'
     expect(

--- a/src/main/notebook/micromamba-cache.ts
+++ b/src/main/notebook/micromamba-cache.ts
@@ -29,6 +29,7 @@ export type MicromambaCacheDeps = {
   platform?: NodeJS.Platform
   env?: NodeJS.ProcessEnv
   canonicalize?: (path: string) => string
+  hardenOwnership?: (path: string) => void
   prepare?: (
     path: string,
     ownership: CacheOwnership
@@ -78,11 +79,45 @@ export const micromambaCacheLockKey = (
 
 const powershellLiteral = (value: string): string => value.replaceAll("'", "''")
 
+export const windowsCacheAclHardeningScript = (path: string): string => {
+  const literal = powershellLiteral(path)
+  return (
+    `$path='${literal}'; ` +
+    '$current=[System.Security.Principal.WindowsIdentity]::GetCurrent().User; ' +
+    "$system=[System.Security.Principal.SecurityIdentifier]::new('S-1-5-18'); " +
+    "$administrators=[System.Security.Principal.SecurityIdentifier]::new('S-1-5-32-544'); " +
+    '$inheritance=[System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor ' +
+    '[System.Security.AccessControl.InheritanceFlags]::ObjectInherit; ' +
+    '$propagation=[System.Security.AccessControl.PropagationFlags]::None; ' +
+    '$allow=[System.Security.AccessControl.AccessControlType]::Allow; ' +
+    '$acl=[System.Security.AccessControl.DirectorySecurity]::new(); ' +
+    '$acl.SetOwner($current); ' +
+    '$acl.SetAccessRuleProtection($true,$false); ' +
+    '@($current,$system,$administrators) | ForEach-Object { ' +
+    '$rule=[System.Security.AccessControl.FileSystemAccessRule]::new(' +
+    '$_,[System.Security.AccessControl.FileSystemRights]::FullControl,' +
+    '$inheritance,$propagation,$allow); ' +
+    '[void]$acl.AddAccessRule($rule) }; ' +
+    '[System.IO.Directory]::SetAccessControl($path,$acl)'
+  )
+}
+
+export const hardenWindowsCacheAcl = (path: string): void => {
+  if (process.platform !== 'win32') return
+  execFileSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', windowsCacheAclHardeningScript(path)],
+    { encoding: 'utf8', windowsHide: true }
+  )
+}
+
 export type WindowsCacheAcl = {
   OwnerSid?: string
   CurrentSid?: string
   Rules?: Array<{ Sid?: string; Rights?: string; Type?: string }>
 }
+
+type WindowsCacheAclRule = NonNullable<WindowsCacheAcl['Rules']>[number]
 
 // Keep this complete dangerous-rights set in sync with windows-runtime-cache-uninstall.ps1.
 // A foreign principal that can write, delete, change permissions, or take ownership can replace
@@ -117,6 +152,38 @@ export const isTrustedWindowsCacheAcl = (acl: WindowsCacheAcl): boolean => {
   )
 }
 
+export const windowsCacheAclReadScript = (path: string): string => {
+  const literal = powershellLiteral(path)
+  return (
+    `$acl=[System.IO.Directory]::GetAccessControl('${literal}'); ` +
+    `$current=[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value; ` +
+    `$owner=$acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value; ` +
+    `$rules=$acl.GetAccessRules($true,$true,` +
+    `[System.Security.Principal.SecurityIdentifier]) | ForEach-Object { ` +
+    `[pscustomobject]@{Sid=$_.IdentityReference.Value; ` +
+    `Rights=$_.FileSystemRights.ToString(); Type=$_.AccessControlType.ToString()} }; ` +
+    `[pscustomobject]@{OwnerSid=$owner; CurrentSid=$current; Rules=$rules} | ` +
+    'ConvertTo-Json -Compress -Depth 4'
+  )
+}
+
+export const readWindowsCacheAcl = (path: string): WindowsCacheAcl => {
+  const script = windowsCacheAclReadScript(path)
+  const raw = execFileSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    {
+      encoding: 'utf8',
+      windowsHide: true
+    }
+  )
+  const acl = JSON.parse(raw) as Omit<WindowsCacheAcl, 'Rules'> & {
+    Rules?: WindowsCacheAclRule | WindowsCacheAclRule[]
+  }
+  const rules = !acl.Rules ? [] : Array.isArray(acl.Rules) ? acl.Rules : [acl.Rules]
+  return { ...acl, Rules: rules }
+}
+
 // A marker proves only that the marker contents are self-consistent. On Windows, a cache outside
 // the profile must also be owned by the current user and must not grant broad principals write
 // access. PowerShell is part of every supported Windows installation; failures fail closed.
@@ -124,35 +191,7 @@ const defaultVerifyOwnership = (path: string, userIdentity: string): boolean => 
   void userIdentity
   if (process.platform !== 'win32') return true
   try {
-    const literal = powershellLiteral(path)
-    const script =
-      `$acl=Get-Acl -LiteralPath '${literal}'; ` +
-      `$current=[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value; ` +
-      `$owner=([System.Security.Principal.NTAccount]$acl.Owner).Translate(` +
-      `[System.Security.Principal.SecurityIdentifier]).Value; ` +
-      `$rules=$acl.Access | ForEach-Object { $sid=''; try { $sid=$_.IdentityReference.Translate(` +
-      `[System.Security.Principal.SecurityIdentifier]).Value } catch {}; ` +
-      `[pscustomobject]@{Sid=$sid; ` +
-      `Rights=$_.FileSystemRights.ToString(); Type=$_.AccessControlType.ToString()} }; ` +
-      `[pscustomobject]@{OwnerSid=$owner; CurrentSid=$current; Rules=$rules} | ` +
-      'ConvertTo-Json -Compress -Depth 4'
-    const raw = execFileSync(
-      'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-Command', script],
-      {
-        encoding: 'utf8',
-        windowsHide: true
-      }
-    )
-    const acl = JSON.parse(raw) as {
-      OwnerSid?: string
-      CurrentSid?: string
-      Rules?:
-        | { Sid?: string; Rights?: string; Type?: string }
-        | Array<{ Sid?: string; Rights?: string; Type?: string }>
-    }
-    const rules = !acl.Rules ? [] : Array.isArray(acl.Rules) ? acl.Rules : [acl.Rules]
-    return isTrustedWindowsCacheAcl({ ...acl, Rules: rules })
+    return isTrustedWindowsCacheAcl(readWindowsCacheAcl(path))
   } catch {
     return false
   }
@@ -161,6 +200,7 @@ const defaultVerifyOwnership = (path: string, userIdentity: string): boolean => 
 const defaultPrepare = (
   path: string,
   ownership: CacheOwnership,
+  hardenOwnership: (path: string) => void,
   verifyOwnership: (path: string, userIdentity: string) => boolean
 ): MicromambaCachePreparation => {
   let created = false
@@ -190,6 +230,11 @@ const defaultPrepare = (
       }
       mkdirSync(path, { mode: 0o700 })
       created = true
+      try {
+        hardenOwnership(path)
+      } catch (error) {
+        return reject(`cache ACL could not be hardened (${errorDetail(error)})`)
+      }
     }
 
     const markerPath = win32.join(path, '.open-science-cache.json')
@@ -317,10 +362,12 @@ export const selectMicromambaCache = (
   const env = deps.env ?? process.env
   const canonicalize = deps.canonicalize ?? canonicalizeExisting
   const { canonicalRoot, userIdentity, leaf, compactLeaf } = cacheIdentity(root, env, canonicalize)
+  const hardenOwnership = deps.hardenOwnership ?? hardenWindowsCacheAcl
   const verifyOwnership = deps.verifyOwnership ?? defaultVerifyOwnership
   const prepare =
     deps.prepare ??
-    ((path: string, ownership: CacheOwnership) => defaultPrepare(path, ownership, verifyOwnership))
+    ((path: string, ownership: CacheOwnership) =>
+      defaultPrepare(path, ownership, hardenOwnership, verifyOwnership))
   const candidates = candidatePaths(canonicalRoot, leaf, compactLeaf, env, canonicalize)
   const rejections: string[] = []
 


### PR DESCRIPTION
## Problem

Follow-up to #397. The managed runtime cache selector rejects directories whose Windows ACL allows an untrusted principal to modify the package cache. Newly created candidates currently rely on `mkdirSync(..., { mode: 0o700 })`, but Windows does not use that POSIX mode to construct the directory DACL. A cache created under a drive root or profile with broad inherited permissions can therefore immediately fail the production trust verifier:

```text
No trusted writable package cache fits the managed runtime path budget.
... ownership or permissions are not trusted
```

This means the shorter cache paths added in #397 can still fail provisioning on affected Windows installations.

## Proposed change

- Harden each newly created Windows cache candidate before writing its trusted marker.
- Build a fresh protected DACL that grants full control only to the current user, LocalSystem, and Builtin Administrators.
- Set the current user as owner and disable inherited access rules.
- Read and write ACLs through Windows PowerShell 5.1's .NET APIs, without relying on `Microsoft.PowerShell.Security` module autoloading.
- Run the hardened ACL through the existing production trust verifier before selecting the cache.
- Remove a directory created by the current attempt if ACL hardening fails, and include the hardening failure in candidate diagnostics.
- Add a hard-gated Windows integration test that applies the ACL and validates it with the production verifier.

## Scope and non-goals

- Existing cache directories are not modified or taken over. They must still have the expected marker and pass the existing trust checks.
- The existing ACL trust policy is unchanged and is not relaxed.
- System Python, R, Conda, PATH, and user-level runtime configuration are unaffected.
- This change does not alter micromamba download, retry, offline, or timeout behavior.

## Acceptance criteria and validation

- New Windows cache directories do not retain broad inherited write permissions.
- The cache owner is the current Windows user.
- Only the current user, LocalSystem, and Builtin Administrators receive explicit full control.
- ACL hardening happens before marker creation and ownership verification.
- A hardening failure cleans up only the directory created by that attempt and reports an actionable candidate diagnostic.
- Existing untrusted directories remain untouched and rejected.
- The Windows integration test is a required CI step even while the general Windows suite remains advisory.

Validation completed locally:

- `npm run typecheck`
- `npm run lint` (`0` errors; existing warnings only)
- Prettier check for all changed files
- Full Vitest suite: `461` files passed, `10` skipped; `6061` tests passed, `84` skipped
- Targeted ACL tests after the CI compatibility fix: `22` passed, `1` Windows-only integration test skipped locally

## Review focus

- PowerShell 5.1 compatibility of the .NET `DirectorySecurity`, `FileSystemAccessRule`, and `Directory.GetAccessControl/SetAccessControl` calls.
- Least-privilege principal set and disabled inheritance.
- The boundary that hardens only directories created by the current attempt.
- Cleanup and diagnostics when ACL application fails.
- The non-advisory Windows integration test placement in the PR workflow.
