### PR TITLE
feat(acp): add context usage indicator

### DIFF
--- a/patches/@agentclientprotocol+claude-agent-acp+0.60.0.patch
+++ b/patches/@agentclientprotocol+claude-agent-acp+0.60.0.patch
@@ -1,0 +1,50 @@
+diff --git a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js b/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
+--- a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
++++ b/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
+@@ -2353,7 +2353,7 @@ export class ClaudeAgent {
+                                     cache_creation_input_tokens: usage.cache_creation_input_tokens ?? prev.cache_creation_input_tokens,
+                                 };
+                             }
+-                            const nextUsage = totalTokens(lastAssistantUsage);
++                            const nextUsage = contextTokens(lastAssistantUsage);
+                             if (nextUsage !== lastAssistantTotalUsage) {
+                                 lastAssistantTotalUsage = nextUsage;
+                                 await sendUpdate({
+@@ -2465,7 +2465,7 @@ export class ClaudeAgent {
+                         // aligned with what the user's current selection is producing.
+                         if (message.type === "assistant" && message.parent_tool_use_id === null) {
+                             lastAssistantUsage = snapshotFromUsage(message.message.usage);
+-                            lastAssistantTotalUsage = totalTokens(lastAssistantUsage);
++                            lastAssistantTotalUsage = contextTokens(lastAssistantUsage);
+                             if (message.message.model && message.message.model !== "<synthetic>") {
+                                 lastAssistantModel = message.message.model;
+                             }
+@@ -4282,15 +4282,10 @@ function sessionUsage(session) {
+             session.accumulatedUsage.cachedWriteTokens,
+     };
+ }
+-/** Sum all four fields as a proxy for post-turn context occupancy: the current
+- *  turn's output becomes next turn's input. Per the Anthropic API, input_tokens
+- *  excludes cache tokens — cache_read and cache_creation are reported
+- *  separately — so summing all four is not double-counting. */
+-function totalTokens(usage) {
+-    return (usage.input_tokens +
+-        usage.output_tokens +
+-        usage.cache_read_input_tokens +
+-        usage.cache_creation_input_tokens);
++/** Report the current upstream request's model-input context. Cache reads are
++ *  part of that input; completion tokens and cache writes are not. */
++function contextTokens(usage) {
++    return usage.input_tokens + usage.cache_read_input_tokens;
+ }
+ /**
+  * Build the `data` payload attached to a `RequestError.internalError` when we
+@@ -4307,7 +4302,7 @@ function errorKindData(errorKind) {
+ }
+ /** Project a nullable API usage object into our non-null snapshot shape.
+  *  Both SDK message_start and assistant message `usage` have `number | null`
+- *  cache fields; we coerce absent values to 0 so `totalTokens` never hits
++ *  cache fields; we coerce absent values to 0 so `contextTokens` never hits
+  *  NaN. `input_tokens`/`output_tokens` are typed `number` by the SDK but
+  *  synthetic or third-party-backend stream events have been observed emitting
+  *  them as null/undefined — coerce those too so a malformed upstream event

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -23,6 +23,7 @@ const emptySnapshot = (): AcpStateSnapshot => ({
   pendingPermissions: [],
   permissionProfiles: {},
   permissionGrants: {},
+  contextUsageBySession: {},
   promptInFlight: false,
   promptInFlightSessionIds: []
 })
@@ -329,6 +330,76 @@ describe('AcpRuntimeCoordinator', () => {
       sessionId: 'old-session',
       text: 'continue on Codex'
     })
+  })
+
+  it('invalidates the old framework context usage until the adopted session reports a new value', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: [`agent-session-${created.length + 1}`],
+        callbacks
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    created[0].emitState({
+      contextUsageBySession: { [session.sessionId]: { used: 24000, size: 200000 } }
+    })
+    expect(coordinator.getSnapshot().contextUsageBySession).toEqual({
+      [session.sessionId]: { used: 24000, size: 200000 }
+    })
+
+    await coordinator.requestAgentFrameworkSwitch()
+    expect(coordinator.getSnapshot().contextUsageBySession).toEqual({})
+
+    await coordinator.resumeSession({
+      sessionId: session.sessionId,
+      cwd: '/workspace',
+      previousFrameworkId: 'claude-code'
+    })
+    expect(coordinator.getSnapshot().contextUsageBySession).toEqual({})
+
+    created[1].emitState({
+      contextUsageBySession: { [session.sessionId]: { used: 18000, size: 128000 } }
+    })
+    expect(coordinator.getSnapshot().contextUsageBySession).toEqual({
+      [session.sessionId]: { used: 18000, size: 128000 }
+    })
+  })
+
+  it('hides a retiring framework context while its active prompt finishes', async () => {
+    const oldPrompt = createDeferred<{ stopReason: string }>()
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: [`agent-session-${created.length + 1}`],
+        callbacks,
+        ...(created.length === 0 ? { prompt: () => oldPrompt.promise } : {})
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    created[0].emitState({
+      contextUsageBySession: { [session.sessionId]: { used: 24000, size: 200000 } }
+    })
+    const turn = coordinator.sendPrompt({ sessionId: session.sessionId, text: 'continue' })
+
+    await coordinator.requestAgentFrameworkSwitch()
+    expect(coordinator.getSnapshot().contextUsageBySession).toEqual({})
+
+    created[0].emitState({
+      contextUsageBySession: { [session.sessionId]: { used: 26000, size: 200000 } }
+    })
+    expect(coordinator.getSnapshot().contextUsageBySession).toEqual({})
+
+    oldPrompt.resolve({ stopReason: 'end_turn' })
+    await turn
   })
 
   it('namespaces events and routes permission responses to their owning runtime', async () => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -68,6 +68,21 @@ class AcpRuntimeCoordinator {
     const promptInFlightSessionIds = snapshots.flatMap(
       ({ snapshot }) => snapshot.promptInFlightSessionIds
     )
+    const contextUsageBySession = Object.fromEntries(
+      snapshots.flatMap(({ runtime, snapshot }) =>
+        // A framework selection takes effect immediately even when the prior generation must finish
+        // an active turn. Keep its conversation visible for routing, but stop publishing its context.
+        this.retiredRuntimes.has(runtime)
+          ? []
+          : this.visibleSessionIds(runtime, snapshot).flatMap((sessionId) => {
+              // A runtime may still hold a stale measurement after the same logical session was adopted
+              // by the next generation. Only the current owner may publish its context.
+              if (this.sessionRuntimes.get(sessionId) !== runtime) return []
+              const contextUsage = snapshot.contextUsageBySession[sessionId]
+              return contextUsage ? [[sessionId, contextUsage] as const] : []
+            })
+      )
+    )
 
     return {
       status: primary?.status ?? 'idle',
@@ -88,6 +103,7 @@ class AcpRuntimeCoordinator {
         {},
         ...snapshots.map(({ snapshot }) => snapshot.permissionGrants)
       ),
+      contextUsageBySession,
       promptInFlight: promptInFlightSessionIds.length > 0,
       promptInFlightSessionIds
     }

--- a/src/main/acp/runtime-events.test.ts
+++ b/src/main/acp/runtime-events.test.ts
@@ -245,6 +245,37 @@ describe('ACP runtime event normalization', () => {
       terminalExitCode: 0
     })
   })
+
+  it('carries token usage and ignores provider cost metadata', () => {
+    const notification: SessionNotification = {
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'usage_update',
+        used: 24890,
+        size: 200000,
+        cost: { amount: 0.12525, currency: 'USD' }
+      }
+    }
+
+    expect(toAcpRuntimeEvent(notification, 'event-7', 1710000000006)).toMatchObject({
+      kind: 'system',
+      contextUsage: { used: 24890, size: 200000 }
+    })
+    expect(
+      toAcpRuntimeEvent(notification, 'event-7', 1710000000006).contextUsage
+    ).not.toHaveProperty('cost')
+  })
+
+  it('preserves an empty context with its required window size', () => {
+    const notification: SessionNotification = {
+      sessionId: 'session-1',
+      update: { sessionUpdate: 'usage_update', used: 0, size: 128000 }
+    }
+
+    const event = toAcpRuntimeEvent(notification, 'event-8', 1710000000007)
+
+    expect(event.contextUsage).toEqual({ used: 0, size: 128000 })
+  })
 })
 
 describe('extractToolFailureText', () => {

--- a/src/main/acp/runtime-events.ts
+++ b/src/main/acp/runtime-events.ts
@@ -255,11 +255,17 @@ const toAcpRuntimeEvent = (
         text: update.sessionUpdate
       }
     case 'usage_update':
+      // Carry the real numbers on the event so the runtime can record context usage by session. The
+      // runtime consumes this and suppresses the event, so it never appears as conversation noise.
       return {
         ...base,
         kind: 'system',
-        title: 'Usage update',
-        text: 'Token usage changed'
+        title: 'Context usage update',
+        text: 'Context usage changed',
+        contextUsage: {
+          used: update.used,
+          size: update.size
+        }
       }
     case 'available_commands_update':
     case 'config_option_update':

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1,6 +1,7 @@
 import * as acp from '@agentclientprotocol/sdk'
 import type {
   ContentBlock,
+  PromptResponse,
   SessionConfigOption,
   SessionModeState,
   SessionNotification
@@ -144,7 +145,7 @@ const startFakeAgent = (
       sessionId: string
       text: string
       prompt: ContentBlock[]
-    }) => Promise<void> | void
+    }) => Promise<PromptResponse | void> | PromptResponse | void
   } = {}
 ): {
   authRequests: unknown[]
@@ -277,7 +278,11 @@ const startFakeAgent = (
 
       prompts.push({ sessionId: ctx.params.sessionId, text })
       actions.push(`prompt:${text}`)
-      await options.onPrompt?.({ sessionId: ctx.params.sessionId, text, prompt: ctx.params.prompt })
+      const promptResponse = await options.onPrompt?.({
+        sessionId: ctx.params.sessionId,
+        text,
+        prompt: ctx.params.prompt
+      })
       // Stream one assistant chunk through the client callback path before stopping.
       await ctx.client.notify(acp.methods.client.session.update, {
         sessionId: ctx.params.sessionId,
@@ -290,8 +295,7 @@ const startFakeAgent = (
           }
         }
       })
-
-      return { stopReason: 'end_turn' }
+      return promptResponse ?? { stopReason: 'end_turn' }
     })
     .onNotification(acp.methods.agent.session.cancel, (ctx) => {
       cancelledSessions.push(ctx.params.sessionId)
@@ -476,6 +480,20 @@ const agentToAppSessionMap = (runtime: AcpRuntime): Map<string, string> =>
 
 const sessionFrameworksMap = (runtime: AcpRuntime): Map<string, string> =>
   (runtime as unknown as { sessionFrameworks: Map<string, string> }).sessionFrameworks
+
+const contextUsageMap = (runtime: AcpRuntime): Map<string, { used: number; size: number }> =>
+  (
+    runtime as unknown as {
+      contextUsageBySession: Map<string, { used: number; size: number }>
+    }
+  ).contextUsageBySession
+
+const handleSessionUpdate = (runtime: AcpRuntime, notification: SessionNotification): void =>
+  (
+    runtime as unknown as {
+      handleSessionUpdate: (value: SessionNotification) => void
+    }
+  ).handleSessionUpdate(notification)
 
 const reviewerSessionIds = (runtime: AcpRuntime): Set<string> =>
   (runtime as unknown as { reviewerSessionIds: Set<string> }).reviewerSessionIds
@@ -1511,6 +1529,23 @@ describe('ACP runtime session management', () => {
     // The fresh session still accepts prompts, so the conversation continues after the reset.
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'continue after compaction' })
     expect(receivedPrompts.at(-1)).toBeDefined()
+  })
+
+  it('clears the previous context usage before a context reset replacement reports usage', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['remote-session-1', 'remote-session-2'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    contextUsageMap(runtime).set(session.sessionId, { used: 6400, size: 128000 })
+
+    await runtime.resetSessionContext({ sessionId: session.sessionId, cwd: '/workspace' })
+
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({})
   })
 
   it('releases the in-flight prompt lock on reset so the recovery resend is not rejected', async () => {
@@ -3618,6 +3653,26 @@ describe('ACP runtime session management', () => {
     expect(reviewerSessionIds(runtime).size).toBe(0)
   })
 
+  it('invalidates context usage when its agent connection disconnects', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['remote-session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    contextUsageMap(runtime).set(session.sessionId, { used: 12000, size: 128000 })
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({
+      [session.sessionId]: { used: 12000, size: 128000 }
+    })
+
+    await runtime.disconnect()
+
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({})
+  })
+
   it('clears a session MCP server names when the session is deleted', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['remote-session-1'])
@@ -4242,10 +4297,129 @@ describe('ACP runtime session management', () => {
     expect(sharedAgent.resumedSessions).toEqual([])
   })
 
-  it('defers a provider reconnect until an in-flight prompt finishes', async () => {
+  it('uses Codex input and cache-read tokens for context usage', async () => {
     const process = new FakeAgentProcess()
-    const gate = createDeferred()
-    startFakeAgent(process, ['s1'], { onPrompt: () => gate.promise })
+    const usageSent = createDeferred()
+    const finishPrompt = createDeferred()
+    startFakeAgent(process, ['s1'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onPrompt: async ({ sessionId }) => {
+        handleSessionUpdate(runtime, {
+          sessionId,
+          // Patched codex-acp reports only the current request's input plus cached input.
+          update: { sessionUpdate: 'usage_update', used: 15, size: 128000 }
+        })
+        usageSent.resolve()
+        await finishPrompt.promise
+
+        return {
+          stopReason: 'end_turn',
+          usage: {
+            totalTokens: 18,
+            inputTokens: 12,
+            cachedReadTokens: 3,
+            outputTokens: 3
+          }
+        }
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: codexFramework
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+    await usageSent.promise
+    const usageWhileGenerating = runtime.getSnapshot().contextUsageBySession
+    finishPrompt.resolve()
+    await prompt
+
+    expect(usageWhileGenerating).toEqual({
+      s1: { used: 15, size: 128000 }
+    })
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({
+      s1: { used: 15, size: 128000 }
+    })
+  })
+
+  it.each([
+    ['Claude Code', claudeCodeFramework, 200_000],
+    ['OpenCode', opencodeFramework, 128_000],
+    ['Codex bridge', codexFramework, 258_400]
+  ] as const)(
+    'uses the selected model context window instead of the %s adapter window',
+    async (_name, framework, adapterWindow) => {
+      const process = new FakeAgentProcess()
+      startFakeAgent(process, ['s1'], {
+        modes:
+          framework.id === 'codex'
+            ? createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+            : undefined
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          executablePath: '/bin/agent',
+          env: {},
+          contextWindow: 1_000_000
+        }),
+        framework
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+      handleSessionUpdate(runtime, {
+        sessionId: 's1',
+        update: { sessionUpdate: 'usage_update', used: 15, size: adapterWindow }
+      })
+
+      expect(runtime.getSnapshot().contextUsageBySession).toEqual({
+        s1: { used: 15, size: 1_000_000 }
+      })
+    }
+  )
+
+  it('uses the latest Claude model request instead of accumulating the agent turn', async () => {
+    const process = new FakeAgentProcess()
+    const firstUsageSent = createDeferred()
+    const sendSecondUsage = createDeferred()
+    const secondUsageSent = createDeferred()
+    const finishPrompt = createDeferred()
+    startFakeAgent(process, ['s1'], {
+      onPrompt: async ({ sessionId }) => {
+        handleSessionUpdate(runtime, {
+          sessionId,
+          // First upstream model response: 12 input + 3 cache read.
+          update: { sessionUpdate: 'usage_update', used: 15, size: 200000 }
+        })
+        firstUsageSent.resolve()
+        await sendSecondUsage.promise
+        handleSessionUpdate(runtime, {
+          sessionId,
+          // A tool-followup model request replaces the first measurement: 19 input + 5 cache read.
+          update: { sessionUpdate: 'usage_update', used: 24, size: 200000 }
+        })
+        secondUsageSent.resolve()
+        await finishPrompt.promise
+
+        return {
+          stopReason: 'end_turn',
+          // claude-agent-acp accumulates PromptResponse.usage across the whole agent turn. The
+          // runtime must not let this overwrite the latest per-request usage_update.
+          usage: {
+            totalTokens: 60,
+            inputTokens: 31,
+            cachedReadTokens: 8,
+            cachedWriteTokens: 7,
+            outputTokens: 14
+          }
+        }
+      }
+    })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
@@ -4253,19 +4427,147 @@ describe('ACP runtime session management', () => {
     })
 
     await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+    await firstUsageSent.promise
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({
+      s1: { used: 15, size: 200000 }
+    })
+
+    sendSecondUsage.resolve()
+    await secondUsageSent.promise
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({
+      s1: { used: 24, size: 200000 }
+    })
+
+    finishPrompt.resolve()
+    await prompt
+
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({
+      s1: { used: 24, size: 200000 }
+    })
+  })
+
+  it('corrects an unpatched external Codex total with its latest request usage at stop', async () => {
+    const process = new FakeAgentProcess()
+    const usageSent = createDeferred()
+    const finishPrompt = createDeferred()
+    startFakeAgent(process, ['s1'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onPrompt: async ({ sessionId }) => {
+        handleSessionUpdate(runtime, {
+          sessionId,
+          update: { sessionUpdate: 'usage_update', used: 18, size: 128000 }
+        })
+        usageSent.resolve()
+        await finishPrompt.promise
+        return {
+          stopReason: 'end_turn',
+          usage: {
+            totalTokens: 18,
+            inputTokens: 12,
+            cachedReadTokens: 3,
+            outputTokens: 3
+          }
+        }
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: codexFramework
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+    await usageSent.promise
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({
+      s1: { used: 18, size: 128000 }
+    })
+
+    finishPrompt.resolve()
+    await prompt
+
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({
+      s1: { used: 15, size: 128000 }
+    })
+  })
+
+  it('uses OpenCode native input and cache-read context usage', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['s1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: opencodeFramework
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    handleSessionUpdate(runtime, {
+      sessionId: 's1',
+      update: { sessionUpdate: 'usage_update', used: 15, size: 128000 }
+    })
+
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({
+      s1: { used: 15, size: 128000 }
+    })
+  })
+
+  it('defers a provider reconnect until an in-flight prompt finishes', async () => {
+    const process = new FakeAgentProcess()
+    const gate = createDeferred()
+    const usageSent = createDeferred()
+    startFakeAgent(process, ['s1'], {
+      onPrompt: async ({ sessionId }) => {
+        handleSessionUpdate(runtime, {
+          sessionId,
+          update: { sessionUpdate: 'usage_update', used: 6800, size: 128000 }
+        })
+        usageSent.resolve()
+        await gate.promise
+        return {
+          stopReason: 'end_turn',
+          usage: {
+            totalTokens: 6800,
+            inputTokens: 6000,
+            cachedReadTokens: 400,
+            cachedWriteTokens: 100,
+            outputTokens: 300
+          }
+        }
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    contextUsageMap(runtime).set('s1', { used: 6400, size: 128000 })
 
     // Start a prompt that stays in flight until the gate is released.
     const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+    await usageSent.promise
 
     // A provider switch requested mid-turn must NOT disconnect the running agent.
     await runtime.requestProviderReconnect()
     expect(process.killed).toBe(false)
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({})
+
+    handleSessionUpdate(runtime, {
+      sessionId: 's1',
+      update: { sessionUpdate: 'usage_update', used: 7200, size: 128000 }
+    })
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({})
 
     // Once the turn finishes, the deferred reconnect is applied (agent torn down for a fresh spawn).
     gate.resolve()
     await prompt
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(process.killed).toBe(true)
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({})
   })
 
   it('retires a framework runtime only after its in-flight prompt finishes', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -31,6 +31,7 @@ import type {
   AcpPromptRequest,
   AcpResumeSessionRequest,
   AcpRevokePermissionGrantRequest,
+  AcpContextUsage,
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
@@ -494,6 +495,9 @@ class AcpRuntime {
   private error: string | undefined
   private events: AcpRuntimeEvent[] = []
   private eventSequence = 0
+  // Latest context-window usage per app session, from ACP usage_update. Consumed by getSnapshot;
+  // entries appear once the active framework emits a usable context count.
+  private contextUsageBySession = new Map<string, AcpContextUsage>()
   private agentProcess: ChildProcessWithoutNullStreams | undefined
   // Latched by shutdown() on app quit. A connect can be mid-spawn (resolveSpawnConfig is async) when
   // quit fires, so this lets the post-spawn path kill a child that was created after killAgentProcess ran.
@@ -592,6 +596,9 @@ class AcpRuntime {
   // frameworks (Claude). Refreshed from the resolved backend on each connect.
   private pendingSessionModel: string | undefined
   private pendingSessionModelRequired = false
+  // The selected upstream model owns the denominator. Adapter values are fallback-only because a
+  // bridge can report its internal transport model (for example Codex gpt-5.5) instead.
+  private selectedModelContextWindow: number | undefined
   // Reasoning-effort level to apply per session via the ACP thought_level configOption; undefined
   // means "don't override" (the agent keeps its own default). Refreshed on each connect.
   private pendingSessionEffort: ReasoningEffort | undefined
@@ -692,6 +699,7 @@ class AcpRuntime {
       permissionGrants: Object.fromEntries(
         sessionIds.map((sessionId) => [sessionId, this.permissionBroker.listGrants(sessionId)])
       ),
+      contextUsageBySession: Object.fromEntries(this.contextUsageBySession),
       promptInFlight: promptInFlightSessionIds.length > 0,
       promptInFlightSessionIds
     }
@@ -1341,6 +1349,9 @@ class AcpRuntime {
 
     // The fresh agent session holds no history, so the accumulated media is gone; start its budget clean.
     this.sessionInlineImageBytes.delete(request.sessionId)
+    // A context reset creates a new agent-side conversation under the same app id. Do not carry the
+    // previous context size into the fresh conversation before its first usage_update arrives.
+    this.contextUsageBySession.delete(request.sessionId)
 
     // Release the failed turn's in-flight lock now. Its own `finally` clears it too, but that runs only
     // after async artifact cleanup, so the recovery resend that follows this reset would otherwise race
@@ -1678,6 +1689,14 @@ class AcpRuntime {
   // until the session goes idle. Because every provider shares one config dir, the reconnect resumes the
   // conversation on the new provider with full context. Called when the active provider changes.
   async requestProviderReconnect(): Promise<void> {
+    // The selected backend changed even if teardown must wait for an active prompt. Its old context
+    // measurement no longer describes the selected generation, so hide it immediately and let the
+    // replacement generation repopulate usage after reconnect/resume.
+    if (this.contextUsageBySession.size > 0) {
+      this.contextUsageBySession.clear()
+      this.emitState()
+    }
+
     if (this.hasBlockingActivity()) {
       this.pendingProviderReconnect = true
       // Arm the barrier so any concurrent createSession waits for the reconnect
@@ -1840,6 +1859,10 @@ class AcpRuntime {
       this.permissionBroker.cancelAll()
       this.clearReviewerSessionState()
       this.promptInFlightSessionIds.clear()
+      // Context usage belongs to this live agent-context generation. Invalidate it before teardown,
+      // including when a later session.dispose throws. A reconnect may resume the native context or
+      // replay history into a fresh one; only that generation's own usage_update can repopulate it.
+      this.contextUsageBySession.clear()
 
       for (const session of this.sessions.values()) {
         session.dispose()
@@ -1953,6 +1976,7 @@ class AcpRuntime {
       backendId: backend.backendId ?? '(unspecified)',
       sessionModel: backend.sessionModel ?? '(framework default)',
       sessionEffort: backend.sessionEffort ?? '(agent default)',
+      contextWindow: backend.contextWindow ?? '(adapter reported)',
       args: backend.args ?? [],
       executablePath: backend.executablePath,
       // Log env keys but not values (may contain credentials)
@@ -1992,6 +2016,7 @@ class AcpRuntime {
     this.pendingSessionModel = backend.sessionModel
     this.pendingSessionModelRequired = backend.sessionModelRequired ?? false
     this.pendingSessionEffort = backend.sessionEffort
+    this.selectedModelContextWindow = backend.contextWindow
     this.pendingAuthentication = backend.authentication
     this.pendingProviderConfiguration = backend.providerConfiguration
     this.responsesBridgeLease = backend.responsesBridgeLease
@@ -2136,6 +2161,11 @@ class AcpRuntime {
         const message = await Promise.race([activeSession.nextUpdate(), promptFailure])
 
         if (message.kind === 'stop') {
+          this.recordCodexPromptResponseContextUsage(
+            request.sessionId,
+            message.response,
+            promptTurn
+          )
           // Emit artifact metadata before stop so the renderer can attach files to the finished message.
           await this.emitArtifactRunEvent(request.sessionId, artifactRun)
           artifactEmitted = true
@@ -2153,6 +2183,11 @@ class AcpRuntime {
           })
           return message.response
         }
+
+        // A reset can adopt a fresh agent session under the same app id while this abandoned prompt
+        // is still unwinding. Ignore any update already queued by that old prompt generation; otherwise
+        // a late usage_update can repopulate the context measurement we deliberately invalidated.
+        if (this.currentPromptTurnBySession.get(request.sessionId) !== promptTurn) continue
 
         // Route the update under the app-facing id so a session adopted onto a new agent (after a
         // provider switch) still streams into the same conversation the renderer is watching. (No
@@ -2348,6 +2383,7 @@ class AcpRuntime {
     this.sessionProjectNames.delete(request.sessionId)
     this.sessionFrameworks.delete(request.sessionId)
     this.sessionBackendIds.delete(request.sessionId)
+    this.contextUsageBySession.delete(request.sessionId)
     this.permissionProfiles.delete(request.sessionId)
     this.artifactSessionIds.delete(request.sessionId)
     this.notebookRoutingIds.delete(request.sessionId)
@@ -3466,6 +3502,33 @@ class AcpRuntime {
     return { outcome: { outcome: 'selected', optionId: allowOption.optionId } }
   }
 
+  // App-managed codex-acp emits the exact per-request numerator during generation. A user-managed
+  // unpatched adapter emits its latest total instead, but Codex PromptResponse.usage is also a
+  // per-request (not per-turn accumulated) snapshot, so use it as a final compatibility correction.
+  private recordCodexPromptResponseContextUsage(
+    sessionId: string,
+    response: PromptResponse,
+    promptTurn: number
+  ): void {
+    if (
+      this.framework.id !== 'codex' ||
+      this.pendingProviderReconnect ||
+      this.currentPromptTurnBySession.get(sessionId) !== promptTurn
+    ) {
+      return
+    }
+
+    const usage = response.usage
+    const current = this.contextUsageBySession.get(sessionId)
+    if (!usage || !current) return
+
+    const used = usage.inputTokens + (usage.cachedReadTokens ?? 0)
+    if (!Number.isFinite(used) || used < 0 || current.used === used) return
+
+    this.contextUsageBySession.set(sessionId, { used, size: current.size })
+    this.emitState()
+  }
+
   // Normalizes low-level session notifications into runtime/workspace events.
   private handleSessionUpdate(notification: SessionNotification, appSessionId?: string): void {
     // When a session was adopted onto a replaced agent, the agent labels updates with its own id;
@@ -3488,6 +3551,21 @@ class AcpRuntime {
     }
 
     const event = toAcpRuntimeEvent(routed, this.nextEventId())
+
+    // usage_update carries the session's context-window usage, not conversation content: record it per
+    // session and emit state so the indicator updates, but never push it as a visible event.
+    if (event.contextUsage) {
+      // A provider switch can wait for this prompt to finish. Any updates from that superseded backend
+      // must stay hidden until disconnect replaces the agent-context generation.
+      if (this.pendingProviderReconnect) return
+
+      this.contextUsageBySession.set(routed.sessionId, {
+        ...event.contextUsage,
+        size: this.selectedModelContextWindow ?? event.contextUsage.size
+      })
+      this.emitState()
+      return
+    }
 
     // Tool results (e.g. WebFetch's claude.ai domain-safety preflight, a failed Bash command) stream as
     // tool_call_update content, which the session-update log omits — so a tool that runs and fails leaves
@@ -3616,6 +3694,7 @@ class AcpRuntime {
     this.sessionMcpServerNames.clear()
     this.codexMcpToolIdentities.clear()
     this.sessionProjectNames.clear()
+    this.contextUsageBySession.clear()
     this.artifactSessionIds.clear()
     this.notebookRoutingIds.clear()
     this.mcpHttpHost?.clear()

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -67,6 +67,7 @@ describe('codexFramework', () => {
         apiEndpoints: ['openai'],
         baseUrl: 'https://gateway.example/v1',
         model: 'chat-model',
+        contextWindow: 128_000,
         key: 'upstream-secret'
       },
       {
@@ -78,6 +79,8 @@ describe('codexFramework', () => {
 
     expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).toMatchObject({
       model: CODEX_BRIDGE_MODEL,
+      model_context_window: 128_000,
+      model_auto_compact_token_limit: 121_600,
       model_provider: 'open-science',
       model_providers: {
         'open-science': {
@@ -112,6 +115,7 @@ describe('codexFramework', () => {
         baseUrl: 'https://api.minimaxi.com/anthropic',
         openaiBaseUrl: 'https://api.minimaxi.com/v1',
         model: 'MiniMax-M3',
+        contextWindow: 1_000_000,
         key: 'mm-secret'
       },
       {
@@ -123,6 +127,8 @@ describe('codexFramework', () => {
 
     expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).toMatchObject({
       model: 'MiniMax-M3',
+      model_context_window: 1_000_000,
+      model_auto_compact_token_limit: 950_000,
       model_providers: {
         'open-science': {
           base_url: 'https://api.minimaxi.com/v1',

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -31,10 +31,12 @@ const CODEX_PROVIDER_ID = 'open-science'
 // answers. It MUST be a classic tool-mode entry (tool_mode unset), not a `code_mode_only` model like
 // the gpt-5.6-* family: code-mode models advertise no function tools and instead drive an
 // OpenAI-hosted code-execution host that a custom Chat Completions gateway cannot provide, so Codex
-// sends zero tools and the agent can only chat. gpt-5.5 advertises the `shell_command` function tool,
-// which the bridge forwards to Chat Completions. (apply_patch is still a freeform tool the bridge
+// sends zero tools and the agent can only chat. gpt-5.4 advertises the `shell_command` function tool
+// and accepts a 1M context override, while the bridge forwards those tools to Chat Completions.
+// (apply_patch is still a freeform tool the bridge
 // filters, so file edits route through shell rather than the dedicated patch tool.)
-export const CODEX_BRIDGE_MODEL = 'gpt-5.5'
+export const CODEX_BRIDGE_MODEL = 'gpt-5.4'
+const CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 95
 const CODEX_MODE_IDS = {
   ask: 'read-only',
   auto: 'agent',
@@ -117,13 +119,24 @@ const buildCodexModelOptions = (input: {
 const buildCodexConfig = (provider: {
   baseUrl?: string
   model?: string
+  contextWindow?: number
   key?: string
   reasoningEffort?: ReasoningEffort
 }): Record<string, unknown> => {
   const baseUrl = normalizeResponsesBaseUrl(provider.baseUrl)
+  const contextWindow =
+    provider.contextWindow && provider.contextWindow > 0 ? provider.contextWindow : undefined
 
   return {
     ...buildCodexModelOptions(provider),
+    ...(contextWindow
+      ? {
+          model_context_window: contextWindow,
+          model_auto_compact_token_limit: Math.floor(
+            (contextWindow * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT) / 100
+          )
+        }
+      : {}),
     model_provider: CODEX_PROVIDER_ID,
     model_providers: {
       [CODEX_PROVIDER_ID]: {
@@ -281,6 +294,9 @@ export const createCodexFramework = ({
           buildCodexConfig({
             ...provider,
             model: codexModel,
+            // Bind ACP usage to the selected upstream model for both native Responses and the bridge;
+            // the latter deliberately uses a local catalog model only for tool metadata.
+            contextWindow: provider.contextWindow,
             baseUrl: responsesBaseUrl,
             key: useBridge ? undefined : provider.key,
             reasoningEffort: ctx.reasoningEffort

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 import { buildOpencodeConfig, opencodeFramework } from './opencode'
 
 describe('opencodeFramework.prepareModelConfig', () => {
-  it('writes the connector instructions file and wires it into opencode.json instructions', () => {
+  it('writes connector conventions and wires them into opencode.json instructions', () => {
     const config = opencodeFramework.prepareModelConfig(
       { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
       {
@@ -112,7 +112,13 @@ describe('opencodeFramework.prepareModelConfig', () => {
 
   it('pins the authoritative provider/model/baseURL (not just permission) in OPENCODE_CONFIG_CONTENT', () => {
     const config = opencodeFramework.prepareModelConfig(
-      { type: 'custom', baseUrl: 'https://gw.example/v1', model: 'deepseek-v4-pro', key: 'k' },
+      {
+        type: 'custom',
+        baseUrl: 'https://gw.example/v1',
+        model: 'deepseek-v4-pro',
+        contextWindow: 128_000,
+        key: 'k'
+      },
       { storageRoot: '/data', executablePath: '/bin/opencode' }
     )
 
@@ -121,12 +127,48 @@ describe('opencodeFramework.prepareModelConfig', () => {
     // repoint the endpoint or swap the model while inheriting the key ref.
     expect(content.model).toBe('anthropic/deepseek-v4-pro')
     expect(content.provider.anthropic.options.baseURL).toBe('https://gw.example/v1')
-    expect(content.provider.anthropic.models).toEqual({ 'deepseek-v4-pro': {} })
+    expect(content.provider.anthropic.models).toEqual({
+      'deepseek-v4-pro': { limit: { context: 128_000, output: 32_000 } }
+    })
     // Permission policy is still pinned.
     expect(content.permission['*']).toBe('ask')
     // The key rides the env as a reference only — never a plaintext literal in the pinned layer.
     expect(content.provider.anthropic.options.apiKey).toBe('{env:OPENCODE_APP_API_KEY}')
     expect(config.env?.OPENCODE_CONFIG_CONTENT).not.toContain('"k"')
+  })
+
+  it('gives the Anthropic AI SDK a /v1 base so it requests /v1/messages', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      {
+        type: 'custom',
+        baseUrl: 'https://gateway.example',
+        model: 'claude-opus-4-8',
+        key: 'k'
+      },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    expect(content.provider.anthropic.options.baseURL).toBe('https://gateway.example/v1')
+  })
+
+  it('caps the required output limit at a custom context window smaller than 32k', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      {
+        type: 'custom',
+        baseUrl: 'https://gateway.example',
+        model: 'small-context-model',
+        contextWindow: 16_000,
+        key: 'k'
+      },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    expect(content.provider.anthropic.models['small-context-model'].limit).toEqual({
+      context: 16_000,
+      output: 16_000
+    })
   })
 
   it('declares image capability in the pinned layer for a multimodal model', () => {
@@ -237,14 +279,17 @@ describe('buildOpencodeConfig', () => {
         type: 'custom',
         baseUrl: 'https://gw.example/v1',
         model: 'deepseek-v4-pro',
-        key: 'sk-secret'
+        key: 'sk-secret',
+        contextWindow: 128_000
       })
     )
 
     // A non-catalog model id is both selected and registered, so opencode treats it as a real model
     // instead of ignoring it and falling back to its own default.
     expect(config.model).toBe('anthropic/deepseek-v4-pro')
-    expect(config.provider.anthropic.models).toEqual({ 'deepseek-v4-pro': {} })
+    expect(config.provider.anthropic.models).toEqual({
+      'deepseek-v4-pro': { limit: { context: 128_000, output: 32_000 } }
+    })
     // The key is referenced via opencode env interpolation, never emitted as a plaintext literal.
     expect(config.provider.anthropic.options).toEqual({
       baseURL: 'https://gw.example/v1',

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -9,7 +9,7 @@ import {
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import { preferredEndpoint } from '../../shared/settings'
 import type { ReasoningEffort } from '../../shared/settings'
-import { openAiCompletionsBase } from '../settings/base-url'
+import { anthropicMessagesBase, openAiCompletionsBase } from '../settings/base-url'
 import { augmentedPathEnv } from '../settings/shell-path'
 import type { ResolvedProvider } from '../settings/provider-env'
 import type {
@@ -65,6 +65,21 @@ const OPENCODE_ENDPOINT_PROVIDER: Record<'anthropic' | 'openai', { id: string; n
 // plaintext key OFF disk — opencode.json only ever holds the reference, never the secret.
 const OPENCODE_API_KEY_ENV = 'OPENCODE_APP_API_KEY'
 
+// opencode's model `limit` block requires BOTH `context` and `output` (its config schema rejects a
+// limit that carries only one — "Missing key ...limit.output" and the ACP connection closes). We set
+// context from the provider catalog (the whole point: it makes opencode emit usage_update); opencode
+// uses these limits for context accounting, so a best-effort output cap is fine here. Tunable.
+const OPENCODE_DEFAULT_OUTPUT_LIMIT = 32_000
+
+const opencodeOutputLimit = (contextWindow: number, configured?: unknown): number => {
+  const requested =
+    typeof configured === 'number' && Number.isFinite(configured) && configured > 0
+      ? configured
+      : OPENCODE_DEFAULT_OUTPUT_LIMIT
+
+  return Math.min(requested, contextWindow)
+}
+
 // The app's permission policy for opencode: every side-effecting/MCP tool must ASK the ACP client (the
 // app's broker then enforces the selected profile); only safe read-only tools run silently (parity with
 // Claude's Ask mode). The `*` catch-all covers unlisted tools (MCP artifact/notebook/connectors, etc.),
@@ -108,9 +123,14 @@ const resolveOpencodeEndpoint = (
   // The @ai-sdk/openai-compatible client appends `/chat/completions` to baseURL, so hand it the
   // resolved OpenAI completions base — an official vendor's exact versioned base (GLM's /api/paas/v4,
   // DeepSeek/Kimi /v1), or a custom gateway root normalized to `<root>/v1`. Matches the validator and
-  // bridge. The anthropic endpoint keeps the provider's own baseUrl.
+  // bridge. The Anthropic AI SDK appends `/messages` (not `/v1/messages`), so its base must carry the
+  // `/v1` segment that Claude Code and the validator append themselves.
   const baseURL =
-    endpoint === 'openai' ? (openAiCompletionsBase(provider) ?? provider.baseUrl) : provider.baseUrl
+    endpoint === 'openai'
+      ? (openAiCompletionsBase(provider) ?? provider.baseUrl)
+      : provider.baseUrl
+        ? anthropicMessagesBase(provider.baseUrl)
+        : undefined
 
   return { bareModel, providerId, npm, baseURL }
 }
@@ -148,6 +168,17 @@ const buildAppConfigContent = (
   reasoningEffort?: ReasoningEffort
 ): Record<string, unknown> => {
   const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
+  const modelConfig = {
+    ...buildModelCapabilities(provider, reasoningEffort),
+    ...(provider.contextWindow === undefined
+      ? {}
+      : {
+          limit: {
+            context: provider.contextWindow,
+            output: opencodeOutputLimit(provider.contextWindow)
+          }
+        })
+  }
 
   return {
     ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
@@ -159,9 +190,7 @@ const buildAppConfigContent = (
           ...(baseURL ? { baseURL } : {}),
           ...(provider.key ? { apiKey: `{env:${OPENCODE_API_KEY_ENV}}` } : {})
         },
-        ...(bareModel
-          ? { models: { [bareModel]: buildModelCapabilities(provider, reasoningEffort) } }
-          : {})
+        ...(bareModel ? { models: { [bareModel]: modelConfig } } : {})
       }
     }
   }
@@ -184,7 +213,31 @@ const buildOpencodeConfig = (
   const baseProvider = asRecord(baseProviders[providerId])
   const baseOptions = asRecord(baseProvider.options)
   const baseModels = asRecord(baseProvider.models)
+  const baseModel = bareModel ? asRecord(baseModels[bareModel]) : {}
+  const baseLimit = asRecord(baseModel.limit)
   const basePermission = asRecord(baseConfig.permission)
+  const modelCapabilities = buildModelCapabilities(provider, reasoningEffort)
+  const modelConfig = {
+    ...baseModel,
+    ...modelCapabilities,
+    ...(modelCapabilities.options
+      ? {
+          options: {
+            ...asRecord(baseModel.options),
+            ...asRecord(modelCapabilities.options)
+          }
+        }
+      : {}),
+    ...(provider.contextWindow === undefined
+      ? {}
+      : {
+          limit: {
+            ...baseLimit,
+            context: provider.contextWindow,
+            output: opencodeOutputLimit(provider.contextWindow, baseLimit.output)
+          }
+        })
+  }
   // Preserve any instructions the base config already declared, then append ours (de-duplicated).
   const baseInstructions = Array.isArray(baseConfig.instructions)
     ? baseConfig.instructions.filter((entry): entry is string => typeof entry === 'string')
@@ -223,7 +276,7 @@ const buildOpencodeConfig = (
           ? {
               models: {
                 ...baseModels,
-                [bareModel]: buildModelCapabilities(provider, reasoningEffort)
+                [bareModel]: modelConfig
               }
             }
           : {})
@@ -282,8 +335,9 @@ export const opencodeFramework: AgentFramework = {
     const configPath = join(opencodeDir, 'opencode.json')
     const configFiles = [{ path: configPath, content: '' }]
 
-    // Connector conventions + tools, wired via opencode's `instructions` config so the agent uses
-    // host.mcp instead of raw HTTP. Absolute path keeps it independent of the session cwd.
+    // Compact connector conventions, wired via opencode's `instructions` config so the agent uses
+    // host.mcp instead of raw HTTP. Detailed schemas remain in on-demand `mcp-*` skills. Absolute path
+    // keeps the baseline independent of the session cwd.
     const instructionPaths: string[] = []
     if (ctx.instructions) {
       const instructionsPath = join(opencodeDir, 'instructions', 'connectors.md')

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -55,9 +55,8 @@ export type ModelConfigContext = {
   // Absolute path to the detected framework executable (claude / opencode).
   executablePath: string
   responsesBridge?: ResponsesBridgeConnection
-  // Combined instructions markdown (connector conventions + tools) for frameworks that lack on-demand
-  // skill loading; the adapter writes it and wires it into the agent's instruction mechanism so the
-  // agent learns host.mcp instead of reimplementing connector calls with raw HTTP. Empty ⇒ omitted.
+  // Compact connector conventions for frameworks that need host.mcp guidance in their baseline
+  // instructions. Detailed connector schemas live in on-demand `mcp-*` skills. Empty ⇒ omitted.
   instructions?: string
   // The user's reasoning-effort preference ('default'/undefined ⇒ don't override; the framework
   // injects nothing and the agent keeps its own default). Each framework maps the level onto its
@@ -152,6 +151,9 @@ export type ResolvedAgentBackend = {
   // Reasoning-effort level to apply per session via the ACP `thought_level` configOption, resolved
   // to the closest level the agent advertises. Undefined ⇒ the agent keeps its own default.
   sessionEffort?: ReasoningEffort
+  // Exact context-window limit for the selected upstream provider model. Framework adapters may
+  // report a fallback or bridge transport model instead, so the runtime treats this as authoritative.
+  contextWindow?: number
   authentication?: AgentAuthentication
   providerConfiguration?: AgentProviderConfiguration
   // A bridged backend owns one reference to its local loopback bridge. Runtime teardown releases it;

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -2,14 +2,17 @@ import { describe, it, expect } from 'vitest'
 import { renderConnectorInstructions, renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
 
 describe('renderConnectorInstructions', () => {
-  it('emits the host.mcp conventions once and each enabled connector, for opencode', () => {
+  it('keeps only shared host.mcp conventions in opencode baseline instructions', () => {
     const md = renderConnectorInstructions(['chemistry'])
 
     expect(md).toContain('host.mcp(')
     // The "do not reimplement with raw HTTP" rule is what steers opencode away from raw requests.
     expect(md).toMatch(/urllib|requests|httpx|fetch/)
-    expect(md).toContain('## chemistry')
-    expect(md).toContain('chemistry / pubchem_get_compounds')
+    expect(md).toContain('mcp-*')
+    expect(md).not.toContain('## chemistry')
+    expect(md).not.toContain('pubchem_get_compounds')
+    expect(md).not.toContain('```json')
+    expect(md.length).toBeLessThan(2_500)
     // Conventions appear once, not per connector.
     expect(
       md.match(/Reach this service ONLY from the REPL control-plane kernel/g)?.length ?? 0

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -92,35 +92,20 @@ export function renderSkillDoc(connectorId: string): string {
   )
 }
 
-// Renders ONE combined instructions doc for agents without on-demand skill loading (opencode): the
-// shared conventions once, then every enabled connector's tools. Delivered via opencode's `instructions`
-// config so the agent reaches connectors through `host.mcp(...)` from the notebook kernel instead of
-// reimplementing the calls with raw HTTP (which bypasses the approval gate, credentials, and limits).
+// Renders the small connector baseline shared by agents with on-demand skill loading. Detailed tool
+// schemas and examples stay in the materialized `mcp-*` skills and enter context only when the agent
+// loads the matching connector. Keeping this document to conventions prevents every enabled connector
+// from consuming the initial context window while still steering calls through the approved host.mcp
+// path instead of raw HTTP.
 export function renderConnectorInstructions(connectorIds: string[]): string {
-  const sections = connectorIds
-    .map((connectorId) => {
-      const meta = CONNECTOR_CATALOG.find((c) => c.id === connectorId)
-      if (!meta) return ''
-
-      const methods = getConnectorTools(connectorId)
-        .map(
-          (t) =>
-            `### ${connectorId} / ${t.id}\n\n${t.description}\n\n\`\`\`json\n${JSON.stringify(t.input, null, 2)}\n\`\`\`\n\n` +
-            (t.returns ? `**Returns:** ${t.returns}\n\n` : '') +
-            renderExample(connectorId, t.id, t.input, t.example)
-        )
-        .join('\n')
-
-      return `## ${connectorId}\n\n${meta.useWhen}\n\n${methods}`
-    })
-    .filter(Boolean)
-
-  if (sections.length === 0) return ''
+  if (!connectorIds.some((id) => CONNECTOR_CATALOG.some((connector) => connector.id === id))) {
+    return ''
+  }
 
   return (
-    `# Open Science data connectors\n\n` +
-    `These connectors are available for this session. ${CONVENTIONS}\n\n` +
-    `# Available connectors\n\n${sections.join('\n\n')}`
+    `# Open Science data connector conventions\n\n` +
+    `Detailed instructions, tool schemas, return shapes, and examples are available through the matching \`mcp-*\` skill. Load that skill before using a connector.\n\n` +
+    CONVENTIONS
   )
 }
 

--- a/src/main/settings/base-url.test.ts
+++ b/src/main/settings/base-url.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  anthropicMessagesBase,
   normalizeAnthropicBaseUrl,
   openAiChatCompletionsUrl,
   openAiCompletionsBase
 } from './base-url'
+
+describe('anthropicMessagesBase', () => {
+  it('returns the versioned base expected by clients that append /messages', () => {
+    expect(anthropicMessagesBase('https://gateway.example')).toBe('https://gateway.example/v1')
+    expect(anthropicMessagesBase('https://gateway.example/v1')).toBe('https://gateway.example/v1')
+    expect(anthropicMessagesBase('https://gateway.example/v1/messages')).toBe(
+      'https://gateway.example/v1'
+    )
+  })
+})
 
 describe('normalizeAnthropicBaseUrl', () => {
   it('leaves a bare gateway root untouched', () => {

--- a/src/main/settings/base-url.ts
+++ b/src/main/settings/base-url.ts
@@ -30,6 +30,12 @@ const appendPath = (base: string, suffix: string): string => {
   }
 }
 
+// The Anthropic AI SDK base used by OpenCode. Unlike Claude Code, which appends `/v1/messages`,
+// the SDK appends only `/messages`; give it a base ending in exactly one `/v1` so both runtimes hit
+// the same endpoint as the provider validator.
+const anthropicMessagesBase = (baseUrl: string): string =>
+  appendPath(normalizeAnthropicBaseUrl(baseUrl), '/v1')
+
 // Appends `/chat/completions` to an already-resolved OpenAI base (see openAiCompletionsBase).
 const appendChatCompletions = (base: string): string => appendPath(base, '/chat/completions')
 
@@ -68,6 +74,7 @@ const openAiChatCompletionsUrl = (provider: OpenAiProviderBase): string | undefi
 }
 
 export {
+  anthropicMessagesBase,
   normalizeAnthropicBaseUrl,
   appendChatCompletions,
   openAiCompletionsBase,

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -89,10 +89,12 @@ import {
   CODEX_ACP_INTEGRITY,
   CODEX_INTEGRITIES,
   CODEX_VERSION,
+  ensureManagedCodexContextUsage,
   managedCodexAdapterEntry,
   managedCodexBinary,
   managedCodexRoot,
   installManagedCodex,
+  patchCodexAcpContextUsageSource,
   resolveManagedCodexPlatform,
   sanitizeManagedCodexDiagnostic,
   verifyManagedCodexPair,
@@ -1105,6 +1107,80 @@ describe('installManagedCodex', () => {
 
     await expect(readFile(managedCodexAdapterEntry(root))).rejects.toThrow()
     expect(await readFile(join(root, 'unrelated-runtime'), 'utf8')).toBe('keep-me')
+  })
+})
+
+describe('patchCodexAcpContextUsageSource', () => {
+  it('treats omitted cached input tokens as zero', () => {
+    const source = [
+      '  const adapter = {',
+      '    sessionState: { lastTokenUsage: { inputTokens: 42 } },',
+      '    createUsageUpdate(params) {',
+      '    const used = this.sessionState.lastTokenUsage?.totalTokens;',
+      '    return used;',
+      '    }',
+      '  };',
+      '  return adapter.createUsageUpdate({});'
+    ].join('\n')
+
+    const patched = patchCodexAcpContextUsageSource(source)
+    const used = Function(patched)() as number
+
+    expect(used).toBe(42)
+  })
+
+  it('reports the latest request input and cached input instead of total tokens', () => {
+    const source = [
+      '  createUsageUpdate(params) {',
+      '    this.handleTokenUsageUpdated(params);',
+      '    const used = this.sessionState.lastTokenUsage?.totalTokens;',
+      '    return { used };',
+      '  }'
+    ].join('\n')
+
+    const patched = patchCodexAcpContextUsageSource(source)
+
+    expect(patched).toContain(
+      'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
+    )
+    expect(patched).not.toContain('lastTokenUsage?.totalTokens')
+    expect(patchCodexAcpContextUsageSource(patched)).toBe(patched)
+  })
+
+  it('updates an already-installed managed adapter in place', async () => {
+    const patchRoot = await mkdtemp(join(tmpdir(), 'managed-codex-patch-'))
+    try {
+      const adapterPath = join(patchRoot, 'index.js')
+      await writeFile(
+        adapterPath,
+        [
+          '  createUsageUpdate(params) {',
+          '    const used = this.sessionState.lastTokenUsage?.totalTokens;',
+          '  }'
+        ].join('\n')
+      )
+
+      await ensureManagedCodexContextUsage(adapterPath)
+      await ensureManagedCodexContextUsage(adapterPath)
+
+      expect(await readFile(adapterPath, 'utf8')).toContain(
+        'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
+      )
+    } finally {
+      await rm(patchRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('fails closed when a Codex ACP bundle no longer matches the pinned patch target', () => {
+    const drifted = [
+      '  createUsageUpdate(params) {',
+      '    const used = this.sessionState.lastTokenUsage.totalTokens;',
+      '  }'
+    ].join('\n')
+
+    expect(() => patchCodexAcpContextUsageSource(drifted)).toThrow(
+      /context-usage patch no longer matches/
+    )
   })
 })
 

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -7,6 +7,7 @@ import {
   mkdir,
   mkdtemp,
   open,
+  readFile,
   readdir,
   rename,
   rm,
@@ -105,6 +106,47 @@ const adapterEntryInRoot = (root: string): string => join(root, 'adapter', 'dist
 
 const codexBinaryInRoot = (root: string, platform: ManagedCodexPlatform): string =>
   join(root, 'codex', 'vendor', platform.target, 'bin', platform.binName)
+
+const CODEX_ACP_CONTEXT_USAGE_SOURCE =
+  '    const used = this.sessionState.lastTokenUsage?.totalTokens;'
+const CODEX_ACP_CONTEXT_USAGE_REPLACEMENT = [
+  '    const lastTokenUsage = this.sessionState.lastTokenUsage;',
+  '    const used =',
+  '      lastTokenUsage == null',
+  '        ? void 0',
+  '        : lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0);'
+].join('\n')
+
+// codex-acp receives a per-request tokenUsage.last snapshot but publishes totalTokens as ACP
+// context usage. Patch the pinned self-contained adapter so `used` excludes output and reasoning.
+// The registry integrity pin fixes the input bundle; the guards make a future source drift fail
+// during installation instead of silently restoring the wrong metric.
+export const patchCodexAcpContextUsageSource = (source: string): string => {
+  if (source.includes(CODEX_ACP_CONTEXT_USAGE_REPLACEMENT)) return source
+
+  const matches = source.split(CODEX_ACP_CONTEXT_USAGE_SOURCE).length - 1
+
+  if (matches === 1) {
+    return source.replace(CODEX_ACP_CONTEXT_USAGE_SOURCE, CODEX_ACP_CONTEXT_USAGE_REPLACEMENT)
+  }
+
+  if (
+    matches > 1 ||
+    (source.includes('createUsageUpdate(params)') && source.includes('totalTokens'))
+  ) {
+    throw new Error('Pinned Codex ACP context-usage patch no longer matches the adapter bundle')
+  }
+
+  // Unit-test fixtures use tiny stand-in adapters rather than the pinned production bundle.
+  return source
+}
+
+export const ensureManagedCodexContextUsage = async (adapterPath: string): Promise<void> => {
+  const source = await readFile(adapterPath, 'utf8')
+  const patched = patchCodexAcpContextUsageSource(source)
+
+  if (patched !== source) await writeFile(adapterPath, patched)
+}
 
 type PackageResolution = { tarball: string; integrity: string }
 
@@ -718,6 +760,7 @@ export const installManagedCodex = async ({
         destPath: stagedAdapter
       })
       if (!foundAdapter) throw new Error('Codex ACP package did not contain dist/index.js')
+      await ensureManagedCodexContextUsage(stagedAdapter)
 
       await extractCodexVendor({
         tgzPath: codexTgz,

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -15,6 +15,9 @@ export type ResolvedProvider = {
   // when the chosen endpoint is openai; falls back to baseUrl when absent.
   openaiBaseUrl?: string
   model?: string
+  // Context limit for the selected model. Framework adapters that register custom model ids (notably
+  // OpenCode) must include this metadata or the framework cannot report context usage over ACP.
+  contextWindow?: number
   key?: string
   // Which chat APIs the endpoint speaks; opencode uses this to pick anthropic vs openai-compatible.
   // Absent ⇒ ['anthropic'].

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -263,6 +263,20 @@ describe('settings repository', () => {
     expect(settings.claude).toEqual({ resolvedPath: '/bin/claude' })
   })
 
+  it('keeps only a positive whole-number custom context window', () => {
+    const base = { id: 'p1', type: 'custom', name: 'Gateway' }
+
+    expect(
+      sanitizeSettings({ providers: [{ ...base, contextWindow: 64_000 }] }).providers[0]
+        .contextWindow
+    ).toBe(64_000)
+    for (const contextWindow of [0, -1, 1.5, Number.NaN, '200000']) {
+      expect(
+        sanitizeSettings({ providers: [{ ...base, contextWindow }] }).providers[0].contextWindow
+      ).toBeUndefined()
+    }
+  })
+
   it('round-trips a recorded validation failure across a reload', async () => {
     const root = await createStorageRoot()
     const repository = new SettingsRepository(root)

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -183,6 +183,11 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   const provider: StoredProvider = { id, type, name }
   const baseUrl = asString(value.baseUrl)
   const model = asString(value.model)
+  const rawContextWindow = asNumber(value.contextWindow)
+  const contextWindow =
+    rawContextWindow !== undefined && Number.isSafeInteger(rawContextWindow) && rawContextWindow > 0
+      ? rawContextWindow
+      : undefined
   const supportsImageInput = asBoolean(value.supportsImageInput)
   const region = asString(value.region)
   const keyRef = asString(value.keyRef)
@@ -218,6 +223,7 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
 
   if (baseUrl) provider.baseUrl = baseUrl
   if (model) provider.model = model
+  if (contextWindow !== undefined) provider.contextWindow = contextWindow
   if (supportsImageInput !== undefined) provider.supportsImageInput = supportsImageInput
   if (apiEndpoints.length > 0) provider.apiEndpoints = apiEndpoints
   if (vendorId) provider.vendorId = vendorId

--- a/src/main/settings/responses-bridge.integration.test.ts
+++ b/src/main/settings/responses-bridge.integration.test.ts
@@ -7,6 +7,7 @@ import { Readable, Writable } from 'node:stream'
 import * as acp from '@agentclientprotocol/sdk'
 import { expect, it, vi } from 'vitest'
 
+import { CODEX_BRIDGE_MODEL } from '../agent-framework/codex'
 import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
 import { ReviewerMcpServer, type SubmitFindingsHandler } from '../reviewer/mcp-server'
 import { ResponsesBridge } from './responses-bridge'
@@ -95,6 +96,12 @@ it.runIf(runLiveContract)(
             id: 'chat-mcp-1',
             model: 'probe-model',
             choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }]
+          },
+          {
+            id: 'chat-mcp-1',
+            model: 'probe-model',
+            choices: [],
+            usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 }
           }
         ])
       }
@@ -115,6 +122,12 @@ it.runIf(runLiveContract)(
           id: 'chat-mcp-2',
           model: 'probe-model',
           choices: [{ index: 0, delta: {}, finish_reason: 'stop' }]
+        },
+        {
+          id: 'chat-mcp-2',
+          model: 'probe-model',
+          choices: [],
+          usage: { prompt_tokens: 15, completion_tokens: 3, total_tokens: 18 }
         }
       ])
     }
@@ -149,7 +162,9 @@ it.runIf(runLiveContract)(
         MODEL_PROVIDER: 'probe',
         NO_BROWSER: '1',
         CODEX_CONFIG: JSON.stringify({
-          model: 'gpt-5.5',
+          model: CODEX_BRIDGE_MODEL,
+          model_context_window: 1_000_000,
+          model_auto_compact_token_limit: 950_000,
           model_provider: 'probe',
           model_providers: {
             probe: {
@@ -214,7 +229,11 @@ it.runIf(runLiveContract)(
               for (;;) {
                 const update = await session.nextUpdate()
                 if (update.kind === 'stop')
-                  return { updates, stopReason: update.response.stopReason }
+                  return {
+                    updates,
+                    response: update.response,
+                    stopReason: update.response.stopReason
+                  }
                 updates.push(update.notification)
               }
             })
@@ -233,6 +252,21 @@ it.runIf(runLiveContract)(
       )
       expect(JSON.stringify(result.updates)).toContain('mcp.probe-server.echo')
       expect(JSON.stringify(result.updates)).toContain('MCP_BRIDGE_OK')
+      expect(result.updates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            update: expect.objectContaining({
+              sessionUpdate: 'usage_update',
+              size: 950_000
+            })
+          })
+        ])
+      )
+      expect(result.response.usage).toMatchObject({
+        inputTokens: 15,
+        cachedReadTokens: 0,
+        outputTokens: 3
+      })
       expect(result.stopReason).toBe('end_turn')
     } catch (error) {
       throw new Error(`${String(error)}\n${stderr.join('')}`)
@@ -408,7 +442,9 @@ it.runIf(runLiveContract)(
         MODEL_PROVIDER: 'probe',
         NO_BROWSER: '1',
         CODEX_CONFIG: JSON.stringify({
-          model: 'gpt-5.5',
+          model: CODEX_BRIDGE_MODEL,
+          model_context_window: 1_000_000,
+          model_auto_compact_token_limit: 950_000,
           model_provider: 'probe',
           model_providers: {
             probe: {

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -259,7 +259,13 @@ describe('Responses-compatible bridge conversion', () => {
             }
           }
         ],
-        usage: { total_tokens: 4 }
+        usage: {
+          prompt_tokens: 3,
+          prompt_tokens_details: { cached_tokens: 1 },
+          completion_tokens: 2,
+          completion_tokens_details: { reasoning_tokens: 1 },
+          total_tokens: 5
+        }
       })
     ).toMatchObject({
       id: 'chat-1',
@@ -268,7 +274,13 @@ describe('Responses-compatible bridge conversion', () => {
         { type: 'message', content: [{ type: 'output_text', text: 'done' }] },
         { type: 'function_call', call_id: 'call-1', name: 'lookup', arguments: '{"id":1}' }
       ],
-      usage: { total_tokens: 4 }
+      usage: {
+        input_tokens: 3,
+        input_tokens_details: { cached_tokens: 1 },
+        output_tokens: 2,
+        output_tokens_details: { reasoning_tokens: 1 },
+        total_tokens: 5
+      }
     })
   })
 
@@ -569,6 +581,17 @@ describe('Responses-compatible bridge conversion', () => {
     ).not.toHaveProperty('reasoning_effort')
   })
 
+  it('requests streaming usage without forwarding Responses-only stream options', () => {
+    expect(
+      responsesToChatRequest({
+        model: 'model-a',
+        input: 'hi',
+        stream: true,
+        stream_options: { include_obfuscation: true }
+      })
+    ).toMatchObject({ stream_options: { include_usage: true } })
+  })
+
   it('surfaces a nested upstream error instead of hiding it behind HTTP status', () => {
     expect(
       upstreamErrorMessage('{"error":{"message":"Model deepseek-v4-flash does not exist"}}', 400)
@@ -588,6 +611,20 @@ describe('Responses-compatible bridge conversion', () => {
                 id: 'chat-1',
                 model: 'model-a',
                 choices: [{ index: 0, delta: { role: 'assistant', content: 'bridge-ok' } }]
+              }),
+            '',
+            'data: ' +
+              JSON.stringify({
+                id: 'chat-1',
+                model: 'model-a',
+                choices: [],
+                usage: {
+                  prompt_tokens: 3,
+                  prompt_tokens_details: { cached_tokens: 1 },
+                  completion_tokens: 2,
+                  completion_tokens_details: { reasoning_tokens: 1 },
+                  total_tokens: 5
+                }
               }),
             '',
             'data: [DONE]',
@@ -630,6 +667,7 @@ describe('Responses-compatible bridge conversion', () => {
       expect(upstreamRequest).toMatchObject({
         model: 'model-a',
         stream: true,
+        stream_options: { include_usage: true },
         messages: [
           { role: 'system', content: 'Be brief.' },
           { role: 'user', content: [{ type: 'text', text: 'hi' }] }
@@ -638,6 +676,20 @@ describe('Responses-compatible bridge conversion', () => {
       expect(output).toContain('response.output_text.delta')
       expect(output).toContain('bridge-ok')
       expect(output).toContain('response.completed')
+      const completed = output
+        .split('\n')
+        .filter((line) => line.startsWith('data: '))
+        .map((line) => JSON.parse(line.slice(6)) as Record<string, unknown>)
+        .find((event) => event.type === 'response.completed') as {
+        response: { usage: Record<string, unknown> }
+      }
+      expect(completed.response.usage).toEqual({
+        input_tokens: 3,
+        input_tokens_details: { cached_tokens: 1 },
+        output_tokens: 2,
+        output_tokens_details: { reasoning_tokens: 1 },
+        total_tokens: 5
+      })
     } finally {
       await bridge.close()
     }

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -689,7 +689,9 @@ export const responsesToChatRequest = (
       : { max_tokens: body.max_output_tokens }),
     ...(chatReasoningEffort ? { reasoning_effort: chatReasoningEffort } : {}),
     stream,
-    ...(stream ? { stream_options: body.stream_options ?? { include_usage: true } } : {})
+    // Responses stream options are not Chat Completions options. Request final usage explicitly and
+    // do not forward fields such as include_obfuscation that a Chat-compatible gateway may reject.
+    ...(stream ? { stream_options: { include_usage: true } } : {})
   }
 }
 
@@ -725,6 +727,32 @@ const responseEnvelope = (
   user: null,
   metadata: {}
 })
+
+// Chat Completions and Responses use different usage field names. Codex validates the Responses
+// shape before publishing its ACP token-usage update, so passing Chat fields through makes usage
+// silently disappear even though the upstream reported it.
+const chatUsageToResponsesUsage = (usage: unknown): JsonObject | undefined => {
+  if (typeof usage !== 'object' || usage === null || Array.isArray(usage)) return undefined
+
+  const chatUsage = usage as JsonObject
+  const tokenCount = (value: unknown): number | undefined =>
+    typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined
+  const inputTokens = tokenCount(chatUsage.prompt_tokens)
+  const outputTokens = tokenCount(chatUsage.completion_tokens)
+
+  if (inputTokens === undefined || outputTokens === undefined) return undefined
+
+  const cachedTokens = tokenCount(chatUsage.prompt_tokens_details?.cached_tokens) ?? 0
+  const reasoningTokens = tokenCount(chatUsage.completion_tokens_details?.reasoning_tokens) ?? 0
+
+  return {
+    input_tokens: inputTokens,
+    input_tokens_details: { cached_tokens: cachedTokens },
+    output_tokens: outputTokens,
+    output_tokens_details: { reasoning_tokens: reasoningTokens },
+    total_tokens: tokenCount(chatUsage.total_tokens) ?? inputTokens + outputTokens
+  }
+}
 
 const completionToResponse = (
   completion: JsonObject,
@@ -766,7 +794,7 @@ const completionToResponse = (
     completion.id ?? `resp_${randomBytes(6).toString('hex')}`,
     completion.model,
     output,
-    completion.usage
+    chatUsageToResponsesUsage(completion.usage)
   )
 }
 
@@ -800,6 +828,7 @@ const streamChatToResponses = async (
   let textItem: JsonObject | undefined
   // Accumulated so the caller can cache it against this turn's tool-call ids (see inputToMessages).
   let reasoning = ''
+  let usage: JsonObject | undefined
   let sequence = 0
   writeEvent(response, 'response.created', sequence++, {
     response: responseEnvelope(responseId, model, [])
@@ -839,6 +868,7 @@ const streamChatToResponses = async (
     return item
   }
   const consume = (chunk: JsonObject): void => {
+    usage = chatUsageToResponsesUsage(chunk.usage) ?? usage
     const finishReason = chunk.choices?.[0]?.finish_reason
     if (typeof finishReason === 'string' && finishReason.length > 0) {
       terminalFinishReason = finishReason
@@ -985,7 +1015,7 @@ const streamChatToResponses = async (
     })
   } else if (terminalFinishReason === 'stop' || terminalFinishReason === 'tool_calls') {
     writeEvent(response, 'response.completed', sequence++, {
-      response: responseEnvelope(responseId, model, output)
+      response: responseEnvelope(responseId, model, output, usage)
     })
   } else if (streamError) {
     log.warn('bridge stream error', {
@@ -993,7 +1023,7 @@ const streamChatToResponses = async (
       error: streamError instanceof Error ? streamError.message : String(streamError)
     })
     writeEvent(response, 'response.failed', sequence++, {
-      response: responseEnvelope(responseId, model, output, undefined, 'failed', {
+      response: responseEnvelope(responseId, model, output, usage, 'failed', {
         type: 'upstream_error',
         message: 'Upstream stream ended before completion'
       })
@@ -1004,19 +1034,19 @@ const streamChatToResponses = async (
     log.warn('bridge stream incomplete', { model, finishReason: terminalFinishReason })
     writeEvent(response, 'response.incomplete', sequence++, {
       response: {
-        ...responseEnvelope(responseId, model, output, undefined, 'incomplete'),
+        ...responseEnvelope(responseId, model, output, usage, 'incomplete'),
         incomplete_details: { reason: terminalFinishReason }
       }
     })
   } else if (sawDone) {
     writeEvent(response, 'response.completed', sequence++, {
-      response: responseEnvelope(responseId, model, output)
+      response: responseEnvelope(responseId, model, output, usage)
     })
   } else {
     // No finish_reason and no [DONE]: the upstream ended mid-stream without a terminal signal.
     log.warn('bridge stream truncated (no terminal finish_reason)', { model })
     writeEvent(response, 'response.failed', sequence++, {
-      response: responseEnvelope(responseId, model, output, undefined, 'failed', {
+      response: responseEnvelope(responseId, model, output, usage, 'failed', {
         type: 'upstream_incomplete',
         message: 'Upstream stream ended without a terminal finish_reason'
       })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -46,6 +46,17 @@ let repository: InstanceType<typeof SettingsRepository>
 const CODEX_SHARED_PROVIDER_ID = CODEX_SUBSCRIPTION_PROVIDER_ID
 const CODEX_ISOLATED_PROVIDER_ID = CODEX_SUBSCRIPTION_PROVIDER_ID
 
+const validAnthropicResponse = (): Response =>
+  new Response(
+    JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'o' }],
+      usage: { input_tokens: 1, output_tokens: 1 }
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  )
+
 type ManagedInstallImpl = (options: {
   installId: string
   onEvent: (event: { kind: string; installId: string }) => void
@@ -498,6 +509,116 @@ describe('SettingsService: providers', () => {
     expect(JSON.stringify(stored)).not.toContain('sk-super-secret')
   })
 
+  it('persists a custom context window and carries it into the OpenCode model metadata', async () => {
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
+    await repository.setAgentFramework('opencode')
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.18.3' }
+    })
+
+    const snapshot = await service.upsertProvider({
+      type: 'custom',
+      name: 'Gateway',
+      baseUrl: 'https://g',
+      model: 'm',
+      contextWindow: 64_000,
+      key: 'k'
+    })
+    const view = snapshot.providers[0]
+    expect(view.contextWindow).toBe(64_000)
+    expect((await repository.getSettings()).providers[0].contextWindow).toBe(64_000)
+
+    await repository.upsertProvider({
+      ...(await repository.getSettings()).providers[0],
+      lastValidatedAt: Date.now()
+    })
+    await service.setActiveProvider(view.id)
+    const backend = await service.resolveActiveAgentBackend()
+    const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    expect(content.provider.anthropic.models.m.limit.context).toBe(64_000)
+  })
+
+  it('uses a 200k runtime default when a custom context window is omitted', async () => {
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
+    await repository.setAgentFramework('opencode')
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.18.3' }
+    })
+    const view = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'Gateway',
+        baseUrl: 'https://g',
+        model: 'm',
+        key: 'k'
+      })
+    ).providers[0]
+    expect(view.contextWindow).toBeUndefined()
+
+    await repository.upsertProvider({
+      ...(await repository.getSettings()).providers[0],
+      lastValidatedAt: Date.now()
+    })
+    await service.setActiveProvider(view.id)
+    const backend = await service.resolveActiveAgentBackend()
+    const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    expect(content.provider.anthropic.models.m.limit.context).toBe(200_000)
+  })
+
+  it('keeps OpenCode connector details in on-demand skills instead of baseline context', async () => {
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
+    await repository.setAgentFramework('opencode')
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.18.3' }
+    })
+    const provider = (
+      await service.upsertProvider({
+        type: 'official',
+        name: 'DeepSeek',
+        vendorId: 'deepseek',
+        key: 'k'
+      })
+    ).providers[0]
+    await service.setActiveProvider(provider.id)
+
+    await service.resolveActiveAgentBackend()
+
+    const baseline = await readFile(
+      join(storageRoot, 'opencode', 'config', 'opencode', 'instructions', 'connectors.md'),
+      'utf8'
+    )
+    expect(baseline).toContain('host.mcp')
+    expect(baseline).toContain('mcp-*')
+    expect(baseline).not.toContain('pubchem_get_compounds')
+    expect(baseline).not.toContain('```json')
+    expect(baseline.length).toBeLessThan(2_500)
+
+    const chemistrySkill = await readFile(
+      join(storageRoot, 'opencode', 'config', 'opencode', 'skills', 'mcp-chemistry', 'SKILL.md'),
+      'utf8'
+    )
+    expect(chemistrySkill).toContain('pubchem_get_compounds')
+    expect(chemistrySkill).toContain('```json')
+  })
+
+  it('rejects an invalid custom context window when IPC bypasses the form', async () => {
+    const service = createService()
+    const base = {
+      type: 'custom' as const,
+      name: 'Gateway',
+      baseUrl: 'https://g',
+      model: 'm',
+      key: 'k'
+    }
+
+    await expect(service.upsertProvider({ ...base, contextWindow: 0 })).rejects.toThrow(
+      /positive whole number/i
+    )
+    await expect(service.upsertProvider({ ...base, contextWindow: 1.5 })).rejects.toThrow(
+      /positive whole number/i
+    )
+  })
+
   it('keeps the stored key when an edit omits a new key', async () => {
     const service = createService()
     const created = (
@@ -567,7 +688,7 @@ describe('SettingsService: providers', () => {
 describe('SettingsService: validation', () => {
   it('records lastValidatedAt for a saved provider on success', async () => {
     const service = createService()
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200 }))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(validAnthropicResponse()))
 
     const created = (
       await service.upsertProvider({
@@ -735,7 +856,7 @@ describe('SettingsService: validation', () => {
     await service.validateProvider({ providerId: created.id })
     expect((await repository.getSettings()).providers[0].lastValidationFailure).toBeDefined()
 
-    fetchMock.mockResolvedValue({ status: 200 })
+    fetchMock.mockResolvedValue(validAnthropicResponse())
     await service.validateProvider({ providerId: created.id })
 
     const stored = (await repository.getSettings()).providers[0]
@@ -746,7 +867,7 @@ describe('SettingsService: validation', () => {
 
   it('invalidates an earlier success when the latest validation fails', async () => {
     const service = createService()
-    const fetchMock = vi.fn().mockResolvedValue({ status: 200 })
+    const fetchMock = vi.fn().mockResolvedValue(validAnthropicResponse())
     vi.stubGlobal('fetch', fetchMock)
     const created = (
       await service.upsertProvider({
@@ -790,7 +911,7 @@ describe('SettingsService: validation', () => {
             releaseSlow = () => resolve({ status: 401 } as Response)
           })
       )
-      .mockResolvedValue({ status: 200 } as Response)
+      .mockResolvedValue(validAnthropicResponse())
     vi.stubGlobal('fetch', fetchMock)
 
     const slow = service.validateProvider({ providerId: created.id })
@@ -811,7 +932,7 @@ describe('SettingsService: validation', () => {
     ['API format', { apiEndpoints: ['responses' as const] }]
   ])('invalidates prior validation when the custom provider %s changes', async (_label, change) => {
     const service = createService()
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200 }))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(validAnthropicResponse()))
     const created = (
       await service.upsertProvider({
         type: 'custom',
@@ -908,10 +1029,8 @@ describe('SettingsService: validation', () => {
 
   it('ignores an older validation result that finishes after a newer success', async () => {
     const service = createService()
-    const resolvers: Array<(response: { status: number }) => void> = []
-    const fetchMock = vi.fn(
-      () => new Promise<{ status: number }>((resolve) => resolvers.push(resolve))
-    )
+    const resolvers: Array<(response: Response) => void> = []
+    const fetchMock = vi.fn(() => new Promise<Response>((resolve) => resolvers.push(resolve)))
     vi.stubGlobal('fetch', fetchMock)
     const created = (
       await service.upsertProvider({
@@ -927,9 +1046,9 @@ describe('SettingsService: validation', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
     const newer = service.validateProvider({ providerId: created.id })
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
-    resolvers[1]({ status: 200 })
+    resolvers[1](validAnthropicResponse())
     await newer
-    resolvers[0]({ status: 401 })
+    resolvers[0](new Response(null, { status: 401 }))
     await older
 
     const stored = (await repository.getSettings()).providers[0]
@@ -972,7 +1091,7 @@ describe('SettingsService: validation', () => {
 describe('SettingsService: preflight & spawn config', () => {
   it('gates on a detected claude and a validated active provider', async () => {
     const service = createService()
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200 }))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(validAnthropicResponse()))
 
     // Seed an existing executable path so the launch re-check passes.
     await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
@@ -1191,6 +1310,47 @@ describe('SettingsService: preflight & spawn config', () => {
     })
   })
 
+  it('patches an existing app-managed Codex adapter before returning the backend', async () => {
+    const { managedCodexAdapterEntry } = await import('./managed-codex')
+    const adapterPath = managedCodexAdapterEntry(storageRoot)
+    await mkdir(dirname(adapterPath), { recursive: true })
+    await writeFile(
+      adapterPath,
+      [
+        '  createUsageUpdate(params) {',
+        '    const used = this.sessionState.lastTokenUsage?.totalTokens;',
+        '  }'
+      ].join('\n')
+    )
+    await chmod(adapterPath, 0o755)
+    await repository.setCodexInfo({
+      resolvedPath: adapterPath,
+      version: '1.1.4',
+      nativePath: '/data/codex-managed/native/codex',
+      nativeVersion: '0.144.6'
+    })
+    await repository.setAgentFramework('codex')
+    const service = createService()
+    const provider = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'Managed Responses',
+        apiEndpoints: ['responses'],
+        baseUrl: 'https://api.openai.com/v1/responses',
+        model: 'gpt-5-codex',
+        key: 'test-key'
+      })
+    ).providers[0]
+    await service.setActiveProvider(provider.id)
+
+    const backend = await service.resolveActiveAgentBackend()
+
+    expect(backend.executablePath).toBe(adapterPath)
+    expect(await readFile(adapterPath, 'utf8')).toContain(
+      'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
+    )
+  })
+
   it.each([
     ['codex-shared', CODEX_SHARED_PROVIDER_ID],
     ['codex-isolated', CODEX_ISOLATED_PROVIDER_ID]
@@ -1308,8 +1468,34 @@ describe('SettingsService: preflight & spawn config', () => {
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
     expect(content.provider['openai-compatible'].models['kimi-k3']).toEqual({
       attachment: true,
-      modalities: { input: ['text', 'image'] }
+      modalities: { input: ['text', 'image'] },
+      limit: { context: 1_000_000, output: 32_000 }
     })
+  })
+
+  it('injects the selected official model context window into OpenCode', async () => {
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
+    await repository.setAgentFramework('opencode')
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.19.0' }
+    })
+    const provider = (
+      await service.upsertProvider({ type: 'official', name: 'GLM', vendorId: 'zhipu', key: 'k' })
+    ).providers[0]
+
+    await service.setActiveProvider(provider.id, 'glm-5.1')
+    const smallBackend = await service.resolveActiveAgentBackend()
+    const smallConfig = JSON.parse(smallBackend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    expect(smallBackend.contextWindow).toBe(200_000)
+    expect(smallConfig.provider['openai-compatible'].models['glm-5.1'].limit.context).toBe(200_000)
+
+    await service.setActiveProvider(provider.id, 'glm-5.2')
+    const largeBackend = await service.resolveActiveAgentBackend()
+    const largeConfig = JSON.parse(largeBackend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    expect(largeBackend.contextWindow).toBe(1_000_000)
+    expect(largeConfig.provider['openai-compatible'].models['glm-5.2'].limit.context).toBe(
+      1_000_000
+    )
   })
 
   it('resolves a Chat Completions provider through the Codex Responses bridge', async () => {
@@ -1350,11 +1536,9 @@ describe('SettingsService: preflight & spawn config', () => {
     await repository.setAgentFramework('codex')
     const provider = (
       await service.upsertProvider({
-        type: 'custom',
+        type: 'official',
         name: 'DeepSeek',
-        apiEndpoints: ['openai'],
-        baseUrl: 'https://api.deepseek.com',
-        model: 'deepseek-v4-flash',
+        vendorId: 'deepseek',
         key: 'test-key'
       })
     ).providers[0]
@@ -1363,14 +1547,15 @@ describe('SettingsService: preflight & spawn config', () => {
       ...storedProvider,
       lastValidatedAt: Date.now()
     })
-    await service.setActiveProvider(provider.id)
+    await service.setActiveProvider(provider.id, 'deepseek-v4-flash')
 
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
     const backend = await service.resolveActiveAgentBackend()
 
     // Chat Completions provider ⇒ bridge ⇒ Codex runs the classic-tool-mode catalog model so it
     // advertises the shell_command function tool the bridge can forward (CODEX_BRIDGE_MODEL).
-    expect(backend.sessionModel).toBe('gpt-5.5')
+    expect(backend.sessionModel).toBe('gpt-5.4')
+    expect(backend.contextWindow).toBe(1_000_000)
     expect(backend.providerConfiguration).toEqual({
       providerId: 'custom-gateway',
       apiType: 'openai',
@@ -1784,6 +1969,7 @@ describe('SettingsService: official vendors', () => {
       ANTHROPIC_AUTH_TOKEN: 'sk-ds',
       ANTHROPIC_MODEL: 'deepseek-v4-flash'
     })
+    expect(config.contextWindow).toBe(1_000_000)
   })
 
   it('refreshes models from the vendor and persists them over the bundled catalog', async () => {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -85,10 +85,12 @@ import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
 import {
   defaultVendorModel,
-  getOfficialVendor,
+  getOfficialVendorModelIds,
   isModelBridgeSupported,
   isOfficialVendorId,
   isVendorModelMultimodal,
+  resolveCustomModelContextWindow,
+  resolveModelContextWindow,
   resolveVendorApiEndpoints,
   resolveVendorBaseUrl,
   resolveVendorModelsUrl,
@@ -130,6 +132,7 @@ import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import { detectNpmAvailable, runInstallWithFallback, type InstallTarget } from './claude-install'
 import { OPENCODE_INSTALL_TARGET } from './opencode-install'
 import {
+  ensureManagedCodexContextUsage,
   installManagedCodex,
   managedCodexAdapterEntry,
   managedCodexBinary,
@@ -362,6 +365,7 @@ const classifyClaudeProbeFailure = (error: unknown): 'auth' | 'network' | 'unkno
 export type AgentSpawnConfig = {
   envOverrides: Record<string, string>
   executablePath: string
+  contextWindow?: number
 }
 
 // Outcome of uninstalling a managed runtime. `activeBackendAffected` is true only when the removed
@@ -1712,16 +1716,27 @@ class SettingsService {
     } else if (request.type === 'custom') {
       const baseUrl = request.baseUrl?.trim() || existing?.baseUrl
       const model = request.model?.trim() || existing?.model
+      const contextWindow =
+        request.contextWindow === null
+          ? undefined
+          : (request.contextWindow ?? existing?.contextWindow)
 
       // Required-field guard: never persist an incomplete custom provider, even if the UI is bypassed.
       if (!baseUrl) throw new Error('Base URL is required for a custom provider.')
       if (!model) throw new Error('Model is required for a custom provider.')
       if (!carryKey()) throw new Error('API key is required for a custom provider.')
+      if (
+        contextWindow !== undefined &&
+        (!Number.isSafeInteger(contextWindow) || contextWindow <= 0)
+      ) {
+        throw new Error('Context window must be a positive whole number of tokens.')
+      }
 
       const apiEndpoints = request.apiEndpoints ?? existing?.apiEndpoints ?? ['anthropic']
 
       provider.baseUrl = baseUrl
       provider.model = model
+      if (contextWindow !== undefined) provider.contextWindow = contextWindow
       provider.supportsImageInput =
         request.supportsImageInput ?? existing?.supportsImageInput ?? false
       // Which chat APIs this gateway speaks (drives per-framework availability); defaults to anthropic.
@@ -2230,7 +2245,7 @@ class SettingsService {
     await syncConnectorSkillDocs(join(configRoot, 'skills'), this.enabledConnectorIds(connectors))
   }
 
-  // Bundled connectors the user hasn't turned off (default-on), for opencode instruction delivery.
+  // Bundled connectors the user hasn't turned off (default-on), for skill and baseline delivery.
   private enabledConnectorIds(connectors: StoredConnectors | undefined): string[] {
     const disabled = new Set(connectors?.disabledConnectorIds ?? [])
 
@@ -2511,15 +2526,13 @@ class SettingsService {
       disabledSkillIds
     })
 
-    const envOverrides = buildProviderEnv(
-      this.resolveProvider(activeProvider, settings.activeModel),
-      {
-        storageRoot: this.storageRoot,
-        claudeExecutablePath: executablePath
-      }
-    )
+    const provider = this.resolveProvider(activeProvider, settings.activeModel)
+    const envOverrides = buildProviderEnv(provider, {
+      storageRoot: this.storageRoot,
+      claudeExecutablePath: executablePath
+    })
 
-    return { envOverrides, executablePath }
+    return { envOverrides, executablePath, contextWindow: provider.contextWindow }
   }
 
   // Resolves the active agent backend for one connect: the selected framework plus its spawn inputs.
@@ -2621,7 +2634,7 @@ class SettingsService {
 
     if (framework.id === 'claude-code') {
       // Unchanged Claude path: skills provisioning + Anthropic-shaped env + local-auth handling.
-      const { envOverrides, executablePath } = await this.resolveSpawnConfig(
+      const { envOverrides, executablePath, contextWindow } = await this.resolveSpawnConfig(
         settings,
         forcedSkillIds
       )
@@ -2631,7 +2644,8 @@ class SettingsService {
         backendId: `${framework.id}:${activeProvider.id}`,
         executablePath,
         env: envOverrides,
-        sessionEffort
+        sessionEffort,
+        contextWindow
       }
     }
 
@@ -2639,6 +2653,9 @@ class SettingsService {
       framework.id === 'codex'
         ? await this.resolveCodexExecutable(settings.codex?.resolvedPath)
         : await this.resolveOpencodeExecutable(settings.opencodePath)
+    if (framework.id === 'codex' && isManagedCodexPath(executablePath, this.storageRoot)) {
+      await ensureManagedCodexContextUsage(executablePath)
+    }
     const provider = this.resolveProvider(activeProvider, settings.activeModel)
     // The settings UI intentionally stores one subscription card, but runtime sessions created
     // under the shared and isolated profiles are not interchangeable. Preserve their legacy
@@ -2681,8 +2698,8 @@ class SettingsService {
         executablePath,
         responsesBridge,
         reasoningEffort: sessionEffort,
-        // Connector conventions + tools, so opencode uses host.mcp instead of raw HTTP (it has no skill
-        // docs like Claude). Enabled bundled connectors only.
+        // Keep only connector calling conventions in OpenCode's baseline. Detailed tools are already
+        // materialized as on-demand `mcp-*` skills above, avoiding a full catalog in every request.
         instructions: renderConnectorInstructions(enabledConnectorIds)
       })
       await this.writeAgentConfigFiles(modelConfig.configFiles)
@@ -2706,6 +2723,7 @@ class SettingsService {
           ? { sessionModelRequired: true }
           : {}),
         sessionEffort,
+        contextWindow: provider.contextWindow,
         authentication: modelConfig.authentication,
         providerConfiguration: modelConfig.providerConfiguration,
         responsesBridgeLease: responsesBridge?.lease
@@ -2880,6 +2898,7 @@ class SettingsService {
       apiEndpoints: this.resolveProviderApiEndpoints(provider),
       baseUrl: provider.baseUrl,
       model: provider.model,
+      contextWindow: provider.contextWindow,
       supportsImageInput: this.providerSupportsImageInput(provider, activeModel),
       vendorId: provider.vendorId,
       region: provider.region,
@@ -2928,14 +2947,14 @@ class SettingsService {
   // override. Codex validates an explicit candidate against the live session options before applying it.
   private availableModels(provider: StoredProvider): string[] {
     if (isCodexSubscriptionProvider(provider.type)) {
-      return getOfficialVendor('openai')?.models ?? []
+      return getOfficialVendorModelIds('openai')
     }
 
     if (provider.type === 'official' && provider.vendorId) {
       // Live-fetched models (via "refresh from vendor") take precedence over the bundled catalog.
       if (provider.fetchedModels && provider.fetchedModels.length > 0) return provider.fetchedModels
 
-      return getOfficialVendor(provider.vendorId)?.models ?? []
+      return getOfficialVendorModelIds(provider.vendorId)
     }
 
     return provider.model ? [provider.model] : []
@@ -2966,21 +2985,34 @@ class SettingsService {
     const key = provider.keyRef ? tryDecryptKey(provider.keyRef) : undefined
 
     if (provider.type === 'official' && provider.vendorId) {
+      const model = modelOverride ?? defaultVendorModel(provider.vendorId)
+      const contextWindow = resolveModelContextWindow(provider.vendorId, model)
+
       return {
         type: 'custom',
         baseUrl: resolveVendorBaseUrl(provider.vendorId, provider.region),
         openaiBaseUrl: resolveVendorOpenAiBaseUrl(provider.vendorId, provider.region),
-        model: modelOverride ?? defaultVendorModel(provider.vendorId),
+        model,
+        ...(contextWindow === undefined ? {} : { contextWindow }),
         key,
         apiEndpoints: this.resolveProviderApiEndpoints(provider),
         supportsImageInput: this.providerSupportsImageInput(provider, modelOverride)
       }
     }
 
+    const model = modelOverride ?? provider.model
+    const contextWindow =
+      provider.type === 'custom'
+        ? resolveCustomModelContextWindow(provider.contextWindow)
+        : provider.type === 'claude-isolated'
+          ? resolveModelContextWindow('anthropic', model)
+          : undefined
+
     return {
       type: provider.type,
       baseUrl: provider.baseUrl,
-      model: modelOverride ?? provider.model,
+      model,
+      ...(contextWindow === undefined ? {} : { contextWindow }),
       key,
       apiEndpoints: this.resolveProviderApiEndpoints(provider),
       supportsImageInput: this.providerSupportsImageInput(provider, modelOverride)
@@ -3006,6 +3038,9 @@ class SettingsService {
       type: draft.type,
       baseUrl: draft.baseUrl,
       model: draft.model,
+      ...(draft.type === 'custom'
+        ? { contextWindow: resolveCustomModelContextWindow(draft.contextWindow ?? undefined) }
+        : {}),
       key: draft.key,
       apiEndpoints: draft.apiEndpoints ?? ['anthropic']
     }

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -30,6 +30,8 @@ export type StoredProvider = {
   apiEndpoints?: ChatApiEndpoint[]
   baseUrl?: string
   model?: string
+  // Optional custom-model override. Absence is meaningful and resolves to the shared 200k default.
+  contextWindow?: number
   supportsImageInput?: boolean
   // Set for official-vendor providers only.
   vendorId?: OfficialVendorId

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -252,8 +252,18 @@ describe('validate: error-body extraction', () => {
 })
 
 describe('validate: provider dispatch', () => {
-  it('returns ok for a 200 custom response', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ status: 200 } as Response)
+  it('returns ok for a valid 200 Anthropic message', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'o' }],
+          usage: { input_tokens: 1, output_tokens: 1 }
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    )
 
     const result = await validateProvider(
       { type: 'custom', baseUrl: 'https://g/v1', key: 'k', model: 'm' },
@@ -261,6 +271,22 @@ describe('validate: provider dispatch', () => {
     )
 
     expect(result).toMatchObject({ ok: true, category: 'ok', status: 200 })
+  })
+
+  it('rejects an empty 200 Anthropic response instead of recording a false validation success', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+
+    const result = await validateProvider(
+      { type: 'custom', baseUrl: 'https://g/v1', key: 'k', model: 'm' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      category: 'unknown',
+      status: 200,
+      message: expect.stringContaining('valid Anthropic message')
+    })
   })
 
   it('requires an actual function call from a Chat Completions bridge provider', async () => {

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -28,6 +28,7 @@ type ValidationHttpRequest = {
   url: string
   headers: Record<string, string>
   body: string
+  endpoint: ChatApiEndpoint
   requiresBridgeToolCall?: boolean
 }
 
@@ -108,7 +109,7 @@ const buildAnthropicValidationRequest = (provider: ResolvedProvider): Validation
     messages: [{ role: 'user', content: 'ping' }]
   })
 
-  return { url, headers, body }
+  return { url, headers, body, endpoint: 'anthropic' }
 }
 
 // A bridge contract probe for /v1/chat/completions. Codex depends on function calls, so a plain text
@@ -153,6 +154,7 @@ const buildOpenAiValidationRequest = (
     url,
     headers,
     body,
+    endpoint: 'openai',
     ...(requireBridgeToolCall ? { requiresBridgeToolCall: true } : {})
   }
 }
@@ -181,11 +183,33 @@ const buildResponsesValidationRequest = (provider: ResolvedProvider): Validation
   return {
     url,
     headers,
+    endpoint: 'responses',
     body: JSON.stringify({
       model: provider.model ?? '',
       input: 'ping',
       max_output_tokens: 16
     })
+  }
+}
+
+const hasValidAnthropicMessage = (bodyText: string): boolean => {
+  try {
+    const parsed = JSON.parse(bodyText) as {
+      type?: unknown
+      role?: unknown
+      content?: unknown
+      usage?: { input_tokens?: unknown; output_tokens?: unknown }
+    }
+
+    return (
+      parsed.type === 'message' &&
+      parsed.role === 'assistant' &&
+      Array.isArray(parsed.content) &&
+      typeof parsed.usage?.input_tokens === 'number' &&
+      typeof parsed.usage?.output_tokens === 'number'
+    )
+  } catch {
+    return false
   }
 }
 
@@ -499,6 +523,21 @@ const validateCustomProvider = async (
         status: response.status,
         message: providerMessage
       })
+    }
+
+    if (category === 'ok' && request.endpoint === 'anthropic') {
+      let bodyText = ''
+      try {
+        bodyText = await response.text()
+      } catch {
+        // An unreadable success body cannot prove the Messages contract.
+      }
+      if (!hasValidAnthropicMessage(bodyText)) {
+        return toResult('unknown', {
+          status: response.status,
+          message: 'The provider returned success without a valid Anthropic message.'
+        })
+      }
     }
 
     if (category === 'ok' && request.requiresBridgeToolCall) {

--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -47,6 +47,7 @@ const createSnapshot = (overrides: Partial<AcpStateSnapshot> = {}): AcpStateSnap
   pendingPermissions: [],
   permissionProfiles: {},
   permissionGrants: {},
+  contextUsageBySession: {},
   promptInFlight: false,
   promptInFlightSessionIds: [],
   ...overrides

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -19,6 +19,7 @@ const emptyAcpState: AcpStateSnapshot = {
   pendingPermissions: [],
   permissionProfiles: {},
   permissionGrants: {},
+  contextUsageBySession: {},
   promptInFlight: false,
   promptInFlightSessionIds: []
 }

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -42,6 +42,7 @@ const createSnapshot = (sessionIds: string[] = []): AcpStateSnapshot => ({
   pendingPermissions: [],
   permissionProfiles: {},
   permissionGrants: {},
+  contextUsageBySession: {},
   promptInFlight: false,
   promptInFlightSessionIds: []
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -5,7 +5,8 @@ import type {
   AcpPermissionGrant,
   AcpPermissionRequest,
   AcpRuntimeEvent,
-  AcpMessageImage
+  AcpMessageImage,
+  AcpContextUsage
 } from '../../../../shared/acp'
 import {
   DEFAULT_PERMISSION_PROFILE,
@@ -1031,6 +1032,7 @@ const useWorkspaceAgentRuntime = (): {
   pendingPermissions: AcpPermissionRequest[]
   permissionProfiles: Record<string, SessionPermissionProfileState>
   permissionGrants: Record<string, AcpPermissionGrant[]>
+  contextUsageBySession: Record<string, AcpContextUsage>
   sendMessage: (input: SendWorkspaceMessageInput) => Promise<SendWorkspaceMessageResult | undefined>
   resendEditedMessage: (
     sessionId: string,
@@ -1202,6 +1204,7 @@ const useWorkspaceAgentRuntime = (): {
     pendingPermissions: runtime.state.pendingPermissions,
     permissionProfiles: runtime.state.permissionProfiles,
     permissionGrants: runtime.state.permissionGrants,
+    contextUsageBySession: runtime.state.contextUsageBySession,
     sendMessage,
     resendEditedMessage,
     cancelRun,

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -58,6 +58,9 @@ describe('ProviderForm field switching', () => {
     expect(container.querySelector('[aria-label="Base URL"]')).not.toBeNull()
     expect(container.querySelector('[aria-label="API key"]')).not.toBeNull()
     expect(container.querySelector('[aria-label="Model"]')).not.toBeNull()
+    expect(
+      container.querySelector<HTMLInputElement>('[aria-label="Context window"]')?.placeholder
+    ).toBe('200000')
     // The auth style selector was removed; custom always uses a bearer token.
     expect(container.querySelector('[aria-label="Auth style"]')).toBeNull()
   })
@@ -76,6 +79,7 @@ describe('ProviderForm field switching', () => {
     expect(container.querySelector('[aria-label="Base URL"]')).toBeNull()
     expect(container.querySelector('[aria-label="API format"]')).toBeNull()
     expect(container.querySelector('[aria-label="Model"]')).toBeNull()
+    expect(container.querySelector('[aria-label="Context window"]')).toBeNull()
     expect(container.textContent).toContain('gpt-5.6-sol')
     expect(container.querySelector<HTMLAnchorElement>('a')?.href).toBe(
       'https://platform.openai.com/api-keys'

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -10,7 +10,11 @@ import {
   SelectLabel,
   SelectTrigger
 } from '@/components/ui/select'
-import { getOfficialVendor, resolveVendorApiKeyUrl } from '../../../../shared/provider-registry'
+import {
+  getOfficialVendor,
+  getOfficialVendorModelIds,
+  resolveVendorApiKeyUrl
+} from '../../../../shared/provider-registry'
 import { getApiKeySecurityCopy } from './provider-key-security'
 import { ProviderKindIcon } from './provider-icons'
 import {
@@ -355,6 +359,29 @@ const ProviderForm = ({
               </p>
             ) : null}
           </div>
+
+          <div className="space-y-1.5">
+            <label className={fieldLabelClassName} htmlFor="provider-context-window">
+              Context window
+            </label>
+            <Input
+              id="provider-context-window"
+              aria-label="Context window"
+              type="number"
+              inputMode="numeric"
+              min={1}
+              step={1000}
+              value={value.contextWindow}
+              disabled={disabled}
+              placeholder="200000"
+              onChange={(event) => onChange({ contextWindow: event.target.value })}
+            />
+            {errors.contextWindow ? (
+              <p className={fieldErrorClassName} role="alert">
+                {errors.contextWindow}
+              </p>
+            ) : null}
+          </div>
         </>
       ) : isOfficial ? (
         <>
@@ -385,7 +412,8 @@ const ProviderForm = ({
           {keyField}
 
           {(() => {
-            const models = supportedModels ?? vendor?.models ?? []
+            const models =
+              supportedModels ?? (value.vendorId ? getOfficialVendorModelIds(value.vendorId) : [])
 
             if (models.length === 0) return null
 

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -62,6 +62,7 @@ const toFormValue = (provider: ProviderView): ProviderFormValue =>
     name: provider.name,
     baseUrl: provider.baseUrl ?? '',
     model: provider.model ?? '',
+    contextWindow: provider.contextWindow?.toString() ?? '',
     apiEndpoint: provider.apiEndpoints?.[0] ?? 'anthropic',
     supportsImageInput: provider.supportsImageInput,
     vendorId: provider.vendorId,
@@ -77,6 +78,12 @@ const toUpsertRequest = (
   name: value.name,
   baseUrl: value.baseUrl,
   model: value.model,
+  contextWindow:
+    value.type === 'custom'
+      ? value.contextWindow.trim()
+        ? Number(value.contextWindow)
+        : null
+      : undefined,
   apiEndpoints: [value.apiEndpoint],
   supportsImageInput: value.supportsImageInput,
   vendorId: value.vendorId,

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -67,6 +67,28 @@ describe('getProviderFormErrors', () => {
     expect(errors).toEqual({})
     expect(hasProviderFormErrors(errors)).toBe(false)
   })
+
+  it('allows a blank context window and rejects non-positive or fractional values', () => {
+    const complete = {
+      type: 'custom' as const,
+      baseUrl: 'https://g',
+      model: 'm',
+      key: 'k'
+    }
+
+    expect(
+      getProviderFormErrors(createEmptyProviderFormValue({ ...complete, contextWindow: '' }))
+        .contextWindow
+    ).toBeUndefined()
+    expect(
+      getProviderFormErrors(createEmptyProviderFormValue({ ...complete, contextWindow: '0' }))
+        .contextWindow
+    ).toMatch(/positive whole number/i)
+    expect(
+      getProviderFormErrors(createEmptyProviderFormValue({ ...complete, contextWindow: '1.5' }))
+        .contextWindow
+    ).toMatch(/positive whole number/i)
+  })
 })
 
 describe('provider-kind helpers', () => {
@@ -105,7 +127,8 @@ describe('provider-kind helpers', () => {
       name: 'MiniMax',
       vendorId: 'minimax',
       region: 'global',
-      model: ''
+      model: '',
+      contextWindow: ''
     })
   })
 
@@ -115,7 +138,8 @@ describe('provider-kind helpers', () => {
       name: 'OpenAI',
       vendorId: 'openai',
       region: undefined,
-      model: ''
+      model: '',
+      contextWindow: ''
     })
     expect(
       selectedKindKey(createEmptyProviderFormValue({ type: 'official', vendorId: 'openai' }))
@@ -127,7 +151,8 @@ describe('provider-kind helpers', () => {
       type: 'custom',
       vendorId: undefined,
       region: undefined,
-      model: ''
+      model: '',
+      contextWindow: ''
     })
   })
 

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -18,6 +18,8 @@ export type ProviderFormValue = {
   name: string
   baseUrl: string
   model: string
+  // Kept as text so an empty optional numeric input remains distinct from the 200k runtime default.
+  contextWindow: string
   // Which chat API a custom gateway speaks; drives which agent frameworks can use it. Defaults to
   // 'anthropic'. A custom provider serves exactly one endpoint (official providers take theirs from
   // the registry); it is stored as the single-entry apiEndpoints array.
@@ -39,6 +41,7 @@ export const createEmptyProviderFormValue = (
   name: '',
   baseUrl: '',
   model: '',
+  contextWindow: '',
   apiEndpoint: 'anthropic',
   supportsImageInput: false,
   key: '',
@@ -74,6 +77,7 @@ export const defaultProviderKindKey = (
 // and model come from the registry).
 export type ProviderFormErrors = {
   baseUrl?: string
+  contextWindow?: string
   key?: string
   model?: string
 }
@@ -89,6 +93,12 @@ export const getProviderFormErrors = (
   if (value.type === 'custom') {
     if (!value.baseUrl.trim()) errors.baseUrl = 'Base URL is required.'
     if (!value.model.trim()) errors.model = 'Model is required.'
+    if (value.contextWindow.trim()) {
+      const contextWindow = Number(value.contextWindow)
+      if (!Number.isSafeInteger(contextWindow) || contextWindow <= 0) {
+        errors.contextWindow = 'Context window must be a positive whole number of tokens.'
+      }
+    }
     if (!value.key.trim() && !options.hasStoredKey) errors.key = 'API key is required.'
   } else if (value.type === 'official') {
     // No model is chosen at add time: the vendor catalog + the global model selection cover that.
@@ -169,6 +179,7 @@ export const providerKindPatch = (key: string): Partial<ProviderFormValue> => {
       apiEndpoint: 'responses',
       baseUrl: '',
       model: '',
+      contextWindow: '',
       key: '',
       vendorId: undefined,
       region: undefined
@@ -183,6 +194,7 @@ export const providerKindPatch = (key: string): Partial<ProviderFormValue> => {
       apiEndpoint: 'anthropic',
       baseUrl: '',
       model: '',
+      contextWindow: '',
       key: '',
       vendorId: undefined,
       region: undefined
@@ -199,11 +211,12 @@ export const providerKindPatch = (key: string): Partial<ProviderFormValue> => {
       name: vendor?.label,
       vendorId,
       region: vendor?.regions?.[0]?.id,
-      model: ''
+      model: '',
+      contextWindow: ''
     }
   }
 
-  return { type: 'custom', vendorId: undefined, region: undefined, model: '' }
+  return { type: 'custom', vendorId: undefined, region: undefined, model: '', contextWindow: '' }
 }
 
 // Maps the current form value back to its provider-kind key (the dropdown's selected value).

--- a/src/renderer/src/pages/workspace/ComposerContextUsage.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerContextUsage.render.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { ComposerContextUsage } from './ComposerContextUsage'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('ComposerContextUsage', () => {
+  it('stays hidden until the current agent context reports usage', () => {
+    act(() => root.render(<ComposerContextUsage contextUsage={undefined} />))
+
+    expect(container.querySelector('button')).toBeNull()
+  })
+
+  it('shows current context occupancy as a percentage with token details', async () => {
+    act(() => root.render(<ComposerContextUsage contextUsage={{ used: 24_890, size: 200_000 }} />))
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-label="Context used: 12%"]')
+    expect(trigger).not.toBeNull()
+    expect(trigger?.textContent).toContain('12%')
+
+    await act(async () => {
+      trigger?.focus()
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Context window')
+    expect(document.body.textContent).toContain('25k / 200k tokens (12%)')
+  })
+})

--- a/src/renderer/src/pages/workspace/ComposerContextUsage.tsx
+++ b/src/renderer/src/pages/workspace/ComposerContextUsage.tsx
@@ -1,0 +1,65 @@
+// Composer context-usage indicator: a compact "% of context window" pill with a hover breakdown,
+// mirroring Claude Code's /context. The numerator (tokens in context) comes from the ACP usage_update
+// the runtime records per session; the denominator is already bound to the same agent-context generation
+// by the main process. Renders nothing until the active framework emits its first usage_update rather
+// than showing a fabricated zero.
+
+import { Gauge } from 'lucide-react'
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { AcpContextUsage } from '../../../../shared/acp'
+
+type ComposerContextUsageProps = {
+  // Latest usage for the active session, or undefined when the framework never reported any.
+  contextUsage: AcpContextUsage | undefined
+}
+
+// Compact token count: 1_000_000 -> "1M", 24_890 -> "25k", 512 -> "512".
+const formatTokens = (tokens: number): string => {
+  if (tokens >= 1_000_000) {
+    const millions = tokens / 1_000_000
+    return `${millions % 1 === 0 ? millions.toFixed(0) : millions.toFixed(1)}M`
+  }
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`
+  return String(Math.round(tokens))
+}
+
+const ComposerContextUsage = ({
+  contextUsage
+}: ComposerContextUsageProps): React.JSX.Element | null => {
+  if (!contextUsage || typeof contextUsage.used !== 'number') return null
+
+  const size = contextUsage.size
+  const used = contextUsage.used
+  const percent = size && size > 0 ? Math.min(100, Math.round((used / size) * 100)) : undefined
+
+  const label = percent !== undefined ? `${percent}%` : formatTokens(used)
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="flex h-8 min-w-0 items-center gap-1.5 rounded-md px-2 text-[12px] text-text-000 transition-colors duration-200 ease-out hover:bg-bg-200"
+            aria-label={`Context used: ${label}`}
+          >
+            <Gauge className="size-3.5 shrink-0" strokeWidth={2} aria-hidden="true" />
+            <span className="tabular-nums @max-[28rem]/composer:hidden">{label}</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-64">
+          <div className="space-y-0.5 text-[12px]">
+            <div className="font-medium">Context window</div>
+            <div>
+              {formatTokens(used)} / {formatTokens(size)} tokens
+              {percent !== undefined ? ` (${percent}%)` : ''}
+            </div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export { ComposerContextUsage }

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -118,6 +118,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         permissionProfile="ask"
         permissionProfileState={undefined}
         permissionGrants={[]}
+        contextUsage={undefined}
         canChangePermissionProfile
         onDraftDocChange={vi.fn()}
         onSendMessage={vi.fn()}

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1,4 +1,8 @@
-import type { AcpPermissionGrant, AcpPermissionRequest } from '../../../../shared/acp'
+import type {
+  AcpPermissionGrant,
+  AcpPermissionRequest,
+  AcpContextUsage
+} from '../../../../shared/acp'
 import type { NotebookSessionReference } from '../../../../shared/notebook'
 import type {
   PermissionProfileId,
@@ -39,6 +43,7 @@ import { useSessionJobStore } from '@/stores/session-job-store'
 import { ComposerEditor } from './composer/ComposerEditor'
 import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
 import { ComposerAgentControlsMenu } from './ComposerAgentControlsMenu'
+import { ComposerContextUsage } from './ComposerContextUsage'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
 import { normalizeRunFailureError } from './error-report'
@@ -95,6 +100,8 @@ type ConversationPanelProps = {
   permissionProfile: PermissionProfileId
   permissionProfileState: SessionPermissionProfileState | undefined
   permissionGrants: AcpPermissionGrant[]
+  // Latest context-window usage for the active session (undefined when the framework never reported it).
+  contextUsage: AcpContextUsage | undefined
   canChangePermissionProfile: boolean
   // Auto-review toggle: whether the current session has auto-review enabled (default false).
   autoReviewEnabled: boolean
@@ -141,6 +148,7 @@ const ConversationPanel = ({
   permissionProfile,
   permissionProfileState,
   permissionGrants,
+  contextUsage,
   canChangePermissionProfile,
   autoReviewEnabled,
   onDraftDocChange,
@@ -494,6 +502,10 @@ const ConversationPanel = ({
                         />
 
                         <div className="flex-1" />
+
+                        {/* Context-window usage for the active session (renders nothing when the
+                            framework doesn't report usage). Sits with the model it pertains to. */}
+                        <ComposerContextUsage contextUsage={contextUsage} />
 
                         {/* Model/provider switcher; hides itself unless more than one is configured.
                             Grouped on the right with Send, mirroring the reference composer layout. */}

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -159,6 +159,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     pendingPermissions,
     permissionProfiles,
     permissionGrants,
+    contextUsageBySession,
     sendMessage,
     resendEditedMessage,
     cancelRun,
@@ -219,6 +220,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     : undefined
   // Always-allow grants only exist for a bound session; new conversations have none yet.
   const activePermissionGrants = activeSession ? (permissionGrants?.[activeSession.id] ?? []) : []
+  const activeContextUsage = activeSession ? contextUsageBySession?.[activeSession.id] : undefined
   // Auto-review defaults off: an existing session is enabled only when explicitly turned on; a new
   // conversation uses the draft toggle (which also starts off).
   const activeAutoReviewEnabled = activeSession
@@ -912,6 +914,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             permissionProfile={activePermissionProfile}
             permissionProfileState={activePermissionProfileState}
             permissionGrants={activePermissionGrants}
+            contextUsage={activeContextUsage}
             canChangePermissionProfile={canChangePermissionProfile}
             autoReviewEnabled={activeAutoReviewEnabled}
             onDraftDocChange={setDraftDoc}

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -96,11 +96,23 @@ export const ACP_PROMPT_FAILED_EVENT_TITLE = 'Prompt failed'
 // the agent context and replays a text-only transcript. Absent on ordinary events.
 export type AcpRecoverableFailure = 'context-overflow'
 
+// Current agent-context usage projected onto its logical app session. `used` is model input tokens plus
+// cache-read tokens; output/completion and cache-write tokens are excluded. `size` is the ACP-required
+// window bound to that same agent-context generation. Both expire when that context disconnects or is
+// replaced. Monetary cost is deliberately excluded: context tracking does not calculate billing.
+export type AcpContextUsage = {
+  used: number
+  size: number
+}
+
 export type AcpRuntimeEvent = {
   id: string
   timestamp: number
   kind: AcpRuntimeEventKind
   level: AcpRuntimeEventLevel
+  // Present only on a usage_update-derived event; the runtime records it per session and does not push
+  // the event into the visible conversation.
+  contextUsage?: AcpContextUsage
   // Set on an error event the app can auto-recover from, so the renderer compacts-and-retries instead
   // of surfacing a dead-end error.
   recoverable?: AcpRecoverableFailure
@@ -202,6 +214,9 @@ export type AcpStateSnapshot = {
   permissionProfiles: Record<string, SessionPermissionProfileState>
   // Per-session always-allow grants (from per-request "Always"), so the UI can show and revoke them.
   permissionGrants: Record<string, AcpPermissionGrant[]>
+  // Latest context-window usage for each logical app session's current agent-context generation.
+  // Missing means unknown or invalidated; framework switches and reconnects clear the old generation.
+  contextUsageBySession: Record<string, AcpContextUsage>
   promptInFlight: boolean
   promptInFlightSessionIds: string[]
 }

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -6,6 +6,8 @@ import {
   getOfficialVendor,
   isOfficialVendorId,
   isVendorModelMultimodal,
+  resolveCustomModelContextWindow,
+  resolveModelContextWindow,
   resolveVendorApiEndpoints,
   resolveVendorApiKeyUrl,
   resolveVendorBaseUrl,
@@ -299,6 +301,57 @@ describe('provider registry', () => {
       expect(isVendorModelMultimodal('openrouter', 'somevendor/unknown-model')).toBe(false)
       // Kimi's list is k3-only; an unknown id is not vision-capable.
       expect(isVendorModelMultimodal('kimi', 'kimi-k9-imaginary')).toBe(false)
+    })
+  })
+
+  describe('resolveModelContextWindow', () => {
+    it('declares a positive context window directly on every bundled model', () => {
+      for (const vendor of OFFICIAL_VENDORS) {
+        for (const model of vendor.models) {
+          expect(model.contextWindow, `${vendor.id}/${model.id}`).toBeGreaterThan(0)
+          expect(resolveModelContextWindow(vendor.id, model.id)).toBe(model.contextWindow)
+        }
+      }
+    })
+
+    it('keeps 1m bundled variants explicit and recognizes the suffix for unknown live models', () => {
+      expect(resolveModelContextWindow('anthropic', 'claude-opus-4-8[1m]')).toBe(1_000_000)
+      expect(resolveModelContextWindow('deepseek', 'deepseek-v4-pro[1m]')).toBe(1_000_000)
+      expect(resolveModelContextWindow('minimax', 'MiniMax-M3[1m]')).toBe(1_000_000)
+      expect(resolveModelContextWindow('anthropic', 'future-claude[1m]')).toBe(1_000_000)
+    })
+
+    it('resolves shipped models with vendor-published per-model limits', () => {
+      expect(resolveModelContextWindow('anthropic', 'claude-opus-4-8')).toBe(1_000_000)
+      expect(resolveModelContextWindow('anthropic', 'claude-haiku-4-5-20251001')).toBe(200_000)
+      expect(resolveModelContextWindow('openai', 'gpt-5.6-sol')).toBe(1_050_000)
+      expect(resolveModelContextWindow('openai', 'gpt-5.4-mini')).toBe(400_000)
+      expect(resolveModelContextWindow('deepseek', 'deepseek-v4-flash')).toBe(1_000_000)
+      expect(resolveModelContextWindow('zhipu', 'glm-5.2')).toBe(1_000_000)
+      expect(resolveModelContextWindow('zhipu', 'glm-5.1')).toBe(200_000)
+      expect(resolveModelContextWindow('kimi', 'kimi-k3')).toBe(1_000_000)
+      expect(resolveModelContextWindow('kimi', 'kimi-k2.7-code')).toBe(256_000)
+    })
+
+    it('resolves OpenRouter cross-vendor slugs from OpenRouter metadata', () => {
+      expect(resolveModelContextWindow('openrouter', 'anthropic/claude-opus-4.8')).toBe(1_000_000)
+      expect(resolveModelContextWindow('openrouter', 'google/gemini-3.1-pro-preview')).toBe(
+        1_048_576
+      )
+      expect(resolveModelContextWindow('openrouter', 'x-ai/grok-4.5')).toBe(500_000)
+      expect(resolveModelContextWindow('openrouter', 'deepseek/deepseek-v4-pro')).toBe(1_048_576)
+    })
+
+    it('uses the conservative fallback for an unknown live-fetched model but not a missing id', () => {
+      expect(resolveModelContextWindow('openai', 'totally-unknown-model')).toBe(200_000)
+      expect(resolveModelContextWindow('anthropic', undefined)).toBeUndefined()
+    })
+  })
+
+  describe('resolveCustomModelContextWindow', () => {
+    it('uses the configured size and falls back to 200k when the user leaves it blank', () => {
+      expect(resolveCustomModelContextWindow(64_000)).toBe(64_000)
+      expect(resolveCustomModelContextWindow(undefined)).toBe(200_000)
     })
   })
 })

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -40,6 +40,12 @@ export type VendorRegion = {
   modelsListUrl?: string
 }
 
+export type OfficialModel = {
+  id: string
+  // Advertised context-window size for this exact model, in tokens.
+  contextWindow: number
+}
+
 export type OfficialVendor = {
   id: OfficialVendorId
   // Human-readable name shown in the provider-type picker and composer group headings.
@@ -50,7 +56,7 @@ export type OfficialVendor = {
   apiEndpoints?: readonly ChatApiEndpoint[]
   // Model ids offered in the composer once a key is stored. First entry is the default selection when
   // the vendor is first added.
-  models: string[]
+  models: OfficialModel[]
   // Models this vendor is known (via our own dev testing, before release) NOT to drive cleanly over
   // the Codex Responses->Chat bridge. Ships with the app so such models are greyed in the picker
   // rather than user-tested. Absent/empty ⇒ every listed model is bridge-compatible.
@@ -93,7 +99,14 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     apiKeyUrl: 'https://platform.openai.com/api-keys',
     // The API exposes a broader mixed catalog (embeddings, image, and audio models); keep the coding
     // catalog curated here instead of importing every id from /v1/models.
-    models: ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini'],
+    models: [
+      { id: 'gpt-5.6-sol', contextWindow: 1_050_000 },
+      { id: 'gpt-5.6-terra', contextWindow: 1_050_000 },
+      { id: 'gpt-5.6-luna', contextWindow: 1_050_000 },
+      { id: 'gpt-5.5', contextWindow: 1_050_000 },
+      { id: 'gpt-5.4', contextWindow: 1_050_000 },
+      { id: 'gpt-5.4-mini', contextWindow: 400_000 }
+    ],
     // The curated coding catalog is all GPT-5+, which is vision-capable across the board.
     multimodal: { allMultimodal: true }
   },
@@ -105,10 +118,10 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     modelsListUrl: 'https://api.anthropic.com/v1/models',
     // Models with a 1M-context variant list both the standard id and the `[1m]` one.
     models: [
-      'claude-opus-4-8',
-      'claude-opus-4-8[1m]',
-      'claude-sonnet-5',
-      'claude-haiku-4-5-20251001'
+      { id: 'claude-opus-4-8', contextWindow: 1_000_000 },
+      { id: 'claude-opus-4-8[1m]', contextWindow: 1_000_000 },
+      { id: 'claude-sonnet-5', contextWindow: 1_000_000 },
+      { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000 }
     ],
     // Every current Claude model is vision-capable, including any surfaced by the live model-list
     // refresh above — so this is a blanket rule, not the four bundled ids.
@@ -126,7 +139,11 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     openaiBaseUrl: 'https://api.deepseek.com/v1',
     apiKeyUrl: 'https://platform.deepseek.com/api_keys',
     modelsListUrl: 'https://api.deepseek.com/v1/models',
-    models: ['deepseek-v4-pro', 'deepseek-v4-pro[1m]', 'deepseek-v4-flash']
+    models: [
+      { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-pro[1m]', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 }
+    ]
     // DeepSeek's chat models are text-only, so no `multimodal` rule (image input stays disabled).
   },
   {
@@ -152,7 +169,13 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         apiKeyUrl: 'https://open.bigmodel.cn/usercenter/apikeys'
       }
     ],
-    models: ['glm-5.2', 'glm-5.1', 'glm-5', 'glm-5v-turbo', 'glm-5-turbo'],
+    models: [
+      { id: 'glm-5.2', contextWindow: 1_000_000 },
+      { id: 'glm-5.1', contextWindow: 200_000 },
+      { id: 'glm-5', contextWindow: 200_000 },
+      { id: 'glm-5v-turbo', contextWindow: 200_000 },
+      { id: 'glm-5-turbo', contextWindow: 200_000 }
+    ],
     // GLM marks vision variants with a `v` after the major version (e.g. glm-5v-turbo); the pattern
     // also covers future `Nv` ids the live refresh may surface.
     multimodal: { multimodalModelPattern: /glm-\d+v/i }
@@ -183,7 +206,12 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     ],
     // The coding plan does not serve GLM's vision variant, so glm-5v-turbo is omitted and there is no
     // `multimodal` rule (image input stays disabled for this endpoint).
-    models: ['glm-5.2', 'glm-5.1', 'glm-5', 'glm-5-turbo']
+    models: [
+      { id: 'glm-5.2', contextWindow: 1_000_000 },
+      { id: 'glm-5.1', contextWindow: 200_000 },
+      { id: 'glm-5', contextWindow: 200_000 },
+      { id: 'glm-5-turbo', contextWindow: 200_000 }
+    ]
   },
   {
     id: 'kimi',
@@ -196,7 +224,12 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     openaiBaseUrl: 'https://api.moonshot.cn/v1',
     apiKeyUrl: 'https://platform.kimi.com/console',
     modelsListUrl: 'https://api.moonshot.cn/v1/models',
-    models: ['kimi-k3', 'kimi-k2.7-code', 'kimi-k2.6', 'kimi-k2.5'],
+    models: [
+      { id: 'kimi-k3', contextWindow: 1_000_000 },
+      { id: 'kimi-k2.7-code', contextWindow: 256_000 },
+      { id: 'kimi-k2.6', contextWindow: 256_000 },
+      { id: 'kimi-k2.5', contextWindow: 256_000 }
+    ],
     // Vision arrives with the k3 generation; older k2.x chat models are text-only.
     multimodal: { multimodalModels: ['kimi-k3'] }
   },
