### PR TITLE
fix(notebook): suppress PowerShell CLIXML progress output

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -10,6 +10,7 @@ import type { NotebookExecutionRequest, NotebookExecutionResult } from './runtim
 import {
   NotebookRuntimeService,
   buildShellEnv,
+  normalizePowerShellStderr,
   resolveDefaultExecutorOptions,
   resolveLoopScriptPaths,
   resolveShellInvocation,
@@ -92,6 +93,7 @@ describe('resolveShellInvocation', () => {
     const script = Buffer.from(invocation.args.at(-1) ?? '', 'base64').toString('utf16le')
     expect(script).toContain('[Console]::OutputEncoding = $openScienceUtf8')
     expect(script).toContain('$OutputEncoding = $openScienceUtf8')
+    expect(script).toContain("$ProgressPreference = 'SilentlyContinue'")
     expect(script).toContain("$ErrorActionPreference = 'Stop'")
     expect(script).toContain('catch {')
     expect(script).toContain('[Console]::Error.WriteLine($_.ToString())')
@@ -125,6 +127,36 @@ describe('resolveShellInvocation', () => {
 })
 
 describe('Windows shell support', () => {
+  const completedProgressClixml =
+    '#< CLIXML\n' +
+    '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">' +
+    '<Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj>' +
+    '<Obj S="progress" RefId="1"><TNRef RefId="0" /><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj>' +
+    '</Objs>\n'
+
+  it('drops progress-only PowerShell CLIXML stderr records', () => {
+    expect(normalizePowerShellStderr(completedProgressClixml, 'win32')).toBe('')
+  })
+
+  it('preserves real stderr around benign PowerShell CLIXML progress records', () => {
+    expect(
+      normalizePowerShellStderr(
+        `real warning\n${completedProgressClixml}\nstill important\n`,
+        'win32'
+      )
+    ).toBe('real warning\nstill important\n')
+  })
+
+  it('preserves non-progress PowerShell CLIXML records', () => {
+    const errorClixml =
+      '#< CLIXML\n' +
+      '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">' +
+      '<Obj S="Error" RefId="0"><MS><S N="Message">boom</S></MS></Obj>' +
+      '</Objs>\n'
+
+    expect(normalizePowerShellStderr(errorClixml, 'win32')).toBe(errorClixml)
+  })
+
   it('keeps Windows shell location variables while excluding host secrets', () => {
     const env = buildShellEnv('/notebook/handoff', 'win32', {
       PATH: 'C:\\Windows\\System32',

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -598,6 +598,54 @@ const buildShellEnv = (
   return env
 }
 
+const POWERSHELL_CLIXML_BLOCK = /#< CLIXML\r?\n<Objs\b[\s\S]*?<\/Objs>(?:\r?\n)?/gu
+
+const isPowerShellProgressClixml = (block: string): boolean => {
+  const xmlStart = block.indexOf('<Objs')
+  if (xmlStart === -1) return false
+
+  const xml = block.slice(xmlStart)
+  const objectStreamPattern = /<Obj\b[^>]*\bS=(["'])(.*?)\1/giu
+  let sawObject = false
+  let match: RegExpExecArray | null
+
+  while ((match = objectStreamPattern.exec(xml)) !== null) {
+    sawObject = true
+    if (match[2].toLowerCase() !== 'progress') return false
+  }
+
+  return sawObject
+}
+
+const skipOneLineBreak = (text: string, index: number): number => {
+  if (text.startsWith('\r\n', index)) return index + 2
+  if (text[index] === '\n' || text[index] === '\r') return index + 1
+  return index
+}
+
+const normalizePowerShellStderr = (
+  stderr: string,
+  platform: NodeJS.Platform = process.platform
+): string => {
+  if (platform !== 'win32' || !stderr.includes('#< CLIXML')) return stderr
+
+  let normalized = ''
+  let cursor = 0
+  let match: RegExpExecArray | null
+  POWERSHELL_CLIXML_BLOCK.lastIndex = 0
+
+  while ((match = POWERSHELL_CLIXML_BLOCK.exec(stderr)) !== null) {
+    if (!isPowerShellProgressClixml(match[0])) continue
+
+    normalized += stderr.slice(cursor, match.index)
+    cursor = match.index + match[0].length
+    if (normalized.endsWith('\n')) cursor = skipOneLineBreak(stderr, cursor)
+  }
+
+  if (cursor === 0) return stderr
+  return normalized + stderr.slice(cursor)
+}
+
 type ShellInvocation = {
   executable: string
   args: string[]
@@ -616,6 +664,7 @@ const encodePowerShellCommand = (command: string): string => {
     '$OutputEncoding = $openScienceUtf8',
     `$openScienceCommandBase64 = '${encodedCommand}'`,
     '$global:LASTEXITCODE = 0',
+    "$ProgressPreference = 'SilentlyContinue'",
     "$ErrorActionPreference = 'Stop'",
     'try {',
     '$openScienceCommandText = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($openScienceCommandBase64))',
@@ -698,7 +747,7 @@ const runShellCommand = (options: {
       if (settled) return
       settled = true
       clearTimeout(timeoutTimer)
-      resolve(result)
+      resolve({ ...result, stderr: normalizePowerShellStderr(result.stderr) })
     }
 
     const timeoutTimer = setTimeout(() => {
@@ -3122,6 +3171,7 @@ class NotebookRuntimeService {
 export {
   NotebookRuntimeService,
   buildShellEnv,
+  normalizePowerShellStderr,
   resolveDefaultExecutorOptions,
   resolveLoopScriptPaths,
   resolveShellInvocation,


### PR DESCRIPTION
## Problem

Fixes #410.

On Windows, notebook `bash_execute` runs through Windows PowerShell. PowerShell can emit progress records as CLIXML on stderr in non-interactive contexts. Open Science persisted that raw stderr as notebook `stream/stderr`, so a successful command could show a red raw XML output block.

## Proposed change

- Set `$ProgressPreference = "SilentlyContinue"` in the Windows PowerShell wrapper before running the user command.
- Normalize Windows shell stderr before returning and persisting it.
- Strip only progress-only PowerShell CLIXML blocks.
- Preserve real stderr and non-progress CLIXML records.

## Scope and non-goals

This keeps the existing notebook output schema and renderer behavior unchanged. The fix lives at the Windows shell adapter boundary instead of adding CLIXML parsing to the UI.

## Acceptance criteria and validation

- `npm run test -- src/main/notebook/runtime-service.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test`

## Review focus

Please focus on the PowerShell CLIXML filtering boundary and whether the progress-only detection is conservative enough to avoid hiding real diagnostics.