### PR TITLE
feat(providers): add StepFun Step Plan vendor

### DIFF
--- a/src/renderer/src/pages/settings/provider-icons.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.tsx
@@ -15,8 +15,9 @@ import volcengineLogo from '@/assets/provider-icons/volcengine.svg'
 import type { OfficialVendorId } from '../../../../shared/provider-registry'
 
 // Official vendor brand marks, bundled as assets. Both Kimi providers (the general Moonshot platform
-// and Kimi For Coding) share the one Kimi mark, and both GLM providers (pay-as-you-go Zhipu and the
-// GLM Coding Plan) share the one GLM mark. Any vendor without an entry falls back to a neutral glyph
+// and Kimi For Coding) share the one Kimi mark, both GLM providers (pay-as-you-go Zhipu and the GLM
+// Coding Plan) share the one GLM mark, and both StepFun providers (pay-as-you-go StepFun and the Step
+// Plan subscription) share the one StepFun mark. Any vendor without an entry falls back to a neutral glyph
 // rather than a made-up logo. Custom uses a plus-in-circle.
 const VENDOR_LOGO: Partial<Record<OfficialVendorId, string>> = {
   openai: openaiLogo,
@@ -24,6 +25,7 @@ const VENDOR_LOGO: Partial<Record<OfficialVendorId, string>> = {
   deepseek: deepseekLogo,
   minimax: minimaxLogo,
   stepfun: stepfunLogo,
+  stepplan: stepfunLogo,
   zhipu: zhipuLogo,
   glmcodingplan: zhipuLogo,
   kimi: kimiLogo,

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -182,6 +182,17 @@ describe('provider registry', () => {
     expect(defaultVendorModel('stepfun')).toBe('step-3.7-flash')
   })
 
+  it('routes Step Plan over Anthropic and OpenAI under /step_plan, no live model list', () => {
+    expect(resolveVendorApiEndpoints('stepplan')).toEqual(['anthropic', 'openai'])
+    expect(vendorHasRegions('stepplan')).toBe(false)
+    expect(resolveVendorBaseUrl('stepplan')).toBe('https://api.stepfun.com/step_plan')
+    expect(resolveVendorOpenAiBaseUrl('stepplan')).toBe('https://api.stepfun.com/step_plan/v1')
+    // Quota-based plan: fixed catalog, no "refresh from vendor" endpoint.
+    expect(resolveVendorModelsUrl('stepplan')).toBeUndefined()
+    expect(resolveVendorApiKeyUrl('stepplan')).toBe('https://platform.stepfun.com/plan-subscribe')
+    expect(defaultVendorModel('stepplan')).toBe('step-3.7-flash')
+  })
+
   it('resolves the key-console URL, preferring the selected region', () => {
     // Single-endpoint vendor: the vendor-level URL.
     expect(resolveVendorApiKeyUrl('deepseek')).toBe('https://platform.deepseek.com/api_keys')
@@ -276,6 +287,9 @@ describe('provider registry', () => {
     it('returns true only for the StepFun multimodal flash model', () => {
       expect(isVendorModelMultimodal('stepfun', 'step-3.7-flash')).toBe(true)
       expect(isVendorModelMultimodal('stepfun', 'step-3.5-flash')).toBe(false)
+      expect(isVendorModelMultimodal('stepplan', 'step-3.7-flash')).toBe(true)
+      expect(isVendorModelMultimodal('stepplan', 'step-3.5-flash-2603')).toBe(false)
+      expect(isVendorModelMultimodal('stepplan', 'step-router-v1')).toBe(false)
     })
 
     it('returns true for OpenRouter vision-capable models', () => {

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -19,6 +19,7 @@ export type OfficialVendorId =
   | 'kimiforcode'
   | 'minimax'
   | 'stepfun'
+  | 'stepplan'
   | 'xiaomimimo'
   | 'sensenova'
   | 'volcengine'
@@ -316,6 +317,29 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       { id: 'step-3.5-flash', contextWindow: 262_144 }
     ],
     // step-3.7-flash is multimodal (vision); step-3.5-flash is text-only.
+    multimodal: { multimodalModels: ['step-3.7-flash'] }
+  },
+  {
+    id: 'stepplan',
+    label: 'Step Plan',
+    // StepFun's Step Plan is a quota-based subscription (platform.stepfun.com/plan-subscribe) that
+    // routes under `/step_plan` on the mainland-China host: Anthropic /v1/messages and the
+    // OpenAI-compatible /v1/chat/completions. `baseUrl` is the `/step_plan` root the Anthropic client
+    // appends /v1/messages to; `openaiBaseUrl` is the /step_plan/v1 base clients append
+    // /chat/completions to. Quota plans ship a fixed catalog and expose no live model list.
+    apiEndpoints: ['anthropic', 'openai'],
+    baseUrl: 'https://api.stepfun.com/step_plan',
+    openaiBaseUrl: 'https://api.stepfun.com/step_plan/v1',
+    apiKeyUrl: 'https://platform.stepfun.com/plan-subscribe',
+    // step-router-v1 auto-switches between deepseek-v4-pro and step-3.7-flash; step-3.5-flash-2603 is
+    // the high-frequency-agent build. step-3.7-flash leads as the recommended flagship default.
+    models: [
+      { id: 'step-3.7-flash', contextWindow: 262_144 },
+      { id: 'step-3.5-flash', contextWindow: 262_144 },
+      { id: 'step-3.5-flash-2603', contextWindow: 262_144 },
+      { id: 'step-router-v1', contextWindow: 262_144 }
+    ],
+    // Only the step-3.7-flash flagship is multimodal (vision); the agent/code builds are text-only.
     multimodal: { multimodalModels: ['step-3.7-flash'] }
   },
   {


### PR DESCRIPTION
## Problem
StepFun ships a separate quota-based subscription, Step Plan
(platform.stepfun.com/plan-subscribe), that routes under `/step_plan` and is
not reachable through the existing pay-as-you-go StepFun vendor entry.

## Proposed change
Add `stepplan` as a new official vendor, placed right after StepFun and reusing
the StepFun brand mark. It serves both the Anthropic (`/v1/messages`) and
OpenAI-compatible (`/v1/chat/completions`) protocols under
`https://api.stepfun.com/step_plan`, ships a fixed catalog (step-3.7-flash,
step-3.5-flash, step-3.5-flash-2603, step-router-v1) with no live model list,
and marks only step-3.7-flash as multimodal.

## Scope and non-goals
- No overseas region: docs only publish the mainland `.com` host under
  `/step_plan`.
- `step-router-v1` is treated as text-only even though it can route to the
  multimodal step-3.7-flash (image input at the router layer is unconfirmed).

## Acceptance criteria and validation
- Step Plan appears after StepFun in the provider picker with the StepFun logo.
- typecheck + lint clean; provider-registry unit tests cover routing, absence
  of a live model list, and per-model multimodal support (40/40 pass).

## Review focus
- URL layout under `/step_plan` for both protocols.
- The `step-router-v1` multimodal decision.
