### PR TITLE
ci(review): simplify check display names

### DIFF
--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -61,7 +61,7 @@ on:
 
 jobs:
   review:
-    name: Codex ${{ inputs.scope }} review
+    name: Run Codex
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -243,7 +243,7 @@ jobs:
           set_gate architecture "$ARCHITECTURE_ENABLED" "$architecture_count"
 
   codex_correctness_review:
-    name: Codex correctness review
+    name: Correctness
     needs: [review_target, codex_review_gate]
     if: ${{ needs.codex_review_gate.outputs.correctness_should_run == 'true' }}
     permissions:
@@ -268,7 +268,7 @@ jobs:
       CODEX_BASE_URL: ${{ secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_BASE_URL }}
 
   codex_architecture_review:
-    name: Codex architecture review
+    name: Architecture
     needs: [review_target, codex_review_gate]
     if: ${{ needs.codex_review_gate.outputs.architecture_should_run == 'true' }}
     permissions:

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -19,6 +19,7 @@ type WorkflowStep = {
 type WorkflowJob = {
   steps?: WorkflowStep[]
   if?: string
+  name?: string
   needs?: string | string[]
   permissions?: Record<string, string>
   secrets?: Record<string, string>
@@ -423,6 +424,9 @@ describe('dual Codex workflow contract', () => {
     const architecture = mainWorkflow.jobs.codex_architecture_review
     expect(correctness.uses).toBe('./.github/workflows/ai-codex-review.yml')
     expect(architecture.uses).toBe('./.github/workflows/ai-codex-review.yml')
+    expect(correctness.name).toBe('Correctness')
+    expect(architecture.name).toBe('Architecture')
+    expect(codexWorkflow.jobs.review.name).toBe('Run Codex')
     expect(correctness.permissions).toEqual({ contents: 'read' })
     expect(architecture.permissions).toEqual({ contents: 'read' })
     expect(correctness.with).toMatchObject({


### PR DESCRIPTION
## Problem

Reusable Codex checks repeat the same reviewer name at consecutive nesting levels, making the pull request check list unnecessarily deep and hard to scan.

## Proposed change

Use concise caller names (`Correctness` and `Architecture`) and a shared reusable job name (`Run Codex`). GitHub will display the checks as `AI PR Review / Correctness / Run Codex` and `AI PR Review / Architecture / Run Codex`.

## Scope and validation

This changes display names only. Workflow contract tests and `actionlint` pass.