### PR TITLE
fix(cli): fail promptly for AppImage sandbox errors

### DIFF
--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -27,6 +27,13 @@ describe('CLI argument parsing', () => {
     })
   })
 
+  it('parses the explicit no-sandbox start fallback', () => {
+    expect(parseCliArgs(['start', '--no-sandbox'])).toEqual({
+      command: 'start',
+      options: { open: true, json: false, noSandbox: true }
+    })
+  })
+
   it('parses status JSON output and rejects invalid options', () => {
     expect(parseCliArgs(['status', '--json'])).toEqual({
       command: 'status',

--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -1,10 +1,15 @@
 import { EventEmitter } from 'node:events'
+import { closeSync } from 'node:fs'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 import {
   buildAppLaunchArgs,
   formatStartupFailure,
+  openLaunchLog,
   statusCommand,
   stopCommand,
   terminateDaemon,
@@ -104,6 +109,20 @@ describe('terminateDaemon', () => {
 })
 
 describe('headless startup', () => {
+  it('starts each launch with an empty diagnostic log', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'open-science-cli-log-'))
+    const logPath = join(directory, 'cli-daemon.log')
+    try {
+      await writeFile(logPath, 'stale SUID sandbox failure')
+
+      closeSync(openLaunchLog(logPath))
+
+      await expect(readFile(logPath, 'utf8')).resolves.toBe('')
+    } finally {
+      await rm(directory, { recursive: true })
+    }
+  })
+
   it('places the no-sandbox runtime switch before the development app path', () => {
     expect(buildAppLaunchArgs(['app-root'], { noSandbox: true }, 44100)).toEqual([
       '--no-sandbox',

--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -131,6 +131,24 @@ describe('headless startup', () => {
     expect(deps.sleep).not.toHaveBeenCalled()
   })
 
+  it('keeps waiting after a successful second-instance handoff', async () => {
+    const child = new EventEmitter()
+    const findServiceState = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        child.emit('exit', 0, null)
+        return Promise.resolve(undefined)
+      })
+      .mockResolvedValue(RUNNING_STATE)
+    const deps = makeDeps({ findServiceState })
+
+    await expect(waitForStartup('/tmp/os-config', child, deps, 30_000)).resolves.toEqual({
+      kind: 'ready',
+      state: RUNNING_STATE
+    })
+    expect(findServiceState).toHaveBeenCalledTimes(2)
+  })
+
   it('explains the AppImage sandbox failure and the explicit security trade-off', () => {
     const message = formatStartupFailure(
       { kind: 'exit', code: 1, signal: null },

--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -1,6 +1,16 @@
+import { EventEmitter } from 'node:events'
+
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
 
-import { statusCommand, stopCommand, terminateDaemon, urlCommand } from './index.mjs'
+import {
+  buildAppLaunchArgs,
+  formatStartupFailure,
+  statusCommand,
+  stopCommand,
+  terminateDaemon,
+  urlCommand,
+  waitForStartup
+} from './index.mjs'
 
 // A running daemon's on-disk state, as findServiceState would return it.
 const RUNNING_STATE = { pid: 4242, port: 44100, configRoot: '/tmp/os-config' }
@@ -90,6 +100,47 @@ describe('terminateDaemon', () => {
     const stopped = await terminateDaemon(7, { ...base, isAlive: () => true, forceKill })
     expect(stopped).toBe(false)
     expect(forceKill).toHaveBeenCalledWith(7)
+  })
+})
+
+describe('headless startup', () => {
+  it('forwards the explicit no-sandbox fallback to Electron', () => {
+    expect(buildAppLaunchArgs(['app-root'], { noSandbox: true }, 44100)).toEqual([
+      'app-root',
+      '--no-sandbox',
+      '--open-science-headless',
+      '--serve=44100'
+    ])
+    expect(buildAppLaunchArgs(['app-root'], {}, 44100)).not.toContain('--no-sandbox')
+  })
+
+  it('stops waiting as soon as the packaged app exits', async () => {
+    const child = new EventEmitter()
+    const deps = makeDeps({
+      findServiceState: vi.fn().mockImplementation(() => {
+        child.emit('exit', 1, null)
+        return Promise.resolve(undefined)
+      })
+    })
+
+    await expect(waitForStartup('/tmp/os-config', child, deps, 30_000)).resolves.toEqual({
+      kind: 'exit',
+      code: 1,
+      signal: null
+    })
+    expect(deps.sleep).not.toHaveBeenCalled()
+  })
+
+  it('explains the AppImage sandbox failure and the explicit security trade-off', () => {
+    const message = formatStartupFailure(
+      { kind: 'exit', code: 1, signal: null },
+      'FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166\nThe SUID sandbox helper binary was found, but is not configured correctly.',
+      { noSandbox: false }
+    )
+
+    expect(message).toContain('open-science start --no-sandbox')
+    expect(message).toContain('reduces security')
+    expect(message).toContain('AppImage')
   })
 })
 

--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -104,10 +104,10 @@ describe('terminateDaemon', () => {
 })
 
 describe('headless startup', () => {
-  it('forwards the explicit no-sandbox fallback to Electron', () => {
+  it('places the no-sandbox runtime switch before the development app path', () => {
     expect(buildAppLaunchArgs(['app-root'], { noSandbox: true }, 44100)).toEqual([
-      'app-root',
       '--no-sandbox',
+      'app-root',
       '--open-science-headless',
       '--serve=44100'
     ])

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -55,6 +55,22 @@ human-readable, JSON, and JSONL output never includes the local token.
 Use `--port <port>` to override the default port of `44100`. `--app-path <path>` selects a specific
 Open Science executable. Development builds also support `--config-root <path>`.
 
+### Linux AppImage sandbox fallback
+
+`open-science start` keeps Chromium sandboxing enabled by default. On some Linux hosts, an AppImage
+mounted with `nosuid` cannot use Chromium's SUID sandbox helper; Ubuntu may also restrict
+unprivileged user namespaces. In that case the command fails promptly with guidance instead of
+waiting for the service timeout.
+
+If the host cannot support sandboxed startup, an explicit rootless fallback is available:
+
+```bash
+open-science start --no-sandbox --no-open
+```
+
+`--no-sandbox` disables Chromium's process sandbox and reduces security. Use it only when necessary;
+the Debian package or a host configuration that supports Chromium sandboxing is preferred.
+
 ## Projects
 
 Create a project and list the projects available to task runs:

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -340,8 +340,8 @@ const readLogTail = async (logPath) => {
 }
 
 export const buildAppLaunchArgs = (appArgs, options, port) => [
-  ...appArgs,
   ...(options.noSandbox ? ['--no-sandbox'] : []),
+  ...appArgs,
   // `--open-science-headless` instead of `--headless`: Chromium consumes `--headless` and renders
   // native menus (like the tray context menu) invisibly on Windows (electron/electron#48982).
   '--open-science-headless',

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -215,6 +215,9 @@ export const waitForStartup = async (
   let cleanup = () => {}
   const childFailure = new Promise((resolveFailure) => {
     const onExit = (code, signal) => {
+      // An already-running desktop app receives --serve through Electron's second-instance relay.
+      // The relay exits successfully before the primary app has necessarily written service state.
+      if (code === 0 && signal === null) return
       abortController.abort()
       resolveFailure({ kind: 'exit', code, signal })
     }

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -339,6 +339,8 @@ const readLogTail = async (logPath) => {
   }
 }
 
+export const openLaunchLog = (logPath) => openSync(logPath, 'w')
+
 export const buildAppLaunchArgs = (appArgs, options, port) => [
   ...(options.noSandbox ? ['--no-sandbox'] : []),
   ...appArgs,
@@ -394,7 +396,7 @@ const startCommand = async (options, deps = DEFAULT_DEPS) => {
   await deps.removeState(configRoot)
 
   const logPath = join(configRoot, 'cli-daemon.log')
-  const logFd = openSync(logPath, 'a')
+  const logFd = openLaunchLog(logPath)
   const port = options.port ?? DEFAULT_PORT
   const childEnv = {
     ...process.env,
@@ -413,10 +415,11 @@ const startCommand = async (options, deps = DEFAULT_DEPS) => {
     windowsHide: true,
     env: childEnv
   })
+  const startupPromise = waitForStartup(configRoot, child, deps)
   child.unref()
   closeSync(logFd)
 
-  const startup = await waitForStartup(configRoot, child, deps)
+  const startup = await startupPromise
   if (startup.kind !== 'ready') {
     const logTail = await readLogTail(logPath)
     if (startup.kind !== 'timeout') {

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -49,6 +49,7 @@ Options:
   --jsonl                With run --wait, stream one machine-readable event per line
   --output <path>        Artifact download destination
   --no-open              Do not open the browser after start
+  --no-sandbox           Disable Chromium's process sandbox (security risk; start only)
   --json                 Emit one machine-readable result
   -h, --help             Show this help`
 
@@ -97,6 +98,7 @@ export const parseCliArgs = (argv) => {
   while (args.length > 0) {
     const arg = args.shift()
     if (arg === '--no-open') options.open = false
+    else if (arg === '--no-sandbox') options.noSandbox = true
     else if (arg === '--json') options.json = true
     else if (arg === '--jsonl') options.jsonl = true
     else if (arg === '--wait') options.wait = true
@@ -141,6 +143,9 @@ export const parseCliArgs = (argv) => {
   if (options.timeoutMs !== undefined && (command !== 'run' || subcommand || !options.wait)) {
     throw new CliUsageError('--timeout-ms requires run --wait.')
   }
+  if (options.noSandbox && command !== 'start') {
+    throw new CliUsageError('--no-sandbox requires start.')
+  }
   return {
     command,
     ...(subcommand ? { subcommand } : {}),
@@ -181,14 +186,58 @@ const healthCheck = async (state, deps = DEFAULT_DEPS) => {
 const sleep = (milliseconds) =>
   new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds))
 
-const waitForState = async (configRoot, deps = DEFAULT_DEPS, timeoutMs = START_TIMEOUT_MS) => {
+const waitForState = async (
+  configRoot,
+  deps = DEFAULT_DEPS,
+  timeoutMs = START_TIMEOUT_MS,
+  signal
+) => {
   const deadline = deps.now() + timeoutMs
-  while (deps.now() < deadline) {
+  while (deps.now() < deadline && !signal?.aborted) {
     const state = await deps.findServiceState({ override: configRoot })
+    if (signal?.aborted) return undefined
     if (await healthCheck(state, deps)) return state
+    if (signal?.aborted) return undefined
     await deps.sleep(250)
   }
   return undefined
+}
+
+// Keep the health poll and child-process lifecycle coupled: a fatal Electron startup error must not
+// look like a slow service startup and consume the full CLI timeout.
+export const waitForStartup = async (
+  configRoot,
+  child,
+  deps = DEFAULT_DEPS,
+  timeoutMs = START_TIMEOUT_MS
+) => {
+  const abortController = new AbortController()
+  let cleanup = () => {}
+  const childFailure = new Promise((resolveFailure) => {
+    const onExit = (code, signal) => {
+      abortController.abort()
+      resolveFailure({ kind: 'exit', code, signal })
+    }
+    const onError = (error) => {
+      abortController.abort()
+      resolveFailure({ kind: 'error', error })
+    }
+    child.once('exit', onExit)
+    child.once('error', onError)
+    cleanup = () => {
+      child.off('exit', onExit)
+      child.off('error', onError)
+    }
+  })
+  const healthy = waitForState(configRoot, deps, timeoutMs, abortController.signal).then((state) =>
+    state ? { kind: 'ready', state } : { kind: 'timeout' }
+  )
+  try {
+    return await Promise.race([healthy, childFailure])
+  } finally {
+    abortController.abort()
+    cleanup()
+  }
 }
 
 const openBrowser = (url) => {
@@ -287,6 +336,38 @@ const readLogTail = async (logPath) => {
   }
 }
 
+export const buildAppLaunchArgs = (appArgs, options, port) => [
+  ...appArgs,
+  ...(options.noSandbox ? ['--no-sandbox'] : []),
+  // `--open-science-headless` instead of `--headless`: Chromium consumes `--headless` and renders
+  // native menus (like the tray context menu) invisibly on Windows (electron/electron#48982).
+  '--open-science-headless',
+  `--serve=${port}`
+]
+
+const sandboxFailurePattern =
+  /SUID sandbox helper binary.*not configured correctly|No usable sandbox|The setuid sandbox is not running/i
+
+export const formatStartupFailure = (outcome, logTail, options) => {
+  if (!options.noSandbox && sandboxFailurePattern.test(logTail)) {
+    return [
+      'Open Science could not start because Chromium sandboxing is unavailable on this host.',
+      logTail,
+      'This can occur when an AppImage mount cannot provide the SUID permissions required by Chromium; some Linux hosts also restrict unprivileged user namespaces.',
+      'For an explicit rootless fallback, run "open-science start --no-sandbox".',
+      "Warning: --no-sandbox disables Chromium's process sandbox and reduces security. Prefer the Debian package or a host configuration that supports sandboxed startup."
+    ]
+      .filter(Boolean)
+      .join('\n\n')
+  }
+  if (outcome.kind === 'error') return `Could not start Open Science: ${outcome.error.message}`
+
+  const exitStatus = outcome.signal
+    ? ` after receiving ${outcome.signal}`
+    : ` with exit code ${outcome.code ?? 'unknown'}`
+  return `Open Science exited before becoming healthy${exitStatus}.${logTail ? `\n\n${logTail}` : ''}`
+}
+
 const startCommand = async (options, deps = DEFAULT_DEPS) => {
   const existing = await deps.findServiceState({ override: options.configRoot })
   if (await healthCheck(existing, deps)) {
@@ -312,8 +393,6 @@ const startCommand = async (options, deps = DEFAULT_DEPS) => {
   const logPath = join(configRoot, 'cli-daemon.log')
   const logFd = openSync(logPath, 'a')
   const port = options.port ?? DEFAULT_PORT
-  // `--open-science-headless` instead of `--headless`: Chromium consumes `--headless` and renders
-  // native menus (like the tray context menu) invisibly on Windows (electron/electron#48982).
   const childEnv = {
     ...process.env,
     ...(app.packaged ? {} : { OPEN_SCIENCE_STORAGE_ROOT: configRoot }),
@@ -322,7 +401,10 @@ const startCommand = async (options, deps = DEFAULT_DEPS) => {
   // The installed launcher runs this CLI via the app's Electron in Node mode (ELECTRON_RUN_AS_NODE=1).
   // Drop it here so the daemon we spawn starts as the normal Electron app, not another Node process.
   delete childEnv.ELECTRON_RUN_AS_NODE
-  const child = spawn(app.command, [...app.args, '--open-science-headless', `--serve=${port}`], {
+  if (options.noSandbox) {
+    deps.warn("Warning: --no-sandbox disables Chromium's process sandbox and reduces security.")
+  }
+  const child = spawn(app.command, buildAppLaunchArgs(app.args, options, port), {
     detached: true,
     stdio: ['ignore', logFd, logFd],
     windowsHide: true,
@@ -331,13 +413,17 @@ const startCommand = async (options, deps = DEFAULT_DEPS) => {
   child.unref()
   closeSync(logFd)
 
-  const state = await waitForState(configRoot, deps)
-  if (!state) {
+  const startup = await waitForStartup(configRoot, child, deps)
+  if (startup.kind !== 'ready') {
     const logTail = await readLogTail(logPath)
+    if (startup.kind !== 'timeout') {
+      throw new Error(formatStartupFailure(startup, logTail, options))
+    }
     throw new Error(
       `Open Science did not become healthy within ${START_TIMEOUT_MS / 1000}s.${logTail ? `\n\n${logTail}` : ''}`
     )
   }
+  const state = startup.state
   const url = await authenticatedUrl(state, deps)
   deps.log(`Open Science started (PID ${state.pid}).`)
   if (options.open) openBrowser(url)


### PR DESCRIPTION
## Problem

On Linux hosts where Chromium sandbox initialization fails, the AppImage headless launcher exits immediately but `open-science start` keeps polling for 30 seconds. The supported CLI also has no explicit way to select the confirmed rootless fallback.

## Proposed change

- Race service-health polling against the spawned Electron process lifecycle and surface spawn/exit failures immediately.
- Recognize Chromium SUID sandbox failures and provide actionable AppImage guidance.
- Add an explicit `start --no-sandbox` option, forward it to Electron, and print a reduced-security warning.
- Document the Linux AppImage fallback and preferred secure alternatives.
- Add regression coverage for parsing/forwarding, prompt child-exit handling, and sandbox diagnostics.

## Scope and non-goals

Sandboxed startup remains the default. This change does not automatically disable Chromium sandboxing or modify AppImage helper permissions. It does not change status or stop semantics.

## Acceptance criteria and validation

- [x] A packaged-app stand-in that exits immediately now makes the CLI fail within 1.2 seconds instead of waiting 30 seconds.
- [x] `npx vitest run cli/index.test.ts cli/lifecycle.test.ts` (23 passed)
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors; 34 pre-existing warnings in unrelated files)
- [ ] `npm run test` could not complete locally because this environment has no installed Electron runtime binary (`Electron failed to install correctly`); the focused CLI suite passes.

## Review focus

Please review the child-process/health-poll race and the security wording around the explicit fallback.

Closes #415