@@ -211,7 +244,11 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     baseUrl: 'https://api.kimi.com/coding',
     openaiBaseUrl: 'https://api.kimi.com/coding/v1',
     apiKeyUrl: 'https://www.kimi.com/code/docs',
-    models: ['kimi-k3', 'kimi-for-coding', 'kimi-for-coding-highspeed'],
+    models: [
+      { id: 'kimi-k3', contextWindow: 1_000_000 },
+      { id: 'kimi-for-coding', contextWindow: 256_000 },
+      { id: 'kimi-for-coding-highspeed', contextWindow: 256_000 }
+    ],
     // Only the k3 model in this plan is vision-capable; the coding-tuned ids are text-only.
     multimodal: { multimodalModels: ['kimi-k3'] }
   },
@@ -239,7 +276,12 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         apiKeyUrl: 'https://platform.minimaxi.com/user-center/basic-information/interface-key'
       }
     ],
-    models: ['MiniMax-M3', 'MiniMax-M3[1m]', 'MiniMax-M2.7', 'MiniMax-M2.5']
+    models: [
+      { id: 'MiniMax-M3', contextWindow: 1_000_000 },
+      { id: 'MiniMax-M3[1m]', contextWindow: 1_000_000 },
+      { id: 'MiniMax-M2.7', contextWindow: 204_800 },
+      { id: 'MiniMax-M2.5', contextWindow: 204_800 }
+    ]
     // MiniMax's chat models are text-only, so no `multimodal` rule (image input stays disabled).
   },
   {
@@ -269,7 +311,10 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         modelsListUrl: 'https://api.stepfun.com/v1/models'
       }
     ],
