### PR TITLE
fix(settings): distinguish server errors from client errors in provider validation

### DIFF
--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -404,6 +404,30 @@ describe('settings repository', () => {
     })
   })
 
+  it('round-trips a server-error validation failure across a reload', async () => {
+    const root = await createStorageRoot()
+    const repository = new SettingsRepository(root)
+
+    await repository.upsertProvider(
+      provider({
+        lastValidationFailure: {
+          at: 1717000000000,
+          category: 'server-error',
+          status: 503,
+          message: 'Service temporarily unavailable'
+        }
+      })
+    )
+
+    const reloaded = await new SettingsRepository(root).getSettings()
+    expect(reloaded.providers[0].lastValidationFailure).toEqual({
+      at: 1717000000000,
+      category: 'server-error',
+      status: 503,
+      message: 'Service temporarily unavailable'
+    })
+  })
+
   it('drops a malformed validation failure (bad category or missing timestamp) on load', async () => {
     const root = await createStorageRoot()
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -62,6 +62,7 @@ const VALIDATION_CATEGORIES = new Set<ValidationCategory>([
   'bad-url',
   'timeout',
   'incompatible',
+  'server-error',
   'unknown'
 ])
 

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -177,7 +177,8 @@ describe('validate: classification', () => {
     expect(classifyStatus(403)).toBe('auth')
     expect(classifyStatus(404)).toBe('model-not-found')
     expect(classifyStatus(400)).toBe('unknown')
-    expect(classifyStatus(500)).toBe('unknown')
+    expect(classifyStatus(500)).toBe('server-error')
+    expect(classifyStatus(503)).toBe('server-error')
   })
 
   it('maps thrown errors to categories', () => {
@@ -469,7 +470,7 @@ describe('validate: provider dispatch', () => {
 
     expect(result).toMatchObject({
       ok: false,
-      category: 'unknown',
+      category: 'server-error',
       status: 503,
       message: 'Service temporarily unavailable'
     })
@@ -486,7 +487,7 @@ describe('validate: provider dispatch', () => {
       { fetchImpl: fetchImpl as unknown as typeof fetch }
     )
 
-    expect(result).toMatchObject({ ok: false, category: 'unknown', status: 500 })
+    expect(result).toMatchObject({ ok: false, category: 'server-error', status: 500 })
     expect(result.message).toBeUndefined()
   })
 

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -399,6 +399,26 @@ describe('validate: provider dispatch', () => {
     expect(result).toMatchObject({ ok: false, category: 'model-not-found', status: 400 })
   })
 
+  it('surfaces a 5xx error message from a bridge validation', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        new Response('{"error":{"message":"Gateway timeout"}}', { status: 502 })
+      )
+
+    const result = await validateProvider(
+      { type: 'custom', apiEndpoints: ['openai'], baseUrl: 'https://g/v1', key: 'k', model: 'm' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch, requireBridgeToolCall: true }
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      category: 'server-error',
+      status: 502,
+      message: 'Gateway timeout'
+    })
+  })
+
   it('keeps a text-only Chat Completions provider unverified', async () => {
     const fetchImpl = vi
       .fn()

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -446,7 +446,7 @@ const validateProviderThroughResponsesBridge = async (
     if (category !== 'ok') {
       return toResult(category, {
         status: response.status,
-        ...(category === 'unknown' ? { message: providerMessage } : {})
+        ...(category === 'unknown' || category === 'server-error' ? { message: providerMessage } : {})
       })
     }
     if (!hasResponsesBridgeProbeToolCall(bodyText)) {

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -214,11 +214,13 @@ const hasValidAnthropicMessage = (bodyText: string): boolean => {
 }
 
 // Maps an HTTP status to a validation category. 2xx is success; auth/model errors are distinguished
-// so the UI can point the user at the credential vs. the model field.
+// so the UI can point the user at the credential vs. the model field. 5xx server errors are surfaced
+// as a distinct category so users can distinguish gateway/upstream issues from client-side problems.
 const classifyStatus = (status: number): ValidationCategory => {
   if (status >= 200 && status < 300) return 'ok'
   if (status === 401 || status === 403) return 'auth'
   if (status === 404) return 'model-not-found'
+  if (status >= 500 && status < 600) return 'server-error'
 
   return 'unknown'
 }

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -516,11 +516,11 @@ const validateCustomProvider = async (
       }
     }
 
-    // Only the catch-all 'unknown' status (402 billing, 429 rate limit, 5xx, …) lacks guidance of its
-    // own, so surface the gateway's error text there — whatever it actually says — rather than an
-    // assumed meaning. auth/model-not-found already map to targeted advice, so their raw bodies would
-    // only muddy it.
-    if (category === 'unknown') {
+    // Only the catch-all 'unknown' status (402 billing, 429 rate limit, …) and 'server-error' (5xx)
+    // lack guidance of their own, so surface the gateway's error text there — whatever it actually
+    // says — rather than an assumed meaning. auth/model-not-found already map to targeted advice, so
+    // their raw bodies would only muddy it.
+    if (category === 'unknown' || category === 'server-error') {
       return toResult(category, {
         status: response.status,
         message: providerMessage

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -176,6 +176,23 @@ describe('ProviderList', () => {
     expect(container.textContent).toContain('authentication rejected')
   })
 
+  it('flags a provider whose last test failed with a server error', () => {
+    renderList([
+      provider({
+        lastValidatedAt: 1,
+        lastValidationFailure: {
+          at: 2,
+          category: 'server-error',
+          status: 503,
+          message: 'Service temporarily unavailable'
+        }
+      })
+    ])
+
+    expect(container.textContent).toContain('Service temporarily unavailable')
+    expect(container.textContent).toContain('HTTP 503')
+  })
+
   it('does not flag a provider whose latest validation succeeded', () => {
     // A stale failure older than the last success is not a warning.
     renderList([

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -82,6 +82,11 @@ const describeValidationFailure = (failure: ProviderValidationFailure): string =
     case 'incompatible':
       // The pairing, not the credential, is the problem — carry the specific route-mismatch reason.
       return failure.message ?? 'Not compatible with the active agent framework.'
+    case 'server-error':
+      // Gateway or upstream service temporarily unavailable — surface the specific error when present.
+      return failure.message
+        ? `Test failed: ${failure.message}${failure.status ? ` (HTTP ${failure.status})` : ''}`
+        : 'Test failed: the gateway or upstream service is temporarily unavailable.'
     default:
       return failure.message ? `Test failed: ${failure.message}` : 'Connection test failed.'
   }

--- a/src/renderer/src/pages/settings/validation-message.ts
+++ b/src/renderer/src/pages/settings/validation-message.ts
@@ -10,12 +10,18 @@ const CATEGORY_MESSAGES: Record<ValidationCategory, string> = {
   'bad-url': 'The base URL is invalid. Enter a full URL like https://gateway.example/v1.',
   timeout: 'The request timed out and was stopped.',
   incompatible: "This provider isn't compatible with the active agent framework.",
+  'server-error': 'The gateway or upstream service is temporarily unavailable. Try again later.',
   unknown: 'Validation failed for an unknown reason.'
 }
 
 // Categories whose generic text benefits from the specific error/probe message (a timeout or network
 // failure). Auth/model/bad-url already carry actionable text.
-const MESSAGE_CATEGORIES = new Set<ValidationCategory>(['network', 'timeout', 'unknown'])
+const MESSAGE_CATEGORIES = new Set<ValidationCategory>([
+  'network',
+  'timeout',
+  'server-error',
+  'unknown'
+])
 
 // Produces the message to show for a validation result, appending a specific server/probe message when
 // the category is generic and an HTTP status when one is available.

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -399,7 +399,15 @@ export type ValidateProviderRequest = {
 // 'incompatible' is decided before any network probe: the provider's API format can't drive the
 // active agent framework, so a raw auth probe would only mislead (the key is fine; the pairing isn't).
 export type ValidationCategory =
-  'ok' | 'network' | 'auth' | 'model-not-found' | 'bad-url' | 'timeout' | 'incompatible' | 'unknown'
+  | 'ok'
+  | 'network'
+  | 'auth'
+  | 'model-not-found'
+  | 'bad-url'
+  | 'timeout'
+  | 'incompatible'
+  | 'server-error'
+  | 'unknown'
 
 export type ValidateProviderResult = {
   ok: boolean


### PR DESCRIPTION
## Problem

Multiple users reported custom gateway connection tests failing with "The server is temporarily unavailable" (issue #404). Investigation revealed this error message comes from the **gateway itself** (HTTP 503), not the application.

However, the current validation flow classifies all 5xx server errors as `'unknown'`, which provides generic guidance that doesn't help users distinguish between:
- **Client-side issues**: wrong URL, network unreachable, invalid configuration
- **Server-side issues**: gateway temporarily down, upstream provider unavailable

## Proposed change

Add a dedicated `'server-error'` validation category for HTTP 5xx responses with clearer messaging.

**Changes:**
1. Extend `ValidationCategory` type with `'server-error'`
2. Update `classifyStatus()` to return `'server-error'` for `status >= 500 && < 600`
3. Add UI message: "The gateway or upstream service is temporarily unavailable. Try again later."
4. Include `'server-error'` in `MESSAGE_CATEGORIES` so gateway error messages are still surfaced alongside the category message

## Scope and non-goals

**In scope:**
- Distinguish 5xx from client-side errors in the validation UI
- Provide clearer, actionable guidance for server-side failures
- Preserve gateway error messages (e.g. "Service temporarily unavailable") as additional context

**Out of scope:**
- Automatic retry logic for 5xx errors (future enhancement)
- Rate limiting detection (separate concern)
- Changes to probe request construction

## Acceptance criteria and validation

- `classifyStatus(503)` returns `'server-error'` instead of `'unknown'`
- UI displays the new message for 5xx responses
- Existing validation tests pass (33/33 in `validate.test.ts`)
- TypeScript compilation succeeds
- Gateway error messages are still shown: "The gateway or upstream service is temporarily unavailable. Try again later. (Service temporarily unavailable)"

## Review focus

- Does the new category name `'server-error'` clearly communicate server-side vs. client-side issues?
- Is the UI message actionable and non-alarming?
- Should we surface HTTP status codes differently for 5xx vs. other categories?

Closes #404