### PR TITLE
fix(managed-codex): publish context usage patch atomically

### DIFF
--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { access, chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, sep } from 'node:path'
 import { Readable } from 'node:stream'
@@ -1187,6 +1188,31 @@ describe('patchCodexAcpContextUsageSource', () => {
       await rm(patchRoot, { recursive: true, force: true })
     }
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves executable access when patching an installed adapter',
+    async () => {
+      const patchRoot = await mkdtemp(join(tmpdir(), 'managed-codex-patch-mode-'))
+      try {
+        const adapterPath = join(patchRoot, 'index.js')
+        await writeFile(
+          adapterPath,
+          [
+            '  createUsageUpdate(params) {',
+            '    const used = this.sessionState.lastTokenUsage?.totalTokens;',
+            '  }'
+          ].join('\n')
+        )
+        await chmod(adapterPath, 0o755)
+
+        await ensureManagedCodexContextUsage(adapterPath)
+
+        await expect(access(adapterPath, constants.X_OK)).resolves.toBeUndefined()
+      } finally {
+        await rm(patchRoot, { recursive: true, force: true })
+      }
+    }
+  )
 
   it('keeps concurrent context-usage checks from observing a partially patched adapter', async () => {
     const patchRoot = await mkdtemp(join(tmpdir(), 'managed-codex-patch-race-'))

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -13,12 +13,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 //   onDestBackup: throw EPERM when dest contains .backup- (destination→backup, upgrade path)
 //   onRestore: throw EPERM when src contains .backup- (backup→destination restore)
 //   cp: throw EPERM from cp() to exercise the copy-failure→backup-restore branch
+//   adapterReplaceFailures: transiently lock the destination during temp→adapter publication
 const fsFaults = vi.hoisted(() => ({
   renameOnStagedMove: false,
   renameOnStagedMoveEio: false,
   renameOnDestBackup: false,
   renameOnRestore: false,
   cpFailure: false,
+  adapterReplaceFailures: 0,
+  adapterReplaceFailureCode: 'EPERM' as 'EPERM' | 'EBUSY',
   pauseNextWrite: false,
   partialWritePublished: undefined as (() => void) | undefined,
   resumeWrite: undefined as Promise<void> | undefined
@@ -44,6 +47,17 @@ vi.mock('node:fs/promises', async (importActual) => {
       if (fsFaults.renameOnRestore && src.includes('.backup-')) {
         fsFaults.renameOnRestore = false
         throw Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' })
+      }
+      if (
+        fsFaults.adapterReplaceFailures > 0 &&
+        src.endsWith('.tmp') &&
+        dest.endsWith('index.js')
+      ) {
+        fsFaults.adapterReplaceFailures -= 1
+        const code = fsFaults.adapterReplaceFailureCode
+        throw Object.assign(new Error(`${code}: destination is temporarily locked, rename`), {
+          code
+        })
       }
       return actual.rename(src, dest)
     }),
@@ -1209,6 +1223,36 @@ describe('patchCodexAcpContextUsageSource', () => {
 
         await expect(access(adapterPath, constants.X_OK)).resolves.toBeUndefined()
       } finally {
+        await rm(patchRoot, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.each(['EPERM', 'EBUSY'] as const)(
+    'retries an atomic adapter replace after a transient %s destination lock',
+    async (errorCode) => {
+      const patchRoot = await mkdtemp(join(tmpdir(), 'managed-codex-patch-lock-'))
+      try {
+        const adapterPath = join(patchRoot, 'index.js')
+        await writeFile(
+          adapterPath,
+          [
+            '  createUsageUpdate(params) {',
+            '    const used = this.sessionState.lastTokenUsage?.totalTokens;',
+            '  }'
+          ].join('\n')
+        )
+        fsFaults.adapterReplaceFailureCode = errorCode
+        fsFaults.adapterReplaceFailures = 1
+
+        await ensureManagedCodexContextUsage(adapterPath)
+
+        expect(await readFile(adapterPath, 'utf8')).toContain(
+          'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
+        )
+      } finally {
+        fsFaults.adapterReplaceFailures = 0
+        fsFaults.adapterReplaceFailureCode = 'EPERM'
         await rm(patchRoot, { recursive: true, force: true })
       }
     }

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -17,7 +17,10 @@ const fsFaults = vi.hoisted(() => ({
   renameOnStagedMoveEio: false,
   renameOnDestBackup: false,
   renameOnRestore: false,
-  cpFailure: false
+  cpFailure: false,
+  pauseNextWrite: false,
+  partialWritePublished: undefined as (() => void) | undefined,
+  resumeWrite: undefined as Promise<void> | undefined
 }))
 
 vi.mock('node:fs/promises', async (importActual) => {
@@ -51,6 +54,20 @@ vi.mock('node:fs/promises', async (importActual) => {
         })
       }
       return actual.cp(src, dest, opts as Parameters<typeof actual.cp>[2])
+    }),
+    writeFile: vi.fn(async (...args: Parameters<typeof actual.writeFile>) => {
+      const [file, data] = args
+      if (fsFaults.pauseNextWrite && typeof data === 'string') {
+        fsFaults.pauseNextWrite = false
+        const patchTarget = '    const lastTokenUsage = this.sessionState.lastTokenUsage;'
+        const targetOffset = data.indexOf(patchTarget)
+        if (targetOffset !== -1) {
+          await actual.writeFile(file, data.slice(0, targetOffset))
+          fsFaults.partialWritePublished?.()
+          await fsFaults.resumeWrite
+        }
+      }
+      return actual.writeFile(...args)
     })
   }
 })
@@ -1167,6 +1184,51 @@ describe('patchCodexAcpContextUsageSource', () => {
         'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
       )
     } finally {
+      await rm(patchRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps concurrent context-usage checks from observing a partially patched adapter', async () => {
+    const patchRoot = await mkdtemp(join(tmpdir(), 'managed-codex-patch-race-'))
+    let releaseWrite: (() => void) | undefined
+    try {
+      const adapterPath = join(patchRoot, 'index.js')
+      await writeFile(
+        adapterPath,
+        [
+          '  const usageSchema = { totalTokens: true };',
+          '  createUsageUpdate(params) {',
+          '    this.handleTokenUsageUpdated(params);',
+          '    const used = this.sessionState.lastTokenUsage?.totalTokens;',
+          '    return { used };',
+          '  }'
+        ].join('\n')
+      )
+
+      const partialWritePublished = new Promise<void>((resolve) => {
+        fsFaults.partialWritePublished = resolve
+      })
+      fsFaults.resumeWrite = new Promise<void>((resolve) => {
+        releaseWrite = resolve
+      })
+      fsFaults.pauseNextWrite = true
+
+      const firstCheck = ensureManagedCodexContextUsage(adapterPath)
+      await partialWritePublished
+      const secondCheck = ensureManagedCodexContextUsage(adapterPath)
+
+      await expect(secondCheck).resolves.toBeUndefined()
+      releaseWrite?.()
+
+      await expect(firstCheck).resolves.toBeUndefined()
+      expect(await readFile(adapterPath, 'utf8')).toContain(
+        'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
+      )
+    } finally {
+      releaseWrite?.()
+      fsFaults.pauseNextWrite = false
+      fsFaults.partialWritePublished = undefined
+      fsFaults.resumeWrite = undefined
       await rm(patchRoot, { recursive: true, force: true })
     }
   })

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -118,6 +118,22 @@ const CODEX_ACP_CONTEXT_USAGE_REPLACEMENT = [
   '        : lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0);'
 ].join('\n')
 
+const CODEX_ADAPTER_REPLACE_RETRY_DELAYS_MS = [25, 50, 100, 200, 400] as const
+
+const renameWithTransientLockRetry = async (source: string, destination: string): Promise<void> => {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await rename(source, destination)
+      return
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code
+      const retryDelay = CODEX_ADAPTER_REPLACE_RETRY_DELAYS_MS[attempt]
+      if ((code !== 'EPERM' && code !== 'EBUSY') || retryDelay === undefined) throw error
+      await new Promise<void>((resolve) => setTimeout(resolve, retryDelay))
+    }
+  }
+}
+
 // codex-acp receives a per-request tokenUsage.last snapshot but publishes totalTokens as ACP
 // context usage. Patch the pinned self-contained adapter so `used` excludes output and reasoning.
 // The registry integrity pin fixes the input bundle; the guards make a future source drift fail
@@ -153,7 +169,7 @@ export const ensureManagedCodexContextUsage = async (adapterPath: string): Promi
     const { mode } = await stat(adapterPath)
     await writeFile(temporaryPath, patched)
     await chmod(temporaryPath, mode & 0o7777)
-    await rename(temporaryPath, adapterPath)
+    await renameWithTransientLockRetry(temporaryPath, adapterPath)
   } finally {
     await rm(temporaryPath, { force: true }).catch(() => undefined)
   }

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -11,6 +11,7 @@ import {
   readdir,
   rename,
   rm,
+  stat,
   writeFile,
   type FileHandle
 } from 'node:fs/promises'
@@ -149,7 +150,9 @@ export const ensureManagedCodexContextUsage = async (adapterPath: string): Promi
 
   const temporaryPath = `${adapterPath}.${randomUUID()}.tmp`
   try {
+    const { mode } = await stat(adapterPath)
     await writeFile(temporaryPath, patched)
+    await chmod(temporaryPath, mode & 0o7777)
     await rename(temporaryPath, adapterPath)
   } finally {
     await rm(temporaryPath, { force: true }).catch(() => undefined)

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -145,7 +145,15 @@ export const ensureManagedCodexContextUsage = async (adapterPath: string): Promi
   const source = await readFile(adapterPath, 'utf8')
   const patched = patchCodexAcpContextUsageSource(source)
 
-  if (patched !== source) await writeFile(adapterPath, patched)
+  if (patched === source) return
+
+  const temporaryPath = `${adapterPath}.${randomUUID()}.tmp`
+  try {
+    await writeFile(temporaryPath, patched)
+    await rename(temporaryPath, adapterPath)
+  } finally {
+    await rm(temporaryPath, { force: true }).catch(() => undefined)
+  }
 }
 
 type PackageResolution = { tarball: string; integrity: string }


### PR DESCRIPTION
## Problem

Concurrent ACP session initialization could read the managed Codex adapter after the existing direct write had truncated the file but before the patched bundle was complete. The partial bundle failed the pinned source guard and blocked session creation with "Pinned Codex ACP context-usage patch no longer matches the adapter bundle".

Atomic replacement must also retain the installed adapter's POSIX permission bits and tolerate transient Windows destination locks. Otherwise the published adapter can lose executable access, or Defender and other readers can make replacement fail with EPERM/EBUSY.

## Proposed change

Write the context-usage-patched adapter to a unique sibling temporary file, restore the original adapter's permission bits, then atomically rename it into place. Retry transient EPERM/EBUSY replacement failures with bounded backoff so Windows scanner locks can clear without falling back to a partial in-place write.

Add deterministic regression tests for concurrent partial reads, executable access preservation, and transient EPERM/EBUSY destination locks.

## Scope and non-goals

This change is limited to publishing the managed Codex context-usage adapter patch. It does not change the Responses bridge, context-usage calculation, adapter integrity pin, or installation lifecycle. Persistent locks and non-lock filesystem errors still fail closed after the bounded retry window.

## Acceptance criteria and validation

- Concurrent context-usage checks cannot observe a partially written adapter.
- Patched POSIX adapters retain executable access.
- Transient EPERM and EBUSY destination locks are retried while publication remains atomic.
- Existing source-drift detection still rejects unsupported adapter bundles.
- npm test passes: 480 files and 6,258 tests passed; 10 files and 84 tests skipped by existing configuration.
- npm run typecheck passes.
- npm run lint passes with no errors (42 unrelated pre-existing warnings).
- Prettier checks and git diff --check pass.

## Review focus

Please focus on atomic publication, permission preservation, the bounded EPERM/EBUSY retry policy, and deterministic regression coverage for concurrent reads and locked destinations.
