### PR TITLE
chore(release): bump version to 0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ This section describes durable product capabilities rather than a version-specif
 | **Built-in cloud providers** | Choose from the provider list shown by the installed app and authenticate with the requested key. |
 | **Custom Gateway**           | Supply a compatible Base URL, API Key, and exact model ID.                                        |
 | **Codex Subscription**       | Select the Codex agent framework first, then you can select Codex subscription in provider type   |
-| **Claude Subscription**      | Run `claude setup-token` in a terminal and paste the resulting long-lived token into the Open Science sign-in prompt. The token is stored encrypted in app data and Claude always runs under an app-owned `CLAUDE_CONFIG_DIR`, isolated from your `~/.claude/`. |
+| **Claude Subscription**      | Sign in with a Claude subscription in two modes: **shared** (a browser login that stores credentials in your default `~/.claude` profile) or **isolated** (an app-managed `claude setup-token` run under an app-owned `CLAUDE_CONFIG_DIR`, fully isolated from `~/.claude/`, with a browser flow plus a paste-a-token fallback). |
 
 The legacy **Local Claude** provider has been removed. Previously stored Local Claude entries are
 dropped during upgrade; add **Claude Subscription** and authenticate with `claude setup-token`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-science",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-science",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-science",
   "productName": "Open Science",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Open Science — an open-source, model-agnostic AI workbench for scientific discovery.",
   "main": "./out/main/index.js",
   "author": "aipoch",


### PR DESCRIPTION
## Summary

Release prep for **v0.7.1**. Bumps the single source of truth (`package.json` + `package-lock.json`) from `0.7.0` to `0.7.1` and updates the docs for what landed since `v0.7.0` (11 PRs). This is a **patch** release: no breaking changes and no Roadmap phase status changes — it adds two Settings-facing conveniences (a switchable app icon and a unified Claude subscription sign-in) and a round of ACP, notebook, provider-validation, and CLI fixes on top of v0.7.0.

### Since v0.7.0 (headline)
- **Switchable app icon** — pick between the Light (dotted mark) and Dark (original) built-in icons under Settings → General, applied to the window/dock at runtime and on every launch. (#426)
- **Claude subscription sign-in (shared + isolated)** — a first-class Claude subscription provider with a browser-OAuth shared login (credentials in `~/.claude`) and an isolated `setup-token` mode (app-owned config dir), both with a browser sign-in flow. (#389)
- **Unified session permission scopes** — Open Science owns the Once / This conversation scopes end-to-end; conversation grants are memory-only, visible, revocable, and survive backend reconnects; bridged Codex sessions now reliably load the selected Connector Skill before the notebook REPL. (#398)
- **False task completion** — a provider `end_turn` after prose that promises later work is no longer reported as task success. (#417)
- Fixes: blank R figures for text output (#422), micromamba env-banner flooding (#423), PowerShell CLIXML progress noise on Windows (#421), server-vs-client provider-validation errors (#419), CLI fast-fail on AppImage sandbox errors + `start --no-sandbox` fallback (#416), atomic managed-Codex context-usage patch publish (#412)
- Test coverage uplift: ~159 new main-process IPC handler / factory unit tests. (#424)

### Doc changes in this PR
- `README.md` — Claude Subscription row updated to describe both the **shared** (browser OAuth into `~/.claude`) and **isolated** (`claude setup-token`, app-owned `CLAUDE_CONFIG_DIR`) sign-in modes. (#389)
- `ROADMAP.md` — no change (no phase or vendor-status changes in this patch release).

## Testing
No code changed — version + docs only. Verification is via CI on this PR (typecheck, lint, test, build); no local lint was run per the release process.

## Release
Tag `v0.7.1` (annotated, message `Open Science v0.7.1`) will be cut on the merge commit after this PR lands, triggering the release workflow.
