### PR TITLE
fix(notebook): skip unused R graphics devices

### DIFF
--- a/resources/notebook/r_loop.R
+++ b/resources/notebook/r_loop.R
@@ -28,13 +28,14 @@ read_request <- function() {
   list(req_id = req_id, code = code)
 }
 
-# Content-addresses each non-empty PNG page produced on the device into figures_dir.
-harvest_figures <- function(pattern_dir) {
+# Content-addresses each non-empty PNG page produced on the device into figures_dir. Raw pages are
+# always removed, including when the device was unused and produced a platform-specific blank PNG.
+harvest_figures <- function(pattern_dir, include = TRUE) {
   files <- list.files(pattern_dir, pattern = "^page-\\d+\\.png$", full.names = TRUE)
   out <- list()
   for (f in files) {
     info <- file.info(f)
-    if (!is.na(info$size) && info$size > 0) {
+    if (include && !is.na(info$size) && info$size > 0) {
       digest <- content_hash(f)
       dest <- file.path(figures_dir, paste0(digest, ".png"))
       file.copy(f, dest, overwrite = TRUE)
@@ -45,6 +46,19 @@ harvest_figures <- function(pattern_dir) {
     unlink(f)
   }
   out
+}
+
+# A print device can create a blank PNG merely by being opened and closed (notably on Windows).
+# Enable the display list and use its recorded operations to distinguish that empty device from a
+# cell that actually drew a plot. If recording is unavailable, retain the figure rather than risk
+# dropping a legitimate output.
+has_recorded_graphics <- function(dev_id) {
+  tryCatch({
+    if (!(dev_id %in% grDevices::dev.list())) return(TRUE)
+    grDevices::dev.set(dev_id)
+    recorded <- grDevices::recordPlot()
+    length(recorded) > 0L && length(recorded[[1L]]) > 0L
+  }, error = function(cnd) TRUE)
 }
 
 # Content hash of a file for figure dedup, using base R's tools::md5sum (no new dependency). The
@@ -58,6 +72,7 @@ run <- function(req) {
   pattern <- file.path(page_dir, "page-%03d.png")
   grDevices::png(filename = pattern, width = 800, height = 600, res = 96)
   dev_id <- grDevices::dev.cur()
+  grDevices::dev.control(displaylist = "enable")
   error <- NULL
   error_line <- NA_integer_
   stdout_text <- ""
@@ -85,8 +100,9 @@ run <- function(req) {
       interrupt = function(cnd) error <<- "interrupted")
     }
   }), collapse = "\n")
+  has_graphics <- has_recorded_graphics(dev_id)
   suppressWarnings(try(grDevices::dev.off(dev_id), silent = TRUE))
-  figures <- if (nzchar(figures_dir)) harvest_figures(page_dir) else list()
+  figures <- if (nzchar(figures_dir)) harvest_figures(page_dir, has_graphics) else list()
   list(stdout = stdout_text, stderr = "", error = if (is.null(error)) NA else error,
        error_line = if (is.na(error_line)) NULL else error_line,
        result = NA, cwd = getwd(), figures = figures)

--- a/src/main/notebook/r-loop.integration.test.ts
+++ b/src/main/notebook/r-loop.integration.test.ts
@@ -88,6 +88,22 @@ gate('r_loop.R', () => {
     }
   }, 60_000)
 
+  it('does not capture a figure when a cell emits only text', async () => {
+    const figuresDir = mkdtempSync(join(tmpdir(), 'os-kernel-figs-r-text-'))
+    const { child, send } = startLoop(rscriptBin(), {
+      OPEN_SCIENCE_KERNEL_FIGURES_DIR: figuresDir
+    })
+    try {
+      const r = await send('print("text only")')
+      expect(r.error).toBeNull()
+      expect(r.stdout).toContain('text only')
+      expect(r.figures).toEqual([])
+    } finally {
+      child.kill()
+      rmSync(figuresDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+
   it('captures a base graphics figure as a content-addressed PNG', async () => {
     const figuresDir = mkdtempSync(join(tmpdir(), 'os-kernel-figs-r-'))
     const { child, send } = startLoop(rscriptBin(), {
@@ -96,13 +112,43 @@ gate('r_loop.R', () => {
     try {
       const r = await send('plot(1:3)')
       expect(r.error).toBeNull()
-      expect(r.figures.length).toBeGreaterThan(0)
+      expect(r.figures).toHaveLength(1)
       const fig = r.figures[0]
       expect(existsSync(fig.path)).toBe(true)
       const bytes = readFileSync(fig.path)
       // PNG magic bytes.
       expect(bytes[0]).toBe(0x89)
       expect(bytes.subarray(1, 4).toString('ascii')).toBe('PNG')
+    } finally {
+      child.kill()
+      rmSync(figuresDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  it('captures the kernel figure when user code opens another graphics device', async () => {
+    const figuresDir = mkdtempSync(join(tmpdir(), 'os-kernel-figs-r-device-'))
+    const { child, send } = startLoop(rscriptBin(), {
+      OPEN_SCIENCE_KERNEL_FIGURES_DIR: figuresDir
+    })
+    try {
+      const r = await send('plot(1:3)\npdf(tempfile())')
+      expect(r.error).toBeNull()
+      expect(r.figures).toHaveLength(1)
+    } finally {
+      child.kill()
+      rmSync(figuresDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  it('captures one figure for each base graphics plot', async () => {
+    const figuresDir = mkdtempSync(join(tmpdir(), 'os-kernel-figs-r-multi-'))
+    const { child, send } = startLoop(rscriptBin(), {
+      OPEN_SCIENCE_KERNEL_FIGURES_DIR: figuresDir
+    })
+    try {
+      const r = await send('plot(1:3)\nplot(3:1)')
+      expect(r.error).toBeNull()
+      expect(r.figures).toHaveLength(2)
     } finally {
       child.kill()
       rmSync(figuresDir, { recursive: true, force: true })


### PR DESCRIPTION
## Problem

On Windows, closing the PNG graphics device that the R notebook kernel opens for every cell can produce a valid blank PNG even when the cell only emits text. The kernel treated every non-empty PNG as a figure, so text-only cells displayed an empty figure block.

## Proposed change

- Enable the R graphics display list and check whether the kernel-owned PNG device recorded any drawing operations.
- Harvest generated PNG pages only when that device contains recorded graphics, while still removing unused raw pages.
- Keep figure detection bound to the kernel device when user code opens another graphics device.
- Add integration coverage for text-only output, exactly one plot, multiple plots, and graphics-device switching.

## Scope and non-goals

This change is limited to R notebook figure capture. It does not change output mapping, renderer behavior, or Python/JavaScript kernels.

## Acceptance criteria and validation

- Text-only R cells return zero figures.
- One base R plot returns exactly one figure.
- Multiple base R plots return one figure per plot.
- Opening another graphics device does not hide the kernel PNG output.
- `RUN_KERNEL=1 OPEN_SCIENCE_TEST_R_ENV=/usr/local npx vitest run src/main/notebook/r-loop.integration.test.ts` (7 passed)
- `npm run typecheck` (passed)
- Targeted ESLint and Prettier checks (passed)
- Full Vitest run reached 5,452 passing tests; 44 suites could not load because the local Electron binary was not installed correctly. CI provides the authoritative full-suite result.

## Review focus

Please verify that display-list recording behaves consistently for the bundled Windows R runtime and that fallback behavior preserves legitimate plots when recording is unavailable.

Closes #414