-    models: ['step-3.7-flash', 'step-3.5-flash'],
+    models: [
+      { id: 'step-3.7-flash', contextWindow: 262_144 },
+      { id: 'step-3.5-flash', contextWindow: 262_144 }
+    ],
     // step-3.7-flash is multimodal (vision); step-3.5-flash is text-only.
     multimodal: { multimodalModels: ['step-3.7-flash'] }
   },
@@ -283,7 +328,10 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     openaiBaseUrl: 'https://api.xiaomimimo.com/v1',
     apiKeyUrl: 'https://platform.xiaomimimo.com/console/api-keys',
     modelsListUrl: 'https://api.xiaomimimo.com/v1/models',
-    models: ['mimo-v2.5-pro', 'mimo-v2.5']
+    models: [
+      { id: 'mimo-v2.5-pro', contextWindow: 1_000_000 },
+      { id: 'mimo-v2.5', contextWindow: 1_000_000 }
+    ]
     // Xiaomi MiMo's chat models are text-only, so no `multimodal` rule (image input stays disabled).
   },
   {
@@ -298,7 +346,10 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     baseUrl: 'https://token.sensenova.cn',
     openaiBaseUrl: 'https://token.sensenova.cn/v1',
     apiKeyUrl: 'https://platform.sensenova.cn/token-plan',
-    models: ['sensenova-6.7-flash-lite', 'deepseek-v4-flash'],
+    models: [
+      { id: 'sensenova-6.7-flash-lite', contextWindow: 256_000 },
+      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 }
+    ],
     // Only sensenova-6.7-flash-lite accepts image input; deepseek-v4-flash is text-only.
     multimodal: { multimodalModels: ['sensenova-6.7-flash-lite'] }
   },
