### PR TITLE
fix(agent-runtime): prevent false task completion

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -761,6 +761,9 @@ describe('ACP runtime session management', () => {
       })
     ])
     expect(JSON.stringify(fakeAgent.newSessions[0]._meta)).toContain(BEGIN_ACTIVITY_GROUP_TOOL_NAME)
+    expect(JSON.stringify(fakeAgent.newSessions[0]._meta)).toContain(
+      'Do not describe a tool-backed action as future work'
+    )
     expect(fakeAgent.prompts[0].text).toContain('mcp__open-science-activity__begin_activity_group')
     expect(fakeAgent.prompts[0].text).toContain('Before each coherent tool group this turn')
 
@@ -812,6 +815,9 @@ describe('ACP runtime session management', () => {
         expect.objectContaining({ name: ACTIVITY_GROUP_MCP_SERVER_NAME })
       ])
       expect(fakeAgent.prompts[0].text).toContain(BEGIN_ACTIVITY_GROUP_TOOL_NAME)
+      expect(fakeAgent.prompts[0].text).toContain(
+        'Do not describe a tool-backed action as future work'
+      )
     }
   )
   it('applies native Full access before the first prompt', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -288,6 +288,14 @@ const ACTIVITY_GROUP_SYSTEM_PROMPT_APPEND = [
   '</open_science_activity_group_instructions>'
 ].join('\n')
 const ACTIVITY_GROUP_TURN_PROMPT_REMINDER = `Before each coherent tool group this turn, call \`${BEGIN_ACTIVITY_GROUP_TOOL_NAME}\` with one concise purpose title immediately before that group's first tool. Repeat the declaration whenever the purpose changes; do not reuse the previous group. Call it once per group, not once per tool.`
+// An end_turn is final from the runtime's perspective, so promised work must be a tool call in the
+// current turn or an explicit request for user input rather than text that implies later execution.
+const TURN_CONTINUITY_SYSTEM_PROMPT_APPEND = [
+  '<open_science_turn_continuity_instructions>',
+  'Do not describe a tool-backed action as future work and then end the turn. If you say you will download, install, run, edit, analyze, or otherwise perform an action that needs a tool, issue the corresponding tool call in this same turn.',
+  'If a required tool cannot be used or its operation fails, do not promise another attempt. Clearly state that the turn has stopped, what prevented progress, and what the user can do next.',
+  '</open_science_turn_continuity_instructions>'
+].join('\n')
 // Appends artifact tool guidance as system prompt metadata so user prompts stay untouched.
 const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '<open_science_artifact_instructions>',
@@ -3099,6 +3107,7 @@ class AcpRuntime {
     // Each append names MCP tools that only exist when that tooling is actually wired for this session;
     // omit it otherwise so the agent isn't told to use tools it wasn't given.
     return [
+      TURN_CONTINUITY_SYSTEM_PROMPT_APPEND,
       SKILLS_READ_GUARD_SYSTEM_PROMPT_APPEND,
       LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND,
       ...(this.activityGroupOptions && this.framework.acceptsStdioMcp

--- a/src/main/notifications/electron-wiring.test.ts
+++ b/src/main/notifications/electron-wiring.test.ts
@@ -62,13 +62,13 @@ describe('buildTaskNotificationShow', () => {
       headless: false
     })
 
-    show({ title: 'Task completed', body: 'b', onClick })
+    show({ title: 'Agent response complete', body: 'b', onClick })
 
     const [notification] = Array.from(notifications)
     expect(notification?.show).toHaveBeenCalledTimes(1)
     expect(log.info).toHaveBeenCalledWith(
       'delivering task notification',
-      expect.objectContaining({ title: 'Task completed' })
+      expect.objectContaining({ title: 'Agent response complete' })
     )
 
     // The click handler stays live across the lifetime of the banner (not GC'd).

--- a/src/main/notifications/electron-wiring.test.ts
+++ b/src/main/notifications/electron-wiring.test.ts
@@ -62,13 +62,13 @@ describe('buildTaskNotificationShow', () => {
       headless: false
     })
 
-    show({ title: 'Agent response complete', body: 'b', onClick })
+    show({ title: 'Task completed', body: 'b', onClick })
 
     const [notification] = Array.from(notifications)
     expect(notification?.show).toHaveBeenCalledTimes(1)
     expect(log.info).toHaveBeenCalledWith(
       'delivering task notification',
-      expect.objectContaining({ title: 'Agent response complete' })
+      expect.objectContaining({ title: 'Task completed' })
     )
 
     // The click handler stays live across the lifetime of the banner (not GC'd).

--- a/src/main/notifications/task-notifications.test.ts
+++ b/src/main/notifications/task-notifications.test.ts
@@ -95,14 +95,14 @@ describe('describeConnectorApprovalNotification', () => {
 describe('describeTaskNotification', () => {
   it('names the task from the prompt snippet when a turn completes', () => {
     expect(describeTaskNotification(stopEvent('end_turn'), 'Plot the curve')).toEqual({
-      title: 'Agent response complete',
+      title: 'Task completed',
       body: 'The agent finished responding to "Plot the curve".'
     })
   })
 
   it('falls back to a generic body when no prompt was tracked', () => {
     expect(describeTaskNotification(stopEvent('end_turn'))).toEqual({
-      title: 'Agent response complete',
+      title: 'Task completed',
       body: 'The agent finished responding.'
     })
   })
@@ -263,7 +263,7 @@ describe('TaskNotificationService', () => {
 
     expect(shown).toHaveLength(1)
     expect(shown[0]).toMatchObject({
-      title: 'Agent response complete',
+      title: 'Task completed',
       body: 'The agent finished responding to "Plot the curve".'
     })
   })

--- a/src/main/notifications/task-notifications.test.ts
+++ b/src/main/notifications/task-notifications.test.ts
@@ -95,15 +95,15 @@ describe('describeConnectorApprovalNotification', () => {
 describe('describeTaskNotification', () => {
   it('names the task from the prompt snippet when a turn completes', () => {
     expect(describeTaskNotification(stopEvent('end_turn'), 'Plot the curve')).toEqual({
-      title: 'Task completed',
-      body: '"Plot the curve" finished.'
+      title: 'Agent response complete',
+      body: 'The agent finished responding to "Plot the curve".'
     })
   })
 
   it('falls back to a generic body when no prompt was tracked', () => {
     expect(describeTaskNotification(stopEvent('end_turn'))).toEqual({
-      title: 'Task completed',
-      body: 'The agent finished your request.'
+      title: 'Agent response complete',
+      body: 'The agent finished responding.'
     })
   })
 
@@ -263,8 +263,8 @@ describe('TaskNotificationService', () => {
 
     expect(shown).toHaveLength(1)
     expect(shown[0]).toMatchObject({
-      title: 'Task completed',
-      body: '"Plot the curve" finished.'
+      title: 'Agent response complete',
+      body: 'The agent finished responding to "Plot the curve".'
     })
   })
 
@@ -274,7 +274,7 @@ describe('TaskNotificationService', () => {
     service.trackPrompt({ sessionId: 'session-1', text: 'First line\nSecond line' })
     await service.handleRuntimeEvent(stopEvent('end_turn'))
 
-    expect(shown[0]?.body).toBe('"First line" finished.')
+    expect(shown[0]?.body).toBe('The agent finished responding to "First line".')
   })
 
   it('does not notify while the app is focused', async () => {
@@ -513,7 +513,7 @@ describe('TaskNotificationService', () => {
     service.untrackPrompt('session-1', trackedB as NonNullable<typeof trackedB>)
     await service.handleRuntimeEvent(stopEvent('end_turn'))
 
-    expect(shown[0]?.body).toBe('"Prompt A" finished.')
+    expect(shown[0]?.body).toBe('The agent finished responding to "Prompt A".')
   })
 
   it('does not corrupt a still-running turn when rejections arrive in sequence', async () => {
@@ -530,7 +530,7 @@ describe('TaskNotificationService', () => {
     service.untrackPrompt('session-1', trackedC as NonNullable<typeof trackedC>)
     await service.handleRuntimeEvent(stopEvent('end_turn'))
 
-    expect(shown[0]?.body).toBe('"Prompt A" finished.')
+    expect(shown[0]?.body).toBe('The agent finished responding to "Prompt A".')
   })
 
   it('untrackPrompt is a no-op once a terminal event consumed the snippet', async () => {

--- a/src/main/notifications/task-notifications.ts
+++ b/src/main/notifications/task-notifications.ts
@@ -3,7 +3,7 @@ import { ACP_PROMPT_FAILED_EVENT_TITLE } from '../../shared/acp'
 import type { OpenSessionFromNotificationRequest } from '../../shared/notifications'
 import type { ConnectorApprovalRequest } from '../../shared/settings'
 
-// What the user sees when a task reaches a terminal state while the app is unfocused.
+// What the user sees when an agent turn reaches a terminal state while the app is unfocused.
 export type TaskNotification = {
   title: string
   body: string
@@ -117,9 +117,11 @@ export const describeTaskNotification = (
     }
 
     return {
-      title: 'Task completed',
+      title: 'Agent response complete',
       body: truncate(
-        taskName ? `${taskName} finished.` : 'The agent finished your request.',
+        taskName
+          ? `The agent finished responding to ${taskName}.`
+          : 'The agent finished responding.',
         MAX_BODY_LENGTH
       )
     }

--- a/src/main/notifications/task-notifications.ts
+++ b/src/main/notifications/task-notifications.ts
@@ -117,7 +117,7 @@ export const describeTaskNotification = (
     }
 
     return {
-      title: 'Agent response complete',
+      title: 'Task completed',
       body: truncate(
         taskName
           ? `The agent finished responding to ${taskName}.`


### PR DESCRIPTION
## Problem

A provider can return a normal `end_turn` after text that promises a later tool-backed action. The runtime has no structured signal that the prose implies unfinished work, so it reported the terminal response as task completion.

## Proposed change

- Add framework-neutral guidance requiring tool-backed work to be called in the current turn, or for the agent to clearly state that it stopped and needs user input.
- Rename the `end_turn` notification from task completion to agent response completion so it does not assert that the user task succeeded.

## Scope and non-goals

This change does not infer intent from response prose or automatically prompt the model again. Automatic continuation could resume or duplicate side-effecting work after the user context has changed.

## Acceptance criteria and validation

- Added Claude, Codex, and OpenCode delivery coverage for the new guidance.
- Added notification wording coverage.
- Passed `npm run typecheck`.
- Passed focused Vitest coverage for runtime guidance and task notifications.
- Passed Prettier checks for changed files.
- `npm run lint` exits successfully with 34 unrelated existing warnings.
- The full `npm run test` suite remains red in unrelated workspace-preview and packaging tests.

## Review focus

Confirm that the prompt guidance is delivered through Claude session metadata and Codex/OpenCode prompt prefixes, and that terminal notifications no longer imply task success.

Fixes #408