### PR TITLE
fix(notebook): stop flooding the env banner with micromamba output

### DIFF
--- a/src/main/notebook/env-ipc.test.ts
+++ b/src/main/notebook/env-ipc.test.ts
@@ -567,6 +567,31 @@ describe('runStartupGate', () => {
     )
   })
 
+  it('logs the FULL micromamba diagnostics (data tails) even though it broadcasts only the short message', async () => {
+    // This automatic path has no per-op logging, so the gate itself must record the structured
+    // `error.data` tails. Otherwise a launch-time failure leaves only a truncated UI excerpt and the
+    // real micromamba output never crosses the main-process boundary (regression the reviewers flagged).
+    loggerSpies.error.mockReset()
+    const micromambaError = Object.assign(
+      new Error('micromamba failed (exit 1; mm create): …tail-excerpt'),
+      {
+        code: 'MICROMAMBA_EXIT',
+        data: { argv: ['mm', 'create'], exitCode: 1, stderrTail: 'Invalid package cache signature' }
+      }
+    )
+    const provisioner = fakeProvisioner({
+      restoreRelocatedEnvs: vi.fn().mockRejectedValue(micromambaError)
+    })
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate-log-'))
+    await runStartupGate(provisioner, dir, vi.fn())
+
+    expect(loggerSpies.error).toHaveBeenCalledOnce()
+    const [, fields] = loggerSpies.error.mock.calls[0] as [string, Record<string, unknown>]
+    // errorLogFields lifts the error's own `data`/`code` keys, so the tails are present in the log.
+    expect(fields.code).toBe('MICROMAMBA_EXIT')
+    expect(JSON.stringify(fields)).toContain('Invalid package cache signature')
+  })
+
   it('refuses to rebuild over a recovery-blocked prefix through the REAL provisioner self-guard', async () => {
     // The startup gate drives repair/upgrade/restore through the provisioner, so the block guarantee
     // must survive that real path — not just a mock guard on the UI handlers. Wire a real

--- a/src/main/notebook/env-ipc.ts
+++ b/src/main/notebook/env-ipc.ts
@@ -299,6 +299,14 @@ export const runStartupGate = async (
     // already-existing managed env; a first-time env is built lazily on first notebook use
     // (ensureDefaultEnvReady), so there is nothing to provision here.
   } catch (error) {
+    // This is the automatic (no per-op logging) path, so record the FULL diagnostics here — including
+    // the structured micromamba tails on `error.data` — before broadcasting only the short UI message.
+    // Otherwise a launch-time restore/upgrade/repair failure would leave nothing but a truncated excerpt.
+    try {
+      log.error('startup gate failed', runtimeErrorLogFields(error))
+    } catch {
+      // Diagnostics are best-effort and must never suppress the progress broadcast below.
+    }
     broadcast({
       phase: 'error',
       message: `Environment preparation failed: ${(error as Error).message}`,

--- a/src/main/notebook/micromamba-cache-recovery.test.ts
+++ b/src/main/notebook/micromamba-cache-recovery.test.ts
@@ -104,6 +104,32 @@ describe('recoverWindowsMaxPathPackage', () => {
     expect(existsSync(sibling)).toBe(true)
   })
 
+  it('recovers when the signature lives only in the error data tails, not the short UI message', () => {
+    // A runMicromamba failure now caps `Error.message` to a short excerpt and keeps the full micromamba
+    // output on `error.data.stderrTail`. Recovery must read the tails (via micromambaDiagnosticText),
+    // or a self-healing MAX_PATH repair would be skipped whenever the signature falls outside the cap.
+    const cache = makeRoot()
+    const leaf = 'libstdcxx-devel_win-64-15.2.0-h0a72980_119'
+    const packageDir = join(cache, 'https', 'conda.anaconda.org', 'conda-forge', 'noarch', leaf)
+    mkdirSync(packageDir, { recursive: true })
+    const missing = join(packageDir, 'Library', 'x'.repeat(280))
+    const error = Object.assign(new Error('micromamba failed (exit 1; mm create): …plan-noise'), {
+      code: 'MICROMAMBA_EXIT',
+      data: {
+        argv: ['mm', 'create'],
+        exitCode: 1,
+        stderrTail:
+          `warning Invalid package cache, file '${missing}' is missing\n` +
+          `Cannot find a valid extracted directory cache for '${leaf}.conda'\n` +
+          'critical Package cache error.',
+        stdoutTail: 'plan-noise'
+      }
+    })
+
+    expect(recoverWindowsMaxPathPackage(error, [cache], { platform: 'win32' })).toBe(true)
+    expect(existsSync(packageDir)).toBe(false)
+  })
+
   it('refuses traversal, cache-root targets, and ambiguous cache errors', () => {
     const cache = makeRoot()
     const outside = makeRoot()

--- a/src/main/notebook/micromamba-cache-recovery.ts
+++ b/src/main/notebook/micromamba-cache-recovery.ts
@@ -2,6 +2,7 @@ import { type Dirent, existsSync, readFileSync, readdirSync, realpathSync, rmSyn
 import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import { WINDOWS_MAX_USABLE_PATH } from './micromamba-cache'
+import { micromambaDiagnosticText } from './provisioner-runtime'
 
 const COMPLETE_MARKER = join('info', 'repodata_record.json')
 const CONDA_SUBDIR = /^(?:noarch|win-64|osx-(?:64|arm64)|linux-(?:64|aarch64|ppc64le|s390x))$/i
@@ -164,7 +165,10 @@ export const recoverWindowsMaxPathPackage = (
   deps: MaxPathRecoveryDeps = {}
 ): boolean => {
   if ((deps.platform ?? process.platform) !== 'win32') return false
-  const message = error instanceof Error ? error.message : String(error)
+  // Parse the FULL micromamba diagnostics (data tails), not the short UI excerpt on `.message`: the
+  // signature and the quoted over-budget path can fall outside the retained excerpt, which would skip
+  // the MAX_PATH repair and fail provisioning instead of self-healing.
+  const message = micromambaDiagnosticText(error)
   const hasMissingContext =
     /invalid package cache/i.test(message) && /(?:is missing|package cache error)/i.test(message)
   const hasRemoveContext =

--- a/src/main/notebook/provisioner-runtime.test.ts
+++ b/src/main/notebook/provisioner-runtime.test.ts
@@ -59,7 +59,9 @@ describe('runMicromamba', () => {
     ).resolves.toBeUndefined()
   })
 
-  it('rejects with a stderr summary on non-zero exit', async () => {
+  it('rejects with a short stderr excerpt on non-zero exit, keeping full tails in data', async () => {
+    // The user-facing message prefers the stderr reason (not the package-plan stdout) so the
+    // provisioning banner never floods; both full tails stay on the error's structured `data`.
     await expect(
       runMicromamba(
         [
@@ -69,7 +71,45 @@ describe('runMicromamba', () => {
         ],
         { MM_STDOUT: 'stdout-only-token', MM_STDERR: 'stderr-only-token' }
       )
-    ).rejects.toThrow(/exit 3[^]*stdout-only-token[^]*stderr-only-token/)
+    ).rejects.toMatchObject({
+      code: 'MICROMAMBA_EXIT',
+      message: expect.stringMatching(/exit 3[^]*stderr-only-token/),
+      data: {
+        exitCode: 3,
+        stderrTail: 'stderr-only-token',
+        stdoutTail: 'stdout-only-token'
+      }
+    })
+  })
+
+  it('omits the stdout package plan from the exit message when stderr carries the reason', async () => {
+    await expect(
+      runMicromamba(
+        [
+          process.execPath,
+          '-e',
+          'process.stdout.write(process.env.MM_STDOUT); process.stderr.write(process.env.MM_STDERR); process.exit(1)'
+        ],
+        { MM_STDOUT: 'plan-noise-token', MM_STDERR: 'the-real-reason' }
+      )
+    ).rejects.toThrow(/^(?:(?!plan-noise-token)[^])*the-real-reason(?:(?!plan-noise-token)[^])*$/)
+  })
+
+  it('caps the exit message excerpt while retaining the full stderr tail in data', async () => {
+    // 2 KB of stderr must not reach the message verbatim (the banner-flood bug); the excerpt is
+    // bounded and prefixed with an ellipsis, but the full tail is preserved on `data`.
+    await expect(
+      runMicromamba([
+        process.execPath,
+        '-e',
+        "process.stderr.write('X'.repeat(2048)); process.exit(2)"
+      ])
+    ).rejects.toMatchObject({
+      code: 'MICROMAMBA_EXIT',
+      // The ellipsis-prefixed excerpt ends in EXACTLY 500 X's — proof the 2048-char tail was capped.
+      message: expect.stringMatching(/…X{500}$/),
+      data: { stderrTail: 'X'.repeat(2048) }
+    })
   })
 
   it('distinguishes timeout from an ordinary non-zero exit and keeps output tails', async () => {

--- a/src/main/notebook/provisioner-runtime.test.ts
+++ b/src/main/notebook/provisioner-runtime.test.ts
@@ -4,7 +4,13 @@ import { join } from 'node:path'
 
 import { describe, expect, it, vi } from 'vitest'
 
-import { killAndConfirmExit, md5File, runMicromamba, verifyExecutable } from './provisioner-runtime'
+import {
+  killAndConfirmExit,
+  md5File,
+  micromambaDiagnosticText,
+  runMicromamba,
+  verifyExecutable
+} from './provisioner-runtime'
 import { condaActivatedPath } from './runtime-paths'
 
 describe('verifyExecutable', () => {
@@ -254,5 +260,33 @@ describe('killAndConfirmExit', () => {
       once: () => undefined // never fires exit
     } as never
     expect(await killAndConfirmExit(fake, 40)).toBe(false)
+  })
+})
+
+describe('micromambaDiagnosticText', () => {
+  it('reconstructs the FULL diagnostics from data tails so recovery parsing survives the short message', () => {
+    // The UI message is a capped excerpt; a cache-corruption / MAX_PATH signature or over-budget path
+    // can sit only in the full stdout/stderr tails. The reconstructed text must expose both.
+    const error = Object.assign(new Error('micromamba failed (exit 1; mm create): …tail-excerpt'), {
+      code: 'MICROMAMBA_EXIT',
+      data: {
+        argv: ['mm', 'create'],
+        exitCode: 1,
+        stderrTail: "Invalid package cache, 'C:/very/long/path/pkg.conda' is missing",
+        stdoutTail: 'plan-line-1\nplan-line-2'
+      }
+    })
+    const text = micromambaDiagnosticText(error)
+    expect(text).toContain('micromamba failed (exit 1')
+    expect(text).toContain('Invalid package cache')
+    expect(text).toContain("'C:/very/long/path/pkg.conda' is missing")
+    expect(text).toContain('plan-line-1')
+  })
+
+  it('falls back to the plain message for an error without structured data (e.g. spawn failure)', () => {
+    expect(micromambaDiagnosticText(new Error('micromamba failed to start (mm): ENOENT'))).toBe(
+      'micromamba failed to start (mm): ENOENT'
+    )
+    expect(micromambaDiagnosticText('not-an-error')).toBe('not-an-error')
   })
 })

--- a/src/main/notebook/provisioner-runtime.ts
+++ b/src/main/notebook/provisioner-runtime.ts
@@ -134,6 +134,9 @@ export const runMicromamba = (
     })
 
     const maxTail = 16 * 1024
+    // Cap the excerpt embedded in the user-facing error message; full tails still reach the logs via
+    // the error's structured `data`.
+    const MESSAGE_TAIL_LIMIT = 500
     let stdout = ''
     let stderr = ''
     let timedOut = false
@@ -163,10 +166,16 @@ export const runMicromamba = (
       clearTimeout(timeout)
       signal?.removeEventListener('abort', onAbort)
     }
-    const output = (): string =>
-      [stdout && `stdout tail:\n${stdout}`, stderr && `stderr tail:\n${stderr}`]
-        .filter(Boolean)
-        .join('\n')
+    // Full tails go into the error's structured `data` for the logs; the user-facing message gets only
+    // this short excerpt. micromamba writes its package plan (thousands of pinned specs) to stdout, so
+    // embedding the raw tails in the message floods the provisioning banner — prefer the stderr reason,
+    // capped, and fall back to stdout only when stderr is empty.
+    const briefTail = (): string => {
+      const source = stderr.trim() || stdout.trim()
+      return source.length > MESSAGE_TAIL_LIMIT
+        ? `…${source.slice(-MESSAGE_TAIL_LIMIT).trimStart()}`
+        : source
+    }
 
     // Record the spawned PID for crash-recovery supervision. If recording FAILS, fail closed: kill the
     // child and only settle once it is CONFIRMED gone — the close handler then rejects with
@@ -216,11 +225,11 @@ export const runMicromamba = (
         reject(new Error('Runtime setup cancelled.'))
         return
       }
-      const tails = output()
+      const excerpt = briefTail()
       if (timedOut) {
         const timeoutError = Object.assign(
           new Error(
-            `micromamba timed out after ${timeoutMs}ms (${argv.join(' ')})${tails ? `:\n${tails}` : ''}`
+            `micromamba timed out after ${timeoutMs}ms (${argv.join(' ')})${excerpt ? `:\n${excerpt}` : ''}`
           ),
           {
             code: 'MICROMAMBA_TIMEOUT',
@@ -244,8 +253,17 @@ export const runMicromamba = (
         return
       }
       const status = code === null ? `signal ${closeSignal ?? 'unknown'}` : `exit ${code}`
+      // Short message for the UI banner; full tails attached to `data` for the logs (see briefTail).
       reject(
-        new Error(`micromamba failed (${status}; ${argv.join(' ')})${tails ? `:\n${tails}` : ''}`)
+        Object.assign(
+          new Error(
+            `micromamba failed (${status}; ${argv.join(' ')})${excerpt ? `:\n${excerpt}` : ''}`
+          ),
+          {
+            code: 'MICROMAMBA_EXIT',
+            data: { argv, exitCode: code, stderrTail: stderr, stdoutTail: stdout }
+          }
+        )
       )
     })
   })

--- a/src/main/notebook/provisioner-runtime.ts
+++ b/src/main/notebook/provisioner-runtime.ts
@@ -14,6 +14,39 @@ export const CHILD_UNCONFIRMED = 'RUNTIME_CHILD_UNCONFIRMED'
 export const isChildUnconfirmedError = (error: unknown): boolean =>
   error instanceof Error && error.message.includes(CHILD_UNCONFIRMED)
 
+// Structured payload attached to a runMicromamba failure (exit / timeout). The user-facing
+// `Error.message` carries only a short excerpt; the full stdout/stderr tails live here so machine
+// consumers (cache-corruption / MAX_PATH recovery parsers, startup-gate logging) keep the complete
+// diagnostics the message no longer holds.
+export type MicromambaErrorData = {
+  argv: string[]
+  exitCode?: number | null
+  stderrTail?: string
+  stdoutTail?: string
+}
+
+const hasMicromambaErrorData = (error: unknown): error is { data: MicromambaErrorData } =>
+  error instanceof Error &&
+  typeof (error as { data?: unknown }).data === 'object' &&
+  (error as { data?: unknown }).data !== null
+
+// The FULL micromamba diagnostic text for machine parsing (not for the UI). Prefers the untruncated
+// stdout+stderr tails on `error.data`; falls back to `error.message` for errors raised without the
+// structured payload (e.g. captureMicromamba, spawn-failure). Recovery heuristics regex-match this, so
+// it must reconstruct what the pre-excerpt `Error.message` used to contain.
+export const micromambaDiagnosticText = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error)
+  if (!hasMicromambaErrorData(error)) return message
+  const { stdoutTail, stderrTail } = error.data
+  return [
+    message,
+    stdoutTail && `stdout tail:\n${stdoutTail}`,
+    stderrTail && `stderr tail:\n${stderrTail}`
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
 // Kills a child and resolves ONLY once it has actually exited, escalating SIGTERM -> SIGKILL. Resolves
 // true when exit is confirmed, false when it can't be confirmed within the deadline (SIGTERM can be
 // ignored/delayed and kill() can return false, so a single kill() is not proof of exit). The caller

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -662,6 +662,52 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     expect(creates).toBe(2)
   })
 
+  it('retains BOTH full micromamba tails on MaxPathRetryError.data when the errors are runMicromamba-style', async () => {
+    // runMicromamba now caps Error.message to a short excerpt and keeps the full tails on error.data.
+    // The MAX_PATH retry wrapper composes its message from the two short .message excerpts, so without
+    // capturing error.data it would lose both full outputs — the exact post-mortem this PR preserves.
+    const root = makeRoot()
+    const cache = pkgsCache(root)
+    const leaf = 'broken-package-1.0-0'
+    const packageDir = join(cache, 'https', 'host', 'channel', 'noarch', leaf)
+    mkdirSync(packageDir, { recursive: true })
+    const missing = join(packageDir, 'Library', 'x'.repeat(280))
+    let creates = 0
+    const provisioner = new DefaultRuntimeProvisioner(
+      makeDeps(root, {
+        platform: 'win32',
+        cache: { path: cache, lockKey: cache },
+        fetchBundle: async (): Promise<FetchedBundle> => ({
+          lockPath: join(root, 'p.lock'),
+          pathBudget: { maxCacheRelativePath: 1, maxEnvRelativePath: 1 }
+        }),
+        runArgv: async () => {
+          creates += 1
+          // Both spawns fail runMicromamba-style: short message excerpt, full tail only on `data`.
+          const stderrTail =
+            creates === 1
+              ? `Invalid package cache, file '${missing}' is missing for '${leaf}.conda'; Package cache error`
+              : 'ORIGINAL_FULL_TAIL_MARKER: a different disk error with lots of detail'
+          throw Object.assign(new Error(`micromamba failed (exit 1; mm create): …short-excerpt`), {
+            code: 'MICROMAMBA_EXIT',
+            data: { argv: ['mm', 'create'], exitCode: 1, stderrTail }
+          })
+        }
+      })
+    )
+
+    const failure = provisioner.provisionPython(() => {}).catch((error: unknown) => error)
+    const error = (await failure) as Error & {
+      data?: { originalDiagnostics?: string; retryDiagnostics?: string }
+    }
+    expect(error.name).toBe('MaxPathRetryError')
+    // The full tails of BOTH the original failure and the retry survive on the structured data.
+    expect(error.data?.originalDiagnostics).toContain('Invalid package cache')
+    expect(error.data?.originalDiagnostics).toContain(missing)
+    expect(error.data?.retryDiagnostics).toContain('ORIGINAL_FULL_TAIL_MARKER')
+    expect(creates).toBe(2)
+  })
+
   it('wires the spawned micromamba child pid into the materialize journal, then clears it on completion', async () => {
     const root = makeRoot()
     const prefix = envPrefix(root, DEFAULT_PY_ENV)

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -49,7 +49,12 @@ import {
   type MicromambaDeps
 } from './micromamba'
 import { defaultOperationChildLiveness, readProcessStartToken } from './operation-recovery'
-import { isChildUnconfirmedError, runMicromamba, verifyExecutable } from './provisioner-runtime'
+import {
+  isChildUnconfirmedError,
+  micromambaDiagnosticText,
+  runMicromamba,
+  verifyExecutable
+} from './provisioner-runtime'
 import { envsLockDir } from './runtime-relocation'
 import {
   DEFAULT_ENV_VERSION,
@@ -1394,7 +1399,9 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
 // clean. Deliberately specific — a bare "not empty" (which many unrelated fs errors contain) must NOT
 // trigger a cache repair, so it is anchored to micromamba's own "remove_all …" extraction phrasing.
 const isCorruptPkgsCacheError = (error: unknown): boolean => {
-  const message = error instanceof Error ? error.message : String(error)
+  // Parse the FULL micromamba diagnostics (data tails), not the short UI excerpt on `.message`, or the
+  // signature that decides a cache repair can fall outside the retained excerpt and self-healing skips.
+  const message = micromambaDiagnosticText(error)
   return (
     /incorrect downloads/i.test(message) ||
     /invalid package cache/i.test(message) ||

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1417,6 +1417,12 @@ const isCorruptPkgsCacheError = (error: unknown): boolean => {
 // offline-rebuild material survives; the removed dirs are simply re-extracted from those tarballs.
 // Returns true if it removed anything (so the caller only retries when there was something to repair).
 class MaxPathRetryError extends Error {
+  // Full micromamba diagnostics of BOTH the original failure and the post-recovery retry. The message
+  // (below) stays short for the UI banner — it composes only the two excerpt-level `.message`s — so the
+  // untruncated stdout/stderr tails would otherwise be lost here. errorLogFields lifts this `data`, so a
+  // recovery-failure post-mortem keeps both full outputs even though neither reaches the banner.
+  readonly data: { originalDiagnostics: string; retryDiagnostics: string }
+
   constructor(original: unknown, retry: unknown) {
     const originalMessage = original instanceof Error ? original.message : String(original)
     const retryMessage = retry instanceof Error ? retry.message : String(retry)
@@ -1427,6 +1433,10 @@ class MaxPathRetryError extends Error {
       { cause: retry }
     )
     this.name = 'MaxPathRetryError'
+    this.data = {
+      originalDiagnostics: micromambaDiagnosticText(original),
+      retryDiagnostics: micromambaDiagnosticText(retry)
+    }
   }
 }
 

--- a/src/renderer/src/pages/workspace/EnvProvisionOverlay.tsx
+++ b/src/renderer/src/pages/workspace/EnvProvisionOverlay.tsx
@@ -47,7 +47,11 @@ const EnvProvisionOverlay = ({
         </>
       ) : (
         <>
-          <p className="text-xs text-text-300">{ui.message}</p>
+          {/* A provisioner failure reason can be long; bound it to a scrollable box so the overlay
+              never grows unbounded. Full diagnostics live in the logs (provisioner-runtime.briefTail). */}
+          <p className="max-h-24 max-w-md overflow-y-auto break-words whitespace-pre-wrap text-xs text-text-300">
+            {ui.message}
+          </p>
           {onRetry ? (
             <button
               type="button"

--- a/src/renderer/src/pages/workspace/EnvStatusBanner.render.test.tsx
+++ b/src/renderer/src/pages/workspace/EnvStatusBanner.render.test.tsx
@@ -113,6 +113,30 @@ describe('EnvStatusBanner', () => {
     expect(retried).toBe(1)
   })
 
+  it('clamps a long error reason and uses the dialog card chrome instead of an unbounded pill', () => {
+    // A provisioner failure can carry thousands of characters (the micromamba package plan). The
+    // banner must not grow unbounded: the reason is line-clamped and the panel adopts the rounded
+    // dialog card. Full diagnostics live in the logs, not this banner.
+    const longReason = `micromamba failed (exit 1): ${'pkg==1.0=hbuild_0 - '.repeat(400)}`
+    act(() =>
+      root.render(
+        <EnvStatusBanner ui={{ kind: 'error', message: longReason }} onRetry={() => {}} />
+      )
+    )
+    const banner = container.querySelector('[data-testid="env-status-banner"]') as HTMLElement
+    expect(banner).not.toBeNull()
+    // Dialog chrome (matches dialog-chrome.ts): rounded card, card surface, dialog shadow.
+    expect(banner.className).toContain('rounded-xl')
+    expect(banner.className).toContain('bg-card')
+    expect(banner.className).toContain('shadow-dialog')
+    // The reason is present but rendered in a line-clamped node so the banner can't fill the screen.
+    const reason = banner.querySelector('.line-clamp-3') as HTMLElement
+    expect(reason).not.toBeNull()
+    expect(reason.textContent).toContain('micromamba failed (exit 1)')
+    // The standing title is separate from the clamped reason.
+    expect(banner.textContent).toContain('Environment update failed')
+  })
+
   it('is hidden for a first-run python preparation (that is the onboarding/gate surface, not a banner)', () => {
     act(() =>
       root.render(

--- a/src/renderer/src/pages/workspace/EnvStatusBanner.render.test.tsx
+++ b/src/renderer/src/pages/workspace/EnvStatusBanner.render.test.tsx
@@ -113,10 +113,10 @@ describe('EnvStatusBanner', () => {
     expect(retried).toBe(1)
   })
 
-  it('clamps a long error reason and uses the dialog card chrome instead of an unbounded pill', () => {
-    // A provisioner failure can carry thousands of characters (the micromamba package plan). The
-    // banner must not grow unbounded: the reason is line-clamped and the panel adopts the rounded
-    // dialog card. Full diagnostics live in the logs, not this banner.
+  it('bounds a long error reason in a scrollable box and uses the dialog card chrome, keeping the full text readable', () => {
+    // A provisioner failure can carry a long reason. This banner is the ONLY error surface outside the
+    // notebook pane (Home has no overlay), so the reason must stay fully readable: bound it to a
+    // scrollable box (max-h + overflow) rather than clamping lines, which could hide the actionable tail.
     const longReason = `micromamba failed (exit 1): ${'pkg==1.0=hbuild_0 - '.repeat(400)}`
     act(() =>
       root.render(
@@ -129,11 +129,16 @@ describe('EnvStatusBanner', () => {
     expect(banner.className).toContain('rounded-xl')
     expect(banner.className).toContain('bg-card')
     expect(banner.className).toContain('shadow-dialog')
-    // The reason is present but rendered in a line-clamped node so the banner can't fill the screen.
-    const reason = banner.querySelector('.line-clamp-3') as HTMLElement
+    // The reason is bounded (max-h) and scrollable (overflow-y-auto) rather than line-clamped, so the
+    // banner cannot fill the screen yet the full excerpt remains reachable — no line-clamp truncation.
+    const reason = banner.querySelector('.overflow-y-auto') as HTMLElement
     expect(reason).not.toBeNull()
+    expect(reason.className).toMatch(/max-h-/)
+    expect(reason.className).not.toContain('line-clamp')
     expect(reason.textContent).toContain('micromamba failed (exit 1)')
-    // The standing title is separate from the clamped reason.
+    // The full reason text is rendered (not truncated in the DOM), so scrolling exposes all of it.
+    expect(reason.textContent).toBe(longReason)
+    // The standing title is separate from the scrollable reason.
     expect(banner.textContent).toContain('Environment update failed')
   })
 

--- a/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
+++ b/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
@@ -17,20 +17,32 @@ const EnvStatusBanner = ({
   const show = (ui.kind === 'preparing' && ui.scope === 'upgrade') || ui.kind === 'error'
   if (!show) return null
 
+  // A preparing banner is a compact single-line pill; an error can carry a long provisioner reason, so
+  // it uses a wider rounded card (matching the app's dialog chrome) with the message clamped to a few
+  // lines. Full diagnostics live in the logs, not this banner (see provisioner-runtime.briefTail).
+  const isError = ui.kind === 'error'
+
   return (
     <div
       data-testid="env-status-banner"
-      className="fixed left-1/2 top-2 z-50 flex max-w-[min(90vw,640px)] -translate-x-1/2 items-center justify-center gap-2 rounded-full border border-border-100 bg-bg-200 px-3 py-1 text-center text-xs text-text-100 shadow-md"
+      className={`fixed left-1/2 top-2 z-50 -translate-x-1/2 border border-border bg-card text-foreground shadow-dialog ${
+        isError
+          ? 'flex max-w-[min(90vw,560px)] items-start gap-3 rounded-xl px-4 py-3 text-left text-xs'
+          : 'flex max-w-[min(90vw,640px)] items-center justify-center gap-2 rounded-full px-3 py-1 text-center text-xs'
+      }`}
     >
       {ui.kind === 'error' ? (
         <>
-          <span>Environment update failed — {ui.message}</span>
+          <div className="min-w-0 flex-1">
+            <p className="font-medium text-foreground">Environment update failed</p>
+            <p className="mt-0.5 line-clamp-3 break-words text-muted-foreground">{ui.message}</p>
+          </div>
           {onRetry ? (
             <button
               type="button"
               data-testid="env-status-banner-retry"
               onClick={onRetry}
-              className="rounded border border-border-100 px-2 py-0.5 text-xs text-text-100 hover:bg-bg-300"
+              className="shrink-0 rounded-lg border border-border px-2 py-0.5 text-xs text-foreground hover:bg-muted"
             >
               Retry
             </button>

--- a/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
+++ b/src/renderer/src/pages/workspace/EnvStatusBanner.tsx
@@ -17,9 +17,12 @@ const EnvStatusBanner = ({
   const show = (ui.kind === 'preparing' && ui.scope === 'upgrade') || ui.kind === 'error'
   if (!show) return null
 
-  // A preparing banner is a compact single-line pill; an error can carry a long provisioner reason, so
-  // it uses a wider rounded card (matching the app's dialog chrome) with the message clamped to a few
-  // lines. Full diagnostics live in the logs, not this banner (see provisioner-runtime.briefTail).
+  // A preparing banner is a compact single-line pill; an error can carry a longer provisioner reason,
+  // so it uses a wider rounded card (matching the app's dialog chrome). This banner is the ONLY error
+  // surface outside the notebook pane (it renders globally from App, incl. Home where there is no
+  // EnvProvisionOverlay), so the reason must stay fully readable — bound it to a scrollable box rather
+  // than clamping lines, which could hide the actionable tail. The source excerpt is already short
+  // (provisioner-runtime.briefTail); full diagnostics also live in the logs.
   const isError = ui.kind === 'error'
 
   return (
@@ -35,7 +38,9 @@ const EnvStatusBanner = ({
         <>
           <div className="min-w-0 flex-1">
             <p className="font-medium text-foreground">Environment update failed</p>
-            <p className="mt-0.5 line-clamp-3 break-words text-muted-foreground">{ui.message}</p>
+            <p className="mt-0.5 max-h-28 overflow-y-auto whitespace-pre-wrap break-words text-muted-foreground">
+              {ui.message}
+            </p>
           </div>
           {onRetry ? (
             <button


### PR DESCRIPTION
## Summary

On an environment setup failure, the provisioning banner dumped micromamba's full stdout/stderr tail (up to 16 KB — mostly the conda package plan, `pkg==1.0=hbuild_0 - …`) into a single **unbounded** top-of-app pill, covering most of the screen and wrecking the UX.

Root cause is two-fold: the main process embedded the raw tails in the user-facing `Error.message`, and the renderer rendered that message with no length bound.

## Changes

- **`provisioner-runtime.ts` (root cause):** `runMicromamba` now embeds only a short, **stderr-preferring** excerpt (capped at 500 chars, ellipsis-prefixed when truncated) in the user-facing `Error.message`, and attaches the full `stderrTail`/`stdoutTail` + `argv`/`exitCode` to the error's structured `data` — mirroring the existing timeout branch. `errorLogFields` captures `data`, so logs keep complete diagnostics; IPC only forwards `message`, so the UI never receives the noise.
- **`EnvStatusBanner.tsx` (defense + restyle):** the error state clamps the reason to 3 lines (`line-clamp-3 break-words`) and adopts the redesigned **dialog chrome** (`rounded-xl`, `bg-card`, `border-border`, `shadow-dialog`, semantic `text-foreground`/`text-muted-foreground`) instead of the old unbounded `rounded-full` pill. The preparing state stays a compact pill.
- **`EnvProvisionOverlay.tsx` (defense):** its error message is now bounded to a `max-h-24` scrollable, `break-words` box.

## Tested

- `npm run typecheck` — clean.
- `npm run lint` — 0 errors; touched files Prettier-formatted, 0 warnings.
- Related suites green (73/73): `provisioner-runtime.test.ts` (new message/data contract + 2 KB cap), `EnvStatusBanner.render.test.tsx` (new clamp + dialog-token assertions), `notebook-env-store`, `provisioning-view`, `NotebookPreview.gate.render`.

Note: the full `npm test` shows pre-existing failures in unrelated files (`ProjectFilesView`, `WorkspaceMessageScroller`, `build/packaging`) — reproduced with these changes stashed, so they are not introduced here.