@@ -316,11 +367,11 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     openaiBaseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
     apiKeyUrl: 'https://console.volcengine.com/ark/region:ark+cn-beijing/apikey',
     models: [
-      'doubao-seed-2-1-pro-260628',
-      'doubao-seed-2-0-pro-260215',
-      'doubao-seed-2-0-lite-260215',
-      'doubao-seed-2-0-mini-260215',
-      'doubao-seed-2-0-code-preview-260215'
+      { id: 'doubao-seed-2-1-pro-260628', contextWindow: 256_000 },
+      { id: 'doubao-seed-2-0-pro-260215', contextWindow: 256_000 },
+      { id: 'doubao-seed-2-0-lite-260215', contextWindow: 256_000 },
+      { id: 'doubao-seed-2-0-mini-260215', contextWindow: 256_000 },
+      { id: 'doubao-seed-2-0-code-preview-260215', contextWindow: 256_000 }
     ],
     // The Seed 2.x general models accept image input; the code-preview coding model is text-only.
     multimodal: {
@@ -346,27 +397,27 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     apiKeyUrl: 'https://openrouter.ai/workspaces/default/keys',
     models: [
       // Anthropic
-      'anthropic/claude-opus-4.8',
-      'anthropic/claude-sonnet-5',
-      'anthropic/claude-haiku-4.5',
+      { id: 'anthropic/claude-opus-4.8', contextWindow: 1_000_000 },
+      { id: 'anthropic/claude-sonnet-5', contextWindow: 1_000_000 },
+      { id: 'anthropic/claude-haiku-4.5', contextWindow: 200_000 },
       // OpenAI
-      'openai/gpt-5.6-terra-pro',
-      'openai/gpt-5.6-terra',
-      'openai/gpt-5.6-sol-pro',
-      'openai/gpt-5.6-sol',
-      'openai/gpt-5.6-luna-pro',
-      'openai/gpt-5.6-luna',
-      'openai/gpt-5.5-pro',
-      'openai/gpt-5.5',
-      'openai/gpt-5.3-codex',
+      { id: 'openai/gpt-5.6-terra-pro', contextWindow: 1_050_000 },
+      { id: 'openai/gpt-5.6-terra', contextWindow: 1_050_000 },
+      { id: 'openai/gpt-5.6-sol-pro', contextWindow: 1_050_000 },
+      { id: 'openai/gpt-5.6-sol', contextWindow: 1_050_000 },
+      { id: 'openai/gpt-5.6-luna-pro', contextWindow: 1_050_000 },
+      { id: 'openai/gpt-5.6-luna', contextWindow: 1_050_000 },
+      { id: 'openai/gpt-5.5-pro', contextWindow: 1_050_000 },
+      { id: 'openai/gpt-5.5', contextWindow: 1_050_000 },
+      { id: 'openai/gpt-5.3-codex', contextWindow: 400_000 },
       // Other top-ranked vendors on OpenRouter
-      'google/gemini-3.1-pro-preview',
-      'google/gemini-3.5-flash',
-      'x-ai/grok-4.5',
-      'deepseek/deepseek-v4-pro',
-      'z-ai/glm-5.2',
-      'moonshotai/kimi-k3',
-      'qwen/qwen3.7-max'
+      { id: 'google/gemini-3.1-pro-preview', contextWindow: 1_048_576 },
+      { id: 'google/gemini-3.5-flash', contextWindow: 1_048_576 },
+      { id: 'x-ai/grok-4.5', contextWindow: 500_000 },
+      { id: 'deepseek/deepseek-v4-pro', contextWindow: 1_048_576 },
+      { id: 'z-ai/glm-5.2', contextWindow: 1_048_576 },
+      { id: 'moonshotai/kimi-k3', contextWindow: 1_048_576 },
+      { id: 'qwen/qwen3.7-max', contextWindow: 1_000_000 }
     ],
     // OpenRouter's catalog is curated (no live refresh), and vision support is an unpredictable subset
     // across vendors — so it is an explicit id list rather than a blanket rule or pattern. The
@@ -405,6 +456,10 @@ export const isOfficialVendorId = (value: unknown): value is OfficialVendorId =>
 // Looks up a vendor definition, or undefined for an unknown id.
 export const getOfficialVendor = (id: OfficialVendorId): OfficialVendor | undefined =>
   VENDORS_BY_ID.get(id)
+
+// Projects the structured bundled catalog into the string ids used by settings persistence and UI.
+export const getOfficialVendorModelIds = (id: OfficialVendorId): string[] =>
+  VENDORS_BY_ID.get(id)?.models.map((model) => model.id) ?? []
 
 // Resolves the base URL for a vendor, honoring the chosen region and falling back to the first region
 // when none/an unknown one is given. Returns undefined for an unknown vendor.
@@ -484,7 +539,7 @@ export const resolveVendorModelsUrl = (
 
 // The default model for a freshly added vendor (first catalog entry).
 export const defaultVendorModel = (id: OfficialVendorId): string | undefined =>
-  VENDORS_BY_ID.get(id)?.models[0]
+  VENDORS_BY_ID.get(id)?.models[0]?.id
 
 // The chat APIs a vendor speaks, defaulting to Anthropic /v1/messages when unset.
 export const resolveVendorApiEndpoints = (id: OfficialVendorId): ChatApiEndpoint[] => {
@@ -531,3 +586,39 @@ export const isVendorModelMultimodal = (
 
   return rule.multimodalModels?.includes(modelId) ?? false
 }
+
+// Custom model ids are opaque: guessing from their name is less reliable than a stable documented
+// default. Users can override this on the provider; an omitted value intentionally means 200k.
+export const DEFAULT_CUSTOM_MODEL_CONTEXT_WINDOW = 200_000
+
+// Live model-list endpoints expose ids but generally omit context limits. Unknown refreshed ids use a
+// stable conservative fallback until their exact metadata is added to the bundled catalog.
+export const DEFAULT_OFFICIAL_MODEL_CONTEXT_WINDOW = 200_000
+
+// The universal, exact convention: a model id ending in `[1m]` denotes a 1M-token context variant.
+const ONE_MILLION_SUFFIX = /\[1m\]$/i
+
+// Resolves an official vendor model's context window from the exact bundled entry. For ids returned
+// later by a live model-list refresh, an exact `[1m]` suffix wins before the conservative fallback.
+// A missing model id or unknown vendor remains unknown.
+export const resolveModelContextWindow = (
+  vendorId: OfficialVendorId,
+  modelId: string | undefined
+): number | undefined => {
+  if (!modelId) return undefined
+
+  const vendor = VENDORS_BY_ID.get(vendorId)
+  if (!vendor) return undefined
+
+  const bundledModel = vendor.models.find((model) => model.id === modelId)
+  if (bundledModel) return bundledModel.contextWindow
+
+  if (ONE_MILLION_SUFFIX.test(modelId)) return 1_000_000
+
+  return DEFAULT_OFFICIAL_MODEL_CONTEXT_WINDOW
+}
+
+// Resolves a custom provider's user-configured window. Model ids are deliberately not inspected:
+// gateway aliases frequently contain vendor-like names without sharing the upstream model's limits.
+export const resolveCustomModelContextWindow = (configured?: number): number =>
+  configured ?? DEFAULT_CUSTOM_MODEL_CONTEXT_WINDOW

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -174,6 +174,8 @@ export type ProviderView = {
   apiEndpoints?: ChatApiEndpoint[]
   baseUrl?: string
   model?: string
+  // User-configured context-window size for a custom model. Omitted means the runtime uses 200k.
+  contextWindow?: number
   supportsImageInput: boolean
   // Set for official-vendor providers: which vendor and (where applicable) which regional endpoint.
   vendorId?: OfficialVendorId
@@ -316,6 +318,9 @@ export type ProviderDraft = {
   name?: string
   baseUrl?: string
   model?: string
+  // Custom model context-window size in tokens. `null` explicitly clears a saved override; omitted
+  // leaves it unchanged on partial edits. A provider with no override resolves to 200k at runtime.
+  contextWindow?: number | null
   supportsImageInput?: boolean
   // Which chat APIs a custom gateway speaks (form selector). Official providers take it from the
   // registry; omitted defaults to ['anthropic'].


### PR DESCRIPTION
## Problem

Context-window occupancy was unavailable or inaccurate across Claude Code, OpenCode, and Codex. Framework adapters disagreed on model context-window limits, and Codex bridge sessions could compact near 258.4k even when the selected upstream model supported 1m.

## Proposed change

- report latest-request input context, including cache-read input
- resolve context windows explicitly per selected provider model
- make selected-model metadata authoritative across frameworks, with adapter values as fallback
- support optional custom-model context windows with a 200k default
- invalidate stale context usage when the framework or backend changes
- align OpenCode model limits and reduce its baseline connector context through on-demand skill details
- configure Codex bridge context and auto-compaction from the selected upstream model

```mermaid
flowchart LR
  A["Framework usage event"] --> B["Adapter normalization"]
  B --> C["Latest request input + cache read"]
  D["Selected model metadata"] --> E["Authoritative context-window size"]
  C --> F["Session contextUsage"]
  E --> F
  F --> G["Composer occupancy indicator"]
```

## Scope and non-goals

This reports context-window occupancy only. It does not calculate billing cost, include output/completion tokens, or report cumulative session token usage. Open Science configures the Codex compaction threshold but does not perform compaction itself.

## Acceptance criteria and validation

- latest request replaces prior context usage rather than accumulating turns
- output, completion, cache-write, and cost values are excluded
- missing Codex cached-input counts are treated as zero rather than producing `NaN`
- Claude Code, OpenCode, and Codex use the selected model denominator
- custom models accept an optional context-window value and default to 200k
- Codex 1m bridge sessions compact near 950k instead of 258.4k
- `npm run typecheck`
- `npm run lint` (0 errors; 42 existing warnings)
- `npm run test` (480 files passed, 10 skipped; 6254 tests passed, 84 skipped)
- real Codex ACP bridge contracts, including exact `usage_update.size = 950000` for a 1m model

## Review focus

- latest-request token semantics
- framework/backend invalidation
- per-model context-window metadata
- Codex bridge compaction configuration
- OpenCode connector detail loading
